### PR TITLE
Derive the rig materialization cache root from the store

### DIFF
--- a/crates/homeboy-rig/src/dependency_materialization_cache.rs
+++ b/crates/homeboy-rig/src/dependency_materialization_cache.rs
@@ -416,11 +416,9 @@ impl DependencyMaterializationCache {
 
 /// Durable root shared by local and runner-side Homeboy processes. Lab invokes
 /// the same rig materialization contract on the runner outside its workspace.
-pub fn cache_root() -> Result<PathBuf> {
-    Ok(cache_root_in_roots(
-        homeboy_paths::PathRoots::from_environment()?.data(),
-    ))
-}
+// The ambient `cache_root()` shim that used to sit here is gone. Its only
+// caller was the rig resource-lifecycle index, which now derives the root from
+// the observation store the index is recorded into (#7505).
 
 /// [`cache_root`] below an explicitly injected data root.
 pub fn cache_root_in_roots(data_root: &Path) -> PathBuf {

--- a/crates/homeboy-rig/src/runner.rs
+++ b/crates/homeboy-rig/src/runner.rs
@@ -1508,7 +1508,23 @@ impl RigRunObserver {
         }
         let mut index = rig_resource_lifecycle_index(&rig.id, &resources, options.clone());
         if cache_enabled {
-            if let Ok(root) = super::dependency_materialization_cache::cache_root() {
+            // The cache root belongs to the same home as the store this index
+            // is recorded into. Only an ambiently-opened store has no better
+            // answer than the environment (#7505).
+            let ambient;
+            let data_root = match self.store.data_root() {
+                Some(root) => Some(root),
+                None => match homeboy_core::paths::PathRoots::from_environment() {
+                    Ok(roots) => {
+                        ambient = roots;
+                        Some(ambient.data())
+                    }
+                    Err(_) => None,
+                },
+            };
+            if let Some(root) =
+                data_root.map(super::dependency_materialization_cache::cache_root_in_roots)
+            {
                 index
                     .resources
                     .push(dependency_materialization_cache_lifecycle_record(


### PR DESCRIPTION
A slice of #7505. Small, and it collapses a pair.

## The split

The rig resource-lifecycle index records a dependency-materialization cache entry **into** an `ObservationStore`, while resolving that cache root from the environment with no reference to the store's home. A rooted store indexed a cache path its own home does not contain — silently, as usual.

It now takes the root from `self.store.data_root()`, matching what `artifact_index` already does with `store.artifact_root()`. Only an ambiently-opened store falls back, because that store genuinely has no better answer.

That took the last caller of `cache_root()`, so the ambient half is deleted and `cache_root_in_roots` is the only form.

```
homeboy-rig:  2 -> 1
```

The survivor is `DependencyMaterializationCache::new`, whose caller `materialize_dependency_step(rig, step, settings)` has no store and no roots. Rooting it means threading from further up the rig runner — a separate change, and inventing a root here would be exactly what the contract forbids.

## Supersedes #12762

I opened #12762 covering both this and `artifact_index`. The `artifact_index` half landed on main independently while it was open, using `store.artifact_root()`. This PR keeps only the part that is still missing and follows main's accessor convention rather than the one I had introduced.

## Verification

`nice -n 10 cargo check --workspace --tests -j2` — clean, 0 warnings, 0 errors. `cargo fmt` clean.

Expect the current red-main set (`output_errors` x2, installer `tar`, `concurrent_first_cooks`, `review::providers_end_to_end`, `daemon::control::legacy_child_recovery`, `evidence::mirroring_lab_job`).
