### PR TITLE
Free the deploy lifecycle round-trip from with_isolated_home

### DIFF
--- a/crates/homeboy-deploy/src/lifecycle.rs
+++ b/crates/homeboy-deploy/src/lifecycle.rs
@@ -363,8 +363,17 @@ mod tests {
 
     #[test]
     fn durable_record_round_trips_target_state_and_partial_timing_evidence() {
-        with_isolated_home(|_| {
-            let roots = homeboy_core::paths::PathRoots::from_environment().expect("path roots");
+        // Deliberately no `with_isolated_home`. Every durable call below already
+        // takes a data root, so this test can name its own instead of mutating
+        // `HOME` and reading it straight back out through `from_environment`.
+        //
+        // That is what #7505 is for. A test that owns its roots needs neither
+        // the environment nor the process-global mutex `HomeGuard` takes to
+        // protect it, so it can run beside any other test instead of queueing
+        // behind all of them.
+        {
+            let data_root = tempfile::tempdir().expect("data root");
+            let data_root = data_root.path();
             let mut run = DeployLifecycleRun::new("run".to_string(), identity());
             let mut timer = homeboy_core::phase_timing::PhaseTimer::new();
             timer.record_failed("transfer", std::time::Duration::from_millis(1));
@@ -374,9 +383,9 @@ mod tests {
                 Some("connection lost".to_string()),
                 Some(timer.into_report()),
             );
-            save_in_roots(roots.data(), &run).expect("persist run before retryable remote work");
+            save_in_roots(data_root, &run).expect("persist run before retryable remote work");
 
-            let restored = load_in_roots(roots.data(), "run").expect("read durable run");
+            let restored = load_in_roots(data_root, "run").expect("read durable run");
             assert_eq!(restored.schema_version, SCHEMA_VERSION);
             assert_eq!(restored.targets[1].status, DeployTargetStatus::Failed);
             assert_eq!(
@@ -391,7 +400,7 @@ mod tests {
                     .map(|span| span.status),
                 Some(homeboy_core::phase_timing::PhaseStatus::Failed)
             );
-        });
+        }
     }
 
     #[test]


### PR DESCRIPTION
Small follow-on to the `homeboy-deploy` rooting already on main. A slice of #7505.

## What it does

`durable_record_round_trips_target_state_and_partial_timing_evidence` wrapped itself in `with_isolated_home` **purely so it could read `HOME` back out**:

```rust
with_isolated_home(|_| {
    let roots = PathRoots::from_environment().expect("path roots");
    ...
    save_in_roots(roots.data(), &run)
```

Every durable call in it already takes a data root. It now names its own `tempdir` and the wrapper is gone.

```
with_isolated_home call sites:  2,523 -> 2,522
```

No `HOME` mutation, no `HomeGuard`, **no share in the process-global mutex that serializes the rest**. It can run beside any other test.

## Why this is the point

#7505's stated outcome is deleting `home_lock` and `HomeGuard`. Every rooting PR so far has been a prerequisite for that and has not visibly moved it. This is the first one that does, on one test.

The mechanism is worth naming because it generalises: rooting `homeboy-deploy` is what made this possible. Once the durable calls took roots, the wrapper had nothing left to protect. **Every crate driven to its boundaries should free the tests below it the same way** — that is where the 2,523 actually comes down, not by editing tests directly.

## Verification

`nice -n 10 cargo check --workspace --tests -j2` — clean, 0 warnings, 0 errors. `cargo fmt` clean.

Expect the current red-main set (7 as of this run: `output_errors` x2, installer `tar`, `concurrent_first_cooks`, `review::providers_end_to_end`, `daemon::control::legacy_child_recovery`, `evidence::mirroring_lab_job`). The prune suite is fixed on main and no longer appears.
