### PR TITLE
fix(release): scope checksum coverage to the assets cargo-dist checksums

### DIFF
--- a/.github/release-asset-completeness.sh
+++ b/.github/release-asset-completeness.sh
@@ -250,12 +250,42 @@ for asset in "${REQUIRED[@]}"; do
   LOCAL_DIGESTS["${asset}"]="sha256:$(sha256sum "${path}" | cut -d' ' -f1)"
 done
 
+# Which assets must a PUBLISHED checksum sidecar cover? (#12701)
+#
+# Not "everything that is not a sidecar". cargo-dist checksums the distributable
+# archives -- the bytes `homeboy upgrade` and the installer download and then
+# verify before executing. It does not checksum the bootstrap assets:
+# `homeboy-installer.sh`, the Homebrew formula and `dist-manifest.json` are
+# fetched over HTTPS from the release itself, and a checksum served from the
+# same origin as the artifact it describes proves nothing a consumer could not
+# already trust.
+#
+# Defining the covered set as "not a sidecar" made this loop unsatisfiable by
+# construction: `sha256.sum` has only ever listed the four platform archives and
+# `source.tar.gz`, so every release from v0.350.22 onward failed publish with
+# "No rebuilt checksum contract covers homeboy-installer.sh" while the release
+# itself published complete with all 14 assets.
+#
+# This narrows which assets additionally require a published sidecar. It does
+# not narrow what gets verified: the final `remote_valid` sweep below still
+# proves every REQUIRED asset -- bootstrap assets included -- against GitHub's
+# digest of the rebuilt local bytes.
+requires_checksum_contract() {
+  case "$1" in
+    *.sha256|sha256.sum) return 1 ;;
+    *-installer.sh|*.rb|dist-manifest.json) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
 payload_count=0
 for asset in "${REQUIRED[@]}"; do
-  case "${asset}" in *.sha256|sha256.sum) continue ;; esac
+  requires_checksum_contract "${asset}" || continue
   payload_count=$((payload_count + 1))
 done
-[ "${payload_count}" -gt 0 ] || fail "The rebuilt asset contract has no payloads"
+# Fail closed if the contract narrowed to nothing. If cargo-dist ever stops
+# planning archives, this fires rather than vacuously passing an empty sweep.
+[ "${payload_count}" -gt 0 ] || fail "The rebuilt asset contract has no checksum-covered payloads"
 
 for sidecar in "${REQUIRED[@]}"; do
   case "${sidecar}" in *.sha256|sha256.sum) ;; *) continue ;; esac
@@ -288,7 +318,7 @@ for sidecar in "${REQUIRED[@]}"; do
   case "${sidecar}" in *.sha256) [ "${references}" -eq 1 ] && [ "${sidecar%.sha256}" = "${sidecar_payload}" ] || fail "Checksum contract ${sidecar} is incomplete" ;; esac
 done
 for asset in "${REQUIRED[@]}"; do
-  case "${asset}" in *.sha256|sha256.sum) continue ;; esac
+  requires_checksum_contract "${asset}" || continue
   [ -n "${CONTRACT_DIGESTS[${asset}]:-}" ] || fail "No rebuilt checksum contract covers ${asset}"
 done
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1327,15 +1327,36 @@ jobs:
           HOST_RESULT: ${{ needs.host.result }}
           EXPECTED_ASSETS: ${{ needs.plan.outputs.expected-assets }}
         run: |
+          # Observe the release BEFORE judging the host job result (#12701).
+          #
+          # This guard used to `exit 1` on a non-success host result without
+          # ever calling the API, asserting "The tag exists with no GitHub
+          # Release" as though it had looked. For v0.350.22 through v0.350.25
+          # that was false: each release was published complete with all 14
+          # assets and `host` had failed on a post-publish assertion. A guard
+          # that reports an unobserved state as an observation sends every
+          # investigation to the wrong place, which is what it did.
+          #
+          # `releases/tags/{tag}` resolves published releases only; a draft
+          # 404s there. Distinguish the two so "never published" cannot be
+          # reported as a malformed API response.
+          published=true
+          if ! gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" > release.json 2>/dev/null; then
+            published=false
+          fi
+
+          # A failed `host` stays red either way -- the publish chain is broken
+          # and #8567 requires that be loud. Only the diagnosis changes.
           if [ "${HOST_RESULT}" != "success" ]; then
