### PR TITLE
Delete the ambient twins nothing calls anymore

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -109,22 +109,6 @@ pub(crate) fn record_pre_execution_failure_in_store(
     Ok(failed_record)
 }
 
-/// Record a post-provider transport/handoff failure without terminalizing a run
-/// that already produced a candidate (#9377). The existing durable record — its
-/// state, aggregate, artifacts, and provider handles — is preserved verbatim;
-/// only a recoverable `transport_follow_up_failure` marker is stamped so
-/// controller reconciliation can adopt the completed candidate rather than
-/// rerunning the provider. The failure stays `retryable` so recovery is
-/// attempted, and never regresses a terminal candidate to `Failed`.
-fn record_transport_follow_up_failure(
-    record: AgentTaskRunRecord,
-    phase: &str,
-    error: &Error,
-) -> Result<AgentTaskRunRecord> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    record_transport_follow_up_failure_in_store(&lifecycle_store, record, phase, error)
-}
-
 fn record_transport_follow_up_failure_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     mut record: AgentTaskRunRecord,
@@ -1203,17 +1187,6 @@ fn terminal_artifact_projection_readiness_for_record_with(
             )
             .to_string(),
     ))
-}
-
-/// Project finalized executor artifacts into the standard observation registry.
-/// The lifecycle aggregate remains the source of task semantics; the registry
-/// supplies the canonical retrievable-byte index used by `runs artifact get`.
-pub(crate) fn project_terminal_artifacts(
-    record: &AgentTaskRunRecord,
-    aggregate: &AgentTaskAggregate,
-) -> Result<()> {
-    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
-    project_terminal_artifacts_in_store(&store, record, aggregate)
 }
 
 fn project_terminal_artifacts_in_store(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
@@ -257,14 +257,6 @@ pub(crate) fn start_candidate_adoption_with_policy_in_store(
     Ok(record)
 }
 
-pub fn checkpoint_candidate_adoption_remediation(
-    run_id: &str,
-    remediation_run_id: &str,
-) -> Result<()> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    checkpoint_candidate_adoption_remediation_in_store(&lifecycle_store, run_id, remediation_run_id)
-}
-
 pub(crate) fn checkpoint_candidate_adoption_remediation_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
@@ -291,22 +283,6 @@ pub(crate) fn checkpoint_candidate_adoption_remediation_in_store(
     ));
     lifecycle_store.write_record(&record)?;
     Ok(())
-}
-
-pub fn start_candidate_adoption_gate(
-    run_id: &str,
-    command: &str,
-    process_group: u32,
-    timeout_seconds: u64,
-) -> Result<()> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    start_candidate_adoption_gate_in_store(
-        &lifecycle_store,
-        run_id,
-        command,
-        process_group,
-        timeout_seconds,
-    )
 }
 
 pub(crate) fn start_candidate_adoption_gate_in_store(
@@ -340,22 +316,6 @@ pub(crate) fn start_candidate_adoption_gate_in_store(
         true
     })?;
     Ok(())
-}
-
-pub(crate) fn heartbeat_candidate_adoption_gate(
-    run_id: &str,
-    visibility: crate::agent_task_gate::AgentTaskGateVisibility,
-    reveal_policy: crate::agent_task_gate::AgentTaskGateRevealPolicy,
-    status: &crate::agent_task_gate::AgentTaskGateLiveStatus,
-) -> Result<()> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    heartbeat_candidate_adoption_gate_in_store(
-        &lifecycle_store,
-        run_id,
-        visibility,
-        reveal_policy,
-        status,
-    )
 }
 
 pub(crate) fn heartbeat_candidate_adoption_gate_in_store(
@@ -407,11 +367,6 @@ pub(crate) fn heartbeat_candidate_adoption_gate_in_store(
     Ok(())
 }
 
-pub fn candidate_adoption_cancel_requested(run_id: &str) -> Result<bool> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    candidate_adoption_cancel_requested_in_store(&lifecycle_store, run_id)
-}
-
 pub(crate) fn candidate_adoption_cancel_requested_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
