### PR TITLE
Root the deferred-workload tests and delete their ambient wrappers

### DIFF
--- a/crates/homeboy-cli/src/deferred_workload.rs
+++ b/crates/homeboy-cli/src/deferred_workload.rs
@@ -252,10 +252,27 @@ pub fn claim_next(runner_id: &str, owner: &str) -> Result<Option<DeferredWorkloa
     claim_next_at(runner_id, owner, now_ms())
 }
 
+pub fn claim_next_in_roots(
+    config_root: &Path,
+    runner_id: &str,
+    owner: &str,
+) -> Result<Option<DeferredWorkload>> {
+    claim_next_at_in_roots(config_root, runner_id, owner, now_ms())
+}
+
 /// Claim the next record using the supplied clock. The worker uses this seam to
 /// make lease recovery deterministic without changing the durable protocol.
 pub fn claim_next_at(runner_id: &str, owner: &str, now: u64) -> Result<Option<DeferredWorkload>> {
     claim_next_matching_at(runner_id, owner, now, |_| true)
+}
+
+pub fn claim_next_at_in_roots(
+    config_root: &Path,
+    runner_id: &str,
+    owner: &str,
+    now: u64,
+) -> Result<Option<DeferredWorkload>> {
+    claim_next_matching_at_in_roots(config_root, runner_id, owner, now, |_| true)
 }
 
 /// Claim the next deferred workload accepted by the selected runner. Records
@@ -369,10 +386,6 @@ pub fn defer_claim_in_roots(config_root: &Path, id: &str, owner: &str) -> Result
 /// Reconciliation terminates a worker that can no longer prove ownership, so
 /// its claims must not sit out the full lease before another worker may take
 /// them. Returns the ids that were released.
