### PR TITLE
fix: an unreaped tunnel reads as live, and a fixture inherits the host's default branch

### DIFF
--- a/crates/homeboy-lab-runner/src/connection_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection_daemon.rs
@@ -310,6 +310,23 @@ fn tunnel_process_identity_matches(
 ) -> bool {
     match (pid, expected) {
         (Some(pid), Some(expected)) => {
+            // An exited process that has not been reaped keeps its `/proc`
+            // entry and its start time, so comparing start identities alone
+            // reports a dead tunnel as live. Homeboy spawns the tunnel itself,
+            // which makes an unreaped zombie the ordinary shape of "the tunnel
+            // died" rather than an edge case: the durability window then failed
+            // as `Unreachable` on the health endpoint instead of the
+            // authoritative `TunnelExited`, and a session whose tunnel was
+            // already gone could be published as live.
+            //
+            // `process_identity_state` reads the state field and reports `Z` as
+            // `Dead`, which is the question actually being asked here.
+            if matches!(
+                homeboy_core::process::process_identity_state(pid, None),
+                homeboy_core::process::ProcessIdentityState::Dead
+            ) {
+                return false;
+            }
             super::capture_tunnel_process_start_identity(Some(pid))
                 .ok()
                 .flatten()
@@ -1349,10 +1366,10 @@ mod tests {
         let Err(failure) = result else {
             panic!("exited tunnel must fail the durability window");
         };
-        assert!(matches!(
-            failure,
-            DaemonHealthProbeFailure::TunnelExited { .. }
-        ));
+        assert!(
+            matches!(failure, DaemonHealthProbeFailure::TunnelExited { .. }),
+            "{failure:?}"
+        );
         assert_eq!(failure_stage(&failure), "tunnel_durability");
         assert!(
             started.elapsed() < Duration::from_secs(5),
@@ -1414,10 +1431,10 @@ mod tests {
             Some(&identity),
         )
         .expect_err("exited tunnel after durability health failure is terminal");
-        assert!(matches!(
-            failure,
-            DaemonHealthProbeFailure::TunnelExited { .. }
-        ));
+        assert!(
+            matches!(failure, DaemonHealthProbeFailure::TunnelExited { .. }),
+            "{failure:?}"
+        );
         assert_eq!(failure_stage(&failure), "tunnel_durability");
         assert!(child.wait().expect("reap tunnel child").success());
         server.join().expect("server");

--- a/crates/homeboy-release/src/release/planner.rs
+++ b/crates/homeboy-release/src/release/planner.rs
@@ -763,7 +763,14 @@ mod tests {
         std::fs::write(dir.join("VERSION"), "1.2.3\n").expect("version");
         std::fs::write(dir.join("package.json"), r#"{"version":"1.2.3"}"#).expect("package");
         std::fs::write(dir.join("CHANGELOG.md"), "# Changelog\n").expect("changelog");
-        git(dir, &["init", "-q"]);
+        // Name the branch explicitly. A bare `git init` takes whatever
+        // `init.defaultBranch` says, which is `master` unless the host
+        // configured otherwise -- so this fixture produced `master` on CI and
+        // `main` only for developers who had set it. The planner then refused:
+        // "Refusing to plan release push from branch 'master' because the repo
+        // default branch is 'main'". The branch under test is part of the
+        // fixture, not of the host's git config.
+        git(dir, &["init", "-q", "-b", "main"]);
         git(dir, &["config", "user.email", "test@example.com"]);
         git(dir, &["config", "user.name", "Test"]);
         git(dir, &["add", "."]);


### PR DESCRIPTION
Three more full-scope failures, two causes. Both reproduce locally, unlike the prune cluster.

---

## 1. `durability_check_rejects_a_tunnel_that_exits_after_apparent_readiness` + `durability_health_failure_rechecks_tunnel_identity`

Both assert `TunnelExited`. Both got:

```
Unreachable { message: "remote daemon health endpoint failed during post-establishment
              durability observation 1",
              attempts: ["… error sending request for url (http://127.0.0.1:37261/health)"] }
```

The recheck after a health failure *was* running (`connection_daemon.rs:281`). It concluded the tunnel was still alive.

### Cause

The fixture spawns `sh -c "sleep 0.05"` and never reaps it. **An exited process that has not been reaped keeps its `/proc` entry and its start time**, so `tunnel_process_identity_matches` compared two identical identities and reported a dead tunnel as live.

Homeboy spawns the tunnel itself, so an unreaped zombie is the *ordinary* shape of "the tunnel died", not an edge case.

This is not only a red test. A session whose tunnel is already gone can be **published as live**, and the durability window blames the health endpoint for it.

### Fix

`process_identity_state` already reads the state field and reports `Z` as `Dead` (`homeboy-core/src/process.rs:405`) — that is exactly the question being asked. Use it before comparing identities. Every other state path is unchanged.

Result: `17 passed; 0 failed` (was 15/2).

---

## 2. `dry_run_plans_reachable_external_release_reconciliation_without_mutation`

```
Refusing to plan release push from branch 'master' because the repo default branch is 'main'
```

The fixture ran a bare `git init -q`, which takes whatever `init.defaultBranch` says — **`master` unless the host configured otherwise**. So it produced `master` on CI and `main` only for developers who had set it.

Named explicitly (`init -q -b main`). The branch under test is part of the fixture, not of the host's git config. A sibling fixture in the same file already does this deliberately with `init -b master`.

Result: `13 passed; 0 failed` (was 12/1).

> Third instance of this family, after `stale_clone` missing a committer identity (#12753). Anything a test fixture takes from global git config is a machine-dependent input.

---

## Diagnostics

Both `matches!` assertions now print the variant they received:

```rust
assert!(matches!(failure, DaemonHealthProbeFailure::TunnelExited { .. }), "{failure:?}");
```

`assert!(matches!(..))` reports only `assertion failed:` and nothing else. The actual failure carried the message, the attempt log and the endpoint — printing it is what made this diagnosable in one run, the same way #12751 cracked #12715.

---

## Verification

`cargo check --workspace --tests -j2` clean, `cargo fmt --check` clean, both target suites green.

## Remaining full-scope red after this

```
homeboy-agents  concurrent_first_cooks_elect_one_recipe_creator_without_replacing_its_plan  (flake)
homeboy-cli     providers_validate_readiness_without_backend_sweeps_every_declared_backend
homeboy-core    legacy_child_recovery_exact_evidence_is_idempotent_and_conflicts_fail_closed
homeboy-lab-runner  evidence::tests::mirroring_lab_job_preserves_agent_task_lifecycle_metadata
```

On the last one I got as far as the cause but not a fix: `run.kind` is `"runner-exec"` where `"agent-task"` is expected. `mirror_job_run` (`evidence/mirror.rs:1056`) only takes the agent-task branch when a run record **already exists in the store carrying `agent_task_run` metadata**; otherwise it falls through to `kind: "runner-exec"` at line 1093. Either the fixture never creates that record or something upstream stopped writing it. Left alone rather than guessed at.