### PR TITLE
Fix merge candidate adoption after base advancement

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization/backend.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/backend.rs
@@ -728,10 +728,23 @@ fn validate_adoption_merge_proof(
     expected: &AgentTaskPromotionCandidate,
     adoption_merge: Option<&serde_json::Value>,
 ) -> Result<()> {
-    let Some(proof) = adoption_merge.filter(|proof| !proof.is_null()) else {
+    let AgentTaskPromotionCandidate::Git { fingerprint } = expected else {
         return Ok(());
     };
-    let AgentTaskPromotionCandidate::Git { fingerprint } = expected else {
+    let parents = git_output(
+        &options.path,
+        &["rev-list", "--parents", "-n", "1", &fingerprint.head],
+    )?;
+    let parents = parents.split_whitespace().skip(1).collect::<Vec<_>>();
+    let Some(proof) = adoption_merge.filter(|proof| !proof.is_null()) else {
+        if parents.len() == 2 {
+            return Err(Error::validation_invalid_argument(
+                "run_id",
+                "two-parent promoted candidate is missing its required adoption merge proof",
+                None,
+                None,
+            ));
+        }
         return Ok(());
     };
     let field = |name| {
@@ -760,15 +773,22 @@ fn validate_adoption_merge_proof(
             None,
         ));
     }
-    let parents = git_output(
-        &options.path,
-        &["rev-list", "--parents", "-n", "1", candidate],
-    )?;
-    let parents = parents.split_whitespace().skip(1).collect::<Vec<_>>();
     if parents.as_slice() != [candidate_parent, resolved_base_parent] {
         return Err(Error::validation_invalid_argument(
             "run_id",
             "adoption merge proof parents do not match the promoted merge candidate",
+            None,
+            None,
+        ));
+    }
+    let actual_candidate_tree = git_output(
+        &options.path,
+        &["rev-parse", &format!("{candidate}^{{tree}}")],
+    )?;
+    if actual_candidate_tree != candidate_tree {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            "adoption merge proof candidate tree does not match the promoted merge candidate",
             None,
             None,
         ));

--- a/crates/homeboy-agents/src/agent_task_finalization/backend.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/backend.rs
@@ -713,7 +713,79 @@ fn validate_real_candidate_fingerprint_from_record(
             &promotion.changed_files,
         ));
     }
+    validate_adoption_merge_proof(
+        options,
+        &expected,
+        promotion.provenance.get("adoption_merge"),
+    )?;
     validate_candidate_fingerprint(options, &expected)
