### PR TITLE
Delete the ambient store wrappers nobody calls

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
@@ -9,13 +9,18 @@
 use super::*;
 use homeboy_core::api_jobs::RemoteRunnerJobRequest;
 
-pub fn reconcile_active_lab_runner_handoffs() -> Result<usize> {
-    reconcile_active_lab_runner_handoffs_in_store(
-        &AgentTaskLifecycleStore::from_current_environment()?,
-    )
-}
+// The ambient `reconcile_active_lab_runner_handoffs()` shim that used to sit
+// above this resolved a root and delegated straight here. It had no callers, so
+// it was a resolution point that existed for nobody (#7505).
+//
+// Worth naming rather than burying: the rooted form below is reached only by
+// `tests::terminal_and_reconcile`, so this scan currently has no production
+// caller either. That is a coverage question, not a rooting one, and deleting
+// the ambient half does not change it — but it is why the shim could rot here
+// unnoticed. The module carries `#[allow(dead_code)]` in `lib.rs`, so the
+// compiler was never going to say so.
 
-/// The store-rooted counterpart of [`reconcile_active_lab_runner_handoffs`].
+/// Reconcile every active lab-runner handoff inside an explicitly rooted store.
 ///
 /// This is a queue scan that mutates every row it selects, so the scan and its
 /// consequences have to name one installation. The queue itself is read from

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -21,20 +21,17 @@ pub(super) fn lab_handoff_acceptance_timeout_seconds() -> i64 {
         .unwrap_or(LAB_HANDOFF_ACCEPTANCE_TIMEOUT_SECONDS)
 }
 
-/// Merge a completed deferred-cleanup candidate into its timeout outcome.
+// The ambient `reconcile_deferred_candidate()` shim that used to sit above this
+// resolved a root and delegated straight here. It had no callers, so it was a
+// resolution point that existed for nobody (#7505).
+
+/// Merge a completed deferred-cleanup candidate into its timeout outcome,
+/// inside an explicitly rooted store.
 ///
 /// The worker owns the mutable workspace until it exits; this lifecycle-side
 /// operation is the only place where its immutable recovery result is adopted.
 /// A per-run advisory lock makes concurrent status/artifact/Cook readers
 /// reread and persist one coherent aggregate and terminal projection.
-pub fn reconcile_deferred_candidate(run_id: &str) -> Result<bool> {
-    reconcile_deferred_candidate_in_store(
-        &AgentTaskLifecycleStore::from_current_environment()?,
-        run_id,
-    )
-}
-
-/// The store-rooted counterpart of [`reconcile_deferred_candidate`].
 ///
 /// The advisory lock is the whole point of this operation, so it must be taken
 /// in the same installation the record, aggregate, plan, and terminal
@@ -1395,32 +1392,17 @@ where
     )
 }
 
-pub(crate) fn submit_plan_with_runtime_admission_on_runner<F, A>(
-    plan: &AgentTaskPlan,
-    requested_run_id: Option<&str>,
-    execution_runner_id: Option<String>,
-    admit_runtime: F,
-) -> Result<AgentTaskRunRecord>
-where
-    F: FnOnce(&str) -> Result<A>,
-    A: RuntimeAdmissionEvidence,
-{
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    submit_plan_with_runtime_admission_in_store(
-        &lifecycle_store,
-        plan,
-        requested_run_id,
-        execution_runner_id,
-        None,
-        Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
-        admit_runtime,
-    )
-}
-
 // `submit_plan_with_runtime_admission_on_runner_with_metadata` lived here. Its
 // only caller was the retry admission, which now calls
 // `submit_plan_with_runtime_admission_in_store` with the store it was handed
 // rather than resolving a second one from the environment (#7505).
