### PR TITLE
Preserve configured worktree provider authority in fanout

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -1509,7 +1509,7 @@ fn finalize_provider_worktrees(
     plan: &BatchCookFanoutPlan,
     report: &agent_task_service::AgentTaskCookBatchReport,
 ) -> Result<()> {
-    if !configured_provider_lifecycle()? {
+    if !configured_provider_workspace_creation()? {
         return Ok(());
     }
     let config = homeboy::core::defaults::load_config();
@@ -1530,6 +1530,14 @@ fn finalize_provider_worktrees(
                 &config,
                 None,
             )?;
+        if homeboy::core::worktree_providers::worktree_provider_lifecycle_finalizer_argv_from_config(
+            &resolution.provider_id,
+            &config,
+        )?
+        .is_none()
+        {
+            continue;
+        }
         let disposition = if cell.exit_code == 0 {
             homeboy::core::worktree_providers::WorktreeProviderTerminalDisposition::Succeeded
         } else {
@@ -2403,7 +2411,7 @@ fn queue_or_reuse_worktrees(
     args: &AgentTaskFanoutCookBatchArgs,
     plan: &BatchCookFanoutPlan,
 ) -> Result<worktree::WorktreeQueueCreateOutput> {
-    let provider_lifecycle = configured_provider_lifecycle()?;
+    let provider_workspace_creation = configured_provider_workspace_creation()?;
     let queue_create = |cooks: Vec<&BatchCookSpec>, dry_run: bool| {
         worktree::queue_create(worktree::WorktreeQueueCreateOptions {
             repo: args.repo.clone(),
@@ -2412,7 +2420,7 @@ fn queue_or_reuse_worktrees(
                 task_url: cook.task_url.clone(),
                 task_ref: cook.task_url.clone(),
                 run_id: Some(cook.run_id()),
-                provider_lifecycle: provider_lifecycle.then(|| {
+                provider_lifecycle: provider_workspace_creation.then(|| {
                     homeboy::core::worktree_providers::WorktreeProviderLifecycleIntent {
                         purpose: "agent_task_cook".to_string(),
                         owner_run_ref: cook.run_id(),
@@ -2434,7 +2442,9 @@ fn queue_or_reuse_worktrees(
     let mut to_create = Vec::new();
     for cook in &plan.cooks {
         let branch = cook.head.as_ref().expect("generated cooks have heads");
-        match (!provider_lifecycle).then(|| active_registered_worktree_path(&cook.to_worktree)) {
+        match (!provider_workspace_creation)
+            .then(|| active_registered_worktree_path(&cook.to_worktree))
+        {
             Some(Some(path)) => {
                 reused.push(worktree::WorktreeQueueCreateRow {
                     branch: branch.clone(),
@@ -2510,7 +2520,7 @@ fn with_workspace_owner_repair_commands(
     plan: &BatchCookFanoutPlan,
     mut worktrees: worktree::WorktreeQueueCreateOutput,
 ) -> Result<worktree::WorktreeQueueCreateOutput> {
-    if !configured_provider_lifecycle()? {
+    if !configured_provider_workspace_creation()? {
         return Ok(worktrees);
     }
 
@@ -2632,7 +2642,11 @@ fn plan_provider_worktrees_dry_run(
 }
 
 fn configured_provider_workspace_creation() -> Result<bool> {
-    configured_provider_lifecycle()
+    let config = homeboy::core::defaults::load_config();
+    Ok(config
+        .worktree_providers
+        .values()
+        .any(|provider| provider.enabled && provider.apply_enabled))
 }
 
 /// Dry-run observes existing managed worktrees but only plans creation for
@@ -2709,20 +2723,6 @@ fn active_registered_worktree_path(handle: &str) -> Option<String> {
         }
         _ => None,
     }
-}
-
-fn configured_provider_lifecycle() -> Result<bool> {
-    let config = homeboy::core::defaults::load_config();
-    for (id, provider) in &config.worktree_providers {
-        if provider.enabled
-            && provider.apply_enabled
-            && provider.commands.ensure.is_some()
-            && homeboy::core::worktree_providers::worktree_provider_lifecycle_finalizer_argv_from_config(id, &config)?.is_some()
-        {
-            return Ok(true);
-        }
-    }
-    Ok(false)
 }
 
 fn preflight_batch_cook_recipes(
@@ -6156,6 +6156,130 @@ fi
                 .expect("planned cooks")
                 .iter()
                 .all(|cook| cook["workspace"].is_string()));
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fanout_uses_an_ensure_resolve_provider_without_a_finalizer_for_creation_binding_and_repair()
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        with_isolated_home(|_| {
+            let fixture = tempfile::tempdir().expect("provider fixture");
+            let workspace_root = fixture.path().join("worktrees");
+            let ensured = fixture.path().join("ensured");
+            let provider = fixture.path().join("provider");
+            std::fs::create_dir(&workspace_root).expect("provider worktree directory");
+            std::fs::write(
+                &provider,
+                format!(
+                    "#!/bin/sh\ncase \"$1\" in\nresolve)\n  path='{}/'$2\n  if [ -d \"$path\" ]; then\n    branch=$(git -C \"$path\" branch --show-current)\n    printf '{{\"worktrees\":[{{\"handle\":\"%s\",\"path\":\"%s\",\"branch\":\"%s\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}\\n' \"$2\" \"$path\" \"$branch\"\n  else\n    exit 1\n  fi\n  ;;\nensure)\n  path='{}/'$2\n  git init --quiet -b \"$5\" \"$path\"\n  printf '%s|%s|%s|%s\\n' \"$2\" \"$8\" \"$9\" \"${{10}}\" >> '{}'\n  ;;\nesac\n",
+                    workspace_root.display(),
+                    workspace_root.display(),
+                    ensured.display(),
+                ),
+            )
+            .expect("write provider");
+            let mut permissions = std::fs::metadata(&provider)
+                .expect("provider metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&provider, permissions).expect("make provider executable");
+
+            let mut config = homeboy::core::defaults::HomeboyConfig::default();
+            config.worktree_providers.insert(
+                "fixture".to_string(),
+                homeboy::core::defaults::WorktreeProviderConfig {
+                    enabled: true,
+                    kind: homeboy::core::defaults::WorktreeProviderKind::Command,
+                    apply_enabled: true,
+                    lookup_timeout_ms: 10_000,
+                    mutation_timeout_ms: 30_000,
+                    lookup_output_limit_bytes: 64 * 1024,
+                    commands: homeboy::core::defaults::WorktreeProviderCommands {
+                        resolve: Some(vec![
+                            provider.display().to_string(),
+                            "resolve".to_string(),
+                            "{handle}".to_string(),
+                        ]),
+                        resolve_not_found_exit_codes: vec![1],
+                        ensure: Some(vec![
+                            provider.display().to_string(),
+                            "ensure".to_string(),
+                            "{handle}".to_string(),
+                            "{repo}".to_string(),
+                            "{base}".to_string(),
+                            "{head}".to_string(),
+                            "{task_url}".to_string(),
+                            "{idempotency_key}".to_string(),
+                            "{purpose}".to_string(),
+                            "{owner_run_ref}".to_string(),
+                            "{cleanup_policy}".to_string(),
+                        ]),
+                        ..Default::default()
+                    },
+                    list_result_mapping: Some(
+                        homeboy::core::defaults::WorktreeProviderListResultMapping {
+                            items: "$.worktrees".to_string(),
+                            handle: "$.handle".to_string(),
+                            path: "$.path".to_string(),
+                            branch: "$.branch".to_string(),
+                            dirty: "$.safety.dirty".to_string(),
+                            unpushed: "$.safety.unpushed".to_string(),
+                            primary: "$.safety.primary".to_string(),
+                            task_url: None,
+                        },
+                    ),
+                },
+            );
+            homeboy::core::defaults::save_config(&config).expect("save provider config");
+
+            let mut args = cook_batch_args();
+            args.dry_run = false;
+            let mut plan = build_cook_batch_plan(&args).expect("fanout plan");
+            let worktrees =
+                queue_or_reuse_worktrees(&args, &plan).expect("provider worktree queue");
+
+            assert!(worktrees.rows.iter().all(|row| {
+                row.status == worktree::WorktreeQueueCreateStatus::Created
+                    && row.path.as_deref().is_some_and(|path| {
+                        path.starts_with(workspace_root.to_string_lossy().as_ref())
+                    })
+            }));
+            assert!(std::fs::read_to_string(&ensured)
+                .expect("provider ensure records")
+                .contains("agent_task_cook"));
+            assert!(worktrees.rows.iter().all(|row| {
+                row.command.first() == Some(&provider.display().to_string())
+                    && !row
+                        .command
+                        .windows(3)
+                        .any(|argv| argv == ["homeboy", "worktree", "create"])
+            }));
+
+            bind_materialized_worktree_paths(&mut plan, &worktrees);
+            assert!(plan.cooks.iter().all(|cook| cook.workspace.is_some()));
+
+            let mut blocked = worktrees.clone();
+            blocked.rows[0].status = worktree::WorktreeQueueCreateStatus::Failed;
+            let actions = cook_batch_next_actions(
+                &args,
+                &plan.fanout_id,
+                "blocked",
+                true,
+                false,
+                &blocked,
+                false,
+                None,
+            );
+            let repair_commands = action_commands(&actions);
+            assert!(repair_commands
+                .iter()
+                .any(|command| command.contains(&provider.display().to_string())));
+            assert!(!repair_commands
+                .iter()
+                .any(|command| command.contains("homeboy worktree create")));
         });
     }
 

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -901,7 +901,7 @@ pub fn select_apply_enabled_worktree_provider_from_config(
 ) -> Result<String> {
     match resolve_apply_enabled_worktree_provider_from_config(&intent.handle, config, None) {
         Ok(resolution) => {
-            validate_lifecycle_provider(&resolution.provider_id, config)?;
+            validate_workspace_creation_provider(&resolution.provider_id, config)?;
             return Ok(resolution.provider_id);
         }
         Err(error)
@@ -913,18 +913,19 @@ pub fn select_apply_enabled_worktree_provider_from_config(
         Err(error) => return Err(error),
     }
     let mut providers = Vec::new();
+    let mut capability_errors = Vec::new();
     for (id, provider) in &config.worktree_providers {
-        if provider.enabled
-            && provider.apply_enabled
-            && provider.commands.ensure.is_some()
-            && worktree_provider_lifecycle_finalizer_argv_from_config(id, config)?.is_some()
-        {
-            providers.push(id.clone());
+        if provider.enabled && provider.apply_enabled {
+            match validate_workspace_creation_provider(id, config) {
+                Ok(()) => providers.push(id.clone()),
+                Err(error) => capability_errors.push(error),
+            }
         }
     }
     providers.sort();
     match providers.as_slice() {
         [provider] => Ok(provider.clone()),
+        [] if capability_errors.len() == 1 => Err(capability_errors.pop().expect("one capability error")),
         [] => Err(Error::validation_invalid_argument("to_worktree", format!("worktree handle `{}` is missing and no enabled apply-enabled provider configures commands.ensure, so Homeboy cannot create it", intent.handle), Some(intent.handle.clone()), Some(missing_ensure_provider_remediation(intent)))),
         _ => Err(Error::validation_invalid_argument("to_worktree", format!("worktree handle `{}` is missing and multiple providers can ensure it: {}", intent.handle, providers.join(", ")), Some(intent.handle.clone()), Some(ambiguous_ensure_provider_remediation(&providers.iter().map(String::as_str).collect::<Vec<_>>())))),
     }
@@ -941,7 +942,7 @@ pub fn plan_apply_enabled_worktree_provider_from_config(
     plan_apply_enabled_worktree_provider_from_config_with_id(intent, None, config)
 }
 
-/// Plan a purpose-owned workspace with the same lifecycle-eligible provider
+/// Plan a purpose-owned workspace with the same creation-capable provider
 /// selection that execution uses, without running its ensure command.
 pub fn plan_apply_enabled_worktree_provider_with_lifecycle_from_config(
     intent: &WorktreeProviderCreateIntent,
@@ -1122,9 +1123,10 @@ fn ambiguous_ensure_provider_remediation(providers: &[&str]) -> Vec<String> {
         .collect()
 }
 
-/// A purpose-owned workspace needs all lifecycle phases before ownership is
-/// persisted. This prevents an unreconcilable ensure from ever being invoked.
-fn validate_lifecycle_provider(provider_id: &str, config: &HomeboyConfig) -> Result<()> {
+/// Creation needs a provider mutation and a provider-backed postcondition
+/// lookup. Terminal finalization is optional: providers that do not expose it
+/// remain authoritative for their ensure/resolve lifecycle.
+fn validate_workspace_creation_provider(provider_id: &str, config: &HomeboyConfig) -> Result<()> {
     let provider = config.worktree_providers.get(provider_id).ok_or_else(|| {
         Error::validation_invalid_argument(
             "worktree_provider",
@@ -1133,19 +1135,56 @@ fn validate_lifecycle_provider(provider_id: &str, config: &HomeboyConfig) -> Res
             None,
         )
     })?;
-    if provider.enabled
-        && provider.apply_enabled
-        && provider.commands.ensure.is_some()
-        && worktree_provider_lifecycle_finalizer_argv_from_config(provider_id, config)?.is_some()
-    {
+    let mut selected_capabilities = Vec::new();
+    if provider.enabled {
+        selected_capabilities.push("enabled");
+    }
+    if provider.apply_enabled {
+        selected_capabilities.push("apply_enabled");
+    }
+    if provider.commands.ensure.is_some() {
+        selected_capabilities.push("ensure");
+    }
+    if provider.commands.resolve.is_some() {
+        selected_capabilities.push("resolve");
+    }
+    if provider.commands.list.is_some() {
+        selected_capabilities.push("list");
+    }
+    if worktree_provider_lifecycle_finalizer_argv_from_config(provider_id, config)?.is_some() {
+        selected_capabilities.push("finalize");
+    }
+    let mut missing_required_capabilities = Vec::new();
+    if !provider.enabled {
+        missing_required_capabilities.push("enabled");
+    }
+    if !provider.apply_enabled {
+        missing_required_capabilities.push("apply_enabled");
+    }
+    if provider.commands.ensure.is_none() {
+        missing_required_capabilities.push("ensure");
+    }
+    if provider.commands.resolve.is_none() && provider.commands.list.is_none() {
+        missing_required_capabilities.push("resolve_or_list");
+    }
+    if missing_required_capabilities.is_empty() {
         return Ok(());
     }
-    Err(Error::validation_invalid_argument(
+    let mut error = Error::validation_invalid_argument(
         "worktree_provider",
-        "purpose-owned workspace provider requires enabled, apply_enabled, commands.ensure, and settings.worktree_provider_lifecycle.<provider>.finalize",
+        format!(
+            "worktree provider `{provider_id}` cannot create and resolve a fanout workspace; missing required capabilities: {}",
+            missing_required_capabilities.join(", ")
+        ),
         Some(provider_id.to_string()),
         None,
-    ))
+    );
+    error.details["worktree_provider_id"] = Value::String(provider_id.to_string());
+    error.details["worktree_provider_selected_capabilities"] =
+        serde_json::json!(selected_capabilities);
+    error.details["worktree_provider_missing_required_capabilities"] =
+        serde_json::json!(missing_required_capabilities);
+    Err(error)
 }
 
 fn provision_apply_enabled_worktree_provider_from_config_with_lifecycle(
@@ -1153,8 +1192,8 @@ fn provision_apply_enabled_worktree_provider_from_config_with_lifecycle(
     lifecycle: Option<&WorktreeProviderLifecycleIntent>,
     config: &HomeboyConfig,
 ) -> Result<WorktreeProviderProvision> {
-    // Lifecycle callers select once using the stricter lifecycle eligibility
-    // contract. Keep that exact identity through ensure and postcondition lookup.
+    // Purpose-owned callers select once using the creation capability contract.
+    // Keep that exact identity through ensure and postcondition lookup.
     let lifecycle_provider = lifecycle
         .map(|_| select_apply_enabled_worktree_provider_from_config(intent, config))
         .transpose()?;
@@ -3757,7 +3796,7 @@ mod tests {
     }
 
     #[test]
-    fn lifecycle_selection_rejects_missing_finalize_before_ensure_can_run() {
+    fn workspace_creation_selection_reports_missing_lookup_capability_before_ensure_can_run() {
         let marker = tempfile::NamedTempFile::new().expect("marker");
         std::fs::remove_file(marker.path()).expect("remove marker");
         let provider = WorktreeProviderConfig {
@@ -3786,8 +3825,12 @@ mod tests {
             },
             &config_with_provider(provider),
         )
-        .expect_err("missing finalizer must reject lifecycle ownership");
-        assert!(error.message.contains("no enabled apply-enabled provider"));
+        .expect_err("missing lookup capability must reject workspace creation");
+        assert_eq!(error.details["worktree_provider_id"], "fixture");
+        assert_eq!(
+            error.details["worktree_provider_missing_required_capabilities"],
+            serde_json::json!(["resolve_or_list"])
+        );
         assert!(!marker.path().exists(), "ensure command must not run");
     }
 
@@ -3848,10 +3891,6 @@ mod tests {
         config
             .worktree_providers
             .insert("competing".to_string(), provider(&competing, false));
-        config.settings.insert(
-            WORKTREE_PROVIDER_LIFECYCLE_SETTINGS_KEY.to_string(),
-            serde_json::json!({ "selected": { "finalize": ["finalize"] } }),
-        );
         let intent = WorktreeProviderCreateIntent {
             handle: "homeboy@fix-12124".to_string(),
             repo: "homeboy".to_string(),


### PR DESCRIPTION
## Summary
- prevent fanout from falling back to legacy component worktrees after provider selection
- separate required ensure/lookup capabilities from optional finalization
- keep repair actions provider-backed and add no-finalizer end-to-end coverage

## Verification
- `cargo fmt --check`
- `cargo check -p homeboy-core -p homeboy-cli`
- 62 core worktree-provider tests passed
- focused no-finalizer fanout regression passed

Closes #12816.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagents implemented and reviewed this change. Chris Huber directed the work and remains responsible for every line.