### PR TITLE
Let the controller admission follow the store's root

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -357,22 +357,28 @@ pub fn submit_plan(
 /// run's own terminal state. Reading that ambiently would let another home's
 /// record of the same identity abandon this store's admission, or leave a
 /// cancellation recorded here unseen while the controller waits on the
-/// admission lock. The controller-runtime store itself stays process-global by
-/// design; only the lifecycle read is rooted here.
+/// admission lock. The controller-runtime store follows the same root now
+/// (#12859), so the admission queue and its lock belong to this installation
+/// rather than the machine.
 pub fn submit_plan_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     plan: &AgentTaskPlan,
     requested_run_id: Option<&str>,
 ) -> Result<AgentTaskRunRecord> {
+    let runtime_root =
+        homeboy_core::controller_runtime::runtime_root_in(lifecycle_store.roots().data())?;
     submit_plan_with_runtime_admission_in_store(
         lifecycle_store,
         plan,
         requested_run_id,
         execution_runner_id(),
         None,
-        Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
+        Some(&|run_id| {
+            homeboy_core::controller_runtime::admission_status_at(&runtime_root, run_id).ok()
+        }),
         |run_id| {
-            homeboy_core::controller_runtime::admit_current_for_with_cancellation_check(
+            homeboy_core::controller_runtime::admit_current_for_with_cancellation_check_in_root(
+                &runtime_root,
                 run_id,
                 || Ok(lifecycle_store.read_record(run_id)?.state.is_terminal()),
             )
@@ -4649,15 +4655,20 @@ fn retry_with_force_inner_in_store(
     force: bool,
     enforce_lineage_reservation: bool,
 ) -> Result<AgentTaskRunRecord> {
+    let runtime_root =
+        homeboy_core::controller_runtime::runtime_root_in(lifecycle_store.roots().data())?;
     retry_with_runtime_admission_in_store(
         lifecycle_store,
         run_id,
         requested_run_id,
         force,
         enforce_lineage_reservation,
-        Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
+        Some(&|run_id| {
+            homeboy_core::controller_runtime::admission_status_at(&runtime_root, run_id).ok()
+        }),
         |run_id| {
-            homeboy_core::controller_runtime::admit_current_for_with_cancellation_check(
+            homeboy_core::controller_runtime::admit_current_for_with_cancellation_check_in_root(
+                &runtime_root,
                 run_id,
                 || Ok(lifecycle_store.read_record(run_id)?.state.is_terminal()),
             )

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -3934,21 +3934,38 @@ fn record_completed_run_exposes_logs_and_artifacts() {
     });
 }
 
-/// Stays on `with_isolated_home` (#7505) — `mark_running`; see
-/// `running_observation_projects_each_terminal_aggregate_state`.
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The whole submit -> run -> complete -> read cycle names one home,
+/// including the controller admission `submit_plan_in_store` takes: that queue
+/// and its lock follow the store's root now (#12859) instead of the machine.
 #[test]
 fn submitted_run_can_be_loaded_marked_running_and_completed() {
-    with_isolated_home(|_| {
+    let test_context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store = AgentTaskLifecycleStore::new(test_context.path_roots());
+    {
         let plan = test_plan();
-        submit_plan(&plan, Some("run-execute")).expect("submitted");
+        submit_plan_in_store(&lifecycle_store, &plan, Some("run-execute")).expect("submitted");
 
-        let loaded_plan = load_plan("run-execute").expect("plan loaded");
-        let running = mark_running("run-execute").expect("marked running");
+        let loaded_plan = load_plan_in_store(&lifecycle_store, "run-execute").expect("plan loaded");
+        let running =
+            mark_running_in_store(&lifecycle_store, "run-execute").expect("marked running");
         let aggregate = succeeded_aggregate(&loaded_plan);
 
-        let completed =
-            record_run_aggregate("run-execute", &loaded_plan, &aggregate).expect("completed");
-        let durable_status = status("run-execute").expect("status");
+        let completed = record_run_aggregate_in_store(
+            &lifecycle_store,
+            "run-execute",
+            &loaded_plan,
+            &aggregate,
+        )
+        .expect("completed");
+        let durable_status = status_in_store(
+            &lifecycle_store,
+            "run-execute",
+            AgentTaskStatusOptions::default(),
+            false,
+        )
+        .expect("status")
+        .record;
 
         assert_eq!(loaded_plan.plan_id, "plan-a");
         assert_eq!(running.state, AgentTaskRunState::Running);
@@ -3969,7 +3986,7 @@ fn submitted_run_can_be_loaded_marked_running_and_completed() {
         assert_eq!(durable_status.tasks[0].state, AgentTaskState::Succeeded);
         assert_eq!(durable_status.totals, Some(aggregate.totals.clone()));
         assert!(completed.aggregate_path.is_some());
-    });
+    }
 }
 
 /// Stays on `with_isolated_home` (#7505) — `record_completed_run`; see

--- a/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
@@ -371,9 +371,13 @@ pub(crate) fn production_runtime_admission(
     lifecycle_store: &AgentTaskLifecycleStore,
 ) -> impl FnOnce(&str) -> Result<Value> + '_ {
     move |run_id| {
-        homeboy_core::controller_runtime::admit_current_for_with_cancellation_check(run_id, || {
-            Ok(lifecycle_store.read_record(run_id)?.state.is_terminal())
-        })
+        let runtime_root =
+            homeboy_core::controller_runtime::runtime_root_in(lifecycle_store.roots().data())?;
+        homeboy_core::controller_runtime::admit_current_for_with_cancellation_check_in_root(
+            &runtime_root,
+            run_id,
+            || Ok(lifecycle_store.read_record(run_id)?.state.is_terminal()),
+        )
         .map(|admission| admission.runtime)
     }
 }


### PR DESCRIPTION
**Stacked on #12859** — base is `core-runtime-root`, not `main`. Merge that first.

#12859 gave the controller-runtime module rooted entry points. This is what they were for.

## A comment that described a constraint as a design

`submit_plan_in_store` carried this:

> The controller-runtime store itself stays **process-global by design**; only the lifecycle read is rooted here.

That was an accurate description of the situation and a wrong explanation of it. Nothing about it was by design — **no rooted form existed**. Three admission chains resolved the machine-global runtime store while holding a perfectly good lifecycle store:

```
submit_plan_in_store
retry_with_runtime_admission        (already a rooted caller!)
production_runtime_admission        (already takes &AgentTaskLifecycleStore!)
```

The middle two are the sharpest version of the problem: functions that had been *deliberately rooted* were still reaching a machine-global admission queue underneath.

## The fix

All three derive the runtime root from the store they were already handed, through the `roots()` accessor added in #12852:

```rust
let runtime_root =
    controller_runtime::runtime_root_in(lifecycle_store.roots().data())?;
```

Both `admit_current_for_with_cancellation_check` and `admission_status` move to their rooted forms. The admission queue and its cross-process lock now belong to the installation the caller named.

## Payoff

```
with_isolated_home:  2352 -> 2351
```

`submitted_run_can_be_loaded_marked_running_and_completed` is freed — submit, load, mark running, complete and read all name one home end to end. It is the second test off the `mark_running` family, and the first that needed the *admission* rooted rather than just the store.

One test per PR is not the rate this finishes at. It is the rate at which the *last* structural blocker gets removed — each of these unpins a family, and the annotations name which tests follow.

<b>CI is the verification for the freed test.</b> `cargo check` cannot prove it still asserts what it should.

## Verification

- `nice -n 10 cargo check --workspace --tests -j2` — clean, **0 errors, 0 warnings** (full workspace on the admission change; incremental `homeboy-agents` on the test)
- `cargo fmt --check` — clean

Expect the known red-main set; see the evidence comment on #12772.
