### PR TITLE
Collapse four more lifecycle_ops wrapper pairs

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1040,15 +1040,8 @@ pub fn record_execution_placement_outcome_in_store(
     lifecycle_store.write_record(&record)
 }
 
-/// Restore an explicit plan placement decision onto a legacy run record.
-///
-/// Placement is opt-in policy evidence. A controller-local plan without a
-/// decision must remain unclassified rather than acquiring a synthetic local
-/// contract that could contradict later runner evidence.
-pub fn normalize_local_execution_placement(run_id: &str) -> Result<AgentTaskRunRecord> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    normalize_local_execution_placement_in_store(&lifecycle_store, run_id)
-}
+// The ambient `normalize_local_execution_placement()` shim that used to sit here is gone;
+// its two normalization tests now normalize inside a store they resolve (#7505).
 
 /// Restore an explicit plan placement decision onto a legacy record inside an
 /// explicitly rooted store.
@@ -1308,12 +1301,16 @@ mod execution_placement_tests {
     #[test]
     fn normalization_preserves_submission_stamp_and_projects_explicit_plan_decision() {
         homeboy_core::test_support::with_isolated_home(|_| {
+            // One store for the whole test: both normalizations and the record
+            // they read must name one installation.
+            let store =
+                AgentTaskLifecycleStore::from_current_environment().expect("lifecycle store");
             let plan = super::super::tests::test_plan();
             let record =
                 submit_plan_with_runtime_admission(&plan, Some("placement-run"), |_| Ok(json!({})))
                     .expect("submit plan");
 
-            let normalized = normalize_local_execution_placement(&record.run_id)
+            let normalized = normalize_local_execution_placement_in_store(&store, &record.run_id)
                 .expect("submission stamp remains authoritative");
             let submission_decision: homeboy_lab_runner_contract::ExecutionPlacementDecision =
                 serde_json::from_value(normalized.metadata["execution_placement_decision"].clone())
@@ -1343,7 +1340,7 @@ mod execution_placement_tests {
                 .remove("execution_placement_decision");
             store::write_record(&legacy_record).expect("remove legacy record projection");
 
-            let normalized = normalize_local_execution_placement(&record.run_id)
+            let normalized = normalize_local_execution_placement_in_store(&store, &record.run_id)
                 .expect("explicit plan decision is restored");
             assert_eq!(
                 normalized.metadata["execution_placement_decision"]["decision_id"],
@@ -2817,16 +2814,8 @@ pub(crate) fn record_provider_execution_terminal_in_store(
     })
 }
 
-/// Whether this run still has a provider execution that can produce work.
-///
-/// Controller-owned artifact harvesting may continue after a provider result is
-/// terminal. Foreground liveness sampling is only meaningful while a provider
-/// boundary remains active, so callers use this durable predicate to stop
-/// sampling during that bounded cleanup phase.
-pub fn has_active_provider_execution(run_id: &str) -> Result<bool> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    has_active_provider_execution_in_store(&lifecycle_store, run_id)
-}
+// The ambient `has_active_provider_execution()` shim that used to sit here is gone;
+// its one scheduler test now asks the store it resolves (#7505).
 
 /// [`has_active_provider_execution`] against explicitly injected durable
 /// lifecycle roots.
@@ -5302,15 +5291,8 @@ pub(crate) fn record_cook_attempt_in_store(
     Ok(index)
 }
 
-/// Register a Cook attempt while the caller owns the config lock.
-pub(crate) fn record_cook_attempt_locked(
-    cook_id: &str,
-    attempt: u32,
-    run_id: &str,
-) -> Result<CookAttemptRegistration> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    record_cook_attempt_locked_in_store(&lifecycle_store, cook_id, attempt, run_id)
-}
+// The ambient `record_cook_attempt_locked()` shim that used to sit here is gone;
+// its one strict-lock test now registers inside the store it resolves (#7505).
 
 pub(crate) fn record_cook_attempt_locked_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
@@ -5413,17 +5395,8 @@ impl CookAttemptRegistration {
     }
 }
 
-/// Record the controller-owned boundary that a resumed Cook must advance.
-/// Provider terminal evidence and promotion reports remain separate so a later
-/// failed attempt cannot replace the source candidate's recovery checkpoint.
-pub fn record_cook_recovery_checkpoint(
-    run_id: &str,
-    phase: &str,
-    next_command: &str,
-) -> Result<AgentTaskRunRecord> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    record_cook_recovery_checkpoint_in_store(&lifecycle_store, run_id, phase, next_command)
-}
+// The ambient `record_cook_recovery_checkpoint()` shim that used to sit here is gone;
+// the fanout resume path was its only caller and now checkpoints inside the store it resolves (#7505).
 
 pub fn record_cook_recovery_checkpoint_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/concurrency.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/concurrency.rs