+}
+
+/// Adoption records the authenticated parent roles separately because a merge
+/// candidate's first-parent fingerprint alone cannot prove which base it merged.
+fn validate_adoption_merge_proof(
+    options: &AgentTaskPrFinalizationOptions,
+    expected: &AgentTaskPromotionCandidate,
+    adoption_merge: Option<&serde_json::Value>,
+) -> Result<()> {
+    let Some(proof) = adoption_merge.filter(|proof| !proof.is_null()) else {
+        return Ok(());
+    };
+    let AgentTaskPromotionCandidate::Git { fingerprint } = expected else {
+        return Ok(());
+    };
+    let field = |name| {
+        proof
+            .get(name)
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "run_id",
+                    format!("adoption merge proof is missing `{name}`"),
+                    None,
+                    None,
+                )
+            })
+    };
+    let candidate = field("candidate")?;
+    let candidate_parent = field("candidate_parent")?;
+    let resolved_base_parent = field("resolved_base_parent")?;
+    let candidate_tree = field("candidate_tree")?;
+    let resolved_base_tree = field("resolved_base_tree")?;
+    if candidate != fingerprint.head || candidate_tree != fingerprint.tree {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            "adoption merge proof does not match the exact promoted candidate SHA and tree",
+            None,
+            None,
+        ));
+    }
+    let parents = git_output(
+        &options.path,
+        &["rev-list", "--parents", "-n", "1", candidate],
+    )?;
+    let parents = parents.split_whitespace().skip(1).collect::<Vec<_>>();
+    if parents.as_slice() != [candidate_parent, resolved_base_parent] {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            "adoption merge proof parents do not match the promoted merge candidate",
+            None,
+            None,
+        ));
+    }
+    let actual_base_tree = git_output(
+        &options.path,
+        &["rev-parse", &format!("{resolved_base_parent}^{{tree}}")],
+    )?;
+    if actual_base_tree != resolved_base_tree {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            "adoption merge proof resolved-base tree does not match its recorded parent",
+            None,
+            None,
+        ));
+    }
+    Ok(())
 }
 
 pub(super) fn validate_candidate_fingerprint(

--- a/crates/homeboy-agents/src/agent_task_finalization/backend.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/backend.rs
@@ -736,6 +736,14 @@ fn validate_adoption_merge_proof(
         &["rev-list", "--parents", "-n", "1", &fingerprint.head],
     )?;
     let parents = parents.split_whitespace().skip(1).collect::<Vec<_>>();
+    if parents.len() > 2 {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            "promoted candidate has more than two parents; finalization accepts only one-parent candidates or authenticated two-parent merges",
+            None,
+            None,
+        ));
+    }
     let Some(proof) = adoption_merge.filter(|proof| !proof.is_null()) else {
         if parents.len() == 2 {
             return Err(Error::validation_invalid_argument(

--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -2183,6 +2183,14 @@ fn production_validator_finalizes_only_the_adopted_merge_candidate_and_resolutio
         };
         let base_branch = git_output(&["branch", "--show-current"]);
         let historical_base = git_output(&["rev-parse", "HEAD"]);
+        let remote = tempfile::tempdir().expect("bare origin");
+        assert!(Command::new("git")
+            .args(["init", "--bare", remote.path().to_str().unwrap()])
+            .status()
+            .expect("create origin")
+            .success());
+        git(&["remote", "add", "origin", remote.path().to_str().unwrap()]);
+        git(&["push", "-u", "origin", &base_branch]);
         git(&["checkout", "-b", "candidate"]);
         std::fs::write(repo.path().join("conflict"), "candidate\n").unwrap();
         std::fs::write(repo.path().join("candidate-only"), "candidate\n").unwrap();
@@ -2195,6 +2203,7 @@ fn production_validator_finalizes_only_the_adopted_merge_candidate_and_resolutio
         git(&["add", "."]);
         git(&["commit", "-m", "advance verified base"]);
         let resolved_base_parent = git_output(&["rev-parse", "HEAD"]);
+        git(&["push", "origin", &base_branch]);
         git(&["checkout", "candidate"]);
         assert!(!Command::new("git")
             .args(["merge", &base_branch, "-m", "merge verified base"])
@@ -2208,9 +2217,6 @@ fn production_validator_finalizes_only_the_adopted_merge_candidate_and_resolutio
         let merged_candidate = git_output(&["rev-parse", "HEAD"]);
         let candidate_tree = git_output(&["rev-parse", "HEAD^{tree}"]);
         let resolved_base_tree = git_output(&["rev-parse", &format!("{base_branch}^{{tree}}")]);
-        let candidate =
-            crate::agent_task_promotion::candidate_fingerprint(repo.path().to_str().unwrap())
-                .expect("fingerprint adopted merge candidate");
 
         let run_id = "adopted-merge-finalization-recovery";
         crate::agent_task_lifecycle::submit_plan(
@@ -2218,27 +2224,91 @@ fn production_validator_finalizes_only_the_adopted_merge_candidate_and_resolutio
             Some(run_id),
         )
         .unwrap();
-        let mut promotion = successful_gate_proof().promotion;
-        promotion.source.run_id = Some(run_id.to_string());
-        promotion.target.path = Some(repo.path().display().to_string());
-        promotion.changed_files = vec!["candidate-only".to_string(), "conflict".to_string()];
-        promotion.provenance = json!({
-            "candidate": candidate,
-            "historical_task_base": historical_base,
-            "adoption_merge": {
-                "candidate": merged_candidate,
-                "candidate_parent": candidate_parent,
-                "resolved_base_parent": resolved_base_parent,
-                "candidate_tree": candidate_tree,
-                "resolved_base_tree": resolved_base_tree,
-                "changed_files": ["candidate-only", "conflict"]
-            }
-        });
+        let outcome = tempfile::NamedTempFile::new().expect("adoption outcome");
+        let source = json!({
+            "schema": crate::agent_task::AGENT_TASK_OUTCOME_SCHEMA,
+            "task_id": "task",
+            "status": "no_op",
+            "artifacts": []
+        })
+        .to_string();
+        std::fs::write(outcome.path(), &source).expect("write adoption outcome");
+        let provider = tempfile::NamedTempFile::new().expect("promotion provider");
+        std::fs::write(
+            provider.path(),
+            format!(
+                "#!/bin/sh\ncat >/dev/null\nprintf '{{\"schema\":\"homeboy/agent-task-promotion-apply-response/v1\",\"workspace_path\":\"{}\",\"command_evidence\":[]}}'\n",
+                repo.path().display()
+            ),
+        )
+        .expect("write promotion provider");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mut permissions = std::fs::metadata(provider.path())
+                .expect("provider metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(provider.path(), permissions)
+                .expect("make provider executable");
+        }
+        let promotion = crate::agent_task_promotion::promote_with_checkpoint(
+            crate::agent_task_promotion::AgentTaskPromotionOptions {
+                source,
+                source_run_id: Some(run_id.to_string()),
+                source_path: Some(outcome.path().to_path_buf()),
+                source_worktree_path: Some(repo.path().to_path_buf()),
+                base_ref: Some(base_branch.clone()),
+                task_base_sha: Some(historical_base),
+                candidate_ref: Some(merged_candidate.clone()),
+                to_worktree: "repo@adopted".to_string(),
+                task_id: None,
+                artifact_id: None,
+                dry_run: false,
+                gates: crate::agent_task_gate::VerifyGateOptions {
+                    verify: vec!["true".to_string()],
+                    ..Default::default()
+                },
+                provider_command: Some(provider.path().display().to_string()),
+                provider_invocation: None,
+            },
+            |checkpoint| {
+                crate::agent_task_lifecycle::record_promotion(
+                    run_id,
+                    serde_json::to_value(checkpoint).expect("serialize adoption checkpoint"),
+                )
+                .map(|_| ())
+            },
+        )
+        .expect("two-parent candidate adopts and persists promotion provenance");
+        assert_eq!(
+            promotion.provenance["adoption_merge"]["candidate"],
+            merged_candidate
+        );
+        assert_eq!(
+            promotion.provenance["adoption_merge"]["candidate_parent"],
+            candidate_parent
+        );
+        assert_eq!(
+            promotion.provenance["adoption_merge"]["resolved_base_parent"],
+            resolved_base_parent
+        );
+        assert_eq!(
+            promotion.provenance["adoption_merge"]["candidate_tree"],
+            candidate_tree
+        );
+        assert_eq!(
+            promotion.provenance["adoption_merge"]["resolved_base_tree"],
+            resolved_base_tree
+        );
+        // Cook adoption persists the returned report after it adds its adoption
+        // provenance; the earlier checkpoint is only the recovery boundary.
         crate::agent_task_lifecycle::record_promotion(
             run_id,
-            serde_json::to_value(promotion.clone()).unwrap(),
+            serde_json::to_value(&promotion).expect("serialize adopted promotion"),
         )
-        .unwrap();
+        .expect("persist adopted promotion provenance");
 
         // An empty recovery commit preserves the complete conflict-resolution tree.
         git(&["commit", "--allow-empty", "-m", "finalization recovery"]);
@@ -2248,6 +2318,19 @@ fn production_validator_finalizes_only_the_adopted_merge_candidate_and_resolutio
         );
         options.run_id = run_id.to_string();
         validate_real_candidate_fingerprint(&options).expect("exact merge recovery accepted");
+
+        let mut stripped_proof = promotion.clone();
+        stripped_proof.provenance["adoption_merge"] = serde_json::Value::Null;
+        crate::agent_task_lifecycle::record_promotion(
+            run_id,
+            serde_json::to_value(stripped_proof).unwrap(),
+        )
+        .unwrap();
+        let error = validate_real_candidate_fingerprint(&options)
+            .expect_err("two-parent candidate without proof rejected");
+        assert!(error
+            .message
+            .contains("missing its required adoption merge proof"));
 
         let mut mismatched_base = promotion.clone();
         mismatched_base.provenance["adoption_merge"]["resolved_base_parent"] =

--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -2156,6 +2156,124 @@ fn production_validator_accepts_only_the_exact_promoted_recovery_commit() {
     });
 }
 
+#[test]
+fn production_validator_finalizes_only_the_adopted_merge_candidate_and_resolution_tree() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let repo = real_git_repo();
+        let git = |args: &[&str]| {
+            assert!(Command::new("git")
+                .args(args)
+                .current_dir(repo.path())
+                .status()
+                .expect("git runs")
+                .success());
+        };
+        let git_output = |args: &[&str]| {
+            String::from_utf8(
+                Command::new("git")
+                    .args(args)
+                    .current_dir(repo.path())
+                    .output()
+                    .expect("git runs")
+                    .stdout,
+            )
+            .expect("git output")
+            .trim()
+            .to_string()
+        };
+        let base_branch = git_output(&["branch", "--show-current"]);
+        let historical_base = git_output(&["rev-parse", "HEAD"]);
+        git(&["checkout", "-b", "candidate"]);
+        std::fs::write(repo.path().join("conflict"), "candidate\n").unwrap();
+        std::fs::write(repo.path().join("candidate-only"), "candidate\n").unwrap();
+        git(&["add", "."]);
+        git(&["commit", "-m", "candidate"]);
+        let candidate_parent = git_output(&["rev-parse", "HEAD"]);
+        git(&["checkout", &base_branch]);
+        std::fs::write(repo.path().join("conflict"), "advanced base\n").unwrap();
+        std::fs::write(repo.path().join("base-only"), "advanced base\n").unwrap();
+        git(&["add", "."]);
+        git(&["commit", "-m", "advance verified base"]);
+        let resolved_base_parent = git_output(&["rev-parse", "HEAD"]);
+        git(&["checkout", "candidate"]);
+        assert!(!Command::new("git")
+            .args(["merge", &base_branch, "-m", "merge verified base"])
+            .current_dir(repo.path())
+            .status()
+            .expect("merge runs")
+            .success());
+        std::fs::write(repo.path().join("conflict"), "fully resolved candidate\n").unwrap();
+        git(&["add", "conflict"]);
+        git(&["commit", "--no-edit"]);
+        let merged_candidate = git_output(&["rev-parse", "HEAD"]);
+        let candidate_tree = git_output(&["rev-parse", "HEAD^{tree}"]);
+        let resolved_base_tree = git_output(&["rev-parse", &format!("{base_branch}^{{tree}}")]);
+        let candidate =
+            crate::agent_task_promotion::candidate_fingerprint(repo.path().to_str().unwrap())
+                .expect("fingerprint adopted merge candidate");
+
+        let run_id = "adopted-merge-finalization-recovery";
+        crate::agent_task_lifecycle::submit_plan(
+            &crate::agent_task_scheduler::AgentTaskPlan::new("validator", Vec::new()),
+            Some(run_id),
+        )
+        .unwrap();
+        let mut promotion = successful_gate_proof().promotion;
+        promotion.source.run_id = Some(run_id.to_string());
+        promotion.target.path = Some(repo.path().display().to_string());
+        promotion.changed_files = vec!["candidate-only".to_string(), "conflict".to_string()];
+        promotion.provenance = json!({
+            "candidate": candidate,
+            "historical_task_base": historical_base,
+            "adoption_merge": {
+                "candidate": merged_candidate,
+                "candidate_parent": candidate_parent,
+                "resolved_base_parent": resolved_base_parent,
+                "candidate_tree": candidate_tree,
+                "resolved_base_tree": resolved_base_tree,
+                "changed_files": ["candidate-only", "conflict"]
+            }
+        });
+        crate::agent_task_lifecycle::record_promotion(
+            run_id,
+            serde_json::to_value(promotion.clone()).unwrap(),
+        )
+        .unwrap();
+
+        // An empty recovery commit preserves the complete conflict-resolution tree.
+        git(&["commit", "--allow-empty", "-m", "finalization recovery"]);
+        let mut options = real_git_finalization_options(
+            repo.path(),
+            vec!["conflict".to_string(), "candidate-only".to_string()],
+        );
+        options.run_id = run_id.to_string();
+        validate_real_candidate_fingerprint(&options).expect("exact merge recovery accepted");
+
+        let mut mismatched_base = promotion.clone();
+        mismatched_base.provenance["adoption_merge"]["resolved_base_parent"] =
+            json!(candidate_parent);
+        crate::agent_task_lifecycle::record_promotion(
+            run_id,
+            serde_json::to_value(mismatched_base).unwrap(),
+        )
+        .unwrap();
+        let error = validate_real_candidate_fingerprint(&options)
+            .expect_err("mismatched resolved-base parent rejected");
+        assert!(error.message.contains("parents do not match"));
+
+        crate::agent_task_lifecycle::record_promotion(
+            run_id,
+            serde_json::to_value(promotion).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(repo.path().join("conflict"), "tree drift\n").unwrap();
+        git(&["add", "conflict"]);
+        git(&["commit", "-m", "recovery tree drift"]);
+        let error = validate_real_candidate_fingerprint(&options).expect_err("tree drift rejected");
+        assert!(error.message.contains("parent and tree exactly match"));
+    });
+}
+
 fn successful_lifecycle(model: &str) -> RunLifecycleRecord {
     RunLifecycleRecord {
         execution: RunExecutionLifecycle {

--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -2357,6 +2357,99 @@ fn production_validator_finalizes_only_the_adopted_merge_candidate_and_resolutio
     });
 }
 
