### PR TITLE
refactor(cli): delete the dead private-batch-plan dir wrapper, and fix the readiness heuristic (#7505)

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -2970,12 +2970,6 @@ fn private_batch_plan_path_in_roots(data_root: &Path, fanout_id: &str) -> PathBu
     ))
 }
 
-fn private_batch_plan_dir() -> Result<PathBuf> {
-    Ok(private_batch_plan_dir_in_roots(
-        &homeboy::core::paths::homeboy_data()?,
-    ))
-}
-
 fn private_batch_plan_dir_in_roots(data_root: &Path) -> PathBuf {
     data_root.join("agent-task").join("private-batch-plans")
 }
@@ -4904,7 +4898,9 @@ mod tests {
     #[test]
     fn private_plan_temp_and_parent_are_owner_only_before_write() {
         with_isolated_home(|_| {
-            let parent = private_batch_plan_dir().expect("private plan dir");
+            let parent = private_batch_plan_dir_in_roots(
+                &homeboy::core::paths::homeboy_data().expect("data root"),
+            );
             fs::create_dir_all(&parent).expect("create parent");
             fs::set_permissions(&parent, fs::Permissions::from_mode(0o755))
                 .expect("make parent permissive for repair test");

--- a/docs/internals/development/contracts/path-roots-injection.md
+++ b/docs/internals/development/contracts/path-roots-injection.md
@@ -145,14 +145,55 @@ them. What is blocked is the callers.
 
 ### How to pick the next increment
 
-Look for a file where the ambient wrappers' callers are **already at or near a
-boundary**. `commands/deferred_workload.rs` qualified: five wrappers, each with
-exactly one caller, and those callers were `run()` (a command entry),
-`cli_runtime.rs` (the process boundary itself), and one sibling command. All
-five collapsed in a single pass, net −22 lines.
+The readiness test is **not** how many ambient calls a file has, and it is not
+how many callers those wrappers have. It is:
 
-A file whose wrappers have dozens of scattered callers is not ready yet. Leave
-it and come back once the layer above has been rooted.
+> Does a root already reach the callee — either because a carrier struct passes
+> through it, or because its caller is itself a boundary?
+
+Measure the **depth from the wrapper to the nearest thing that holds, or can
+trivially hold, a root**:
+
+| depth | meaning | example | verdict |
+|---|---|---|---|
+| 0 | a carrier struct already threads through the callee | `ReleaseExecutionContext`, `ReleaseWorkspace` | ready |
+| 1 | the wrapper's caller is a command or process entry | `commands/deferred_workload.rs` | ready |
+| many | intermediate functions with no other reason to know about paths | `agent_task/fanout.rs`, below | **not ready** |
+
+`commands/deferred_workload.rs` was depth 1: five wrappers, one caller each, and
+those callers were `run()` (a command entry), `cli_runtime.rs` (the process
+boundary itself), and one sibling command. All five collapsed in one pass.
+
+### The counter-example: agent_task/fanout.rs
+
+Fanout looks like an easy target by every surface metric — two ambient wrappers,
+and only two production callers between them. It is not ready, and the reason is
+depth:
+
+```text
+fanout()                                  <- the only real boundary
+  -> cook_batch / run_batch_cook_fanout
+    -> cook_batch_inner / run_batch_cook_fanout_plan
+      -> run_batch_cook_fanout_plan_with_executor
+        -> run_batch_cook_fanout_plan_with_executor_claim
+          -> claim_fanout_run_batch_coordinator
+            -> persist_fanout_run_batch_record
+              -> secure_batch_plan_execution
+                -> private_batch_plan_path        <- the ambient call
+```
+
+Rooting this means adding a `data_root: &Path` parameter to eight functions
+whose job has nothing to do with paths, plus a `pub(crate)` signature with an
+external caller in `commands/infra/route.rs` — to remove **one** duplicate
+resolution per command. That is the definition of adding plumbing.
+
+Leave it. Either a carrier appears as the layer above is rooted, or the
+duplicate resolution falls out when one does. **Low caller count is not low
+depth, and only depth predicts whether the change is net-negative.**
+
+What *was* safe to take here: `private_batch_plan_dir()` had exactly one caller
+and it was a test. A wrapper whose last non-test caller has already disappeared
+is dead weight regardless of depth — delete it on sight.
 
 ## Tests are a boundary too
 


### PR DESCRIPTION
Small code change, and a correction to the heuristic I added in #12748.

## The code

`private_batch_plan_dir()` resolved a data root and delegated to `private_batch_plan_dir_in_roots`. Its last non-test caller was already gone — the only one left was a single assertion in this file's own tests. A wrapper kept alive by one test is dead weight, so it goes and the test resolves for itself.

## Why the rest of fanout is untouched

I picked fanout as the next target because it looked easy: two ambient wrappers, two production callers between them. It isn't ready, and the reason is **depth**, not caller count.

```text
fanout()                                  <- the only real boundary
  -> cook_batch / run_batch_cook_fanout
    -> cook_batch_inner / run_batch_cook_fanout_plan
      -> run_batch_cook_fanout_plan_with_executor
        -> run_batch_cook_fanout_plan_with_executor_claim
          -> claim_fanout_run_batch_coordinator
            -> persist_fanout_run_batch_record
              -> secure_batch_plan_execution
                -> private_batch_plan_path        <- the ambient call
```

Rooting that means a `data_root: &Path` parameter on **eight** functions whose job has nothing to do with paths, plus a `pub(crate)` signature with an external caller in `commands/infra/route.rs` — to remove **one** duplicate resolution per command. By this doc's own standard that is adding plumbing, not removing debt.

## The heuristic was wrong

#12748 said to look for wrappers whose callers are near a boundary, and to skip files whose wrappers have *dozens of scattered callers*. Fanout has **two** callers and fails anyway — exactly the case that wording gets wrong.

Replaced with depth to the nearest thing that holds, or can trivially hold, a root:

| depth | meaning | example | verdict |
|---|---|---|---|
| 0 | a carrier struct already threads through the callee | `ReleaseExecutionContext`, `ReleaseWorkspace` | ready |
| 1 | the wrapper's caller is a command or process entry | `commands/deferred_workload.rs` | ready |
| many | intermediate functions with no other reason to know about paths | `agent_task/fanout.rs` | **not ready** |

That is consistent with what actually landed: release qualified at depth 0, deferred-workload at depth 1. **Low caller count is not low depth, and only depth predicts whether the change is net-negative.**

One rule survives unchanged and is worth stating separately: a wrapper whose last *non-test* caller has already disappeared is dead weight regardless of depth. Delete it on sight. That is the whole of this PR's code diff.

## Verification

`nice -n 10 cargo check --workspace --tests -j2` — clean, zero errors and zero warnings. `cargo fmt` applied. `target/` removed.

Filed #12749 separately for the four untracked test failures currently red on main.