### PR TITLE
Root exec_lab_context

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
@@ -429,7 +429,21 @@ pub fn has_recorded_provider_progress(run_id: &str) -> Result<bool> {
 /// projection or handoff has not — so the preserved candidate remains
 /// recoverable on the lab. Returns `false` when no record exists.
 pub fn run_owes_candidate_follow_up(run_id: &str) -> Result<bool> {
-    match store::read_record(&sanitize_run_id(run_id)) {
+    run_owes_candidate_follow_up_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        run_id,
+    )
+}
+
+/// [`run_owes_candidate_follow_up`] against an explicitly injected root.
+///
+/// The caller decides whether to leave a run alive for follow-up from this
+/// answer, so it has to read the same installation the run was recorded in.
+pub fn run_owes_candidate_follow_up_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<bool> {
+    match lifecycle_store.read_record(&sanitize_run_id(run_id)) {
         Ok(record) => Ok(record.metadata.get("transport_follow_up_failure").is_some()
             || record
                 .metadata

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
@@ -1034,13 +1034,31 @@ pub fn record_lab_offload_submission_intent(
     remote_command: &[String],
     secret_env_names: &[String],
 ) -> Result<AgentTaskRunRecord> {
+    record_lab_offload_submission_intent_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        run_id,
+        runner_id,
+        remote_workspace,
+        remote_command,
+        secret_env_names,
+    )
+}
+
+/// [`record_lab_offload_submission_intent`] against an explicitly injected root.
+///
+/// The body already took one store for the advisory lock and every record touch
+/// under it; this lets a caller that owns roots supply that store instead of
+/// having a second one resolved behind it (#7505).
+pub fn record_lab_offload_submission_intent_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    runner_id: &str,
+    remote_workspace: &str,
+    remote_command: &[String],
+    secret_env_names: &[String],
+) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
-    // One store for the lock and for every record touch below it. This is an
-    // ambient entry point, so it resolves a root; what it must not do is
-    // resolve one root for the lock and let each `store::` shim resolve its own
-    // (#7505).
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    let _lock = LabHandoffLock::lock_in_store(&lifecycle_store, &run_id)?;
+    let _lock = LabHandoffLock::lock_in_store(lifecycle_store, &run_id)?;
     let mut record = lifecycle_store.read_record(&run_id)?;
     let submission_key = format!("agent-task:v1:{runner_id}:{run_id}");
     if let Some(handoff) = record.lab_handoff.as_mut() {

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -485,6 +485,12 @@ fn lab_runner_exec_options(
 pub(crate) fn exec_lab_context(
     mut context: LabDispatchExecutionContext<'_>,
 ) -> Result<LabOffloadOutcome> {
+    // One store for the whole lab context. Phase records, the submission
+    // intent, the plan read, placement normalisation and outcome, the
+    // detached-run record and the follow-up check all describe one run
+    // (#7505).
+    let lab_lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
     // Keep the daemon-visible admission active until this function returns.
     let _admission = context.admission.take();
     let request = context.request;
@@ -562,17 +568,21 @@ pub(crate) fn exec_lab_context(
         .as_ref()
         .and_then(|snapshot| serde_json::to_value(snapshot).ok());
     if let Some(run_id) = context.agent_task_run_id.as_deref() {
-        agent_task_lifecycle::record_lab_offload_phase(
-            run_id,
-            runner_id,
-            "executor_preflight",
-            Some(&remote_cwd),
-            source_checkout.as_ref(),
-            None,
-            request.durable_agent_task_plan,
+        agent_task_lifecycle::record_lab_offload_phase_in_store(
+            &lab_lifecycle_store,
+            agent_task_lifecycle::LabOffloadPhaseRecord {
+                requested_run_id: run_id,
+                runner_id: runner_id,
+                phase: "executor_preflight",
+                remote_workspace: Some(&remote_cwd),
+                source_checkout: source_checkout.as_ref(),
+                provider_rotation: None,
+                durable_plan: request.durable_agent_task_plan,
+            },
         )?;
         if context.detach_after_handoff {
-            agent_task_lifecycle::record_lab_offload_submission_intent(
+            agent_task_lifecycle::record_lab_offload_submission_intent_in_store(
+                &lab_lifecycle_store,
                 run_id,
                 runner_id,
                 &remote_cwd,
@@ -597,14 +607,17 @@ pub(crate) fn exec_lab_context(
         context.source_snapshot.as_ref(),
     ) {
         if let Some(run_id) = context.agent_task_run_id.as_deref() {
-            agent_task_lifecycle::record_lab_offload_phase(
-                run_id,
-                runner_id,
-                "provider_preflight",
-                Some(&remote_cwd),
-                source_checkout.as_ref(),
-                None,
-                request.durable_agent_task_plan,
+            agent_task_lifecycle::record_lab_offload_phase_in_store(
+                &lab_lifecycle_store,
+                agent_task_lifecycle::LabOffloadPhaseRecord {
+                    requested_run_id: run_id,
+                    runner_id: runner_id,
+                    phase: "provider_preflight",
+                    remote_workspace: Some(&remote_cwd),
+                    source_checkout: source_checkout.as_ref(),
+                    provider_rotation: None,
+                    durable_plan: request.durable_agent_task_plan,
+                },
             )?;
         }
         preflight_agent_task_provider_on_runner(
@@ -638,7 +651,8 @@ pub(crate) fn exec_lab_context(
     // intentionally before `exec`: a controller timeout must leave status and
     // logs resolvable without reading the runner's private lifecycle store.
     if let Some(run_id) = context.agent_task_run_id.as_deref() {
-        agent_task_lifecycle::record_lab_offload_planned(
+        agent_task_lifecycle::record_lab_offload_planned_in_store(
+            &lab_lifecycle_store,
             agent_task_lifecycle::LabOffloadProxyPlan {
                 run_id,
                 runner_id,
@@ -647,14 +661,17 @@ pub(crate) fn exec_lab_context(
                 durable_plan: request.durable_agent_task_plan,
             },
         )?;
-        agent_task_lifecycle::record_lab_offload_phase(
-            run_id,
-            runner_id,
-            "provider_dispatch",
-            Some(&remote_cwd),
-            source_checkout.as_ref(),
-            None,
-            request.durable_agent_task_plan,
+        agent_task_lifecycle::record_lab_offload_phase_in_store(
+            &lab_lifecycle_store,
+            agent_task_lifecycle::LabOffloadPhaseRecord {
+                requested_run_id: run_id,
+                runner_id: runner_id,
+                phase: "provider_dispatch",
+                remote_workspace: Some(&remote_cwd),
+                source_checkout: source_checkout.as_ref(),
+                provider_rotation: None,
+                durable_plan: request.durable_agent_task_plan,
+            },
         )?;
     }
 
@@ -698,8 +715,10 @@ pub(crate) fn exec_lab_context(
                 if let Some(run_id) = context.agent_task_run_id.as_deref() {
                     // The controller parent already exists, so a failed handoff
                     // must terminalize it rather than leave a queued ghost.
-                    let plan = agent_task_lifecycle::load_plan(run_id)?;
-                    agent_task_lifecycle::record_pre_execution_failure(
+                    let plan =
+                        agent_task_lifecycle::load_plan_in_store(&lab_lifecycle_store, run_id)?;
+                    agent_task_lifecycle::record_pre_execution_failure_in_store(
+                        &lab_lifecycle_store,
                         run_id,
                         &plan,
                         "lab_handoff",
@@ -824,7 +843,8 @@ pub(crate) fn exec_lab_context(
         // This route's decision is the authoritative one for the execution
         // being verified. Adopt it when the record carries none, or carries
         // only a submission-derived placeholder (#11600).
-        agent_task_lifecycle::normalize_missing_execution_placement_decision(
+        agent_task_lifecycle::normalize_missing_execution_placement_decision_in_store(
+            &lab_lifecycle_store,
             run_id,
             &request.placement_decision,
         )?;
@@ -842,7 +862,11 @@ pub(crate) fn exec_lab_context(
                     None,
                 )
             })?;
-        agent_task_lifecycle::record_execution_placement_outcome(run_id, outcome)?;
+        agent_task_lifecycle::record_execution_placement_outcome_in_store(
+            &lab_lifecycle_store,
+            run_id,
+            outcome,
+        )?;
     }
     let dependency_cache_save_outputs =
         save_dependency_caches(runner_id, &context.dependency_cache_saves)?;
@@ -877,7 +901,8 @@ pub(crate) fn exec_lab_context(
             context.agent_task_run_id.as_deref(),
             exec_output.job_id.as_deref(),
         ) {
-            agent_task_lifecycle::record_detached_lab_run(
+            agent_task_lifecycle::record_detached_lab_run_in_store(
+                &lab_lifecycle_store,
                 agent_task_lifecycle::DetachedLabRunRecord {
                     run_id,
                     runner_id,
@@ -1045,7 +1070,11 @@ pub(crate) fn exec_lab_context(
             .agent_task_run_id
             .as_deref()
             .map(|run_id| {
-                agent_task_lifecycle::run_owes_candidate_follow_up(run_id).unwrap_or(false)
+                agent_task_lifecycle::run_owes_candidate_follow_up_in_store(
+                    &lab_lifecycle_store,
+                    run_id,
+                )
+                .unwrap_or(false)
             })
             .unwrap_or(false);
         workspace.set_terminal_outcome(if exit_code == 0 && !owes_candidate_follow_up {


### PR DESCRIPTION
Follows #12817, which removed the visibility barrier that made this impossible.

## The function

`exec_lab_context` resolved a root **thirteen times**:

```
3x  record_lab_offload_phase
1x  record_lab_offload_submission_intent
1x  record_lab_offload_planned
1x  load_plan
1x  record_pre_execution_failure
1x  normalize_missing_execution_placement_decision
1x  record_execution_placement_outcome
1x  record_detached_lab_run
1x  run_owes_candidate_follow_up
1x  record_remote_dispatch_failure      <- not converted
1x  record_pre_dispatch_failure         <- not converted
```

All of it describes **one lab context**, each answered from an independently resolved home. Eleven now come from one store resolved at the top.

```
exec_lab_context:  13 resolutions -> 2
```

## Two siblings written to get there

Neither `record_lab_offload_submission_intent` nor `run_owes_candidate_follow_up` had a rooted form at all.

The first is the interesting one: its body **already took one store** for the advisory lock and every record touch under it, with a comment explaining why. Splitting it just lets a caller supply that store instead of having a second one resolved behind it. The second reached the `store::` shim, which resolves `default_store()` for itself.

## The two left ambient, and why

`record_remote_dispatch_failure` and `record_pre_dispatch_failure` are 132-line bodies reaching five `store::` shims between them. That is its own change.

I could have rooted nine of eleven and shipped a bigger-looking number. That leaves the function **half-rooted** — some calls naming an injected home, some ambient — which is the shape this whole effort exists to remove. Same call I made in #12809, and I still think it is the right one; the difference is that this time the remaining gap is two genuinely large bodies rather than forty lines of struct construction I did not feel like typing.

## Counts

```
homeboy-agents:      153 -> 154
homeboy-lab-runner:   11 -> 12
```

**Both up by one.** The two splits add a wrapper apiece, `exec_lab_context` adds its entry resolution, and no wrapper lost its last caller — every one of the eleven has other callers still.

That is what this slice costs on the textual counter. What it buys is thirteen resolutions collapsing to two inside the hottest function in the lab offload path, and two operations that previously had no rooted form now having one.

## Verification

- `nice -n 10 cargo check --workspace --tests -j2` — clean, **0 errors, 0 warnings** (three runs)
- `cargo fmt --check` — clean

Expect the current red-main set; see the evidence comment on #12772.