@@ -421,11 +376,6 @@ pub(crate) fn candidate_adoption_cancel_requested_in_store(
         .candidate_adoption
         .as_ref()
         .is_some_and(|attempt| attempt.state == "cancel_requested" || attempt.state == "cancelled"))
-}
-
-pub fn checkpoint_candidate_adoption(run_id: &str, phase: &str, active_gate: &str) -> Result<()> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    checkpoint_candidate_adoption_in_store(&lifecycle_store, run_id, phase, active_gate)
 }
 
 pub(crate) fn checkpoint_candidate_adoption_in_store(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2449,18 +2449,6 @@ pub fn running_owner_pid_in_store(
         .owner_pid())
 }
 
-/// Persist the controller-owned Cook phase independently of provider output.
-/// This gives foreground observers a restart-safe liveness source without
-/// treating an arbitrary provider transcript line as durable state.
-pub fn record_cook_progress(
-    run_id: &str,
-    phase: &str,
-    attempt: u32,
-    detail: Option<&str>,
-) -> Result<AgentTaskRunRecord> {
-    record_cook_progress_with_activity(run_id, phase, attempt, detail, None)
-}
-
 /// Persist the controller-owned Cook phase into an explicitly rooted store.
 pub fn record_cook_progress_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
@@ -2616,18 +2604,6 @@ pub fn record_cook_progress_with_activity_in_store(
     record.ok_or_else(|| Error::internal_unexpected("Cook progress record was unchanged"))
 }
 
-/// Persist a failed foreground observer delivery without changing the Cook's
-/// controller-owned progress. Observers are notification sinks, so their
-/// transport lifetime cannot determine whether a durable operation continues.
-pub fn record_cook_observer_event(
-    run_id: &str,
-    phase: &str,
-    diagnostic: Value,
-) -> Result<AgentTaskRunRecord> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    record_cook_observer_event_in_store(&lifecycle_store, run_id, phase, diagnostic)
-}
-
 pub fn record_cook_observer_event_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
@@ -2670,26 +2646,6 @@ const MAX_COOK_RESOURCE_SAMPLES: usize = 240;
 /// Supervision events retained. Decisions are announced on escalation only, so
 /// a run reaches a handful of these, not hundreds.
 const MAX_COOK_SUPERVISION_EVENTS: usize = 32;
-
-/// Persist one supervision tick: the resource observation, plus any decision
-/// the policy reached on it.
-///
-/// The two land in different places on purpose. The **timeline** is a rolling
-/// window of what the run cost, which answers "was this expensive?" and is
-/// naturally lossy at the head. The **events** are the decisions Homeboy took,
-/// which answer "why was this stopped?" and must not be evicted by a long tail
-/// of routine samples. Collapsing them into one array would let an hour of
-/// quiet heartbeats push the stop decision out of the evidence that exists to
-/// explain the stop (#7015).
-pub fn record_cook_supervision(
-    run_id: &str,
-    attempt: u32,
-    sample: Option<Value>,
-    decisions: Vec<Value>,
-) -> Result<AgentTaskRunRecord> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    record_cook_supervision_in_store(&lifecycle_store, run_id, attempt, sample, decisions)
-}
 
 pub fn record_cook_supervision_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
@@ -2742,22 +2698,6 @@ pub fn record_cook_supervision_in_store(
     record.ok_or_else(|| Error::internal_unexpected("Cook supervision record was unchanged"))
 }
 
-/// Persist the outcome of a supervision-ordered termination.
-///
-/// Recorded separately from the decision that ordered it because the two can
-/// disagree: a policy can order a stop that the host then fails to carry out
-/// (a pid that survives SIGKILL, a non-Unix host with no process-tree
-/// cancellation at all). Evidence that shows only the order would let a reader
-/// conclude a run was stopped when it was not.
-pub fn record_cook_supervision_stop(
-    run_id: &str,
-    attempt: u32,
-    outcome: Value,
-) -> Result<AgentTaskRunRecord> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    record_cook_supervision_stop_in_store(&lifecycle_store, run_id, attempt, outcome)
-}
-
 pub fn record_cook_supervision_stop_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
