### PR TITLE
refactor(extension): take one root for every lock a trace run acquires (#7505)

### DIFF
--- a/crates/homeboy-extension/src/trace/overlay.rs
+++ b/crates/homeboy-extension/src/trace/overlay.rs
@@ -41,9 +41,14 @@ pub(super) fn acquire_trace_overlay_locks(
         overlay_paths.push(request.overlay_path.clone());
     }
 
+    // One resolution for every lock this run takes. Acquiring per component
+    // used to re-resolve per iteration, which is how a single run's locks
+    // could end up split across two homes (#7505).
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
     let mut locks = Vec::new();
     for (component_path, overlay_paths) in component_requests.values() {
         locks.push(overlay_lock::TraceOverlayLock::acquire(
+            &roots,
             component_path,
             overlay_paths,
             run_dir,

--- a/crates/homeboy-extension/src/trace/overlay_lock.rs
+++ b/crates/homeboy-extension/src/trace/overlay_lock.rs
@@ -49,21 +49,17 @@ pub struct TraceOverlayLockCleanupResult {
 }
 
 impl TraceOverlayLock {
-    /// Ambient boundary: resolve the data root once, then acquire rooted.
-    pub(super) fn acquire(
-        component_path: &Path,
-        overlay_paths: &[String],
-        run_dir: &RunDir,
-    ) -> Result<Self> {
-        let roots = paths::PathRoots::from_environment()?;
-        Self::acquire_in_roots(&roots, component_path, overlay_paths, run_dir)
-    }
-
     /// Acquire the component's overlay lock below explicitly supplied roots.
     ///
     /// `run_dir` is already an injected value, so the data root is the only
     /// ambient reach this path had.
-    fn acquire_in_roots(
+    ///
+    /// Roots come from the caller because one trace run acquires a lock per
+    /// component in a loop. The ambient form resolved once per iteration, so a
+    /// repoint mid-loop could leave some of a single run's locks in one home
+    /// and the rest in another -- and the release path would then find only
+    /// some of them (#7505).
+    pub(super) fn acquire(
         roots: &paths::PathRoots,
         component_path: &Path,
         overlay_paths: &[String],
@@ -460,6 +456,14 @@ fn trace_overlay_dirty_files(
 
 #[cfg(test)]
 mod tests {
+    /// The roots of the isolated home each test below installs.
+    ///
+    /// These tests are their own boundary: `acquire` takes roots now, so the
+    /// test resolves once where the trace run resolves once (#7505).
+    fn test_roots() -> paths::PathRoots {
+        paths::PathRoots::from_environment().expect("path roots")
+    }
+
     use super::*;
     use homeboy_core::test_support::with_isolated_home;
 
@@ -471,7 +475,9 @@ mod tests {
             let lock_path;
 
             {
-                let lock = TraceOverlayLock::acquire(component_dir.path(), &[], &run_dir).unwrap();
+                let lock =
+                    TraceOverlayLock::acquire(&test_roots(), component_dir.path(), &[], &run_dir)
+                        .unwrap();
                 lock_path = lock.path.clone();
                 assert!(lock_path.exists());
                 assert!(lock_path.join("holder.json").exists());
@@ -506,7 +512,9 @@ mod tests {
         with_isolated_home(|_| {
             let component_dir = tempfile::tempdir().unwrap();
             let run_dir = RunDir::create().unwrap();
-            let lock = TraceOverlayLock::acquire(component_dir.path(), &[], &run_dir).unwrap();
+            let lock =
+                TraceOverlayLock::acquire(&test_roots(), component_dir.path(), &[], &run_dir)
+                    .unwrap();
 
             let holder = read_trace_overlay_lock_holder(&lock.path).unwrap();
 
@@ -524,10 +532,16 @@ mod tests {
             let first_run_dir = RunDir::create().unwrap();
             let second_run_dir = RunDir::create().unwrap();
             let lock =
-                TraceOverlayLock::acquire(component_dir.path(), &[], &first_run_dir).unwrap();
+                TraceOverlayLock::acquire(&test_roots(), component_dir.path(), &[], &first_run_dir)
+                    .unwrap();
 
-            let err =
-                TraceOverlayLock::acquire(component_dir.path(), &[], &second_run_dir).unwrap_err();
+            let err = TraceOverlayLock::acquire(
+                &test_roots(),
+                component_dir.path(),
+                &[],
+                &second_run_dir,
+            )
+            .unwrap_err();
 
             assert!(err.message.contains("Trace overlay already active"));
             assert!(err
@@ -565,7 +579,9 @@ mod tests {
         with_isolated_home(|_| {
             let component_dir = tempfile::tempdir().unwrap();
             let run_dir = RunDir::create().unwrap();
-            let lock = TraceOverlayLock::acquire(component_dir.path(), &[], &run_dir).unwrap();
+            let lock =
+                TraceOverlayLock::acquire(&test_roots(), component_dir.path(), &[], &run_dir)
+                    .unwrap();
 
             let locks = list_trace_overlay_locks().unwrap();
 


### PR DESCRIPTION
## The defect

`acquire_trace_overlay_locks` groups a trace run's overlay requests by component, then acquires one lock **per component in a loop**:

```rust
for (component_path, overlay_paths) in component_requests.values() {
    locks.push(overlay_lock::TraceOverlayLock::acquire(   // <- resolved its own roots
        component_path, overlay_paths, run_dir,
    )?);
}
```

Every iteration called `PathRoots::from_environment()`. **A trace run over N components performed N independent resolutions while taking locks.**

A repoint mid-loop leaves some of a single run's locks in one home and the rest in another. The release path walks one lock directory, so it finds only some of them — **the rest stay held with no live holder to explain them.**

That is worse than the stale-record class this campaign has mostly been fixing. `cleanup_stale_trace_overlay_locks` decides staleness by checking whether the holder PID is alive; an orphan from the other home looks exactly like a lock whose process died, except `--force` is the only thing that will clear it.

## The fix

The loop resolves once and `acquire` takes the roots. Ambient wrapper deleted, rooted form takes the plain name.

## What deliberately stays

Three `PathRoots::from_environment()` calls remain in this module and all three are correct:

| call | why it stays |
|---|---|
| `list_trace_overlay_locks` | a CLI subcommand — one unit of work |
| `cleanup_stale_trace_overlay_locks` | a CLI subcommand — one unit of work |
| `trace_overlay_lock_dir` | `#[cfg(test)]` only |

Those are boundaries doing their job. Reporting this file as "4 ambient sites → 1" would be the wrong decomposition — it was always **1 ambient + 3 boundaries**, and the one is now gone.

## How I found it

Looked for per-item resolution inside a loop — the same shape as the deploy receipt store in #12757. Worth grepping for elsewhere: a `for` loop whose body calls something that resolves, when the loop itself is the unit of work.

## Verification

`nice -n 10 cargo check --workspace --tests -j2` — clean first try, zero errors and zero warnings. `cargo fmt` applied. `target/` removed.

Scoped to `homeboy-extension`. `homeboy-agents` is being worked in parallel and is deliberately untouched here.
