### PR TITLE
docs: repoint two comments at functions that still exist (#7505)

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1333,7 +1333,8 @@ fn collect_extension_cli_info() -> ExtensionCliDiscovery {
 /// Discovery in metadata-only mode: no `ready_check` is spawned.
 ///
 /// The extension-provided command surface comes from each installed manifest's
-/// `cli` block, and broken-link health comes from `broken_extension_links()`.
+/// `cli` block, and broken-link health comes from
+/// `broken_extension_links_in_root()`.
 /// Neither reads readiness, so the rendered `--help` surface and the augmented
 /// parser are byte-identical either way (#10616).
 fn collect_extension_cli_info_metadata_only() -> ExtensionCliDiscovery {

--- a/crates/homeboy-core/src/engine/invocation/child.rs
+++ b/crates/homeboy-core/src/engine/invocation/child.rs
@@ -318,9 +318,9 @@ mod audit_coverage_tests {
 
     /// The config root of the isolated home each test below installs.
     ///
-    /// The ambient `cleanup_invocation_children` / `cleanup_stale_child_records`
-    /// wrappers existed only to serve these two assertions. The test is its own
-    /// boundary, so it resolves here and calls the rooted form directly (#7505).
+    /// These tests are their own boundary: the child-record cleanup entry points
+    /// take a config root, so the test resolves once here and calls them
+    /// directly rather than through the process environment (#7505).
     fn test_config_root() -> std::path::PathBuf {
         paths::homeboy().expect("config root")
     }


### PR DESCRIPTION
Deleting a `pub` function doesn't break a comment that names it, and `cargo check` doesn't read prose. Both of these survived every gate this campaign ran.

## The one that matters

```rust
/// The extension-provided command surface comes from each installed manifest's
/// `cli` block, and broken-link health comes from `broken_extension_links()`.
fn collect_extension_cli_info_metadata_only() -> ExtensionCliDiscovery {
```

That comment is **pre-existing** — from #10616 — and was correct when written. I deleted `broken_extension_links()` in #12771 as a dead ambient wrapper and left the comment pointing at nothing.

This is the worse kind of stale comment: it isn't merely outdated, it's a **dead end for anyone trying to follow it**. Someone asking "where does broken-link health come from?" gets a name that no longer exists. It now names `broken_extension_links_in_root()`, which is what actually answers.

## The one that was mine

The test helper in `engine::invocation::child`, added in #12755, named the two ambient wrappers that *same commit* removed. Rewritten to describe the current arrangement without naming things that are gone.

## What I deliberately did not change

Comments of the form *"the ambient form resolved X independently"* stay. They:

- name no live symbol
- explain **why** a signature takes roots
- are the reason someone doesn't reintroduce the wrapper

**A comment describing a removed design is documentation. A comment naming a removed function as a live source is a broken reference.** Only the second kind is a defect.

## Sweep

Checked every function this campaign deleted — ~20 of them — for surviving references, plus rustdoc intra-doc links (`[\`item\`]`) pointing at them. These two were the only hits. **Zero broken intra-doc links.**

Worth noting the gap: `cargo check` passes on a comment naming a deleted symbol, and rustdoc's `broken_intra_doc_links` only fires for bracketed link syntax — plain backticked names in prose are invisible to both. Deleting a `pub` item needs a grep for its name, not just a green build.

## Verification

`nice -n 10 cargo check --workspace --tests -j2` — clean, zero errors and zero warnings. `cargo fmt` applied.