### PR TITLE
Fix explicit Cook path promotion through workspace providers

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/apply.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/apply.rs
@@ -120,6 +120,16 @@ pub(crate) fn preflight_configured_workspace_provider_with_config(
     if resolve_homeboy_workspace(to_workspace)?.is_some() {
         return Ok(());
     }
+    if Path::new(to_workspace).is_dir() {
+        return worktree_providers::resolve_apply_enabled_worktree_provider_path_from_config(
+            Path::new(to_workspace),
+            config,
+            None,
+            None,
+        )?
+        .map(|_| ())
+        .ok_or_else(|| provider_path_not_found(to_workspace));
+    }
     worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
         to_workspace,
         config,
@@ -493,12 +503,22 @@ impl ExternalPromotionWorkspaceProvider {
                         head: trusted.head.clone(),
                     },
                 );
-            let resolution = worktree_providers::resolve_apply_enabled_worktree_provider_with_trusted_unpushed_destination_from_config(
-            &request.to_workspace,
-            &configured_fallback.config,
-            request.gate_feedback_baseline.as_ref(),
-            trusted_unpushed_destination.as_ref(),
-        )?;
+            let resolution = if Path::new(&request.to_workspace).is_dir() {
+                worktree_providers::resolve_apply_enabled_worktree_provider_path_from_config(
+                    Path::new(&request.to_workspace),
+                    &configured_fallback.config,
+                    request.gate_feedback_baseline.as_ref(),
+                    trusted_unpushed_destination.as_ref(),
+                )?
+                .ok_or_else(|| provider_path_not_found(&request.to_workspace))?
+            } else {
+                worktree_providers::resolve_apply_enabled_worktree_provider_with_trusted_unpushed_destination_from_config(
+                    &request.to_workspace,
+                    &configured_fallback.config,
+                    request.gate_feedback_baseline.as_ref(),
+                    trusted_unpushed_destination.as_ref(),
+                )?
+            };
             let workspace = resolution.worktree.path;
             self.provenance = Some(serde_json::json!({
                 "id": resolution.provider_id,
@@ -531,6 +551,15 @@ impl ExternalPromotionWorkspaceProvider {
         }
         error
     }
+}
+
+fn provider_path_not_found(path: &str) -> Error {
+    Error::validation_invalid_argument(
+        "to_worktree",
+        format!("configured worktree providers do not own explicit destination path `{path}`"),
+        Some(path.to_string()),
+        None,
+    )
 }
 
 fn invocation_program_and_args(invocation: &CommandInvocation) -> Option<(String, Vec<String>)> {

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
@@ -255,6 +255,110 @@ fn configured_command_provider_is_resolved_lazily_with_provenance() {
 }
 
 #[test]
+fn configured_command_provider_resolves_an_explicit_destination_path() {
+    let workspace_root = tempfile::tempdir().expect("workspace");
+    git(workspace_root.path(), &["init", "-b", "cook-target"]);
+    let workspace = workspace_root
+        .path()
+        .canonicalize()
+        .expect("canonical workspace");
+    let provider = tempfile::NamedTempFile::new()
+        .expect("provider command")
+        .into_temp_path();
+    std::fs::write(
+        &provider,
+        format!(
+            "#!/bin/sh\n[ \"$1\" = '{}' ] || exit 44\nprintf '%s\\n' '{}'\n",
+            workspace.display(),
+            serde_json::json!({
+                "worktrees": [{
+                    "handle": "fixture@cook-target",
+                    "path": workspace,
+                    "branch": "cook-target",
+                    "safety": { "dirty": false, "unpushed": false, "primary": false }
+                }]
+            })
+        ),
+    )
+    .expect("write provider command");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(&provider)
+            .expect("provider metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&provider, permissions).expect("make provider executable");
+    }
+    let mut config = HomeboyConfig::default();
+    config.worktree_providers.insert(
+        "fixture".to_string(),
+        WorktreeProviderConfig {
+            enabled: true,
+            kind: WorktreeProviderKind::Command,
+            apply_enabled: true,
+            lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
+            lookup_output_limit_bytes: 64 * 1024,
+            commands: WorktreeProviderCommands {
+                resolve_path: Some(vec![provider.display().to_string(), "{path}".to_string()]),
+                ..Default::default()
+            },
+            list_result_mapping: Some(WorktreeProviderListResultMapping {
+                items: "$.worktrees".to_string(),
+                handle: "$.handle".to_string(),
+                path: "$.path".to_string(),
+                branch: "$.branch".to_string(),
+                dirty: "$.safety.dirty".to_string(),
+                unpushed: "$.safety.unpushed".to_string(),
+                primary: "$.safety.primary".to_string(),
+                task_url: None,
+            }),
+        },
+    );
+
+    preflight_configured_workspace_provider_with_config(
+        workspace.to_str().expect("UTF-8 workspace"),
+        &config,
+    )
+    .expect("explicit provider path passes preflight");
+    let mut promotion =
+        ExternalPromotionWorkspaceProvider::from_options_with_config_and_environment(
+            &promotion_options(workspace.to_str().expect("UTF-8 workspace")),
+            &config,
+            Some(PathBuf::from("/fixture/homeboy")),
+            None,
+        );
+    promotion
+        .apply_patch(AgentTaskPromotionApplyRequest {
+            schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
+            to_workspace: workspace.display().to_string(),
+            patch: Some(VALID_PATCH.to_string()),
+            patch_path: "changes.patch".to_string(),
+            changed_files: vec!["src/lib.rs".to_string()],
+            gate_feedback_baseline: None,
+            dry_run: false,
+            trusted_unpushed_candidate_destination: None,
+        })
+        .expect_err("fixture executable is not an adapter");
+
+    assert_eq!(
+        promotion.invocation().expect("invocation").argv,
+        vec![
+            "/fixture/homeboy".to_string(),
+            "agent-task".to_string(),
+            "promotion-provider".to_string(),
+            "--workspace".to_string(),
+            workspace.display().to_string(),
+        ]
+    );
+    assert_eq!(
+        promotion.provenance().expect("provenance")["handle"],
+        "fixture@cook-target"
+    );
+}
+
+#[test]
 fn configured_provider_accepts_only_the_unpushed_immutable_candidate_destination() {
     let (_temp, repo, _base, candidate) = adopted_commit_repo();
     let provider = tempfile::NamedTempFile::new()

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -372,6 +372,33 @@ pub fn resolve_worktree_provider_path_from_config(
     path: &std::path::Path,
     config: &HomeboyConfig,
 ) -> Result<Option<WorktreeProviderResolution>> {
+    resolve_worktree_provider_path_with_policy_from_config(path, config, false, None, None)
+}
+
+/// Resolve an exact provider-owned checkout path for mutation while applying
+/// the same destination safety policy as handle-based promotion.
+pub fn resolve_apply_enabled_worktree_provider_path_from_config(
+    path: &std::path::Path,
+    config: &HomeboyConfig,
+    gate_feedback_baseline: Option<&serde_json::Value>,
+    trusted_unpushed_destination: Option<&TrustedUnpushedWorktree>,
+) -> Result<Option<WorktreeProviderResolution>> {
+    resolve_worktree_provider_path_with_policy_from_config(
+        path,
+        config,
+        true,
+        gate_feedback_baseline,
+        trusted_unpushed_destination,
+    )
+}
+
+fn resolve_worktree_provider_path_with_policy_from_config(
+    path: &std::path::Path,
+    config: &HomeboyConfig,
+    require_apply_enabled: bool,
+    gate_feedback_baseline: Option<&serde_json::Value>,
+    trusted_unpushed_destination: Option<&TrustedUnpushedWorktree>,
+) -> Result<Option<WorktreeProviderResolution>> {
     let requested = match std::fs::canonicalize(path) {
         Ok(path) => path,
         Err(_) => return Ok(None),
@@ -384,7 +411,7 @@ pub fn resolve_worktree_provider_path_from_config(
     provider_ids.sort();
     for provider_id in provider_ids {
         let provider = &config.worktree_providers[&provider_id];
-        if !provider.enabled {
+        if !provider.enabled || (require_apply_enabled && !provider.apply_enabled) {
             continue;
         }
         let worktree = if let Some(command) = provider.commands.resolve_path.as_ref() {
@@ -409,7 +436,12 @@ pub fn resolve_worktree_provider_path_from_config(
         let Some(worktree) = worktree else {
             continue;
         };
-        validate_provider_handle(&provider_id, &worktree, None, None)?;
+        validate_provider_handle(
+            &provider_id,
+            &worktree,
+            gate_feedback_baseline,
+            trusted_unpushed_destination,
+        )?;
         return Ok(Some(WorktreeProviderResolution {
             provider_id,
             worktree,


### PR DESCRIPTION
## Summary
- resolve provider-owned explicit destination paths through the typed `resolve_path` contract
- preserve apply-enabled filtering and existing dirty/unpushed/primary promotion policy
- cover preflight and promotion provenance for path-shaped `--cwd` destinations

Closes #12088.

## Verification
- `cargo test -p homeboy-core worktree_providers::tests::path_resolution -- --nocapture`
- `cargo test -p homeboy-agents configured_command_provider_resolves_an_explicit_destination_path -- --nocapture`
- `cargo test -p homeboy-agents configured_command_provider_is_resolved_lazily_with_provenance -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`

`cargo clippy -p homeboy-core -p homeboy-agents --lib --no-deps -- -D warnings` remains blocked by 11 pre-existing warnings in source-disjoint files.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode traced the DMC/Homeboy identity mismatch, implemented the provider-path repair and regression coverage, and ran the listed verification. Chris Huber reviewed and remains responsible for every line.