### PR TITLE
Free two tests the rooted admission unblocked

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1924,10 +1924,11 @@ pub fn record_completed_run(
 /// aggregate write in another leaves a queued record that never completes and a
 /// terminal projection with no run behind it, and neither write ever fails.
 ///
-/// The controller-runtime admission that `submit_plan_in_store` performs stays
-/// process-global by design — it is a content-addressed executable pin shared
-/// across homes, not durable lifecycle state, so it is not one of this store's
-/// roots.
+/// The controller-runtime admission that `submit_plan_in_store` performs
+/// follows this store's root as well (#12859, #12862). The pin itself is
+/// content-addressed and shared, but the admission queue and its cross-process
+/// lock are per-installation: resolving them from the ambient home made every
+/// rooted caller serialize on one machine-global lock.
 pub fn record_completed_run_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     plan: &AgentTaskPlan,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -3858,15 +3858,17 @@ fn pre_dispatch_failure_persists_failed_run_without_provider_handle() {
     });
 }
 
-/// Stays on `with_isolated_home` (#7505). `record_completed_run_in_store` is
-/// rooted for its aggregate half but opens with `submit_plan_in_store`, which
-/// supplies the *real* controller admission — `admit_current_for_with_cancellation_check`
-/// against the machine-global `paths::controller_runtimes_store()`. There is no
-/// `record_completed_run_with_submission_in_store` to hand a stub to, so a
-/// rooted spelling of this test would enqueue against the operator's real home.
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The blocker this test used to carry was real: `submit_plan_in_store`
+/// enqueued its controller admission against the machine-global
+/// `paths::controller_runtimes_store()`, so a rooted spelling would have queued
+/// against the operator's own home. That admission follows the store's root now
+/// (#12862), and no stub is needed to make the submission safe.
 #[test]
 fn record_completed_run_exposes_logs_and_artifacts() {
-    with_isolated_home(|_| {
+    let test_context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store = AgentTaskLifecycleStore::new(test_context.path_roots());
+    {
         let plan = test_plan();
         let aggregate = AgentTaskAggregate {
             schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
@@ -3922,16 +3924,21 @@ fn record_completed_run_exposes_logs_and_artifacts() {
             queue: Default::default(),
         };
 
-        let record =
-            record_completed_run(&plan, &aggregate, Some("run-complete")).expect("recorded");
-        let log = logs(&record.run_id).expect("logs");
-        let artifacts = artifacts(&record.run_id).expect("artifacts");
+        let record = record_completed_run_in_store(
+            &lifecycle_store,
+            &plan,
+            &aggregate,
+            Some("run-complete"),
+        )
+        .expect("recorded");
+        let log = logs_in_store(&lifecycle_store, &record.run_id).expect("logs");
+        let artifacts = artifacts_in_store(&lifecycle_store, &record.run_id).expect("artifacts");
 
         assert_eq!(record.state, AgentTaskRunState::Succeeded);
         assert_eq!(log.events[0].status, AgentTaskState::Succeeded);
         assert_eq!(artifacts.artifacts[0].id, "patch");
         assert_eq!(artifacts.evidence_refs[0].kind, "transcript");
-    });
+    }
 }
 
 /// Rooted in an explicit store rather than a mutated process environment
@@ -4048,19 +4055,34 @@ fn completed_run_persists_opaque_provider_handles_from_outcome_metadata() {
     });
 }
 
