### PR TITLE
fix(ci): require terminal gates execution verdict

### DIFF
--- a/.github/required-gates-ruleset.json
+++ b/.github/required-gates-ruleset.json
@@ -23,7 +23,8 @@
           { "context": "homeboy / Rustfmt", "integration_id": 15368 },
           { "context": "homeboy / Audit", "integration_id": 15368 },
           { "context": "homeboy / Lint", "integration_id": 15368 },
-          { "context": "homeboy / Test", "integration_id": 15368 }
+          { "context": "homeboy / Test", "integration_id": 15368 },
+          { "context": "homeboy / Required Gates Executed", "integration_id": 15368 }
         ]
       }
     }

--- a/docs/operations/required-ci-gates.md
+++ b/docs/operations/required-ci-gates.md
@@ -35,7 +35,7 @@ required contexts, strict setting, and bypass actors:
 
 ```
 ::notice::required-gates enforcement basis=live-branch-rules repo=… branch=main
-  ruleset=… head=… declared=7 live=0 rules=0 strict=false bypass_actors=0
+  ruleset=… head=… declared=8 live=0 rules=0 strict=false bypass_actors=0
   current_user_can_bypass=never outcome=unenforced
 ```
 
@@ -120,9 +120,11 @@ gh api repos/Extra-Chill/homeboy/rulesets/13680120
 all exit non-zero. It is deliberately not what CI runs.
 
 The final command is review evidence. Its `required_status_checks` rule must
-contain exactly the seven contexts in the payload and set
-`strict_required_status_checks_policy` to `true`. Test the installation with a
-PR that leaves `homeboy / Test`, `homeboy / Lint`, or `homeboy / Audit` pending;
+contain exactly the eight contexts in the payload and set
+`strict_required_status_checks_policy` to `true`. The terminal
+`homeboy / Required Gates Executed` context is required because it fails when
+the other gates are cancelled or skipped. Test the installation with a PR that
+leaves it, `homeboy / Test`, `homeboy / Lint`, or `homeboy / Audit` pending;
 GitHub must report the PR as blocked until the check succeeds. Until that apply
 happens, the CI job reports `unenforced` on every pull request, which is the
 honest answer rather than a silent green tick.

--- a/tests/required_gates_policy_test.rs
+++ b/tests/required_gates_policy_test.rs
@@ -147,6 +147,7 @@ fn required_gate_policy_is_complete_and_emitted_by_every_pr_ci_run() {
             "homeboy / Audit",
             "homeboy / Lint",
             "homeboy / Test",
+            "homeboy / Required Gates Executed",
         ],
         "the versioned policy must enumerate every main-merge gate"
     );
@@ -516,6 +517,28 @@ fn github_mode_passes_when_live_enforcement_matches_the_declaration() {
 }
 
 #[test]
+fn github_mode_rejects_rulesets_that_omit_the_terminal_execution_verdict() {
+    let scratch = Scratch::new("missing-terminal-verdict");
+    let contexts: Vec<String> = declared_contexts()
+        .into_iter()
+        .filter(|context| context != "homeboy / Required Gates Executed")
+        .collect();
+    let rules = scratch.write("rules.json", &live_rules(&contexts, true));
+    let output = run_validator("--github", &[("REQUIRED_GATES_LIVE_RULES", rules.as_str())]);
+
+    assert!(
+        !output.status.success(),
+        "a ruleset without the terminal execution verdict permits cancelled or skipped gates to merge: {}",
+        stdout_of(&output)
+    );
+    assert!(
+        stderr_of(&output).contains("enforcement is divergent"),
+        "{}",
+        stderr_of(&output)
+    );
+}
+
+#[test]
 fn github_mode_fails_closed_when_live_state_cannot_be_read() {
     let scratch = Scratch::new("github-unverified");
     let output = run_validator(
@@ -580,7 +603,7 @@ fn enforcement_evidence_records_branch_ruleset_bypass_and_head_sha() {
         "branch=main",
         "ruleset=13680120",
         "head=0000000000000000000000000000000000000000",
-        "declared=7",
+        "declared=8",
         "live=0",
         "bypass_actors=0",
         "current_user_can_bypass=never",


### PR DESCRIPTION
## Summary

Require `homeboy / Required Gates Executed` in the versioned `main` ruleset. This terminal check fails when declared gates are cancelled, skipped, absent, or failed, preventing the PR #12831 regression once an administrator applies the reviewed ruleset artifact.

## Changes

- Add the terminal execution verdict to `.github/required-gates-ruleset.json`.
- Add fail-closed policy coverage for a live ruleset that omits that verdict.
- Document the eight required contexts and the administrator apply/verify contract.

## Verification

- `cargo test --test required_gates_policy_test`
- `bash .github/validate-required-gates.sh --local`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #12833

## AI assistance

OpenAI openai/gpt-5.6-sol via OpenCode general coding subagent implemented and verified this change; Chris Huber directed and remains responsible for the change.