@@ -2785,19 +2725,6 @@ pub fn record_cook_supervision_stop_in_store(
         true
     })?;
     record.ok_or_else(|| Error::internal_unexpected("Cook supervision stop was unchanged"))
-}
-
-/// Bind the Cook's authoritative command result to its terminal progress
-/// record. Provider and gate state alone cannot establish whether publication
-/// completed, so readers use this positive completion fact rather than a list
-/// of success-status strings.
-pub fn record_cook_terminal_result(
-    run_id: &str,
-    terminal_success: bool,
-    exit_code: i32,
-) -> Result<AgentTaskRunRecord> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    record_cook_terminal_result_in_store(&lifecycle_store, run_id, terminal_success, exit_code)
 }
 
 pub fn record_cook_terminal_result_in_store(
@@ -3379,15 +3306,6 @@ pub(crate) fn trusted_dispatcher_kind(kind: &str) -> Option<String> {
 
 fn queue_quarantine_remediation() -> &'static str {
     "inspect retained diagnostics with: homeboy agent-task status <run-id> --exact --full"
-}
-
-fn quarantine_queued_run(
-    record: &AgentTaskRunRecord,
-    plan: Option<&AgentTaskPlan>,
-    error: &Error,
-) -> Result<()> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    quarantine_queued_run_in_store(&lifecycle_store, record, plan, error)
 }
 
 /// Retain the redacted admission diagnostic on the record inside the store the
@@ -5933,10 +5851,6 @@ fn substantive_candidate_from_aggregate(
     })
 }
 
-fn substantive_candidate(run_id: &str) -> Option<(String, String)> {
-    substantive_candidate_in_store(run_id, None)
-}
-
 fn substantive_candidate_in_store(
     run_id: &str,
     lifecycle_store: Option<&AgentTaskLifecycleStore>,
@@ -6253,15 +6167,6 @@ pub(crate) fn record_promotion_in_store(
         )?;
     }
     Ok(record)
-}
-
-pub fn record_acceptance_verdict(
-    run_id: &str,
-    verdict: AgentTaskAcceptanceVerdict,
-    evidence_refs: Vec<String>,
-    token: String,
-) -> Result<AgentTaskRunRecord> {
-    record_acceptance_verdict_with_feedback(run_id, verdict, evidence_refs, token, None)
 }
 
 /// Record a verdict against an explicitly rooted store. The thin delegation to
@@ -6651,11 +6556,6 @@ pub(crate) fn record_cook_moving_base_recovery_in_store(
         Some(record) => Ok(record),
         None => lifecycle_store.read_record(&run_id),
     }
