### PR TITLE
Root the Cook retry boundary

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -5333,7 +5333,7 @@ pub(crate) fn record_cook_attempt_locked(
     record_cook_attempt_locked_in_store(&lifecycle_store, cook_id, attempt, run_id)
 }
 
-fn record_cook_attempt_locked_in_store(
+pub(crate) fn record_cook_attempt_locked_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     cook_id: &str,
     attempt: u32,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs
@@ -263,6 +263,51 @@ pub fn recover_completed_cook_operation(
     Ok(())
 }
 
+/// [`recover_completed_cook_operation`] against an explicitly injected durable
+/// lifecycle root.
+///
+/// The claim this repairs was taken in some installation and the side effect it
+/// vouches for was recovered there. Restoring the completion marker in a
+/// different home would leave the real claim un-completed while inventing a
+/// completed one beside a record nobody is retrying (#7505).
+pub(crate) fn recover_completed_cook_operation_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    operation_key: &str,
+    result: Value,
+) -> Result<()> {
+    let run_id = sanitize_run_id(run_id);
+    let now = now_timestamp();
+    lifecycle_store.mutate_record(&run_id, |record| {
+        let metadata = record.ensure_metadata_object();
+        let claims = metadata
+            .entry(OPERATION_CLAIMS_KEY.to_string())
+            .or_insert_with(|| json!([]));
+        if !claims.is_array() {
+            *claims = json!([]);
+        }
+        let claims = claims.as_array_mut().expect("operation claims array");
+        if let Some(claim) = claims
+            .iter()
+            .find(|claim| claim["operation_key"] == json!(operation_key))
+        {
+            return claim["state"] != json!("completed");
+        }
+        claims.push(json!({
+            "operation_key": operation_key,
+            "state": "completed",
+            "leased_at": now,
+            "completed_at": now,
+            "owner_pid": std::process::id(),
+            "result": result,
+            "recovered_from_authoritative_successor": true,
+        }));
+        record.updated_at = Some(now.clone());
+        true
+    })?;
+    Ok(())
+}
+
 /// Terminalize a claimed operation that did not produce its external result.
 /// Failed claims retain their exact bounded diagnostic but are intentionally
 /// reclaimable by a later explicit continuation.

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -718,17 +718,29 @@ pub fn retry(
     run: bool,
     force: bool,
 ) -> Result<AgentTaskRetryServiceResult> {
-    let source = agent_task_lifecycle::normalize_local_execution_placement(run_id)?;
-    let cook_retry = retryable_cook_attempt(&source)?;
+    // One lifecycle store for the whole retry. Reserving the successor,
+    // proving the reservation is exact, persisting the controller plan, and
+    // binding the Cook attempt are one durable lineage: a successor reserved in
+    // one installation and bound in another is a retry that cannot be proved to
+    // own the work it replaces (#7505).
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    let source = agent_task_lifecycle::normalize_local_execution_placement_in_store(
+        &lifecycle_store,
+        run_id,
+    )?;
+    let cook_retry = retryable_cook_attempt(&lifecycle_store, &source)?;
     let record = match cook_retry {
         Some(cook_retry) => {
-            let discovered_run_id = agent_task_lifecycle::find_unbound_cook_retry_successor(
-                &source.run_id,
-                &cook_retry.cook_id,
-                cook_retry.attempt,
-                &cook_retry.plan,
-            )?
-            .map(|record| record.run_id);
+            let discovered_run_id =
+                agent_task_lifecycle::find_unbound_cook_retry_successor_in_store(
+                    &lifecycle_store,
+                    &source.run_id,
+                    &cook_retry.cook_id,
+                    cook_retry.attempt,
+                    &cook_retry.plan,
+                )?
+                .map(|record| record.run_id);
             let mut retry_run_id = cook_retry
                 .pending_run_id
                 .as_deref()
@@ -743,9 +755,15 @@ pub fn retry(
                         cook_retry.cook_id, cook_retry.attempt
                     )
                 });
-            let retry_exists = agent_task_lifecycle::run_record_exists(&retry_run_id)?;
+            let retry_exists =
+                agent_task_lifecycle::run_record_exists_in_store(&lifecycle_store, &retry_run_id)?;
             if retry_exists
-                && !is_exact_retry_reservation(&source, &cook_retry.plan, &retry_run_id)?
+                && !is_exact_retry_reservation(
+                    &lifecycle_store,
+                    &source,
+                    &cook_retry.plan,
+                    &retry_run_id,
+                )?
             {
                 return Err(Error::validation_invalid_argument(
                     "new_run_id",
@@ -758,8 +776,13 @@ pub fn retry(
             // before recipe/index binding, so recovery can prove ownership without
             // adopting an unrelated same-plan run.
             if !retry_exists {
-                retry_run_id =
-                    reserve_cook_retry_lifecycle(&source, &cook_retry, &retry_run_id, force)?;
+                retry_run_id = reserve_cook_retry_lifecycle(
+                    &lifecycle_store,
+                    &source,
+                    &cook_retry,
+                    &retry_run_id,
+                    force,
+                )?;
             }
             // Recipe and index are one Cook-owned binding boundary. Serialize
             // concurrent claim observers so neither can overwrite the other's
@@ -768,39 +791,59 @@ pub fn retry(
                 // The retry reservation starts from the source plan. Persist
                 // Cook-authored remediation inputs before binding either record
                 // so a restarted executor loads the same plan as the recipe.
-                agent_task_lifecycle::persist_controller_plan(&retry_run_id, &cook_retry.plan)?;
+                agent_task_lifecycle::persist_controller_plan_in_store(
+                    &lifecycle_store,
+                    &retry_run_id,
+                    &cook_retry.plan,
+                )?;
                 super::record_recipe_attempt(
                     &cook_retry.cook_id,
                     cook_retry.attempt,
                     &retry_run_id,
                     &cook_retry.plan,
                 )?;
-                agent_task_lifecycle::record_cook_attempt_locked(
+                agent_task_lifecycle::record_cook_attempt_locked_in_store(
+                    &lifecycle_store,
                     &cook_retry.cook_id,
                     cook_retry.attempt,
                     &retry_run_id,
                 )
             })?;
             registration.project_terminal_after_unlock()?;
-            let record = agent_task_lifecycle::status(&retry_run_id)?;
+            // `status` is this call with `Default::default()` and `exact = false`,
+            // resolved against an ambient store. Same read, explicit root.
+            let record = agent_task_lifecycle::status_in_store(
+                &lifecycle_store,
+                &retry_run_id,
+                agent_task_lifecycle::AgentTaskStatusOptions::default(),
+                false,
+            )?
+            .record;
             if record.state.is_terminal() {
                 return Ok(AgentTaskRetryServiceResult { record, run: false });
             }
             record
         }
-        None => agent_task_lifecycle::retry_with_force(&source.run_id, new_run_id, force)?,
+        None => agent_task_lifecycle::retry_with_force_in_store(
+            &lifecycle_store,
+            &source.run_id,
+            new_run_id,
+            force,
+        )?,
     };
     Ok(AgentTaskRetryServiceResult { record, run })
 }
 
 fn reserve_cook_retry_lifecycle(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     source: &agent_task_lifecycle::AgentTaskRunRecord,
     retry: &CookRetryAttempt,
     retry_run_id: &str,
     force: bool,
 ) -> Result<String> {
     let operation_key = format!("retry:{}:{}", retry.cook_id, retry.attempt);
-    match agent_task_lifecycle::claim_cook_operation(
+    match agent_task_lifecycle::claim_cook_operation_in_store(
+        lifecycle_store,
         &source.run_id,
         &operation_key,
         Duration::from_secs(30),
@@ -809,14 +852,21 @@ fn reserve_cook_retry_lifecycle(
             // The Cook operation claim coordinates recipe/index binding; the
             // lifecycle retry lock also makes the first durable successor
             // idempotent across concurrent controllers and processes.
-            agent_task_lifecycle::retry_with_force(&source.run_id, Some(retry_run_id), force)?;
+            agent_task_lifecycle::retry_with_force_in_store(
+                lifecycle_store,
+                &source.run_id,
+                Some(retry_run_id),
+                force,
+            )?;
             let result = json!({ "run_id": retry_run_id });
-            if let Err(error) = agent_task_lifecycle::complete_cook_operation(
+            if let Err(error) = agent_task_lifecycle::complete_cook_operation_in_store(
+                lifecycle_store,
                 &source.run_id,
                 &operation_key,
                 result.clone(),
             ) {
-                let recovered = agent_task_lifecycle::find_unbound_cook_retry_successor(
+                let recovered = agent_task_lifecycle::find_unbound_cook_retry_successor_in_store(
+                    lifecycle_store,
                     &source.run_id,
                     &retry.cook_id,
                     retry.attempt,
@@ -825,7 +875,8 @@ fn reserve_cook_retry_lifecycle(
                 if recovered.as_ref().map(|record| record.run_id.as_str()) != Some(retry_run_id) {
                     return Err(error);
                 }
-                agent_task_lifecycle::recover_completed_cook_operation(
+                agent_task_lifecycle::recover_completed_cook_operation_in_store(
+                    lifecycle_store,
                     &source.run_id,
                     &operation_key,
                     result,
@@ -847,12 +898,15 @@ fn reserve_cook_retry_lifecycle(
             // handoff window. Bound the observer wait above that window so a
             // crashed winner remains recoverable rather than waiting forever.
             for _ in 0..2_000 {
-                if let Some(record) = agent_task_lifecycle::find_unbound_cook_retry_successor(
-                    &source.run_id,
-                    &retry.cook_id,
-                    retry.attempt,
-                    &retry.plan,
-                )? {
+                if let Some(record) =
+                    agent_task_lifecycle::find_unbound_cook_retry_successor_in_store(
+                        lifecycle_store,
+                        &source.run_id,
+                        &retry.cook_id,
+                        retry.attempt,
+                        &retry.plan,
+                    )?
+                {
                     return Ok(record.run_id);
                 }
                 std::thread::sleep(Duration::from_millis(10));
@@ -872,6 +926,7 @@ fn reserve_cook_retry_lifecycle(
 /// ownership; the Cook index prevents a failed provider retry from superseding
 /// an already-promotable sibling candidate.
 fn retryable_cook_attempt(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     source: &agent_task_lifecycle::AgentTaskRunRecord,
 ) -> Result<Option<CookRetryAttempt>> {
     let Some(cook_id) = source.metadata["cook_id"].as_str() else {
@@ -922,7 +977,7 @@ fn retryable_cook_attempt(
         agent_task_lifecycle::AgentTaskRunState::Failed
             | agent_task_lifecycle::AgentTaskRunState::Cancelled
     ) && !retryable_pre_execution_failure
-        && agent_task_lifecycle::select_cook_candidate(cook_id)
+        && agent_task_lifecycle::select_cook_candidate_in_store(lifecycle_store, cook_id)
             .ok()
             .is_some_and(|selection| {
                 selection.run_id == source.run_id && selection.selected_artifact_id.is_none()
@@ -937,7 +992,10 @@ fn retryable_cook_attempt(
         .iter()
         .filter(|recipe_attempt| recipe_attempt.attempt == attempt.saturating_add(1))
     {
-        if !agent_task_lifecycle::run_record_exists(&recipe_attempt.run_id)? {
+        if !agent_task_lifecycle::run_record_exists_in_store(
+            lifecycle_store,
+            &recipe_attempt.run_id,
+        )? {
             return Err(Error::validation_invalid_argument(
                 "cook_recipe.attempts",
                 "pending Cook retry recipe entry has no durable lifecycle reservation",
@@ -945,7 +1003,8 @@ fn retryable_cook_attempt(
                 None,
             ));
         }
-        let record = agent_task_lifecycle::exact_record(&recipe_attempt.run_id)?;
+        let record =
+            agent_task_lifecycle::exact_record_in_store(lifecycle_store, &recipe_attempt.run_id)?;
         if record.metadata["retry_of"] != source.run_id {
             return Err(Error::validation_invalid_argument(
                 "cook_recipe.attempts",
@@ -956,7 +1015,7 @@ fn retryable_cook_attempt(
         }
         if !cook_retry_plans_match(
             &recipe_attempt.plan,
-            &agent_task_lifecycle::load_plan(&recipe_attempt.run_id)?,
+            &agent_task_lifecycle::load_plan_in_store(lifecycle_store, &recipe_attempt.run_id)?,
         ) {
             return Err(Error::validation_invalid_argument(
                 "cook_recipe.attempts",
@@ -1059,13 +1118,17 @@ fn retryable_cook_attempt(
 }
 
 fn is_exact_retry_reservation(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     source: &agent_task_lifecycle::AgentTaskRunRecord,
     plan: &AgentTaskPlan,
     run_id: &str,
 ) -> Result<bool> {
-    let record = agent_task_lifecycle::exact_record(run_id)?;
+    let record = agent_task_lifecycle::exact_record_in_store(lifecycle_store, run_id)?;
     Ok(record.metadata["retry_of"] == source.run_id
-        && cook_retry_plans_match(plan, &agent_task_lifecycle::load_plan(run_id)?))
+        && cook_retry_plans_match(
+            plan,
+            &agent_task_lifecycle::load_plan_in_store(lifecycle_store, run_id)?,
+        ))
 }
 
 pub(super) fn cook_retry_plans_match(expected: &AgentTaskPlan, observed: &AgentTaskPlan) -> bool {


### PR DESCRIPTION
A slice of #7505.

## The boundary

`retry` is not one function — it is a four-function transaction, and it resolved a root **19 separate times** to complete it:

| function | ambient resolutions |
|---|---|
| `retry` | 7 |
| `reserve_cook_retry_lifecycle` | 6 |
| `retryable_cook_attempt` | 4 |
| `is_exact_retry_reservation` | 2 |

Reserving the successor, proving the reservation is exact, persisting the controller plan, and binding the Cook attempt are **one lineage**. A successor reserved in one installation and bound in another is a retry that cannot be proved to own the work it replaces — and the operation claim meant to serialize concurrent retries excludes nobody once the two homes differ.

`retry` keeps its public signature and becomes the env-resolving entry point: it resolves one store and threads it into all three helpers, which now take `&AgentTaskLifecycleStore`. That is the shape `tests/agent_task_store_injection_test.rs` documents as legal — resolve everything in one place, inject downward.

**0 ambient `agent_task_lifecycle::` calls remain across all four functions** (verified by line-range scan).

## Two gaps closed first

- `recover_completed_cook_operation` had **no rooted sibling at all**. Added `recover_completed_cook_operation_in_store`, reaching `lifecycle_store.mutate_record` where the ambient form reached the `store::` shim that resolves `default_store()` for itself.
- `record_cook_attempt_locked_in_store` was module-private; widened to `pub(crate)`.

## Honest framing: this fixes no live split

All 19 calls resolved the *same* ambient root today, so they agreed. Nothing was broken. What changes is that the retry boundary can now be **handed** roots instead of being structurally unable to accept them.

That distinction matters for reading the rest of #7505, so I want to state it plainly: across this and the previous slices I can no longer find a **live** cross-home split in this codebase. The ones that existed — the terminal-notification claim protocol (#12732), the durable failure report (#12733), the Cook spine's reads (#12734) — are fixed. What remains is enabling injection, which is real work but a different claim.

## Count delta

```
AgentTaskLifecycleStore::from_current_environment(   unchanged
```

One explicit resolution added in `retry`; 19 implicit ones removed from the call graph. No wrapper lost its last caller, so nothing became deletable.

## Verification

- `nice -n 10 cargo check --workspace --tests -j2` — **clean, 0 warnings, 0 errors**
- `cargo fmt` — clean
- `tests/agent_task_store_injection_test.rs` standalone — **7/7 pass**
- Line-range scan of all four functions: **0 remaining ambient calls**

### What the gate caught

The mechanical substitution assumed `status_in_store` was a 2-arg drop-in for `status`. It is not — it takes four arguments and returns `AgentTaskStatusOutcome`, not `AgentTaskRunRecord`. That surfaced as four errors (`E0061`, `E0609`, two `E0308`) and is now written as the explicit four-argument call with `.record`, matching what the ambient `status` does.

Two earlier scripted edits were also stopped by match-count assertions before being written (`find_unbound_cook_retry_successor` appears twice in `reserve_cook_retry_lifecycle`, not once). Recording both because the diff looks mechanical and was not.

Not run locally: the full suite (~28G build). CI is the check; expect the documented red-main set (#12715, #12721).
