### PR TITLE
Recover upgrades from removed runner ownership

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -898,6 +898,16 @@ fn classify_live_cancellation(record: &AgentTaskRunRecord) -> Result<LiveCancell
     if record.is_runner_backed() {
         let runner_id = record.runner_id().map(str::to_string);
         let runner_job_id = record.runner_job_id().map(str::to_string);
+        if runner_id.as_deref().is_some_and(|runner_id| {
+            super::runner_continuation::with_runner_continuation(|provider| {
+                provider.runner_authority(runner_id) == RunnerAuthority::Removed
+            })
+        }) {
+            // A successful registry inventory proved the original daemon
+            // authority was removed. There is no remote job left to cancel, so
+            // reclaim only the durable controller projection.
+            return Ok(LiveCancellationOutcome::NotRunning);
+        }
         if let (Some(runner_id), Some(runner_job_id)) =
             (runner_id.as_deref(), runner_job_id.as_deref())
         {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
@@ -232,7 +232,9 @@ fn resume_transport_proxy_on_runner_in_store(
         }));
     };
 
-    if !super::runner_continuation::with_runner_continuation(|p| p.runner_exists(&runner_id)) {
+    if !super::runner_continuation::with_runner_continuation(|p| {
+        p.runner_authority(&runner_id).is_configured()
+    }) {
         lifecycle_store.write_record(&record)?;
         return Ok(Some(TransportProxyRecovery::ReconnectRequired {
             record,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
@@ -86,8 +86,8 @@ pub use runner_continuation::{
     clear_runner_continuation_provider_for_test, RunnerContinuationTestGuard,
 };
 pub use runner_continuation::{
-    register_runner_continuation_provider, runner_exists, RunnerContinuationProvider,
-    RunnerJobReconciliation,
+    register_runner_continuation_provider, runner_authority, RunnerAuthority,
+    RunnerContinuationProvider, RunnerJobReconciliation,
 };
 pub use runner_exec::*;
 pub use workspace_authority::*;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
@@ -86,7 +86,8 @@ pub use runner_continuation::{
     clear_runner_continuation_provider_for_test, RunnerContinuationTestGuard,
 };
 pub use runner_continuation::{
-    register_runner_continuation_provider, RunnerContinuationProvider, RunnerJobReconciliation,
+    register_runner_continuation_provider, runner_exists, RunnerContinuationProvider,
+    RunnerJobReconciliation,
 };
 pub use runner_exec::*;
 pub use workspace_authority::*;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
@@ -29,6 +29,22 @@ pub enum RunnerJobReconciliation {
     UnconfirmedAbsence,
 }
 
+/// What the current runner provider can authoritatively establish about a
+/// durable runner id. Unknown must retain runner ownership: unavailable
+/// provider/configuration evidence cannot prove a removed authority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunnerAuthority {
+    Configured,
+    Removed,
+    Unknown,
+}
+
+impl RunnerAuthority {
+    pub fn is_configured(self) -> bool {
+        matches!(self, Self::Configured)
+    }
+}
+
 /// Runner-side operations the agent-task lifecycle needs when reconciling or
 /// resuming a run that was handed off to a remote runner.
 pub trait RunnerContinuationProvider: Send + Sync {
@@ -118,8 +134,11 @@ pub trait RunnerContinuationProvider: Send + Sync {
     /// Whether the runner currently reports a live connection.
     fn is_runner_connected(&self, runner_id: &str) -> bool;
 
-    /// Whether a runner with this id is configured/registered.
-    fn runner_exists(&self, runner_id: &str) -> bool;
+    /// Authoritative configuration state for a durable runner id. Providers
+    /// that cannot inspect their configuration return `Unknown` fail-closed.
+    fn runner_authority(&self, _runner_id: &str) -> RunnerAuthority {
+        RunnerAuthority::Unknown
+    }
 
     /// Execute a continuation command on the runner, returning the exit code.
     fn run_continuation_exec(
@@ -167,10 +186,6 @@ impl RunnerContinuationProvider for NoopProvider {
         false
     }
 
-    fn runner_exists(&self, _runner_id: &str) -> bool {
-        false
-    }
-
     fn run_continuation_exec(
         &self,
         _runner_id: &str,
@@ -205,11 +220,10 @@ homeboy_engine_primitives::provider_registry! {
     with: pub(crate) fn with_runner_continuation,
 }
 
-/// Whether the current runner provider has a configured authority for this id.
-/// A missing configuration proves the durable runner projection is orphaned;
-/// connection state alone does not.
-pub fn runner_exists(runner_id: &str) -> bool {
-    with_runner_continuation(|provider| provider.runner_exists(runner_id))
+/// Resolve the current provider's authoritative configuration state for a
+/// durable runner id. A missing provider remains unknown, not removed.
+pub fn runner_authority(runner_id: &str) -> RunnerAuthority {
+    with_runner_continuation(|provider| provider.runner_authority(runner_id))
 }
 
 /// Clear any registered runner-continuation provider so a fresh test starts from

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
@@ -205,6 +205,13 @@ homeboy_engine_primitives::provider_registry! {
     with: pub(crate) fn with_runner_continuation,
 }
 
+/// Whether the current runner provider has a configured authority for this id.
+/// A missing configuration proves the durable runner projection is orphaned;
+/// connection state alone does not.
+pub fn runner_exists(runner_id: &str) -> bool {
+    with_runner_continuation(|provider| provider.runner_exists(runner_id))
+}
+
 /// Clear any registered runner-continuation provider so a fresh test starts from
 /// the no-op default. The provider slot is a process-global; without this reset a
 /// provider registered by one test would leak into every later test in the same

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -59,8 +59,8 @@ impl RunnerContinuationProvider for ReconciliationProvider {
         true
     }
 
-    fn runner_exists(&self, _runner_id: &str) -> bool {
-        true
+    fn runner_authority(&self, _runner_id: &str) -> RunnerAuthority {
+        RunnerAuthority::Configured
     }
 
     fn run_continuation_exec(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/mod.rs
@@ -78,8 +78,8 @@ impl RunnerContinuationProvider for IntentReplayProvider {
     fn is_runner_connected(&self, _runner_id: &str) -> bool {
         true
     }
-    fn runner_exists(&self, _runner_id: &str) -> bool {
-        true
+    fn runner_authority(&self, _runner_id: &str) -> RunnerAuthority {
+        RunnerAuthority::Configured
     }
 
     fn run_continuation_exec(
@@ -176,8 +176,8 @@ impl RunnerContinuationProvider for ConnectedRunnerProvider {
         true
     }
 
-    fn runner_exists(&self, _runner_id: &str) -> bool {
-        true
+    fn runner_authority(&self, _runner_id: &str) -> RunnerAuthority {
+        RunnerAuthority::Configured
     }
 
     fn run_continuation_exec(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -3018,9 +3018,9 @@ impl RunnerContinuationProvider for CountingRunnerProvider {
         true
     }
 
-    fn runner_exists(&self, _runner_id: &str) -> bool {
+    fn runner_authority(&self, _runner_id: &str) -> RunnerAuthority {
         self.record();
-        true
+        RunnerAuthority::Configured
     }
 
     fn run_continuation_exec(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -166,8 +166,8 @@ impl RunnerContinuationProvider for TerminalSnapshotProvider {
         true
     }
 
-    fn runner_exists(&self, _runner_id: &str) -> bool {
-        true
+    fn runner_authority(&self, _runner_id: &str) -> RunnerAuthority {
+        RunnerAuthority::Configured
     }
 
     fn run_continuation_exec(
@@ -206,8 +206,8 @@ impl RunnerContinuationProvider for ServiceRunnerFixture {
         true
     }
 
-    fn runner_exists(&self, _runner_id: &str) -> bool {
-        true
+    fn runner_authority(&self, _runner_id: &str) -> RunnerAuthority {
+        RunnerAuthority::Configured
     }
 
     fn run_continuation_exec(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
@@ -166,7 +166,11 @@ pub(crate) fn resolve_terminal_workspace_authority_in_store(
             });
         };
         if !with_runner_continuation(|provider| provider.supports_terminal_workspace_authority())
-            || !with_runner_continuation(|provider| provider.runner_exists(&handoff.runner_id))
+            || !with_runner_continuation(|provider| {
+                provider
+                    .runner_authority(&handoff.runner_id)
+                    .is_configured()
+            })
             || !with_runner_continuation(|provider| {
                 provider.is_runner_connected(&handoff.runner_id)
             })
@@ -263,7 +267,7 @@ fn configured_terminal_authorities() -> std::result::Result<Vec<String>, String>
         for runner_id in &ids {
             if runner_id.trim().is_empty()
                 || runner_id == "controller"
-                || !provider.runner_exists(runner_id)
+                || !provider.runner_authority(runner_id).is_configured()
                 || !provider.is_runner_connected(runner_id)
             {
                 return Err(Error::validation_invalid_argument(
@@ -1527,8 +1531,8 @@ mod tests {
             true
         }
 
-        fn runner_exists(&self, _runner_id: &str) -> bool {
-            true
+        fn runner_authority(&self, _runner_id: &str) -> RunnerAuthority {
+            RunnerAuthority::Configured
         }
 
         fn run_continuation_exec(

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -521,19 +521,20 @@ pub(crate) fn controller_upgrade_admission_for_records(
                 let recovery_command = if invalid_handoff_parents.contains(record.run_id.as_str()) {
                     "homeboy agent-task reconcile-records --dry-run".to_string()
                 } else {
-                    record
-                        .runner_id()
-                        .filter(|runner| agent_task_lifecycle::runner_exists(runner))
-                        .map(|runner| format!("homeboy runner reconcile {runner}"))
-                        .unwrap_or_else(|| {
-                            if liveness == AgentTaskLiveness::Active {
-                                format!("homeboy agent-task cancel {group_run_id}")
-                            } else {
-                                format!(
-                                    "homeboy --placement local agent-task reconcile {group_run_id} --apply"
-                                )
-                            }
-                        })
+                    match record.runner_id() {
+                        Some(runner)
+                            if agent_task_lifecycle::runner_authority(runner)
+                                != agent_task_lifecycle::RunnerAuthority::Removed =>
+                        {
+                            format!("homeboy runner reconcile {runner}")
+                        }
+                        _ if liveness == AgentTaskLiveness::Active => {
+                            format!("homeboy agent-task cancel {group_run_id}")
+                        }
+                        _ => format!(
+                            "homeboy --placement local agent-task reconcile {group_run_id} --apply"
+                        ),
+                    }
                 };
                 let (owner, scope, postcondition) = if recovery_command
                     .starts_with("homeboy runner reconcile ")

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -523,12 +523,15 @@ pub(crate) fn controller_upgrade_admission_for_records(
                 } else {
                     record
                         .runner_id()
+                        .filter(|runner| agent_task_lifecycle::runner_exists(runner))
                         .map(|runner| format!("homeboy runner reconcile {runner}"))
                         .unwrap_or_else(|| {
                             if liveness == AgentTaskLiveness::Active {
                                 format!("homeboy agent-task cancel {group_run_id}")
                             } else {
-                                format!("homeboy agent-task reconcile {group_run_id} --apply")
+                                format!(
+                                    "homeboy --placement local agent-task reconcile {group_run_id} --apply"
+                                )
                             }
                         })
                 };

--- a/crates/homeboy-agents/src/agent_task_service/reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_service/reconcile.rs
@@ -322,6 +322,24 @@ pub fn reconcile_run(run_id: &str, dry_run: bool) -> Result<AgentTaskReconcileRe
                         action: "no-op",
                         error: None,
                     });
+                } else if refreshed.runner_id().is_some()
+                    && refreshed.runner_job_id().is_some()
+                    && refreshed.runner_id().is_some_and(|runner_id| {
+                        agent_task_lifecycle::runner_authority(runner_id)
+                            != agent_task_lifecycle::RunnerAuthority::Removed
+                    })
+                {
+                    // An accepted remote handoff remains runner-owned unless its
+                    // provider authoritatively confirms the runner was removed.
+                    runs.push(AgentTaskReconcileRun {
+                        run_id: resolved_run_id.clone(),
+                        liveness,
+                        source: run.source,
+                        authoritative_state: refreshed.state,
+                        stale_reason: run.stale_reason,
+                        action: "no-op",
+                        error: None,
+                    });
                 } else if dry_run {
                     runs.push(AgentTaskReconcileRun {
                         run_id: resolved_run_id.clone(),
@@ -333,6 +351,25 @@ pub fn reconcile_run(run_id: &str, dry_run: bool) -> Result<AgentTaskReconcileRe
                         error: None,
                     });
                 } else {
+                    if let Some(runner_id) = refreshed.runner_id() {
+                        if agent_task_lifecycle::runner_authority(runner_id)
+                            != agent_task_lifecycle::RunnerAuthority::Removed
+                        {
+                            failed += 1;
+                            runs.push(AgentTaskReconcileRun {
+                                run_id: resolved_run_id.clone(),
+                                liveness,
+                                source: run.source,
+                                authoritative_state: refreshed.state,
+                                stale_reason: run.stale_reason,
+                                action: "failed",
+                                error: Some(format!(
+                                    "runner `{runner_id}` ownership is not authoritatively removed; reconcile it through homeboy runner reconcile {runner_id}"
+                                )),
+                            });
+                            continue;
+                        }
+                    }
                     let expired_detached_admission =
                         agent_task_lifecycle::has_expired_detached_cook_admission(
                             &refreshed,

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -1787,6 +1787,9 @@ fn upgrade_admission_dedupes_linked_parent_and_attempt_recovery_commands() {
     with_isolated_home(|_| {
         let cook_id = "cook-upgrade-alias";
         let attempt_id = agent_task_lifecycle::cook_attempt_run_id(cook_id, 1);
+        let _runner = agent_task_lifecycle::RunnerContinuationTestGuard::install(Box::new(
+            AbsentSubmissionProvider,
+        ));
         agent_task_lifecycle::record_detached_cook_handoff_parent(cook_id).expect("parent");
         agent_task_lifecycle::submit_plan(&discovery_plan(), Some(&attempt_id)).expect("attempt");
         agent_task_lifecycle::rewrite_record_for_test(cook_id, |record| {
@@ -1822,6 +1825,46 @@ fn upgrade_admission_dedupes_linked_parent_and_attempt_recovery_commands() {
         );
         assert_eq!(admission.blockers[0].owner, "runner_generations");
         assert_eq!(admission.blockers[0].action, "homeboy runner reconcile lab");
+    });
+}
+
+#[test]
+fn upgrade_admission_recovers_an_orphaned_removed_runner_record_locally() {
+    with_isolated_home(|_| {
+        let cook_id = "concurrent-first-cook-run";
+        agent_task_lifecycle::submit_plan(&discovery_plan(), Some(cook_id)).expect("submitted");
+        agent_task_lifecycle::rewrite_record_for_test(cook_id, |record| {
+            record.submitted_at = "2000-01-01T00:00:00+00:00".to_string();
+            record.updated_at = None;
+            record.metadata["runner_id"] = serde_json::json!("fixture-lab");
+            record.metadata["runner_job_id"] = serde_json::json!("removed-runner-job");
+        })
+        .expect("orphaned runner projection stored");
+
+        let (records, health) = agent_task_lifecycle::read_records_with_health().expect("records");
+        let admission =
+            controller_upgrade_admission_for_records(&records, health, chrono::Utc::now());
+        assert_eq!(admission.blockers.len(), 1);
+        let blocker = &admission.blockers[0];
+        assert_eq!(blocker.run_id, cook_id);
+        assert_eq!(blocker.owner, "durable_agent_tasks");
+        assert_eq!(
+            blocker.recovery_command,
+            "homeboy --placement local agent-task reconcile concurrent-first-cook-run --apply"
+        );
+
+        let applied = reconcile_run(cook_id, false).expect("orphaned record reconciles locally");
+        assert_eq!(applied.reconciled, 1);
+        assert_eq!(applied.runs[0].action, "reconciled");
+        assert_eq!(
+            lifecycle_status(cook_id).expect("reconciled record").state,
+            AgentTaskRunState::Cancelled
+        );
+        let (records, health) = agent_task_lifecycle::read_records_with_health().expect("records");
+        assert!(
+            controller_upgrade_admission_for_records(&records, health, chrono::Utc::now())
+                .allows_controller_replacement()
+        );
     });
 }
 
@@ -2398,7 +2441,10 @@ fn controller_upgrade_admission_uses_liveness_and_bounded_record_health() {
             .find(|blocker| blocker.run_id == "unverified-runner")
             .expect("unverified runner blocks");
         assert_eq!(runner.reason, "runner_job_unverified_after_daemon_restart");
-        assert_eq!(runner.recovery_command, "homeboy runner reconcile lab");
+        assert_eq!(
+            runner.recovery_command,
+            "homeboy --placement local agent-task reconcile unverified-runner --apply"
+        );
         assert!(!admission
             .blockers
             .iter()

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -1788,7 +1788,7 @@ fn upgrade_admission_dedupes_linked_parent_and_attempt_recovery_commands() {
         let cook_id = "cook-upgrade-alias";
         let attempt_id = agent_task_lifecycle::cook_attempt_run_id(cook_id, 1);
         let _runner = agent_task_lifecycle::RunnerContinuationTestGuard::install(Box::new(
-            AbsentSubmissionProvider,
+            RunnerAuthorityFixture::configured_disconnected(),
         ));
         agent_task_lifecycle::record_detached_cook_handoff_parent(cook_id).expect("parent");
         agent_task_lifecycle::submit_plan(&discovery_plan(), Some(&attempt_id)).expect("attempt");
@@ -1832,14 +1832,10 @@ fn upgrade_admission_dedupes_linked_parent_and_attempt_recovery_commands() {
 fn upgrade_admission_recovers_an_orphaned_removed_runner_record_locally() {
     with_isolated_home(|_| {
         let cook_id = "concurrent-first-cook-run";
-        agent_task_lifecycle::submit_plan(&discovery_plan(), Some(cook_id)).expect("submitted");
-        agent_task_lifecycle::rewrite_record_for_test(cook_id, |record| {
-            record.submitted_at = "2000-01-01T00:00:00+00:00".to_string();
-            record.updated_at = None;
-            record.metadata["runner_id"] = serde_json::json!("fixture-lab");
-            record.metadata["runner_job_id"] = serde_json::json!("removed-runner-job");
-        })
-        .expect("orphaned runner projection stored");
+        let _runner = agent_task_lifecycle::RunnerContinuationTestGuard::install(Box::new(
+            RunnerAuthorityFixture::removed(),
+        ));
+        record_stale_accepted_lab_handoff(cook_id, "fixture-lab");
 
         let (records, health) = agent_task_lifecycle::read_records_with_health().expect("records");
         let admission =
@@ -1864,6 +1860,63 @@ fn upgrade_admission_recovers_an_orphaned_removed_runner_record_locally() {
         assert!(
             controller_upgrade_admission_for_records(&records, health, chrono::Utc::now())
                 .allows_controller_replacement()
+        );
+    });
+}
+
+#[test]
+fn upgrade_admission_keeps_configured_disconnected_runner_ownership() {
+    with_isolated_home(|_| {
+        let cook_id = "configured-offline-cook-run";
+        let _runner = agent_task_lifecycle::RunnerContinuationTestGuard::install(Box::new(
+            RunnerAuthorityFixture::configured_disconnected(),
+        ));
+        record_stale_accepted_lab_handoff(cook_id, "fixture-lab");
+
+        let (records, health) = agent_task_lifecycle::read_records_with_health().expect("records");
+        let admission =
+            controller_upgrade_admission_for_records(&records, health, chrono::Utc::now());
+        assert_eq!(admission.blockers.len(), 1);
+        assert_eq!(admission.blockers[0].owner, "runner_generations");
+        assert_eq!(
+            admission.blockers[0].recovery_command,
+            "homeboy runner reconcile fixture-lab"
+        );
+        let report = reconcile_run(cook_id, false).expect("configured runner remains fail-closed");
+        assert_eq!(report.reconciled, 0);
+        assert_eq!(report.runs[0].action, "no-op");
+        assert_eq!(
+            lifecycle_status(cook_id)
+                .expect("remote record retained")
+                .state,
+            AgentTaskRunState::Running
+        );
+    });
+}
+
+#[test]
+fn upgrade_admission_keeps_provider_unavailable_runner_ownership() {
+    with_isolated_home(|_| {
+        let cook_id = "unknown-offline-cook-run";
+        record_stale_accepted_lab_handoff(cook_id, "fixture-lab");
+
+        let (records, health) = agent_task_lifecycle::read_records_with_health().expect("records");
+        let admission =
+            controller_upgrade_admission_for_records(&records, health, chrono::Utc::now());
+        assert_eq!(admission.blockers.len(), 1);
+        assert_eq!(admission.blockers[0].owner, "runner_generations");
+        assert_eq!(
+            admission.blockers[0].recovery_command,
+            "homeboy runner reconcile fixture-lab"
+        );
+        let report = reconcile_run(cook_id, false).expect("unknown runner remains fail-closed");
+        assert_eq!(report.reconciled, 0);
+        assert_eq!(report.runs[0].action, "no-op");
+        assert_eq!(
+            lifecycle_status(cook_id)
+                .expect("remote record retained")
+                .state,
+            AgentTaskRunState::Running
         );
     });
 }
@@ -2441,10 +2494,7 @@ fn controller_upgrade_admission_uses_liveness_and_bounded_record_health() {
             .find(|blocker| blocker.run_id == "unverified-runner")
             .expect("unverified runner blocks");
         assert_eq!(runner.reason, "runner_job_unverified_after_daemon_restart");
-        assert_eq!(
-            runner.recovery_command,
-            "homeboy --placement local agent-task reconcile unverified-runner --apply"
-        );
+        assert_eq!(runner.recovery_command, "homeboy runner reconcile lab");
         assert!(!admission
             .blockers
             .iter()
@@ -2652,7 +2702,7 @@ fn reconcile_terminalizes_an_unaccepted_controller_handoff_after_its_deadline() 
         );
 
         let _runner = agent_task_lifecycle::RunnerContinuationTestGuard::install(Box::new(
-            AbsentSubmissionProvider,
+            RunnerAuthorityFixture::configured_disconnected(),
         ));
         let terminal = lifecycle_status("controller-handoff-unaccepted")
             .expect("terminal controller record after confirmed absence");
@@ -2662,9 +2712,55 @@ fn reconcile_terminalizes_an_unaccepted_controller_handoff_after_its_deadline() 
     });
 }
 
-struct AbsentSubmissionProvider;
+fn record_stale_accepted_lab_handoff(run_id: &str, runner_id: &str) {
+    let command = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "cook".to_string(),
+    ];
+    agent_task_lifecycle::submit_plan(&discovery_plan(), Some(run_id)).expect("submitted");
+    agent_task_lifecycle::record_detached_lab_run(agent_task_lifecycle::DetachedLabRunRecord {
+        run_id,
+        runner_id,
+        runner_job_id: "accepted-daemon-job",
+        remote_workspace: "/runner/workspace/homeboy",
+        remote_command: &command,
+    })
+    .expect("accepted Lab handoff");
+    agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+        record.submitted_at = "2000-01-01T00:00:00+00:00".to_string();
+        record.updated_at = Some("2000-01-01T00:00:00+00:00".to_string());
+        record
+            .metadata
+            .as_object_mut()
+            .expect("record metadata")
+            .remove("detached_cook_handoff");
+    })
+    .expect("age accepted handoff");
+}
 
-impl agent_task_lifecycle::RunnerContinuationProvider for AbsentSubmissionProvider {
+struct RunnerAuthorityFixture {
+    authority: agent_task_lifecycle::RunnerAuthority,
+    connected: bool,
+}
+
+impl RunnerAuthorityFixture {
+    fn configured_disconnected() -> Self {
+        Self {
+            authority: agent_task_lifecycle::RunnerAuthority::Configured,
+            connected: false,
+        }
+    }
+
+    fn removed() -> Self {
+        Self {
+            authority: agent_task_lifecycle::RunnerAuthority::Removed,
+            connected: false,
+        }
+    }
+}
+
+impl agent_task_lifecycle::RunnerContinuationProvider for RunnerAuthorityFixture {
     fn runner_job_log_snapshot(
         &self,
         _runner_id: &str,
@@ -2676,11 +2772,11 @@ impl agent_task_lifecycle::RunnerContinuationProvider for AbsentSubmissionProvid
     }
 
     fn is_runner_connected(&self, _runner_id: &str) -> bool {
-        true
+        self.connected
     }
 
-    fn runner_exists(&self, _runner_id: &str) -> bool {
-        true
+    fn runner_authority(&self, _runner_id: &str) -> agent_task_lifecycle::RunnerAuthority {
+        self.authority
     }
 
     fn run_continuation_exec(

--- a/crates/homeboy-lab-runner/src/continuation_provider.rs
+++ b/crates/homeboy-lab-runner/src/continuation_provider.rs
@@ -5,7 +5,9 @@
 //! behavior directly. This adapter delegates to the runner connection,
 //! execution, and evidence functions.
 
-use homeboy_agents::agent_task_lifecycle::{RunnerContinuationProvider, RunnerJobReconciliation};
+use homeboy_agents::agent_task_lifecycle::{
+    RunnerAuthority, RunnerContinuationProvider, RunnerJobReconciliation,
+};
 use homeboy_core::api_jobs::{Job, RemoteRunnerJobRequest, RunnerJobLogSnapshot};
 use std::time::Duration;
 
@@ -185,8 +187,19 @@ impl RunnerContinuationProvider for RunnerContinuation {
             .unwrap_or(true)
     }
 
-    fn runner_exists(&self, runner_id: &str) -> bool {
-        super::exists(runner_id)
+    fn runner_authority(&self, runner_id: &str) -> RunnerAuthority {
+        // `list` failing means the registry cannot establish absence. Only a
+        // successful inventory that omits this id proves a removed authority.
+        let Ok(runners) = super::list() else {
+            return RunnerAuthority::Unknown;
+        };
+        if runners.iter().any(|runner| runner.id == runner_id)
+            || (runner_id.eq_ignore_ascii_case("lab") && super::load(runner_id).is_ok())
+        {
+            RunnerAuthority::Configured
+        } else {
+            RunnerAuthority::Removed
+        }
     }
 
     fn run_continuation_exec(


### PR DESCRIPTION
## Summary

- model runner authority as configured, authoritatively removed, or unknown
- allow controller-local reconciliation only for proven removed runners
- keep configured/disconnected and unavailable authority fail-closed under runner ownership
- emit an executable local reconciliation path for removed-runner upgrade blockers

## Verification

- `cargo fmt --check`
- upgrade admission tests: 7 passed
- reconciliation tests: 8 passed
- `homeboy-upgrade` tests: 196 passed
- `git diff --check`

Closes #12794.

## AI assistance

OpenAI `openai/gpt-5.6-sol` via OpenCode general coding agents implemented, safety-reviewed, and corrected the tri-state runner authority contract. Chris Huber reviewed and is responsible for every line.