### PR TITLE
fix(recovery): resolve startup recovery roots at the CLI boundary

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -829,7 +829,14 @@ fn schedule_runner_exec_recovery() {
     if cfg!(test) {
         return;
     }
-    let Ok(Some(schedule)) = crate::runner::schedule_terminal_runner_exec_recovery() else {
+    // Startup recovery is one unit of work, so the boundary resolves the roots
+    // once and every step below claims, spawns against, and terminalizes the
+    // same installation. Each callee resolving its own would let the survey,
+    // the owner claim, and the failure record land in different homes (#7505).
+    let Ok(roots) = homeboy::core::paths::PathRoots::from_environment() else {
+        return;
+    };
+    let Ok(Some(schedule)) = crate::runner::schedule_terminal_runner_exec_recovery(&roots) else {
         return;
     };
     if !schedule.is_new_owner {
@@ -846,6 +853,7 @@ fn schedule_runner_exec_recovery() {
                 &schedule.owner_id,
                 &schedule.owner_token,
                 &error,
+                &roots,
             );
             return;
         }
@@ -867,6 +875,7 @@ fn schedule_runner_exec_recovery() {
             &schedule.owner_id,
             &schedule.owner_token,
             &error,
+            &roots,
         );
     }
 }

--- a/crates/homeboy-lab-runner/src/execution/recovery.rs
+++ b/crates/homeboy-lab-runner/src/execution/recovery.rs
@@ -84,14 +84,20 @@ pub struct RunnerExecRecoveryOwnerWork {
 /// Reserve a durable, independently inspectable owner before a background
 /// recovery worker is spawned. Scheduling only reads local evidence; remote
 /// reconciliation belongs to the owner, never to the mutating caller.
-pub fn schedule_terminal_runner_exec_recovery() -> Result<Option<RunnerExecRecoverySchedule>> {
-    let reader = ObservationStore::open_scheduler_reader()?;
+/// The reader that finds candidates and the writer that claims the singleton
+/// owner must describe the same installation. Resolving each from the
+/// environment independently let this survey one home and claim the lease in
+/// another, so both share the caller's roots (#7505).
+pub fn schedule_terminal_runner_exec_recovery(
+    roots: &homeboy_core::paths::PathRoots,
+) -> Result<Option<RunnerExecRecoverySchedule>> {
+    let reader = ObservationStore::open_scheduler_reader_in_roots(roots)?;
     let candidates = recovery_candidates(&reader)?;
     drop(reader);
     if candidates.is_empty() {
         return Ok(None);
     }
-    let store = ObservationStore::open_scheduler_writer()?;
+    let store = ObservationStore::open_scheduler_writer_in_roots(roots)?;
     // The store's expiring claim is keyed by run ID. A stable ID is therefore
     // the singleton identity; a fresh UUID here would only make each scheduler
     // claim itself and permit overlapping recovery workers.
@@ -815,12 +821,15 @@ fn try_acquire_child_lock_in_roots(
     }
 }
 
+/// Terminalizes the owner record the scheduler just claimed, so it resolves the
+/// same roots the claim used rather than reading the environment again (#7505).
 pub fn record_scheduled_terminal_runner_exec_recovery_spawn_failure(
     owner_id: &str,
     owner_token: &str,
     error: &std::io::Error,
+    roots: &homeboy_core::paths::PathRoots,
 ) -> Result<()> {
-    let store = ObservationStore::open_initialized()?;
+    let store = ObservationStore::open_initialized_in_roots(roots)?;
     let Some(owner) = store.get_run(owner_id)? else {
         return Ok(());
     };
@@ -973,6 +982,14 @@ mod tests {
     use homeboy_core::{Error, ErrorCode};
     use std::sync::{Arc, Barrier};
 
+    /// These cases already run inside `with_isolated_home`, so reading the
+    /// environment here observes that isolated home. Naming the roots keeps the
+    /// call sites honest about what the scheduler is being pointed at, and lets
+    /// a future case point one at a different home without touching globals.
+    fn test_roots() -> homeboy_core::paths::PathRoots {
+        homeboy_core::paths::PathRoots::from_environment().expect("path roots")
+    }
+
     #[test]
     fn startup_recovery_does_not_materialize_unrelated_active_payloads() {
         with_isolated_home(|_| {
@@ -1051,7 +1068,7 @@ mod tests {
                 .expect("historical runner job");
             }
 
-            let schedule = schedule_terminal_runner_exec_recovery()
+            let schedule = schedule_terminal_runner_exec_recovery(&test_roots())
                 .expect("schedule recovery")
                 .expect("historical jobs need an owner");
             assert_eq!(
@@ -1142,7 +1159,7 @@ mod tests {
 
             let mut child_ids = BTreeSet::new();
             for attempt in 1..=MAX_SOURCE_RECOVERY_DEFERRALS {
-                let owner = schedule_terminal_runner_exec_recovery()
+                let owner = schedule_terminal_runner_exec_recovery(&test_roots())
                     .expect("schedule")
                     .expect("owner");
                 let work = run_scheduled_terminal_runner_exec_recovery(
@@ -1211,7 +1228,7 @@ mod tests {
             assert_eq!(child_ids.len(), 1, "retries reuse one child identity");
             assert_eq!(children.len(), 1, "retries do not accumulate children");
             assert_ne!(children[0].status, RunStatus::Running.as_str());
-            assert!(schedule_terminal_runner_exec_recovery()
+            assert!(schedule_terminal_runner_exec_recovery(&test_roots())
                 .expect("final schedule")
                 .is_none());
         });
@@ -1230,7 +1247,7 @@ mod tests {
                 )
                 .expect("source");
             }
-            let owner = schedule_terminal_runner_exec_recovery()
+            let owner = schedule_terminal_runner_exec_recovery(&test_roots())
                 .expect("schedule")
                 .expect("owner");
             let work =
@@ -1278,7 +1295,7 @@ mod tests {
                 let barrier = Arc::clone(&barrier);
                 workers.push(std::thread::spawn(move || {
                     barrier.wait();
-                    schedule_terminal_runner_exec_recovery().expect("schedule")
+                    schedule_terminal_runner_exec_recovery(&test_roots()).expect("schedule")
                 }));
             }
             barrier.wait();
@@ -1376,7 +1393,7 @@ mod tests {
                 &[],
             )
             .expect("historical runner job");
-            let first = schedule_terminal_runner_exec_recovery()
+            let first = schedule_terminal_runner_exec_recovery(&test_roots())
                 .expect("schedule")
                 .expect("owner");
             let store = ObservationStore::open_initialized().expect("store");
@@ -1388,7 +1405,7 @@ mod tests {
             store
                 .update_run_metadata(&owner.id, owner.metadata_json)
                 .expect("expire lease");
-            let second = schedule_terminal_runner_exec_recovery()
+            let second = schedule_terminal_runner_exec_recovery(&test_roots())
                 .expect("schedule")
                 .expect("replacement owner");
             assert!(second.is_new_owner);


### PR DESCRIPTION
Part of #7505. Follows #12845, which rooted the recovery child; this roots the scheduler that spawns it.

## Survey and claim could describe different homes

`schedule_terminal_runner_exec_recovery` read the environment twice:

```rust
let reader = ObservationStore::open_scheduler_reader()?;   // find candidates
let candidates = recovery_candidates(&reader)?;
drop(reader);
if candidates.is_empty() { return Ok(None); }
let store = ObservationStore::open_scheduler_writer()?;    // claim the owner
```

The reader decides whether there is anything to recover. The writer claims the expiring singleton that authorizes recovering it. Nothing tied those two to the same installation — they agreed only because both happened to read the same environment at slightly different moments.

The claim is the part that matters. `claim_expiring_singleton_run` is keyed by a stable run ID precisely so two schedulers cannot both own recovery. That guarantee is per-installation, so surveying one home and claiming in another does not just mislabel work — it hands out an owner lease that the home holding the candidates never sees.

## The boundary had no roots at all

`cli_runtime::schedule_runner_exec_recovery` is where this path starts, and it made three independent ambient resolutions: scheduling, then spawning a detached child, then recording spawn failure. It now resolves once:

```rust
let Ok(roots) = homeboy::core::paths::PathRoots::from_environment() else { return; };
```

and threads that value into all three. The child process it spawns already resolves its own roots at its own boundary, which is correct — it is a separate process, not a separate opinion.

## Result

This clears the last ambient sites in `recovery.rs`. Every remaining `open_initialized()` in the file is inside the `#[cfg(test)]` module that begins at line 978.

| site | before | after |
|---|---|---|
| scheduler reader | ambient | `_in_roots` |
| scheduler writer | ambient | `_in_roots` |
| spawn-failure record | ambient | `_in_roots` |
| CLI boundary | none | resolves once |

## Tests

The seven test call sites now pass explicit roots via a named `test_roots()` helper. They already run inside `with_isolated_home`, so behaviour is unchanged — but the call sites now say which home the scheduler is pointed at instead of depending on an ambient read observing the right one. That is the direction #7505 is moving these toward, and it lets a future case point a scheduler at a different home without touching globals.

## Verification

`cargo check --workspace --tests -j2` — clean, 3m19s, zero errors.

Both replacement batches asserted their expected match count before writing (2 spawn-failure sites, 7 test sites).