### PR TITLE
Root the Cook spine's remaining ambient reads

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2415,13 +2415,14 @@ pub fn record_provider_execution_process_in_store(
     })
 }
 
-/// Return the unambiguous running provider PID for activity sampling.
-pub fn running_owner_pid(run_id: &str) -> Result<Option<u32>> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    running_owner_pid_in_store(&lifecycle_store, run_id)
-}
+// The ambient `running_owner_pid()` shim that used to sit above this is gone.
+// Its last caller was the Cook heartbeat, which samples activity on a thread
+// that already held a borrow of the injected lifecycle store for its
+// supervision writes — so it now reads the owner PID from the same installation
+// it records the sample into (#7505).
 
-/// [`running_owner_pid`] against explicitly injected durable lifecycle roots.
+/// Return the unambiguous running provider PID for activity sampling, from an
+/// explicitly injected durable lifecycle root.
 pub fn running_owner_pid_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4109,6 +4109,33 @@ fn durable_cook_error_report_with_store(
     Err(error)
 }
 
+/// [`agent_task_lifecycle::status`] against an explicitly injected lifecycle
+/// root.
+///
+/// The ambient `status()` is exactly this call with a store resolved from the
+/// process environment, so the two agree on everything except which
+/// installation they read — which is the only difference that matters on a
+/// spine whose caller chose its own roots.
+///
+/// One asymmetry is worth naming rather than hiding: `status_in_store` derives
+/// its recipe store from `lifecycle_store.data_root()`, so a caller that passes
+/// a recipe store rooted somewhere else still gets a recipe view derived from
+/// the lifecycle root. That is not made worse here — the ambient form derived it
+/// from the ambient root, which agreed with neither — and closing it means
+/// giving `status_in_store` both roots, which is its own change.
+fn rooted_status(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<agent_task_lifecycle::AgentTaskRunRecord> {
+    Ok(agent_task_lifecycle::status_in_store(
+        lifecycle_store,
+        run_id,
+        agent_task_lifecycle::AgentTaskStatusOptions::default(),
+        false,
+    )?
+    .record)
+}
+
 /// The Cook spine, bound to explicit recipe and lifecycle roots. Every durable
 /// write on this path resolves through the two passed stores, so a caller can
 /// place a Cook's recipe and its lifecycle records wherever it owns them
@@ -4447,9 +4474,12 @@ fn run_cook_spine(
                 options.cook_id.clone(),
                 Vec::new(),
                 pre_execution_failure_details(
-                    agent_task_lifecycle::exact_record(&options.initial_run_id)
-                        .ok()
-                        .as_ref(),
+                    agent_task_lifecycle::exact_record_in_store(
+                        lifecycle_store,
+                        &options.initial_run_id,
+                    )
+                    .ok()
+                    .as_ref(),
                     &error,
                 ),
                 error,
@@ -4494,9 +4524,12 @@ fn run_cook_spine(
             options.cook_id.clone(),
             Vec::new(),
             pre_execution_failure_details(
-                agent_task_lifecycle::exact_record(&options.initial_run_id)
-                    .ok()
-                    .as_ref(),
+                agent_task_lifecycle::exact_record_in_store(
+                    lifecycle_store,
+                    &options.initial_run_id,
+                )
+                .ok()
+                .as_ref(),
                 &error,
             ),
             error,
@@ -4852,8 +4885,7 @@ fn run_cook_spine(
                                 // provider execution is active, this heartbeat
                                 // would otherwise sample only its own `ps`
                                 // subprocess while that cleanup completes.
-                                if !agent_task_lifecycle::has_active_provider_execution(
-                                    &heartbeat_run_id,
+                                if !agent_task_lifecycle::has_active_provider_execution_in_store(heartbeat_lifecycle_store, &heartbeat_run_id,
                                 )
                                 .unwrap_or(true)
                                 {
@@ -4863,8 +4895,7 @@ fn run_cook_spine(
                                     continue;
                                 }
                                 next_heartbeat = Instant::now() + COOK_HEARTBEAT_INTERVAL;
-                                let activity_owner_pid = agent_task_lifecycle::running_owner_pid(
-                                    &heartbeat_run_id,
+                                let activity_owner_pid = agent_task_lifecycle::running_owner_pid_in_store(heartbeat_lifecycle_store, &heartbeat_run_id,
                                 )
                                 .ok()
                                 .flatten()
@@ -5019,7 +5050,7 @@ fn run_cook_spine(
                         dispatch_plan,
                     )?;
                 }
-                let record = match agent_task_lifecycle::status(&run_id) {
+                let record = match rooted_status(lifecycle_store, &run_id) {
                     Ok(record)
                         if record.state == agent_task_lifecycle::AgentTaskRunState::Queued =>
                     {
@@ -5034,7 +5065,7 @@ fn run_cook_spine(
                             &error,
                             phase,
                         )?;
-                        agent_task_lifecycle::status(&run_id).ok()
+                        rooted_status(lifecycle_store, &run_id).ok()
                     }
                     Ok(record) => Some(record),
                     Err(_) => {
@@ -5049,7 +5080,7 @@ fn run_cook_spine(
                             &error,
                             phase,
                         )?;
-                        agent_task_lifecycle::status(&run_id).ok()
+                        rooted_status(lifecycle_store, &run_id).ok()
                     }
                 };
                 let pre_execution_failure = pre_execution_failure_details(record.as_ref(), &error);
@@ -5112,7 +5143,7 @@ fn run_cook_spine(
         let mut record = if rooted_promotion_continuation {
             lifecycle_store.read_record(&run_id)?
         } else {
-            agent_task_lifecycle::status(&run_id)?
+            rooted_status(lifecycle_store, &run_id)?
         };
         // A local controller can disappear after the provider ledger records a
         // terminal result but before the run projection is terminalized. Repair
@@ -5126,7 +5157,7 @@ fn run_cook_spine(
             record = if rooted_promotion_continuation {
                 lifecycle_store.read_record(&run_id)?
             } else {
-                agent_task_lifecycle::status(&run_id)?
+                rooted_status(lifecycle_store, &run_id)?
             };
         }
         let controller_owned_staging = record


### PR DESCRIPTION
A slice of #7505. Touches `cook.rs` and `lifecycle_ops.rs`; independent of open PR #12732.

## The gap

`run_cook_spine` is handed both stores, and its own doc claims the point:

> *Every durable write on this path resolves through the two passed stores, so a caller can place a Cook's recipe and its lifecycle records wherever it owns them instead of wherever the process environment happens to point (#7505).*

**Writes**, yes. Nine **reads** did not — they reached `agent_task_lifecycle` free shims, each resolving its own root from the environment.

The sharpest one is a single expression with one rooted branch and one ambient branch:

```rust
let mut record = if rooted_promotion_continuation {
    lifecycle_store.read_record(&run_id)?      // injected home
} else {
    agent_task_lifecycle::status(&run_id)?     // ambient home
};
```

The same record, read from two different installations depending on a boolean.

## Converted (all inside the spine)

| n | from | to |
|---|---|---|
| 2 | `exact_record` | `exact_record_in_store` |
| 1 | `has_active_provider_execution` | `_in_store` |
| 1 | `running_owner_pid` | `_in_store` |
| 5 | `status` | `rooted_status` |

**Zero ambient `agent_task_lifecycle::` calls remain in the spine** (verified by scanning the function's line range).

## The heartbeat pair is worth naming

Those two probes run on a thread that **already held** `heartbeat_lifecycle_store` — a borrow bound before the spawn, with a comment explaining it was bound there specifically so the supervision writes could be rooted:

```rust
// Bound before the `move` closure: naming the store inside
// it would capture the store itself by value rather than this borrow.
let heartbeat_lifecycle_store = &lifecycle_store;
```

The supervision writes used it. The liveness reads beside them did not. So the heartbeat decided *whether to keep sampling* by reading one home, and recorded *what it sampled* into another.

## `rooted_status`

Added rather than repeating the four-argument `status_in_store` call five times. Its doc names the one asymmetry it does **not** fix: `status_in_store` derives its recipe store from `lifecycle_store.data_root()`, so a caller passing a recipe store rooted elsewhere still gets a lifecycle-derived recipe view.

That is strictly better than the ambient form, which agreed with *neither* root — but it is not fully closed, and closing it means giving `status_in_store` both roots, which is its own change.

## Count delta

```
AgentTaskLifecycleStore::from_current_environment(   142 -> 141   (-1)
CookRecipeStore::from_current_data_root(              16 -> 16
PathRoots::from_environment(                          40 -> 40
```

`running_owner_pid` lost its last caller to this conversion and is deleted with it — that is the −1. A conversion that produces a dead wrapper is the shape worth repeating: the resolution point disappears instead of moving.

## Deliberately not converted

`exact_record` is also called in `authorize_cook_continue_route_with_artifact` and `has_cook_continue_route`. **Neither holds a lifecycle store**, so converting them would have meant inventing one. My first patch attempt tried a global replace, and an assertion on the expected match count caught it before it was written — 4 occurrences, only 2 in scope.

## Verification

- `nice -n 10 cargo check --workspace --tests -j2` — **clean, 0 warnings, 0 errors** (run twice: once after the conversions, once after deleting the dead wrapper)
- `cargo fmt --check` — clean
- `tests/agent_task_store_injection_test.rs` standalone — **7/7 pass**
- Line-range scan of `run_cook_spine`: **0 remaining ambient `agent_task_lifecycle::` calls**
- Dead-wrapper rescan: **0 remaining, no further cascade**

Not run locally: the full suite (`cargo test` is ~28G on this box). `cargo check --tests` compiled it; CI is the check. The risk here is concentrated in `status` -> `rooted_status`, which is semantically the same call the ambient wrapper makes (`status_in_store(store, run_id, Default::default(), false)?.record`) with the store chosen explicitly.