-pub fn release_claims_for_owner(owner: &str) -> Result<Vec<String>> {
-    release_claims_for_owner_in_roots(&ambient_config_root()?, owner)
-}
-
 pub fn release_claims_for_owner_in_roots(config_root: &Path, owner: &str) -> Result<Vec<String>> {
     update_in_roots(config_root, |records| {
         let now = now_ms();
@@ -417,10 +430,6 @@ pub fn has_pending_work_in_roots(config_root: &Path) -> Result<bool> {
 /// that outlives the command which started it must not hold a caller's
 /// ephemeral worktree open, because worktree cleanup then leaves the process
 /// anchored to a deleted directory (#12081).
-pub fn worker_root() -> Result<PathBuf> {
-    worker_root_in_roots(&ambient_config_root()?)
-}
-
 pub fn worker_root_in_roots(config_root: &Path) -> Result<PathBuf> {
     let root = config_root.to_path_buf();
     fs::create_dir_all(&root).map_err(|error| {
@@ -438,10 +447,6 @@ pub fn worker_root_in_roots(config_root: &Path) -> Result<PathBuf> {
             )),
         )
     })
-}
-
-pub fn try_acquire_worker_lock() -> Result<Option<DeferredWorkloadWorkerLock>> {
-    try_acquire_worker_lock_in_roots(&ambient_config_root()?)
 }
 
 pub fn try_acquire_worker_lock_in_roots(
@@ -500,10 +505,6 @@ pub fn acquire_worker_start_lock_in_roots(
     Ok(DeferredWorkloadWorkerStartLock { _file: file })
 }
 
-pub fn worker_status() -> Result<Option<DeferredWorkloadWorkerStatus>> {
-    worker_status_in_roots(&ambient_config_root()?)
-}
-
 pub fn worker_status_in_roots(config_root: &Path) -> Result<Option<DeferredWorkloadWorkerStatus>> {
     let path = store_path_in_roots(config_root).with_extension("worker-status.json");
     if !path.exists() {
@@ -515,15 +516,6 @@ pub fn worker_status_in_roots(config_root: &Path) -> Result<Option<DeferredWorkl
     serde_json::from_slice(&bytes)
         .map(Some)
         .map_err(|error| Error::config_invalid_json(path.display().to_string(), error))
-}
-
-pub fn worker_is_live(status: &DeferredWorkloadWorkerStatus) -> bool {
-    // An unresolvable root is indistinguishable from an unacquirable lock here:
-    // both mean this process cannot prove the singleton is alive.
-    let Ok(config_root) = ambient_config_root() else {
-        return false;
-    };
-    worker_is_live_in_roots(&config_root, status)
 }
 
 pub fn worker_is_live_in_roots(config_root: &Path, status: &DeferredWorkloadWorkerStatus) -> bool {
@@ -785,14 +777,6 @@ fn process_working_directory(_pid: u32) -> (Option<String>, bool) {
     (None, false)
 }
 
-pub fn write_worker_status(
-    owner_token: &str,
-    state: &str,
-    detail: impl Into<String>,
-) -> Result<()> {
-    write_worker_status_in_roots(&ambient_config_root()?, owner_token, state, detail)
-}
-
 pub fn write_worker_status_in_roots(
     config_root: &Path,
     owner_token: &str,
@@ -860,23 +844,8 @@ fn fingerprint(input: &DeferredWorkloadInput) -> Result<String> {
     Ok(sha256_hex(&value))
 }
 
-/// Ambient store path. No production caller resolves here any more: every
-/// public entry point either takes a root or resolves one exactly once and
-/// delegates to [`store_path_in_roots`]. Retained for the hermetic tests, which
-/// assert against the store the isolated home owns.
-#[cfg(test)]
-fn store_path() -> Result<PathBuf> {
-    Ok(store_path_in_roots(&ambient_config_root()?))
-}
-
 fn store_path_in_roots(config_root: &Path) -> PathBuf {
     config_root.join("deferred-workloads.json")
-}
-
-/// Ambient mutation. Test-only for the same reason as [`store_path`].
-#[cfg(test)]
-fn update<T>(mutate: impl FnOnce(&mut Vec<DeferredWorkload>) -> Result<T>) -> Result<T> {
-    update_in_roots(&ambient_config_root()?, mutate)
 }
 
 fn update_in_roots<T>(
@@ -1057,124 +1026,144 @@ mod tests {
 
     #[test]
     fn deferred_workload_is_idempotent_and_survives_restart_before_claim() {
-        homeboy_core::test_support::with_isolated_home(|_| {
-            let first = defer(input()).expect("defer workload");
-            let replay = defer(input()).expect("replay deferred workload");
-            assert_eq!(first.id, replay.id);
-            assert_eq!(replay.state, DeferredWorkloadState::Deferred);
+        let ctx = homeboy_core::test_support::HermeticTestContext::new();
+        let config_root = ctx.config_dir();
 
-            let claimed = claim(&input(), "warm-lab", "first-owner")
-                .expect("claim workload")
-                .expect("pending workload");
-            assert_eq!(claimed.id, first.id);
-            assert_eq!(claimed.runner_id.as_deref(), Some("warm-lab"));
-            assert!(claim(&input(), "other-lab", "second-owner")
+        let first = defer_in_roots(&config_root, input()).expect("defer workload");
+        let replay = defer_in_roots(&config_root, input()).expect("replay deferred workload");
+        assert_eq!(first.id, replay.id);
+        assert_eq!(replay.state, DeferredWorkloadState::Deferred);
+
+        let claimed = claim_in_roots(&config_root, &input(), "warm-lab", "first-owner")
+            .expect("claim workload")
+            .expect("pending workload");
+        assert_eq!(claimed.id, first.id);
+        assert_eq!(claimed.runner_id.as_deref(), Some("warm-lab"));
+        assert!(
+            claim_in_roots(&config_root, &input(), "other-lab", "second-owner")
                 .expect("idempotent claim")
-                .is_none());
-        });
+                .is_none()
+        );
     }
 
     #[test]
     fn reading_an_absent_store_does_not_create_runtime_state() {
-        homeboy_core::test_support::with_isolated_home(|_| {
-            let path = store_path().expect("store path");
+        let ctx = homeboy_core::test_support::HermeticTestContext::new();
+        let config_root = ctx.config_dir();
+        let path = store_path_in_roots(&config_root);
 
-            assert!(records().expect("read absent store").is_empty());
-            assert!(!path.exists(), "read created deferred workload store");
-            assert!(
-                !path.with_extension("lock").exists(),
-                "read created deferred workload lock"
-            );
-        });
+        assert!(records_in_roots(&config_root)
+            .expect("read absent store")
+            .is_empty());
+        assert!(!path.exists(), "read created deferred workload store");
+        assert!(
+            !path.with_extension("lock").exists(),
+            "read created deferred workload lock"
+        );
     }
 
     #[test]
     fn terminalized_workload_does_not_reappear_as_a_ghost() {
-        homeboy_core::test_support::with_isolated_home(|_| {
-            let deferred = defer(input()).expect("defer workload");
-            let claimed = claim(&input(), "warm-lab", "owner")
-                .expect("claim workload")
-                .expect("pending workload");
-            terminalize(&claimed.id, true).expect("terminalize workload");
-            assert!(claim(&input(), "warm-lab", "other-owner")
-                .expect("claim after terminal state")
-                .is_none());
+        let ctx = homeboy_core::test_support::HermeticTestContext::new();
+        let config_root = ctx.config_dir();
 
-            let next = defer(input()).expect("new explicit workload after terminal state");
-            assert_ne!(
-                next.id, deferred.id,
-                "terminal work must not be revived by a replay"
-            );
-        });
+        let deferred = defer_in_roots(&config_root, input()).expect("defer workload");
+        let claimed = claim_in_roots(&config_root, &input(), "warm-lab", "owner")
+            .expect("claim workload")
+            .expect("pending workload");
+        terminalize_in_roots(&config_root, &claimed.id, true).expect("terminalize workload");
+        assert!(
+            claim_in_roots(&config_root, &input(), "warm-lab", "other-owner")
+                .expect("claim after terminal state")
+                .is_none()
+        );
+
+        let next = defer_in_roots(&config_root, input())
+            .expect("new explicit workload after terminal state");
+        assert_ne!(
+            next.id, deferred.id,
+            "terminal work must not be revived by a replay"
+        );
     }
 
     #[test]
     fn expired_claim_is_reclaimed_after_a_post_claim_crash() {
-        homeboy_core::test_support::with_isolated_home(|_| {
-            defer(input()).expect("defer workload");
-            let claimed = claim(&input(), "first-lab", "crashed-owner")
-                .expect("claim workload")
-                .expect("pending workload");
-            update(|records| {
-                let record = records
-                    .iter_mut()
-                    .find(|record| record.id == claimed.id)
-                    .expect("claimed record");
-                record.claim_expires_at_ms = Some(0);
-                Ok(())
-            })
-            .expect("expire crashed claim");
+        let ctx = homeboy_core::test_support::HermeticTestContext::new();
+        let config_root = ctx.config_dir();
 
-            let recovered = claim(&input(), "warm-lab", "recovery-owner")
-                .expect("reclaim workload")
-                .expect("expired claim is reclaimable");
-            assert_eq!(recovered.runner_id.as_deref(), Some("warm-lab"));
-            assert_eq!(recovered.claim_owner.as_deref(), Some("recovery-owner"));
-        });
+        defer_in_roots(&config_root, input()).expect("defer workload");
+        let claimed = claim_in_roots(&config_root, &input(), "first-lab", "crashed-owner")
+            .expect("claim workload")
+            .expect("pending workload");
+        update_in_roots(&config_root, |records| {
+            let record = records
+                .iter_mut()
+                .find(|record| record.id == claimed.id)
+                .expect("claimed record");
+            record.claim_expires_at_ms = Some(0);
+            Ok(())
+        })
+        .expect("expire crashed claim");
+
+        let recovered = claim_in_roots(&config_root, &input(), "warm-lab", "recovery-owner")
+            .expect("reclaim workload")
+            .expect("expired claim is reclaimable");
+        assert_eq!(recovered.runner_id.as_deref(), Some("warm-lab"));
+        assert_eq!(recovered.claim_owner.as_deref(), Some("recovery-owner"));
     }
 
     #[test]
     fn next_claim_heartbeats_and_publishes_durable_worker_status() {
-        homeboy_core::test_support::with_isolated_home(|_| {
-            let deferred = defer(input()).expect("defer workload");
-            let claimed = claim_next("ready-runner", "worker-a")
-                .expect("claim next")
-                .expect("deferred workload");
-            assert_eq!(claimed.id, deferred.id);
-            assert_eq!(claimed.runner_id.as_deref(), Some("ready-runner"));
-            assert!(heartbeat(&claimed.id, "worker-a").expect("heartbeat"));
-            assert!(!heartbeat(&claimed.id, "worker-b").expect("wrong worker heartbeat"));
+        let ctx = homeboy_core::test_support::HermeticTestContext::new();
+        let config_root = ctx.config_dir();
 
-            write_worker_status("test-owner", "dispatching", "replaying deferred workload")
-                .expect("write worker status");
-            let status = worker_status()
-                .expect("read worker status")
-                .expect("status exists");
-            assert_eq!(status.state, "dispatching");
-            assert_eq!(status.detail, "replaying deferred workload");
-            assert_eq!(status.owner_token, "test-owner");
-        });
+        let deferred = defer_in_roots(&config_root, input()).expect("defer workload");
+        let claimed = claim_next_in_roots(&config_root, "ready-runner", "worker-a")
+            .expect("claim next")
+            .expect("deferred workload");
+        assert_eq!(claimed.id, deferred.id);
+        assert_eq!(claimed.runner_id.as_deref(), Some("ready-runner"));
+        assert!(heartbeat_in_roots(&config_root, &claimed.id, "worker-a").expect("heartbeat"));
+        assert!(!heartbeat_in_roots(&config_root, &claimed.id, "worker-b")
+            .expect("wrong worker heartbeat"));
+
+        write_worker_status_in_roots(
+            &config_root,
+            "test-owner",
+            "dispatching",
+            "replaying deferred workload",
+        )
+        .expect("write worker status");
+        let status = worker_status_in_roots(&config_root)
+            .expect("read worker status")
+            .expect("status exists");
+        assert_eq!(status.state, "dispatching");
+        assert_eq!(status.detail, "replaying deferred workload");
+        assert_eq!(status.owner_token, "test-owner");
     }
 
     #[test]
     fn matching_claim_skips_a_live_claimed_head_for_a_later_deferred_record() {
-        homeboy_core::test_support::with_isolated_home(|_| {
-            let first = defer(input()).expect("first workload");
-            let mut later_input = input();
-            later_input.args.push("later".to_string());
-            let later = defer(later_input).expect("later workload");
-            claim_next_at("other-runner", "other-worker", 1)
-                .expect("claim first")
-                .expect("first workload is claimed");
+        let ctx = homeboy_core::test_support::HermeticTestContext::new();
+        let config_root = ctx.config_dir();
 
-            let claimed =
-                claim_next_matching_at("ready-runner", "worker", 2, |record| record.id == later.id)
-                    .expect("claim matching workload")
-                    .expect("later deferred workload is claimable");
+        let first = defer_in_roots(&config_root, input()).expect("first workload");
+        let mut later_input = input();
+        later_input.args.push("later".to_string());
+        let later = defer_in_roots(&config_root, later_input).expect("later workload");
+        claim_next_at_in_roots(&config_root, "other-runner", "other-worker", 1)
+            .expect("claim first")
+            .expect("first workload is claimed");
 
-            assert_eq!(claimed.id, later.id);
-            assert_ne!(claimed.id, first.id);
-        });
+        let claimed =
+            claim_next_matching_at_in_roots(&config_root, "ready-runner", "worker", 2, |record| {
+                record.id == later.id
+            })
+            .expect("claim matching workload")
+            .expect("later deferred workload is claimable");
+
+        assert_eq!(claimed.id, later.id);
+        assert_ne!(claimed.id, first.id);
     }
 
     #[test]
@@ -1198,27 +1187,26 @@ mod tests {
 
     #[test]
     fn worker_lock_survives_replacement_of_the_legacy_adjacent_lock_file() {
-        homeboy_core::test_support::with_isolated_home(|_| {
-            let owner = try_acquire_worker_lock()
-                .expect("acquire worker lock")
-                .expect("first worker owns lock");
-            let legacy_lock = store_path()
-                .expect("store path")
-                .with_extension("worker.lock");
-            std::fs::write(&legacy_lock, b"old lock inode").expect("write old lock file");
-            let replacement = legacy_lock.with_extension("replacement");
-            std::fs::write(&replacement, b"replacement lock inode")
-                .expect("write replacement lock file");
-            std::fs::rename(&replacement, &legacy_lock).expect("replace legacy lock file");
+        let ctx = homeboy_core::test_support::HermeticTestContext::new();
+        let config_root = ctx.config_dir();
 
-            assert!(
-                try_acquire_worker_lock()
-                    .expect("check competing worker")
-                    .is_none(),
-                "replacing the old lock pathname must not create a second owner"
-            );
-            drop(owner);
-        });
+        let owner = try_acquire_worker_lock_in_roots(&config_root)
+            .expect("acquire worker lock")
+            .expect("first worker owns lock");
+        let legacy_lock = store_path_in_roots(&config_root).with_extension("worker.lock");
+        std::fs::write(&legacy_lock, b"old lock inode").expect("write old lock file");
+        let replacement = legacy_lock.with_extension("replacement");
+        std::fs::write(&replacement, b"replacement lock inode")
+            .expect("write replacement lock file");
+        std::fs::rename(&replacement, &legacy_lock).expect("replace legacy lock file");
+
+        assert!(
+            try_acquire_worker_lock_in_roots(&config_root)
+                .expect("check competing worker")
+                .is_none(),
+            "replacing the old lock pathname must not create a second owner"
+        );
+        drop(owner);
     }
 
     #[test]
@@ -1232,7 +1220,15 @@ mod tests {
             while !root.join("start").exists() {
                 thread::sleep(Duration::from_millis(5));
             }
-            if let Some(_owner) = try_acquire_worker_lock().expect("acquire worker lock") {
+            // The parent injects this child's `HOME`; resolving the config root
+            // from it explicitly is the same path the ambient resolver produced,
+            // without reaching through a process-global resolver to get it.
+            let config_root = PathBuf::from(std::env::var("HOME").expect("test home"))
+                .join(".config")
+                .join("homeboy");
+            if let Some(_owner) =
+                try_acquire_worker_lock_in_roots(&config_root).expect("acquire worker lock")
+            {
                 std::fs::write(root.join(format!("readiness-{child_id}")), b"polled")
                     .expect("record readiness polling");
                 thread::sleep(Duration::from_millis(250));
@@ -1300,31 +1296,32 @@ mod tests {
 
     #[test]
     fn corrupt_store_fails_closed_without_resetting_records() {
-        homeboy_core::test_support::with_isolated_home(|_| {
-            let path = store_path().expect("store path");
-            std::fs::create_dir_all(path.parent().expect("store parent")).expect("create parent");
-            std::fs::write(&path, b"not-json").expect("write corrupt store");
-            assert!(defer(input()).is_err());
-            assert_eq!(
-                std::fs::read(&path).expect("corrupt bytes remain"),
-                b"not-json"
-            );
-        });
+        let ctx = homeboy_core::test_support::HermeticTestContext::new();
+        let config_root = ctx.config_dir();
+        let path = store_path_in_roots(&config_root);
+        std::fs::create_dir_all(path.parent().expect("store parent")).expect("create parent");
+        std::fs::write(&path, b"not-json").expect("write corrupt store");
+        assert!(defer_in_roots(&config_root, input()).is_err());
+        assert_eq!(
+            std::fs::read(&path).expect("corrupt bytes remain"),
+            b"not-json"
+        );
     }
 
     #[test]
     fn refuses_inline_values_for_runner_secret_identities() {
-        homeboy_core::test_support::with_isolated_home(|_| {
-            let mut input = input();
-            input.job_overrides.env.insert(
-                "DB_SERVICE_PASSWORD".to_string(),
-                "fixture-password".to_string(),
-            );
-            input.job_overrides.secret_env_names = vec!["DB_SERVICE_PASSWORD".to_string()];
+        let ctx = homeboy_core::test_support::HermeticTestContext::new();
+        let config_root = ctx.config_dir();
 
-            assert!(defer(input).is_err());
-            assert!(records().expect("records").is_empty());
-        });
+        let mut input = input();
+        input.job_overrides.env.insert(
+            "DB_SERVICE_PASSWORD".to_string(),
+            "fixture-password".to_string(),
+        );
+        input.job_overrides.secret_env_names = vec!["DB_SERVICE_PASSWORD".to_string()];
+
+        assert!(defer_in_roots(&config_root, input).is_err());
+        assert!(records_in_roots(&config_root).expect("records").is_empty());
     }
 
     /// The same command deferred from two worktrees is two workloads. Collapsing
@@ -1332,63 +1329,69 @@ mod tests {
     /// carries the worktree it must be replayed against.
     #[test]
     fn two_worktrees_deferring_the_same_command_are_two_records() {
-        homeboy_core::test_support::with_isolated_home(|_| {
-            let mut first = input();
-            first.source_directory = Some("/workspace/repo@one".to_string());
-            let mut second = input();
-            second.source_directory = Some("/workspace/repo@two".to_string());
+        let ctx = homeboy_core::test_support::HermeticTestContext::new();
+        let config_root = ctx.config_dir();
 
-            let first = defer(first).expect("defer first worktree");
-            let second = defer(second).expect("defer second worktree");
+        let mut first = input();
+        first.source_directory = Some("/workspace/repo@one".to_string());
+        let mut second = input();
+        second.source_directory = Some("/workspace/repo@two".to_string());
 
-            assert_ne!(first.id, second.id);
-            assert_eq!(
-                first.source_directory.as_deref(),
-                Some("/workspace/repo@one")
-            );
-            assert_eq!(records().expect("records").len(), 2);
-        });
+        let first = defer_in_roots(&config_root, first).expect("defer first worktree");
+        let second = defer_in_roots(&config_root, second).expect("defer second worktree");
+
+        assert_ne!(first.id, second.id);
+        assert_eq!(
+            first.source_directory.as_deref(),
+            Some("/workspace/repo@one")
+        );
+        assert_eq!(records_in_roots(&config_root).expect("records").len(), 2);
     }
 
     /// A record deferred before `source_directory` existed must still load.
     #[test]
     fn a_record_without_a_recorded_source_directory_still_loads() {
-        homeboy_core::test_support::with_isolated_home(|_| {
-            let record = defer(input()).expect("defer workload");
-            let mut value = serde_json::to_value(&record).expect("record serializes");
-            value
-                .as_object_mut()
-                .expect("record object")
-                .remove("source_directory");
-            let path = store_path().expect("store path");
-            std::fs::write(
-                &path,
-                serde_json::to_vec(&serde_json::json!({ "schema": SCHEMA, "records": [value] }))
-                    .expect("legacy store serializes"),
-            )
-            .expect("write legacy store");
+        let ctx = homeboy_core::test_support::HermeticTestContext::new();
+        let config_root = ctx.config_dir();
 
-            let loaded = records().expect("read legacy store");
-            assert_eq!(loaded.len(), 1);
-            assert!(loaded[0].source_directory.is_none());
-        });
+        let record = defer_in_roots(&config_root, input()).expect("defer workload");
+        let mut value = serde_json::to_value(&record).expect("record serializes");
+        value
+            .as_object_mut()
+            .expect("record object")
+            .remove("source_directory");
+        let path = store_path_in_roots(&config_root);
+        std::fs::write(
+            &path,
+            serde_json::to_vec(&serde_json::json!({ "schema": SCHEMA, "records": [value] }))
+                .expect("legacy store serializes"),
+        )
+        .expect("write legacy store");
+
+        let loaded = records_in_roots(&config_root).expect("read legacy store");
+        assert_eq!(loaded.len(), 1);
+        assert!(loaded[0].source_directory.is_none());
     }
 
     #[test]
     fn terminating_a_worker_returns_its_claims_to_the_queue() {
-        homeboy_core::test_support::with_isolated_home(|_| {
-            let deferred = defer(input()).expect("defer workload");
-            claim_next_at("runner", "doomed-worker", 1).expect("claim workload");
+        let ctx = homeboy_core::test_support::HermeticTestContext::new();
+        let config_root = ctx.config_dir();
 
-            let released = release_claims_for_owner("doomed-worker").expect("release claims");
+        let deferred = defer_in_roots(&config_root, input()).expect("defer workload");
+        claim_next_at_in_roots(&config_root, "runner", "doomed-worker", 1).expect("claim workload");
 
-            assert_eq!(released, vec![deferred.id]);
-            assert_eq!(
-                records().expect("records")[0].state,
-                DeferredWorkloadState::Deferred
-            );
-            assert!(records().expect("records")[0].claim_owner.is_none());
-        });
+        let released = release_claims_for_owner_in_roots(&config_root, "doomed-worker")
+            .expect("release claims");
+
+        assert_eq!(released, vec![deferred.id]);
+        assert_eq!(
+            records_in_roots(&config_root).expect("records")[0].state,
+            DeferredWorkloadState::Deferred
+        );
+        assert!(records_in_roots(&config_root).expect("records")[0]
+            .claim_owner
+            .is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Deleting *unused* wrappers (#12705) only reached the ones no caller wanted. The wrappers that remain are held in place by **tests** — so the way to delete them is to root the tests that need them. That's the same work #7505 wants anyway, approached from the end that terminates.

| | before | after |
|---|---|---|
| `with_isolated_home` in this module | **12** | **0** |
| `HermeticTestContext` | 0 | 12 |
| ambient wrappers | 8 | **deleted** |

## The substitution is exact, not approximate

This is the part worth checking, so here it is explicitly:

```
with_isolated_home  →  sets XDG_CONFIG_HOME = <root>/.config
                    →  ambient_config_root() = paths::homeboy() = <root>/.config/homeboy

HermeticTestContext →  config_dir() = home().join(".config/homeboy")
                    →  home() returns root()
                    →  <root>/.config/homeboy
```

**Identical.** The tests read the same directory they always did — they just no longer mutate the process to say so.

Adds `claim_next_in_roots` and `claim_next_at_in_roots`, which two tests needed for entry points that had no rooted form. Neither calls `ambient_config_root()`.

## Two deletions I got wrong on the way in

I handed out a keep-list built from a caller census. It said `update` had **37** production callers and `store_path` had **2**. Both are in fact `#[cfg(test)]` **private** fns in this file, with doc comments reading *"Retained for the hermetic tests."*

```rust
/// Ambient mutation. Test-only for the same reason as [`store_path`].
#[cfg(test)]
fn update<T>(mutate: impl FnOnce(&mut Vec<DeferredWorkload>) -> Result<T>) -> Result<T> {
```

A bare-name frequency count across a workspace this size **measures the name, not the function.** Every unrelated `update(` in every crate scored as a caller.

<callout accent="#f59e0b">
It fails toward *keeping dead code* rather than *deleting live code* — the right direction, but still wrong. Left in place, both would have become unreachable `#[cfg(test)]` fns and failed CI under `-D warnings` as `dead_code`.
</callout>

## One test still reads the environment, deliberately

`worker_lock_contenders_reach_readiness_once_across_processes` re-execs itself. **An in-process root cannot cross an exec boundary**, so the child derives its root from the `HOME` the parent injects:

```rust
let config_root = PathBuf::from(std::env::var("HOME").expect("test home"))
    .join(".config").join("homeboy");
```

This is the one place in the file that touches the environment, and it's the *real env-var wiring* #7505's desired outcome asks be covered by an integration test rather than eliminated. Flag it in review if you'd rather it used a dedicated variable than `HOME`.

## Verification

`cargo check --workspace --tests` is clean, zero warnings.

**It does not run these tests.** The assertions here are about filesystem layout — precisely the class that compiles green and fails at runtime. This wants a real Test gate before it merges; please don't admin-merge it.

Refs #7505