@@ -93,8 +93,12 @@ pub(super) mod concurrency_tests {
         assert!(execution["post_provider_cleanup_elapsed_ms"].is_u64());
         assert!(execution["post_provider_cleanup_finished_at"].is_string());
         assert!(
-            !crate::agent_task_lifecycle::has_active_provider_execution(run_id)
-                .expect("terminal provider is inactive")
+            !crate::agent_task_lifecycle::has_active_provider_execution_in_store(
+                &crate::agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()
+                    .expect("lifecycle store"),
+                run_id,
+            )
+            .expect("terminal provider is inactive")
         );
     }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -3020,7 +3020,10 @@ where
         // a later provider attempt failed and became the cook-index latest run.
         options.initial_run_id = attempt.run_id.clone();
         options.initial_plan = attempt.plan.clone();
-        agent_task_lifecycle::record_cook_recovery_checkpoint(
+        let lifecycle_store =
+            agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+        agent_task_lifecycle::record_cook_recovery_checkpoint_in_store(
+            &lifecycle_store,
             &attempt.run_id,
             "verification_pending",
             &format!("homeboy agent-task fanout resume {batch_id}"),

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -7050,8 +7050,14 @@ fn strict_locked_retry_registration_uses_the_outer_transaction() {
             .initial_plan;
             agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("reserve retry run");
             homeboy_core::config::with_config_lock(|| {
-                agent_task_lifecycle::record_cook_attempt_locked(cook_id, 2, run_id)
-                    .expect("register retry through outer transaction");
+                agent_task_lifecycle::record_cook_attempt_locked_in_store(
+                    &agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()
+                        .expect("lifecycle store"),
+                    cook_id,
+                    2,
+                    run_id,
+                )
+                .expect("register retry through outer transaction");
                 Ok(())
             })
             .expect("strict lock accepts one owner");


### PR DESCRIPTION
Second slice in the `homeboy-agents` lane. Follows #12772.

## What it does

Four more operations existed as **two functions** — an ambient wrapper plus an `_in_store` sibling. Converting each wrapper's callers left the ambient half unreferenced, so all four are deleted:

```
normalize_local_execution_placement  <- its normalization test
record_cook_recovery_checkpoint      <- the fanout resume path
has_active_provider_execution        <- one scheduler concurrency test
record_cook_attempt_locked           <- one strict-lock cook test
```

Every one of these is entirely inside `homeboy-agents`, chosen deliberately so it cannot collide with the `pathroots-*` work in the other crates.

## One detail worth the extra pass

`normalization_preserves_submission_stamp_and_projects_explicit_plan_decision` called its wrapper **twice**. My first version gave each call its own resolution, which would have traded one wrapper resolution for two caller ones — a net increase.

Both calls now share one store resolved at the top of the test. That is also what the test actually means: the two normalizations and the record they read have to name one installation, and giving them separate resolutions would have made the test assert something weaker than it looks like it asserts.

## Count delta

```
homeboy-agents:            160 -> 160
lifecycle_ops.rs:           64 -> 61
functions deleted:           4
lines:                     -14   (32 insertions, 46 deletions)
```

Flat overall, as with #12772: four wrapper resolutions out, four caller resolutions in. What moves is the function count and where the resolution sits — the file the wrappers lived in is three lighter, and each resolution is now at a caller that can eventually be handed roots from above instead of resolving.

## Verification

- `nice -n 10 cargo check --workspace --tests -j2` — clean, 0 warnings, 0 errors
- `cargo fmt --check` — clean

Expect the current red-main set. As of the last two runs that is `concurrent_first_cooks`, `output_errors` x2, `daemon::control::legacy_child_recovery`, installer `tar`, `evidence::mirroring_lab_job`, plus intermittent members of the `review::providers_*` family and `broker_http`'s stall-timing test — see the evidence comment on #12772 for why those two are flaky rather than regressions.