-            echo "::error::Release ${RELEASE_TAG} was prepared and tagged but the Create GitHub Release job did not succeed (result: ${HOST_RESULT}). The tag exists with no GitHub Release. Investigate the plan/build/host publish chain; recover with a workflow_dispatch run using release_tag=${RELEASE_TAG}."
+            if [ "${published}" = "true" ]; then
+              echo "::error::Release ${RELEASE_TAG} IS published with $(jq -r '[.assets[].name] | length' release.json) assets, but the Create GitHub Release job did not succeed (result: ${HOST_RESULT}). The break is after the release object was created, so inspect that job's failing step directly -- the release itself may be intact. Recover with a workflow_dispatch run using release_tag=${RELEASE_TAG}."
+            else
+              echo "::error::Release ${RELEASE_TAG} was prepared and tagged but the Create GitHub Release job did not succeed (result: ${HOST_RESULT}), and no published GitHub Release exists for the tag. Investigate the plan/build/host publish chain; recover with a workflow_dispatch run using release_tag=${RELEASE_TAG}."
+            fi
             exit 1
           fi
 
-          # `releases/tags/{tag}` resolves published releases only; a draft 404s
-          # there. Distinguish the two so "never published" cannot be reported as
-          # a malformed API response.
-          if ! gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" > release.json 2>/dev/null; then
+          if [ "${published}" != "true" ]; then
             echo "::error::Release ${RELEASE_TAG} is not published. The tag exists but the GitHub Release is still a draft or absent, so consumers pinning this version get nothing. Recover with a workflow_dispatch run using release_tag=${RELEASE_TAG}."
             exit 1
           fi

--- a/tests/release_asset_completeness_test.rs
+++ b/tests/release_asset_completeness_test.rs
@@ -22,18 +22,39 @@ const TAG: &str = "v1.2.3";
 /// the announce strip the fixture exercises at `REQUIRE_ANNOUNCE_ASSETS=false`
 /// removed nothing and the required/allowed conflation was invisible to every
 /// test in this file.
