### PR TITLE
Give every rooted sibling its ambient twin's visibility

### DIFF
--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -200,7 +200,7 @@ fn validate_fanout_run_batch(fanout_id: &str, children: &[FanoutRunBatchChild]) 
     Ok(())
 }
 
-fn persist_fanout_run_batch_in_store(
+pub fn persist_fanout_run_batch_in_store(
     store: &AgentTaskBatchStore,
     fanout_id: &str,
     plan_id: &str,
@@ -257,7 +257,7 @@ pub fn claim_fanout_run_batch(batch_id: &str) -> Result<Option<String>> {
     AgentTaskBatchStore::from_current_data_root()?.claim_fanout_run_batch(batch_id)
 }
 
-fn claim_fanout_run_batch_in_store(
+pub fn claim_fanout_run_batch_in_store(
     store: &AgentTaskBatchStore,
     batch_id: &str,
 ) -> Result<Option<String>> {
@@ -301,7 +301,7 @@ pub fn heartbeat_fanout_run_batch(batch_id: &str, claim_id: &str) -> Result<()> 
     AgentTaskBatchStore::from_current_data_root()?.heartbeat_fanout_run_batch(batch_id, claim_id)
 }
 
-fn heartbeat_fanout_run_batch_in_store(
+pub fn heartbeat_fanout_run_batch_in_store(
     store: &AgentTaskBatchStore,
     batch_id: &str,
     claim_id: &str,
@@ -346,7 +346,7 @@ pub fn record_fanout_run_batch_failure(
         .record_fanout_run_batch_failure(batch_id, claim_id, stage, failure)
 }
 
-fn record_fanout_run_batch_failure_in_store(
+pub fn record_fanout_run_batch_failure_in_store(
     store: &AgentTaskBatchStore,
     batch_id: &str,
     claim_id: &str,
@@ -394,7 +394,7 @@ pub fn record_fanout_run_batch_failed_admissions<'a>(
         .record_fanout_run_batch_failed_admissions(batch_id, failed_run_ids)
 }
 
-fn record_fanout_run_batch_failed_admissions_in_store<'a>(
+pub fn record_fanout_run_batch_failed_admissions_in_store<'a>(
     store: &AgentTaskBatchStore,
     batch_id: &str,
     failed_run_ids: impl IntoIterator<Item = &'a str>,
@@ -460,7 +460,7 @@ pub fn expire_stalled_fanout_admission(batch_id: &str) -> Result<bool> {
 /// id could report a started child and hold a genuinely stranded coordinator in
 /// `admitting` forever, or report no child and terminalize a wave that is
 /// running somewhere else (#7505, #12619).
-fn expire_stalled_fanout_admission_in_store(
+pub fn expire_stalled_fanout_admission_in_store(
     store: &AgentTaskBatchStore,
     lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     batch_id: &str,
@@ -715,7 +715,7 @@ pub fn fanout_dependency_graph_with_finalization_statuses(
         .fanout_dependency_graph_with_finalization_statuses(batch_id, statuses)
 }
 
-fn fanout_dependency_graph_with_finalization_statuses_in_store(
+pub fn fanout_dependency_graph_with_finalization_statuses_in_store(
     store: &AgentTaskBatchStore,
     batch_id: &str,
     statuses: &BTreeMap<String, String>,
@@ -872,7 +872,7 @@ pub fn fanout_ready_child_run_ids(batch_id: &str) -> Result<Option<HashSet<Strin
     AgentTaskBatchStore::from_current_data_root()?.fanout_ready_child_run_ids(batch_id)
 }
 
-fn fanout_ready_child_run_ids_in_store(
+pub fn fanout_ready_child_run_ids_in_store(
     store: &AgentTaskBatchStore,
     batch_id: &str,
 ) -> Result<Option<HashSet<String>>> {
@@ -904,7 +904,7 @@ pub fn owned_child_run_ids(batch_id: &str) -> Result<HashSet<String>> {
     AgentTaskBatchStore::from_current_data_root()?.owned_child_run_ids(batch_id)
 }
 
-fn owned_child_run_ids_in_store(
+pub fn owned_child_run_ids_in_store(
     store: &AgentTaskBatchStore,
     batch_id: &str,
 ) -> Result<HashSet<String>> {
@@ -1501,7 +1501,7 @@ pub fn read_batch_record(batch_id: &str) -> Result<AgentTaskBatchRecord> {
     AgentTaskBatchStore::from_current_data_root()?.read_batch_record(batch_id)
 }
 
-fn read_batch_record_in_store(
+pub fn read_batch_record_in_store(
     store: &AgentTaskBatchStore,
     batch_id: &str,
 ) -> Result<AgentTaskBatchRecord> {
@@ -1524,7 +1524,7 @@ pub fn record_child_finalization(
     )
 }
 
-fn record_child_finalization_in_store(
+pub fn record_child_finalization_in_store(
     store: &AgentTaskBatchStore,
     batch_id: &str,
     child_run_id: &str,
@@ -1573,7 +1573,7 @@ pub fn record_coordinator_cancellation(batch_id: &str, reason: &str) -> Result<(
     AgentTaskBatchStore::from_current_data_root()?.record_coordinator_cancellation(batch_id, reason)
 }
 
-fn record_coordinator_cancellation_in_store(
+pub fn record_coordinator_cancellation_in_store(
     store: &AgentTaskBatchStore,
     batch_id: &str,
     reason: &str,
@@ -1611,7 +1611,7 @@ pub fn coordinator_is_cancelled(batch_id: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn coordinator_is_cancelled_in_store(store: &AgentTaskBatchStore, batch_id: &str) -> bool {
+pub fn coordinator_is_cancelled_in_store(store: &AgentTaskBatchStore, batch_id: &str) -> bool {
     store
         .read_batch(batch_id)
         .ok()
@@ -1625,7 +1625,7 @@ pub fn dependency_action_receipt(batch_id: &str, key: &str) -> Result<Option<Val
     AgentTaskBatchStore::from_current_data_root()?.dependency_action_receipt(batch_id, key)
 }
 
-fn dependency_action_receipt_in_store(
+pub fn dependency_action_receipt_in_store(
     store: &AgentTaskBatchStore,
     batch_id: &str,
     key: &str,
@@ -1641,7 +1641,7 @@ pub fn record_dependency_action_receipt(batch_id: &str, key: &str, receipt: Valu
         .record_dependency_action_receipt(batch_id, key, receipt)
 }
 
-fn record_dependency_action_receipt_in_store(
+pub fn record_dependency_action_receipt_in_store(
     store: &AgentTaskBatchStore,
     batch_id: &str,
     key: &str,

--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -48,7 +48,7 @@ pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     finalize_pr_with_backend_mode(options, backend, true, None)
 }
 
-pub(crate) fn finalize_pr_with_backend_in_store<B: AgentTaskPrFinalizationBackend>(
+pub fn finalize_pr_with_backend_in_store<B: AgentTaskPrFinalizationBackend>(
     options: AgentTaskPrFinalizationOptions,
     backend: &mut B,
     lifecycle_store: &crate::agent_task_lifecycle::AgentTaskLifecycleStore,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -35,7 +35,7 @@ pub fn cancel_run(run_id: &str, reason: Option<&str>) -> Result<AgentTaskRunReco
 /// index that names attempts the cancelled store has never heard of — and would
 /// terminate the loop on an equality between two different homes' answers
 /// (#7505).
-pub(crate) fn cancel_run_in_store(
+pub fn cancel_run_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     reason: Option<&str>,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -13,7 +13,7 @@ pub fn record_pre_execution_failure(
     record_pre_execution_failure_in_store(&lifecycle_store, run_id, plan, phase, error)
 }
 
-pub(crate) fn record_pre_execution_failure_in_store(
+pub fn record_pre_execution_failure_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     plan: &AgentTaskPlan,
@@ -1809,7 +1809,7 @@ pub fn verified_controller_artifact_projection_path(
     verified_controller_artifact_projection_path_in_store(&store, run_id, task_id, artifact)
 }
 
-pub(crate) fn verified_controller_artifact_projection_path_in_store(
+pub fn verified_controller_artifact_projection_path_in_store(
     store: &homeboy_core::observation::ObservationStore,
     run_id: &str,
     task_id: &str,
@@ -1935,7 +1935,7 @@ pub fn verified_controller_artifact_projection(
     )
 }
 
-pub(crate) fn verified_controller_artifact_projection_in_store(
+pub fn verified_controller_artifact_projection_in_store(
     store: &homeboy_core::observation::ObservationStore,
     run_id: &str,
     task_id: &str,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
@@ -218,7 +218,7 @@ pub fn reconcile_pending_runner_submission_intent(run_id: &str) -> Result<bool> 
 /// The broker transport stays process-global on purpose:
 /// `with_runner_continuation` resolves the configured provider registry, which
 /// is trust material and a subprocess contract, not a lifecycle root.
-pub(crate) fn reconcile_pending_runner_submission_intent_in_store(
+pub fn reconcile_pending_runner_submission_intent_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
 ) -> Result<bool> {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
@@ -66,7 +66,7 @@ pub fn bind_accepted_lab_runner_job(
 /// written back all have to name the same installation. Rooting only the
 /// wrapper would leave the daemon's authoritative binding landing wherever the
 /// process environment happened to point (#7505).
-pub(crate) fn bind_accepted_lab_runner_job_in_store(
+pub fn bind_accepted_lab_runner_job_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     identity: &homeboy_core::lab_contract::RunnerJobIdentity,
     remote_workspace: &str,
@@ -114,7 +114,7 @@ pub fn record_lab_offload_planned(input: LabOffloadProxyPlan<'_>) -> Result<Agen
 }
 
 /// The store-rooted counterpart of [`record_lab_offload_planned`].
-pub(crate) fn record_lab_offload_planned_in_store(
+pub fn record_lab_offload_planned_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     input: LabOffloadProxyPlan<'_>,
 ) -> Result<AgentTaskRunRecord> {
@@ -189,7 +189,7 @@ pub fn record_lab_offload_phase(
 /// and the write-back are one operation. Resolving the proxy in one home and
 /// committing the phase into another would leave a run advertising a setup
 /// phase that its own record never entered (#7505).
-pub(crate) fn record_lab_offload_phase_in_store(
+pub fn record_lab_offload_phase_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     input: LabOffloadPhaseRecord<'_>,
 ) -> Result<AgentTaskRunRecord> {
@@ -257,7 +257,7 @@ pub fn record_local_lab_identity_fallback(
 }
 
 /// The store-rooted counterpart of [`record_local_lab_identity_fallback`].
-pub(crate) fn record_local_lab_identity_fallback_in_store(
+pub fn record_local_lab_identity_fallback_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     runner_id: &str,
@@ -338,7 +338,7 @@ pub fn record_lab_offload_phase_executions(
 /// The terminal guard is read from the same record the execution ids are
 /// written back onto, so a staging job cannot be recorded against a run that
 /// another installation already finished (#7505).
-pub(crate) fn record_lab_offload_phase_executions_in_store(
+pub fn record_lab_offload_phase_executions_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     phase: &str,
@@ -387,7 +387,7 @@ pub fn record_lab_staging_controller_job(
 /// The staging job id is the controller's only handle on a materialization it
 /// can outlive, so the terminal guard and the binding must name one record in
 /// one installation (#7505).
-pub(crate) fn record_lab_staging_controller_job_in_store(
+pub fn record_lab_staging_controller_job_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     runner_id: &str,
@@ -414,31 +414,9 @@ pub(crate) fn record_lab_staging_controller_job_in_store(
     Ok(record)
 }
 
-/// Name a reserved Lab admission on the durable run the moment it is taken,
-/// before any further dispatch work can fail.
-///
-/// A reservation that exists only inside the controller process is unfindable:
-/// a caller killed between reservation and runner acceptance leaves capacity
-/// held by an admission nothing can associate with a run id, which is what
-/// forced manual job-ID cancellation in #9163. The daemon's admission-lease
-/// sweep still owns automatic reclaim; this write owns *identity*, so an
-/// operator can see which run holds which reservation and when it self-expires.
-pub fn record_lab_admission_reservation(
-    run_id: &str,
-    runner_id: &str,
-    daemon_lease_id: &str,
-    reservation_job_id: &str,
-    lease_expires_at_ms: u64,
-) -> Result<AgentTaskRunRecord> {
-    record_lab_admission_reservation_in_store(
-        &AgentTaskLifecycleStore::from_current_environment()?,
-        run_id,
-        runner_id,
-        daemon_lease_id,
-        reservation_job_id,
-        lease_expires_at_ms,
-    )
-}
+// The ambient `record_lab_admission_reservation()` shim that used to sit here
+// is gone; the lab offload inner loop was its only caller and now reserves
+// admission in the store it resolved for the whole offload (#7505).
 
 /// The store-rooted counterpart of [`record_lab_admission_reservation`].
 ///
@@ -446,7 +424,7 @@ pub fn record_lab_admission_reservation(
 /// reservation. A reservation named in one installation while the run it names
 /// lives in another is exactly the unfindable state #9163 forced manual
 /// job-id cancellation for, so the read and the write are one home (#7505).
-pub(crate) fn record_lab_admission_reservation_in_store(
+pub fn record_lab_admission_reservation_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     runner_id: &str,
@@ -499,7 +477,7 @@ pub fn record_lab_staging_controller_failure(
 /// This is terminal-stage evidence about one run, and the retry command it
 /// publishes is only actionable in the installation the record lives in, so the
 /// read and the write name the same store (#7505).
-pub(crate) fn record_lab_staging_controller_failure_in_store(
+pub fn record_lab_staging_controller_failure_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     phase: &str,
@@ -573,7 +551,7 @@ pub fn record_detached_lab_run(input: DetachedLabRunRecord<'_>) -> Result<AgentT
 /// an acceptance validated against one home's record and committed into
 /// another's would silently permit two different runners to own the same run,
 /// and the handoff lock would not have excluded either of them (#7505).
-pub(crate) fn record_detached_lab_run_in_store(
+pub fn record_detached_lab_run_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     input: DetachedLabRunRecord<'_>,
 ) -> Result<AgentTaskRunRecord> {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
@@ -122,7 +122,7 @@ pub fn start_candidate_adoption_with_policy(
     )
 }
 
-pub(crate) fn start_candidate_adoption_with_policy_in_store(
+pub fn start_candidate_adoption_with_policy_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     candidate_sha: &str,
@@ -411,7 +411,7 @@ pub fn finish_candidate_adoption(
     finish_candidate_adoption_in_store(&lifecycle_store, run_id, error)
 }
 
-pub(crate) fn finish_candidate_adoption_in_store(
+pub fn finish_candidate_adoption_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     error: Option<String>,
@@ -447,7 +447,7 @@ pub fn record_candidate_adoption_result(run_id: &str, result: Value) -> Result<(
     record_candidate_adoption_result_in_store(&lifecycle_store, run_id, result)
 }
 
-pub(crate) fn record_candidate_adoption_result_in_store(
+pub fn record_candidate_adoption_result_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     result: Value,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -359,7 +359,7 @@ pub fn submit_plan(
 /// cancellation recorded here unseen while the controller waits on the
 /// admission lock. The controller-runtime store itself stays process-global by
 /// design; only the lifecycle read is rooted here.
-pub(crate) fn submit_plan_in_store(
+pub fn submit_plan_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     plan: &AgentTaskPlan,
     requested_run_id: Option<&str>,
@@ -463,7 +463,7 @@ pub fn require_detached_cook_handoff_fence_open(cook_id: &str) -> Result<()> {
 /// refused because an unrelated parent elsewhere was cancelled. An absent or
 /// unreadable record is still an open fence — a parent that was never persisted
 /// cannot have been cancelled.
-pub(crate) fn require_detached_cook_handoff_fence_open_in_store(
+pub fn require_detached_cook_handoff_fence_open_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     cook_id: &str,
 ) -> Result<()> {
@@ -589,7 +589,7 @@ pub fn reserve_detached_cook_handoff_materialization(
 
 /// Reserve a detached Cook's first attempt within its explicitly selected
 /// lifecycle roots.
-pub(crate) fn reserve_detached_cook_handoff_materialization_in_store(
+pub fn reserve_detached_cook_handoff_materialization_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     cook_id: &str,
     attempt_run_id: &str,
@@ -652,7 +652,7 @@ pub fn cancel_reserved_detached_cook_handoff_attempt_if_cancelled(cook_id: &str)
     cancel_reserved_detached_cook_handoff_attempt_if_cancelled_in_store(&lifecycle_store, cook_id)
 }
 
-pub(crate) fn cancel_reserved_detached_cook_handoff_attempt_if_cancelled_in_store(
+pub fn cancel_reserved_detached_cook_handoff_attempt_if_cancelled_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     cook_id: &str,
 ) -> Result<bool> {
@@ -1956,7 +1956,7 @@ pub fn load_controller_plan(run_id: &str) -> Result<AgentTaskPlan> {
 /// Load the controller-owned plan from an explicitly rooted store. Both halves
 /// follow the injected root: the Cook alias is resolved against that store's
 /// own index, and the plan is read from that store's own run directory.
-pub(crate) fn load_controller_plan_in_store(
+pub fn load_controller_plan_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
 ) -> Result<AgentTaskPlan> {
@@ -1979,7 +1979,7 @@ pub fn load_plan_for_execution(run_id: &str) -> Result<AgentTaskPlan> {
 /// config lock. Resolving the Cook alias against one home's index and
 /// migrating another home's plan file would rewrite a plan this caller never
 /// read (#7505).
-pub(crate) fn load_plan_for_execution_in_store(
+pub fn load_plan_for_execution_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
 ) -> Result<AgentTaskPlan> {
@@ -2001,7 +2001,7 @@ pub fn validate_controller_runtime(run_id: &str) -> Result<AgentTaskRunRecord> {
 /// `controller_runtime::validate` consults is deliberately left process-global:
 /// it is a content-addressed executable cache shared across homes, not durable
 /// lifecycle state, so it is not one of this store's roots.
-pub(crate) fn validate_controller_runtime_in_store(
+pub fn validate_controller_runtime_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
 ) -> Result<AgentTaskRunRecord> {
@@ -2187,7 +2187,7 @@ pub fn recover_controller_runtime(
 /// `validate_controller_runtime_in_store` leaves it alone: it is a
 /// content-addressed executable cache shared across homes, not durable lifecycle
 /// state, so it is not one of this store's roots.
-pub(crate) fn recover_controller_runtime_in_store(
+pub fn recover_controller_runtime_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     artifact: Option<&std::path::Path>,
@@ -2224,7 +2224,7 @@ pub fn mark_running(run_id: &str) -> Result<AgentTaskRunRecord> {
     mark_running_in_store(&lifecycle_store, run_id)
 }
 
-pub(crate) fn mark_running_in_store(
+pub fn mark_running_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
 ) -> Result<AgentTaskRunRecord> {
@@ -2304,7 +2304,7 @@ pub fn reserve_provider_execution(
     reserve_provider_execution_in_store(&lifecycle_store, run_id, task, attempt)
 }
 
-pub(crate) fn reserve_provider_execution_in_store(
+pub fn reserve_provider_execution_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     task: &AgentTaskRequest,
@@ -2761,7 +2761,7 @@ pub fn record_provider_execution_terminal(
     record_provider_execution_terminal_in_store(&lifecycle_store, run_id, task_id, attempt, state)
 }
 
-pub(crate) fn record_provider_execution_terminal_in_store(
+pub fn record_provider_execution_terminal_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     task_id: &str,
@@ -2860,7 +2860,7 @@ pub fn record_provider_execution_cleanup_elapsed(
     )
 }
 
-pub(crate) fn record_provider_execution_cleanup_elapsed_in_store(
+pub fn record_provider_execution_cleanup_elapsed_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     task_id: &str,
@@ -3459,7 +3459,7 @@ pub fn rearm_quarantined_run(run_id: &str) -> Result<AgentTaskRunRecord> {
 /// as "not quarantined" and refuse to re-arm, while a run quarantined only in
 /// the ambient home would report success and leave this store's queue still
 /// skipping the record on every claim.
-pub(crate) fn rearm_quarantined_run_in_store(
+pub fn rearm_quarantined_run_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
 ) -> Result<AgentTaskRunRecord> {
@@ -3499,7 +3499,7 @@ pub fn quarantine_queued_run_exact(run_id: &str, reason: &str) -> Result<AgentTa
 /// store must see it. Written ambiently, the operator would be told the run is
 /// quarantined while this store's queue kept handing it out, and
 /// `rearm_quarantined_run_in_store` would then find nothing to clear.
-pub(crate) fn quarantine_queued_run_exact_in_store(
+pub fn quarantine_queued_run_exact_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     reason: &str,
@@ -3579,7 +3579,7 @@ pub fn record_run_aggregate(
     record_run_aggregate_in_store(&lifecycle_store, run_id, plan, aggregate)
 }
 
-pub(crate) fn record_run_aggregate_in_store(
+pub fn record_run_aggregate_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     plan: &AgentTaskPlan,
@@ -5292,7 +5292,7 @@ pub fn record_cook_attempt(
     record_cook_attempt_in_store(&lifecycle_store, cook_id, attempt, run_id)
 }
 
-pub(crate) fn record_cook_attempt_in_store(
+pub fn record_cook_attempt_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     cook_id: &str,
     attempt: u32,
@@ -6080,7 +6080,7 @@ pub fn record_promotion(run_id: &str, promotion: Value) -> Result<AgentTaskRunRe
     record_promotion_in_store(&lifecycle_store, run_id, promotion)
 }
 
-pub(crate) fn record_promotion_in_store(
+pub fn record_promotion_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     promotion: Value,
@@ -6399,7 +6399,7 @@ pub fn record_cook_finalization(run_id: &str, finalization: Value) -> Result<Age
     record_cook_finalization_in_store(&lifecycle_store, run_id, finalization)
 }
 
-pub(crate) fn record_cook_finalization_in_store(
+pub fn record_cook_finalization_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     finalization: Value,
@@ -6519,7 +6519,7 @@ pub fn record_cook_moving_base_recovery(
     record_cook_moving_base_recovery_in_store(&lifecycle_store, run_id, recovery)
 }
 
-pub(crate) fn record_cook_moving_base_recovery_in_store(
+pub fn record_cook_moving_base_recovery_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     recovery: Value,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
@@ -67,7 +67,7 @@ pub fn recover_transport_proxy(run_id: &str) -> Result<Option<TransportProxyReco
 /// `with_runner_continuation` is deliberately still process-global: the runner
 /// continuation registry is configured trust material and a subprocess
 /// contract, not a durable lifecycle root (#12618).
-pub(crate) fn recover_transport_proxy_in_store(
+pub fn recover_transport_proxy_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
 ) -> Result<Option<TransportProxyRecovery>> {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs
@@ -95,7 +95,7 @@ pub fn claim_cook_operation(
     claim_cook_operation_in_store(&lifecycle_store, run_id, operation_key, lease)
 }
 
-pub(crate) fn claim_cook_operation_in_store(
+pub fn claim_cook_operation_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     operation_key: &str,
@@ -181,7 +181,7 @@ pub fn complete_cook_operation(run_id: &str, operation_key: &str, result: Value)
     complete_cook_operation_in_store(&lifecycle_store, run_id, operation_key, result)
 }
 
-pub(crate) fn complete_cook_operation_in_store(
+pub fn complete_cook_operation_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     operation_key: &str,
@@ -270,7 +270,7 @@ pub fn recover_completed_cook_operation(
 /// vouches for was recovered there. Restoring the completion marker in a
 /// different home would leave the real claim un-completed while inventing a
 /// completed one beside a record nobody is retrying (#7505).
-pub(crate) fn recover_completed_cook_operation_in_store(
+pub fn recover_completed_cook_operation_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     operation_key: &str,
@@ -316,7 +316,7 @@ pub fn fail_cook_operation(run_id: &str, operation_key: &str, result: Value) -> 
     fail_cook_operation_in_store(&lifecycle_store, run_id, operation_key, result)
 }
 
-pub(crate) fn fail_cook_operation_in_store(
+pub fn fail_cook_operation_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     operation_key: &str,
@@ -362,7 +362,7 @@ pub fn operation_claim(run_id: &str, operation_key: &str) -> Result<Option<Opera
     operation_claim_in_store(&lifecycle_store, run_id, operation_key)
 }
 
-pub(crate) fn operation_claim_in_store(
+pub fn operation_claim_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     operation_key: &str,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
@@ -27,7 +27,7 @@ pub fn record_runner_job_identity(
 ///
 /// The read and the write are one operation — the record read back is the one
 /// returned to the caller — so they must name the same installation (#7505).
-pub(crate) fn record_runner_job_identity_in_store(
+pub fn record_runner_job_identity_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     runner_id: &str,
@@ -71,7 +71,7 @@ pub fn accepted_lab_runner_job_identity(
 /// verified against another's record would report "not accepted" for a run that
 /// is already bound — the mirror image of the double-acceptance the write side
 /// refuses — so both halves have to name the same store (#7505).
-pub(crate) fn accepted_lab_runner_job_identity_in_store(
+pub fn accepted_lab_runner_job_identity_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
 ) -> Result<Option<homeboy_core::lab_contract::RunnerJobIdentity>> {
@@ -700,7 +700,7 @@ pub fn project_terminal_runner_exec_result(
 /// artifact-promotion checkpoint. Rooting it through the maintenance-deferring
 /// lifecycle opener would have changed behaviour rather than just its home
 /// (#7505).
-pub(crate) fn project_terminal_runner_exec_result_in_store(
+pub fn project_terminal_runner_exec_result_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     snapshot: &RunnerJobLogSnapshot,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
@@ -63,7 +63,7 @@ pub fn resolve_terminal_workspace_authority(
 /// gate concludes "no live local workspace owner" for a workspace that is still
 /// owned — a fail-open on the exact check that is supposed to fail closed
 /// (#7505). One store now roots both reads.
-pub(crate) fn resolve_terminal_workspace_authority_in_store(
+pub fn resolve_terminal_workspace_authority_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     record: &TaskWorktreeRecord,
 ) -> Result<TerminalWorkspaceAuthorityResolution> {

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -1027,7 +1027,7 @@ pub(crate) fn candidate_adoption_source(
     candidate_adoption_source_in_store(&lifecycle_store, record, source_request)
 }
 
-fn candidate_adoption_source_in_store(
+pub(crate) fn candidate_adoption_source_in_store(
     lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     record: &agent_task_lifecycle::AgentTaskRunRecord,
     source_request: &AgentTaskRequest,

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -156,7 +156,7 @@ pub(crate) fn canonical_cook_patch_artifact_id(
     canonical_cook_patch_artifact_id_in_store(&lifecycle_store, options, run_id)
 }
 
-fn canonical_cook_patch_artifact_id_in_store(
+pub(crate) fn canonical_cook_patch_artifact_id_in_store(
     lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     options: &AgentTaskCookServiceOptions,
     run_id: &str,

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -45,9 +45,9 @@ pub struct CookRecipeStore {
 ///
 /// `created` is elected by the exclusive recipe write, not by a caller's
 /// observation of the store before it starts materializing an attempt.
-pub(crate) struct InitialRecipeMaterialization {
-    pub(crate) recipe: AgentTaskCookRecipe,
-    pub(crate) created: bool,
+pub struct InitialRecipeMaterialization {
+    pub recipe: AgentTaskCookRecipe,
+    pub created: bool,
 }
 
 impl InitialRecipeMaterialization {
@@ -354,7 +354,7 @@ pub fn persist_initial_recipe(
     default_store()?.persist_initial_recipe(options)
 }
 
-fn persist_initial_recipe_in_store(
+pub fn persist_initial_recipe_in_store(
     store: &CookRecipeStore,
     options: &AgentTaskCookServiceOptions,
 ) -> Result<InitialRecipeMaterialization> {
@@ -520,7 +520,7 @@ pub fn validate_initial_recipe_compatibility(options: &AgentTaskCookServiceOptio
     default_store()?.validate_initial_recipe_compatibility(options)
 }
 
-fn validate_initial_recipe_compatibility_in_store(
+pub fn validate_initial_recipe_compatibility_in_store(
     store: &CookRecipeStore,
     options: &AgentTaskCookServiceOptions,
 ) -> Result<()> {
@@ -988,7 +988,7 @@ pub fn record_recipe_attempt(
     default_store()?.record_recipe_attempt(cook_id, attempt, run_id, plan)
 }
 
-fn record_recipe_attempt_in_store(
+pub fn record_recipe_attempt_in_store(
     store: &CookRecipeStore,
     cook_id: &str,
     attempt: u32,
@@ -1059,7 +1059,7 @@ pub fn record_recipe_attempt_replacement(
     default_store()?.record_recipe_attempt_replacement(cook_id, replaced_run_id, replacement_run_id)
 }
 
-fn record_recipe_attempt_replacement_in_store(
+pub fn record_recipe_attempt_replacement_in_store(
     store: &CookRecipeStore,
     cook_id: &str,
     replaced_run_id: &str,
@@ -1518,7 +1518,7 @@ pub fn continuation_state(cook_id: &str, run_id: &str) -> Result<CookContinuatio
 
 /// [`continuation_state`] against an explicitly injected recipe store. Every
 /// path this reads hangs off that store's own queue root.
-fn continuation_state_in_store(
+pub fn continuation_state_in_store(
     store: &CookRecipeStore,
     cook_id: &str,
     run_id: &str,
@@ -1565,7 +1565,7 @@ pub fn claim_continuation_for_recovery(
 /// The recipe membership check and the atomic failed-to-claimed rename are one
 /// decision: a run authorized by one home's recipe must never be able to claim
 /// another home's queue entry.
-fn claim_continuation_for_recovery_in_store(
+pub fn claim_continuation_for_recovery_in_store(
     store: &CookRecipeStore,
     cook_id: &str,
     run_id: &str,
@@ -1747,7 +1747,7 @@ pub fn resolve_cook_continuation_run_id(cook_or_attempt_id: &str) -> Result<Stri
 /// another home would select an attempt this recipe has never declared — which
 /// is exactly the mismatch the guard below reports, only sourced from the wrong
 /// installation (#7505).
-fn resolve_cook_continuation_run_id_in_store(
+pub fn resolve_cook_continuation_run_id_in_store(
     store: &CookRecipeStore,
     lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     cook_or_attempt_id: &str,

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -851,7 +851,7 @@ pub(super) fn write_plan(run_id: &str, plan: &AgentTaskPlan) -> Result<PathBuf> 
     write_plan_in_store(&default_store()?, run_id, plan)
 }
 
-fn write_plan_in_store(
+pub(super) fn write_plan_in_store(
     store: &AgentTaskLifecycleStore,
     run_id: &str,
     plan: &AgentTaskPlan,
@@ -960,7 +960,7 @@ pub(super) fn write_aggregate(run_id: &str, aggregate: &AgentTaskAggregate) -> R
     write_aggregate_in_store(&default_store()?, run_id, aggregate)
 }
 
-fn write_aggregate_in_store(
+pub(super) fn write_aggregate_in_store(
     store: &AgentTaskLifecycleStore,
     run_id: &str,
     aggregate: &AgentTaskAggregate,
@@ -999,7 +999,7 @@ pub(super) fn read_aggregate_bounded(run_id: &str) -> Result<AgentTaskAggregate>
     read_aggregate_bounded_in_store(&default_store()?, run_id)
 }
 
-fn read_aggregate_bounded_in_store(
+pub(super) fn read_aggregate_bounded_in_store(
     store: &AgentTaskLifecycleStore,
     run_id: &str,
 ) -> Result<AgentTaskAggregate> {
@@ -1155,7 +1155,7 @@ pub(super) fn read_record(run_id: &str) -> Result<AgentTaskRunRecord> {
     default_store()?.read_record(run_id)
 }
 
-fn read_record_in_store(
+pub(super) fn read_record_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
 ) -> Result<AgentTaskRunRecord> {
@@ -1177,7 +1177,7 @@ pub(super) fn read_record_bounded(run_id: &str) -> Result<AgentTaskRunRecord> {
     default_store()?.read_record_bounded(run_id)
 }
 
-fn read_record_bounded_in_store(
+pub(super) fn read_record_bounded_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
 ) -> Result<AgentTaskRunRecord> {
@@ -1230,7 +1230,7 @@ pub(super) fn write_cook_index_attempt(
     )
 }
 
-fn write_cook_index_attempt_in_store(
+pub(super) fn write_cook_index_attempt_in_store(
     store: &AgentTaskLifecycleStore,
     cook_id: &str,
     attempt: u32,
@@ -1268,7 +1268,7 @@ pub(super) fn write_cook_index_attempt_locked(
     )
 }
 
-fn write_cook_index_attempt_locked_in_store(
+pub(super) fn write_cook_index_attempt_locked_in_store(
     store: &AgentTaskLifecycleStore,
     cook_id: &str,
     attempt: u32,
@@ -1330,7 +1330,7 @@ pub(super) fn read_cook_index(cook_id: &str) -> Result<AgentTaskCookIndex> {
     read_cook_index_in_store(&default_store()?, cook_id)
 }
 
-fn read_cook_index_in_store(
+pub(super) fn read_cook_index_in_store(
     store: &AgentTaskLifecycleStore,
     cook_id: &str,
 ) -> Result<AgentTaskCookIndex> {
@@ -1357,7 +1357,7 @@ pub(super) fn claim_cook_notification(cook_id: &str, marker: &Value) -> Result<b
 /// function is `default_store()?`, so the store's own method is used here: the
 /// claim marker is a bare filesystem create with no record read in front of it,
 /// and an ambient reach would land the marker in another home without failing.
-fn claim_cook_notification_in_store(
+pub(super) fn claim_cook_notification_in_store(
     store: &AgentTaskLifecycleStore,
     cook_id: &str,
     marker: &Value,
@@ -1425,7 +1425,7 @@ pub(super) fn confirm_cook_notification(cook_id: &str, marker: &Value) -> Result
     confirm_cook_notification_in_store(&default_store()?, cook_id, marker)
 }
 
-fn confirm_cook_notification_in_store(
+pub(super) fn confirm_cook_notification_in_store(
     store: &AgentTaskLifecycleStore,
     cook_id: &str,
     marker: &Value,
@@ -1450,7 +1450,7 @@ pub(super) fn release_cook_notification_claim(cook_id: &str) -> Result<()> {
 /// later observer this release exists to unblock — while deleting a claim
 /// nobody took. Neither half fails: `remove_file` treats `NotFound` as success,
 /// so the wrong-root release returns `Ok(())` having done nothing (#7505).
-fn release_cook_notification_claim_in_store(
+pub(super) fn release_cook_notification_claim_in_store(
     store: &AgentTaskLifecycleStore,
     cook_id: &str,
 ) -> Result<()> {
@@ -1472,7 +1472,7 @@ pub(super) fn write_cook_notification_outcome(cook_id: &str, outcome: &Value) ->
     write_cook_notification_outcome_in_store(&default_store()?, cook_id, outcome)
 }
 
-fn write_cook_notification_outcome_in_store(
+pub(super) fn write_cook_notification_outcome_in_store(
     store: &AgentTaskLifecycleStore,
     cook_id: &str,
     outcome: &Value,
@@ -1515,7 +1515,7 @@ pub(super) fn validate_cook_index_attempt(cook_id: &str, attempt: u32, run_id: &
     validate_cook_index_attempt_in_store(&default_store()?, cook_id, attempt, run_id)
 }
 
-fn validate_cook_index_attempt_in_store(
+pub(super) fn validate_cook_index_attempt_in_store(
     store: &AgentTaskLifecycleStore,
     cook_id: &str,
     attempt: u32,
@@ -1588,7 +1588,7 @@ pub(super) fn read_retry_successors(source_run_id: &str) -> Result<Vec<AgentTask
 /// callers treat "no successor" as authority to create one, so a lineage scanned
 /// in the wrong home answers "none" for a source whose successor is durable here
 /// and double-books the reservation.
-fn read_retry_successors_in_store(
+pub(super) fn read_retry_successors_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     source_run_id: &str,
 ) -> Result<Vec<AgentTaskRunRecord>> {

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1324,6 +1324,12 @@ pub(crate) fn run_lab_offload_inner(
     mut overhead: LabOffloadOverhead,
     prepared_runner_status: RunnerStatusReport,
 ) -> Result<LabOffloadOutcome> {
+    // One store for the whole offload. Every phase record, plan read,
+    // admission reservation and pre-execution failure below describes one
+    // run; separately resolved homes let a phase land beside a record that
+    // does not have it (#7505).
+    let lab_lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
     let runner_id = &selection.runner_id;
     let mut runner = load(runner_id)?;
     let mut runner_status = status_for_admission(runner_id)?;
@@ -1395,7 +1401,8 @@ pub(crate) fn run_lab_offload_inner(
             Ok(submission) => submission,
             Err(error) => {
                 if error.retryable != Some(true) {
-                    let _ = agent_task_lifecycle::record_pre_execution_failure(
+                    let _ = agent_task_lifecycle::record_pre_execution_failure_in_store(
+                        &lab_lifecycle_store,
                         run_id,
                         durable_plan,
                         "lab_staging_submission",
@@ -1577,23 +1584,29 @@ pub(crate) fn run_lab_offload_inner(
         serde_json::to_value(homeboy_core::defaults::load_config().agent_task.rotation)
             .unwrap_or(serde_json::Value::Null);
     if let Some(run_id) = pre_acceptance_run_id.as_deref() {
-        agent_task_lifecycle::record_lab_offload_phase(
-            run_id,
-            runner_id,
-            "validation",
-            None,
-            Some(&source_checkout),
-            Some(&provider_rotation),
-            request.durable_agent_task_plan,
+        agent_task_lifecycle::record_lab_offload_phase_in_store(
+            &lab_lifecycle_store,
+            agent_task_lifecycle::LabOffloadPhaseRecord {
+                requested_run_id: run_id,
+                runner_id,
+                phase: "validation",
+                remote_workspace: None,
+                source_checkout: Some(&source_checkout),
+                provider_rotation: Some(&provider_rotation),
+                durable_plan: request.durable_agent_task_plan,
+            },
         )?;
-        agent_task_lifecycle::record_lab_offload_phase(
-            run_id,
-            runner_id,
-            "materializing",
-            None,
-            Some(&source_checkout),
-            Some(&provider_rotation),
-            request.durable_agent_task_plan,
+        agent_task_lifecycle::record_lab_offload_phase_in_store(
+            &lab_lifecycle_store,
+            agent_task_lifecycle::LabOffloadPhaseRecord {
+                requested_run_id: run_id,
+                runner_id,
+                phase: "materializing",
+                remote_workspace: None,
+                source_checkout: Some(&source_checkout),
+                provider_rotation: Some(&provider_rotation),
+                durable_plan: request.durable_agent_task_plan,
+            },
         )?;
     }
     let homeboy_path = final_preflight_homeboy_path(converged_homeboy_path.as_deref(), &runner)?;
@@ -1883,7 +1896,8 @@ pub(crate) fn run_lab_offload_inner(
                 // controller idempotency key instead of contradicting live work.
                 if error.retryable != Some(true) {
                     if let Some(durable_plan) = request.durable_agent_task_plan.as_ref() {
-                        let _ = agent_task_lifecycle::record_pre_execution_failure(
+                        let _ = agent_task_lifecycle::record_pre_execution_failure_in_store(
+                            &lab_lifecycle_store,
                             run_id,
                             durable_plan,
                             "lab_staging_submission",
@@ -1938,10 +1952,13 @@ pub(crate) fn run_lab_offload_inner(
                 error
             };
             if let Some(run_id) = pre_acceptance_run_id.as_deref() {
-                if let Ok(plan) = agent_task_lifecycle::load_plan(run_id) {
+                if let Ok(plan) =
+                    agent_task_lifecycle::load_plan_in_store(&lab_lifecycle_store, run_id)
+                {
                     // Staging is still controller-side. Make a failed handoff
                     // actionable instead of retaining an unclaimed proxy.
-                    let _ = agent_task_lifecycle::record_pre_execution_failure(
+                    let _ = agent_task_lifecycle::record_pre_execution_failure_in_store(
+                        &lab_lifecycle_store,
                         run_id,
                         &plan,
                         "lab_workspace_stage",
@@ -2051,14 +2068,17 @@ pub(crate) fn run_lab_offload_inner(
     command = runtime.command;
     remote_command = runtime.remote_command;
     if let Some(run_id) = agent_task_run_id.as_deref() {
-        agent_task_lifecycle::record_lab_offload_phase(
-            run_id,
-            runner_id,
-            "hydrating",
-            Some(&remote_cwd),
-            Some(&source_checkout),
-            Some(&provider_rotation),
-            request.durable_agent_task_plan,
+        agent_task_lifecycle::record_lab_offload_phase_in_store(
+            &lab_lifecycle_store,
+            agent_task_lifecycle::LabOffloadPhaseRecord {
+                requested_run_id: run_id,
+                runner_id,
+                phase: "hydrating",
+                remote_workspace: Some(&remote_cwd),
+                source_checkout: Some(&source_checkout),
+                provider_rotation: Some(&provider_rotation),
+                durable_plan: request.durable_agent_task_plan,
+            },
         )?;
     }
 
@@ -2075,14 +2095,17 @@ pub(crate) fn run_lab_offload_inner(
     let dependency_hydration = recorded_dependency_hydration.hydration;
     plan = dependency_hydration.plan;
     if let Some(run_id) = agent_task_run_id.as_deref() {
-        agent_task_lifecycle::record_lab_offload_phase(
-            run_id,
-            runner_id,
-            "dispatching",
-            Some(&remote_cwd),
-            Some(&source_checkout),
-            Some(&provider_rotation),
-            request.durable_agent_task_plan,
+        agent_task_lifecycle::record_lab_offload_phase_in_store(
+            &lab_lifecycle_store,
+            agent_task_lifecycle::LabOffloadPhaseRecord {
+                requested_run_id: run_id,
+                runner_id,
+                phase: "dispatching",
+                remote_workspace: Some(&remote_cwd),
+                source_checkout: Some(&source_checkout),
+                provider_rotation: Some(&provider_rotation),
+                durable_plan: request.durable_agent_task_plan,
+            },
         )?;
     }
 
@@ -2338,7 +2361,8 @@ pub(crate) fn run_lab_offload_inner(
     // run id in the meantime (#9163).
     if let (Some(run_id), Some(reservation)) = (agent_task_run_id.as_deref(), admission.as_ref()) {
         let authority = reservation.authority();
-        agent_task_lifecycle::record_lab_admission_reservation(
+        agent_task_lifecycle::record_lab_admission_reservation_in_store(
+            &lab_lifecycle_store,
             run_id,
             runner_id,
             authority.daemon_lease_id(),


### PR DESCRIPTION
The systemic fix I have been deferring, plus the conversion it unblocks.

## The asymmetry

84 rooted `_in_store` siblings were declared **less visible than the ambient wrapper they exist to replace**:

```
46   pub(crate)  under a  pub        twin
22   private     under a  pub        twin
14   private     under a  pub(super) twin
 2   private     under a  pub(crate) twin
```

A caller outside the narrower scope could not reach the rooted form at all. The ambient one was the only option available to it. That is not a preference or an oversight in each individual case — it is a structural reason the rooted halves stay unused.

**All 84 are fixed. The remaining count is 0.**

## Why this is here now rather than earlier

I have identified this four times — #12736 (where I surveyed it), #12792, #12809, and again while writing this change. Every time I widened the one to five siblings my current conversion needed and moved on, describing the systemic version as "a much larger blast radius" and "API surface with no consumer."

That reasoning was wrong. Widening does not add functions. It makes existing ones as reachable as the ambient twins already are, and the gap is what keeps the ambient twins alive. Chubes called this out directly; he was right.

The rule applied is **parity, not maximum exposure** — each sibling is raised to exactly its twin's visibility and no further. Names with more than one definition in the crate are skipped rather than guessed at, which is why `record_pre_execution_failure_in_store` needed widening separately.

One type moved too: `InitialRecipeMaterialization` and its fields become `pub`, because `persist_initial_recipe_in_store` returns it and the CLI calls the ambient form in three places. Without it the rooted form is visible but unusable — the compiler said so (`private_interfaces`).

## The conversion this unblocks

`run_lab_offload_inner` resolved a root **nine times** — four phase records, a plan read, three pre-execution failures, and an admission reservation, all describing one offload. Separately resolved homes let a phase record land beside a record that does not have it.

It resolves once now.

```
run_lab_offload_inner:  9 resolutions -> 1
```

Four of those nine are exactly why **#12809 left this function alone**: `record_lab_offload_phase_in_store` takes a `LabOffloadPhaseRecord` struct rather than the ambient form's seven loose arguments, so they need constructing rather than prefixing. I called that "a pass that can do it properly" and deferred it. It is about forty lines of mechanical work and it is done here.

`record_lab_admission_reservation` lost its last caller and is deleted.

## Counts

```
visibility gaps:   84 -> 0
homeboy-agents:   157 -> 156
lab-runner:        10 -> 8
```

The counter barely moves, as usual — one wrapper out, one entry-point resolution in. The number that matters is that a caller anywhere in the workspace can now reach the rooted form of any operation whose ambient form it can reach, which is the precondition for every remaining conversion in #7505.

## Verification

- `nice -n 10 cargo check --workspace --tests -j2` — clean, **0 errors, 0 warnings** (five runs across the change)
- `cargo fmt --check` — clean
- Re-ran the asymmetry survey after the change: 0 remaining

The gate caught two things: the `private_interfaces` warning on the return type above, and `record_pre_execution_failure_in_store` still being private because my parity script skips ambiguous names. Both are fixed rather than worked around.

Expect the current red-main set; see the evidence comment on #12772.
