### PR TITLE
Quarantine leaked fixture agent-task records

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/health.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/health.rs
@@ -3,6 +3,33 @@ use homeboy_core::observation::RunRecord;
 
 pub(crate) const HEALTH_SAMPLE_LIMIT: usize = 20;
 const QUARANTINE_KEY: &str = "agent_task_lifecycle_quarantine";
+const FIXTURE_RUNNER_QUARANTINE_REASON: &str = "fixture_runner_provenance";
+
+/// Fixture executor records cannot represent production runner ownership. The
+/// conjunction keeps an unknown real runner fail-closed: it requires an accepted
+/// runner handoff, a complete runner-job identity, and a plan made entirely of
+/// the in-tree test executor.
+pub(crate) fn fixture_runner_provenance(
+    record: &AgentTaskRunRecord,
+    plan: &AgentTaskPlan,
+) -> Option<Value> {
+    let runner_id = record.runner_id()?;
+    let runner_job_id = record.runner_job_id()?;
+    (record.has_accepted_lab_handoff()
+        && !plan.tasks.is_empty()
+        && plan
+            .tasks
+            .iter()
+            .all(|task| task.executor.backend == "fixture"))
+    .then(|| {
+        json!({
+            "schema": "homeboy/agent-task-fixture-runner-provenance/v1",
+            "runner_id": runner_id,
+            "runner_job_id": runner_job_id,
+            "executor_backends": ["fixture"],
+        })
+    })
+}
 
 pub(crate) fn diagnose_run(
     run: &RunRecord,
@@ -28,7 +55,15 @@ pub(crate) fn diagnose_run(
             remediation: remediation.to_string(),
         }
     })?;
