### PR TITLE
CLI: expose placement in compact Cook help

### DIFF
--- a/crates/homeboy-cli/src/cli_surface/mod.rs
+++ b/crates/homeboy-cli/src/cli_surface/mod.rs
@@ -55,9 +55,8 @@ pub struct Cli {
     )]
     pub notification_route: Option<String>,
 
-    /// Select where eligible work executes without pinning a runner. `auto` uses
-    /// the command contract, controller pressure, and ready Lab capacity. Use
-    /// `--runner <id>` instead to pin a connected Lab runner.
+    /// Select where eligible work executes. `auto` (default) follows command
+    /// policy; `local` is an explicit authorized override.
     #[arg(
         long,
         global = true,

--- a/crates/homeboy-cli/src/command_contract/lab.rs
+++ b/crates/homeboy-cli/src/command_contract/lab.rs
@@ -56,6 +56,7 @@ fn scope_cook_help(command: Command) -> Command {
         "no_finalize",
         "draft_pr",
         "max_attempts",
+        "placement",
     ];
 
     fn visit(command: Command, path: &[String]) -> Command {

--- a/crates/homeboy-cli/src/command_contract/lab/tests.rs
+++ b/crates/homeboy-cli/src/command_contract/lab/tests.rs
@@ -38,6 +38,15 @@ fn cook_help_snapshot_is_task_first_and_full_help_retains_advanced_controls() {
     assert!(compact.contains("--task-url <URL>"), "{compact}");
     assert!(compact.contains("--preview"), "{compact}");
     assert!(compact.contains("--help-full"), "{compact}");
+    // Resource admission directs operators to this explicit local override, so
+    // it must remain discoverable in the compact task-dispatch help.
+    assert!(compact.contains("--placement <PLACEMENT>"), "{compact}");
+    assert!(compact.contains("`auto` (default)"), "{compact}");
+    assert!(
+        compact.contains("`local` is an explicit authorized override"),
+        "{compact}"
+    );
+    assert!(!compact.contains("--runner <RUNNER_ID>"), "{compact}");
     assert!(!compact.contains("--max-provider-rotations"), "{compact}");
     assert!(full.contains("--max-provider-rotations"), "{full}");
     assert!(full.contains("--provider-command"), "{full}");

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -900,8 +900,8 @@ mod tests {
 #[derive(Args, Debug, Clone)]
 #[command(disable_help_flag = true)]
 pub struct AgentTaskCookArgs {
-    /// Show the compact task-first Cook help. Use `--help-full` for every
-    /// advanced transport, provider, gate, and recovery option.
+    /// Show compact task-first Cook help. Use `--help-full` for the complete
+    /// Cook option reference.
     #[arg(short = 'h', long, action = clap::ArgAction::HelpShort)]
     pub help: Option<bool>,
     /// Show the complete Cook option reference.


### PR DESCRIPTION
Closes #12807

## Summary
- expose `--placement` in compact `agent-task cook` help
- preserve the full advanced-help surface and command contract
- add a snapshot assertion for the compact placement option

## Verification
- `cargo test -p homeboy-cli command_contract::lab` (6 passed)
- `cargo fmt --check`
- `git diff --check`

## AI assistance
Implemented and reviewed with OpenCode using OpenAI gpt-5.6-sol. AI assisted with diagnosis, implementation, tests, and verification; Chris Huber reviewed and remains responsible for the change.