### PR TITLE
fix(rig): root the run observer's store at the rig entry points

### DIFF
--- a/crates/homeboy-rig/src/runner.rs
+++ b/crates/homeboy-rig/src/runner.rs
@@ -202,7 +202,10 @@ pub enum SymlinkStatusState {
 pub fn run_up(rig: &RigSpec) -> Result<UpReport> {
     preflight_effective_component_checkouts(rig)?;
     let _lease = acquire_active_run_lease(rig, "up")?;
-    let observer = RigRunObserver::start(rig, "up");
+    // One rig run is one unit of work, so the entry point resolves the roots
+    // once and the observer carries them for the rest of it (#7505).
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let observer = RigRunObserver::start(rig, "up", &roots);
 
     let execute = || {
         let outcome = run_pipeline(rig, "up", true)?;
@@ -260,7 +263,8 @@ pub fn run_check_with_settings(
     settings: &[(String, String)],
 ) -> Result<CheckReport> {
     preflight_effective_component_checkouts(rig)?;
-    let observer = RigRunObserver::start(rig, "check");
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let observer = RigRunObserver::start(rig, "check", &roots);
 
     let execute = || {
         let requirements = evaluate_requirements(rig);
@@ -422,7 +426,8 @@ pub fn run_fuzz_prepare(
 
     // Dependency-cache evidence must belong to a real, completed run rather
     // than depending on a caller to have installed a rig observer.
-    let observer = RigRunObserver::start(rig, "fuzz_prepare");
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let observer = RigRunObserver::start(rig, "fuzz_prepare", &roots);
     let execute = || {
         let dependency_outcome =
             run_dependency_materialization_steps(rig, "fuzz_prepare", settings)?;
@@ -1365,8 +1370,13 @@ struct RigRunObserver {
 }
 
 impl RigRunObserver {
-    fn start(rig: &RigSpec, command: &str) -> Option<Self> {
-        let store = ObservationStore::open_initialized().ok()?;
+    /// The observer carries the store for the whole run, and
+    /// [`Self::record_resource_lifecycle_index`] derives the dependency-cache
+    /// root from it. Opening ambiently here left that store unrooted, so the
+    /// cache lookup fell through to its own environment read every time — two
+    /// resolutions that only agreed by coincidence (#7505).
+    fn start(rig: &RigSpec, command: &str, roots: &homeboy_core::paths::PathRoots) -> Option<Self> {
+        let store = ObservationStore::open_initialized_in_roots(roots).ok()?;
         let artifact_manifest = tempfile::NamedTempFile::new().ok()?;
         let cwd = std::env::current_dir().ok();
         let run = store


### PR DESCRIPTION
Part of #7505.

## A fallback that fired every time

`record_resource_lifecycle_index` derives the dependency-materialization cache root from the store the observer is carrying, and falls back to the environment when that store is unrooted:

```rust
// The cache root belongs to the same home as the store this index
// is recorded into. Only an ambiently-opened store has no better
// answer than the environment (#7505).
let data_root = match self.store.data_root() {
    Some(root) => Some(root),
    None => match homeboy_core::paths::PathRoots::from_environment() { ... }
};
```

The comment is right about the condition and that is exactly the condition that held. `RigRunObserver::start` opened with `ObservationStore::open_initialized()`, so `data_root()` returned `None` and the fallback ran on every rig run.

So a single rig run performed two independent resolutions: one when the observer opened its store, another when the cache root was derived. They agreed because nothing repointed between them, not because anything made them agree.

## Fix

`start` takes the roots and opens `_in_roots`. `data_root()` now answers, and the fallback becomes unreachable on this path — it stays for callers that genuinely hand over an unrooted store.

`run_up`, `run_check_with_settings`, and `run_fuzz_prepare` each resolve once at the top and pass the value down. One rig run is one unit of work, matching the boundary pattern already used in `runs::import_from_gh_actions`.

## Why here and not in the CLI

Each of the three has exactly one production caller:

| entry | caller |
|---|---|
| `run_up` | `commands/rig/mod.rs:632` |
| `run_check_with_settings` | `commands/bench/matrix.rs:866` |
| `run_fuzz_prepare` | `commands/fuzz/execution.rs:50` |

None of those three CLI sites has roots in scope, so pushing resolution up one level would relocate three ambient reads rather than remove them, and would change a public rig API on the way. Resolving at the rig entry is a strict reduction now — two resolutions per run become one — and leaves the signature free to accept injected roots later, when the CLI side is rooted.

## Verification

`cargo check --workspace --tests -j2` — clean, 3m23s, zero errors.

All three call-site replacements asserted a unique match before writing.