### PR TITLE
refactor(core): delete three more dead ambient wrappers the first scan missed (#7505)

### DIFF
--- a/crates/homeboy-cli/src/commands/runs/gh_actions_cache.rs
+++ b/crates/homeboy-cli/src/commands/runs/gh_actions_cache.rs
@@ -5,7 +5,6 @@
 //! orchestration of directory creation and byte writes lives here.
 
 use homeboy::core::error::{Error, Result};
-use homeboy::core::paths;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -42,14 +41,6 @@ pub fn persist_artifact_file_in_roots(
         )
     })?;
     Ok(target)
-}
-
-/// Compute (and ensure) the cache path for a list-runs cache entry.
-///
-/// Creates `<homeboy>/cache/gh-actions-runs/` and returns the path for
-/// `<key>.<ext>`. Errors propagate.
-pub fn list_runs_cache_path(key: &str, ext: &str) -> Result<PathBuf> {
-    list_runs_cache_path_in_roots(&paths::homeboy()?, key, ext)
 }
 
 /// Compute (and ensure) a list-runs cache entry under an injected config root.

--- a/crates/homeboy-core/src/config.rs
+++ b/crates/homeboy-core/src/config.rs
@@ -785,12 +785,6 @@ pub fn validate<T: ConfigEntity>(entity: &T) -> Result<()> {
     entity.validate_in_root(&paths::homeboy()?)
 }
 
-/// Ambient sibling of [`ConfigEntity::dependents_in_root`]. Free function for
-/// the same reason as [`validate`].
-pub fn dependents<T: ConfigEntity>(id: &str) -> Result<Vec<String>> {
-    T::dependents_in_root(&paths::homeboy()?, id)
-}
-
 /// Validate and write an entity below an already-resolved config root.
 ///
 /// Every root-sensitive step — the cross-entity ID/alias collision guard, the

--- a/crates/homeboy-core/src/extension_store.rs
+++ b/crates/homeboy-core/src/extension_store.rs
@@ -319,13 +319,6 @@ pub fn broken_extension_links_in_root(config_root: &Path) -> Vec<BrokenExtension
     broken_extension_links_at(&paths::extensions_in_root(config_root))
 }
 