-}
-
-pub fn clear_cook_moving_base_recovery(run_id: &str) -> Result<AgentTaskRunRecord> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    clear_cook_moving_base_recovery_in_store(&lifecycle_store, run_id)
 }
 
 pub(crate) fn clear_cook_moving_base_recovery_in_store(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
@@ -1305,18 +1305,6 @@ pub fn release_local_workspace_claim(claim: &WorkspaceClaim) -> Result<()> {
     store()?.release(claim, now_ms())
 }
 
-pub(crate) fn register_local_workspace_owner(
-    workspace: WorkspaceIdentity,
-    run_id: &str,
-) -> Result<WorkspaceOwnerLease> {
-    store()?.register_owner(
-        workspace,
-        run_id,
-        LOCAL_WORKSPACE_OWNER_LEASE_TTL_MS,
-        now_ms(),
-    )
-}
-
 pub(crate) fn register_local_workspace_owner_in_store(
     store: &WorkspaceClaimStore,
     workspace: WorkspaceIdentity,
@@ -1336,10 +1324,6 @@ pub(crate) fn renew_local_workspace_owner(
     store()?.renew_owner(lease, LOCAL_WORKSPACE_OWNER_LEASE_TTL_MS, now_ms())
 }
 
-pub(crate) fn validate_local_workspace_owner(lease: &WorkspaceOwnerLease) -> Result<bool> {
-    store()?.validate_owner(lease, now_ms())
-}
-
 pub(crate) fn validate_local_workspace_owner_in_store(
     store: &WorkspaceClaimStore,
     lease: &WorkspaceOwnerLease,
@@ -1347,19 +1331,11 @@ pub(crate) fn validate_local_workspace_owner_in_store(
     store.validate_owner(lease, now_ms())
 }
 
-pub(crate) fn release_local_workspace_owner(lease: &WorkspaceOwnerLease) -> Result<()> {
-    store()?.release_owner(lease, now_ms())
-}
-
 pub(crate) fn release_local_workspace_owner_in_store(
     store: &WorkspaceClaimStore,
     lease: &WorkspaceOwnerLease,
 ) -> Result<()> {
     store.release_owner(lease, now_ms())
-}
-
-pub(crate) fn renew_record_workspace_owner(record: &mut AgentTaskRunRecord) -> Result<()> {
-    renew_record_workspace_owner_in_store(&store()?, record)
 }
 
 pub(crate) fn renew_record_workspace_owner_in_store(
@@ -1452,10 +1428,6 @@ pub(crate) fn require_record_workspace_owner_in_store(
         ));
     }
     Ok(())
-}
-
-pub(crate) fn release_terminal_record_workspace_owner(record: &AgentTaskRunRecord) -> Result<()> {
-    release_terminal_record_workspace_owner_in_store(&store()?, record)
 }
 
 pub(crate) fn release_terminal_record_workspace_owner_in_store(

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -1258,19 +1258,6 @@ pub(super) fn resolve_adoption_target_with_attempt_in_stores(
     ))
 }
 
-fn materialize_adoption_attempt(
-    recipe: super::AgentTaskCookRecipe,
-    run_id: String,
-) -> Result<(
-    agent_task_lifecycle::AgentTaskRunRecord,
-    super::AgentTaskCookRecipe,
-)> {
-    let recipe_store = CookRecipeStore::from_current_data_root()?;
-    let lifecycle_store =
-        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
-    materialize_adoption_attempt_in_stores(&recipe_store, &lifecycle_store, recipe, run_id)
-}
-
 fn materialize_adoption_attempt_in_stores(
     recipe_store: &CookRecipeStore,
     lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,

--- a/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
@@ -289,19 +289,6 @@ fn materialize_initial_cook_attempt_with_store_and_lifecycle(
     Ok(recipe_created_by_invocation)
 }
 
-/// Complete recipe, run-record, and index registration for an attempt. Each
-/// write is independently durable, so replay must repair whichever suffix of
-/// the sequence was interrupted.
-pub(crate) fn materialize_cook_attempt(
-    cook_id: &str,
-    run_id: &str,
-    plan: &AgentTaskPlan,
-) -> Result<()> {
-    let recipe_store = CookRecipeStore::from_current_data_root()?;
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    materialize_cook_attempt_with_stores(&recipe_store, &lifecycle_store, cook_id, run_id, plan)
-}
-
 /// Complete recipe, run-record, and index registration through explicit recipe
 /// and lifecycle stores so the record and Cook index always land beside the
 /// recipe's authority instead of the ambient environment.
@@ -511,15 +498,6 @@ pub(crate) fn recover_recipe_attempt_with_stores(
         production_runtime_admission(lifecycle_store),
         |cook_id| reconcile_reserved_cancellation_in_store(lifecycle_store, cook_id),
     )
-}
-
-pub(crate) fn recover_adoption_attempt(
-    cook_id: &str,
-    run_id: &str,
-) -> Result<agent_task_lifecycle::AgentTaskRunRecord> {
-    let recipe_store = CookRecipeStore::from_current_data_root()?;
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    recover_adoption_attempt_with_stores(&recipe_store, &lifecycle_store, cook_id, run_id)
 }
 
 /// Recover an adopted attempt through explicit recipe and lifecycle stores so

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -468,14 +468,6 @@ pub(crate) fn promote_or_load_attempt_in_store(
     Ok(promotion)
 }
 
