### PR TITLE
Align historical Cook continuation preflight with execution

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -3654,7 +3654,7 @@ pub fn preflight_cook_continuation_admission(options: &AgentTaskCookServiceOptio
                 == Some("verification_pending")
         });
     let authenticated_historical_review_continuation =
-        authenticated_historical_review_form_workspace(options)?;
+        authenticated_historical_review_form_workspace_with_trace(options, false)?;
     if !moving_base_continuation
         && !verification_pending_continuation
         && !authenticated_historical_review_continuation
@@ -6639,7 +6639,21 @@ fn validate_pending_cook_repository_identity(plan: &AgentTaskPlan, target: &Path
 fn authenticated_historical_review_form_workspace(
     options: &AgentTaskCookServiceOptions,
 ) -> Result<bool> {
+    authenticated_historical_review_form_workspace_with_trace(options, true)
+}
+
+fn authenticated_historical_review_form_workspace_with_trace(
+    options: &AgentTaskCookServiceOptions,
+    persist_trace: bool,
+) -> Result<bool> {
     let mut trace = ContinuationAdmissionTrace::new();
+    let record_trace = |trace: &ContinuationAdmissionTrace| {
+        if persist_trace {
+            record_continuation_admission_trace(&options.initial_run_id, trace)
+        } else {
+            Ok(())
+        }
+    };
     if !agent_task_lifecycle::run_record_exists(&options.initial_run_id)? {
         trace.deny("run_record", "unavailable");
         return Ok(false);
@@ -6650,24 +6664,24 @@ fn authenticated_historical_review_form_workspace(
         Ok(true) => trace.pass("terminal_review_form_eligibility"),
         Ok(false) => {
             trace.deny("terminal_review_form_eligibility", "fail");
-            record_continuation_admission_trace(&options.initial_run_id, &trace)?;
+            record_trace(&trace)?;
             return Ok(false);
         }
         Err(_) => {
             trace.deny("terminal_review_form_eligibility", "unavailable");
-            record_continuation_admission_trace(&options.initial_run_id, &trace)?;
+            record_trace(&trace)?;
             return Ok(false);
         }
     }
     let Some(promotion) = persisted_promotion_for_attempt(&options.initial_run_id).unwrap_or(None)
     else {
         trace.deny("applied_promotion", "unavailable");
-        record_continuation_admission_trace(&options.initial_run_id, &trace)?;
+        record_trace(&trace)?;
         return Ok(false);
     };
     if promotion.status != AgentTaskPromotionStatus::Applied {
         trace.deny("applied_promotion", "fail");
-        record_continuation_admission_trace(&options.initial_run_id, &trace)?;
+        record_trace(&trace)?;
         return Ok(false);
     }
     trace.pass("applied_promotion");
@@ -6675,12 +6689,12 @@ fn authenticated_historical_review_form_workspace(
         Ok(Some(continuation)) => continuation,
         Ok(None) => {
             trace.deny("continuation_evidence", "unavailable");
-            record_continuation_admission_trace(&options.initial_run_id, &trace)?;
+            record_trace(&trace)?;
             return Ok(false);
         }
         Err(_) => {
             trace.deny("continuation_evidence", "fail");
-            record_continuation_admission_trace(&options.initial_run_id, &trace)?;
+            record_trace(&trace)?;
             return Ok(false);
         }
     };
@@ -6701,7 +6715,7 @@ fn authenticated_historical_review_form_workspace(
                     "provider_resolution"
                 };
                 trace.deny(predicate, "fail");
-                record_continuation_admission_trace(&options.initial_run_id, &trace)?;
+                record_trace(&trace)?;
                 return Ok(false);
             }
         };
@@ -6715,22 +6729,22 @@ fn authenticated_historical_review_form_workspace(
         .is_err()
     {
         trace.deny("worktree_root", "fail");
-        record_continuation_admission_trace(&options.initial_run_id, &trace)?;
+        record_trace(&trace)?;
         return Ok(false);
     }
     trace.pass("worktree_root");
     let Ok(target) = std::fs::canonicalize(&resolution.worktree.path) else {
         trace.deny("candidate_fingerprint", "unavailable");
-        record_continuation_admission_trace(&options.initial_run_id, &trace)?;
+        record_trace(&trace)?;
         return Ok(false);
     };
     if authenticate_tracked_promotion_continuation(&target, &continuation).is_err() {
         trace.deny("candidate_fingerprint", "fail");
-        record_continuation_admission_trace(&options.initial_run_id, &trace)?;
+        record_trace(&trace)?;
         return Ok(false);
     }
     trace.pass("candidate_fingerprint");
-    record_continuation_admission_trace(&options.initial_run_id, &trace)?;
+    record_trace(&trace)?;
     Ok(true)
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -1719,6 +1719,22 @@ pub fn reconstruct_adoption_options(
     reconstruct_recipe_options(recipe, None, false, false)
 }
 
+/// A historical recipe can only continue through the terminal adoption path.
+/// Other states could still dispatch or replay provider work and must retain
+/// the runtime pin.
+pub fn historical_terminal_continuation_is_eligible(
+    recipe: &AgentTaskCookRecipe,
+    state: agent_task_lifecycle::AgentTaskRunState,
+) -> bool {
+    recipe.runtime_generation != homeboy_core::build_identity::current().display
+        && matches!(
+            state,
+            agent_task_lifecycle::AgentTaskRunState::Succeeded
+                | agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable
+                | agent_task_lifecycle::AgentTaskRunState::PartialRecoverable
+        )
+}
+
 /// Resolve a Cook identifier to its latest durable attempt. Candidate selection
 /// is promotion authority, not continuation authority: a failed gate-feedback
 /// attempt must remain the source of the next retry.
@@ -2843,6 +2859,32 @@ mod tests {
         assert!(adoption.gates.verify.is_empty());
         assert!(adoption.no_finalize);
         assert!(adoption.attempt_dispatcher.is_none());
+    }
+
+    #[test]
+    fn historical_terminal_admission_matches_provider_replay_policy() {
+        let current = recipe();
+        assert!(!historical_terminal_continuation_is_eligible(
+            &current,
+            agent_task_lifecycle::AgentTaskRunState::Succeeded
+        ));
+        reconstruct_options(&current).expect("current runtime permits normal continuation");
+
+        let mut historical = current.clone();
+        historical.runtime_generation = "homeboy 0.291.2+96820fe8cc53".to_string();
+        assert!(historical_terminal_continuation_is_eligible(
+            &historical,
+            agent_task_lifecycle::AgentTaskRunState::Succeeded
+        ));
+        reconstruct_adoption_options(&historical)
+            .expect("historical terminal continuation avoids provider replay");
+
+        assert!(!historical_terminal_continuation_is_eligible(
+            &historical,
+            agent_task_lifecycle::AgentTaskRunState::Failed
+        ));
+        reconstruct_options(&historical)
+            .expect_err("historical provider replay retains runtime pin");
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -11416,9 +11416,22 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
         );
         assert_eq!(fixture.continuation_record.state, "partial_failure");
 
+        let before_preflight =
+            serde_json::to_value(agent_task_lifecycle::status(&historical.initial_run_id).unwrap())
+                .unwrap();
+        assert!(
+            authenticated_historical_review_form_workspace_with_trace(&historical, false).unwrap(),
+            "the exact dirty candidate authorizes only this historical continuation"
+        );
+        assert_eq!(
+            serde_json::to_value(agent_task_lifecycle::status(&historical.initial_run_id).unwrap())
+                .unwrap(),
+            before_preflight,
+            "read-only admission must not persist a continuation trace"
+        );
         assert!(
             authenticated_historical_review_form_workspace(&historical).unwrap(),
-            "the exact dirty candidate authorizes only this historical continuation"
+            "execution records its exact admission trace"
         );
         historical.attempt_dispatcher = None;
         let executions = Arc::new(AtomicUsize::new(0));

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -1093,7 +1093,10 @@ where
         };
         let mut result = None;
         let historical_terminal =
-            recipe.runtime_generation != homeboy::core::build_identity::current().display;
+            agent_task_service_direct::historical_terminal_continuation_is_eligible(
+                &recipe,
+                record.state,
+            );
         let dispatcher = reconstruct_dispatcher;
         let executor = executor.clone();
         let execute = |options| {
@@ -1388,7 +1391,12 @@ pub(crate) fn preflight_continue_cook(args: CookContinueArgs) -> CmdResult<Value
         .expect("continuation selection is recipe-bound");
     let terminal_review =
         agent_task_service::terminal_review_form_continuation_is_eligible(&attempt.plan, &record)?;
-    let mut options = match if terminal_review {
+    let historical_terminal =
+        agent_task_service_direct::historical_terminal_continuation_is_eligible(
+            &recipe,
+            record.state,
+        );
+    let mut options = match if terminal_review || historical_terminal {
         agent_task_service::reconstruct_adoption_options_with_dispatcher(&recipe, dispatcher)
     } else {
         agent_task_service::reconstruct_options_with_dispatcher(&recipe, dispatcher)
@@ -1431,6 +1439,16 @@ pub(crate) fn preflight_continue_cook(args: CookContinueArgs) -> CmdResult<Value
             "admitted": true,
             "selected_attempt": { "run_id": selected_run_id },
             "candidate_fingerprint": candidate_fingerprint,
+            "continuation": {
+                "path": if historical_terminal {
+                    "historical_terminal"
+                } else if terminal_review {
+                    "terminal_review_form"
+                } else {
+                    "current_runtime"
+                },
+                "provider_replay": terminal_review
+            },
             "phases": phases,
             "side_effects": { "provider_dispatch": false, "git_mutation": false, "github_mutation": false, "finalization": false }
         }),


### PR DESCRIPTION
## Summary
- share historical-terminal eligibility between continuation preflight and execution
- keep preflight mutation-free while execution retains admission diagnostics
- report whether each admitted continuation path can replay provider work
- cover current-runtime, historical-terminal, and historical-provider-replay policy

Closes #12787.

## Verification
- `cargo test -p homeboy-agents historical --lib`
- `cargo test -p homeboy-agents cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate --lib`
- `cargo test -p homeboy-cli cook_continue_preflight_reports_a_read_only_rejection_without_creating_a_run --lib`
- `cargo check -p homeboy-cli`
- `cargo fmt --check`
- `git diff --check`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagents implemented and independently reviewed the continuation policy, mutation-free admission, and tests. Chris Huber directed the work and remains responsible for every line.