### PR TITLE
refactor(extension): resolve once per linked-extension group, not per member (#7505)

### DIFF
--- a/crates/homeboy-extension/src/lifecycle/update.rs
+++ b/crates/homeboy-extension/src/lifecycle/update.rs
@@ -125,9 +125,13 @@ pub fn update(extension_id: &str, force: bool) -> Result<UpdateResult> {
 
 /// Refresh every linked extension sharing one Git root as one transaction.
 pub fn update_linked_group(extension_ids: &[String], force: bool) -> Result<Vec<UpdateResult>> {
+    // One resolution for the whole group. This function's contract is that the
+    // group refreshes as ONE transaction; resolving per member meant a repoint
+    // mid-loop could span two installations and still report success (#7505).
+    let config_root = paths::homeboy()?;
     let mut entries = Vec::new();
     for id in extension_ids {
-        let extension_dir = paths::extension(id)?;
+        let extension_dir = paths::extension_in_root(&config_root, id);
         let source_dir = linked_source_dir(&extension_dir)?;
         let git_root = linked_extension_git_root(id, &source_dir)?;
         entries.push((id.as_str(), extension_dir, source_dir, git_root));

--- a/crates/homeboy-extension/src/maintenance.rs
+++ b/crates/homeboy-extension/src/maintenance.rs
@@ -16,13 +16,22 @@ pub fn update_all(force: bool) -> UpdateAllResult {
     let mut skipped_details = Vec::new();
     let mut repaired_source_metadata = Vec::new();
     let mut linked_groups: HashMap<String, Vec<String>> = HashMap::new();
+    // One resolution for the whole sweep. Grouping asks whether several
+    // extensions share a Git root, which is only a meaningful question if every
+    // member was resolved against the same installation (#7505).
+    //
+    // An unresolvable config root yields no groups, exactly as the per-item
+    // form did when its `paths::extension` call failed.
+    let config_root = homeboy_core::paths::homeboy().ok();
     for id in &extension_ids {
-        if homeboy_core::extension_store::is_extension_linked(id) {
-            if let Ok(path) = homeboy_core::paths::extension(id) {
-                if let Ok(source) = std::fs::canonicalize(path) {
-                    if let Ok(root) = homeboy_core::git::get_git_root(&source.to_string_lossy()) {
-                        linked_groups.entry(root).or_default().push(id.clone());
-                    }
+        let Some(config_root) = config_root.as_deref() else {
+            break;
+        };
+        if homeboy_core::extension_store::is_extension_linked_in_root(config_root, id) {
+            let path = homeboy_core::paths::extension_in_root(config_root, id);
+            if let Ok(source) = std::fs::canonicalize(path) {
+                if let Ok(root) = homeboy_core::git::get_git_root(&source.to_string_lossy()) {
+                    linked_groups.entry(root).or_default().push(id.clone());
                 }
             }
         }


### PR DESCRIPTION
Two loops resolved the config root on **every iteration**.

## `update_linked_group` — a transaction that wasn't

Its own doc comment:

> *"Refresh every linked extension sharing one Git root **as one transaction**."*

```rust
for id in extension_ids {
    let extension_dir = paths::extension(id)?;   // <- resolved per member
```

The transaction's members were located through N independent reads of process state. A repoint mid-loop spans two installations **and still reports success** — because the group-consistency check that follows compares *Git roots*, which would agree, not homes:

```rust
if entries.iter().any(|(_, _, _, root)| root != &git_root) {
    return Err(Error::internal_unexpected("linked extension group spans multiple Git roots"));
}
```

That guard cannot see the failure it looks like it would catch.

## `update_all` — building those groups

Two ambient resolutions per extension (`is_extension_linked(id)`, then `paths::extension(id)`) to decide which extensions share a Git root. That question is only meaningful if every member was resolved against the same installation.

Both resolve once up front now and use the rooted forms.

## The capacity kept in #12771 is what this uses

`update_all` now calls `is_extension_linked_in_root`. That function had **zero callers**, and #12771 deliberately kept it on the grounds that a dead *rooted* sibling is unused capacity rather than debt — the injection point the layer above would need once its turn came.

This is that turn. The five lines didn't need rewriting, which is the argument for the rule.

## Behavior

`update_all` returns no `Result`, so an unresolvable config root yields no linked groups. That matches what it replaced — the per-item form reached `paths::extension(id)` inside `if let Ok(...)` and skipped the id when it failed.

## Seam status in my lane

Scanned `homeboy-lab-runner`, `homeboy-cli`, `homeboy-extension`, `homeboy-rig`, `homeboy-release`, `homeboy-deploy` for both bug-producing shapes:

| shape | hits |
|---|---|
| carrier in signature, environment in body | **0** — closed |
| resolution inside a loop | these two |

The remaining `from_environment()` calls in `lab-runner` (`workspace/sync`, `lab/offload/hydration`, `evidence/download`) are each a single resolution at a real boundary, several with explicit rationale for resolving at point-of-use rather than function top. Those are boundaries doing their job, not debt.

## Verification

`nice -n 10 cargo check --workspace --tests -j2` — clean first try, zero errors and zero warnings. `cargo fmt` applied. `target/` removed.

Scoped away from `homeboy-agents`, which is being worked in parallel.
