### PR TITLE
refactor(release): thread PathRoots from the release boundary (#7505)

### DIFF
--- a/crates/homeboy-release/src/release/deployment.rs
+++ b/crates/homeboy-release/src/release/deployment.rs
@@ -35,6 +35,7 @@ pub(super) fn plan_deployment(component_id: &str) -> ReleaseDeploymentResult {
 }
 
 pub(super) fn run_deployment_step(
+    data_root: &Path,
     component: &homeboy_core::component::Component,
     expected_version: Option<&str>,
     released_tag: Option<&str>,
@@ -42,6 +43,7 @@ pub(super) fn run_deployment_step(
     package_owned_paths: &[String],
 ) -> ReleaseStepResult {
     let deployment = execute_deployment(
+        data_root,
         component,
         expected_version,
         released_tag,
@@ -74,7 +76,15 @@ pub(super) fn extract_deployment_from_run(run: &ReleaseRun) -> Option<ReleaseDep
         .and_then(|deployment| serde_json::from_value(deployment.clone()).ok())
 }
 
+/// Run the deploy step against an explicitly injected data root.
+///
+/// `execute_deployment` returns an unwrapped result, so it could never have
+/// resolved roots itself without swallowing the failure — the ambient
+/// `save_recovery`/`remove_recovery` wrappers existed to hide exactly that.
+/// Taking the root the plan already resolved removes both the hiding and the
+/// second resolution (#7505).
 fn execute_deployment(
+    data_root: &Path,
     component: &homeboy_core::component::Component,
     expected_version: Option<&str>,
     released_tag: Option<&str>,
@@ -120,6 +130,7 @@ fn execute_deployment(
             if result.summary.failed > 0 {
                 if let Some(run_id) = result.resume_run_id.as_deref() {
                     if let Err(error) = save_recovery(
+                        data_root,
                         component,
                         expected_version,
                         &projects,
@@ -136,7 +147,7 @@ fn execute_deployment(
                     }
                 }
             } else {
-                if let Err(error) = remove_recovery(&component.id) {
+                if let Err(error) = remove_recovery(data_root, &component.id) {
                     return failed_deployment(
                         &projects,
                         format!("Deployment succeeded but its recovery checkpoint could not be cleared: {error}"),
@@ -418,26 +429,12 @@ fn recovery_path_in_roots(data_root: &Path, component_id: &str) -> std::path::Pa
         .join(format!("{}.json", component_id.replace('/', "_")))
 }
 
+/// Write the release deploy recovery checkpoint below an explicitly injected
+/// data root.
+///
+/// The checkpoint and the clear that eventually retires it must address the
+/// same home, so both take the root their caller already resolved (#7505).
 fn save_recovery(
-    component: &homeboy_core::component::Component,
-    expected_version: Option<&str>,
-    projects: &[String],
-    config: &DeployConfig,
-    deploy_run_id: &str,
-    package_owned_paths: &[String],
-) -> Result<()> {
-    save_recovery_in_roots(
-        homeboy_core::paths::PathRoots::from_environment()?.data(),
-        component,
-        expected_version,
-        projects,
-        config,
-        deploy_run_id,
-        package_owned_paths,
-    )
-}
-
-fn save_recovery_in_roots(
     data_root: &Path,
     component: &homeboy_core::component::Component,
     expected_version: Option<&str>,
@@ -478,14 +475,7 @@ fn save_recovery_in_roots(
         .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))
 }
 
-fn remove_recovery(component_id: &str) -> Result<()> {
-    remove_recovery_in_roots(
-        homeboy_core::paths::PathRoots::from_environment()?.data(),
-        component_id,
-    )
-}
-
-fn remove_recovery_in_roots(data_root: &Path, component_id: &str) -> Result<()> {
+fn remove_recovery(data_root: &Path, component_id: &str) -> Result<()> {
     let path = recovery_path_in_roots(data_root, component_id);
     if path.exists() {
         fs::remove_file(path).map_err(|error| Error::internal_io(error.to_string(), None))?;
@@ -546,7 +536,7 @@ pub(super) fn resume_deployment(component_id: &str) -> Result<Option<ReleaseDepl
         if !record.component_path.is_empty() {
             cleanup_release_artifacts(&record.component_path, &record.package_owned_paths);
         }
-        remove_recovery_in_roots(roots.data(), component_id)?;
+        remove_recovery(roots.data(), component_id)?;
     }
     Ok(Some(deployment))
 }
@@ -624,14 +614,20 @@ mod tests {
     use std::io::Write;
     use std::path::Path;
 
+    /// The isolated home each test below installs, named as roots.
+    ///
+    /// These tests are their own boundary: `with_isolated_home` establishes the
+    /// home, and this resolves it once so the call under test receives a root
+    /// the same way `execute_plan_steps_at_source` hands one to the deploy
+    /// step. Production code in this module no longer resolves anything except
+    /// `resume_deployment`, which is itself a crate entry point (#7505).
+    fn test_roots() -> homeboy_core::paths::PathRoots {
+        homeboy_core::paths::PathRoots::from_environment().expect("path roots")
+    }
+
     /// The checkpoint path for the ambient home these tests already isolate.
     fn recovery_path(component_id: &str) -> std::path::PathBuf {
-        super::recovery_path_in_roots(
-            homeboy_core::paths::PathRoots::from_environment()
-                .expect("path roots")
-                .data(),
-            component_id,
-        )
+        super::recovery_path_in_roots(test_roots().data(), component_id)
     }
 
     fn run_git(path: &Path, args: &[&str]) -> String {
@@ -871,6 +867,7 @@ mod tests {
     #[test]
     fn test_run_deployment_step() {
         let result = super::run_deployment_step(
+            test_roots().data(),
             &homeboy_core::component::Component {
                 id: "definitely-not-used-by-projects".to_string(),
                 local_path: "/tmp".to_string(),
@@ -907,6 +904,7 @@ mod tests {
         }];
 
         let result = super::run_deployment_step(
+            test_roots().data(),
             &homeboy_core::component::Component {
                 id: "definitely-not-used-by-projects".to_string(),
                 local_path: temp.path().to_string_lossy().to_string(),
@@ -1157,6 +1155,7 @@ mod tests {
             }
 
             let first = run_deployment_step(
+                test_roots().data(),
                 &component,
                 Some("1.2.4"),
                 None,

--- a/crates/homeboy-release/src/release/execution_dispatch.rs
+++ b/crates/homeboy-release/src/release/execution_dispatch.rs
@@ -14,6 +14,14 @@ pub(super) struct ReleaseExecutionContext<'a> {
     pub(super) extensions: &'a [ExtensionManifest],
     pub(super) component_id: &'a str,
     pub(super) options: &'a ReleaseOptions,
+    /// Homeboy roots resolved once for the whole plan by
+    /// [`execute_plan_steps_at_source`](super::execution_plan::execute_plan_steps_at_source).
+    ///
+    /// Steps read this instead of calling `PathRoots::from_environment()`
+    /// themselves. That is the difference between a plan that addresses one
+    /// home and a plan whose steps each independently rediscover a home that
+    /// may have moved between them (#7505).
+    pub(super) roots: homeboy_core::paths::PathRoots,
     pub(super) state: ReleaseState,
     pub(super) publish_failed: bool,
 }
@@ -134,6 +142,7 @@ pub(super) fn execute_release_plan_step(
         }
         "package" => Ok(Some(
             executor::run_package(
+                &context.roots,
                 context.extensions,
                 &mut context.state,
                 context.component,
@@ -244,7 +253,7 @@ pub(super) fn execute_release_plan_step(
             .unwrap_or_else(|err| failed_result("github.release", "github.release", err)),
         )),
         "cleanup" => Ok(Some(
-            executor::run_cleanup(context.component, &context.state)
+            executor::run_cleanup(context.roots.data(), context.component, &context.state)
                 .unwrap_or_else(|err| failed_result("cleanup", "cleanup", err)),
         )),
         "post_release" => {
@@ -255,6 +264,7 @@ pub(super) fn execute_release_plan_step(
             ))
         }
         "deploy" => Ok(Some(super::deployment::run_deployment_step(
+            context.roots.data(),
             context.component,
             context.state.version.as_deref(),
             context.state.tag.as_deref(),
@@ -988,6 +998,15 @@ fn dirty_side_effect_failure(step: &PlanStep, files: Vec<String>) -> ReleaseStep
 
 #[cfg(test)]
 mod tests {
+    /// The isolated home each test below installs, named as roots.
+    ///
+    /// A test that builds a `ReleaseExecutionContext` by hand is standing in
+    /// for `execute_plan_steps_at_source`, so it resolves once here exactly
+    /// where the real executor resolves once — not inside the step (#7505).
+    fn test_roots() -> homeboy_core::paths::PathRoots {
+        homeboy_core::paths::PathRoots::from_environment().expect("path roots")
+    }
+
     use super::{
         dependency_preflight_result, execute_release_plan_step, planned_release_tag_name,
         release_step_is_plan_only, release_step_is_show_stopper,
@@ -1074,6 +1093,7 @@ mod tests {
                 extensions: &extensions,
                 component_id: "fixture",
                 options: &options,
+                roots: test_roots(),
                 state: ReleaseState::default(),
                 publish_failed: false,
             };
@@ -1126,6 +1146,7 @@ mod tests {
                 extensions: &extensions,
                 component_id: "fixture",
                 options: &options,
+                roots: test_roots(),
                 state: ReleaseState {
                     version: Some("1.2.3".to_string()),
                     ..ReleaseState::default()
@@ -1186,6 +1207,7 @@ mod tests {
                 extensions: &extensions,
                 component_id: "fixture",
                 options: &options,
+                roots: test_roots(),
                 state: ReleaseState {
                     version: Some("1.2.3".to_string()),
                     ..ReleaseState::default()
@@ -1250,6 +1272,7 @@ mod tests {
                 extensions: &extensions,
                 component_id: "fixture",
                 options: &options,
+                roots: test_roots(),
                 state: ReleaseState {
                     version: Some("1.2.3".to_string()),
                     ..ReleaseState::default()
@@ -1283,6 +1306,7 @@ mod tests {
                 extensions: &recovery_extensions,
                 component_id: "fixture",
                 options: &options,
+                roots: test_roots(),
                 state: ReleaseState {
                     version: Some("1.2.3".to_string()),
                     ..ReleaseState::default()
@@ -1339,6 +1363,7 @@ mod tests {
                 extensions: &extensions,
                 component_id: "fixture",
                 options: &options,
+                roots: test_roots(),
                 state: ReleaseState {
                     version: Some("1.2.3".to_string()),
                     ..ReleaseState::default()
@@ -1410,6 +1435,7 @@ mod tests {
             extensions: &[],
             component_id: "fixture",
             options: &options,
+            roots: test_roots(),
             state: ReleaseState::default(),
             publish_failed: false,
         };
@@ -1550,6 +1576,7 @@ mod tests {
             extensions: &[],
             component_id: "fixture",
             options: &options,
+            roots: test_roots(),
             state: ReleaseState::default(),
             publish_failed: false,
         };
@@ -1581,6 +1608,7 @@ mod tests {
             extensions: &[],
             component_id: "fixture",
             options: &options,
+            roots: test_roots(),
             state: ReleaseState::default(),
             publish_failed: false,
         };
@@ -1615,6 +1643,7 @@ mod tests {
             extensions: &[],
             component_id: "fixture",
             options: &options,
+            roots: test_roots(),
             state: ReleaseState::default(),
             publish_failed: true,
         };
@@ -1654,6 +1683,7 @@ mod tests {
             extensions: &[],
             component_id: "fixture",
             options: &options,
+            roots: test_roots(),
             state: ReleaseState::default(),
             publish_failed: false,
         };
@@ -1699,6 +1729,7 @@ mod tests {
             extensions: &[],
             component_id: "fixture",
             options: &options,
+            roots: test_roots(),
             state: ReleaseState::default(),
             publish_failed: false,
         };
@@ -1743,6 +1774,7 @@ mod tests {
             extensions: &[],
             component_id: "fixture",
             options: &options,
+            roots: test_roots(),
             state: ReleaseState {
                 tag: Some("v1.2.3".to_string()),
                 ..Default::default()
@@ -1802,6 +1834,7 @@ mod tests {
             extensions: &[],
             component_id: "fixture",
             options: &options,
+            roots: test_roots(),
             state: ReleaseState::default(),
             publish_failed: false,
         };
@@ -1832,6 +1865,7 @@ mod tests {
             extensions: &[],
             component_id: "fixture",
             options: &options,
+            roots: test_roots(),
             state: ReleaseState::default(),
             publish_failed: false,
         };
@@ -1884,6 +1918,7 @@ mod tests {
                 extensions: &extensions,
                 component_id: "fixture",
                 options: &options,
+                roots: test_roots(),
                 state: ReleaseState::default(),
                 publish_failed: false,
             };
@@ -1946,6 +1981,7 @@ mod tests {
             extensions: &[],
             component_id: "fixture",
             options: &options,
+            roots: test_roots(),
             state: ReleaseState::default(),
             publish_failed: false,
         };
@@ -2015,6 +2051,7 @@ mod tests {
             extensions: &[],
             component_id: "fixture",
             options: &options,
+            roots: test_roots(),
             state: ReleaseState::default(),
             publish_failed: false,
         };
@@ -2059,6 +2096,7 @@ mod tests {
             extensions: &[],
             component_id: "fixture",
             options: &options,
+            roots: test_roots(),
             state: ReleaseState::default(),
             publish_failed: false,
         };
@@ -2094,6 +2132,7 @@ mod tests {
             extensions: &[],
             component_id: "fixture",
             options: &options,
+            roots: test_roots(),
             state: ReleaseState::default(),
             publish_failed: false,
         };
@@ -2132,6 +2171,7 @@ mod tests {
             extensions: &[],
             component_id: "fixture",
             options: &options,
+            roots: test_roots(),
             state: ReleaseState::default(),
             publish_failed: false,
         };
@@ -2172,6 +2212,7 @@ mod tests {
             extensions: &[],
             component_id: "fixture",
             options: &options,
+            roots: test_roots(),
             state: ReleaseState::default(),
             publish_failed: false,
         };
@@ -2208,6 +2249,7 @@ mod tests {
             extensions: &[],
             component_id: "fixture",
             options: &options,
+            roots: test_roots(),
             state: ReleaseState::default(),
             publish_failed: false,
         };
@@ -2258,6 +2300,7 @@ mod tests {
             extensions: &[],
             component_id: "fixture",
             options: &options,
+            roots: test_roots(),
             state: ReleaseState::default(),
             publish_failed: false,
         };
@@ -2329,6 +2372,7 @@ mod tests {
             extensions: &[],
             component_id: "fixture",
             options: &options,
+            roots: test_roots(),
             state: ReleaseState::default(),
             publish_failed: false,
         };

--- a/crates/homeboy-release/src/release/execution_plan.rs
+++ b/crates/homeboy-release/src/release/execution_plan.rs
@@ -97,16 +97,32 @@ fn early_tag_availability_step(options: &ReleaseOptions, dry_run: bool) -> Optio
 }
 
 pub(super) fn execute_plan_steps(
+    roots: &homeboy_core::paths::PathRoots,
     steps: &[PlanStep],
     component_id: &str,
     options: &ReleaseOptions,
     results: &mut Vec<ReleaseStepResult>,
     skip_step_ids: &HashSet<&'static str>,
 ) -> Result<bool> {
-    execute_plan_steps_at_source(steps, component_id, options, results, skip_step_ids, None)
+    execute_plan_steps_at_source(
+        roots,
+        steps,
+        component_id,
+        options,
+        results,
+        skip_step_ids,
+        None,
+    )
 }
 
+/// Walk planned release steps against roots resolved by the caller.
+///
+/// A release runs this twice — once for executable preflight, once for the
+/// rebuilt mutation plan — and both phases must address the same home. Taking
+/// roots rather than resolving them here is what makes that guarantee
+/// structural instead of incidental (#7505).
 pub(super) fn execute_plan_steps_at_source(
+    roots: &homeboy_core::paths::PathRoots,
     steps: &[PlanStep],
     component_id: &str,
     options: &ReleaseOptions,
@@ -120,11 +136,17 @@ pub(super) fn execute_plan_steps_at_source(
 
     let component = load_component(component_id, options)?;
     let extensions = resolve_extensions(&component)?;
+    // Every step that touches Homeboy state — package artifacts, the
+    // failed-attempt ownership record, the deploy recovery checkpoint — now
+    // reads the caller's roots off the context instead of consulting the
+    // environment again, so a repoint mid-plan cannot split a single release
+    // across two homes (#7505).
     let mut context = ReleaseExecutionContext {
         component: &component,
         extensions: &extensions,
         component_id,
         options,
+        roots: roots.clone(),
         state: initial_release_state(&component, component_id, options)?,
         publish_failed: false,
     };
@@ -310,6 +332,15 @@ fn read_current_release_notes(component: &Component) -> Result<Option<String>> {
 
 #[cfg(test)]
 mod tests {
+    /// The isolated home each test below installs, named as roots.
+    ///
+    /// These tests call the plan executor directly, so they occupy the
+    /// position `orchestrator::run_with_plan` holds in production: resolve
+    /// once, then hand the result down (#7505).
+    fn test_roots() -> homeboy_core::paths::PathRoots {
+        homeboy_core::paths::PathRoots::from_environment().expect("path roots")
+    }
+
     use super::{
         build_dry_run_preflight_plan, build_initial_preflight_plan, execute_plan_steps,
         initial_executable_preflight_ids, release_tag_version, resolve_head_release,
@@ -609,6 +640,7 @@ mod tests {
         let plan = build_dry_run_preflight_plan("fixture", &options);
         let mut results = Vec::new();
         let stopped = execute_plan_steps(
+            &test_roots(),
             &plan.plan.steps,
             "fixture",
             &options,
@@ -726,6 +758,7 @@ mod tests {
         let mut results = Vec::new();
 
         let error = execute_plan_steps(
+            &test_roots(),
             &plan.plan.steps,
             "fixture",
             &options,
@@ -785,6 +818,7 @@ mod tests {
         let mut results = Vec::new();
 
         let stopped = execute_plan_steps(
+            &test_roots(),
             &plan.plan.steps,
             "fixture",
             &options,
@@ -853,6 +887,7 @@ mod tests {
         let mut results = Vec::new();
 
         let stopped = execute_plan_steps(
+            &test_roots(),
             &[],
             "missing-component-is-not-loaded-for-empty-plan",
             &ReleaseOptions::default(),
@@ -957,6 +992,7 @@ mod tests {
         let mut results = Vec::new();
 
         let error = execute_plan_steps(
+            &test_roots(),
             &plan.plan.steps,
             "fixture",
             &options,

--- a/crates/homeboy-release/src/release/executor.rs
+++ b/crates/homeboy-release/src/release/executor.rs
@@ -37,8 +37,7 @@ pub use github_release::release_notes_path;
 pub(crate) use github_release::release_notes_path as github_release_notes_path;
 pub(crate) use github_release::run_github_release;
 pub(crate) use package::{
-    build_release_payload, run_extension_release_preflight, run_package, run_package_in_roots,
-    PackageRequest,
+    build_release_payload, run_extension_release_preflight, run_package, PackageRequest,
 };
 pub(crate) use publish::{publish_response_output, run_publish};
 pub(crate) use tagging::{
@@ -361,25 +360,13 @@ pub(crate) fn run_git_commit(
 
 /// Delete release-generated artifact directories. Skipped when the caller chose
 /// `--deploy` so the deploy step can still find the artifact.
-pub(crate) fn run_cleanup(
-    component: &Component,
-    state: &ReleaseState,
-) -> Result<ReleaseStepResult> {
-    run_cleanup_in_roots(
-        homeboy_core::paths::PathRoots::from_environment()?.data(),
-        component,
-        state,
-    )
-}
-
-/// [`run_cleanup`] against an explicitly injected data root.
 ///
 /// Reading the failed-attempt ownership record and acknowledging it are one
 /// transaction over one file. The ambient form resolved the data root once per
 /// call, so a repoint between them could have removed paths recorded in one
 /// home and then acknowledged a record in another, permanently stranding the
 /// first home's entries (#7505).
-pub(crate) fn run_cleanup_in_roots(
+pub(crate) fn run_cleanup(
     data_root: &std::path::Path,
     component: &Component,
     state: &ReleaseState,
@@ -554,6 +541,16 @@ fn should_amend_release_commit(local_path: &str) -> Result<bool> {
 /// forward so the default payload is unchanged.
 #[cfg(test)]
 mod tests {
+    /// The isolated home each test below installs, named as roots.
+    ///
+    /// These tests are their own boundary: `with_isolated_home` establishes the
+    /// home, and this resolves it once so the call under test receives roots
+    /// the same way `execute_plan_steps_at_source` hands them to a real step.
+    /// Production code in this module no longer resolves anything (#7505).
+    fn test_roots() -> homeboy_core::paths::PathRoots {
+        homeboy_core::paths::PathRoots::from_environment().expect("path roots")
+    }
+
     use super::package::store_artifacts_from_output;
     use super::{github_release, package_preflight, run_cleanup, run_package, PackageRequest};
     use crate::release::types::ReleaseState;
@@ -746,7 +743,7 @@ mod tests {
             ..ReleaseState::default()
         };
 
-        let result = run_cleanup(&component, &state).expect("cleanup");
+        let result = run_cleanup(test_roots().data(), &component, &state).expect("cleanup");
 
         assert_eq!(result.status, ReleaseStepStatus::Success);
         assert!(!build_dir.exists());
@@ -767,7 +764,7 @@ mod tests {
         };
         let state = ReleaseState::default();
 
-        let result = run_cleanup(&component, &state).expect("cleanup");
+        let result = run_cleanup(test_roots().data(), &component, &state).expect("cleanup");
 
         assert_eq!(result.status, ReleaseStepStatus::Success);
         assert!(build_dir.exists());
@@ -785,7 +782,7 @@ mod tests {
             ..Component::default()
         };
 
-        run_cleanup(&component, &ReleaseState::default()).expect("cleanup");
+        run_cleanup(test_roots().data(), &component, &ReleaseState::default()).expect("cleanup");
 
         assert!(temp.path().join("build/user.txt").is_file());
         assert!(temp.path().join("fixture-1.2.3.tgz").is_file());
@@ -951,6 +948,7 @@ mod tests {
                 ..ReleaseState::default()
             };
             let result = run_package(
+                &test_roots(),
                 &[package],
                 &mut state,
                 &component_config,
@@ -985,7 +983,7 @@ mod tests {
             assert!(repair.create_command.contains(durable_path));
 
             let build_dir = component.path().join("build");
-            run_cleanup(&component_config, &state).expect("cleanup");
+            run_cleanup(test_roots().data(), &component_config, &state).expect("cleanup");
 
             assert!(!build_dir.exists());
             assert!(std::path::Path::new(durable_path).is_file());
@@ -1020,6 +1018,7 @@ mod tests {
                 ..ReleaseState::default()
             };
             run_package(
+                &test_roots(),
                 &[package],
                 &mut state,
                 &component,
@@ -1078,6 +1077,7 @@ mod tests {
             };
 
             let result = run_package(
+                &test_roots(),
                 &[],
                 &mut state,
                 &component,
@@ -1147,6 +1147,7 @@ mod tests {
             homeboy_extension::save_manifest(&package).expect("save package extension");
 
             let error = run_package(
+                &test_roots(),
                 &[package],
                 &mut ReleaseState::default(),
                 &Component::default(),
@@ -1315,6 +1316,7 @@ mod tests {
 
             let mut state = crate::release::types::ReleaseState::default();
             let result = run_package(
+                &test_roots(),
                 &[package_a, non_package_extension("docs"), package_b],
                 &mut state,
                 &Component::default(),
@@ -1353,6 +1355,7 @@ mod tests {
 
             let mut state = crate::release::types::ReleaseState::default();
             let result = run_package(
+                &test_roots(),
                 &[package],
                 &mut state,
                 &Component::default(),
@@ -1457,6 +1460,7 @@ mod tests {
 
             let mut state = ReleaseState::default();
             let err = run_package(
+                &test_roots(),
                 &[package],
                 &mut state,
                 &Component::default(),
@@ -1492,6 +1496,7 @@ mod tests {
 
             let mut state = crate::release::types::ReleaseState::default();
             let err = run_package(
+                &test_roots(),
                 &[package_a, package_b],
                 &mut state,
                 &Component::default(),
@@ -1533,6 +1538,7 @@ mod tests {
 
             let mut state = crate::release::types::ReleaseState::default();
             let err = run_package(
+                &test_roots(),
                 &[package],
                 &mut state,
                 &Component::default(),
@@ -1588,6 +1594,7 @@ mod tests {
 
             let mut state = crate::release::types::ReleaseState::default();
             let result = run_package(
+                &test_roots(),
                 &[package],
                 &mut state,
                 &Component::default(),

--- a/crates/homeboy-release/src/release/executor/package.rs
+++ b/crates/homeboy-release/src/release/executor/package.rs
@@ -36,26 +36,6 @@ pub(crate) struct PackageRequest<'a> {
 /// Invoke the `release.package` action on every extension that provides it,
 /// parse the emitted artifacts, and stash them in [`ReleaseState::artifacts`]
 /// for downstream publish targets and for the GitHub Release step.
-pub(crate) fn run_package(
-    extensions: &[ExtensionManifest],
-    state: &mut ReleaseState,
-    component: &Component,
-    component_id: &str,
-    component_local_path: &str,
-    request: PackageRequest<'_>,
-) -> Result<ReleaseStepResult> {
-    run_package_in_roots(
-        &homeboy_core::paths::PathRoots::from_environment()?,
-        extensions,
-        state,
-        component,
-        component_id,
-        component_local_path,
-        request,
-    )
-}
-
-/// [`run_package`] against explicitly injected roots.
 ///
 /// Both halves of this step are Homeboy state and both are injected together,
 /// on purpose. The durable artifact copies land under `roots.artifacts()` and
@@ -67,7 +47,7 @@ pub(crate) fn run_package(
 /// and `run_package_action_with_retry` hand work to a *subprocess* — the
 /// component's own build script and the extension's `release.package` action.
 /// Those children read their own environment by design and must keep doing so.
-pub(crate) fn run_package_in_roots(
+pub(crate) fn run_package(
     roots: &homeboy_core::paths::PathRoots,
     extensions: &[ExtensionManifest],
     state: &mut ReleaseState,

--- a/crates/homeboy-release/src/release/orchestrator.rs
+++ b/crates/homeboy-release/src/release/orchestrator.rs
@@ -29,6 +29,11 @@ pub(crate) fn run_with_plan(
     component_id: &str,
     options: &ReleaseOptions,
 ) -> Result<(ReleasePlan, ReleaseRun, Option<ReleaseWorkspaceOutput>)> {
+    // One resolution for the entire release. Both plan phases below — the
+    // executable preflight pass and the rebuilt mutation pass — receive it,
+    // so a release cannot package into one home and then clean up, checkpoint,
+    // or record its deploy recovery against another (#7505).
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
     let component = super::context::load_component(component_id, options)?;
     let mut workspace = super::workspace::ReleaseWorkspace::select(&component)?;
     let mut workspace_options = options.clone();
@@ -38,6 +43,7 @@ pub(crate) fn run_with_plan(
 
     let staging_source_sha = workspace.source_sha();
     match run_with_plan_inner(
+        &roots,
         component_id,
         &workspace_options,
         checkout_guard.as_ref(),
@@ -94,6 +100,7 @@ pub(crate) fn run_with_plan(
 }
 
 fn run_with_plan_inner(
+    roots: &homeboy_core::paths::PathRoots,
     component_id: &str,
     options: &ReleaseOptions,
     checkout_guard: Option<&super::checkout_guard::ReleaseCheckoutGuard>,
@@ -106,6 +113,7 @@ fn run_with_plan_inner(
     let mut timer = PhaseTimer::new();
     let initial_stop = timer.time("package_preflight", || {
         super::execution_plan::execute_plan_steps_at_source(
+            roots,
             &initial_plan.plan.steps,
             component_id,
             options,
@@ -142,6 +150,7 @@ fn run_with_plan_inner(
     super::preflight_identity::revalidate(&preflight_component, &preflight_source)?;
     timer.time("package", || {
         super::execution_plan::execute_plan_steps_at_source(
+            roots,
             &release_plan.plan.steps,
             component_id,
             options,

--- a/crates/homeboy-release/src/release/package_recovery.rs
+++ b/crates/homeboy-release/src/release/package_recovery.rs
@@ -10,7 +10,7 @@ use super::context::{load_component, resolve_extensions};
 use super::executor::artifacts::{
     PACKAGE_RECOVERY_MANIFEST_SCHEMA, PACKAGE_RECOVERY_MANIFEST_SCHEMA_VERSION,
 };
-use super::executor::{run_cleanup_in_roots, run_package_in_roots, PackageRequest};
+use super::executor::{run_cleanup, run_package, PackageRequest};
 use super::types::{ReleaseArtifact, ReleaseOptions, ReleaseState, ReleaseStepResult};
 
 #[derive(Debug, Clone, Serialize)]
@@ -70,7 +70,7 @@ pub fn package_existing_tag(
         ..Default::default()
     };
 
-    let package_step = run_package_in_roots(
+    let package_step = run_package(
         &roots,
         &extensions,
         &mut state,
@@ -135,7 +135,7 @@ pub fn package_existing_tag(
 
     // The durable recovery directory now owns the deliverables. Remove only
     // checkout paths proven to have been created by this package invocation.
-    run_cleanup_in_roots(roots.data(), &component, &state)?;
+    run_cleanup(roots.data(), &component, &state)?;
 
     homeboy_core::log_status!(
         "release",

--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -404,7 +404,11 @@ fn run_command_with_workspace_inner(
             ));
         }
 
-        let dry_run_preflight = run_dry_run_preflights(&input.component_id, &options)?;
+        let dry_run_preflight = run_dry_run_preflights(
+            &homeboy_core::paths::PathRoots::from_environment()?,
+            &input.component_id,
+            &options,
+        )?;
         if let Some(run) = dry_run_preflight {
             let status = release_command_status(true, skipped_reason.as_deref(), Some(&run));
             let release_summary = release_summary_from_run(&run);
@@ -627,7 +631,13 @@ fn prepared_tag_publish_recovery_decision(
     }
 }
 
+/// Run the dry-run preflight plan against roots resolved by the caller.
+///
+/// Dry run is its own entry into plan execution — it never reaches
+/// `orchestrator::run_with_plan` — so it receives roots from the workflow
+/// boundary rather than letting individual steps rediscover a home (#7505).
 fn run_dry_run_preflights(
+    roots: &homeboy_core::paths::PathRoots,
     component_id: &str,
     options: &ReleaseOptions,
 ) -> Result<Option<ReleaseRun>> {
@@ -636,6 +646,7 @@ fn run_dry_run_preflights(
     let preflight_plan = super::execution_plan::build_dry_run_preflight_plan(component_id, options);
     let mut results = Vec::new();
     let stopped = super::execution_plan::execute_plan_steps(
+        roots,
         &preflight_plan.plan.steps,
         component_id,
         options,

--- a/docs/internals/development/contracts/path-roots-injection.md
+++ b/docs/internals/development/contracts/path-roots-injection.md
@@ -1,0 +1,146 @@
+# PathRoots injection contract
+
+`homeboy_core::paths::PathRoots` names one Homeboy home: a config root, a data
+root, and an artifact root resolved together. Its own doc states the contract:
+
+> Stateful services receive this value instead of repeatedly consulting
+> process-global environment and overrides. This lets independent in-process
+> workloads own distinct Homeboy state without serializing path resolution.
+
+This page describes how to satisfy that contract in a crate that does not yet,
+using `homeboy-release` as the worked example (#7505).
+
+## Why ad hoc resolution is a defect, not a style preference
+
+`PathRoots::from_environment()` reads process-global state. Two calls are two
+independent answers. Any operation that resolves more than once is therefore
+one operation spread across two possibly-different homes, and the failure mode
+is silent: bytes land in one home while the record describing them lands in
+another.
+
+Concretely, before this change a single release resolved roots at least three
+separate times:
+
+```
+release run
+├── package step      -> from_environment()   artifacts + failed-attempt record
+├── cleanup step      -> from_environment()   read record, acknowledge record
+└── deploy step       -> from_environment()   save / clear recovery checkpoint
+```
+
+Nothing tied those three answers together. The same property is what forces
+every test through `HomeGuard`'s process-global mutex: if a path can only be
+found by reading the environment, then isolating a test means mutating the
+environment, and mutating process-global state means no two tests can run at
+once.
+
+## The shape
+
+**Resolve once at a named boundary. Pass the value down. Never resolve in a
+step, a helper, or a store method.**
+
+A boundary is a function that begins a unit of work a user asked for. In
+`homeboy-release` there are exactly four:
+
+| Boundary | Unit of work |
+|---|---|
+| `orchestrator::run_with_plan` | a release |
+| `workflow::run_dry_run_preflights`' caller | a dry run |
+| `package_recovery::package_existing_tag` | repackaging a published tag |
+| `deployment::resume_deployment` | resuming a checkpointed deploy |
+
+Everything below a boundary takes what it needs as a parameter — `&PathRoots`
+when it needs more than one root, `&Path` when it needs exactly one:
+
+```rust
+// boundary: the one resolution for the whole release
+let roots = homeboy_core::paths::PathRoots::from_environment()?;
+
+// carrier: threaded onto the context every step already receives
+let mut context = ReleaseExecutionContext { roots: roots.clone(), .. };
+
+// step: reads the carrier, never the environment
+executor::run_cleanup(context.roots.data(), context.component, &context.state)
+```
+
+Prefer threading onto a struct a callee already receives over adding a
+parameter to a long chain. `ReleaseExecutionContext` already carried
+`component`, `extensions`, and `options` to every step, so adding `roots`
+reached ten call sites through one field.
+
+## Collapse the pair; do not keep it
+
+A crate mid-migration tends to grow ambient/rooted sibling pairs:
+
+```rust
+fn run_cleanup(component: &Component) -> Result<T> {                 // ambient
+    run_cleanup_in_roots(PathRoots::from_environment()?.data(), component)
+}
+fn run_cleanup_in_roots(data_root: &Path, component: &Component) -> Result<T> { .. }
+```
+
+The pair is scaffolding, not an API. It is load-bearing only while some caller
+still cannot supply a root. **When the last such caller converts, delete the
+ambient wrapper and give the rooted function the plain name.** The end state is
+one function that takes a root, not two functions that differ by a suffix.
+
+That deletion is what makes this work net-negative. A change that only adds
+`_in_roots` variants has added plumbing; a change that removes the wrapper has
+removed an ambient resolution point.
+
+The `_in_root(s)` suffix stays legitimate in one place: `homeboy_core::paths`
+itself, where both forms are genuinely public API (`observation_db()` and
+`observation_db_in_root()`). Elsewhere it should be temporary.
+
+### Watch for return types that hide the failure
+
+`execute_deployment` returned an unwrapped `ReleaseDeploymentResult`, so it
+could not have called `from_environment()?` itself. The ambient
+`save_recovery`/`remove_recovery` wrappers existed precisely to absorb that
+`Result` out of sight. An ambient wrapper hanging off an infallible function is
+a strong signal that resolution belongs further up.
+
+## Tests are a boundary too
+
+Tests that construct a carrier by hand, or call a rooted function directly,
+occupy the position the real boundary holds. Resolve once in a local helper:
+
+```rust
+/// The isolated home each test below installs, named as roots.
+fn test_roots() -> homeboy_core::paths::PathRoots {
+    homeboy_core::paths::PathRoots::from_environment().expect("path roots")
+}
+```
+
+This is not a loophole. The test genuinely is the entry point for its unit of
+work. What matters is that the *production* path below it resolves nothing.
+
+## Reporting progress
+
+Raw `from_environment()` counts are a misleading headline, because a correct
+boundary is also a call. Decompose instead:
+
+- **ambient resolution points** — calls inside steps, helpers, and stores.
+  This is the number that must reach zero.
+- **boundary resolutions** — one per named unit of work. This number is
+  supposed to be small and non-zero.
+- **test helpers** — one per test module.
+
+For `homeboy-release`, the increment that produced this document moved ambient
+points from 7 to 3 and left 4 named boundaries. The remaining 3 all live in
+`OperationRecordStore`, whose static methods resolve per call; converting it
+wants `homeboy-cli` to thread roots first, so its callers have something to
+pass.
+
+## Verifying
+
+`cargo check --workspace --tests` is the gate. The two errors this work
+reliably produces are:
+
+- `E0063` — a struct gained a `roots` field and test initializers do not set it.
+  Expect one per hand-built carrier; there were 25 in `execution_dispatch.rs`.
+- `E0061` — a collapsed function now takes an extra leading argument.
+
+When scripting the call-site edits, assert the expected match count before
+writing. A pattern like `run_deployment_step\(\n` matches the definition as
+well as the calls, and the assertion is what catches it.

--- a/docs/internals/index.md
+++ b/docs/internals/index.md
@@ -22,6 +22,7 @@ Internals docs are for people maintaining Homeboy itself: architecture, implemen
 
 - [Compiler warning extension](development/contracts/compiler-warning-extension.md)
 - [Command argument provenance](development/contracts/command-argument-provenance.md)
+- [PathRoots injection](development/contracts/path-roots-injection.md)
 - [Verification phases](development/contracts/verification-phases.md)
 
 ## Docs Maintenance


### PR DESCRIPTION
Part of #7505. Scoped to `homeboy-release`.

## The problem this removes

A single release resolved `PathRoots::from_environment()` at least three separate times, each an independent read of process-global state, with nothing tying the answers together:

```
release run
├── package step      -> from_environment()   artifacts + failed-attempt record
├── cleanup step      -> from_environment()   read record, acknowledge record
└── deploy step       -> from_environment()   save / clear recovery checkpoint
```

A repoint between any two could leave bytes in one home and the record describing them in another. Silently.

## What this does

Resolves once at `orchestrator::run_with_plan` — the function that begins a release — and threads the value down. `ReleaseExecutionContext` already carried `component`, `extensions`, and `options` to every step, so one new `roots` field reaches all of them through a single carrier. Both plan phases (executable preflight, rebuilt mutation plan) now receive the same roots rather than resolving independently.

Four ambient wrappers lost their last caller and are **deleted**, each collapsing into the rooted function which takes the plain name:

| deleted | survivor |
|---|---|
| `run_package` | `run_package(roots, ..)` |
| `run_cleanup` | `run_cleanup(data_root, ..)` |
| `save_recovery` | `save_recovery(data_root, ..)` |
| `remove_recovery` | `remove_recovery(data_root, ..)` |

`execute_deployment` returns an unwrapped `ReleaseDeploymentResult`, so it could never have called `from_environment()?` itself — the `save_recovery`/`remove_recovery` wrappers existed precisely to absorb that `Result` out of sight. It takes a `&Path` now. An ambient wrapper hanging off an infallible function is a reliable signal that resolution belongs further up.

## Before / after, honestly

Raw `from_environment()` counts are a misleading headline, because a correct boundary is also a call. Decomposed:

| | before | after |
|---|---|---|
| **ambient** (inside steps/helpers/stores) | **7** | **3** |
| **boundary** (one per unit of work) | 2 | 4 |
| test helpers | 1 | 4 |
| total | 10 | 11 |

The 3 remaining ambient points are all `OperationRecordStore`'s static `update` / `load` / `for_subject`. Converting that store wants the `homeboy-cli` increment to land first — it has three call sites of its own, and without roots at the CLI the conversion would relocate ambient calls rather than remove them.

The 4 boundaries are named, and are supposed to exist:

| boundary | unit of work |
|---|---|
| `orchestrator::run_with_plan` | a release |
| `workflow::run_command_with_workspace_inner` (dry run) | a dry run |
| `package_recovery::package_existing_tag` | repackaging a published tag |
| `deployment::resume_deployment` | resuming a checkpointed deploy |

Runtime resolutions per release: **3+ → 1**.

## Why this unblocks the actual goal

#7505 asks for `home_lock` and `HomeGuard` to be deleted. They can't be while paths are only findable by reading the environment — isolating a test then means *mutating* the environment, which is what forces all 2,523 `with_isolated_home` call sites through one process-global mutex. The ~205 ambient resolution points are the blocker list. This clears 4 of them and establishes the shape for the rest.

## Pattern doc

`docs/internals/development/contracts/path-roots-injection.md` records it so the remaining crates copy rather than rediscover: resolve at a boundary, thread down, **delete the wrapper when its last caller converts**. It also covers the two errors this work reliably produces (`E0063` on hand-built carriers — 25 of them here; `E0061` on collapsed signatures) and why raw call counts are the wrong metric.

Per-crate ambient totals remaining: `homeboy-agents` 162, `homeboy-lab-runner` 9, `homeboy-extension` 6, `homeboy-deploy` 5, `homeboy-rig` 4, `homeboy-cli` 4.

## Verification

`nice -n 10 cargo check --workspace --tests -j2` — clean, zero errors and zero warnings across the workspace. `cargo fmt` applied. No behavior change intended: every converted call site receives the same root the ambient call would have resolved, only once and from further up.