### PR TITLE
Erase the executor type parameter

### DIFF
--- a/crates/homeboy-agents/src/agent_task_controller_service/actions.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/actions.rs
@@ -17,14 +17,13 @@ const COMMAND_GATE_DEFAULT_TIMEOUT_SECONDS: u64 = 300;
 pub(super) const RUN_COMMAND_DEFAULT_TIMEOUT_SECONDS: u64 = 900;
 const COMMAND_GATE_OUTPUT_CAP_BYTES: usize = 64 * 1024;
 
-pub(super) fn execute_controller_action<E, D>(
+pub(super) fn execute_controller_action<D>(
     record: &mut AgentTaskLoopControllerRecord,
     action_id: &str,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     dispatch: &D,
 ) -> Result<AgentTaskRunResult<ControllerActionReport>>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     D: ControllerDispatchHook,
 {
     execute_controller_action_with_runner_availability(
@@ -36,15 +35,14 @@ where
     )
 }
 
-pub(super) fn execute_controller_action_with_runner_availability<E, D, F>(
+pub(super) fn execute_controller_action_with_runner_availability<D, F>(
     record: &mut AgentTaskLoopControllerRecord,
     action_id: &str,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     dispatch: &D,
     mut runner_availability: F,
 ) -> Result<AgentTaskRunResult<ControllerActionReport>>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     D: ControllerDispatchHook,
     F: FnMut(&str) -> AgentTaskLoopRunnerAvailability,
 {
@@ -444,14 +442,13 @@ fn first_action_diagnostic_message(
         .map(|diagnostic| diagnostic.message.clone())
 }
 
-pub(super) fn execute_claimed_controller_action<E, D>(
+pub(super) fn execute_claimed_controller_action<D>(
     record: &mut AgentTaskLoopControllerRecord,
     action: &AgentTaskLoopPolicyActionRecord,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     dispatch: &D,
 ) -> Result<(Value, i32)>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     D: ControllerDispatchHook,
 {
     match &action.action {
@@ -710,17 +707,16 @@ pub(super) fn execute_request_changes_action(
     ))
 }
 
-pub(super) fn execute_spawn_task_action<E, D>(
+pub(super) fn execute_spawn_task_action<D>(
     record: &mut AgentTaskLoopControllerRecord,
     action: &AgentTaskLoopPolicyActionRecord,
     dedupe_key: &str,
     entity_id: Option<&str>,
     request: &Value,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     dispatch: &D,
 ) -> Result<(Value, i32)>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     D: ControllerDispatchHook,
 {
     let request = hydrate_consumed_artifacts(record, request);
@@ -918,7 +914,7 @@ fn request_with_controller_dispatch_identity(
     clippy::too_many_arguments,
     reason = "controller action keeps lifecycle state, dispatch identity, and provider contract explicit"
 )]
-pub(super) fn execute_fan_out_action<E, D>(
+pub(super) fn execute_fan_out_action<D>(
     record: &mut AgentTaskLoopControllerRecord,
     action: &AgentTaskLoopPolicyActionRecord,
     dedupe_key: &str,
@@ -929,11 +925,10 @@ pub(super) fn execute_fan_out_action<E, D>(
     max_items: usize,
     fail_fast: bool,
     request_template: &Value,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     dispatch: &D,
 ) -> Result<(Value, i32)>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     D: ControllerDispatchHook,
 {
     let expanded_entity_ids = if entity_ids.is_empty() {
@@ -1447,18 +1442,17 @@ pub(super) fn collect_capped_command_output(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(super) fn execute_route_finding_action<E, D>(
+pub(super) fn execute_route_finding_action<D>(
     record: &mut AgentTaskLoopControllerRecord,
     action: &AgentTaskLoopPolicyActionRecord,
     finding: &controller::AgentTaskLoopFindingPacket,
     dedupe_key: &str,
     entity_id: Option<&str>,
     request_template: &Value,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     dispatch: &D,
 ) -> Result<(Value, i32)>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     D: ControllerDispatchHook,
 {
     let entity_id = ensure_finding_entity(record, finding, entity_id);

--- a/crates/homeboy-agents/src/agent_task_controller_service/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/mod.rs
@@ -28,7 +28,7 @@ use crate::agent_task_loop_controller::{
     AgentTaskLoopTerminalStatus, AgentTaskLoopTransition, AgentTaskPrOwnershipRequest,
     AgentTaskPrOwnershipState, AgentTaskPrOwnershipStatusUpdate,
 };
-use crate::agent_task_scheduler::{AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskPlan};
+use crate::agent_task_scheduler::{AgentTaskAggregate, AgentTaskPlan, SharedAgentTaskExecutor};
 use crate::agent_task_service::{self, AgentTaskRunResult};
 use homeboy_core::git::{pr_find, pr_view, PrFindOptions, PrState};
 use homeboy_core::plan::{HomeboyPlan, PlanArtifact, PlanKind, PlanStep, PlanStepStatus};
@@ -1179,13 +1179,12 @@ fn project_runner_terminal_action(
 }
 
 /// Claim and execute the first pending controller action, if any.
-pub fn run_next<E, D>(
+pub fn run_next<D>(
     loop_id: &str,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     dispatch: &D,
 ) -> Result<AgentTaskRunResult<ControllerActionReport>>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     D: ControllerDispatchHook,
 {
     let mut record = controller::controller_status(loop_id)?;
@@ -1212,14 +1211,13 @@ where
 }
 
 /// Claim and execute the named pending controller action.
-pub fn run_action<E, D>(
+pub fn run_action<D>(
     loop_id: &str,
     action_id: &str,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     dispatch: &D,
 ) -> Result<AgentTaskRunResult<ControllerActionReport>>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     D: ControllerDispatchHook,
 {
     let mut record = controller::load_controller(loop_id)?;
@@ -1227,13 +1225,12 @@ where
 }
 
 /// Drain pending controller actions until the default finite limit, idle, terminal state, or failure.
-pub fn resume<E, D>(
+pub fn resume<D>(
     loop_id: &str,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     dispatch: &D,
 ) -> Result<AgentTaskRunResult<ControllerResumeReport>>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     D: ControllerDispatchHook,
 {
     resume_with_options(
@@ -1245,14 +1242,13 @@ where
 }
 
 /// Drain pending controller actions until the supplied finite options stop execution.
-pub fn resume_with_options<E, D>(
+pub fn resume_with_options<D>(
     loop_id: &str,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     dispatch: &D,
     options: ControllerResumeOptions,
 ) -> Result<AgentTaskRunResult<ControllerResumeReport>>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     D: ControllerDispatchHook,
 {
     let mut results = Vec::new();

--- a/crates/homeboy-agents/src/agent_task_controller_service/tests/action_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/tests/action_tests.rs
@@ -56,7 +56,7 @@ fn runtime_bundle_action_result_exposes_budgets_and_observed_wait_outcome() {
 
         let result = resume(
             "loop-service-runtime-budget-evidence",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &RuntimeBudgetDispatchHook,
         )
         .expect("controller resumed");
@@ -142,7 +142,7 @@ fn run_action_executes_only_requested_action_id() {
         let result = run_action(
             "loop-service-action",
             "action-2",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &NoopDispatchHook,
         )
         .expect("action executed");
@@ -182,7 +182,7 @@ fn retry_action_queues_durable_retry_and_records_parent_lineage() {
 
         let result = run_next(
             "loop-service-retry",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &NoopDispatchHook,
         )
         .expect("retry action executed");
@@ -235,7 +235,7 @@ fn request_changes_action_records_normalized_feedback() {
 
         let result = run_next(
             "loop-service-request-changes",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &NoopDispatchHook,
         )
         .expect("request changes action executed");
@@ -282,7 +282,7 @@ fn complete_action_transitions_only_when_executed() {
 
         let result = run_next(
             "loop-service-complete",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &NoopDispatchHook,
         )
         .expect("complete action executed");
@@ -332,7 +332,7 @@ fn route_finding_action_spawns_materialized_plan() {
 
         let result = run_next(
             "loop-service-route-finding",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &NoopDispatchHook,
         )
         .expect("route finding executed");
@@ -402,7 +402,7 @@ fn controller_escalates_when_action_cap_is_reached() {
         // The next execution must not claim and run another action: it escalates.
         let result = run_next(
             "loop-service-action-cap",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &NoopDispatchHook,
         )
         .expect("cap guard returns a report");
@@ -428,7 +428,7 @@ fn controller_escalates_when_action_cap_is_reached() {
         // outcomes are appended.
         let again = run_next(
             "loop-service-action-cap",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &NoopDispatchHook,
         )
         .expect("escalated controller returns a report again");

--- a/crates/homeboy-agents/src/agent_task_controller_service/tests/dispatch_execute_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/tests/dispatch_execute_tests.rs
@@ -93,7 +93,7 @@ fn execute_controller_action_marks_blocked_no_local_fallback_policy() {
             },
             "policy matched",
         );
-        let executor = CapturingExecutor::default();
+        let executor = Arc::new(CapturingExecutor::default());
         let dispatch = CapturingDispatchHook::default();
 
         let result = execute_controller_action_with_runner_availability(
@@ -155,7 +155,7 @@ fn execute_controller_action_dispatches_an_available_runner_target() {
             },
             "policy matched",
         );
-        let executor = CapturingExecutor::default();
+        let executor = Arc::new(CapturingExecutor::default());
         let dispatch = CapturingDispatchHook::default();
 
         let result = execute_controller_action_with_runner_availability(
@@ -228,7 +228,7 @@ fn execute_controller_dispatch_injects_action_scoped_identity() {
         let result = execute_controller_action_with_runner_availability(
             &mut record,
             &action.action_id,
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &dispatch,
             |_| unreachable!("dispatch action has no runner policy"),
         )
@@ -282,7 +282,7 @@ fn accepted_lab_runner_handoff_waits_and_terminal_replay_is_idempotent() {
         let accepted = execute_controller_action_with_runner_availability(
             &mut record,
             &action.action_id,
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &LabRunnerHandoffDispatchHook,
             |_| AgentTaskLoopRunnerAvailability::Available,
         )

--- a/crates/homeboy-agents/src/agent_task_controller_service/tests/resume_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/tests/resume_tests.rs
@@ -55,7 +55,7 @@ fn resume_fails_required_workflow_artifact_handoff_before_downstream_action() {
 
         let result = resume(
             "loop-service-required-handoff",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &CapturingDispatchHook::default(),
         )
         .expect("controller resumed");
@@ -122,7 +122,7 @@ fn resume_failed_action_result_includes_top_level_failure_summary() {
 
         let result = resume(
             "loop-service-failure-summary",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &FailingDispatchHook,
         )
         .expect("controller resumed");
@@ -232,7 +232,7 @@ fn resume_with_options_stops_at_max_actions_with_pending_work_remaining() {
 
         let result = resume_with_options(
             "loop-service-bounded-resume",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &NoopDispatchHook,
             ControllerResumeOptions {
                 max_actions: 2,
@@ -294,7 +294,7 @@ fn resume_with_options_stops_after_terminal_state() {
 
         let result = resume_with_options(
             "loop-service-terminal-resume",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &NoopDispatchHook,
             ControllerResumeOptions {
                 max_actions: 10,
@@ -377,7 +377,7 @@ fn completed_typed_artifacts_are_carried_to_later_required_workflow_artifacts() 
         let dispatch = TypedArtifactHandoffDispatchHook::default();
         let result = resume(
             "loop-service-typed-artifact-handoff",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &dispatch,
         )
         .expect("controller resumed");
@@ -461,7 +461,7 @@ fn resume_recovers_running_action_with_stale_child_run() {
 
         let result = resume(
             "loop-service-stale-child",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &NoopDispatchHook,
         )
         .expect("controller resumed");
@@ -516,7 +516,7 @@ fn resume_stops_when_wait_action_blocks_controller() {
 
         let result = resume(
             "loop-service-wait-stop",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &NoopDispatchHook,
         )
         .expect("controller resumed");
@@ -572,7 +572,7 @@ fn wait_for_controller_resumes_after_child_terminal_state() {
 
         let result = resume(
             "loop-service-parent",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &NoopDispatchHook,
         )
         .expect("controller resumed");
@@ -720,7 +720,7 @@ fn from_spec_resume_drives_workflow_lineage_then_blocks_on_pending_manual_gate()
         let dispatch = ArtifactDispatchHook::default();
         let result = resume(
             "repo-loop-generic-execution",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &dispatch,
         )
         .expect("controller resumed");

--- a/crates/homeboy-agents/src/agent_task_controller_service/tests/run_command_workflow_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/tests/run_command_workflow_tests.rs
@@ -63,7 +63,7 @@ fn run_command_workflow_executes_deterministic_artifact_action() {
 
         let result = run_next(
             "repo-loop-command",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &CapturingDispatchHook::default(),
         )
         .expect("run command action");
@@ -162,7 +162,7 @@ fn run_command_workflow_inherits_dispatch_default_cwd() {
 
         let result = run_next(
             "repo-loop-command-cwd",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &CapturingDispatchHook::default(),
         )
         .expect("run command action");
@@ -227,7 +227,7 @@ fn run_command_workflow_times_out_instead_of_blocking_controller() {
         init_from_spec(ControllerFromSpecRequest { spec }).expect("init");
         let result = run_next(
             "repo-loop-command-timeout",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &CapturingDispatchHook::default(),
         )
         .expect("run command action");
@@ -299,7 +299,7 @@ fn run_command_workflow_timeout_kills_child_process_group() {
         init_from_spec(ControllerFromSpecRequest { spec }).expect("init");
         let result = run_next(
             "repo-loop-command-process-group-timeout",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &CapturingDispatchHook::default(),
         )
         .expect("run command action");

--- a/crates/homeboy-agents/src/agent_task_controller_service/tests/run_gates_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/tests/run_gates_tests.rs
@@ -26,7 +26,7 @@ fn run_gates_records_generic_terminal_outcomes() {
 
         let passed_result = run_next(
             "loop-service-gate-passed",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &NoopDispatchHook,
         )
         .expect("gate action executed");
@@ -65,7 +65,7 @@ fn run_gates_records_generic_terminal_outcomes() {
 
         let blocked_result = run_next(
             "loop-service-gate-blocked",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &NoopDispatchHook,
         )
         .expect("gate action executed");
@@ -110,7 +110,7 @@ fn run_gates_blocks_on_pending_manual_check() {
         // A manual-only bundle must NOT auto-pass as an acceptable warning.
         let result = run_next(
             "loop-service-gate-manual",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &NoopDispatchHook,
         )
         .expect("gate action executed");
@@ -174,7 +174,7 @@ fn run_gates_executes_command_bundle_and_records_result() {
 
         let result = run_next(
             "loop-service-gates",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &NoopDispatchHook,
         )
         .expect("gates executed");

--- a/crates/homeboy-agents/src/agent_task_controller_service/tests/run_next_fan_out_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/tests/run_next_fan_out_tests.rs
@@ -13,7 +13,7 @@ fn run_next_returns_unclaimed_when_no_pending_actions() {
 
         let result = run_next(
             "loop-service-noop",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &NoopDispatchHook,
         )
         .expect("controller polled");
@@ -51,7 +51,7 @@ fn run_next_executes_spawn_task_action_and_records_lineage() {
         );
         controller::write_controller(&record).expect("controller written");
 
-        let executor = CapturingExecutor::default();
+        let executor = Arc::new(CapturingExecutor::default());
         let result = run_next("loop-service-spawn", executor.clone(), &NoopDispatchHook)
             .expect("controller action executed");
 
@@ -120,7 +120,7 @@ fn run_next_indexes_spawn_task_evidence_into_lineage_and_entity_outputs() {
 
         let result = run_next(
             "loop-service-spawn-evidence",
-            EvidenceExecutor,
+            Arc::new(EvidenceExecutor),
             &NoopDispatchHook,
         )
         .expect("controller action executed");
@@ -184,7 +184,7 @@ fn run_next_treats_zero_item_fan_out_as_deterministic_no_actionable_findings() {
 
         let result = run_next(
             "loop-service-empty-fanout",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &NoopDispatchHook,
         )
         .expect("fan-out action executed");
@@ -267,7 +267,7 @@ fn run_next_expands_dynamic_artifact_fan_out_groups() {
         let dispatch = CapturingDispatchHook::default();
         let result = run_next(
             "loop-service-dynamic-fanout",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &dispatch,
         )
         .expect("dynamic fan-out action executed");
@@ -327,7 +327,7 @@ fn fan_out_stops_after_max_items() {
         let dispatch = CapturingDispatchHook::default();
         let result = run_next(
             "loop-service-fanout-max-items",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &dispatch,
         )
         .expect("fan-out action executed");
@@ -383,7 +383,7 @@ fn fan_out_fail_fast_stops_after_first_failure() {
         let dispatch = CountingFailingDispatchHook::default();
         let result = run_next(
             "loop-service-fanout-fail-fast",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &dispatch,
         )
         .expect("fan-out action executed");
@@ -439,7 +439,7 @@ fn fan_out_indexes_each_child_task_evidence_on_its_entity() {
 
         let result = run_next(
             "loop-service-fanout-evidence",
-            EvidenceExecutor,
+            Arc::new(EvidenceExecutor),
             &NoopDispatchHook,
         )
         .expect("fan-out action executed");

--- a/crates/homeboy-agents/src/agent_task_controller_service/tests/wait_reconcile_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/tests/wait_reconcile_tests.rs
@@ -367,7 +367,7 @@ fn resume_resolves_a_satisfied_wait_instead_of_reporting_idle() {
 
         let result = resume(
             "wait-parent-resume",
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             &NoopDispatchHook,
         )
         .expect("resumed");

--- a/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
@@ -790,6 +790,7 @@ mod tests {
     use homeboy_core::test_support::with_isolated_home;
     use std::collections::HashMap;
     use std::process::Command;
+    use std::sync::Arc;
 
     #[test]
     fn generated_change_guardrails_describe_positive_success_criteria() {
@@ -1828,7 +1829,7 @@ mod tests {
                     },
                     ..DispatchRequestOverrides::default()
                 }),
-                NoopExecutor,
+                Arc::new(NoopExecutor),
             )
             .expect("dispatch queued");
 
@@ -1858,7 +1859,7 @@ mod tests {
                     run_id: Some("dispatch-missing-secret".to_string()),
                     ..DispatchRequestOverrides::default()
                 }),
-                NoopExecutor,
+                Arc::new(NoopExecutor),
             )
             .expect_err("missing secret should fail before submit");
 

--- a/crates/homeboy-agents/src/agent_task_dispatch_service.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_service.rs
@@ -20,8 +20,8 @@ use crate::agent_task_provider::{
     AgentTaskProviderCatalog, ProviderResolution,
 };
 use crate::agent_task_scheduler::{
-    AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskPlan, AgentTaskProviderRotationPolicy,
-    AgentTaskRetryPolicy, AgentTaskScheduler,
+    AgentTaskAggregate, AgentTaskPlan, AgentTaskProviderRotationPolicy, AgentTaskRetryPolicy,
+    AgentTaskScheduler, SharedAgentTaskExecutor,
 };
 use crate::agent_task_service::{aggregate_exit_code, terminal_run_result, AgentTaskRunResult};
 use homeboy_core::{Error, Result};
@@ -178,25 +178,19 @@ pub struct AgentTaskDispatchReport {
     pub aggregate: Option<AgentTaskAggregate>,
 }
 
-pub fn dispatch<E>(
+pub fn dispatch(
     request: AgentTaskDispatchRequest,
-    executor: E,
-) -> Result<AgentTaskRunResult<AgentTaskDispatchReport>>
-where
-    E: AgentTaskExecutorAdapter,
-{
+    executor: SharedAgentTaskExecutor,
+) -> Result<AgentTaskRunResult<AgentTaskDispatchReport>> {
     let catalog = AgentTaskProviderCatalog::discover();
     dispatch_with_provider_catalog(request, executor, &catalog)
 }
 
-fn dispatch_with_provider_catalog<E>(
+fn dispatch_with_provider_catalog(
     request: AgentTaskDispatchRequest,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     catalog: &AgentTaskProviderCatalog,
-) -> Result<AgentTaskRunResult<AgentTaskDispatchReport>>
-where
-    E: AgentTaskExecutorAdapter,
-{
+) -> Result<AgentTaskRunResult<AgentTaskDispatchReport>> {
     let backend_selection = request.backend_selection.clone();
     // Credentials first: the selected backend's declared credentials are
     // knowable before a plan exists, before a workspace is resolved, and before
@@ -231,14 +225,11 @@ where
     )
 }
 
-pub fn dispatch_with_provider_requirements<E>(
+pub fn dispatch_with_provider_requirements(
     request: AgentTaskDispatchRequest,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     provider_requires_cwd_git_checkout: impl Fn(&str, Option<&str>) -> bool,
-) -> Result<AgentTaskRunResult<AgentTaskDispatchReport>>
-where
-    E: AgentTaskExecutorAdapter,
-{
+) -> Result<AgentTaskRunResult<AgentTaskDispatchReport>> {
     let backend_selection = request.backend_selection.clone();
     preflight_provider_credentials_for_backend(
         AgentTaskProviderCatalog::discover().providers(),
@@ -275,16 +266,13 @@ where
 /// The only durable dispatch-to-scheduler path. Both provider-catalog entry
 /// points prepare a plan differently, then share lifecycle transitions,
 /// scheduler execution, aggregate persistence, and report construction here.
-fn run_dispatch_plan<E>(
+fn run_dispatch_plan(
     plan: AgentTaskPlan,
     requested_run_id: Option<&str>,
     queue_only: bool,
     backend_selection: Option<BackendSelection>,
-    executor: E,
-) -> Result<AgentTaskRunResult<AgentTaskDispatchReport>>
-where
-    E: AgentTaskExecutorAdapter,
-{
+    executor: SharedAgentTaskExecutor,
+) -> Result<AgentTaskRunResult<AgentTaskDispatchReport>> {
     let submitted = lifecycle::submit_plan(&plan, requested_run_id)?;
     let run_id = submitted.run_id.clone();
 
@@ -704,25 +692,19 @@ fn resolve_dispatch_request_with_sources(
 
 /// Run a dispatch invocation end to end: resolve the request, dispatch it through
 /// the scheduler, and adapt the report into a JSON value plus process exit code.
-pub fn run_dispatch_command<E>(
+pub fn run_dispatch_command(
     command: AgentTaskDispatchCommand,
-    executor: E,
-) -> Result<(Value, i32)>
-where
-    E: AgentTaskExecutorAdapter,
-{
+    executor: SharedAgentTaskExecutor,
+) -> Result<(Value, i32)> {
     let catalog = AgentTaskProviderCatalog::discover();
     run_dispatch_command_with_provider_catalog(command, executor, &catalog)
 }
 
-pub fn run_dispatch_command_with_provider_catalog<E>(
+pub fn run_dispatch_command_with_provider_catalog(
     command: AgentTaskDispatchCommand,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     catalog: &AgentTaskProviderCatalog,
-) -> Result<(Value, i32)>
-where
-    E: AgentTaskExecutorAdapter,
-{
+) -> Result<(Value, i32)> {
     let request = resolve_dispatch_request(command)?;
     let result = dispatch_with_provider_catalog(request, executor, catalog)?;
     Ok((command_json_value(result.value)?, result.exit_code))
@@ -736,7 +718,8 @@ fn command_json_value<T: Serialize>(value: T) -> Result<Value> {
 mod tests {
     use super::*;
     use crate::agent_task::{AgentTaskOutcome, AgentTaskRequest};
-    use crate::agent_task_scheduler::AgentTaskExecutionContext;
+    use crate::agent_task_scheduler::{AgentTaskExecutionContext, AgentTaskExecutorAdapter};
+    use std::sync::Arc;
 
     /// An executor that must never be reached. A credential gap is a
     /// configuration failure, so it must be reported before a provider
@@ -791,7 +774,7 @@ mod tests {
             backend_selection: None,
         };
 
-        let error = dispatch_with_provider_catalog(request, NeverRunExecutor, &catalog)
+        let error = dispatch_with_provider_catalog(request, Arc::new(NeverRunExecutor), &catalog)
             .expect_err("a missing declared credential must fail dispatch");
 
         assert_eq!(error.details["field"], "provider_credentials");

--- a/crates/homeboy-agents/src/agent_task_fanout.rs
+++ b/crates/homeboy-agents/src/agent_task_fanout.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 
 use crate::agent_task::{AgentTaskAggregateReport, AgentTaskRequest};
 use crate::agent_task_scheduler::{
-    AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskOutputDependencies, AgentTaskPlan,
-    AgentTaskScheduleOptions, AgentTaskScheduler,
+    AgentTaskAggregate, AgentTaskOutputDependencies, AgentTaskPlan, AgentTaskScheduleOptions,
+    AgentTaskScheduler, SharedAgentTaskExecutor,
 };
 use homeboy_core::plan::{HomeboyPlan, PlanKind, PlanStep};
 
@@ -61,8 +61,8 @@ pub struct AgentTaskFanoutAggregate {
     pub metadata: Value,
 }
 
-pub struct AgentTaskFanoutScheduler<E> {
-    scheduler: AgentTaskScheduler<E>,
+pub struct AgentTaskFanoutScheduler {
+    scheduler: AgentTaskScheduler,
 }
 
 impl AgentTaskFanoutPlan {
@@ -297,11 +297,8 @@ impl AgentTaskFanoutAggregate {
     }
 }
 
-impl<E> AgentTaskFanoutScheduler<E>
-where
-    E: AgentTaskExecutorAdapter,
-{
-    pub fn new(executor: E) -> Self {
+impl AgentTaskFanoutScheduler {
+    pub fn new(executor: SharedAgentTaskExecutor) -> Self {
         Self {
             scheduler: AgentTaskScheduler::new_controller(executor),
         }
@@ -349,13 +346,15 @@ mod tests {
         AgentTaskExecutor, AgentTaskOutcome, AgentTaskOutcomeStatus, AgentTaskPolicy,
         AgentTaskWorkspace, AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
     };
-    use crate::agent_task_scheduler::{AgentTaskExecutionContext, AgentTaskOutputBinding};
+    use crate::agent_task_scheduler::{
+        AgentTaskExecutionContext, AgentTaskExecutorAdapter, AgentTaskOutputBinding,
+    };
     use serde_json::json;
     use std::sync::{Arc, Mutex};
 
     #[test]
     fn isolated_fanout_stamps_plan_metadata_and_aggregates_reconciliation() {
-        let scheduler = AgentTaskFanoutScheduler::new(RecordingExecutor::default());
+        let scheduler = AgentTaskFanoutScheduler::new(Arc::new(RecordingExecutor::default()));
         let mut plan = AgentTaskFanoutPlan::new(
             "fanout/audit-batch",
             AgentTaskFanoutPlane::IsolatedTasks,
@@ -384,9 +383,9 @@ mod tests {
     #[test]
     fn workflow_fanout_preserves_output_dependencies_inside_one_plane() {
         let observed = Arc::new(Mutex::new(Vec::new()));
-        let scheduler = AgentTaskFanoutScheduler::new(RecordingExecutor {
+        let scheduler = AgentTaskFanoutScheduler::new(Arc::new(RecordingExecutor {
             observed: Arc::clone(&observed),
-        });
+        }));
         let mut plan = AgentTaskFanoutPlan::new(
             "fanout/site-workflow",
             AgentTaskFanoutPlane::Workflow,
@@ -499,7 +498,7 @@ mod tests {
 
     #[test]
     fn fanout_aggregate_exposes_child_run_and_artifact_bindings() {
-        let scheduler = AgentTaskFanoutScheduler::new(GenericChildRunExecutor);
+        let scheduler = AgentTaskFanoutScheduler::new(Arc::new(GenericChildRunExecutor));
         let plan = AgentTaskFanoutPlan::new(
             "fuzz/campaign-1",
             AgentTaskFanoutPlane::IsolatedTasks,

--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -4,7 +4,7 @@ use crate::agent_task::AgentTaskArtifactDeclaration;
 use crate::agent_task_scheduler::{
     AgentTaskAggregateStatus, AgentTaskProviderRotationEntry, AgentTaskProviderRotationPolicy,
 };
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 static DEFAULT_TIMEOUT_ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -82,11 +82,10 @@ fn remapped_lab_cook_spawns_and_harvests_from_runner_snapshot_identity() {
     crate::agent_task_service::bind_runner_snapshot_workspace_attestations(&mut plan)
         .expect("bind runner snapshot");
 
-    let aggregate =
-        AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
-            provider,
-        ]))
-        .run(plan);
+    let aggregate = AgentTaskScheduler::new(Arc::new(
+        ExtensionProviderAgentTaskExecutor::with_providers(vec![provider]),
+    ))
+    .run(plan);
 
     assert_eq!(aggregate.totals.succeeded, 1, "{aggregate:?}");
     let provider_observation: serde_json::Value =
@@ -145,11 +144,10 @@ fn remapped_lab_cook_rejects_runner_snapshot_drift_before_provider_spawn() {
         .expect("replace runner git directory");
     std::fs::create_dir(runner.join(".git")).expect("new runner git directory");
 
-    let aggregate =
-        AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
-            provider,
-        ]))
-        .run(plan);
+    let aggregate = AgentTaskScheduler::new(Arc::new(
+        ExtensionProviderAgentTaskExecutor::with_providers(vec![provider]),
+    ))
+    .run(plan);
 
     assert_eq!(aggregate.totals.failed, 1);
     assert_eq!(
@@ -216,11 +214,10 @@ fn isolated_cook_rejects_source_identity_drift_before_snapshotting() {
     std::fs::write(source.join(".git"), "gitdir: ../replaced-gitdir\n")
         .expect("replace source gitdir reference");
 
-    let aggregate =
-        AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
-            provider,
-        ]))
-        .run(AgentTaskPlan::new("source-drift-cook", vec![request]));
+    let aggregate = AgentTaskScheduler::new(Arc::new(
+        ExtensionProviderAgentTaskExecutor::with_providers(vec![provider]),
+    ))
+    .run(AgentTaskPlan::new("source-drift-cook", vec![request]));
 
     assert_eq!(aggregate.totals.failed, 1);
     assert_eq!(
@@ -240,10 +237,9 @@ fn scheduler_dispatches_extension_provider_command() {
         script("let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'succeeded',summary:'ok',outputs:{issue_number:3447}}));")
     );
     let (request, provider) = request("task-a", command);
-    let scheduler =
-        AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
-            provider,
-        ]));
+    let scheduler = AgentTaskScheduler::new(Arc::new(
+        ExtensionProviderAgentTaskExecutor::with_providers(vec![provider]),
+    ));
 
     let aggregate = scheduler.run(AgentTaskPlan::new("plan-a", vec![request]));
 
@@ -273,10 +269,10 @@ fn executor_materializes_runner_local_artifacts_for_no_op_and_editing_requests()
     let mut editing = no_op.clone();
     editing.task_id = "task-editing".to_string();
     editing.executor.config["no_op"] = json!(false);
-    let scheduler = AgentTaskScheduler::new(
+    let scheduler = AgentTaskScheduler::new(Arc::new(
         ExtensionProviderAgentTaskExecutor::with_providers(vec![provider])
             .with_path_roots(roots.clone()),
-    )
+    ))
     .with_scratch_root(roots.data().to_path_buf());
 
     let aggregate = scheduler.run(AgentTaskPlan::new(
@@ -306,18 +302,16 @@ fn executor_artifact_paths_are_distinct_per_run() {
             script("let fs=require('fs'); let req=JSON.parse(fs.readFileSync(0,'utf8')); process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'succeeded',summary:req.artifacts_path}));")
         );
         let (request, provider) = request("same-task", command);
-        let first =
-            AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
-                provider.clone(),
-            ]))
-            .with_run_id("run-one")
-            .run(AgentTaskPlan::new("plan", vec![request.clone()]));
-        let second =
-            AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
-                provider,
-            ]))
-            .with_run_id("run-two")
-            .run(AgentTaskPlan::new("plan", vec![request]));
+        let first = AgentTaskScheduler::new(Arc::new(
+            ExtensionProviderAgentTaskExecutor::with_providers(vec![provider.clone()]),
+        ))
+        .with_run_id("run-one")
+        .run(AgentTaskPlan::new("plan", vec![request.clone()]));
+        let second = AgentTaskScheduler::new(Arc::new(
+            ExtensionProviderAgentTaskExecutor::with_providers(vec![provider]),
+        ))
+        .with_run_id("run-two")
+        .run(AgentTaskPlan::new("plan", vec![request]));
 
         assert_ne!(first.outcomes[0].summary, second.outcomes[0].summary);
     }
@@ -326,7 +320,8 @@ fn executor_artifact_paths_are_distinct_per_run() {
 #[test]
 fn scheduler_reports_missing_extension_provider() {
     let (request, _provider) = request("task-missing-provider", "unused".to_string());
-    let scheduler = AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::default());
+    let scheduler =
+        AgentTaskScheduler::new(Arc::new(ExtensionProviderAgentTaskExecutor::default()));
 
     let aggregate = scheduler.run(AgentTaskPlan::new("plan-missing-provider", vec![request]));
 
@@ -349,10 +344,9 @@ fn scheduler_reports_provider_selector_mismatch() {
     provider.id = "example.synthetic-agent-task-executor".to_string();
     provider.backend = "synthetic-runtime".to_string();
     provider.cli.reserved_selector_hints = vec!["codex".to_string()];
-    let scheduler =
-        AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
-            provider,
-        ]));
+    let scheduler = AgentTaskScheduler::new(Arc::new(
+        ExtensionProviderAgentTaskExecutor::with_providers(vec![provider]),
+    ));
 
     let aggregate = scheduler.run(AgentTaskPlan::new("plan-selector-mismatch", vec![request]));
 
@@ -378,10 +372,9 @@ fn scheduler_reports_provider_selector_mismatch() {
 fn scheduler_reports_missing_provider_capability() {
     let (mut request, provider) = request("task-missing-capability", "unused".to_string());
     request.executor.required_capabilities = vec!["workspace_write".to_string()];
-    let scheduler =
-        AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
-            provider,
-        ]));
+    let scheduler = AgentTaskScheduler::new(Arc::new(
+        ExtensionProviderAgentTaskExecutor::with_providers(vec![provider]),
+    ));
 
     let aggregate = scheduler.run(AgentTaskPlan::new("plan-missing-capability", vec![request]));
 
@@ -412,10 +405,9 @@ fn scheduler_reports_missing_provider_capability() {
 fn scheduler_normalizes_malformed_provider_output() {
     let command = format!("node {}", script("process.stdout.write('{not json');"));
     let (request, provider) = request("task-malformed-provider", command);
-    let scheduler =
-        AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
-            provider,
-        ]));
+    let scheduler = AgentTaskScheduler::new(Arc::new(
+        ExtensionProviderAgentTaskExecutor::with_providers(vec![provider]),
+    ));
 
     let aggregate = scheduler.run(AgentTaskPlan::new("plan-malformed-provider", vec![request]));
 
@@ -600,10 +592,10 @@ fn provider_empty_stdout_records_failed_run_with_executor_evidence() {
     let (request, provider) = request("task-empty-stdout-recorded", command);
     let plan = AgentTaskPlan::new("plan-empty-stdout-recorded", vec![request]);
     let run_id = "run-empty-provider-output";
-    let scheduler = AgentTaskScheduler::new(
+    let scheduler = AgentTaskScheduler::new(Arc::new(
         ExtensionProviderAgentTaskExecutor::with_providers(vec![provider])
             .with_path_roots(roots.clone()),
-    )
+    ))
     .with_scratch_root(roots.data().to_path_buf());
 
     lifecycle_store
@@ -642,10 +634,9 @@ fn provider_timeout_returns_structured_outcome() {
     let command = format!("node {}", script("setInterval(() => {}, 1000);"));
     let (mut request, provider) = request("task-timeout", command);
     request.limits.timeout_ms = Some(50);
-    let scheduler =
-        AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
-            provider,
-        ]));
+    let scheduler = AgentTaskScheduler::new(Arc::new(
+        ExtensionProviderAgentTaskExecutor::with_providers(vec![provider]),
+    ));
 
     let aggregate = scheduler.run(AgentTaskPlan::new("plan-timeout", vec![request]));
 
@@ -743,10 +734,9 @@ fn stalled_provider_is_killed_and_rotates_to_configured_fallback() {
         .split_whitespace()
         .map(str::to_string)
         .collect();
-    let scheduler =
-        AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
-            primary, fallback,
-        ]));
+    let scheduler = AgentTaskScheduler::new(Arc::new(
+        ExtensionProviderAgentTaskExecutor::with_providers(vec![primary, fallback]),
+    ));
     let mut plan = AgentTaskPlan::new("plan-stalled-rotation", vec![request]);
     plan.options.rotation = Some(AgentTaskProviderRotationPolicy {
         entries: vec![AgentTaskProviderRotationEntry {
@@ -903,10 +893,9 @@ fn provider_command_receives_executor_config_env() {
     request.executor.config = json!({ "marker": "configured" });
     provider.extension_id = Some("wordpress".to_string());
     provider.extension_path = Some("/tmp/homeboy-extension".to_string());
-    let scheduler =
-        AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
-            provider,
-        ]));
+    let scheduler = AgentTaskScheduler::new(Arc::new(
+        ExtensionProviderAgentTaskExecutor::with_providers(vec![provider]),
+    ));
 
     let aggregate = scheduler.run(AgentTaskPlan::new("plan-config", vec![request]));
 
@@ -936,10 +925,10 @@ fn provider_attempts_receive_distinct_allocated_runtime_tmpdirs() {
     plan.options.retry.retryable_failure_classifications =
         vec![AgentTaskFailureClassification::ExecutionFailed];
 
-    let aggregate = AgentTaskScheduler::new(
+    let aggregate = AgentTaskScheduler::new(Arc::new(
         ExtensionProviderAgentTaskExecutor::with_providers(vec![provider])
             .with_path_roots(roots.clone()),
-    )
+    ))
     .with_scratch_root(roots.data().to_path_buf())
     .run(plan);
 
@@ -996,10 +985,9 @@ fn provider_command_receives_declared_secret_env() {
     );
     let (mut request, provider) = request("task-secret-env", command);
     request.executor.secret_env = vec![secret_name.clone()];
-    let scheduler =
-        AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
-            provider,
-        ]));
+    let scheduler = AgentTaskScheduler::new(Arc::new(
+        ExtensionProviderAgentTaskExecutor::with_providers(vec![provider]),
+    ));
 
     let aggregate = scheduler.run(AgentTaskPlan::new("plan-secret-env", vec![request]));
 
@@ -1030,10 +1018,9 @@ fn provider_command_receives_canonical_secret_env_plan_without_values() {
         extra: BTreeMap::new(),
     }];
     request.executor.secret_env = vec![secret_name.clone()];
-    let scheduler =
-        AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
-            provider,
-        ]));
+    let scheduler = AgentTaskScheduler::new(Arc::new(
+        ExtensionProviderAgentTaskExecutor::with_providers(vec![provider]),
+    ));
 
     let aggregate = scheduler.run(AgentTaskPlan::new("plan-secret-env-plan", vec![request]));
 
@@ -1059,10 +1046,9 @@ fn missing_declared_secret_env_fails_before_provider_spawn() {
     );
     let (mut request, provider) = request("task-missing-secret-env", command);
     request.executor.secret_env = vec![secret_name.clone()];
-    let scheduler =
-        AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::with_providers(vec![
-            provider,
-        ]));
+    let scheduler = AgentTaskScheduler::new(Arc::new(
+        ExtensionProviderAgentTaskExecutor::with_providers(vec![provider]),
+    ));
 
     let aggregate = scheduler.run(AgentTaskPlan::new("plan-missing-secret-env", vec![request]));
 
@@ -1090,7 +1076,8 @@ fn fixture_backend_produces_deterministic_smoke_artifacts() {
         "artifact_root": artifact_root.path().display().to_string(),
         "changed_file": "docs/smoke.md"
     });
-    let scheduler = AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::default());
+    let scheduler =
+        AgentTaskScheduler::new(Arc::new(ExtensionProviderAgentTaskExecutor::default()));
 
     let aggregate = scheduler.run(AgentTaskPlan::new("plan-fixture", vec![request]));
 
@@ -1120,7 +1107,8 @@ fn fixture_backend_classifies_empty_runtime_bundle() {
         "artifact_root": artifact_root.path().display().to_string(),
         "mode": "empty_runtime_bundle"
     });
-    let scheduler = AgentTaskScheduler::new(ExtensionProviderAgentTaskExecutor::default());
+    let scheduler =
+        AgentTaskScheduler::new(Arc::new(ExtensionProviderAgentTaskExecutor::default()));
 
     let aggregate = scheduler.run(AgentTaskPlan::new("plan-empty-runtime", vec![request]));
 

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -23,8 +23,25 @@ pub trait AgentTaskExecutorAdapter: Send + Sync + 'static {
 
     fn cancel(&self, _task_id: &str) {}
 }
-pub struct AgentTaskScheduler<E> {
-    executor: Arc<E>,
+
+/// The one shape an executor takes once it reaches the scheduler.
+///
+/// Execution dispatch is a runtime choice -- extension provider, test double,
+/// bench harness -- and never a compile-time one, so the executor is carried as
+/// an erased shared pointer rather than a type parameter. The trait is
+/// object-safe by construction: `execute` and `cancel` both take `&self`,
+/// neither is generic, and neither mentions `Self` in return position.
+///
+/// Sharing is the whole point. A Cook hands the executor to each retry attempt
+/// and each parallel branch, and `Arc` makes that a refcount bump onto one
+/// underlying adapter instead of a copy -- which matters, because a provider
+/// adapter holds real state. `AgentTaskScheduler` has always stored its executor
+/// behind an `Arc`, so this is the ownership model that was already in effect,
+/// now written into the type.
+pub type SharedAgentTaskExecutor = Arc<dyn AgentTaskExecutorAdapter>;
+
+pub struct AgentTaskScheduler {
+    executor: SharedAgentTaskExecutor,
     run_id: Option<String>,
     harvest_context: HarvestExecutionContext,
     lifecycle_store: Option<crate::agent_task_lifecycle::AgentTaskLifecycleStore>,
@@ -32,19 +49,16 @@ pub struct AgentTaskScheduler<E> {
     scratch_root: Option<std::path::PathBuf>,
 }
 
-impl<E> AgentTaskScheduler<E>
-where
-    E: AgentTaskExecutorAdapter,
-{
-    pub fn new(executor: E) -> Self {
+impl AgentTaskScheduler {
+    pub fn new(executor: SharedAgentTaskExecutor) -> Self {
         Self::new_controller(executor)
     }
 
     /// Construct a controller-local scheduler that intentionally ignores
     /// ambient Lab transport metadata.
-    pub fn new_controller(executor: E) -> Self {
+    pub fn new_controller(executor: SharedAgentTaskExecutor) -> Self {
         Self {
-            executor: Arc::new(executor),
+            executor,
             run_id: None,
             harvest_context: HarvestExecutionContext::default(),
             lifecycle_store: None,
@@ -1843,4 +1857,51 @@ fn first_non_empty_json_string<'a>(
             .filter(|value| !value.is_empty())
             .map(ToString::to_string)
     })
+}
+
+#[cfg(test)]
+mod executor_erasure_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct CountingExecutor(Arc<AtomicUsize>);
+
+    impl AgentTaskExecutorAdapter for CountingExecutor {
+        fn execute(
+            &self,
+            _request: AgentTaskRequest,
+            _context: AgentTaskExecutionContext,
+        ) -> AgentTaskOutcome {
+            unreachable!("this fixture exercises the bound and cancel(), never execution");
+        }
+
+        fn cancel(&self, _task_id: &str) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    /// What the real call sites do: take the executor by value and hand a clone
+    /// onward, once per retry attempt and once per parallel branch.
+    fn dispatch_then_hand_on(executor: SharedAgentTaskExecutor) -> SharedAgentTaskExecutor {
+        executor.cancel("task");
+        executor.clone()
+    }
+
+    #[test]
+    fn cloning_a_shared_executor_shares_one_underlying_executor() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let executor: SharedAgentTaskExecutor = Arc::new(CountingExecutor(Arc::clone(&calls)));
+
+        let cloned = dispatch_then_hand_on(executor);
+        cloned.cancel("task");
+
+        // Cloning must share one executor rather than duplicate it. Retry
+        // attempts hand out clones and a provider adapter holds real state --
+        // per-clone copies would silently give each attempt its own.
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "both the original and its clone must dispatch to the same executor"
+        );
+    }
 }

--- a/crates/homeboy-agents/src/agent_task_scheduler/postprocess.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/postprocess.rs
@@ -2064,7 +2064,7 @@ mod tests {
                     }
                 }
             }
-            let aggregate = AgentTaskScheduler::new(Executor(Arc::clone(&calls)))
+            let aggregate = AgentTaskScheduler::new(Arc::new(Executor(Arc::clone(&calls))))
                 .with_run_id("restart-run")
                 .run(plan);
             assert_eq!(

--- a/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
@@ -647,16 +647,14 @@ impl AgentTaskScheduleSupport {
         ));
     }
 
-    pub(super) fn expire_timed_out_tasks<E>(
+    pub(super) fn expire_timed_out_tasks(
         running: &mut Vec<RunningTask>,
         quarantined: &mut Vec<QuarantinedTask>,
         outcomes: &mut Vec<AgentTaskOutcome>,
         events: &mut Vec<AgentTaskProgressEvent>,
-        executor: &E,
+        executor: &dyn AgentTaskExecutorAdapter,
         lifecycle_store: Option<&crate::agent_task_lifecycle::AgentTaskLifecycleStore>,
-    ) where
-        E: AgentTaskExecutorAdapter,
-    {
+    ) {
         let mut index = 0;
         while index < running.len() {
             let Some(timeout_ms) = running[index].timeout_ms else {

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/outcome_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/outcome_tests.rs
@@ -38,7 +38,7 @@ fn provider_reported_model_is_retained_separately_from_requested_and_resolved_mo
 
 #[test]
 fn nested_failed_executor_status_fails_succeeded_wrapper_outcome() {
-    let scheduler = AgentTaskScheduler::new(NestedFailedStatusExecutor);
+    let scheduler = AgentTaskScheduler::new(Arc::new(NestedFailedStatusExecutor));
 
     let aggregate = scheduler.run(plan_with_tasks(1));
 
@@ -62,7 +62,7 @@ fn nested_failed_executor_status_fails_succeeded_wrapper_outcome() {
 
 #[test]
 fn nested_terminal_state_failure_fails_succeeded_wrapper_outcome() {
-    let scheduler = AgentTaskScheduler::new(NestedTerminalStateFailedExecutor);
+    let scheduler = AgentTaskScheduler::new(Arc::new(NestedTerminalStateFailedExecutor));
 
     let aggregate = scheduler.run(plan_with_tasks(1));
 
@@ -94,7 +94,7 @@ fn nested_terminal_state_failure_fails_succeeded_wrapper_outcome() {
 
 #[test]
 fn nested_agent_result_failure_fails_succeeded_wrapper_outcome() {
-    let scheduler = AgentTaskScheduler::new(NestedAgentResultFailedExecutor);
+    let scheduler = AgentTaskScheduler::new(Arc::new(NestedAgentResultFailedExecutor));
 
     let aggregate = scheduler.run(plan_with_tasks(1));
 
@@ -114,7 +114,7 @@ fn nested_agent_result_failure_fails_succeeded_wrapper_outcome() {
 
 #[test]
 fn missing_required_typed_artifacts_fails_succeeded_outcome() {
-    let scheduler = AgentTaskScheduler::new(SuccessMissingRequiredArtifactsExecutor);
+    let scheduler = AgentTaskScheduler::new(Arc::new(SuccessMissingRequiredArtifactsExecutor));
 
     let aggregate = scheduler.run(plan_with_required_artifacts(&[
         "import_validation_result",
@@ -141,7 +141,7 @@ fn missing_required_typed_artifacts_fails_succeeded_outcome() {
 
 #[test]
 fn nested_executor_failure_context_wins_over_missing_required_artifacts() {
-    let scheduler = AgentTaskScheduler::new(NestedFailedStatusMissingArtifactsExecutor);
+    let scheduler = AgentTaskScheduler::new(Arc::new(NestedFailedStatusMissingArtifactsExecutor));
 
     let aggregate = scheduler.run(plan_with_required_artifacts(&[
         "patch",
@@ -193,11 +193,11 @@ fn empty_required_patch_artifact_is_valid_no_diff_evidence() {
     let temp = tempfile::tempdir().expect("tempdir");
     let patch_path = temp.path().join("patch.diff");
     fs::write(&patch_path, "").expect("empty patch");
-    let scheduler = AgentTaskScheduler::new(SuccessEmptyRequiredTypedArtifactExecutor {
+    let scheduler = AgentTaskScheduler::new(Arc::new(SuccessEmptyRequiredTypedArtifactExecutor {
         artifact_path: patch_path.clone(),
         artifact_name: "patch",
         artifact_kind: "patch",
-    });
+    }));
 
     let aggregate = scheduler.run(plan_with_required_artifacts(&["patch"]));
 
@@ -218,11 +218,11 @@ fn empty_required_non_patch_typed_artifact_fails_with_operator_pointer() {
     let temp = tempfile::tempdir().expect("tempdir");
     let report_path = temp.path().join("report.json");
     fs::write(&report_path, "").expect("empty report");
-    let scheduler = AgentTaskScheduler::new(SuccessEmptyRequiredTypedArtifactExecutor {
+    let scheduler = AgentTaskScheduler::new(Arc::new(SuccessEmptyRequiredTypedArtifactExecutor {
         artifact_path: report_path.clone(),
         artifact_name: "agent_result",
         artifact_kind: "json",
-    });
+    }));
 
     let plan = plan_with_required_artifacts(&["agent_result"]);
     assert_eq!(plan.options.execution_budget.max_provider_executions, 1);
@@ -327,7 +327,7 @@ fn nested_terminal_status_detection_only_flags_failure_values() {
 fn incomplete_empty_executor_result_is_retryable_provider_failure() {
     let executor = EmptyIncompleteThenSuccessExecutor::default();
     let attempts = Arc::clone(&executor.attempts);
-    let scheduler = AgentTaskScheduler::new(executor);
+    let scheduler = AgentTaskScheduler::new(Arc::new(executor));
     let mut plan = plan_with_tasks(1);
     plan.options.retry.max_attempts = 2;
     plan.options.execution_budget.max_provider_executions = 2;
@@ -349,7 +349,7 @@ fn incomplete_empty_executor_result_is_retryable_provider_failure() {
 
 #[test]
 fn incomplete_empty_executor_result_fails_when_retries_are_unavailable() {
-    let scheduler = AgentTaskScheduler::new(EmptyIncompleteExecutor);
+    let scheduler = AgentTaskScheduler::new(Arc::new(EmptyIncompleteExecutor));
 
     let aggregate = scheduler.run(plan_with_tasks(1));
 
@@ -511,7 +511,7 @@ fn flat_incomplete_provider_result_is_still_detected() {
 
 #[test]
 fn incomplete_nested_outputs_executor_result_fails_when_retries_are_unavailable() {
-    let scheduler = AgentTaskScheduler::new(NestedOutputsIncompleteExecutor);
+    let scheduler = AgentTaskScheduler::new(Arc::new(NestedOutputsIncompleteExecutor));
 
     let aggregate = scheduler.run(plan_with_tasks(1));
 

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/adaptive_concurrency.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/adaptive_concurrency.rs
@@ -10,7 +10,7 @@ mod adaptive_concurrency_tests {
     fn adaptive_concurrency_scales_up_when_runner_slots_are_available() {
         let executor = RecordingExecutor::new(HashMap::new(), Duration::from_millis(25));
         let max_seen = Arc::clone(&executor.max_seen);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(4);
         plan.options.max_concurrency = 1;
         plan.options.adaptive_concurrency = Some(AgentTaskAdaptiveConcurrencyPolicy {
@@ -44,7 +44,7 @@ mod adaptive_concurrency_tests {
     fn adaptive_concurrency_scales_down_under_runner_pressure() {
         let executor = RecordingExecutor::new(HashMap::new(), Duration::from_millis(25));
         let max_seen = Arc::clone(&executor.max_seen);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(3);
         plan.options.max_concurrency = 4;
         plan.options.adaptive_concurrency = Some(AgentTaskAdaptiveConcurrencyPolicy {
@@ -82,7 +82,7 @@ mod adaptive_concurrency_tests {
             cancel_calls: Arc::new(Mutex::new(Vec::new())),
         };
         let max_seen = Arc::clone(&executor.max_seen);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(2);
         plan.options.max_concurrency = 2;
         plan.options.adaptive_concurrency = Some(AgentTaskAdaptiveConcurrencyPolicy {
@@ -117,10 +117,10 @@ mod adaptive_concurrency_tests {
 
     #[test]
     fn adaptive_concurrency_status_records_held_decision() {
-        let scheduler = AgentTaskScheduler::new(RecordingExecutor::new(
+        let scheduler = AgentTaskScheduler::new(Arc::new(RecordingExecutor::new(
             HashMap::new(),
             Duration::from_millis(0),
-        ));
+        )));
         let mut plan = plan_with_tasks(1);
         plan.options.max_concurrency = 2;
         plan.options.adaptive_concurrency = Some(AgentTaskAdaptiveConcurrencyPolicy::default());

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/artifact_binding.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/artifact_binding.rs
@@ -17,10 +17,10 @@ mod artifact_binding_tests {
         fs::write(&patch_path, "diff --git a/a.txt b/a.txt\n").expect("patch");
         fs::write(&transcript_path, "{\"events\":[]}").expect("transcript");
 
-        let scheduler = AgentTaskScheduler::new(RuntimeBundleOutcomeExecutor {
+        let scheduler = AgentTaskScheduler::new(Arc::new(RuntimeBundleOutcomeExecutor {
             patch_path: patch_path.clone(),
             transcript_path: transcript_path.clone(),
-        });
+        }));
         let mut plan = plan_with_tasks(1);
         plan.tasks[0].expected_artifacts = vec![
             "patch".to_string(),
@@ -66,10 +66,10 @@ mod artifact_binding_tests {
     #[test]
     fn templates_prior_output_into_downstream_task_request() {
         let observed = Arc::new(Mutex::new(Vec::new()));
-        let scheduler = AgentTaskScheduler::new(OutputTemplateExecutor {
+        let scheduler = AgentTaskScheduler::new(Arc::new(OutputTemplateExecutor {
             observed: Arc::clone(&observed),
             include_issue_number: true,
-        });
+        }));
         let mut plan =
             AgentTaskPlan::new("plan-output-dag", vec![request("idea"), request("design")]);
         plan.options.max_concurrency = 2;
@@ -131,10 +131,10 @@ mod artifact_binding_tests {
     #[test]
     fn binds_typed_artifact_payload_into_downstream_task_request() {
         let observed = Arc::new(Mutex::new(Vec::new()));
-        let scheduler = AgentTaskScheduler::new(OutputTemplateExecutor {
+        let scheduler = AgentTaskScheduler::new(Arc::new(OutputTemplateExecutor {
             observed: Arc::clone(&observed),
             include_issue_number: true,
-        });
+        }));
         let mut plan = AgentTaskPlan::new(
             "plan-artifact-dag",
             vec![request("idea"), request("design")],
@@ -194,10 +194,10 @@ mod artifact_binding_tests {
     fn required_concept_packet_binding_uses_canonical_typed_artifact() {
         let observed = Arc::new(Mutex::new(Vec::new()));
         let scheduler =
-            crate::agent_task_scheduler::AgentTaskScheduler::new(ConceptPacketExecutor {
+            crate::agent_task_scheduler::AgentTaskScheduler::new(Arc::new(ConceptPacketExecutor {
                 observed: Arc::clone(&observed),
                 emit_concept_packet: true,
-            });
+            }));
         let mut plan = AgentTaskPlan::new(
             "plan-concept-packet-typed-artifact",
             vec![request("idea"), request("build")],
@@ -243,10 +243,10 @@ mod artifact_binding_tests {
     fn required_concept_packet_binding_fails_without_canonical_typed_artifact() {
         let observed = Arc::new(Mutex::new(Vec::new()));
         let scheduler =
-            crate::agent_task_scheduler::AgentTaskScheduler::new(ConceptPacketExecutor {
+            crate::agent_task_scheduler::AgentTaskScheduler::new(Arc::new(ConceptPacketExecutor {
                 observed: Arc::clone(&observed),
                 emit_concept_packet: false,
-            });
+            }));
         let mut plan = AgentTaskPlan::new(
             "plan-concept-packet-missing-typed-artifact",
             vec![request("idea"), request("build")],
@@ -315,7 +315,7 @@ mod artifact_binding_tests {
 
     #[test]
     fn binds_artifacts_to_generic_child_run_ids_for_durable_fanout() {
-        let scheduler = AgentTaskScheduler::new(GenericChildRunExecutor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(GenericChildRunExecutor));
         let mut plan = AgentTaskPlan::new(
             "fuzz/campaign-1",
             vec![request("case-a"), request("case-b")],
@@ -348,10 +348,10 @@ mod artifact_binding_tests {
     #[test]
     fn skips_required_typed_artifact_binding_when_artifact_is_missing() {
         let observed = Arc::new(Mutex::new(Vec::new()));
-        let scheduler = AgentTaskScheduler::new(OutputTemplateExecutor {
+        let scheduler = AgentTaskScheduler::new(Arc::new(OutputTemplateExecutor {
             observed: Arc::clone(&observed),
             include_issue_number: false,
-        });
+        }));
         let mut plan = AgentTaskPlan::new(
             "plan-artifact-skip",
             vec![request("idea"), request("design")],
@@ -400,10 +400,10 @@ mod artifact_binding_tests {
     #[test]
     fn optional_typed_artifact_binding_uses_default() {
         let observed = Arc::new(Mutex::new(Vec::new()));
-        let scheduler = AgentTaskScheduler::new(OutputTemplateExecutor {
+        let scheduler = AgentTaskScheduler::new(Arc::new(OutputTemplateExecutor {
             observed: Arc::clone(&observed),
             include_issue_number: false,
-        });
+        }));
         let mut plan = AgentTaskPlan::new(
             "plan-artifact-default",
             vec![request("idea"), request("design")],
@@ -448,10 +448,10 @@ mod artifact_binding_tests {
     #[test]
     fn skips_downstream_task_when_required_output_is_missing() {
         let observed = Arc::new(Mutex::new(Vec::new()));
-        let scheduler = AgentTaskScheduler::new(OutputTemplateExecutor {
+        let scheduler = AgentTaskScheduler::new(Arc::new(OutputTemplateExecutor {
             observed: Arc::clone(&observed),
             include_issue_number: false,
-        });
+        }));
         let mut plan =
             AgentTaskPlan::new("plan-output-skip", vec![request("idea"), request("design")]);
         plan.options.max_concurrency = 2;

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/cancellation.rs
@@ -34,7 +34,7 @@ mod cancellation_tests {
         let executor = RecordingExecutor::new(HashMap::new(), Duration::from_millis(100));
         let cancel_calls = Arc::clone(&executor.cancel_calls);
         let running = Arc::clone(&executor.running);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(3);
         plan.options.max_concurrency = 1;
         let token = AgentTaskCancellationToken::default();

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/concurrency.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/concurrency.rs
@@ -23,7 +23,8 @@ pub(super) mod concurrency_tests {
     fn provider_panic_returns_a_terminal_failure_without_hanging_the_scheduler() {
         let (sender, receiver) = std::sync::mpsc::channel();
         std::thread::spawn(move || {
-            let aggregate = AgentTaskScheduler::new(PanickingExecutor).run(plan_with_tasks(1));
+            let aggregate =
+                AgentTaskScheduler::new(Arc::new(PanickingExecutor)).run(plan_with_tasks(1));
             let _ = sender.send(aggregate);
         });
 
@@ -75,7 +76,7 @@ pub(super) mod concurrency_tests {
         let plan = plan_with_tasks(1);
         crate::agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("durable run");
 
-        let aggregate = AgentTaskScheduler::new(PolicyDeniedExecutor)
+        let aggregate = AgentTaskScheduler::new(Arc::new(PolicyDeniedExecutor))
             .with_run_id(run_id)
             .run(plan);
 
@@ -130,7 +131,7 @@ pub(super) mod concurrency_tests {
     fn schedules_tasks_with_bounded_concurrency_and_success_aggregate() {
         let executor = RecordingExecutor::new(HashMap::new(), Duration::from_millis(25));
         let max_seen = Arc::clone(&executor.max_seen);
-        let scheduler = crate::agent_task_scheduler::AgentTaskScheduler::new(executor);
+        let scheduler = crate::agent_task_scheduler::AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(4);
         plan.options.max_concurrency = 2;
 
@@ -176,10 +177,10 @@ pub(super) mod concurrency_tests {
     #[test]
     fn first_green_returns_after_concurrent_winner_and_supervises_sibling() {
         let cancelled = Arc::new(AtomicBool::new(false));
-        let scheduler = AgentTaskScheduler::new(FirstGreenExecutor {
+        let scheduler = AgentTaskScheduler::new(Arc::new(FirstGreenExecutor {
             entered: Arc::new(std::sync::Barrier::new(2)),
             cancelled: Arc::clone(&cancelled),
-        });
+        }));
         let mut plan = plan_with_tasks(2);
         plan.group_key = Some("candidate-group".to_string());
         for task in &mut plan.tasks {
@@ -207,7 +208,7 @@ pub(super) mod concurrency_tests {
     #[test]
     fn wait_all_remains_the_default_candidate_completion_policy() {
         let executor = RecordingExecutor::new(HashMap::new(), Duration::from_millis(20));
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(2);
         plan.group_key = Some("candidate-group".to_string());
         for task in &mut plan.tasks {
@@ -232,7 +233,7 @@ pub(super) mod concurrency_tests {
     fn candidate_resource_budget_can_intentionally_serialize_execution() {
         let executor = RecordingExecutor::new(HashMap::new(), Duration::from_millis(25));
         let max_seen = Arc::clone(&executor.max_seen);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(2);
         plan.group_key = Some("candidate-group".to_string());
         for task in &mut plan.tasks {
@@ -248,10 +249,10 @@ pub(super) mod concurrency_tests {
 
     #[test]
     fn blocks_tasks_over_queue_depth_and_reports_backpressure() {
-        let scheduler = AgentTaskScheduler::new(RecordingExecutor::new(
+        let scheduler = AgentTaskScheduler::new(Arc::new(RecordingExecutor::new(
             HashMap::new(),
             Duration::from_millis(0),
-        ));
+        )));
         let mut plan = plan_with_tasks(3);
         plan.options.max_queue_depth = Some(2);
 
@@ -280,7 +281,7 @@ pub(super) mod concurrency_tests {
     fn applies_per_executor_concurrency_below_global_limit() {
         let executor = RecordingExecutor::new(HashMap::new(), Duration::from_millis(25));
         let max_seen = Arc::clone(&executor.max_seen);
-        let scheduler = crate::agent_task_scheduler::AgentTaskScheduler::new(executor);
+        let scheduler = crate::agent_task_scheduler::AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(3);
         plan.options.max_concurrency = 3;
         plan.options
@@ -304,7 +305,7 @@ pub(super) mod concurrency_tests {
     fn applies_per_model_concurrency_below_global_limit() {
         let executor = RecordingExecutor::new(HashMap::new(), Duration::from_millis(25));
         let max_seen = Arc::clone(&executor.max_seen);
-        let scheduler = crate::agent_task_scheduler::AgentTaskScheduler::new(executor);
+        let scheduler = crate::agent_task_scheduler::AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(3);
         for task in &mut plan.tasks {
             task.executor.model = Some("model-a".to_string());
@@ -334,7 +335,7 @@ pub(super) mod concurrency_tests {
         init_git_workspace(&workspace);
         let executor = RecordingExecutor::new(HashMap::new(), Duration::from_millis(25));
         let max_seen = Arc::clone(&executor.max_seen);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(2);
         plan.options.max_concurrency = 2;
         for task in &mut plan.tasks {
@@ -373,7 +374,7 @@ pub(super) mod concurrency_tests {
     fn serializes_tasks_with_the_same_declared_exclusive_resource() {
         let executor = RecordingExecutor::new(HashMap::new(), Duration::from_millis(25));
         let max_seen = Arc::clone(&executor.max_seen);
-        let scheduler = crate::agent_task_scheduler::AgentTaskScheduler::new(executor);
+        let scheduler = crate::agent_task_scheduler::AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(2);
         plan.options.max_concurrency = 2;
         for task in &mut plan.tasks {
@@ -421,7 +422,7 @@ pub(super) mod concurrency_tests {
     fn unrelated_declared_resources_remain_concurrent() {
         let executor = RecordingExecutor::new(HashMap::new(), Duration::from_millis(25));
         let max_seen = Arc::clone(&executor.max_seen);
-        let scheduler = crate::agent_task_scheduler::AgentTaskScheduler::new(executor);
+        let scheduler = crate::agent_task_scheduler::AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(2);
         plan.options.max_concurrency = 2;
         plan.tasks[0].limits.exclusive_resource_keys = vec!["cache:one".to_string()];
@@ -465,7 +466,7 @@ pub(super) mod concurrency_tests {
 
     #[test]
     fn execution_timeout_excludes_declared_resource_wait() {
-        let scheduler = AgentTaskScheduler::new(ResourceTimeoutExecutor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(ResourceTimeoutExecutor));
         let mut plan = plan_with_tasks(2);
         plan.options.max_concurrency = 2;
         for task in &mut plan.tasks {
@@ -509,7 +510,7 @@ pub(super) mod concurrency_tests {
         fs::create_dir(&child).expect("child");
         let executor = RecordingExecutor::new(HashMap::new(), Duration::from_millis(25));
         let max_seen = Arc::clone(&executor.max_seen);
-        let scheduler = crate::agent_task_scheduler::AgentTaskScheduler::new(executor);
+        let scheduler = crate::agent_task_scheduler::AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(3);
         plan.options.max_concurrency = 3;
         plan.tasks[0].workspace.root = Some(workspace.display().to_string());
@@ -640,13 +641,13 @@ pub(super) mod concurrency_tests {
         let attempt_roots = Arc::new(Mutex::new(Vec::new()));
         let scratch_roots = Arc::new(Mutex::new(Vec::new()));
         let scratch_active_while_running = Arc::new(AtomicBool::new(false));
-        let scheduler = AgentTaskScheduler::new(LateMutatingExecutor {
+        let scheduler = AgentTaskScheduler::new(Arc::new(LateMutatingExecutor {
             events: Arc::clone(&events),
             finished: Arc::clone(&finished),
             attempt_roots: Arc::clone(&attempt_roots),
             scratch_roots: Arc::clone(&scratch_roots),
             scratch_active_while_running: Arc::clone(&scratch_active_while_running),
-        });
+        }));
         let mut plan = plan_with_tasks(3);
         plan.options.max_concurrency = 3;
         plan.tasks[0].workspace.root = Some(workspace.display().to_string());
@@ -757,7 +758,7 @@ pub(super) mod concurrency_tests {
         fs::write(workspace.join("user-edit.txt"), "keep me\n").expect("user edit");
         let executor = RecordingExecutor::new(HashMap::new(), Duration::from_millis(0));
         let max_seen = Arc::clone(&executor.max_seen);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(1);
         plan.tasks[0].workspace.root = Some(workspace.display().to_string());
 
@@ -876,7 +877,7 @@ pub(super) mod concurrency_tests {
         };
         let attempts = Arc::clone(&executor.attempts);
         let workspaces = Arc::clone(&executor.workspaces);
-        let scheduler = AgentTaskScheduler::new(executor).with_run_id("retry-isolation");
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor)).with_run_id("retry-isolation");
         let mut plan = plan_with_tasks(1);
         plan.tasks[0].workspace.root = Some(source.display().to_string());
         plan.tasks[0].executor.config = json!({
@@ -948,10 +949,10 @@ pub(super) mod concurrency_tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let workspace = temp.path().join("workspace");
         init_git_workspace(&workspace);
-        let scheduler = AgentTaskScheduler::new(RecordingExecutor::new(
+        let scheduler = AgentTaskScheduler::new(Arc::new(RecordingExecutor::new(
             HashMap::new(),
             Duration::from_millis(0),
-        ));
+        )));
         let mut plan = plan_with_tasks(1);
         plan.tasks[0].workspace.root = Some(workspace.display().to_string());
 

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/plan_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/plan_projection.rs
@@ -13,9 +13,9 @@ mod plan_projection_tests {
             "fanout/site-smoke[model=gpt-5.5,prompt=site-b]".to_string(),
             AgentTaskOutcomeStatus::Failed,
         );
-        let scheduler = crate::agent_task_scheduler::AgentTaskScheduler::new(
+        let scheduler = crate::agent_task_scheduler::AgentTaskScheduler::new(Arc::new(
             RecordingExecutor::new(statuses, Duration::from_millis(0)),
-        );
+        ));
         let matrix_plan = expand_agent_task_matrix(
             "fanout/site-smoke",
             vec![
@@ -74,10 +74,10 @@ mod plan_projection_tests {
 
     #[test]
     fn static_batch_plans_remain_compatible_without_output_dependencies() {
-        let scheduler = AgentTaskScheduler::new(RecordingExecutor::new(
+        let scheduler = AgentTaskScheduler::new(Arc::new(RecordingExecutor::new(
             HashMap::new(),
             Duration::from_millis(0),
-        ));
+        )));
         let plan_json = serde_json::to_string(&plan_with_tasks(2)).expect("plan json");
         let plan: AgentTaskPlan = serde_json::from_str(&plan_json).expect("static plan decodes");
 
@@ -96,10 +96,10 @@ mod plan_projection_tests {
     #[test]
     fn plan_level_component_contracts_are_preserved_on_executor_requests() {
         let observed = Arc::new(Mutex::new(Vec::new()));
-        let scheduler = AgentTaskScheduler::new(OutputTemplateExecutor {
+        let scheduler = AgentTaskScheduler::new(Arc::new(OutputTemplateExecutor {
             observed: Arc::clone(&observed),
             include_issue_number: true,
-        });
+        }));
         let raw = serde_json::json!({
             "schema": AGENT_TASK_PLAN_SCHEMA,
             "plan_id": "plan-components",
@@ -199,10 +199,10 @@ mod plan_projection_tests {
     #[test]
     fn scheduler_executes_from_projected_homeboy_plan() {
         let observed = Arc::new(Mutex::new(Vec::new()));
-        let scheduler = AgentTaskScheduler::new(OutputTemplateExecutor {
+        let scheduler = AgentTaskScheduler::new(Arc::new(OutputTemplateExecutor {
             observed: Arc::clone(&observed),
             include_issue_number: true,
-        });
+        }));
         let mut plan = AgentTaskPlan::new(
             "plan-homeboy-projection",
             vec![request("idea"), request("design")],

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
@@ -233,7 +233,7 @@ mod provider_rotation_tests {
     fn total_execution_budget_of_one_prevents_provider_rotation() {
         let executor = RotationScriptedExecutor::new(vec![provider_failure(), success()]);
         let calls = Arc::clone(&executor.calls);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(1);
         plan.options.rotation = Some(rotation_policy(vec![entry("fallback-backend-a")]));
         plan.options.execution_budget = AgentTaskExecutionBudget {
@@ -258,7 +258,7 @@ mod provider_rotation_tests {
         let executor = RotationScriptedExecutor::new(vec![provider_failure(), success()]);
         let observed = Arc::clone(&executor.observed);
         let calls = Arc::clone(&executor.calls);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(1);
         plan.tasks[0].executor.model = Some("primary-model".to_string());
         plan.options.rotation = Some(rotation_policy(vec![
@@ -329,7 +329,7 @@ mod provider_rotation_tests {
     #[test]
     fn same_backend_model_rotation_announces_and_records_the_producing_model() {
         let executor = RotationScriptedExecutor::new(vec![provider_failure(), success()]);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(1);
         plan.tasks[0].executor.backend = "opencode".to_string();
         plan.tasks[0].executor.model = Some("openai/gpt-5.6-sol".to_string());
@@ -359,9 +359,9 @@ mod provider_rotation_tests {
 
     #[test]
     fn rotation_records_a_provider_reported_model_that_differs_from_the_attempted_model() {
-        let scheduler = AgentTaskScheduler::new(ProviderReportedRotationExecutor {
+        let scheduler = AgentTaskScheduler::new(Arc::new(ProviderReportedRotationExecutor {
             calls: AtomicUsize::new(0),
-        });
+        }));
         let mut plan = plan_with_tasks(1);
         plan.tasks[0].executor.model = Some("openai/gpt-5.6-sol".to_string());
         plan.options.rotation = Some(rotation_policy(vec![AgentTaskProviderRotationEntry {
@@ -388,10 +388,10 @@ mod provider_rotation_tests {
         let workspace = temp.path().join("workspace");
         super::super::concurrency::concurrency_tests::init_git_workspace(&workspace);
         let observed_roots = Arc::new(Mutex::new(Vec::new()));
-        let scheduler = AgentTaskScheduler::new(DirtyCandidateThenSuccessExecutor {
+        let scheduler = AgentTaskScheduler::new(Arc::new(DirtyCandidateThenSuccessExecutor {
             observed_roots: Arc::clone(&observed_roots),
             calls: AtomicUsize::new(0),
-        })
+        }))
         .with_run_id("cook-detached-37abbb52-d638-495c-b270-46fdc965fc9c-attempt-1-fb890874");
         let mut plan = plan_with_tasks(1);
         plan.tasks[0].workspace.root = Some(workspace.display().to_string());
@@ -525,11 +525,11 @@ mod provider_rotation_tests {
         plan.options.rotation = Some(rotation_policy(vec![entry("fallback-backend-a")]));
         enable_rotation(&mut plan);
         crate::agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("submit run");
-        let aggregate = AgentTaskScheduler::new(DirtyCandidateThenTerminalExecutor {
+        let aggregate = AgentTaskScheduler::new(Arc::new(DirtyCandidateThenTerminalExecutor {
             calls: AtomicUsize::new(0),
             terminal,
             terminal_outputs,
-        })
+        }))
         .with_run_id(run_id)
         .run(plan);
 
@@ -607,7 +607,7 @@ mod provider_rotation_tests {
         // has to exist before the scheduler dispatches it.
         crate::agent_task_lifecycle::submit_plan(&plan, Some("run-adopt"))
             .expect("durable run record");
-        let aggregate = AgentTaskScheduler::new(scheduler)
+        let aggregate = AgentTaskScheduler::new(Arc::new(scheduler))
             .with_run_id("run-adopt")
             .run(plan);
 
@@ -654,9 +654,9 @@ mod provider_rotation_tests {
         fs::write(&patch_path, &patch).expect("persist candidate patch");
         let expected_fingerprint = fingerprint(patch.as_bytes());
         let observed = Arc::new(Mutex::new(None));
-        let scheduler = AgentTaskScheduler::new(AdoptionExecutor {
+        let scheduler = AgentTaskScheduler::new(Arc::new(AdoptionExecutor {
             observed: Arc::clone(&observed),
-        });
+        }));
         let mut plan = plan_with_tasks(1);
         plan.tasks[0].workspace.root = Some(workspace.display().to_string());
         plan.tasks[0].workspace.attempt = Some(crate::agent_task::AgentTaskAttemptWorkspace {
@@ -698,7 +698,7 @@ mod provider_rotation_tests {
     fn primary_success_does_not_rotate() {
         let executor = RotationScriptedExecutor::new(vec![success()]);
         let calls = Arc::clone(&executor.calls);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(1);
         plan.options.rotation = Some(rotation_policy(vec![entry("fallback-backend-a")]));
         enable_rotation(&mut plan);
@@ -722,7 +722,7 @@ mod provider_rotation_tests {
         // finalization after publishing a PR.
         let executor = RotationScriptedExecutor::new(vec![success()]);
         let observed = Arc::clone(&executor.observed);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(1);
         assert!(
             plan.tasks[0].executor.model.is_none(),
@@ -754,7 +754,7 @@ mod provider_rotation_tests {
         // the request wins over the configured entry default.
         let executor = RotationScriptedExecutor::new(vec![success()]);
         let observed = Arc::clone(&executor.observed);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(1);
         plan.tasks[0].executor.model = Some("explicit-cli-model".to_string());
         plan.options.rotation = Some(rotation_policy(vec![AgentTaskProviderRotationEntry {
@@ -781,7 +781,7 @@ mod provider_rotation_tests {
     fn one_provider_execution_budget_never_rotates() {
         let executor = RotationScriptedExecutor::new(vec![provider_failure(), success()]);
         let calls = Arc::clone(&executor.calls);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(1);
         plan.options.execution_budget = AgentTaskExecutionBudget {
             version: AgentTaskExecutionBudget::VERSION,
@@ -826,7 +826,7 @@ mod provider_rotation_tests {
             let executor =
                 RotationScriptedExecutor::new(vec![(status, Some(classification)), success()]);
             let calls = Arc::clone(&executor.calls);
-            let scheduler = AgentTaskScheduler::new(executor);
+            let scheduler = AgentTaskScheduler::new(Arc::new(executor));
             let mut plan = plan_with_tasks(1);
             plan.options.rotation = Some(rotation_policy(vec![entry("fallback-backend-a")]));
             enable_rotation(&mut plan);
@@ -893,14 +893,14 @@ mod provider_rotation_tests {
         let scratch_roots = Arc::new(Mutex::new(Vec::new()));
         let (cancellation, cancellation_receiver) = std::sync::mpsc::channel();
         let cancel_calls = Arc::new(AtomicUsize::new(0));
-        let scheduler = AgentTaskScheduler::new(TimeoutThenSuccessExecutor {
+        let scheduler = AgentTaskScheduler::new(Arc::new(TimeoutThenSuccessExecutor {
             calls: AtomicUsize::new(0),
             cancellation,
             cancel_calls: Arc::clone(&cancel_calls),
             cancellation_receiver: Mutex::new(cancellation_receiver),
             scratch_index: scratch_index.clone(),
             scratch_roots: Arc::clone(&scratch_roots),
-        })
+        }))
         .with_run_id(run_id);
         let mut plan = plan_with_tasks(1);
         // The first worker returns only after the scheduler reaches the normal
@@ -950,7 +950,7 @@ mod provider_rotation_tests {
                 success(),
             ]);
             let calls = Arc::clone(&executor.calls);
-            let scheduler = AgentTaskScheduler::new(executor);
+            let scheduler = AgentTaskScheduler::new(Arc::new(executor));
             let mut plan = plan_with_tasks(1);
             plan.options.rotation = Some(rotation_policy(vec![entry("fallback-backend-a")]));
             enable_rotation(&mut plan);
@@ -982,7 +982,7 @@ mod provider_rotation_tests {
     fn rotation_exhausts_entries_and_records_attempt_sequence_in_order() {
         let executor = RotationScriptedExecutor::new(vec![provider_failure()]);
         let observed = Arc::clone(&executor.observed);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(1);
         plan.options.rotation = Some(rotation_policy(vec![
             entry("fallback-backend-a"),
@@ -1019,7 +1019,7 @@ mod provider_rotation_tests {
     fn rotation_respects_configured_max_attempts_bound() {
         let executor = RotationScriptedExecutor::new(vec![provider_failure()]);
         let calls = Arc::clone(&executor.calls);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(1);
         plan.options.rotation = Some(AgentTaskProviderRotationPolicy {
             entries: vec![
@@ -1048,7 +1048,7 @@ mod provider_rotation_tests {
     fn request_metadata_rotation_overrides_plan_policy() {
         let executor = RotationScriptedExecutor::new(vec![provider_failure(), success()]);
         let observed = Arc::clone(&executor.observed);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(1);
         plan.options.rotation = Some(rotation_policy(vec![entry("plan-fallback")]));
         enable_rotation(&mut plan);
@@ -1069,7 +1069,7 @@ mod provider_rotation_tests {
     fn no_rotation_policy_keeps_single_attempt_behavior_unchanged() {
         let executor = RotationScriptedExecutor::new(vec![provider_failure()]);
         let calls = Arc::clone(&executor.calls);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(1);
         plan.options.execution_budget = AgentTaskExecutionBudget::new(1, 0, 0);
 

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/resource_budget.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/resource_budget.rs
@@ -10,7 +10,7 @@ mod resource_budget_tests {
     fn resource_budget_limits_concurrent_task_cost() {
         let executor = RecordingExecutor::new(HashMap::new(), Duration::from_millis(25));
         let max_seen = Arc::clone(&executor.max_seen);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(4);
         plan.options.max_concurrency = 4;
         plan.options.resource_budget.max_active_units = Some(2);
@@ -30,10 +30,10 @@ mod resource_budget_tests {
 
     #[test]
     fn resource_budget_blocks_task_that_cannot_fit() {
-        let scheduler = AgentTaskScheduler::new(RecordingExecutor::new(
+        let scheduler = AgentTaskScheduler::new(Arc::new(RecordingExecutor::new(
             HashMap::new(),
             Duration::from_millis(0),
-        ));
+        )));
         let mut plan = plan_with_tasks(1);
         plan.options.resource_budget.max_active_units = Some(2);
         plan.options.resource_budget.default_task_units = 3;
@@ -57,7 +57,7 @@ mod resource_budget_tests {
     fn retry_budget_and_failure_classifications_gate_retries() {
         let executor = RetryOnceExecutor::default();
         let attempts = Arc::clone(&executor.attempts);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(1);
         plan.options.retry.max_attempts = 3;
         plan.options.retry.max_retries_total = Some(0);

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/retry_failure.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/retry_failure.rs
@@ -10,8 +10,10 @@ mod retry_failure_tests {
     fn preserves_partial_failure_evidence() {
         let mut statuses = HashMap::new();
         statuses.insert("task-2".to_string(), AgentTaskOutcomeStatus::Failed);
-        let scheduler =
-            AgentTaskScheduler::new(RecordingExecutor::new(statuses, Duration::from_millis(0)));
+        let scheduler = AgentTaskScheduler::new(Arc::new(RecordingExecutor::new(
+            statuses,
+            Duration::from_millis(0),
+        )));
         let mut plan = plan_with_tasks(3);
         plan.options.max_concurrency = 3;
 
@@ -36,8 +38,10 @@ mod retry_failure_tests {
     fn failed_single_task_is_not_also_counted_as_queued() {
         let mut statuses = HashMap::new();
         statuses.insert("task-1".to_string(), AgentTaskOutcomeStatus::Failed);
-        let scheduler =
-            AgentTaskScheduler::new(RecordingExecutor::new(statuses, Duration::from_millis(0)));
+        let scheduler = AgentTaskScheduler::new(Arc::new(RecordingExecutor::new(
+            statuses,
+            Duration::from_millis(0),
+        )));
 
         let aggregate = scheduler.run(plan_with_tasks(1));
 
@@ -54,7 +58,7 @@ mod retry_failure_tests {
     fn retries_failed_tasks_until_success() {
         let executor = RetryOnceExecutor::default();
         let attempts = Arc::clone(&executor.attempts);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(1);
         plan.options.execution_budget.max_provider_executions = 2;
         plan.options.execution_budget.max_same_provider_retries = 1;
@@ -73,7 +77,7 @@ mod retry_failure_tests {
     fn default_unbounded_budget_does_not_retry_without_a_retry_policy() {
         let executor = RetryOnceExecutor::default();
         let attempts = Arc::clone(&executor.attempts);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let plan = AgentTaskPlan::new("default-no-retry", vec![request("task-1")]);
 
         let aggregate = scheduler.run(plan);
@@ -86,7 +90,7 @@ mod retry_failure_tests {
     fn legacy_retry_policy_retries_with_the_legacy_unbounded_budget() {
         let executor = RetryOnceExecutor::default();
         let attempts = Arc::clone(&executor.attempts);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = AgentTaskPlan::new("legacy-retry", vec![request("task-1")]);
         plan.options.retry.max_attempts = 2;
 
@@ -100,7 +104,7 @@ mod retry_failure_tests {
     fn lower_retry_cap_wins_over_execution_budget() {
         let executor = RetryTwiceExecutor::default();
         let attempts = Arc::clone(&executor.attempts);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(1);
         plan.options.retry.max_attempts = 2;
         plan.options.execution_budget.max_provider_executions = 3;
@@ -116,7 +120,7 @@ mod retry_failure_tests {
     fn lower_execution_budget_wins_over_retry_cap() {
         let executor = RetryTwiceExecutor::default();
         let attempts = Arc::clone(&executor.attempts);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(1);
         plan.options.retry.max_attempts = 3;
         plan.options.execution_budget.max_provider_executions = 2;

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/timeout.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/timeout.rs
@@ -8,10 +8,10 @@ mod timeout_tests {
 
     #[test]
     fn normalizes_slow_task_to_timeout() {
-        let scheduler = AgentTaskScheduler::new(RecordingExecutor::new(
+        let scheduler = AgentTaskScheduler::new(Arc::new(RecordingExecutor::new(
             HashMap::new(),
             Duration::from_millis(25),
-        ));
+        )));
         let mut plan = plan_with_tasks(1);
         plan.tasks[0].limits.timeout_ms = Some(1);
 
@@ -36,7 +36,7 @@ mod timeout_tests {
     fn expired_execution_deadline_skips_materialization_and_provider_dispatch() {
         let executor = RecordingExecutor::new(HashMap::new(), Duration::ZERO);
         let started = Arc::clone(&executor.max_seen);
-        let scheduler = AgentTaskScheduler::new(executor);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
         let mut plan = plan_with_tasks(1);
         plan.options.execution_budget.deadline_unix_ms =
             Some(crate::agent_task_timeout::now_unix_ms().saturating_sub(1));
@@ -60,10 +60,10 @@ mod timeout_tests {
     #[test]
     fn execution_deadline_is_propagated_to_the_executor_request() {
         let observed = Arc::new(Mutex::new(Vec::new()));
-        let scheduler = AgentTaskScheduler::new(ConceptPacketExecutor {
+        let scheduler = AgentTaskScheduler::new(Arc::new(ConceptPacketExecutor {
             observed: Arc::clone(&observed),
             emit_concept_packet: false,
-        });
+        }));
         let mut plan = plan_with_tasks(1);
         let deadline = crate::agent_task_timeout::now_unix_ms().saturating_add(60_000);
         plan.options.execution_budget.deadline_unix_ms = Some(deadline);
@@ -130,10 +130,10 @@ mod timeout_tests {
         )
         .expect("agent result");
 
-        let scheduler = AgentTaskScheduler::new(RecordingExecutor::new(
+        let scheduler = AgentTaskScheduler::new(Arc::new(RecordingExecutor::new(
             HashMap::new(),
             Duration::from_millis(25),
-        ));
+        )));
         let mut plan = plan_with_tasks(1);
         plan.tasks[0].limits.timeout_ms = Some(1);
         plan.tasks[0].metadata = json!({ "artifact_root": artifact_root });
@@ -221,7 +221,7 @@ mod timeout_tests {
                 .expect("submit run");
             crate::agent_task_service::run_submitted(
                 "timeout-patch-run".to_string(),
-                PatchThenTimeout,
+                Arc::new(PatchThenTimeout),
             )
             .expect("run timed-out provider");
             let aggregate = crate::agent_task_lifecycle::read_aggregate("timeout-patch-run")
@@ -303,10 +303,10 @@ mod timeout_tests {
         )
         .expect("agent result");
 
-        let scheduler = AgentTaskScheduler::new(RecordingExecutor::new(
+        let scheduler = AgentTaskScheduler::new(Arc::new(RecordingExecutor::new(
             HashMap::new(),
             Duration::from_millis(25),
-        ));
+        )));
         let mut plan = plan_with_tasks(1);
         plan.tasks[0].limits.timeout_ms = Some(1);
         plan.tasks[0].metadata = json!({ "artifact_root": artifact_root });

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/timeout_propagation_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/timeout_propagation_tests.rs
@@ -12,7 +12,7 @@ fn plan_timeout_reaches_each_rotated_provider_attempt() {
         Some(AgentTaskFailureClassification::Provider),
     )]);
     let observed = Arc::clone(&executor.observed);
-    let scheduler = AgentTaskScheduler::new(executor);
+    let scheduler = AgentTaskScheduler::new(Arc::new(executor));
     let mut plan = plan_with_tasks(1);
     plan.options.timeout_ms = Some(2_700_000);
     plan.options.rotation = Some(AgentTaskProviderRotationPolicy {

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -17,7 +17,7 @@ use crate::agent_task_gate::VerifyGateOptions;
 use crate::agent_task_lifecycle::{self, AgentTaskLifecycleStore};
 use crate::agent_task_promotion::{AgentTaskPromotionReport, AgentTaskPromotionStatus};
 use crate::agent_task_scheduler::{
-    AgentTaskExecutionBudget, AgentTaskExecutorAdapter, AgentTaskPlan,
+    AgentTaskExecutionBudget, AgentTaskPlan, SharedAgentTaskExecutor,
 };
 use crate::agent_task_timeout::{capture_cook_deadline, expired_cook_deadline, CookDeadline};
 use homeboy_core::command_invocation::CommandInvocation;
@@ -2456,13 +2456,10 @@ impl AgentTaskCookBatchControl {
 ///
 /// This is the unowned coordinator: it runs to completion or dies with its
 /// caller. A caller with a durable owner uses [`run_cook_batch_with_control`].
-pub fn run_cook_batch<E>(
+pub fn run_cook_batch(
     options: AgentTaskCookBatchOptions,
-    executor: E,
-) -> Result<AgentTaskRunResult<AgentTaskCookBatchReport>>
-where
-    E: AgentTaskExecutorAdapter + Clone + Send,
-{
+    executor: SharedAgentTaskExecutor,
+) -> Result<AgentTaskRunResult<AgentTaskCookBatchReport>> {
     run_cook_batch_with_control(options, executor, AgentTaskCookBatchControl::default())
 }
 
@@ -2474,14 +2471,11 @@ where
 /// ceiling resolved by `resolve_batch_concurrency`, and it does not introduce a
 /// second deadline — the batch `CookDeadline` is still captured once here and
 /// re-bound onto every worker.
-pub fn run_cook_batch_with_control<E>(
+pub fn run_cook_batch_with_control(
     options: AgentTaskCookBatchOptions,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     control: AgentTaskCookBatchControl,
-) -> Result<AgentTaskRunResult<AgentTaskCookBatchReport>>
-where
-    E: AgentTaskExecutorAdapter + Clone + Send,
-{
+) -> Result<AgentTaskRunResult<AgentTaskCookBatchReport>> {
     let total = options.cooks.len();
     if total == 0 {
         return Err(Error::validation_invalid_argument(
@@ -2700,13 +2694,12 @@ fn observed_child_cell(
 /// in flight on a runner daemon is reported as-is rather than forced. The
 /// per-child finalization state is reconciled back into the durable batch record
 /// so repeated resume calls converge instead of re-finalizing (#9525).
-pub fn resume_cook_batch<E, D>(
+pub fn resume_cook_batch<D>(
     batch_id: &str,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     reconstruct_dispatcher: D,
 ) -> Result<AgentTaskRunResult<AgentTaskCookBatchReport>>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     D: Fn(&Value) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
 {
     resume_cook_batch_with_finalizer(
@@ -2720,14 +2713,13 @@ where
 /// Resume one durable Cook through its original provider, promotion, gates, and
 /// finalization contract. Fanout supervisors use this child-local entrypoint so
 /// a blocked sibling cannot prevent a ready candidate from advancing.
-pub fn resume_cook<E, D>(
+pub fn resume_cook<D>(
     cook_id: &str,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     reconstruct_dispatcher: D,
     rerun_completed_gates: bool,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     D: Fn(&Value) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
 {
     let mut finalize = finalize_or_load_cook_pr;
@@ -2745,14 +2737,13 @@ where
     })
 }
 
-fn resume_cook_batch_with_finalizer<E, D, F>(
+fn resume_cook_batch_with_finalizer<D, F>(
     batch_id: &str,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     reconstruct_dispatcher: D,
     mut finalize: F,
 ) -> Result<AgentTaskRunResult<AgentTaskCookBatchReport>>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     D: Fn(&Value) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
     F: FnMut(&AgentTaskCookServiceOptions, &str, &AgentTaskPromotionReport) -> Result<Value>,
 {
@@ -2889,15 +2880,14 @@ fn cook_batch_result(
 /// Reconstruct one batch child's cook from its durable recipe and re-run it.
 /// A missing recipe means the child never reached cook start; surface an
 /// actionable resumability error instead of fabricating a cook.
-fn resume_batch_child<E, D, F>(
+fn resume_batch_child<D, F>(
     batch_id: &str,
     cook_id: &str,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     reconstruct_dispatcher: &D,
     finalize: &mut F,
 ) -> Result<AgentTaskCookReport>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     D: Fn(&Value) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
     F: FnMut(&AgentTaskCookServiceOptions, &str, &AgentTaskPromotionReport) -> Result<Value>,
 {
@@ -2911,16 +2901,15 @@ where
     )
 }
 
-fn resume_batch_child_with_gate_rerun<E, D, F>(
+fn resume_batch_child_with_gate_rerun<D, F>(
     batch_id: &str,
     cook_id: &str,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     reconstruct_dispatcher: &D,
     finalize: &mut F,
     rerun_completed_gates: bool,
 ) -> Result<AgentTaskCookReport>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     D: Fn(&Value) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
     F: FnMut(&AgentTaskCookServiceOptions, &str, &AgentTaskPromotionReport) -> Result<Value>,
 {
@@ -3212,10 +3201,10 @@ pub(super) fn validate_cook_follow_up_stores(
     clippy::too_many_arguments,
     reason = "Cook follow-up retains explicit durable recipe and dispatch identity fields"
 )]
-pub(crate) fn dispatch_cook_follow_up<E>(
+pub(crate) fn dispatch_cook_follow_up(
     stores: (&CookRecipeStore, &AgentTaskLifecycleStore),
     options: &AgentTaskCookServiceOptions,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     cook_id: &str,
     attempt: u32,
     source_run_id: &str,
@@ -3228,10 +3217,7 @@ pub(crate) fn dispatch_cook_follow_up<E>(
     budget_limit: &AgentTaskExecutionBudget,
     budget_used: ExecutionBudgetUsage,
     remediation_category_usage: &mut ExecutionBudgetUsage,
-) -> Result<CookFollowUpDispatch>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+) -> Result<CookFollowUpDispatch> {
     let (recipe_store, lifecycle_store) = stores;
     validate_cook_follow_up_stores(recipe_store, lifecycle_store)?;
     if let Some(reason) = remediation_tool_policy_error(&follow_up_request) {
@@ -3668,27 +3654,21 @@ fn reserve_cook_materialization_capacity(
     )
 }
 
-pub fn run_cook<E>(
+pub fn run_cook(
     options: AgentTaskCookServiceOptions,
-    executor: E,
-) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+    executor: SharedAgentTaskExecutor,
+) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
     let store = CookRecipeStore::from_current_data_root()?;
     run_cook_with_store(&store, options, executor)
 }
 
 /// Run Cook against an explicit durable recipe store. Lifecycle storage remains
 /// ambient; this boundary scopes only Cook recipes and continuations.
-pub fn run_cook_with_store<E>(
+pub fn run_cook_with_store(
     store: &CookRecipeStore,
     options: AgentTaskCookServiceOptions,
-    executor: E,
-) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+    executor: SharedAgentTaskExecutor,
+) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
     let side_effects =
         DefaultCookSideEffects::new(|lifecycle_store, options, run_id, promotion| {
             finalize_or_load_cook_pr_with_stores(store, lifecycle_store, options, run_id, promotion)
@@ -3696,13 +3676,10 @@ where
     run_cook_with_boundaries_with_store(store, options, executor, side_effects)
 }
 
-pub fn run_terminal_cook_continuation<E>(
+pub fn run_terminal_cook_continuation(
     options: AgentTaskCookServiceOptions,
-    executor: E,
-) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+    executor: SharedAgentTaskExecutor,
+) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
     let store = CookRecipeStore::from_current_data_root()?;
     let side_effects =
         DefaultCookSideEffects::new(|lifecycle_store, options, run_id, promotion| {
@@ -3727,14 +3704,11 @@ where
 /// Run Cook while reporting the authoritative attempt only after its durable
 /// recipe has been persisted. Callers must treat pre-observer work as
 /// invocation-local because no run recovery identity exists yet.
-pub fn run_cook_with_durable_observer<E>(
+pub fn run_cook_with_durable_observer(
     options: AgentTaskCookServiceOptions,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     observer: &CookProgressObserver<'_>,
-) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
     let store = CookRecipeStore::from_current_data_root()?;
     let side_effects =
         DefaultCookSideEffects::new(|lifecycle_store, options, run_id, promotion| {
@@ -3755,27 +3729,25 @@ where
     )
 }
 
-pub(crate) fn run_cook_with_finalizer<E, F>(
+pub(crate) fn run_cook_with_finalizer<F>(
     options: AgentTaskCookServiceOptions,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     finalize: F,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     F: FnMut(&AgentTaskCookServiceOptions, &str, &AgentTaskPromotionReport) -> Result<Value>,
 {
     let store = CookRecipeStore::from_current_data_root()?;
     run_cook_with_finalizer_with_store(&store, options, executor, finalize)
 }
 
-pub(crate) fn run_cook_with_finalizer_with_store<E, F>(
+pub(crate) fn run_cook_with_finalizer_with_store<F>(
     store: &CookRecipeStore,
     options: AgentTaskCookServiceOptions,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     mut finalize: F,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     F: FnMut(&AgentTaskCookServiceOptions, &str, &AgentTaskPromotionReport) -> Result<Value>,
 {
     let side_effects = DefaultCookSideEffects::new(|_, options, run_id, promotion| {
@@ -3784,27 +3756,25 @@ where
     run_cook_with_boundaries_with_store(store, options, executor, side_effects)
 }
 
-fn run_cook_with_boundaries<E, S>(
+fn run_cook_with_boundaries<S>(
     options: AgentTaskCookServiceOptions,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     side_effects: S,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     S: CookSideEffectService,
 {
     let store = CookRecipeStore::from_current_data_root()?;
     run_cook_with_boundaries_with_store(&store, options, executor, side_effects)
 }
 
-fn run_cook_with_boundaries_with_store<E, S>(
+fn run_cook_with_boundaries_with_store<S>(
     store: &CookRecipeStore,
     options: AgentTaskCookServiceOptions,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     side_effects: S,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     S: CookSideEffectService,
 {
     run_cook_with_boundaries_observed_with_store(store, options, executor, side_effects, None)
@@ -3852,14 +3822,13 @@ pub(crate) fn exhausted_budget_guidance(
     )
 }
 
-fn run_cook_with_boundaries_observed<E, S>(
+fn run_cook_with_boundaries_observed<S>(
     options: AgentTaskCookServiceOptions,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     side_effects: S,
     durable_observer: Option<&CookProgressObserver<'_>>,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     S: CookSideEffectService,
 {
     let store = CookRecipeStore::from_current_data_root()?;
@@ -3872,15 +3841,14 @@ where
     )
 }
 
-fn run_cook_with_boundaries_observed_with_store<E, S>(
+fn run_cook_with_boundaries_observed_with_store<S>(
     store: &CookRecipeStore,
     options: AgentTaskCookServiceOptions,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     side_effects: S,
     durable_observer: Option<&CookProgressObserver<'_>>,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     S: CookSideEffectService,
 {
     run_cook_with_boundaries_observed_policy_with_store(
@@ -3893,15 +3861,14 @@ where
     )
 }
 
-fn run_cook_with_boundaries_observed_policy<E, S>(
+fn run_cook_with_boundaries_observed_policy<S>(
     options: AgentTaskCookServiceOptions,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     side_effects: S,
     durable_observer: Option<&CookProgressObserver<'_>>,
     allow_historical_terminal: bool,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     S: CookSideEffectService,
 {
     let store = CookRecipeStore::from_current_data_root()?;
@@ -3915,16 +3882,15 @@ where
     )
 }
 
-fn run_cook_with_boundaries_observed_policy_with_store<E, S>(
+fn run_cook_with_boundaries_observed_policy_with_store<S>(
     store: &CookRecipeStore,
     options: AgentTaskCookServiceOptions,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     side_effects: S,
     durable_observer: Option<&CookProgressObserver<'_>>,
     allow_historical_terminal: bool,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     S: CookSideEffectService,
 {
     // Every exit from the observed boundary funnels through one notification
@@ -3951,16 +3917,15 @@ where
     result
 }
 
-fn run_cook_with_boundaries_reported<E, S>(
+fn run_cook_with_boundaries_reported<S>(
     store: &CookRecipeStore,
     options: AgentTaskCookServiceOptions,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     side_effects: S,
     durable_observer: Option<&CookProgressObserver<'_>>,
     allow_historical_terminal: bool,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     S: CookSideEffectService,
 {
     // The spine used to resolve this store itself. Resolve it here instead and
@@ -3982,17 +3947,16 @@ where
     )
 }
 
-fn run_cook_with_boundaries_reported_with_stores<E, S>(
+fn run_cook_with_boundaries_reported_with_stores<S>(
     store: &CookRecipeStore,
     lifecycle_store: &AgentTaskLifecycleStore,
     options: AgentTaskCookServiceOptions,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     side_effects: S,
     durable_observer: Option<&CookProgressObserver<'_>>,
     allow_historical_terminal: bool,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     S: CookSideEffectService,
 {
     let failure_options = options.clone();
@@ -4151,15 +4115,14 @@ fn durable_cook_error_report_with_store(
     Err(error)
 }
 
-fn run_cook_with_boundaries_observed_inner<E, S>(
+fn run_cook_with_boundaries_observed_inner<S>(
     options: AgentTaskCookServiceOptions,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     side_effects: S,
     durable_observer: Option<&CookProgressObserver<'_>>,
     allow_historical_terminal: bool,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     S: CookSideEffectService,
 {
     // Env-resolving entry point. Both stores are resolved here, once, so the
@@ -4181,17 +4144,16 @@ where
 /// write on this path resolves through the two passed stores, so a caller can
 /// place a Cook's recipe and its lifecycle records wherever it owns them
 /// instead of wherever the process environment happens to point (#7505).
-fn run_cook_with_boundaries_observed_inner_with_stores<E, S>(
+fn run_cook_with_boundaries_observed_inner_with_stores<S>(
     store: &CookRecipeStore,
     lifecycle_store: &AgentTaskLifecycleStore,
     mut options: AgentTaskCookServiceOptions,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     mut side_effects: S,
     durable_observer: Option<&CookProgressObserver<'_>>,
     allow_historical_terminal: bool,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     S: CookSideEffectService,
 {
     // The local detached launcher persists this fence before spawn. Recheck it

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -28,6 +28,7 @@ use crate::agent_task_promotion::{
     AgentTaskPromotionReport,
 };
 use crate::agent_task_provider::ExtensionProviderAgentTaskExecutor;
+use crate::agent_task_scheduler::SharedAgentTaskExecutor;
 use homeboy_core::cook_status::CookDisposition;
 use homeboy_core::{Error, Result};
 
@@ -153,24 +154,21 @@ pub fn adopt_cook_candidate_with_options_and_dispatcher(
         candidate_ref,
         adoption,
         reconstruct_dispatcher,
-        ExtensionProviderAgentTaskExecutor::discover(),
+        Arc::new(ExtensionProviderAgentTaskExecutor::discover()),
     )
 }
 
 /// Adopt a candidate and retain the normal Cook execution boundary for any
 /// remediation requested by its deterministic feedback.
-pub fn adopt_cook_candidate_with_options_dispatcher_and_executor<E>(
+pub fn adopt_cook_candidate_with_options_dispatcher_and_executor(
     cook_or_run_id: &str,
     candidate_ref: &str,
     adoption: AgentTaskCandidateAdoptionOptions,
     reconstruct_dispatcher: impl FnOnce(
         &Value,
     ) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
-    executor: E,
-) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
-where
-    E: crate::agent_task_scheduler::AgentTaskExecutorAdapter + Clone,
-{
+    executor: SharedAgentTaskExecutor,
+) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
     adopt_cook_candidate_with_options_dispatcher_and_executor_for_attempt(
         cook_or_run_id,
         None,
@@ -182,7 +180,7 @@ where
 }
 
 /// Adopt a candidate against an explicit numbered Cook attempt.
-pub fn adopt_cook_candidate_with_options_dispatcher_and_executor_for_attempt<E>(
+pub fn adopt_cook_candidate_with_options_dispatcher_and_executor_for_attempt(
     cook_or_run_id: &str,
     attempt: Option<u32>,
     candidate_ref: &str,
@@ -190,11 +188,8 @@ pub fn adopt_cook_candidate_with_options_dispatcher_and_executor_for_attempt<E>(
     reconstruct_dispatcher: impl FnOnce(
         &Value,
     ) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
-    executor: E,
-) -> Result<AgentTaskRunResult<AgentTaskCookReport>>
-where
-    E: crate::agent_task_scheduler::AgentTaskExecutorAdapter + Clone,
-{
+    executor: SharedAgentTaskExecutor,
+) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
     adopt_cook_candidate_with_dispatcher_and_backend_for_attempt(
         cook_or_run_id,
         attempt,
@@ -207,7 +202,6 @@ where
 }
 
 pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend<
-    E: crate::agent_task_scheduler::AgentTaskExecutorAdapter + Clone,
     B: AgentTaskPrFinalizationBackend,
 >(
     cook_or_run_id: &str,
@@ -216,7 +210,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend<
     reconstruct_dispatcher: impl FnOnce(
         &Value,
     ) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     backend: &mut B,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
     adopt_cook_candidate_with_dispatcher_and_backend_for_attempt(
@@ -231,7 +225,6 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend<
 }
 
 pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
-    E: crate::agent_task_scheduler::AgentTaskExecutorAdapter + Clone,
     B: AgentTaskPrFinalizationBackend,
 >(
     cook_or_run_id: &str,
@@ -241,7 +234,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
     reconstruct_dispatcher: impl FnOnce(
         &Value,
     ) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     backend: &mut B,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
     let recipe_store = CookRecipeStore::from_current_data_root()?;
@@ -261,7 +254,6 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt<
 }
 
 pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_stores<
-    E: crate::agent_task_scheduler::AgentTaskExecutorAdapter + Clone,
     B: AgentTaskPrFinalizationBackend,
 >(
     recipe_store: &CookRecipeStore,
@@ -273,7 +265,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
     reconstruct_dispatcher: impl FnOnce(
         &Value,
     ) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     backend: &mut B,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
     super::cook::validate_cook_follow_up_stores(recipe_store, lifecycle_store)?;

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -36,7 +36,7 @@ use crate::agent_task_finalization::{
     RealAgentTaskPrFinalizationBackend,
 };
 use crate::agent_task_lifecycle::{AgentTaskLifecycleStore, AgentTaskRunState};
-use crate::agent_task_scheduler::AgentTaskState;
+use crate::agent_task_scheduler::{AgentTaskExecutorAdapter, AgentTaskState};
 use homeboy_core::run_lifecycle_record::{
     ProviderRuntimeLifecycle, ProviderRuntimeState, RunExecutionLifecycle, RunExecutionState,
     RunLifecycleRecord,
@@ -347,7 +347,7 @@ fn run_next_skips_persisted_test_detached_recipe_and_executes_eligible_work() {
         .expect("eligible work queued");
 
         let result = super::super::run_next_with_cook_dispatcher(
-            ImmediateSuccessExecutor,
+            Arc::new(ImmediateSuccessExecutor),
             |_| Ok(None),
             None,
         )
@@ -410,7 +410,7 @@ fn scoped_run_next_claims_its_fanout_cook_continuation_by_exact_identity() {
             .expect("owned fanout child");
 
         let result = super::super::run_next_with_cook_dispatcher(
-            ImmediateSuccessExecutor,
+            Arc::new(ImmediateSuccessExecutor),
             |_| Ok(None),
             Some(&scope),
         )
@@ -477,7 +477,7 @@ fn scoped_run_next_skips_bad_fanout_continuation_and_claims_queued_child() {
             .expect("owned children");
 
         let result = super::super::run_next_with_cook_dispatcher(
-            ImmediateSuccessExecutor,
+            Arc::new(ImmediateSuccessExecutor),
             |_| Ok(None),
             Some(&scope),
         )
@@ -541,7 +541,7 @@ fn run_next_redacts_poisoned_recipe_dispatcher_kind() {
         .expect("eligible work queued");
 
         let result = super::super::run_next_with_cook_dispatcher(
-            ImmediateSuccessExecutor,
+            Arc::new(ImmediateSuccessExecutor),
             |_| Ok(None),
             None,
         )
@@ -587,7 +587,7 @@ fn malformed_continuation_does_not_head_of_line_block_run_next() {
         .expect("eligible work queued");
 
         let result = super::super::run_next_with_cook_dispatcher(
-            ImmediateSuccessExecutor,
+            Arc::new(ImmediateSuccessExecutor),
             |_| Ok(None),
             None,
         )
@@ -1166,7 +1166,7 @@ fn cook_promotes_the_rotated_success_after_a_retained_timeout_with_aliases_colla
         let selected_artifact = Arc::new(Mutex::new(None));
         let result = run_cook_with_boundaries(
             resumed_options,
-            UnusedExecutor,
+            Arc::new(UnusedExecutor),
             CanonicalSelectionSideEffects {
                 promotions: Arc::clone(&promotions),
                 selected_artifact: Arc::clone(&selected_artifact),
@@ -1211,7 +1211,7 @@ fn cook_persists_selection_required_before_promotion_or_gates() {
         let promotions = Arc::new(AtomicUsize::new(0));
         let result = run_cook_with_boundaries(
             options.clone(),
-            UnusedExecutor,
+            Arc::new(UnusedExecutor),
             CanonicalSelectionSideEffects {
                 promotions: Arc::clone(&promotions),
                 selected_artifact: Arc::new(Mutex::new(None)),
@@ -1308,7 +1308,7 @@ fn cook_selection_required_metadata_uses_supplied_lifecycle_store() {
         &recipe_store,
         &supplied_store,
         options,
-        UnusedExecutor,
+        Arc::new(UnusedExecutor),
         SelectionRequiredSideEffects,
         None,
         false,
@@ -1771,7 +1771,7 @@ fn cook_spine_materializes_into_the_injected_stores_across_split_recipe_and_life
         &recipe_store,
         &lifecycle_store,
         options,
-        UnusedExecutor,
+        Arc::new(UnusedExecutor),
         DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({}))),
         None,
         false,
@@ -2340,15 +2340,16 @@ fn moving_base_continuation_finalizes_without_a_second_provider_dispatch() {
         })
         .unwrap();
 
-        let first = run_cook_with_finalizer(options.clone(), UnusedExecutor, |_, _, _| {
-            Err(Error::validation_invalid_argument(
-                "base",
-                "HEAD is behind or diverged from resolved base `main`",
-                None,
-                None,
-            ))
-        })
-        .unwrap();
+        let first =
+            run_cook_with_finalizer(options.clone(), Arc::new(UnusedExecutor), |_, _, _| {
+                Err(Error::validation_invalid_argument(
+                    "base",
+                    "HEAD is behind or diverged from resolved base `main`",
+                    None,
+                    None,
+                ))
+            })
+            .unwrap();
         assert_eq!(first.value.status, "candidate_recoverable");
         let claim = crate::agent_task_service::claim_continuation()
             .unwrap()
@@ -2359,7 +2360,7 @@ fn moving_base_continuation_finalizes_without_a_second_provider_dispatch() {
         let finalization_count_for_finalize = Arc::clone(&finalization_count);
         let second = run_cook_with_boundaries(
             options.clone(),
-            UnusedExecutor,
+            Arc::new(UnusedExecutor),
             TestCookSideEffects::new(
                 move |_: &_, _: &_, promotion: &AgentTaskPromotionReport| {
                     finalization_count_for_finalize.fetch_add(1, Ordering::SeqCst);
@@ -2412,7 +2413,7 @@ fn moving_base_continuation_finalizes_without_a_second_provider_dispatch() {
         .unwrap();
         let third = run_cook_with_boundaries(
             options,
-            UnusedExecutor,
+            Arc::new(UnusedExecutor),
             TestCookSideEffects::new(
                 |_: &_, _: &_, _: &_| panic!("failed rebased gates must not finalize"),
                 |_: &AgentTaskCookServiceOptions, recovery: &MovingBaseCookRecovery| {
@@ -2609,15 +2610,16 @@ fn moving_base_recovery_rebases_real_authenticated_candidate_and_refuses_diverge
             record.metadata["provider_executions_consumed"] = serde_json::json!(1);
         })
         .unwrap();
-        let first = run_cook_with_finalizer(options.clone(), UnusedExecutor, |_, _, _| {
-            Err(Error::validation_invalid_argument(
-                "base",
-                "HEAD is behind or diverged from resolved base `main`",
-                None,
-                None,
-            ))
-        })
-        .unwrap();
+        let first =
+            run_cook_with_finalizer(options.clone(), Arc::new(UnusedExecutor), |_, _, _| {
+                Err(Error::validation_invalid_argument(
+                    "base",
+                    "HEAD is behind or diverged from resolved base `main`",
+                    None,
+                    None,
+                ))
+            })
+            .unwrap();
         assert_eq!(first.value.status, "candidate_recoverable");
         assert!(moving_base_recovery_for_run(run_id).unwrap().is_some());
         let claim = crate::agent_task_service::claim_continuation()
@@ -2626,14 +2628,17 @@ fn moving_base_recovery_rebases_real_authenticated_candidate_and_refuses_diverge
         let finalization_calls = Arc::new(AtomicUsize::new(0));
         let finalization_calls_for_finalizer = Arc::clone(&finalization_calls);
         let expected_base = advanced_base.clone();
-        let second =
-            run_cook_with_finalizer(options.clone(), UnusedExecutor, move |_, _, recovered| {
+        let second = run_cook_with_finalizer(
+            options.clone(),
+            Arc::new(UnusedExecutor),
+            move |_, _, recovered| {
                 finalization_calls_for_finalizer.fetch_add(1, Ordering::SeqCst);
                 assert_eq!(recovered.status, AgentTaskPromotionStatus::Applied);
                 assert_eq!(recovered.verified_base.as_ref().unwrap().sha, expected_base);
                 Ok(serde_json::json!({"status": "review_ready"}))
-            })
-            .unwrap();
+            },
+        )
+        .unwrap();
         assert_eq!(second.value.status, "review_ready");
         claim.complete().unwrap();
         assert_eq!(finalization_calls.load(Ordering::SeqCst), 1);
@@ -2996,7 +3001,7 @@ impl AgentTaskCookAttemptDispatcher for ProviderDiscoveryReplayDispatcher {
             run_loaded_plan_with_derived_cook_baseline(
                 plan,
                 Some(run_id),
-                ProviderMissingExecutor,
+                Arc::new(ProviderMissingExecutor),
                 derived_cook_baseline,
                 None,
             )?
@@ -3004,7 +3009,7 @@ impl AgentTaskCookAttemptDispatcher for ProviderDiscoveryReplayDispatcher {
             run_loaded_plan_with_derived_cook_baseline(
                 plan,
                 Some(run_id),
-                ReviewFormOnlyExecutor,
+                Arc::new(ReviewFormOnlyExecutor),
                 derived_cook_baseline,
                 None,
             )?
@@ -3731,7 +3736,8 @@ fn dirty_explicit_cwd_blocks_detached_provider_dispatch() {
             serde_json::json!({ "kind": "explicit_cwd" });
         std::fs::write(target.join("untracked.txt"), "user drift\n").expect("write drift");
 
-        let result = run_cook(options, UnusedExecutor).expect("Cook reports admission failure");
+        let result =
+            run_cook(options, Arc::new(UnusedExecutor)).expect("Cook reports admission failure");
         assert_eq!(result.value.status, "pre_execution_failure");
         assert_eq!(dispatches.load(Ordering::SeqCst), 0);
     });
@@ -3829,7 +3835,7 @@ fn reconstructed_cook_rejects_a_removed_managed_workspace_before_provider_execut
         assert_eq!(error.details["field"], "to_worktree");
         assert!(error.message.contains("no longer active"));
 
-        let result = run_cook(reconstructed, UnusedExecutor)
+        let result = run_cook(reconstructed, Arc::new(UnusedExecutor))
             .expect("durable Cook failure report before provider execution");
         assert_eq!(result.exit_code, 1);
         assert_eq!(result.value.status, "durable_failure");
@@ -3858,7 +3864,7 @@ fn concurrent_first_cooks_elect_one_recipe_creator_without_replacing_its_plan() 
                 &store,
                 &lifecycle_store,
                 winner,
-                UnusedExecutor,
+                Arc::new(UnusedExecutor),
                 DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({}))),
                 None,
                 false,
@@ -3869,7 +3875,7 @@ fn concurrent_first_cooks_elect_one_recipe_creator_without_replacing_its_plan() 
                 &store,
                 &lifecycle_store,
                 loser,
-                UnusedExecutor,
+                Arc::new(UnusedExecutor),
                 DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({}))),
                 None,
                 false,
@@ -4237,10 +4243,10 @@ impl CandidateAdoptionFixture {
         self.authenticate_pre_provider_recovery();
     }
 
-    fn adopt<E: AgentTaskExecutorAdapter + Clone>(
+    fn adopt(
         &self,
         dispatcher: impl FnOnce(&Value) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
-        executor: E,
+        executor: SharedAgentTaskExecutor,
         backend: &mut CaptureBackend,
     ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
         self.adopt_run_with_inherited_failure_acceptance(
@@ -4252,11 +4258,11 @@ impl CandidateAdoptionFixture {
         )
     }
 
-    fn adopt_run<E: AgentTaskExecutorAdapter + Clone>(
+    fn adopt_run(
         &self,
         run_id: &str,
         dispatcher: impl FnOnce(&Value) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
-        executor: E,
+        executor: SharedAgentTaskExecutor,
         backend: &mut CaptureBackend,
     ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
         self.adopt_run_with_inherited_failure_acceptance(
@@ -4264,12 +4270,12 @@ impl CandidateAdoptionFixture {
         )
     }
 
-    fn adopt_run_with_inherited_failure_acceptance<E: AgentTaskExecutorAdapter + Clone>(
+    fn adopt_run_with_inherited_failure_acceptance(
         &self,
         run_id: &str,
         accept_inherited_failures: bool,
         dispatcher: impl FnOnce(&Value) -> Result<Option<Arc<dyn AgentTaskCookAttemptDispatcher>>>,
-        executor: E,
+        executor: SharedAgentTaskExecutor,
         backend: &mut CaptureBackend,
     ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
         adopt_cook_candidate_with_dispatcher_and_backend(
@@ -4305,7 +4311,7 @@ fn adoption_accepts_an_identical_immutable_baseline_failure_when_explicitly_auth
                 &fixture.run_id,
                 true,
                 |_| Ok(None),
-                UnusedExecutor,
+                Arc::new(UnusedExecutor),
                 &mut backend,
             )
             .expect("identical inherited failure is accepted");
@@ -4341,7 +4347,7 @@ fn adoption_accepts_an_identical_immutable_baseline_failure_when_explicitly_auth
         );
 
         let reused = fixture
-            .adopt(|_| Ok(None), UnusedExecutor, &mut backend)
+            .adopt(|_| Ok(None), Arc::new(UnusedExecutor), &mut backend)
             .expect("completed adoption returns its durable report");
         assert_eq!(reused.exit_code, 1, "{:#?}", reused.value);
         assert_eq!(reused.value.status, "baseline_red");
@@ -4366,7 +4372,7 @@ fn adoption_blocks_a_changed_failure_despite_inherited_failure_authorization() {
                 &fixture.run_id,
                 true,
                 |_| Ok(None),
-                UnusedExecutor,
+                Arc::new(UnusedExecutor),
                 &mut backend,
             )
             .expect("regression produces a blocking report");
@@ -4438,7 +4444,7 @@ fn adoption_blocks_inherited_failure_when_candidate_package_artifact_differs_fro
                 &fixture.run_id,
                 true,
                 |_| Ok(None),
-                UnusedExecutor,
+                Arc::new(UnusedExecutor),
                 &mut backend,
             )
             .expect("package drift produces a blocking report");
@@ -4537,13 +4543,16 @@ fn continuation_finalizes_applied_green_candidate_despite_recoverable_artifact_d
 
         let finalizations = Arc::new(AtomicUsize::new(0));
         let observed = Arc::clone(&finalizations);
-        let result =
-            run_cook_with_finalizer(options, UnusedExecutor, move |_, finalized_run, _| {
+        let result = run_cook_with_finalizer(
+            options,
+            Arc::new(UnusedExecutor),
+            move |_, finalized_run, _| {
                 observed.fetch_add(1, Ordering::SeqCst);
                 assert_eq!(finalized_run, run_id);
                 Ok(serde_json::json!({"status": "review_ready"}))
-            })
-            .expect("continue through finalization");
+            },
+        )
+        .expect("continue through finalization");
 
         assert_eq!(result.value.status, "review_ready");
         assert_eq!(finalizations.load(Ordering::SeqCst), 1);
@@ -4569,7 +4578,7 @@ fn cook_persists_controller_admission_timeout_before_provider_execution() {
                 initial_run_id: run_id.to_string(),
                 ..options
             },
-            UnusedExecutor,
+            Arc::new(UnusedExecutor),
         )
         .expect("cook returns the persisted dispatch failure");
 
@@ -4736,8 +4745,8 @@ fn review_12349_same_cook_retry_resumes_pending_provider_lookup_after_resolver_t
         });
         let exact_handle = options.to_worktree.clone();
 
-        let result =
-            run_cook(options.clone(), UnusedExecutor).expect("Cook records lookup failure");
+        let result = run_cook(options.clone(), Arc::new(UnusedExecutor))
+            .expect("Cook records lookup failure");
 
         assert_eq!(result.exit_code, 1);
         assert_eq!(result.value.cook_id, cook_id);
@@ -4820,7 +4829,7 @@ fn review_12349_same_cook_retry_resumes_pending_provider_lookup_after_resolver_t
         resumed_options.initial_run_id = retry.record.run_id.clone();
         resumed_options.initial_plan =
             agent_task_lifecycle::load_plan(&retry.record.run_id).expect("load durable retry plan");
-        let resumed = run_cook(resumed_options, UnusedExecutor)
+        let resumed = run_cook(resumed_options, Arc::new(UnusedExecutor))
             .expect("same Cook retry materializes its recovered provider workspace");
         assert_eq!(resumed.value.cook_id, cook_id);
         let resumed_plan =
@@ -5045,8 +5054,8 @@ fn deferred_ensure_only_provider_fails_after_durable_cook_admission() {
             },
         });
 
-        let result =
-            run_cook(options, UnusedExecutor).expect("Cook reports the postcondition failure");
+        let result = run_cook(options, Arc::new(UnusedExecutor))
+            .expect("Cook reports the postcondition failure");
 
         assert_eq!(result.exit_code, 1);
         assert_eq!(result.value.status, "pre_execution_failure");
@@ -5133,7 +5142,7 @@ fn deferred_ensure_only_failure_uses_injected_recipe_and_lifecycle_stores() {
             &recipe_store,
             &lifecycle_store,
             options,
-            UnusedExecutor,
+            Arc::new(UnusedExecutor),
             DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({}))),
             None,
             false,
@@ -5214,7 +5223,7 @@ fn review_12349_deferred_lookup_cancellation_preserves_cancelled_state() {
             "worktree_provider_id": "fixture",
         });
 
-        let cook = std::thread::spawn(move || run_cook(options, UnusedExecutor));
+        let cook = std::thread::spawn(move || run_cook(options, Arc::new(UnusedExecutor)));
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
         while !marker.exists() && std::time::Instant::now() < deadline {
             std::thread::sleep(std::time::Duration::from_millis(10));
@@ -5300,7 +5309,7 @@ fn split_identity_timeout_persists_legacy_lookup_pending_recipe_and_retry() {
                 .push((event.phase.to_string(), event.detail.map(str::to_string)));
             Ok(())
         };
-        let result = run_cook_with_durable_observer(options, UnusedExecutor, &observer)
+        let result = run_cook_with_durable_observer(options, Arc::new(UnusedExecutor), &observer)
             .expect("Cook records split lookup timeout");
         assert_eq!(result.value.status, "pre_execution_failure");
         let record = agent_task_lifecycle::status(run_id).expect("durable timeout record");
@@ -5764,7 +5773,8 @@ fn pending_repo_only_lookup_rejects_provider_workspace_from_another_repository()
             "provenance": "--repo:requested-repository",
         });
 
-        let result = run_cook(options, UnusedExecutor).expect("Cook records identity failure");
+        let result =
+            run_cook(options, Arc::new(UnusedExecutor)).expect("Cook records identity failure");
 
         assert_eq!(result.value.status, "pre_execution_failure");
         let record = agent_task_lifecycle::status(run_id).expect("durable identity failure");
@@ -5923,7 +5933,7 @@ fn retryable_pre_provider_retry_stays_attached_to_its_cook() {
         let retry_run_id = retry.record.run_id.clone();
         let completed = crate::agent_task_service::execution::run_submitted(
             retry_run_id.clone(),
-            ImmediateSuccessExecutor,
+            Arc::new(ImmediateSuccessExecutor),
         )
         .expect("corrected environment retry succeeds");
 
@@ -5962,7 +5972,7 @@ fn approved_empty_provider_failure_retry_stays_attached_and_becomes_continuation
 
         let failed = crate::agent_task_service::execution::run_submitted(
             options.initial_run_id.clone(),
-            ProviderMissingExecutor,
+            Arc::new(ProviderMissingExecutor),
         )
         .expect("record provider failure");
         assert_eq!(failed.exit_code, 1);
@@ -6407,7 +6417,7 @@ fn retryable_pre_provider_retry_returns_terminal_successor_without_reexecution()
             .expect("persist successor retry proof");
         crate::agent_task_service::execution::run_submitted(
             successor_run_id.clone(),
-            TerminalSuccessExecutor,
+            Arc::new(TerminalSuccessExecutor),
         )
         .expect("complete successor successfully");
 
@@ -6476,21 +6486,22 @@ fn cook_repairs_initial_alias_after_submit_before_index_interruption() {
 
         let observed = Arc::new(Mutex::new(Vec::new()));
         let observer_records = observed.clone();
-        let result = run_cook_with_durable_observer(options, UnusedExecutor, &move |event| {
-            let (phase, cook, run) = (event.phase, event.cook_id, event.run_id);
-            let status =
-                agent_task_lifecycle::status(cook).expect("Cook alias resolves in observer");
-            let logs =
-                agent_task_lifecycle::logs(cook).expect("Cook alias logs resolve in observer");
-            assert_eq!(status.run_id, run);
-            assert!(!logs.events.is_empty());
-            observer_records
-                .lock()
-                .expect("observer records lock")
-                .push((phase.to_string(), cook.to_string(), run.to_string()));
-            Ok(())
-        })
-        .expect("restart repairs the Cook alias");
+        let result =
+            run_cook_with_durable_observer(options, Arc::new(UnusedExecutor), &move |event| {
+                let (phase, cook, run) = (event.phase, event.cook_id, event.run_id);
+                let status =
+                    agent_task_lifecycle::status(cook).expect("Cook alias resolves in observer");
+                let logs =
+                    agent_task_lifecycle::logs(cook).expect("Cook alias logs resolve in observer");
+                assert_eq!(status.run_id, run);
+                assert!(!logs.events.is_empty());
+                observer_records
+                    .lock()
+                    .expect("observer records lock")
+                    .push((phase.to_string(), cook.to_string(), run.to_string()));
+                Ok(())
+            })
+            .expect("restart repairs the Cook alias");
 
         assert_eq!(result.value.latest_run_id.as_deref(), Some(run_id));
         assert_eq!(
@@ -6596,23 +6607,24 @@ fn cook_publishes_durable_identity_before_materialization_and_survives_interrupt
 
         let observed = Arc::new(Mutex::new(Vec::new()));
         let observer_records = observed.clone();
-        let result = run_cook_with_durable_observer(options, UnusedExecutor, &move |event| {
-            let (phase, cook, run) = (event.phase, event.cook_id, event.run_id);
-            observer_records
-                .lock()
-                .expect("observer records lock")
-                .push((phase.to_string(), run.to_string()));
-            // Every identity-bearing event must be immediately actionable:
-            // the caller can look the run up the moment it is told about it.
-            assert_eq!(
-                agent_task_lifecycle::status(cook)
-                    .expect("Cook alias resolves in observer")
-                    .run_id,
-                run
-            );
-            Ok(())
-        })
-        .expect("interrupted materialization returns a durable report");
+        let result =
+            run_cook_with_durable_observer(options, Arc::new(UnusedExecutor), &move |event| {
+                let (phase, cook, run) = (event.phase, event.cook_id, event.run_id);
+                observer_records
+                    .lock()
+                    .expect("observer records lock")
+                    .push((phase.to_string(), run.to_string()));
+                // Every identity-bearing event must be immediately actionable:
+                // the caller can look the run up the moment it is told about it.
+                assert_eq!(
+                    agent_task_lifecycle::status(cook)
+                        .expect("Cook alias resolves in observer")
+                        .run_id,
+                    run
+                );
+                Ok(())
+            })
+            .expect("interrupted materialization returns a durable report");
 
         // 1. Identity is published before any materialization work.
         assert_eq!(
@@ -6669,7 +6681,7 @@ fn provider_dispatch_observes_a_durable_provider_start_boundary() {
             }),
         );
 
-        let result = run_cook(options, UnusedExecutor).expect("dispatch Cook");
+        let result = run_cook(options, Arc::new(UnusedExecutor)).expect("dispatch Cook");
 
         assert_eq!(result.value.status, "in_flight");
         assert_eq!(
@@ -6783,7 +6795,7 @@ fn cook_continue_adopts_recipe_bound_retry_missing_run_and_index() {
 
         let result = run_cook_with_boundaries_observed_inner(
             options.clone(),
-            UnusedExecutor,
+            Arc::new(UnusedExecutor),
             DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({}))),
             None,
             false,
@@ -6791,7 +6803,7 @@ fn cook_continue_adopts_recipe_bound_retry_missing_run_and_index() {
         .expect("continuation repairs and dispatches recipe-bound retry");
         let repeated = run_cook_with_boundaries_observed_inner(
             options,
-            UnusedExecutor,
+            Arc::new(UnusedExecutor),
             DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({}))),
             None,
             false,
@@ -7175,7 +7187,7 @@ fn retry_after_admission_failure_restores_managed_workspace_after_baseline_clean
             "branch": "fix/cook-admission-retry",
         });
 
-        run_cook(options, UnusedExecutor).expect("persist admission failure");
+        run_cook(options, Arc::new(UnusedExecutor)).expect("persist admission failure");
         let failed_plan = agent_task_lifecycle::load_plan(run_id).expect("failed plan");
         let transient_root = std::path::PathBuf::from(
             failed_plan.tasks[0]
@@ -7206,9 +7218,11 @@ fn retry_after_admission_failure_restores_managed_workspace_after_baseline_clean
             Some(source.to_str().expect("UTF-8 source path"))
         );
 
-        let result =
-            crate::agent_task_service::execution::run_submitted(retry.run_id, SucceedingExecutor)
-                .expect("retry reaches a real Git workspace");
+        let result = crate::agent_task_service::execution::run_submitted(
+            retry.run_id,
+            Arc::new(SucceedingExecutor),
+        )
+        .expect("retry reaches a real Git workspace");
         assert_eq!(result.exit_code, 0, "{:#?}", result.value);
     });
 }
@@ -7266,7 +7280,7 @@ fn retry_reports_missing_candidate_source_as_retryable_recovery() {
             "branch": "fix/cook-missing-worktree",
         });
 
-        run_cook(options, UnusedExecutor).expect("persist admission failure");
+        run_cook(options, Arc::new(UnusedExecutor)).expect("persist admission failure");
         std::fs::remove_dir_all(&source).expect("remove managed worktree");
 
         let error = agent_task_lifecycle::retry(run_id, Some("cook-missing-worktree-retry"))
@@ -7295,7 +7309,7 @@ fn cook_transport_preparation_failure_is_durable_and_resumes_after_runner_recove
         options.initial_run_id = first_run_id.to_string();
         options.max_attempts = 2;
 
-        let failure = run_cook(options.clone(), UnusedExecutor)
+        let failure = run_cook(options.clone(), Arc::new(UnusedExecutor))
             .expect("transport preparation failure is durably reported");
         assert_eq!(failure.exit_code, 1);
         assert_eq!(failure.value.status, "durable_failure");
@@ -7311,7 +7325,7 @@ fn cook_transport_preparation_failure_is_durable_and_resumes_after_runner_recove
             Value::Bool(true)
         );
 
-        let resumed = run_cook(options, UnusedExecutor)
+        let resumed = run_cook(options, Arc::new(UnusedExecutor))
             .expect("repaired runner resumes the immutable cook attempt");
         assert_eq!(resumed.value.status, "in_flight");
         assert_eq!(
@@ -7335,8 +7349,8 @@ fn cook_persists_materialization_failure_without_provider_execution() {
         options.source_worktree_path = Some(temp.path().to_path_buf());
         options.max_attempts = 3;
 
-        let result =
-            run_cook(options, UnusedExecutor).expect("cook records materialization failure");
+        let result = run_cook(options, Arc::new(UnusedExecutor))
+            .expect("cook records materialization failure");
 
         assert_eq!(result.value.status, "pre_execution_failure");
         assert_eq!(result.value.attempts.len(), 1);
@@ -7371,7 +7385,7 @@ fn run_cook_persists_recipe_in_explicit_store_only() {
         options.initial_run_id = "cook-explicit-recipe-store-attempt-1".to_string();
         options.source_worktree_path = Some(source.path().to_path_buf());
 
-        let result = run_cook_with_store(&store, options, UnusedExecutor)
+        let result = run_cook_with_store(&store, options, Arc::new(UnusedExecutor))
             .expect("Cook reports the lifecycle materialization failure");
 
         assert_eq!(result.value.status, "durable_failure");
@@ -7479,7 +7493,7 @@ fn cook_claims_its_durable_attempt_before_slow_baseline_materialization() {
             "branch": "fix/cook-slow-baseline",
         });
         let resume_options = options.clone();
-        let controller = std::thread::spawn(move || run_cook(options, UnusedExecutor));
+        let controller = std::thread::spawn(move || run_cook(options, Arc::new(UnusedExecutor)));
         let entered_staging = (0..500).any(|_| {
             if entered.exists() {
                 true
@@ -7512,7 +7526,8 @@ fn cook_claims_its_durable_attempt_before_slow_baseline_materialization() {
         assert_eq!(result.value.status, "in_flight");
         assert_eq!(dispatches.load(Ordering::SeqCst), 1);
 
-        let resumed = run_cook(resume_options, UnusedExecutor).expect("resume accepted handoff");
+        let resumed =
+            run_cook(resume_options, Arc::new(UnusedExecutor)).expect("resume accepted handoff");
         assert_eq!(resumed.value.status, "in_flight");
         assert_eq!(dispatches.load(Ordering::SeqCst), 1);
     });
@@ -7532,7 +7547,7 @@ fn cook_transport_preparation_failure_does_not_exhaust_cook_retries() {
         options.initial_run_id = "cook-runner-exhaustion-attempt-1".to_string();
         options.max_attempts = 2;
 
-        let failure = run_cook(options, UnusedExecutor)
+        let failure = run_cook(options, Arc::new(UnusedExecutor))
             .expect("transport preparation failure is durably reported");
         assert_eq!(failure.exit_code, 1);
         assert_eq!(failure.value.status, "durable_failure");
@@ -7584,7 +7599,8 @@ fn cook_prepares_transport_before_pinning_runtime_generation() {
         options.provider_command = Some("fixture-provider".to_string());
         options.initial_run_id = "cook-pin-ordering-attempt-1".to_string();
 
-        let result = run_cook(options, UnusedExecutor).expect("cook accepts detached handoff");
+        let result =
+            run_cook(options, Arc::new(UnusedExecutor)).expect("cook accepts detached handoff");
 
         assert_eq!(result.value.status, "in_flight");
         assert!(
@@ -7612,7 +7628,7 @@ fn cook_persists_controller_runtime_mismatch_before_provider_execution() {
                 initial_run_id: run_id.to_string(),
                 ..options
             },
-            UnusedExecutor,
+            Arc::new(UnusedExecutor),
         )
         .expect("cook returns the persisted runtime mismatch");
 
@@ -7653,8 +7669,8 @@ fn cook_does_not_retry_deterministic_pre_provider_input_failures() {
         options.initial_run_id = run_id.to_string();
         options.max_attempts = 2;
 
-        let result =
-            run_cook(options, UnusedExecutor).expect("cook returns the persisted input failure");
+        let result = run_cook(options, Arc::new(UnusedExecutor))
+            .expect("cook returns the persisted input failure");
 
         assert_eq!(result.exit_code, 1);
         assert_eq!(result.value.status, "pre_execution_failure");
@@ -7775,7 +7791,8 @@ fn cook_retries_retryable_pre_provider_transport_failures_within_attempt_budget(
         options.initial_run_id = "cook-retryable-transport-attempt-1".to_string();
         options.max_attempts = 2;
 
-        let result = run_cook(options, UnusedExecutor).expect("cook records transport retries");
+        let result =
+            run_cook(options, Arc::new(UnusedExecutor)).expect("cook records transport retries");
 
         assert_eq!(result.exit_code, 1);
         assert_eq!(result.value.status, "pre_execution_failure");
@@ -7922,7 +7939,7 @@ fn a_daemon_owned_cook_batch_never_re_runs_a_durably_terminal_child_process() {
             cooks,
             max_concurrency: 2,
         },
-        UnusedExecutor,
+        Arc::new(UnusedExecutor),
         AgentTaskCookBatchControl::daemon_owned(),
     )
     .expect("batch completes");
@@ -7972,7 +7989,7 @@ fn an_unowned_cook_batch_still_runs_every_child_process() {
             cooks,
             max_concurrency: 2,
         },
-        UnusedExecutor,
+        Arc::new(UnusedExecutor),
     )
     .expect("batch completes");
 
@@ -8039,7 +8056,7 @@ fn cancelling_a_daemon_owned_cook_batch_stops_it_starting_further_children_proce
             cooks,
             max_concurrency: 2,
         },
-        UnusedExecutor,
+        Arc::new(UnusedExecutor),
         AgentTaskCookBatchControl::daemon_owned(),
     )
     .expect("a cancelled batch still returns a complete report");
@@ -8101,7 +8118,7 @@ fn a_daemon_owned_cook_batch_publishes_each_child_as_it_terminalizes_process() {
             cooks,
             max_concurrency: 1,
         },
-        UnusedExecutor,
+        Arc::new(UnusedExecutor),
         AgentTaskCookBatchControl::daemon_owned(),
     )
     .expect("batch completes");
@@ -8151,7 +8168,7 @@ fn cook_batch_children_inherit_the_callers_notification_route_process() {
                 cooks,
                 max_concurrency: 2,
             },
-            UnusedExecutor,
+            Arc::new(UnusedExecutor),
         )
         .expect("batch completes")
     });
@@ -8198,7 +8215,7 @@ fn cook_batch_preserves_order_concurrency_and_failure_isolation_process() {
             cooks: vec![first, second],
             max_concurrency: 2,
         },
-        UnusedExecutor,
+        Arc::new(UnusedExecutor),
     )
     .expect("batch completes despite an individual cook failure");
 
@@ -8385,7 +8402,7 @@ fn cook_returns_after_accepted_detached_attempt_without_waiting_for_daemon_compl
                 attempt_dispatcher: Some(Arc::new(AcceptedDetachedAttemptDispatcher)),
                 harvest_context: Default::default(),
             },
-            UnusedExecutor,
+            Arc::new(UnusedExecutor),
         )
         .expect("accepted detached cook returns");
 
@@ -8423,13 +8440,15 @@ fn orphaned_recipe_materializes_once_and_replays_from_durable_inputs() {
         super::super::persist_initial_recipe(&options).expect("persist orphaned recipe");
         assert!(!agent_task_lifecycle::run_record_exists(run_id).expect("check orphan"));
 
-        let recovered = run_cook(options.clone(), UnusedExecutor).expect("recover orphan");
+        let recovered =
+            run_cook(options.clone(), Arc::new(UnusedExecutor)).expect("recover orphan");
         assert_eq!(recovered.value.status, "in_flight");
         assert_eq!(dispatches.load(Ordering::SeqCst), 1);
         let record = agent_task_lifecycle::status(run_id).expect("materialized run record");
         assert_eq!(record.runner_job_id(), Some("recording-daemon-job"));
 
-        let replayed = run_cook(options.clone(), UnusedExecutor).expect("idempotent replay");
+        let replayed =
+            run_cook(options.clone(), Arc::new(UnusedExecutor)).expect("idempotent replay");
         assert_eq!(replayed.value.status, "in_flight");
         assert_eq!(dispatches.load(Ordering::SeqCst), 1);
         let replayed_record = agent_task_lifecycle::status(run_id).unwrap();
@@ -8440,8 +8459,8 @@ fn orphaned_recipe_materializes_once_and_replays_from_durable_inputs() {
 
         let mut changed = options;
         changed.title = "changed immutable finalization title".to_string();
-        let replayed =
-            run_cook(changed, UnusedExecutor).expect("durable recipe remains authoritative");
+        let replayed = run_cook(changed, Arc::new(UnusedExecutor))
+            .expect("durable recipe remains authoritative");
         assert_eq!(replayed.value.status, "in_flight");
         assert_eq!(dispatches.load(Ordering::SeqCst), 1);
     });
@@ -8670,7 +8689,7 @@ fn historical_orphan_recipe_adoption_uses_recorded_policy_without_provider_repla
                     accept_inherited_failures: false,
                 },
                 |_| Ok(None),
-                ReviewFormOnlyExecutor,
+                Arc::new(ReviewFormOnlyExecutor),
                 &mut backend,
             );
             (result, backend)
@@ -8894,7 +8913,7 @@ fn adoption_green_candidate_missing_review_form_runs_form_only_follow_up_and_fin
                 accept_inherited_failures: false,
             },
             |_| Ok(None),
-            ReviewFormOnlyExecutor,
+            Arc::new(ReviewFormOnlyExecutor),
             &mut backend,
         )
         .expect("adoption retries only the missing review form");
@@ -9046,7 +9065,7 @@ fn pre_provider_adoption_retries_only_the_missing_form_binds_model_and_reaches_r
         };
 
         let result = fixture
-            .adopt(|_| Ok(None), ReviewFormOnlyExecutor, &mut backend)
+            .adopt(|_| Ok(None), Arc::new(ReviewFormOnlyExecutor), &mut backend)
             .expect("authenticated pre-provider adoption succeeds");
 
         let follow_up_aggregate = result
@@ -9111,7 +9130,7 @@ fn adoption_review_child_plan_remains_one_bounded_execution() {
         };
 
         let result = fixture
-            .adopt(|_| Ok(None), ReviewFormOnlyExecutor, &mut backend)
+            .adopt(|_| Ok(None), Arc::new(ReviewFormOnlyExecutor), &mut backend)
             .expect("adoption review has a separate bounded execution allowance");
 
         assert_eq!(result.value.status, "review_ready");
@@ -9167,7 +9186,7 @@ fn legacy_adoption_budget_failure_reenters_once_through_review_authority() {
         let mut backend = CaptureBackend::default();
 
         let result = fixture
-            .adopt(|_| Ok(None), ReviewFormOnlyExecutor, &mut backend)
+            .adopt(|_| Ok(None), Arc::new(ReviewFormOnlyExecutor), &mut backend)
             .expect("legacy budget failure re-enters through repaired review authority");
 
         assert_eq!(
@@ -9200,12 +9219,12 @@ fn adoption_review_allowance_is_terminal_and_replay_does_not_dispatch() {
         let mut backend = CaptureBackend::default();
 
         let first = fixture
-            .adopt(|_| Ok(None), ReviewFormOnlyExecutor, &mut backend)
+            .adopt(|_| Ok(None), Arc::new(ReviewFormOnlyExecutor), &mut backend)
             .expect("adoption review consumes its bounded allowance");
         let replay = fixture
             .adopt(
                 |_| panic!("terminal adoption must not reconstruct a dispatcher"),
-                UnusedExecutor,
+                Arc::new(UnusedExecutor),
                 &mut backend,
             )
             .expect("identical adoption replays its terminal result");
@@ -9235,7 +9254,7 @@ fn adoption_of_attempt_n_appends_n_plus_one_and_resumes_that_attempt() {
         let mut backend = CaptureBackend::default();
 
         let result = fixture
-            .adopt(|_| Ok(None), ReviewFormOnlyExecutor, &mut backend)
+            .adopt(|_| Ok(None), Arc::new(ReviewFormOnlyExecutor), &mut backend)
             .expect("attempt N adoption resumes through its form-only retry");
 
         assert_eq!(
@@ -9267,7 +9286,7 @@ fn adoption_of_historical_attempt_appends_after_the_latest_recipe_attempt() {
             .adopt_run(
                 &historical_run_id,
                 |_| Ok(None),
-                ReviewFormOnlyExecutor,
+                Arc::new(ReviewFormOnlyExecutor),
                 &mut backend,
             )
             .expect("historical attempt adoption allocates after the durable recipe tail");
@@ -9304,7 +9323,7 @@ fn adoption_replays_provider_discovery_failure_in_the_same_recipe_attempt() {
         fixture
             .adopt(
                 |_| Ok(Some(dispatcher.clone())),
-                UnusedExecutor,
+                Arc::new(UnusedExecutor),
                 &mut backend,
             )
             .expect_err("runner provider discovery failure interrupts adoption");
@@ -9354,7 +9373,7 @@ fn adoption_replays_provider_discovery_failure_in_the_same_recipe_attempt() {
         let result = fixture
             .adopt(
                 |_| Ok(Some(dispatcher.clone())),
-                UnusedExecutor,
+                Arc::new(UnusedExecutor),
                 &mut backend,
             )
             .expect("provider discovery repair replays the durable attempt");
@@ -9408,7 +9427,7 @@ fn repeated_provider_discovery_failures_exhaust_the_adoption_review_allowance() 
             fixture
                 .adopt(
                     |_| Ok(Some(dispatcher.clone())),
-                    UnusedExecutor,
+                    Arc::new(UnusedExecutor),
                     &mut backend,
                 )
                 .expect_err("provider discovery failure interrupts adoption");
@@ -9430,7 +9449,7 @@ fn repeated_provider_discovery_failures_exhaust_the_adoption_review_allowance() 
         let exhausted = fixture
             .adopt(
                 |_| Ok(Some(dispatcher.clone())),
-                UnusedExecutor,
+                Arc::new(UnusedExecutor),
                 &mut backend,
             )
             .expect("budget exhaustion is a durable Cook result");
@@ -9475,7 +9494,7 @@ fn detached_adoption_follow_up_records_before_dispatch_then_finalizes_once_witho
         let first = fixture
             .adopt(
                 |_| Ok(Some(dispatcher.clone())),
-                UnusedExecutor,
+                Arc::new(UnusedExecutor),
                 &mut backend,
             )
             .expect("detached form retry is accepted");
@@ -9509,9 +9528,18 @@ fn detached_adoption_follow_up_records_before_dispatch_then_finalizes_once_witho
             claim,
             |_| Ok(Some(dispatcher.clone())),
             |options| {
-                run_cook_with_finalizer(options, UnusedExecutor, |options, run_id, promotion| {
-                    finalize_cook_pr_with_backend(options, run_id, promotion, &mut resumed_backend)
-                })
+                run_cook_with_finalizer(
+                    options,
+                    Arc::new(UnusedExecutor),
+                    |options, run_id, promotion| {
+                        finalize_cook_pr_with_backend(
+                            options,
+                            run_id,
+                            promotion,
+                            &mut resumed_backend,
+                        )
+                    },
+                )
                 .map(|result| result.exit_code)
             },
         )
@@ -9550,7 +9578,7 @@ fn detached_adoption_follow_up_failure_stays_non_green_and_skips_finalization() 
         let first = fixture
             .adopt(
                 |_| Ok(Some(dispatcher.clone())),
-                UnusedExecutor,
+                Arc::new(UnusedExecutor),
                 &mut backend,
             )
             .expect("detached form retry is accepted");
@@ -11344,9 +11372,9 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
         );
         historical.attempt_dispatcher = None;
         let executions = Arc::new(AtomicUsize::new(0));
-        let executor = RecordingReviewFormExecutor {
+        let executor = Arc::new(RecordingReviewFormExecutor {
             executions: Arc::clone(&executions),
-        };
+        });
 
         std::fs::write(target.join("tracked.txt"), "drifted\n").unwrap();
         assert!(
@@ -11608,7 +11636,7 @@ fn closed_observer_pipe_does_not_stop_explicitly_accepted_inherited_gate_finaliz
         };
         let result = run_cook_with_boundaries_observed(
             options,
-            UnusedExecutor,
+            Arc::new(UnusedExecutor),
             DefaultCookSideEffects::new(move |_, _, received_run, promotion| {
                 finalization_count.fetch_add(1, Ordering::SeqCst);
                 assert_eq!(received_run, expected_run_id);
@@ -13916,8 +13944,12 @@ fn resume_cook_batch_harvests_terminal_children_without_redispatching_the_provid
         // UnusedExecutor asserts the provider is never dispatched again: a
         // terminal child is harvested straight through gates and finalization.
         // The dispatcher is reconstructed only to satisfy the recipe contract.
-        let result = resume_cook_batch("batch-9525", UnusedExecutor, test_reconstruct_dispatcher)
-            .expect("resume harvests terminal children");
+        let result = resume_cook_batch(
+            "batch-9525",
+            Arc::new(UnusedExecutor),
+            test_reconstruct_dispatcher,
+        )
+        .expect("resume harvests terminal children");
 
         assert_eq!(
             result.exit_code, 0,
@@ -13949,8 +13981,12 @@ fn resume_cook_batch_harvests_terminal_children_without_redispatching_the_provid
 
         // Resume is idempotent: a second call still succeeds and does not
         // redispatch or duplicate a PR (finalization is loaded, not recreated).
-        let second = resume_cook_batch("batch-9525", UnusedExecutor, test_reconstruct_dispatcher)
-            .expect("second resume is idempotent");
+        let second = resume_cook_batch(
+            "batch-9525",
+            Arc::new(UnusedExecutor),
+            test_reconstruct_dispatcher,
+        )
+        .expect("second resume is idempotent");
         assert_eq!(second.exit_code, 0);
         assert_eq!(second.value.succeeded, 3);
     });
@@ -14105,7 +14141,7 @@ fn fanout_resume_prefers_immutable_verification_checkpoint_over_later_failed_att
         };
         let first = resume_cook_batch_with_finalizer(
             "batch-9703",
-            UnusedExecutor,
+            Arc::new(UnusedExecutor),
             |_| {
                 Ok(Some(Arc::new(RecordingDetachedAttemptDispatcher {
                     dispatches: Arc::clone(&dispatches),
@@ -14150,7 +14186,7 @@ fn fanout_resume_prefers_immutable_verification_checkpoint_over_later_failed_att
         backend.created = false;
         let second = resume_cook_batch_with_finalizer(
             "batch-9703",
-            UnusedExecutor,
+            Arc::new(UnusedExecutor),
             |_| {
                 Ok(Some(Arc::new(RecordingDetachedAttemptDispatcher {
                     dispatches: Arc::clone(&dispatches),
@@ -14192,7 +14228,7 @@ fn resume_cook_batch_reports_a_child_with_no_recipe_as_unresumable() {
 
         let result = resume_cook_batch(
             "batch-9525-missing",
-            UnusedExecutor,
+            Arc::new(UnusedExecutor),
             test_reconstruct_dispatcher,
         )
         .expect("resume returns a report even when a child cannot resume");

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -18,7 +18,7 @@ use crate::agent_task_provider::{
     apply_provider_runner_secret_env_contracts, provider_secret_sources_for_plan,
 };
 use crate::agent_task_scheduler::{
-    AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskPlan, AgentTaskScheduler,
+    AgentTaskAggregate, AgentTaskPlan, AgentTaskScheduler, SharedAgentTaskExecutor,
 };
 use crate::agent_task_secrets::validate_secret_env_with_fallbacks;
 use homeboy_core::secret_env_plan::SecretEnvPlan;
@@ -69,27 +69,21 @@ pub fn read_plan(spec: &str) -> Result<AgentTaskPlan> {
     Ok(plan)
 }
 
-pub fn run_loaded_plan<E>(
+pub fn run_loaded_plan(
     plan: AgentTaskPlan,
     record_run_id: Option<&str>,
-    executor: E,
-) -> Result<AgentTaskRunResult<AgentTaskAggregate>>
-where
-    E: AgentTaskExecutorAdapter,
-{
+    executor: SharedAgentTaskExecutor,
+) -> Result<AgentTaskRunResult<AgentTaskAggregate>> {
     run_loaded_plan_with_derived_cook_baseline(plan, record_run_id, executor, None, None)
 }
 
-pub(crate) fn run_loaded_plan_with_derived_cook_baseline<E>(
+pub(crate) fn run_loaded_plan_with_derived_cook_baseline(
     plan: AgentTaskPlan,
     record_run_id: Option<&str>,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
     supplied_harvest_context: Option<crate::agent_task_scheduler::HarvestExecutionContext>,
-) -> Result<AgentTaskRunResult<AgentTaskAggregate>>
-where
-    E: AgentTaskExecutorAdapter,
-{
+) -> Result<AgentTaskRunResult<AgentTaskAggregate>> {
     run_loaded_plan_with_derived_cook_baseline_in_optional_store(
         None,
         plan,
@@ -100,17 +94,14 @@ where
     )
 }
 
-pub(crate) fn run_loaded_plan_with_derived_cook_baseline_in_store<E>(
+pub(crate) fn run_loaded_plan_with_derived_cook_baseline_in_store(
     lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     plan: AgentTaskPlan,
     record_run_id: Option<&str>,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
     supplied_harvest_context: Option<crate::agent_task_scheduler::HarvestExecutionContext>,
-) -> Result<AgentTaskRunResult<AgentTaskAggregate>>
-where
-    E: AgentTaskExecutorAdapter,
-{
+) -> Result<AgentTaskRunResult<AgentTaskAggregate>> {
     run_loaded_plan_with_derived_cook_baseline_in_optional_store(
         Some(lifecycle_store),
         plan,
@@ -121,17 +112,14 @@ where
     )
 }
 
-fn run_loaded_plan_with_derived_cook_baseline_in_optional_store<E>(
+fn run_loaded_plan_with_derived_cook_baseline_in_optional_store(
     lifecycle_store: Option<&agent_task_lifecycle::AgentTaskLifecycleStore>,
     mut plan: AgentTaskPlan,
     record_run_id: Option<&str>,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
     supplied_harvest_context: Option<crate::agent_task_scheduler::HarvestExecutionContext>,
-) -> Result<AgentTaskRunResult<AgentTaskAggregate>>
-where
-    E: AgentTaskExecutorAdapter,
-{
+) -> Result<AgentTaskRunResult<AgentTaskAggregate>> {
     if let Some(run_id) = record_run_id {
         // Prepare before persistence so the lifecycle record and scheduler use
         // the same materialized workspace contract. In particular, Cook's
@@ -278,24 +266,18 @@ pub fn submit_plan_spec(spec: &str, run_id: Option<&str>) -> Result<AgentTaskRun
     agent_task_lifecycle::submit_plan(&plan, run_id)
 }
 
-pub fn run_submitted<E>(
+pub fn run_submitted(
     run_id: String,
-    executor: E,
-) -> Result<AgentTaskRunResult<AgentTaskAggregate>>
-where
-    E: AgentTaskExecutorAdapter,
-{
+    executor: SharedAgentTaskExecutor,
+) -> Result<AgentTaskRunResult<AgentTaskAggregate>> {
     run_submitted_with_timeout(run_id, None, executor)
 }
 
-pub fn run_submitted_with_timeout<E>(
+pub fn run_submitted_with_timeout(
     run_id: String,
     timeout_ms: Option<u64>,
-    executor: E,
-) -> Result<AgentTaskRunResult<AgentTaskAggregate>>
-where
-    E: AgentTaskExecutorAdapter,
-{
+    executor: SharedAgentTaskExecutor,
+) -> Result<AgentTaskRunResult<AgentTaskAggregate>> {
     if let Some(result) = terminal_run_result(&run_id)? {
         return Ok(result);
     }
@@ -359,25 +341,19 @@ pub struct AgentTaskQueueAdmission {
     pub limit_reached: bool,
 }
 
-pub fn run_next<E>(executor: E) -> Result<AgentTaskRunNextResult>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+pub fn run_next(executor: SharedAgentTaskExecutor) -> Result<AgentTaskRunNextResult> {
     run_next_with_cook_dispatcher(executor, |_| Ok(None), None)
 }
 
-pub fn run_next_with_cook_dispatcher<E>(
-    executor: E,
+pub fn run_next_with_cook_dispatcher(
+    executor: SharedAgentTaskExecutor,
     dispatcher: impl Fn(
         &Value,
     ) -> Result<
         Option<std::sync::Arc<dyn super::cook::AgentTaskCookAttemptDispatcher>>,
     >,
     scoped_run_ids: Option<&HashSet<String>>,
-) -> Result<AgentTaskRunNextResult>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+) -> Result<AgentTaskRunNextResult> {
     run_next_with_cook_dispatcher_and_queue_preflight(
         executor,
         dispatcher,
@@ -389,8 +365,8 @@ where
     )
 }
 
-pub(crate) fn run_next_with_cook_dispatcher_and_queue_preflight<E>(
-    executor: E,
+pub(crate) fn run_next_with_cook_dispatcher_and_queue_preflight(
+    executor: SharedAgentTaskExecutor,
     dispatcher: impl Fn(
         &Value,
     ) -> Result<
@@ -398,10 +374,7 @@ pub(crate) fn run_next_with_cook_dispatcher_and_queue_preflight<E>(
     >,
     scoped_run_ids: Option<&HashSet<String>>,
     queue_preflight: impl Fn(&AgentTaskRunRecord, &AgentTaskPlan) -> Result<()>,
-) -> Result<AgentTaskRunNextResult>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+) -> Result<AgentTaskRunNextResult> {
     let mut skipped = Vec::new();
     let mut inspected = 0;
     if let Some(scoped_run_ids) = scoped_run_ids {
@@ -520,19 +493,16 @@ fn validate_queued_cook_identity(record: &AgentTaskRunRecord) -> Result<()> {
     super::validate_recipe_attempt_record(&recipe, &record.run_id, record)
 }
 
-fn consume_claimed_continuation<E>(
+fn consume_claimed_continuation(
     claim: super::ClaimedCookContinuation,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     dispatcher: &impl Fn(
         &Value,
     ) -> Result<
         Option<std::sync::Arc<dyn super::cook::AgentTaskCookAttemptDispatcher>>,
     >,
     mut skipped: Vec<AgentTaskRunNextSkip>,
-) -> Result<AgentTaskRunNextResult>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+) -> Result<AgentTaskRunNextResult> {
     let store = super::CookRecipeStore::from_current_data_root()?;
     let cook_id = claim.continuation().cook_id.clone();
     let run_id = claim.continuation().run_id.clone();
@@ -646,10 +616,10 @@ fn continuation_skip(
     }
 }
 
-pub fn resume<E>(run_id: String, executor: E) -> Result<AgentTaskRunResult<AgentTaskAggregate>>
-where
-    E: AgentTaskExecutorAdapter,
-{
+pub fn resume(
+    run_id: String,
+    executor: SharedAgentTaskExecutor,
+) -> Result<AgentTaskRunResult<AgentTaskAggregate>> {
     if let Some(result) = terminal_run_result(&run_id)? {
         return Ok(result);
     }
@@ -1198,10 +1168,10 @@ pub fn normalize_plan_workspaces(plan: &mut AgentTaskPlan) -> Result<()> {
     Ok(())
 }
 
-fn run_claimed<E>(run_id: String, executor: E) -> Result<AgentTaskRunResult<AgentTaskAggregate>>
-where
-    E: AgentTaskExecutorAdapter,
-{
+fn run_claimed(
+    run_id: String,
+    executor: SharedAgentTaskExecutor,
+) -> Result<AgentTaskRunResult<AgentTaskAggregate>> {
     let mut plan = agent_task_lifecycle::load_plan_for_execution(&run_id)?;
     if let Err(error) = prepare_plan_for_execution(&mut plan, Some(&run_id)) {
         agent_task_lifecycle::record_pre_execution_failure(
@@ -1228,15 +1198,12 @@ where
     run_prepared_claimed(run_id, plan, executor, harvest_context)
 }
 
-fn run_prepared_claimed<E>(
+fn run_prepared_claimed(
     run_id: String,
     plan: AgentTaskPlan,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     harvest_context: crate::agent_task_scheduler::HarvestExecutionContext,
-) -> Result<AgentTaskRunResult<AgentTaskAggregate>>
-where
-    E: AgentTaskExecutorAdapter,
-{
+) -> Result<AgentTaskRunResult<AgentTaskAggregate>> {
     let aggregate = run_plan_with_scheduler(
         None,
         plan.clone(),
@@ -1322,17 +1289,14 @@ fn preflight_queued_plan_provider_eligibility(plan: &AgentTaskPlan) -> Result<()
     )
 }
 
-fn run_plan_with_scheduler<E>(
+fn run_plan_with_scheduler(
     lifecycle_store: Option<&agent_task_lifecycle::AgentTaskLifecycleStore>,
     plan: AgentTaskPlan,
     run_id: Option<&str>,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
     harvest_context: crate::agent_task_scheduler::HarvestExecutionContext,
-) -> Result<AgentTaskAggregate>
-where
-    E: AgentTaskExecutorAdapter,
-{
+) -> Result<AgentTaskAggregate> {
     let scheduler =
         AgentTaskScheduler::new_controller(executor).with_harvest_context(harvest_context);
     let scheduler = match lifecycle_store {
@@ -1510,6 +1474,7 @@ mod tests {
     use std::collections::HashMap;
     use std::path::Path;
     use std::process::Command;
+    use std::sync::Arc;
 
     use super::*;
     use crate::agent_task::{
@@ -1518,8 +1483,8 @@ mod tests {
         AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
     };
     use crate::agent_task_scheduler::{
-        AgentTaskExecutionContext, AgentTaskManagedService, AgentTaskManagedServiceLifecycle,
-        AgentTaskPlan, HarvestExecutionContext,
+        AgentTaskExecutionContext, AgentTaskExecutorAdapter, AgentTaskManagedService,
+        AgentTaskManagedServiceLifecycle, AgentTaskPlan, HarvestExecutionContext,
     };
 
     #[derive(Clone)]
@@ -1686,7 +1651,7 @@ mod tests {
                 store,
                 one_task_plan(plan_id, workspace),
                 Some(run_id),
-                SuccessfulExecutor,
+                Arc::new(SuccessfulExecutor),
                 None,
                 Some(HarvestExecutionContext::default()),
             )

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -38,9 +38,9 @@ fn cook_usage_reads_scheduler_rotation_metadata_and_decrements_budget() {
         }],
         ..Default::default()
     });
-    let aggregate = AgentTaskScheduler::new(RotationThenSuccess {
+    let aggregate = AgentTaskScheduler::new(Arc::new(RotationThenSuccess {
         calls: Arc::clone(&calls),
-    })
+    }))
     .run(plan);
 
     let usage = execution_budget_usage(&aggregate);
@@ -344,8 +344,12 @@ fn cook_retry_intent_rejects_explicitly_disabled_gate_remediation() {
 #[test]
 fn service_run_loaded_plan_persists_durable_lifecycle() {
     with_isolated_home(|_| {
-        let result = run_loaded_plan(test_plan(), Some("service-run"), SucceedingExecutor)
-            .expect("service run completed");
+        let result = run_loaded_plan(
+            test_plan(),
+            Some("service-run"),
+            Arc::new(SucceedingExecutor),
+        )
+        .expect("service run completed");
         let record = lifecycle_status("service-run").expect("status persisted");
 
         assert_eq!(result.exit_code, 0);
@@ -384,9 +388,9 @@ fn provider_execution_reservation_is_exactly_once_and_terminal() {
             agent_task_lifecycle::ProviderExecutionReservation::AlreadyReserved
         );
         let calls = Arc::new(AtomicUsize::new(0));
-        AgentTaskScheduler::new(CountingExecutor {
+        AgentTaskScheduler::new(Arc::new(CountingExecutor {
             calls: Arc::clone(&calls),
-        })
+        }))
         .with_run_id("provider-reservation")
         .run(plan.clone());
         assert_eq!(
@@ -453,10 +457,10 @@ fn local_provider_execution_observes_its_durable_running_boundary() {
         run_loaded_plan(
             test_plan(),
             Some("local-provider-boundary"),
-            LocalBoundaryExecutor {
+            Arc::new(LocalBoundaryExecutor {
                 run_id: "local-provider-boundary".to_string(),
                 observed: Arc::clone(&observed),
-            },
+            }),
         )
         .expect("local provider run completes");
 
@@ -482,7 +486,7 @@ fn concurrent_schedulers_dispatch_one_reserved_provider_execution() {
             let barrier = Arc::clone(&barrier);
             threads.push(std::thread::spawn(move || {
                 barrier.wait();
-                AgentTaskScheduler::new(CountingExecutor { calls })
+                AgentTaskScheduler::new(Arc::new(CountingExecutor { calls }))
                     .with_run_id("concurrent-provider-reservation")
                     .run(plan)
             }));
@@ -532,7 +536,7 @@ fn lab_handoff_run_plan_executes_with_runner_provenance_after_transport_is_consu
         let result = run_loaded_plan(
             test_plan(),
             Some("lab-handoff-run-plan"),
-            SucceedingExecutor,
+            Arc::new(SucceedingExecutor),
         )
         .expect("runner-local provider execution starts without a nested daemon connection");
         assert_eq!(
@@ -574,7 +578,7 @@ fn lab_runner_handoff_materializes_the_run_before_preparation_failure() {
         let error = run_loaded_plan(
             plan,
             Some("controller-proxy-interrupted-lab-runner-handoff"),
-            SucceedingExecutor,
+            Arc::new(SucceedingExecutor),
         )
         .expect_err("runner preparation fails after receiving the durable plan");
         let record = lifecycle_status("controller-proxy-interrupted-lab-runner-handoff")
@@ -583,7 +587,7 @@ fn lab_runner_handoff_materializes_the_run_before_preparation_failure() {
             .expect("runner-scoped logs resolve from its materialized record");
         let recovery = run_submitted(
             "controller-proxy-interrupted-lab-runner-handoff".to_string(),
-            SucceedingExecutor,
+            Arc::new(SucceedingExecutor),
         )
         .expect("runner-scoped run resolves the materialized terminal record");
 
@@ -613,7 +617,7 @@ fn runner_exec_materializes_the_run_before_incomplete_harvest_transport_failure(
         let error = run_loaded_plan(
             test_plan(),
             Some("runner-exec-incomplete-harvest-transport"),
-            SucceedingExecutor,
+            Arc::new(SucceedingExecutor),
         )
         .expect_err("runner exec source metadata requires paired Lab transport");
 
@@ -643,19 +647,19 @@ fn submitted_terminal_runs_reuse_durable_evidence_without_reexecution() {
     with_isolated_home(|_| {
         for (run_id, expected_exit_code) in [("terminal-succeeded", 0), ("terminal-failed", 1)] {
             if run_id == "terminal-succeeded" {
-                run_loaded_plan(test_plan(), Some(run_id), SucceedingExecutor)
+                run_loaded_plan(test_plan(), Some(run_id), Arc::new(SucceedingExecutor))
                     .expect("succeeded run completed");
             } else {
-                run_loaded_plan(test_plan(), Some(run_id), TimeoutExecutor)
+                run_loaded_plan(test_plan(), Some(run_id), Arc::new(TimeoutExecutor))
                     .expect("failed run completed");
             }
 
             let observed_request = Arc::new(Mutex::new(None));
             let result = run_submitted(
                 run_id.to_string(),
-                CapturingExecutor {
+                Arc::new(CapturingExecutor {
                     observed_request: Arc::clone(&observed_request),
-                },
+                }),
             )
             .expect("terminal run returns its durable aggregate");
 
@@ -676,9 +680,9 @@ fn cancelled_terminal_run_is_not_reexecuted_without_durable_aggregate() {
         let observed_request = Arc::new(Mutex::new(None));
         let error = run_submitted(
             "terminal-cancelled".to_string(),
-            CapturingExecutor {
+            Arc::new(CapturingExecutor {
                 observed_request: Arc::clone(&observed_request),
-            },
+            }),
         )
         .expect_err("cancelled run has no aggregate to reuse");
 
@@ -697,9 +701,9 @@ fn submitted_incomplete_run_still_executes_for_recovery() {
         let observed_request = Arc::new(Mutex::new(None));
         let result = run_submitted(
             "incomplete-queued".to_string(),
-            CapturingExecutor {
+            Arc::new(CapturingExecutor {
                 observed_request: Arc::clone(&observed_request),
-            },
+            }),
         )
         .expect("queued run recovers through normal execution");
 
@@ -715,8 +719,12 @@ fn submitted_incomplete_run_still_executes_for_recovery() {
 #[test]
 fn service_persists_timed_out_run_record_and_evidence_refs() {
     with_isolated_home(|_| {
-        let result = run_loaded_plan(test_plan(), Some("service-timeout"), TimeoutExecutor)
-            .expect("timeout run completed");
+        let result = run_loaded_plan(
+            test_plan(),
+            Some("service-timeout"),
+            Arc::new(TimeoutExecutor),
+        )
+        .expect("timeout run completed");
         let record = lifecycle_status("service-timeout").expect("status persisted");
         let artifacts = artifacts("service-timeout").expect("artifacts persisted");
 
@@ -791,9 +799,9 @@ fn service_materializes_component_worktree_before_provider_dispatch() {
         let result = run_loaded_plan(
             plan,
             Some("service-materialized-worktree"),
-            CapturingExecutor {
+            Arc::new(CapturingExecutor {
                 observed_request: Arc::clone(&observed_request),
-            },
+            }),
         )
         .expect("run-plan completed");
         let observed = observed_request
@@ -865,7 +873,7 @@ fn run_next_quarantines_missing_required_secret_before_claiming_and_runs_later_w
         agent_task_lifecycle::submit_plan(&test_plan(), Some("run-next-b-eligible"))
             .expect("eligible work submitted");
 
-        let result = run_next(SucceedingExecutor).expect("eligible work runs");
+        let result = run_next(Arc::new(SucceedingExecutor)).expect("eligible work runs");
         let record =
             lifecycle_status("run-next-a-missing-secret").expect("quarantined record persisted");
 
@@ -932,9 +940,9 @@ fn run_next_quarantines_an_older_ineligible_record_and_executes_the_next_record(
             .expect("eligible record submitted");
         let calls = Arc::new(AtomicUsize::new(0));
 
-        let result = run_next(CountingExecutor {
+        let result = run_next(Arc::new(CountingExecutor {
             calls: Arc::clone(&calls),
-        })
+        }))
         .expect("next eligible record executes");
         let quarantined = agent_task_lifecycle::exact_record("run-next-test-detached")
             .expect("quarantined record");
@@ -978,7 +986,7 @@ fn run_next_bounds_stale_global_admission_and_reports_progress() {
         agent_task_lifecycle::submit_plan(&test_plan(), Some("bounded-ready"))
             .expect("ready work submitted");
 
-        let first = run_next(SucceedingExecutor).expect("bounded claim returns");
+        let first = run_next(Arc::new(SucceedingExecutor)).expect("bounded claim returns");
         assert!(first.value.is_none());
         assert_eq!(
             first.queue_admission.inspected,
@@ -990,7 +998,8 @@ fn run_next_bounds_stale_global_admission_and_reports_progress() {
             agent_task_lifecycle::MAX_QUEUE_ADMISSION_RECORDS
         );
 
-        let second = run_next(SucceedingExecutor).expect("next claim progresses to ready work");
+        let second =
+            run_next(Arc::new(SucceedingExecutor)).expect("next claim progresses to ready work");
         assert_eq!(
             second.value.expect("ready aggregate").plan_id,
             "service-plan"
@@ -1020,7 +1029,8 @@ fn run_next_bounds_malformed_continuation_admission_and_progresses_on_retry() {
         agent_task_lifecycle::submit_plan(&test_plan(), Some("continuation-ready"))
             .expect("ready work submitted");
 
-        let first = run_next(SucceedingExecutor).expect("bounded continuation scan returns");
+        let first =
+            run_next(Arc::new(SucceedingExecutor)).expect("bounded continuation scan returns");
         assert!(first.value.is_none());
         assert_eq!(
             first.queue_admission.inspected,
@@ -1039,7 +1049,7 @@ fn run_next_bounds_malformed_continuation_admission_and_progresses_on_retry() {
             agent_task_lifecycle::MAX_QUEUE_ADMISSION_RECORDS
         );
 
-        let second = run_next(SucceedingExecutor).expect("later ready work progresses");
+        let second = run_next(Arc::new(SucceedingExecutor)).expect("later ready work progresses");
         assert_eq!(
             second.value.expect("ready aggregate").plan_id,
             "service-plan"
@@ -1073,7 +1083,7 @@ fn run_next_shares_admission_budget_between_continuations_and_queued_records() {
         agent_task_lifecycle::submit_plan(&test_plan(), Some("shared-ready"))
             .expect("ready submitted");
 
-        let first = run_next(SucceedingExecutor).expect("shared budget returns");
+        let first = run_next(Arc::new(SucceedingExecutor)).expect("shared budget returns");
         assert!(first.value.is_none());
         assert_eq!(
             first.queue_admission.inspected,
@@ -1081,7 +1091,8 @@ fn run_next_shares_admission_budget_between_continuations_and_queued_records() {
         );
         assert!(first.queue_admission.limit_reached);
 
-        let second = run_next(SucceedingExecutor).expect("ready work progresses next invocation");
+        let second =
+            run_next(Arc::new(SucceedingExecutor)).expect("ready work progresses next invocation");
         assert_eq!(
             second.value.expect("ready aggregate").plan_id,
             "service-plan"
@@ -1102,7 +1113,7 @@ fn run_next_quarantines_stale_cook_identity_and_runs_later_work() {
         agent_task_lifecycle::submit_plan(&test_plan(), Some("identity-ready"))
             .expect("ready work submitted");
 
-        let result = run_next(SucceedingExecutor).expect("ready work runs");
+        let result = run_next(Arc::new(SucceedingExecutor)).expect("ready work runs");
         let stale = agent_task_lifecycle::exact_record("stale-identity").expect("stale record");
 
         assert_eq!(
@@ -1170,7 +1181,7 @@ fn run_next_redacts_adversarial_provider_readiness_diagnostics_everywhere() {
             .expect("eligible run submitted");
 
         let result = run_next_with_cook_dispatcher_and_queue_preflight(
-            SucceedingExecutor,
+            Arc::new(SucceedingExecutor),
             |_| Ok(None),
             None,
             |_, plan| {
@@ -1234,9 +1245,9 @@ fn run_submitted_selects_an_exact_run_id_without_claiming_older_queued_work() {
 
         let result = run_submitted(
             "run-exact-target".to_string(),
-            CountingExecutor {
+            Arc::new(CountingExecutor {
                 calls: Arc::clone(&calls),
-            },
+            }),
         )
         .expect("exact run executes");
 
@@ -1432,7 +1443,7 @@ fn discovery_active_filters_to_queued_and_running_runs() {
         run_loaded_plan(
             discovery_plan(),
             Some("run-active-complete"),
-            SucceedingExecutor,
+            Arc::new(SucceedingExecutor),
         )
         .expect("completed");
 

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -120,7 +120,9 @@ pub use super::agent_task_schedule::{
 // schedule-side variant, so name it explicitly here.
 pub use super::agent_task_schedule::AgentTaskProgressEvent;
 
-pub use super::agent_task_scheduler::{AgentTaskExecutorAdapter, AgentTaskScheduler};
+pub use super::agent_task_scheduler::{
+    AgentTaskExecutorAdapter, AgentTaskScheduler, SharedAgentTaskExecutor,
+};
 
 pub use super::agent_tool_control_plane::{
     dispatch_agent_tool_request, AgentToolControlPlaneDispatcher, AgentToolDispatchEvidence,
@@ -449,7 +451,9 @@ pub mod scheduler {
         AgentTaskResourceBudgetStatus, AgentTaskResourcePressure, AgentTaskRetryPolicy,
         AgentTaskScheduleOptions, AgentTaskState, AGENT_TASK_PLAN_SCHEMA,
     };
-    pub use super::super::agent_task_scheduler::{AgentTaskExecutorAdapter, AgentTaskScheduler};
+    pub use super::super::agent_task_scheduler::{
+        AgentTaskExecutorAdapter, AgentTaskScheduler, SharedAgentTaskExecutor,
+    };
 }
 
 /// Secret-env mapping and resolution helpers.

--- a/crates/homeboy-cli/src/commands/agent_task.rs
+++ b/crates/homeboy-cli/src/commands/agent_task.rs
@@ -230,7 +230,9 @@ pub(crate) fn run_with_cook_progress_and_provenance(
             if progress.is_some() {
                 run::run_cook_with_executor_and_dispatcher_with_progress(
                     *cook_args,
-                    homeboy::agents::agent_tasks::provider::ExtensionProviderAgentTaskExecutor::discover(),
+                    std::sync::Arc::new(
+                        homeboy::agents::agent_tasks::provider::ExtensionProviderAgentTaskExecutor::discover(),
+                    ),
                     None,
                     progress,
                     provenance,

--- a/crates/homeboy-cli/src/commands/agent_task/controller.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/controller.rs
@@ -2,6 +2,7 @@
 //! lifecycle, spec defaults, and the CLI dispatch bridge.
 
 use serde_json::Value;
+use std::sync::Arc;
 
 use homeboy::agents::agent_task_controller_service::{
     build_run_failure_summary, controller_spec_fingerprint_for_status,
@@ -21,7 +22,7 @@ use homeboy::agents::agent_tasks::controller_service::{
 use homeboy::agents::agent_tasks::provider::{
     is_fixture_backend, ExtensionProviderAgentTaskExecutor,
 };
-use homeboy::agents::agent_tasks::scheduler::AgentTaskExecutorAdapter;
+use homeboy::agents::agent_tasks::scheduler::SharedAgentTaskExecutor;
 use homeboy::core::config;
 use homeboy::core::proof::validate_proof_value;
 
@@ -264,7 +265,7 @@ fn loop_define(args: AgentTaskLoopDefineArgs) -> CmdResult<Value> {
     let (resume_report, exit_code) = loop_resume_with_executor(
         report.loop_id.clone(),
         args.revolution_limit,
-        ExtensionProviderAgentTaskExecutor::discover(),
+        Arc::new(ExtensionProviderAgentTaskExecutor::discover()),
         defaults,
     )?;
     Ok((
@@ -299,20 +300,17 @@ fn loop_resume(args: AgentTaskLoopResumeArgs) -> CmdResult<Value> {
     loop_resume_with_executor(
         args.loop_id,
         args.revolution_limit,
-        ExtensionProviderAgentTaskExecutor::discover(),
+        Arc::new(ExtensionProviderAgentTaskExecutor::discover()),
         defaults,
     )
 }
 
-fn loop_resume_with_executor<E>(
+fn loop_resume_with_executor(
     loop_id: String,
     revolution_limit: Option<u32>,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     defaults: ControllerDispatchDefaults,
-) -> CmdResult<Value>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+) -> CmdResult<Value> {
     let mut record = homeboy::agents::agent_tasks::loop_controller::load_controller(&loop_id)?;
     let runtime = loop_runtime_metadata(&record.metadata);
     if !runtime["on"].as_bool().unwrap_or(true) {
@@ -389,27 +387,24 @@ fn loop_stop(args: AgentTaskLoopStatusArgs) -> CmdResult<Value> {
 /// dispatches through the existing controller run-from-spec path and emits
 /// either the run result (preview URL / evidence) or a compact failure summary.
 fn controller_proof(args: AgentTaskControllerProofArgs) -> CmdResult<Value> {
-    controller_proof_with_executor(args, ExtensionProviderAgentTaskExecutor::discover())
+    controller_proof_with_executor(
+        args,
+        Arc::new(ExtensionProviderAgentTaskExecutor::discover()),
+    )
 }
 
 #[cfg(test)]
-pub(super) fn controller_proof_with_test_executor<E>(
+pub(super) fn controller_proof_with_test_executor(
     args: AgentTaskControllerProofArgs,
-    executor: E,
-) -> CmdResult<Value>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+    executor: SharedAgentTaskExecutor,
+) -> CmdResult<Value> {
     controller_proof_with_executor(args, executor)
 }
 
-fn controller_proof_with_executor<E>(
+fn controller_proof_with_executor(
     args: AgentTaskControllerProofArgs,
-    executor: E,
-) -> CmdResult<Value>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+    executor: SharedAgentTaskExecutor,
+) -> CmdResult<Value> {
     let profile = agent_task_controller_service::resolve_proof_profile(
         &args.profile,
         args.profiles.as_deref(),
@@ -533,27 +528,24 @@ pub(super) fn controller_materialize(args: AgentTaskControllerMaterializeArgs) -
 }
 
 fn controller_run_from_spec(args: AgentTaskControllerRunFromSpecArgs) -> CmdResult<Value> {
-    controller_run_from_spec_with_executor(args, ExtensionProviderAgentTaskExecutor::discover())
+    controller_run_from_spec_with_executor(
+        args,
+        Arc::new(ExtensionProviderAgentTaskExecutor::discover()),
+    )
 }
 
 #[cfg(test)]
-pub(super) fn controller_run_from_spec_with_test_executor<E>(
+pub(super) fn controller_run_from_spec_with_test_executor(
     args: AgentTaskControllerRunFromSpecArgs,
-    executor: E,
-) -> CmdResult<Value>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+    executor: SharedAgentTaskExecutor,
+) -> CmdResult<Value> {
     controller_run_from_spec_with_executor(args, executor)
 }
 
-fn controller_run_from_spec_with_executor<E>(
+fn controller_run_from_spec_with_executor(
     args: AgentTaskControllerRunFromSpecArgs,
-    executor: E,
-) -> CmdResult<Value>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+    executor: SharedAgentTaskExecutor,
+) -> CmdResult<Value> {
     if args.max_actions == 0 {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "max-actions",
@@ -794,12 +786,12 @@ pub(super) fn controller_from_spec(args: AgentTaskControllerFromSpecArgs) -> Cmd
     }
 
     let dispatch = CliDispatchHook {
-        executor: ExtensionProviderAgentTaskExecutor::discover(),
+        executor: Arc::new(ExtensionProviderAgentTaskExecutor::discover()),
         defaults,
     };
     let resume_result = agent_task_controller_service::resume_with_options(
         &report.loop_id,
-        ExtensionProviderAgentTaskExecutor::discover(),
+        Arc::new(ExtensionProviderAgentTaskExecutor::discover()),
         &dispatch,
         agent_task_controller_service::ControllerResumeOptions {
             max_actions: args.max_actions.unwrap_or(100) as usize,
@@ -1063,8 +1055,8 @@ fn doctor_check(
 
 /// Bridge controller spawn-task `"dispatch"` requests into the CLI dispatch path.
 #[derive(Clone)]
-struct CliDispatchHook<E> {
-    executor: E,
+struct CliDispatchHook {
+    executor: SharedAgentTaskExecutor,
     defaults: ControllerDispatchDefaults,
 }
 
@@ -1329,10 +1321,7 @@ fn loop_runtime_metadata(metadata: &Value) -> Value {
     })
 }
 
-impl<E> ControllerDispatchHook for CliDispatchHook<E>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+impl ControllerDispatchHook for CliDispatchHook {
     fn dispatch(&self, request: &Value) -> homeboy::core::Result<(Value, i32)> {
         let command = agent_task_controller_service::controller_request_dispatch_command(
             request,
@@ -1389,7 +1378,7 @@ fn controller_run_next(args: AgentTaskControllerRunNextArgs) -> CmdResult<Value>
     let defaults = ControllerDispatchDefaults::from_run_next_args(&args);
     controller_run_next_with_executor_and_defaults(
         args.loop_id,
-        ExtensionProviderAgentTaskExecutor::discover(),
+        Arc::new(ExtensionProviderAgentTaskExecutor::discover()),
         defaults,
     )
 }
@@ -1399,7 +1388,7 @@ fn controller_run_action(args: AgentTaskControllerRunArgs) -> CmdResult<Value> {
     controller_run_action_with_executor_and_defaults(
         args.loop_id,
         args.action_id,
-        ExtensionProviderAgentTaskExecutor::discover(),
+        Arc::new(ExtensionProviderAgentTaskExecutor::discover()),
         defaults,
     )
 }
@@ -1408,16 +1397,16 @@ fn controller_resume(args: AgentTaskControllerRunNextArgs) -> CmdResult<Value> {
     let defaults = ControllerDispatchDefaults::from_run_next_args(&args);
     controller_resume_with_executor_and_defaults(
         args.loop_id,
-        ExtensionProviderAgentTaskExecutor::discover(),
+        Arc::new(ExtensionProviderAgentTaskExecutor::discover()),
         defaults,
     )
 }
 
 #[cfg(test)]
-pub(super) fn controller_run_next_with_executor<E>(loop_id: String, executor: E) -> CmdResult<Value>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+pub(super) fn controller_run_next_with_executor(
+    loop_id: String,
+    executor: SharedAgentTaskExecutor,
+) -> CmdResult<Value> {
     controller_run_next_with_executor_and_defaults(
         loop_id,
         executor,
@@ -1425,14 +1414,11 @@ where
     )
 }
 
-fn controller_run_next_with_executor_and_defaults<E>(
+fn controller_run_next_with_executor_and_defaults(
     loop_id: String,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     defaults: ControllerDispatchDefaults,
-) -> CmdResult<Value>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+) -> CmdResult<Value> {
     let dispatch = CliDispatchHook {
         executor: executor.clone(),
         defaults,
@@ -1442,14 +1428,11 @@ where
 }
 
 #[cfg(test)]
-pub(super) fn controller_run_action_with_executor<E>(
+pub(super) fn controller_run_action_with_executor(
     loop_id: String,
     action_id: String,
-    executor: E,
-) -> CmdResult<Value>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+    executor: SharedAgentTaskExecutor,
+) -> CmdResult<Value> {
     controller_run_action_with_executor_and_defaults(
         loop_id,
         action_id,
@@ -1458,15 +1441,12 @@ where
     )
 }
 
-fn controller_run_action_with_executor_and_defaults<E>(
+fn controller_run_action_with_executor_and_defaults(
     loop_id: String,
     action_id: String,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     defaults: ControllerDispatchDefaults,
-) -> CmdResult<Value>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+) -> CmdResult<Value> {
     let dispatch = CliDispatchHook {
         executor: executor.clone(),
         defaults,
@@ -1476,14 +1456,11 @@ where
     Ok((command_json_value(result.value)?, result.exit_code))
 }
 
-fn controller_resume_with_executor_and_defaults<E>(
+fn controller_resume_with_executor_and_defaults(
     loop_id: String,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     defaults: ControllerDispatchDefaults,
-) -> CmdResult<Value>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+) -> CmdResult<Value> {
     let dispatch = CliDispatchHook {
         executor: executor.clone(),
         defaults,

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -9,6 +9,7 @@ use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use homeboy::agents::agent_task_provider::AgentTaskProviderProfileDeclaration;
@@ -34,7 +35,7 @@ use homeboy::agents::agent_tasks::gate::{
 };
 use homeboy::agents::agent_tasks::lifecycle as agent_task_lifecycle;
 use homeboy::agents::agent_tasks::provider::{self, AgentTaskProviderCatalog};
-use homeboy::agents::agent_tasks::scheduler::AgentTaskPlan;
+use homeboy::agents::agent_tasks::scheduler::{AgentTaskPlan, SharedAgentTaskExecutor};
 use homeboy::agents::agent_tasks::service::{
     self as agent_task_service, AgentTaskCookServiceOptions,
 };
@@ -317,7 +318,7 @@ fn batch_resume(args: AgentTaskFanoutBatchStatusArgs) -> CmdResult<Value> {
     reconcile_fanout_pr_states(&args.batch_id, true)?;
     let result = agent_task_service::resume_cook_batch(
         &args.batch_id,
-        provider::ExtensionProviderAgentTaskExecutor::discover(),
+        Arc::new(provider::ExtensionProviderAgentTaskExecutor::discover()),
         crate::commands::infra::route::reconstruct_cook_attempt_dispatcher,
     )?;
     let exit_code = result.exit_code;
@@ -937,7 +938,7 @@ fn resume_fanout_child(
 ) -> Result<()> {
     agent_task_service::resume_cook(
         &child.run_id,
-        provider::ExtensionProviderAgentTaskExecutor::discover(),
+        Arc::new(provider::ExtensionProviderAgentTaskExecutor::discover()),
         crate::commands::infra::route::reconstruct_cook_attempt_dispatcher,
         rerun_completed_gates,
     )?;
@@ -1371,7 +1372,7 @@ fn run_batch_cook_fanout_plan_with_attempt_dispatcher_claim(
                     cooks,
                     max_concurrency: concurrency.limit,
                 },
-                provider::ExtensionProviderAgentTaskExecutor::discover(),
+                Arc::new(provider::ExtensionProviderAgentTaskExecutor::discover()),
                 agent_task_service::detached_batch_coordinator_control(&plan.fanout_id),
             )
         });
@@ -1392,28 +1393,22 @@ fn run_batch_cook_fanout_plan_with_attempt_dispatcher_claim(
 fn run_batch_cook_fanout_plan(plan: BatchCookFanoutPlan) -> CmdResult<Value> {
     run_batch_cook_fanout_plan_with_executor(
         plan,
-        provider::ExtensionProviderAgentTaskExecutor::discover(),
+        Arc::new(provider::ExtensionProviderAgentTaskExecutor::discover()),
     )
 }
 
-fn run_batch_cook_fanout_plan_with_executor<E>(
+fn run_batch_cook_fanout_plan_with_executor(
     plan: BatchCookFanoutPlan,
-    executor: E,
-) -> CmdResult<Value>
-where
-    E: homeboy::agents::agent_tasks::scheduler::AgentTaskExecutorAdapter + Clone + Send,
-{
+    executor: SharedAgentTaskExecutor,
+) -> CmdResult<Value> {
     run_batch_cook_fanout_plan_with_executor_claim(plan, executor, None)
 }
 
-fn run_batch_cook_fanout_plan_with_executor_claim<E>(
+fn run_batch_cook_fanout_plan_with_executor_claim(
     plan: BatchCookFanoutPlan,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     claim_id: Option<String>,
-) -> CmdResult<Value>
-where
-    E: homeboy::agents::agent_tasks::scheduler::AgentTaskExecutorAdapter + Clone + Send,
-{
+) -> CmdResult<Value> {
     let gate_workspace = batch_plan_gate_workspace(&plan)?;
     let gate_contract_validation = validate_batch_gate_contracts(&plan, gate_workspace.as_deref())?;
     let claim_id = match claim_id {
@@ -1893,7 +1888,7 @@ fn cook_batch_inner(
             )?,
             None => run_batch_cook_fanout_plan_with_executor_claim(
                 plan.clone(),
-                provider::ExtensionProviderAgentTaskExecutor::discover(),
+                Arc::new(provider::ExtensionProviderAgentTaskExecutor::discover()),
                 claim_id.clone(),
             )?,
         };

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -1,5 +1,6 @@
 use clap::Args;
 use serde_json::Value;
+use std::sync::Arc;
 
 use homeboy::agents::agent_tasks::cook_loop::{evaluate_cook_loop, AgentTaskCookLoopOptions};
 use homeboy::agents::agent_tasks::dispatch_service as agent_task_dispatch_service;
@@ -502,7 +503,7 @@ pub(crate) fn adopt_candidate(args: AdoptArgs) -> CmdResult<Value> {
                 accept_inherited_failures: args.accept_inherited_failures,
             },
             crate::commands::infra::route::reconstruct_cook_attempt_dispatcher,
-            ExtensionProviderAgentTaskExecutor::discover(),
+            Arc::new(ExtensionProviderAgentTaskExecutor::discover()),
         )?;
     let exit_code = result.exit_code;
     let cook_id = result.value.cook_id.clone();

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -16,7 +16,7 @@ use homeboy::agents::agent_tasks::lifecycle as agent_task_lifecycle;
 use homeboy::agents::agent_tasks::provider;
 use homeboy::agents::agent_tasks::provider::ExtensionProviderAgentTaskExecutor;
 use homeboy::agents::agent_tasks::scheduler::{
-    AgentTaskAggregate, AgentTaskExecutorAdapter, AgentTaskPlan,
+    AgentTaskAggregate, AgentTaskPlan, SharedAgentTaskExecutor,
 };
 use homeboy::agents::agent_tasks::service as agent_task_service;
 use homeboy::core::command_invocation::CommandInvocation;
@@ -205,7 +205,10 @@ pub(crate) fn run_cook(mut args: AgentTaskCookArgs) -> CmdResult<Value> {
     args.gates.snapshot_file_inputs()?;
     let args = resolve_cook_destination(args)?;
     validate_cook_request(&args)?;
-    run_cook_with_executor(args, ExtensionProviderAgentTaskExecutor::discover())
+    run_cook_with_executor(
+        args,
+        Arc::new(ExtensionProviderAgentTaskExecutor::discover()),
+    )
 }
 
 /// Resolve the same pre-provisioning Cook inputs used by execution. This path
@@ -1008,18 +1011,17 @@ mod preview_tests {
 pub(crate) fn continue_cook(args: CookContinueArgs) -> CmdResult<Value> {
     continue_cook_with(
         args,
-        ExtensionProviderAgentTaskExecutor::discover(),
+        Arc::new(ExtensionProviderAgentTaskExecutor::discover()),
         crate::commands::infra::route::reconstruct_cook_attempt_dispatcher,
     )
 }
 
-pub(crate) fn continue_cook_with<E, F>(
+pub(crate) fn continue_cook_with<F>(
     args: CookContinueArgs,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     reconstruct_dispatcher: F,
 ) -> CmdResult<Value>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     F: Fn(
             &Value,
         ) -> homeboy::core::Result<
@@ -1032,14 +1034,13 @@ where
 /// `retry --run` owns a fresh queued replacement attempt. It may dispatch that
 /// attempt through the immutable Cook recipe; ordinary `cook-continue` remains
 /// observation-only until the attempt becomes terminal.
-fn continue_cook_with_queued_execution<E, F>(
+fn continue_cook_with_queued_execution<F>(
     args: CookContinueArgs,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     reconstruct_dispatcher: F,
     execute_queued_attempt: bool,
 ) -> CmdResult<Value>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     F: Fn(
             &Value,
         ) -> homeboy::core::Result<
@@ -1170,13 +1171,12 @@ where
 }
 
 #[cfg(test)]
-pub(crate) fn consume_queued_cook_retry_with<E, F>(
+pub(crate) fn consume_queued_cook_retry_with<F>(
     args: CookContinueArgs,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     reconstruct_dispatcher: F,
 ) -> CmdResult<Value>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     F: Fn(
             &Value,
         ) -> homeboy::core::Result<
@@ -1189,15 +1189,14 @@ where
 /// A retry reservation creates a queued record before its external dispatch.
 /// Claim that effect separately so competing `retry --run` consumers converge
 /// on one dispatcher invocation.
-fn dispatch_queued_cook_retry<E, F>(
+fn dispatch_queued_cook_retry<F>(
     recipe: &homeboy::agents::agent_task_service::AgentTaskCookRecipe,
     run_id: &str,
     full: bool,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     reconstruct_dispatcher: F,
 ) -> CmdResult<Value>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     F: Fn(
             &Value,
         ) -> homeboy::core::Result<
@@ -2543,23 +2542,20 @@ pub(crate) fn promotion_provider(args: PromotionProviderArgs) -> CmdResult<Value
     .map(|value| (value, 0))
 }
 
-pub(super) fn run_cook_with_executor<E>(args: AgentTaskCookArgs, executor: E) -> CmdResult<Value>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+pub(super) fn run_cook_with_executor(
+    args: AgentTaskCookArgs,
+    executor: SharedAgentTaskExecutor,
+) -> CmdResult<Value> {
     run_cook_with_executor_and_dispatcher(args, executor, None)
 }
 
-pub(crate) fn run_cook_with_executor_and_dispatcher<E>(
+pub(crate) fn run_cook_with_executor_and_dispatcher(
     args: AgentTaskCookArgs,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     attempt_dispatcher: Option<
         Arc<dyn crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher>,
     >,
-) -> CmdResult<Value>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+) -> CmdResult<Value> {
     run_cook_with_executor_and_dispatcher_with_progress(
         args,
         executor,
@@ -2569,18 +2565,15 @@ where
     )
 }
 
-pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress<E>(
+pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress(
     mut args: AgentTaskCookArgs,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     attempt_dispatcher: Option<
         Arc<dyn crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher>,
     >,
     progress: super::CookProgress<'_>,
     provenance: Option<&crate::cli_surface::CommandArgumentProvenance>,
-) -> CmdResult<Value>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+) -> CmdResult<Value> {
     args.gates.snapshot_file_inputs()?;
     let args = resolve_cook_destination(args)?;
     validate_cook_request_with_provenance(&args, provenance)?;
@@ -3670,7 +3663,7 @@ pub(super) fn run_plan(args: RunPlanArgs) -> CmdResult<Value> {
     run_loaded_plan(
         plan,
         record_run_id.as_deref(),
-        ExtensionProviderAgentTaskExecutor::discover(),
+        Arc::new(ExtensionProviderAgentTaskExecutor::discover()),
     )
 }
 
@@ -3696,14 +3689,11 @@ fn emit_runner_lifecycle_progress(plan: &AgentTaskPlan, run_id: Option<&str>) {
     }
 }
 
-pub(super) fn run_loaded_plan<E>(
+pub(super) fn run_loaded_plan(
     plan: AgentTaskPlan,
     record_run_id: Option<&str>,
-    executor: E,
-) -> CmdResult<Value>
-where
-    E: AgentTaskExecutorAdapter,
-{
+    executor: SharedAgentTaskExecutor,
+) -> CmdResult<Value> {
     let result = agent_task_service::run_loaded_plan(plan, record_run_id, executor)?;
     let value =
         if std::env::var_os(homeboy::core::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV).is_some() {
@@ -3718,18 +3708,15 @@ pub(super) fn run_submitted(args: RunArgs) -> CmdResult<Value> {
     run_submitted_with_executor(
         args.run_id,
         args.timeout_ms,
-        ExtensionProviderAgentTaskExecutor::discover(),
+        Arc::new(ExtensionProviderAgentTaskExecutor::discover()),
     )
 }
 
-pub(super) fn run_submitted_with_executor<E>(
+pub(super) fn run_submitted_with_executor(
     run_id: String,
     timeout_ms: Option<u64>,
-    executor: E,
-) -> CmdResult<Value>
-where
-    E: AgentTaskExecutorAdapter,
-{
+    executor: SharedAgentTaskExecutor,
+) -> CmdResult<Value> {
     let result =
         agent_task_service::run_submitted_with_timeout(run_id.clone(), timeout_ms, executor)?;
     Ok((
@@ -3739,23 +3726,20 @@ where
 }
 
 pub(super) fn run_next(args: RunNextArgs) -> CmdResult<Value> {
-    run_next_with_executor_and_fanout(ExtensionProviderAgentTaskExecutor::discover(), args.fanout)
+    run_next_with_executor_and_fanout(
+        Arc::new(ExtensionProviderAgentTaskExecutor::discover()),
+        args.fanout,
+    )
 }
 
-pub(super) fn run_next_with_executor<E>(executor: E) -> CmdResult<Value>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+pub(super) fn run_next_with_executor(executor: SharedAgentTaskExecutor) -> CmdResult<Value> {
     run_next_with_executor_and_fanout(executor, None)
 }
 
-pub(super) fn run_next_with_executor_and_fanout<E>(
-    executor: E,
+pub(super) fn run_next_with_executor_and_fanout(
+    executor: SharedAgentTaskExecutor,
     fanout_id: Option<String>,
-) -> CmdResult<Value>
-where
-    E: AgentTaskExecutorAdapter + Clone,
-{
+) -> CmdResult<Value> {
     let scoped_run_ids = fanout_id
         .as_deref()
         .map(homeboy::agents::agent_tasks::batch::owned_child_run_ids)
@@ -3798,27 +3782,24 @@ pub(super) fn resume(args: impl Into<LifecycleReadArgs>) -> CmdResult<Value> {
         args.bridge,
         args.since_cursor,
         args.full,
-        ExtensionProviderAgentTaskExecutor::discover(),
+        Arc::new(ExtensionProviderAgentTaskExecutor::discover()),
     )
 }
 
-pub(super) fn run_resume_with_executor<E>(run_id: String, executor: E) -> CmdResult<Value>
-where
-    E: AgentTaskExecutorAdapter,
-{
+pub(super) fn run_resume_with_executor(
+    run_id: String,
+    executor: SharedAgentTaskExecutor,
+) -> CmdResult<Value> {
     run_resume_with_executor_and_bridge(run_id, false, None, false, executor)
 }
 
-pub(super) fn run_resume_with_executor_and_bridge<E>(
+pub(super) fn run_resume_with_executor_and_bridge(
     run_id: String,
     bridge: bool,
     since_cursor: Option<u64>,
     full: bool,
-    executor: E,
-) -> CmdResult<Value>
-where
-    E: AgentTaskExecutorAdapter,
-{
+    executor: SharedAgentTaskExecutor,
+) -> CmdResult<Value> {
     let needs_transport_recovery =
         bridge && agent_task_service::terminal_transport_recovery_required(&run_id);
     if needs_transport_recovery {
@@ -3851,18 +3832,17 @@ where
 pub(super) fn retry(args: RetryArgs) -> CmdResult<Value> {
     retry_with(
         args,
-        ExtensionProviderAgentTaskExecutor::discover(),
+        Arc::new(ExtensionProviderAgentTaskExecutor::discover()),
         crate::commands::infra::route::reconstruct_cook_attempt_dispatcher,
     )
 }
 
-pub(super) fn retry_with<E, F>(
+pub(super) fn retry_with<F>(
     args: RetryArgs,
-    executor: E,
+    executor: SharedAgentTaskExecutor,
     reconstruct_dispatcher: F,
 ) -> CmdResult<Value>
 where
-    E: AgentTaskExecutorAdapter + Clone,
     F: Fn(
             &Value,
         ) -> homeboy::core::Result<

--- a/crates/homeboy-cli/src/commands/agent_task/tests/controller_proof.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/controller_proof.rs
@@ -55,7 +55,7 @@ fn proof_fails_before_dispatch_on_missing_secret_with_fix_command() {
 
         let (value, exit_code) = controller_proof_with_test_executor(
             proof_args("example-proof", "homeboy-lab", Some(&registry), false),
-            NeverDispatchExecutor,
+            Arc::new(NeverDispatchExecutor),
         )
         .expect("proof command runs");
 
@@ -84,7 +84,7 @@ fn proof_fails_before_dispatch_without_profile_registry() {
     with_temp_home(|| {
         let error = controller_proof_with_test_executor(
             proof_args("example-proof", "homeboy-lab", None, false),
-            NeverDispatchExecutor,
+            Arc::new(NeverDispatchExecutor),
         )
         .expect_err("missing registry is a hard error");
         assert!(error.message.contains("no proof profile registry"));
@@ -108,7 +108,7 @@ fn proof_passes_preflight_and_composes_identity_and_policy() {
 
         let (value, exit_code) = controller_proof_with_test_executor(
             proof_args("example-proof", "homeboy-lab", Some(&registry), true),
-            NeverDispatchExecutor,
+            Arc::new(NeverDispatchExecutor),
         )
         .expect("proof command runs");
 

--- a/crates/homeboy-cli/src/commands/agent_task/tests/controller_run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/controller_run.rs
@@ -35,9 +35,9 @@ fn controller_run_next_executes_spawn_task_plan_and_records_dedupe_lineage() {
 
         let (value, exit_code) = controller_run_next_with_executor(
             "loop-controller-run-next".to_string(),
-            CapturingExecutor {
+            Arc::new(CapturingExecutor {
                 observed_request: Arc::clone(&observed_request),
-            },
+            }),
         )
         .expect("controller action executed");
 
@@ -102,7 +102,7 @@ fn controller_cli_hook_blocks_unavailable_required_runner_without_local_fallback
 
         let (value, exit_code) = controller_run_next_with_executor(
             "loop-cli-runner-unavailable".to_string(),
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
         )
         .expect("controller reports policy block");
         assert_eq!(exit_code, 1, "{value:#}");
@@ -160,9 +160,9 @@ fn controller_dispatch_runtime_component_contracts_reach_spawned_agent_task_requ
 
         let (value, exit_code) = controller_run_next_with_executor(
             "loop-controller-runtime-components".to_string(),
-            ArtifactCapturingExecutor {
+            Arc::new(ArtifactCapturingExecutor {
                 observed_request: Arc::clone(&observed_request),
-            },
+            }),
         )
         .expect("controller action executed");
 
@@ -227,7 +227,7 @@ fn controller_run_from_spec_materializes_runs_bounded_actions_and_returns_status
                     dispatch_provider_config: None,
                 },
             },
-            ArtifactCapturingExecutor::default(),
+            Arc::new(ArtifactCapturingExecutor::default()),
         )
         .expect("run from spec");
 
@@ -289,9 +289,9 @@ fn controller_run_from_spec_persists_dispatch_defaults_for_generated_actions() {
                     dispatch_provider_config: Some(r#"{"runtime_version":"6.9"}"#.to_string()),
                 },
             },
-            CapturingExecutor {
+            Arc::new(CapturingExecutor {
                 observed_request: Arc::clone(&observed_request),
-            },
+            }),
         )
         .expect("run from spec");
 
@@ -390,9 +390,9 @@ fn controller_run_from_spec_preserves_runtime_execution_and_components() {
                     ),
                 },
             },
-            CapturingExecutor {
+            Arc::new(CapturingExecutor {
                 observed_request: Arc::clone(&observed_request),
-            },
+            }),
         )
         .expect("run from spec");
 
@@ -460,7 +460,7 @@ fn controller_run_from_spec_rejects_unbounded_zero_max_actions() {
                     dispatch_provider_config: None,
                 },
             },
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
         )
         .expect_err("zero max-actions is rejected");
 
@@ -501,9 +501,9 @@ fn controller_run_from_spec_rejects_command_runtime_without_command_kind() {
                     dispatch_provider_config: None,
                 },
             },
-            CapturingExecutor {
+            Arc::new(CapturingExecutor {
                 observed_request: Arc::clone(&observed_request),
-            },
+            }),
         )
         .expect_err("command-shaped runtime execution is rejected before dispatch");
 
@@ -580,7 +580,7 @@ fn controller_run_from_spec_guards_stale_state_with_actionable_diagnostics() {
         // First proof run persists base controller state.
         controller_run_from_spec_with_test_executor(
             run_from_spec_proof_args("run-from-spec-stale-guard", "Draft the brief.", false),
-            ArtifactCapturingExecutor::default(),
+            Arc::new(ArtifactCapturingExecutor::default()),
         )
         .expect("base proof run");
 
@@ -588,7 +588,7 @@ fn controller_run_from_spec_guards_stale_state_with_actionable_diagnostics() {
         // stale base controller state on a run-scoped proof run.
         let error = controller_run_from_spec_with_test_executor(
             run_from_spec_proof_args("run-from-spec-stale-guard", "Rewrite the brief.", false),
-            ArtifactCapturingExecutor::default(),
+            Arc::new(ArtifactCapturingExecutor::default()),
         )
         .expect_err("stale state is guarded");
 
@@ -662,14 +662,14 @@ fn controller_run_from_spec_reconcile_stale_recovers_without_manual_cleanup() {
         };
         controller_run_from_spec_with_test_executor(
             proof_args("Draft the brief.", false),
-            ArtifactCapturingExecutor::default(),
+            Arc::new(ArtifactCapturingExecutor::default()),
         )
         .expect("base proof run");
 
         // The one-flag safe mode resets run-scoped state automatically.
         let (value, exit_code) = controller_run_from_spec_with_test_executor(
             proof_args("Rewrite the brief.", true),
-            ArtifactCapturingExecutor::default(),
+            Arc::new(ArtifactCapturingExecutor::default()),
         )
         .expect("reconcile-stale recovers the proof run");
 
@@ -738,7 +738,7 @@ fn controller_run_from_spec_fork_isolates_repeated_replays_from_stale_child_runs
         };
         controller_run_from_spec_with_test_executor(
             args("Draft the brief."),
-            ArtifactCapturingExecutor::default(),
+            Arc::new(ArtifactCapturingExecutor::default()),
         )
         .expect("base proof run");
 
@@ -749,12 +749,12 @@ fn controller_run_from_spec_fork_isolates_repeated_replays_from_stale_child_runs
 
         let (first, first_exit_code) = controller_run_from_spec_with_test_executor(
             first_fork_args,
-            ArtifactCapturingExecutor::default(),
+            Arc::new(ArtifactCapturingExecutor::default()),
         )
         .expect("first fork run");
         let (second, second_exit_code) = controller_run_from_spec_with_test_executor(
             second_fork_args,
-            ArtifactCapturingExecutor::default(),
+            Arc::new(ArtifactCapturingExecutor::default()),
         )
         .expect("second fork run");
 
@@ -860,7 +860,7 @@ fn controller_run_executes_requested_action_id_only() {
         let (_value, exit_code) = controller_run_action_with_executor(
             "loop-controller-run-action".to_string(),
             "action-2".to_string(),
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
         )
         .expect("specific action executed");
         let loaded = agent_task_loop_controller::load_controller("loop-controller-run-action")

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -653,7 +653,7 @@ fn cook_rejects_queue_only_before_creating_a_durable_recipe() {
 
         let error = super::super::run::run_cook_with_executor(
             *cook,
-            ExtensionProviderAgentTaskExecutor::default(),
+            Arc::new(ExtensionProviderAgentTaskExecutor::default()),
         )
         .expect_err("queue-only cook must fail before resolving its worktree");
 
@@ -762,7 +762,7 @@ fn cook_goal_frames_explicit_prompt_without_creating_another_provider_cell() {
 
         run_cook_with_executor_and_dispatcher(
             *cook,
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             Some(Arc::new(RecipeOnlyDispatcher)),
         )
         .expect("persist Cook recipe before provider dispatch");
@@ -830,7 +830,7 @@ fn cook_goal_without_explicit_work_remains_one_provider_cell() {
 
         run_cook_with_executor_and_dispatcher(
             *cook,
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             Some(Arc::new(RecipeOnlyDispatcher)),
         )
         .expect("persist Cook recipe before provider dispatch");
@@ -970,8 +970,11 @@ fn invalid_cook_inputs_do_not_mutate_a_configured_provider_destination() {
             let AgentTaskCommand::Cook(cook) = agent_task.command else {
                 panic!("cook command")
             };
-            run_cook_with_executor(*cook, ExtensionProviderAgentTaskExecutor::default())
-                .expect_err("invalid Cook input is rejected before provider ensure");
+            run_cook_with_executor(
+                *cook,
+                Arc::new(ExtensionProviderAgentTaskExecutor::default()),
+            )
+            .expect_err("invalid Cook input is rejected before provider ensure");
         }
         assert!(
             !ensured.exists(),
@@ -1525,7 +1528,7 @@ fn cook_rejects_an_inactive_managed_destination_before_provider_execution() {
             handle,
             "--no-finalize".to_string(),
         ]);
-        let executor = CountingExecutor::default();
+        let executor = Arc::new(CountingExecutor::default());
         let error = run_cook_with_executor(args, executor.clone())
             .expect_err("inactive managed destination must fail before execution");
 

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -255,7 +255,7 @@ fn invalid_cook_sources_stop_before_worktree_provider_runner_executor_or_budget(
                 run_id.clone(),
                 "--no-finalize".to_string(),
             ]);
-            let executor = CountingCookExecutor::default();
+            let executor = Arc::new(CountingCookExecutor::default());
             let dispatcher = Arc::new(CountingCookDispatcher::default());
 
             let error = run_cook_with_executor_and_dispatcher(
@@ -479,7 +479,7 @@ fn cook_runner_preflight_failure_is_visible_and_resumable_through_public_command
 
         let (failed, exit_code) = run_cook_with_executor_and_dispatcher(
             recoverable_runner_cook_args(&source),
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             Some(dispatcher.clone()),
         )
         .expect("runner preflight failure is durably reported");
@@ -518,7 +518,7 @@ fn cook_runner_preflight_failure_is_visible_and_resumable_through_public_command
         dispatcher.unavailable.store(false, Ordering::SeqCst);
         let (resumed, exit_code) = run_cook_with_executor_and_dispatcher(
             recoverable_runner_cook_args(&source),
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
             Some(dispatcher.clone()),
         )
         .expect("same immutable cook resumes after runner repair");
@@ -617,7 +617,7 @@ fn status_and_cook_continue_materialize_recipe_only_attempt_without_provider_wor
         assert!(!agent_task_lifecycle::cook_index_exists(cook_id).expect("status did not index"));
         assert_eq!(filesystem_snapshot(&data_root), before_status);
 
-        let executor = CountingCookExecutor::default();
+        let executor = Arc::new(CountingCookExecutor::default());
         let continued = continue_cook_with(
             CookContinueArgs {
                 cook_or_attempt_id: cook_id.to_string(),
@@ -749,7 +749,7 @@ fn cook_continue_reconciles_a_delayed_runner_attempt_then_advances_its_terminal_
         agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("persist provider attempt");
         agent_task_lifecycle::record_cook_attempt(cook_id, 1, run_id)
             .expect("bind immutable Cook attempt");
-        let executor = CountingCookExecutor::default();
+        let executor = Arc::new(CountingCookExecutor::default());
         let before = continue_cook_with(
             CookContinueArgs {
                 cook_or_attempt_id: cook_id.to_string(),
@@ -1117,7 +1117,7 @@ printf '%s\n' '{{"schema":"homeboy/agent-task-promotion-apply-response/v1","work
             Some("selected"),
         )
         .expect("restart rewrites the aggregate to the controller projection");
-        let executor = CountingCookExecutor::default();
+        let executor = Arc::new(CountingCookExecutor::default());
         let ambiguous = continue_cook_with(
             CookContinueArgs {
                 cook_or_attempt_id: cook_id.to_string(),
@@ -1365,7 +1365,7 @@ fn controller_proxy_run_uses_transport_recovery_without_provider_dispatch() {
             },
         )
         .expect("controller proxy persisted");
-        let executor = CapturingExecutor::default();
+        let executor = Arc::new(CapturingExecutor::default());
 
         let error = run_submitted_with_executor(
             "run-cli-transport-proxy".to_string(),
@@ -1409,7 +1409,7 @@ fn controller_proxy_resume_uses_transport_recovery_without_provider_dispatch() {
             },
         )
         .expect("controller proxy persisted");
-        let executor = CapturingExecutor::default();
+        let executor = Arc::new(CapturingExecutor::default());
 
         let error = run_resume_with_executor(
             "run-cli-resume-transport-proxy".to_string(),
@@ -1461,7 +1461,7 @@ fn controller_proxy_run_resumes_on_its_recorded_runner_workspace() {
         )
         .expect("controller proxy persisted");
 
-        let executor = CapturingExecutor::default();
+        let executor = Arc::new(CapturingExecutor::default());
         let error = run_submitted_with_executor(
             "run-cli-runner-resume-proxy".to_string(),
             None,
@@ -1495,7 +1495,7 @@ fn run_next_leaves_transport_proxy_queued_for_runner_recovery() {
             },
         )
         .expect("controller proxy persisted");
-        let executor = CapturingExecutor::default();
+        let executor = Arc::new(CapturingExecutor::default());
 
         let (_, exit_code) =
             run_next_with_executor(executor.clone()).expect("run-next skips proxy");
@@ -1614,8 +1614,12 @@ fn submit_run_status_reports_terminal_state() {
 fn failed_run_status_logs_and_review_include_outcome_diagnostic_summary() {
     with_temp_home(|| {
         let run_id = "run-cli-diagnostic-summary";
-        run_loaded_plan(test_plan(), Some(run_id), DiagnosticFailureExecutor)
-            .expect("run completed with failed outcome");
+        run_loaded_plan(
+            test_plan(),
+            Some(run_id),
+            Arc::new(DiagnosticFailureExecutor),
+        )
+        .expect("run completed with failed outcome");
 
         let (status_value, _) = status(StatusArgs {
             run_id: run_id.to_string(),
@@ -1669,10 +1673,10 @@ fn evidence_command_hydrates_homeboy_and_file_refs_with_filters_and_redaction() 
         run_loaded_plan(
             test_plan(),
             Some(run_id),
-            EvidenceFixtureExecutor {
+            Arc::new(EvidenceFixtureExecutor {
                 run_id: run_id.to_string(),
                 file_uri: format!("file://{}", file_path.display()),
-            },
+            }),
         )
         .expect("run completed");
 
@@ -1741,9 +1745,9 @@ fn diagnose_hydrates_executor_result_evidence_root_cause() {
         run_loaded_plan(
             test_plan(),
             Some("run-cli-diagnose-evidence"),
-            ExecutorResultEvidenceFailureExecutor {
+            Arc::new(ExecutorResultEvidenceFailureExecutor {
                 evidence_uri: format!("file://{}", evidence_path.display()),
-            },
+            }),
         )
         .expect("run completed with failed outcome");
 
@@ -1993,9 +1997,9 @@ fn diagnose_prioritizes_structured_policy_denial_over_successful_provider_exit()
         run_loaded_plan(
             test_plan(),
             Some(run_id),
-            ExecutorResultEvidenceFailureExecutor {
+            Arc::new(ExecutorResultEvidenceFailureExecutor {
                 evidence_uri: format!("file://{}", evidence_path.display()),
-            },
+            }),
         )
         .expect("run completed with failed outcome");
 
@@ -2101,9 +2105,9 @@ fn diagnose_prioritizes_provider_stream_cause_over_malformed_wrapper() {
         run_loaded_plan(
             test_plan(),
             Some(run_id),
-            ExecutorResultEvidenceFailureExecutor {
+            Arc::new(ExecutorResultEvidenceFailureExecutor {
                 evidence_uri: format!("file://{}", evidence_path.display()),
-            },
+            }),
         )
         .expect("run completed with failed outcome");
 
@@ -2185,9 +2189,9 @@ fn diagnose_surfaces_a_raw_provider_cause_from_a_bounded_stream_uri() {
         run_loaded_plan(
             test_plan(),
             Some(run_id),
-            ExecutorResultEvidenceFailureExecutor {
+            Arc::new(ExecutorResultEvidenceFailureExecutor {
                 evidence_uri: format!("file://{}", evidence_path.display()),
-            },
+            }),
         )
         .expect("run completed with failed outcome");
 
@@ -2241,9 +2245,9 @@ fn diagnose_reports_unavailable_process_streams_without_failing() {
         run_loaded_plan(
             test_plan(),
             Some(run_id),
-            ExecutorResultEvidenceFailureExecutor {
+            Arc::new(ExecutorResultEvidenceFailureExecutor {
                 evidence_uri: format!("file://{}", evidence_path.display()),
-            },
+            }),
         )
         .expect("run completed with failed outcome");
 
@@ -2276,9 +2280,9 @@ fn diagnose_derives_next_actions_from_the_failure_classification() {
         run_loaded_plan(
             test_plan(),
             Some(run_id),
-            ClassifiedFailureExecutor {
+            Arc::new(ClassifiedFailureExecutor {
                 classification: AgentTaskFailureClassification::Timeout,
-            },
+            }),
         )
         .expect("run completed with a classified failure");
 
@@ -2347,9 +2351,9 @@ fn diagnose_falls_back_to_the_generic_set_for_an_unclassified_failure() {
         run_loaded_plan(
             test_plan(),
             Some(run_id),
-            ClassifiedFailureExecutor {
+            Arc::new(ClassifiedFailureExecutor {
                 classification: AgentTaskFailureClassification::Unknown,
-            },
+            }),
         )
         .expect("run completed with an unclassified failure");
 
@@ -2393,9 +2397,9 @@ fn diagnose_next_actions_name_the_artifacts_that_were_not_produced() {
         run_loaded_plan(
             test_plan(),
             Some(run_id),
-            ExecutorResultEvidenceFailureExecutor {
+            Arc::new(ExecutorResultEvidenceFailureExecutor {
                 evidence_uri: format!("file://{}", evidence_path.display()),
-            },
+            }),
         )
         .expect("run completed with missing declared artifacts");
 
@@ -2486,12 +2490,12 @@ fn replay_provider_boundary_projects_latest_executor_input() {
         run_loaded_plan(
             test_plan(),
             Some("run-cli-provider-boundary-replay"),
-            ExecutorInputEvidenceExecutor {
+            Arc::new(ExecutorInputEvidenceExecutor {
                 evidence_uris: vec![
                     format!("file://{}", stale_evidence_path.display()),
                     format!("file://{}", evidence_path.display()),
                 ],
-            },
+            }),
         )
         .expect("run completed");
 
@@ -2546,11 +2550,11 @@ fn replay_provider_boundary_hydrates_persisted_plan_executor_input() {
         run_loaded_plan(
             plan,
             Some(run_id),
-            ExecutorInputEvidenceExecutor {
+            Arc::new(ExecutorInputEvidenceExecutor {
                 evidence_uris: vec![format!(
                     "homeboy://agent-task/run/{run_id}/plan#task=task-a"
                 )],
-            },
+            }),
         )
         .expect("run completed");
 
@@ -2587,7 +2591,7 @@ fn generic_contract_fixtures_surface_runtime_import_before_missing_artifact() {
         run_loaded_plan(
             test_plan(),
             Some(run_id),
-            FixtureOutcomeExecutor { outcome },
+            Arc::new(FixtureOutcomeExecutor { outcome }),
         )
         .expect("run completed with fixture outcome");
 
@@ -2878,7 +2882,7 @@ fn generic_contract_fixtures_hydrate_local_file_and_path_evidence() {
         run_loaded_plan(
             test_plan(),
             Some(run_id),
-            FixtureOutcomeExecutor { outcome },
+            Arc::new(FixtureOutcomeExecutor { outcome }),
         )
         .expect("run completed with fixture outcome");
 
@@ -2965,10 +2969,10 @@ fn evidence_command_hydrates_plain_local_path_refs_and_summarizes_unsupported_re
         run_loaded_plan(
             test_plan(),
             Some(run_id),
-            EvidencePathFixtureExecutor {
+            Arc::new(EvidencePathFixtureExecutor {
                 local_path: file_path.display().to_string(),
                 unsupported_uri: "provider-result://opaque/ref".to_string(),
-            },
+            }),
         )
         .expect("run completed");
 
@@ -3053,10 +3057,10 @@ fn evidence_command_truncates_large_file_evidence() {
         run_loaded_plan(
             test_plan(),
             Some(run_id),
-            EvidenceFixtureExecutor {
+            Arc::new(EvidenceFixtureExecutor {
                 run_id: run_id.to_string(),
                 file_uri: format!("file://{}", file_path.display()),
-            },
+            }),
         )
         .expect("run completed");
 
@@ -3083,9 +3087,9 @@ fn terminal_provider_failure_with_large_promotion_evidence_keeps_full_readers_lo
         run_loaded_plan(
             test_plan(),
             Some(run_id),
-            ClassifiedFailureExecutor {
+            Arc::new(ClassifiedFailureExecutor {
                 classification: AgentTaskFailureClassification::PolicyDenied,
-            },
+            }),
         )
         .expect("terminal provider failure");
         let patch = "x".repeat(30 * 1024);
@@ -3186,10 +3190,10 @@ fn run_plan_record_run_id_persists_running_status_before_executor_runs() {
     with_temp_home(|| {
         let run_id = "run-plan-durable";
         let observed_status = Arc::new(Mutex::new(None));
-        let executor = InspectingExecutor {
+        let executor = Arc::new(InspectingExecutor {
             run_id: run_id.to_string(),
             observed_status: Arc::clone(&observed_status),
-        };
+        });
 
         let (value, exit_code) =
             run_loaded_plan(test_plan(), Some(run_id), executor).expect("run-plan completed");
@@ -3225,7 +3229,7 @@ fn run_plan_lab_context_returns_lossless_terminal_aggregate() {
         let result = run_loaded_plan(
             test_plan(),
             Some("run-plan-lab-terminal"),
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
         );
 
         match previous {
@@ -3251,7 +3255,7 @@ fn run_plan_fails_fast_when_required_secret_env_is_missing() {
         std::env::remove_var(missing_secret);
         let mut plan = test_plan();
         plan.tasks[0].executor.secret_env = vec![missing_secret.to_string()];
-        let executor = CapturingExecutor::default();
+        let executor = Arc::new(CapturingExecutor::default());
         let observed_request = Arc::clone(&executor.observed_request);
 
         let error = run_loaded_plan(plan, Some("run-plan-missing-secret"), executor)
@@ -3311,10 +3315,10 @@ fn run_next_claims_oldest_queued_run_and_leaves_later_runs_queued() {
             .expect("pinned controller identity validates");
         let observed_status = Arc::new(Mutex::new(None));
 
-        let (_value, exit_code) = run_next_with_executor(InspectingExecutor {
+        let (_value, exit_code) = run_next_with_executor(Arc::new(InspectingExecutor {
             run_id: "run-next-a".to_string(),
             observed_status: Arc::clone(&observed_status),
-        })
+        }))
         .expect("claimed run completed");
 
         let observed = observed_status
@@ -3375,7 +3379,7 @@ fn run_next_fanout_claims_ready_children_without_inspecting_unrelated_stale_queu
         .expect("fanout persisted");
 
         let (_value, exit_code) = run_next_with_executor_and_fanout(
-            InspectingExecutor::noop("target-child-a"),
+            Arc::new(InspectingExecutor::noop("target-child-a")),
             Some("target-fanout".to_string()),
         )
         .expect("scoped queue claim succeeds");
@@ -3405,10 +3409,10 @@ fn run_next_fanout_claims_ready_children_without_inspecting_unrelated_stale_queu
 #[test]
 fn run_next_returns_unclaimed_when_no_queued_runs_exist() {
     with_temp_home(|| {
-        let (value, exit_code) = run_next_with_executor(InspectingExecutor {
+        let (value, exit_code) = run_next_with_executor(Arc::new(InspectingExecutor {
             run_id: "unused".to_string(),
             observed_status: Arc::new(Mutex::new(None)),
-        })
+        }))
         .expect("run-next checked queue");
 
         assert_eq!(exit_code, 0);
@@ -3595,7 +3599,7 @@ fn cook_retry_run_executes_the_replacement_through_its_cook_lifecycle() {
         )
         .expect("terminalize retryable source attempt");
 
-        let executor = CountingCookExecutor::default();
+        let executor = Arc::new(CountingCookExecutor::default());
         let (value, _exit_code) = retry_with(
             RetryArgs {
                 run_id: source_run_id.to_string(),
@@ -3695,7 +3699,7 @@ fn competing_retry_run_consumers_dispatch_a_queued_cook_replacement_exactly_once
                             artifact_id: None,
                             full: false,
                         },
-                        CountingCookExecutor::default(),
+                        Arc::new(CountingCookExecutor::default()),
                         |_| Ok(Some(Arc::new(RetryRunDispatcher))),
                     )
                 })
@@ -3775,10 +3779,10 @@ fn resume_command_executes_existing_run() {
 
         let (_value, exit_code) = run_resume_with_executor(
             "run-resume-cli".to_string(),
-            InspectingExecutor {
+            Arc::new(InspectingExecutor {
                 run_id: "run-resume-cli".to_string(),
                 observed_status: Arc::clone(&observed_status),
-            },
+            }),
         )
         .expect("resumed");
 
@@ -3969,9 +3973,9 @@ fn run_plan_maps_resolved_component_worktree_before_provider_dispatch() {
         init_runtime_component_checkout(workspace.path());
         let workspace_root = workspace.path().display().to_string();
         let observed_request = Arc::new(Mutex::new(None));
-        let executor = CapturingExecutor {
+        let executor = Arc::new(CapturingExecutor {
             observed_request: Arc::clone(&observed_request),
-        };
+        });
         let mut plan = test_plan();
         plan.tasks[0].workspace.kind = Some("component-worktree".to_string());
         plan.tasks[0].workspace.component_id = Some("sample-agent-runtime".to_string());
@@ -4030,7 +4034,7 @@ fn run_plan_rejects_component_worktree_without_branch() {
         plan.tasks[0].workspace.kind = Some("component-worktree".to_string());
         plan.tasks[0].workspace.component_id = Some("sample-agent-runtime".to_string());
 
-        let error = run_loaded_plan(plan, None, CapturingExecutor::default())
+        let error = run_loaded_plan(plan, None, Arc::new(CapturingExecutor::default()))
             .expect_err("component worktree without branch rejected");
         let message = error.to_string();
 
@@ -4106,7 +4110,7 @@ fn cook_without_gate_but_with_no_finalize_passes_the_gate_requirement() {
 
         let result = run_cook_with_executor(
             gate_requirement_cook_args(&target, false, true),
-            CapturingExecutor::default(),
+            Arc::new(CapturingExecutor::default()),
         );
 
         if let Err(error) = result {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -10,8 +10,12 @@ fn promotion_source_resolves_completed_run_id() {
     with_temp_home(|| {
         let run_id = "run-promotion-source";
 
-        run_loaded_plan(test_plan(), Some(run_id), InspectingExecutor::noop(run_id))
-            .expect("run completed");
+        run_loaded_plan(
+            test_plan(),
+            Some(run_id),
+            Arc::new(InspectingExecutor::noop(run_id)),
+        )
+        .expect("run completed");
 
         let (raw, path) = review::read_promotion_source(run_id).expect("promotion source resolved");
 
@@ -105,7 +109,7 @@ fn review_reports_completed_aggregate_and_promotion_hints() {
         run_loaded_plan(
             test_plan(),
             Some("run-review-completed"),
-            ApplyArtifactExecutor,
+            Arc::new(ApplyArtifactExecutor),
         )
         .expect("run completed");
 
@@ -158,7 +162,7 @@ fn default_review_is_bounded_and_points_to_full_evidence() {
         run_loaded_plan(
             test_plan(),
             Some("run-review-default-bounded"),
-            ApplyArtifactExecutor,
+            Arc::new(ApplyArtifactExecutor),
         )
         .expect("run completed");
 
@@ -291,18 +295,22 @@ fn cook_readers_keep_the_substantive_candidate_after_a_no_change_retry() {
         run_loaded_plan(
             test_plan(),
             Some(candidate_run_id),
-            PatchExecutor {
+            Arc::new(PatchExecutor {
                 path: patch.path().display().to_string(),
                 run_id: candidate_run_id.to_string(),
                 size_bytes: patch_contents.len() as u64,
                 sha256: homeboy_engine_primitives::content_hash::sha256_hex(
                     patch_contents.as_bytes(),
                 ),
-            },
+            }),
         )
         .expect("substantive candidate completed");
-        run_loaded_plan(test_plan(), Some(retry_run_id), NoChangeReviewExecutor)
-            .expect("intentional no-change retry completed");
+        run_loaded_plan(
+            test_plan(),
+            Some(retry_run_id),
+            Arc::new(NoChangeReviewExecutor),
+        )
+        .expect("intentional no-change retry completed");
         agent_task_lifecycle::record_cook_attempt(cook_id, 1, candidate_run_id)
             .expect("record substantive candidate");
         agent_task_lifecycle::record_cook_attempt(cook_id, 2, retry_run_id)
@@ -569,13 +577,13 @@ fn exact_status_inspects_initial_cook_record_after_alias_advances() {
         run_loaded_plan(
             test_plan(),
             Some(cook_id),
-            InspectingExecutor::noop(cook_id),
+            Arc::new(InspectingExecutor::noop(cook_id)),
         )
         .expect("initial Cook record completed");
         run_loaded_plan(
             test_plan(),
             Some(retry_run_id),
-            InspectingExecutor::noop(retry_run_id),
+            Arc::new(InspectingExecutor::noop(retry_run_id)),
         )
         .expect("retry Cook record completed");
         agent_task_lifecycle::record_cook_attempt(cook_id, 1, cook_id)
@@ -806,7 +814,7 @@ fn cook_preserves_successful_candidate_when_provider_response_has_wrong_schema()
                 acceptance_policy: None,
                 repository_identity: None,
             },
-            ExtensionProviderAgentTaskExecutor::default(),
+            Arc::new(ExtensionProviderAgentTaskExecutor::default()),
         )
         .expect("cook reported controlled failure");
 
@@ -932,7 +940,7 @@ impl AgentTaskExecutorAdapter for CommittingExecutor {
 /// the completed aggregate is written under the controller-owned attempt id.
 #[derive(Debug, Clone)]
 struct MirroredAttemptDispatcher {
-    executor: CommittingExecutor,
+    executor: Arc<CommittingExecutor>,
     prepared: Arc<std::sync::atomic::AtomicBool>,
 }
 
@@ -1116,9 +1124,9 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
         )
         .expect("write promotion provider");
 
-        let executor = CommittingExecutor {
+        let executor = Arc::new(CommittingExecutor {
             workspace: target.clone(),
-        };
+        });
         let prepared = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let (value, exit_code) = run_cook_with_executor_and_dispatcher(
             AgentTaskCookArgs {

--- a/crates/homeboy-cli/src/commands/agent_task_dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_dispatch.rs
@@ -253,6 +253,7 @@ mod tests {
         AgentTaskOutcome, AgentTaskOutcomeStatus, AGENT_TASK_OUTCOME_SCHEMA,
     };
     use serde_json::Value;
+    use std::sync::Arc;
 
     #[test]
     fn dispatch_adapter_preserves_queue_only_envelope_shape() {
@@ -271,7 +272,7 @@ mod tests {
                     ..DispatchArgOverrides::default()
                 })
                 .into(),
-                NoopExecutor,
+                Arc::new(NoopExecutor),
             )
             .expect("dispatch queued");
 
@@ -304,7 +305,7 @@ mod tests {
                     ..DispatchArgOverrides::default()
                 })
                 .into(),
-                NoopExecutor,
+                Arc::new(NoopExecutor),
             )
             .expect("dispatch queued");
 

--- a/crates/homeboy-cli/src/commands/bench/fanout.rs
+++ b/crates/homeboy-cli/src/commands/bench/fanout.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use homeboy::agents::agent_tasks::scheduler::{
     AgentTaskExecutionContext, AgentTaskPlan, AgentTaskScheduleOptions, AgentTaskScheduler,
@@ -91,7 +92,7 @@ pub(super) fn run_matrix_fanout(
         "report": run_args.report,
     });
 
-    let scheduler = AgentTaskScheduler::new_controller(LocalBenchMatrixExecutor);
+    let scheduler = AgentTaskScheduler::new_controller(Arc::new(LocalBenchMatrixExecutor));
     let scheduler_aggregate = scheduler.run(schedule);
     let matrix_aggregate =
         AgentTaskMatrixAggregate::from_outcomes(&matrix_plan, &scheduler_aggregate.outcomes);

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -1170,7 +1170,9 @@ fn run_split_placement_cook(
     let (value, exit_code) =
         crate::commands::agent_task::run::run_cook_with_executor_and_dispatcher_with_progress(
             *controller,
-            homeboy::agents::agent_tasks::provider::ExtensionProviderAgentTaskExecutor::discover(),
+            std::sync::Arc::new(
+                homeboy::agents::agent_tasks::provider::ExtensionProviderAgentTaskExecutor::discover(),
+            ),
             Some(dispatcher),
             Some(&progress),
             provenance,

--- a/crates/homeboy-lab-runner/src/workspace/provenance.rs
+++ b/crates/homeboy-lab-runner/src/workspace/provenance.rs
@@ -1693,10 +1693,10 @@ mod tests {
                 "snapshot:outer-update-2".to_string(),
             ];
             let dispatched = Arc::new(AtomicBool::new(false));
-            let scheduler = AgentTaskScheduler::new(FilesystemSnapshotProvider {
+            let scheduler = AgentTaskScheduler::new(Arc::new(FilesystemSnapshotProvider {
                 change_workspace,
                 dispatched: Arc::clone(&dispatched),
-            })
+            }))
             .with_harvest_context(
                 HarvestExecutionContext::from_lab_transport(runtime_snapshot, lab)
                     .expect("paired Lab transport"),

--- a/tests/postprocess_worker_startup.rs
+++ b/tests/postprocess_worker_startup.rs
@@ -110,7 +110,8 @@ fn scheduler_recovers_a_worker_killed_before_claim_creation() {
         let root = homeboy::core::artifacts::root()
             .expect("artifact root")
             .join("agent-task/postprocess/race-run/compose");
-        let scheduler = Arc::new(AgentTaskScheduler::new(NoopExecutor).with_run_id("race-run"));
+        let scheduler =
+            Arc::new(AgentTaskScheduler::new(Arc::new(NoopExecutor)).with_run_id("race-run"));
         let worker = thread::spawn({
             let scheduler = Arc::clone(&scheduler);
             move || scheduler.run(plan)
@@ -188,7 +189,7 @@ fn scheduler_restart_adopts_a_live_worker_without_reinvoking_helper() {
             .expect("artifact root")
             .join("agent-task/postprocess/restart-run/compose");
         let first = thread::spawn(|| {
-            AgentTaskScheduler::new(NoopExecutor)
+            AgentTaskScheduler::new(Arc::new(NoopExecutor))
                 .with_run_id("restart-run")
                 .run(postprocess_plan())
         });
@@ -203,7 +204,7 @@ fn scheduler_restart_adopts_a_live_worker_without_reinvoking_helper() {
         );
 
         let restarted = thread::spawn(|| {
-            AgentTaskScheduler::new(NoopExecutor)
+            AgentTaskScheduler::new(Arc::new(NoopExecutor))
                 .with_run_id("restart-run")
                 .run(postprocess_plan())
         });


### PR DESCRIPTION
## What this does

Erases the executor type parameter. **The generic is gone, not made optional.**

| | before | after |
|---|---|---|
| `AgentTaskExecutorAdapter + Clone` bounds | 69 | **0** |
| bare `E: AgentTaskExecutorAdapter` bounds | 39 | **0** |
| `AgentTaskScheduler<E>` | generic | **not generic** |
| executor-generic functions | 62 | **0** |
| `impl AgentTaskExecutorAdapter for X` | 74 | **74 — untouched** |

**48 files, +972 / −1002. Net −30 lines**, which is the `where` clauses coming out against the `Arc::new` wrappers going in.

## Why

`agent_task_service::cook` has seventeen `run_cook*` entry points. They aren't seventeen behaviours — they're one behaviour and a cartesian product of optional axes, spelled out longhand because Rust has no default arguments, so *"which defaults do you want"* can't be a parameter and has to be a **name**.

The fix is one entry point taking an options struct. That doesn't work while the executor is a type parameter — a struct holding a generic `E` still forces every caller to name the type. One bound held it in place:

```rust
E: AgentTaskExecutorAdapter + Clone
```

`Clone` implies `Sized`, so `dyn AgentTaskExecutorAdapter` can't satisfy it. And the `Clone` is **load-bearing** — a Cook hands a clone to each retry attempt and each parallel branch — so it couldn't just be dropped.

Nothing else was blocking erasure:

- the trait is already object-safe — `execute`/`cancel` take `&self`, neither generic, neither returns `Self`
- `Arc<T>` is `Clone` for any `T` including `?Sized`, so **`Arc` supplies the bound the trait alone cannot**
- `AgentTaskScheduler` already stored `Arc<E>`, so ownership is unchanged
- the crate already uses `Arc<dyn AgentTaskCookAttemptDispatcher>` for a sibling trait — the pattern was accepted here, cook just never got it

## A shim was written and then deleted

<callout accent="#8b5cf6">
The first draft of this branch added a blanket `impl<T: ?Sized + AgentTaskExecutorAdapter> AgentTaskExecutorAdapter for Arc<T>` so generic and erased forms could coexist, letting call sites migrate one at a time.

That is deleted. It would have left seventeen variants in place and added an **eighteenth** thing to reason about — the exact accretion this change exists to stop. A compatibility layer for a migration nobody is forced to finish is how the `_with_store` axis happened in the first place.
</callout>

## Scope discipline

**The seventeen `run_cook*` functions are still seventeen functions.** Erasing the generic is what makes collapsing them possible; doing both in one diff makes it unreviewable. They just lost their `<E>`.

Executors are untouched — all 74 `impl` blocks remain, only their *construction sites* gain an `Arc::new`.

## Judgement calls worth a reviewer's eye

- **`expire_timed_out_tasks`** took `&E`; it is now `&dyn AgentTaskExecutorAdapter` rather than `&SharedAgentTaskExecutor`, since its only caller passes `self.executor.as_ref()`.
- **`MirroredAttemptDispatcher.executor`** is `Arc<CommittingExecutor>`, not `SharedAgentTaskExecutor` — the struct is `#[derive(Debug)]` and `Arc<dyn _>` is not `Debug`.
- **`run_cook_batch`'s bound was `+ Clone + Send`.** It resolves for free because the trait declares `Send + Sync + 'static`, but it is the one bound whose satisfaction is not obvious from the alias alone. The batch coordinator spawns scoped threads over it.
- **`SharedAgentTaskExecutor` had to be added to two curated re-export lists** in `agent_tasks.rs` — they name types explicitly rather than globbing, so the CLI crate could not otherwise see the alias.
- Five files had `AgentTaskExecutorAdapter` orphaned in non-test builds once bounds came out; the import moved into the test module rather than being left unused under `-D warnings`.

## Next

```rust
run_cook(CookContext {
    executor,                    // SharedAgentTaskExecutor
    store, lifecycle_store,      // explicit roots, no ambient fallback
    ..Default::default()         // observer, policy, finalizer, reporting
})
```

Seventeen to one, and a new axis becomes a struct field instead of eight new names. It also closes an #7505 ambient twin as a side effect: `run_cook`'s entire body is `CookRecipeStore::from_current_data_root()`, so "no store supplied" stops being a silent fallback and becomes a field you have to fill.

`cargo check --workspace --tests` clean, zero warnings.

Refs #7505