+#[test]
+fn production_validator_rejects_an_octopus_candidate_at_finalization() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let repo = real_git_repo();
+        let git = |args: &[&str]| {
+            assert!(Command::new("git")
+                .args(args)
+                .current_dir(repo.path())
+                .status()
+                .expect("git runs")
+                .success());
+        };
+        let git_output = |args: &[&str]| {
+            String::from_utf8(
+                Command::new("git")
+                    .args(args)
+                    .current_dir(repo.path())
+                    .output()
+                    .expect("git runs")
+                    .stdout,
+            )
+            .expect("git output")
+            .trim()
+            .to_string()
+        };
+        let base_branch = git_output(&["branch", "--show-current"]);
+        git(&["checkout", "-b", "candidate"]);
+        std::fs::write(repo.path().join("candidate"), "candidate\n").unwrap();
+        git(&["add", "candidate"]);
+        git(&["commit", "-m", "candidate"]);
+        git(&["checkout", "-b", "side-a", &base_branch]);
+        std::fs::write(repo.path().join("side-a"), "side a\n").unwrap();
+        git(&["add", "side-a"]);
+        git(&["commit", "-m", "side a"]);
+        git(&["checkout", "-b", "side-b", &base_branch]);
+        std::fs::write(repo.path().join("side-b"), "side b\n").unwrap();
+        git(&["add", "side-b"]);
+        git(&["commit", "-m", "side b"]);
+        git(&["checkout", "candidate"]);
+        git(&[
+            "merge",
+            "--no-ff",
+            "side-a",
+            "side-b",
+            "-m",
+            "octopus candidate",
+        ]);
+        let candidate =
+            crate::agent_task_promotion::candidate_fingerprint(repo.path().to_str().unwrap())
+                .expect("fingerprint octopus candidate");
+        assert_eq!(
+            git_output(&["rev-list", "--parents", "-n", "1", "HEAD"])
+                .split_whitespace()
+                .count(),
+            4
+        );
+
+        let run_id = "octopus-finalization-rejection";
+        crate::agent_task_lifecycle::submit_plan(
+            &crate::agent_task_scheduler::AgentTaskPlan::new("validator", Vec::new()),
+            Some(run_id),
+        )
+        .unwrap();
+        let mut promotion = successful_gate_proof().promotion;
+        promotion.source.run_id = Some(run_id.to_string());
+        promotion.target.path = Some(repo.path().display().to_string());
+        promotion.changed_files = vec![
+            "candidate".to_string(),
+            "side-a".to_string(),
+            "side-b".to_string(),
+        ];
+        promotion.provenance = json!({ "candidate": candidate });
+        crate::agent_task_lifecycle::record_promotion(
+            run_id,
+            serde_json::to_value(promotion).expect("serialize promotion"),
+        )
+        .expect("persist malformed historical promotion");
+
+        let mut options = real_git_finalization_options(
+            repo.path(),
+            vec![
+                "candidate".to_string(),
+                "side-a".to_string(),
+                "side-b".to_string(),
+            ],
+        );
+        options.run_id = run_id.to_string();
+        let error = validate_real_candidate_fingerprint(&options)
+            .expect_err("octopus candidate rejected at finalization");
+        assert!(error.message.contains("more than two parents"));
+    });
+}
+
 fn successful_lifecycle(model: &str) -> RunLifecycleRecord {
     RunLifecycleRecord {
         execution: RunExecutionLifecycle {

--- a/crates/homeboy-agents/src/agent_task_promotion/committed_changes.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/committed_changes.rs
@@ -26,7 +26,8 @@ pub(crate) struct CommittedChangesPatch {
 pub(crate) struct AdoptionMergeProof {
     pub(crate) candidate_parent: String,
     pub(crate) resolved_base_parent: String,
-    pub(crate) candidate_delta_base: String,
+    pub(crate) candidate_tree: String,
+    pub(crate) resolved_base_tree: String,
 }
 
 pub(crate) fn committed_changes_patch(
@@ -59,6 +60,7 @@ pub(crate) fn committed_changes_patch(
             worktree_path,
             &candidate,
             options.task_base_sha.as_deref(),
+            options.base_ref.as_deref(),
         )?
     } else {
         let Some(base_ref) = resolve_committed_changes_base(
@@ -85,15 +87,9 @@ pub(crate) fn committed_changes_patch(
             None,
         ));
     }
-    // The merge itself incorporates the advanced base. Promotion must project
-    // only the authenticated candidate-side commit, not that base-side tree.
-    let delta_candidate = adoption_merge
-        .as_ref()
-        .map(|proof| proof.candidate_parent.as_str())
-        .unwrap_or(&candidate);
     let changed_files = git_lines(
         worktree_path,
-        &["diff", "--name-only", &base_ref, delta_candidate],
+        &["diff", "--name-only", &base_ref, &candidate],
     )?;
     if changed_files.is_empty() {
         return Ok(None);
@@ -106,13 +102,13 @@ pub(crate) fn committed_changes_patch(
             "--full-index",
             "--find-renames",
             &base_ref,
-            delta_candidate,
+            &candidate,
         ],
     )?;
     if patch.trim().is_empty() {
         return Ok(None);
     }
-    let commit_range = format!("{base_ref}..{delta_candidate}");
+    let commit_range = format!("{base_ref}..{candidate}");
     let commits = committed_change_evidence(worktree_path, &commit_range)?;
     if commits.is_empty() {
         return Ok(None);
@@ -147,6 +143,7 @@ fn resolve_adoption_candidate_base(
     cwd: &Path,
     candidate: &str,
     task_base_sha: Option<&str>,
+    resolved_base_ref: Option<&str>,
 ) -> Result<(String, Option<String>, Option<AdoptionMergeProof>)> {
     let parents = git_stdout(cwd, &["rev-list", "--parents", "-n", "1", candidate])?;
     let mut identities = parents.split_whitespace();
@@ -173,13 +170,28 @@ fn resolve_adoption_candidate_base(
             Ok((parent.clone(), historical_task_base, None))
         }
         [candidate_parent, resolved_base_parent] => {
-            let candidate_parents = git_commit_parents(cwd, candidate_parent)?;
-            let [candidate_delta_base] = candidate_parents.as_slice() else {
+            let resolved_base = resolved_base_ref
+                .filter(|base| !base.trim().is_empty())
+                .map(|base| {
+                    git_stdout(
+                        cwd,
+                        &["rev-parse", "--verify", &format!("{base}^{{commit}}")],
+                    )
+                })
+                .transpose()?
+                .map(|base| base.trim().to_string())
+                .ok_or_else(|| {
+                    adoption_graph_error(
+                        candidate,
+                        "merge candidate requires the resolved immutable base ref",
+                    )
+                })?;
+            if resolved_base != *resolved_base_parent {
                 return Err(adoption_graph_error(
                     candidate,
-                    "merge candidate's first parent must have exactly one parent",
+                    "merge candidate's second parent does not equal the resolved immutable base",
                 ));
-            };
+            }
             let historical = historical_task_base.as_deref().ok_or_else(|| {
                 adoption_graph_error(
                     candidate,
@@ -187,7 +199,6 @@ fn resolve_adoption_candidate_base(
                 )
             })?;
             for (role, revision) in [
-                ("candidate delta base", candidate_delta_base.as_str()),
                 ("candidate-side parent", candidate_parent.as_str()),
                 ("resolved base parent", resolved_base_parent.as_str()),
             ] {
@@ -206,12 +217,19 @@ fn resolve_adoption_candidate_base(
                 ));
             }
             Ok((
-                candidate_delta_base.clone(),
+                resolved_base_parent.clone(),
                 historical_task_base,
                 Some(AdoptionMergeProof {
                     candidate_parent: candidate_parent.clone(),
                     resolved_base_parent: resolved_base_parent.clone(),
-                    candidate_delta_base: candidate_delta_base.clone(),
+                    candidate_tree: git_stdout(
+                        cwd,
+                        &["rev-parse", &format!("{candidate}^{{tree}}")],
+                    )?,
+                    resolved_base_tree: git_stdout(
+                        cwd,
+                        &["rev-parse", &format!("{resolved_base_parent}^{{tree}}")],
+                    )?,
                 }),
             ))
         }

--- a/crates/homeboy-agents/src/agent_task_promotion/committed_changes.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/committed_changes.rs
@@ -225,11 +225,15 @@ fn resolve_adoption_candidate_base(
                     candidate_tree: git_stdout(
                         cwd,
                         &["rev-parse", &format!("{candidate}^{{tree}}")],
-                    )?,
+                    )?
+                    .trim()
+                    .to_string(),
                     resolved_base_tree: git_stdout(
                         cwd,
                         &["rev-parse", &format!("{resolved_base_parent}^{{tree}}")],
-                    )?,
+                    )?
+                    .trim()
+                    .to_string(),
                 }),
             ))
         }

