### PR TITLE
refactor(cli): root the deferred-workload worker path + the top-down ordering law (#7505)

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -471,7 +471,9 @@ impl CliRuntime {
         if command_capability == CommandCapability::Mutation
             && normalized.get(1).map(String::as_str) != Some("deferred-workload")
         {
-            let _ = crate::commands::deferred_workload::restart_worker_if_pending();
+            if let Ok(config_root) = crate::core::paths::homeboy() {
+                let _ = crate::commands::deferred_workload::restart_worker_if_pending(&config_root);
+            }
         }
 
         if is_top_level_version_request(&normalized) {

--- a/crates/homeboy-cli/src/commands/deferred_workload.rs
+++ b/crates/homeboy-cli/src/commands/deferred_workload.rs
@@ -60,6 +60,12 @@ struct DeferredWorkloadStatusOutput {
 }
 
 pub fn run(args: DeferredWorkloadArgs) -> CmdResult<serde_json::Value> {
+    // One resolution for the whole command. `status` reads the worker status
+    // file and the record store; `reconcile` walks that same store and may
+    // spawn against it. Both address one Homeboy installation, and resolving
+    // per subcommand — as `reconcile` did, a second time below `run` — is how
+    // a single invocation ends up describing two of them (#7505).
+    let config_root = homeboy::core::paths::homeboy()?;
     match args.command {
         DeferredWorkloadCommand::Worker { startup_token } => {
             run_worker(&startup_token)?;
@@ -69,11 +75,6 @@ pub fn run(args: DeferredWorkloadArgs) -> CmdResult<serde_json::Value> {
             ))
         }
         DeferredWorkloadCommand::Status => {
-            // One resolution for the whole command: the worker status file and
-            // the record store are two files under the same root, and reading
-            // them from two independently resolved roots is how a status report
-            // ends up describing two different Homeboy installations.
-            let config_root = homeboy::core::paths::homeboy()?;
             let output = DeferredWorkloadStatusOutput {
                 schema: "homeboy/deferred-workload-status/v1",
                 worker: deferred_workload::worker_status_in_roots(&config_root)?,
@@ -93,7 +94,7 @@ pub fn run(args: DeferredWorkloadArgs) -> CmdResult<serde_json::Value> {
             ))
         }
         DeferredWorkloadCommand::Reconcile { dry_run } => Ok((
-            serde_json::to_value(reconcile_workers(dry_run)?)
+            serde_json::to_value(reconcile_workers(&config_root, dry_run)?)
                 .expect("deferred workload reconciliation serializes"),
             0,
         )),
@@ -129,11 +130,7 @@ struct DeferredWorkloadOrphan {
 /// decided by the durable record store and the startup token the process can
 /// prove from its own environment, so a foreign process that happens to share
 /// the command name is never signaled on that basis (#12081).
-fn reconcile_workers(dry_run: bool) -> homeboy::core::Result<DeferredWorkloadReconcileOutput> {
-    reconcile_workers_in_roots(&homeboy::core::paths::homeboy()?, dry_run)
-}
-
-fn reconcile_workers_in_roots(
+fn reconcile_workers(
     config_root: &Path,
     dry_run: bool,
 ) -> homeboy::core::Result<DeferredWorkloadReconcileOutput> {
@@ -237,10 +234,6 @@ fn reconcile_workers_in_roots(
     })
 }
 
-pub fn ensure_worker() -> homeboy::core::Result<()> {
-    ensure_worker_in_roots(&homeboy::core::paths::homeboy()?)
-}
-
 /// Spawn the singleton worker against an already-resolved config root.
 ///
 /// The start lock, the liveness probe, the worker's working directory, the
@@ -248,7 +241,7 @@ pub fn ensure_worker() -> homeboy::core::Result<()> {
 /// Homeboy installation. Resolving them independently let a five-second poll
 /// re-resolve the root up to 250 times, and left the spawned worker free to
 /// disagree with the probe that was waiting on it.
-fn ensure_worker_in_roots(config_root: &Path) -> homeboy::core::Result<()> {
+pub fn ensure_worker(config_root: &Path) -> homeboy::core::Result<()> {
     let _start_lock = deferred_workload::acquire_worker_start_lock_in_roots(config_root)?;
     ensure_worker_with(
         config_root,
@@ -333,17 +326,13 @@ fn ensure_worker_in_roots(config_root: &Path) -> homeboy::core::Result<()> {
     )
 }
 
-pub fn restart_worker_if_pending() -> homeboy::core::Result<()> {
-    restart_worker_if_pending_in_roots(&homeboy::core::paths::homeboy()?)
-}
-
-fn restart_worker_if_pending_in_roots(config_root: &Path) -> homeboy::core::Result<()> {
-    restart_worker_if_pending_with_in_roots(
+pub fn restart_worker_if_pending(config_root: &Path) -> homeboy::core::Result<()> {
+    restart_worker_if_pending_with(
         config_root,
         |status: &deferred_workload::DeferredWorkloadWorkerStatus| {
             deferred_workload::worker_is_live_in_roots(config_root, status)
         },
-        || ensure_worker_in_roots(config_root),
+        || ensure_worker(config_root),
     )
 }
 
@@ -362,13 +351,6 @@ fn ensure_worker_with(
 }
 
 fn restart_worker_if_pending_with(
-    is_live: impl Fn(&deferred_workload::DeferredWorkloadWorkerStatus) -> bool,
-    spawn: impl FnOnce() -> homeboy::core::Result<()>,
-) -> homeboy::core::Result<()> {
-    restart_worker_if_pending_with_in_roots(&homeboy::core::paths::homeboy()?, is_live, spawn)
-}
-
-fn restart_worker_if_pending_with_in_roots(
     config_root: &Path,
     is_live: impl Fn(&deferred_workload::DeferredWorkloadWorkerStatus) -> bool,
     spawn: impl FnOnce() -> homeboy::core::Result<()>,
@@ -499,34 +481,10 @@ fn run_worker_while_holding_lock(
     now: impl Fn() -> u64,
     sleep: impl FnMut(Duration),
 ) -> homeboy::core::Result<()> {
-    run_worker_with_in_roots(config_root, owner, readiness, dispatch, now, sleep)
+    run_worker_with(config_root, owner, readiness, dispatch, now, sleep)
 }
 
-/// Ambient entry point for the worker loop, retained for callers that own no
-/// resolved root (the hermetic tests). Production runs
-/// [`run_worker_with_in_roots`] from the single resolution `run_worker` makes.
 pub(crate) fn run_worker_with(
-    owner: &str,
-    readiness: impl FnMut() -> homeboy::core::Result<Option<RunnerCapabilityInventory>>,
-    dispatch: impl FnMut(
-        &deferred_workload::DeferredWorkload,
-        &str,
-        &str,
-    ) -> homeboy::core::Result<bool>,
-    now: impl Fn() -> u64,
-    sleep: impl FnMut(Duration),
-) -> homeboy::core::Result<()> {
-    run_worker_with_in_roots(
-        &homeboy::core::paths::homeboy()?,
-        owner,
-        readiness,
-        dispatch,
-        now,
-        sleep,
-    )
-}
-
-pub(crate) fn run_worker_with_in_roots(
     config_root: &Path,
     owner: &str,
     mut readiness: impl FnMut() -> homeboy::core::Result<Option<RunnerCapabilityInventory>>,
@@ -830,6 +788,15 @@ fn redact_settings_args(args: &mut [serde_json::Value]) {
 
 #[cfg(test)]
 mod tests {
+    /// The config root of the isolated home each test below installs.
+    ///
+    /// These tests are their own boundary: the worker loop now takes a root,
+    /// so the test resolves once exactly where `run`/`run_worker` resolve once
+    /// in production (#7505).
+    fn test_config_root() -> std::path::PathBuf {
+        homeboy::core::paths::homeboy().expect("config root")
+    }
+
     use super::*;
     use std::cell::{Cell, RefCell};
     use std::rc::Rc;
@@ -958,6 +925,7 @@ mod tests {
             let dispatched_by_worker = dispatched.clone();
 
             run_worker_with(
+                &test_config_root(),
                 "worker-a",
                 || Ok(ready.get().then(|| inventory("compatible-runner"))),
                 move |record, runner_id, _| {
@@ -1000,6 +968,7 @@ mod tests {
             let ready_after_wait = ready.clone();
 
             run_worker_with(
+                &test_config_root(),
                 "worker-a",
                 || Ok(ready.get().then(|| inventory("compatible-runner"))),
                 move |record, runner_id, _| {
@@ -1043,6 +1012,7 @@ mod tests {
             let dispatch_count = dispatches.clone();
 
             run_worker_with(
+                &test_config_root(),
                 "worker-a",
                 move || {
                     calls.set(calls.get() + 1);
@@ -1081,6 +1051,7 @@ mod tests {
             let dispatches = Cell::new(0);
 
             run_worker_with(
+                &test_config_root(),
                 "worker-a",
                 || {
                     Ok(Some(RunnerCapabilityInventory {
@@ -1157,6 +1128,7 @@ mod tests {
             let dispatch_count = dispatched.clone();
 
             run_worker_with(
+                &test_config_root(),
                 "restarted-worker",
                 || Ok(Some(inventory("recovery-runner"))),
                 move |record, runner_id, owner| {
@@ -1185,6 +1157,7 @@ mod tests {
             deferred_workload::defer(input()).expect("defer workload");
             let spawned = Cell::new(0);
             restart_worker_if_pending_with(
+                &test_config_root(),
                 |_| false,
                 || {
                     spawned.set(spawned.get() + 1);
@@ -1207,6 +1180,7 @@ mod tests {
             let deferred = deferred_workload::defer(input).expect("defer workload");
 
             run_worker_with(
+                &test_config_root(),
                 "worker-a",
                 || Ok(Some(inventory("compatible-runner"))),
                 |_, _, _| panic!("a deleted source worktree must not be dispatched"),
@@ -1238,6 +1212,7 @@ mod tests {
             let dispatched_by_worker = dispatched.clone();
 
             run_worker_with(
+                &test_config_root(),
                 "worker-a",
                 || Ok(Some(inventory("compatible-runner"))),
                 move |record, _, _| {
@@ -1297,7 +1272,7 @@ mod tests {
     #[test]
     fn a_dry_run_reconciliation_signals_nothing_and_retains_nothing() {
         crate::test_support::with_isolated_home(|_| {
-            let outcome = reconcile_workers(true).expect("reconcile");
+            let outcome = reconcile_workers(&test_config_root(), true).expect("reconcile");
 
             assert_eq!(outcome.schema, "homeboy/deferred-workload-reconcile/v1");
             assert!(outcome.dry_run);

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -249,7 +249,7 @@ pub fn route_after_parse_with_provenance(
             &portable_deferred_args(&normalized_args),
             deferred_requirements.expect("review tests always resolve deferred requirements"),
         )?)?;
-        crate::commands::deferred_workload::ensure_worker()?;
+        crate::commands::deferred_workload::ensure_worker(&homeboy::core::paths::homeboy()?)?;
         println!(
             "{}",
             serde_json::to_string(&serde_json::json!({

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -1215,6 +1215,7 @@ fn manifest_resolved_portable_db_service_warm_defers_and_dispatches_secret_ident
         let ready = std::cell::Cell::new(false);
         let ready_after_wait = &ready;
         crate::commands::deferred_workload::run_worker_with(
+            &homeboy::core::paths::homeboy().expect("config root"),
             "worker-token",
             || {
                 Ok(ready.get().then(|| {

--- a/docs/internals/development/contracts/path-roots-injection.md
+++ b/docs/internals/development/contracts/path-roots-injection.md
@@ -100,6 +100,60 @@ could not have called `from_environment()?` itself. The ambient
 `Result` out of sight. An ambient wrapper hanging off an infallible function is
 a strong signal that resolution belongs further up.
 
+## Migrate top-down, never bottom-up
+
+The instinct is to attack the crate with the most ambient calls. That is
+backwards, and the codebase punishes it twice over.
+
+An ambient wrapper can only be deleted when its callers can supply a root. If
+they cannot, "converting" the callee just relocates the resolution outward and
+multiplies it:
+
+| target | ambient calls in the callee | call sites that would have to resolve instead |
+|---|---|---|
+| `config::*` entity CRUD | 17 | **61** |
+| `defaults::load_config` | 6 | **113** |
+| `OperationRecordStore` | 3 | 14 |
+
+Converting `config.rs` today would turn 17 ambient resolutions into 61. That is
+not progress measured badly; it is a regression.
+
+So the ordering law is:
+
+```text
+process boundary  (main.rs -> CliRuntime::run_from_args)
+      |  resolve here first
+      v
+command entry     (commands/<name>::run)
+      v
+subsystem entry   (orchestrator::run_with_plan, workflow::run_command_*)
+      v
+stateful stores   (OperationRecordStore, ReleaseWorkspace)
+      v
+leaf helpers / core primitives   (config::*, defaults::*, paths::*)
+      ^  delete these wrappers LAST
+```
+
+Each layer can only shed its wrappers after the layer above it holds roots.
+`OperationRecordStore` demonstrated this: it was untouchable until
+`workflow::run_command_with_workspace` resolved, and then it fell in one pass.
+
+`homeboy-core` therefore looks like the biggest prize (96 ambient calls) and is
+actually the **last** work, not the first. Its `_in_root` siblings already
+exist for essentially every ambient function; nothing is blocked on designing
+them. What is blocked is the callers.
+
+### How to pick the next increment
+
+Look for a file where the ambient wrappers' callers are **already at or near a
+boundary**. `commands/deferred_workload.rs` qualified: five wrappers, each with
+exactly one caller, and those callers were `run()` (a command entry),
+`cli_runtime.rs` (the process boundary itself), and one sibling command. All
+five collapsed in a single pass, net −22 lines.
+
+A file whose wrappers have dozens of scattered callers is not ready yet. Leave
+it and come back once the layer above has been rooted.
+
 ## Tests are a boundary too
 
 Tests that construct a carrier by hand, or call a rooted function directly,


### PR DESCRIPTION
I went at `homeboy-core` (96 ambient calls, the biggest holding) and found it is the **wrong target**. This PR lands the increment that *is* ready, and documents the ordering law so the next person doesn't repeat the survey.

## Why not homeboy-core

An ambient wrapper can only be deleted when its callers can supply a root. If they can't, "converting" the callee relocates the resolution outward and **multiplies** it:

| target | ambient calls in the callee | call sites that would resolve instead |
|---|---|---|
| `config::*` entity CRUD | 17 | **61** |
| `defaults::load_config` | 6 | **113** |
| `OperationRecordStore` (already done) | 3 | 14 |

Converting `config.rs` today turns 17 ambient resolutions into 61. That isn't progress measured badly — it's a regression. Core's `_in_root` siblings already exist for essentially every ambient function; nothing is blocked on design. What's blocked is the callers.

**`homeboy-core` looks like the biggest prize and is actually the last work.**

```text
process boundary  (main.rs -> CliRuntime::run_from_args)
      |  resolve here first
      v
command entry     (commands/<name>::run)
      v
subsystem entry   (orchestrator::run_with_plan, workflow::run_command_*)
      v
stateful stores   (OperationRecordStore, ReleaseWorkspace)
      v
leaf helpers / core primitives   (config::*, defaults::*, paths::*)
      ^  delete these wrappers LAST
```

`OperationRecordStore` already demonstrated this: untouchable until `workflow::run_command_with_workspace` resolved, then it fell in one pass.

## What this PR lands

`commands/deferred_workload.rs` — a file whose wrappers' callers were *already at boundaries*. Five wrappers, one caller each.

The clearest defect was `run()`: the `status` arm resolved a config root for itself, while the `reconcile` arm called `reconcile_workers`, which resolved a **second** one below it. One invocation, two independent answers about which installation it was describing.

All five deleted, rooted siblings take the plain name:

| deleted | survivor |
|---|---|
| `reconcile_workers` | `reconcile_workers(config_root, ..)` |
| `ensure_worker` | `ensure_worker(config_root)` |
| `restart_worker_if_pending` | `restart_worker_if_pending(config_root)` |
| `restart_worker_if_pending_with` | `restart_worker_if_pending_with(config_root, ..)` |
| `run_worker_with` | `run_worker_with(config_root, ..)` |

`run()` resolves once for both subcommands. Remaining callers resolve at their own boundaries — and one of them is **the process boundary itself**: `cli_runtime::run_from_args` now resolves before restarting a pending worker.

`run_worker_with` had been kept explicitly *"for callers that own no resolved root (the hermetic tests)"*. Those 8 tests now resolve at the top of the test, which is where they were always the boundary — so the wrapper goes. That comment is the tell to look for: a wrapper justified by its test callers is a wrapper whose tests haven't been asked to act like boundaries yet.

**Ambient resolution points in `deferred_workload.rs`: 7 → 0.** The three `paths::homeboy()` calls left are the `run()` command boundary, the `run_worker()` process-entry boundary, and one test helper. **Net −22 lines.**

## How to pick the next increment

Look for a file whose ambient wrappers' callers are already at or near a boundary. That's what qualified this one. A file whose wrappers have dozens of scattered callers is not ready — leave it, root the layer above first.

Also worth correcting: the per-crate figures circulating for this issue are stale. Current `PathRoots::from_environment()` counts are `homeboy-agents` 20 (not 162) and `homeboy-cli` 2 (not 4). The real ambient surface is dominated by the free resolvers (`paths::homeboy()` ×60 in core alone), and **`homeboy-core` at 96 was not on the list at all**.

## Verification

`nice -n 10 cargo check --workspace --tests -j2` — clean first try, zero errors and zero warnings. `cargo fmt` applied. `target/` removed, 21G free.