### PR TITLE
fix(core): locate terminal retention paths in the store's own home (#7505)

### DIFF
--- a/crates/homeboy-core/src/observation/runs_service/mod.rs
+++ b/crates/homeboy-core/src/observation/runs_service/mod.rs
@@ -184,8 +184,14 @@ pub fn retain_terminal_runs(
     // The store and artifact root are resolved once for the whole sweep. Both
     // used to be re-derived inside each per-run plan call, which meant one
     // connection open plus a full migration ladder per candidate run.
+    //
+    // The artifact root comes from the store rather than from process state,
+    // so the bytes this sweep removes are the ones the rows it read actually
+    // index. `artifacts::root()` is `paths::artifact_root()`, which is exactly
+    // what an ambiently-opened store answers with, so this is identical today
+    // and correct if the store is ever opened rooted (#7505).
     let mut store = ObservationStore::open_initialized()?;
-    let artifact_root = crate::artifacts::root()?;
+    let artifact_root = store.artifact_root()?;
     let candidate_run_ids = store.terminal_run_ids_before(&finished_before, options.limit)?;
     let mut artifact_cleanup = Vec::new();
     let mut lifecycle_directories = Vec::new();
@@ -332,7 +338,14 @@ fn terminal_run_lifecycle_directory(
         return Ok(None);
     }
 
-    let root = crate::paths::homeboy_data()?.join("agent-task-runs");
+    // The run came out of `store`; its lifecycle directory has to be located
+    // under the same home. Resolving the data root ambiently here meant
+    // terminal retention could read a run from one installation and then
+    // report -- and remove -- a directory belonging to another (#7505).
+    let data_root = store.data_root().ok_or_else(|| {
+        Error::internal_unexpected("observation store has no resolvable data root")
+    })?;
+    let root = data_root.join("agent-task-runs");
     let path = root.join(crate::paths::sanitize_path_segment(run_id));
     let exists = path.exists();
     let size_bytes = if exists { path_size_bytes(&path)? } else { 0 };


### PR DESCRIPTION
Found by grepping for the shape #12767 turned up: **a function that already receives a carrier which knows its own root, while the body reaches for the environment anyway.**

## The bug

```rust
fn terminal_run_lifecycle_directory(
    store: &ObservationStore,      // <- knows its own home
    run_id: &str,
) -> Result<Option<TerminalRunLifecycleDirectory>> {
    let Some(run) = store.get_run(run_id)? else { ... };   // read from the store
    ...
    let root = crate::paths::homeboy_data()?.join("agent-task-runs");  // <- ambient
```

It reads the run **out of the store**, then resolves that run's lifecycle directory from process state with no reference to whichever home the store was opened against.

This is **terminal retention**. The directory it names is one the sweep goes on to report and remove:

```
store.terminal_run_ids_before(...)        -> rows from the store's home
  terminal_run_lifecycle_directory(...)   -> path in the AMBIENT home
    -> reported as removable, and removed
```

A store opened against injected roots reads a run from one installation and deletes a directory belonging to another. Deletion safety, not tidiness.

It now derives from `store.data_root()` — injected roots when present, otherwise the database file's own parent. Both are properties of the handle, so it cannot disagree with the rows it just read.

## The same split, one level up

The sweep's own comment already stated the principle:

> *"The store and artifact root are resolved once for the whole sweep."*

But the artifact root came from `crate::artifacts::root()` — process state — while the rows came from the store. `artifacts::root()` is literally:

```rust
pub fn root() -> Result<PathBuf> { super::artifact_root() }
```

which is exactly what an ambiently-opened store answers with. So `store.artifact_root()` is **identical today** and correct if that store is ever opened rooted.

## Scope

**No behavior change on the current ambient path** — both values are the same ones, resolved a different way. What changes is that they can no longer diverge.

I scanned the whole workspace for this shape (`crates/`, `src/`, and the repo-root `tests/` tree). Seven candidates; four were doc-comment false positives, one was the injection-scanner test itself, one was a scan-window artifact. This was the only real hit outside the two already fixed in #12767 — so that seam is now closed too.

## Verification

`nice -n 10 cargo check --workspace --tests -j2` — clean first try, zero errors and zero warnings. `cargo fmt` applied. `target/` removed.