+//
+// `submit_plan_with_runtime_admission_on_runner` lived here too, and went the
+// same way for a weaker reason: it never had a caller at all. It resolved a
+// root from the environment and passed it to
+// `submit_plan_with_runtime_admission_in_store` with an explicit
+// `execution_runner_id`, which is what every remaining caller already does with
+// the store it was handed (#7505).
 
 pub(crate) fn submit_plan_with_runtime_admission_in_store<F, A>(
     lifecycle_store: &AgentTaskLifecycleStore,
@@ -2493,15 +2475,15 @@ pub fn record_cook_controller_failure_in_store(
     record.ok_or_else(|| Error::internal_unexpected("Cook controller failure record was unchanged"))
 }
 
+// The ambient `clear_cook_controller_failure()` shim that used to sit above
+// this resolved a root and delegated straight here. It had no callers, so it
+// was a resolution point that existed for nobody (#7505).
+
+/// Clear a durable controller failure inside an explicitly rooted store.
+///
 /// A successful explicit rearm starts a new continuation pass. Its prior
 /// controller failure remains in the failed continuation artifact, but must not
 /// be presented as the cause of a later terminal promotion or finalization.
-pub fn clear_cook_controller_failure(run_id: &str) -> Result<()> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    clear_cook_controller_failure_in_store(&lifecycle_store, run_id)
-}
-
-/// Clear a durable controller failure inside an explicitly rooted store.
 ///
 /// This is the erasing half of [`record_cook_controller_failure_in_store`] and
 /// has to follow the same root. An ambient reach would leave the injected

--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
@@ -1256,39 +1256,15 @@ fn now_ms() -> u64 {
     chrono::Utc::now().timestamp_millis().max(0) as u64
 }
 
