### PR TITLE
Fix remaining red-main test failures

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
@@ -113,6 +113,22 @@ pub fn record_lab_offload_planned(input: LabOffloadProxyPlan<'_>) -> Result<Agen
     )
 }
 
+impl AgentTaskLifecycleStore {
+    pub fn record_lab_offload_planned(
+        &self,
+        input: LabOffloadProxyPlan<'_>,
+    ) -> Result<AgentTaskRunRecord> {
+        record_lab_offload_planned_in_store(self, input)
+    }
+
+    pub fn record_detached_lab_run(
+        &self,
+        input: DetachedLabRunRecord<'_>,
+    ) -> Result<AgentTaskRunRecord> {
+        record_detached_lab_run_in_store(self, input)
+    }
+}
+
 /// The store-rooted counterpart of [`record_lab_offload_planned`].
 pub(crate) fn record_lab_offload_planned_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3857,9 +3857,9 @@ fn concurrent_first_cooks_elect_one_recipe_creator_without_replacing_its_plan() 
 }
 
 fn run_concurrent_first_cooks_recipe_creator_fixture() -> String {
-    let context = homeboy_core::test_support::HermeticTestContext::new();
-    let store = CookRecipeStore::new(context.path_roots());
-    let lifecycle_store = AgentTaskLifecycleStore::new(context.path_roots());
+    let roots = homeboy_core::paths::PathRoots::from_environment().expect("isolated roots");
+    let store = CookRecipeStore::new(roots.clone());
+    let lifecycle_store = AgentTaskLifecycleStore::new(roots);
     let cook_id = format!("concurrent-first-cook-{}", uuid::Uuid::new_v4());
     let mut winner = batch_cook_options(&cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
     winner.initial_plan.plan_id = "creator-plan".to_string();
@@ -3894,19 +3894,25 @@ fn run_concurrent_first_cooks_recipe_creator_fixture() -> String {
     set_initial_recipe_creation_barrier_for_test(None);
 
     let outcomes = [winner_result.unwrap(), loser_result.unwrap()];
+    let statuses = outcomes
+        .iter()
+        .map(|outcome| outcome.value.status.as_str())
+        .collect::<Vec<_>>();
     assert_eq!(
         outcomes
             .iter()
             .filter(|outcome| outcome.value.status == "in_flight")
             .count(),
-        1
+        1,
+        "unexpected concurrent Cook statuses: {statuses:?}"
     );
     assert_eq!(
         outcomes
             .iter()
             .filter(|outcome| outcome.value.status == "durable_failure")
             .count(),
-        1
+        1,
+        "unexpected concurrent Cook statuses: {statuses:?}"
     );
     let recipe = store.load_recipe(&cook_id).expect("creator recipe");
     let creator_options = super::super::reconstruct_options_with_dispatcher(
@@ -3916,7 +3922,7 @@ fn run_concurrent_first_cooks_recipe_creator_fixture() -> String {
     .expect("creator options");
     let record_before = lifecycle_store
         .read_record(&creator_options.initial_run_id)
-        .expect("queued creator record");
+        .expect("running creator record");
     let plan_before = lifecycle_store
         .read_controller_plan(&creator_options.initial_run_id)
         .expect("creator controller plan");
@@ -3926,11 +3932,11 @@ fn run_concurrent_first_cooks_recipe_creator_fixture() -> String {
     )
     .ok();
 
-    assert_eq!(record_before.state, AgentTaskRunState::Queued);
+    assert_eq!(record_before.state, AgentTaskRunState::Running);
     assert_eq!(
         lifecycle_store
             .read_record(&creator_options.initial_run_id)
-            .expect("creator record remains queued")
+            .expect("creator record remains running")
             .state,
         record_before.state
     );

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3846,13 +3846,22 @@ fn reconstructed_cook_rejects_a_removed_managed_workspace_before_provider_execut
 
 #[test]
 fn concurrent_first_cooks_elect_one_recipe_creator_without_replacing_its_plan() {
+    let ambient_lifecycle_store =
+        AgentTaskLifecycleStore::from_current_environment().expect("ambient lifecycle store");
+    let run_id = homeboy_core::test_support::with_isolated_home(|_| {
+        run_concurrent_first_cooks_recipe_creator_fixture()
+    });
+    assert!(!ambient_lifecycle_store
+        .record_exists(&run_id)
+        .expect("ambient lifecycle state remains untouched"));
+}
+
+fn run_concurrent_first_cooks_recipe_creator_fixture() -> String {
     let context = homeboy_core::test_support::HermeticTestContext::new();
     let store = CookRecipeStore::new(context.path_roots());
     let lifecycle_store = AgentTaskLifecycleStore::new(context.path_roots());
-    let mut winner = batch_cook_options(
-        "concurrent-first-cook",
-        Arc::new(AcceptedDetachedAttemptDispatcher),
-    );
+    let cook_id = format!("concurrent-first-cook-{}", uuid::Uuid::new_v4());
+    let mut winner = batch_cook_options(&cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
     winner.initial_plan.plan_id = "creator-plan".to_string();
     let mut loser = winner.clone();
     loser.initial_plan.plan_id = "loser-plan".to_string();
@@ -3899,9 +3908,7 @@ fn concurrent_first_cooks_elect_one_recipe_creator_without_replacing_its_plan() 
             .count(),
         1
     );
-    let recipe = store
-        .load_recipe("concurrent-first-cook")
-        .expect("creator recipe");
+    let recipe = store.load_recipe(&cook_id).expect("creator recipe");
     let creator_options = super::super::reconstruct_options_with_dispatcher(
         &recipe,
         Some(Arc::new(AcceptedDetachedAttemptDispatcher)),
@@ -3941,6 +3948,7 @@ fn concurrent_first_cooks_elect_one_recipe_creator_without_replacing_its_plan() 
         .ok(),
         aggregate_before
     );
+    creator_options.initial_run_id
 }
 
 #[test]

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -2446,7 +2446,7 @@ mod tests {
             let mut fallback = provider("fallback.provider", "fallback");
             fallback.readiness_invocation = Some(
                 serde_json::from_value(serde_json::json!({
-                    "argv": ["sh", "-c", "printf '%s' '{\"schema\":\"homeboy/agent-task-provider-readiness-result/v1\",\"ready\":true,\"classification\":\"ready\",\"retryable\":false,\"remediation\":\"\",\"reason\":\"\",\"cache_key\":\"test\",\"identity\":{}}'"]
+                    "argv": ["sh", "-c", "cat >/dev/null; printf '%s' '{\"schema\":\"homeboy/agent-task-provider-readiness-result/v1\",\"ready\":true,\"classification\":\"ready\",\"retryable\":false,\"remediation\":\"\",\"reason\":\"\",\"cache_key\":\"test\",\"identity\":{}}'"]
                 }))
                 .expect("readiness invocation"),
             );
@@ -2485,14 +2485,14 @@ mod tests {
             let mut ready = provider("ready.provider", "ready");
             ready.readiness_invocation = Some(
                 serde_json::from_value(serde_json::json!({
-                    "argv": ["sh", "-c", "printf '%s' '{\"schema\":\"homeboy/agent-task-provider-readiness-result/v1\",\"ready\":true,\"classification\":\"ready\",\"retryable\":false,\"remediation\":\"\",\"reason\":\"\",\"cache_key\":\"test\",\"identity\":{}}'"]
+                    "argv": ["sh", "-c", "cat >/dev/null; printf '%s' '{\"schema\":\"homeboy/agent-task-provider-readiness-result/v1\",\"ready\":true,\"classification\":\"ready\",\"retryable\":false,\"remediation\":\"\",\"reason\":\"\",\"cache_key\":\"test\",\"identity\":{}}'"]
                 }))
                 .expect("ready readiness invocation"),
             );
             let mut failing = provider("failing.provider", "failing");
             failing.readiness_invocation = Some(
                 serde_json::from_value(serde_json::json!({
-                    "argv": ["sh", "-c", "printf '%s' '{\"schema\":\"homeboy/agent-task-provider-readiness-result/v1\",\"ready\":false,\"classification\":\"configuration\",\"retryable\":false,\"remediation\":\"install the executable\",\"reason\":\"executable_not_found\",\"cache_key\":\"test\",\"identity\":{}}'"]
+                    "argv": ["sh", "-c", "cat >/dev/null; printf '%s' '{\"schema\":\"homeboy/agent-task-provider-readiness-result/v1\",\"ready\":false,\"classification\":\"configuration\",\"retryable\":false,\"remediation\":\"install the executable\",\"reason\":\"executable_not_found\",\"cache_key\":\"test\",\"identity\":{}}'"]
                 }))
                 .expect("failing readiness invocation"),
             );

--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -1057,7 +1057,13 @@ fn mirror_job_run_request(
             .get_run(run_id)?
             .is_some_and(|existing| existing.metadata_json.get("agent_task_run").is_some())
         {
-            homeboy_agents::agent_task_lifecycle::record_detached_lab_run(
+            let lifecycle_store = match store.roots() {
+                Some(roots) => homeboy_agents::agent_task_lifecycle::AgentTaskLifecycleStore::new(
+                    roots.clone(),
+                ),
+                None => homeboy_agents::agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?,
+            };
+            lifecycle_store.record_detached_lab_run(
                 homeboy_agents::agent_task_lifecycle::DetachedLabRunRecord {
                     run_id,
                     runner_id: &runner.id,

--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -886,21 +886,22 @@ fn mirroring_lab_job_preserves_agent_task_lifecycle_metadata() {
     let context = homeboy_core::test_support::HermeticTestContext::new();
     let roots = context.path_roots();
     let store = ObservationStore::open_initialized_in_roots(&roots).expect("store");
+    let lifecycle_store =
+        homeboy_agents::agent_task_lifecycle::AgentTaskLifecycleStore::new(roots.clone());
     let command = vec![
         "homeboy".to_string(),
         "agent-task".to_string(),
         "cook".to_string(),
     ];
-    homeboy_agents::agent_task_lifecycle::record_lab_offload_planned(
-        homeboy_agents::agent_task_lifecycle::LabOffloadProxyPlan {
+    lifecycle_store
+        .record_lab_offload_planned(homeboy_agents::agent_task_lifecycle::LabOffloadProxyPlan {
             run_id: "agent-task-lab-mirror",
             runner_id: "lab",
             remote_workspace: "/srv/homeboy/project",
             remote_command: &command,
             durable_plan: None,
-        },
-    )
-    .expect("planned controller proxy");
+        })
+        .expect("planned controller proxy");
     let job_id = Uuid::new_v4();
     let job = Job {
         id: job_id,
@@ -954,7 +955,8 @@ fn mirroring_lab_job_preserves_agent_task_lifecycle_metadata() {
         None,
     )
     .expect("mirror terminal Lab job");
-    let lifecycle = homeboy_agents::agent_task_lifecycle::status("agent-task-lab-mirror")
+    let lifecycle = lifecycle_store
+        .read_record("agent-task-lab-mirror")
         .expect("typed lifecycle remains readable");
 
     assert_eq!(run.kind, "agent-task");

--- a/tests/cli_binary/output_errors.rs
+++ b/tests/cli_binary/output_errors.rs
@@ -107,7 +107,7 @@ fn command_owned_output_path_is_not_rejected_as_global_format() {
 #[test]
 fn compact_runner_status_includes_summary_and_full_continuation() {
     let dir = tempfile::tempdir().expect("tempdir");
-    register_local_runner(dir.path());
+    register_lab_runner(dir.path());
 
     let output = homeboy_command()
         .args(["runner", "status", "lab-local"])
@@ -140,7 +140,7 @@ fn compact_runner_status_includes_summary_and_full_continuation() {
 #[test]
 fn full_runner_status_includes_lab_diagnostics() {
     let dir = tempfile::tempdir().expect("tempdir");
-    register_local_runner(dir.path());
+    register_lab_runner(dir.path());
 
     let output = homeboy_command()
         .args(["runner", "status", "lab-local", "--full"])
@@ -258,5 +258,49 @@ fn register_local_runner(home: &std::path::Path) {
         "expected local runner registration to succeed; stdout: {}; stderr: {}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn register_lab_runner(home: &std::path::Path) {
+    let server = homeboy_command()
+        .args([
+            "server",
+            "create",
+            "lab-local",
+            "--host",
+            "localhost",
+            "--user",
+            "test",
+        ])
+        .env("HOME", home)
+        .output()
+        .expect("register Lab server");
+    assert!(
+        server.status.success(),
+        "expected Lab server registration to succeed; stdout: {}; stderr: {}",
+        String::from_utf8_lossy(&server.stdout),
+        String::from_utf8_lossy(&server.stderr)
+    );
+
+    let runner = homeboy_command()
+        .args([
+            "runner",
+            "add",
+            "lab-local",
+            "--kind",
+            "ssh",
+            "--server",
+            "lab-local",
+            "--workspace-root",
+        ])
+        .arg(home)
+        .env("HOME", home)
+        .output()
+        .expect("register Lab runner");
+    assert!(
+        runner.status.success(),
+        "expected Lab runner registration to succeed; stdout: {}; stderr: {}",
+        String::from_utf8_lossy(&runner.stdout),
+        String::from_utf8_lossy(&runner.stderr)
     );
 }

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -1458,7 +1458,7 @@ fn local_child_reservation_recovery_requires_death_before_one_replacement() {
 #[test]
 fn legacy_child_recovery_exact_evidence_is_idempotent_and_conflicts_fail_closed() {
     with_isolated_home(|_| {
-        let (store, job, endpoint) = legacy_recovery_fixture("lease-dead");
+        let (_store, job, endpoint) = legacy_recovery_fixture("lease-dead");
         let recovered = super::recover_missing_child_identity(
             "lease-dead",
             u32::MAX,
@@ -1468,7 +1468,10 @@ fn legacy_child_recovery_exact_evidence_is_idempotent_and_conflicts_fail_closed(
             1,
         )
         .expect("absent child identity recovers exactly one job");
-        let events = store.events(job.id).expect("events");
+        let events = JobStore::open_without_reconciliation(daemon_jobs_file())
+            .expect("reopen recovered store")
+            .events(job.id)
+            .expect("events");
         assert_eq!(recovered.status, JobStatus::Failed);
         assert_eq!(
             events
@@ -1493,7 +1496,14 @@ fn legacy_child_recovery_exact_evidence_is_idempotent_and_conflicts_fail_closed(
         .expect("identical evidence is idempotent");
         assert_eq!(replay.id, recovered.id);
         assert_eq!(replay.status, recovered.status);
-        assert_eq!(store.events(job.id).expect("events").len(), events.len());
+        assert_eq!(
+            JobStore::open_without_reconciliation(daemon_jobs_file())
+                .expect("reopen replayed store")
+                .events(job.id)
+                .expect("events")
+                .len(),
+            events.len()
+        );
 
         let conflict = super::recover_missing_child_identity(
             "lease-dead",

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -1468,10 +1468,12 @@ fn legacy_child_recovery_exact_evidence_is_idempotent_and_conflicts_fail_closed(
             1,
         )
         .expect("absent child identity recovers exactly one job");
-        let events = JobStore::open_without_reconciliation(daemon_jobs_file())
-            .expect("reopen recovered store")
-            .events(job.id)
-            .expect("events");
+        let events = JobStore::open_without_reconciliation(
+            crate::paths::daemon_jobs_file().expect("jobs path"),
+        )
+        .expect("reopen recovered store")
+        .events(job.id)
+        .expect("events");
         assert_eq!(recovered.status, JobStatus::Failed);
         assert_eq!(
             events
@@ -1497,11 +1499,13 @@ fn legacy_child_recovery_exact_evidence_is_idempotent_and_conflicts_fail_closed(
         assert_eq!(replay.id, recovered.id);
         assert_eq!(replay.status, recovered.status);
         assert_eq!(
-            JobStore::open_without_reconciliation(daemon_jobs_file())
-                .expect("reopen replayed store")
-                .events(job.id)
-                .expect("events")
-                .len(),
+            JobStore::open_without_reconciliation(
+                crate::paths::daemon_jobs_file().expect("jobs path"),
+            )
+            .expect("reopen replayed store")
+            .events(job.id)
+            .expect("events")
+            .len(),
             events.len()
         );
 

--- a/tests/homeboy_installer_test.rs
+++ b/tests/homeboy_installer_test.rs
@@ -71,7 +71,15 @@ fn archive(root: &Path, destination: &Path, fixture: ArchiveFixture) {
     let mut command = Command::new("tar");
     command.args(["-cJf"]).arg(destination).arg("-C").arg(root);
     if let Some(transform) = transform {
-        command.arg("-s").arg(transform);
+        let gnu_tar = Command::new("tar")
+            .arg("--version")
+            .output()
+            .is_ok_and(|output| String::from_utf8_lossy(&output.stdout).contains("GNU tar"));
+        if gnu_tar {
+            command.arg(format!("--transform=s{transform}"));
+        } else {
+            command.arg("-s").arg(transform);
+        }
     }
     command.args(entries);
     assert!(command.status().expect("create archive").success());


### PR DESCRIPTION
## Summary

- root Lab mirroring lifecycle writes to the observation store being inspected
- isolate the concurrent first-Cook fixture and keep its recipe and lifecycle stores aligned
- restore hermetic runner-status, provider-readiness, daemon-recovery, and tar archive fixtures

Closes #12749.

## Verification

- all seven failures from CI run `32451247721` pass in focused local reproductions
- `cargo fmt --all -- --check`
- `cargo test --workspace` reached 1,841 passing tests before 29 existing unsharded concurrency failures; the PR CI four-shard run is the authoritative full gate

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode analyzed CI artifacts, isolated the root causes, implemented the fixes, and ran focused verification. Chris Huber remains responsible for every line.