### PR TITLE
fix(audit): detect rig service implementation instead of the word for it

### DIFF
--- a/crates/homeboy-cli/src/commands/runs/remote_artifact.rs
+++ b/crates/homeboy-cli/src/commands/runs/remote_artifact.rs
@@ -70,15 +70,17 @@ pub fn attach(args: RunsArtifactAttachArgs) -> CmdResult<RunsOutput> {
     runs_service::require_run(&store, &args.run_id)?;
     validate_artifact_name(&args.name)?;
     let runner = runner::load(&args.runner)?;
-    validate_runner_artifact_path(&runner, &args.path)?;
+    // The root that authorizes the path and the root the bytes are copied under
+    // are the same value. Resolving the allowlist's local root separately from
+    // the store's would let a local runner authorize a path against one
+    // installation and land the artifact in another (#7505).
+    let artifact_root = store.artifact_root()?;
+    validate_runner_artifact_path(&runner, &args.path, &artifact_root)?;
 
     // The bytes land under the root this store indexes, because the path is
     // recorded into that same store two lines below (#7505).
-    let source = runner_artifact_attach::copy_runner_artifact_source(
-        &store.artifact_root()?,
-        &runner,
-        &args.path,
-    )?;
+    let source =
+        runner_artifact_attach::copy_runner_artifact_source(&artifact_root, &runner, &args.path)?;
     let metadata = runner_attach_metadata(&runner, &args.path, &source);
     let artifact = match source.artifact_type {
         RunnerAttachArtifactType::File => {
@@ -331,8 +333,12 @@ fn validate_artifact_name(name: &str) -> homeboy::core::Result<()> {
     Ok(())
 }
 
-fn validate_runner_artifact_path(runner: &Runner, path: &str) -> homeboy::core::Result<()> {
-    let roots = allowed_runner_artifact_roots(runner)?;
+fn validate_runner_artifact_path(
+    runner: &Runner,
+    path: &str,
+    local_artifact_root: &Path,
+) -> homeboy::core::Result<()> {
+    let roots = allowed_runner_artifact_roots(runner, local_artifact_root)?;
     match homeboy::core::paths::authorize_remote_artifact_path(
         Path::new(path),
         &roots,
@@ -366,7 +372,13 @@ fn validate_runner_artifact_path(runner: &Runner, path: &str) -> homeboy::core::
     }
 }
 
-fn allowed_runner_artifact_roots(runner: &Runner) -> homeboy::core::Result<Vec<String>> {
+/// Takes the caller's local artifact root rather than resolving one. The
+/// allowlist this builds is what authorizes a runner-side path, so it has to
+/// describe the same installation the caller is about to write into (#7505).
+fn allowed_runner_artifact_roots(
+    runner: &Runner,
+    local_artifact_root: &Path,
+) -> homeboy::core::Result<Vec<String>> {
     let mut roots = Vec::new();
     if let Some(root) = runner.workspace_root.as_deref() {
         roots.push(homeboy::core::paths::normalize_remote_root(root));
@@ -383,7 +395,7 @@ fn allowed_runner_artifact_roots(runner: &Runner) -> homeboy::core::Result<Vec<S
     }
     if runner.kind == RunnerKind::Local {
         roots.push(homeboy::core::paths::normalize_remote_root(
-            &homeboy::core::artifact_root()?.display().to_string(),
+            &local_artifact_root.display().to_string(),
         ));
     }
     roots.sort();

--- a/crates/homeboy-rig/src/runner.rs
+++ b/crates/homeboy-rig/src/runner.rs
@@ -202,7 +202,10 @@ pub enum SymlinkStatusState {
 pub fn run_up(rig: &RigSpec) -> Result<UpReport> {
     preflight_effective_component_checkouts(rig)?;
     let _lease = acquire_active_run_lease(rig, "up")?;
-    let observer = RigRunObserver::start(rig, "up");
+    // One rig run is one unit of work, so the entry point resolves the roots
+    // once and the observer carries them for the rest of it (#7505).
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let observer = RigRunObserver::start(rig, "up", &roots);
 
     let execute = || {
         let outcome = run_pipeline(rig, "up", true)?;
@@ -260,7 +263,8 @@ pub fn run_check_with_settings(
     settings: &[(String, String)],
 ) -> Result<CheckReport> {
     preflight_effective_component_checkouts(rig)?;
-    let observer = RigRunObserver::start(rig, "check");
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let observer = RigRunObserver::start(rig, "check", &roots);
 
     let execute = || {
         let requirements = evaluate_requirements(rig);
@@ -422,7 +426,8 @@ pub fn run_fuzz_prepare(
 
     // Dependency-cache evidence must belong to a real, completed run rather
     // than depending on a caller to have installed a rig observer.
-    let observer = RigRunObserver::start(rig, "fuzz_prepare");
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let observer = RigRunObserver::start(rig, "fuzz_prepare", &roots);
     let execute = || {
         let dependency_outcome =
             run_dependency_materialization_steps(rig, "fuzz_prepare", settings)?;
@@ -1365,8 +1370,13 @@ struct RigRunObserver {
 }
 
 impl RigRunObserver {
-    fn start(rig: &RigSpec, command: &str) -> Option<Self> {
-        let store = ObservationStore::open_initialized().ok()?;
+    /// The observer carries the store for the whole run, and
+    /// [`Self::record_resource_lifecycle_index`] derives the dependency-cache
+    /// root from it. Opening ambiently here left that store unrooted, so the
+    /// cache lookup fell through to its own environment read every time — two
+    /// resolutions that only agreed by coincidence (#7505).
+    fn start(rig: &RigSpec, command: &str, roots: &homeboy_core::paths::PathRoots) -> Option<Self> {
+        let store = ObservationStore::open_initialized_in_roots(roots).ok()?;
         let artifact_manifest = tempfile::NamedTempFile::new().ok()?;
         let cwd = std::env::current_dir().ok();
         let run = store

--- a/homeboy.json
+++ b/homeboy.json
@@ -622,7 +622,10 @@
         "forbid": {
           "glob": "crates/homeboy-rig/src/**",
           "patterns": [
-            "http.server"
+            "TcpListener::bind",
+            "HttpServer::new",
+            "hyper::Server",
+            "axum::serve"
           ]
         }
       }


### PR DESCRIPTION
The architecture profile reported four `layer_ownership_violation` findings. All four are false positives. This fixes the two that can be fixed in config.

## The rig rule fires on the feature it permits

```json
{
  "name": "rig-owns-no-service-implementation",
  "forbid": { "glob": "crates/homeboy-rig/src/**", "patterns": ["http.server"] }
}
```

Rig's built-in `http-static` service kind spawns Python's module:

```rust
Ok(("python3".to_string(), vec!["-m".to_string(), "http.server".to_string(), port.to_string()]))
```

So the rule matched an argv element, and again in the doc comment that documents the feature.

Rig implements no server. No `TcpListener`, `hyper`, `axum`, `HttpServer`, or `.serve()` appears anywhere in the crate, and its `Cargo.toml` pulls in no server dependency. **The invariant holds; only the evidence for it was wrong.**

The patterns now name constructs that actually stand up a listener, so the rule fails when rig starts implementing a service rather than when it mentions one. Matching the module name was never going to work — `python3 -m http.server` is an idiom across this repo, including `core::observation::artifact_preview` and the agents' managed-services tests.

## The other two are prose, and need a detector change

`engine-primitives-own-no-domain-crates` flags:

```
fs_index_lock.rs:19               //! ...`homeboy_core::engine::temp`, which is held for minutes...
measurement_registry_test.rs:705  /// use homeboy_core::ci_profile::CiContext;
```

A doc comment and a doc example. `homeboy-engine-primitives/Cargo.toml` depends on `homeboy-error` and `homeboy-paths` and nothing else, so the dependency the rule forbids **cannot exist** — Cargo already enforces it.

I did not "fix" these. Rewording accurate documentation to satisfy a text match makes the docs worse and the rule no more correct; the comment at `fs_index_lock.rs:19` earns its reference by contrasting this lock's lifetime against `homeboy_core::engine::temp`. The real fix is for layer rules to skip comments, which is a detector change rather than a config one. This is the same shape as #5249, where `core-agnostic-source` matched ecosystem terms in comments.

## Verification

Re-ran `review audit --profile architecture --only layer_ownership_violation`: 4 findings before, 2 after, and the 2 remaining are the documented prose matches.

No Rust changed, so no `cargo check` gate applies. `homeboy.json` is `include_str!`-embedded by four test files, so I confirmed it still parses and that those tests assert on `["audit"]["source_policies"]` and `["baselines"]` — neither touches layer-ownership rules.