-/// A selector is accepted only from the route authority written by
-/// `cook-continue`; normal Cook promotion retains automatic selection.
-fn continuation_artifact_id(run_id: &str) -> Result<Option<String>> {
-    let lifecycle_store =
-        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
-    continuation_artifact_id_in_store(&lifecycle_store, run_id)
-}
-
 fn continuation_artifact_id_in_store(
     lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     run_id: &str,

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -1702,10 +1702,6 @@ fn record_from_run_with_schema_policy(
     Ok(record)
 }
 
-fn read_mirrored_aggregate(run_id: &str) -> Result<Option<AgentTaskAggregate>> {
-    read_mirrored_aggregate_in_store(&default_store()?, run_id)
-}
-
 fn read_mirrored_aggregate_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,

--- a/crates/homeboy-cli/src/commands/runs/gh_actions_cache.rs
+++ b/crates/homeboy-cli/src/commands/runs/gh_actions_cache.rs
@@ -14,25 +14,6 @@ pub fn sanitize_artifact_file_name(raw: &str) -> String {
     raw.replace(['/', '\\', '\0'], "_")
 }
 
-/// Materialize a downloaded artifact file under the homeboy data dir.
-///
-/// Creates `<data>/artifacts/<homeboy_run_id>/` and writes
-/// `<artifact_id>-<safe_name>`, returning the written path. Errors propagate.
-pub fn persist_artifact_file(
-    homeboy_run_id: &str,
-    artifact_id: &str,
-    file_name: &str,
-    bytes: &[u8],
-) -> Result<PathBuf> {
-    persist_artifact_file_in_roots(
-        &paths::homeboy_data()?,
-        homeboy_run_id,
-        artifact_id,
-        file_name,
-        bytes,
-    )
-}
-
 /// Materialize a downloaded artifact file under an already-resolved data root.
 ///
 /// An import walks every artifact of every run; resolving the data root per

--- a/crates/homeboy-cli/src/deferred_workload.rs
+++ b/crates/homeboy-cli/src/deferred_workload.rs
@@ -347,12 +347,6 @@ pub fn terminalize_in_roots(config_root: &Path, id: &str, succeeded: bool) -> Re
     })
 }
 
-/// Return a claimed workload to the queue when runner preflight discovers that
-/// the selected runner no longer satisfies its persisted contract.
-pub fn defer_claim(id: &str, owner: &str) -> Result<()> {
-    defer_claim_in_roots(&ambient_config_root()?, id, owner)
-}
-
 pub fn defer_claim_in_roots(config_root: &Path, id: &str, owner: &str) -> Result<()> {
     update_in_roots(config_root, |records| {
         if let Some(record) = records.iter_mut().find(|record| record.id == id) {
@@ -406,11 +400,6 @@ pub fn records() -> Result<Vec<DeferredWorkload>> {
 
 pub fn records_in_roots(config_root: &Path) -> Result<Vec<DeferredWorkload>> {
     read_store(&store_path_in_roots(config_root))
-}
-
-/// Whether any record still needs a worker.
-pub fn has_pending_work() -> Result<bool> {
-    has_pending_work_in_roots(&ambient_config_root()?)
 }
 
 pub fn has_pending_work_in_roots(config_root: &Path) -> Result<bool> {
@@ -476,10 +465,6 @@ pub fn try_acquire_worker_lock_in_roots(
             )),
         )),
     }
-}
-
-pub fn acquire_worker_start_lock() -> Result<DeferredWorkloadWorkerStartLock> {
-    acquire_worker_start_lock_in_roots(&ambient_config_root()?)
 }
 
 pub fn acquire_worker_start_lock_in_roots(
@@ -835,10 +820,6 @@ pub fn write_worker_status_in_roots(
         )
     })?;
     write_store(&path, &bytes)
