### PR TITLE
fix(cook): finalize reviewed existing candidates

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -749,6 +749,32 @@ fn promote_with_provider_and_checkpoint_internal(
             .as_deref()
             .map(crate::agent_task_promotion::candidate_fingerprint)
             .transpose()?;
+        // An empty provider patch can be a review of a candidate that was
+        // already committed on the declared destination. Retain that immutable
+        // candidate delta so Cook can distinguish it from a base-equal no-op.
+        let verified_base = worktree_path
+            .zip(options.base_ref.as_deref())
+            .map(|(path, base)| capture_declared_base(path, Some(base)))
+            .transpose()?
+            .flatten();
+        let changed_files = verified_base
+            .as_ref()
+            .map(|base| {
+                git_output(
+                    worktree_path.expect("verified base requires a worktree path"),
+                    &["diff", "--name-only", &base.sha, "HEAD"],
+                )
+                .map(|output| {
+                    output
+                        .lines()
+                        .map(str::trim)
+                        .filter(|path| !path.is_empty())
+                        .map(str::to_string)
+                        .collect()
+                })
+            })
+            .transpose()?
+            .unwrap_or_default();
 
         return Ok(AgentTaskPromotionReport {
             schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
@@ -762,11 +788,11 @@ fn promote_with_provider_and_checkpoint_internal(
                 path: patch_path.display().to_string(),
                 sha256: artifact.sha256,
             },
-            changed_files: Vec::new(),
+            changed_files,
             command_evidence: Vec::new(),
             deterministic_gates: gates.deterministic_gates,
             gate_results: gates.gate_results,
-            verified_base: None,
+            verified_base,
             provenance: json!({
                 "source_schema": outcome.schema,
                 "artifact_metadata": artifact.metadata,

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
@@ -251,16 +251,24 @@ fn normalize_promotion_patch_strips_lab_sandbox_workspace_prefix() {
 }
 
 #[test]
-fn empty_patch_runs_public_and_private_gates_against_destination() {
+fn empty_patch_records_declared_base_candidate_delta_before_running_gates() {
     let temp = tempfile::tempdir().expect("tempdir");
     let repo = temp.path().join("repo");
     std::fs::create_dir(&repo).expect("create repo");
     git(&repo, &["init"]);
     git(&repo, &["config", "user.email", "homeboy@example.test"]);
     git(&repo, &["config", "user.name", "Homeboy Test"]);
-    std::fs::write(repo.join("lib.rs"), "candidate\n").expect("write candidate");
+    git(&repo, &["checkout", "-b", "main"]);
+    std::fs::write(repo.join("lib.rs"), "base\n").expect("write base");
     git(&repo, &["add", "lib.rs"]);
-    git(&repo, &["commit", "-m", "candidate"]);
+    git(&repo, &["commit", "-m", "base"]);
+    git(
+        &repo,
+        &["remote", "add", "origin", repo.to_str().expect("repo path")],
+    );
+    git(&repo, &["checkout", "-b", "fix/candidate"]);
+    std::fs::write(repo.join("lib.rs"), "candidate\n").expect("write candidate");
+    git(&repo, &["commit", "-am", "candidate"]);
     let revision = git_head(&repo, "HEAD");
     let (source_path, source) = write_empty_patch_source(&temp);
     let mut provider = FakePromotionWorkspaceProvider {
@@ -274,8 +282,10 @@ fn empty_patch_runs_public_and_private_gates_against_destination() {
             source_run_id: Some("run-empty".to_string()),
             source_path: Some(source_path),
             source_worktree_path: Some(repo.clone()),
-            base_ref: None,
-            task_base_sha: None,
+            base_ref: Some("main".to_string()),
+            // Cook's inspected revision can equal the existing candidate. The
+            // declared base remains the publication authority.
+            task_base_sha: Some(revision.clone()),
             candidate_ref: None,
             to_worktree: "repo@candidate".to_string(),
             task_id: None,
@@ -297,6 +307,15 @@ fn empty_patch_runs_public_and_private_gates_against_destination() {
     assert_eq!(report.status, AgentTaskPromotionStatus::VerifiedNoChanges);
     assert_eq!(report.target.head.as_deref(), Some(revision.as_str()));
     assert_eq!(report.provenance["verified_revision"], revision);
+    assert_eq!(report.changed_files, ["lib.rs"]);
+    assert_eq!(
+        report
+            .verified_base
+            .as_ref()
+            .expect("declared base is retained")
+            .base,
+        "main"
+    );
     assert_eq!(provider.apply_calls.len(), 0);
     assert_eq!(provider.verify_calls.len(), 2);
     assert_eq!(provider.verify_calls[0].0, repo);

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -5699,6 +5699,55 @@ fn run_cook_spine(
                 let declaration = feedback
                     .intentional_no_change
                     .expect("intentional no-change feedback carries its declaration");
+                if !options.no_finalize && !promotion.changed_files.is_empty() {
+                    report_cook_progress(
+                        lifecycle_store,
+                        durable_observer,
+                        &cook_id,
+                        &run_id,
+                        "finalization",
+                        attempt,
+                        Some(
+                            "verified intentional no-change review accepted an existing candidate",
+                        ),
+                    )?;
+                    let finalization =
+                        side_effects.finalize(lifecycle_store, &options, &run_id, &promotion)?;
+                    let final_status = finalization["status"]
+                        .as_str()
+                        .unwrap_or("unknown")
+                        .to_string();
+                    let mut report = cook_report(CookReportInput {
+                        cook_id,
+                        status: if matches!(
+                            final_status.as_str(),
+                            "review_ready" | "draft_published"
+                        ) {
+                            "intentional_no_change_finalized_existing_candidate"
+                        } else {
+                            &final_status
+                        },
+                        disposition: CookDisposition::Terminal,
+                        attempts,
+                        finalization: Some(finalization),
+                        stop_reason: None,
+                        exit_code: if matches!(
+                            final_status.as_str(),
+                            "review_ready" | "draft_published"
+                        ) {
+                            0
+                        } else {
+                            1
+                        },
+                        invocation_latest_run_id: Some(&run_id),
+                    });
+                    report.value.intentional_no_change =
+                        Some(AgentTaskCookIntentionalNoChangeReport {
+                            declaration,
+                            review_form,
+                        });
+                    return Ok(report);
+                }
                 let mut report = cook_report(CookReportInput {
                     cook_id,
                     status: "intentional_no_change",


### PR DESCRIPTION
## Summary

- retain the declared-base delta for an empty-patch provider review when the inspected revision is an existing committed candidate
- finalize that candidate through Cook's existing exactly-once publication path after a verified intentional-no-change review
- retain the ordinary base-equal intentional no-change outcome without publication

Closes #12832.

## Test evidence

- `cargo test -p homeboy-agents --lib agent_task_promotion::tests::part_d`
- `cargo test -p homeboy-agents --lib agent_task_cook_loop::tests -- --nocapture`
- `cargo check -p homeboy-agents`
- `cargo fmt --check`

## AI assistance

OpenAI openai/gpt-5.6-sol via OpenCode general coding subagent implemented and verified this change; Chris Huber directed and remains responsible for the change.