### PR TITLE
fix(runs): authorize runner artifact paths against the store's root

### DIFF
--- a/crates/homeboy-cli/src/commands/runs/remote_artifact.rs
+++ b/crates/homeboy-cli/src/commands/runs/remote_artifact.rs
@@ -70,15 +70,17 @@ pub fn attach(args: RunsArtifactAttachArgs) -> CmdResult<RunsOutput> {
     runs_service::require_run(&store, &args.run_id)?;
     validate_artifact_name(&args.name)?;
     let runner = runner::load(&args.runner)?;
-    validate_runner_artifact_path(&runner, &args.path)?;
+    // The root that authorizes the path and the root the bytes are copied under
+    // are the same value. Resolving the allowlist's local root separately from
+    // the store's would let a local runner authorize a path against one
+    // installation and land the artifact in another (#7505).
+    let artifact_root = store.artifact_root()?;
+    validate_runner_artifact_path(&runner, &args.path, &artifact_root)?;
 
     // The bytes land under the root this store indexes, because the path is
     // recorded into that same store two lines below (#7505).
-    let source = runner_artifact_attach::copy_runner_artifact_source(
-        &store.artifact_root()?,
-        &runner,
-        &args.path,
-    )?;
+    let source =
+        runner_artifact_attach::copy_runner_artifact_source(&artifact_root, &runner, &args.path)?;
     let metadata = runner_attach_metadata(&runner, &args.path, &source);
     let artifact = match source.artifact_type {
         RunnerAttachArtifactType::File => {
@@ -331,8 +333,12 @@ fn validate_artifact_name(name: &str) -> homeboy::core::Result<()> {
     Ok(())
 }
 
-fn validate_runner_artifact_path(runner: &Runner, path: &str) -> homeboy::core::Result<()> {
-    let roots = allowed_runner_artifact_roots(runner)?;
+fn validate_runner_artifact_path(
+    runner: &Runner,
+    path: &str,
+    local_artifact_root: &Path,
+) -> homeboy::core::Result<()> {
+    let roots = allowed_runner_artifact_roots(runner, local_artifact_root)?;
     match homeboy::core::paths::authorize_remote_artifact_path(
         Path::new(path),
         &roots,
@@ -366,7 +372,13 @@ fn validate_runner_artifact_path(runner: &Runner, path: &str) -> homeboy::core::
     }
 }
 
-fn allowed_runner_artifact_roots(runner: &Runner) -> homeboy::core::Result<Vec<String>> {
+/// Takes the caller's local artifact root rather than resolving one. The
+/// allowlist this builds is what authorizes a runner-side path, so it has to
+/// describe the same installation the caller is about to write into (#7505).
+fn allowed_runner_artifact_roots(
+    runner: &Runner,
+    local_artifact_root: &Path,
+) -> homeboy::core::Result<Vec<String>> {
     let mut roots = Vec::new();
     if let Some(root) = runner.workspace_root.as_deref() {
         roots.push(homeboy::core::paths::normalize_remote_root(root));
@@ -383,7 +395,7 @@ fn allowed_runner_artifact_roots(runner: &Runner) -> homeboy::core::Result<Vec<S
     }
     if runner.kind == RunnerKind::Local {
         roots.push(homeboy::core::paths::normalize_remote_root(
-            &homeboy::core::artifact_root()?.display().to_string(),
+            &local_artifact_root.display().to_string(),
         ));
     }
     roots.sort();

--- a/crates/homeboy-rig/src/runner.rs
+++ b/crates/homeboy-rig/src/runner.rs
@@ -202,7 +202,10 @@ pub enum SymlinkStatusState {
 pub fn run_up(rig: &RigSpec) -> Result<UpReport> {
     preflight_effective_component_checkouts(rig)?;
     let _lease = acquire_active_run_lease(rig, "up")?;
-    let observer = RigRunObserver::start(rig, "up");
+    // One rig run is one unit of work, so the entry point resolves the roots
+    // once and the observer carries them for the rest of it (#7505).
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let observer = RigRunObserver::start(rig, "up", &roots);
 
     let execute = || {
         let outcome = run_pipeline(rig, "up", true)?;
@@ -260,7 +263,8 @@ pub fn run_check_with_settings(
     settings: &[(String, String)],
 ) -> Result<CheckReport> {
     preflight_effective_component_checkouts(rig)?;
-    let observer = RigRunObserver::start(rig, "check");
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let observer = RigRunObserver::start(rig, "check", &roots);
 
     let execute = || {
         let requirements = evaluate_requirements(rig);
@@ -422,7 +426,8 @@ pub fn run_fuzz_prepare(
 
     // Dependency-cache evidence must belong to a real, completed run rather
     // than depending on a caller to have installed a rig observer.
-    let observer = RigRunObserver::start(rig, "fuzz_prepare");
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let observer = RigRunObserver::start(rig, "fuzz_prepare", &roots);
     let execute = || {
         let dependency_outcome =
             run_dependency_materialization_steps(rig, "fuzz_prepare", settings)?;
@@ -1365,8 +1370,13 @@ struct RigRunObserver {
 }
 
 impl RigRunObserver {
-    fn start(rig: &RigSpec, command: &str) -> Option<Self> {
-        let store = ObservationStore::open_initialized().ok()?;
+    /// The observer carries the store for the whole run, and
+    /// [`Self::record_resource_lifecycle_index`] derives the dependency-cache
+    /// root from it. Opening ambiently here left that store unrooted, so the
+    /// cache lookup fell through to its own environment read every time — two
+    /// resolutions that only agreed by coincidence (#7505).
+    fn start(rig: &RigSpec, command: &str, roots: &homeboy_core::paths::PathRoots) -> Option<Self> {
+        let store = ObservationStore::open_initialized_in_roots(roots).ok()?;
         let artifact_manifest = tempfile::NamedTempFile::new().ok()?;
         let cwd = std::env::current_dir().ok();
         let run = store


### PR DESCRIPTION
Part of #7505. An authorization check and the operation it guards resolved their roots separately.

## The split

`runs artifacts attach` takes a runner-side path, checks it against an allowlist, then copies the bytes locally. Those two steps used different roots:

```
line 69  let store = ObservationStore::open_initialized()?;   // ambient
line 73  validate_runner_artifact_path(&runner, &args.path)?; // allowlist adds core::artifact_root()
line 78  copy_runner_artifact_source(&store.artifact_root()?, ...)
```

For a local runner, `allowed_runner_artifact_roots` appended its own resolution:

```rust
if runner.kind == RunnerKind::Local {
    roots.push(normalize_remote_root(&homeboy::core::artifact_root()?.display().to_string()));
}
```

So the path was authorized against `core::artifact_root()` and the bytes landed under `store.artifact_root()`.

## Why it matters even though it works today

Both reads observe the same environment right now, because the store on line 69 is itself opened ambiently. The check and the operation agree — but they agree as a **consequence of the store still being unrooted**, not because anything relates them.

That is a bad property for an allowlist to depend on. It decides whether a path is permitted, and permission is only meaningful relative to the root the caller is about to write into. The moment `attach` resolves roots explicitly — which is the direction this issue is moving every command — the validator would have kept reading the environment while the copy used the injected roots, and the check would have started authorizing against an installation the bytes never touch.

That failure is silent. There is no error, no mismatch to observe; the path is simply approved by the wrong authority.

## Fix

`attach` resolves the store's artifact root once and passes the same value to both:

```rust
let artifact_root = store.artifact_root()?;
validate_runner_artifact_path(&runner, &args.path, &artifact_root)?;
let source = copy_runner_artifact_source(&artifact_root, &runner, &args.path)?;
```

`allowed_runner_artifact_roots` now takes the local root instead of resolving one, so the allowlist describes the installation the caller is writing into by construction.

## Scope

- `preview` and `capture` do not accept runner-side paths and never called the validator.
- `allowed_runner_exec_artifact_roots` in `homeboy-lab-runner` builds its allowlist purely from runner configuration and never had this split. `artifact_promotion` already derives its root from the store and copies with `_in_roots`.
- This file now has no ambient `core::artifact_root()` reads left.

## Verification

`cargo check --workspace --tests -j2` — clean, 3m26s, zero errors.