### PR TITLE
Collapse five more wrapper pairs

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -79,18 +79,9 @@ pub(crate) fn cancel_run_in_store(
     )))
 }
 
-/// Cancel one literal durable record without resolving a Cook alias.
-///
-/// Grouped lifecycle recovery uses this boundary after it has explicitly
-/// selected every parent/attempt record to mutate. Alias-aware cancellation is
-/// intentionally broader because it follows an advancing Cook index.
-pub fn cancel_exact_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunRecord> {
-    cancel_resolved_run_in_store(
-        &AgentTaskLifecycleStore::from_current_environment()?,
-        &sanitize_run_id(run_id),
-        reason,
-    )
-}
+// The ambient `cancel_exact_run()` shim that used to sit here is gone; its one
+// remaining caller was a cancellation test, which now cancels inside the store
+// it resolves (#7505).
 
 /// Cancel one literal run through an explicitly selected lifecycle store.
 ///
@@ -1197,7 +1188,13 @@ mod tests {
                     "parent cancellation must preserve the terminal child"
                 );
                 assert!(
-                    cancel_exact_run(&attempt_id, None).is_err(),
+                    cancel_exact_run_in_store(
+                        &AgentTaskLifecycleStore::from_current_environment()
+                            .expect("lifecycle store"),
+                        &attempt_id,
+                        None
+                    )
+                    .is_err(),
                     "direct cancellation retains strict terminal-run semantics"
                 );
             }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -474,8 +474,11 @@ pub fn record_remote_dispatch_failure(
             .and_then(Value::as_str)
             .map(ToString::to_string);
         let plan = synthetic_remote_dispatch_plan(&run_id, &failure, envelope, &aggregate);
-        let mut record = submit_plan(&plan, Some(&run_id))?;
-        record_aggregate(&mut record, &plan, &aggregate)?;
+        // One store for both: the record this submits and the aggregate written
+        // against it are one durable outcome (#7505).
+        let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+        let mut record = submit_plan_in_store(&lifecycle_store, &plan, Some(&run_id))?;
+        record_aggregate_in_store(&lifecycle_store, &mut record, &plan, &aggregate)?;
         (
             record,
             remote_run_id,
@@ -645,14 +648,9 @@ fn synthetic_remote_dispatch_plan(
     plan
 }
 
-pub(crate) fn record_aggregate(
-    record: &mut AgentTaskRunRecord,
-    plan: &AgentTaskPlan,
-    aggregate: &AgentTaskAggregate,
-) -> Result<AgentTaskRunRecord> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    record_aggregate_in_store(&lifecycle_store, record, plan, aggregate)
-}
+// The ambient `record_aggregate()` shim that used to sit here is gone; the
+// remote-dispatch failure recorder was its only caller and now writes the
+// aggregate into the same store it submitted the record to (#7505).
 
 pub(crate) fn record_aggregate_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -5940,13 +5940,9 @@ pub fn exact_record_in_store(
     lifecycle_store.read_record(&sanitize_run_id(run_id))
 }
 
-/// Return the exact durable records a reconciliation request owns. A Cook id
-/// with a materialized detached-handoff parent names both that parent and its
-/// current attempt; an exact attempt remains scoped to itself.
-pub fn reconcile_scope_run_ids(run_id: &str) -> Result<Vec<String>> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    reconcile_scope_run_ids_in_store(&lifecycle_store, run_id)
-}
+// The ambient `reconcile_scope_run_ids()` shim that used to sit here is gone;
+// the reconciler moved to the rooted form in a prior slice and the one
+// remaining test caller now resolves its own store (#7505).
 
 /// [`reconcile_scope_run_ids`] against explicitly injected durable lifecycle
 /// roots.

--- a/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
@@ -354,10 +354,9 @@ fn materialize_cook_attempt_with_stores_and_runtime(
     Ok(())
 }
 
-pub(crate) fn reconcile_reserved_cancellation(cook_id: &str) -> Result<()> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    reconcile_reserved_cancellation_in_store(&lifecycle_store, cook_id)
-}
+// The ambient `reconcile_reserved_cancellation()` shim that used to sit here
+// is gone. Its apparent call site invokes the closure parameter of the same
+// name; the free function itself had no callers (#7505).
 
 pub(crate) fn reconcile_reserved_cancellation_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -1337,16 +1337,9 @@ pub fn enqueue_terminal_continuation(cook_id: &str, run_id: &str) -> Result<bool
     default_store()?.enqueue_terminal_continuation(cook_id, run_id)
 }
 
