### PR TITLE
Take the rig artifact root from the store it is recorded into

### DIFF
--- a/crates/homeboy-cli/src/commands/runs/common.rs
+++ b/crates/homeboy-cli/src/commands/runs/common.rs
@@ -46,17 +46,34 @@ pub fn run_summaries_with_artifact_indexes(
         .map(|run| run.id.clone())
         .collect::<Vec<_>>();
     let mut artifacts_by_run = store.list_artifacts_for_runs(&rig_run_ids)?;
+    // These indexes are rendered as operator retrieval commands, so they must
+    // name the home the records were listed from rather than whatever the
+    // environment points at (#7505).
+    let artifact_root = store
+        .roots()
+        .map(|roots| roots.artifacts().to_path_buf())
+        .or_else(|| {
+            homeboy::core::paths::PathRoots::from_environment()
+                .ok()
+                .map(|roots| roots.artifacts().to_path_buf())
+        });
     Ok(run_records
         .into_iter()
         .map(|run| {
             let artifacts = artifacts_by_run.remove(&run.id).unwrap_or_default();
-            run_summary_with_artifact_index(run, &artifacts)
+            run_summary_with_artifact_index(artifact_root.as_deref(), run, &artifacts)
         })
         .collect())
 }
 
-fn run_summary_with_artifact_index(run: RunRecord, artifacts: &[ArtifactRecord]) -> RunSummary {
-    let artifact_index = homeboy::rig::artifact_index_for_run_with_artifacts(&run, artifacts);
+fn run_summary_with_artifact_index(
+    artifact_root: Option<&std::path::Path>,
+    run: RunRecord,
+    artifacts: &[ArtifactRecord],
+) -> RunSummary {
+    let artifact_index = artifact_root.and_then(|artifact_root| {
+        homeboy::rig::artifact_index_for_run_with_artifacts_in_roots(artifact_root, &run, artifacts)
+    });
     RunSummary {
         artifact_index,
         ..super::run_summary(run)

--- a/crates/homeboy-rig/src/artifact_index.rs
+++ b/crates/homeboy-rig/src/artifact_index.rs
@@ -53,8 +53,19 @@ pub fn for_completed_rig_run(
     status: &str,
     pipeline: Option<&PipelineOutcome>,
 ) -> Option<RigRunArtifactIndex> {
-    let roots = homeboy_core::paths::PathRoots::from_environment().ok()?;
-    for_completed_rig_run_in_roots(roots.artifacts(), store, rig, run_id, status, pipeline)
+    // The index file lands under the artifact root and its path is then
+    // recorded *into* `store`. Take the root the store was opened against so
+    // the file and the row describing it cannot name different homes; only an
+    // ambiently-opened store has no better answer than the environment (#7505).
+    let ambient;
+    let artifact_root = match store.roots() {
+        Some(roots) => roots.artifacts(),
+        None => {
+            ambient = homeboy_core::paths::PathRoots::from_environment().ok()?;
+            ambient.artifacts()
+        }
+    };
+    for_completed_rig_run_in_roots(artifact_root, store, rig, run_id, status, pipeline)
 }
 
 /// [`for_completed_rig_run`] against an explicitly injected artifact root.
@@ -103,23 +114,22 @@ pub fn for_run(store: &ObservationStore, run: &RunRecord) -> Option<RigRunArtifa
         return None;
     }
     let artifacts = store.list_artifacts(&run.id).unwrap_or_default();
-    for_run_with_artifacts(run, &artifacts)
+    // Same store, same root: the paths this renders are handed to operators as
+    // retrieval commands, so they must name the home the records came from.
+    let ambient;
+    let artifact_root = match store.roots() {
+        Some(roots) => roots.artifacts(),
+        None => {
+            ambient = homeboy_core::paths::PathRoots::from_environment().ok()?;
+            ambient.artifacts()
+        }
+    };
+    for_run_with_artifacts_in_roots(artifact_root, run, &artifacts)
 }
 
-pub fn for_run_with_artifacts(
-    run: &RunRecord,
-    artifacts: &[ArtifactRecord],
-) -> Option<RigRunArtifactIndex> {
-    // Guard before resolving. This is called once per run while rendering a
-    // run listing, and the ambient form only reached the artifact root after
-    // rejecting non-rig runs; resolving first would put three environment
-    // reads on every non-rig row.
-    if run.rig_id.is_none() || run.kind != "rig" {
-        return None;
-    }
-    let roots = homeboy_core::paths::PathRoots::from_environment().ok()?;
-    for_run_with_artifacts_in_roots(roots.artifacts(), run, artifacts)
-}
+// The ambient `for_run_with_artifacts()` shim that used to sit here is gone.
+// `for_run` was its only caller and now passes the root its store was opened
+// against (#7505).
 
 /// [`for_run_with_artifacts`] against an explicitly injected artifact root.
 ///

--- a/crates/homeboy-rig/src/dependency_materialization_cache.rs
+++ b/crates/homeboy-rig/src/dependency_materialization_cache.rs
@@ -414,15 +414,13 @@ impl DependencyMaterializationCache {
     }
 }
 
-/// Durable root shared by local and runner-side Homeboy processes. Lab invokes
-/// the same rig materialization contract on the runner outside its workspace.
-pub fn cache_root() -> Result<PathBuf> {
-    Ok(cache_root_in_roots(
-        homeboy_paths::PathRoots::from_environment()?.data(),
-    ))
-}
+// The ambient `cache_root()` shim that used to sit here is gone. Its only
+// caller was the rig resource-lifecycle index, which now derives the root from
+// the observation store the index is recorded into (#7505).
 
