### PR TITLE
Compare recoverable Cook candidates semantically

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -6,10 +6,15 @@ use std::process::Command;
 use std::sync::Arc;
 
 use serde_json::{json, Value};
+use std::collections::BTreeMap;
 
 use crate::agent_task::{
     AgentTaskArtifact, AgentTaskOutcome, AgentTaskOutcomeStatus, AGENT_TASK_OUTCOME_SCHEMA,
 };
+
+const CANONICAL_PATCH_CANDIDATE_LIMIT: usize = 16;
+const CANONICAL_PATCH_BYTES_PER_CANDIDATE_LIMIT: u64 = 256 * 1024;
+const CANONICAL_PATCH_BYTES_TOTAL_LIMIT: u64 = 1024 * 1024;
 use crate::agent_task_gate::{
     AgentTaskGateCandidateCheckout, AgentTaskGateRevealPolicy, AgentTaskGateStatus,
     AgentTaskGateVisibility,
@@ -2550,7 +2555,13 @@ fn select_recoverable_patch_artifact(
 #[derive(Debug, Clone)]
 pub struct CanonicalRecoverablePatchArtifacts {
     pub artifacts: Vec<AgentTaskArtifact>,
+    /// Normalized patch bodies keyed by canonical artifact ID. Callers use this
+    /// only for bounded, deterministic projections; full patches remain at their
+    /// durable artifact addresses.
+    pub patch_contents: BTreeMap<String, String>,
     pub unavailable: Vec<Value>,
+    pub omitted_candidate_count: usize,
+    pub omitted_patch_bytes: u64,
 }
 
 /// Resolve and normalize recoverable provider artifacts into deterministic patch
@@ -2589,9 +2600,15 @@ fn canonical_recoverable_patch_artifacts_internal(
         .cloned()
         .collect::<Vec<_>>();
     candidates.sort_by(|left, right| left.id.cmp(&right.id));
+    let omitted_candidate_count = candidates
+        .len()
+        .saturating_sub(CANONICAL_PATCH_CANDIDATE_LIMIT);
+    candidates.truncate(CANONICAL_PATCH_CANDIDATE_LIMIT);
 
-    let mut canonical = Vec::<(String, AgentTaskArtifact)>::new();
+    let mut canonical = Vec::<(String, AgentTaskArtifact, String)>::new();
     let mut unavailable = Vec::new();
+    let mut read_patch_bytes = 0_u64;
+    let mut omitted_patch_bytes = 0_u64;
     for mut artifact in candidates {
         let Some(kind) = canonical_patch_kind(&artifact.kind) else {
             continue;
@@ -2610,6 +2627,25 @@ fn canonical_recoverable_patch_artifacts_internal(
                 continue;
             }
         };
+        let patch_bytes = match std::fs::metadata(&path) {
+            Ok(metadata) => metadata.len(),
+            Err(error) => {
+                unavailable
+                    .push(json!({ "id": artifact.id, "path": path, "reason": error.to_string() }));
+                continue;
+            }
+        };
+        if patch_bytes > CANONICAL_PATCH_BYTES_PER_CANDIDATE_LIMIT
+            || read_patch_bytes.saturating_add(patch_bytes) > CANONICAL_PATCH_BYTES_TOTAL_LIMIT
+        {
+            omitted_patch_bytes = omitted_patch_bytes.saturating_add(patch_bytes);
+            unavailable.push(json!({
+                "id": artifact.id,
+                "reason": "canonical_patch_byte_budget_exceeded",
+                "size_bytes": patch_bytes,
+            }));
+            continue;
+        }
         let patch = match std::fs::read_to_string(&path) {
             Ok(patch) => patch,
             Err(error) => {
@@ -2618,6 +2654,7 @@ fn canonical_recoverable_patch_artifacts_internal(
                 continue;
             }
         };
+        read_patch_bytes = read_patch_bytes.saturating_add(patch_bytes);
         if let Err(error) = validate_artifact_content(&artifact, &patch) {
             unavailable.push(json!({ "id": artifact.id, "path": path, "reason": error.message }));
             continue;
@@ -2632,17 +2669,26 @@ fn canonical_recoverable_patch_artifacts_internal(
         };
         let digest = content_hash::sha256_hex(normalized.content.as_bytes());
         let identity = canonical_patch_identity_with_digest(&artifact, &digest);
-        if !canonical.iter().any(|(existing, _)| existing == &identity) {
-            canonical.push((identity, artifact));
+        if !canonical
+            .iter()
+            .any(|(existing, _, _)| existing == &identity)
+        {
+            canonical.push((identity, artifact, normalized.content));
         }
     }
 
     Ok(CanonicalRecoverablePatchArtifacts {
         artifacts: canonical
+            .iter()
+            .map(|(_, artifact, _)| artifact.clone())
+            .collect(),
+        patch_contents: canonical
             .into_iter()
-            .map(|(_, artifact)| artifact)
+            .map(|(_, artifact, patch)| (artifact.id, patch))
             .collect(),
         unavailable,
+        omitted_candidate_count,
+        omitted_patch_bytes,
     })
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -10,6 +10,7 @@
 //! keeps the promote → finalize boundary in one place.
 
 use serde_json::{json, Value};
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 use homeboy_core::cook_status::{CookDisposition, CookStatus};
@@ -197,16 +198,15 @@ pub(crate) fn canonical_cook_patch_artifact_id_in_store(
         [] => Ok(None),
         [artifact] => Ok(Some(artifact.id.clone())),
         artifacts => {
-            let choices = artifacts
-                .iter()
-                .map(|artifact| {
-                    json!({
-                        "artifact_id": artifact.id,
-                        "sha256": artifact.sha256,
-                        "command": cook_promotion_command(options, run_id, &outcome.task_id, &artifact.id),
-                    })
-                })
-                .collect::<Vec<_>>();
+            let (choices, comparison) = cook_candidate_comparison(
+                outcome,
+                artifacts,
+                &canonical.patch_contents,
+                canonical.omitted_candidate_count,
+                canonical.omitted_patch_bytes,
+                options,
+                run_id,
+            );
             Err(Error::new(
                 homeboy_core::ErrorCode::ValidationInvalidArgument,
                 "Cook found distinct canonical patch candidates; select one before promotion",
@@ -215,10 +215,259 @@ pub(crate) fn canonical_cook_patch_artifact_id_in_store(
                     "state": "selection_required",
                     "selection_required": true,
                     "choices": choices,
+                    "comparison": comparison,
                 }),
             ))
         }
     }
+}
+
+const CANDIDATE_FILE_LIMIT: usize = 12;
+const CANDIDATE_EVIDENCE_LIMIT: usize = 6;
+const CANDIDATE_DIAGNOSTIC_LIMIT: usize = 6;
+const CANDIDATE_JSON_BYTES_LIMIT: usize = 2048;
+
+/// Project only facts present in canonical patch bytes and durable outcome
+/// evidence. This deliberately does not infer behavior from generated prose.
+fn cook_candidate_comparison(
+    outcome: &crate::agent_task::AgentTaskOutcome,
+    artifacts: &[crate::agent_task::AgentTaskArtifact],
+    patches: &BTreeMap<String, String>,
+    omitted_candidate_count: usize,
+    omitted_patch_bytes: u64,
+    options: &AgentTaskCookServiceOptions,
+    run_id: &str,
+) -> (Vec<Value>, Value) {
+    let summaries = artifacts
+        .iter()
+        .map(|artifact| {
+            let patch = patches
+                .get(&artifact.id)
+                .map(String::as_str)
+                .unwrap_or_default();
+            let stats = patch_stats(patch);
+            let (test_evidence, omitted_test_evidence_count) = bounded_test_evidence(artifact);
+            let mut risk_flags = patch_risk_flags(patch, &stats.all_files);
+            if test_evidence.is_empty() {
+                risk_flags.push("missing_test_evidence".to_string());
+            }
+            CandidateSummary {
+                artifact,
+                all_files: stats.all_files,
+                file_count: stats.file_count,
+                insertions: stats.insertions,
+                deletions: stats.deletions,
+                test_evidence,
+                risk_flags,
+                omitted_test_evidence_count,
+            }
+        })
+        .collect::<Vec<_>>();
+    let common_files = summaries
+        .iter()
+        .map(|summary| summary.all_files.clone())
+        .reduce(|left, right| left.intersection(&right).cloned().collect())
+        .unwrap_or_default();
+    let recommendation = deterministic_recommendation(&summaries);
+    let choices = summaries
+        .iter()
+        .map(|summary| {
+            let unique_files = summary
+                .all_files
+                .iter()
+                .filter(|file| !common_files.contains(*file))
+                .cloned()
+                .collect::<Vec<_>>();
+            let rationale = recommendation.as_ref().and_then(|recommended| {
+                (recommended == &summary.artifact.id).then_some(
+                    "Only candidate with recorded test evidence and no artifact-derived risk flags.",
+                )
+            });
+            json!({
+                "artifact_id": summary.artifact.id,
+                "sha256": summary.artifact.sha256,
+                "patch_artifact": {
+                    "path": summary.artifact.path,
+                    "url": summary.artifact.url,
+                },
+                "provider": summary.artifact.metadata.get("provider_backend"),
+                "model": outcome.selected_model(),
+                "attempt": summary.artifact.metadata.get("producer_attempt"),
+                "changed_files": preview(&summary.all_files),
+                "changed_file_count": summary.file_count,
+                "changed_files_omitted_count": summary.file_count.saturating_sub(CANDIDATE_FILE_LIMIT),
+                "line_stats": { "insertions": summary.insertions, "deletions": summary.deletions },
+                "diff_summary": format!(
+                    "{} file(s), {} insertion(s), {} deletion(s)",
+                    summary.file_count, summary.insertions, summary.deletions
+                ),
+                "test_evidence": summary.test_evidence,
+                "test_evidence_omitted_count": summary.omitted_test_evidence_count,
+                "overlap": {
+                    "shared_changed_files": preview(&common_files),
+                    "shared_changed_files_omitted_count": common_files.len().saturating_sub(CANDIDATE_FILE_LIMIT),
+                },
+                "differences": {
+                    "unique_changed_files": preview(&unique_files.into_iter().collect()),
+                    "unique_changed_files_omitted_count": summary.file_count.saturating_sub(common_files.len()).saturating_sub(CANDIDATE_FILE_LIMIT),
+                },
+                "risk_flags": summary.risk_flags,
+                "recommendation": rationale.map(|rationale| json!({ "rationale": rationale })),
+                "command": cook_promotion_command(options, run_id, &outcome.task_id, &summary.artifact.id),
+            })
+        })
+        .collect();
+    let (shared_evidence, omitted_evidence_count) = bounded_shared_evidence(outcome);
+    let (shared_diagnostics, omitted_diagnostic_count) = bounded_diagnostics(outcome);
+    (
+        choices,
+        json!({
+            "shared_outcome_evidence": shared_evidence,
+            "shared_outcome_evidence_omitted_count": omitted_evidence_count,
+            "shared_outcome_diagnostics": shared_diagnostics,
+            "shared_outcome_diagnostics_omitted_count": omitted_diagnostic_count,
+            "omitted_candidate_count": omitted_candidate_count,
+            "omitted_patch_bytes": omitted_patch_bytes,
+        }),
+    )
+}
+
+struct CandidateSummary<'a> {
+    artifact: &'a crate::agent_task::AgentTaskArtifact,
+    all_files: BTreeSet<String>,
+    file_count: usize,
+    insertions: usize,
+    deletions: usize,
+    test_evidence: Vec<Value>,
+    risk_flags: Vec<String>,
+    omitted_test_evidence_count: usize,
+}
+
+struct PatchStats {
+    all_files: BTreeSet<String>,
+    file_count: usize,
+    insertions: usize,
+    deletions: usize,
+}
+
+fn patch_stats(patch: &str) -> PatchStats {
+    let mut all_files = BTreeSet::new();
+    let mut insertions = 0;
+    let mut deletions = 0;
+    for line in patch.lines() {
+        if let Some(path) = line
+            .strip_prefix("diff --git a/")
+            .and_then(|line| line.split_once(" b/").map(|(_, path)| path))
+        {
+            all_files.insert(path.to_string());
+        } else if line.starts_with('+') && !line.starts_with("+++") {
+            insertions += 1;
+        } else if line.starts_with('-') && !line.starts_with("---") {
+            deletions += 1;
+        }
+    }
+    let file_count = all_files.len();
+    PatchStats {
+        all_files,
+        file_count,
+        insertions,
+        deletions,
+    }
+}
+
+fn bounded_test_evidence(artifact: &crate::agent_task::AgentTaskArtifact) -> (Vec<Value>, usize) {
+    let evidence = artifact
+        .metadata
+        .get("test_evidence")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .cloned()
+        .collect::<Vec<_>>();
+    bounded_json_values(evidence, CANDIDATE_EVIDENCE_LIMIT)
+}
+
+fn bounded_shared_evidence(outcome: &crate::agent_task::AgentTaskOutcome) -> (Vec<Value>, usize) {
+    bounded_json_values(
+        outcome.evidence_refs.iter().map(|evidence| {
+            json!({ "kind": evidence.kind, "uri": evidence.uri, "label": evidence.label })
+        }).collect(),
+        CANDIDATE_EVIDENCE_LIMIT,
+    )
+}
+
+fn bounded_diagnostics(outcome: &crate::agent_task::AgentTaskOutcome) -> (Vec<Value>, usize) {
+    bounded_json_values(
+        outcome
+            .diagnostics
+            .iter()
+            .map(|diagnostic| json!({ "class": diagnostic.class, "message": diagnostic.message }))
+            .collect(),
+        CANDIDATE_DIAGNOSTIC_LIMIT,
+    )
+}
+
+fn bounded_json_values(values: Vec<Value>, limit: usize) -> (Vec<Value>, usize) {
+    let omitted = values.len().saturating_sub(limit);
+    (
+        values
+            .into_iter()
+            .take(limit)
+            .map(bounded_json_value)
+            .collect(),
+        omitted,
+    )
+}
+
+fn bounded_json_value(value: Value) -> Value {
+    let bytes = serde_json::to_vec(&value).unwrap_or_default();
+    (bytes.len() <= CANDIDATE_JSON_BYTES_LIMIT)
+        .then_some(value)
+        .unwrap_or_else(|| {
+            json!({
+                "omitted": "json_value_exceeds_byte_limit",
+                "size_bytes": bytes.len(),
+            })
+        })
+}
+
+fn preview(files: &BTreeSet<String>) -> Vec<String> {
+    files.iter().take(CANDIDATE_FILE_LIMIT).cloned().collect()
+}
+
+fn patch_risk_flags(patch: &str, files: &BTreeSet<String>) -> Vec<String> {
+    let mut flags = BTreeSet::new();
+    if files.iter().any(|file| {
+        file.starts_with(".github/workflows/")
+            || file.ends_with("/Dockerfile")
+            || file == "Dockerfile"
+    }) {
+        flags.insert("security_sensitive_automation_change");
+    }
+    if patch
+        .lines()
+        .any(|line| line.starts_with("new file mode 100755"))
+    {
+        flags.insert("new_executable_file");
+    }
+    if patch.lines().any(|line| {
+        line.starts_with('+')
+            && !line.starts_with("+++")
+            && ["-----BEGIN", "AKIA", "password=", "secret=", "token="]
+                .iter()
+                .any(|pattern| line.contains(pattern))
+    }) {
+        flags.insert("sensitive_literal_pattern_added");
+    }
+    flags.into_iter().map(str::to_string).collect()
+}
+
+fn deterministic_recommendation(summaries: &[CandidateSummary<'_>]) -> Option<String> {
+    let eligible = summaries
+        .iter()
+        .filter(|summary| !summary.test_evidence.is_empty() && summary.risk_flags.is_empty())
+        .collect::<Vec<_>>();
+    (eligible.len() == 1).then(|| eligible[0].artifact.id.clone())
 }
 
 /// Render an explicit promotion command from Cook's durable execution contract.

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -817,9 +817,91 @@ fn seed_patch_alias_aggregate(
     plan: &AgentTaskPlan,
     patches: &[(&str, &std::path::Path, &str)],
 ) {
+    let patches = patches
+        .iter()
+        .map(|(id, path, patch)| {
+            (
+                *id,
+                *path,
+                *patch,
+                serde_json::json!({
+                    "producer_attempt": 2,
+                    "base_ref": "main",
+                    "provider_backend": "fixture",
+                }),
+            )
+        })
+        .collect::<Vec<_>>();
     let lifecycle_store =
         AgentTaskLifecycleStore::from_current_environment().expect("ambient lifecycle store");
-    seed_patch_alias_aggregate_in_store(&lifecycle_store, run_id, plan, patches);
+    seed_patch_alias_aggregate_with_metadata(&lifecycle_store, run_id, plan, &patches, Vec::new());
+}
+
+fn seed_patch_alias_aggregate_with_metadata(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    plan: &AgentTaskPlan,
+    patches: &[(&str, &std::path::Path, &str, Value)],
+    diagnostics: Vec<crate::agent_task::AgentTaskDiagnostic>,
+) {
+    use crate::agent_task::{AgentTaskArtifact, AgentTaskOutcome, AgentTaskOutcomeStatus};
+    use crate::agent_task_scheduler::{
+        AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
+    };
+
+    let task = plan.tasks.first().expect("candidate plan has one task");
+    let artifacts = patches
+        .iter()
+        .map(|(id, path, patch, metadata)| {
+            std::fs::write(path, patch).expect("write candidate patch");
+            AgentTaskArtifact {
+                id: (*id).to_string(),
+                kind: "patch".to_string(),
+                path: Some(path.display().to_string()),
+                size_bytes: Some(patch.len() as u64),
+                sha256: Some(homeboy_engine_primitives::content_hash::sha256_hex(
+                    patch.as_bytes(),
+                )),
+                metadata: metadata.clone(),
+                ..Default::default()
+            }
+        })
+        .collect();
+    lifecycle_store
+        .record_run_aggregate(
+            run_id,
+            plan,
+            &AgentTaskAggregate {
+                schema: crate::agent_task::AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+                plan_id: plan.plan_id.clone(),
+                status: AgentTaskAggregateStatus::Succeeded,
+                totals: AgentTaskAggregateTotals {
+                    succeeded: 1,
+                    ..Default::default()
+                },
+                outcomes: vec![AgentTaskOutcome {
+                    schema: crate::agent_task::AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                    task_id: task.task_id.clone(),
+                    status: AgentTaskOutcomeStatus::Succeeded,
+                    summary: None,
+                    failure_classification: None,
+                    artifacts,
+                    typed_artifacts: Vec::new(),
+                    evidence_refs: Vec::new(),
+                    diagnostics,
+                    outputs: test_review_form_outputs(),
+                    workflow: None,
+                    follow_up: None,
+                    metadata: serde_json::json!({ "model": task.executor.model() }),
+                }],
+                events: Vec::new(),
+                artifact_lineage: Vec::new(),
+                child_runs: Vec::new(),
+                artifact_bindings: Vec::new(),
+                queue: Default::default(),
+            },
+        )
+        .expect("persist candidate aggregate");
 }
 
 fn seed_patch_alias_aggregate_in_store(
@@ -951,7 +1033,6 @@ fn cook_requires_selection_for_distinct_canonical_patches_before_promotion() {
                 ),
             ],
         );
-
         let error = canonical_cook_patch_artifact_id(&options, &options.initial_run_id)
             .expect_err("distinct candidates require a choice");
         assert_eq!(error.details["state"], "selection_required");
@@ -960,6 +1041,255 @@ fn cook_requires_selection_for_distinct_canonical_patches_before_promotion() {
             .as_str()
             .unwrap()
             .contains("--private-verify"));
+    });
+}
+
+#[test]
+fn cook_selection_comparison_projects_three_distinct_candidates_from_patch_artifacts() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("candidate artifacts");
+        let options = batch_cook_options(
+            "cook-semantic-candidates",
+            Arc::new(AcceptedDetachedAttemptDispatcher),
+        );
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&options.initial_run_id))
+            .expect("submit candidate plan");
+        seed_patch_alias_aggregate(
+            &options.initial_run_id,
+            &options.initial_plan,
+            &[
+                (
+                    "patch-a",
+                    &temp.path().join("a"),
+                    "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+one\n",
+                ),
+                (
+                    "patch-b",
+                    &temp.path().join("b"),
+                    "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+two\n",
+                ),
+                (
+                    "patch-c",
+                    &temp.path().join("c"),
+                    "diff --git a/.github/workflows/test.yml b/.github/workflows/test.yml\n--- a/.github/workflows/test.yml\n+++ b/.github/workflows/test.yml\n@@ -1 +1 @@\n-old\n+token=fixture\n",
+                ),
+            ],
+        );
+
+        let error = canonical_cook_patch_artifact_id(&options, &options.initial_run_id)
+            .expect_err("distinct candidates require a choice");
+        let choices = error.details["choices"]
+            .as_array()
+            .expect("comparison choices");
+        assert_eq!(choices.len(), 3);
+        let patch_a = choices
+            .iter()
+            .find(|choice| choice["artifact_id"] == "patch-a")
+            .expect("patch a comparison");
+        let patch_b = choices
+            .iter()
+            .find(|choice| choice["artifact_id"] == "patch-b")
+            .expect("patch b comparison");
+        let patch_c = choices
+            .iter()
+            .find(|choice| choice["artifact_id"] == "patch-c")
+            .expect("patch c comparison");
+        assert_eq!(patch_a["changed_files"], serde_json::json!(["src/lib.rs"]));
+        assert_eq!(
+            patch_a["line_stats"],
+            serde_json::json!({ "insertions": 1, "deletions": 1 })
+        );
+        assert_eq!(
+            patch_a["diff_summary"],
+            "1 file(s), 1 insertion(s), 1 deletion(s)"
+        );
+        assert_eq!(
+            patch_a["overlap"]["shared_changed_files"],
+            serde_json::json!([]),
+            "all three candidates must share a file before it is reported as common"
+        );
+        assert!(patch_a["risk_flags"]
+            .as_array()
+            .expect("risk flags")
+            .contains(&serde_json::json!("missing_test_evidence")));
+        assert!(patch_b["risk_flags"]
+            .as_array()
+            .expect("risk flags")
+            .contains(&serde_json::json!("missing_test_evidence")));
+        assert!(patch_c["risk_flags"]
+            .as_array()
+            .expect("risk flags")
+            .contains(&serde_json::json!("security_sensitive_automation_change")));
+        assert!(patch_c["risk_flags"]
+            .as_array()
+            .expect("risk flags")
+            .contains(&serde_json::json!("sensitive_literal_pattern_added")));
+        for choice in choices {
+            assert!(choice["patch_artifact"]["path"].is_string());
+            assert!(choice["provider"].is_string());
+            assert!(choice["attempt"].is_number());
+            assert!(choice["test_evidence"].is_array());
+            assert!(choice.get("diagnostics").is_none());
+            assert!(choice["command"]
+                .as_str()
+                .expect("promotion command")
+                .contains("--artifact-id"));
+        }
+        assert!(error.details["comparison"]["shared_outcome_diagnostics"].is_array());
+    });
+}
+
+#[test]
+fn cook_selection_risks_use_files_beyond_the_preview_limit() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("candidate artifacts");
+        let options = batch_cook_options(
+            "cook-preview-risk",
+            Arc::new(AcceptedDetachedAttemptDispatcher),
+        );
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&options.initial_run_id))
+            .unwrap();
+        let mut late_security = String::new();
+        for index in 0..12 {
+            late_security.push_str(&format!("diff --git a/src/{index}.rs b/src/{index}.rs\n--- a/src/{index}.rs\n+++ b/src/{index}.rs\n@@ -1 +1 @@\n-old\n+new\n"));
+        }
+        late_security.push_str("diff --git a/zz/Dockerfile b/zz/Dockerfile\n--- a/zz/Dockerfile\n+++ b/zz/Dockerfile\n@@ -1 +1 @@\n-old\n+new\n");
+        seed_patch_alias_aggregate(
+            &options.initial_run_id,
+            &options.initial_plan,
+            &[
+                (
+                    "safe",
+                    &temp.path().join("safe"),
+                    "diff --git a/a b/a\n--- a/a\n+++ b/a\n@@ -1 +1 @@\n-old\n+new\n",
+                ),
+                ("late-risk", &temp.path().join("late-risk"), &late_security),
+            ],
+        );
+        let error =
+            canonical_cook_patch_artifact_id(&options, &options.initial_run_id).unwrap_err();
+        let candidate = error.details["choices"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|choice| choice["artifact_id"] == "late-risk")
+            .unwrap();
+        assert_eq!(candidate["changed_file_count"], 13);
+        assert_eq!(candidate["changed_files_omitted_count"], 1);
+        assert!(candidate["risk_flags"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("security_sensitive_automation_change")));
+    });
+}
+
+#[test]
+fn cook_selection_candidate_evidence_does_not_bless_other_candidates() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("candidate artifacts");
+        let options = batch_cook_options(
+            "cook-evidence-attribution",
+            Arc::new(AcceptedDetachedAttemptDispatcher),
+        );
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&options.initial_run_id))
+            .unwrap();
+        let metadata = |test_evidence: Value| {
+            serde_json::json!({
+                "producer_attempt": 2, "base_ref": "main", "provider_backend": "fixture", "test_evidence": test_evidence,
+            })
+        };
+        seed_patch_alias_aggregate_with_metadata(
+            &AgentTaskLifecycleStore::from_current_environment().unwrap(),
+            &options.initial_run_id,
+            &options.initial_plan,
+            &[
+                (
+                    "a",
+                    &temp.path().join("a"),
+                    "diff --git a/a b/a\n--- a/a\n+++ b/a\n@@ -1 +1 @@\n-old\n+one\n",
+                    metadata(serde_json::json!([{ "command": "cargo test", "exit_code": 0 }])),
+                ),
+                (
+                    "b",
+                    &temp.path().join("b"),
+                    "diff --git a/b b/b\n--- a/b\n+++ b/b\n@@ -1 +1 @@\n-old\n+two\n",
+                    metadata(serde_json::json!([])),
+                ),
+            ],
+            Vec::new(),
+        );
+        let error =
+            canonical_cook_patch_artifact_id(&options, &options.initial_run_id).unwrap_err();
+        let choices = error.details["choices"].as_array().unwrap();
+        let a = choices
+            .iter()
+            .find(|choice| choice["artifact_id"] == "a")
+            .unwrap();
+        let b = choices
+            .iter()
+            .find(|choice| choice["artifact_id"] == "b")
+            .unwrap();
+        assert!(a["recommendation"].is_object());
+        assert!(b["test_evidence"].as_array().unwrap().is_empty());
+        assert!(b["recommendation"].is_null());
+    });
+}
+
+#[test]
+fn cook_selection_bounds_candidate_inventory_and_oversized_diagnostics() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("candidate artifacts");
+        let options = batch_cook_options(
+            "cook-bounded-inventory",
+            Arc::new(AcceptedDetachedAttemptDispatcher),
+        );
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&options.initial_run_id))
+            .unwrap();
+        let patches = (0..18)
+            .map(|index| {
+                let id = format!("candidate-{index:02}");
+                let path = temp.path().join(&id);
+                let patch = format!(
+                    "diff --git a/{id} b/{id}\n--- a/{id}\n+++ b/{id}\n@@ -1 +1 @@\n-old\n+new\n"
+                );
+                (
+                    id,
+                    path,
+                    patch,
+                    serde_json::json!({ "producer_attempt": 2, "provider_backend": "fixture" }),
+                )
+            })
+            .collect::<Vec<_>>();
+        let refs = patches
+            .iter()
+            .map(|(id, path, patch, metadata)| {
+                (
+                    id.as_str(),
+                    path.as_path(),
+                    patch.as_str(),
+                    metadata.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        seed_patch_alias_aggregate_with_metadata(
+            &AgentTaskLifecycleStore::from_current_environment().unwrap(),
+            &options.initial_run_id,
+            &options.initial_plan,
+            &refs,
+            vec![crate::agent_task::AgentTaskDiagnostic {
+                class: "fixture".to_string(),
+                message: "x".repeat(4096),
+                data: Value::Null,
+            }],
+        );
+        let error =
+            canonical_cook_patch_artifact_id(&options, &options.initial_run_id).unwrap_err();
+        assert_eq!(error.details["choices"].as_array().unwrap().len(), 16);
+        assert_eq!(error.details["comparison"]["omitted_candidate_count"], 2);
+        assert_eq!(
+            error.details["comparison"]["shared_outcome_diagnostics"][0]["omitted"],
+            "json_value_exceeds_byte_limit"
+        );
     });
 }
 


### PR DESCRIPTION
## Summary

- project bounded changed-file, line-stat, provenance, evidence, diagnostic, overlap, and risk comparisons
- keep full patches addressable while bounding candidates, bytes, previews, and messages
- prevent shared evidence or truncated file previews from producing unsafe recommendations
- return exact runnable promotion commands for each candidate

Closes #12840.

## Verification

- `cargo test -p homeboy-agents cook_selection_ --lib`
- `cargo check -p homeboy-agents`
- `cargo fmt --check`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6-sol via OpenCode and OpenCode general coding/review subagents were used to design the deterministic comparison, implement bounds and risk analysis, add adversarial tests, and review the diff. Chris Huber remains responsible for every line.