### PR TITLE
fix(release): declare a digest for every asset in the recovery manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1167,6 +1167,30 @@ jobs:
         run: |
           set -euo pipefail
           COMMIT="$(git rev-parse "${RELEASE_TAG}^{}")"
+
+          # Declare a sha256 for every asset (#12701 follow-up).
+          #
+          # This emitted `{path: .}` and nothing else, so every artifact in the
+          # manifest carried a null sha256. `validate_recovery_artifact` requires
+          # a 64-hex digest for each one and rejected the first it read, which is
+          # why v0.350.27 failed with "Recovered release asset
+          # 'dist-manifest.json' is missing a valid sha256" -- that asset is
+          # simply first in the sorted expected set, not special. The manifest
+          # and its validator had disagreed since the manifest was introduced;
+          # nothing reached the validator before, because the asset-completeness
+          # gate failed earlier in the job.
+          #
+          # The bytes are already in `artifacts/`: the preceding preserve step
+          # placed them, and `set -euo pipefail` makes a missing file fail this
+          # step loudly rather than emit a manifest with a hole in it.
+          artifacts_json="$(
+            while IFS= read -r name; do
+              jq -n --arg path "${name}" \
+                    --arg sha256 "$(sha256sum "artifacts/${name}" | cut -d' ' -f1)" \
+                    '{path: $path, sha256: $sha256}'
+            done < <(jq -r '.[]' <<< "${EXPECTED_ASSETS}") | jq -sc '.'
+          )"
+
           jq -n \
             --arg schema homeboy.package-recovery \
             --argjson schema_version 1 \
@@ -1174,8 +1198,8 @@ jobs:
             --arg tag "${RELEASE_TAG}" \
             --arg version "${RELEASE_VERSION}" \
             --arg commit "${COMMIT}" \