-/// Explicit operator recovery may rearm a continuation that previously failed
-/// before Cook execution. Automatic scheduling keeps failed entries terminal.
-pub fn rearm_failed_terminal_continuation(cook_id: &str, run_id: &str) -> Result<bool> {
-    rearm_failed_terminal_continuation_in_store(
-        &default_store()?,
-        &agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?,
-        cook_id,
-        run_id,
-    )
-}
+// The ambient `rearm_failed_terminal_continuation()` shim that used to sit
+// here is gone. It had no callers and was reachable only through the
+// `agent_tasks::lifecycle` facade, which nothing outside the crate used (#7505).
 
 /// [`rearm_failed_terminal_continuation`] against explicitly injected durable
 /// roots.

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -1930,7 +1930,12 @@ fn scoped_reconcile_uses_validated_handoff_child_not_later_index_attempt() {
         .expect("bind accepted child");
         index_cook_attempts(cook_id, &attempt_one, &attempt_two);
 
-        let scope = agent_task_lifecycle::reconcile_scope_run_ids(cook_id).expect("scope");
+        let scope = agent_task_lifecycle::reconcile_scope_run_ids_in_store(
+            &agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()
+                .expect("lifecycle store"),
+            cook_id,
+        )
+        .expect("scope");
         assert_eq!(scope, vec![cook_id.to_string(), attempt_one]);
         assert!(!scope.contains(&attempt_two));
     });

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -489,7 +489,7 @@ pub mod service {
         offloaded_status_remediation, persist_initial_recipe, persist_manual_finalization_intent,
         persist_provider_boundary_replay_evidence, persisted_status,
         preflight_cook_continuation_admission, prepare_manual_finalization_identity,
-        promotion_is_resumable, promotion_source, read_plan, rearm_failed_terminal_continuation,
+        promotion_is_resumable, promotion_source, read_plan,
         reconcile_recipe_attempt_for_continuation, reconcile_terminal_artifact_projection,
         reconstruct_adoption_options_with_dispatcher, reconstruct_options_with_dispatcher,
         record_replacement_gate_proof, recover_cook_pr, recover_terminal_transport_proxy_evidence,


### PR DESCRIPTION
Fifth slice in the `homeboy-agents` lane.

## Two were dead outright

```
rearm_failed_terminal_continuation   reachable only through the agent_tasks::lifecycle
                                     facade, which nothing outside the crate used
reconcile_reserved_cancellation      its apparent call site invokes a closure parameter
                                     of the same name, not the free function
```

Both survived only because `agent_task_service` and `agent_task_lifecycle` carry `#[allow(dead_code)]` at the module level, so the compiler never mentioned them.

## Three more lost their last caller

```
record_aggregate          <- the remote-dispatch failure recorder
cancel_exact_run          <- one cancellation test
reconcile_scope_run_ids   <- one reconcile test  (the production caller moved in #12792)
```

## One had a real defect

`record_remote_dispatch_failure` submitted a record and then wrote an aggregate **against that record** through two separately resolved roots:

```rust
let mut record = submit_plan(&plan, Some(&run_id))?;
record_aggregate(&mut record, &plan, &aggregate)?;
```

The aggregate could land beside a record it does not describe. Both now use one store.

## What actually found these

I had been scanning `lifecycle_ops.rs` only, where the single-caller tier looked exhausted — 28 wrappers, 2 collapsible, one of which structurally cannot collapse.

Scanning **the whole crate** instead:

```
                        lifecycle_ops.rs    homeboy-agents
wrapper pairs                 28                60
single-caller                  2                12
zero-caller                    0                 3
```

The file I had been staring at held less than half of them. Worth remembering before concluding a tier is done.

## Count delta

```
homeboy-agents:  157 -> 155
functions deleted:   5
lines:             -12   (34 insertions, 46 deletions)
```

## Verification

- `nice -n 10 cargo check --workspace --tests -j2` — clean, 0 warnings, 0 errors
- `cargo fmt --check` — clean

Two of the three zero-caller candidates were false positives I checked before deleting: `project_terminal_after_unlock` is a **method**, called as `registration.project_terminal_after_unlock()` and invisible to a free-function search. `reconcile_reserved_cancellation` needed the opposite check — its one apparent call site is a **closure parameter** shadowing the name, so it really was dead. Same two hazards, opposite conclusions.

Expect the current red-main set; see the evidence comment on #12772.
