### PR TITLE
test(runner): make prune failures say why the scan withheld a workspace

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/prune.rs
@@ -21,6 +21,34 @@ use crate::workspace::types::{
 use crate::{MaterializedWorkspace, WorkspaceCleanupPolicy, WorkspaceTerminalOutcome};
 use homeboy_core::api_jobs::JobStatus;
 
+/// Why the scan produced the candidate set it did.
+///
+/// Every prune failure reported from CI has been a bare `left: 0, right: 1`
+/// with no indication of which guard withheld the workspace, and #12715 stayed
+/// unexplained for weeks behind exactly that comparison. The reasons were never
+/// missing -- `prune_workspaces` already returns `skipped`,
+/// `withheld_by_liveness_reason`, `scanned_workspace_count` and `scan_complete`
+/// -- the assertions simply threw them away, so a failure that reproduces only
+/// on CI could not be read from CI.
+///
+/// Same defect as the promotion provider assertion in #12741, which printed
+/// `error.message` and discarded the `error.details` naming the operation.
+fn prune_diagnosis(output: &crate::workspace::types::RunnerWorkspacePruneOutput) -> String {
+    format!(
+        "scanned={} scan_complete={} candidates={} removed={} skipped_live={} skipped_unknown={}\n  withheld_by_liveness_reason={:?}\n  skipped={:?}\n  workspace_root={} lab_workspaces_root={}",
+        output.scanned_workspace_count,
+        output.scan_complete,
+        output.candidates.len(),
+        output.removed.len(),
+        output.skipped_live_count,
+        output.skipped_unknown_count,
+        output.withheld_by_liveness_reason,
+        output.skipped,
+        output.workspace_root,
+        output.lab_workspaces_root,
+    )
+}
+
 #[test]
 fn prune_workspaces_previews_orphans_without_deleting_by_default() {
     homeboy_core::test_support::with_isolated_home(|_| {
@@ -59,7 +87,7 @@ fn prune_workspaces_previews_orphans_without_deleting_by_default() {
 
         assert_eq!(exit_code, 0);
         assert!(output.dry_run);
-        assert_eq!(output.candidates.len(), 1);
+        assert_eq!(output.candidates.len(), 1, "{}", prune_diagnosis(&output));
         assert_eq!(output.total_candidate_count, 1);
         assert!(output.total_candidate_bytes > 0);
         assert_eq!(output.remaining_candidate_count, 0);
@@ -128,7 +156,7 @@ fn prune_workspaces_apply_removes_only_metadata_backed_orphans() {
 
         assert_eq!(exit_code, 0);
         assert!(!output.dry_run);
-        assert_eq!(output.removed.len(), 2);
+        assert_eq!(output.removed.len(), 2, "{}", prune_diagnosis(&output));
         assert_eq!(output.total_candidate_count, 2);
         assert!(output.total_candidate_bytes >= output.total_removed_bytes);
         assert_eq!(output.remaining_candidate_count, 0);
@@ -292,7 +320,7 @@ fn retained_terminal_receipt_reclassifies_and_releases_compacted_workspace() {
             },
         )
         .expect("preview receipt-authorized workspace");
-        assert_eq!(preview.candidates.len(), 1);
+        assert_eq!(preview.candidates.len(), 1, "{}", prune_diagnosis(&preview));
         assert_eq!(preview.candidates[0].reason, "terminal_resource_lifecycle");
         assert!(preview.withheld_by_liveness_reason.is_empty());
         homeboy_agents::agent_task_lifecycle::begin_workspace_terminal_authority_release(
@@ -314,7 +342,7 @@ fn retained_terminal_receipt_reclassifies_and_releases_compacted_workspace() {
             },
         )
         .expect("remove receipt-authorized workspace");
-        assert_eq!(applied.removed.len(), 1);
+        assert_eq!(applied.removed.len(), 1, "{}", prune_diagnosis(&applied));
         assert!(!workspace.exists());
         homeboy_agents::agent_task_lifecycle::persist_workspace_terminal_authority_for_test(
             run_id,
@@ -578,7 +606,7 @@ fn prune_workspaces_reaps_ttl_expired_lifecycle_workspace_with_live_source() {
         .expect("prune preview");
 
         assert_eq!(exit_code, 0);
-        assert_eq!(output.candidates.len(), 1);
+        assert_eq!(output.candidates.len(), 1, "{}", prune_diagnosis(&output));
         assert_eq!(output.candidates[0].remote_path, synced.remote_path);
         assert_eq!(output.candidates[0].reason, "resource_ttl_expired");
         assert!(Path::new(&synced.remote_path).exists());
@@ -622,7 +650,7 @@ fn prune_workspaces_reaps_stale_materialized_workspace_with_live_source() {
         .expect("prune stale materialized workspace");
 
         assert_eq!(exit_code, 0);
-        assert_eq!(output.removed.len(), 1);
+        assert_eq!(output.removed.len(), 1, "{}", prune_diagnosis(&output));
         assert_eq!(
             output.removed[0].reason,
             "stale_materialized_workspace_lifecycle"
@@ -669,7 +697,7 @@ fn prune_workspaces_prefers_stale_materialized_lifecycle_when_source_is_missing(
         .expect("prune stale materialized workspace with missing source");
 
         assert_eq!(exit_code, 0);
-        assert_eq!(output.removed.len(), 1);
+        assert_eq!(output.removed.len(), 1, "{}", prune_diagnosis(&output));
         assert_eq!(
             output.removed[0].reason,
             "stale_materialized_workspace_lifecycle"
@@ -745,6 +773,7 @@ fn preserved_failure_lifecycle_is_registered_for_ttl_pruning() {
         )
         .expect("prune preview");
 
+        assert_eq!(preview.candidates.len(), 1, "{}", prune_diagnosis(&preview));
         assert_eq!(preview.candidates[0].reason, "resource_ttl_expired");
         assert_eq!(preview.candidates[0].remote_path, synced.remote_path);
         assert!(Path::new(&synced.remote_path).exists());
@@ -763,7 +792,7 @@ fn preserved_failure_lifecycle_is_registered_for_ttl_pruning() {
         .expect("apply ttl prune");
 
         assert_eq!(exit_code, 0);
-        assert_eq!(applied.removed.len(), 1);
+        assert_eq!(applied.removed.len(), 1, "{}", prune_diagnosis(&applied));
         assert_eq!(applied.removed[0].reason, "resource_ttl_expired");
         assert_eq!(applied.removed[0].remote_path, synced.remote_path);
         assert!(
@@ -880,7 +909,7 @@ fn prune_workspaces_preview_reports_synthetic_odd_path_without_deleting() {
 
         assert_eq!(exit_code, 0);
         assert!(output.dry_run);
-        assert_eq!(output.candidates.len(), 1);
+        assert_eq!(output.candidates.len(), 1, "{}", prune_diagnosis(&output));
         assert_eq!(
             output.candidates[0].remote_path,
             workspace.display().to_string()
@@ -941,7 +970,7 @@ fn prune_workspaces_reports_remaining_bytes_and_drain_command_when_limited() {
 
         assert_eq!(exit_code, 0);
         assert!(output.dry_run);
-        assert_eq!(output.candidates.len(), 1);
+        assert_eq!(output.candidates.len(), 1, "{}", prune_diagnosis(&output));
         assert_eq!(output.scanned_workspace_count, 1);
         assert!(!output.scan_complete);
         assert_eq!(output.total_candidate_count, 1);
@@ -1009,7 +1038,7 @@ fn prune_workspaces_apply_passes_drain_until_empty() {
         assert!(!output.dry_run);
         assert_eq!(output.scanned_workspace_count, 2);
         assert_eq!(output.total_candidate_count, 1);
-        assert_eq!(output.removed.len(), 2);
+        assert_eq!(output.removed.len(), 2, "{}", prune_diagnosis(&output));
         assert_eq!(output.remaining_candidate_count, 0);
         assert_eq!(output.remaining_candidate_bytes, 0);
         assert!(!output.has_more);


### PR DESCRIPTION
Refs #12715.

## Why

My EACCES fix in #12744 was wrong, or at least incomplete. It repaired 14 tests under a local `setpriv` harness — 18 failures down to 4 — and the 14 matched CI's list name for name. It did **not** fix CI. The same 14 still fail on `main`, now at *different* assertions:

```
before: prune.rs:883, 944, 1083, 1195
after:  prune.rs:581, 672, 748
```

Behaviour changed, the symptom did not. Still `left: 0, right: 1`.

I cannot reproduce it locally. As root all 30 pass. Unprivileged, serial or parallel, 26 pass and the only 4 failures are `ssh_*` tests that **pass on CI** — the local and CI failure sets are disjoint, so my harness is not faithful. `/tmp` is `noexec` on my box, so the hermetic wrapper picks `/var/tmp` and workspaces can never live where CI puts them:

```
/tmp/.homeboy-test-tmp/run.l8mmy5/.tmpTEGXkS/_lab_workspaces/live-source-…
```

Rather than keep guessing, make CI answer.

## What

The diagnosis was already in the output and was being discarded:

```rust
pub skipped: Vec<RunnerWorkspacePruneSkippedEntry>,
pub skipped_live_count: usize,
pub skipped_unknown_count: usize,
/// Capacity withheld by liveness evidence, grouped by its exact reason.
pub withheld_by_liveness_reason: Vec<RunnerWorkspacePruneWithheldReason>,
pub scanned_workspace_count: usize,
pub scan_complete: bool,
```

Every count assertion now carries it:

```rust
assert_eq!(output.candidates.len(), 1, "{}", prune_diagnosis(&output));
```

11 assertions annotated, plus the missing length guard before the `preview.candidates[0]` access that otherwise panics with a bare `index out of bounds: the len is 0 but the index is 0` and tells you nothing.

This distinguishes the possibilities the bare count cannot:

- `scanned_workspace_count == 0` → the shell scan never emitted the directory
- scanned, but `withheld_by_liveness_reason` populated → Rust classification withheld it, and which reason
- `skipped_unknown_count > 0` → a probe returned `unknown`
- `scan_complete == false` → the scan window ended early

## Scope

Tests only. No production code, no assertion semantics changed. All 30 prune tests pass locally before and after.

This is the same lesson as #12741, where the assertion printed `error.message` — the canned string `"IO error"` — and discarded the `error.details` that named the failing operation. A test that cannot explain its own failure on the only machine where it fails is not carrying information.

I will read the shard output from this PR and follow up on #12715 with the actual cause.