### PR TITLE
refactor(rig): index artifacts against the store's own root (#7505)

### DIFF
--- a/crates/homeboy-cli/src/commands/runs/common.rs
+++ b/crates/homeboy-cli/src/commands/runs/common.rs
@@ -46,17 +46,27 @@ pub fn run_summaries_with_artifact_indexes(
         .map(|run| run.id.clone())
         .collect::<Vec<_>>();
     let mut artifacts_by_run = store.list_artifacts_for_runs(&rig_run_ids)?;
+    // Resolved once for the whole listing, from the store being listed. The
+    // ambient form resolved per row and guarded first to keep that affordable;
+    // asking the store once removes the per-row cost and the disagreement
+    // between the listing's home and the store's (#7505).
+    let artifact_root = store.artifact_root()?;
     Ok(run_records
         .into_iter()
         .map(|run| {
             let artifacts = artifacts_by_run.remove(&run.id).unwrap_or_default();
-            run_summary_with_artifact_index(run, &artifacts)
+            run_summary_with_artifact_index(&artifact_root, run, &artifacts)
         })
         .collect())
 }
 
-fn run_summary_with_artifact_index(run: RunRecord, artifacts: &[ArtifactRecord]) -> RunSummary {
-    let artifact_index = homeboy::rig::artifact_index_for_run_with_artifacts(&run, artifacts);
+fn run_summary_with_artifact_index(
+    artifact_root: &std::path::Path,
+    run: RunRecord,
+    artifacts: &[ArtifactRecord],
+) -> RunSummary {
+    let artifact_index =
+        homeboy::rig::artifact_index_for_run_with_artifacts(artifact_root, &run, artifacts);
     RunSummary {
         artifact_index,
         ..super::run_summary(run)

--- a/crates/homeboy-rig/src/artifact_index.rs
+++ b/crates/homeboy-rig/src/artifact_index.rs
@@ -46,6 +46,18 @@ pub struct RigRunFailedStepRef {
     pub error: Option<String>,
 }
 
+/// Write the rig artifact index for a finished run, under the artifact root
+/// that `store` itself indexes against.
+///
+/// This function writes the index file under an artifact root and then records
+/// that same path *into* `store`, so the two must be the same home. It used to
+/// resolve the root from ambient process state with no reference to whichever
+/// home `store` was opened against, which meant a caller holding a non-ambient
+/// store indexed a file that store's home does not contain.
+///
+/// `ObservationStore::artifact_root` is the authority: injected roots answer
+/// directly, and an ambiently-opened store answers with the ambient root it
+/// was already using. Asking the store cannot disagree with the store (#7505).
 pub fn for_completed_rig_run(
     store: &ObservationStore,
     rig: &RigSpec,
@@ -53,30 +65,8 @@ pub fn for_completed_rig_run(
     status: &str,
     pipeline: Option<&PipelineOutcome>,
 ) -> Option<RigRunArtifactIndex> {
-    let roots = homeboy_core::paths::PathRoots::from_environment().ok()?;
-    for_completed_rig_run_in_roots(roots.artifacts(), store, rig, run_id, status, pipeline)
-}
-
-/// [`for_completed_rig_run`] against an explicitly injected artifact root.
-///
-/// The injection point exists because this function writes the index file
-/// under the artifact root and then records that same path *into* `store`. The
-/// ambient form resolved the root with no reference to whichever home `store`
-/// was opened against, so a caller holding a non-ambient store would index a
-/// file that store's home does not contain. Callers that own both should pass
-/// the root the store was opened with.
-///
-/// `ObservationStore` does not expose the roots it resolved, so the ambient
-/// wrapper above is currently the only production caller; closing that half
-/// needs `homeboy-core` (#7505).
-pub fn for_completed_rig_run_in_roots(
-    artifact_root: &Path,
-    store: &ObservationStore,
-    rig: &RigSpec,
-    run_id: &str,
-    status: &str,
-    pipeline: Option<&PipelineOutcome>,
-) -> Option<RigRunArtifactIndex> {
+    let artifact_root = store.artifact_root().ok()?;
+    let artifact_root = artifact_root.as_path();
     let run_artifact_root = artifact_root.join(run_id);
     let artifact_index_path = run_artifact_root.join("rig-artifact-index.json");
     let artifacts = store.list_artifacts(run_id).unwrap_or_default();
@@ -103,32 +93,25 @@ pub fn for_run(store: &ObservationStore, run: &RunRecord) -> Option<RigRunArtifa
         return None;
     }
     let artifacts = store.list_artifacts(&run.id).unwrap_or_default();
-    for_run_with_artifacts(run, &artifacts)
+    // The store knows which home it indexes; re-resolving here is how a
+    // listing ends up naming another home's index path (#7505).
+    for_run_with_artifacts(&store.artifact_root().ok()?, run, &artifacts)
 }
 
-pub fn for_run_with_artifacts(
-    run: &RunRecord,
-    artifacts: &[ArtifactRecord],
-) -> Option<RigRunArtifactIndex> {
-    // Guard before resolving. This is called once per run while rendering a
-    // run listing, and the ambient form only reached the artifact root after
-    // rejecting non-rig runs; resolving first would put three environment
-    // reads on every non-rig row.
-    if run.rig_id.is_none() || run.kind != "rig" {
-        return None;
-    }
-    let roots = homeboy_core::paths::PathRoots::from_environment().ok()?;
-    for_run_with_artifacts_in_roots(roots.artifacts(), run, artifacts)
-}
-
-/// [`for_run_with_artifacts`] against an explicitly injected artifact root.
+/// Report where an already-recorded run's index lives, under an explicitly
+/// supplied artifact root.
+///
+/// The caller resolves once and reuses it across a listing. The ambient form
+/// this replaced guarded before resolving precisely because it was called per
+/// row; a root passed in from above removes the per-row resolution entirely
+/// rather than merely deferring it.
 ///
 /// Read-only: this reports where the index for an already-recorded run lives.
 /// It is rooted anyway because the paths it renders are handed to operators as
 /// retrieval commands, and a report naming one home's index while the records
 /// came from another is exactly the kind of quiet disagreement #7505 exists to
 /// remove.
-pub fn for_run_with_artifacts_in_roots(
+pub fn for_run_with_artifacts(
     artifact_root: &Path,
     run: &RunRecord,
     artifacts: &[ArtifactRecord],


### PR DESCRIPTION
I went in to make `ObservationStore.roots` non-optional, because `artifact_index.rs` carried a comment saying it was blocked on core:

> `ObservationStore` does not expose the roots it resolved, so the ambient wrapper above is currently the only production caller; **closing that half needs `homeboy-core`** (#7505).

**That comment is stale, and core needed no change at all.**

`ObservationStore::artifact_root()` is already public. Injected roots answer directly; an ambiently-opened store answers with the ambient root it was already using. **Asking the store cannot disagree with the store** — which is the entire point.

## The bug this closes

`for_completed_rig_run` writes the index file under an artifact root and then records *that same path* into the store:

```rust
write_index_file(&artifact_index_path, &index);
store.record_artifact(run_id, "rig_artifact_index", &artifact_index_path)
```

It resolved that root from ambient process state with **no reference to whichever home `store` was opened against**. A caller holding a non-ambient store therefore indexed a file that store's home does not contain — the store's records point at a path in another installation.

## The change

Both ambient wrappers gone; both rooted siblings take the plain name:

| function | root now comes from |
|---|---|
| `for_completed_rig_run` | its own `store` parameter |
| `for_run_with_artifacts` | the caller that resolved once |

`for_run` already held the store and now hands its root down instead of re-resolving.

On the CLI side, `run_summary_with_artifact_index` runs **once per row** of a run listing. The ambient form guarded before resolving specifically to keep that affordable:

> *"resolving first would put three environment reads on every non-rig row"*

The root is now resolved **once for the whole listing**, from the store being listed. That removes the per-row cost rather than deferring it, so the guard is no longer load-bearing.

**Ambient resolution points in `homeboy-rig/artifact_index.rs`: 2 → 0.**

## Correction for the campaign

Making `ObservationStore.roots` non-optional is **not** the unlock it appeared to be. Constructor usage:

| constructor | call sites |
|---|---|
| `open_initialized()` (ambient) | **504** |
| `open_initialized_in_roots()` | 68 |
| `open_initialized_at()` (database-only) | 22 |

The `Option` is load-bearing until those 504 are rooted — it honestly encodes "this store was opened at the ambient boundary". Removing it is the *end* of the campaign, not a step in it. The accessor was always sufficient for callers that hold a store; only the comment claimed otherwise.

Worth checking other `_in_roots` siblings for the same stale-blocker shape: a function that already receives a store, cache, or context which knows its own root, while the wrapper above it reaches for the environment.

## Verification

`nice -n 10 cargo check --workspace --tests -j2` — clean first try, zero errors and zero warnings. `cargo fmt` applied. `target/` removed.