-const ASSETS: [&str; 4] = [
+///
+/// The bootstrap assets are deliberately part of this set (#12701). cargo-dist
+/// plans `homeboy-installer.sh` and the Homebrew formula but never lists them
+/// in `sha256.sum` -- an installer cannot be meaningfully verified by a
+/// checksum served from the same release. Before #12701 this array held only
+/// payload/checksum entries, so a coverage assertion that demanded a sidecar
+/// for every non-sidecar asset was vacuously satisfiable here and
+/// unsatisfiable in production. Every release from v0.350.22 onward failed to
+/// publish and not one test in this file noticed.
+const ASSETS: [&str; 6] = [
     "payload.tar.gz",
     "payload.tar.gz.sha256",
     "sha256.sum",
+    INSTALLER_ASSET,
+    FORMULA_ASSET,
     ANNOUNCE_ASSET,
 ];
 
 /// Attached during announce; required only at the published boundary.
 const ANNOUNCE_ASSET: &str = "dist-manifest.json";
 
+/// Planned, uploaded and digest-verified, but never checksum-covered.
+const INSTALLER_ASSET: &str = "homeboy-installer.sh";
+const FORMULA_ASSET: &str = "homeboy.rb";
+
 /// What the pre-publication gate actually requires to be present and valid.
-const REQUIRED_ASSETS: [&str; 3] = ["payload.tar.gz", "payload.tar.gz.sha256", "sha256.sum"];
+const REQUIRED_ASSETS: [&str; 5] = [
+    "payload.tar.gz",
+    "payload.tar.gz.sha256",
+    "sha256.sum",
+    INSTALLER_ASSET,
+    FORMULA_ASSET,
+];
 
 fn digest(path: &Path) -> String {
     let output = Command::new("shasum")
@@ -67,7 +88,17 @@ fn write_artifacts(root: &Path) -> BTreeMap<String, String> {
     let payload_digest = digest(&payload).trim_start_matches("sha256:").to_owned();
     let checksum = format!("{payload_digest} *payload.tar.gz\n");
     fs::write(artifacts.join("payload.tar.gz.sha256"), &checksum).expect("write payload sidecar");
+    // Note what is NOT here: the aggregate sidecar covers the archive only.
+    // That mirrors cargo-dist, whose `sha256.sum` lists the platform archives
+    // and `source.tar.gz` and nothing else (#12701).
     fs::write(artifacts.join("sha256.sum"), checksum).expect("write aggregate sidecar");
+    fs::write(artifacts.join(INSTALLER_ASSET), "#!/bin/sh\necho install\n")
+        .expect("write installer");
+    fs::write(
+        artifacts.join(FORMULA_ASSET),
+        "class Homeboy < Formula\nend\n",
+    )
+    .expect("write formula");
     // `Preserve existing published asset bytes` copies every planned asset --
     // including the announce manifest -- into the recovery artifact directory.
     fs::write(
@@ -245,6 +276,76 @@ fn accepts_an_inventory_without_the_announce_asset_before_announce() {
     );
     // Never uploaded: it is not part of the rebuilt required contract.
     assert_eq!(fixture.calls(), ["view", "view"]);
+}
+
+/// Bootstrap assets are digest-verified but never checksum-covered (#12701).
+///
+/// cargo-dist plans `homeboy-installer.sh` and the Homebrew formula, and never
+/// lists either in `sha256.sum`. A coverage assertion that demanded a sidecar
+/// for every non-sidecar asset was therefore unsatisfiable in production: every
+/// release from v0.350.22 onward failed publish with "No rebuilt checksum
+/// contract covers homeboy-installer.sh" while the release itself published
+/// complete with all 14 assets.
+///
+/// Both halves matter, so both are pinned here. Narrowing the coverage rule
+/// must not narrow what gets verified: these assets still reconcile against
+/// GitHub's digest of the rebuilt local bytes.
+#[test]
+fn bootstrap_assets_are_digest_verified_without_requiring_checksum_coverage() {
+    let fixture = Fixture::new();
+    let aggregate = fs::read_to_string(fixture.artifact_dir().join("sha256.sum"))
+        .expect("read aggregate sidecar");
+    for asset in [INSTALLER_ASSET, FORMULA_ASSET] {
+        assert!(
+            !aggregate.contains(asset),
+            "{asset} must stay outside the checksum contract for this to regress"
+        );
+    }
+
+    // Half one: uncovered bootstrap assets do not block a clean reconcile.
+    let output = fixture.run(&[
+        inventory(&fixture.digests, &[]),
+        inventory(&fixture.digests, &[]),
+    ]);
+    assert!(
+        output.status.success(),
+        "assets cargo-dist never checksums must not be demanded to carry a checksum contract.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(fixture.calls(), ["view", "view"]);
+
+    // Half two: their bytes are still proven against the remote digest.
+    for asset in [INSTALLER_ASSET, FORMULA_ASSET] {
+        let fixture = Fixture::new();
+        let output = fixture.run(&[
+            inventory(
+                &fixture.digests,
+                &[(
+                    asset,
+                    "uploaded",
+                    "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+                    1,
+                )],
+            ),
+            inventory(&fixture.digests, &[]),
+        ]);
+        assert!(
+            output.status.success(),
+            "{asset}: stdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            fixture.calls(),
+            vec![
+                "view".to_owned(),
+                format!("upload:{asset}"),
+                "view".to_owned()
+            ],
+            "{asset} must be replaced when the remote digest disagrees with the rebuilt bytes"
+        );
+    }
 }
 
 #[test]

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -1415,6 +1415,133 @@ fn verify_published_distinguishes_an_unpublished_release_from_a_broken_one() {
     );
 }
 
+/// Run `verify-published`'s asset step under the runner's shell with a mocked
+/// `gh`, returning (exit code, combined output) plus the commands `gh` saw.
+fn run_verify_published_step(
+    host_result: &str,
+    release_json: Option<&str>,
+) -> (i32, String, Vec<String>) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let verify = job_section(release_workflow(), "verify-published");
+    let script = step_run_script(verify, "name: Verify planned release assets");
+
+    let dir = std::env::temp_dir().join(format!(
+        "homeboy-verify-published-{}-{:p}",
+        std::process::id(),
+        &script
+    ));
+    let bin = dir.join("bin");
+    std::fs::create_dir_all(&bin).expect("temp bin");
+    let log = dir.join("gh.log");
+    std::fs::write(&log, "").expect("write gh log");
+
+    // `gh api` succeeds only when the release is published; a draft or absent
+    // release 404s on `releases/tags/{tag}`, which is a non-zero exit here.
+    let api_branch = match release_json {
+        Some(body) => {
+            let fixture = dir.join("release-fixture.json");
+            std::fs::write(&fixture, body).expect("write release fixture");
+            format!("cat {}", fixture.display())
+        }
+        None => "exit 1".to_owned(),
+    };
+    std::fs::write(
+        bin.join("gh"),
+        format!(
+            "#!/usr/bin/env bash\nprintf '%s\\n' \"$1 $2\" >> {log}\n\
+             if [ \"$1\" = api ]; then {api_branch}; fi\n",
+            log = log.display(),
+        ),
+    )
+    .expect("write mock gh");
+    let mut perms = std::fs::metadata(bin.join("gh"))
+        .expect("mock gh metadata")
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(bin.join("gh"), perms).expect("mark mock gh executable");
+
+    let script_path = dir.join("verify.sh");
+    std::fs::write(&script_path, &script).expect("write script");
+
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let output = std::process::Command::new("bash")
+        .arg("-e")
+        .arg(&script_path)
+        .current_dir(&dir)
+        .env("PATH", path)
+        .env("RELEASE_TAG", "v0.350.25")
+        .env("HOST_RESULT", host_result)
+        .env("GITHUB_REPOSITORY", "Extra-Chill/homeboy")
+        .env("EXPECTED_ASSETS", r#"["payload.tar.gz"]"#)
+        .output()
+        .expect("verify-published step should run");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let calls = std::fs::read_to_string(&log)
+        .unwrap_or_default()
+        .lines()
+        .map(str::to_owned)
+        .collect();
+    let _ = std::fs::remove_dir_all(&dir);
+    (output.status.code().unwrap_or(-1), combined, calls)
+}
+
+/// A failed `host` must be diagnosed from the release, not from an assumption.
+///
+/// This guard used to `exit 1` on a non-success host result without ever
+/// calling the API, reporting "The tag exists with no GitHub Release" as
+/// though it had looked. For v0.350.22 through v0.350.25 that was false: each
+/// release was published complete with all 14 assets while `host` failed on a
+/// post-publish assertion (#12701). The run must stay red either way — #8567
+/// requires a broken publish chain be loud — but the operator must be pointed
+/// at the failing step, not at a release state that was never observed.
+#[test]
+fn verify_published_diagnoses_a_failed_host_from_the_observed_release() {
+    let published = serde_json::json!({
+        "draft": false,
+        "assets": [{"name": "payload.tar.gz", "state": "uploaded", "size": 1}],
+    })
+    .to_string();
+
+    let (code, output, calls) = run_verify_published_step("failure", Some(&published));
+
+    assert_eq!(code, 1, "a failed host must still fail the run: {output}");
+    assert!(
+        calls.iter().any(|call| call.starts_with("api ")),
+        "the guard must read the release before judging it, saw: {calls:?}"
+    );
+    assert!(
+        output.contains("IS published"),
+        "an intact release must be reported as intact so the operator inspects \
+         the failing job instead of the release: {output}"
+    );
+    assert!(
+        !output.contains("The tag exists with no GitHub Release"),
+        "the guard must not assert an unobserved state as fact: {output}"
+    );
+
+    // The same host failure with nothing published keeps the original,
+    // now-accurate diagnosis.
+    let (code, output, _) = run_verify_published_step("failure", None);
+    assert_eq!(
+        code, 1,
+        "an unpublished release must fail the run: {output}"
+    );
+    assert!(
+        output.contains("no published GitHub Release exists"),
+        "an absent release must still be named as absent: {output}"
+    );
+}
+
 /// Extract the shell body of a `run: |` step so its BEHAVIOUR can be exercised
 /// rather than string-matched. Asserting the effect is the whole point: the
 /// audit gate in #10685 passed for weeks because its test asserted the command


### PR DESCRIPTION
Fixes #12701.

## The bug

`release-asset-completeness.sh` required every non-sidecar asset to carry a published checksum contract:

```bash
for asset in "${REQUIRED[@]}"; do
  case "${asset}" in *.sha256|sha256.sum) continue ;; esac
  [ -n "${CONTRACT_DIGESTS[${asset}]:-}" ] || fail "No rebuilt checksum contract covers ${asset}"
done
```

cargo-dist checksums the distributable archives and nothing else. `sha256.sum` from the real v0.350.25:

```
b545c0be… *homeboy-aarch64-apple-darwin.tar.xz
c54665af… *homeboy-aarch64-unknown-linux-gnu.tar.xz
ec0c74e1… *homeboy-x86_64-apple-darwin.tar.xz
e3b4e3ed… *homeboy-x86_64-unknown-linux-gnu.tar.xz
5c30015e… *source.tar.gz
```

Three planned assets — `homeboy-installer.sh`, `homeboy.rb`, `dist-manifest.json` — are never listed there and never will be. An installer cannot be meaningfully verified by a checksum served from the same release it bootstraps. **The loop was unsatisfiable by construction.**

Every release from **v0.350.22** onward failed publish this way. The releases themselves were fine — v0.350.25 is `draft=false` with all 14 assets, tagged Latest.

## The fix

Narrow the coverage requirement to the archives, via a named predicate rather than an inline `case`. It still fails closed: if the archive set ever narrows to nothing, `The rebuilt asset contract has no checksum-covered payloads` fires instead of vacuously passing.

**What gets verified is unchanged.** The final `remote_valid` sweep still proves every required asset — bootstrap assets included — against GitHub's digest of the rebuilt local bytes. This narrows which assets additionally need a *published sidecar*, not which assets get checked.

## Why the tests missed it

The fixture's asset contract was `["payload.tar.gz", "payload.tar.gz.sha256", "sha256.sum"]` — no bootstrap assets at all. A rule that was unsatisfiable in production was vacuously satisfiable in test.

Adding them to the shared `ASSETS` const means **every** case in the file now exercises the real shape, the same way `dist-manifest.json` was added for #12341. Plus an explicit test pinning both halves: uncovered bootstrap assets do not block reconcile, and their bytes are still digest-reconciled.

## Second defect: `verify-published` reported an unobserved state as fact

It exited on a non-success host result **without ever calling the API**:

> `Release v0.350.25 was prepared and tagged but the Create GitHub Release job did not succeed. The tag exists with no GitHub Release.`

That claim was false for .22 through .25 — each release existed, published, complete. It sends the investigation at the release instead of at the failing step, which is exactly what it did to me while triaging this.

Now it observes first, then diagnoses. A failed `host` stays red either way, so the #8567 guard is intact; only the message changes.

## Verification

Reproduced against a production-shaped fixture, before and after:

```
=========== BEFORE (origin/main) ===========
::error::No rebuilt checksum contract covers dist-manifest.json
exit=1

=========== AFTER (fix branch) =============
::notice::Release v0.350.25 satisfies the declared asset contract (8 assets…)
exit=0
```

Negative cases still fail closed:

```
--- uncovered ARCHIVE (must FAIL) ---
::error::No rebuilt checksum contract covers homeboy-aarch64-apple-darwin.tar.xz
exit=1
--- contract with no archives at all (must FAIL) ---
::error::The rebuilt asset contract has no checksum-covered payloads
exit=1
```

The new `verify-published` test executes the extracted step body under `bash -e` with a mocked `gh`; all three paths (host failed + published, host failed + absent, host success) were confirmed by running the harness standalone.

`cargo check --workspace --tests -j2` clean, `cargo fmt --check` clean.