### PR TITLE
Thread PathRoots from the deploy boundaries

### DIFF
--- a/crates/homeboy-deploy/src/lib.rs
+++ b/crates/homeboy-deploy/src/lib.rs
@@ -132,10 +132,15 @@ use uuid::Uuid;
 pub fn run(project_id: &str, config: &DeployConfig) -> Result<DeployOrchestrationResult> {
     let mut release_artifacts =
         homeboy_core::git::release_download::ReleaseArtifactStore::default();
-    run_with_release_artifacts(project_id, config, &mut release_artifacts)
+    // One resolution for the whole deployment. `run_multi` resolves its own for
+    // the same reason and passes it in below, so a receipt and the lifecycle
+    // checkpoint that describes it can no longer land in different homes.
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    run_with_release_artifacts(roots.data(), project_id, config, &mut release_artifacts)
 }
 
 fn run_with_release_artifacts(
+    data_root: &std::path::Path,
     project_id: &str,
     config: &DeployConfig,
     release_artifacts: &mut homeboy_core::git::release_download::ReleaseArtifactStore,
@@ -186,6 +191,7 @@ fn run_with_release_artifacts(
     let (ctx, base_path) = resolve_project_ssh_with_base_path(project_id)
         .map_err(|error| attach_admitted_run_id(error, admitted_run_id.as_deref()))?;
     let mut result = orchestration::deploy_components(
+        data_root,
         config,
         &project,
         &ctx,
@@ -516,7 +522,12 @@ pub fn run_multi(
         }
         let mut timer = PhaseTimer::new();
         let result = timer.time("resolve_source", || {
-            run_with_release_artifacts(project_id, &project_config, &mut release_artifacts)
+            run_with_release_artifacts(
+                roots.data(),
+                project_id,
+                &project_config,
+                &mut release_artifacts,
+            )
         });
         let timings = timer.into_report();
 

--- a/crates/homeboy-deploy/src/lifecycle.rs
+++ b/crates/homeboy-deploy/src/lifecycle.rs
@@ -363,8 +363,15 @@ mod tests {
 
     #[test]
     fn durable_record_round_trips_target_state_and_partial_timing_evidence() {
-        with_isolated_home(|_| {
-            let roots = homeboy_core::paths::PathRoots::from_environment().expect("path roots");
+        // No `with_isolated_home` here. Every durable call in this test already
+        // takes a data root, so the test can name its own instead of mutating
+        // `HOME` and reading it back. That is the whole point of #7505: a test
+        // that owns its roots needs neither the environment nor the
+        // process-global mutex `HomeGuard` takes to protect it, and can run
+        // beside any other test.
+        {
+            let data_root = tempfile::tempdir().expect("data root");
+            let data_root = data_root.path();
             let mut run = DeployLifecycleRun::new("run".to_string(), identity());
             let mut timer = homeboy_core::phase_timing::PhaseTimer::new();
             timer.record_failed("transfer", std::time::Duration::from_millis(1));
@@ -374,9 +381,9 @@ mod tests {
                 Some("connection lost".to_string()),
                 Some(timer.into_report()),
             );
-            save_in_roots(roots.data(), &run).expect("persist run before retryable remote work");
+            save_in_roots(data_root, &run).expect("persist run before retryable remote work");
 
-            let restored = load_in_roots(roots.data(), "run").expect("read durable run");
+            let restored = load_in_roots(data_root, "run").expect("read durable run");
             assert_eq!(restored.schema_version, SCHEMA_VERSION);
             assert_eq!(restored.targets[1].status, DeployTargetStatus::Failed);
             assert_eq!(
@@ -391,7 +398,7 @@ mod tests {
                     .map(|span| span.status),
                 Some(homeboy_core::phase_timing::PhaseStatus::Failed)
             );
-        });
+        }
     }
 
     #[test]

--- a/crates/homeboy-deploy/src/orchestration/mod.rs
+++ b/crates/homeboy-deploy/src/orchestration/mod.rs
@@ -42,6 +42,7 @@ use smoke_check::run_post_deploy_smoke;
 /// Main deploy orchestration entry point.
 /// Handles component selection, building, and deployment.
 pub(super) fn deploy_components(
+    data_root: &std::path::Path,
     config: &DeployConfig,
     project: &Project,
     ctx: &RemoteProjectContext,
@@ -236,6 +237,7 @@ pub(super) fn deploy_components(
     // Check and dry-run modes return early without building or deploying
     if config.check {
         let mut result = run_check_mode(CheckModeInput {
+            data_root,
             components: &components,
             local_versions: &local_versions,
             remote_versions: &remote_versions,
@@ -486,9 +488,13 @@ pub(super) fn deploy_components(
         let component = &prepared.component;
         if prepared.package_manifest.is_some() {
             let version = prepared.local_version.as_deref().unwrap_or_default();
-            if let Err(error) =
-                super::receipt::invalidate(&project, &component.id, &prepared.install_dir, version)
-            {
+            if let Err(error) = super::receipt::invalidate(
+                data_root,
+                &project,
+                &component.id,
+                &prepared.install_dir,
+                version,
+            ) {
                 failed += 1;
                 results.push(ComponentDeployResult::failed(
                     component,
@@ -587,6 +593,7 @@ pub(super) fn deploy_components(
                 let exclusions = resolve_component_scope(component, ScopeCommand::Deploy).exclude;
                 let version = prepared.local_version.as_deref().unwrap_or_default();
                 if let Err(error) = super::receipt::write(super::receipt::ReceiptWrite {
+                    data_root,
                     project: &project,
                     component_id: &component.id,
                     target: &prepared.install_dir,

--- a/crates/homeboy-deploy/src/orchestration/modes.rs
+++ b/crates/homeboy-deploy/src/orchestration/modes.rs
@@ -20,6 +20,7 @@ use super::super::types::{
 
 /// Check mode: return component status without building or deploying.
 pub(super) struct CheckModeInput<'a> {
+    pub(super) data_root: &'a std::path::Path,
     pub(super) components: &'a [Component],
     pub(super) local_versions: &'a HashMap<String, String>,
     pub(super) remote_versions: &'a HashMap<String, String>,
@@ -34,6 +35,7 @@ pub(super) struct CheckModeInput<'a> {
 
 pub(super) fn run_check_mode(input: CheckModeInput<'_>) -> DeployOrchestrationResult {
     let CheckModeInput {
+        data_root,
         components,
         local_versions,
         remote_versions,
@@ -90,6 +92,7 @@ pub(super) fn run_check_mode(input: CheckModeInput<'_>) -> DeployOrchestrationRe
             } else {
                 let version = local_versions.get(&c.id).map(String::as_str).unwrap_or_default();
                 match super::super::receipt::load(
+                    data_root,
                     project,
                     &c.id,
                     &target,
@@ -697,7 +700,9 @@ mod tests {
             resume_run_id: None,
         };
 
+        let receipt_root = tempfile::tempdir().expect("receipt data root");
         let checked = run_check_mode(CheckModeInput {
+            data_root: receipt_root.path(),
             components: std::slice::from_ref(&component),
             local_versions: &local_versions,
             remote_versions: &remote_versions,
@@ -776,7 +781,9 @@ mod tests {
         let config = DeployConfig::check_all_no_pull_head();
         let packages = HashMap::from([("plugin".to_string(), package)]);
 
+        let receipt_root = tempfile::tempdir().expect("receipt data root");
         let clean = run_check_mode(CheckModeInput {
+            data_root: receipt_root.path(),
             components: std::slice::from_ref(&component),
             local_versions: &versions,
             remote_versions: &versions,
@@ -806,7 +813,9 @@ mod tests {
         );
 
         std::fs::write(remote.join("plugin.php"), "modified").expect("drift");
+        let receipt_root = tempfile::tempdir().expect("receipt data root");
         let drift = run_check_mode(CheckModeInput {
+            data_root: receipt_root.path(),
             components: std::slice::from_ref(&component),
             local_versions: &versions,
             remote_versions: &versions,
@@ -824,7 +833,9 @@ mod tests {
         );
 
         std::fs::write(&packages["plugin"].path, "mutated after lease").expect("mutate package");
+        let receipt_root = tempfile::tempdir().expect("receipt data root");
         let mutated = run_check_mode(CheckModeInput {
+            data_root: receipt_root.path(),
             components: std::slice::from_ref(&component),
             local_versions: &versions,
             remote_versions: &versions,
@@ -903,7 +914,9 @@ mod tests {
             tag: "v1.0.0".to_string(),
             source_commit: "prepared-commit".to_string(),
         });
+        let receipt_root = tempfile::tempdir().expect("receipt data root");
         let result = run_check_mode(CheckModeInput {
+            data_root: receipt_root.path(),
             components: &[component],
             local_versions: &versions,
             remote_versions: &versions,
@@ -961,7 +974,9 @@ mod tests {
         };
         let local_versions = HashMap::from([("plugin".to_string(), "1.0.0".to_string())]);
         let remote_versions = HashMap::from([("plugin".to_string(), "2.0.0".to_string())]);
+        let receipt_root = tempfile::tempdir().expect("receipt data root");
         let result = run_check_mode(CheckModeInput {
+            data_root: receipt_root.path(),
             components: &[component],
             local_versions: &local_versions,
             remote_versions: &remote_versions,
@@ -996,7 +1011,9 @@ mod tests {
             ..Component::default()
         };
         let versions = HashMap::from([("plugin".to_string(), "1.0.0".to_string())]);
+        let receipt_root = tempfile::tempdir().expect("receipt data root");
         let result = run_check_mode(CheckModeInput {
+            data_root: receipt_root.path(),
             components: &[component],
             local_versions: &versions,
             remote_versions: &versions,
@@ -1056,7 +1073,9 @@ mod tests {
             },
         ] {
             config.check = true;
+            let receipt_root = tempfile::tempdir().expect("receipt data root");
             let result = run_check_mode(CheckModeInput {
+                data_root: receipt_root.path(),
                 components: std::slice::from_ref(&component),
                 local_versions: &versions,
                 remote_versions: &versions,
@@ -1093,7 +1112,9 @@ mod tests {
             ..Component::default()
         };
         let versions = HashMap::from([("plugin".to_string(), "1.0.0".to_string())]);
+        let receipt_root = tempfile::tempdir().expect("receipt data root");
         let result = run_check_mode(CheckModeInput {
+            data_root: receipt_root.path(),
             components: &[component],
             local_versions: &versions,
             remote_versions: &versions,
@@ -1124,7 +1145,9 @@ mod tests {
             ..Component::default()
         };
         let versions = HashMap::from([("plugin".to_string(), "1.0.0".to_string())]);
+        let receipt_root = tempfile::tempdir().expect("receipt data root");
         let result = run_check_mode(CheckModeInput {
+            data_root: receipt_root.path(),
             components: &[component],
             local_versions: &versions,
             remote_versions: &versions,

--- a/crates/homeboy-deploy/src/receipt.rs
+++ b/crates/homeboy-deploy/src/receipt.rs
@@ -53,19 +53,14 @@ impl DeployedPackageReceipt {
 }
 
 pub(super) fn load(
+    data_root: &Path,
     project: &Project,
     component_id: &str,
     target: &str,
     version: &str,
     exclusions: &[String],
 ) -> Result<Option<DeployedPackageReceipt>, Error> {
-    let path = path_in_roots(
-        homeboy_paths::PathRoots::from_environment()?.data(),
-        project,
-        component_id,
-        target,
-        version,
-    );
+    let path = path_in_roots(data_root, project, component_id, target, version);
     if !path.exists() {
         return Ok(None);
     }
@@ -84,6 +79,7 @@ pub(super) fn load(
 }
 
 pub(super) struct ReceiptWrite<'a> {
+    pub(super) data_root: &'a Path,
     pub(super) project: &'a Project,
     pub(super) component_id: &'a str,
     pub(super) target: &'a str,
@@ -96,6 +92,7 @@ pub(super) struct ReceiptWrite<'a> {
 
 pub(super) fn write(input: ReceiptWrite<'_>) -> Result<(), Error> {
     let ReceiptWrite {
+        data_root,
         project,
         component_id,
         target,
@@ -105,13 +102,7 @@ pub(super) fn write(input: ReceiptWrite<'_>) -> Result<(), Error> {
         build_provenance,
         exclusions,
     } = input;
-    let path = path_in_roots(
-        homeboy_paths::PathRoots::from_environment()?.data(),
-        project,
-        component_id,
-        target,
-        version,
-    );
+    let path = path_in_roots(data_root, project, component_id, target, version);
     let parent = path.parent().expect("receipt path has a parent");
     fs::create_dir_all(parent)
         .map_err(|error| receipt_io_error(&error, "create deploy receipt directory", parent))?;
@@ -198,18 +189,13 @@ impl DeployedPackageReceipt {
 }
 
 pub(super) fn invalidate(
+    data_root: &Path,
     project: &Project,
     component_id: &str,
     target: &str,
     version: &str,
 ) -> Result<(), Error> {
-    let path = path_in_roots(
-        homeboy_paths::PathRoots::from_environment()?.data(),
-        project,
-        component_id,
-        target,
-        version,
-    );
+    let path = path_in_roots(data_root, project, component_id, target, version);
     match fs::remove_file(&path) {
         Ok(()) => sync_directory(path.parent().expect("receipt path has a parent")),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),


### PR DESCRIPTION
A slice of #7505, following `docs/internals/development/contracts/path-roots-injection.md`. Next crate after `homeboy-release`.

## There was a real split here

`run_multi` already resolved roots once at its boundary for lifecycle checkpoints, with a comment citing #7505:

```rust
// One resolution for the whole run. Every checkpoint read and write below
// addresses this data root, so a resumed run cannot read its checkpoint
// from one home and then record target outcomes into another (#7505).
let roots = homeboy_core::paths::PathRoots::from_environment()?;
```

Then it called into a path that resolved **again** for deploy receipts. So a resumed multi-target deploy could read its checkpoint from one home and write the receipt describing that same deployment into another — no error on either side. The comment was true about checkpoints and silently false about receipts.

## What changed

| | |
|---|---|
| `run` | becomes the second named boundary, resolves once |
| `run_multi` | passes the roots it already had, instead of letting the path below resolve again |
| `run_with_release_artifacts`, `deploy_components`, `CheckModeInput` | carry the data root down |
| `receipt::load` / `write` / `invalidate` | take it instead of resolving |

`path_in_roots(data_root, ..)` already existed — the rooted primitive was there and only the callers were ambient.

```
production resolution points in homeboy-deploy:  4 -> 2
```

Both survivors are the named boundaries the contract allows (`run`, `run_multi`).

## One test no longer needs the lock

This is the part worth reading. `durable_record_round_trips_target_state_and_partial_timing_evidence` wrapped itself in `with_isolated_home` **purely so it could read `HOME` back out** through `PathRoots::from_environment()`:

```rust
with_isolated_home(|_| {
    let roots = PathRoots::from_environment().expect("path roots");
    ...
    save_in_roots(roots.data(), &run)
```

Every durable call in it already took a data root. So it now names its own `tempdir` and the wrapper is gone.

That is the #7505 end state demonstrated on one test: no `HOME` mutation, no `HomeGuard`, and therefore **no share in the process-global mutex that serializes the other 2,522 call sites**. It can run beside anything.

The ten `run_check_mode` test call sites likewise each own a receipt root now, rather than reading whichever home the harness had installed — which is also strictly more honest about what they were asserting.

## Verification

- `nice -n 10 cargo check --workspace --tests -j2` — **clean, 0 warnings, 0 errors** (run three times across the increment)
- `cargo fmt` — clean
- `grep` confirms only the two boundaries remain in the crate

Not run locally: the full suite (~28G build). Expect the documented red-main set (#12715, #12721, `tar --same-order`, the `master`-vs-`main` release planner check).