-            --argjson expected_assets "${EXPECTED_ASSETS}" \
-            '{schema: $schema, schema_version: $schema_version, component_id: $component_id, tag: $tag, version: $version, commit: $commit, artifacts: [$expected_assets[] | {path: .}]}' > artifacts/manifest.json
+            --argjson artifacts "${artifacts_json}" \
+            '{schema: $schema, schema_version: $schema_version, component_id: $component_id, tag: $tag, version: $version, commit: $commit, artifacts: $artifacts}' > artifacts/manifest.json
 
       - name: Reconcile rebuilt recovery assets
         if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete != 'true'

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -1121,7 +1121,7 @@ fn incomplete_recovery_delivers_identity_bound_artifacts_to_the_finalizer() {
     assert!(recovery.contains("--arg schema homeboy.package-recovery"));
     assert!(recovery.contains("--arg tag \"${RELEASE_TAG}\""));
     assert!(recovery.contains("--arg commit \"${COMMIT}\""));
-    assert!(recovery.contains("artifacts: [$expected_assets[] | {path: .}]"));
+    assert!(recovery.contains("--argjson artifacts \"${artifacts_json}\""));
     assert!(
         !recovery.contains("path: (\"artifacts/\" + .)"),
         "manifest paths are relative to --from-artifacts artifacts"
@@ -1540,6 +1540,137 @@ fn verify_published_diagnoses_a_failed_host_from_the_observed_release() {
         output.contains("no published GitHub Release exists"),
         "an absent release must still be named as absent: {output}"
     );
+}
+
+/// The recovery manifest must declare a real digest for every expected asset.
+///
+/// It emitted `{path: .}` and nothing else, so every artifact carried a null
+/// `sha256` — while `validate_recovery_artifact`
+/// (`homeboy-release/src/release/executor/artifacts.rs`) requires a 64-hex
+/// digest for each one and rejects the first it reads. The manifest and its
+/// only reader had disagreed since the manifest was introduced. Nothing
+/// reached the reader until the asset-completeness gate ahead of it was fixed,
+/// at which point v0.350.27 failed with "Recovered release asset
+/// 'dist-manifest.json' is missing a valid sha256" — that asset is merely
+/// first in the sorted expected set, not special.
+///
+/// Executed rather than string-matched. The previous assertion pinned the jq
+/// expression exactly and still could not see that the document it produced
+/// was rejected by the code that consumes it, which is the whole reason this
+/// file has a script harness.
+#[test]
+fn recovery_manifest_declares_a_verified_digest_for_every_expected_asset() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let host = job_section(release_workflow(), "host");
+    let script = step_run_script(host, "name: Create authoritative recovery manifest");
+
+    let dir = std::env::temp_dir().join(format!(
+        "homeboy-recovery-manifest-{}-{:p}",
+        std::process::id(),
+        &script
+    ));
+    let bin = dir.join("bin");
+    std::fs::create_dir_all(&bin).expect("temp bin");
+    std::fs::create_dir_all(dir.join("artifacts")).expect("artifacts dir");
+
+    // The bootstrap assets cargo-dist never checksums are deliberately included.
+    let assets = [
+        "dist-manifest.json",
+        "homeboy-installer.sh",
+        "homeboy.rb",
+        "sha256.sum",
+        "source.tar.gz",
+    ];
+    for asset in assets {
+        std::fs::write(
+            dir.join("artifacts").join(asset),
+            format!("bytes of {asset}\n"),
+        )
+        .expect("write asset");
+    }
+
+    let commit = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    std::fs::write(
+        bin.join("git"),
+        format!("#!/usr/bin/env bash\nprintf '%s\\n' {commit}\n"),
+    )
+    .expect("write mock git");
+    let mut perms = std::fs::metadata(bin.join("git"))
+        .expect("mock git metadata")
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(bin.join("git"), perms).expect("mark mock git executable");
+
+    let script_path = dir.join("manifest.sh");
+    std::fs::write(&script_path, &script).expect("write script");
+
+    let output = std::process::Command::new("bash")
+        .arg("-e")
+        .arg(&script_path)
+        .current_dir(&dir)
+        .env(
+            "PATH",
+            format!(
+                "{}:{}",
+                bin.display(),
+                std::env::var("PATH").unwrap_or_default()
+            ),
+        )
+        .env("RELEASE_TAG", "v0.350.28")
+        .env("RELEASE_VERSION", "0.350.28")
+        .env(
+            "EXPECTED_ASSETS",
+            serde_json::to_string(&assets).expect("asset JSON"),
+        )
+        .output()
+        .expect("recovery manifest step should run");
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let manifest: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(dir.join("artifacts").join("manifest.json")).expect("read manifest"),
+    )
+    .expect("manifest is JSON");
+
+    let artifacts = manifest["artifacts"]
+        .as_array()
+        .expect("manifest declares artifacts");
+    assert_eq!(
+        artifacts.len(),
+        assets.len(),
+        "every expected asset must appear: {manifest}"
+    );
+
+    for (artifact, asset) in artifacts.iter().zip(assets) {
+        assert_eq!(artifact["path"], serde_json::json!(asset));
+        let declared = artifact["sha256"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{asset} must declare a sha256: {manifest}"));
+        // Exactly the predicate `validate_recovery_artifact` applies.
+        assert!(
+            declared.len() == 64 && declared.bytes().all(|byte| byte.is_ascii_hexdigit()),
+            "{asset} sha256 {declared:?} must satisfy the recovery validator"
+        );
+        // And it must be the digest of the bytes actually on disk, not a
+        // placeholder that merely satisfies the shape.
+        let expected = std::process::Command::new("sha256sum")
+            .arg(dir.join("artifacts").join(asset))
+            .output()
+            .expect("sha256sum");
+        let expected = String::from_utf8_lossy(&expected.stdout)
+            .split_whitespace()
+            .next()
+            .expect("digest")
+            .to_owned();
+        assert_eq!(declared, expected, "{asset} digest must match its bytes");
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
 }
 
 /// Extract the shell body of a `run: |` step so its BEHAVIOUR can be exercised


### PR DESCRIPTION
Follow-up to #12738. This is the **second** defect blocking release publication, uncovered by fixing the first.

## What v0.350.27 proved

#12738 worked. The step that killed v0.350.22 through v0.350.26 now passes:

> `::notice::Release v0.350.27 satisfies the declared asset contract (13 assets from cargo-dist release plan).`

The run then got one step further and failed somewhere new:

```
Release step preflight.recovery_artifacts failed: Invalid argument 'from-artifacts':
Recovered release asset 'dist-manifest.json' is missing a valid sha256
```

## Cause

`.github/workflows/release.yml`, *Create authoritative recovery manifest*:

```jq
artifacts: [$expected_assets[] | {path: .}]
```

Every artifact is declared with a path and **nothing else**. Its only reader requires a digest — `homeboy-release/src/release/executor/artifacts.rs`, `validate_recovery_artifact`:

```rust
let expected_sha256 = artifact
    .sha256
    .as_deref()
    .filter(|hash| hash.len() == 64 && hash.bytes().all(|byte| byte.is_ascii_hexdigit()))
    .ok_or_else(|| /* "is missing a valid sha256" */)?;
```

The writer and the reader have disagreed since the manifest was introduced. Nothing reached the reader because the asset-completeness gate ahead of it failed first, every time.

**`dist-manifest.json` is not special.** It is first in the sorted expected set. Every asset in that manifest was equally undeclared.

## Fix

Compute each digest from the bytes already staged in `artifacts/` by the preceding *Preserve existing published asset bytes* step. `set -euo pipefail` means a missing file fails this step loudly instead of emitting a manifest with a hole in it, and the digests are re-verified downstream against the same files.

Verified by running the extracted step body with a mocked `git`:

```
exit=0
artifacts: 5
all valid 64-hex: True
paths: ['dist-manifest.json', 'homeboy-installer.sh', 'homeboy.rb', 'sha256.sum', 'source.tar.gz']
```

and confirming the manifest against the real files:

```
artifacts/dist-manifest.json:   OK
artifacts/homeboy-installer.sh: OK
artifacts/homeboy.rb:           OK
artifacts/sha256.sum:           OK
artifacts/source.tar.gz:        OK
```

## The test that could not see this

`incomplete_recovery_delivers_identity_bound_artifacts_to_the_finalizer` asserted the jq expression **verbatim**:

```rust
assert!(recovery.contains("artifacts: [$expected_assets[] | {path: .}]"));
```

It pinned the exact string that was wrong, and had no way to notice the document it produced was rejected by its own reader. That is precisely the antipattern `step_run_script` was added to this file to avoid:

> Asserting the effect is the whole point: the audit gate in #10685 passed for weeks because its test asserted the command it ran instead of what that command produced.

Replaced with an executable test that runs the step and checks the emitted manifest against **the validator's own predicate** (`len == 64 && all ascii_hexdigit`), and that each declared digest is the digest of the bytes on disk — not a placeholder of the right shape.

## Scope

The sibling *Create remote draft adoption manifest* is deliberately untouched. It declares `expected_assets` names for a remote inventory verified against GitHub's digests and never carries local bytes through `validate_recovery_artifact`.

`cargo check --workspace --tests -j2` clean, `cargo fmt --check` clean.