### PR TITLE
Root the controller-runtime admission lock

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2152,12 +2152,17 @@ fn migrate_record_controller_runtime_in_store(
         return Ok(());
     };
     let original = runtime.clone();
-    let migrated =
-        homeboy_core::controller_runtime::migrate_legacy_pin_and_persist(&original, |migrated| {
+    let runtime_root =
+        homeboy_core::controller_runtime::runtime_root_in(lifecycle_store.roots().data())?;
+    let migrated = homeboy_core::controller_runtime::migrate_legacy_pin_and_persist_in_root(
+        &runtime_root,
+        &original,
+        |migrated| {
             record.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] =
                 migrated.clone();
             lifecycle_store.write_record(record)
-        })?;
+        },
+    )?;
     record.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] = migrated;
     Ok(())
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -4054,19 +4054,24 @@ fn status_recovers_terminal_state_from_durable_aggregate() {
     });
 }
 
-/// Stays on `with_isolated_home` (#7505) — `mark_running` is the subject; see
-/// `running_observation_projects_each_terminal_aggregate_state`.
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). `mark_running` used to pin this test to an ambient home: its pin
+/// migration took the admission lock under `runtime_root()`, which is
+/// machine-global, so a rooted store was not enough to isolate it. The lock now
+/// lives under the root the store was built from, and the submission, the first
+/// running projection and the rejection of the second all name one home.
 #[test]
 fn mark_running_rejects_live_running_record() {
-    with_isolated_home(|_| {
-        let plan = test_plan();
-        submit_plan(&plan, Some("run-live-owner")).expect("submitted");
-        mark_running("run-live-owner").expect("marked running");
+    let test_context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store = AgentTaskLifecycleStore::new(test_context.path_roots());
+    let plan = test_plan();
+    submit_plan_in_store(&lifecycle_store, &plan, Some("run-live-owner")).expect("submitted");
+    mark_running_in_store(&lifecycle_store, "run-live-owner").expect("marked running");
 
-        let error = mark_running("run-live-owner").expect_err("live run rejected");
+    let error =
+        mark_running_in_store(&lifecycle_store, "run-live-owner").expect_err("live run rejected");
 
-        assert!(error.message.contains("already running"));
-    });
+    assert!(error.message.contains("already running"));
 }
 
 /// Rooted in an explicit store rather than a mutated process environment

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -33,6 +33,15 @@ impl AgentTaskLifecycleStore {
         Self { roots }
     }
 