-/// [`cache_root`] below an explicitly injected data root.
+/// Durable root shared by local and runner-side Homeboy processes, below an
+/// explicitly injected data root. Lab invokes the same rig materialization
+/// contract on the runner outside its workspace.
 pub fn cache_root_in_roots(data_root: &Path) -> PathBuf {
     data_root
         .join("cache")

--- a/crates/homeboy-rig/src/lib.rs
+++ b/crates/homeboy-rig/src/lib.rs
@@ -50,8 +50,8 @@ mod rig_test_support;
 pub use app::{AppLauncherAction, AppLauncherOptions, AppLauncherReport};
 pub use artifact_index::{
     for_run as artifact_index_for_run,
-    for_run_with_artifacts as artifact_index_for_run_with_artifacts, RigRunArtifactIndex,
-    RigRunArtifactRef, RigRunFailedStepRef,
+    for_run_with_artifacts_in_roots as artifact_index_for_run_with_artifacts_in_roots,
+    RigRunArtifactIndex, RigRunArtifactRef, RigRunFailedStepRef,
 };
 pub use capabilities::{
     evaluate_requirements, plan_requirement_checks, runner_capability_preflight,

--- a/crates/homeboy-rig/src/runner.rs
+++ b/crates/homeboy-rig/src/runner.rs
@@ -1508,7 +1508,22 @@ impl RigRunObserver {
         }
         let mut index = rig_resource_lifecycle_index(&rig.id, &resources, options.clone());
         if cache_enabled {
-            if let Ok(root) = super::dependency_materialization_cache::cache_root() {
+            // The cache root belongs to the same home as the store this index
+            // is recorded into; only an ambiently-opened store falls back.
+            let ambient;
+            let data_root = match self.store.roots() {
+                Some(roots) => Some(roots.data()),
+                None => match homeboy_core::paths::PathRoots::from_environment() {
+                    Ok(roots) => {
+                        ambient = roots;
+                        Some(ambient.data())
+                    }
+                    Err(_) => None,
+                },
+            };
+            if let Some(root) =
+                data_root.map(super::dependency_materialization_cache::cache_root_in_roots)
+            {
                 index
                     .resources
                     .push(dependency_materialization_cache_lifecycle_record(


### PR DESCRIPTION
A slice of #7505, per `docs/internals/development/contracts/path-roots-injection.md`. Third crate after `homeboy-release` and `homeboy-deploy` (#12759).

## The split

`homeboy-rig` writes index files under the artifact root and then records those same paths **into** an `ObservationStore`. It resolved the root from the environment with no reference to whichever home the store was opened against.

A caller holding a rooted store therefore indexed files that store's home does not contain — and neither half fails while doing it. The file writes fine, the row writes fine, they just describe different worlds.

## The blocker was stale documentation

`for_completed_rig_run_in_roots` carried this doc:

> *"`ObservationStore` does not expose the roots it resolved, so the ambient wrapper above is currently the only production caller; closing that half..."*

`ObservationStore::roots()` **already exists** (`observation/store/runs.rs:257`), with a doc that describes exactly this use case:

> *"This is what lets a caller holding its own `PathRoots` ask the store which roots it is actually indexing against, rather than independently re-resolving the ambient ones and silently comparing two different worlds (#7505)."*

The rooted halves were written and left unused because of a note that had stopped being true. Every caller converted here had the store in hand the whole time.

> I found this by adding the accessor myself and getting `E0592: duplicate definitions with name 'roots'`. The existing one has a better doc than the one I wrote; mine is gone and this PR touches no `homeboy-core` code.

## What changed

| | |
|---|---|
| `for_completed_rig_run` | takes the root from the store it writes into |
| `for_run` | same, and passes it down — took the last caller of `for_run_with_artifacts`, **pair collapsed** |
| rig resource-lifecycle index | derives the cache root from `self.store` — took the last caller of `cache_root`, **pair collapsed** |
| CLI run listing | threads the root from the store it listed records from, so retrieval commands name the right home |

## Count delta — flat, and that is the honest number

```
PathRoots::from_environment() in homeboy-rig:   4 -> 4
```

Three of the four are now reached **only when `store.roots()` is `None`** — an ambiently-opened store, which genuinely has no better answer. A rooted store never reaches them. Two functions are deleted.

So the counter does not move, but the defect does: the artifact root can no longer disagree with the store recording it.

## Deliberately not converted

`DependencyMaterializationCache::new` — its caller `materialize_dependency_step(rig, step, settings)` has no store and no roots. Rooting it means threading from further up the rig runner, which is a separate change. Converting it here would have meant inventing a root at a non-boundary, which is the thing the contract forbids.

## Verification

- `nice -n 10 cargo check --workspace --tests -j2` — **clean, 0 warnings, 0 errors**
- `cargo fmt` — clean
- `git diff crates/homeboy-core/` — empty

### A grep hazard worth recording

`for_run_with_artifacts` looked like it had one caller. It had two: `homeboy-cli` reaches it through a **renamed re-export** (`for_run_with_artifacts as artifact_index_for_run_with_artifacts`), which no search for the original name finds. The gate caught it as `E0432` after I deleted the function. Aliased re-exports hide callers — worth checking `pub use ... as ...` before concluding a function is unreferenced.
