### PR TITLE
fix(runner): stop one fat process withholding every prunable workspace

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -3506,7 +3506,11 @@ fn liveness(state: &str, observations: Vec<String>) -> RunnerWorkspaceLivenessEv
 #[cfg(target_os = "linux")]
 fn local_process_liveness(path: &Path) -> RunnerWorkspaceLivenessEvidence {
     const MAX_PROCESSES: usize = 4096;
-    const MAX_FDS_PER_PROCESS: usize = 1024;
+    // 1024 was below what ordinary hosts actually run (#12715). A CI runner
+    // agent, a container daemon or a language server holds thousands of
+    // descriptors as a matter of course, and every one of them tripped the
+    // bound. Bound the work at a ceiling only a pathological process reaches.
+    const MAX_FDS_PER_PROCESS: usize = 65_536;
     let target = path.to_string_lossy();
     let Ok(processes) = fs::read_dir("/proc") else {
         return liveness(
@@ -3572,9 +3576,20 @@ fn local_process_liveness(path: &Path) -> RunnerWorkspaceLivenessEvidence {
             }
             Err(_) => return liveness("unknown", vec!["process_probe_fd_failed".to_string()]),
         };
+        // Exceeding the bound describes THIS process's descriptor table, not
+        // this workspace (#12715). Returning `unknown` here abandoned the whole
+        // probe on the first fat process on the machine and withheld every
+        // workspace from pruning -- `withheld_by_liveness_reason:
+        // process_probe_fd_limit`, on every CI run.
+        //
+        // The two strong signals for this process have already been evaluated
+        // above: its cwd is not inside the workspace and its argv does not name
+        // it. The descriptor sweep is the weak supplementary check, so stop
+        // sweeping this one and go on to the next process rather than
+        // poisoning the verdict for every workspace in the scan.
         for (index, fd) in fds.flatten().enumerate() {
             if index >= MAX_FDS_PER_PROCESS {
-                return liveness("unknown", vec!["process_probe_fd_limit".to_string()]);
+                break;
             }
             if fs::read_link(fd.path())
                 .ok()


### PR DESCRIPTION
Fixes #12715. This is the second half of the defect; #12744 was the first and was insufficient on its own.

## CI answered directly

Once #12751 stopped the assertions discarding the evidence, the shard log said it outright:

```
scanned=1 scan_complete=true candidates=0 removed=0 skipped_live=0 skipped_unknown=1
withheld_by_liveness_reason=[RunnerWorkspacePruneWithheldReason {
    reason: "process_probe_fd_limit", workspace_count: 1, bytes: 16384 }]
```

**The shell scan found the directory.** Classification withheld it. No more guessing about `find`, `du`, `mktemp`, `TMPDIR` or the three silent `continue` guards — none of them were involved.

## Cause

`workspace/sync/mod.rs`, `local_process_liveness`:

```rust
const MAX_FDS_PER_PROCESS: usize = 1024;
...
for (index, fd) in fds.flatten().enumerate() {
    if index >= MAX_FDS_PER_PROCESS {
        return liveness("unknown", vec!["process_probe_fd_limit".to_string()]);
    }
```

`return`, not `break` — the whole probe is abandoned. And **1024 descriptors is below what ordinary hosts run**: a CI runner agent, a container daemon or a language server holds thousands routinely. On CI the first such process ended the sweep and nothing was ever prunable.

Zero processes on my host exceed 1024 fds, which is why it never reproduced locally.

## Fix

Exceeding the bound describes *that process's descriptor table*, not this workspace. By the time the sweep starts, both strong signals for the process have already been evaluated — its cwd is not inside the workspace and its argv does not name it — so the descriptor sweep is the weak supplementary check. `break` to the next process instead of poisoning the verdict for every workspace in the scan, and raise the bound to a ceiling only a pathological process reaches.

## Proof

Forcing `MAX_FDS_PER_PROCESS` to `1` makes every process trip the bound, reproducing CI on a host that otherwise cannot:

| behaviour | result |
| --- | --- |
| `return unknown` (old) | 16 passed, **14 failed** |
| `break` (new) | **30 passed**, 0 failed |

The 14 are **exactly** the 14 CI reports — `diff` of the two sorted lists is empty.

## Why #12744 was not enough

That change was correct and incomplete. Before it, the probe died on the first *foreign* process (`EACCES` on `/proc/<pid>/cwd`) and never reached any descriptor table at all. Skipping foreign processes let it walk far enough to hit this bound instead — which is why the panic sites moved:

```
before #12744: prune.rs:883, 944, 1083, 1195
after  #12744: prune.rs:581, 672, 748
```

while the symptom stayed `left: 0, right: 1`. Two bounds in the same loop, each independently sufficient to make the feature inoperative.

## Standing back

`homeboy runner workspace prune` reported zero candidates and exited 0 on any host that is either multi-user or busy. Both halves were guards that read as fail-closed and were in practice fail-*shut* — the safe-looking branch was the one that silently disabled the feature.

Worth noting the sequence: this took a correction, a diagnostics-only PR, and a forced-bound reproduction to pin down. The single change that made it solvable was #12751 printing evidence the code had been returning all along.