### PR TITLE
Root three staging and hydration callers

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -13,7 +13,7 @@ pub fn record_pre_execution_failure(
     record_pre_execution_failure_in_store(&lifecycle_store, run_id, plan, phase, error)
 }
 
-pub(crate) fn record_pre_execution_failure_in_store(
+pub fn record_pre_execution_failure_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     plan: &AgentTaskPlan,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
@@ -317,28 +317,16 @@ pub(crate) fn record_local_lab_identity_fallback_in_store(
     Ok(record)
 }
 
-/// Record child setup executions against the controller proxy. A staging job
-/// can outlive the foreground caller, so its runner IDs belong to the durable
-/// phase record rather than only transient command output.
-pub fn record_lab_offload_phase_executions(
-    run_id: &str,
-    phase: &str,
-    execution_ids: impl IntoIterator<Item = String>,
-) -> Result<AgentTaskRunRecord> {
-    record_lab_offload_phase_executions_in_store(
-        &AgentTaskLifecycleStore::from_current_environment()?,
-        run_id,
-        phase,
-        execution_ids,
-    )
-}
+// The ambient `record_lab_offload_phase_executions()` shim that used to sit here
+// is gone; the lab workspace-exec hydration was its only caller and now records into the store it
+// resolved for the whole operation (#7505).
 
 /// The store-rooted counterpart of [`record_lab_offload_phase_executions`].
 ///
 /// The terminal guard is read from the same record the execution ids are
 /// written back onto, so a staging job cannot be recorded against a run that
 /// another installation already finished (#7505).
-pub(crate) fn record_lab_offload_phase_executions_in_store(
+pub fn record_lab_offload_phase_executions_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     phase: &str,
@@ -368,26 +356,16 @@ pub(crate) fn record_lab_offload_phase_executions_in_store(
     Ok(record)
 }
 
-/// Bind the controller-owned staging job separately from the eventual runner job.
-pub fn record_lab_staging_controller_job(
-    run_id: &str,
-    runner_id: &str,
-    controller_job_id: &str,
-) -> Result<AgentTaskRunRecord> {
-    record_lab_staging_controller_job_in_store(
-        &AgentTaskLifecycleStore::from_current_environment()?,
-        run_id,
-        runner_id,
-        controller_job_id,
-    )
-}
+// The ambient `record_lab_staging_controller_job()` shim that used to sit here
+// is gone; the detached staging submitter was its only caller and now records into the store it
+// resolved for the whole operation (#7505).
 
 /// The store-rooted counterpart of [`record_lab_staging_controller_job`].
 ///
 /// The staging job id is the controller's only handle on a materialization it
 /// can outlive, so the terminal guard and the binding must name one record in
 /// one installation (#7505).
-pub(crate) fn record_lab_staging_controller_job_in_store(
+pub fn record_lab_staging_controller_job_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     runner_id: &str,
@@ -479,27 +457,16 @@ pub(crate) fn record_lab_admission_reservation_in_store(
     Ok(record)
 }
 
-/// Preserve the controller-stage terminal context on the durable parent after
-/// its generic controller job has failed.
-pub fn record_lab_staging_controller_failure(
-    run_id: &str,
-    phase: &str,
-    controller_job_id: &str,
-) -> Result<AgentTaskRunRecord> {
-    record_lab_staging_controller_failure_in_store(
-        &AgentTaskLifecycleStore::from_current_environment()?,
-        run_id,
-        phase,
-        controller_job_id,
-    )
-}
+// The ambient `record_lab_staging_controller_failure()` shim that used to sit here
+// is gone; the staging checkpoint executor was its only caller and now records into the store it
+// resolved for the whole operation (#7505).
 
 /// The store-rooted counterpart of [`record_lab_staging_controller_failure`].
 ///
 /// This is terminal-stage evidence about one run, and the retry command it
 /// publishes is only actionable in the installation the record lives in, so the
 /// read and the write name the same store (#7505).
-pub(crate) fn record_lab_staging_controller_failure_in_store(
+pub fn record_lab_staging_controller_failure_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     phase: &str,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1956,7 +1956,7 @@ pub fn load_controller_plan(run_id: &str) -> Result<AgentTaskPlan> {
 /// Load the controller-owned plan from an explicitly rooted store. Both halves
 /// follow the injected root: the Cook alias is resolved against that store's
 /// own index, and the plan is read from that store's own run directory.
-pub(crate) fn load_controller_plan_in_store(
+pub fn load_controller_plan_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
 ) -> Result<AgentTaskPlan> {

--- a/crates/homeboy-lab-runner/src/lab/offload/hydration.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/hydration.rs
@@ -477,6 +477,9 @@ pub(crate) fn hydrate_for_lab_workspace_exec_with_lifecycle(
     plan: HomeboyPlan,
     agent_task_run_id: Option<&str>,
 ) -> Result<RecordedLabDependencyHydration> {
+    // The phase executions recorded here belong to the run this hydrates (#7505).
+    let lab_lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
     let hydration = hydrate_for_lab_workspace_exec_internal(
         skip_deps_hydration,
         runner_id,
@@ -494,7 +497,8 @@ pub(crate) fn hydrate_for_lab_workspace_exec_with_lifecycle(
         LabWorkspaceHydrationRecord::NotApplied { .. } => Vec::new(),
     };
     if let Some(run_id) = agent_task_run_id {
-        agent_task_lifecycle::record_lab_offload_phase_executions(
+        agent_task_lifecycle::record_lab_offload_phase_executions_in_store(
+            &lab_lifecycle_store,
             run_id,
             "hydrating",
             execution_ids.clone(),

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -982,6 +982,10 @@ fn submit_detached_staging_with_daemon_ensure<Ensure>(
 where
     Ensure: FnOnce() -> Result<homeboy_core::daemon::DaemonStartResult>,
 {
+    // One store: the controller plan read and the staging job recorded against
+    // it are one submission (#7505).
+    let lab_lifecycle_store =
+        homeboy_agents::agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
     if !routing_ready() {
         return Err(Error::validation_invalid_argument(
             "lab_staging_adapter",
@@ -1013,7 +1017,10 @@ where
     let attachment = homeboy_agents::agent_task_lifecycle::load_private_run_attachment::<
         LabStagingRecipe,
     >(run_id, LAB_STAGING_RECIPE_ATTACHMENT_KIND)?;
-    let plan = homeboy_agents::agent_task_lifecycle::load_controller_plan(run_id)?;
+    let plan = homeboy_agents::agent_task_lifecycle::load_controller_plan_in_store(
+        &lab_lifecycle_store,
+        run_id,
+    )?;
     let envelope = LabStagingDispatchEnvelope::new(
         run_id,
         runner_id,
@@ -1051,8 +1058,11 @@ where
     let job = create;
     validate_controller_job(&job)?;
     let job_id = job.id.to_string();
-    homeboy_agents::agent_task_lifecycle::record_lab_staging_controller_job(
-        run_id, runner_id, &job_id,
+    homeboy_agents::agent_task_lifecycle::record_lab_staging_controller_job_in_store(
+        &lab_lifecycle_store,
+        run_id,
+        runner_id,
+        &job_id,
     )?;
 
     let started = post_controller_job_with_retries(
@@ -4158,6 +4168,10 @@ impl LabStagingDispatchDriver {
         job: ControllerJobHandle,
         resume: bool,
     ) -> Result<Value> {
+        // One store: the staging-controller failure and the pre-execution failure
+        // beside it describe one checkpoint (#7505).
+        let lab_lifecycle_store =
+            homeboy_agents::agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
         checkpoint.validate()?;
         let adapter = require_production_adapter()?;
         let request = match &checkpoint.input {
@@ -4181,16 +4195,14 @@ impl LabStagingDispatchDriver {
         };
         let checkpoint = result.inspect_err(|error| {
             if !job.is_cancelled()
-                && homeboy_agents::agent_task_lifecycle::record_pre_execution_failure(
-                    &request.recipe.run_id,
+                && homeboy_agents::agent_task_lifecycle::record_pre_execution_failure_in_store(&lab_lifecycle_store, &request.recipe.run_id,
                     &request.durable_agent_task_plan,
                     "lab_staging_controller",
                     error,
                 )
                 .is_ok()
             {
-                let _ = homeboy_agents::agent_task_lifecycle::record_lab_staging_controller_failure(
-                    &request.recipe.run_id,
+                let _ = homeboy_agents::agent_task_lifecycle::record_lab_staging_controller_failure_in_store(&lab_lifecycle_store, &request.recipe.run_id,
                     &format!("{:?}", expected_identity.phase),
                     &job.job_id(),
                 );


### PR DESCRIPTION
Seventh slice in the `homeboy-agents` lane.

## The blocker was visibility, again

Three ambient wrappers survived only because `homeboy-lab-runner` **could not see** their rooted siblings — each was `pub(crate)` in `homeboy-agents`, so the ambient form was the only one visible across the crate boundary.

Widening five siblings to `pub` let each caller convert, and all three wrappers lost their last caller:

```
record_lab_offload_phase_executions    <- lab workspace-exec hydration
record_lab_staging_controller_failure  <- the staging checkpoint executor
record_lab_staging_controller_job      <- the detached staging submitter
```

That is the fourth time this asymmetry has been the thing standing in the way (see the ~94-pair survey in #12736). Only the five siblings a caller actually needs are widened.

## Two callers fold a second call into the same store

- `execute_checkpoint` also records a **pre-execution failure describing the same checkpoint**
- `submit_detached_staging_with_daemon_ensure` reads the **controller plan the staging job is recorded against**

Those pairs now name one installation instead of two.

```
homeboy-agents:  157 -> 154
functions deleted:   3
lines:             -17   (38 insertions, 55 deletions)
```

## What is deliberately not here

`run_lab_offload_inner` was the biggest target in this file — **nine** ambient calls, one store. I converted it, and the gate rejected it: four of the nine are `record_lab_offload_phase`, whose rooted sibling takes a `LabOffloadPhaseRecord` struct rather than the ambient form's seven loose arguments (`E0061`, four times).

Converting those means constructing the struct at each site. Rooting only the other five would leave the function **half-rooted** — some calls naming an injected home, some the ambient one — which is precisely the shape this work exists to remove and the thing I have been flagging in every other PR.

So it is reverted here and left whole for a pass that can do it properly. I also reverted the two `pub(crate) -> pub` widenings that conversion would have justified, since nothing demands them now.

## Verification

- `nice -n 10 cargo check --workspace --tests -j2` — clean, 0 warnings, 0 errors
- `cargo fmt --check` — clean

Expect the current red-main set; see the evidence comment on #12772.
