### PR TITLE
fix(recovery): carry the caller's roots into the lease heartbeat

### DIFF
--- a/crates/homeboy-lab-runner/src/execution/recovery.rs
+++ b/crates/homeboy-lab-runner/src/execution/recovery.rs
@@ -156,8 +156,11 @@ fn recovery_schedule(
 fn reconcile_terminal_runner_exec_runs_with_owner(
     worker: &RecoveryWorker,
     source_run_id: &str,
+    roots: &homeboy_core::paths::PathRoots,
 ) -> Result<(usize, usize, Option<RunnerExecRecoveryDiagnostic>)> {
-    let store = ObservationStore::open_initialized()?;
+    // Reconciliation runs under the caller's child lock and writes the same
+    // runs the caller already opened, so it shares the caller's roots (#7505).
+    let store = ObservationStore::open_initialized_in_roots(roots)?;
     let mut reconciled = 0;
     let mut deferred = 0;
     let mut unavailable_endpoints = BTreeSet::new();
@@ -708,13 +711,19 @@ pub fn run_scheduled_terminal_runner_exec_recovery_child(
     let stop = Arc::new(AtomicBool::new(false));
     let heartbeat_stop = Arc::clone(&stop);
     let heartbeat_worker = worker.clone();
+    // The heartbeat renews the same lease the caller's lock arbitrates, so it
+    // carries the caller's roots instead of resolving its own. Reading the
+    // environment again here is the disagreement the function doc warns about:
+    // this thread runs for up to a day, and a repoint mid-run would renew the
+    // lease in one installation while the child lock guards another (#7505).
+    let heartbeat_roots = roots.clone();
     let heartbeat = thread::spawn(move || {
         while !heartbeat_stop.load(Ordering::Acquire) {
             thread::sleep(RECOVERY_LEASE_HEARTBEAT);
             if heartbeat_stop.load(Ordering::Acquire) {
                 break;
             }
-            let Ok(store) = ObservationStore::open_initialized() else {
+            let Ok(store) = ObservationStore::open_initialized_in_roots(&heartbeat_roots) else {
                 break;
             };
             if heartbeat_worker.renew(&store).is_err() {
@@ -722,7 +731,7 @@ pub fn run_scheduled_terminal_runner_exec_recovery_child(
             }
         }
     });
-    let result = reconcile_terminal_runner_exec_runs_with_owner(&worker, &source_run_id);
+    let result = reconcile_terminal_runner_exec_runs_with_owner(&worker, &source_run_id, &roots);
     stop.store(true, Ordering::Release);
     let _ = heartbeat.join();
     match result {


### PR DESCRIPTION
Part of #7505. A lock and the lease it guards could arbitrate different installations.

## The bug

`run_scheduled_terminal_runner_exec_recovery_child` carries this doc comment:

> Accepting injected roots while the store stayed ambient would let the lock and the lease disagree about which home they arbitrate (#7505).

It does the right thing on the main path — resolves roots once, opens the store with `open_initialized_in_roots`, takes the child lock under `roots.config()`. Then it spawns a heartbeat thread that did this every tick:

```rust
let Ok(store) = ObservationStore::open_initialized() else { break; };
if heartbeat_worker.renew(&store).is_err() { break; }
```

That is a second independent read of the environment, which is precisely the disagreement the comment describes. The heartbeat renews the lease; the caller's lock guards the child. They are supposed to be talking about the same installation, and nothing was keeping them that way.

The window is not small. The worker is constructed with a 24-hour deadline:

```rust
deadline: Instant::now() + Duration::from_secs(24 * 60 * 60),
```

so any repoint of the data root during that day sends the renewal to one home while the lock sits in another. The lease then expires where it is actually being watched, and the run is treated as abandoned while the child is still working it.

Secondary: this reopened SQLite once per `RECOVERY_LEASE_HEARTBEAT` for the life of the thread. Same shape as the `exec_via_daemon` renewal fix.

## Fix

Clone the caller's roots into the thread and open against them. The heartbeat now renews in the same installation the lock arbitrates, by construction rather than by coincidence.

## Second site

`reconcile_terminal_runner_exec_runs_with_owner` had the same gap — it opened its own store while its **single** caller already held roots:

```
crates/homeboy-lab-runner/src/execution/recovery.rs:731  (only caller)
```

It runs under that caller's child lock and writes the same runs, so it now takes `roots`.

## What is deliberately left

`record_scheduled_terminal_runner_exec_recovery_spawn_failure` still resolves ambiently. Its callers are in `cli_runtime.rs:845` and `:866`, and that file has no `PathRoots` in scope at all — the neighbouring `schedule_terminal_runner_exec_recovery()` is unrooted too. Rooting one call from inside would just relocate the resolution rather than remove it, so it waits for the CLI entry work.

## Scope note

The file has 14 bare `open_initialized()` calls, but 11 sit inside the `#[cfg(test)]` module that begins at line 966, and `record_evicted_evidence_loss` already takes an injected `&ObservationStore`. Three were production; two are fixed here.

## Verification

`cargo check --workspace --tests -j2` — clean, 3m25s, zero errors.