### PR TITLE
fix: two deterministic red-main failures with environment-shaped causes

### DIFF
--- a/crates/homeboy-deploy/src/orchestration_ref_checkout.rs
+++ b/crates/homeboy-deploy/src/orchestration_ref_checkout.rs
@@ -1269,6 +1269,13 @@ mod tests {
                 fixture.remote.to_str().unwrap(),
             ],
         );
+        // `git clone` does not inherit the source repository's local config, so
+        // this checkout has no committer identity of its own. Tests that commit
+        // into it therefore passed only on machines with a global git identity
+        // and failed on CI with "Author identity unknown". Set it here, the same
+        // way the fixture repository does after `git init`.
+        git(&checkout, &["config", "user.name", "Homeboy Test"]);
+        git(&checkout, &["config", "user.email", "homeboy@example.test"]);
         checkout
     }
 

--- a/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
+++ b/crates/homeboy-engine-primitives/src/measurement_registry_test.rs
@@ -374,6 +374,14 @@ const GATE_LAYER_SITES: &[GateLayerSite] = &[
     },
     GateLayerSite {
         file: ".github/ci-required-gates-executed.sh",
+        decision: "exit 0",
+        basis: MeasurementBasis::PerUnitEvaluation,
+        renders_skip: false,
+        fixture: None,
+        note: "NO FIXTURE: the terminal gate first proves the declared context population is non-empty, then evaluates every required dependency and check-run conclusion before passing.",
+    },
+    GateLayerSite {
+        file: ".github/ci-required-gates-executed.sh",
         decision: "exit 1",
         basis: MeasurementBasis::Projection,
         renders_skip: false,
@@ -382,14 +390,6 @@ const GATE_LAYER_SITES: &[GateLayerSite] = &[
                no declared contexts, a skipped dependency, a missing job, or a non-success \
                conclusion. This terminal exit cannot manufacture a green verdict; it is \
                registered so the scan records the script's complete terminal contract.",
-    },
-    GateLayerSite {
-        file: ".github/ci-required-gates-executed.sh",
-        decision: "exit 0",
-        basis: MeasurementBasis::PerUnitEvaluation,
-        renders_skip: false,
-        fixture: None,
-        note: "NO FIXTURE: the terminal gate first proves the declared context population is non-empty, then evaluates every required dependency and check-run conclusion before passing.",
     },
     GateLayerSite {
         file: ".github/ci-required-gates-executed.sh",


### PR DESCRIPTION
Two of the remaining full-scope failures on `main`. Unrelated causes, both cheap and both proven.

---

## 1. `preflighted_sha_is_materialized_after_the_requested_branch_moves`

```
git ["commit", "-q", "-m", "move accepted branch"]: Author identity unknown
*** Please tell me who you are.
```

`stale_clone` builds its checkout with `git clone`, and **a clone does not inherit the source repository's local config**. So that checkout had no committer identity, and the commit silently resolved one from the developer's *global* git config. CI has none.

The fixture repository already does the right thing after `git init`:

```rust
git(repo.path(), &["init", "-q"]);
git(repo.path(), &["config", "user.name", "Homeboy Test"]);
git(repo.path(), &["config", "user.email", "homeboy@example.test"]);
```

The clone now does the same.

### Proof

Pointing `HOME` at an empty directory reproduces CI exactly — no global identity, everything else unchanged:

| | result |
| --- | --- |
| **without** the fix | 16 passed, **1 failed** |
| **with** the fix | **17 passed**, 0 failed |

The single failure is precisely the test CI reports, and it is the only `homeboy-deploy` test in CI's failure set.

> I first tried `GIT_CONFIG_GLOBAL=/dev/null`, which produced 10 failures — a harsher condition than CI, not a reproduction. An empty `HOME` is the faithful one. Worth noting for anyone reproducing the rest of these.

---

## 2. `the_gate_layer_registry_is_sorted`

Four `ci-required-gates-executed.sh` entries in `GATE_LAYER_SITES` were declared out of order:

```
declared: exit 0, exit 1, exit 0, exit 1
required: exit 0, exit 0, exit 1, exit 1
```

The registry requires entries sorted by `(file, decision)` so failure messages stay actionable. Reordered. **Data only** — no entry, note, or `basis` is changed, nothing added or removed.

This one is deterministic on every machine, not CI-shaped. That it survived on `main` at all is the clearest illustration yet of how little the Test gate has been carrying: a statically-sorted-list assertion, broken, unselected by a `--changed-since` scoped gate.

---

## Verification

`cargo check --workspace --tests -j2` clean, `cargo fmt --check` clean, both target tests pass.

## Still red after this

The `workspace::tests::prune` cluster (#12715, diagnostics in #12751) plus these singletons, none yet triaged:

```
homeboy-agents  concurrent_first_cooks_elect_one_recipe_creator_without_replacing_its_plan
homeboy-cli     providers_validate_readiness_without_backend_sweeps_every_declared_backend
homeboy-core    legacy_child_recovery_exact_evidence_is_idempotent_and_conflicts_fail_closed
homeboy-lab-runner  durability_check_rejects_a_tunnel_that_exits_after_apparent_readiness
homeboy-lab-runner  durability_health_failure_rechecks_tunnel_identity
homeboy-lab-runner  mirroring_lab_job_preserves_agent_task_lifecycle_metadata
homeboy-release dry_run_plans_reachable_external_release_reconciliation_without_mutation
```