### PR TITLE
refactor(release): give OperationRecordStore its root — homeboy-release reaches 0 ambient (#7505)

### DIFF
--- a/crates/homeboy-cli/src/commands/release/mod.rs
+++ b/crates/homeboy-cli/src/commands/release/mod.rs
@@ -503,16 +503,22 @@ pub fn run(args: ReleaseArgs) -> CmdResult<ReleaseCommandOutput> {
         }
         Some(ReleaseSubcommand::Readiness(args)) => match args.command {
             ReleaseReadinessCommand::Show { reference } => {
+                // The readiness subcommand is its own unit of work, so it
+                // resolves roots once and binds the record store to them
+                // rather than letting each store call rediscover a home
+                // (#7505).
+                let store = release::operation_record::OperationRecordStore::in_roots(
+                    &homeboy::core::paths::PathRoots::from_environment()?,
+                );
                 let owner_run_ref = reference.strip_prefix("operation://").unwrap_or(&reference);
-                let record = release::operation_record::OperationRecordStore::load(owner_run_ref)?
-                    .ok_or_else(|| {
-                        homeboy::core::Error::validation_invalid_argument(
-                            "reference",
-                            "release readiness operation does not exist",
-                            Some(reference.clone()),
-                            None,
-                        )
-                    })?;
+                let record = store.load(owner_run_ref)?.ok_or_else(|| {
+                    homeboy::core::Error::validation_invalid_argument(
+                        "reference",
+                        "release readiness operation does not exist",
+                        Some(reference.clone()),
+                        None,
+                    )
+                })?;
                 if record.operation != "release_readiness" {
                     return Err(homeboy::core::Error::validation_invalid_argument(
                         "reference",
@@ -530,11 +536,10 @@ pub fn run(args: ReleaseArgs) -> CmdResult<ReleaseCommandOutput> {
                 ));
             }
             ReleaseReadinessCommand::List { component_id } => {
-                let records = release::operation_record::OperationRecordStore::for_subject(
-                    "release_readiness",
-                    &component_id,
-                    false,
-                )?;
+                let store = release::operation_record::OperationRecordStore::in_roots(
+                    &homeboy::core::paths::PathRoots::from_environment()?,
+                );
+                let records = store.for_subject("release_readiness", &component_id, false)?;
                 return Ok((
                     ReleaseCommandOutput::ReadinessList(ReleaseReadinessListOutput {
                         variant: "readiness-list",
@@ -1564,6 +1569,16 @@ mod tests {
     use super::*;
     use std::cell::RefCell;
 
+    /// The record store for the isolated home each test below installs.
+    ///
+    /// `with_isolated_home` establishes the home; this binds a store to it once,
+    /// the same way the release boundary binds one for a whole command (#7505).
+    fn test_store() -> release::operation_record::OperationRecordStore {
+        release::operation_record::OperationRecordStore::in_roots(
+            &homeboy::core::paths::PathRoots::from_environment().expect("path roots"),
+        )
+    }
+
     fn args(components: &[&str]) -> ReleaseExecuteArgs {
         ReleaseExecuteArgs {
             components: components.iter().map(|value| value.to_string()).collect(),
@@ -2158,7 +2173,7 @@ jobs:
                 continuation_evidence: Vec::new(),
                 attributes: Default::default(),
             };
-            release::operation_record::OperationRecordStore::create(&record).expect("record");
+            test_store().create(&record).expect("record");
             let (output, exit_code) = run(ReleaseArgs {
                 command: Some(ReleaseSubcommand::Readiness(ReleaseReadinessArgs {
                     command: ReleaseReadinessCommand::Show {
@@ -2197,7 +2212,7 @@ jobs:
                 continuation_evidence: Vec::new(),
                 attributes: Default::default(),
             };
-            release::operation_record::OperationRecordStore::create(&record).expect("record");
+            test_store().create(&record).expect("record");
             let error = match run(ReleaseArgs {
                 command: Some(ReleaseSubcommand::Readiness(ReleaseReadinessArgs {
                     command: ReleaseReadinessCommand::Show {

--- a/crates/homeboy-release/src/release/deployment.rs
+++ b/crates/homeboy-release/src/release/deployment.rs
@@ -490,8 +490,10 @@ fn remove_recovery(data_root: &Path, component_id: &str) -> Result<()> {
 /// another. The redeploy between them — `deploy::run_multi` — still resolves
 /// its own roots inside `homeboy-deploy`; that boundary is not reachable from
 /// here without changing a public signature (#7505).
-pub(super) fn resume_deployment(component_id: &str) -> Result<Option<ReleaseDeploymentResult>> {
-    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+pub(super) fn resume_deployment(
+    roots: &homeboy_core::paths::PathRoots,
+    component_id: &str,
+) -> Result<Option<ReleaseDeploymentResult>> {
     let path = recovery_path_in_roots(roots.data(), component_id);
     if !path.exists() {
         return Ok(None);
@@ -1256,7 +1258,7 @@ mod tests {
                 "terminal success clears the durable checkpoint"
             );
 
-            assert!(super::resume_deployment(&component.id)
+            assert!(super::resume_deployment(&test_roots(), &component.id)
                 .expect("terminal recovery lookup")
                 .is_none());
             assert_eq!(run_git(&source, &["tag", "--list"]), "v1.2.4");

--- a/crates/homeboy-release/src/release/operation_record.rs
+++ b/crates/homeboy-release/src/release/operation_record.rs
@@ -48,38 +48,43 @@ impl OperationRecord {
     }
 }
 
-pub struct OperationRecordStore;
+/// Durable operation records below one explicitly injected data root.
+///
+/// Stateful on purpose. A single release workspace lifecycle writes this store
+/// roughly a dozen times — publish ownership, record the provisioned path,
+/// mark a failed verification, claim finalization, complete it — and the
+/// ambient form resolved a data root independently for every one of them.
+/// Binding the root once at construction is what makes those writes provably
+/// the same home's, rather than incidentally so (#7505).
+pub struct OperationRecordStore {
+    data_root: PathBuf,
+}
 
 impl OperationRecordStore {
-    pub fn create(record: &OperationRecord) -> Result<OperationRecord> {
-        Self::update(&record.owner_run_ref, |_| Ok(record.clone()))
+    /// Bind the store to the data root its caller already resolved.
+    pub fn in_roots(roots: &paths::PathRoots) -> Self {
+        Self {
+            data_root: roots.data().to_path_buf(),
+        }
+    }
+
+    pub fn create(&self, record: &OperationRecord) -> Result<OperationRecord> {
+        self.update(&record.owner_run_ref, |_| Ok(record.clone()))
     }
 
     /// Compare/update is serialized across processes and atomically replaces the
     /// record, so a recovered finalizer cannot race a still-running owner.
-    pub fn update(
-        owner_run_ref: &str,
-        update: impl FnOnce(Option<OperationRecord>) -> Result<OperationRecord>,
-    ) -> Result<OperationRecord> {
-        Self::update_in_roots(
-            paths::PathRoots::from_environment()?.data(),
-            owner_run_ref,
-            update,
-        )
-    }
-
-    /// [`update`](Self::update) against an explicitly injected data root.
     ///
-    /// The lock and the record path are now derived from one resolution. The
-    /// ambient form resolved the data root twice — once inside `lock()` and
-    /// again inside `record_path()` — so a repoint between them could have
-    /// serialized against one home's `.lock` while replacing the other home's
-    /// record (#7505).
-    fn update_in_roots(
-        data_root: &Path,
+    /// The lock and the record path derive from one root. The ambient form
+    /// resolved the data root twice — once inside `lock()` and again inside
+    /// `record_path()` — so a repoint between them could have serialized
+    /// against one home's `.lock` while replacing the other home's record.
+    pub fn update(
+        &self,
         owner_run_ref: &str,
         update: impl FnOnce(Option<OperationRecord>) -> Result<OperationRecord>,
     ) -> Result<OperationRecord> {
+        let data_root = self.data_root.as_path();
         let _lock = lock_in_roots(data_root)?;
         let path = record_path_in_roots(data_root, owner_run_ref);
         let current = read_path(&path)?;
@@ -104,19 +109,19 @@ impl OperationRecordStore {
         Ok(next)
     }
 
-    pub fn load(owner_run_ref: &str) -> Result<Option<OperationRecord>> {
-        let roots = paths::PathRoots::from_environment()?;
-        let _lock = lock_in_roots(roots.data())?;
-        read_path(&record_path_in_roots(roots.data(), owner_run_ref))
+    pub fn load(&self, owner_run_ref: &str) -> Result<Option<OperationRecord>> {
+        let data_root = self.data_root.as_path();
+        let _lock = lock_in_roots(data_root)?;
+        read_path(&record_path_in_roots(data_root, owner_run_ref))
     }
 
     /// Claims finalization before an external provider call. A live lease is
     /// never stolen; only a bounded stale lease can be retried.
-    pub fn claim_finalization(owner_run_ref: &str) -> Result<FinalizationClaim> {
+    pub fn claim_finalization(&self, owner_run_ref: &str) -> Result<FinalizationClaim> {
         const STALE_LEASE_MS: u128 = 5 * 60 * 1000;
         let now = now_ms();
         let candidate_lease = uuid::Uuid::new_v4().to_string();
-        Self::update(owner_run_ref, |record| {
+        self.update(owner_run_ref, |record| {
             let mut record = record.ok_or_else(|| {
                 Error::validation_invalid_argument(
                     "owner_run_ref",
@@ -157,8 +162,12 @@ impl OperationRecordStore {
         })
     }
 
-    pub fn complete_finalization(owner_run_ref: &str, lease: &str) -> Result<OperationRecord> {
-        Self::update(owner_run_ref, |record| {
+    pub fn complete_finalization(
+        &self,
+        owner_run_ref: &str,
+        lease: &str,
+    ) -> Result<OperationRecord> {
+        self.update(owner_run_ref, |record| {
             let mut record = record.ok_or_else(|| {
                 Error::validation_invalid_argument(
                     "owner_run_ref",
@@ -182,11 +191,12 @@ impl OperationRecordStore {
     }
 
     pub fn fail_finalization(
+        &self,
         owner_run_ref: &str,
         lease: &str,
         error: String,
     ) -> Result<OperationRecord> {
-        Self::update(owner_run_ref, |record| {
+        self.update(owner_run_ref, |record| {
             let mut record = record.ok_or_else(|| {
                 Error::validation_invalid_argument(
                     "owner_run_ref",
@@ -207,18 +217,23 @@ impl OperationRecordStore {
         })
     }
 
-    pub fn pending_for_subject(operation: &str, subject: &str) -> Result<Vec<OperationRecord>> {
-        Self::for_subject(operation, subject, true)
+    pub fn pending_for_subject(
+        &self,
+        operation: &str,
+        subject: &str,
+    ) -> Result<Vec<OperationRecord>> {
+        self.for_subject(operation, subject, true)
     }
 
     pub fn for_subject(
+        &self,
         operation: &str,
         subject: &str,
         pending_only: bool,
     ) -> Result<Vec<OperationRecord>> {
-        let roots = paths::PathRoots::from_environment()?;
-        let _lock = lock_in_roots(roots.data())?;
-        let dir = store_dir_in_roots(roots.data());
+        let data_root = self.data_root.as_path();
+        let _lock = lock_in_roots(data_root)?;
+        let dir = store_dir_in_roots(data_root);
         let mut records = Vec::new();
         if !dir.exists() {
             return Ok(records);
@@ -318,6 +333,16 @@ mod tests {
         Arc, Barrier,
     };
 
+    /// The record store for the isolated home each test below installs.
+    ///
+    /// `with_isolated_home` establishes the home; this binds a store to it once,
+    /// the same way the release boundary binds one for a whole command (#7505).
+    fn test_store() -> OperationRecordStore {
+        OperationRecordStore::in_roots(
+            &homeboy_core::paths::PathRoots::from_environment().expect("path roots"),
+        )
+    }
+
     fn record() -> OperationRecord {
         OperationRecord {
             owner_run_ref: "release/test-owner".to_string(),
@@ -343,25 +368,26 @@ mod tests {
     fn persists_reloads_and_compare_updates_operation_records() {
         with_isolated_home(|_| {
             let record = record();
-            OperationRecordStore::create(&record).expect("persist");
-            let reloaded = OperationRecordStore::load(&record.owner_run_ref)
+            test_store().create(&record).expect("persist");
+            let reloaded = test_store()
+                .load(&record.owner_run_ref)
                 .expect("load")
                 .expect("record");
             assert_eq!(reloaded, record);
-            let updated = OperationRecordStore::update(&record.owner_run_ref, |current| {
-                let mut current = current.expect("record");
-                current.attempt_count += 1;
-                current.finalization_status = "completed".to_string();
-                Ok(current)
-            })
-            .expect("atomic update");
+            let updated = test_store()
+                .update(&record.owner_run_ref, |current| {
+                    let mut current = current.expect("record");
+                    current.attempt_count += 1;
+                    current.finalization_status = "completed".to_string();
+                    Ok(current)
+                })
+                .expect("atomic update");
             assert_eq!(updated.attempt_count, 1);
-            assert!(
-                !OperationRecordStore::pending_for_subject("provider_workspace", "component")
-                    .expect("pending")
-                    .iter()
-                    .any(|record| record.owner_run_ref == "release/test-owner")
-            );
+            assert!(!test_store()
+                .pending_for_subject("provider_workspace", "component")
+                .expect("pending")
+                .iter()
+                .any(|record| record.owner_run_ref == "release/test-owner"));
         });
     }
 
@@ -369,7 +395,7 @@ mod tests {
     fn concurrent_finalizers_claim_one_provider_effect() {
         with_isolated_home(|_| {
             let record = record();
-            OperationRecordStore::create(&record).expect("persist");
+            test_store().create(&record).expect("persist");
             let barrier = Arc::new(Barrier::new(2));
             let effects = Arc::new(AtomicUsize::new(0));
             let workers = (0..2)
@@ -380,11 +406,12 @@ mod tests {
                     std::thread::spawn(move || {
                         barrier.wait();
                         if let FinalizationClaim::Claimed { lease, .. } =
-                            OperationRecordStore::claim_finalization(&owner).expect("claim")
+                            test_store().claim_finalization(&owner).expect("claim")
                         {
                             // This is the provider-effect boundary: only a claimant may cross it.
                             effects.fetch_add(1, Ordering::SeqCst);
-                            OperationRecordStore::complete_finalization(&owner, &lease)
+                            test_store()
+                                .complete_finalization(&owner, &lease)
                                 .expect("complete");
                         }
                     })
@@ -394,12 +421,14 @@ mod tests {
                 worker.join().expect("finalizer thread");
             }
             assert_eq!(effects.load(Ordering::SeqCst), 1);
-            let completed = OperationRecordStore::load(&record.owner_run_ref)
+            let completed = test_store()
+                .load(&record.owner_run_ref)
                 .expect("load")
                 .expect("record");
             assert_eq!(completed.finalization_status, "completed");
             assert!(matches!(
-                OperationRecordStore::claim_finalization(&record.owner_run_ref)
+                test_store()
+                    .claim_finalization(&record.owner_run_ref)
                     .expect("completed claim"),
                 FinalizationClaim::AlreadyCompleted(_)
             ));

--- a/crates/homeboy-release/src/release/orchestrator.rs
+++ b/crates/homeboy-release/src/release/orchestrator.rs
@@ -21,21 +21,24 @@ use homeboy_core::worktree_providers::WorktreeProviderTerminalDisposition;
 /// Runs the executable preflight validations, rebuilds the full release plan
 /// after those preflights, then walks the planned release steps in order.
 pub fn run(component_id: &str, options: &ReleaseOptions) -> Result<ReleaseRun> {
-    run_with_plan(component_id, options).map(|(_plan, run, _workspace)| run)
+    // The public convenience entry: callers without roots of their own get one
+    // resolution here, which `run_with_plan` then threads through the release.
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    run_with_plan(&roots, component_id, options).map(|(_plan, run, _workspace)| run)
 }
 
 /// Execute a release and return the plan that drove it alongside the run.
 pub(crate) fn run_with_plan(
+    roots: &homeboy_core::paths::PathRoots,
     component_id: &str,
     options: &ReleaseOptions,
 ) -> Result<(ReleasePlan, ReleaseRun, Option<ReleaseWorkspaceOutput>)> {
-    // One resolution for the entire release. Both plan phases below — the
-    // executable preflight pass and the rebuilt mutation pass — receive it,
-    // so a release cannot package into one home and then clean up, checkpoint,
-    // or record its deploy recovery against another (#7505).
-    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    // Roots arrive from the caller and cover the entire release: workspace
+    // provisioning and its finalization record, both plan phases, packaging,
+    // cleanup, and the deploy checkpoint. A release therefore cannot package
+    // into one home and then record its state against another (#7505).
     let component = super::context::load_component(component_id, options)?;
-    let mut workspace = super::workspace::ReleaseWorkspace::select(&component)?;
+    let mut workspace = super::workspace::ReleaseWorkspace::select(roots, &component)?;
     let mut workspace_options = options.clone();
     workspace_options.path_override = Some(workspace.component.local_path.clone());
     let checkout_guard =
@@ -43,7 +46,7 @@ pub(crate) fn run_with_plan(
 
     let staging_source_sha = workspace.source_sha();
     match run_with_plan_inner(
-        &roots,
+        roots,
         component_id,
         &workspace_options,
         checkout_guard.as_ref(),

--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -51,6 +51,12 @@ pub fn run_command_with_workspace(
     mut input: ReleaseCommandInput,
     recovery_owner_run_ref: Option<&str>,
 ) -> Result<(ReleaseWorkspaceCommandResult, i32)> {
+    // One resolution for an entire release command. The readiness operation
+    // record, the dry-run preflight plan, recovery reconciliation, and the
+    // release pipeline itself all receive it, so a single invocation cannot
+    // spread its durable state across two homes (#7505).
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let store = super::operation_record::OperationRecordStore::in_roots(&roots);
     let readiness_owner_run_ref = if let Some(readiness) = input.readiness.as_mut() {
         let owner_run_ref = format!("release-readiness-{}", uuid::Uuid::new_v4());
         let operation_ref = format!("operation://{owner_run_ref}");
@@ -66,37 +72,32 @@ pub fn run_command_with_workspace(
                 gate.evidence_refs.push(operation_ref.clone());
             }
         }
-        super::operation_record::OperationRecordStore::create(
-            &super::operation_record::OperationRecord {
-                owner_run_ref: owner_run_ref.clone(),
-                operation: "release_readiness".to_string(),
-                subject: input.component_id.clone(),
-                provider: readiness
-                    .runner_id
-                    .clone()
-                    .unwrap_or_else(|| "controller".to_string()),
-                handle: readiness.source.commit.clone(),
-                path: None,
-                source_sha: readiness.source.commit.clone(),
-                cleanup_policy: "retain".to_string(),
-                lifecycle_state: "running".to_string(),
-                terminal_disposition: None,
-                finalization_status: "pending".to_string(),
-                finalization_lease: None,
-                finalization_lease_started_ms: None,
-                attempt_count: 1,
-                continuation_evidence: readiness.evidence_refs.clone(),
-                attributes: serde_json::Map::from_iter([(
-                    "readiness".to_string(),
-                    serde_json::to_value(&*readiness).map_err(|error| {
-                        Error::internal_json(
-                            error.to_string(),
-                            Some("release readiness".to_string()),
-                        )
-                    })?,
-                )]),
-            },
-        )?;
+        store.create(&super::operation_record::OperationRecord {
+            owner_run_ref: owner_run_ref.clone(),
+            operation: "release_readiness".to_string(),
+            subject: input.component_id.clone(),
+            provider: readiness
+                .runner_id
+                .clone()
+                .unwrap_or_else(|| "controller".to_string()),
+            handle: readiness.source.commit.clone(),
+            path: None,
+            source_sha: readiness.source.commit.clone(),
+            cleanup_policy: "retain".to_string(),
+            lifecycle_state: "running".to_string(),
+            terminal_disposition: None,
+            finalization_status: "pending".to_string(),
+            finalization_lease: None,
+            finalization_lease_started_ms: None,
+            attempt_count: 1,
+            continuation_evidence: readiness.evidence_refs.clone(),
+            attributes: serde_json::Map::from_iter([(
+                "readiness".to_string(),
+                serde_json::to_value(&*readiness).map_err(|error| {
+                    Error::internal_json(error.to_string(), Some("release readiness".to_string()))
+                })?,
+            )]),
+        })?;
         Some(owner_run_ref)
     } else {
         None
@@ -115,6 +116,7 @@ pub fn run_command_with_workspace(
         );
         if let Some(owner_run_ref) = readiness_owner_run_ref.as_deref() {
             complete_readiness_operation(
+                &store,
                 owner_run_ref,
                 false,
                 serde_json::json!({ "error": error.to_string() }),
@@ -125,10 +127,11 @@ pub fn run_command_with_workspace(
         }
         return Err(error);
     }
-    match run_command_with_workspace_inner(input, recovery_owner_run_ref) {
+    match run_command_with_workspace_inner(&roots, input, recovery_owner_run_ref) {
         Ok((mut output, exit_code)) => {
             if let Some(owner_run_ref) = readiness_owner_run_ref.as_deref() {
                 complete_readiness_operation(
+                    &store,
                     owner_run_ref,
                     readiness_succeeded,
                     serde_json::json!({
@@ -143,6 +146,7 @@ pub fn run_command_with_workspace(
         Err(error) => {
             if let Some(owner_run_ref) = readiness_owner_run_ref.as_deref() {
                 complete_readiness_operation(
+                    &store,
                     owner_run_ref,
                     readiness_succeeded,
                     serde_json::json!({ "error": error.to_string() }),
@@ -157,11 +161,12 @@ pub fn run_command_with_workspace(
 }
 
 fn complete_readiness_operation(
+    store: &super::operation_record::OperationRecordStore,
     owner_run_ref: &str,
     succeeded: bool,
     downstream_release: serde_json::Value,
 ) -> Result<()> {
-    super::operation_record::OperationRecordStore::update(owner_run_ref, |record| {
+    store.update(owner_run_ref, |record| {
         let mut record = record.ok_or_else(|| {
             Error::validation_invalid_argument(
                 "owner_run_ref",
@@ -183,6 +188,7 @@ fn complete_readiness_operation(
 }
 
 fn run_command_with_workspace_inner(
+    roots: &homeboy_core::paths::PathRoots,
     input: ReleaseCommandInput,
     recovery_owner_run_ref: Option<&str>,
 ) -> Result<(ReleaseWorkspaceCommandResult, i32)> {
@@ -200,7 +206,7 @@ fn run_command_with_workspace_inner(
             super::preflight_identity::revalidate(&component, &readiness.source)?;
             super::executor::package_preflight::run_package_preflight(&component.local_path)?;
         }
-        return run_recover(&input, recovery_owner_run_ref).map(
+        return run_recover(roots, &input, recovery_owner_run_ref).map(
             |(result, workspace, exit_code)| {
                 (
                     ReleaseWorkspaceCommandResult { result, workspace },
@@ -404,11 +410,7 @@ fn run_command_with_workspace_inner(
             ));
         }
 
-        let dry_run_preflight = run_dry_run_preflights(
-            &homeboy_core::paths::PathRoots::from_environment()?,
-            &input.component_id,
-            &options,
-        )?;
+        let dry_run_preflight = run_dry_run_preflights(roots, &input.component_id, &options)?;
         if let Some(run) = dry_run_preflight {
             let status = release_command_status(true, skipped_reason.as_deref(), Some(&run));
             let release_summary = release_summary_from_run(&run);
@@ -477,7 +479,7 @@ fn run_command_with_workspace_inner(
     }
 
     let (plan, run_result, workspace) =
-        super::pipeline::run_with_plan(&input.component_id, &options)?;
+        super::pipeline::run_with_plan(roots, &input.component_id, &options)?;
     display_release_summary(&run_result);
 
     let new_version = if input.pipeline.head {
@@ -1119,6 +1121,17 @@ pub fn run_batch(
 mod tests {
     use super::*;
     use crate::release::types::ReleasePhase;
+
+    /// The record store for the isolated home each test below installs.
+    ///
+    /// `with_isolated_home` establishes the home; this binds a store to it once,
+    /// the same way the release boundary binds one for a whole command (#7505).
+    fn test_store() -> crate::release::operation_record::OperationRecordStore {
+        crate::release::operation_record::OperationRecordStore::in_roots(
+            &homeboy_core::paths::PathRoots::from_environment().expect("path roots"),
+        )
+    }
+
     use crate::release::{
         ReleasePreflightPlacement, ReleasePreflightSourceIdentity, ReleaseReadinessEnvelope,
         ReleaseReadinessGateResult, ReleaseRollbackEvidence, ReleaseRunResult, ReleaseStepResult,
@@ -1218,15 +1231,12 @@ mod tests {
             )
             .expect_err("failed readiness must stop release before controller mutation");
 
-            let record = super::super::operation_record::OperationRecordStore::for_subject(
-                "release_readiness",
-                "fixture",
-                false,
-            )
-            .expect("list readiness records")
-            .into_iter()
-            .find(|record| record.source_sha == source)
-            .expect("readiness record is retained");
+            let record = test_store()
+                .for_subject("release_readiness", "fixture", false)
+                .expect("list readiness records")
+                .into_iter()
+                .find(|record| record.source_sha == source)
+                .expect("readiness record is retained");
             let owner = record.owner_run_ref.clone();
             assert_eq!(error.code.as_str(), "validation.invalid_argument");
             assert!(error.message.contains("invalid selected gate evidence"));
@@ -1264,12 +1274,9 @@ mod tests {
                 .expect_err("failed readiness blocks before component resolution");
             }
 
-            let records = super::super::operation_record::OperationRecordStore::for_subject(
-                "release_readiness",
-                "fixture",
-                false,
-            )
-            .expect("list records");
+            let records = test_store()
+                .for_subject("release_readiness", "fixture", false)
+                .expect("list records");
             assert_eq!(records.len(), 2);
             assert_ne!(records[0].owner_run_ref, records[1].owner_run_ref);
             assert!(records.iter().all(|record| {
@@ -1305,12 +1312,9 @@ mod tests {
                 worker.join().expect("worker succeeds");
             }
 
-            let records = super::super::operation_record::OperationRecordStore::for_subject(
-                "release_readiness",
-                "fixture",
-                false,
-            )
-            .expect("list records");
+            let records = test_store()
+                .for_subject("release_readiness", "fixture", false)
+                .expect("list records");
             assert_eq!(records.len(), 2);
             assert_ne!(records[0].owner_run_ref, records[1].owner_run_ref);
             assert!(records.iter().all(|record| {
@@ -1325,8 +1329,8 @@ mod tests {
     fn readiness_succeeds_when_downstream_release_is_intentionally_skipped() {
         with_isolated_home(|_| {
             let owner = "release-readiness-skip";
-            super::super::operation_record::OperationRecordStore::create(
-                &super::super::operation_record::OperationRecord {
+            test_store()
+                .create(&super::super::operation_record::OperationRecord {
                     owner_run_ref: owner.to_string(),
                     operation: "release_readiness".to_string(),
                     subject: "fixture".to_string(),
@@ -1343,20 +1347,18 @@ mod tests {
                     attempt_count: 1,
                     continuation_evidence: Vec::new(),
                     attributes: Default::default(),
-                },
-            )
-            .expect("create readiness");
+                })
+                .expect("create readiness");
 
             complete_readiness_operation(
+                &test_store(),
                 owner,
                 true,
                 serde_json::json!({ "exit_code": SKIPPED_RELEASE_EXIT_CODE, "status": "skipped" }),
             )
             .expect("complete readiness");
 
-            let record = super::super::operation_record::OperationRecordStore::load(owner)
-                .expect("load")
-                .expect("record");
+            let record = test_store().load(owner).expect("load").expect("record");
             assert_eq!(record.terminal_disposition.as_deref(), Some("succeeded"));
             assert_eq!(
                 record.attributes["downstream_release"]["exit_code"],
@@ -1379,14 +1381,11 @@ mod tests {
                 None,
             )
             .expect_err("failed readiness blocks dry-run planning");
-            let record = super::super::operation_record::OperationRecordStore::for_subject(
-                "release_readiness",
-                "fixture",
-                false,
-            )
-            .expect("records")
-            .pop()
-            .expect("record");
+            let record = test_store()
+                .for_subject("release_readiness", "fixture", false)
+                .expect("records")
+                .pop()
+                .expect("record");
             assert_eq!(record.terminal_disposition.as_deref(), Some("failed"));
             assert!(record.attributes["downstream_release"]["error"].is_string());
         });
@@ -1404,14 +1403,11 @@ mod tests {
                 None,
             )
             .expect_err("missing component is downstream of validated readiness");
-            let record = super::super::operation_record::OperationRecordStore::for_subject(
-                "release_readiness",
-                "missing-component",
-                false,
-            )
-            .expect("records")
-            .pop()
-            .expect("record");
+            let record = test_store()
+                .for_subject("release_readiness", "missing-component", false)
+                .expect("records")
+                .pop()
+                .expect("record");
             assert_eq!(record.terminal_disposition.as_deref(), Some("succeeded"));
             assert!(record.attributes["downstream_release"]["error"].is_string());
         });
@@ -1436,14 +1432,11 @@ mod tests {
                     None,
                 )
                 .expect_err("invalid readiness blocks before component mutation");
-                let record = super::super::operation_record::OperationRecordStore::for_subject(
-                    "release_readiness",
-                    source,
-                    false,
-                )
-                .expect("records")
-                .pop()
-                .expect("record");
+                let record = test_store()
+                    .for_subject("release_readiness", source, false)
+                    .expect("records")
+                    .pop()
+                    .expect("record");
                 assert_eq!(record.terminal_disposition.as_deref(), Some("failed"));
             }
         });
@@ -1465,14 +1458,11 @@ mod tests {
                 None,
             )
             .expect_err("downstream component error follows authorized skipped readiness");
-            let record = super::super::operation_record::OperationRecordStore::for_subject(
-                "release_readiness",
-                "missing-component",
-                false,
-            )
-            .expect("records")
-            .pop()
-            .expect("record");
+            let record = test_store()
+                .for_subject("release_readiness", "missing-component", false)
+                .expect("records")
+                .pop()
+                .expect("record");
             assert_eq!(record.terminal_disposition.as_deref(), Some("succeeded"));
         });
     }

--- a/crates/homeboy-release/src/release/workflow_recover.rs
+++ b/crates/homeboy-release/src/release/workflow_recover.rs
@@ -50,6 +50,7 @@ fn publication_continuation_command(input: &ReleaseCommandInput) -> String {
 }
 
 pub(super) fn run_recover(
+    roots: &homeboy_core::paths::PathRoots,
     input: &ReleaseCommandInput,
     owner_run_ref: Option<&str>,
 ) -> Result<(
@@ -57,7 +58,9 @@ pub(super) fn run_recover(
     Option<super::types::ReleaseWorkspaceOutput>,
     i32,
 )> {
-    if let Some(record) = super::workspace::reconcile_pending(&input.component_id, owner_run_ref)? {
+    if let Some(record) =
+        super::workspace::reconcile_pending(roots, &input.component_id, owner_run_ref)?
+    {
         return Ok((ReleaseCommandResult {
             component_id: input.component_id.clone(), status: if record.attributes.get("release_pushed").and_then(serde_json::Value::as_bool).unwrap_or(false) { "released" } else { "workspace_reconciled" }.to_string(),
             phase: release_execution_plan(input).phase, bump_type: "recover".to_string(), dry_run: false,
@@ -67,7 +70,7 @@ pub(super) fn run_recover(
             readiness: None,
         }, Some(super::workspace::output_from_record(&record)), 0));
     }
-    if let Some(deployment) = super::deployment::resume_deployment(&input.component_id)? {
+    if let Some(deployment) = super::deployment::resume_deployment(roots, &input.component_id)? {
         let failed = deployment.summary.failed > 0;
         return Ok((
             ReleaseCommandResult {

--- a/crates/homeboy-release/src/release/workspace.rs
+++ b/crates/homeboy-release/src/release/workspace.rs
@@ -21,6 +21,10 @@ pub(super) struct ReleaseWorkspace {
     output: ReleaseWorkspaceOutput,
     owned: Option<(WorktreeProviderResolution, WorktreeProviderLifecycleIntent)>,
     record_owner: Option<String>,
+    /// Bound to the roots the release boundary resolved. Provisioning and
+    /// finalization write the same record from different phases of a release,
+    /// so both must address the same home (#7505).
+    store: OperationRecordStore,
 }
 
 impl ReleaseWorkspace {
@@ -28,13 +32,18 @@ impl ReleaseWorkspace {
         self.output.source_sha.clone()
     }
 
-    pub(super) fn select(component: &Component) -> Result<Self> {
+    pub(super) fn select(
+        roots: &homeboy_core::paths::PathRoots,
+        component: &Component,
+    ) -> Result<Self> {
+        let store = OperationRecordStore::in_roots(roots);
         if in_place_eligible(component) {
             return Ok(Self {
                 component: component.clone(),
                 output: ReleaseWorkspaceOutput::in_place(&component.local_path),
                 owned: None,
                 record_owner: None,
+                store,
             });
         }
 
@@ -63,6 +72,7 @@ impl ReleaseWorkspace {
                 output: ReleaseWorkspaceOutput::in_place(&component.local_path),
                 owned: None,
                 record_owner: None,
+                store,
             });
         }
 
@@ -90,7 +100,7 @@ impl ReleaseWorkspace {
             select_apply_enabled_worktree_provider_from_config(&intent, &config)?;
         // Publish ownership before invoking the provider. A crash during ensure
         // is therefore recoverable through the same idempotency owner reference.
-        OperationRecordStore::create(&OperationRecord {
+        store.create(&OperationRecord {
             owner_run_ref: lifecycle.owner_run_ref.clone(),
             operation: "provider_workspace".to_string(),
             subject: component.id.clone(),
@@ -128,7 +138,7 @@ impl ReleaseWorkspace {
                 None,
             ));
         }
-        OperationRecordStore::update(&lifecycle.owner_run_ref, |record| {
+        store.update(&lifecycle.owner_run_ref, |record| {
             let mut record = record.ok_or_else(|| missing_record(&lifecycle.owner_run_ref))?;
             record.provider = provision.resolution.provider_id.clone();
             record.path = Some(provision.resolution.worktree.path.clone());
@@ -140,7 +150,7 @@ impl ReleaseWorkspace {
         })?;
         if let Err(validation_error) = verify_staging_workspace(&provision.resolution, &source_sha)
         {
-            OperationRecordStore::update(&lifecycle.owner_run_ref, |record| {
+            store.update(&lifecycle.owner_run_ref, |record| {
                 let mut record = record.ok_or_else(|| missing_record(&lifecycle.owner_run_ref))?;
                 record.terminal_disposition = Some(
                     WorktreeProviderTerminalDisposition::Failed
@@ -150,6 +160,7 @@ impl ReleaseWorkspace {
                 Ok(record)
             })?;
             let finalization_error = finalize_record(
+                &store,
                 &lifecycle.owner_run_ref,
                 &provision.resolution,
                 &lifecycle,
@@ -190,6 +201,7 @@ impl ReleaseWorkspace {
             },
             owned: Some((provision.resolution, lifecycle)),
             record_owner: Some(record_owner),
+            store,
         })
     }
 
@@ -205,7 +217,7 @@ impl ReleaseWorkspace {
                     Some("provider-owned workspace has no durable owner record".to_string());
                 return self.output.clone();
             };
-            let _ = OperationRecordStore::update(owner, |record| {
+            let _ = self.store.update(owner, |record| {
                 let mut record = record.ok_or_else(|| missing_record(owner))?;
                 record.terminal_disposition = Some(disposition.as_str().to_string());
                 record.attributes.insert(
@@ -214,7 +226,7 @@ impl ReleaseWorkspace {
                 );
                 Ok(record)
             });
-            match finalize_record(owner, resolution, lifecycle, disposition) {
+            match finalize_record(&self.store, owner, resolution, lifecycle, disposition) {
                 Ok(_) => {
                     self.owned = None;
                     self.output.final_disposition = Some(
@@ -238,12 +250,14 @@ impl ReleaseWorkspace {
 }
 
 pub(super) fn reconcile_pending(
+    roots: &homeboy_core::paths::PathRoots,
     component_id: &str,
     selector: Option<&str>,
 ) -> Result<Option<OperationRecord>> {
+    let store = OperationRecordStore::in_roots(roots);
     let records = match selector {
-        Some(owner) => OperationRecordStore::load(owner)?.into_iter().collect(),
-        None => OperationRecordStore::pending_for_subject("provider_workspace", component_id)?,
+        Some(owner) => store.load(owner)?.into_iter().collect(),
+        None => store.pending_for_subject("provider_workspace", component_id)?,
     };
     let record = match records.as_slice() {
         [] => return Ok(None),
@@ -320,7 +334,7 @@ pub(super) fn reconcile_pending(
                 None,
             ));
         }
-        OperationRecordStore::update(&record.owner_run_ref, |current| {
+        store.update(&record.owner_run_ref, |current| {
             let mut current = current.ok_or_else(|| missing_record(&record.owner_run_ref))?;
             current.path = Some(provision.resolution.worktree.path.clone());
             current.lifecycle_state = "provisioned".to_string();
@@ -365,7 +379,14 @@ pub(super) fn reconcile_pending(
         Some("timed_out") => WorktreeProviderTerminalDisposition::TimedOut,
         _ => WorktreeProviderTerminalDisposition::Interrupted,
     };
-    finalize_record(&record.owner_run_ref, &resolution, &lifecycle, disposition).map(Some)
+    finalize_record(
+        &store,
+        &record.owner_run_ref,
+        &resolution,
+        &lifecycle,
+        disposition,
+    )
+    .map(Some)
 }
 
 pub(super) fn output_from_record(record: &OperationRecord) -> ReleaseWorkspaceOutput {
@@ -404,12 +425,13 @@ struct PersistedProvisionIntent {
 }
 
 fn finalize_record(
+    store: &OperationRecordStore,
     owner: &str,
     resolution: &WorktreeProviderResolution,
     lifecycle: &WorktreeProviderLifecycleIntent,
     disposition: WorktreeProviderTerminalDisposition,
 ) -> Result<OperationRecord> {
-    match OperationRecordStore::claim_finalization(owner)? {
+    match store.claim_finalization(owner)? {
         FinalizationClaim::AlreadyCompleted(record) => Ok(record),
         FinalizationClaim::InProgress(record) => Err(Error::validation_invalid_argument(
             "owner_run_ref",
@@ -427,10 +449,9 @@ fn finalize_record(
                 disposition,
                 &defaults::load_config(),
             ) {
-                Ok(_) => OperationRecordStore::complete_finalization(owner, &lease),
+                Ok(_) => store.complete_finalization(owner, &lease),
                 Err(error) => {
-                    let _ =
-                        OperationRecordStore::fail_finalization(owner, &lease, error.to_string());
+                    let _ = store.fail_finalization(owner, &lease, error.to_string());
                     Err(error)
                 }
             }
@@ -513,6 +534,22 @@ fn verify_staging_workspace(
 mod tests {
     use super::{finalize_record, in_place_eligible, reconcile_pending};
     use crate::release::operation_record::{OperationRecord, OperationRecordStore};
+
+    /// The isolated home each test below installs, named as roots.
+    fn test_roots() -> homeboy_core::paths::PathRoots {
+        homeboy_core::paths::PathRoots::from_environment().expect("path roots")
+    }
+
+    /// The record store for the isolated home each test below installs.
+    ///
+    /// `with_isolated_home` establishes the home; this binds a store to it once,
+    /// the same way the release boundary binds one for a whole command (#7505).
+    fn test_store() -> OperationRecordStore {
+        OperationRecordStore::in_roots(
+            &homeboy_core::paths::PathRoots::from_environment().expect("path roots"),
+        )
+    }
+
     use homeboy_core::component::Component;
     use homeboy_core::defaults::{
         save_config, HomeboyConfig, WorktreeProviderCommands, WorktreeProviderConfig,
@@ -584,15 +621,17 @@ mod tests {
                 continuation_evidence: Vec::new(),
                 attributes: serde_json::Map::new(),
             };
-            OperationRecordStore::create(&record).expect("persist completed record");
+            test_store()
+                .create(&record)
+                .expect("persist completed record");
             assert_eq!(
-                reconcile_pending("component", Some("release/completed"))
+                reconcile_pending(&test_roots(), "component", Some("release/completed"))
                     .expect("completed recovery must no-op")
                     .expect("completed record")
                     .finalization_status,
                 "completed"
             );
-            assert!(reconcile_pending("component", None)
+            assert!(reconcile_pending(&test_roots(), "component", None)
                 .expect("implicit recovery ignores historical completion")
                 .is_none());
         });
@@ -602,26 +641,27 @@ mod tests {
     fn active_finalization_lease_remains_pending_for_racing_recovery() {
         homeboy_core::test_support::with_isolated_home(|_| {
             let owner = "release/finalizing";
-            OperationRecordStore::create(&OperationRecord {
-                owner_run_ref: owner.to_string(),
-                operation: "provider_workspace".to_string(),
-                subject: "component".to_string(),
-                provider: "fixture".to_string(),
-                handle: "release-fixture".to_string(),
-                path: Some("/workspace".to_string()),
-                source_sha: "abc".to_string(),
-                cleanup_policy: "remove_on_success".to_string(),
-                lifecycle_state: "provisioned".to_string(),
-                terminal_disposition: Some("succeeded".to_string()),
-                finalization_status: "pending".to_string(),
-                finalization_lease: None,
-                finalization_lease_started_ms: None,
-                attempt_count: 0,
-                continuation_evidence: Vec::new(),
-                attributes: serde_json::Map::new(),
-            })
-            .expect("persist record");
-            let _claim = OperationRecordStore::claim_finalization(owner).expect("claim lease");
+            test_store()
+                .create(&OperationRecord {
+                    owner_run_ref: owner.to_string(),
+                    operation: "provider_workspace".to_string(),
+                    subject: "component".to_string(),
+                    provider: "fixture".to_string(),
+                    handle: "release-fixture".to_string(),
+                    path: Some("/workspace".to_string()),
+                    source_sha: "abc".to_string(),
+                    cleanup_policy: "remove_on_success".to_string(),
+                    lifecycle_state: "provisioned".to_string(),
+                    terminal_disposition: Some("succeeded".to_string()),
+                    finalization_status: "pending".to_string(),
+                    finalization_lease: None,
+                    finalization_lease_started_ms: None,
+                    attempt_count: 0,
+                    continuation_evidence: Vec::new(),
+                    attributes: serde_json::Map::new(),
+                })
+                .expect("persist record");
+            let _claim = test_store().claim_finalization(owner).expect("claim lease");
             let resolution = WorktreeProviderResolution {
                 provider_id: "fixture".to_string(),
                 worktree: WorktreeProviderHandle {
@@ -643,6 +683,7 @@ mod tests {
             };
 
             let error = finalize_record(
+                &test_store(),
                 owner,
                 &resolution,
                 &lifecycle,
@@ -651,7 +692,8 @@ mod tests {
             .expect_err("racing recovery must not report finalization success");
             assert!(error.message.contains("already in progress"));
             assert_eq!(
-                OperationRecordStore::load(owner)
+                test_store()
+                    .load(owner)
                     .expect("load")
                     .expect("record")
                     .finalization_status,
@@ -736,16 +778,16 @@ mod tests {
             );
             save_config(&config).expect("save provider config");
             let owner = "release/pre-ensure";
-            OperationRecordStore::create(&OperationRecord {
+            test_store().create(&OperationRecord {
                 owner_run_ref: owner.to_string(), operation: "provider_workspace".to_string(), subject: "component".to_string(), provider: "fixture".to_string(), handle: "release-fixture".to_string(), path: None, source_sha: "abc".to_string(), cleanup_policy: "remove_on_success".to_string(), lifecycle_state: "provisioning".to_string(), terminal_disposition: None, finalization_status: "pending".to_string(), finalization_lease: None, finalization_lease_started_ms: None, attempt_count: 0, continuation_evidence: Vec::new(),
                 attributes: serde_json::Map::from_iter([("provision_intent".to_string(), serde_json::json!({ "repo": "repo", "base": "main", "head": "abc", "task_url": "release/pre-ensure", "idempotency_key": "release-fixture:repo:main:abc" }))]),
             }).expect("persist pre-ensure record");
 
-            let completed = reconcile_pending("component", Some(owner))
+            let completed = reconcile_pending(&test_roots(), "component", Some(owner))
                 .expect("recover provider workspace")
                 .expect("record");
             assert_eq!(completed.finalization_status, "completed");
-            let repeated = reconcile_pending("component", Some(owner))
+            let repeated = reconcile_pending(&test_roots(), "component", Some(owner))
                 .expect("completed recovery is idempotent")
                 .expect("record");
             assert_eq!(repeated.finalization_status, "completed");
@@ -763,11 +805,10 @@ mod tests {
                     .count(),
                 1
             );
-            assert!(
-                OperationRecordStore::pending_for_subject("provider_workspace", "component")
-                    .expect("pending records")
-                    .is_empty()
-            );
+            assert!(test_store()
+                .pending_for_subject("provider_workspace", "component")
+                .expect("pending records")
+                .is_empty());
         });
     }
 }

--- a/docs/internals/development/contracts/path-roots-injection.md
+++ b/docs/internals/development/contracts/path-roots-injection.md
@@ -126,11 +126,61 @@ boundary is also a call. Decompose instead:
   supposed to be small and non-zero.
 - **test helpers** — one per test module.
 
-For `homeboy-release`, the increment that produced this document moved ambient
-points from 7 to 3 and left 4 named boundaries. The remaining 3 all live in
-`OperationRecordStore`, whose static methods resolve per call; converting it
-wants `homeboy-cli` to thread roots first, so its callers have something to
-pass.
+`homeboy-release` is the completed reference. It took two increments:
+
+| | start | after #12746 | after store conversion |
+|---|---|---|---|
+| ambient | 7 | 3 | **0** |
+| boundaries | 2 | 4 | 3 |
+| test helpers | 1 | 4 | 8 |
+
+Boundaries *decreased* in the second increment, which is the shape to expect
+near the end: `deployment::resume_deployment` and the dry-run preflight entry
+stopped resolving and started receiving, because a caller above them had roots
+to give. A boundary is only a boundary while nothing above it can supply one.
+
+The number that actually matters is resolutions per invocation. A
+provider-staged `homeboy release` performed **eight** independent resolutions —
+seven of them inside `OperationRecordStore`, one in the orchestrator — and now
+performs exactly **one**, at `run_command_with_workspace`.
+
+## Stateful stores
+
+A store with associated (`Self::`) methods that each resolve a root is the
+worst version of this defect, because the per-call resolution is invisible at
+the call site. `OperationRecordStore::update(owner, f)` looks free; it was a
+filesystem-root rediscovery.
+
+Give the store the root at construction:
+
+```rust
+pub struct OperationRecordStore {
+    data_root: PathBuf,
+}
+
+impl OperationRecordStore {
+    pub fn in_roots(roots: &paths::PathRoots) -> Self { .. }
+    pub fn update(&self, owner_run_ref: &str, ..) -> Result<OperationRecord> { .. }
+}
+```
+
+Then hold the store — not the roots — on whatever already models the lifetime
+of the work. `ReleaseWorkspace` gained a `store` field because provisioning and
+finalization write the same record from different phases of one release; the
+struct that spans both phases is the right owner.
+
+Converting a store is mechanical but wide: 14 production call sites and 26 test
+call sites here. Two collision shapes cost time and are worth pre-empting:
+
+- **Indentation substring collisions.** A literal anchor of `        foo(` also
+  matches a `            foo(` line, because the 12-space text is a substring of
+  the 16-space line. Anchor on `\n` + indent, or on a unique neighbouring line.
+- **Same call at the same indent in production and tests.** Anchor on the
+  preceding statement, not the call itself.
+
+Assert the expected match count before writing, and write the whole file only
+after every assertion passes. Both collisions above surfaced as a failed
+assertion rather than a bad edit.
 
 ## Verifying
 


### PR DESCRIPTION
Follow-up to #12746. Finishes `homeboy-release`.

## The defect

`OperationRecordStore`'s associated methods each resolved a data root of their own:

```rust
pub fn update(owner_run_ref: &str, f: ..) -> Result<OperationRecord> {
    Self::update_in_roots(PathRoots::from_environment()?.data(), owner_run_ref, f)
}
```

`OperationRecordStore::update(owner, f)` looks free at the call site. It was a filesystem-root rediscovery, and there are **14 production call sites**. This is the worst version of the #7505 defect precisely because it is invisible — nothing at the call site suggests a path is being resolved.

A provider-staged release resolved roots **eight** separate times: seven through this store (publish ownership, record provisioned path, mark failed verification, set terminal disposition, claim finalization, complete it, plus the readiness record), one in the orchestrator. Nothing tied those answers together.

## The fix

The store holds the root it was constructed with:

```rust
pub struct OperationRecordStore { data_root: PathBuf }
impl OperationRecordStore {
    pub fn in_roots(roots: &paths::PathRoots) -> Self { .. }
    pub fn update(&self, owner_run_ref: &str, ..) -> Result<OperationRecord> { .. }
}
```

`ReleaseWorkspace` gained a `store` field. Provisioning and finalization write the same record from *different phases of one release*, so the struct that spans both phases is the right owner — not each call. `finalize_record` and `reconcile_pending` take the store rather than reaching for a new one.

`workflow::run_command_with_workspace` becomes the single resolution for an entire release command, threading roots into the readiness record, the dry-run preflight plan, recovery reconciliation, and the release pipeline itself.

## Result

| | start (pre-#12746) | after #12746 | **this PR** |
|---|---|---|---|
| **ambient** | 7 | 3 | **0** |
| boundaries | 2 | 4 | 3 |
| test helpers | 1 | 4 | 8 |

**Resolutions per `homeboy release` invocation: 8 → 1.**

Boundaries went **4 → 3**, and that direction is the point. `deployment::resume_deployment` and the dry-run preflight entry stopped resolving and started *receiving*, because a caller above them finally had roots to give. A boundary is only a boundary while nothing above it can supply one.

The three that remain are supposed to:

| boundary | unit of work |
|---|---|
| `orchestrator::run` | public convenience entry for callers without roots |
| `workflow::run_command_with_workspace` | a release command |
| `package_recovery::package_existing_tag` | repackaging a published tag |

`homeboy-release` now has **zero ambient resolution points**. It is the completed reference implementation for the remaining crates.

## Doc

`path-roots-injection.md` gains a **stateful stores** section, and records the two edit-collision shapes this conversion actually hit — both caught by match-count assertions rather than by the compiler:

- **Indentation substring collisions** — a literal anchor of `        foo(` also matches a `            foo(` line, since the 12-space text is a substring of the 16-space line. Hit twice.
- **Identical calls at identical indent in production and tests** — `complete_readiness_operation(\n                &store,` matched line 118 (production) and line 1353 (test).

Scripts assert expected counts and write the whole file only after every assertion passes, so a failed assertion leaves the tree untouched.

## Verification

`nice -n 10 cargo check --workspace --tests -j2` — clean, zero errors and zero warnings. `cargo fmt` applied. `target/` removed, 21G free.

No behavior change intended: every converted call site receives the same root the ambient call would have resolved, once and from further up.