### PR TITLE
Root the reconciler and collapse three pairs

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -97,7 +97,7 @@ pub fn cancel_exact_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskR
 /// Reserved handoff reconciliation needs exact-record semantics, but must not
 /// cross into another root merely because two test or controller roots use the
 /// same run ID.
-pub(super) fn cancel_exact_run_in_store(
+pub(crate) fn cancel_exact_run_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     reason: Option<&str>,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
@@ -126,12 +126,20 @@ pub(crate) fn has_expired_pending_runner_submission_intent(
         && record.has_expired_pending_lab_handoff(now)
 }
 
-/// Check whether a controller-owned Lab handoff remains unaccepted after its
-/// durable deadline. Terminalization rechecks this predicate under the handoff
-/// lock before mutating the record.
-pub(crate) fn has_expired_unaccepted_lab_handoff(run_id: &str) -> Result<bool> {
+// The ambient `has_expired_unaccepted_lab_handoff()` shim that used to sit here is
+// gone; the reconciler was its only caller and now asks the store it is about to act on (#7505).
+
+/// [`has_expired_unaccepted_lab_handoff`] against an explicitly injected root.
+///
+/// The reconciler decides whether to expire a handoff from this answer and then
+/// expires it; both halves must read the same installation or it expires a
+/// handoff it never observed (#7505).
+pub(crate) fn has_expired_unaccepted_lab_handoff_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<bool> {
     Ok(has_expired_pending_runner_submission_intent(
-        &store::read_record(&sanitize_run_id(run_id))?,
+        &lifecycle_store.read_record(&sanitize_run_id(run_id))?,
         chrono::Utc::now(),
     ))
 }
@@ -443,16 +451,8 @@ pub(crate) fn is_accepted_runner_handoff(record: &AgentTaskRunRecord) -> bool {
     record.has_accepted_lab_handoff()
 }
 
-/// Reconstruct an authenticated pre-provider transport failure that can safely
-/// admit an externally prepared immutable candidate. Expired handoffs retain
-/// their aggregate-free legacy shape; preacceptance failures retain their
-/// canonical failure aggregate and its synthetic runtime projection.
-pub(crate) fn expire_unaccepted_lab_handoff(run_id: &str) -> Result<bool> {
-    expire_unaccepted_lab_handoff_in_store(
-        &AgentTaskLifecycleStore::from_current_environment()?,
-        run_id,
-    )
-}
+// The ambient `expire_unaccepted_lab_handoff()` shim that used to sit here is
+// gone; the reconciler was its only caller and now expires inside the store it read the handoff from (#7505).
 
 /// The store-rooted counterpart of [`expire_unaccepted_lab_handoff`].
 ///

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -809,10 +809,8 @@ pub fn has_expired_detached_cook_admission(
     has_pending_detached_cook_handoff(record) && !detached_cook_admission_is_live(record, now)
 }
 
-pub fn expire_detached_cook_admission(cook_id: &str) -> Result<bool> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    expire_detached_cook_admission_in_store(&lifecycle_store, cook_id)
-}
+// The ambient `expire_detached_cook_admission()` shim that used to sit here is
+// gone; the reconciler was its only caller and now expires inside the store it classified the run from (#7505).
 
 /// Expire a detached Cook's admission lease inside an explicitly rooted store.
 ///
@@ -3775,19 +3773,8 @@ pub fn status_with_options(
     status_in_store(&lifecycle_store, run_id, options, false)
 }
 
-/// Reconcile one literal durable record without following a Cook alias. Scoped
-/// repair uses this when a logical Cook id has both a handoff parent and an
-/// attempt, because each record is independently authoritative evidence.
-pub fn exact_status(run_id: &str) -> Result<AgentTaskRunRecord> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    Ok(status_in_store(
-        &lifecycle_store,
-        run_id,
-        AgentTaskStatusOptions::default(),
-        true,
-    )?
-    .record)
-}
+// The ambient `exact_status()` shim that used to sit here is
+// gone; the reconciler was its only caller and now reads exactly through the store it resolved once (#7505).
 
 /// The shared, store-rooted body of [`status`], [`status_with_options`], and
 /// [`exact_status`].

