### PR TITLE
Collapse three lifecycle_ops wrapper pairs

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/controller_pin_reference_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/controller_pin_reference_provider.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 use serde_json::Value;
 
-use crate::agent_task_lifecycle::{list_records_with_health, AgentTaskRunState};
+use crate::agent_task_lifecycle::AgentTaskRunState;
 use homeboy_core::controller_pin_reference::{
     register_controller_pin_reference_provider, ControllerPinReferenceProvider,
 };
@@ -25,7 +25,10 @@ struct AgentTaskControllerPinReferenceProvider;
 
 impl ControllerPinReferenceProvider for AgentTaskControllerPinReferenceProvider {
     fn referenced_controller_pins(&self) -> Result<Vec<PathBuf>> {
-        let (records, _) = list_records_with_health()?;
+        // Pins are retained against the records read here, so both halves must
+        // name one installation (#7505).
+        let lifecycle_store = super::AgentTaskLifecycleStore::from_current_environment()?;
+        let (records, _) = super::list_records_with_health_in_store(&lifecycle_store)?;
         let mut referenced = Vec::new();
         for record in records {
             if !state_retains_pin(&record) {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2031,8 +2031,13 @@ pub(crate) fn validate_controller_runtime_in_store(
 /// Resolve the compatible immutable executable for a lifecycle mutation.
 /// Legacy pins are migrated atomically before returning a path for re-exec.
 pub fn pinned_runtime_for_mutation(run_id: &str) -> Result<Option<std::path::PathBuf>> {
-    let mut record = store::read_record(&resolve_run_id(run_id)?)?;
-    migrate_record_controller_runtime(&mut record)?;
+    // One root for the whole read: resolving the run id, reading the record,
+    // and migrating its pin are one operation. Three separately resolved homes
+    // migrate a pin in a record the caller cannot read back (#7505).
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    let resolved = resolve_run_id_in_store(&lifecycle_store, run_id)?;
+    let mut record = lifecycle_store.read_record(&resolved)?;
+    migrate_record_controller_runtime_in_store(&lifecycle_store, &mut record)?;
     homeboy_core::controller_runtime::pinned_executable_for_mutation(
         &record.metadata,
         &homeboy_core::build_identity::current().display,
@@ -2137,10 +2142,9 @@ pub fn prune_controller_runtime_pins(
     homeboy_core::controller_runtime::prune_pins(apply, overrides)
 }
 
-fn migrate_record_controller_runtime(record: &mut AgentTaskRunRecord) -> Result<()> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    migrate_record_controller_runtime_in_store(&lifecycle_store, record)
-}
+// The ambient `migrate_record_controller_runtime()` shim that used to sit here
+// is gone. `pinned_runtime_for_mutation` was its only caller and now migrates
+// inside the store it read the record from (#7505).
 
 fn migrate_record_controller_runtime_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
@@ -4323,11 +4327,9 @@ pub fn list_records_in_store(
     Ok(records)
 }
 
-pub fn list_records_with_health() -> Result<(Vec<AgentTaskRunRecord>, AgentTaskRecordHealthSummary)>
-{
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    list_records_with_health_in_store(&lifecycle_store)
-}
+// The ambient `list_records_with_health()` shim that used to sit here is gone.
+// The controller-pin reference provider was its only caller and now lists from
+// a store it resolves once (#7505).
 
 /// [`list_records_with_health`] against explicitly injected durable lifecycle
 /// roots.
@@ -4513,10 +4515,9 @@ pub fn run_record_exists_resolved_in_store(
     lifecycle_store.record_exists(&resolve_run_id_in_store(lifecycle_store, run_id)?)
 }
 
-pub fn mark_resuming(run_id: &str) -> Result<AgentTaskRunRecord> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    mark_resuming_in_store(&lifecycle_store, run_id)
-}
+// The ambient `mark_resuming()` shim that used to sit here is gone. The resume
+// path was its only caller and now marks inside the store it resolved for the
+// resume itself (#7505).
 
 /// Stamp the resume request and re-enter Running inside an explicitly rooted
 /// store.

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -635,7 +635,9 @@ pub fn resume(
         }
         return Err(transport_proxy_recovery_error(recovery));
     }
-    agent_task_lifecycle::mark_resuming(&run_id)?;
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    agent_task_lifecycle::mark_resuming_in_store(&lifecycle_store, &run_id)?;
     run_claimed(run_id, executor)
 }
 

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -309,7 +309,7 @@ pub mod lifecycle {
         exact_durable_local_read_in_store, exact_record, fail_cook_operation,
         fail_detached_cook_handoff_parent, fail_detached_cook_handoff_parent_in_store,
         has_accepted_runner_handoff, invalidate_cook_finalization_for_dependency, list_records,
-        load_controller_plan, load_plan, load_plan_in_store, logs, mark_resuming, mark_running,
+        load_controller_plan, load_plan, load_plan_in_store, logs, mark_running,
         materialize_recovered_patch_artifact, persisted_status, pin_current_controller_runtime,
         pinned_runtime_for_mutation, prune_controller_runtime_pins, quarantine_queued_run_exact,
         rearm_quarantined_run, reconcile_record_health, reconcile_terminal_artifact_projection,


### PR DESCRIPTION
A slice of #7505, first in `homeboy-agents`.

## Lane note

I have collided with the `pathroots-*` work twice (#12759, #12762, both closed as superseded). I have messaged that thread and taken **`homeboy-agents` (158 sites, ~81% of what remains)**, leaving the small crates to it. This PR is the first slice in that lane.

## What it does

Three operations in `lifecycle_ops.rs` existed as an ambient wrapper plus an `_in_store` sibling. Each wrapper had **exactly one caller**, so converting that caller left the ambient half unreferenced:

```
migrate_record_controller_runtime   <- pinned_runtime_for_mutation
list_records_with_health            <- referenced_controller_pins
mark_resuming                       <- execution::resume
```

All three deleted. Each operation now exists once instead of twice.

## One had a real defect

`pinned_runtime_for_mutation` was not just duplication:

```rust
let mut record = store::read_record(&resolve_run_id(run_id)?)?;
migrate_record_controller_runtime(&mut record)?;
```

Three separately resolved homes for one operation — `resolve_run_id`, the `store::` shim, and the migrate. That migrates a pin into a record the caller cannot read back. It resolves once now and does all three against that store.

`mark_resuming` was also re-exported through the `agent_tasks::lifecycle` facade with no caller outside the crate; that entry is dropped.

## Count delta — flat, and I want to be plain about it

```
homeboy-agents:  158 -> 158
```

Three wrapper resolutions removed, three caller resolutions added. **The counter does not move.**

What changed is that three functions are gone and the resolution sits one frame closer to the boundary. That is the same shape as #12739, whose wrappers only became deletable one PR later (#12742, −3) once their last callers had moved. Whether this slice eventually shows up as a number depends on whether those three callers later receive roots from above rather than resolving.

Diff is `25 insertions, 19 deletions`, and I trimmed the comments after noticing they were most of the addition.

## Verification

- `nice -n 10 cargo check --workspace --tests -j2` — clean, 0 warnings, 0 errors
- `cargo fmt --check` — clean

Two stale references caught by the gate, both worth noting as hazards: a now-unused `use` import (`E0432`), and a **facade re-export** of `mark_resuming` in `agent_tasks.rs` — the same aliased-re-export class that hid a caller in #12762.

Expect the current red-main set (`output_errors` x2, installer `tar`, `concurrent_first_cooks`, `review::providers_end_to_end`, `daemon::control::legacy_child_recovery`, `evidence::mirroring_lab_job`).
