### PR TITLE
refactor(lab-runner): take the artifact root from the store the records land in (#7505)

### DIFF
--- a/crates/homeboy-cli/src/commands/runs/remote_artifact.rs
+++ b/crates/homeboy-cli/src/commands/runs/remote_artifact.rs
@@ -72,7 +72,13 @@ pub fn attach(args: RunsArtifactAttachArgs) -> CmdResult<RunsOutput> {
     let runner = runner::load(&args.runner)?;
     validate_runner_artifact_path(&runner, &args.path)?;
 
-    let source = runner_artifact_attach::copy_runner_artifact_source(&runner, &args.path)?;
+    // The bytes land under the root this store indexes, because the path is
+    // recorded into that same store two lines below (#7505).
+    let source = runner_artifact_attach::copy_runner_artifact_source(
+        &store.artifact_root()?,
+        &runner,
+        &args.path,
+    )?;
     let metadata = runner_attach_metadata(&runner, &args.path, &source);
     let artifact = match source.artifact_type {
         RunnerAttachArtifactType::File => {

--- a/crates/homeboy-lab-runner/src/artifact_attach.rs
+++ b/crates/homeboy-lab-runner/src/artifact_attach.rs
@@ -29,26 +29,19 @@ pub struct RunnerAttachSource {
 }
 
 /// Resolve and, for SSH runners, download the runner-side artifact into a temp
-/// location under the artifact root.
-pub fn copy_runner_artifact_source(
-    runner: &Runner,
-    path: &str,
-) -> homeboy_core::Result<RunnerAttachSource> {
-    copy_runner_artifact_source_in_roots(
-        homeboy_core::paths::PathRoots::from_environment()?.artifacts(),
-        runner,
-        path,
-    )
-}
-
-/// [`copy_runner_artifact_source`] against an explicitly injected artifact root.
+/// location under an explicitly supplied artifact root.
+///
+/// The caller supplies the root because the downloaded path is handed straight
+/// to `ObservationStore::record_artifact*`. Resolving it here, independently of
+/// the store the record lands in, meant the bytes and the row indexing them
+/// agreed only by coincidence (#7505).
 ///
 /// Only the download destination is rooted, because only the download
 /// destination is Homeboy state: the artifact type probe and the transfer both
 /// address the *runner* filesystem through an SSH client. The one remaining
 /// ambient reach on this path is `server::load`, which resolves the config root
 /// inside `homeboy-core` and is out of this crate's reach (#7505).
-pub fn copy_runner_artifact_source_in_roots(
+pub fn copy_runner_artifact_source(
     artifact_root: &Path,
     runner: &Runner,
     path: &str,

--- a/crates/homeboy-lab-runner/src/execution/artifact_promotion.rs
+++ b/crates/homeboy-lab-runner/src/execution/artifact_promotion.rs
@@ -49,9 +49,12 @@ pub fn promote_runner_exec_artifact_dirs(
     }
 
     let store = ObservationStore::open_initialized()?;
-    // Resolved once beside the store so downloaded bytes and the records that
-    // index them cannot land in two different homes (#7505).
-    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    // Taken FROM the store, not resolved beside it. Downloaded bytes land under
+    // this root and the records indexing them are written into that same store,
+    // so the two cannot be allowed to disagree. Resolving separately made them
+    // equal by coincidence -- two reads of process state that happened to
+    // agree -- rather than by construction (#7505).
+    let artifact_root = store.artifact_root()?;
     let runner = match output.mode {
         runner::RunnerExecMode::Local => None,
         runner::RunnerExecMode::Daemon
@@ -62,7 +65,7 @@ pub fn promote_runner_exec_artifact_dirs(
     for declared_dir in artifact_dir_outputs {
         let runner_dir = resolve_runner_exec_artifact_path(&output.remote_cwd, declared_dir);
         let record_dir = if let Some(runner) = runner.as_ref() {
-            copy_runner_exec_artifact_source_in_roots(roots.artifacts(), runner, &runner_dir)?
+            copy_runner_exec_artifact_source_in_roots(&artifact_root, runner, &runner_dir)?
         } else {
             runner_dir.clone()
         };
@@ -304,9 +307,12 @@ fn promote_runner_exec_outputs(
     }
 
     let store = ObservationStore::open_initialized()?;
-    // Resolved once beside the store so downloaded bytes and the records that
-    // index them cannot land in two different homes (#7505).
-    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    // Taken FROM the store, not resolved beside it. Downloaded bytes land under
+    // this root and the records indexing them are written into that same store,
+    // so the two cannot be allowed to disagree. Resolving separately made them
+    // equal by coincidence -- two reads of process state that happened to
+    // agree -- rather than by construction (#7505).
+    let artifact_root = store.artifact_root()?;
     let runner = match output.mode {
         runner::RunnerExecMode::Local => None,
         runner::RunnerExecMode::Daemon
@@ -328,7 +334,7 @@ fn promote_runner_exec_outputs(
                 metadata["source"] = serde_json::json!("runner_path_attach");
                 metadata["runner_id"] = serde_json::json!(runner.id.clone());
                 metadata["runner_path"] = serde_json::json!(runner_path.display().to_string());
-                copy_runner_exec_artifact_source_in_roots(roots.artifacts(), runner, &runner_path)?
+                copy_runner_exec_artifact_source_in_roots(&artifact_root, runner, &runner_path)?
             } else {
                 runner_path.clone()
             };


### PR DESCRIPTION
Three places downloaded runner-side bytes to one artifact root, then wrote the resulting path into an `ObservationStore` that resolved its own. Both halves read process state, so they agreed **by coincidence rather than by construction**.

## Two of them said so in a comment while doing the opposite

```rust
let store = ObservationStore::open_initialized()?;
// Resolved once beside the store so downloaded bytes and the records that
// index them cannot land in two different homes (#7505).
let roots = homeboy_core::paths::PathRoots::from_environment()?;
```

**"Beside" is the bug.** The store is never consulted — a second independent read of the same environment is. A repoint between those two lines puts the bytes under one home and the row describing them under another, and **the row still looks valid**, because nothing checks that an artifact's path is inside the home it was recorded in.

Both now take `store.artifact_root()`.

## The third is `runs artifact attach`

```rust
let source = copy_runner_artifact_source(&runner, &args.path)?;   // ambient root
...
store.record_artifact_with_metadata(&args.run_id, &args.name, &source.path, metadata)?;
```

The download destination was resolved ambiently and the returned path handed straight to the store two lines later. Ambient wrapper deleted, rooted form takes the plain name, and the command passes the root of the store it is recording into.

## The pattern keeps showing up next to a comment claiming it's handled

This is the same shape as #12768, where `terminal_run_lifecycle_directory` read a run *from* a store and then resolved its deletion path ambiently — also under a comment asserting the sweep resolved once.

Three separate sites now, each with prose stating the invariant and code not enforcing it. **A comment is not evidence that the tie exists.** When a function holds a carrier and also reaches for the environment, check which one actually reaches the filesystem.

## Scope

No behavior change on the current ambient path — an ambiently-opened store answers with `paths::artifact_root()`, which is exactly what these resolved anyway. What changes is that they can no longer diverge.

## Verification

`nice -n 10 cargo check --workspace --tests -j2` — clean first try, zero errors and zero warnings. `cargo fmt` applied. `target/` removed.

Scoped to `homeboy-lab-runner` and its one CLI caller. `homeboy-agents` is being worked in parallel and is deliberately untouched here.
