### PR TITLE
Preserve Cook placement in recovery commands

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -79,10 +79,12 @@ pub fn cook_continue_command(
     rearm: bool,
     artifact_id: Option<&str>,
 ) -> String {
-    let executable = executable.unwrap_or("homeboy");
+    let executable = executable
+        .map(quote_arg)
+        .unwrap_or_else(|| cook_recovery_command_prefix(cook_or_attempt_id));
     let mut command = format!(
         "{} agent-task cook-continue {}",
-        quote_arg(executable),
+        executable,
         quote_arg(cook_or_attempt_id)
     );
     if rearm {
@@ -91,6 +93,74 @@ pub fn cook_continue_command(
     if let Some(artifact_id) = artifact_id {
         command.push_str(" --artifact-id ");
         command.push_str(&quote_arg(artifact_id));
+    }
+    command
+}
+
+/// Render the executable and global flags authorized by this exact durable Cook
+/// attempt. Callers append `agent-task` and the lifecycle subcommand.
+///
+/// A local prefix is only recovered from an explicit, durable override. Other
+/// controller-local attempts remain subject to current resource policy instead
+/// of turning ownership evidence into a new global authorization.
+pub fn cook_recovery_command_prefix(run_id: &str) -> String {
+    let decision = agent_task_lifecycle::exact_record(run_id)
+        .ok()
+        .and_then(|record| cook_recovery_placement_decision(&record));
+    cook_recovery_command_prefix_for_decision(decision.as_ref())
+}
+
+/// Render the recovery prefix from an already-loaded durable attempt record.
+/// This keeps callers with an injected lifecycle store from reading ambient
+/// placement state while constructing a follow-up command.
+pub fn cook_recovery_command_prefix_for_record(
+    record: &agent_task_lifecycle::AgentTaskRunRecord,
+) -> String {
+    let decision = cook_recovery_placement_decision(record);
+    cook_recovery_command_prefix_for_decision(decision.as_ref())
+}
+
+fn cook_recovery_placement_decision(
+    record: &agent_task_lifecycle::AgentTaskRunRecord,
+) -> Option<homeboy_lab_runner_contract::ExecutionPlacementDecision> {
+    serde_json::from_value(record.metadata["execution_placement_decision"].clone()).ok()
+}
+
+fn cook_recovery_command_prefix_for_decision(
+    decision: Option<&homeboy_lab_runner_contract::ExecutionPlacementDecision>,
+) -> String {
+    match decision {
+        Some(decision)
+            if decision.requested == homeboy_lab_runner_contract::Placement::Local
+                && decision.override_authorization.authorized =>
+        {
+            "homeboy --placement local".to_string()
+        }
+        Some(decision)
+            if decision.selected
+                == homeboy_lab_runner_contract::EffectiveExecutionPlacement::Lab =>
+        {
+            decision.runner.as_ref().map_or_else(
+                || "homeboy".to_string(),
+                |runner| format!("homeboy --runner {}", quote_arg(&runner.runner_id)),
+            )
+        }
+        _ => "homeboy".to_string(),
+    }
+}
+
+/// Build an owner-bound recovery command from the durable placement decision.
+pub fn cook_recovery_command(run_id: &str, args: &[&str]) -> String {
+    let prefix = cook_recovery_command_prefix(run_id);
+    cook_recovery_command_with_prefix(&prefix, args)
+}
+
+/// Build a recovery command from a previously resolved durable prefix.
+pub fn cook_recovery_command_with_prefix(prefix: &str, args: &[&str]) -> String {
+    let mut command = format!("{prefix} agent-task");
+    for arg in args {
+        command.push(' ');
+        command.push_str(&quote_arg(arg));
     }
     command
 }
@@ -1408,7 +1478,7 @@ pub fn cook_completion(
         .flatten()
         .map(|run_id| AgentTaskCookRecoveryAction {
             action: "finalize_pr".to_string(),
-            command: format!("homeboy agent-task finalize-pr --recover {run_id}"),
+            command: cook_recovery_command(&run_id, &["finalize-pr", "--recover", &run_id]),
         });
     Some(AgentTaskCookCompletion {
         schema: "homeboy/agent-task-cook-completion/v1",
@@ -1927,6 +1997,70 @@ impl serde::Serialize for AgentTaskCookBatchReport {
 #[cfg(test)]
 mod run_lifecycle_projection_tests {
     use super::*;
+
+    #[test]
+    fn recovery_prefix_preserves_only_explicit_local_authority() {
+        let identity = homeboy_lab_runner_contract::ExecutionPlacementIdentity {
+            repository: "fixture".to_string(),
+            workspace: "fixture".to_string(),
+            task: "task".to_string(),
+            candidate: None,
+            base: None,
+        };
+        let local = homeboy_lab_runner_contract::ExecutionPlacementDecision::controller_local(
+            "fixture",
+            "v1",
+            identity.clone(),
+            homeboy_lab_runner_contract::Placement::Local,
+        );
+        let automatic = homeboy_lab_runner_contract::ExecutionPlacementDecision::controller_local(
+            "fixture",
+            "v1",
+            identity,
+            homeboy_lab_runner_contract::Placement::Auto,
+        );
+
+        assert_eq!(
+            cook_recovery_command_prefix_for_decision(Some(&local)),
+            "homeboy --placement local"
+        );
+        assert_eq!(
+            cook_recovery_command_prefix_for_decision(Some(&automatic)),
+            "homeboy"
+        );
+        let lab = homeboy_lab_runner_contract::ExecutionPlacementDecision::new(
+            "fixture",
+            "v1",
+            homeboy_lab_runner_contract::ExecutionPlacementIdentity {
+                repository: "fixture".to_string(),
+                workspace: "fixture".to_string(),
+                task: "task".to_string(),
+                candidate: None,
+                base: None,
+            },
+            homeboy_lab_runner_contract::Placement::Lab,
+            homeboy_lab_runner_contract::ExecutionPlacementRequirement::Lab,
+            homeboy_lab_runner_contract::EffectiveExecutionPlacement::Lab,
+            Some(
+                homeboy_lab_runner_contract::ExecutionPlacementRunnerSelection {
+                    runner_id: "lab-fixture".to_string(),
+                    source: homeboy_lab_runner_contract::RunnerSelectionSource::Explicit,
+                },
+            ),
+            homeboy_lab_runner_contract::ExecutionPlacementFallback {
+                local_allowed: false,
+                reason: None,
+            },
+            homeboy_lab_runner_contract::ExecutionPlacementOverrideAuthorization {
+                authorized: false,
+                authority: None,
+            },
+        );
+        assert_eq!(
+            cook_recovery_command_prefix_for_decision(Some(&lab)),
+            "homeboy --runner lab-fixture"
+        );
+    }
 
     fn report(status: &str, disposition: CookDisposition) -> AgentTaskCookReport {
         AgentTaskCookReport {
@@ -5731,8 +5865,9 @@ fn run_cook_spine(
                                 "status": "awaiting_acceptance",
                                 "reason": error.message,
                                 "run_id": run_id,
-                                "status_command": format!(
-                                    "homeboy agent-task status {run_id} --full"
+                                "status_command": cook_recovery_command(
+                                    &run_id,
+                                    &["status", &run_id, "--full"],
                                 ),
                             })),
                             stop_reason: Some(
@@ -6971,7 +7106,9 @@ fn record_active_cook_worktree_warning(options: &AgentTaskCookServiceOptions) ->
             "schema": "homeboy/cook-active-worktree-warning/v1",
             "canonical_worktree": target,
             "active_run_ids": run_ids,
-            "status_commands": active.iter().map(|record| format!("homeboy agent-task status {}", record.run_id)).collect::<Vec<_>>(),
+            "status_commands": active.iter().map(|record| {
+                cook_recovery_command(&record.run_id, &["status", &record.run_id])
+            }).collect::<Vec<_>>(),
         }),
     )?;
     Ok(())

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -923,7 +923,9 @@ pub(crate) fn moving_base_recovery_for_run_with_stores(
             // Recoveries written before scoped continuation used `run-next`.
             // The run ID remains authoritative, so expose the safe command
             // without requiring an unsafe migration of historical records.
-            recovery.continuation = super::cook_continue_command(None, run_id, false, None);
+            let prefix = super::cook_recovery_command_prefix_for_record(&record);
+            recovery.continuation =
+                super::cook_recovery_command_with_prefix(&prefix, &["cook-continue", run_id]);
             Ok(Some(recovery))
         })
 }
@@ -961,7 +963,7 @@ pub(crate) fn moving_base_recovery_from_promotion(
         blocker: String::new(),
         // This recovery belongs to one immutable Cook attempt. `run-next` is a
         // global scheduler operation and must never be offered as its recovery.
-        continuation: super::cook_continue_command(None, run_id, false, None),
+        continuation: super::cook_recovery_command(run_id, &["cook-continue", run_id]),
         base_movements: 0,
     }
 }
@@ -3696,17 +3698,17 @@ fn cook_recovery_actions(
     let mut actions = vec![
         super::AgentTaskCookRecoveryAction {
             action: "status".to_string(),
-            command: format!("homeboy agent-task status {run_id} --full"),
+            command: super::cook_recovery_command(run_id, &["status", run_id, "--full"]),
         },
         super::AgentTaskCookRecoveryAction {
             action: "diagnose".to_string(),
-            command: format!("homeboy agent-task diagnose {run_id}"),
+            command: super::cook_recovery_command(run_id, &["diagnose", run_id]),
         },
     ];
     if blocking_claim {
         actions.push(super::AgentTaskCookRecoveryAction {
             action: "reconcile".to_string(),
-            command: format!("homeboy agent-task reconcile {run_id} --dry-run"),
+            command: super::cook_recovery_command(run_id, &["reconcile", run_id, "--dry-run"]),
         });
     }
     if exact_checkpoint_candidate_mismatch {
@@ -3715,19 +3717,28 @@ fn cook_recovery_actions(
         // can safely continue against a diverged worktree.
         actions.push(super::AgentTaskCookRecoveryAction {
             action: "fork_replacement".to_string(),
-            command: format!("homeboy agent-task retry {run_id} --run"),
+            command: super::cook_recovery_command(run_id, &["retry", run_id, "--run"]),
         });
     } else if !ambiguous_artifact_ids.is_empty() {
         actions.extend(ambiguous_artifact_ids.into_iter().map(|artifact_id| {
             super::AgentTaskCookRecoveryAction {
                 action: "resume_with_artifact".to_string(),
-                command: super::cook_continue_command(None, run_id, true, Some(&artifact_id)),
+                command: super::cook_recovery_command(
+                    run_id,
+                    &[
+                        "cook-continue",
+                        run_id,
+                        "--rearm",
+                        "--artifact-id",
+                        &artifact_id,
+                    ],
+                ),
             }
         }));
     } else if continuation_eligible {
         actions.push(super::AgentTaskCookRecoveryAction {
             action: "resume".to_string(),
-            command: super::cook_continue_command(None, run_id, false, None),
+            command: super::cook_recovery_command(run_id, &["cook-continue", run_id]),
         });
     }
     let next_actions = actions.clone();

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -2152,6 +2152,28 @@ fn moving_base_recovery_isolates_identical_attempts_across_explicit_stores() {
             .unwrap();
     }
 
+    left_lifecycle_store
+        .mutate_record(run_id, |record| {
+            let identity = homeboy_lab_runner_contract::ExecutionPlacementIdentity {
+                repository: "fixture".to_string(),
+                workspace: "fixture".to_string(),
+                task: "task".to_string(),
+                candidate: None,
+                base: None,
+            };
+            record.metadata["execution_placement_decision"] = serde_json::to_value(
+                homeboy_lab_runner_contract::ExecutionPlacementDecision::controller_local(
+                    "fixture",
+                    "v1",
+                    identity,
+                    homeboy_lab_runner_contract::Placement::Local,
+                ),
+            )
+            .unwrap();
+            true
+        })
+        .unwrap();
+
     let left =
         moving_base_recovery_for_run_with_stores(&left_recipe_store, &left_lifecycle_store, run_id)
             .unwrap()
@@ -2166,6 +2188,14 @@ fn moving_base_recovery_isolates_identical_attempts_across_explicit_stores() {
 
     assert_eq!(left.blocker, "left blocker");
     assert_eq!(right.blocker, "right blocker");
+    assert_eq!(
+        left.continuation,
+        format!("homeboy --placement local agent-task cook-continue {run_id}")
+    );
+    assert_eq!(
+        right.continuation,
+        format!("homeboy agent-task cook-continue {run_id}")
+    );
     assert_ne!(
         left_lifecycle_store.run_dir(run_id),
         right_lifecycle_store.run_dir(run_id)

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -961,7 +961,7 @@ fn retryable_cook_attempt(
             Some(source.run_id.clone()),
             Some(vec![format!(
                 "Continue the owning Cook with: {}",
-                super::cook_continue_command(None, cook_id, false, None)
+                super::cook_continue_command(None, &source.run_id, false, None)
             )]),
         ));
     };

--- a/crates/homeboy-cli/src/cli_surface/mod.rs
+++ b/crates/homeboy-cli/src/cli_surface/mod.rs
@@ -1155,7 +1155,7 @@ mod tests {
 
     #[test]
     fn generated_cook_continuation_commands_parse_against_the_live_cli() {
-        use homeboy_agents::agent_task_service::cook_continue_command;
+        use homeboy_agents::agent_task_service::{cook_continue_command, cook_recovery_command};
 
         for command in [
             cook_continue_command(None, "cook-1", false, None),
@@ -1167,6 +1167,10 @@ mod tests {
                 "cook-1-attempt-2",
                 false,
                 None,
+            ),
+            cook_recovery_command(
+                "cook-1-attempt-2",
+                &["finalize-pr", "--recover", "cook-1-attempt-2"],
             ),
         ] {
             let argv =

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -193,6 +193,8 @@ fn status_once(args: StatusArgs) -> CmdResult<Value> {
         Err(error) => return Err(error),
     };
     let record = durable_read.record;
+    let recovery_prefix =
+        agent_task_service_direct::cook_recovery_command_prefix_for_record(&record);
     let runner_probe = runner_probe_projection(&agent_task_lifecycle::runner_probe_plan(
         &record,
         agent_task_lifecycle::AgentTaskStatusOptions {
@@ -266,7 +268,7 @@ fn status_once(args: StatusArgs) -> CmdResult<Value> {
         attach_full_status_candidate(&mut value, aggregate.as_ref(), run_id);
         attach_runner_probe(&mut value, &runner_probe);
         attach_agent_task_status_actionable(&mut value, run_id);
-        preserve_controller_owner_placement(&mut value, run_id);
+        preserve_controller_owner_placement_with_prefix(&mut value, run_id, &recovery_prefix);
         if args.bounded {
             value = bounded_full_status(value, run_id);
         }
@@ -282,7 +284,7 @@ fn status_once(args: StatusArgs) -> CmdResult<Value> {
     }
     attach_runner_probe(&mut summary, &runner_probe);
     attach_agent_task_status_actionable(&mut summary, run_id);
-    preserve_controller_owner_placement(&mut summary, run_id);
+    preserve_controller_owner_placement_with_prefix(&mut summary, run_id, &recovery_prefix);
     let summary = enforce_compact_status_budget(summary);
     let exit_code = subject_exit_code(&summary, args.strict_subject_exit);
     Ok((summary, exit_code))
@@ -1647,14 +1649,23 @@ fn attach_actionable_metadata(value: &mut Value, metadata: CommandActionableMeta
     }
 }
 
-/// Follow-up lifecycle commands must retain the controller-local ownership of
-/// the record even when a default Lab runner becomes available between reads.
+/// Follow-up lifecycle commands retain the exact durable placement decision
+/// that authorized their owning Cook attempt.
 fn preserve_controller_owner_placement(value: &mut Value, run_id: &str) {
+    let recovery_prefix = agent_task_service_direct::cook_recovery_command_prefix(run_id);
+    preserve_controller_owner_placement_with_prefix(value, run_id, &recovery_prefix);
+}
+
+fn preserve_controller_owner_placement_with_prefix(
+    value: &mut Value,
+    run_id: &str,
+    recovery_prefix: &str,
+) {
     match value {
         Value::String(command) => {
-            let prefix = "homeboy agent-task ";
+            let command_prefix = "homeboy agent-task ";
             let lifecycle_command = command
-                .strip_prefix(prefix)
+                .strip_prefix(command_prefix)
                 .and_then(|rest| rest.split_whitespace().next())
                 .is_some_and(|operation| {
                     matches!(
@@ -1668,20 +1679,23 @@ fn preserve_controller_owner_placement(value: &mut Value, run_id: &str) {
                             | "retry"
                             | "reconcile"
                             | "cancel"
+                            | "cook-continue"
+                            | "finalize-pr"
                     )
                 });
             if lifecycle_command && command.contains(run_id) {
-                *command = command.replacen(prefix, "homeboy --placement local agent-task ", 1);
+                *command =
+                    command.replacen(command_prefix, &format!("{recovery_prefix} agent-task "), 1);
             }
         }
         Value::Array(values) => {
             for value in values {
-                preserve_controller_owner_placement(value, run_id);
+                preserve_controller_owner_placement_with_prefix(value, run_id, recovery_prefix);
             }
         }
         Value::Object(values) => {
             for value in values.values_mut() {
-                preserve_controller_owner_placement(value, run_id);
+                preserve_controller_owner_placement_with_prefix(value, run_id, recovery_prefix);
             }
         }
         _ => {}
@@ -1938,7 +1952,9 @@ pub(super) fn diagnose(args: DiagnoseArgs) -> CmdResult<Value> {
         retry.continuation.as_ref(),
         runner_cancellation.is_some(),
     );
-    preserve_controller_owner_placement(&mut value, run_id);
+    let recovery_prefix =
+        agent_task_service_direct::cook_recovery_command_prefix_for_record(&record);
+    preserve_controller_owner_placement_with_prefix(&mut value, run_id, &recovery_prefix);
     Ok((value, 0))
 }
 
@@ -6376,6 +6392,29 @@ fn diagnose_next_commands(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn placement_rewrite_threads_one_resolved_prefix_through_nested_commands() {
+        let mut value = json!({
+            "command": "homeboy agent-task status cook-1 --full",
+            "nested": ["homeboy agent-task finalize-pr --recover cook-1"],
+        });
+
+        preserve_controller_owner_placement_with_prefix(
+            &mut value,
+            "cook-1",
+            "homeboy --placement local",
+        );
+
+        assert_eq!(
+            value["command"],
+            "homeboy --placement local agent-task status cook-1 --full"
+        );
+        assert_eq!(
+            value["nested"][0],
+            "homeboy --placement local agent-task finalize-pr --recover cook-1"
+        );
+    }
 
     #[test]
     fn actionable_diagnostics_outrank_a_successful_provider_process_exit() {

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
@@ -1576,6 +1576,34 @@ mod tests {
     }
 
     #[test]
+    fn warm_machine_accepts_emitted_local_finalize_recovery_without_argument_surgery() {
+        let _lock = env_lock();
+        let _guard = EnvVarGuard::remove(crate::runner::RUNNER_HOSTED_EXEC_ENV);
+        let _ci = EnvVarGuard::remove("GITHUB_ACTIONS");
+        let command = homeboy_agents::agent_task_service::cook_recovery_command_with_prefix(
+            "homeboy --placement local",
+            &["finalize-pr", "--recover", "cook-local-finalize"],
+        );
+        let argv = shlex::split(&command).expect("emitted local recovery command is shell-safe");
+        let cli = Cli::try_parse_from(argv).expect("emitted local recovery command parses");
+        let warning = evaluate(
+            lab_supported_hot("agent-task finalize-pr"),
+            &resources(ResourceRecommendation::Warm),
+        )
+        .expect("warm machines require placement admission");
+
+        assert_eq!(cli.placement, crate::cli_surface::Placement::Local);
+        assert!(non_interactive_preflight_error(
+            &warning,
+            cli.placement == crate::cli_surface::Placement::Local,
+            false,
+            None,
+            false,
+        )
+        .is_none());
+    }
+
+    #[test]
     fn portable_refusal_rerun_uses_eligible_lab_runner() {
         let rerun = rerun_command(
             lab_supported_hot("audit"),


### PR DESCRIPTION
## Summary

- derive recovery command prefixes from the exact durable Cook placement decision
- preserve explicitly authorized local and pinned Lab ownership across completion, diagnose, status, and continuation
- avoid ambient-store placement drift and repeated per-node durable lookups
- validate every generated continuation against the live CLI

## Verification

- `cargo fmt --check`
- affected crate checks passed
- generated command parser, injected-store, nested rewrite, and warm-machine local recovery tests passed
- `git diff --check`

Closes #12796.

## AI assistance

OpenAI `openai/gpt-5.6-sol` via OpenCode general coding agents implemented, reviewed, and corrected the owner-bound recovery command contract. Chris Huber reviewed and is responsible for every line.