### PR TITLE
Runner: fence recovery on ownership proof

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/doctor/repair.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/repair.rs
@@ -57,6 +57,11 @@ pub fn apply(
 
     repair_managed_sources(client, report);
 
+    if let Some(repair) = terminal_daemon_recovery_repair(report) {
+        report.repairs.push(repair);
+        return;
+    }
+
     // The report already carries a lease-specific, controller-frame plan.
     // Executing it is the whole point of `--repair`; the fixed
     // disconnect/connect pair below is the fallback for a connected daemon whose
@@ -164,6 +169,144 @@ pub fn apply(
     }
 }
 
+fn terminal_daemon_recovery_blocker(report: &RunnerDoctorOutput) -> bool {
+    report
+        .daemon_recovery
+        .as_ref()
+        .is_some_and(|recovery| recovery.blocks_automatic_recovery())
+}
+
+fn terminal_daemon_recovery_repair(report: &RunnerDoctorOutput) -> Option<RunnerRepair> {
+    terminal_daemon_recovery_blocker(report).then(|| RunnerRepair {
+        id: "repair.daemon".to_string(),
+        status: RunnerDoctorStatus::Warning,
+        message: format!(
+            "No automatic daemon repair was applied because the current daemon evidence authorizes no recovery: {}",
+            report
+                .daemon_recovery
+                .as_ref()
+                .and_then(|recovery| recovery.ownership_evidence.as_deref())
+                .unwrap_or("no ownership evidence was recorded")
+        ),
+        commands: Vec::new(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::runner::doctor::types::{
+        RunnerCapabilities, RunnerResources, RunnerTargetSummary,
+    };
+
+    #[test]
+    fn unavailable_lease_missing_ownership_with_a_plan_is_terminal() {
+        for recovery_evidence in [Some(
+            homeboy::core::daemon::DaemonRecoveryEvidence::Unavailable,
+        )] {
+            let mut report = RunnerDoctorOutput {
+                variant: "doctor",
+                command: "runner.doctor",
+                runner_id: "lab".to_string(),
+                runner: RunnerTargetSummary {
+                    target_type: "ssh",
+                    registry: None,
+                    server: None,
+                },
+                status: RunnerDoctorStatus::Error,
+                capabilities: RunnerCapabilities::default(),
+                resources: RunnerResources::default(),
+                checks: Vec::new(),
+                secret_env_migration: None,
+                diagnostics: None,
+                daemon_recovery: Some(homeboy::core::daemon::DaemonFreshnessReport {
+                    fresh: false,
+                    stale_reason_code: Some(
+                        homeboy::core::daemon::DaemonStaleReasonCode::LeaseMissing,
+                    ),
+                    restartable: false,
+                    lease_id: None,
+                    pid: None,
+                    recovery_evidence,
+                    ownership_evidence: Some("remote lease ownership unavailable".to_string()),
+                    adoption_command: None,
+                    binary_hash: None,
+                    daemon_version: Some("0.349.0".to_string()),
+                    daemon_build_identity: Some("homeboy 0.349.0+incompatible".to_string()),
+                    runtime_paths: None,
+                    active_jobs: 0,
+                    termination_evidence: None,
+                    repair_plan: vec![homeboy::core::daemon::DaemonRepairStep::text(
+                        "runner_reconcile_leaseless_orphans",
+                        "homeboy runner connect lab --reconcile-leaseless-orphans --confirm-no-daemon-owner",
+                    )],
+                }),
+                admission_summary: None,
+                provider_readiness: None,
+                repairs: Vec::new(),
+            };
+
+            assert!(
+                !apply_daemon_repair_plan("lab", &mut report),
+                "unavailable ownership must reject a non-empty reconciliation plan"
+            );
+            let repair = terminal_daemon_recovery_repair(&report).expect("terminal repair result");
+
+            assert_eq!(repair.status, RunnerDoctorStatus::Warning);
+            assert!(repair.commands.is_empty());
+            assert!(repair
+                .message
+                .contains("remote lease ownership unavailable"));
+        }
+    }
+
+    #[test]
+    fn stale_typed_proof_without_a_plan_is_terminal_before_generic_reconnect() {
+        let report = RunnerDoctorOutput {
+            variant: "doctor",
+            command: "runner.doctor",
+            runner_id: "lab".to_string(),
+            runner: RunnerTargetSummary {
+                target_type: "ssh",
+                registry: None,
+                server: None,
+            },
+            status: RunnerDoctorStatus::Error,
+            capabilities: RunnerCapabilities::default(),
+            resources: RunnerResources::default(),
+            checks: Vec::new(),
+            secret_env_migration: None,
+            diagnostics: None,
+            daemon_recovery: Some(homeboy::core::daemon::DaemonFreshnessReport {
+                fresh: false,
+                stale_reason_code: Some(
+                    homeboy::core::daemon::DaemonStaleReasonCode::LeaseSchemaMismatch,
+                ),
+                restartable: true,
+                lease_id: None,
+                pid: None,
+                recovery_evidence: Some(homeboy::core::daemon::DaemonRecoveryEvidence::Recoverable),
+                ownership_evidence: Some("no validated recovery action".to_string()),
+                adoption_command: None,
+                binary_hash: None,
+                daemon_version: None,
+                daemon_build_identity: None,
+                runtime_paths: None,
+                active_jobs: 0,
+                termination_evidence: None,
+                repair_plan: Vec::new(),
+            }),
+            admission_summary: None,
+            provider_readiness: None,
+            repairs: Vec::new(),
+        };
+
+        let repair = terminal_daemon_recovery_repair(&report).expect("terminal repair result");
+        assert!(repair.commands.is_empty());
+        assert!(repair.message.contains("no validated recovery action"));
+    }
+}
+
 /// What an executor should do about one typed repair step.
 ///
 /// Dispatch is a pure function of the step's code plus typed evidence from the
@@ -250,7 +393,7 @@ fn apply_daemon_repair_plan(runner_id: &str, report: &mut RunnerDoctorOutput) ->
     let Some(recovery) = report.daemon_recovery.as_ref() else {
         return false;
     };
-    if recovery.repair_plan.is_empty() {
+    if recovery.repair_plan.is_empty() || !recovery.has_recovery_ownership_proof() {
         return false;
     }
 

--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/daemon.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/daemon.rs
@@ -325,6 +325,89 @@ fn disconnected_lab_doctor_reuses_daemon_recovery_envelope() {
     assert_eq!(report.daemon_recovery.expect("recovery").active_jobs, 1);
 }
 
+#[test]
+fn disconnected_incompatible_daemon_with_unavailable_ownership_is_terminal() {
+    let recovery = homeboy::core::daemon::DaemonFreshnessReport {
+        fresh: false,
+        stale_reason_code: Some(homeboy::core::daemon::DaemonStaleReasonCode::VersionMismatch),
+        restartable: false,
+        lease_id: None,
+        pid: None,
+        recovery_evidence: Some(homeboy::core::daemon::DaemonRecoveryEvidence::Unavailable),
+        ownership_evidence: Some(
+            "remote daemon lease ownership could not be established".to_string(),
+        ),
+        adoption_command: None,
+        binary_hash: None,
+        daemon_version: Some("0.349.0".to_string()),
+        daemon_build_identity: Some("homeboy 0.349.0+incompatible".to_string()),
+        runtime_paths: None,
+        active_jobs: 0,
+        termination_evidence: None,
+        repair_plan: Vec::new(),
+    };
+    let runner = Runner {
+        id: "lab".to_string(),
+        kind: RunnerKind::Ssh,
+        server_id: Some("lab".to_string()),
+        workspace_root: None,
+        settings: server::RunnerSettings::default(),
+        env: Default::default(),
+        secret_env: Default::default(),
+        resources: Default::default(),
+        policy: server::RunnerPolicy::default(),
+    };
+    let server = server::Server {
+        id: "lab".to_string(),
+        aliases: Vec::new(),
+        host: "example.test".to_string(),
+        user: "runner".to_string(),
+        port: 22,
+        identity_file: None,
+        kind: None,
+        auth: None,
+        env: Default::default(),
+        runner: None,
+    };
+    let summary = homeboy::runner::runners::RunnerAdmissionSummary {
+        runner_id: "lab".to_string(),
+        connected: false,
+        daemon_fresh: false,
+        daemon_compatible: false,
+        accepting_jobs: false,
+        active_job_count: 0,
+        live_daemon_job_count: 0,
+        retained_durable_job_count: 0,
+        unresolved_retained_projection_count: 0,
+        admission_blocking_job_ids: Vec::new(),
+        unresolved_job_owners: Vec::new(),
+        unresolved_generation_ids: Vec::new(),
+        stale_job_count: 0,
+        daemon_build_identity: Some("homeboy 0.349.0+incompatible".to_string()),
+        blocking_generation: None,
+        draining_generation_count: 0,
+        safe_to_rotate: false,
+        next_action: None,
+    };
+
+    let report =
+        remote::disconnected_report("lab", &runner, &server, Some(recovery), Some(summary));
+
+    assert_eq!(report.checks[0].remediation, None);
+    assert_eq!(
+        report.checks[0]
+            .details
+            .get("ownership_evidence")
+            .map(String::as_str),
+        Some("remote daemon lease ownership could not be established")
+    );
+    assert_eq!(
+        report.admission_summary.expect("admission").next_action,
+        None,
+        "doctor must not recommend the invocation that produced this terminal diagnosis"
+    );
+}
+
 /// #11103: the repair plan was computed everywhere and executed nowhere.
 /// `--repair` refused most scopes outright and, for the one scope it handled,
 /// emitted a fixed disconnect/connect pair regardless of what the report said.

--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -272,7 +272,10 @@ pub(super) fn execution_capabilities_with_local_placement(
         sessions
             .iter()
             .find(|report| !is_controller_local_runner(runners, &report.runner_id))
-            .map(|report| report.status_action().render_command())
+            .map(|report| {
+                terminal_daemon_ownership_diagnostic(report)
+                    .unwrap_or_else(|| report.status_action().render_command())
+            })
     } else {
         None
     };
@@ -371,58 +374,88 @@ pub(super) fn reconciliation_outcome(
     }
 
     let reconcile_command = format!("homeboy runner reconcile {}", shell_arg(runner_id));
-    let (remaining_blocker, next_action, retry_predicate) = if unresolved_projection {
-        (
-            "unresolved_generation_projection".to_string(),
-            format!("homeboy runner status {} --full", shell_arg(runner_id)),
-            "a fresh authoritative generation projection resolves every retained count".to_string(),
-        )
-    } else if !admission.connected {
-        (
-            "runner_disconnected".to_string(),
-            reconciliation_remediation(&reconcile_command, admission, report)
-                .unwrap_or_else(|| format!("homeboy runner connect {}", shell_arg(runner_id))),
-            "the runner reconnects and publishes a current daemon session".to_string(),
-        )
-    } else if !admission.daemon_fresh {
-        (
-            daemon_freshness_blocker(report),
-            reconciliation_remediation(&reconcile_command, admission, report).unwrap_or_else(
-                || {
-                    format!(
-                        "homeboy runner doctor {} --scope lab-offload",
-                        shell_arg(runner_id)
-                    )
-                },
-            ),
-            "daemon_fresh=true after the selected daemon repair completes".to_string(),
-        )
-    } else if !admission.daemon_compatible {
-        (
-            "daemon_compatibility".to_string(),
-            reconciliation_remediation(&reconcile_command, admission, report).unwrap_or_else(
-                || {
-                    format!(
-                        "homeboy runner doctor {} --scope lab-offload",
-                        shell_arg(runner_id)
-                    )
-                },
-            ),
-            "daemon_compatible=true after the selected daemon identity is repaired".to_string(),
-        )
-    } else if admission.blocking_generation.is_some() {
-        (
-            "retained_generation_ownership".to_string(),
-            format!("homeboy runner job list {} --active", shell_arg(runner_id)),
-            "the retained generation has no authoritative active job owners".to_string(),
-        )
-    } else {
-        (
-            "admission_unavailable".to_string(),
-            format!("homeboy runner status {} --full", shell_arg(runner_id)),
-            "an authoritative active-job view is available".to_string(),
-        )
-    };
+    let (remaining_blocker, next_action, retry_predicate) =
+        if terminal_daemon_ownership_blocker(report) {
+            (
+                "daemon_ownership_evidence_unavailable".to_string(),
+                None,
+                format!(
+                    "ownership evidence required before daemon recovery: {}",
+                    report
+                        .daemon_freshness
+                        .as_ref()
+                        .and_then(|freshness| freshness.ownership_evidence.as_deref())
+                        .unwrap_or("no ownership evidence was recorded")
+                ),
+            )
+        } else if unresolved_projection {
+            (
+                "unresolved_generation_projection".to_string(),
+                Some(format!(
+                    "homeboy runner status {} --full",
+                    shell_arg(runner_id)
+                )),
+                "a fresh authoritative generation projection resolves every retained count"
+                    .to_string(),
+            )
+        } else if !admission.connected {
+            (
+                "runner_disconnected".to_string(),
+                Some(
+                    reconciliation_remediation(&reconcile_command, admission, report)
+                        .unwrap_or_else(|| {
+                            format!("homeboy runner connect {}", shell_arg(runner_id))
+                        }),
+                ),
+                "the runner reconnects and publishes a current daemon session".to_string(),
+            )
+        } else if !admission.daemon_fresh {
+            (
+                daemon_freshness_blocker(report),
+                Some(
+                    reconciliation_remediation(&reconcile_command, admission, report)
+                        .unwrap_or_else(|| {
+                            format!(
+                                "homeboy runner doctor {} --scope lab-offload",
+                                shell_arg(runner_id)
+                            )
+                        }),
+                ),
+                "daemon_fresh=true after the selected daemon repair completes".to_string(),
+            )
+        } else if !admission.daemon_compatible {
+            (
+                "daemon_compatibility".to_string(),
+                Some(
+                    reconciliation_remediation(&reconcile_command, admission, report)
+                        .unwrap_or_else(|| {
+                            format!(
+                                "homeboy runner doctor {} --scope lab-offload",
+                                shell_arg(runner_id)
+                            )
+                        }),
+                ),
+                "daemon_compatible=true after the selected daemon identity is repaired".to_string(),
+            )
+        } else if admission.blocking_generation.is_some() {
+            (
+                "retained_generation_ownership".to_string(),
+                Some(format!(
+                    "homeboy runner job list {} --active",
+                    shell_arg(runner_id)
+                )),
+                "the retained generation has no authoritative active job owners".to_string(),
+            )
+        } else {
+            (
+                "admission_unavailable".to_string(),
+                Some(format!(
+                    "homeboy runner status {} --full",
+                    shell_arg(runner_id)
+                )),
+                "an authoritative active-job view is available".to_string(),
+            )
+        };
 
     RunnerReconciliationOutcome {
         changed_state: reconciliation_changed_state(retired_generation_count),
@@ -435,11 +468,35 @@ pub(super) fn reconciliation_outcome(
             RunnerReconciliationStatus::Blocked
         },
         remaining_blocker: Some(remaining_blocker),
-        next_action: Some(next_action),
+        next_action,
         retry_predicate: Some(retry_predicate),
         retired_generation_count,
         retired_generation_ids,
     }
+}
+
+fn terminal_daemon_ownership_blocker(report: &RunnerStatusReport) -> bool {
+    report
+        .daemon_freshness
+        .as_ref()
+        .is_some_and(|freshness| freshness.has_terminal_recovery_ownership_blocker())
+}
+
+fn terminal_daemon_ownership_diagnostic(report: &RunnerStatusReport) -> Option<String> {
+    terminal_daemon_ownership_blocker(report).then(|| {
+        format!(
+            "No automatic daemon recovery: typed ownership evidence is insufficient: {}",
+            report
+                .daemon_freshness
+                .as_ref()
+                .and_then(|freshness| freshness.ownership_evidence.as_deref())
+                .unwrap_or("no ownership evidence was recorded")
+        )
+    })
+}
+
+fn terminal_daemon_ownership_blocks_mutation(report: &RunnerStatusReport) -> bool {
+    terminal_daemon_ownership_blocker(report)
 }
 
 fn reconciliation_changed_state(retired_generation_count: usize) -> String {
@@ -622,7 +679,8 @@ pub(super) fn operator_summary(report: &RunnerStatusReport) -> RunnerOperatorSum
         identity: bounded_status_text(&report.runner_id),
         state: format!("{:?}", report.state).to_ascii_lowercase(),
         risk,
-        next_action: report.status_action().render_command(),
+        next_action: terminal_daemon_ownership_diagnostic(report)
+            .unwrap_or_else(|| report.status_action().render_command()),
     }
 }
 
@@ -744,7 +802,10 @@ fn lab_runner_homeboy_output_with_recovery_guidance(
 ) -> LabRunnerHomeboyOutput {
     let mut materialization =
         RuntimeMaterializationStatus::for_homeboy_runner(runner_id, configured_executable, status);
-    let refresh_command = recovery_refresh_command(&shell_arg(runner_id), guidance);
+    let recovery_blocked = terminal_daemon_ownership_blocks_mutation(status);
+    let refresh_command = (!recovery_blocked)
+        .then(|| recovery_refresh_command(&shell_arg(runner_id), guidance))
+        .flatten();
     materialization.stale_daemon_refresh_command = refresh_command.clone();
     let stale_daemon = status
         .stale_daemon
@@ -783,11 +844,15 @@ fn lab_runner_homeboy_output_with_recovery_guidance(
             status,
             has_drift,
         ),
-        refresh_commands: lab_runner_homeboy_refresh_commands(runner_id, status),
-        upgrade_command: format!(
-            "homeboy upgrade --force --upgrade-runner {}",
-            shell_arg(runner_id)
-        ),
+        refresh_commands: (!recovery_blocked)
+            .then(|| lab_runner_homeboy_refresh_commands(runner_id, status))
+            .unwrap_or_default(),
+        upgrade_command: (!recovery_blocked).then(|| {
+            format!(
+                "homeboy upgrade --force --upgrade-runner {}",
+                shell_arg(runner_id)
+            )
+        }),
         dev_sync: runner::load(runner_id)
             .ok()
             .and_then(|runner| runner.resources.get("dev_sync").cloned()),
@@ -1265,7 +1330,9 @@ pub(super) fn runner_artifact_feature_diagnostics(
     let binary = shell_arg(homeboy_path);
     let runner_arg = shell_arg(runner_id);
     let mut hints = Vec::new();
-    if version_drift || status.stale_daemon.is_some() {
+    if !terminal_daemon_ownership_blocks_mutation(status)
+        && (version_drift || status.stale_daemon.is_some())
+    {
         hints.push(format!(
             "Runner `{runner_id}` reports Homeboy version/build drift. If artifact commands are missing on runner jobs, restart the active daemon with `homeboy runner disconnect {runner_arg}` then `homeboy runner connect {runner_arg}`."
         ));
@@ -1400,7 +1467,17 @@ pub(crate) fn runner_followups_with_admission(
     admission: Option<&runner::RunnerAdmissionSummary>,
 ) -> Vec<LabFollowup> {
     let mut followups = runner_followups(runner_id, status);
-    let Some(action) = admission.and_then(|admission| admission.next_action.as_ref()) else {
+    let Some(admission) = admission else {
+        return followups;
+    };
+    let terminal_ownership_blocker = status.is_some_and(terminal_daemon_ownership_blocker);
+    let Some(action) = admission.next_action.as_ref() else {
+        if !terminal_ownership_blocker {
+            return followups;
+        }
+        // No repair is safe, but generic mutation guidance is unsafe too.
+        // Retain only diagnostic follow-ups and the terminal freshness evidence.
+        followups.retain(|followup| !is_terminal_ownership_mutating_followup(followup));
         return followups;
     };
 
@@ -1408,18 +1485,27 @@ pub(crate) fn runner_followups_with_admission(
     // restart guidance. In particular, a missing lease with ambiguous daemon
     // candidates cannot be made safe by refreshing, upgrading, disconnecting,
     // or reconnecting the controller session.
-    followups.retain(|followup| {
-        !matches!(
-            followup.label.as_str(),
-            "refresh_homeboy" | "homeboy_binary_refresh" | "homeboy_binary_upgrade"
-        )
-    });
+    followups.retain(|followup| !is_terminal_ownership_mutating_followup(followup));
     followups.push(LabFollowup {
         label: "admission_recovery".to_string(),
         command: action.clone(),
         purpose: "Apply the authoritative runner admission recovery selected from the current daemon evidence.".to_string(),
     });
     followups
+}
+
+fn is_terminal_ownership_mutating_followup(followup: &LabFollowup) -> bool {
+    // Generic runner exec accepts arbitrary argv, so it is mutating for
+    // terminal ownership recovery even when its displayed purpose is diagnostic.
+    matches!(
+        followup.label.as_str(),
+        "exec"
+            | "refresh_homeboy"
+            | "homeboy_binary_refresh"
+            | "homeboy_binary_upgrade"
+            | "workspace_prune_drain"
+            | "workspace_sync"
+    )
 }
 
 pub(crate) fn selected_admission_summary(
@@ -1687,20 +1773,27 @@ pub(super) fn runner_status_operator_hints(report: &RunnerStatusReport) -> Vec<S
     if report.stale_daemon.is_some() {
         let mut materialization =
             RuntimeMaterializationStatus::for_homeboy_runner(&report.runner_id, "homeboy", report);
-        materialization.stale_daemon_refresh_command = recovery_refresh_command(
-            &shell_arg(&report.runner_id),
-            recovery_refresh_guidance(report),
-        );
+        materialization.stale_daemon_refresh_command =
+            (!terminal_daemon_ownership_blocks_mutation(report))
+                .then(|| {
+                    recovery_refresh_command(
+                        &shell_arg(&report.runner_id),
+                        recovery_refresh_guidance(report),
+                    )
+                })
+                .flatten();
         hints.extend(materialization.stale_daemon_hint());
     }
-    if let RecoveryRefreshGuidance::IdentityDrift { controller, runner } =
-        recovery_refresh_guidance(report)
-    {
-        hints.push(format!(
-            "Runner `{}` reports exact Homeboy build drift: controller={} runner={runner}. Recovery will not recommend refresh-homeboy until ancestry is verified; use `--allow-downgrade` only for an intentional rollback.",
-            report.runner_id,
-            controller.as_deref().unwrap_or("unavailable"),
-        ));
+    if !terminal_daemon_ownership_blocks_mutation(report) {
+        if let RecoveryRefreshGuidance::IdentityDrift { controller, runner } =
+            recovery_refresh_guidance(report)
+        {
+            hints.push(format!(
+                "Runner `{}` reports exact Homeboy build drift: controller={} runner={runner}. Recovery will not recommend refresh-homeboy until ancestry is verified; use `--allow-downgrade` only for an intentional rollback.",
+                report.runner_id,
+                controller.as_deref().unwrap_or("unavailable"),
+            ));
+        }
     }
     match session.mode {
         RunnerTunnelMode::DirectSsh => {
@@ -1721,6 +1814,20 @@ fn reverse_runner_status_hints(
     session: &RunnerSession,
     hints: &mut Vec<String>,
 ) {
+    if terminal_daemon_ownership_blocks_mutation(report) {
+        if session.broker_url.is_none() {
+            hints.push(format!(
+                "Reverse runner `{}` has no broker URL. Inspect the persisted session and daemon ownership evidence before any lifecycle action.",
+                report.runner_id
+            ));
+        } else {
+            hints.push(format!(
+                "Reverse runner `{}` has a broker-backed job view. List authoritative live jobs and retained durable projections with `homeboy runner job list {} --active`.",
+                report.runner_id, report.runner_id
+            ));
+        }
+        return;
+    }
     if session.broker_url.is_none() {
         hints.push(format!(
             "Reverse runner `{}` has no broker URL; active-job listing, logs, and cancel require reconnecting with `homeboy runner connect <controller-id> --reverse --reverse-runner {} --broker-url <url>`.",
@@ -1901,7 +2008,8 @@ fn runner_status_operator_commands_with_recovery_guidance(
     }
 
     if let Some(freshness) = report.daemon_freshness.as_ref().filter(|freshness| {
-        freshness.active_jobs > 0
+        freshness.has_recovery_ownership_proof()
+            && freshness.active_jobs > 0
             && freshness.stale_reason_code == Some(DaemonStaleReasonCode::VersionMismatch)
     }) {
         if let Some(command) = freshness.adoption_command.as_ref() {
@@ -1933,7 +2041,25 @@ fn runner_status_operator_commands_with_recovery_guidance(
         }
     }
 
+    if terminal_daemon_ownership_blocks_mutation(report) {
+        commands.retain(|command| !is_terminal_ownership_mutating_command(command));
+    }
+
     commands
+}
+
+fn is_terminal_ownership_mutating_command(command: &RunnerOperatorCommand) -> bool {
+    matches!(
+        command.scope,
+        "unknown_owner_reconcile"
+            | "agent_task_retry"
+            | "job_cancel"
+            | "broker_reconcile"
+            | "generation_reconcile"
+            | "daemon_refresh"
+            | "daemon_reconcile_split_view"
+            | "daemon_reconnect_fresh_idle"
+    )
 }
 
 #[cfg(test)]

--- a/crates/homeboy-cli/src/commands/runner/tests/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/status.rs
@@ -7,9 +7,12 @@ use homeboy::core::agent_runtime_manifest::{
     AgentRuntimeSourceConsistencyDiagnostic, AgentRuntimeToolDiagnosticDeclaration,
 };
 use homeboy::core::api_jobs::{JobEvent, JobStatus};
-use homeboy::core::daemon::{DaemonFreshnessReport, DaemonStaleReasonCode};
+use homeboy::core::daemon::{
+    DaemonFreshnessReport, DaemonRecoveryEvidence, DaemonRepairStep, DaemonStaleReasonCode,
+};
 use homeboy::runner::runners::{
-    self as runner, Runner, RunnerKind, RunnerSession, RunnerStatusReport, RunnerTunnelMode,
+    self as runner, Runner, RunnerDaemonGenerationStatus, RunnerKind, RunnerSession,
+    RunnerStatusReport, RunnerTunnelMode,
 };
 use homeboy::runner::{RunnerActiveJobError, RunnerActiveJobSource, RunnerActiveJobState};
 
@@ -20,7 +23,7 @@ use super::super::status::{
     execution_capabilities_with_local_placement, lab_runner_homeboy_output, non_local_sessions,
     operator_summary, reconcile_output, reconciliation_outcome,
     runner_artifact_feature_diagnostics, runner_followups, runner_followups_with_admission,
-    runner_status_operator_commands, selected_admission_summary,
+    runner_status_operator_commands, runner_status_operator_hints, selected_admission_summary,
 };
 use super::super::types::{RunnerConnectionOutput, RunnerReconciliationStatus};
 use crate::cli_surface::Cli;
@@ -107,7 +110,7 @@ fn reconcile_reports_retired_generation_progress_with_remaining_skew_and_ownersh
         restartable: true,
         lease_id: None,
         pid: None,
-        recovery_evidence: None,
+        recovery_evidence: Some(DaemonRecoveryEvidence::Recoverable),
         ownership_evidence: None,
         adoption_command: None,
         binary_hash: None,
@@ -248,7 +251,7 @@ fn reconcile_uses_authoritative_non_version_freshness_blocker() {
         restartable: false,
         lease_id: None,
         pid: None,
-        recovery_evidence: None,
+        recovery_evidence: Some(DaemonRecoveryEvidence::ProvenDead),
         ownership_evidence: None,
         adoption_command: None,
         binary_hash: None,
@@ -257,7 +260,10 @@ fn reconcile_uses_authoritative_non_version_freshness_blocker() {
         runtime_paths: None,
         active_jobs: 0,
         termination_evidence: None,
-        repair_plan: Vec::new(),
+        repair_plan: vec![DaemonRepairStep::text(
+            "runner_reconcile_leaseless_orphans",
+            "homeboy runner connect homeboy-lab --reconcile-leaseless-orphans --confirm-no-daemon-owner",
+        )],
     });
     let mut admission = admission_fixture();
     admission.daemon_fresh = false;
@@ -268,6 +274,133 @@ fn reconcile_uses_authoritative_non_version_freshness_blocker() {
         outcome.remaining_blocker.as_deref(),
         Some("daemon_lease_missing")
     );
+}
+
+#[test]
+fn unavailable_daemon_ownership_is_terminal_across_status_and_reconcile() {
+    let mut report = disconnected_report();
+    report.daemon_freshness = Some(DaemonFreshnessReport {
+        fresh: false,
+        stale_reason_code: Some(DaemonStaleReasonCode::LeaseCorrupt),
+        restartable: false,
+        lease_id: None,
+        pid: None,
+        recovery_evidence: Some(DaemonRecoveryEvidence::Unavailable),
+        ownership_evidence: Some(
+            "remote daemon lease ownership could not be established".to_string(),
+        ),
+        adoption_command: None,
+        binary_hash: None,
+        daemon_version: Some("0.349.0".to_string()),
+        daemon_build_identity: Some("homeboy 0.349.0+incompatible".to_string()),
+        runtime_paths: None,
+        active_jobs: 0,
+        termination_evidence: None,
+        repair_plan: vec![DaemonRepairStep::text(
+            "runner_reconcile_leaseless_orphans",
+            "homeboy runner connect 'homeboy lab' --reconcile-leaseless-orphans --confirm-no-daemon-owner",
+        )],
+    });
+
+    let admission = report.admission_summary(0);
+    let outcome = reconciliation_outcome("homeboy lab", Vec::new(), &report, &admission);
+
+    assert!(!admission.accepting_jobs);
+    assert_eq!(admission.next_action, None);
+    assert_eq!(
+        outcome.remaining_blocker.as_deref(),
+        Some("daemon_ownership_evidence_unavailable")
+    );
+    assert_eq!(outcome.next_action, None);
+    assert_eq!(
+        outcome.retry_predicate.as_deref(),
+        Some("ownership evidence required before daemon recovery: remote daemon lease ownership could not be established")
+    );
+    let status = operator_summary(&report);
+    assert_eq!(
+        status.next_action,
+        "No automatic daemon recovery: typed ownership evidence is insufficient: remote daemon lease ownership could not be established"
+    );
+    assert!(!status.next_action.contains("runner doctor"));
+
+    report
+        .daemon_freshness
+        .as_mut()
+        .expect("freshness")
+        .recovery_evidence = None;
+    let admission = report.admission_summary(0);
+    let outcome = reconciliation_outcome("homeboy lab", Vec::new(), &report, &admission);
+    assert_eq!(outcome.next_action, None);
+    assert_eq!(
+        operator_summary(&report).next_action,
+        "No automatic daemon recovery: typed ownership evidence is insufficient: remote daemon lease ownership could not be established"
+    );
+}
+
+#[test]
+fn terminal_ownership_dominates_unresolved_retained_generation_projections() {
+    let mut report = disconnected_report();
+    let mut session = runner_session_fixture();
+    session.runner_id = "homeboy lab".to_string();
+    report.session = Some(session);
+    report.active_job_state = RunnerActiveJobState::Unavailable;
+    report.daemon_freshness = Some(DaemonFreshnessReport {
+        fresh: false,
+        stale_reason_code: Some(DaemonStaleReasonCode::LeaseMissing),
+        restartable: false,
+        lease_id: None,
+        pid: None,
+        recovery_evidence: Some(DaemonRecoveryEvidence::Unavailable),
+        ownership_evidence: Some("ambiguous remote daemon candidates".to_string()),
+        adoption_command: None,
+        binary_hash: None,
+        daemon_version: None,
+        daemon_build_identity: None,
+        runtime_paths: None,
+        active_jobs: 0,
+        termination_evidence: None,
+        repair_plan: Vec::new(),
+    });
+    let generations = vec![RunnerDaemonGenerationStatus {
+        generation: "lease-old".to_string(),
+        admission_owner: false,
+        drain_state: homeboy_lab_runner::RollingDrainState::Draining,
+        active_job_count: 2,
+        observed_active_job_count: None,
+        active_job_count_authoritative: false,
+        job_owner_count: 2,
+        run_owner_count: 0,
+        artifact_owner_count: 0,
+        homeboy_build_identity: None,
+        remote_daemon_lease_id: Some("lease-old".to_string()),
+        remote_daemon_address: None,
+        local_url: None,
+    }];
+
+    let admission = report.admission_summary_with_generations(&generations, &[], 1);
+    let summary = operator_summary(&report);
+    let followups =
+        runner_followups_with_admission(Some("homeboy lab"), Some(&report), Some(&admission));
+
+    assert_eq!(admission.unresolved_retained_projection_count, 2);
+    assert_eq!(
+        admission.next_action, None,
+        "compact status must not reconcile"
+    );
+    assert!(summary
+        .next_action
+        .contains("typed ownership evidence is insufficient"));
+    assert!(!summary.next_action.contains("runner reconcile"));
+    assert!(followups.iter().all(|followup| {
+        !followup.command.contains("runner reconcile")
+            && !matches!(
+                followup.label.as_str(),
+                "refresh_homeboy" | "homeboy_binary_refresh" | "homeboy_binary_upgrade"
+            )
+    }));
+    assert!(runner_status_operator_commands(&report)
+        .iter()
+        .all(|command| !command.command.contains("runner reconcile")));
 }
 
 #[test]
@@ -555,7 +688,7 @@ fn disconnected_split_view_status_exposes_bounded_reconciliation_command() {
             restartable: false,
             lease_id: Some("lease-23456".to_string()),
             pid: Some(23456),
-            recovery_evidence: None,
+        recovery_evidence: Some(DaemonRecoveryEvidence::ProvenDead),
             ownership_evidence: None,
             adoption_command: Some("homeboy runner connect homeboy-lab --reconcile-leaseless-orphans --confirm-no-daemon-owner".to_string()),
             binary_hash: None,
@@ -693,13 +826,184 @@ fn admission_followups_replace_generic_restart_for_ambiguous_missing_lease() {
     assert!(followups.iter().all(|followup| {
         !matches!(
             followup.label.as_str(),
-            "refresh_homeboy" | "homeboy_binary_refresh" | "homeboy_binary_upgrade"
+            "exec" | "refresh_homeboy" | "homeboy_binary_refresh" | "homeboy_binary_upgrade"
         )
     }));
-    assert!(followups.iter().any(|followup| {
-        followup.label == "admission_recovery"
-            && Some(&followup.command) == admission.next_action.as_ref()
+    assert!(admission.next_action.is_none());
+    assert!(followups
+        .iter()
+        .all(|followup| followup.label != "admission_recovery"));
+}
+
+#[test]
+fn terminal_ownership_suppresses_mutating_full_status_guidance_across_projections() {
+    let mut report = disconnected_report();
+    report.connected = true;
+    report.state = runner::RunnerSessionState::Connected;
+    let mut session = runner_session_fixture();
+    session.runner_id = report.runner_id.clone();
+    session.mode = RunnerTunnelMode::Reverse;
+    session.broker_url = Some("https://broker.example.test/".to_string());
+    session.homeboy_build_identity = Some("homeboy 0.320.0+runner".to_string());
+    report.session = Some(session);
+    report.active_job_count = 1;
+    report.stale_daemon = Some(homeboy::runner::runners::RunnerStaleDaemonWarning::new(
+        "homeboy-lab",
+        "homeboy 0.320.0".to_string(),
+        "homeboy 0.321.0".to_string(),
+        Some("homeboy 0.320.0+runner".to_string()),
+        Some("homeboy 0.321.0+configured".to_string()),
+    ));
+    report.daemon_freshness = Some(DaemonFreshnessReport {
+        fresh: false,
+        stale_reason_code: Some(DaemonStaleReasonCode::VersionMismatch),
+        restartable: false,
+        lease_id: None,
+        pid: None,
+        recovery_evidence: Some(DaemonRecoveryEvidence::Unavailable),
+        ownership_evidence: Some("ambiguous remote daemon candidates".to_string()),
+        adoption_command: None,
+        binary_hash: None,
+        daemon_version: Some("0.320.0".to_string()),
+        daemon_build_identity: Some("homeboy 0.320.0+runner".to_string()),
+        runtime_paths: None,
+        active_jobs: 0,
+        termination_evidence: None,
+        repair_plan: vec![DaemonRepairStep::text(
+            "runner_reconcile_leaseless_orphans",
+            "homeboy runner connect homeboy-lab --reconcile-leaseless-orphans --confirm-no-daemon-owner",
+        )],
+    });
+    let generations = vec![RunnerDaemonGenerationStatus {
+        generation: "lease-retained".to_string(),
+        admission_owner: false,
+        drain_state: homeboy_lab_runner::RollingDrainState::Draining,
+        active_job_count: 2,
+        observed_active_job_count: None,
+        active_job_count_authoritative: false,
+        job_owner_count: 2,
+        run_owner_count: 0,
+        artifact_owner_count: 0,
+        homeboy_build_identity: None,
+        remote_daemon_lease_id: Some("lease-retained".to_string()),
+        remote_daemon_address: None,
+        local_url: None,
+    }];
+
+    let admission = report.admission_summary_with_generations(&generations, &[], 1);
+    let outcome = reconciliation_outcome("homeboy-lab", Vec::new(), &report, &admission);
+    let followups =
+        runner_followups_with_admission(Some("homeboy-lab"), Some(&report), Some(&admission));
+    let commands = runner_status_operator_commands(&report);
+    let hints = runner_status_operator_hints(&report);
+    let output = lab_runner_homeboy_output("homeboy-lab", "/opt/homeboy", &report);
+
+    assert_eq!(
+        outcome.remaining_blocker.as_deref(),
+        Some("daemon_ownership_evidence_unavailable")
+    );
+    assert_eq!(outcome.next_action, None);
+    assert!(followups.iter().all(|followup| {
+        !matches!(
+            followup.label.as_str(),
+            "exec"
+                | "refresh_homeboy"
+                | "homeboy_binary_refresh"
+                | "homeboy_binary_upgrade"
+                | "workspace_prune_drain"
+                | "workspace_sync"
+        )
     }));
+    assert!(commands.iter().all(|command| {
+        !matches!(
+            command.scope,
+            "unknown_owner_reconcile"
+                | "agent_task_retry"
+                | "job_cancel"
+                | "broker_reconcile"
+                | "generation_reconcile"
+                | "daemon_refresh"
+                | "daemon_reconcile_split_view"
+                | "daemon_reconnect_fresh_idle"
+        )
+    }));
+    assert!(output.refresh_commands.is_empty());
+    assert_eq!(output.upgrade_command, None);
+    assert_eq!(output.stale_daemon_refresh_command, None);
+    assert!(hints.iter().all(|hint| !hint.contains("refresh-homeboy")));
+    assert!(hints.iter().all(|hint| {
+        !hint.contains("runner job cancel") && !hint.contains("runner job reconcile")
+    }));
+    let mut missing_broker_report = report.clone();
+    missing_broker_report
+        .session
+        .as_mut()
+        .expect("reverse session")
+        .broker_url = None;
+    assert!(runner_status_operator_hints(&missing_broker_report)
+        .iter()
+        .all(|hint| !hint.contains("reconnecting with")));
+    assert!(output
+        .artifact_features
+        .hints
+        .iter()
+        .all(|hint| !hint.contains("runner disconnect")));
+}
+
+#[test]
+fn reverse_runner_and_workspace_sync_guidance_remain_available_without_terminal_ownership() {
+    let mut reverse_report = connected_report();
+    reverse_report.active_job_count = 1;
+    let mut reverse_session = runner_session_fixture();
+    reverse_session.runner_id = reverse_report.runner_id.clone();
+    reverse_session.mode = RunnerTunnelMode::Reverse;
+    reverse_session.broker_url = Some("https://broker.example.test/".to_string());
+    reverse_report.session = Some(reverse_session);
+
+    let reverse_hints = runner_status_operator_hints(&reverse_report);
+    assert!(reverse_hints
+        .iter()
+        .any(|hint| hint.contains("runner job cancel")));
+    assert!(reverse_hints
+        .iter()
+        .any(|hint| hint.contains("runner job reconcile")));
+
+    let mut missing_broker_report = reverse_report.clone();
+    missing_broker_report
+        .session
+        .as_mut()
+        .expect("reverse session")
+        .broker_url = None;
+    assert!(runner_status_operator_hints(&missing_broker_report)
+        .iter()
+        .any(|hint| hint.contains("reconnecting with")));
+
+    let mut workspace_report = connected_report();
+    workspace_report.daemon_freshness = Some(DaemonFreshnessReport {
+        fresh: true,
+        stale_reason_code: None,
+        restartable: false,
+        lease_id: None,
+        pid: None,
+        recovery_evidence: None,
+        ownership_evidence: None,
+        adoption_command: None,
+        binary_hash: None,
+        daemon_version: None,
+        daemon_build_identity: None,
+        runtime_paths: None,
+        active_jobs: 0,
+        termination_evidence: None,
+        repair_plan: Vec::new(),
+    });
+    let admission = workspace_report.admission_summary(0);
+    assert!(runner_followups_with_admission(
+        Some("homeboy lab"),
+        Some(&workspace_report),
+        Some(&admission),
+    )
+    .iter()
+    .any(|followup| followup.label == "workspace_sync"));
 }
 
 #[test]
@@ -733,10 +1037,10 @@ fn unqualified_status_followups_use_selected_admission_action() {
             "refresh_homeboy" | "homeboy_binary_refresh" | "homeboy_binary_upgrade"
         )
     }));
-    assert!(followups.iter().any(|followup| {
-        followup.label == "admission_recovery"
-            && Some(&followup.command) == admission.next_action.as_ref()
-    }));
+    assert!(admission.next_action.is_none());
+    assert!(followups
+        .iter()
+        .all(|followup| followup.label != "admission_recovery"));
 }
 
 #[test]

--- a/crates/homeboy-cli/src/commands/runner/types.rs
+++ b/crates/homeboy-cli/src/commands/runner/types.rs
@@ -263,7 +263,8 @@ pub struct LabRunnerHomeboyOutput {
     pub command_availability_checks: Vec<String>,
     pub artifact_features: RunnerArtifactFeatureDiagnostics,
     pub refresh_commands: Vec<String>,
-    pub upgrade_command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub upgrade_command: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dev_sync: Option<Value>,
 }

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -674,6 +674,31 @@ pub struct DaemonFreshnessReport {
     pub repair_plan: Vec<DaemonRepairStep>,
 }
 
+impl DaemonFreshnessReport {
+    /// Typed evidence required before a controller can mutate a stale daemon
+    /// session. Textual ownership diagnostics are explanatory, not authority.
+    pub fn has_recovery_ownership_proof(&self) -> bool {
+        matches!(
+            self.recovery_evidence,
+            Some(DaemonRecoveryEvidence::ProvenDead | DaemonRecoveryEvidence::Recoverable)
+        )
+    }
+
+    /// A stale report without typed ownership proof is terminal: callers must
+    /// surface its evidence rather than offer or execute any recovery action.
+    pub fn has_terminal_recovery_ownership_blocker(&self) -> bool {
+        !self.fresh && !self.has_recovery_ownership_proof()
+    }
+
+    /// A stale report may only enter automatic recovery through a validated
+    /// typed plan. An empty plan is terminal even when its ownership proof is
+    /// sufficient, because there is no authorized mutation to execute.
+    pub fn blocks_automatic_recovery(&self) -> bool {
+        self.has_terminal_recovery_ownership_blocker()
+            || (!self.fresh && self.repair_plan.is_empty())
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct DaemonStartResult {
     pub pid: u32,

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -938,7 +938,7 @@ pub(super) fn remote_daemon_recovery_freshness_from_status(
 }
 
 pub(super) fn unavailable_recovery_freshness(
-    runner_id: &str,
+    _runner_id: &str,
     error: impl Into<String>,
 ) -> DaemonFreshnessReport {
     DaemonFreshnessReport {
@@ -953,9 +953,8 @@ pub(super) fn unavailable_recovery_freshness(
             error.into()
         )),
         // No lease, PID, or job count survived the transport failure, so no
-        // lease-specific action can be named. Rebuilding the controller session
-        // is the only honest step, and it is emitted as typed steps rather than
-        // left to a downstream prose fallback.
+        // controller mutation is authorized. A later probe must establish typed
+        // ownership before any reconnect can be proposed.
         adoption_command: None,
         binary_hash: None,
         daemon_version: None,
@@ -963,7 +962,7 @@ pub(super) fn unavailable_recovery_freshness(
         runtime_paths: None,
         active_jobs: 0,
         termination_evidence: None,
-        repair_plan: daemon_repair::reconnect_plan(runner_id),
+        repair_plan: Vec::new(),
     }
 }
 

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -1027,8 +1027,8 @@ fn remote_recovery_repair_plan_carries_the_lease_specific_action() {
 #[test]
 fn remote_recovery_without_evidence_emits_no_repair_plan() {
     // Nothing was proven about ownership or liveness, so no lease-specific step
-    // can be named. An empty plan is the honest answer and is what lets the
-    // generic reconnect fallback fire downstream.
+    // can be named. An empty plan is the honest answer; downstream projections
+    // retain it as a terminal diagnostic rather than reconnecting blindly.
     let status = remote_daemon_status_for_test(false, false, 1, "lease-unknown", 4545);
 
     let recovery = remote_daemon_recovery_freshness_from_status("homeboy-lab", &status);
@@ -1052,20 +1052,7 @@ fn unavailable_remote_recovery_is_fail_closed() {
     assert!(recovery.lease_id.is_none());
     assert!(recovery.pid.is_none());
     assert!(recovery.adoption_command.is_none());
-    // No lease-specific action is knowable, but the controller-side session
-    // rebuild is, and it must arrive as typed steps rather than as prose
-    // assembled by a downstream fallback (#10302).
-    assert_eq!(
-        recovery
-            .repair_plan
-            .iter()
-            .map(|step| (step.code.as_str(), step.command.as_str()))
-            .collect::<Vec<_>>(),
-        vec![
-            ("runner_disconnect", "homeboy runner disconnect homeboy-lab"),
-            ("runner_connect", "homeboy runner connect homeboy-lab"),
-        ]
-    );
+    assert!(recovery.repair_plan.is_empty());
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/daemon_repair.rs
+++ b/crates/homeboy-lab-runner/src/daemon_repair.rs
@@ -230,6 +230,12 @@ pub(crate) fn controller_frame_plan(
     if report.fresh && report.stale_reason_code.is_none() {
         return Vec::new();
     }
+    // A mismatch identifies an incompatible binary, but not necessarily the
+    // daemon that owns it. Do not turn that observation into a refresh until
+    // the remote probe has established ownership well enough to authorize it.
+    if !report.has_recovery_ownership_proof() {
+        return Vec::new();
+    }
     // Adoption eligibility is authored by the daemon after its process and
     // candidate checks. `PidDead` alone is insufficient once the report has
     // crossed the runner boundary: a conflicting candidate deliberately clears
@@ -280,11 +286,10 @@ pub(crate) fn controller_frame_plan(
     if report.restartable {
         return reconnect_plan(runner_id);
     }
-    // A stale report that matched no branch above named a real problem and no
-    // authorized mutation. Returning an empty plan hands the operator nothing
-    // at all, so the honest answer is the read-only re-probe: the evidence that
-    // would let a later pass match a branch (#11103).
-    vec![action_step(RUNNER_DIAGNOSE, diagnose_action(runner_id))]
+    // A stale report that matched no branch names a real problem but authorizes
+    // no mutation. The report's ownership evidence is the terminal diagnostic;
+    // prescribing another probe here can make doctor recommend itself forever.
+    Vec::new()
 }
 
 /// Render a plan as the `&&`-joined shell text used in operator prose.
@@ -301,6 +306,7 @@ pub(crate) fn render(steps: &[DaemonRepairStep]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use homeboy_core::daemon::DaemonRecoveryEvidence;
 
     fn report(
         stale_reason_code: Option<DaemonStaleReasonCode>,
@@ -347,6 +353,7 @@ mod tests {
     #[test]
     fn a_dead_lease_becomes_an_explicit_runner_side_adoption() {
         let mut report = report(Some(DaemonStaleReasonCode::PidDead), 1, false);
+        report.recovery_evidence = Some(DaemonRecoveryEvidence::ProvenDead);
         report.adoption_command =
             Some("homeboy daemon adopt-orphan --lease-id lease-remote".to_string());
         assert_eq!(
@@ -369,8 +376,10 @@ mod tests {
 
     #[test]
     fn durable_jobs_without_an_owning_lease_become_explicit_reconciliation() {
+        let mut report = report(Some(DaemonStaleReasonCode::LeaseMissing), 2, false);
+        report.recovery_evidence = Some(DaemonRecoveryEvidence::ProvenDead);
         assert_eq!(
-            plan(&report(Some(DaemonStaleReasonCode::LeaseMissing), 2, false)),
+            plan(&report),
             vec![(
                 RUNNER_RECONCILE_LEASELESS_ORPHANS.to_string(),
                 "homeboy runner connect homeboy-lab --reconcile-leaseless-orphans --confirm-no-daemon-owner".to_string()
@@ -405,12 +414,10 @@ mod tests {
 
     #[test]
     fn identity_drift_refreshes_the_runner_binary_rather_than_reconnecting_it() {
+        let mut report = report(Some(DaemonStaleReasonCode::BuildIdentityMismatch), 0, true);
+        report.recovery_evidence = Some(DaemonRecoveryEvidence::Recoverable);
         assert_eq!(
-            plan(&report(
-                Some(DaemonStaleReasonCode::BuildIdentityMismatch),
-                0,
-                true
-            )),
+            plan(&report),
             vec![(
                 RUNNER_REFRESH_HOMEBOY.to_string(),
                 "homeboy runner refresh-homeboy homeboy-lab --reconnect".to_string()
@@ -419,13 +426,23 @@ mod tests {
     }
 
     #[test]
-    fn a_restartable_lease_rebuilds_the_controller_session() {
+    fn incompatible_daemon_without_ownership_evidence_has_no_repair_plan() {
+        let mut report = report(Some(DaemonStaleReasonCode::VersionMismatch), 0, false);
+        report.recovery_evidence = Some(DaemonRecoveryEvidence::Unavailable);
+        report.ownership_evidence = Some("daemon lease owner could not be established".to_string());
+
+        assert!(
+            controller_frame_plan("homeboy-lab", &report).is_empty(),
+            "version skew alone must not authorize a daemon mutation"
+        );
+    }
+
+    #[test]
+    fn a_restartable_lease_with_typed_ownership_rebuilds_the_controller_session() {
+        let mut report = report(Some(DaemonStaleReasonCode::RuntimePathsDrift), 0, true);
+        report.recovery_evidence = Some(DaemonRecoveryEvidence::Recoverable);
         assert_eq!(
-            plan(&report(
-                Some(DaemonStaleReasonCode::RuntimePathsDrift),
-                0,
-                true
-            )),
+            plan(&report),
             vec![
                 (
                     RUNNER_DISCONNECT.to_string(),
@@ -439,26 +456,19 @@ mod tests {
         );
     }
 
-    /// #11103: a report that matches no repair branch used to return an empty
-    /// plan, so the operator was handed a stale daemon and nothing to do about
-    /// it. The fallback is read-only rather than a guessed mutation.
+    /// A report with insufficient ownership evidence remains terminal. A
+    /// read-only doctor fallback would be self-referential when this plan was
+    /// projected by doctor itself.
     #[test]
-    fn a_report_matching_no_branch_still_produces_an_actionable_step() {
-        let plan = controller_frame_plan(
-            "homeboy-lab",
-            &report(Some(DaemonStaleReasonCode::TransportUnreachable), 0, false),
-        );
-
-        assert_eq!(plan.len(), 1, "an unmatched stale report is never empty");
-        assert_eq!(plan[0].code, RUNNER_DIAGNOSE);
-        assert_eq!(
-            plan[0].command,
-            "homeboy runner doctor homeboy-lab --scope lab-offload"
-        );
-        let action = plan[0].action.as_ref().expect("fallback carries argv");
-        assert_eq!(action.safety, ActionSafety::ReadOnly);
-        assert_eq!(action.args[0], "runner");
-        assert_eq!(action.args[1], "doctor");
+    fn unmatched_stale_reports_without_typed_ownership_have_no_automatic_repair() {
+        for evidence in [None, Some(DaemonRecoveryEvidence::Unavailable)] {
+            let mut report = report(Some(DaemonStaleReasonCode::TransportUnreachable), 0, true);
+            report.recovery_evidence = evidence;
+            assert!(
+                controller_frame_plan("homeboy-lab", &report).is_empty(),
+                "{evidence:?} ownership evidence must not authorize reconnect"
+            );
+        }
     }
 
     /// Every branch must carry argv, or the executor is back to shell-parsing
@@ -480,8 +490,13 @@ mod tests {
                 for active_jobs in [0, 1] {
                     let mut report = report(Some(code), active_jobs, restartable);
                     report.adoption_command = Some("daemon-authored".to_string());
+                    report.recovery_evidence = Some(DaemonRecoveryEvidence::ProvenDead);
                     let plan = controller_frame_plan("homeboy-lab", &report);
-                    assert!(!plan.is_empty(), "{code:?} produced no step at all");
+                    if plan.is_empty() {
+                        // Unavailable ownership evidence is terminal, not an
+                        // implicit read-only or mutating recovery command.
+                        continue;
+                    }
                     for step in plan {
                         let action = step.action.as_ref().unwrap_or_else(|| {
                             panic!("{code:?} step {} carries no argv", step.code)
@@ -509,10 +524,9 @@ mod tests {
             DaemonStaleReasonCode::RuntimePathsDrift,
             DaemonStaleReasonCode::TransportUnreachable,
         ] {
-            for command in plan(&report(Some(code), 1, true))
-                .into_iter()
-                .map(|(_, command)| command)
-            {
+            let mut report = report(Some(code), 1, true);
+            report.recovery_evidence = Some(DaemonRecoveryEvidence::ProvenDead);
+            for command in plan(&report).into_iter().map(|(_, command)| command) {
                 assert!(
                     command.starts_with("homeboy runner "),
                     "{code:?} produced a non-controller-frame command: {command}"

--- a/crates/homeboy-lab-runner/src/lab/preparation_tests.rs
+++ b/crates/homeboy-lab-runner/src/lab/preparation_tests.rs
@@ -10,7 +10,9 @@ use crate::{
     RunnerActiveJobState, RunnerConnectReport, RunnerStatusReport, RunnerTunnelMode,
     RunnerTunnelProcessStartIdentity,
 };
-use homeboy_core::daemon::{DaemonFreshnessReport, DaemonStaleReasonCode};
+use homeboy_core::daemon::{
+    DaemonFreshnessReport, DaemonRecoveryEvidence, DaemonRepairStep, DaemonStaleReasonCode,
+};
 use homeboy_core::{Error, ErrorCode};
 
 use super::super::session::{RunnerStaleDaemonWarning, RunnerStaleRuntimePath};
@@ -887,6 +889,9 @@ fn lab_runner_preparation_errors_for_explicit_stale_daemon_version() {
     assert!(err.message.contains("homeboy 0.219.0"));
     assert!(err
         .message
+        .contains("typed ownership evidence is insufficient"));
+    assert!(!err
+        .message
         .contains("homeboy runner doctor lab --scope lab-offload"));
     assert!(err
         .details
@@ -894,13 +899,69 @@ fn lab_runner_preparation_errors_for_explicit_stale_daemon_version() {
         .and_then(serde_json::Value::as_array)
         .into_iter()
         .flatten()
-        .any(|suggestion| suggestion
+        .all(|suggestion| suggestion
             .as_str()
-            .is_some_and(|value| value.contains("homeboy runner doctor lab --scope lab-offload"))));
+            .is_none_or(|value| !value.contains("homeboy runner doctor lab --scope lab-offload"))));
     assert!(err
         .details
         .get(homeboy_core::error::ACTIONS_DETAILS_KEY)
         .is_none());
+}
+
+#[test]
+fn lab_preparation_does_not_offer_an_unavailable_reconciliation_plan() {
+    let selection = LabRunnerSelection {
+        runner_id: "lab".to_string(),
+        source: LabRunnerSelectionSource::Explicit,
+        mode: RunnerTunnelMode::DirectSsh,
+    };
+    let mut freshness = restartable_daemon_freshness();
+    freshness.stale_reason_code = Some(DaemonStaleReasonCode::LeaseCorrupt);
+    freshness.recovery_evidence = Some(DaemonRecoveryEvidence::Unavailable);
+    freshness.ownership_evidence = Some("ambiguous remote daemon candidates".to_string());
+    freshness.repair_plan = vec![DaemonRepairStep::text(
+        "runner_reconcile_leaseless_orphans",
+        "homeboy runner connect lab --reconcile-leaseless-orphans --confirm-no-daemon-owner",
+    )];
+
+    let error = prepare_lab_runner_for_offload_with(
+        &selection,
+        |runner_id| {
+            Ok(RunnerStatusReport {
+                runner_id: runner_id.to_string(),
+                connected: true,
+                state: super::super::RunnerSessionState::Connected,
+                session: Some(connected_direct_session(
+                    runner_id,
+                    Some("http://127.0.0.1:1234"),
+                )),
+                stale_daemon: Some(stale_daemon_warning(runner_id)),
+                configured_job_binary_build_identity: None,
+                daemon_freshness: Some(freshness.clone()),
+                active_jobs: Vec::new(),
+                active_runner_jobs: Vec::new(),
+                active_job_count: 0,
+                stale_runner_jobs: Vec::new(),
+                stale_runner_job_count: 0,
+                active_job_state: RunnerActiveJobState::NotQueried,
+                active_job_source: None,
+                active_job_error: None,
+                active_job_recovery_evidence: None,
+                session_path: "/tmp/lab.json".to_string(),
+            })
+        },
+        |_| panic!("terminal ownership evidence must not reconnect"),
+    )
+    .expect_err("ambiguous remote lease ownership must block explicit offload");
+
+    let rendered = format!(
+        "{} {}",
+        error.message,
+        serde_json::to_string(&error.details).expect("serialize error details")
+    );
+    assert!(rendered.contains("typed ownership evidence is insufficient"));
+    assert!(rendered.contains("ambiguous remote daemon candidates"));
+    assert!(!rendered.contains("reconcile-leaseless-orphans"));
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/lab_selection.rs
+++ b/crates/homeboy-lab-runner/src/lab_selection.rs
@@ -1392,6 +1392,19 @@ fn connected_runner_not_ready_reason(
     runner_id: &str,
     status: &RunnerStatusReport,
 ) -> Option<String> {
+    if let Some(report) = status
+        .daemon_freshness
+        .as_ref()
+        .filter(|report| report.has_terminal_recovery_ownership_blocker())
+    {
+        return Some(format!(
+            "connected runner `{runner_id}` daemon recovery is blocked because typed ownership evidence is insufficient: {}",
+            report
+                .ownership_evidence
+                .as_deref()
+                .unwrap_or("no ownership evidence was recorded")
+        ));
+    }
     if let Some(warning) = status.admission_blocking_stale_daemon() {
         let restart = daemon_repair_command(runner_id, status);
         if !warning.stale_runtime_paths.is_empty() || !warning.changed_runtime_paths.is_empty() {
@@ -1432,9 +1445,38 @@ fn daemon_repair_steps(runner_id: &str, status: &RunnerStatusReport) -> Vec<Daem
     if let Some(report) = status
         .daemon_freshness
         .as_ref()
-        .filter(|report| !report.repair_plan.is_empty())
+        .filter(|report| report.has_terminal_recovery_ownership_blocker())
+    {
+        return vec![DaemonRepairStep::text(
+            daemon_repair::RUNNER_DIAGNOSE,
+            format!(
+                "Daemon recovery is blocked because typed ownership evidence is insufficient: {}",
+                report
+                    .ownership_evidence
+                    .as_deref()
+                    .unwrap_or("no ownership evidence was recorded")
+            ),
+        )];
+    }
+    if let Some(report) = status
+        .daemon_freshness
+        .as_ref()
+        .filter(|report| !report.repair_plan.is_empty() && report.has_recovery_ownership_proof())
     {
         return report.repair_plan.clone();
+    }
+    if status
+        .daemon_freshness
+        .as_ref()
+        .is_some_and(|report| !report.fresh)
+    {
+        // This projection is used by runner doctor itself. A stale report with
+        // typed proof but no validated action must terminate with its evidence,
+        // not recommend the identical doctor invocation that produced it.
+        return vec![DaemonRepairStep::text(
+            daemon_repair::RUNNER_DIAGNOSE,
+            "Daemon recovery is blocked because no validated recovery action was derived from the current typed daemon evidence.".to_string(),
+        )];
     }
     if let Some(warning) = status.stale_daemon.as_ref() {
         let steps: Vec<_> = warning
@@ -1758,7 +1800,7 @@ mod daemon_repair_step_tests {
             restartable: false,
             lease_id: Some("lease-dead".to_string()),
             pid: Some(4545),
-            recovery_evidence: None,
+            recovery_evidence: Some(homeboy_core::daemon::DaemonRecoveryEvidence::ProvenDead),
             ownership_evidence: None,
             adoption_command: None,
             binary_hash: None,
@@ -1848,26 +1890,77 @@ mod daemon_repair_step_tests {
     }
 
     #[test]
-    fn generic_reconnect_fires_only_when_nothing_specific_is_known() {
-        let report = status_report("homeboy-lab", Some(freshness_with_plan(Vec::new())), None);
+    fn unavailable_ownership_plan_offers_a_non_circular_terminal_diagnostic() {
+        let mut freshness = freshness_with_plan(vec![daemon_repair::action_step(
+            daemon_repair::RUNNER_RECONCILE_LEASELESS_ORPHANS,
+            daemon_repair::reconcile_leaseless_orphans_action("homeboy-lab"),
+        )]);
+        freshness.stale_reason_code =
+            Some(homeboy_core::daemon::DaemonStaleReasonCode::LeaseMissing);
+        freshness.recovery_evidence =
+            Some(homeboy_core::daemon::DaemonRecoveryEvidence::Unavailable);
+        freshness.ownership_evidence = Some("ambiguous remote daemon candidates".to_string());
+        let report = status_report("homeboy-lab", Some(freshness), None);
 
         let steps = daemon_repair_steps("homeboy-lab", &report);
 
-        assert_eq!(
-            steps
-                .iter()
-                .map(|step| (step.code.as_str(), step.command.as_str()))
-                .collect::<Vec<_>>(),
-            vec![
-                ("runner_disconnect", "homeboy runner disconnect homeboy-lab"),
-                ("runner_connect", "homeboy runner connect homeboy-lab"),
-            ]
-        );
-        // The rendered prose is the same text the old joined-string fallback
-        // produced, so operator-facing messages are unchanged.
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].code, daemon_repair::RUNNER_DIAGNOSE);
         assert_eq!(
             daemon_repair_command("homeboy-lab", &report),
-            "homeboy runner disconnect homeboy-lab && homeboy runner connect homeboy-lab"
+            "Daemon recovery is blocked because typed ownership evidence is insufficient: ambiguous remote daemon candidates"
+        );
+        assert!(steps[0].action.is_none());
+        assert!(daemon_repair_action("homeboy-lab", &report).is_none());
+    }
+
+    #[test]
+    fn terminal_ownership_evidence_is_not_rendered_as_a_restart_command() {
+        let mut freshness = freshness_with_plan(Vec::new());
+        freshness.recovery_evidence =
+            Some(homeboy_core::daemon::DaemonRecoveryEvidence::Unavailable);
+        freshness.ownership_evidence = Some("ambiguous remote daemon candidates".to_string());
+        let report = status_report(
+            "homeboy-lab",
+            Some(freshness),
+            Some(RunnerStaleDaemonWarning::new(
+                "homeboy-lab",
+                "homeboy 0.218.0".to_string(),
+                "homeboy 0.219.0".to_string(),
+                Some("homeboy 0.218.0+old".to_string()),
+                Some("homeboy 0.219.0+new".to_string()),
+            )),
+        );
+
+        let reason = connected_runner_not_ready_reason("homeboy-lab", &report)
+            .expect("terminal ownership blocks preparation");
+
+        assert!(reason.contains("typed ownership evidence is insufficient"));
+        assert!(reason.contains("ambiguous remote daemon candidates"));
+        assert!(!reason.contains("restart the active daemon"));
+        assert!(!reason.contains("refresh with `"));
+        assert!(!reason.contains("homeboy runner"));
+    }
+
+    #[test]
+    fn typed_proof_without_a_validated_plan_offers_a_non_circular_terminal_diagnostic() {
+        let mut freshness = freshness_with_plan(Vec::new());
+        freshness.stale_reason_code =
+            Some(homeboy_core::daemon::DaemonStaleReasonCode::LeaseSchemaMismatch);
+        freshness.recovery_evidence =
+            Some(homeboy_core::daemon::DaemonRecoveryEvidence::Recoverable);
+        let report = status_report("homeboy-lab", Some(freshness), None);
+
+        let steps = daemon_repair_steps("homeboy-lab", &report);
+
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].code, daemon_repair::RUNNER_DIAGNOSE);
+        assert!(steps[0].action.is_none());
+        assert!(steps[0].command.contains("no validated recovery action"));
+        assert!(!steps[0].command.contains("runner doctor"));
+        assert_ne!(
+            daemon_repair_command("homeboy-lab", &report),
+            "homeboy runner doctor homeboy-lab --scope lab-offload"
         );
     }
 }

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -927,14 +927,22 @@ impl RunnerStatusReport {
         // Reconciliation settles terminal jobs through the connected daemon.
         // A disconnected report must first select its reconnect, refresh, or
         // ownership-recovery action rather than advertising that unavailable path.
-        let next_action = self
-            .admission_action()
-            .or_else(|| {
+        // Terminal ownership uncertainty dominates every retained-generation
+        // projection. Reconciliation mutates the ledger and cannot become an
+        // implicit fallback when the daemon owner itself is not established.
+        let next_action = (!self
+            .daemon_freshness
+            .as_ref()
+            .is_some_and(DaemonFreshnessReport::has_terminal_recovery_ownership_blocker))
+        .then(|| {
+            self.admission_action().or_else(|| {
                 unresolved_generation
                     .as_ref()
                     .map(|_| reconcile_action(&self.runner_id))
             })
-            .map(|action| action.render_command());
+        })
+        .flatten()
+        .map(|action| action.render_command());
 
         RunnerAdmissionSummary {
             runner_id: self.runner_id.clone(),
@@ -965,6 +973,9 @@ impl RunnerStatusReport {
     /// the source prevents either surface from dropping the runner id.
     pub fn admission_action(&self) -> Option<ExecutableAction> {
         if let Some(freshness) = self.daemon_freshness.as_ref() {
+            if freshness.has_terminal_recovery_ownership_blocker() {
+                return None;
+            }
             if let Some(action) = freshness
                 .repair_plan
                 .first()
@@ -973,9 +984,10 @@ impl RunnerStatusReport {
                 return Some(action);
             }
             if !freshness.fresh {
-                // Missing lease evidence without an authorized repair must be
-                // reprobed, not replaced with a generic reconnect.
-                return Some(crate::daemon_repair::diagnose_action(&self.runner_id));
+                // Missing typed ownership proof means no mutation is authorized.
+                // Keep admission closed and expose the freshness evidence as the
+                // terminal blocker rather than prescribing a read-only loop.
+                return None;
             }
         }
         if let Some(warning) = &self.stale_daemon {
@@ -1441,7 +1453,7 @@ mod status_serialization_tests {
     }
 
     #[test]
-    fn admission_summary_lease_missing_without_repair_plan_requires_diagnosis() {
+    fn admission_summary_lease_missing_with_unavailable_reconciliation_plan_is_terminal() {
         let mut report = base_report();
         report.connected = false;
         report.state = RunnerSessionState::Disconnected;
@@ -1461,7 +1473,10 @@ mod status_serialization_tests {
             runtime_paths: None,
             active_jobs: 0,
             termination_evidence: None,
-            repair_plan: Vec::new(),
+            repair_plan: vec![homeboy_core::daemon::DaemonRepairStep::text(
+                "runner_reconcile_leaseless_orphans",
+                "homeboy runner connect homeboy-lab --reconcile-leaseless-orphans --confirm-no-daemon-owner",
+            )],
         });
 
         let summary = report.admission_summary(0);
@@ -1469,10 +1484,7 @@ mod status_serialization_tests {
         assert!(!summary.daemon_fresh);
         assert!(!summary.accepting_jobs);
         assert!(!summary.safe_to_rotate);
-        assert_eq!(
-            summary.next_action.as_deref(),
-            Some("homeboy runner doctor homeboy-lab --scope lab-offload")
-        );
+        assert_eq!(summary.next_action, None);
     }
 
     #[test]
@@ -1622,6 +1634,50 @@ mod status_serialization_tests {
             summary.next_action.as_deref(),
             Some("homeboy runner reconcile homeboy-lab")
         );
+    }
+
+    #[test]
+    fn terminal_ownership_blocks_retained_generation_reconciliation_fallback() {
+        let mut report = base_report();
+        report.active_job_state = RunnerActiveJobState::Unavailable;
+        report.daemon_freshness = Some(DaemonFreshnessReport {
+            fresh: false,
+            stale_reason_code: Some(homeboy_core::daemon::DaemonStaleReasonCode::LeaseMissing),
+            restartable: false,
+            lease_id: None,
+            pid: None,
+            recovery_evidence: Some(homeboy_core::daemon::DaemonRecoveryEvidence::Unavailable),
+            ownership_evidence: Some("ambiguous remote daemon candidates".to_string()),
+            adoption_command: None,
+            binary_hash: None,
+            daemon_version: None,
+            daemon_build_identity: None,
+            runtime_paths: None,
+            active_jobs: 0,
+            termination_evidence: None,
+            repair_plan: Vec::new(),
+        });
+        let generations = vec![RunnerDaemonGenerationStatus {
+            generation: "lease-old".to_string(),
+            admission_owner: false,
+            drain_state: crate::RollingDrainState::Draining,
+            active_job_count: 2,
+            observed_active_job_count: None,
+            active_job_count_authoritative: false,
+            job_owner_count: 2,
+            run_owner_count: 0,
+            artifact_owner_count: 0,
+            homeboy_build_identity: None,
+            remote_daemon_lease_id: Some("lease-old".to_string()),
+            remote_daemon_address: None,
+            local_url: None,
+        }];
+
+        let summary = report.admission_summary_with_generations(&generations, &[], 1);
+
+        assert_eq!(summary.unresolved_retained_projection_count, 2);
+        assert_eq!(summary.unresolved_generation_ids, ["lease-old"]);
+        assert_eq!(summary.next_action, None);
     }
 
     #[test]


### PR DESCRIPTION
Closes #12806

## Summary
- make daemon recovery depend on typed ownership and freshness evidence
- keep terminal ownership uncertainty evidence-only across status, doctor, Lab selection, and session admission
- suppress reconnect, cancel, reconcile, workspace sync, and arbitrary exec mutation surfaces until ownership is proven
- remove circular recovery guidance and preserve safe exact repair plans

## Verification
- `cargo test -p homeboy-cli --lib commands::runner::tests::status` (36 passed)
- `cargo test -p homeboy-lab-runner --lib lab_selection::daemon_repair_step_tests` (6 passed)
- `cargo fmt --check`
- `git diff --check`

## AI assistance
Implemented and adversarially reviewed with OpenCode using OpenAI gpt-5.6-sol. AI assisted with diagnosis, implementation, regression coverage, and verification; Chris Huber reviewed and remains responsible for the change.