### PR TITLE
Infer Cook base from repository evidence

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -991,9 +991,10 @@ pub struct AgentTaskCookArgs {
     #[arg(long)]
     pub no_progress: bool,
     /// Base branch the finalized pull request targets and the branch changes are
-    /// diffed against (default `main`).
-    #[arg(long, default_value = "main", value_name = "BRANCH")]
-    pub base: String,
+    /// diffed against. When omitted, Cook resolves repository evidence before
+    /// falling back to `main`.
+    #[arg(long, value_name = "BRANCH")]
+    pub base: Option<String>,
     /// Head branch to push and open the PR from. Defaults to the branch the
     /// destination worktree is already on.
     #[arg(long, value_name = "BRANCH")]
@@ -1034,6 +1035,9 @@ pub struct AgentTaskCookArgs {
     /// not caller input: Cook persists it with the compiled plan.
     #[arg(skip)]
     pub repository_identity: Option<serde_json::Value>,
+    /// Controller-resolved base provenance persisted with the Cook plan.
+    #[arg(skip)]
+    pub base_resolution: Option<serde_json::Value>,
 }
 
 pub(crate) fn parse_provider_evidence_input(

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -21,6 +21,7 @@ use homeboy::agents::agent_tasks::scheduler::{
 use homeboy::agents::agent_tasks::service as agent_task_service;
 use homeboy::core::command_invocation::CommandInvocation;
 use homeboy::core::defaults;
+use homeboy::core::engine::shell::quote_args;
 use homeboy::core::worktree_providers::{
     provision_apply_enabled_worktree_provider_from_config, WorktreeProviderCreateIntent,
 };
@@ -361,9 +362,13 @@ fn cook_preview_replay_argv(args: &AgentTaskCookArgs) -> PreviewReplayArgv {
         );
     }
 
-    // Unit callers do not have the original process argv. Keep their fallback
-    // useful for embedding while the CLI path above preserves every supplied
-    // advanced flag exactly.
+    redact_preview_replay_argv(cook_replay_argv(args))
+}
+
+// Unit callers do not have the original process argv. Keep their fallback
+// useful for embedding while the CLI path above preserves every supplied
+// advanced flag exactly.
+fn cook_replay_argv(args: &AgentTaskCookArgs) -> Vec<String> {
     let mut argv = vec![
         "homeboy".to_string(),
         "agent-task".to_string(),
@@ -381,13 +386,24 @@ fn cook_preview_replay_argv(args: &AgentTaskCookArgs) -> PreviewReplayArgv {
     if let Some(task_url) = &args.dispatch.task_url {
         argv.extend(["--task-url".to_string(), task_url.clone()]);
     }
+    if let Some(backend) = &args.dispatch.backend {
+        argv.extend(["--backend".to_string(), backend.clone()]);
+    }
+    if let Some(selector) = &args.dispatch.selector {
+        argv.extend(["--selector".to_string(), selector.clone()]);
+    }
+    if let Some(model) = &args.dispatch.model {
+        argv.extend(["--model".to_string(), model.clone()]);
+    }
     if let Some(worktree) = &args.to_worktree {
         argv.extend(["--to-worktree".to_string(), worktree.clone()]);
     }
     for gate in &args.gates.verify {
         argv.extend(["--verify".to_string(), gate.clone()]);
     }
-    argv.extend(["--base".to_string(), args.base.clone()]);
+    if let Some(base) = &args.base {
+        argv.extend(["--base".to_string(), base.clone()]);
+    }
     if let Some(head) = &args.head {
         argv.extend(["--head".to_string(), head.clone()]);
     }
@@ -397,7 +413,7 @@ fn cook_preview_replay_argv(args: &AgentTaskCookArgs) -> PreviewReplayArgv {
     if args.draft_pr {
         argv.push("--draft-pr".to_string());
     }
-    redact_preview_replay_argv(argv)
+    argv
 }
 
 fn redact_preview_replay_argv(argv: impl IntoIterator<Item = String>) -> PreviewReplayArgv {
@@ -1841,6 +1857,7 @@ fn cook_report_with_continuation(mut value: Value) -> Value {
 /// Converge a Cook promotion destination before compiling a task plan. This is
 /// controller-owned so local and Lab dispatch use the same managed checkout.
 pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::core::Result<Value> {
+    validate_cook_base_before_provisioning(args)?;
     let to_worktree = args.to_worktree.as_deref().ok_or_else(|| {
         homeboy::core::Error::validation_missing_argument(vec![
             "--to-worktree is required before provisioning a Cook destination".to_string(),
@@ -2004,7 +2021,10 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
         &WorktreeProviderCreateIntent {
             handle: to_worktree.to_string(),
             repo,
-            base: args.base.clone(),
+            base: args
+                .base
+                .clone()
+                .expect("Cook base is resolved before provisioning"),
             head,
             task_url,
         },
@@ -2115,6 +2135,7 @@ pub(crate) fn resolve_cook_destination(
 ) -> homeboy::core::Result<AgentTaskCookArgs> {
     normalize_cook_repository_identity(&mut args)?;
     if args.to_worktree.is_some() {
+        resolve_cook_base(&mut args)?;
         return Ok(args);
     }
     if let Some(cwd) = args.dispatch.cwd.as_deref() {
@@ -2124,6 +2145,7 @@ pub(crate) fn resolve_cook_destination(
         // A supplied checkout is the writable Cook authority. Preserve its
         // canonical path instead of deriving an unrelated issue handle.
         args.to_worktree = Some(cwd.display().to_string());
+        resolve_cook_base(&mut args)?;
         return Ok(args);
     }
     let repo = args.dispatch.repo.as_deref().ok_or_else(|| {
@@ -2153,7 +2175,153 @@ pub(crate) fn resolve_cook_destination(
     if args.head.is_none() {
         args.head = Some(derived_cook_branch(task_url)?);
     }
+    resolve_cook_base(&mut args)?;
     Ok(args)
+}
+
+fn resolve_cook_base(args: &mut AgentTaskCookArgs) -> homeboy::core::Result<()> {
+    if let Some(base) = args.base.clone() {
+        args.base_resolution = Some(serde_json::json!({ "base": base, "source": "explicit" }));
+        return Ok(());
+    }
+
+    let workspace = args
+        .dispatch
+        .workspace
+        .as_deref()
+        .or(args.dispatch.cwd.as_deref())
+        .and_then(|path| homeboy::core::git::repo_root(Path::new(path)));
+    if let Some(workspace) = workspace {
+        if let Some(upstream) = git_upstream_branch(&workspace) {
+            set_resolved_cook_base(args, upstream, "workspace_upstream", &workspace);
+            return Ok(());
+        }
+    }
+
+    if let Some(component) = args
+        .dispatch
+        .repo
+        .as_deref()
+        .map(homeboy::core::component::registered_by_id)
+        .transpose()?
+        .flatten()
+    {
+        let path = PathBuf::from(component.local_path);
+        if let Some(base) = homeboy::core::git::default_branch_name(&path) {
+            set_resolved_cook_base(args, base, "repository_metadata", &path);
+            return Ok(());
+        }
+    }
+
+    if let Some(path) = args
+        .to_worktree
+        .as_deref()
+        .map(PathBuf::from)
+        .filter(|path| path.is_dir())
+    {
+        if let Some(base) = homeboy::core::git::default_branch_name(&path) {
+            set_resolved_cook_base(args, base, "remote_head", &path);
+            return Ok(());
+        }
+    }
+
+    args.base = Some("main".to_string());
+    args.base_resolution = Some(serde_json::json!({
+        "base": "main",
+        "source": "compatibility_fallback",
+        "evidence": "repository default-branch evidence unavailable",
+    }));
+    Ok(())
+}
+
+fn git_upstream_branch(path: &Path) -> Option<String> {
+    homeboy::core::git::output_optional(path, &["rev-parse", "--abbrev-ref", "@{upstream}"])
+        .and_then(|upstream| {
+            upstream
+                .trim()
+                .split_once('/')
+                .map(|(_, branch)| branch.to_string())
+        })
+        .filter(|branch| !branch.is_empty())
+}
+
+fn set_resolved_cook_base(args: &mut AgentTaskCookArgs, base: String, source: &str, path: &Path) {
+    args.base = Some(base.clone());
+    args.base_resolution = Some(serde_json::json!({
+        "base": base,
+        "source": source,
+        "evidence_path": path,
+    }));
+}
+
+fn validate_cook_base_before_provisioning(args: &AgentTaskCookArgs) -> homeboy::core::Result<()> {
+    let base = args
+        .base
+        .as_deref()
+        .expect("Cook base is resolved before provisioning");
+    let path = args
+        .dispatch
+        .workspace
+        .as_deref()
+        .or(args.dispatch.cwd.as_deref())
+        .map(PathBuf::from)
+        .or_else(|| {
+            args.to_worktree
+                .as_deref()
+                .map(PathBuf::from)
+                .filter(|path| path.is_dir())
+        })
+        .or_else(|| {
+            args.dispatch.repo.as_deref().and_then(|repo| {
+                homeboy::core::component::registered_by_id(repo)
+                    .ok()
+                    .flatten()
+                    .map(|component| PathBuf::from(component.local_path))
+            })
+        });
+    let Some(path) = path else {
+        return Ok(());
+    };
+    let remote = homeboy::core::git::resolve_default_remote(&path);
+    let remote_base = format!("{remote}/{base}");
+    if homeboy::core::git::output_optional(
+        &path,
+        &["rev-parse", "--verify", "--quiet", &remote_base],
+    )
+    .is_some()
+        || homeboy::core::git::output_optional(&path, &["rev-parse", "--verify", "--quiet", base])
+            .is_some()
+    {
+        return Ok(());
+    }
+    let replay_argv = homeboy::core::git::default_branch_name(&path)
+        .map(|corrected| corrected_cook_base_replay_argv(args, &corrected));
+    let mut error = homeboy::core::Error::validation_invalid_argument(
+        "base",
+        format!("resolved Cook base `{base}` is unavailable before worktree provisioning"),
+        Some(base.to_string()),
+        replay_argv.as_ref().map(|argv| {
+            vec![format!(
+                "Replay with the repository default base: {}",
+                quote_args(argv)
+            )]
+        }),
+    );
+    if let Some(argv) = replay_argv {
+        error.details["correction_argv"] = serde_json::json!(argv);
+    }
+    Err(error)
+}
+
+/// Build the correction as typed argv first. The rendered shell command is a
+/// display projection only, so branch and worktree values never become syntax.
+pub(crate) fn corrected_cook_base_replay_argv(
+    args: &AgentTaskCookArgs,
+    corrected_base: &str,
+) -> Vec<String> {
+    let mut corrected = args.clone();
+    corrected.base = Some(corrected_base.to_string());
+    cook_replay_argv(&corrected)
 }
 
 /// Preview performs only bounded provider identity resolution. It never invokes
@@ -2226,6 +2394,7 @@ fn resolve_cook_preview_destination(
         if homeboy::core::worktree_providers::worktree_provider_path_requires_materialization(
             &identity.path,
         ) {
+            resolve_cook_base(&mut args)?;
             return Ok((
                 args,
                 serde_json::json!({
@@ -2244,6 +2413,7 @@ fn resolve_cook_preview_destination(
         validate_cook_destination_identity(&args, &path)?;
         path
     };
+    resolve_cook_base(&mut args)?;
     Ok((
         args,
         serde_json::json!({
@@ -3005,7 +3175,7 @@ pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress(
             max_attempts: args.max_attempts,
             no_finalize: args.no_finalize,
             draft_pr: args.draft_pr,
-            base: args.base,
+            base: args.base.expect("Cook base is resolved before execution"),
             task_base_sha,
             head: args.head,
             title,
@@ -3341,6 +3511,9 @@ pub(crate) fn compile_cook_plan(
     record_cook_provision(&mut plan, provision);
     if let Some(identity) = &args.repository_identity {
         plan.metadata["cook_repository_identity"] = identity.clone();
+    }
+    if let Some(resolution) = &args.base_resolution {
+        plan.metadata["cook_base_resolution"] = resolution.clone();
     }
     for task in &mut plan.tasks {
         if pending_lookup {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -245,6 +245,10 @@ fn cook_infers_repo_from_an_explicit_git_workspace_and_persists_its_provenance()
             plan.metadata["cook_repository_identity"],
             args.repository_identity.expect("identity")
         );
+        assert_eq!(
+            plan.metadata["cook_base_resolution"]["source"],
+            "compatibility_fallback"
+        );
     });
 }
 
@@ -303,6 +307,255 @@ fn repo_only_cook_without_registered_component_persists_requested_repository_exp
         assert_eq!(identity["repository_name"], "unidentified");
         assert_eq!(identity["provenance"], "--repo:requested-repository");
     });
+}
+
+#[test]
+fn cook_resolves_omitted_base_from_workspace_upstream_for_standard_and_custom_branches() {
+    with_isolated_home(|_| {
+        for branch in ["main", "master", "trunk", "release/2026"] {
+            let source = tempfile::tempdir().expect("source checkout");
+            let remote = tempfile::tempdir().expect("bare remote");
+            for args in [
+                vec!["init", "-b", branch],
+                vec!["config", "user.email", "test@example.com"],
+                vec!["config", "user.name", "Test"],
+            ] {
+                assert!(Command::new("git")
+                    .args(args)
+                    .current_dir(source.path())
+                    .status()
+                    .expect("configure source")
+                    .success());
+            }
+            std::fs::write(source.path().join("README"), branch).expect("write source");
+            assert!(Command::new("git")
+                .args(["add", "README"])
+                .current_dir(source.path())
+                .status()
+                .expect("stage source")
+                .success());
+            assert!(Command::new("git")
+                .args(["commit", "-m", "initial"])
+                .current_dir(source.path())
+                .status()
+                .expect("commit source")
+                .success());
+            assert!(Command::new("git")
+                .args([
+                    "init",
+                    "--bare",
+                    "--initial-branch",
+                    branch,
+                    remote.path().to_str().unwrap()
+                ])
+                .status()
+                .expect("create remote")
+                .success());
+            add_remote(source.path(), "origin", remote.path().to_str().unwrap());
+            assert!(Command::new("git")
+                .args(["push", "-u", "origin", branch])
+                .current_dir(source.path())
+                .status()
+                .expect("push upstream")
+                .success());
+            let component_remote = format!("https://github.com/example/{branch}.git");
+            assert!(Command::new("git")
+                .args(["remote", "set-url", "origin", &component_remote])
+                .current_dir(source.path())
+                .status()
+                .expect("normalize fixture remote")
+                .success());
+            register_component("fixture", source.path(), &component_remote);
+
+            let args = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+                "--prompt".to_string(),
+                "resolve base".to_string(),
+                "--workspace".to_string(),
+                source.path().display().to_string(),
+                "--to-worktree".to_string(),
+                source.path().display().to_string(),
+                "--repo".to_string(),
+                "fixture".to_string(),
+                "--backend".to_string(),
+                "fixture".to_string(),
+                "--no-finalize".to_string(),
+            ]))
+            .expect("resolve workspace upstream");
+            assert_eq!(args.base.as_deref(), Some(branch));
+            assert_eq!(
+                args.base_resolution.as_ref().expect("base evidence")["source"],
+                "workspace_upstream"
+            );
+        }
+    });
+}
+
+#[test]
+fn cook_resolves_omitted_base_from_repository_metadata_or_compatibility_fallback() {
+    with_isolated_home(|_| {
+        let source = tempfile::tempdir().expect("source checkout");
+        init_runtime_component_checkout(source.path());
+        let remote = tempfile::tempdir().expect("bare remote");
+        assert!(Command::new("git")
+            .args([
+                "init",
+                "--bare",
+                "--initial-branch",
+                "trunk",
+                remote.path().to_str().unwrap()
+            ])
+            .status()
+            .expect("create remote")
+            .success());
+        add_remote(source.path(), "origin", remote.path().to_str().unwrap());
+        assert!(Command::new("git")
+            .args(["push", "origin", "HEAD:trunk"])
+            .current_dir(source.path())
+            .status()
+            .expect("push trunk")
+            .success());
+        assert!(Command::new("git")
+            .args(["remote", "set-head", "origin", "trunk"])
+            .current_dir(source.path())
+            .status()
+            .expect("set remote head")
+            .success());
+        assert!(Command::new("git")
+            .args(["checkout", "-b", "feature", "origin/trunk"])
+            .current_dir(source.path())
+            .status()
+            .expect("leave the old default branch")
+            .success());
+        assert!(Command::new("git")
+            .args(["branch", "-D", "main"])
+            .current_dir(source.path())
+            .status()
+            .expect("remove unavailable main")
+            .success());
+        let component_remote = "https://github.com/example/fixture.git";
+        assert!(Command::new("git")
+            .args(["remote", "set-url", "origin", component_remote])
+            .current_dir(source.path())
+            .status()
+            .expect("normalize fixture remote")
+            .success());
+        register_component("fixture", source.path(), component_remote);
+
+        let metadata = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "resolve metadata".to_string(),
+            "--repo".to_string(),
+            "fixture".to_string(),
+            "--to-worktree".to_string(),
+            "fixture@missing".to_string(),
+            "--no-finalize".to_string(),
+        ]))
+        .expect("resolve repository metadata");
+        assert_eq!(metadata.base.as_deref(), Some("trunk"));
+        assert_eq!(
+            metadata.base_resolution.as_ref().expect("base evidence")["source"],
+            "repository_metadata"
+        );
+
+        let mut mismatch = metadata;
+        mismatch.base = Some("main".to_string());
+        mismatch.base_resolution = Some(json!({ "base": "main", "source": "explicit" }));
+        let error = super::super::run::provision_cook_destination(&mismatch)
+            .expect_err("invalid base must fail before provisioning");
+        assert_eq!(error.details["field"], "base");
+        assert!(error.details["tried"].as_array().is_some_and(|replays| {
+            replays.iter().any(|replay| {
+                replay
+                    .as_str()
+                    .is_some_and(|replay| replay.contains("--base trunk"))
+            })
+        }));
+        assert_eq!(
+            error.details["correction_argv"],
+            json!([
+                "homeboy",
+                "agent-task",
+                "cook",
+                "--prompt",
+                "resolve metadata",
+                "--repo",
+                "fixture",
+                "--to-worktree",
+                "fixture@missing",
+                "--base",
+                "trunk",
+                "--no-finalize",
+            ])
+        );
+
+        let fallback = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "fallback".to_string(),
+            "--repo".to_string(),
+            "unavailable".to_string(),
+            "--to-worktree".to_string(),
+            "unavailable@missing".to_string(),
+            "--no-finalize".to_string(),
+        ]))
+        .expect("fall back without metadata");
+        assert_eq!(fallback.base.as_deref(), Some("main"));
+        assert_eq!(
+            fallback.base_resolution.expect("base evidence")["source"],
+            "compatibility_fallback"
+        );
+    });
+}
+
+#[test]
+fn corrected_cook_base_replay_keeps_adversarial_values_as_typed_argv() {
+    let worktree = "fixture@work tree;$(touch pwned) 'quoted'";
+    let branch = "trunk;$(touch pwned) 'quoted'";
+    let args = cook_args_from_cli(vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "cook".to_string(),
+        "--prompt".to_string(),
+        "resolve safely".to_string(),
+        "--repo".to_string(),
+        "fixture".to_string(),
+        "--to-worktree".to_string(),
+        worktree.to_string(),
+        "--base".to_string(),
+        "main".to_string(),
+        "--no-finalize".to_string(),
+    ]);
+
+    let argv = super::super::run::corrected_cook_base_replay_argv(&args, branch);
+    assert_eq!(
+        argv,
+        vec![
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "resolve safely",
+            "--repo",
+            "fixture",
+            "--to-worktree",
+            worktree,
+            "--base",
+            branch,
+            "--no-finalize",
+        ]
+    );
+    assert_eq!(
+        homeboy::core::engine::shell::quote_args(&argv),
+        "homeboy agent-task cook --prompt 'resolve safely' --repo fixture --to-worktree 'fixture@work tree;$(touch pwned) '\\''quoted'\\''' --base 'trunk;$(touch pwned) '\\''quoted'\\''' --no-finalize"
+    );
 }
 
 #[test]

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -802,7 +802,7 @@ fn cook_preserves_successful_candidate_when_provider_response_has_wrong_schema()
                 draft_pr: false,
                 full: true,
                 no_progress: false,
-                base: "main".to_string(),
+                base: Some("main".to_string()),
                 head: None,
                 title: None,
                 commit_message: None,
@@ -813,6 +813,7 @@ fn cook_preserves_successful_candidate_when_provider_response_has_wrong_schema()
                 acceptance_authority: None,
                 acceptance_policy: None,
                 repository_identity: None,
+                base_resolution: None,
             },
             Arc::new(ExtensionProviderAgentTaskExecutor::default()),
         )
@@ -1202,7 +1203,7 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
                 draft_pr: false,
                 full: true,
                 no_progress: false,
-                base: "main".to_string(),
+                base: Some("main".to_string()),
                 head: Some("fixture-promoted".to_string()),
                 title: None,
                 commit_message: None,
@@ -1213,6 +1214,7 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
                 acceptance_authority: None,
                 acceptance_policy: None,
                 repository_identity: None,
+                base_resolution: None,
             },
             executor.clone(),
             Some(Arc::new(MirroredAttemptDispatcher {


### PR DESCRIPTION
## Summary

- preserve omitted `--base` intent instead of forcing `main` at argument parsing
- resolve base from workspace upstream, configured metadata, remote HEAD, then compatibility fallback
- persist resolution evidence and validate before provisioning
- return shell-safe typed correction argv for unavailable bases

Closes #12843.

## Verification

- `cargo test -p homeboy-cli cook_resolves_omitted_base`
- `cargo test -p homeboy-cli corrected_cook_base_replay_keeps_adversarial_values_as_typed_argv`
- `cargo check -p homeboy-cli`
- `cargo fmt --check`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6-sol via OpenCode and OpenCode general coding/review subagents were used to reproduce the trunk/main mismatch, implement evidence-based resolution and safe replay, run tests, and review the diff. Chris Huber remains responsible for every line.