### PR TITLE
fix(audit): drop the contract scenario a stale branch resurrected

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -35,15 +35,6 @@
           "id": "release-golden-contract"
         },
         {
-          "command": "review",
-          "expected_fields": {
-            "/data/command": "review",
-            "/success": false
-          },
-          "file": "tests/fixtures/output_contracts/quality/review-artifact.json",
-          "id": "review-artifact-golden"
-        },
-        {
           "command": "runs",
           "expected_fields": {
             "/scenarios/0/payload/data/payload/command": "runs.list",


### PR DESCRIPTION
The architecture profile's one `command_status_fixture_missing` warning is a two-month-old merge accident.

## What happened

Two commits landed on 2026-06-26:

| commit | PR | effect |
|---|---|---|
| `e320740b4` | #6608 | removed 4 quality fixtures **and** all 4 matching scenario entries |
| `458030f10` | #6621 | split an unrelated god-file — and re-added `review-artifact-golden` |

`git log -S` on `homeboy.json` shows the resurrection directly:

```
+          "file": "tests/fixtures/output_contracts/quality/review-artifact.json",
+          "id": "review-artifact-golden"
```

#6621 was branched before #6608 merged, so its `homeboy.json` still held the pre-cleanup scenario list. It did not touch `tests/fixtures/`, so the fixture stayed deleted while the entry came back. The scenario has pointed at a non-existent file ever since, and the audit has warned about it on every run.

## Why removal is the right direction

#6608 is titled "trim low-signal command contract tests" and removed all four quality fixtures deliberately. Three of them — `audit-summary-golden`, `lint-findings-golden`, `test-summary-golden` — are still absent, which is the intended state. Only this one came back, and only in config.

Restoring the fixture would reinstate a test that was deliberately retired, based on nothing more than a merge artifact deciding it for us.

## Verification

```
scenarios: 6 -> 5
review audit --profile architecture --only command_status_fixture_missing
  findings: 0   (was 1)
```

The remaining five scenarios all resolve to files that exist. The removal asserted the orphan was unique and that its path matched the deleted fixture before writing.

No Rust changed. `homeboy.json` is `include_str!`-embedded by four test files; it still parses, and those tests assert on `["audit"]["source_policies"]` and `["baselines"]`, not on `command_status_contracts`.