### PR TITLE
Pin Homeboy Action v2.14.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
     # partitioning coverage), #402 (immutable extension revisions), and #405
     # (downloaded Test archives stay out of consumer Git state). Refs
     # #10997 and #11751 W1-2, W1-7, W1-10.
-    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@ae5161e2ce2d5818c41a4b09ae811d1521bb4f95
+    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@4327685846f05b1a82babb29cbb61adc9a88eada
     with:
       commands: review test
       # `review test` defaults to running the extension's pre-test lint, which


### PR DESCRIPTION
## Summary

- update the immutable reusable Test workflow pin to Homeboy Action v2.14.4
- activate mixed-attempt archive/plan resolution and per-shard evidence selection from homeboy-action#412
- preserve the existing `action-ref: v2` runtime checkout contract

## Evidence

- `bash .github/validate-action-pin.sh`
- `git diff --check`
- failed pre-pin rerun: https://github.com/Extra-Chill/homeboy/actions/runs/32488508119/attempts/2

Closes #12780.

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode traced the immutable reusable-workflow pin separately from the nested runtime action checkout and prepared this bounded consumer deployment update. Chris Huber reviewed and remains responsible for every line.