-/// Stays on `with_isolated_home` (#7505) — `mark_running`; see
-/// `running_observation_projects_each_terminal_aggregate_state`.
+/// Rooted in an explicit store rather than a mutated process environment
+/// (#7505). The aggregate this plants by hand and the record `status` rebuilds
+/// from it are the same run in one home. `mark_running` used to pin this to an
+/// ambient home through its pin migration's machine-global admission lock; that
+/// lock follows the store's root now (#12852, #12859).
 #[test]
 fn status_recovers_terminal_state_from_durable_aggregate() {
-    with_isolated_home(|_| {
+    let test_context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store = AgentTaskLifecycleStore::new(test_context.path_roots());
+    {
         let plan = test_plan();
-        submit_plan(&plan, Some("run-stale-status")).expect("submitted");
-        mark_running("run-stale-status").expect("marked running");
+        submit_plan_in_store(&lifecycle_store, &plan, Some("run-stale-status")).expect("submitted");
+        mark_running_in_store(&lifecycle_store, "run-stale-status").expect("marked running");
         let aggregate = succeeded_aggregate(&plan);
-        store::write_aggregate("run-stale-status", &aggregate).expect("aggregate written");
+        store::write_aggregate_in_store(&lifecycle_store, "run-stale-status", &aggregate)
+            .expect("aggregate written");
 
-        let recovered = status("run-stale-status").expect("status recovered");
-        let persisted = store::read_record("run-stale-status").expect("record persisted");
+        let recovered = status_in_store(
+            &lifecycle_store,
+            "run-stale-status",
+            AgentTaskStatusOptions::default(),
+            false,
+        )
+        .expect("status recovered")
+        .record;
+        let persisted = lifecycle_store
+            .read_record("run-stale-status")
+            .expect("record persisted");
 
         assert_eq!(recovered.state, AgentTaskRunState::Succeeded);
         assert_eq!(recovered.tasks[0].state, AgentTaskState::Succeeded);
@@ -4068,7 +4090,7 @@ fn status_recovers_terminal_state_from_durable_aggregate() {
         assert_eq!(persisted.state, AgentTaskRunState::Succeeded);
         assert_eq!(persisted.tasks[0].state, AgentTaskState::Succeeded);
         assert_eq!(persisted.totals, Some(aggregate.totals.clone()));
-    });
+    }
 }
 
 /// Rooted in an explicit store rather than a mutated process environment


### PR DESCRIPTION
**Stacked on #12862**, which is stacked on #12859. Merge order: **#12859 → #12862 → this**.

#12862 rooted the controller admission that `submit_plan_in_store` performs. Two annotated tests named exactly that as their reason for staying on `with_isolated_home`. They come off it now.

```
with_isolated_home:  2351 -> 2349
```

## The annotations were load-bearing

`record_completed_run_exposes_logs_and_artifacts` carried this:

> There is no `record_completed_run_with_submission_in_store` to hand a stub to, so a rooted spelling of this test would **enqueue against the operator's real home**.

That is not a stylistic note — it says the obvious refactor was *actively unsafe* until the admission was rooted. I went looking to write the missing `_with_submission_in_store` sibling the annotation asks for and found it unnecessary: rooting the admission removed the reason a stub was needed at all.

## A doc comment that was half right

`record_completed_run_in_store` claimed its admission:

> stays process-global by design — it is a content-addressed executable pin shared across homes, not durable lifecycle state

The **pin** is shared and content-addressed — that part is true and worth keeping. The **admission queue and its cross-process lock** are not the pin, and treating them as one thing is what made every rooted caller serialize on a single machine-global lock.

Corrected rather than deleted, because the distinction is the useful part.

## Remaining blockers, from the annotations themselves

The 14 surviving annotations sort into four causes:

| blocker | tests |
|---|---|
| `reached_freeze_boundary` reads `status` ambiently | **4** |
| process-global `AtomicBool` fault injection | **3** |
| `pinned_runtime_for_mutation` has no rooted sibling | 1 |
| `RunnerContinuationTestGuard` / provider installation | 1 |

`reached_freeze_boundary` is the next single highest-value fix — one rooted read frees four tests.

<b>CI is the verification for both freed tests.</b> `cargo check` cannot prove they still assert what they should.

## Verification

- `nice -n 10 cargo check --workspace --tests -j2` — clean, **0 errors, 0 warnings**
- `cargo fmt --check` — clean

Expect the known red-main set; see the evidence comment on #12772.
