### PR TITLE
Delete 13 ambient wrappers nothing called

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2519,32 +2519,6 @@ pub fn clear_cook_controller_failure_in_store(
     Ok(())
 }
 
-/// Persist Cook phase together with a sample of what the provider is doing.
-///
-/// The activity sample is written into the same record as the phase so
-/// `agent-task status` answers "is this cook making progress?" from durable
-/// state, without the reader having to find the worktree and run `ps` and
-/// `git status` by hand (#11482). It is evidence, not authority: an absent
-/// sample leaves the previously recorded one in place rather than erasing it,
-/// because a single failed probe is not proof the provider stopped working.
-pub fn record_cook_progress_with_activity(
-    run_id: &str,
-    phase: &str,
-    attempt: u32,
-    detail: Option<&str>,
-    activity: Option<Value>,
-) -> Result<AgentTaskRunRecord> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    record_cook_progress_with_activity_in_store(
-        &lifecycle_store,
-        run_id,
-        phase,
-        attempt,
-        detail,
-        activity,
-    )
-}
-
 pub fn record_cook_progress_with_activity_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -1051,14 +1051,6 @@ pub fn record_recipe_attempt_in_store(
     Ok(recipe)
 }
 
-pub fn record_recipe_attempt_replacement(
-    cook_id: &str,
-    replaced_run_id: &str,
-    replacement_run_id: &str,
-) -> Result<AgentTaskCookRecipe> {
-    default_store()?.record_recipe_attempt_replacement(cook_id, replaced_run_id, replacement_run_id)
-}
-
 pub fn record_recipe_attempt_replacement_in_store(
     store: &CookRecipeStore,
     cook_id: &str,

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -847,10 +847,6 @@ static INTERRUPT_AFTER_TERMINAL_COMMIT: AtomicBool = AtomicBool::new(false);
 /// keeps that crash window from permanently suppressing a detached resume.
 const COOK_NOTIFICATION_CLAIM_LEASE: Duration = Duration::from_secs(5 * 60);
 
-pub(super) fn write_plan(run_id: &str, plan: &AgentTaskPlan) -> Result<PathBuf> {
-    write_plan_in_store(&default_store()?, run_id, plan)
-}
-
 pub(super) fn write_plan_in_store(
     store: &AgentTaskLifecycleStore,
     run_id: &str,
@@ -1048,19 +1044,6 @@ pub(super) fn write_record(record: &AgentTaskRunRecord) -> Result<()> {
     default_store()?.write_record(record)
 }
 
-/// Persist a record while the caller owns the config lock. Terminal workspace
-/// authority is deliberately deferred because it acquires its own lock.
-pub(super) fn write_record_locked_without_terminal_projection(
-    record: &AgentTaskRunRecord,
-) -> Result<AgentTaskRunRecord> {
-    default_store()?.write_record_locked_without_terminal_projection(record)
-}
-
-/// Complete terminal projection from committed lifecycle truth after unlocking.
-pub(super) fn project_terminal_record_after_unlock(run_id: &str) -> Result<()> {
-    default_store()?.project_terminal_record_after_unlock(run_id)
-}
-
 /// Serialize a record read-modify-write so independent lifecycle projections do
 /// not replace metadata written by another controller operation.
 pub(super) fn mutate_record(
@@ -1068,16 +1051,6 @@ pub(super) fn mutate_record(
     mutate: impl FnOnce(&mut AgentTaskRunRecord) -> bool,
 ) -> Result<Option<AgentTaskRunRecord>> {
     default_store()?.mutate_record(run_id, mutate)
-}
-
-/// Mutate a record while the caller owns the config lock. Terminal authority is
-/// deliberately deferred to the caller's post-lock projection, matching
-/// [`write_record_locked_without_terminal_projection`].
-pub(super) fn mutate_record_locked_without_terminal_projection(
-    run_id: &str,
-    mutate: impl FnOnce(&mut AgentTaskRunRecord) -> bool,
-) -> Result<Option<AgentTaskRunRecord>> {
-    default_store()?.mutate_record_locked_without_terminal_projection(run_id, mutate)
 }
 
 /// Commit the controller projection and child aggregate in one observation row.
@@ -1213,23 +1186,6 @@ pub(super) fn inject_raw_record_metadata_for_corruption_test(
     store.upsert_imported_run(&run)
 }
 
-pub(super) fn write_cook_index_attempt(
-    cook_id: &str,
-    attempt: u32,
-    run_id: &str,
-    recorded_at: String,
-    candidate: Option<AgentTaskCookLatestSubstantiveCandidate>,
-) -> Result<AgentTaskCookIndex> {
-    write_cook_index_attempt_in_store(
-        &default_store()?,
-        cook_id,
-        attempt,
-        run_id,
-        recorded_at,
-        candidate,
-    )
-}
-
 pub(super) fn write_cook_index_attempt_in_store(
     store: &AgentTaskLifecycleStore,
     cook_id: &str,
@@ -1248,24 +1204,6 @@ pub(super) fn write_cook_index_attempt_in_store(
             candidate,
         )
     })
-}
-
-/// Write one Cook index attempt while the caller owns the config lock.
-pub(super) fn write_cook_index_attempt_locked(
-    cook_id: &str,
-    attempt: u32,
-    run_id: &str,
-    recorded_at: String,
-    candidate: Option<AgentTaskCookLatestSubstantiveCandidate>,
-) -> Result<AgentTaskCookIndex> {
-    write_cook_index_attempt_locked_in_store(
-        &default_store()?,
-        cook_id,
-        attempt,
-        run_id,
-        recorded_at,
-        candidate,
-    )
 }
 
 pub(super) fn write_cook_index_attempt_locked_in_store(
@@ -1341,18 +1279,6 @@ pub(super) fn cook_index_exists(cook_id: &str) -> Result<bool> {
     Ok(default_store()?.cook_index_path(cook_id).exists())
 }
 
-/// Claim the one terminal notification a Cook is allowed to deliver.
-///
-/// The claim is the creation of the marker file itself: `create_new` is
-/// `O_EXCL`, so exactly one caller — in any process, on any thread — observes
-/// `Ok(true)`. This is the cook-scoped counterpart of
-/// `ObservationStore::mark_notification_delivered`, which cannot serve here
-/// because it is keyed on a `runs` row and a Cook id is an alias with no row
-/// of its own.
-pub(super) fn claim_cook_notification(cook_id: &str, marker: &Value) -> Result<bool> {
-    claim_cook_notification_in_store(&default_store()?, cook_id, marker)
-}
-
 /// Claim within one explicitly rooted store. `cook_index_path` as a free
 /// function is `default_store()?`, so the store's own method is used here: the
 /// claim marker is a bare filesystem create with no record read in front of it,
@@ -1419,12 +1345,6 @@ pub(super) fn claim_cook_notification_in_store(
     }
 }
 
-/// Commit a successful notification claim. Only a confirmed transport delivery
-/// becomes the durable exactly-once marker.
-pub(super) fn confirm_cook_notification(cook_id: &str, marker: &Value) -> Result<()> {
-    confirm_cook_notification_in_store(&default_store()?, cook_id, marker)
-}
-
 pub(super) fn confirm_cook_notification_in_store(
     store: &AgentTaskLifecycleStore,
     cook_id: &str,
@@ -1467,11 +1387,6 @@ pub(super) fn release_cook_notification_claim_in_store(
     }
 }
 
-/// Persist the latest bounded, secret-safe terminal notification outcome.
-pub(super) fn write_cook_notification_outcome(cook_id: &str, outcome: &Value) -> Result<()> {
-    write_cook_notification_outcome_in_store(&default_store()?, cook_id, outcome)
-}
-
 pub(super) fn write_cook_notification_outcome_in_store(
     store: &AgentTaskLifecycleStore,
     cook_id: &str,
@@ -1492,13 +1407,6 @@ pub(super) fn read_cook_notification_outcome(cook_id: &str) -> Result<Option<Val
     read_json(&path).map(Some)
 }
 
-pub(super) fn update_cook_index(
-    cook_id: &str,
-    mutate: impl FnOnce(&mut AgentTaskCookIndex) -> bool,
-) -> Result<Option<AgentTaskCookIndex>> {
-    default_store()?.update_cook_index(cook_id, mutate)
-}
-
 pub(super) fn record_exists(run_id: &str) -> Result<bool> {
     Ok(ObservationStore::open_initialized_for_lifecycle()?
         .get_run(run_id)?
@@ -1509,10 +1417,6 @@ pub(super) fn record_exists(run_id: &str) -> Result<bool> {
 /// migrations, or triggering startup repair work.
 pub(super) fn record_exists_readonly(run_id: &str) -> Result<bool> {
     default_store()?.record_exists_readonly(run_id)
-}
-
-pub(super) fn validate_cook_index_attempt(cook_id: &str, attempt: u32, run_id: &str) -> Result<()> {
-    validate_cook_index_attempt_in_store(&default_store()?, cook_id, attempt, run_id)
 }
 
 pub(super) fn validate_cook_index_attempt_in_store(


### PR DESCRIPTION
Went looking for `run_cook` and `load_recipe` (next on the blocker ranking) and found something better.

## The ranking was wrong about both

**`run_cook` is not a violation.** It already takes `CookContext { store: Option<&CookRecipeStore>, lifecycle_store: Option<&AgentTaskLifecycleStore>, .. }`. It resolves once, only when nothing was injected — which is exactly the contract's "resolve at a named boundary". The 18 tests reaching it are ones passing `None`; that is test-side work, not a missing sibling.

**`load_recipe` needs no sibling either.** Its whole body is `default_store()?.load_recipe(cook_id)`. The rooted form already exists — it is the store method.

My earlier scan counted "missing `_in_store` free function" as the blocker. For this shape the correct fix is **deleting the free function**, not adding one.

## What that shape is worth

**35 thin ambient delegates** exist in `homeboy-agents` whose entire body is `resolve() + one store method call`. Five had zero callers and are gone here.

Eight more ambient wrappers had no callers at all — including `write_plan`, orphaned by #12827 when its last caller moved to `write_plan_in_store`. That lag is the normal rhythm: a wrapper stops being reached one PR before it can be deleted.

```
homeboy-agents resolutions:  206 -> 193
130 lines deleted, 0 added
```

## One that looked dead and is not

`finalize_or_load_cook_pr` came up in the same sweep. It is **passed as a function value**:

```rust
let mut finalize = finalize_or_load_cook_pr;
```

Never called by name. A caller search matching `name(` cannot see that — I deleted it, the compiler rejected it, I put it back. Worth naming because every dead-code sweep in this campaign has used that same call-shaped grep.

## Verification

- `nice -n 10 cargo check --workspace --tests -j2` — clean, **0 errors, 0 warnings**
- `cargo fmt --check` — clean
- Each deletion confirmed to have zero non-method, non-definition references, and re-confirmed for bare (non-call) references after the `finalize_or_load_cook_pr` catch

Expect the known red-main set; see the evidence comment on #12772.