-pub fn broken_extension_links() -> Vec<BrokenExtensionLink> {
-    let Ok(dir) = paths::extensions() else {
-        return Vec::new();
-    };
-    broken_extension_links_at(&dir)
-}
-
 fn broken_extension_links_at(extensions_dir: &Path) -> Vec<BrokenExtensionLink> {
     let Ok(entries) = std::fs::read_dir(extensions_dir) else {
         return Vec::new();
@@ -758,7 +751,7 @@ mod tests {
             let target = extensions_dir.join("missing-sample-runtime");
             std::os::unix::fs::symlink(&target, &link).unwrap();
 
-            let broken = broken_extension_links();
+            let broken = broken_extension_links_in_root(&paths::homeboy().expect("config root"));
             assert_eq!(broken.len(), 1);
             assert_eq!(broken[0].id, "sample-runtime");
             assert_eq!(broken[0].target, target);

--- a/docs/internals/development/contracts/path-roots-injection.md
+++ b/docs/internals/development/contracts/path-roots-injection.md
@@ -195,6 +195,54 @@ What *was* safe to take here: `private_batch_plan_dir()` had exactly one caller
 and it was a test. A wrapper whose last non-test caller has already disappeared
 is dead weight regardless of depth — delete it on sight.
 
+## Dead wrappers: direction matters
+
+Two different things look identical to a reachability scan, and only one is debt.
+
+**A dead *ambient* wrapper is debt.** It resolves from process state, nothing
+calls it, and `pub` items are not dead-code analysed so the compiler will never
+say so. Delete on sight.
+
+**A dead *rooted* sibling is unused capacity.** It takes an explicit root, and
+nothing calls it *yet* because the callers above it have not been rooted. It is
+ahead of demand, not behind it. Deleting it means re-adding the same five lines
+when that layer's turn comes.
+
+`extension_store` has one of each, side by side:
+
+| function | callers | verdict |
+|---|---|---|
+| `is_extension_linked` (ambient) | 20+ | live |
+| `is_extension_linked_in_root` (rooted) | **0** | **keep** — it is the injection point `homeboy-extension`'s 22 ambient sites will need |
+| `broken_extension_links` (ambient) | 1, a test | **delete** |
+| `broken_extension_links_in_root` (rooted) | 0 → 1 | keep, test now calls it |
+
+Before deleting anything a scan calls dead, check which half it is.
+
+### Scanning for them correctly
+
+A wrapper delegates to its rooted sibling in one of two argument shapes, and a
+pattern that only knows the first will silently under-report:
+
+```rust
+let root = paths::homeboy()?;          // shape A: resolve, then call
+foo_in_root(&root, id)
+
+foo_in_root(&paths::homeboy()?, id)    // shape B: resolve inside the call
+```
+
+The first sweep of this codebase only matched shape A and reported the seam
+closed. Re-scanning for both found three more dead wrappers, including one in
+`config.rs`. Match both, and search `crates/`, `src/`, **and** the repo-root
+`tests/` tree — files there are pulled into libs by `#[path]` and a scan scoped
+to `crates/` reads as a false zero for anything they reference.
+
+Also beware module-qualified shadowing. `gh_actions.rs` has a private
+`mod helpers` exporting its own rooted `list_runs_cache_path`, so unqualified
+call sites resolve to that rather than to the same-named ambient function in
+`gh_actions_cache`. Confirm with a module-qualified grep before believing a
+caller count.
+
 ## Tests are a boundary too
 
 Tests that construct a carrier by hand, or call a rooted function directly,


### PR DESCRIPTION
#12755 reported the dead-wrapper seam closed. **It wasn't** — the scan only matched one of the two shapes a wrapper can take.

```rust
let root = paths::homeboy()?;          // shape A -- matched
foo_in_root(&root, id)

foo_in_root(&paths::homeboy()?, id)    // shape B -- MISSED
```

Re-scanning for both, across `crates/`, `src/`, and the repo-root `tests/` tree, found three more with no callers at all:

| function | callers |
|---|---|
| `config::dependents<T>` | **zero** |
| `extension_store::broken_extension_links` | one, a test |
| `runs::gh_actions_cache::list_runs_cache_path` | **zero** |

## The last one needed a module-qualified grep

`gh_actions.rs` has a private `mod helpers` exporting its **own rooted** `list_runs_cache_path`:

```rust
mod helpers {
    pub fn list_runs_cache_path(config_root: &Path, key: &str, ext: &str) -> Result<PathBuf> {
        crate::commands::runs::gh_actions_cache::list_runs_cache_path_in_roots(config_root, key, ext)
    }
}
```

So the unqualified call sites in that file resolve to the helper, not to the same-named ambient function in `gh_actions_cache`. **An unqualified caller count reports two; the real count is zero.**

## Deliberately NOT deleted, and why it matters

`is_extension_linked_in_root` also has zero callers. It is the **opposite case**, and the distinction is worth writing down:

- **A dead *ambient* wrapper is debt.** It resolves from process state and nothing wants it. Delete on sight.
- **A dead *rooted* sibling is unused capacity.** Nothing calls it *yet* because the layer above hasn't been rooted. It is precisely the injection point `homeboy-extension`'s 22 ambient sites will need. Deleting it means re-adding the same five lines later.

`extension_store` carries one of each side by side, which is what made the asymmetry visible:

| function | callers | verdict |
|---|---|---|
| `is_extension_linked` (ambient) | 20+ | live |
| `is_extension_linked_in_root` (rooted) | 0 | **keep** |
| `broken_extension_links` (ambient) | 1 test | **delete** |
| `broken_extension_links_in_root` (rooted) | 0 → 1 | keep |

Before deleting anything a scan calls dead, check which half it is. All three hazards — both argument shapes, the `tests/` tree, and module-qualified shadowing — are now in the pattern doc.

## Verification

`nice -n 10 cargo check --workspace --tests -j2` — clean, zero errors and **zero warnings** (the deletion orphaned a `use homeboy::core::paths`, which the Warning Clean gate would have caught). `cargo fmt` applied.

Stacked note: #12768 is independent and touches different files.