-    let reason = if record.lab_handoff_validation_error().is_some() {
+    let reason = if quarantined
+        && run
+            .metadata_json
+            .pointer("/agent_task_lifecycle_quarantine/reason_code")
+            .and_then(Value::as_str)
+            == Some(FIXTURE_RUNNER_QUARANTINE_REASON)
+    {
+        Some(AgentTaskRecordHealthReason::FixtureRunnerProvenance)
+    } else if record.lab_handoff_validation_error().is_some() {
         Some(AgentTaskRecordHealthReason::MalformedMetadata)
     } else if record.schema != schemas::RUN
         || record.lifecycle.schema != RUN_LIFECYCLE_RECORD_SCHEMA
@@ -59,6 +94,7 @@ pub(crate) fn record_health_item(
         | AgentTaskRecordHealthReason::MalformedMetadata => health.malformed += 1,
         AgentTaskRecordHealthReason::LegacySchema => health.legacy += 1,
         AgentTaskRecordHealthReason::ConflictingProjections => health.conflicting += 1,
+        AgentTaskRecordHealthReason::FixtureRunnerProvenance => health.fixture += 1,
     }
     if item.quarantined {
         health.quarantined += 1;
@@ -125,8 +161,26 @@ pub fn reconcile_record_health_in_store(
         records: Vec::new(),
     };
     for run in lifecycle_store.observation_runs()? {
-        let Err(item) = diagnose_run(&run) else {
-            continue;
+        let item = match diagnose_run(&run) {
+            Err(item) => item,
+            Ok(record) => {
+                let fixture_provenance = lifecycle_store
+                    .read_controller_plan(&run.id)
+                    .ok()
+                    .and_then(|plan| fixture_runner_provenance(&record, &plan));
+                let Some(provenance) = fixture_provenance else {
+                    continue;
+                };
+                AgentTaskRecordHealthItem {
+                    run_id: run.id.clone(),
+                    reason: AgentTaskRecordHealthReason::FixtureRunnerProvenance,
+                    quarantined: false,
+                    remediation: format!(
+                        "fixture runner provenance must remain quarantined: {}",
+                        provenance
+                    ),
+                }
+            }
         };
         // Quarantine is durable operator evidence, not a retry queue. Repeating
         // apply must be a no-op until an operator supplies new source evidence.

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -37,6 +37,7 @@ pub enum AgentTaskRecordHealthReason {
     MalformedMetadata,
     LegacySchema,
     ConflictingProjections,
+    FixtureRunnerProvenance,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -54,6 +55,7 @@ pub struct AgentTaskRecordHealthSummary {
     pub malformed: usize,
     pub legacy: usize,
     pub conflicting: usize,
+    pub fixture: usize,
     pub quarantined: usize,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub samples: Vec<AgentTaskRecordHealthItem>,

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -290,6 +290,10 @@ fn discovery_report(
             None,
         ));
     }
+    // Fixture-backed runner rows were once written by an in-process concurrent
+    // Cook test. Treat only the durable fixture provenance as non-production;
+    // an unknown runner with any real/unknown executor stays visible and blocks.
+    records.retain(|record| !is_fixture_runner_record(record));
     let is_active = filter == AgentTaskDiscoveryFilter::Active;
     if is_active {
         records.retain(|record| {
@@ -471,10 +475,15 @@ pub(crate) fn controller_upgrade_admission_for_records(
     record_health: AgentTaskRecordHealthSummary,
     now: chrono::DateTime<chrono::Utc>,
 ) -> ControllerUpgradeAdmission {
-    let summary = liveness_summary_for_records(records, now);
+    let records = records
+        .iter()
+        .filter(|record| !is_fixture_runner_record(record))
+        .cloned()
+        .collect::<Vec<_>>();
+    let summary = liveness_summary_for_records(&records, now);
     let mut parent_by_attempt = BTreeMap::new();
     let mut invalid_handoff_parents = BTreeSet::new();
-    for record in records {
+    for record in &records {
         if let Some(attempt) = record
             .metadata
             .pointer("/detached_cook_handoff/attempt_run_id")
@@ -708,6 +717,13 @@ fn run_source(record: &AgentTaskRunRecord) -> String {
         return "remote".to_string();
     }
     "local".to_string()
+}
+
+fn is_fixture_runner_record(record: &AgentTaskRunRecord) -> bool {
+    agent_task_lifecycle::load_controller_plan(&record.run_id)
+        .ok()
+        .and_then(|plan| agent_task_lifecycle::fixture_runner_provenance(record, &plan))
+        .is_some()
 }
 
 /// Age in whole minutes between `timestamp` (RFC3339) and `now`, clamped to

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -2412,6 +2412,75 @@ fn controller_upgrade_admission_uses_liveness_and_bounded_record_health() {
 }
 
 #[test]
+fn fixture_runner_records_are_quarantined_without_hiding_unknown_runner_ownership() {
+    with_isolated_home(|_| {
+        let fixture_run_id = "concurrent-first-cook-run";
+        let mut fixture_plan = discovery_plan();
+        fixture_plan.tasks[0].executor.backend = "fixture".to_string();
+        agent_task_lifecycle::submit_plan(&fixture_plan, Some(fixture_run_id))
+            .expect("persist leaked concurrent Cook fixture");
+        agent_task_lifecycle::record_detached_lab_run(agent_task_lifecycle::DetachedLabRunRecord {
+            run_id: fixture_run_id,
+            runner_id: "fixture-lab",
+            runner_job_id: "accepted-daemon-job",
+            remote_workspace: "/runner/workspace",
+            remote_command: &["homeboy".to_string(), "agent-task".to_string()],
+        })
+        .expect("attach fixture runner record");
+
+        let unknown_run_id = "unknown-runner-control";
+        agent_task_lifecycle::submit_plan(&discovery_plan(), Some(unknown_run_id))
+            .expect("persist unknown runner control");
+        agent_task_lifecycle::record_detached_lab_run(agent_task_lifecycle::DetachedLabRunRecord {
+            run_id: unknown_run_id,
+            runner_id: "offline-unknown-runner",
+            runner_job_id: "unknown-job",
+            remote_workspace: "/runner/workspace",
+            remote_command: &["homeboy".to_string(), "agent-task".to_string()],
+        })
+        .expect("attach unknown runner control");
+
+        for run_id in [fixture_run_id, unknown_run_id] {
+            agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+                record.submitted_at = "2000-01-01T00:00:00+00:00".to_string();
+                record.updated_at = None;
+            })
+            .expect("age runner record");
+        }
+
+        let discovery = discover_runs(AgentTaskDiscoveryFilter::Active).expect("active discovery");
+        assert_eq!(discovery.total, 1);
+        assert_eq!(discovery.runs[0].run_id, unknown_run_id);
+
+        let (records, health) = agent_task_lifecycle::read_records_with_health().expect("records");
+        let admission =
+            controller_upgrade_admission_for_records(&records, health, chrono::Utc::now());
+        assert_eq!(admission.blockers.len(), 1);
+        assert_eq!(admission.blockers[0].run_id, unknown_run_id);
+        assert_eq!(
+            admission.blockers[0].recovery_command,
+            "homeboy runner reconcile offline-unknown-runner"
+        );
+
+        let preview = agent_task_lifecycle::reconcile_record_health(true).expect("preview repair");
+        assert_eq!(preview.considered, 1);
+        assert_eq!(preview.quarantined, 0);
+        assert_eq!(preview.records[0].run_id, fixture_run_id);
+        assert_eq!(
+            preview.records[0].reason,
+            agent_task_lifecycle::AgentTaskRecordHealthReason::FixtureRunnerProvenance
+        );
+        assert_eq!(preview.records[0].action, "would-quarantine");
+
+        let repaired = agent_task_lifecycle::reconcile_record_health(false).expect("apply repair");
+        assert_eq!(repaired.quarantined, 1);
+        let health = agent_task_lifecycle::record_health_summary().expect("quarantine health");
+        assert_eq!(health.fixture, 1);
+        assert_eq!(health.quarantined, 1);
+    });
+}
+
+#[test]
 fn discovery_rejects_invalid_submitted_after_timestamps() {
     with_isolated_home(|_| {
         agent_task_lifecycle::submit_plan(&discovery_plan(), Some("run-invalid-timestamp-filter"))


### PR DESCRIPTION
## Summary

- detect previously leaked fixture-runner records from durable handoff and fixture-only plan provenance
- exclude proven fixture contamination from production discovery and upgrade admission
- quarantine those records through `reconcile-records` while preserving unknown runner ownership fail-closed

## Verification

- `cargo fmt --check`
- fixture quarantine, concurrent Cook, upgrade admission, and record-health focused tests
- `git diff --check`

Closes #12704.

## AI assistance

OpenAI `openai/gpt-5.6-sol` via OpenCode general coding agents implemented and reviewed the durable provenance repair and tests. Chris Huber reviewed and is responsible for every line.