### PR TITLE
fix: recover verified no-change cooks

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -595,10 +595,14 @@ fn validate_gate_proof_binding(
     options: &AgentTaskPrFinalizationOptions,
 ) -> Result<()> {
     use crate::agent_task_promotion::AgentTaskPromotionStatus;
-    if gate_proof.promotion.status != AgentTaskPromotionStatus::Applied {
+    if gate_proof.promotion.status != AgentTaskPromotionStatus::Applied
+        && !(gate_proof.promotion.status == AgentTaskPromotionStatus::VerifiedNoChanges
+            && !gate_proof.promotion.changed_files.is_empty()
+            && gate_proof.promotion.finalization_eligible(false))
+    {
         return Err(Error::validation_invalid_argument(
             "run_id",
-            "durable gate proof must record an applied promotion",
+            "durable gate proof must record an applied promotion or a verified existing-candidate delta",
             None,
             None,
         ));

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -749,6 +749,32 @@ fn promote_with_provider_and_checkpoint_internal(
             .as_deref()
             .map(crate::agent_task_promotion::candidate_fingerprint)
             .transpose()?;
+        // An empty provider patch can be a review of a candidate that was
+        // already committed on the declared destination. Retain that immutable
+        // candidate delta so Cook can distinguish it from a base-equal no-op.
+        let verified_base = worktree_path
+            .zip(options.base_ref.as_deref())
+            .map(|(path, base)| capture_declared_base(path, Some(base)))
+            .transpose()?
+            .flatten();
+        let changed_files = verified_base
+            .as_ref()
+            .map(|base| {
+                git_output(
+                    worktree_path.expect("verified base requires a worktree path"),
+                    &["diff", "--name-only", &base.sha, "HEAD"],
+                )
+                .map(|output| {
+                    output
+                        .lines()
+                        .map(str::trim)
+                        .filter(|path| !path.is_empty())
+                        .map(str::to_string)
+                        .collect()
+                })
+            })
+            .transpose()?
+            .unwrap_or_default();
 
         return Ok(AgentTaskPromotionReport {
             schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
@@ -762,11 +788,11 @@ fn promote_with_provider_and_checkpoint_internal(
                 path: patch_path.display().to_string(),
                 sha256: artifact.sha256,
             },
-            changed_files: Vec::new(),
+            changed_files,
             command_evidence: Vec::new(),
             deterministic_gates: gates.deterministic_gates,
             gate_results: gates.gate_results,
-            verified_base: None,
+            verified_base,
             provenance: json!({
                 "source_schema": outcome.schema,
                 "artifact_metadata": artifact.metadata,

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
@@ -251,16 +251,24 @@ fn normalize_promotion_patch_strips_lab_sandbox_workspace_prefix() {
 }
 
 #[test]
-fn empty_patch_runs_public_and_private_gates_against_destination() {
+fn empty_patch_records_declared_base_candidate_delta_before_running_gates() {
     let temp = tempfile::tempdir().expect("tempdir");
     let repo = temp.path().join("repo");
     std::fs::create_dir(&repo).expect("create repo");
     git(&repo, &["init"]);
     git(&repo, &["config", "user.email", "homeboy@example.test"]);
     git(&repo, &["config", "user.name", "Homeboy Test"]);
-    std::fs::write(repo.join("lib.rs"), "candidate\n").expect("write candidate");
+    git(&repo, &["checkout", "-b", "main"]);
+    std::fs::write(repo.join("lib.rs"), "base\n").expect("write base");
     git(&repo, &["add", "lib.rs"]);
-    git(&repo, &["commit", "-m", "candidate"]);
+    git(&repo, &["commit", "-m", "base"]);
+    git(
+        &repo,
+        &["remote", "add", "origin", repo.to_str().expect("repo path")],
+    );
+    git(&repo, &["checkout", "-b", "fix/candidate"]);
+    std::fs::write(repo.join("lib.rs"), "candidate\n").expect("write candidate");
+    git(&repo, &["commit", "-am", "candidate"]);
     let revision = git_head(&repo, "HEAD");
     let (source_path, source) = write_empty_patch_source(&temp);
     let mut provider = FakePromotionWorkspaceProvider {
@@ -274,8 +282,10 @@ fn empty_patch_runs_public_and_private_gates_against_destination() {
             source_run_id: Some("run-empty".to_string()),
             source_path: Some(source_path),
             source_worktree_path: Some(repo.clone()),
-            base_ref: None,
-            task_base_sha: None,
+            base_ref: Some("main".to_string()),
+            // Cook's inspected revision can equal the existing candidate. The
+            // declared base remains the publication authority.
+            task_base_sha: Some(revision.clone()),
             candidate_ref: None,
             to_worktree: "repo@candidate".to_string(),
             task_id: None,
@@ -297,6 +307,15 @@ fn empty_patch_runs_public_and_private_gates_against_destination() {
     assert_eq!(report.status, AgentTaskPromotionStatus::VerifiedNoChanges);
     assert_eq!(report.target.head.as_deref(), Some(revision.as_str()));
     assert_eq!(report.provenance["verified_revision"], revision);
+    assert_eq!(report.changed_files, ["lib.rs"]);
+    assert_eq!(
+        report
+            .verified_base
+            .as_ref()
+            .expect("declared base is retained")
+            .base,
+        "main"
+    );
     assert_eq!(provider.apply_calls.len(), 0);
     assert_eq!(provider.verify_calls.len(), 2);
     assert_eq!(provider.verify_calls[0].0, repo);

--- a/crates/homeboy-agents/src/agent_task_promotion/types.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/types.rs
@@ -150,13 +150,15 @@ impl AgentTaskPromotionReport {
     /// A reviewer-visible command needs a durable passing gate for this exact
     /// command and immutable candidate. Status-only evidence never qualifies.
     pub fn has_visible_passed_gate_for_command(&self, command: &str) -> bool {
-        self.gate_outcome().status == AgentTaskPromotionStatus::Applied
-            && self.deterministic_gates.iter().any(|gate| {
-                gate.visibility == HomeboyGateVisibility::Visible
-                    && gate.command.as_slice() == ["sh", "-lc", command]
-                    && durable_gate_passed(gate)
-                    && self.gate_candidate_identity_matches(gate)
-            })
+        matches!(
+            self.gate_outcome().status,
+            AgentTaskPromotionStatus::Applied | AgentTaskPromotionStatus::VerifiedNoChanges
+        ) && self.deterministic_gates.iter().any(|gate| {
+            gate.visibility == HomeboyGateVisibility::Visible
+                && gate.command.as_slice() == ["sh", "-lc", command]
+                && durable_gate_passed(gate)
+                && self.gate_candidate_identity_matches(gate)
+        })
     }
 
     fn gate_candidate_identity_matches(&self, gate: &AgentTaskGateReport) -> bool {

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -245,7 +245,7 @@ fn pre_artifact_interruption_phase(
     }
 }
 
-fn intentional_no_change_from_aggregate(
+pub(crate) fn intentional_no_change_from_aggregate(
     aggregate: &crate::agent_task_scheduler::AgentTaskAggregate,
 ) -> Option<AgentTaskIntentionalNoChange> {
     aggregate.outcomes.iter().find_map(|outcome| {

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -5699,6 +5699,55 @@ fn run_cook_spine(
                 let declaration = feedback
                     .intentional_no_change
                     .expect("intentional no-change feedback carries its declaration");
+                if !options.no_finalize && !promotion.changed_files.is_empty() {
+                    report_cook_progress(
+                        lifecycle_store,
+                        durable_observer,
+                        &cook_id,
+                        &run_id,
+                        "finalization",
+                        attempt,
+                        Some(
+                            "verified intentional no-change review accepted an existing candidate",
+                        ),
+                    )?;
+                    let finalization =
+                        side_effects.finalize(lifecycle_store, &options, &run_id, &promotion)?;
+                    let final_status = finalization["status"]
+                        .as_str()
+                        .unwrap_or("unknown")
+                        .to_string();
+                    let mut report = cook_report(CookReportInput {
+                        cook_id,
+                        status: if matches!(
+                            final_status.as_str(),
+                            "review_ready" | "draft_published"
+                        ) {
+                            "intentional_no_change_finalized_existing_candidate"
+                        } else {
+                            &final_status
+                        },
+                        disposition: CookDisposition::Terminal,
+                        attempts,
+                        finalization: Some(finalization),
+                        stop_reason: None,
+                        exit_code: if matches!(
+                            final_status.as_str(),
+                            "review_ready" | "draft_published"
+                        ) {
+                            0
+                        } else {
+                            1
+                        },
+                        invocation_latest_run_id: Some(&run_id),
+                    });
+                    report.value.intentional_no_change =
+                        Some(AgentTaskCookIntentionalNoChangeReport {
+                            declaration,
+                            review_form,
+                        });
+                    return Ok(report);
+                }
                 let mut report = cook_report(CookReportInput {
                     cook_id,
                     status: "intentional_no_change",

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -2300,8 +2300,13 @@ pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
             )
         })?
     };
-    if let Some(receipt) = recover_verified_no_change_finalization(&recipe, &run_id)? {
-        return Ok(receipt);
+    if persisted_promotion_for_attempt(&run_id)?.is_some_and(|promotion| {
+        promotion.status == AgentTaskPromotionStatus::VerifiedNoChanges
+            && promotion.changed_files.is_empty()
+    }) {
+        if let Some(receipt) = recover_verified_no_change_finalization(&recipe, &run_id)? {
+            return Ok(receipt);
+        }
     }
     let promotion = persisted_promotion_for_attempt(&run_id)?.ok_or_else(|| {
         Error::validation_invalid_argument(
@@ -2317,12 +2322,15 @@ pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     // accept_inherited_failures rather than requiring a green-gate Applied.
     let recovery_outcome = promotion.gate_outcome();
     if recovery_outcome.status != AgentTaskPromotionStatus::Applied
+        && !(recovery_outcome.status == AgentTaskPromotionStatus::VerifiedNoChanges
+            && !promotion.changed_files.is_empty()
+            && promotion.finalization_eligible(options.gates.accept_inherited_failures))
         && !(recovery_outcome.status == AgentTaskPromotionStatus::GateFailed
             && promotion.finalization_eligible(options.gates.accept_inherited_failures))
     {
         return Err(Error::validation_invalid_argument(
             "latest_promotion.status",
-            "recovery requires an applied promotion with green gates or an explicitly accepted inherited baseline failure",
+            "recovery requires an applied promotion, a verified existing-candidate delta, or an explicitly accepted inherited baseline failure",
             Some(run_id),
             None,
         ));
@@ -2369,7 +2377,7 @@ fn recover_verified_no_change_finalization(
         )
     })?;
     let options = super::cook_recipe::reconstruct_adoption_options(recipe)?;
-    let verified_base = promotion
+    let _verified_base = promotion
         .verified_base
         .as_ref()
         .filter(|base| base.base == options.base && !base.sha.trim().is_empty())
@@ -2401,6 +2409,14 @@ fn recover_verified_no_change_finalization(
                 None,
             )
         })?;
+    if selection["selected_task_id"].as_str() != Some(promotion.source.task_id.as_str()) {
+        return Err(Error::validation_invalid_argument(
+            "latest_promotion.source.task_id",
+            "verified no-change recovery requires the promotion source task to match the Cook-bound candidate",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
     let expected: AgentTaskPromotionCandidate = serde_json::from_value(
         promotion
             .provenance
@@ -2437,10 +2453,10 @@ fn recover_verified_no_change_finalization(
             )
         })?;
     let actual = candidate_fingerprint(path)?;
-    if !verified_no_change_candidate_is_valid(&expected, &actual, &verified_base.sha) {
+    if !verified_no_change_candidate_is_valid(&expected, &actual) {
         return Err(Error::validation_invalid_argument(
             "path",
-            "verified no-change recovery requires the exact clean, non-base candidate checked by deterministic gates",
+            "verified no-change recovery requires the exact clean candidate checked by deterministic gates",
             Some(path.to_string()),
             None,
         ));
@@ -2463,14 +2479,11 @@ fn recover_verified_no_change_finalization(
 fn verified_no_change_candidate_is_valid(
     expected: &AgentTaskPromotionCandidate,
     actual: &AgentTaskPromotionCandidate,
-    verified_base_sha: &str,
 ) -> bool {
     let AgentTaskPromotionCandidate::Git { fingerprint } = expected else {
         return false;
     };
-    expected == actual
-        && fingerprint.changed_files.is_empty()
-        && fingerprint.head != verified_base_sha
+    expected == actual && fingerprint.changed_files.is_empty()
 }
 
 #[cfg(test)]
@@ -2494,36 +2507,24 @@ mod no_change_recovery_tests {
     }
 
     #[test]
-    fn verified_no_change_candidate_requires_exact_clean_non_base_binding() {
+    fn verified_no_change_candidate_requires_exact_clean_binding() {
         let bound = candidate("candidate-head", &[]);
-        assert!(verified_no_change_candidate_is_valid(
-            &bound,
-            &bound,
-            "verified-base"
-        ));
+        assert!(verified_no_change_candidate_is_valid(&bound, &bound,));
 
         assert!(!verified_no_change_candidate_is_valid(
-            &candidate("verified-base", &[]),
-            &candidate("verified-base", &[]),
-            "verified-base"
-        ));
-        assert!(!verified_no_change_candidate_is_valid(
             &candidate("candidate-head", &["dirty.rs"]),
-            &candidate("candidate-head", &["dirty.rs"]),
-            "verified-base"
+            &candidate("candidate-head", &["dirty.rs"])
         ));
         assert!(!verified_no_change_candidate_is_valid(
             &bound,
-            &candidate("different-head", &[]),
-            "verified-base"
+            &candidate("different-head", &[])
         ));
         assert!(!verified_no_change_candidate_is_valid(
             &candidate("candidate-head", &[]),
             &serde_json::from_value(
                 json!({ "kind": "non_git", "disposition": "not_a_git_worktree" })
             )
-            .expect("unbound candidate fixture"),
-            "verified-base"
+            .expect("unbound candidate fixture")
         ));
     }
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -28,8 +28,8 @@ use crate::agent_task_promotion::{
     candidate_fingerprint, canonical_recoverable_patch_artifacts,
     canonical_recoverable_patch_artifacts_in_observation_store,
     promote_with_checkpoint_in_observation_store, resume_promoted_patch_in_observation_store,
-    resume_promoted_patch_replacement_gates_in_observation_store, AgentTaskPromotionOptions,
-    AgentTaskPromotionReport, AgentTaskPromotionStatus,
+    resume_promoted_patch_replacement_gates_in_observation_store, AgentTaskPromotionCandidate,
+    AgentTaskPromotionOptions, AgentTaskPromotionReport, AgentTaskPromotionStatus,
 };
 use crate::agent_task_review_dossier::{
     resolve_review_profile, AgentTaskReviewAiAssistance, AgentTaskReviewDossier,
@@ -2300,6 +2300,9 @@ pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
             )
         })?
     };
+    if let Some(receipt) = recover_verified_no_change_finalization(&recipe, &run_id)? {
+        return Ok(receipt);
+    }
     let promotion = persisted_promotion_for_attempt(&run_id)?.ok_or_else(|| {
         Error::validation_invalid_argument(
             "latest_promotion",
@@ -2341,6 +2344,188 @@ pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
         agent_task_lifecycle::record_cook_finalization(&run_id, value.clone())?;
     }
     Ok(value)
+}
+
+/// Finalize a verified no-change Cook without routing it through patch publication.
+/// The candidate is still re-read exactly: a no-change declaration authorizes no
+/// publication only for the clean, bound candidate that deterministic gates checked.
+fn recover_verified_no_change_finalization(
+    recipe: &super::cook_recipe::AgentTaskCookRecipe,
+    run_id: &str,
+) -> Result<Option<Value>> {
+    let Some(promotion) = persisted_promotion_for_attempt(run_id)? else {
+        return Ok(None);
+    };
+    if promotion.status != AgentTaskPromotionStatus::VerifiedNoChanges {
+        return Ok(None);
+    }
+    let aggregate = agent_task_lifecycle::read_attempt_aggregate(run_id)?;
+    let declaration = super::cook::intentional_no_change_from_aggregate(&aggregate).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "intentional_no_change",
+            "verified no-change recovery requires the attempt's durable intentional-no-change declaration",
+            Some(run_id.to_string()),
+            None,
+        )
+    })?;
+    let options = super::cook_recipe::reconstruct_adoption_options(recipe)?;
+    let verified_base = promotion
+        .verified_base
+        .as_ref()
+        .filter(|base| base.base == options.base && !base.sha.trim().is_empty())
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "promotion.verified_base",
+                "verified no-change recovery requires the Cook's declared immutable base snapshot",
+                Some(run_id.to_string()),
+                None,
+            )
+        })?;
+    if !promotion.finalization_eligible(false) {
+        return Err(Error::validation_invalid_argument(
+            "latest_promotion",
+            "verified no-change recovery requires green deterministic gates",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+    let selection = canonical_cook_candidate(&recipe.cook_id)
+        .filter(|candidate| {
+            candidate["incomplete"] != true && candidate["run_id"].as_str() == Some(run_id)
+        })
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "run_or_cook_id",
+                "verified no-change recovery requires the exact Cook-bound candidate",
+                Some(run_id.to_string()),
+                None,
+            )
+        })?;
+    let expected: AgentTaskPromotionCandidate = serde_json::from_value(
+        promotion
+            .provenance
+            .get("candidate")
+            .cloned()
+            .unwrap_or(Value::Null),
+    )
+    .map_err(|_| {
+        Error::validation_invalid_argument(
+            "latest_promotion.provenance.candidate",
+            "verified no-change recovery requires a durable Git candidate fingerprint",
+            Some(run_id.to_string()),
+            None,
+        )
+    })?;
+    let AgentTaskPromotionCandidate::Git { .. } = &expected else {
+        return Err(Error::validation_invalid_argument(
+            "latest_promotion.provenance.candidate",
+            "verified no-change recovery requires a durable Git candidate fingerprint",
+            Some(run_id.to_string()),
+            None,
+        ));
+    };
+    let path = promotion
+        .provenance
+        .pointer("/worktree_path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "latest_promotion.provenance.worktree_path",
+                "verified no-change recovery requires the verified candidate worktree path",
+                Some(run_id.to_string()),
+                None,
+            )
+        })?;
+    let actual = candidate_fingerprint(path)?;
+    if !verified_no_change_candidate_is_valid(&expected, &actual, &verified_base.sha) {
+        return Err(Error::validation_invalid_argument(
+            "path",
+            "verified no-change recovery requires the exact clean, non-base candidate checked by deterministic gates",
+            Some(path.to_string()),
+            None,
+        ));
+    }
+    let receipt = json!({
+        "schema": "homeboy/agent-task-cook-no-change-finalization/v1",
+        "run_id": run_id,
+        "status": "intentional_no_change_finalized",
+        "disposition": "no_change_finalized",
+        "publication": { "action": "none", "committed": false, "pushed": false, "published": false },
+        "source_attempt": { "cook_id": recipe.cook_id, "run_id": run_id, "candidate": selection },
+        "intentional_no_change": declaration,
+        "gate_results": promotion.gate_outcome().gate_results,
+    });
+    // A completed receipt makes recovery idempotent without inventing a patch publication.
+    agent_task_lifecycle::record_cook_finalization(run_id, receipt.clone())?;
+    Ok(Some(receipt))
+}
+
+fn verified_no_change_candidate_is_valid(
+    expected: &AgentTaskPromotionCandidate,
+    actual: &AgentTaskPromotionCandidate,
+    verified_base_sha: &str,
+) -> bool {
+    let AgentTaskPromotionCandidate::Git { fingerprint } = expected else {
+        return false;
+    };
+    expected == actual
+        && fingerprint.changed_files.is_empty()
+        && fingerprint.head != verified_base_sha
+}
+
+#[cfg(test)]
+mod no_change_recovery_tests {
+    use super::*;
+
+    fn candidate(head: &str, changed_files: &[&str]) -> AgentTaskPromotionCandidate {
+        serde_json::from_value(json!({
+            "kind": "git",
+            "fingerprint": {
+                "schema": "homeboy/agent-task-candidate-fingerprint/v1",
+                "target_path": "/fixture",
+                "head": head,
+                "base": "parent-head",
+                "sha256": "candidate-sha",
+                "tree": "candidate-tree",
+                "changed_files": changed_files
+            }
+        }))
+        .expect("candidate fixture")
+    }
+
+    #[test]
+    fn verified_no_change_candidate_requires_exact_clean_non_base_binding() {
+        let bound = candidate("candidate-head", &[]);
+        assert!(verified_no_change_candidate_is_valid(
+            &bound,
+            &bound,
+            "verified-base"
+        ));
+
+        assert!(!verified_no_change_candidate_is_valid(
+            &candidate("verified-base", &[]),
+            &candidate("verified-base", &[]),
+            "verified-base"
+        ));
+        assert!(!verified_no_change_candidate_is_valid(
+            &candidate("candidate-head", &["dirty.rs"]),
+            &candidate("candidate-head", &["dirty.rs"]),
+            "verified-base"
+        ));
+        assert!(!verified_no_change_candidate_is_valid(
+            &bound,
+            &candidate("different-head", &[]),
+            "verified-base"
+        ));
+        assert!(!verified_no_change_candidate_is_valid(
+            &candidate("candidate-head", &[]),
+            &serde_json::from_value(
+                json!({ "kind": "non_git", "disposition": "not_a_git_worktree" })
+            )
+            .expect("unbound candidate fixture"),
+            "verified-base"
+        ));
+    }
 }
 
 pub(crate) fn canonical_cook_recovery_run_id(cook_id: &str) -> Option<String> {
@@ -2450,6 +2635,9 @@ fn completed_finalization_receipt_for_recovery(
         let Some(value) = record.metadata.get("cook_finalization") else {
             continue;
         };
+        if value["status"].as_str() == Some("intentional_no_change_finalized") {
+            return Ok(Some(value.clone()));
+        }
         if !matches!(
             value["status"].as_str(),
             Some("review_ready" | "draft_published")

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -13115,6 +13115,120 @@ fn standalone_manual_preflight_continuation_recovers_and_is_idempotent() {
 }
 
 #[test]
+fn verified_existing_candidate_no_change_recovery_finalizes_once() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-12836-existing-candidate";
+        let run_id = "cook-12836-existing-candidate-attempt-1";
+        let target = tempfile::tempdir().expect("candidate repository");
+        for args in [
+            vec!["init", "-b", "main"],
+            vec!["config", "user.email", "test@example.com"],
+            vec!["config", "user.name", "Test"],
+        ] {
+            assert!(Command::new("git")
+                .args(args)
+                .current_dir(target.path())
+                .status()
+                .unwrap()
+                .success());
+        }
+        std::fs::write(target.path().join("lib.rs"), "base\n").unwrap();
+        assert!(Command::new("git")
+            .args(["add", "lib.rs"])
+            .current_dir(target.path())
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args(["commit", "-m", "base"])
+            .current_dir(target.path())
+            .status()
+            .unwrap()
+            .success());
+        let base = String::from_utf8(
+            Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .current_dir(target.path())
+                .output()
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+        std::fs::write(target.path().join("lib.rs"), "candidate\n").unwrap();
+        assert!(Command::new("git")
+            .args(["commit", "-am", "candidate"])
+            .current_dir(target.path())
+            .status()
+            .unwrap()
+            .success());
+
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = run_id.to_string();
+        options.to_worktree = target.path().display().to_string();
+        options.initial_plan.tasks[0].executor.model = Some("fixture-model".to_string());
+        persist_initial_recipe(&options).expect("persist recipe");
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id)).expect("submit run");
+        agent_task_lifecycle::record_cook_attempt(cook_id, 1, run_id).expect("record Cook attempt");
+        let patch = target.path().join("candidate.patch");
+        seed_substantive_candidate_aggregate(run_id, &options.initial_plan, &patch, "candidate\n");
+        let mut aggregate =
+            agent_task_lifecycle::read_attempt_aggregate(run_id).expect("read aggregate");
+        aggregate.outcomes[0].outputs = serde_json::json!({
+            "review_form": test_review_form(),
+            "provider_run_result": { "intentional_no_change": {
+                "schema": "homeboy/agent-task-intentional-no-change/v1",
+                "verdict": "already_satisfied",
+                "inspected_revision": "candidate",
+                "source_evidence": ["fixture"]
+            }}
+        });
+        agent_task_lifecycle::record_run_aggregate(run_id, &options.initial_plan, &aggregate)
+            .expect("persist intentional no-change aggregate");
+        let mut promotion = promotion_with_existing_path(run_id, target.path());
+        promotion.status = AgentTaskPromotionStatus::VerifiedNoChanges;
+        promotion.changed_files = vec!["lib.rs".to_string()];
+        promotion.verified_base = Some(
+            crate::agent_task_promotion::AgentTaskPromotionVerifiedBase {
+                base: options.base.clone(),
+                sha: base,
+            },
+        );
+        promotion.provenance["candidate"] = serde_json::to_value(
+            crate::agent_task_promotion::candidate_fingerprint(target.path().to_str().unwrap())
+                .expect("candidate fingerprint"),
+        )
+        .unwrap();
+        agent_task_lifecycle::record_promotion(run_id, serde_json::to_value(&promotion).unwrap())
+            .expect("persist verified existing candidate");
+
+        let mut backend = CaptureBackend {
+            candidate_state: Some(
+                crate::agent_task_finalization::AgentTaskPrCandidateState::Committed {
+                    changed_files: vec!["lib.rs".to_string()],
+                    push_required: false,
+                },
+            ),
+            synthetic_gate_proof: Some(promotion),
+            ..Default::default()
+        };
+        let recovered = recover_cook_pr_with_backend(run_id, Vec::new(), false, &mut backend)
+            .expect("recover publishes the verified existing candidate");
+        assert_eq!(recovered["status"], "review_ready");
+        assert!(backend.created);
+
+        let mut repeated = CaptureBackend::default();
+        assert_eq!(
+            recover_cook_pr_with_backend(run_id, Vec::new(), false, &mut repeated)
+                .expect("recovery is exactly once"),
+            recovered
+        );
+        assert!(!repeated.created);
+    });
+}
+
+#[test]
 fn manual_preflight_intent_does_not_block_normal_cook_finalization() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let cook_id = "cook-10980-normal";


### PR DESCRIPTION
## Summary
- recover empty verified intentional-no-change outcomes with an explicit no-change-finalized receipt
- route a verified intentional-no-change outcome with a retained declared-base candidate delta through exact-once PR finalization
- require green durable gates and the exact candidate binding in both routes

Closes #12836

## Dependency and Merge Order
This PR includes `0df0dea59` from #12855. Merge #12855 first, then #12856. #12855 retains the declared-base delta for reviewed existing candidates; this PR recovers that delta through finalization after interruption.

## Tests
- `cargo fmt --check`
- `cargo check -p homeboy-agents`
- `cargo test -p homeboy-agents verified_existing_candidate_no_change_recovery_finalizes_once --lib`
- `cargo test -p homeboy-agents verified_no_change_candidate_requires_exact_clean_binding --lib`
- `cargo test -p homeboy-agents --lib agent_task_promotion::tests::part_d`

## AI Assistance
OpenAI openai/gpt-5.6-sol via OpenCode general coding subagent implemented and verified this change; Chris Huber directed and remains responsible for the change.

## Remediation AI Assistance
OpenAI openai/gpt-5.6-sol via OpenCode general coding subagent implemented and verified this remediation; Chris Huber directed and remains responsible for the change.