### PR TITLE
Root sync_workspace and the runner lookup under it

### DIFF
--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -644,22 +644,31 @@ pub fn register_runner_config_entity() {
 }
 
 pub fn load(id: &str) -> Result<Runner> {
+    load_in_roots(&homeboy_core::paths::PathRoots::from_environment()?, id)
+}
+
+/// [`load`] against an explicitly injected root.
+///
+/// The registry probe, the server-backed fallback, and the alias retry all have
+/// to describe the same installation: a runner found in one home and a server
+/// record read from another is not a runner definition, it is two (#7505).
+pub fn load_in_roots(roots: &homeboy_core::paths::PathRoots, id: &str) -> Result<Runner> {
     if id == "local" {
         return Ok(builtin_local_runner());
     }
 
-    if let Ok(runner) = config::load::<Runner>(id) {
+    if let Ok(runner) = config::load_in_root::<Runner>(roots.config(), id) {
         if runner.kind == RunnerKind::Local {
             return Ok(runner);
         }
     }
 
-    if let Ok(runner) = load_server_runner(id) {
+    if let Ok(runner) = load_server_runner_in_root(roots.config(), id) {
         return Ok(runner);
     }
 
     if let Some(runner_id) = resolve_reserved_runner_alias(id)? {
-        return load_server_runner(&runner_id);
+        return load_server_runner_in_root(roots.config(), &runner_id);
     }
 
     if let Some(runner) = execution_context_runner(id) {
@@ -1535,7 +1544,12 @@ fn create_single_value(value: Value) -> Result<CreateResult<Runner>> {
 }
 
 fn load_server_runner(id: &str) -> Result<Runner> {
-    let server = server::load(id)?;
+    load_server_runner_in_root(&homeboy_core::paths::homeboy()?, id)
+}
+
+/// [`load_server_runner`] against an already-resolved config root.
+fn load_server_runner_in_root(config_root: &std::path::Path, id: &str) -> Result<Runner> {
+    let server = server::load_in_root(config_root, id)?;
     let runner = server
         .runner
         .ok_or_else(|| Error::runner_not_found(id.to_string(), vec![]))?;

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -22,7 +22,8 @@ use super::super::validation_dependencies::{
     sync_validation_dependency_workspaces, RunnerValidationDependencySyncOutput,
 };
 use super::super::{
-    load, source_materialization, Runner, RunnerKind, RunnerLifecycleOwner, RunnerWorkspaceLease,
+    load, load_in_roots, source_materialization, Runner, RunnerKind, RunnerLifecycleOwner,
+    RunnerWorkspaceLease,
 };
 use super::git::{
     git_snapshot, materialize_git, materialize_git_from_controller_bundle,
@@ -83,7 +84,25 @@ pub fn sync_workspace(
     runner_id: &str,
     options: RunnerWorkspaceSyncOptions,
 ) -> Result<(RunnerWorkspaceSyncOutput, i32)> {
-    let runner = load(runner_id)?;
+    sync_workspace_in_roots(
+        &homeboy_core::paths::PathRoots::from_environment()?,
+        runner_id,
+        options,
+    )
+}
+
+/// [`sync_workspace`] against explicitly injected roots.
+///
+/// The runner definition this syncs and the filesystem reservation the snapshot
+/// modes take are the same installation's state. Resolving the runner from the
+/// ambient config root while reserving space under an injected data root would
+/// sync one home's runner into another home's disk budget (#7505).
+pub fn sync_workspace_in_roots(
+    roots: &homeboy_core::paths::PathRoots,
+    runner_id: &str,
+    options: RunnerWorkspaceSyncOptions,
+) -> Result<(RunnerWorkspaceSyncOutput, i32)> {
+    let runner = load_in_roots(roots, runner_id)?;
     let local_path = canonical_workspace_path(&options.path)?;
     let workspace_root = runner.workspace_root.as_deref().ok_or_else(|| {
         Error::validation_invalid_argument(
@@ -153,11 +172,8 @@ pub fn sync_workspace(
                 &excludes,
                 WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
             )?;
-            // Resolved at the point of use rather than at the top of the
-            // function: only the snapshot modes take a filesystem reservation,
-            // so the other sync modes keep resolving nothing they do not use.
             let admission = require_snapshot_filesystem_admission(
-                homeboy_core::paths::PathRoots::from_environment()?.data(),
+                roots.data(),
                 &runner,
                 &local_path,
                 &remote_path,


### PR DESCRIPTION
`sync_workspace` is the **single largest test-pinning resolver in the tree** — 51 `with_isolated_home` sites reach it.

## Two ambient dependencies, one of them hidden

**Visible:** `PathRoots::from_environment()` at the snapshot admission call, deliberately placed at the point of use with a comment explaining that non-snapshot modes should resolve nothing they do not use. That reasoning was sound *while the root was ambient*. With an injected root there is nothing to defer, so the comment goes with it.

**Hidden:** `load(runner_id)` — reads the runner definition through `config::load` against the **ambient config root**. My first pass at this PR would have rooted only the data root, which produces the worst possible shape:

```
runner definition  <- ambient config root
disk reservation   <- injected data root
```

A runner resolved from one home reserving disk under another. So the lookup had to be rooted with it.

## What that pulled in

```
sync_workspace_in_roots
  └─ load_in_roots                     (new)
       ├─ config::load_in_root         (already existed)
       └─ load_server_runner_in_root   (new)
            └─ server::load_in_root    (already existed, entity_crud!-generated)
```

Both rooted primitives were already there. This routes to them rather than inventing anything.

## Deliberately left

`builtin_local_runner` still reads `current_dir`. That is the **process working directory, not an installation root** — injecting a root there would be wrong, not just unnecessary.

## Honest scope

This does **not** by itself free those 51 tests. It removes the store/root dependency from their path; whatever else each test needs from an isolated home still has to be checked test by test. It is necessary, not sufficient — and it was the largest single blocker on the list.

## Verification

- `nice -n 10 cargo check --workspace --tests -j2` — clean, **0 errors, 0 warnings**
- `cargo fmt --check` — clean
- `sync_workspace_in_roots` body (433 lines): 0 `from_environment`, 0 `default_store`, 0 ambient `load(runner_id)`
- `load_in_roots`: 0 `from_environment`, 0 `config::load::<`, 0 ambient `load_server_runner`

Expect the known red-main set; see the evidence comment on #12772.