--- a/crates/homeboy-agents/src/agent_task_promotion/committed_changes.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/committed_changes.rs
@@ -12,10 +12,21 @@ pub(crate) struct CommittedChangesPatch {
     pub(crate) base_ref: String,
     pub(crate) candidate: String,
     pub(crate) historical_task_base: Option<String>,
+    pub(crate) adoption_merge: Option<AdoptionMergeProof>,
     pub(crate) patch_path: PathBuf,
     pub(crate) sha256: String,
     pub(crate) commit_range: String,
     pub(crate) commits: Vec<Value>,
+}
+
+/// The graph roles authenticated when adoption selects a merge commit. Keeping
+/// these immutable IDs in promotion evidence makes the candidate-only delta
+/// independently reviewable without relying on branch names or mutable refs.
+#[derive(Clone)]
+pub(crate) struct AdoptionMergeProof {
+    pub(crate) candidate_parent: String,
+    pub(crate) resolved_base_parent: String,
+    pub(crate) candidate_delta_base: String,
 }
 
 pub(crate) fn committed_changes_patch(
@@ -43,7 +54,7 @@ pub(crate) fn committed_changes_patch(
         }
     }
 
-    let (base_ref, historical_task_base) = if options.candidate_ref.is_some() {
+    let (base_ref, historical_task_base, adoption_merge) = if options.candidate_ref.is_some() {
         resolve_adoption_candidate_base(
             worktree_path,
             &candidate,
@@ -58,7 +69,7 @@ pub(crate) fn committed_changes_patch(
         else {
             return Ok(None);
         };
-        (base_ref, None)
+        (base_ref, None, None)
     };
     let is_ancestor = Command::new("git")
         .args(["merge-base", "--is-ancestor", &base_ref, &candidate])
@@ -74,9 +85,15 @@ pub(crate) fn committed_changes_patch(
             None,
         ));
     }
+    // The merge itself incorporates the advanced base. Promotion must project
+    // only the authenticated candidate-side commit, not that base-side tree.
+    let delta_candidate = adoption_merge
+        .as_ref()
+        .map(|proof| proof.candidate_parent.as_str())
+        .unwrap_or(&candidate);
     let changed_files = git_lines(
         worktree_path,
-        &["diff", "--name-only", &base_ref, &candidate],
+        &["diff", "--name-only", &base_ref, delta_candidate],
     )?;
     if changed_files.is_empty() {
         return Ok(None);
@@ -89,13 +106,13 @@ pub(crate) fn committed_changes_patch(
             "--full-index",
             "--find-renames",
             &base_ref,
-            &candidate,
+            delta_candidate,
         ],
     )?;
     if patch.trim().is_empty() {
         return Ok(None);
     }
-    let commit_range = format!("{base_ref}..{candidate}");
+    let commit_range = format!("{base_ref}..{delta_candidate}");
     let commits = committed_change_evidence(worktree_path, &commit_range)?;
     if commits.is_empty() {
         return Ok(None);
@@ -115,6 +132,7 @@ pub(crate) fn committed_changes_patch(
         base_ref,
         candidate,
         historical_task_base,
+        adoption_merge,
         patch_path,
         sha256,
         commit_range,
@@ -122,41 +140,18 @@ pub(crate) fn committed_changes_patch(
     }))
 }
 
