### PR TITLE
Compact durable recoverable attempt worktrees

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
@@ -167,8 +167,22 @@ impl AttemptWorkspace {
                 unpushed.trim()
             ));
         }
-        let remove = Command::new("git")
-            .args(["worktree", "remove"])
+        self.remove(false)
+    }
+
+    /// The scheduler calls this only after durable artifact provenance and the
+    /// exact staged-patch proof authorize reclaiming a dirty checkout.
+    pub(super) fn cleanup_verified_recoverable_patch(&self) -> Result<(), String> {
+        self.remove(true)
+    }
+
+    fn remove(&self, force: bool) -> Result<(), String> {
+        let mut command = Command::new("git");
+        command.args(["worktree", "remove"]);
+        if force {
+            command.arg("--force");
+        }
+        let remove = command
             .arg(&self.root)
             .current_dir(&self.source_root)
             .status()

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -614,7 +614,8 @@ impl AgentTaskScheduler {
                             committed_harvest_preflight_outcome(task_id.clone()),
                             error,
                         );
-                        release_scratch(&scratch, "attempt_workspace_setup_failed", &outcome);
+                        let _ =
+                            release_scratch(&scratch, "attempt_workspace_setup_failed", &outcome);
                         events.push(event(
                             &task_id,
                             AgentTaskState::Failed,
@@ -648,7 +649,7 @@ impl AgentTaskScheduler {
                         task_base_sha.as_deref(),
                     ) {
                         outcome.task_id = task_id.clone();
-                        release_scratch(&scratch, "candidate_adoption_failed", &outcome);
+                        let _ = release_scratch(&scratch, "candidate_adoption_failed", &outcome);
                         record_completed_outcome(&mut completed_by_task, &mut outcomes, outcome);
                         continue;
                     }
@@ -695,7 +696,7 @@ impl AgentTaskScheduler {
                                 task_id.clone(),
                                 "provider execution was already reserved by an interrupted controller; reconcile the durable run instead of redispatching".to_string(),
                             );
-                            release_scratch(&scratch, "provider_execution_already_reserved", &outcome);
+                            let _ = release_scratch(&scratch, "provider_execution_already_reserved", &outcome);
                             events.push(event(&task_id, AgentTaskState::Failed, attempt, outcome.summary.clone()));
                             record_completed_outcome(&mut completed_by_task, &mut outcomes, outcome);
                             continue;
@@ -708,7 +709,7 @@ impl AgentTaskScheduler {
                                 error.message
                             ),
                         );
-                        release_scratch(
+                        let _ = release_scratch(
                             &scratch,
                             "provider_execution_persistence_failed",
                             &outcome,
@@ -1010,8 +1011,21 @@ impl AgentTaskScheduler {
                         retry_budget_used,
                         &plan.options.retry.retryable_failure_classifications,
                     ) {
-                        cleanup_attempt_workspace(&mut outcome, &running_task);
-                        release_scratch(&result.scratch, "retry", &outcome);
+                        let timeout_compaction = (outcome.failure_classification
+                            == Some(AgentTaskFailureClassification::Timeout))
+                        .then_some("timeout");
+                        let authorization = cleanup_attempt_workspace(
+                            &mut outcome,
+                            &running_task,
+                            timeout_compaction,
+                        );
+                        release_and_compact_attempt_workspace(
+                            &result.scratch,
+                            "retry",
+                            &mut outcome,
+                            &running_task,
+                            authorization,
+                        );
                         retry_budget_used += 1;
                         let retry_evidence = retry_attempt_evidence(&outcome, &running_task);
                         let mut retry_attempts = running_task.retry_attempts;
@@ -1057,8 +1071,18 @@ impl AgentTaskScheduler {
                             execution_budget.max_provider_executions,
                             execution_budget.max_provider_rotations,
                         ) {
-                            cleanup_attempt_workspace(&mut outcome, &running_task);
-                            release_scratch(&result.scratch, "provider_rotation", &outcome);
+                            let authorization = cleanup_attempt_workspace(
+                                &mut outcome,
+                                &running_task,
+                                Some("provider_rotation"),
+                            );
+                            release_and_compact_attempt_workspace(
+                                &result.scratch,
+                                "provider_rotation",
+                                &mut outcome,
+                                &running_task,
+                                authorization,
+                            );
                             let mut rotation_attempts = running_task.rotation_attempts.clone();
                             rotation_attempts.push(
                                 AgentTaskScheduleSupport::rotation_attempt_record(
@@ -1160,7 +1184,7 @@ impl AgentTaskScheduler {
                         reason = "the branch deliberately shadows its pre-retry outcome before terminal mutation"
                     )]
                     let mut outcome = outcome;
-                    cleanup_attempt_workspace(&mut outcome, &running_task);
+                    cleanup_attempt_workspace(&mut outcome, &running_task, None);
                     append_unique_artifacts(
                         &mut outcome.artifacts,
                         running_task.candidate_artifacts,
@@ -1203,7 +1227,7 @@ impl AgentTaskScheduler {
                         running_task.rotation_index,
                         same_provider_retries_used,
                     );
-                    release_scratch(
+                    let _ = release_scratch(
                         &result.scratch,
                         if running_task.timeout_cancel_requested {
                             "scheduler_timeout_completion"
@@ -1596,23 +1620,40 @@ pub(super) fn release_scratch(
     allocation: &crate::controller_scratch::ControllerScratchAllocation,
     reason: &str,
     outcome: &AgentTaskOutcome,
-) {
-    let evidence = serde_json::json!({
+) -> homeboy_core::Result<()> {
+    crate::controller_scratch::release_attempt(
+        allocation,
+        reason,
+        serde_json::json!({
         "task_id": outcome.task_id,
         "status": outcome.status,
         "outcome": outcome,
-    });
-    let _ = crate::controller_scratch::release_attempt(allocation, reason, evidence);
+        }),
+    )
 }
 
 /// A clean attempt is unregistered from Git before its enclosing scratch lease
 /// is released. Dirty, unpushed, and indeterminate checkouts remain registered
 /// for lifecycle cleanup instead of being force-removed.
-fn cleanup_attempt_workspace(outcome: &mut AgentTaskOutcome, running: &RunningTask) {
+fn cleanup_attempt_workspace(
+    outcome: &mut AgentTaskOutcome,
+    running: &RunningTask,
+    compaction_reason: Option<&str>,
+) -> Option<RecoverablePatchProof> {
     let Some(workspace) = &running._attempt_workspace else {
-        return;
+        return None;
     };
     if let Err(error) = workspace.cleanup() {
+        if let Some(reason) = compaction_reason {
+            match recoverable_patch_proof(outcome, running, workspace) {
+                Ok(proof) => return Some(proof.with_reason(reason)),
+                Err(refusal) => outcome.diagnostics.push(AgentTaskDiagnostic {
+                    class: "agent_task.attempt_workspace_compaction_refused".to_string(),
+                    message: format!("attempt workspace retained: compact recovery proof refused: {refusal}"),
+                    data: serde_json::json!({ "outcome": "refused", "reason": reason, "refusal_reason": refusal, "path": running.request.workspace.root }),
+                }),
+            }
+        }
         outcome.diagnostics.push(AgentTaskDiagnostic {
             class: "agent_task.attempt_workspace_retained".to_string(),
             message: format!("attempt workspace retained for lifecycle cleanup: {error}"),
@@ -1622,6 +1663,135 @@ fn cleanup_attempt_workspace(outcome: &mut AgentTaskOutcome, running: &RunningTa
             }),
         });
     }
+    None
+}
+
+struct RecoverablePatchProof {
+    id: String,
+    sha256: String,
+    base_ref: String,
+    reason: String,
+}
+
+impl RecoverablePatchProof {
+    fn with_reason(mut self, reason: &str) -> Self {
+        self.reason = reason.to_string();
+        self
+    }
+}
+
+/// Persist terminal evidence before a force removal. A successful release is
+/// also the durable authorization a later controller-scratch cleanup rechecks
+/// if the process stops between these two operations.
+fn release_and_compact_attempt_workspace(
+    allocation: &crate::controller_scratch::ControllerScratchAllocation,
+    reason: &str,
+    outcome: &mut AgentTaskOutcome,
+    running: &RunningTask,
+    authorization: Option<RecoverablePatchProof>,
+) {
+    let Some(authorization) = authorization else {
+        let _ = release_scratch(allocation, reason, outcome);
+        return;
+    };
+    let evidence = serde_json::json!({
+        "task_id": outcome.task_id,
+        "status": outcome.status,
+        "outcome": outcome,
+        "compaction_authorization": {
+            "outcome": "authorized",
+            "reason": authorization.reason,
+            "patch_artifact_id": authorization.id,
+            "patch_sha256": authorization.sha256,
+            "base_ref": authorization.base_ref,
+        },
+    });
+    match crate::controller_scratch::release_attempt_with_compaction_authorization(
+        allocation, reason, evidence,
+    ) {
+        Ok(()) => {
+            let Some(workspace) = &running._attempt_workspace else {
+                return;
+            };
+            match workspace.cleanup_verified_recoverable_patch() {
+                Ok(()) => outcome.diagnostics.push(AgentTaskDiagnostic {
+                    class: "agent_task.attempt_workspace_compacted".to_string(),
+                    message: "attempt checkout was compacted after durable authorization and exact patch verification".to_string(),
+                    data: serde_json::json!({
+                        "outcome": "compacted",
+                        "reason": authorization.reason,
+                        "path": running.request.workspace.root,
+                        "patch_artifact_id": authorization.id,
+                        "patch_sha256": authorization.sha256,
+                        "base_ref": authorization.base_ref,
+                    }),
+                }),
+                Err(error) => outcome.diagnostics.push(AgentTaskDiagnostic {
+                    class: "agent_task.attempt_workspace_compaction_refused".to_string(),
+                    message: format!("attempt workspace retained after durable authorization: {error}"),
+                    data: serde_json::json!({ "outcome": "refused", "reason": authorization.reason, "refusal_reason": "worktree_remove_failed", "path": running.request.workspace.root }),
+                }),
+            }
+        }
+        Err(error) => outcome.diagnostics.push(AgentTaskDiagnostic {
+            class: "agent_task.attempt_workspace_compaction_refused".to_string(),
+            message: format!("attempt workspace retained because durable compaction authorization could not be persisted: {}", error.message),
+            data: serde_json::json!({ "outcome": "refused", "reason": authorization.reason, "refusal_reason": "authorization_persistence_failed", "path": running.request.workspace.root }),
+        }),
+    }
+}
+
+fn recoverable_patch_proof(
+    outcome: &AgentTaskOutcome,
+    running: &RunningTask,
+    workspace: &AttemptWorkspace,
+) -> Result<RecoverablePatchProof, String> {
+    let artifact_root = artifact_root_for_running(running).map_err(|error| format!("{error:?}"))?;
+    let mut matches = outcome.artifacts.iter().filter(|artifact| {
+        artifact.kind == "patch"
+            && artifact.metadata["run_id"].as_str() == running.run_id.as_deref()
+            && artifact.metadata["task_id"].as_str() == Some(running.task_id.as_str())
+            && artifact.metadata["producer_attempt"].as_u64() == Some(running.attempt as u64)
+            && artifact.metadata["base_ref"].as_str() == Some(workspace.base_sha())
+    });
+    let Some(artifact) = matches.next() else {
+        return Err("no finalized patch artifact is bound to this attempt base".to_string());
+    };
+    if matches.next().is_some() {
+        return Err(
+            "multiple finalized patch artifacts are bound to this attempt base".to_string(),
+        );
+    }
+    let Some(path) = artifact.path.as_deref().map(std::path::PathBuf::from) else {
+        return Err("patch artifact has no readable path".to_string());
+    };
+    if !path.starts_with(&artifact_root) {
+        return Err("patch artifact is outside the durable artifact root".to_string());
+    }
+    let Some(expected_sha256) = artifact.sha256.as_deref() else {
+        return Err("patch artifact has no content hash".to_string());
+    };
+    let patch =
+        std::fs::read(&path).map_err(|error| format!("cannot read patch artifact: {error}"))?;
+    if homeboy_engine_primitives::content_hash::sha256_hex(&patch) != expected_sha256 {
+        return Err("patch artifact content hash does not match its finalized record".to_string());
+    }
+    if !crate::controller_scratch::workspace_matches_staged_patch(
+        workspace.root(),
+        workspace.base_sha(),
+        &patch,
+    ) {
+        return Err(
+            "checkout does not exactly match the finalized patch against its immutable base"
+                .to_string(),
+        );
+    }
+    Ok(RecoverablePatchProof {
+        id: artifact.id.clone(),
+        sha256: expected_sha256.to_string(),
+        base_ref: workspace.base_sha().to_string(),
+        reason: String::new(),
+    })
 }
 
 fn terminal_reason(outcome: &AgentTaskOutcome, cancelled: bool) -> &'static str {

--- a/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
@@ -769,7 +769,7 @@ impl AgentTaskScheduleSupport {
                             );
                             super::finalize_candidate_artifacts(&mut recovered, &task);
                         }
-                        super::engine::release_scratch(
+                        let _ = super::engine::release_scratch(
                             &task.scratch,
                             "scheduler_timeout_completion",
                             &recovered,

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
@@ -9,6 +9,7 @@ mod provider_rotation_tests {
     struct DirtyCandidateThenSuccessExecutor {
         observed_roots: Arc<Mutex<Vec<std::path::PathBuf>>>,
         calls: AtomicUsize,
+        declared_mismatched_patch: bool,
     }
 
     struct AdoptionExecutor {
@@ -175,6 +176,25 @@ mod provider_rotation_tests {
                 fs::write(root.join("candidate.txt"), "candidate\n").expect("candidate edit");
                 let mut outcome = outcome(request.task_id, AgentTaskOutcomeStatus::Timeout);
                 outcome.failure_classification = Some(AgentTaskFailureClassification::Timeout);
+                if self.declared_mismatched_patch {
+                    let patch_path = root.join("reported.patch");
+                    fs::write(&patch_path, "not the candidate patch\n").expect("mismatched patch");
+                    outcome.artifacts.push(AgentTaskArtifact {
+                        schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+                        id: "mismatched-patch".to_string(),
+                        kind: "patch".to_string(),
+                        name: Some("reported.patch".to_string()),
+                        label: None,
+                        role: Some("patch".to_string()),
+                        semantic_key: None,
+                        path: Some(patch_path.display().to_string()),
+                        url: None,
+                        mime: Some("text/x-patch".to_string()),
+                        size_bytes: None,
+                        sha256: None,
+                        metadata: Value::Null,
+                    });
+                }
                 return outcome;
             }
             assert!(
@@ -382,7 +402,16 @@ mod provider_rotation_tests {
     }
 
     #[test]
-    fn rotation_preserves_uncommitted_candidate_and_dispatches_next_provider_from_clean_baseline() {
+    fn rotation_compacts_exact_recoverable_patch() {
+        rotation_compacts_only_exact_recoverable_patch(false);
+    }
+
+    #[test]
+    fn rotation_retains_mismatched_recoverable_patch() {
+        rotation_compacts_only_exact_recoverable_patch(true);
+    }
+
+    fn rotation_compacts_only_exact_recoverable_patch(declared_mismatched_patch: bool) {
         let _home = homeboy_core::test_support::HomeGuard::new();
         let temp = tempfile::tempdir().expect("tempdir");
         let workspace = temp.path().join("workspace");
@@ -391,6 +420,7 @@ mod provider_rotation_tests {
         let scheduler = AgentTaskScheduler::new(Arc::new(DirtyCandidateThenSuccessExecutor {
             observed_roots: Arc::clone(&observed_roots),
             calls: AtomicUsize::new(0),
+            declared_mismatched_patch,
         }))
         .with_run_id("cook-detached-37abbb52-d638-495c-b270-46fdc965fc9c-attempt-1-fb890874");
         let mut plan = plan_with_tasks(1);
@@ -437,7 +467,14 @@ mod provider_rotation_tests {
         let candidate = aggregate.outcomes[0]
             .artifacts
             .iter()
-            .find(|artifact| artifact.id == "task-1-attempt-1-uncommitted-changes")
+            .find(|artifact| {
+                artifact.id
+                    == if declared_mismatched_patch {
+                        "mismatched-patch"
+                    } else {
+                        "task-1-attempt-1-uncommitted-changes"
+                    }
+            })
             .expect("failed attempt patch candidate is retained for promotion");
         assert_eq!(candidate.kind, "patch");
         assert_eq!(candidate.metadata["producer_attempt"], 1);
@@ -455,18 +492,23 @@ mod provider_rotation_tests {
         assert_eq!(candidate.metadata["task_id"], "task-1");
         let patch = fs::read_to_string(candidate.path.as_deref().expect("candidate path"))
             .expect("candidate patch remains available");
-        assert!(patch.contains("diff --git a/candidate.txt b/candidate.txt"));
+        if declared_mismatched_patch {
+            assert_eq!(patch, "not the candidate patch\n");
+        } else {
+            assert!(patch.contains("diff --git a/candidate.txt b/candidate.txt"));
+        }
         assert!(candidate
             .path
             .as_deref()
             .is_some_and(|path| path.contains("agent-task/attempt-patches/cook-detached-37abbb52-d638-495c-b270-46fdc965fc9c-attempt-1-fb890874/task-1")));
-        // The first attempt left an uncommitted candidate (captured above as a
-        // promoted patch artifact), so scheduler cleanup retains its checkout for
-        // lifecycle cleanup rather than force-removing it (#8579). The second,
-        // cleanly-succeeding attempt holds no work and its checkout is retired.
-        assert!(
+        // The first attempt left an uncommitted candidate, but the finalized
+        // durable patch byte-for-byte proves the staged checkout against base.
+        // Rotation can therefore unregister it without retaining multi-GB
+        // build state; the second clean attempt is retired normally.
+        assert_eq!(
             roots[0].exists(),
-            "attempt with a retained uncommitted candidate keeps its checkout for lifecycle cleanup"
+            declared_mismatched_patch,
+            "only an exactly represented candidate may retain its checkout"
         );
         assert!(
             !roots[1].exists(),

--- a/crates/homeboy-agents/src/controller_scratch.rs
+++ b/crates/homeboy-agents/src/controller_scratch.rs
@@ -263,6 +263,49 @@ pub fn release_attempt(
     })
 }
 
+/// Persist a terminal record that authorizes destructive attempt compaction.
+/// Unlike ordinary release replay, an already-finalized lease is accepted only
+/// when it contains byte-for-byte the same evidence. A different earlier
+/// terminal record cannot accidentally authorize a later force removal.
+pub fn release_attempt_with_compaction_authorization(
+    allocation: &ControllerScratchAllocation,
+    reason: &str,
+    evidence: serde_json::Value,
+) -> Result<()> {
+    with_index_lock(&allocation.index_path, || {
+        let mut index = read_index_at_unlocked(&allocation.index_path)?;
+        let Some(resource) = index.resources.iter_mut().find(|resource| {
+            resource.lease_id == allocation.lease_id
+                && Path::new(&resource.path) == allocation.path.as_path()
+        }) else {
+            return Err(Error::validation_invalid_argument(
+                "controller_scratch.lease_id",
+                "allocated scratch lease is not registered",
+                Some(allocation.lease_id.clone()),
+                None,
+            ));
+        };
+        if resource.finalized_at.is_none() {
+            resource.lifecycle_state = "released".to_string();
+            resource.finalized_at = Some(chrono::Utc::now().to_rfc3339());
+            resource.terminal_reason = Some(reason.to_string());
+            resource.terminal_evidence = Some(evidence);
+            return write_index_at_unlocked(&allocation.index_path, &index);
+        }
+        if resource.terminal_reason.as_deref() == Some(reason)
+            && resource.terminal_evidence.as_ref() == Some(&evidence)
+        {
+            return Ok(());
+        }
+        Err(Error::validation_invalid_argument(
+            "controller_scratch.compaction_authorization",
+            "lease already has different terminal evidence and cannot authorize compaction",
+            Some(allocation.lease_id.clone()),
+            None,
+        ))
+    })
+}
+
 /// Mark a controller-owned allocation as disposable temporary state. This is
 /// intentionally separate from ordinary attempt scratch: an interrupted
 /// detached checkout has no upstream by design, so the normal unpushed-Git
@@ -1389,6 +1432,7 @@ fn cleanup_block_reason_with_observation(
     if !resource.ephemeral {
         match git_safety_path(resource, path) {
             Some(path) if recovered_workspace_matches(resource, &path) => {}
+            Some(path) if terminal_evidence_attempt_workspace_matches(resource, &path) => {}
             Some(path) if promoted_attempt_workspace_matches(resource, &path) => {}
             Some(path) if git_dirty_or_unpushed(&path) => {
                 return Ok(Some("git checkout has dirty or unpushed state".to_string()));
@@ -1668,7 +1712,94 @@ fn promoted_attempt_workspace_matches(
     workspace_matches_staged_patch(workspace, base, &patch)
 }
 
-fn workspace_matches_staged_patch(workspace: &Path, base: &str, patch: &[u8]) -> bool {
+/// A scheduler may stop after persisting authorization but before it can call
+/// `git worktree remove --force`. The release record is then the only durable
+/// authority for compaction; revalidate both the recorded artifact and the
+/// current checkout before allowing ordinary scratch cleanup to converge.
+fn terminal_evidence_attempt_workspace_matches(
+    resource: &ControllerScratchResource,
+    workspace: &Path,
+) -> bool {
+    let Some(evidence) = resource.terminal_evidence.as_ref() else {
+        return false;
+    };
+    let Some(authorization) = evidence.get("compaction_authorization") else {
+        return false;
+    };
+    if authorization
+        .get("outcome")
+        .and_then(serde_json::Value::as_str)
+        != Some("authorized")
+        || !matches!(
+            authorization
+                .get("reason")
+                .and_then(serde_json::Value::as_str),
+            Some("timeout") | Some("provider_rotation")
+        )
+    {
+        return false;
+    }
+    let Some(id) = authorization
+        .get("patch_artifact_id")
+        .and_then(serde_json::Value::as_str)
+    else {
+        return false;
+    };
+    let Some(expected_sha256) = authorization
+        .get("patch_sha256")
+        .and_then(serde_json::Value::as_str)
+    else {
+        return false;
+    };
+    let Some(base) = authorization
+        .get("base_ref")
+        .and_then(serde_json::Value::as_str)
+    else {
+        return false;
+    };
+    let Some(artifact) = evidence
+        .pointer("/outcome/artifacts")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|artifacts| {
+            artifacts.iter().find(|artifact| {
+                artifact.get("id").and_then(serde_json::Value::as_str) == Some(id)
+                    && artifact.get("kind").and_then(serde_json::Value::as_str) == Some("patch")
+                    && artifact.get("sha256").and_then(serde_json::Value::as_str)
+                        == Some(expected_sha256)
+                    && artifact
+                        .pointer("/metadata/run_id")
+                        .and_then(serde_json::Value::as_str)
+                        == Some(resource.run_id.as_str())
+                    && artifact
+                        .pointer("/metadata/task_id")
+                        .and_then(serde_json::Value::as_str)
+                        == Some(resource.task_id.as_str())
+                    && artifact
+                        .pointer("/metadata/producer_attempt")
+                        .and_then(serde_json::Value::as_u64)
+                        == Some(resource.attempt as u64)
+                    && artifact
+                        .pointer("/metadata/base_ref")
+                        .and_then(serde_json::Value::as_str)
+                        == Some(base)
+            })
+        })
+    else {
+        return false;
+    };
+    let Some(path) = artifact.get("path").and_then(serde_json::Value::as_str) else {
+        return false;
+    };
+    let Ok(patch) = fs::read(path) else {
+        return false;
+    };
+    sha256(&patch) == expected_sha256 && workspace_matches_staged_patch(workspace, base, &patch)
+}
+
+/// Verify that a checkout contains only the supplied staged patch against its
+/// immutable base. Scheduler compaction reuses this promotion proof rather
+/// than treating a persisted patch as sufficient evidence on its own.
+pub(crate) fn workspace_matches_staged_patch(workspace: &Path, base: &str, patch: &[u8]) -> bool {
     let Ok(head) = git::run_git(workspace, &["rev-parse", "HEAD"], "git rev-parse HEAD") else {
         return false;
     };
@@ -1677,7 +1808,15 @@ fn workspace_matches_staged_patch(workspace: &Path, base: &str, patch: &[u8]) ->
     }
     let Ok(status) = git::run_git(
         workspace,
-        &["status", "--porcelain=v1", "--ignored"],
+        &[
+            "status",
+            "--porcelain=v1",
+            "--ignored",
+            "--",
+            ".",
+            ":(exclude).homeboy/runner-workspace.json",
+            ":(exclude).homeboy/lab-at-files/**",
+        ],
         "git status",
     ) else {
         return false;
@@ -1700,6 +1839,8 @@ fn workspace_matches_staged_patch(workspace: &Path, base: &str, patch: &[u8]) ->
             "HEAD",
             "--",
             ".",
+            ":(exclude).homeboy/runner-workspace.json",
+            ":(exclude).homeboy/lab-at-files/**",
         ],
         "git diff cached",
     )
@@ -3684,6 +3825,14 @@ mod tests {
             "the harvested staged candidate must match exactly"
         );
 
+        fs::create_dir_all(worktree.join(".homeboy/lab-at-files")).expect("runner metadata");
+        fs::write(worktree.join(".homeboy/runner-workspace.json"), "{}").expect("runner metadata");
+        fs::write(worktree.join(".homeboy/lab-at-files/plan.json"), "{}").expect("runner metadata");
+        assert!(
+            workspace_matches_staged_patch(&worktree, &base, &patch),
+            "Homeboy runner metadata excluded from harvest must not block compaction"
+        );
+
         fs::write(worktree.join("untracked.txt"), "not in the patch\n").expect("extra file");
         assert!(
             !workspace_matches_staged_patch(&worktree, &base, &patch),
@@ -3703,6 +3852,66 @@ mod tests {
         assert!(
             !workspace_matches_staged_patch(&worktree, &base, &patch),
             "a provider commit must remain recoverable even when its diff matches"
+        );
+    }
+
+    #[test]
+    fn terminal_compaction_authorization_converges_after_scheduler_stops() {
+        let root = tempfile::tempdir().expect("root");
+        let lease = root.path().join("lease");
+        let (_source, worktree) = attempt_worktree(root.path(), &lease);
+        let base = git::run_git(&worktree, &["rev-parse", "HEAD"], "git rev-parse HEAD")
+            .expect("base")
+            .trim()
+            .to_string();
+        fs::write(worktree.join("candidate.txt"), "candidate\n").expect("candidate");
+        run_git(&worktree, &["add", "candidate.txt"]);
+        let patch = git::run_git(
+            &worktree,
+            &[
+                "diff",
+                "--cached",
+                "--binary",
+                "--full-index",
+                "--find-renames",
+                "HEAD",
+                "--",
+                ".",
+            ],
+            "git diff cached",
+        )
+        .expect("patch");
+        let patch_path = root.path().join("candidate.patch");
+        fs::write(&patch_path, &patch).expect("persisted patch");
+        let mut resource = resource(&lease, root.path());
+        resource.attempt = 1;
+        resource.terminal_evidence = Some(serde_json::json!({
+            "outcome": {
+                "artifacts": [{
+                    "id": "candidate",
+                    "kind": "patch",
+                    "path": patch_path,
+                    "sha256": sha256(patch.as_bytes()),
+                    "metadata": {
+                        "run_id": resource.run_id.clone(),
+                        "task_id": resource.task_id.clone(),
+                        "producer_attempt": 1,
+                        "base_ref": base.clone(),
+                    },
+                }],
+            },
+            "compaction_authorization": {
+                "outcome": "authorized",
+                "reason": "provider_rotation",
+                "patch_artifact_id": "candidate",
+                "patch_sha256": sha256(patch.as_bytes()),
+                "base_ref": base.clone(),
+            },
+        }));
+
+        assert!(
+            terminal_evidence_attempt_workspace_matches(&resource, &worktree),
+            "durable authorization must allow cleanup to converge after an interrupted scheduler"
         );
     }
 


### PR DESCRIPTION
## Summary

- compact timeout and provider-rotation worktrees only when the finalized patch exactly reproduces the checkout against its immutable base
- persist durable controller-scratch authorization before force removal and revalidate it during interrupted cleanup recovery
- preserve every unmatched byte, commit, missing artifact, hash mismatch, or persistence failure fail-closed
- align proof with Homeboy-owned runner metadata exclusions and emit structured compaction evidence

Closes #12729.

## Verification

- `cargo fmt --check`
- `cargo check -p homeboy-agents`
- `cargo test -p homeboy-agents controller_scratch --lib` (39 passed)
- `cargo test -p homeboy-agents rotation_compacts_exact_recoverable_patch --lib`
- `cargo test -p homeboy-agents rotation_retains_mismatched_recoverable_patch --lib`
- `cargo test -p homeboy-agents retries_failed_tasks_until_success --lib`
- `cargo test -p homeboy-agents retry_uses_clean_isolated_workspace_after_permission_denial --lib`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode correlated production scratch retention with durable run evidence, implemented and reviewed the crash-consistent compaction path, and ran the verification above under Chris Huber direction. Chris reviewed the resulting diff and remains responsible for every line.