### PR TITLE
refactor(deploy): root the deploy receipt store (#7505)

### DIFF
--- a/crates/homeboy-deploy/src/lib.rs
+++ b/crates/homeboy-deploy/src/lib.rs
@@ -132,10 +132,14 @@ use uuid::Uuid;
 pub fn run(project_id: &str, config: &DeployConfig) -> Result<DeployOrchestrationResult> {
     let mut release_artifacts =
         homeboy_core::git::release_download::ReleaseArtifactStore::default();
-    run_with_release_artifacts(project_id, config, &mut release_artifacts)
+    // Single-project deploy is its own unit of work: resolve once here so the
+    // receipt read, write, and invalidation below all address one home (#7505).
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    run_with_release_artifacts(roots.data(), project_id, config, &mut release_artifacts)
 }
 
 fn run_with_release_artifacts(
+    data_root: &std::path::Path,
     project_id: &str,
     config: &DeployConfig,
     release_artifacts: &mut homeboy_core::git::release_download::ReleaseArtifactStore,
@@ -186,6 +190,7 @@ fn run_with_release_artifacts(
     let (ctx, base_path) = resolve_project_ssh_with_base_path(project_id)
         .map_err(|error| attach_admitted_run_id(error, admitted_run_id.as_deref()))?;
     let mut result = orchestration::deploy_components(
+        data_root,
         config,
         &project,
         &ctx,
@@ -516,7 +521,12 @@ pub fn run_multi(
         }
         let mut timer = PhaseTimer::new();
         let result = timer.time("resolve_source", || {
-            run_with_release_artifacts(project_id, &project_config, &mut release_artifacts)
+            run_with_release_artifacts(
+                roots.data(),
+                project_id,
+                &project_config,
+                &mut release_artifacts,
+            )
         });
         let timings = timer.into_report();
 

--- a/crates/homeboy-deploy/src/orchestration/mod.rs
+++ b/crates/homeboy-deploy/src/orchestration/mod.rs
@@ -42,6 +42,7 @@ use smoke_check::run_post_deploy_smoke;
 /// Main deploy orchestration entry point.
 /// Handles component selection, building, and deployment.
 pub(super) fn deploy_components(
+    data_root: &std::path::Path,
     config: &DeployConfig,
     project: &Project,
     ctx: &RemoteProjectContext,
@@ -236,6 +237,7 @@ pub(super) fn deploy_components(
     // Check and dry-run modes return early without building or deploying
     if config.check {
         let mut result = run_check_mode(CheckModeInput {
+            data_root,
             components: &components,
             local_versions: &local_versions,
             remote_versions: &remote_versions,
@@ -486,9 +488,13 @@ pub(super) fn deploy_components(
         let component = &prepared.component;
         if prepared.package_manifest.is_some() {
             let version = prepared.local_version.as_deref().unwrap_or_default();
-            if let Err(error) =
-                super::receipt::invalidate(&project, &component.id, &prepared.install_dir, version)
-            {
+            if let Err(error) = super::receipt::invalidate(
+                data_root,
+                &project,
+                &component.id,
+                &prepared.install_dir,
+                version,
+            ) {
                 failed += 1;
                 results.push(ComponentDeployResult::failed(
                     component,
@@ -586,16 +592,19 @@ pub(super) fn deploy_components(
             ) {
                 let exclusions = resolve_component_scope(component, ScopeCommand::Deploy).exclude;
                 let version = prepared.local_version.as_deref().unwrap_or_default();
-                if let Err(error) = super::receipt::write(super::receipt::ReceiptWrite {
-                    project: &project,
-                    component_id: &component.id,
-                    target: &prepared.install_dir,
-                    version,
-                    manifest,
-                    payload_sha256,
-                    build_provenance,
-                    exclusions,
-                }) {
+                if let Err(error) = super::receipt::write(
+                    data_root,
+                    super::receipt::ReceiptWrite {
+                        project: &project,
+                        component_id: &component.id,
+                        target: &prepared.install_dir,
+                        version,
+                        manifest,
+                        payload_sha256,
+                        build_provenance,
+                        exclusions,
+                    },
+                ) {
                     result.status = "failed".to_string();
                     result.error = Some(format!(
                         "deployment completed but authoritative deployed-package receipt could not be persisted: {}",

--- a/crates/homeboy-deploy/src/orchestration/modes.rs
+++ b/crates/homeboy-deploy/src/orchestration/modes.rs
@@ -20,6 +20,10 @@ use super::super::types::{
 
 /// Check mode: return component status without building or deploying.
 pub(super) struct CheckModeInput<'a> {
+    /// Data root resolved by the deploy boundary. Check mode reads receipts
+    /// the apply path later writes and invalidates, so all three must address
+    /// the same home (#7505).
+    pub(super) data_root: &'a std::path::Path,
     pub(super) components: &'a [Component],
     pub(super) local_versions: &'a HashMap<String, String>,
     pub(super) remote_versions: &'a HashMap<String, String>,
@@ -34,6 +38,7 @@ pub(super) struct CheckModeInput<'a> {
 
 pub(super) fn run_check_mode(input: CheckModeInput<'_>) -> DeployOrchestrationResult {
     let CheckModeInput {
+        data_root,
         components,
         local_versions,
         remote_versions,
@@ -90,6 +95,7 @@ pub(super) fn run_check_mode(input: CheckModeInput<'_>) -> DeployOrchestrationRe
             } else {
                 let version = local_versions.get(&c.id).map(String::as_str).unwrap_or_default();
                 match super::super::receipt::load(
+                    data_root,
                     project,
                     &c.id,
                     &target,
@@ -384,6 +390,14 @@ fn latest_deploy_tag(component: &Component, expected_version: Option<&str>) -> R
 
 #[cfg(test)]
 mod tests {
+    /// The data root of the isolated home each test below installs.
+    ///
+    /// Check mode reads receipts that the apply path writes and invalidates, so
+    /// the test stands in for the deploy boundary and resolves once (#7505).
+    fn test_data_root() -> std::path::PathBuf {
+        homeboy_core::paths::homeboy_data().expect("data root")
+    }
+
     use super::*;
     use crate::PreparedDeployArtifact;
     use std::collections::BTreeMap;
@@ -698,6 +712,7 @@ mod tests {
         };
 
         let checked = run_check_mode(CheckModeInput {
+            data_root: &test_data_root(),
             components: std::slice::from_ref(&component),
             local_versions: &local_versions,
             remote_versions: &remote_versions,
@@ -777,6 +792,7 @@ mod tests {
         let packages = HashMap::from([("plugin".to_string(), package)]);
 
         let clean = run_check_mode(CheckModeInput {
+            data_root: &test_data_root(),
             components: std::slice::from_ref(&component),
             local_versions: &versions,
             remote_versions: &versions,
@@ -807,6 +823,7 @@ mod tests {
 
         std::fs::write(remote.join("plugin.php"), "modified").expect("drift");
         let drift = run_check_mode(CheckModeInput {
+            data_root: &test_data_root(),
             components: std::slice::from_ref(&component),
             local_versions: &versions,
             remote_versions: &versions,
@@ -825,6 +842,7 @@ mod tests {
 
         std::fs::write(&packages["plugin"].path, "mutated after lease").expect("mutate package");
         let mutated = run_check_mode(CheckModeInput {
+            data_root: &test_data_root(),
             components: std::slice::from_ref(&component),
             local_versions: &versions,
             remote_versions: &versions,
@@ -904,6 +922,7 @@ mod tests {
             source_commit: "prepared-commit".to_string(),
         });
         let result = run_check_mode(CheckModeInput {
+            data_root: &test_data_root(),
             components: &[component],
             local_versions: &versions,
             remote_versions: &versions,
@@ -962,6 +981,7 @@ mod tests {
         let local_versions = HashMap::from([("plugin".to_string(), "1.0.0".to_string())]);
         let remote_versions = HashMap::from([("plugin".to_string(), "2.0.0".to_string())]);
         let result = run_check_mode(CheckModeInput {
+            data_root: &test_data_root(),
             components: &[component],
             local_versions: &local_versions,
             remote_versions: &remote_versions,
@@ -997,6 +1017,7 @@ mod tests {
         };
         let versions = HashMap::from([("plugin".to_string(), "1.0.0".to_string())]);
         let result = run_check_mode(CheckModeInput {
+            data_root: &test_data_root(),
             components: &[component],
             local_versions: &versions,
             remote_versions: &versions,
@@ -1057,6 +1078,7 @@ mod tests {
         ] {
             config.check = true;
             let result = run_check_mode(CheckModeInput {
+                data_root: &test_data_root(),
                 components: std::slice::from_ref(&component),
                 local_versions: &versions,
                 remote_versions: &versions,
@@ -1094,6 +1116,7 @@ mod tests {
         };
         let versions = HashMap::from([("plugin".to_string(), "1.0.0".to_string())]);
         let result = run_check_mode(CheckModeInput {
+            data_root: &test_data_root(),
             components: &[component],
             local_versions: &versions,
             remote_versions: &versions,
@@ -1125,6 +1148,7 @@ mod tests {
         };
         let versions = HashMap::from([("plugin".to_string(), "1.0.0".to_string())]);
         let result = run_check_mode(CheckModeInput {
+            data_root: &test_data_root(),
             components: &[component],
             local_versions: &versions,
             remote_versions: &versions,

--- a/crates/homeboy-deploy/src/receipt.rs
+++ b/crates/homeboy-deploy/src/receipt.rs
@@ -53,19 +53,14 @@ impl DeployedPackageReceipt {
 }
 
 pub(super) fn load(
+    data_root: &Path,
     project: &Project,
     component_id: &str,
     target: &str,
     version: &str,
     exclusions: &[String],
 ) -> Result<Option<DeployedPackageReceipt>, Error> {
-    let path = path_in_roots(
-        homeboy_paths::PathRoots::from_environment()?.data(),
-        project,
-        component_id,
-        target,
-        version,
-    );
+    let path = path_in_roots(data_root, project, component_id, target, version);
     if !path.exists() {
         return Ok(None);
     }
@@ -94,7 +89,7 @@ pub(super) struct ReceiptWrite<'a> {
     pub(super) exclusions: Vec<String>,
 }
 
-pub(super) fn write(input: ReceiptWrite<'_>) -> Result<(), Error> {
+pub(super) fn write(data_root: &Path, input: ReceiptWrite<'_>) -> Result<(), Error> {
     let ReceiptWrite {
         project,
         component_id,
@@ -105,13 +100,7 @@ pub(super) fn write(input: ReceiptWrite<'_>) -> Result<(), Error> {
         build_provenance,
         exclusions,
     } = input;
-    let path = path_in_roots(
-        homeboy_paths::PathRoots::from_environment()?.data(),
-        project,
-        component_id,
-        target,
-        version,
-    );
+    let path = path_in_roots(data_root, project, component_id, target, version);
     let parent = path.parent().expect("receipt path has a parent");
     fs::create_dir_all(parent)
         .map_err(|error| receipt_io_error(&error, "create deploy receipt directory", parent))?;
@@ -198,18 +187,13 @@ impl DeployedPackageReceipt {
 }
 
 pub(super) fn invalidate(
+    data_root: &Path,
     project: &Project,
     component_id: &str,
     target: &str,
     version: &str,
 ) -> Result<(), Error> {
-    let path = path_in_roots(
-        homeboy_paths::PathRoots::from_environment()?.data(),
-        project,
-        component_id,
-        target,
-        version,
-    );
+    let path = path_in_roots(data_root, project, component_id, target, version);
     match fs::remove_file(&path) {
         Ok(()) => sync_directory(path.parent().expect("receipt path has a parent")),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),


### PR DESCRIPTION
The release crate left a standing note at its deploy handoff:

> The redeploy between them — `deploy::run_multi` — still resolves its own roots inside `homeboy-deploy`; that boundary is not reachable from here without changing a public signature (#7505).

This is that boundary.

## The defect

`run_multi` already resolved once and said so — *"One resolution for the whole run."* But the receipt store below it never participated. `receipt::load`, `receipt::write`, and `receipt::invalidate` each called `PathRoots::from_environment()` independently — and all three act on the **same receipt**, for the same component and version:

```
check mode   -> receipt::load       resolution #1   "is this component already deployed?"
apply        -> receipt::write      resolution #2   record what we just deployed
rollback     -> receipt::invalidate resolution #3   remove that record
```

A repoint between them means deciding a component is up to date from one home's receipt while writing the evidence into another. That is the same failure shape as the `OperationRecordStore` conversion in #12747, and it is a correctness bug rather than a tidiness one.

## The fix

```text
run                -> resolves (single-project deploy is its own unit of work)
run_multi          -> already resolved; now passes the root down
  run_with_release_artifacts
    deploy_components
      receipt::{load, write, invalidate}
      run_check_mode  via  CheckModeInput.data_root
```

`CheckModeInput` was already the carrier for every other piece of check-mode context — components, versions, project, config, client, packages — so the root travels as **one more field**, not a new parameter. That is the depth-0 case from the readiness heuristic: a carrier already threads through the callee.

| | before | after |
|---|---|---|
| ambient resolution points in `homeboy-deploy` | 5 | **2** (both named entries) |
| resolutions per deploy | 4+ | **1** |

## Also checked: the dead-wrapper seam is exhausted

I reran the #12755 scan across the **entire** workspace this time — `crates/`, `src/`, and the repo-root `tests/` tree that the first pass missed. 28 ambient-wrapper candidates, and the only unreachable ones are the five already deleted in #12755. No further dead surface to reclaim; that seam is closed.

## Verification

`nice -n 10 cargo check --workspace --tests -j2` — clean, zero errors and zero warnings. `cargo fmt` applied. `target/` removed.

Two iterations to get there, both the predictable shapes: `E0027` (the struct is destructured, so a new field must be added to the pattern *and* the field access rewritten to the binding) and `E0063` × 10 (hand-built `CheckModeInput` in tests). Those ten tests now resolve once at the top, which is the position the deploy boundary holds in production.

Note #12755 is still open; this PR is independent of it and touches no overlapping files.