-}
-
-pub fn append_worker_log(message: impl AsRef<str>) -> Result<()> {
-    append_worker_log_in_roots(&ambient_config_root()?, message)
 }
 
 pub fn append_worker_log_in_roots(config_root: &Path, message: impl AsRef<str>) -> Result<()> {

--- a/crates/homeboy-paths/src/runtime.rs
+++ b/crates/homeboy-paths/src/runtime.rs
@@ -168,16 +168,6 @@ pub(crate) fn runner_lease_evidence_file_in_root(
         .join(format!("{}.json", sanitize_path_segment(lease_id)))
 }
 
-/// Controller-owned lease evidence retained after an ephemeral runner session
-/// or remote daemon state file disappears.
-pub(crate) fn runner_lease_evidence_file(runner_id: &str, lease_id: &str) -> Result<PathBuf> {
-    Ok(runner_lease_evidence_file_in_root(
-        &homeboy()?,
-        runner_id,
-        lease_id,
-    ))
-}
-
 /// Runner-owned durable reverse-execution evidence below an already-resolved
 /// config root.
 pub fn runner_job_execution_context_evidence_file_in_root(


### PR DESCRIPTION
## Summary

Each rooted `_in_root`/`_in_store` function added during #7505 left its ambient original in place so callers could migrate incrementally. **433 such twins now exist.** 32 have no callers left at all — the migration already moved everyone, and the wrapper stayed behind only because deleting it was never the same PR as replacing it.

This deletes those 32. **300 lines, 11 files, `cargo check --workspace --tests` clean.**

## Why an unused wrapper isn't harmless

Every one bottoms out in `from_current_data_root()` or an equivalent process-global read. Each is a live path by which a future caller could silently reacquire the exact ambient behavior #7505 exists to remove.

> An unused wrapper here is not dead code. It is a loaded default waiting for a caller.

## Two hazards that shaped the screen

Both produce a **confident wrong answer**, and both were caught only because the deletion was verified rather than trusted.

**1. "Zero callers" from a `name(` regex is not zero usage.**

23 of the 67 apparently-unused twins are referenced **bare** — passed as function values, never called with parens:

```
config_dir              crates/homeboy-tunnel/src/entity.rs:52
runtime_dir             crates/homeboy-tunnel/src/lifecycle.rs:64
merge_batch_from_json   crates/homeboy-lab-runner/src/lib.rs:1420
rig_registry_root       crates/homeboy-lab-runner/src/execution_bundle.rs:123
```

Deleting those breaks compilation in a way *the search that selected them cannot see*. One more is re-exported via `pub use`. **Those 24 are excluded.**

**2. A trait method always looks uncalled** — it is invoked through the trait, not by name.

12 candidates were trait impl methods. My first attempt deleted them and produced:

```
error: expected one of `!` or `::`, found keyword `fn`
  --> crates/homeboy-agents/src/agent_task_finalization/tests.rs:125:5
```

...having removed a required member from an impl block. The screen now excludes anything inside an `impl` or `trait` block.

<callout accent="#3b82f6">
**44 candidates → 32 shipped.** The 12-item gap is entirely trait methods that would have broken the build, and it is the reason this is verified by a real `cargo check` rather than by the grep that produced the list.
</callout>

## Where this leaves #7505

| | before | after |
|---|---|---|
| ambient twins | 433 | **401** |

The remaining 401 split into **94 with test-only callers** (479 sites) and **272 with production callers** (8,507 sites).

The test-only group is the next tranche: deleting each one forces its tests to root, and **the compiler enumerates them exhaustively** — which is the property the per-test migration never had.

Refs #7505
