### PR TITLE
Unify Cook candidate inventory projections

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/candidate.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/candidate.rs
@@ -1,4 +1,9 @@
-use std::collections::BTreeMap;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    io::Read,
+    path::Path,
+};
 
 use serde_json::{json, Value};
 
@@ -48,6 +53,8 @@ impl CandidateState {
 const MAX_ATTEMPTS_SCANNED: usize = 64;
 const MAX_OUTCOMES_SCANNED: usize = 256;
 const MAX_ARTIFACTS_SCANNED: usize = 256;
+const MAX_CHANGED_FILES_ARTIFACT_BYTES: u64 = 1024 * 1024;
+const MAX_CHANGED_FILES_PATHS: usize = 4096;
 
 /// The canonical terminal result for a Cook's candidate evidence. Evidence is
 /// monotonic: a finalized PR, promoted/adopted candidate, or durable patch
@@ -62,6 +69,9 @@ pub(crate) struct CandidateResult {
     pub(crate) retained_only: usize,
     pub(crate) unknown: usize,
     pub(crate) diff_bytes: u64,
+    pub(crate) changed_files: usize,
+    pub(crate) changed_files_unknown_patches: usize,
+    pub(crate) provider_executions: Option<usize>,
     pub(crate) finalized: bool,
     pub(crate) promoted: bool,
     pub(crate) attempts_omitted: usize,
@@ -102,7 +112,7 @@ impl CandidateResult {
         self.attempts_omitted > 0 || self.outcomes_omitted > 0 || self.artifacts_omitted > 0
     }
 
-    fn record(&mut self, state: CandidateState, size: Option<u64>) {
+    fn record(&mut self, state: CandidateState, size: Option<u64>, changed_files: Option<usize>) {
         match state {
             CandidateState::Finalized | CandidateState::Promoted => {
                 unreachable!("terminal facts are recorded directly")
@@ -110,6 +120,10 @@ impl CandidateResult {
             CandidateState::PatchAvailable => {
                 self.available += 1;
                 self.diff_bytes += size.unwrap_or_default();
+                match changed_files {
+                    Some(count) => self.changed_files += count,
+                    None => self.changed_files_unknown_patches += 1,
+                }
             }
             CandidateState::NoChangesProduced => self.no_changes_produced = true,
             CandidateState::Empty => self.empty += 1,
@@ -162,6 +176,13 @@ pub(crate) fn classify_candidates(payload: &Value) -> CandidateResult {
             .and_then(Value::as_str)
             .unwrap_or("unnamed")
             .to_string();
+        // Only content-addressed artifacts can be aliases of one another. Older
+        // aggregate entries can reuse an id across independent task outcomes.
+        let identity = if artifact.get("sha256").and_then(Value::as_str).is_some() {
+            identity
+        } else {
+            format!("{identity}@{:p}", artifact)
+        };
         by_identity.entry(identity).or_default().push(artifact);
     }
 
@@ -169,6 +190,7 @@ pub(crate) fn classify_candidates(payload: &Value) -> CandidateResult {
         attempts_omitted,
         outcomes_omitted,
         artifacts_omitted,
+        provider_executions: provider_execution_count(payload),
         ..Default::default()
     };
     for artifacts in by_identity.into_values() {
@@ -203,7 +225,7 @@ pub(crate) fn classify_candidates(payload: &Value) -> CandidateResult {
                 None => CandidateState::Unknown,
             }
         };
-        counts.record(state, size);
+        counts.record(state, size, changed_files_for_artifact(artifact));
     }
     counts.no_changes_produced = counts.available == 0
         && counts.empty == 0
@@ -226,6 +248,9 @@ pub(crate) fn canonical_candidate_projection(result: CandidateResult) -> Value {
         "schema": "homeboy/agent-task-candidate/v1",
         "state": result.state().as_str(),
         "diff_bytes": result.diff_bytes,
+        "changed_files": result.changed_files,
+        "changed_files_unknown_patches": result.changed_files_unknown_patches,
+        "provider_executions": result.provider_executions,
         "counts": {
             "patch_available": result.available,
             "empty": result.empty,
@@ -287,6 +312,20 @@ fn candidate_result_from_projection(value: &Value) -> Option<CandidateResult> {
             .get("diff_bytes")
             .and_then(Value::as_u64)
             .unwrap_or_default(),
+        changed_files: value
+            .get("changed_files")
+            .and_then(Value::as_u64)
+            .and_then(|count| usize::try_from(count).ok())
+            .unwrap_or_default(),
+        changed_files_unknown_patches: value
+            .get("changed_files_unknown_patches")
+            .and_then(Value::as_u64)
+            .and_then(|count| usize::try_from(count).ok())
+            .unwrap_or_default(),
+        provider_executions: value
+            .get("provider_executions")
+            .and_then(Value::as_u64)
+            .and_then(|count| usize::try_from(count).ok()),
         finalized: state == CandidateState::Finalized,
         promoted: state == CandidateState::Promoted,
         attempts_omitted: omitted("attempts_omitted"),
@@ -294,6 +333,151 @@ fn candidate_result_from_projection(value: &Value) -> Option<CandidateResult> {
         artifacts_omitted: omitted("artifacts_omitted"),
         no_changes_produced: state == CandidateState::NoChangesProduced,
     })
+}
+
+/// Return durable provider executions rather than normalized aggregate outcomes.
+/// Timeout recovery can leave a patch without a successful normalized task.
+fn provider_execution_count(payload: &Value) -> Option<usize> {
+    let metadata = payload
+        .get("metadata")
+        .or_else(|| payload.pointer("/record/metadata"));
+    metadata
+        .and_then(|metadata| metadata.get("provider_executions_consumed"))
+        .and_then(Value::as_u64)
+        .and_then(|count| usize::try_from(count).ok())
+        .or_else(|| {
+            metadata
+                .and_then(|metadata| metadata.get("provider_executions"))
+                .and_then(Value::as_array)
+                .map(Vec::len)
+        })
+        .or_else(|| {
+            payload
+                .get("attempts")
+                .and_then(Value::as_array)
+                .map(Vec::len)
+        })
+}
+
+pub(crate) fn changed_files_for_artifact(artifact: &Value) -> Option<usize> {
+    if let Some(files) = artifact
+        .pointer("/metadata/changed_files")
+        .and_then(Value::as_array)
+    {
+        return Some(files.len());
+    }
+    if let Some(count) = artifact
+        .pointer("/metadata/changed_file_count")
+        .and_then(Value::as_u64)
+    {
+        return usize::try_from(count).ok();
+    }
+    if !is_homeboy_durable_artifact(artifact) {
+        return None;
+    }
+    let path = Path::new(artifact.get("path").and_then(Value::as_str)?);
+    let artifact_root = homeboy::core::artifact_root().ok()?.canonicalize().ok()?;
+    let metadata = fs::symlink_metadata(path).ok()?;
+    if !metadata.file_type().is_file()
+        || metadata.len() > MAX_CHANGED_FILES_ARTIFACT_BYTES
+        || artifact
+            .get("size_bytes")
+            .and_then(Value::as_u64)
+            .is_some_and(|size| size > MAX_CHANGED_FILES_ARTIFACT_BYTES)
+    {
+        return None;
+    }
+    let canonical = path.canonicalize().ok()?;
+    if !canonical.starts_with(&artifact_root) {
+        return None;
+    }
+
+    let mut options = fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    let file = options.open(path).ok()?;
+    let opened = file.metadata().ok()?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if metadata.dev() != opened.dev() || metadata.ino() != opened.ino() {
+            return None;
+        }
+    }
+    if !opened.is_file() || opened.len() > MAX_CHANGED_FILES_ARTIFACT_BYTES {
+        return None;
+    }
+    let mut bytes = Vec::with_capacity(opened.len() as usize);
+    file.take(MAX_CHANGED_FILES_ARTIFACT_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .ok()?;
+    if bytes.len() as u64 > MAX_CHANGED_FILES_ARTIFACT_BYTES {
+        return None;
+    }
+    let patch = std::str::from_utf8(&bytes).ok()?;
+    changed_paths_from_patch(patch)
+}
+
+fn is_homeboy_durable_artifact(artifact: &Value) -> bool {
+    artifact
+        .pointer("/metadata/executor_artifact_finalized")
+        .and_then(Value::as_bool)
+        == Some(true)
+        && artifact
+            .get("url")
+            .and_then(Value::as_str)
+            .is_some_and(|url| {
+                url.starts_with("homeboy://agent-task/run/") && url.contains("/artifacts")
+            })
+}
+
+fn changed_paths_from_patch(patch: &str) -> Option<usize> {
+    let mut paths = BTreeSet::new();
+    for line in patch.lines() {
+        if let Some(rest) = line.strip_prefix("diff --git ") {
+            let mut parts = rest.split_whitespace();
+            let old = parts.next().map(strip_diff_path_prefix);
+            let new = parts.next().map(strip_diff_path_prefix);
+            match (new, old) {
+                (Some(new), _) if new != "/dev/null" => insert_changed_path(&mut paths, Some(new)),
+                (_, Some(old)) => insert_changed_path(&mut paths, Some(old)),
+                _ => {}
+            }
+        } else if let Some(rest) = line.strip_prefix("+++ ") {
+            let path = strip_diff_path_prefix(rest.split('\t').next().unwrap_or(rest));
+            if path != "/dev/null" {
+                insert_changed_path(&mut paths, Some(path));
+            }
+        } else if let Some(rest) = line.strip_prefix("--- ") {
+            let path = strip_diff_path_prefix(rest.split('\t').next().unwrap_or(rest));
+            if path != "/dev/null" {
+                insert_changed_path(&mut paths, Some(path));
+            }
+        }
+        if paths.len() > MAX_CHANGED_FILES_PATHS {
+            return None;
+        }
+    }
+    Some(paths.len())
+}
+
+fn insert_changed_path(paths: &mut BTreeSet<String>, candidate: Option<String>) {
+    if let Some(path) = candidate.filter(|path| !path.is_empty()) {
+        paths.insert(path);
+    }
+}
+
+fn strip_diff_path_prefix(token: &str) -> String {
+    let token = token.trim().trim_matches('"');
+    token
+        .strip_prefix("a/")
+        .or_else(|| token.strip_prefix("b/"))
+        .unwrap_or(token)
+        .to_string()
 }
 
 fn aggregate_artifacts(payload: &Value) -> (Vec<&Value>, usize, usize, usize) {
@@ -339,12 +523,56 @@ fn aggregate_artifacts(payload: &Value) -> (Vec<&Value>, usize, usize, usize) {
             );
         }
     }
+    // Older review/status projections carry no aggregate. Their candidate
+    // inventory and artifact references remain authoritative fallback evidence.
+    if artifacts.is_empty() {
+        if let Some(inventory) = payload
+            .pointer("/aggregate_review/artifact_inventory")
+            .and_then(Value::as_array)
+        {
+            let candidate_ids = review_candidate_ids(payload);
+            artifacts.extend(inventory.iter().filter(|artifact| {
+                let task_id = artifact.get("task_id").and_then(Value::as_str);
+                let artifact_id = artifact.get("artifact_id").and_then(Value::as_str);
+                task_id
+                    .zip(artifact_id)
+                    .is_some_and(|identity| candidate_ids.contains(&identity))
+            }));
+        }
+    }
+    if artifacts.is_empty() {
+        if let Some(references) = payload.get("artifact_refs").and_then(Value::as_array) {
+            artifacts.extend(references.iter());
+        }
+    }
     (
         artifacts,
         attempts_omitted,
         outcomes_omitted,
         artifacts_omitted,
     )
+}
+
+fn review_candidate_ids(payload: &Value) -> Vec<(&str, &str)> {
+    ["apply_candidates", "review_candidates"]
+        .into_iter()
+        .flat_map(|kind| {
+            payload
+                .pointer(&format!("/aggregate_review/{kind}"))
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .flat_map(|candidate| {
+                    let task_id = candidate.get("task_id").and_then(Value::as_str);
+                    candidate
+                        .get("artifact_ids")
+                        .and_then(Value::as_array)
+                        .into_iter()
+                        .flatten()
+                        .filter_map(move |artifact_id| task_id.zip(artifact_id.as_str()))
+                })
+        })
+        .collect()
 }
 
 /// Count omitted entries from array lengths while only visiting individual
@@ -508,6 +736,10 @@ fn declared_location(artifact: &Value) -> bool {
             .get("url")
             .and_then(Value::as_str)
             .is_some_and(|url| !url.trim().is_empty())
+        || artifact
+            .get("uri")
+            .and_then(Value::as_str)
+            .is_some_and(|uri| !uri.trim().is_empty())
 }
 
 #[cfg(test)]
@@ -531,6 +763,84 @@ mod tests {
             "url": format!("homeboy://agent-task/run/lab-restarted/artifacts#task=cook-intelligence&artifact={id}"),
             "metadata": { "executor_artifact_finalized": true, "source_provenance": { "runner_id": "homeboy-lab" } }
         })
+    }
+
+    fn durable_patch(path: &Path, size_bytes: u64) -> Value {
+        json!({
+            "id": "patch",
+            "kind": "patch",
+            "path": path,
+            "size_bytes": size_bytes,
+            "url": "homeboy://agent-task/run/test/artifacts#task=cook&artifact=patch",
+            "metadata": { "executor_artifact_finalized": true },
+        })
+    }
+
+    #[test]
+    fn changed_file_parsing_refuses_unmanaged_persisted_paths() {
+        crate::test_support::with_isolated_home(|_| {
+            let unmanaged = tempfile::tempdir().expect("unmanaged directory");
+            let patch = unmanaged.path().join("outside.patch");
+            std::fs::write(&patch, "diff --git a/a.rs b/a.rs\n").expect("write unmanaged patch");
+
+            assert_eq!(changed_files_for_artifact(&durable_patch(&patch, 26)), None);
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn changed_file_parsing_refuses_special_files_without_opening_them() {
+        use std::{ffi::CString, os::unix::ffi::OsStrExt};
+
+        crate::test_support::with_isolated_home(|_| {
+            let root = homeboy::core::artifact_root().expect("artifact root");
+            std::fs::create_dir_all(&root).expect("create artifact root");
+            let fifo = root.join("patch.fifo");
+            let fifo_path = CString::new(fifo.as_os_str().as_bytes()).expect("fifo path");
+            assert_eq!(unsafe { libc::mkfifo(fifo_path.as_ptr(), 0o600) }, 0);
+
+            assert_eq!(changed_files_for_artifact(&durable_patch(&fifo, 0)), None);
+        });
+    }
+
+    #[test]
+    fn changed_file_parsing_refuses_oversized_durable_patch() {
+        crate::test_support::with_isolated_home(|_| {
+            let root = homeboy::core::artifact_root().expect("artifact root");
+            std::fs::create_dir_all(&root).expect("create artifact root");
+            let patch = root.join("oversized.patch");
+            std::fs::write(
+                &patch,
+                vec![b'x'; MAX_CHANGED_FILES_ARTIFACT_BYTES as usize + 1],
+            )
+            .expect("write oversized patch");
+
+            assert_eq!(
+                changed_files_for_artifact(&durable_patch(
+                    &patch,
+                    MAX_CHANGED_FILES_ARTIFACT_BYTES + 1,
+                )),
+                None
+            );
+        });
+    }
+
+    #[test]
+    fn changed_file_parsing_refuses_patches_with_too_many_paths() {
+        crate::test_support::with_isolated_home(|_| {
+            let root = homeboy::core::artifact_root().expect("artifact root");
+            std::fs::create_dir_all(&root).expect("create artifact root");
+            let patch = root.join("many-paths.patch");
+            let content = (0..=MAX_CHANGED_FILES_PATHS)
+                .map(|index| format!("diff --git a/{index}.rs b/{index}.rs\n"))
+                .collect::<String>();
+            std::fs::write(&patch, &content).expect("write patch");
+
+            assert_eq!(
+                changed_files_for_artifact(&durable_patch(&patch, content.len() as u64)),
+                None
+            );
+        });
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -287,6 +287,7 @@ pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
                 "unavailable_sources": durable_read.unavailable_sources,
             }
     });
+    value["canonical_candidate"] = canonical_candidate_projection(classify_candidates(&value));
     if let Some(selection) = target.selection {
         let latest_attempt_run_id = selection["latest_attempt_run_id"].as_str();
         if latest_attempt_run_id.is_some_and(|latest| latest != record.run_id) {

--- a/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
@@ -1,6 +1,8 @@
 use serde_json::Value;
 
-use super::agent_task::candidate::{classify_candidates, CandidateState};
+use super::agent_task::candidate::{
+    changed_files_for_artifact, classify_candidates, CandidateState,
+};
 use super::agent_task::{AgentTaskArgs, AgentTaskCommand, AgentTaskControllerCommand};
 use super::summary_json::{array_len, string_value, u64_value, usize_value, value_at};
 
@@ -57,7 +59,11 @@ fn render_cook_summary(payload: &Value) -> Option<String> {
     let tasks_planned = usize_value(payload, &["task_count"])
         .or_else(|| array_len(payload, &["record", "tasks"]))
         .unwrap_or(0);
-    let tasks_attempted = aggregate_outcome_count(payload).unwrap_or(0);
+    let canonical = classify_candidates(payload);
+    let tasks_attempted = canonical
+        .provider_executions
+        .or_else(|| aggregate_outcome_count(payload))
+        .unwrap_or(0);
     let aggregate_path = string_value(payload, &["aggregate_path"])
         .or_else(|| string_value(payload, &["record", "aggregate_path"]));
     let metrics = code_production_metrics(payload);
@@ -106,7 +112,10 @@ fn render_status_summary(payload: &Value) -> Option<String> {
     let run_id = string_value(payload, &["run_id"])?;
     let raw_state = string_value(payload, &["state"]).unwrap_or("unknown");
     let tasks_planned = array_len(payload, &["tasks"]).unwrap_or(0);
-    let tasks_attempted = status_attempted_task_count(payload);
+    let canonical = classify_candidates(payload);
+    let tasks_attempted = canonical
+        .provider_executions
+        .unwrap_or_else(|| status_attempted_task_count(payload));
     let metrics = code_production_metrics(payload);
     let state = string_value(payload, &["cook", "state"]).unwrap_or_else(|| {
         effective_run_state(
@@ -432,14 +441,6 @@ fn aggregate_artifact_count(payload: &Value) -> usize {
         .unwrap_or_else(|| array_len(payload, &["artifact_refs"]).unwrap_or(0))
 }
 
-const APPLY_ARTIFACT_KINDS: &[&str] = &[
-    "patch",
-    "diff",
-    "change_artifact",
-    "workspace_patch",
-    "artifact",
-];
-
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 struct CodeProductionMetrics {
     non_empty_patches: usize,
@@ -508,58 +509,17 @@ fn code_production_metrics(payload: &Value) -> CodeProductionMetrics {
         metrics.candidate_scan_degraded = canonical.is_degraded();
         return metrics;
     }
-    if payload.get("aggregate").is_none()
-        && payload
-            .pointer("/canonical_candidate/schema")
-            .and_then(Value::as_str)
-            == Some("homeboy/agent-task-candidate/v1")
-    {
-        metrics.non_empty_patches = canonical.available;
-        metrics.empty_patches = canonical.empty;
-        metrics.diff_bytes = canonical.diff_bytes;
-        metrics.unknown_size_patches = canonical.unknown
-            + canonical.missing
-            + canonical.unreadable
-            + canonical.conflicting
-            + canonical.retained_only;
-        // Compact projections intentionally omit patch contents and changed-file
-        // metadata, so never present their absent detail as a verified zero.
-        metrics.changed_files_unknown_patches = canonical.available;
-        metrics.candidate_state = canonical.state();
-        metrics.candidate_scan_degraded = canonical.is_degraded();
-        return metrics;
-    }
-    // Metrics intentionally come from the display/review artifacts so rejected,
-    // unreadable, and changed-file evidence retains its established semantics.
-    // The candidate classifier only annotates that evidence with terminal state.
-    if !canonical.is_degraded() {
-        for patch in collect_patch_artifacts(payload) {
-            match patch.size_bytes {
-                Some(size) if size > 0 => {
-                    metrics.non_empty_patches += 1;
-                    metrics.diff_bytes += size;
-                    match patch.changed_files {
-                        Some(count) => metrics.changed_files += count,
-                        None => metrics.changed_files_unknown_patches += 1,
-                    }
-                }
-                Some(_) => metrics.empty_patches += 1,
-                None => metrics.unknown_size_patches += 1,
-            }
-        }
-    }
-    let measured_state = if metrics.non_empty_patches > 0 {
-        CandidateState::PatchAvailable
-    } else if metrics.empty_patches > 0 {
-        CandidateState::Empty
-    } else {
-        CandidateState::Unknown
-    };
-    metrics.candidate_state = if canonical.state() == CandidateState::Unknown {
-        measured_state
-    } else {
-        canonical.state()
-    };
+    metrics.non_empty_patches = canonical.available;
+    metrics.empty_patches = canonical.empty;
+    metrics.diff_bytes = canonical.diff_bytes;
+    metrics.changed_files = canonical.changed_files;
+    metrics.changed_files_unknown_patches = canonical.changed_files_unknown_patches;
+    metrics.unknown_size_patches = canonical.unknown
+        + canonical.missing
+        + canonical.unreadable
+        + canonical.conflicting
+        + canonical.retained_only;
+    metrics.candidate_state = canonical.state();
     metrics.candidate_scan_degraded = canonical.is_degraded();
     metrics
 }
@@ -569,124 +529,6 @@ struct PatchArtifact {
     /// `Some(n)` when the changed-file count is known (from metadata or by
     /// parsing the patch content); `None` when it could not be determined.
     changed_files: Option<usize>,
-}
-
-fn collect_patch_artifacts(payload: &Value) -> Vec<PatchArtifact> {
-    if let Some(inventory) =
-        value_at(payload, &["aggregate_review", "artifact_inventory"]).and_then(Value::as_array)
-    {
-        let candidate_ids = review_candidate_ids(payload);
-        return inventory
-            .iter()
-            .filter_map(|item| {
-                let artifact_id = string_value(item, &["artifact_id"])?;
-                let task_id = string_value(item, &["task_id"])?;
-                if !candidate_ids.contains(&(task_id, artifact_id)) {
-                    return None;
-                }
-                if !is_apply_kind(item) {
-                    return None;
-                }
-                Some(PatchArtifact {
-                    size_bytes: u64_value(item, &["size_bytes"]),
-                    changed_files: resolve_changed_files(item),
-                })
-            })
-            .collect();
-    }
-
-    if let Some(outcomes) = value_at(payload, &["aggregate", "outcomes"]).and_then(Value::as_array)
-    {
-        return outcomes
-            .iter()
-            .flat_map(|outcome| {
-                value_at(outcome, &["artifacts"])
-                    .and_then(Value::as_array)
-                    .into_iter()
-                    .flatten()
-                    .filter(|artifact| is_display_apply_artifact(artifact))
-                    .map(|artifact| PatchArtifact {
-                        size_bytes: u64_value(artifact, &["size_bytes"]),
-                        changed_files: resolve_changed_files(artifact),
-                    })
-            })
-            .collect();
-    }
-
-    if let Some(attempts) = value_at(payload, &["attempts"]).and_then(Value::as_array) {
-        let artifacts: Vec<&Value> = attempts
-            .iter()
-            .flat_map(|attempt| {
-                value_at(attempt, &["aggregate", "outcomes"])
-                    .and_then(Value::as_array)
-                    .into_iter()
-                    .flatten()
-                    .flat_map(|outcome| {
-                        value_at(outcome, &["artifacts"])
-                            .and_then(Value::as_array)
-                            .into_iter()
-                            .flatten()
-                    })
-            })
-            .collect();
-        let canonical: Vec<&Value> = artifacts
-            .iter()
-            .copied()
-            .filter(|artifact| is_canonical_mirror(artifact))
-            .collect();
-        let artifacts = if canonical.is_empty() {
-            artifacts
-        } else {
-            canonical
-        };
-        return artifacts
-            .into_iter()
-            .filter(|artifact| is_display_apply_artifact(artifact))
-            .map(|artifact| PatchArtifact {
-                size_bytes: u64_value(artifact, &["size_bytes"]),
-                changed_files: resolve_changed_files(artifact),
-            })
-            .collect();
-    }
-
-    if let Some(references) = value_at(payload, &["artifact_refs"]).and_then(Value::as_array) {
-        return references
-            .iter()
-            .filter(|reference| is_apply_kind(reference))
-            .map(|reference| PatchArtifact {
-                size_bytes: u64_value(reference, &["size_bytes"]),
-                changed_files: resolve_changed_files(reference),
-            })
-            .collect();
-    }
-
-    Vec::new()
-}
-
-fn review_candidate_ids(payload: &Value) -> Vec<(&str, &str)> {
-    let mut ids = Vec::new();
-    for kind in ["apply_candidates", "review_candidates"] {
-        if let Some(candidates) =
-            value_at(payload, &["aggregate_review", kind]).and_then(Value::as_array)
-        {
-            for candidate in candidates {
-                let Some(task_id) = string_value(candidate, &["task_id"]) else {
-                    continue;
-                };
-                let Some(artifact_ids) =
-                    value_at(candidate, &["artifact_ids"]).and_then(Value::as_array)
-                else {
-                    continue;
-                };
-                for artifact_id in artifact_ids {
-                    if let Some(artifact_id) = artifact_id.as_str() {
-                        ids.push((task_id, artifact_id));
-                    }
-                }
-            }
-        }
-    }
-    ids
 }
 
 fn selected_candidate_patch(payload: &Value) -> Option<PatchArtifact> {
@@ -706,34 +548,6 @@ fn selected_candidate_patch(payload: &Value) -> Option<PatchArtifact> {
     })
 }
 
-fn is_apply_kind(artifact: &Value) -> bool {
-    let Some(kind) = string_value(artifact, &["kind"]) else {
-        return false;
-    };
-    APPLY_ARTIFACT_KINDS.contains(&kind)
-}
-
-fn is_display_apply_artifact(artifact: &Value) -> bool {
-    if !is_apply_kind(artifact) {
-        return false;
-    }
-    !(artifact_flag(artifact, "rejected") || artifact_flag(artifact, "false_positive"))
-}
-
-fn is_canonical_mirror(artifact: &Value) -> bool {
-    value_at(artifact, &["metadata", "executor_artifact_finalized"]).and_then(Value::as_bool)
-        == Some(true)
-        || string_value(artifact, &["url"])
-            .is_some_and(|url| url.starts_with("homeboy://agent-task/run/"))
-}
-
-fn artifact_flag(artifact: &Value, key: &str) -> bool {
-    value_at(artifact, &["metadata"])
-        .and_then(|metadata| metadata.get(key))
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
-}
-
 /// Resolve the number of files a patch artifact changes.
 ///
 /// Prefers authoritative metadata (`changed_files` list or
@@ -742,20 +556,7 @@ fn artifact_flag(artifact: &Value, key: &str) -> bool {
 /// cannot be determined so callers can render `unknown` instead of a misleading
 /// zero for a substantive patch (#9742).
 fn resolve_changed_files(artifact: &Value) -> Option<usize> {
-    if let Some(files) =
-        value_at(artifact, &["metadata", "changed_files"]).and_then(Value::as_array)
-    {
-        return Some(files.len());
-    }
-    if let Some(count) =
-        value_at(artifact, &["metadata", "changed_file_count"]).and_then(Value::as_u64)
-    {
-        return Some(count as usize);
-    }
-    // No metadata: parse the patch file the artifact points at.
-    let path = string_value(artifact, &["path"])?;
-    let content = std::fs::read_to_string(path).ok()?;
-    Some(changed_paths_from_patch(&content).len())
+    changed_files_for_artifact(artifact)
 }
 
 /// Extract the set of unique file paths a unified-diff patch touches.
@@ -1132,40 +933,45 @@ mod tests {
     fn cook_summary_parses_changed_files_from_patch_when_metadata_absent() {
         // Regression for #9742: a substantive patch with no changed-file
         // metadata must report the real count parsed from patch content, not 0.
-        let dir = tempfile::tempdir().expect("tempdir");
-        let patch_path = dir.path().join("patch.diff");
-        let patch = "diff --git a/crates/a/src/x.rs b/crates/a/src/x.rs\n\
+        crate::test_support::with_isolated_home(|_| {
+            let root = homeboy::core::artifact_root().expect("artifact root");
+            std::fs::create_dir_all(&root).expect("create artifact root");
+            let patch_path = root.join("patch.diff");
+            let patch = "diff --git a/crates/a/src/x.rs b/crates/a/src/x.rs\n\
              --- a/crates/a/src/x.rs\n+++ b/crates/a/src/x.rs\n@@ -1 +1 @@\n-a\n+b\n\
              diff --git a/crates/a/src/y.rs b/crates/a/src/y.rs\n\
              --- a/crates/a/src/y.rs\n+++ b/crates/a/src/y.rs\n@@ -1 +1 @@\n-c\n+d\n\
              diff --git a/crates/a/src/z.rs b/crates/a/src/z.rs\n\
              --- a/crates/a/src/z.rs\n+++ b/crates/a/src/z.rs\n@@ -1 +1 @@\n-e\n+f\n";
-        std::fs::write(&patch_path, patch).expect("write patch");
+            std::fs::write(&patch_path, patch).expect("write patch");
 
-        let payload = json!({
-            "run_id": "agent-task-9742",
-            "state": "succeeded",
-            "task_count": 1,
-            "aggregate": {
-                "outcomes": [{
-                    "task_id": "agent-task-9742",
-                    "artifacts": [{
-                        "id": "patch",
-                        "kind": "patch",
-                        "path": patch_path.to_str().unwrap(),
-                        "size_bytes": 17338
+            let payload = json!({
+                "run_id": "agent-task-9742",
+                "state": "succeeded",
+                "task_count": 1,
+                "aggregate": {
+                    "outcomes": [{
+                        "task_id": "agent-task-9742",
+                        "artifacts": [{
+                            "id": "patch",
+                            "kind": "patch",
+                            "path": patch_path.to_str().unwrap(),
+                            "size_bytes": patch.len(),
+                            "url": "homeboy://agent-task/run/agent-task-9742/artifacts#task=agent-task-9742&artifact=patch",
+                            "metadata": { "executor_artifact_finalized": true }
+                        }]
                     }]
-                }]
-            }
+                }
+            });
+
+            let summary = render_agent_task_summary(AgentTaskSummaryKind::Cook, &payload).unwrap();
+
+            assert!(summary.contains("Patch candidates: 1 non-empty / 0 empty\n"));
+            assert!(
+                summary.contains("Changed files: 3\n"),
+                "expected 3 changed files parsed from patch content, got: {summary}"
+            );
         });
-
-        let summary = render_agent_task_summary(AgentTaskSummaryKind::Cook, &payload).unwrap();
-
-        assert!(summary.contains("Patch candidates: 1 non-empty / 0 empty\n"));
-        assert!(
-            summary.contains("Changed files: 3\n"),
-            "expected 3 changed files parsed from patch content, got: {summary}"
-        );
     }
 
     #[test]
@@ -1221,6 +1027,73 @@ mod tests {
 
         assert!(summary.contains("Changed files: 3\n"));
         assert!(summary.contains("Diff bytes: 7635\n"));
+    }
+
+    #[test]
+    fn selection_required_timeout_recovery_has_matching_status_and_review_inventory() {
+        // Three providers timed out from the scheduler's perspective but each
+        // deferred cleanup harvested a distinct durable patch. There are no
+        // normalized task entries, which previously made status say zero tasks
+        // while review discarded all three candidates.
+        let candidates = [
+            ("timeout-recovered-1", 32_318, 2),
+            ("timeout-recovered-2", 32_318, 3),
+            ("timeout-recovered-3", 32_412, 4),
+        ]
+        .into_iter()
+        .map(|(id, size_bytes, changed_file_count)| {
+            json!({
+                "id": id,
+                "kind": "patch",
+                "size_bytes": size_bytes,
+                "url": format!("homeboy://agent-task/run/selection-required/artifacts#{id}"),
+                "metadata": {
+                    "executor_artifact_finalized": true,
+                    "changed_file_count": changed_file_count,
+                    "recovered_from": "scheduler_timeout",
+                },
+            })
+        })
+        .collect::<Vec<_>>();
+        let aggregate = json!({
+            "outcomes": [{ "task_id": "cook", "artifacts": candidates }],
+        });
+        let status = json!({
+            "run_id": "selection-required",
+            "state": "selection_required",
+            "tasks": [],
+            "metadata": { "provider_executions_consumed": 3 },
+            "aggregate": aggregate,
+        });
+        let review = json!({
+            "run_id": "selection-required",
+            "state": "partial_recoverable",
+            "record": { "metadata": { "provider_executions_consumed": 3 } },
+            "aggregate": status["aggregate"].clone(),
+            "aggregate_review": { "summary": { "apply_candidates": 3, "failed": 0 } },
+        });
+
+        let status_summary =
+            render_agent_task_summary(AgentTaskSummaryKind::Status, &status).expect("status");
+        let review_summary =
+            render_agent_task_summary(AgentTaskSummaryKind::Review, &review).expect("review");
+
+        for summary in [&status_summary, &review_summary] {
+            assert!(
+                summary.contains("Patch candidates: 3 non-empty / 0 empty\n"),
+                "{summary}"
+            );
+            assert!(
+                summary.contains("Candidate state: patch_available\n"),
+                "{summary}"
+            );
+            assert!(summary.contains("Changed files: 9\n"), "{summary}");
+            assert!(summary.contains("Diff bytes: 97048\n"), "{summary}");
+        }
+        assert!(
+            status_summary.contains("Tasks attempted: 3\n"),
+            "{status_summary}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- derive status and review candidate metrics from one canonical inventory
- count durable provider executions and preserve truthful unknown file evidence
- harden patch inspection to bounded Homeboy-owned regular artifacts
- cover three timeout-recovered candidates and adversarial artifact paths

Closes #12839.

## Verification

- `cargo test -p homeboy-cli agent_task::candidate::tests`
- `cargo test -p homeboy-cli agent_task_summary::tests`
- `cargo fmt --check`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6-sol via OpenCode and OpenCode general coding/review subagents were used to trace the conflicting projections, implement bounded canonical inventory, test adversarial artifacts, and review the diff. Chris Huber remains responsible for every line.