-/// Inventory is local-controller evidence only. Runner authority composition is
-/// deliberately delegated to `RunnerContinuationProvider` in a later layer.
-pub fn local_workspace_authority_inventory() -> Result<Vec<AgentTaskRunRecord>> {
-    local_workspace_authority_inventory_in_store(
-        &AgentTaskLifecycleStore::from_current_environment()?,
-    )
-}
-
-/// The store-rooted counterpart of [`local_workspace_authority_inventory`].
-///
-/// The records and the owner leases that qualify them must come from one
-/// installation. Reading records from the ambient lifecycle store and then
-/// validating each lease against a separately resolved claim store degrades to
-/// an empty inventory rather than an error, and callers treat an empty
-/// inventory as "no live authority" — the composite acquisition gate clears a
-/// token-free intent marker on exactly that answer (#7505).
-pub(crate) fn local_workspace_authority_inventory_in_store(
-    lifecycle_store: &AgentTaskLifecycleStore,
-) -> Result<Vec<AgentTaskRunRecord>> {
-    let claim_store = lifecycle_store.workspace_claim_store();
-    lifecycle_store.read_records().map(|records| {
-        records
-            .into_iter()
-            .filter(|record| {
-                !record.state.is_terminal()
-                    && record.workspace_owner_lease.as_ref().is_some_and(|lease| {
-                        validate_local_workspace_owner_in_store(&claim_store, lease)
-                            .unwrap_or(false)
-                    })
-            })
-            .collect()
-    })
-}
+// `local_workspace_authority_inventory` and its
+// `local_workspace_authority_inventory_in_store` sibling lived here. The pair
+// was dead end to end: the ambient half had no callers, and the rooted half had
+// exactly one — the ambient half. Inventory was local-controller evidence only,
+// and runner authority composition is already delegated to
+// `RunnerContinuationProvider` in a later layer, so nothing was left to read it.
+// Deleting the ambient half removed a resolution point that existed for nobody;
+// the rooted half went with it rather than being left behind as a rooted body
+// no caller reaches (#7505).
 
 pub fn acquire_local_workspace_claim(
     workspace: WorkspaceIdentity,

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -556,7 +556,7 @@ fn finalize_with_operation_claim_in_store(
 
 /// Promote a cook attempt under a durable exactly-once operation claim.
 ///
-/// `promote_or_load_attempt` already loads an already-persisted promotion, but
+/// `promote_or_load_attempt_in_store` already loads an already-persisted promotion, but
 /// the fresh-promote path performs its external effect (`promote_attempt`) and
 /// only then records the result. A controller crash in that window re-runs the
 /// effect on restart. The claim closes it: reserve `promote:<run_id>` before the
@@ -583,7 +583,7 @@ fn promote_with_operation_claim_in_store(
             promote_or_load_attempt_in_store(lifecycle_store, options, run_id)
         }
         // Another pass holds a still-fresh lease. The persisted-promotion read in
-        // `promote_or_load_attempt` still resolves an already-produced promotion;
+        // `promote_or_load_attempt_in_store` still resolves an already-produced promotion;
         // if none exists yet, promotion proceeds (content-addressed and idempotent
         // on disk). Do not mark the claim completed from here — its owner does.
         agent_task_lifecycle::ClaimOutcome::LeaseHeld => {

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -2,7 +2,7 @@
 //!
 //! Extracted from `cook.rs`: the `adopt_cook_candidate*` family that admits an
 //! externally prepared immutable commit into a durable cook, plus the adoption
-//! resolution helpers (`resolve_cook_adoption_attempt`/`resolve_adoption_target`/
+//! resolution helpers (`resolve_cook_adoption_attempt_in_store`/`resolve_adoption_target`/
 //! `candidate_adoption_source`/`concrete_adoption_ai_model`) and gate-failure
 //! comparison (`compare_adoption_gate_failures_to_base`). Adoption never replays
 //! provider work — it replaces provider artifact harvesting while the source
@@ -1282,17 +1282,18 @@ fn materialize_adoption_attempt_in_stores(
     Ok((record, recipe))
 }
 
+// The ambient `resolve_cook_adoption_attempt()` shim that used to sit above
+// this resolved a root and delegated straight here. It had no callers, so it
+// was a resolution point that existed for nobody (#7505).
+
 /// A retried cook may have several lifecycle attempts for the same immutable
 /// plan. The earliest is the stable target; different plans require an explicit
 /// run ID so a candidate is never attached to the wrong policy.
-fn resolve_cook_adoption_attempt(
-    recipe: &super::AgentTaskCookRecipe,
-) -> Result<&super::AgentTaskCookRecipeAttempt> {
-    let lifecycle_store =
-        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
-    resolve_cook_adoption_attempt_in_store(&lifecycle_store, recipe)
-}
-
+///
+/// The candidate selection this reads and the recipe attempt it returns must
+/// name one installation: selecting from an ambient store and then binding the
+/// adopted attempt into an injected one silently attaches a candidate to the
+/// wrong policy without failing.
 fn resolve_cook_adoption_attempt_in_store<'a>(
     lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     recipe: &'a super::AgentTaskCookRecipe,

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -2,7 +2,7 @@
 //!
 //! Extracted from `cook.rs`: promotion-source resolution
 //! (`promotion_source`/`source_spec_path`/`source_worktree_path`), the durable
-//! promote-or-load boundary (`promote_attempt`/`promote_or_load_attempt`/
+//! promote-or-load boundary (`promote_attempt`/`promote_or_load_attempt_in_store`/
 //! `persisted_promotion_for_attempt`), PR finalization
 //! (`finalize_or_load_cook_pr*`/`finalize_cook_pr_with_backend`), the
 //! `cook_report` builder, and small spec helpers. These sit downstream of a
@@ -384,18 +384,17 @@ pub(crate) fn selected_candidate_task_id_in_store(
         .map(|outcome| outcome.task_id.clone()))
 }
 
+// The ambient `promote_or_load_attempt()` shim that used to sit above this
+// resolved a root and delegated straight here. It had no callers, so it was a
+// resolution point that existed for nobody (#7505).
+
 /// Promotion is the durable boundary between a terminal provider result and
 /// controller-owned gates. Reconciliation must reuse this exact report rather
 /// than apply the selected artifact again.
-pub(crate) fn promote_or_load_attempt(
-    options: &AgentTaskCookServiceOptions,
-    run_id: &str,
-) -> Result<AgentTaskPromotionReport> {
-    let lifecycle_store =
-        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
-    promote_or_load_attempt_in_store(&lifecycle_store, options, run_id)
-}
-
+///
+/// The persisted promotion this loads and the one it writes have to come from
+/// one installation, or a reconciliation would reuse a report the injected
+/// store never recorded.
 pub(crate) fn promote_or_load_attempt_in_store(
     lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     options: &AgentTaskCookServiceOptions,

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -1518,7 +1518,7 @@ fn validate_cook_index_attempt_in_store(
 /// observation database instead of `paths::observation_db()`.
 ///
 /// The ambient `read_records()` free shim that used to sit above this is gone.
-/// Its last caller was `reconcile_active_lab_runner_handoffs`, a queue scan that
+/// Its last caller was `reconcile_active_lab_runner_handoffs_in_store`, a queue scan that
 /// mutates every row it selects — expiring, terminalizing, and reconciling them
 /// — so it now scans the store it was handed rather than deciding from one
 /// installation's queue and committing into another (#7505).


### PR DESCRIPTION
Closes nothing on its own; a slice of #7505.

## What this removes

Seven free functions in `homeboy-agents` had exactly this shape — resolve a durable root from the process environment, delegate straight to an `_in_store` sibling — and **no callers at all**:

| file | function | visibility |
|---|---|---|
| `lab_handoff_reconciliation.rs` | `reconcile_active_lab_runner_handoffs` | `pub` |
| `lifecycle_ops.rs` | `reconcile_deferred_candidate` | `pub` |
| `lifecycle_ops.rs` | `submit_plan_with_runtime_admission_on_runner` | `pub(crate)` |
| `lifecycle_ops.rs` | `clear_cook_controller_failure` | `pub` |
| `workspace_claims.rs` | `local_workspace_authority_inventory` | `pub` |
| `cook_adoption.rs` | `resolve_cook_adoption_attempt` | private |
| `cook_promotion.rs` | `promote_or_load_attempt` | `pub(crate)` |

## Count delta

```
AgentTaskLifecycleStore::from_current_environment(    149 -> 142   (-7)
CookRecipeStore::from_current_data_root(               21 -> 21    (unchanged)
PathRoots::from_environment(                           40 -> 40    (unchanged)
```

Measured over `crates/**/*.rs` with line comments stripped, against `origin/main` @ `8c8e0f7e8`.

## Why this is a removal, not a relocation

The trap in this area is converting a caller so that the ambient constructor moves outward instead of disappearing — the count drops in one file and rises in ten. That did not happen here, and the reason is structural rather than careful: **these functions had no callers to push resolution onto.** Every `_in_store` sibling keeps the callers it already had.

One exception, stated plainly: `local_workspace_authority_inventory_in_store` was deleted too. Its only caller was the ambient half, so the pair was dead end to end. Leaving the rooted body behind would have left a rooted function no caller reaches.

## Why it rotted invisibly

`lib.rs` puts `#[allow(dead_code)]` on both modules involved:

```rust
#[allow(dead_code, unused_imports,
        reason = "Lifecycle test shards share fixtures and recovery helpers.")]
pub mod agent_task_lifecycle;

#[allow(dead_code,
        reason = "Cook adoption helpers support recovery and explicit operator flows.")]
pub mod agent_task_service;
```

So an unreferenced `pub(crate)` or private wrapper never produced a warning, and `pub` ones are exempt from `dead_code` regardless. `cargo check -D warnings` was never going to find these.

## Coverage finding, reported rather than hidden

`reconcile_active_lab_runner_handoffs_in_store` — the rooted survivor — is reached only by `tests::terminal_and_reconcile`. That scan therefore has no production caller either. Deleting the ambient half does not change that, so I left the rooted form in place and named the situation in a comment rather than quietly deleting a capability. It is a coverage question, not a rooting one, and it deserves its own decision.

## Verification

- `nice -n 10 cargo check --workspace --tests -j2` — **clean, 0 warnings, 0 errors**, 3m16s
- `cargo fmt --check` — clean
- `tests/agent_task_store_injection_test.rs` compiled standalone — **7/7 pass**, incl. both non-vacuity guards and both `KNOWN_*` staleness checks
- Re-ran the dead-wrapper scan after the edit: **0 remaining, and no new orphans from cascade**
- `validate_local_workspace_owner_in_store` and `workspace_claim_store()` both verified to retain many other callers

Not run locally: the full test suite (a `cargo test` build is ~28G on this box). No behavior is reachable from these deletions — nothing called them — so the risk is concentrated in compilation, which `check --tests` covers.
