### PR TITLE
Stop the durable failure report splitting its roots

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -3764,7 +3764,11 @@ pub fn run_cook(ctx: CookContext<'_>) -> Result<AgentTaskRunResult<AgentTaskCook
                 resolved_lifecycle_store = lifecycle_store;
                 &resolved_lifecycle_store
             }
-            Err(error) => return durable_cook_error_report_with_store(store, &options, error),
+            // No lifecycle store exists to inject: resolving one is what just
+            // failed. The report still names the recipe roots the caller owns.
+            Err(error) => {
+                return durable_cook_error_report_with_store(store, None, &options, error)
+            }
         },
     };
 
@@ -3931,7 +3935,12 @@ fn run_cook_reported(
                     ));
                 }
             }
-            return durable_cook_error_report_with_store(store, &failure_options, error);
+            return durable_cook_error_report_with_store(
+                store,
+                Some(lifecycle_store),
+                &failure_options,
+                error,
+            );
         }
     };
     if let Some(run_id) = result.value.latest_run_id.as_deref() {
@@ -3951,7 +3960,12 @@ fn run_cook_reported(
             attempt,
             Some(&result.value.status),
         ) {
-            return durable_cook_error_report_with_store(store, &failure_options, error);
+            return durable_cook_error_report_with_store(
+                store,
+                Some(lifecycle_store),
+                &failure_options,
+                error,
+            );
         }
         if phase == "terminal" {
             if let Err(error) = agent_task_lifecycle::record_cook_terminal_result_in_store(
@@ -3960,7 +3974,12 @@ fn run_cook_reported(
                 result.exit_code == 0,
                 result.exit_code,
             ) {
-                return durable_cook_error_report_with_store(store, &failure_options, error);
+                return durable_cook_error_report_with_store(
+                    store,
+                    Some(lifecycle_store),
+                    &failure_options,
+                    error,
+                );
             }
         }
     }
@@ -3975,30 +3994,61 @@ fn durable_cook_error_report(
     error: Error,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
     let store = CookRecipeStore::from_current_data_root()?;
-    durable_cook_error_report_with_store(&store, options, error)
+    // The fully ambient entry point: it resolves the recipe root and holds no
+    // lifecycle store, so nothing is injected here and nothing is split.
+    durable_cook_error_report_with_store(&store, None, options, error)
 }
 
+/// The durable failure report, bound to the roots its caller owns.
+///
+/// `lifecycle_store` is `Option` because one caller genuinely has none: `run_cook`
+/// routes here precisely when `AgentTaskLifecycleStore::from_current_environment()`
+/// failed, so there is no store to inject and the ambient reads below will fail
+/// the same way they always did. Every caller that *does* hold a lifecycle store
+/// now passes it.
+///
+/// That distinction is the whole point. This function reads the recipe from an
+/// injected `CookRecipeStore` and used to write the controller failure through
+/// ambient `agent_task_lifecycle` shims, so a Cook whose recipe lives in an
+/// injected home had its failure diagnostic recorded in whatever home the
+/// environment pointed at — and nothing failed while doing it: the report still
+/// returned, the recipe still read back correct, and only the cause went
+/// missing. That is the split `KNOWN_MIXED_STORE_FUNCTIONS` was written for; it
+/// stayed invisible to the scanner because it reached through wrappers instead
+/// of naming a store constructor (#7505).
 fn durable_cook_error_report_with_store(
     store: &CookRecipeStore,
+    lifecycle_store: Option<&AgentTaskLifecycleStore>,
     options: &AgentTaskCookServiceOptions,
     error: Error,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
+    // The attempt record is presentation only — a missing one degrades to an
+    // empty attempts list, exactly as the ambient read's `.ok()` already did.
+    let attempt_record = |run_id: &str| match lifecycle_store {
+        Some(lifecycle_store) => agent_task_lifecycle::status_in_store(
+            lifecycle_store,
+            run_id,
+            agent_task_lifecycle::AgentTaskStatusOptions::default(),
+            false,
+        )
+        .ok()
+        .map(|outcome| outcome.record),
+        None => agent_task_lifecycle::status(run_id).ok(),
+    };
     if store.recipe_exists(&options.cook_id) {
         let attempts = store
             .load_recipe(&options.cook_id)
             .ok()
             .and_then(|recipe| recipe.attempts.last().cloned())
             .and_then(|attempt| {
-                agent_task_lifecycle::status(&attempt.run_id)
-                    .ok()
-                    .map(|record| AgentTaskCookAttemptReport {
-                        attempt: attempt.attempt,
-                        run_id: attempt.run_id,
-                        run_state: format!("{:?}", record.state),
-                        aggregate_path: record.aggregate_path,
-                        promotion: None,
-                        feedback: None,
-                    })
+                attempt_record(&attempt.run_id).map(|record| AgentTaskCookAttemptReport {
+                    attempt: attempt.attempt,
+                    run_id: attempt.run_id,
+                    run_state: format!("{:?}", record.state),
+                    aggregate_path: record.aggregate_path,
+                    promotion: None,
+                    feedback: None,
+                })
             })
             .into_iter()
             .collect();
@@ -4026,11 +4076,32 @@ fn durable_cook_error_report_with_store(
             context.phase = "controller".to_string();
             context.reason_code = error.code.as_str().to_string();
             context.diagnostic = Some(bounded_error_diagnostic(&error));
-            if agent_task_lifecycle::run_record_exists(&options.initial_run_id)? {
-                agent_task_lifecycle::record_cook_controller_failure(
-                    &options.initial_run_id,
-                    context.diagnostic.as_ref().expect("controller diagnostic"),
-                )?;
+            // The existence check and the write that follows it must name one
+            // installation: probing the ambient home and then recording into
+            // the injected one (or the reverse) is a check that answers about a
+            // record the write never touches.
+            let diagnostic = context.diagnostic.as_ref().expect("controller diagnostic");
+            match lifecycle_store {
+                Some(lifecycle_store) => {
+                    if agent_task_lifecycle::run_record_exists_in_store(
+                        lifecycle_store,
+                        &options.initial_run_id,
+                    )? {
+                        agent_task_lifecycle::record_cook_controller_failure_in_store(
+                            lifecycle_store,
+                            &options.initial_run_id,
+                            diagnostic,
+                        )?;
+                    }
+                }
+                None => {
+                    if agent_task_lifecycle::run_record_exists(&options.initial_run_id)? {
+                        agent_task_lifecycle::record_cook_controller_failure(
+                            &options.initial_run_id,
+                            diagnostic,
+                        )?;
+                    }
+                }
             }
         }
         return Ok(report);


### PR DESCRIPTION
A slice of #7505. Touches only `cook.rs`; independent of open PR #12732.

## The split

`durable_cook_error_report_with_store` takes an injected `CookRecipeStore`, reads the recipe from it — then recorded the controller failure through ambient `agent_task_lifecycle` shims:

```rust
fn durable_cook_error_report_with_store(store: &CookRecipeStore, ...) {
    store.load_recipe(&options.cook_id)                       // injected home
    agent_task_lifecycle::status(&attempt.run_id)             // ambient home
    agent_task_lifecycle::run_record_exists(...)              // ambient home
    agent_task_lifecycle::record_cook_controller_failure(...) // ambient home
}
```

A Cook whose recipe lives in an injected home had its failure diagnostic written wherever the environment pointed.

**Nothing fails while doing it.** The report still returns, the recipe still reads back correct, and only the cause goes missing — the same silent shape as #12618. It is invisible to `tests/agent_task_store_injection_test.rs` because it reaches through *wrappers* rather than naming a store constructor, which is exactly the blind spot #12595 named.

The worst pair is the existence check and the write that follows it: probing one home and recording into another is a check that answers about a record the write never touches.

## Not theoretical

`run_cook_reported` already guards on:

```rust
&& store.data_root() == lifecycle_store.data_root()
```

The codebase already knows these two roots can differ. This is the failure path that didn't get the memo.

## Why `Option`, not a required parameter

One caller genuinely has no store. `run_cook` routes here **precisely when** `AgentTaskLifecycleStore::from_current_environment()` failed:

```rust
Err(error) => return durable_cook_error_report_with_store(store, None, &options, error),
```

Making the parameter required would have meant inventing a store for the one path that proves none exists. The other `None` is `durable_cook_error_report`, the fully ambient entry point — it injects nothing and therefore splits nothing.

Both `None` arms have no store in hand to shadow, which is the same reasoning that keeps `substantive_candidate_in_store` off the hazard list.

| call site | store | why |
|---|---|---|
| `run_cook` (resolution failed) | `None` | resolving one is what just failed |
| `run_cook_reported` ×3 | `Some(lifecycle_store)` | **converted** |
| `durable_cook_error_report` | `None` | ambient entry point, injects nothing |

## Count delta — flat, and that is the honest answer

```
AgentTaskLifecycleStore::from_current_environment(   142 -> 142
CookRecipeStore::from_current_data_root(              16 -> 16
PathRoots::from_environment(                          40 -> 40
```

**This slice removes no resolution points.** It makes an already-injected function use the root it was handed. Three of five call sites now inject a lifecycle store.

If the measure of #7505 is the constructor count, this PR scores zero. I think the count is the wrong measure for this one — the defect here is a Cook that reports its own failure into the wrong home — but I would rather say that plainly than dress it up.

## Verification

- `nice -n 10 cargo check --workspace --tests -j2` — **clean, 0 warnings, 0 errors**, 3m20s
- `cargo fmt --check` — clean
- `tests/agent_task_store_injection_test.rs` standalone — **7/7 pass**
- Confirmed the `Some` arm reaches no ambient state; the residual scanner hit on this function is the `None` arm, by design

### Things I checked that turned out to be false alarms

Worth recording, because each is a grep trap that would have produced a wrong change:

- `record_pre_execution_failure` in `cook.rs` resolves to `cook_pre_execution::record_pre_execution_failure`, a **rooted 5-arg helper**, not the ambient `agent_task_lifecycle` one. Those call sites were already correct.
- `status_in_store` in `agent_task_batch.rs` is a generic `<S, P>` — a **different function** from `agent_task_lifecycle::status_in_store`.
- `run_cook_spine` has further `agent_task_lifecycle::`-qualified reaches (`has_active_provider_execution`, `running_owner_pid`, and several `status`). They are real, but it is a 1000+ line function and rooting it deserves its own slice rather than being tacked on here.

Not run locally: the full suite (`cargo test` is ~28G on this box). `cargo check --tests` compiled it; CI is the check.
