### PR TITLE
Report Cook preview placement admission

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -222,8 +222,9 @@ pub(crate) fn preview_cook(
     // it applies before an execution route can inspect the destination.
     validate_cook_request_with_provenance(&args, provenance)?;
     let (args, provision) = resolve_cook_preview_destination(args)?;
+    let replay = cook_preview_replay_argv(&args);
+    let placement = preview_placement_policy_with_admission(&replay.argv);
     if provision["action"] == "materialization_required" {
-        let replay = cook_preview_replay_argv(&args);
         return Ok((
             serde_json::json!({
                 "schema": "homeboy/agent-task-cook-preview/v1",
@@ -233,7 +234,7 @@ pub(crate) fn preview_cook(
                     "worktree": args.to_worktree,
                     "base": args.base,
                     "head": args.head,
-                    "placement": preview_placement_policy(),
+                    "placement": placement,
                     "materialization": provision,
                 },
                 "replay_argv": replay.argv,
@@ -305,7 +306,6 @@ pub(crate) fn preview_cook(
         .first()
         .map(|task| serde_json::to_value(&task.executor).unwrap_or(Value::Null))
         .unwrap_or(Value::Null);
-    let replay = cook_preview_replay_argv(&args);
     Ok((
         serde_json::json!({
             "schema": "homeboy/agent-task-cook-preview/v1",
@@ -315,7 +315,7 @@ pub(crate) fn preview_cook(
                 "worktree": args.to_worktree,
                 "base": args.base,
                 "head": args.head,
-                "placement": preview_placement_policy(),
+                "placement": placement,
                 "provider": executor,
                 "gates": {
                     "public": args.gates.verify.len(),
@@ -520,6 +520,58 @@ fn preview_placement_policy() -> Value {
     preview_placement_policy_from_argv(&argv)
 }
 
+fn preview_placement_policy_with_admission(replay_args: &[String]) -> Value {
+    let mut policy = preview_placement_policy();
+    let placement = match policy["requested"].as_str() {
+        Some("local") => crate::cli_surface::Placement::Local,
+        Some("lab") => crate::cli_surface::Placement::Lab,
+        Some("lab-or-local") => crate::cli_surface::Placement::LabOrLocal,
+        _ => crate::cli_surface::Placement::Auto,
+    };
+    let runner = policy["runner"].as_str();
+    let detach_after_handoff = policy["detach_after_handoff"].as_bool().unwrap_or(false);
+    let admission = match crate::commands::resources::run_preflight() {
+        Ok((resources, _)) => {
+            let readiness = (!placement.is_explicit_local_override())
+                .then(crate::runner::lab_runner_readiness)
+                .transpose()
+                .ok()
+                .flatten();
+            crate::commands::utils::resource_policy::cook_preview_placement_admission(
+                crate::commands::utils::resource_policy::HotCommand {
+                    label: "agent-task cook/run-plan/retry --run",
+                    lab_offload_supported: true,
+                    lab_offload_unsupported_reason: None,
+                    allows_warm_runner_coordination: true,
+                    offload_only_when_hot: false,
+                },
+                &resources,
+                placement,
+                runner,
+                detach_after_handoff,
+                readiness.as_ref(),
+                replay_args,
+            )
+        }
+        Err(error) => crate::commands::utils::resource_policy::CookPreviewPlacementAdmission {
+            schema: "homeboy/cook-preview-placement-admission/v1",
+            state: crate::commands::utils::resource_policy::CookPreviewPlacementAdmissionState::Indeterminate,
+            revalidate_before_execution: true,
+            blockers: vec![
+                crate::commands::utils::resource_policy::CookPreviewPlacementBlocker {
+                    id: "controller_resource_snapshot_unavailable".to_string(),
+                    detail: error.message,
+                },
+            ],
+            deferred_to: Some("controller_resource_snapshot".to_string()),
+            recovery: None,
+        },
+    };
+    policy["admission"] =
+        serde_json::to_value(admission).expect("Cook preview placement admission serializes");
+    policy
+}
+
 fn preview_placement_policy_from_argv(argv: &[String]) -> Value {
     let argv = crate::command_capability::homeboy_owned_args(argv);
     let placement = argv
@@ -546,7 +598,12 @@ fn preview_placement_policy_from_argv(argv: &[String]) -> Value {
                     .flatten()
             })
     });
-    serde_json::json!({ "requested": placement, "runner": runner, "route_executed": false })
+    serde_json::json!({
+        "requested": placement,
+        "runner": runner,
+        "detach_after_handoff": argv.iter().any(|value| value == "--detach-after-handoff"),
+        "route_executed": false,
+    })
 }
 
 #[cfg(test)]
@@ -859,6 +916,7 @@ mod preview_tests {
         let policy = preview_placement_policy_from_argv(&[
             "homeboy".to_string(),
             "--placement=lab-or-local".to_string(),
+            "--detach-after-handoff".to_string(),
             "agent-task".to_string(),
             "cook".to_string(),
             "--".to_string(),
@@ -867,7 +925,60 @@ mod preview_tests {
         ]);
         assert_eq!(policy["requested"], "lab-or-local");
         assert_eq!(policy["runner"], Value::Null);
+        assert_eq!(policy["detach_after_handoff"], true);
         assert_eq!(policy["route_executed"], false);
+    }
+
+    #[test]
+    fn compiled_plan_preview_emits_placement_admission_schema() {
+        crate::test_support::with_isolated_home(|_| {
+            let workspace = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../..")
+                .canonicalize()
+                .expect("workspace root")
+                .display()
+                .to_string();
+            let cli = Cli::try_parse_from([
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+                "--preview".to_string(),
+                "--backend".to_string(),
+                "fixture".to_string(),
+                "--prompt".to_string(),
+                "inspect the task".to_string(),
+                "--to-worktree".to_string(),
+                workspace,
+                "--no-finalize".to_string(),
+                "--verify".to_string(),
+                "true".to_string(),
+            ])
+            .expect("parse preview");
+            let Commands::AgentTask(agent_task) = cli.command else {
+                panic!("agent-task command");
+            };
+            let super::super::AgentTaskCommand::Cook(args) = agent_task.command else {
+                panic!("Cook command");
+            };
+            let (preview, exit_code) = preview_cook(*args, None).expect("compile preview");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(preview["schema"], "homeboy/agent-task-cook-preview/v1");
+            assert_eq!(preview["mutates"], false);
+            assert!(preview["resolved"]["provider"].is_object());
+            assert_eq!(
+                preview["resolved"]["placement"]["admission"]["schema"],
+                "homeboy/cook-preview-placement-admission/v1"
+            );
+            assert!(matches!(
+                preview["resolved"]["placement"]["admission"]["state"].as_str(),
+                Some("admissible" | "blocked" | "indeterminate")
+            ));
+            assert_eq!(
+                preview["resolved"]["placement"]["admission"]["revalidate_before_execution"],
+                true
+            );
+        });
     }
 
     #[test]
@@ -994,6 +1105,20 @@ mod preview_tests {
             )
             .expect("registered remote workspace returns a preview requirement");
             assert_eq!(exit_code, 0);
+            assert_eq!(preview["schema"], "homeboy/agent-task-cook-preview/v1");
+            assert_eq!(preview["mutates"], false);
+            assert_eq!(
+                preview["resolved"]["placement"]["admission"]["schema"],
+                "homeboy/cook-preview-placement-admission/v1"
+            );
+            assert!(matches!(
+                preview["resolved"]["placement"]["admission"]["state"].as_str(),
+                Some("admissible" | "blocked" | "indeterminate")
+            ));
+            assert_eq!(
+                preview["resolved"]["placement"]["admission"]["revalidate_before_execution"],
+                true
+            );
             assert_eq!(
                 preview["resolved"]["materialization"]["action"],
                 "materialization_required"

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
@@ -86,6 +86,34 @@ pub struct ResourcePolicyWarning {
     pub message: String,
 }
 
+/// A read-only answer to whether the controller would admit Cook's requested
+/// placement now. It is a snapshot, not a route or a runner reservation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct CookPreviewPlacementAdmission {
+    pub schema: &'static str,
+    pub state: CookPreviewPlacementAdmissionState,
+    pub revalidate_before_execution: bool,
+    pub blockers: Vec<CookPreviewPlacementBlocker>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deferred_to: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recovery: Option<ResourceAdmissionRecovery>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CookPreviewPlacementAdmissionState {
+    Admissible,
+    Blocked,
+    Indeterminate,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct CookPreviewPlacementBlocker {
+    pub id: String,
+    pub detail: String,
+}
+
 const RESOURCE_ADMISSION_RECOVERY_SCHEMA: &str = "homeboy/resource-admission-recovery/v1";
 const PRESSURE_RETRY_AFTER_SECONDS: u64 = 60;
 
@@ -335,6 +363,129 @@ pub(crate) fn is_cook_preview(command: &Commands) -> bool {
             command: agent_task::AgentTaskCommand::Cook(cook),
         }) if cook.preview
     )
+}
+
+/// Project the resource-admission decision Cook execution would make without
+/// routing, refreshing inventory, or reserving a runner. Branches where
+/// execution owns a later mutating or runner-specific admission remain explicit
+/// `indeterminate` snapshots rather than weaker preview-only refusals.
+pub(crate) fn cook_preview_placement_admission(
+    command: HotCommand,
+    resources: &DoctorOutput,
+    placement: crate::cli_surface::Placement,
+    runner: Option<&str>,
+    detach_after_handoff: bool,
+    lab_readiness: Option<&LabRunnerReadiness>,
+    replay_args: &[String],
+) -> CookPreviewPlacementAdmission {
+    // Execution intentionally lets Lab routing validate an explicit runner's
+    // availability and capabilities. Preview must preserve that authority.
+    if runner.is_some() {
+        return CookPreviewPlacementAdmission {
+            schema: "homeboy/cook-preview-placement-admission/v1",
+            state: CookPreviewPlacementAdmissionState::Indeterminate,
+            revalidate_before_execution: true,
+            blockers: Vec::new(),
+            deferred_to: Some("lab_route".to_string()),
+            recovery: None,
+        };
+    }
+    // Detached Cook always asks execution to recheck reverse-runner capacity and
+    // submit through its broker queue. This is independent of controller load.
+    if detach_after_handoff && !placement.is_explicit_local_override() {
+        return CookPreviewPlacementAdmission {
+            schema: "homeboy/cook-preview-placement-admission/v1",
+            state: CookPreviewPlacementAdmissionState::Indeterminate,
+            revalidate_before_execution: true,
+            blockers: Vec::new(),
+            deferred_to: Some("detached_queue_admission".to_string()),
+            recovery: None,
+        };
+    }
+    let Some(warning) = evaluate_with_runner_hint(command, resources, lab_readiness) else {
+        return CookPreviewPlacementAdmission {
+            schema: "homeboy/cook-preview-placement-admission/v1",
+            state: CookPreviewPlacementAdmissionState::Admissible,
+            revalidate_before_execution: true,
+            blockers: Vec::new(),
+            deferred_to: None,
+            recovery: None,
+        };
+    };
+
+    // A stale projection receives one runner-owned authoritative refresh before
+    // execution refuses. Preview deliberately does not perform that refresh.
+    if matches!(
+        lab_readiness.map(|readiness| readiness.state),
+        Some(crate::runner::runners::LabRunnerReadinessState::Stale)
+    ) {
+        return CookPreviewPlacementAdmission {
+            schema: "homeboy/cook-preview-placement-admission/v1",
+            state: CookPreviewPlacementAdmissionState::Indeterminate,
+            revalidate_before_execution: true,
+            blockers: Vec::new(),
+            deferred_to: Some("lab_inventory_refresh".to_string()),
+            recovery: None,
+        };
+    }
+    let runner_admitted = admits_warm_runner_coordination(
+        command,
+        resources,
+        lab_readiness.and_then(|readiness| readiness.selected_runner_id.as_deref()),
+        lab_readiness,
+    );
+    let local_admitted = placement.is_explicit_local_override()
+        || admits_auto_local_capacity_fallback(command, resources, lab_readiness, placement);
+    if runner_admitted || local_admitted {
+        return CookPreviewPlacementAdmission {
+            schema: "homeboy/cook-preview-placement-admission/v1",
+            state: CookPreviewPlacementAdmissionState::Admissible,
+            revalidate_before_execution: true,
+            blockers: Vec::new(),
+            deferred_to: None,
+            recovery: None,
+        };
+    }
+
+    let mut blockers = vec![CookPreviewPlacementBlocker {
+        id: "controller_resource_pressure".to_string(),
+        detail: warning.message,
+    }];
+    if !placement.is_explicit_local_override() {
+        if let Some(readiness) = lab_readiness {
+            let (id, detail) = match readiness.state {
+                crate::runner::runners::LabRunnerReadinessState::Stale => (
+                    "lab_inventory_stale",
+                    "Lab runner inventory is stale; refresh or reconcile the runner before execution.",
+                ),
+                crate::runner::runners::LabRunnerReadinessState::Absent => (
+                    "no_lab_runner",
+                    "No Lab runner is configured for automatic offload.",
+                ),
+                _ => (
+                    "no_admissible_lab_runner",
+                    "No ready Lab runner can admit this Cook now.",
+                ),
+            };
+            blockers.push(CookPreviewPlacementBlocker {
+                id: id.to_string(),
+                detail: detail.to_string(),
+            });
+        } else {
+            blockers.push(CookPreviewPlacementBlocker {
+                id: "lab_inventory_unavailable".to_string(),
+                detail: "Lab runner inventory could not be observed for this preview.".to_string(),
+            });
+        }
+    }
+    CookPreviewPlacementAdmission {
+        schema: "homeboy/cook-preview-placement-admission/v1",
+        state: CookPreviewPlacementAdmissionState::Blocked,
+        revalidate_before_execution: true,
+        blockers,
+        deferred_to: None,
+        recovery: admission_recovery(replay_args, lab_readiness),
+    }
 }
 
 pub fn evaluate(command: HotCommand, resources: &DoctorOutput) -> Option<ResourcePolicyWarning> {
@@ -619,7 +770,7 @@ pub fn rerun_command(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cli_surface::Cli;
+    use crate::cli_surface::{Cli, Placement};
     use crate::commands::resources::{LoadSummary, MemorySummary, ProcessSummary, RigLeaseSummary};
     use crate::test_support::with_isolated_home;
     use clap::Parser;
@@ -695,6 +846,185 @@ mod tests {
             lab_offload_unsupported_reason: Some(reason),
             allows_warm_runner_coordination: false,
             offload_only_when_hot: false,
+        }
+    }
+
+    fn cook_hot() -> HotCommand {
+        HotCommand {
+            label: "agent-task cook/run-plan/retry --run",
+            lab_offload_supported: true,
+            lab_offload_unsupported_reason: None,
+            allows_warm_runner_coordination: true,
+            offload_only_when_hot: false,
+        }
+    }
+
+    fn preview_replay_args() -> Vec<String> {
+        vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "inspect".to_string(),
+        ]
+    }
+
+    #[test]
+    fn cook_preview_admission_accepts_auto_placement_with_ready_lab_capacity() {
+        let ready = ready_lab();
+        let admission = cook_preview_placement_admission(
+            cook_hot(),
+            &resources(ResourceRecommendation::Hot),
+            Placement::Auto,
+            None,
+            false,
+            Some(&ready),
+            &preview_replay_args(),
+        );
+
+        assert_eq!(
+            admission.state,
+            CookPreviewPlacementAdmissionState::Admissible
+        );
+        assert!(admission.blockers.is_empty());
+        assert!(admission.recovery.is_none());
+    }
+
+    #[test]
+    fn cook_preview_admission_blocks_hot_local_placement_without_override() {
+        let admission = cook_preview_placement_admission(
+            cook_hot(),
+            &resources(ResourceRecommendation::Hot),
+            Placement::Auto,
+            None,
+            false,
+            None,
+            &preview_replay_args(),
+        );
+
+        assert_eq!(admission.state, CookPreviewPlacementAdmissionState::Blocked);
+        assert_eq!(admission.blockers[0].id, "controller_resource_pressure");
+        assert_eq!(admission.blockers[1].id, "lab_inventory_unavailable");
+        assert_eq!(
+            admission.recovery.expect("recovery").choices[1].command,
+            "homeboy --placement local agent-task cook --prompt inspect"
+        );
+    }
+
+    #[test]
+    fn cook_preview_admission_defers_stale_inventory_and_blocks_missing_lab() {
+        for (state, expected_state, expected_blocker) in [
+            (
+                crate::runner::runners::LabRunnerReadinessState::Stale,
+                CookPreviewPlacementAdmissionState::Indeterminate,
+                None,
+            ),
+            (
+                crate::runner::runners::LabRunnerReadinessState::Absent,
+                CookPreviewPlacementAdmissionState::Blocked,
+                Some("no_lab_runner"),
+            ),
+        ] {
+            let readiness = LabRunnerReadiness {
+                state,
+                selected_runner_id: None,
+                available_runner_ids: Vec::new(),
+                reasons: Vec::new(),
+                remediation_commands: vec!["homeboy runner reconcile lab".to_string()],
+            };
+            let admission = cook_preview_placement_admission(
+                cook_hot(),
+                &resources(ResourceRecommendation::Hot),
+                Placement::Auto,
+                None,
+                false,
+                Some(&readiness),
+                &preview_replay_args(),
+            );
+
+            assert_eq!(admission.state, expected_state, "{state:?}");
+            assert_eq!(
+                admission.blockers.get(1).map(|blocker| blocker.id.as_str()),
+                expected_blocker,
+                "{state:?}"
+            );
+            assert_eq!(
+                admission.deferred_to.as_deref(),
+                (state == crate::runner::runners::LabRunnerReadinessState::Stale)
+                    .then_some("lab_inventory_refresh")
+            );
+        }
+    }
+
+    #[test]
+    fn cook_preview_admission_honors_explicit_local_override() {
+        let admission = cook_preview_placement_admission(
+            cook_hot(),
+            &resources(ResourceRecommendation::Hot),
+            Placement::Local,
+            None,
+            false,
+            None,
+            &preview_replay_args(),
+        );
+
+        assert_eq!(
+            admission.state,
+            CookPreviewPlacementAdmissionState::Admissible
+        );
+        assert!(admission.blockers.is_empty());
+    }
+
+    #[test]
+    fn cook_preview_admission_defers_explicit_runner_to_lab_route() {
+        let ready = ready_lab();
+        let admission = cook_preview_placement_admission(
+            cook_hot(),
+            &resources(ResourceRecommendation::Hot),
+            Placement::Auto,
+            Some("other-lab"),
+            false,
+            Some(&ready),
+            &preview_replay_args(),
+        );
+
+        assert_eq!(
+            admission.state,
+            CookPreviewPlacementAdmissionState::Indeterminate
+        );
+        assert_eq!(admission.deferred_to.as_deref(), Some("lab_route"));
+        assert!(admission.blockers.is_empty());
+    }
+
+    #[test]
+    fn cook_preview_admission_defers_detached_queue_admission() {
+        for recommendation in [ResourceRecommendation::Ok, ResourceRecommendation::Hot] {
+            let admission = cook_preview_placement_admission(
+                cook_hot(),
+                &resources(recommendation),
+                Placement::Auto,
+                None,
+                true,
+                Some(&LabRunnerReadiness {
+                    state: crate::runner::runners::LabRunnerReadinessState::CapacityBlocked,
+                    selected_runner_id: None,
+                    available_runner_ids: Vec::new(),
+                    reasons: Vec::new(),
+                    remediation_commands: Vec::new(),
+                }),
+                &preview_replay_args(),
+            );
+
+            assert_eq!(
+                admission.state,
+                CookPreviewPlacementAdmissionState::Indeterminate,
+                "{recommendation:?}"
+            );
+            assert_eq!(
+                admission.deferred_to.as_deref(),
+                Some("detached_queue_admission"),
+                "{recommendation:?}"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

Add a non-mutating placement-admission snapshot to `agent-task cook --preview` so operators can distinguish immediately admissible execution from blocked or execution-owned indeterminate states.

## What changed

- Add `homeboy/cook-preview-placement-admission/v1` under `resolved.placement.admission`.
- Report `admissible`, `blocked`, or `indeterminate` with mandatory execution-time revalidation.
- Project controller pressure and Lab readiness without routing, refreshing inventory, reserving runners, sealing runtimes, or creating durable state.
- Defer explicit runner validation to the Lab route, detached Cook to queue admission, and stale inventory to execution-owned bounded refresh.
- Preserve explicit local override semantics and provide typed recovery when current auto placement is blocked.

## Verification

- `cargo test -p homeboy-cli cook_preview --lib`
- `cargo test -p homeboy-cli compiled_plan_preview_emits_placement_admission_schema --lib`
- `cargo check -p homeboy-cli`
- `cargo fmt --check`
- `git diff --check`

This is a bounded predictive-preview slice of #8288; general plan validation and lifecycle action eligibility remain separately scoped.

Refs #8288

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode orchestrated issue deduplication, supplied the implementation task to an OpenCode general coding subagent, ran two rounds of independent review, directed fixes for execution-parity findings, and reran deterministic verification. Chris Huber reviewed and remains responsible for every line.