-/// Explicit adoption is scoped to the immutable candidate's sole parent, not
-/// the task's historical workspace base. A rebased candidate may have many
-/// unrelated upstream commits between those two points.
+/// Explicit adoption is scoped to the immutable candidate delta, not the task's
+/// historical workspace base. A candidate may be a normal one-parent commit or
+/// a two-parent merge that incorporates the verified base after it advanced.
 fn resolve_adoption_candidate_base(
     cwd: &Path,
     candidate: &str,
     task_base_sha: Option<&str>,
-) -> Result<(String, Option<String>)> {
+) -> Result<(String, Option<String>, Option<AdoptionMergeProof>)> {
     let parents = git_stdout(cwd, &["rev-list", "--parents", "-n", "1", candidate])?;
     let mut identities = parents.split_whitespace();
     let _commit = identities.next();
-    let parent = identities.next();
-    if parent.is_none() || identities.next().is_some() {
-        return Err(Error::validation_invalid_argument(
-            "candidate_ref",
-            "adopted candidate must have exactly one parent so its immutable base is unambiguous",
-            Some(candidate.to_string()),
-            None,
-        ));
-    }
-    let parent = parent.expect("validated candidate parent").to_string();
-    let is_ancestor = Command::new("git")
-        .args(["merge-base", "--is-ancestor", &parent, candidate])
-        .current_dir(cwd)
-        .status()
-        .map_err(|error| Error::git_command_failed(error.to_string()))?
-        .success();
-    if !is_ancestor {
-        return Err(Error::validation_invalid_argument(
-            "candidate_ref",
-            "adopted candidate is not descended from its immutable parent base",
-            Some(candidate.to_string()),
-            None,
-        ));
-    }
+    let parents = identities.map(str::to_string).collect::<Vec<_>>();
     let historical_task_base = task_base_sha
         .filter(|base| !base.trim().is_empty())
         .map(|base| {
@@ -167,25 +162,111 @@ fn resolve_adoption_candidate_base(
             .map(|base| base.trim().to_string())
         })
         .transpose()?;
-    if let Some(historical) = historical_task_base.as_deref() {
-        if historical != candidate {
-            let related = Command::new("git")
-                .args(["merge-base", "--is-ancestor", historical, &parent])
-                .current_dir(cwd)
-                .status()
-                .map_err(|error| Error::git_command_failed(error.to_string()))?
-                .success();
-            if !related {
-                return Err(Error::validation_invalid_argument(
-                    "task_base_sha",
-                    "recorded task base is unrelated to the adopted candidate parent; refusing ambiguous adoption provenance",
-                    Some(historical.to_string()),
-                    None,
+    match parents.as_slice() {
+        [parent] => {
+            validate_adoption_parent_lineage(
+                cwd,
+                candidate,
+                parent,
+                historical_task_base.as_deref(),
+            )?;
+            Ok((parent.clone(), historical_task_base, None))
+        }
+        [candidate_parent, resolved_base_parent] => {
+            let candidate_parents = git_commit_parents(cwd, candidate_parent)?;
+            let [candidate_delta_base] = candidate_parents.as_slice() else {
+                return Err(adoption_graph_error(
+                    candidate,
+                    "merge candidate's first parent must have exactly one parent",
+                ));
+            };
+            let historical = historical_task_base.as_deref().ok_or_else(|| {
+                adoption_graph_error(
+                    candidate,
+                    "merge candidate requires the recorded immutable task base",
+                )
+            })?;
+            for (role, revision) in [
+                ("candidate delta base", candidate_delta_base.as_str()),
+                ("candidate-side parent", candidate_parent.as_str()),
+                ("resolved base parent", resolved_base_parent.as_str()),
+            ] {
+                if !is_ancestor(cwd, historical, revision)? {
+                    return Err(adoption_graph_error(candidate, &format!(
+                        "merge candidate's {role} regresses or is unrelated to the recorded task base"
+                    )));
+                }
+            }
+            if is_ancestor(cwd, resolved_base_parent, candidate_parent)?
+                || is_ancestor(cwd, candidate_parent, resolved_base_parent)?
+            {
+                return Err(adoption_graph_error(
+                    candidate,
+                    "merge parents do not represent distinct candidate and advanced-base lineages",
                 ));
             }
+            Ok((
+                candidate_delta_base.clone(),
+                historical_task_base,
+                Some(AdoptionMergeProof {
+                    candidate_parent: candidate_parent.clone(),
+                    resolved_base_parent: resolved_base_parent.clone(),
+                    candidate_delta_base: candidate_delta_base.clone(),
+                }),
+            ))
+        }
+        _ => Err(adoption_graph_error(
+            candidate,
+            "adopted candidate must have one parent or exactly two authenticated merge parents",
+        )),
+    }
+}
+
+fn validate_adoption_parent_lineage(
+    cwd: &Path,
+    candidate: &str,
+    parent: &str,
+    historical_task_base: Option<&str>,
+) -> Result<()> {
+    if !is_ancestor(cwd, parent, candidate)? {
+        return Err(adoption_graph_error(
+            candidate,
+            "adopted candidate is not descended from its immutable parent base",
+        ));
+    }
+    if let Some(historical) = historical_task_base.filter(|historical| *historical != candidate) {
+        if !is_ancestor(cwd, historical, parent)? {
+            return Err(Error::validation_invalid_argument(
+                "task_base_sha",
+                "recorded task base is unrelated to the adopted candidate parent; refusing ambiguous adoption provenance",
+                Some(historical.to_string()),
+                None,
+            ));
         }
     }
-    Ok((parent, historical_task_base))
+    Ok(())
+}
+
+fn git_commit_parents(cwd: &Path, revision: &str) -> Result<Vec<String>> {
+    let output = git_stdout(cwd, &["rev-list", "--parents", "-n", "1", revision])?;
+    Ok(output
+        .split_whitespace()
+        .skip(1)
+        .map(str::to_string)
+        .collect())
+}
+
+fn is_ancestor(cwd: &Path, ancestor: &str, descendant: &str) -> Result<bool> {
+    Command::new("git")
+        .args(["merge-base", "--is-ancestor", ancestor, descendant])
+        .current_dir(cwd)
+        .status()
+        .map(|status| status.success())
+        .map_err(|error| Error::git_command_failed(error.to_string()))
+}
+
+fn adoption_graph_error(candidate: &str, message: &str) -> Error {
+    Error::validation_invalid_argument("candidate_ref", message, Some(candidate.to_string()), None)
 }
 
 fn ensure_clean_source(cwd: &Path) -> Result<()> {

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -908,7 +908,6 @@ fn promote_with_provider_and_checkpoint_internal(
     let gate_feedback_baseline = post_apply
         .as_ref()
         .and_then(|report| report.provenance.get("gate_feedback_baseline").cloned());
-
     Ok(AgentTaskPromotionReport {
         schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
         status: gates.status,
@@ -1533,6 +1532,16 @@ fn promote_committed_changes(
     let gate_feedback_baseline = post_apply
         .as_ref()
         .and_then(|report| report.provenance.get("gate_feedback_baseline").cloned());
+    let adoption_merge = committed_patch.adoption_merge.as_ref().map(|proof| {
+        json!({
+            "candidate_parent": &proof.candidate_parent,
+            "resolved_base_parent": &proof.resolved_base_parent,
+            "candidate_delta_base": &proof.candidate_delta_base,
+            "candidate": &committed_patch.candidate,
+            "changed_files": &normalized_patch.changed_files,
+            "patch_sha256": &committed_patch.sha256,
+        })
+    });
 
     Ok(AgentTaskPromotionReport {
         schema: AGENT_TASK_PROMOTION_REPORT_SCHEMA.to_string(),
@@ -1546,7 +1555,14 @@ fn promote_committed_changes(
             path: retained_patch_path.display().to_string(),
             sha256: Some(committed_patch.sha256),
         },
-        changed_files: persisted_changed_files(normalized_patch.changed_files, candidate.as_ref()),
+        // A merge candidate's workspace fingerprint may include base-side files
+        // after the provider applies its candidate-only patch. Its durable review
+        // scope is the graph-proven candidate delta, never those base changes.
+        changed_files: if adoption_merge.is_some() {
+            normalized_patch.changed_files.clone()
+        } else {
+            persisted_changed_files(normalized_patch.changed_files, candidate.as_ref())
+        },
         command_evidence,
         deterministic_gates: gates.deterministic_gates,
         gate_results: gates.gate_results,
@@ -1564,6 +1580,7 @@ fn promote_committed_changes(
             "commit_range": committed_patch.commit_range,
             "commits": committed_patch.commits,
             "historical_task_base": committed_patch.historical_task_base,
+            "adoption_merge": adoption_merge,
             "candidate": candidate,
             "destination_baseline": candidate,
             "gate_feedback_baseline": gate_feedback_baseline,

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -1536,7 +1536,8 @@ fn promote_committed_changes(
         json!({
             "candidate_parent": &proof.candidate_parent,
             "resolved_base_parent": &proof.resolved_base_parent,
-            "candidate_delta_base": &proof.candidate_delta_base,
+            "candidate_tree": &proof.candidate_tree,
+            "resolved_base_tree": &proof.resolved_base_tree,
             "candidate": &committed_patch.candidate,
             "changed_files": &normalized_patch.changed_files,
             "patch_sha256": &committed_patch.sha256,
@@ -1555,14 +1556,7 @@ fn promote_committed_changes(
             path: retained_patch_path.display().to_string(),
             sha256: Some(committed_patch.sha256),
         },
-        // A merge candidate's workspace fingerprint may include base-side files
-        // after the provider applies its candidate-only patch. Its durable review
-        // scope is the graph-proven candidate delta, never those base changes.
-        changed_files: if adoption_merge.is_some() {
-            normalized_patch.changed_files.clone()
-        } else {
-            persisted_changed_files(normalized_patch.changed_files, candidate.as_ref())
-        },
+        changed_files: persisted_changed_files(normalized_patch.changed_files, candidate.as_ref()),
         command_evidence,
         deterministic_gates: gates.deterministic_gates,
         gate_results: gates.gate_results,

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -419,7 +419,7 @@ fn follow_up_promotion_records_and_forwards_verified_chain_baseline() {
             source_run_id: Some("v2-run".to_string()),
             source_path: None,
             source_worktree_path: None,
-            base_ref: None,
+            base_ref: Some("main".to_string()),
             task_base_sha: None,
             candidate_ref: None,
             to_worktree: "fixture@target".to_string(),
@@ -489,7 +489,7 @@ fn promote_recoverable_candidate_reports_distinct_patch_review_choices() {
             source_run_id: Some("recoverable-run".to_string()),
             source_path: Some(source_path),
             source_worktree_path: None,
-            base_ref: None,
+            base_ref: Some("main".to_string()),
             task_base_sha: None,
             candidate_ref: None,
             to_worktree: "repo@recoverable".to_string(),
@@ -822,19 +822,27 @@ fn adoption_accepts_a_two_parent_merge_and_exports_only_the_candidate_delta() {
     git(&repo, &["add", "."]);
     git(&repo, &["commit", "-m", "historical base"]);
     let historical_base = git_head(&repo, "HEAD");
+    let remote = temp.path().join("origin.git");
+    std::fs::create_dir(&remote).expect("create remote");
+    git(&remote, &["init", "--bare", "-b", "main"]);
+    git(
+        &repo,
+        &["remote", "add", "origin", remote.to_str().unwrap()],
+    );
+    git(&repo, &["push", "-u", "origin", "main"]);
 
     git(&repo, &["checkout", "-b", "candidate"]);
     std::fs::write(repo.join("candidate.txt"), "candidate\n").expect("write candidate");
     git(&repo, &["add", "candidate.txt"]);
     git(&repo, &["commit", "-m", "candidate change"]);
     let candidate_parent = git_head(&repo, "HEAD");
-    let candidate_delta_base = git_head(&repo, "HEAD~1");
 
     git(&repo, &["checkout", "main"]);
     std::fs::write(repo.join("base-advance.txt"), "advanced\n").expect("advance base");
     git(&repo, &["add", "base-advance.txt"]);
     git(&repo, &["commit", "-m", "base advance"]);
     let resolved_base_parent = git_head(&repo, "HEAD");
+    git(&repo, &["push", "origin", "main"]);
     git(&repo, &["checkout", "candidate"]);
     git(
         &repo,
@@ -853,7 +861,7 @@ fn adoption_accepts_a_two_parent_merge_and_exports_only_the_candidate_delta() {
             source_run_id: Some("adopted-run".to_string()),
             source_path: Some(source_path),
             source_worktree_path: Some(repo.clone()),
-            base_ref: None,
+            base_ref: Some("main".to_string()),
             task_base_sha: Some(historical_base),
             candidate_ref: Some(merged_candidate.clone()),
             to_worktree: "repo@adopted".to_string(),
@@ -873,7 +881,7 @@ fn adoption_accepts_a_two_parent_merge_and_exports_only_the_candidate_delta() {
 
     assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
     assert_eq!(report.changed_files, vec!["candidate.txt"]);
-    assert_eq!(report.provenance["base_ref"], candidate_delta_base);
+    assert_eq!(report.provenance["base_ref"], resolved_base_parent);
     assert_eq!(
         report.provenance["adoption_merge"]["candidate_parent"],
         candidate_parent
@@ -933,7 +941,7 @@ fn adoption_rejects_merge_candidates_without_a_related_advanced_base() {
             source_run_id: Some("adopted-run".to_string()),
             source_path: Some(source_path),
             source_worktree_path: Some(repo.clone()),
-            base_ref: None,
+            base_ref: Some("unrelated".to_string()),
             task_base_sha: Some(historical_base),
             candidate_ref: Some(git_head(&repo, "HEAD")),
             to_worktree: "repo@adopted".to_string(),

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -881,6 +881,14 @@ fn adoption_accepts_a_two_parent_merge_and_exports_only_the_candidate_delta() {
 
     assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
     assert_eq!(report.changed_files, vec!["candidate.txt"]);
+    assert_eq!(
+        report.provenance["candidate"]["fingerprint"]["head"],
+        merged_candidate
+    );
+    assert_eq!(
+        report.provenance["candidate"]["fingerprint"]["tree"],
+        report.provenance["adoption_merge"]["candidate_tree"]
+    );
     assert_eq!(report.provenance["base_ref"], resolved_base_parent);
     assert_eq!(
         report.provenance["adoption_merge"]["candidate_parent"],

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -811,6 +811,152 @@ fn adoption_scopes_a_rebased_two_file_candidate_to_its_parent() {
 }
 
 #[test]
+fn adoption_accepts_a_two_parent_merge_and_exports_only_the_candidate_delta() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let repo = temp.path().join("repo");
+    std::fs::create_dir(&repo).expect("create repo");
+    git(&repo, &["init", "-b", "main"]);
+    git(&repo, &["config", "user.email", "agent@example.test"]);
+    git(&repo, &["config", "user.name", "Agent"]);
+    std::fs::write(repo.join("base.txt"), "base\n").expect("write base");
+    git(&repo, &["add", "."]);
+    git(&repo, &["commit", "-m", "historical base"]);
+    let historical_base = git_head(&repo, "HEAD");
+
+    git(&repo, &["checkout", "-b", "candidate"]);
+    std::fs::write(repo.join("candidate.txt"), "candidate\n").expect("write candidate");
+    git(&repo, &["add", "candidate.txt"]);
+    git(&repo, &["commit", "-m", "candidate change"]);
+    let candidate_parent = git_head(&repo, "HEAD");
+    let candidate_delta_base = git_head(&repo, "HEAD~1");
+
+    git(&repo, &["checkout", "main"]);
+    std::fs::write(repo.join("base-advance.txt"), "advanced\n").expect("advance base");
+    git(&repo, &["add", "base-advance.txt"]);
+    git(&repo, &["commit", "-m", "base advance"]);
+    let resolved_base_parent = git_head(&repo, "HEAD");
+    git(&repo, &["checkout", "candidate"]);
+    git(
+        &repo,
+        &["merge", "--no-ff", "main", "-m", "merge verified base"],
+    );
+    let merged_candidate = git_head(&repo, "HEAD");
+    let (source_path, source) = write_empty_patch_source(&temp);
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(repo.clone()),
+        ..Default::default()
+    };
+
+    let report = promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("adopted-run".to_string()),
+            source_path: Some(source_path),
+            source_worktree_path: Some(repo.clone()),
+            base_ref: None,
+            task_base_sha: Some(historical_base),
+            candidate_ref: Some(merged_candidate.clone()),
+            to_worktree: "repo@adopted".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions {
+                verify: vec!["true".to_string()],
+                ..Default::default()
+            },
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut provider,
+    )
+    .expect("merged candidate adopts");
+
+    assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
+    assert_eq!(report.changed_files, vec!["candidate.txt"]);
+    assert_eq!(report.provenance["base_ref"], candidate_delta_base);
+    assert_eq!(
+        report.provenance["adoption_merge"]["candidate_parent"],
+        candidate_parent
+    );
+    assert_eq!(
+        report.provenance["adoption_merge"]["resolved_base_parent"],
+        resolved_base_parent
+    );
+    assert_eq!(
+        report.provenance["adoption_merge"]["candidate"],
+        merged_candidate
+    );
+    assert_eq!(
+        report.provenance["adoption_merge"]["changed_files"],
+        serde_json::json!(["candidate.txt"])
+    );
+    assert_eq!(provider.verify_calls.len(), 1);
+}
+
+#[test]
+fn adoption_rejects_merge_candidates_without_a_related_advanced_base() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let repo = temp.path().join("repo");
+    std::fs::create_dir(&repo).expect("create repo");
+    git(&repo, &["init", "-b", "main"]);
+    git(&repo, &["config", "user.email", "agent@example.test"]);
+    git(&repo, &["config", "user.name", "Agent"]);
+    std::fs::write(repo.join("base.txt"), "base\n").expect("write base");
+    git(&repo, &["add", "."]);
+    git(&repo, &["commit", "-m", "historical base"]);
+    let historical_base = git_head(&repo, "HEAD");
+    git(&repo, &["checkout", "-b", "candidate"]);
+    std::fs::write(repo.join("candidate.txt"), "candidate\n").expect("write candidate");
+    git(&repo, &["add", "candidate.txt"]);
+    git(&repo, &["commit", "-m", "candidate change"]);
+    git(&repo, &["checkout", "--orphan", "unrelated"]);
+    git(&repo, &["rm", "-rf", "."]);
+    std::fs::write(repo.join("unrelated.txt"), "unrelated\n").expect("write unrelated");
+    git(&repo, &["add", "."]);
+    git(&repo, &["commit", "-m", "unrelated base"]);
+    git(&repo, &["checkout", "candidate"]);
+    git(
+        &repo,
+        &[
+            "merge",
+            "--allow-unrelated-histories",
+            "unrelated",
+            "-m",
+            "merge unrelated",
+        ],
+    );
+    let (source_path, source) = write_empty_patch_source(&temp);
+
+    let error = promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("adopted-run".to_string()),
+            source_path: Some(source_path),
+            source_worktree_path: Some(repo.clone()),
+            base_ref: None,
+            task_base_sha: Some(historical_base),
+            candidate_ref: Some(git_head(&repo, "HEAD")),
+            to_worktree: "repo@adopted".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions::default(),
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut FakePromotionWorkspaceProvider {
+            workspace_path: Some(repo),
+            ..Default::default()
+        },
+    )
+    .expect_err("unrelated merge must fail closed");
+
+    assert!(error
+        .message
+        .contains("resolved base parent regresses or is unrelated"));
+}
+
+#[test]
 fn adoption_rejects_an_unrelated_historical_task_base() {
     let temp = tempfile::tempdir().expect("tempdir");
     let repo = temp.path().join("repo");


### PR DESCRIPTION
Closes #12837

Accept a two-parent immutable merge only when its first parent is a one-parent candidate lineage and its second parent is a distinct descendant of the recorded task base. Promotion exports the candidate-side delta only and records immutable parent-role evidence. Finalization accepts only one-parent candidates or authenticated two-parent merges: it fails closed for missing merge proof and octopus candidates, and revalidates parent roles plus merge-candidate/base trees before recovery.

Evidence:
- `cargo test -p homeboy-agents adoption_accepts_a_two_parent_merge_and_exports_only_the_candidate_delta`
- `cargo test -p homeboy-agents production_validator_finalizes_only_the_adopted_merge_candidate_and_resolution_tree`
- `cargo test -p homeboy-agents production_validator_rejects_an_octopus_candidate_at_finalization`
- `cargo fmt --all -- --check`
- `cargo check -p homeboy-agents`

AI Assistance: OpenAI `openai/gpt-5.6-terra` via OpenCode inspected and addressed review findings, added real-Git promotion/finalization and octopus-finalization coverage, and ran the listed checks. Chris Huber directed and remains responsible for the change.