--- a/crates/homeboy-agents/src/agent_task_service/reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_service/reconcile.rs
@@ -60,7 +60,41 @@ pub struct AgentTaskReconcileRun {
 /// Genuinely-active runs (live owner/runner with a fresh heartbeat, or queued
 /// work) are never touched. With `dry_run`, candidates are reported but no
 /// record is mutated so an operator can preview the blast radius first.
+/// [`agent_task_lifecycle::status`] against an explicitly injected root.
+fn rooted_status(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<agent_task_lifecycle::AgentTaskRunRecord> {
+    Ok(agent_task_lifecycle::status_in_store(
+        lifecycle_store,
+        run_id,
+        agent_task_lifecycle::AgentTaskStatusOptions::default(),
+        false,
+    )?
+    .record)
+}
+
+/// [`agent_task_lifecycle::exact_status`] against an explicitly injected root.
+fn rooted_exact_status(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<agent_task_lifecycle::AgentTaskRunRecord> {
+    Ok(agent_task_lifecycle::status_in_store(
+        lifecycle_store,
+        run_id,
+        agent_task_lifecycle::AgentTaskStatusOptions::default(),
+        true,
+    )?
+    .record)
+}
+
 pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileReport> {
+    // One store for the whole sweep. Every run this classifies, expires, and
+    // cancels is decided from a record read here; a decision taken against one
+    // installation and committed into another cancels a run it never saw
+    // (#7505).
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
     // Read the durable snapshot first so an expired controller handoff remains
     // visible to this managed recovery command. `status` also converges expiry,
     // but would otherwise terminalize it before this report can record the
@@ -91,7 +125,7 @@ pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileRe
         // daemon may still be active or may have already published the terminal
         // aggregate and artifacts while the controller caller was gone.
         if run.runner_id.is_some() && run.runner_job_id.is_some() {
-            match agent_task_lifecycle::status(&run.run_id) {
+            match rooted_status(&lifecycle_store, &run.run_id) {
                 Ok(refreshed) if refreshed.state.is_terminal() => continue,
                 Ok(refreshed) if !refreshed.is_stale_running() => continue,
                 Ok(refreshed) => authoritative_state = refreshed.state,
@@ -113,9 +147,11 @@ pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileRe
             }
         }
 
-        let expired_handoff =
-            agent_task_lifecycle::has_expired_unaccepted_lab_handoff(&run.run_id)?;
-        let record = agent_task_lifecycle::exact_record(&run.run_id)?;
+        let expired_handoff = agent_task_lifecycle::has_expired_unaccepted_lab_handoff_in_store(
+            &lifecycle_store,
+            &run.run_id,
+        )?;
+        let record = agent_task_lifecycle::exact_record_in_store(&lifecycle_store, &run.run_id)?;
         let expired_detached_admission =
             agent_task_lifecycle::has_expired_detached_cook_admission(&record, chrono::Utc::now());
         if dry_run {
@@ -132,14 +168,17 @@ pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileRe
             continue;
         }
         if expired_detached_admission {
-            match agent_task_lifecycle::expire_detached_cook_admission(&run.run_id) {
+            match agent_task_lifecycle::expire_detached_cook_admission_in_store(
+                &lifecycle_store,
+                &run.run_id,
+            ) {
                 Ok(true) => {
                     reconciled += 1;
                     runs.push(AgentTaskReconcileRun {
                         run_id: run.run_id.clone(),
                         liveness,
                         source: run.source,
-                        authoritative_state: agent_task_lifecycle::status(&run.run_id)?.state,
+                        authoritative_state: rooted_status(&lifecycle_store, &run.run_id)?.state,
                         stale_reason: run.stale_reason,
                         action: "reconciled",
                         error: None,
@@ -149,7 +188,7 @@ pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileRe
                     run_id: run.run_id.clone(),
                     liveness,
                     source: run.source,
-                    authoritative_state: agent_task_lifecycle::status(&run.run_id)?.state,
+                    authoritative_state: rooted_status(&lifecycle_store, &run.run_id)?.state,
                     stale_reason: run.stale_reason,
                     action: "no-op",
                     error: None,
@@ -177,13 +216,18 @@ pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileRe
         let result = if expired_handoff {
             // Handoff expiry answers whether it expired, not what state that
             // left behind; re-read the record for the post-mutation state.
-            agent_task_lifecycle::expire_unaccepted_lab_handoff(&run.run_id).map(|_| {
-                agent_task_lifecycle::status(&run.run_id)
+            agent_task_lifecycle::expire_unaccepted_lab_handoff_in_store(
+                &lifecycle_store,
+                &run.run_id,
+            )
+            .map(|_| {
+                rooted_status(&lifecycle_store, &run.run_id)
                     .map(|record| record.state)
                     .unwrap_or(authoritative_state)
             })
         } else {
-            agent_task_lifecycle::cancel_run(&run.run_id, Some(&reason)).map(|record| record.state)
+            agent_task_lifecycle::cancel_run_in_store(&lifecycle_store, &run.run_id, Some(&reason))
+                .map(|record| record.state)
         };
         match result {
             Ok(state) => {
@@ -235,13 +279,19 @@ pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileRe
 /// reconciliation: a state or ownership change becomes a no-op rather than a
 /// reason to inspect or mutate any other record (#10001).
 pub fn reconcile_run(run_id: &str, dry_run: bool) -> Result<AgentTaskReconcileReport> {
+    // One store for the whole reconciliation: the scope resolution, every
+    // authoritative read, and the expiry or cancellation that follows are one
+    // answer about one run.
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
     let requested_run_id = run_id.to_string();
-    let resolved_run_ids = agent_task_lifecycle::reconcile_scope_run_ids(run_id)?;
+    let resolved_run_ids =
+        agent_task_lifecycle::reconcile_scope_run_ids_in_store(&lifecycle_store, run_id)?;
     let mut runs = Vec::new();
     let mut reconciled = 0;
     let mut failed = 0;
     for resolved_run_id in &resolved_run_ids {
-        let authoritative = agent_task_lifecycle::exact_status(resolved_run_id)?;
+        let authoritative = rooted_exact_status(&lifecycle_store, resolved_run_id)?;
         let source = authoritative
             .runner_id()
             .map(|runner_id| format!("runner:{runner_id}"))
@@ -255,7 +305,7 @@ pub fn reconcile_run(run_id: &str, dry_run: bool) -> Result<AgentTaskReconcileRe
                 let liveness = run.liveness.expect("checked reconcilable liveness");
                 // Re-read immediately before apply. A newly-live runner or a changed
                 // owner is authoritative and turns this scoped request into a no-op.
-                let refreshed = agent_task_lifecycle::exact_status(resolved_run_id)?;
+                let refreshed = rooted_exact_status(&lifecycle_store, resolved_run_id)?;
                 let still_reconcilable = discover_runs(AgentTaskDiscoveryFilter::Active)?
                     .runs
                     .into_iter()
@@ -289,15 +339,18 @@ pub fn reconcile_run(run_id: &str, dry_run: bool) -> Result<AgentTaskReconcileRe
                             chrono::Utc::now(),
                         );
                     if expired_detached_admission {
-                        match agent_task_lifecycle::expire_detached_cook_admission(resolved_run_id)
-                        {
+                        match agent_task_lifecycle::expire_detached_cook_admission_in_store(
+                            &lifecycle_store,
+                            resolved_run_id,
+                        ) {
                             Ok(true) => {
                                 reconciled += 1;
                                 runs.push(AgentTaskReconcileRun {
                                     run_id: resolved_run_id.clone(),
                                     liveness,
                                     source: run.source,
-                                    authoritative_state: agent_task_lifecycle::status(
+                                    authoritative_state: rooted_status(
+                                        &lifecycle_store,
                                         resolved_run_id,
                                     )?
                                     .state,
@@ -310,8 +363,11 @@ pub fn reconcile_run(run_id: &str, dry_run: bool) -> Result<AgentTaskReconcileRe
                                 run_id: resolved_run_id.clone(),
                                 liveness,
                                 source: run.source,
-                                authoritative_state: agent_task_lifecycle::status(resolved_run_id)?
-                                    .state,
+                                authoritative_state: rooted_status(
+                                    &lifecycle_store,
+                                    resolved_run_id,
+                                )?
+                                .state,
                                 stale_reason: run.stale_reason,
                                 action: "no-op",
                                 error: None,
@@ -335,7 +391,11 @@ pub fn reconcile_run(run_id: &str, dry_run: bool) -> Result<AgentTaskReconcileRe
                         .stale_reason
                         .clone()
                         .unwrap_or_else(|| format!("reconciled stale-{} run", liveness.as_str()));
-                    match agent_task_lifecycle::cancel_exact_run(resolved_run_id, Some(&reason)) {
+                    match agent_task_lifecycle::cancel_exact_run_in_store(
+                        &lifecycle_store,
+                        resolved_run_id,
+                        Some(&reason),
+                    ) {
                         Ok(record) => {
                             reconciled += 1;
                             runs.push(AgentTaskReconcileRun {


### PR DESCRIPTION
Fourth slice in the `homeboy-agents` lane. Follows #12772, #12778, #12785.

## The defect

`reconcile_stale_active_runs` and `reconcile_run` decide a run's fate from records they read, then commit that decision through further calls — **seven and six distinct ambient calls, thirteen call sites between them.**

A decision taken against one installation and committed into another **cancels or expires a run it never observed**. Neither half fails while doing it.

Both now resolve one store at the top and answer every read, expiry and cancellation from it.

```
reconcile.rs runtime resolutions:  13 -> 2
```

## Three pairs collapsed

That took the last caller of:

```
expire_detached_cook_admission
expire_unaccepted_lab_handoff
exact_status
```

`has_expired_unaccepted_lab_handoff` had **no rooted form at all** — it reached the `store::` shim, which resolves `default_store()` for itself. Added one; its ambient half then had no callers either and went the same way.

## The visibility asymmetry again

`cancel_exact_run_in_store` was `pub(super)` while its ambient twin `cancel_exact_run` was `pub`, so `agent_task_service` literally could not call the rooted form. Widened to `pub(crate)`.

That is the third time this pattern has blocked a conversion (see #12736 for the ~94-pair survey). **The rooted half being less reachable than the ambient half is why these stay unused.**

## Count delta

```
homeboy-agents:  157 -> 156
```

−1, because three wrapper resolutions came out and two entry-point resolutions went in. The counter understates this one: the meaningful number is 13 → 2 runtime resolutions in the reconciler.

Diff is `+99 / −52`. About 30 of those insertions are the two `rooted_status` / `rooted_exact_status` helpers, which exist because `status_in_store` takes four arguments and thirteen inline copies would be unreadable. Same shape as `rooted_status` in `cook.rs`.

## Verification

- `nice -n 10 cargo check --workspace --tests -j2` — clean, 0 warnings, 0 errors (three runs across the batch)
- `cargo fmt --check` — clean

The gate caught the `pub(super)` visibility issue (`E0603`) and nothing else.

Expect the current red-main set; see the evidence comment on #12772 for the two intermittent members.