+    /// The roots this store was built from.
+    ///
+    /// Exposed so operations that reach sibling stores below the same
+    /// installation can derive their roots from this one rather than resolving
+    /// the environment again (#7505).
+    pub fn roots(&self) -> &paths::PathRoots {
+        &self.roots
+    }
+
     /// Construct an explicitly self-contained store from a data root.
     ///
     /// The companion roots live below the supplied root so this constructor

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -1060,8 +1060,16 @@ pub fn migrate_legacy_pin_and_persist(
     runtime: &Value,
     persist: impl FnOnce(&Value) -> Result<()>,
 ) -> Result<Value> {
-    let root = runtime_root()?;
-    let _lock = acquire_admission_lock(&root.join(ADMISSION_LOCK_DIR))?;
+    migrate_legacy_pin_and_persist_in_root(&runtime_root()?, runtime, persist)
+}
+
+/// [`migrate_legacy_pin_and_persist`] under an already-resolved runtime root.
+pub fn migrate_legacy_pin_and_persist_in_root(
+    runtime_root: &Path,
+    runtime: &Value,
+    persist: impl FnOnce(&Value) -> Result<()>,
+) -> Result<Value> {
+    let _lock = acquire_admission_lock(&runtime_root.join(ADMISSION_LOCK_DIR))?;
     let migrated = migrate_legacy_pin_unlocked(runtime)?;
     if &migrated != runtime {
         persist(&migrated)?;
@@ -1143,8 +1151,18 @@ pub fn recover_pin_and_persist(
     source: Option<&Path>,
     persist: impl FnOnce(&Value) -> Result<()>,
 ) -> Result<Value> {
-    let root = runtime_root()?;
-    let _lock = acquire_admission_lock(&root.join(ADMISSION_LOCK_DIR))?;
+    recover_pin_and_persist_in_root(&runtime_root()?, runtime, artifact, source, persist)
+}
+
+/// [`recover_pin_and_persist`] under an already-resolved runtime root.
+pub fn recover_pin_and_persist_in_root(
+    runtime_root: &Path,
+    runtime: &Value,
+    artifact: Option<&Path>,
+    source: Option<&Path>,
+    persist: impl FnOnce(&Value) -> Result<()>,
+) -> Result<Value> {
+    let _lock = acquire_admission_lock(&runtime_root.join(ADMISSION_LOCK_DIR))?;
     let recovered = recover_pin_unlocked(runtime, artifact, source)?;
     persist(&recovered)?;
     Ok(recovered)
@@ -1289,7 +1307,17 @@ fn recover_pin_unlocked(
 }
 
 fn runtime_root() -> Result<PathBuf> {
-    let root = paths::controller_runtimes_store()?;
+    runtime_root_in(&paths::PathRoots::from_environment()?.data().to_path_buf())
+}
+
+/// [`runtime_root`] below an already-resolved data root.
+///
+/// The admission lock this root carries is machine-global when the root is
+/// ambient: two tests marking a run running serialize against each other even
+/// with separate stores. Supplying the root is what makes that lock local to
+/// the caller's installation (#7505).
+pub fn runtime_root_in(data_root: &Path) -> Result<PathBuf> {
+    let root = paths::controller_runtimes_store_in_root(data_root);
     fs::create_dir_all(&root).map_err(|error| {
         Error::internal_io(
             error.to_string(),

--- a/crates/homeboy-paths/src/lib.rs
+++ b/crates/homeboy-paths/src/lib.rs
@@ -303,6 +303,11 @@ pub fn controller_runtimes_store() -> Result<PathBuf> {
     homeboy_data_store(CONTROLLER_RUNTIMES_STORE)
 }
 
+/// Controller runtimes store below an already-resolved data root.
+pub fn controller_runtimes_store_in_root(data_root: &Path) -> PathBuf {
+    homeboy_data_store_in_root(data_root, CONTROLLER_RUNTIMES_STORE)
+}
+
 /// Controller scratch store below an already-resolved data root.
 pub fn controller_scratch_store_in_root(data_root: &Path) -> PathBuf {
     homeboy_data_store_in_root(data_root, CONTROLLER_SCRATCH_STORE)


### PR DESCRIPTION
I set out to collapse the 30 remaining thin ambient delegates. That turned out to be the wrong target, and the codebase told me where the right one was.

## Why the delegate collapse is not the next lever

Of ~68 remaining delegate call sites, **4 are in functions that already hold a store** — and 2 of those are tests. Every other caller would have to resolve a store itself, which *moves* a resolution rather than removing one.

Those delegates are serving as the ambient entry point for one-off CLI commands. That is the legitimate boundary shape, not debt. Converting them would be churn with a net-zero counter.

## What the annotations said instead

`submit_and_persist.rs` carries 18 `Stays on with_isolated_home (#7505)` annotations. `mark_running` is the most-cited blocker, and the annotation is precise:

> `mark_running_in_store` is rooted for its lifecycle reads and writes but still calls `migrate_record_controller_runtime_in_store` first, which resolves `runtime_root()` and takes the **machine-global admission lock**. A run submitted with a stub `{}` admission — the only submission a rooted test can make without reaching that same lock — therefore cannot be marked running at all.

I had assumed those annotations were stale, since `mark_running_in_store` exists. **They were not.** Reading them is what stopped me making a bad change: a store-rooted test still serializes on a lock resolved from an ambient root.

## The fix

```
paths::controller_runtimes_store_in_root
controller_runtime::runtime_root_in
controller_runtime::migrate_legacy_pin_and_persist_in_root
controller_runtime::recover_pin_and_persist_in_root
```

`AgentTaskLifecycleStore` gains `roots()` so the pin migration derives its runtime root from the store it was handed, instead of resolving the environment a second time.

## Proof

`mark_running_rejects_live_running_record` drops `with_isolated_home` for `HermeticTestContext` + an explicit store. It is the first test freed from the `mark_running` family.

<b>CI is the verification here.</b> `cargo check` proves this compiles; it cannot prove the freed test still asserts what it should. That is exactly the class that bit me on #11561, so I am flagging it rather than claiming green.

## Scope

`controller_runtime.rs` has **23 other ambient `runtime_root()` callers**. This roots the pin-migration path the lifecycle depends on — not the module. The remaining three `mark_running`-annotated tests need the same treatment for `store::write_aggregate` and the record-health path.

## Verification

- `nice -n 10 cargo check --workspace --tests -j2` — clean, **0 errors, 0 warnings**
- `cargo fmt --check` — clean

Expect the known red-main set; see the evidence comment on #12772.
