### PR TITLE
Stream durable promotion progress

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -6059,6 +6059,52 @@ pub fn record_promotion(run_id: &str, promotion: Value) -> Result<AgentTaskRunRe
     record_promotion_in_store(&lifecycle_store, run_id, promotion)
 }
 
+/// Retain a bounded, ordered replay of runner-delivered promotion frames. This
+/// is observer evidence only; promotion checkpoints remain the recovery authority.
+pub fn record_promotion_progress_frames(
+    run_id: &str,
+    runner_job_id: &str,
+    frames: impl IntoIterator<Item = (u64, Value)>,
+) -> Result<()> {
+    const MAX_FRAMES: usize = 64;
+
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    let run_id = sanitize_run_id(run_id);
+    let _ = lifecycle_store.mutate_record(&run_id, |record| {
+        let metadata = record.ensure_metadata_object();
+        let events = metadata
+            .entry("promotion_progress_frames".to_string())
+            .or_insert_with(|| json!([]));
+        let events = events
+            .as_array_mut()
+            .expect("promotion progress frames are an array");
+        let mut changed = false;
+        for (sequence, frame) in frames {
+            if events.iter().any(|event| {
+                event.get("runner_job_id").and_then(Value::as_str) == Some(runner_job_id)
+                    && event.get("sequence").and_then(Value::as_u64) == Some(sequence)
+            }) {
+                continue;
+            }
+            let frame = json!({
+                "runner_job_id": runner_job_id,
+                "sequence": sequence,
+                "frame": frame,
+                "recorded_at": now_timestamp(),
+            });
+            events.push(homeboy_core::redaction::redact_json(&frame));
+            changed = true;
+        }
+        if events.len() > MAX_FRAMES {
+            let excess = events.len() - MAX_FRAMES;
+            events.drain(..excess);
+            changed = true;
+        }
+        changed
+    })?;
+    Ok(())
+}
+
 pub fn record_promotion_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,

--- a/crates/homeboy-agents/src/agent_task_promotion/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/mod.rs
@@ -23,15 +23,17 @@ pub use fingerprint::{
     candidate_fingerprint, AgentTaskCandidateFingerprint, AgentTaskPromotionCandidate,
 };
 pub(crate) use patch::{normalize_promotion_patch, validate_artifact_content};
-pub use promote::promote;
-pub use promote::promote_with_checkpoint;
-pub use promote::resume_promoted_patch;
+pub(crate) use promote::emit_promotion_progress;
 pub(crate) use promote::with_gate_supervision;
 pub use promote::{canonical_recoverable_patch_artifacts, CanonicalRecoverablePatchArtifacts};
 pub(crate) use promote::{
     canonical_recoverable_patch_artifacts_in_observation_store,
     promote_with_checkpoint_in_observation_store, resume_promoted_patch_in_observation_store,
     resume_promoted_patch_replacement_gates_in_observation_store,
+};
+pub use promote::{
+    promote, promote_with_checkpoint, resume_promoted_patch, with_promotion_progress,
+    PromotionProgress, PromotionProgressCallback,
 };
 pub use run_plan_projection::mirror_agent_task_run_plan_aggregate;
 pub use types::{

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -42,6 +42,48 @@ use gate_run::PromotionGateRun;
 
 thread_local! {
     static GATE_SUPERVISION: RefCell<Option<Arc<crate::agent_task_gate::GateSupervision>>> = const { RefCell::new(None) };
+    static PROMOTION_PROGRESS: RefCell<Option<PromotionProgressCallback>> = const { RefCell::new(None) };
+}
+
+pub type PromotionProgressCallback = Arc<dyn Fn(&PromotionProgress) -> Result<()> + Send + Sync>;
+
+#[derive(Debug, Clone)]
+pub struct PromotionProgress {
+    pub phase: &'static str,
+    pub gate: Option<String>,
+    pub last_progress: Option<String>,
+}
+
+pub fn with_promotion_progress<T>(
+    progress: PromotionProgressCallback,
+    operation: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    PROMOTION_PROGRESS.with(|slot| {
+        assert!(
+            slot.borrow().is_none(),
+            "promotion progress scopes cannot nest"
+        );
+        *slot.borrow_mut() = Some(progress);
+        let result = operation();
+        *slot.borrow_mut() = None;
+        result
+    })
+}
+
+pub(crate) fn emit_promotion_progress(
+    phase: &'static str,
+    gate: Option<String>,
+    last_progress: Option<String>,
+) {
+    PROMOTION_PROGRESS.with(|slot| {
+        if let Some(progress) = slot.borrow().as_ref() {
+            let _ = progress(&PromotionProgress {
+                phase,
+                gate,
+                last_progress,
+            });
+        }
+    });
 }
 
 pub(crate) fn with_gate_supervision<T>(
@@ -576,6 +618,11 @@ fn promote_with_provider_and_checkpoint_internal(
     checkpoint: &mut impl FnMut(&AgentTaskPromotionReport) -> Result<()>,
     observation_store: Option<&homeboy_core::observation::ObservationStore>,
 ) -> Result<AgentTaskPromotionReport> {
+    emit_promotion_progress(
+        "apply",
+        None,
+        Some("validating promotion input".to_string()),
+    );
     validate_workspace_handle(&options.to_worktree)?;
     let source_value: Value = serde_json::from_str(&options.source).map_err(|error| {
         Error::validation_invalid_json(
@@ -817,6 +864,7 @@ fn promote_with_provider_and_checkpoint_internal(
         // be replaced before the provider opens it.
         let normalized_patch_file = write_normalized_patch(&normalized_patch.content)?;
         let provider_patch_path = normalized_patch_file.path().display().to_string();
+        emit_promotion_progress("apply", None, Some("applying patch".to_string()));
         let target = provider.apply_patch(AgentTaskPromotionApplyRequest {
             schema: AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA.to_string(),
             to_workspace: options.to_worktree.clone(),
@@ -1647,6 +1695,11 @@ fn run_promotion_gates(
     worktree_path: &Path,
     expected_candidate: Option<&crate::agent_task_promotion::AgentTaskPromotionCandidate>,
 ) -> Result<PromotionGateRun> {
+    emit_promotion_progress(
+        "hydration",
+        None,
+        Some("preparing candidate and dependencies".to_string()),
+    );
     if worktree_path.is_dir() {
         homeboy_core::repository_integrity::verify_tracked_symlink_portability(
             worktree_path,
@@ -1720,6 +1773,11 @@ fn run_promotion_gates(
                 blocking_gate_id,
             )
         } else {
+            emit_promotion_progress(
+                "gate",
+                Some(format!("gate-{}", index + 1)),
+                Some("starting deterministic gate".to_string()),
+            );
             run_promotion_gate(
                 options,
                 provider,
@@ -1738,6 +1796,11 @@ fn run_promotion_gates(
         }
         deterministic_gates.push(gate);
     }
+    emit_promotion_progress(
+        "cleanup",
+        None,
+        Some("cleaning promotion gate resources".to_string()),
+    );
     let has_gate_failure = deterministic_gates
         .iter()
         .any(|gate| gate.status == AgentTaskGateStatus::Failed);

--- a/crates/homeboy-agents/src/agent_task_service/promotion_service.rs
+++ b/crates/homeboy-agents/src/agent_task_service/promotion_service.rs
@@ -5,6 +5,7 @@
 
 use homeboy_engine_primitives::content_hash;
 use std::path::Path;
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -18,8 +19,8 @@ use homeboy_core::Result;
 use crate::agent_task_gate::VerifyGateOptions;
 use crate::agent_task_lifecycle;
 use crate::agent_task_promotion::{
-    promote_with_checkpoint, resume_promoted_patch, AgentTaskPromotionOptions,
-    AgentTaskPromotionReport,
+    promote_with_checkpoint, resume_promoted_patch, with_gate_supervision, with_promotion_progress,
+    AgentTaskPromotionOptions, AgentTaskPromotionReport, PromotionProgressCallback,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -274,7 +275,15 @@ impl AgentTaskPromotionJobDriver {
             )
         })?)?;
         handle.progress(serde_json::json!({ "phase": job.phase }))?;
-        job.report = Some(execute_promotion(job.request.clone())?);
+        let cancellation_handle = handle.clone();
+        let progress_handle = handle.clone();
+        job.report = Some(execute_promotion_with_progress_and_cancellation(
+            job.request.clone(),
+            Some(Arc::new(move |progress| {
+                progress_handle.progress(serde_json::json!({ "phase": progress.phase }))
+            })),
+            Arc::new(move || cancellation_handle.is_cancelled()),
+        )?);
         job.phase = AgentTaskPromotionJobPhase::Completed;
         handle.checkpoint(serde_json::to_value(&job).map_err(|error| {
             homeboy_core::Error::internal_json(
@@ -324,6 +333,83 @@ impl AgentTaskPromotionRequest {
 /// is the operation key: each post-apply checkpoint is persisted before gates,
 /// so a restart can only verify the same materialized candidate.
 pub fn execute_promotion(request: AgentTaskPromotionRequest) -> Result<AgentTaskPromotionReport> {
+    execute_promotion_with_progress(request, None)
+}
+
+pub fn execute_promotion_with_progress(
+    request: AgentTaskPromotionRequest,
+    progress: Option<PromotionProgressCallback>,
+) -> Result<AgentTaskPromotionReport> {
+    execute_promotion_with_progress_and_cancellation(request, progress, Arc::new(|| false))
+}
+
+pub fn execute_promotion_with_progress_and_cancellation(
+    request: AgentTaskPromotionRequest,
+    progress: Option<PromotionProgressCallback>,
+    is_cancelled: Arc<dyn Fn() -> bool + Send + Sync>,
+) -> Result<AgentTaskPromotionReport> {
+    match progress {
+        Some(progress) => {
+            let gates = request.gates.clone();
+            with_promotion_progress(progress, || {
+                let gate_ordinal = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+                let spawned_gate_ordinal = gate_ordinal.clone();
+                let active_gate = Arc::new(std::sync::Mutex::new(None));
+                let spawned_active_gate = active_gate.clone();
+                let result = with_gate_supervision(
+                    crate::agent_task_gate::GateSupervision {
+                        timeout: gates.gate_timeout(),
+                        no_progress_timeout: gates.gate_no_progress_timeout(),
+                        heartbeat_interval: gates.gate_heartbeat_interval(),
+                        on_spawn: Arc::new(move |_, _| {
+                            let gate = format!(
+                                "gate-{}",
+                                spawned_gate_ordinal
+                                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                                    + 1
+                            );
+                            *spawned_active_gate.lock().expect("active promotion gate") =
+                                Some(gate.clone());
+                            crate::agent_task_promotion::emit_promotion_progress(
+                                "gate",
+                                Some(gate),
+                                Some("gate process started".to_string()),
+                            );
+                            Ok(())
+                        }),
+                        on_heartbeat: Arc::new(move |status| {
+                            crate::agent_task_promotion::emit_promotion_progress(
+                                "gate",
+                                active_gate.lock().expect("active promotion gate").clone(),
+                                Some(format!(
+                                    "gate elapsed={}ms last-progress={}ms",
+                                    status.elapsed_ms,
+                                    status.last_progress_ms_ago.unwrap_or(status.elapsed_ms),
+                                )),
+                            );
+                            Ok(())
+                        }),
+                        is_cancelled,
+                    },
+                    || execute_promotion_inner(request),
+                );
+                crate::agent_task_promotion::emit_promotion_progress(
+                    "terminal",
+                    None,
+                    Some(if result.is_ok() {
+                        "promotion complete".to_string()
+                    } else {
+                        "promotion stopped".to_string()
+                    }),
+                );
+                result
+            })
+        }
+        None => execute_promotion_inner(request),
+    }
+}
+
+fn execute_promotion_inner(request: AgentTaskPromotionRequest) -> Result<AgentTaskPromotionReport> {
     let previous = request.source_run_id.as_ref().and_then(|run_id| {
         agent_task_lifecycle::status(run_id)
             .ok()
@@ -364,6 +450,11 @@ pub fn execute_promotion(request: AgentTaskPromotionRequest) -> Result<AgentTask
             Ok(())
         })?
     };
+    crate::agent_task_promotion::emit_promotion_progress(
+        "finalization",
+        None,
+        Some("persisting promotion result".to_string()),
+    );
     if let Some(run_id) = request.source_run_id.filter(|_| !request.dry_run) {
         agent_task_lifecycle::record_promotion(
             &run_id,
@@ -375,6 +466,11 @@ pub fn execute_promotion(request: AgentTaskPromotionRequest) -> Result<AgentTask
             })?,
         )?;
     }
+    crate::agent_task_promotion::emit_promotion_progress(
+        "cleanup",
+        None,
+        Some("promotion complete".to_string()),
+    );
     Ok(report)
 }
 

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -392,7 +392,7 @@ pub mod promotion {
         AgentTaskPromotionNotification, AgentTaskPromotionOptions, AgentTaskPromotionReport,
         AgentTaskPromotionSource, AgentTaskPromotionStatus, AgentTaskPromotionTarget,
         AgentTaskPromotionVerifiedBase, CanonicalRecoverablePatchArtifacts,
-        AGENT_TASK_PROMOTION_REPORT_SCHEMA,
+        PromotionProgressCallback, AGENT_TASK_PROMOTION_REPORT_SCHEMA,
     };
 }
 
@@ -484,12 +484,12 @@ pub mod service {
         compile_cook_attempt_with_readiness_cache, consume_claimed_terminal_with_dispatcher,
         consume_claimed_with_dispatcher, continuation_state, cook_batch_job_submission,
         detached_batch_coordinator_control, discover_runs, enqueue_terminal_continuation,
-        evidence_ref_task_id, execute_promotion, hydrate_evidence_ref, hydrate_evidence_summary,
-        load_recipe, load_recipe_for_attempt, logs, normalize_plan_workspaces,
-        offloaded_status_remediation, persist_initial_recipe, persist_manual_finalization_intent,
-        persist_provider_boundary_replay_evidence, persisted_status,
-        preflight_cook_continuation_admission, prepare_manual_finalization_identity,
-        promotion_is_resumable, promotion_source, read_plan,
+        evidence_ref_task_id, execute_promotion, execute_promotion_with_progress,
+        hydrate_evidence_ref, hydrate_evidence_summary, load_recipe, load_recipe_for_attempt, logs,
+        normalize_plan_workspaces, offloaded_status_remediation, persist_initial_recipe,
+        persist_manual_finalization_intent, persist_provider_boundary_replay_evidence,
+        persisted_status, preflight_cook_continuation_admission,
+        prepare_manual_finalization_identity, promotion_is_resumable, promotion_source, read_plan,
         reconcile_recipe_attempt_for_continuation, reconcile_terminal_artifact_projection,
         reconstruct_adoption_options_with_dispatcher, reconstruct_options_with_dispatcher,
         record_replacement_gate_proof, recover_cook_pr, recover_terminal_transport_proxy_evidence,

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1047,9 +1047,9 @@ fn delegate_agent_task_lifecycle_to_pinned_runtime(
     // runtime that creates it rather than inheriting the source's (possibly stale)
     // pinned runtime. Delegating Retry here stamped the replacement with the
     // obsolete runtime after an upgrade (Extra-Chill/homeboy#8550).
-    let run_id = match &cli.command {
+    let run_id: Option<String> = match &cli.command {
         Commands::AgentTask(agent_task) => match &agent_task.command {
-            crate::commands::agent_task::AgentTaskCommand::Run(args) => Some(&args.run_id),
+            crate::commands::agent_task::AgentTaskCommand::Run(args) => Some(args.run_id.clone()),
             crate::commands::agent_task::AgentTaskCommand::Resume(args)
                 if args.bridge
                     && crate::agents::agent_tasks::service::terminal_transport_recovery_required(
@@ -1058,8 +1058,19 @@ fn delegate_agent_task_lifecycle_to_pinned_runtime(
             {
                 None
             }
-            crate::commands::agent_task::AgentTaskCommand::Resume(args) => Some(&args.run_id),
-            crate::commands::agent_task::AgentTaskCommand::Accept(args) => Some(&args.run_id),
+            crate::commands::agent_task::AgentTaskCommand::Resume(args) => Some(args.run_id.clone()),
+            crate::commands::agent_task::AgentTaskCommand::Accept(args) => Some(args.run_id.clone()),
+            // Promotion mutates the durable source run (checkpointing apply and
+            // final reports) and must therefore execute under the controller
+            // runtime that admitted that run. Without this branch a promoted
+            // runtime could own the process that writes an older run's record,
+            // and any live stderr progress would be stranded behind a later
+            // routing boundary.
+            crate::commands::agent_task::AgentTaskCommand::Promote(args) => {
+                crate::agents::agent_tasks::lifecycle::status(&args.source)
+                    .ok()
+                    .map(|record| record.run_id)
+            }
             crate::commands::agent_task::AgentTaskCommand::CookContinue(args) => {
                 if matches!(cli.placement, crate::cli_surface::Placement::Local) {
                     return Ok(None);
@@ -1073,7 +1084,7 @@ fn delegate_agent_task_lifecycle_to_pinned_runtime(
     let Some(run_id) = run_id else {
         return Ok(None);
     };
-    delegate_agent_task_lifecycle_to_resolved_runtime(run_id, normalized_args)
+    delegate_agent_task_lifecycle_to_resolved_runtime(&run_id, normalized_args)
 }
 
 fn delegate_cook_continue_to_pinned_runtime(

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -1,6 +1,9 @@
 use clap::Args;
 use serde_json::Value;
-use std::sync::Arc;
+use std::io::Write;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use homeboy::agents::agent_tasks::cook_loop::{evaluate_cook_loop, AgentTaskCookLoopOptions};
 use homeboy::agents::agent_tasks::dispatch_service as agent_task_dispatch_service;
@@ -467,7 +470,17 @@ pub(crate) fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
             ..Default::default()
         }),
     };
-    let report = agent_task_service::execute_promotion(promotion_request)?;
+    let reporter = PromotionProgressReporter::new(
+        source_run_id.as_deref(),
+        &to_worktree,
+        promotion_request.gates.gate_heartbeat_interval(),
+    );
+    let report = agent_task_service::execute_promotion_with_progress(
+        promotion_request,
+        Some(reporter.callback()),
+    );
+    reporter.finish();
+    let report = report?;
     let exit_code = if report.status == AgentTaskPromotionStatus::GateFailed {
         1
     } else {
@@ -485,6 +498,117 @@ pub(crate) fn promote_artifact(args: PromoteArgs) -> CmdResult<Value> {
     }
 
     Ok((value, exit_code))
+}
+
+#[derive(Clone)]
+struct PromotionProgressState {
+    phase: &'static str,
+    gate: Option<String>,
+    last_progress: String,
+}
+
+struct PromotionProgressReporter {
+    state: Arc<Mutex<PromotionProgressState>>,
+    stopped: Arc<AtomicBool>,
+    worker: Option<std::thread::JoinHandle<()>>,
+}
+
+impl PromotionProgressReporter {
+    fn new(run_id: Option<&str>, to_worktree: &str, interval: std::time::Duration) -> Self {
+        let source = run_id.unwrap_or("unrecorded-promotion");
+        promotion_progress_line(&format!(
+            "promotion: durable source run `{source}`; status -> homeboy agent-task status {source} --full"
+        ));
+        promotion_progress_line(&format!(
+            "promotion: resume -> homeboy agent-task promote {source} --to-worktree {to_worktree}"
+        ));
+        let state = Arc::new(Mutex::new(PromotionProgressState {
+            phase: "apply",
+            gate: None,
+            last_progress: "promotion accepted".to_string(),
+        }));
+        let stopped = Arc::new(AtomicBool::new(false));
+        let worker_state = state.clone();
+        let worker_stopped = stopped.clone();
+        let started = Instant::now();
+        let worker = std::thread::spawn(move || {
+            while !worker_stopped.load(Ordering::SeqCst) {
+                let deadline = Instant::now() + interval;
+                while !worker_stopped.load(Ordering::SeqCst) && Instant::now() < deadline {
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                }
+                if worker_stopped.load(Ordering::SeqCst) {
+                    break;
+                }
+                let state = worker_state
+                    .lock()
+                    .expect("promotion progress state")
+                    .clone();
+                let gate = state.gate.as_deref().unwrap_or("none");
+                promotion_progress_line(&format!(
+                    "promotion heartbeat: phase={} gate={} elapsed={}s last-progress={}",
+                    state.phase,
+                    gate,
+                    started.elapsed().as_secs(),
+                    state.last_progress,
+                ));
+            }
+        });
+        Self {
+            state,
+            stopped,
+            worker: Some(worker),
+        }
+    }
+
+    fn callback(&self) -> homeboy::agents::agent_tasks::promotion::PromotionProgressCallback {
+        let state = self.state.clone();
+        Arc::new(move |progress| {
+            let mut state = state.lock().expect("promotion progress state");
+            state.phase = progress.phase;
+            state.gate = progress.gate.clone();
+            if let Some(last_progress) = &progress.last_progress {
+                state.last_progress = last_progress.clone();
+            }
+            promotion_progress_line(&format!(
+                "promotion progress: phase={} gate={} last-progress={}",
+                state.phase,
+                state.gate.as_deref().unwrap_or("none"),
+                state.last_progress,
+            ));
+            Ok(())
+        })
+    }
+
+    fn finish(mut self) {
+        self.stopped.store(true, Ordering::SeqCst);
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+fn promotion_progress_line(message: &str) {
+    let message = homeboy::core::redaction::redact_string(message);
+    if std::env::var_os(homeboy::core::lab_contract::LAB_EXECUTION_RUNNER_ID_ENV).is_some() {
+        let frame = serde_json::json!({
+            "schema": "homeboy/runner-progress/v1",
+            "phase": "promotion",
+            "metadata": {
+                "promotion": {
+                    "schema": "homeboy/promotion-progress-frame/v1",
+                    "message": message,
+                }
+            }
+        });
+        let mut stdout = std::io::stdout().lock();
+        let _ = writeln!(stdout, "HOMEBOY_RUNNER_PROGRESS {frame}");
+        let _ = stdout.flush();
+        return;
+    }
+    let mut stderr = std::io::stderr().lock();
+    let _ = writeln!(stderr, "{message}");
+    let _ = stderr.flush();
 }
 
 pub(crate) fn promotion_is_resumable(previous: &Value, rerun_completed_gates: bool) -> bool {

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -349,6 +349,7 @@ pub(super) fn exec_via_reverse_broker(
     }
 
     let deadline = Instant::now() + runner_exec_wait_timeout();
+    let mut reported_progress_sequence = 0;
     while !matches!(
         job.status,
         JobStatus::Succeeded | JobStatus::Failed | JobStatus::Cancelled
@@ -386,11 +387,27 @@ pub(super) fn exec_via_reverse_broker(
                 err,
             )
         })?;
+        if let Ok(events) = fetch_daemon_events(&client, broker_url, &job_id) {
+            let events =
+                redact_runner_job_events(&events, &redaction_env, &redaction_secret_env_names);
+            super::daemon::record_and_report_promotion_progress_frames(
+                run_id.as_deref(),
+                &job_id,
+                &events,
+                &mut reported_progress_sequence,
+            );
+        }
     }
     let events = redact_runner_job_events(
         &fetch_daemon_events(&client, broker_url, &job.id.to_string())?,
         &redaction_env,
         &redaction_secret_env_names,
+    );
+    super::daemon::record_and_report_promotion_progress_frames(
+        run_id.as_deref(),
+        &job.id.to_string(),
+        &events,
+        &mut reported_progress_sequence,
     );
 
     let RunnerJobResultFields {

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -300,11 +300,18 @@ pub(super) fn exec_via_daemon(
 
     let deadline = Instant::now() + runner_exec_wait_timeout();
     let mut daemon_endpoint = local_url.to_string();
+    let mut reported_progress_sequence = 0;
     while !job.status.is_terminal() {
         if Instant::now() >= deadline {
             let events = fetch_daemon_events(&client, &daemon_endpoint, &job.id.to_string())
                 .map(|events| redact_runner_job_events(&events, &env, &secret_env_names))
                 .unwrap_or_default();
+            record_and_report_promotion_progress_frames(
+                run_id.as_deref(),
+                &job.id.to_string(),
+                &events,
+                &mut reported_progress_sequence,
+            );
             return Err(daemon_job_wait_timeout(
                 runner,
                 &cwd,
@@ -346,6 +353,15 @@ pub(super) fn exec_via_daemon(
         })?;
         daemon_endpoint = refreshed_endpoint;
         job = refreshed_job;
+        if let Ok(events) = fetch_daemon_events(&client, &daemon_endpoint, &job_id) {
+            let events = redact_runner_job_events(&events, &env, &secret_env_names);
+            record_and_report_promotion_progress_frames(
+                run_id.as_deref(),
+                &job_id,
+                &events,
+                &mut reported_progress_sequence,
+            );
+        }
     }
     let job_id = job.id.to_string();
     let mut events = match fetch_daemon_events(&client, &daemon_endpoint, &job_id) {
@@ -356,6 +372,12 @@ pub(super) fn exec_via_daemon(
             ))
         }
     };
+    record_and_report_promotion_progress_frames(
+        run_id.as_deref(),
+        &job_id,
+        &events,
+        &mut reported_progress_sequence,
+    );
     append_agent_task_lifecycle_workload_event(
         &mut events,
         lab_runner_workload.as_ref(),
@@ -547,6 +569,104 @@ pub(super) fn exec_via_daemon(
         append_runner_exec_diagnostic_hint(&mut output, Some(hint.to_string()));
     }
     Ok((output, exit_code))
+}
+
+pub(super) fn record_and_report_promotion_progress_frames(
+    run_id: Option<&str>,
+    runner_job_id: &str,
+    events: &[JobEvent],
+    last_sequence: &mut u64,
+) {
+    let frames = promotion_progress_frames(events, last_sequence);
+    if let Some(run_id) = run_id {
+        let _ = homeboy_agents::agent_task_lifecycle::record_promotion_progress_frames(
+            run_id,
+            runner_job_id,
+            frames.iter().map(|(sequence, _)| {
+                let event = events
+                    .iter()
+                    .find(|event| event.sequence == *sequence)
+                    .expect("selected promotion event exists");
+                (*sequence, event.data.clone().expect("promotion frame data"))
+            }),
+        );
+    }
+    for (_, message) in frames {
+        eprintln!("{message}");
+    }
+}
+
+fn promotion_progress_frames(events: &[JobEvent], last_sequence: &mut u64) -> Vec<(u64, String)> {
+    let mut frames = Vec::new();
+    for event in events {
+        if event.sequence <= *last_sequence {
+            continue;
+        }
+        *last_sequence = event.sequence;
+        let Some(message) = event
+            .data
+            .as_ref()
+            .and_then(|data| data.pointer("/metadata/promotion/schema"))
+            .filter(|schema| {
+                schema.as_str() == Some(crate::progress::PROMOTION_PROGRESS_FRAME_SCHEMA)
+            })
+            .and_then(|_| {
+                event
+                    .data
+                    .as_ref()?
+                    .pointer("/metadata/promotion/message")?
+                    .as_str()
+            })
+        else {
+            continue;
+        };
+        frames.push((event.sequence, message.to_string()));
+    }
+    frames
+}
+
+#[cfg(test)]
+mod promotion_progress_tests {
+    use super::*;
+
+    fn frame(sequence: u64, message: &str) -> JobEvent {
+        JobEvent {
+            sequence,
+            job_id: uuid::Uuid::nil(),
+            kind: homeboy_core::api_jobs::JobEventKind::Progress,
+            timestamp_ms: sequence,
+            message: None,
+            data: Some(json!({
+                "schema": "homeboy/runner-progress/v1",
+                "phase": "promotion",
+                "metadata": {
+                    "promotion": {
+                        "schema": crate::progress::PROMOTION_PROGRESS_FRAME_SCHEMA,
+                        "message": message,
+                    }
+                }
+            })),
+        }
+    }
+
+    #[test]
+    fn promotion_progress_replays_in_sequence_once_for_late_observers() {
+        let events = vec![
+            frame(4, "promotion progress: applying patch"),
+            frame(5, "promotion progress: gate running"),
+        ];
+        let mut cursor = 0;
+
+        assert_eq!(
+            promotion_progress_frames(&events, &mut cursor),
+            vec![
+                (4, "promotion progress: applying patch".to_string()),
+                (5, "promotion progress: gate running".to_string()),
+            ]
+        );
+        assert_eq!(cursor, 5);
+        assert!(promotion_progress_frames(&events, &mut cursor).is_empty());
+    }
 }
 
 pub(super) fn runner_exec_source_claim_error(

--- a/crates/homeboy-lab-runner/src/execution/process.rs
+++ b/crates/homeboy-lab-runner/src/execution/process.rs
@@ -1429,7 +1429,11 @@ pub(super) fn command_output_until_cancelled_with_progress(
     )?;
     let output = measured.output;
     Ok(ProcessOutput {
-        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stdout: crate::progress::remove_child_progress_lines(
+            &String::from_utf8_lossy(&output.stdout),
+            env,
+            secret_env_names,
+        ),
         stderr: String::from_utf8_lossy(&output.stderr).to_string(),
         exit_code: output.status.code().unwrap_or(1),
         metrics: Some(measured.metrics),

--- a/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
@@ -730,7 +730,7 @@ fn reverse_broker_exec_detached_surfaces_persisted_run_id() {
 }
 
 #[test]
-fn direct_daemon_detached_handoff_returns_while_the_workload_remains_running() {
+fn routed_slow_child_streams_promotion_progress_and_replays_it_after_completion() {
     homeboy_core::test_support::with_isolated_home(|_| {
         // The in-process daemon's /exec endpoint drives runner processes through
         // the RunnerExecDriver hook (production wires this at CLI startup); register
@@ -768,7 +768,7 @@ fn direct_daemon_detached_handoff_returns_while_the_workload_remains_running() {
             vec![
                 "sh".to_string(),
                 "-c".to_string(),
-                "printf 'HOMEBOY_RUNNER_PROGRESS {\"schema\":\"homeboy/runner-progress/v1\",\"phase\":\"provider_dispatch\",\"current_item\":\"task-8341\",\"metadata\":{\"event\":\"provider_selected\",\"provider\":\"fixture\"}}\\n'; printf started > \"$1\"; while [ ! -e \"$2\" ]; do sleep 0.01; done".to_string(),
+                "printf 'HOMEBOY_RUNNER_PROGRESS {\"schema\":\"homeboy/runner-progress/v1\",\"phase\":\"promotion\",\"metadata\":{\"promotion\":{\"schema\":\"homeboy/promotion-progress-frame/v1\",\"message\":\"promotion progress: applying patch\"}}}\\n'; printf started > \"$1\"; while [ ! -e \"$2\" ]; do sleep 0.01; done".to_string(),
                 "sh".to_string(),
                 started.display().to_string(),
                 release.display().to_string(),
@@ -835,13 +835,31 @@ fn direct_daemon_detached_handoff_returns_while_the_workload_remains_running() {
                     .then(|| event.data.as_ref())
                     .flatten()
             })
-            .find(|data| data["phase"] == "provider_dispatch")
-            .expect("provider progress is forwarded before process completion");
-        assert_eq!(progress["phase"], "provider_dispatch");
-        assert_eq!(progress["metadata"]["event"], "provider_selected");
+            .find(|data| {
+                data.pointer("/metadata/promotion/schema")
+                    .and_then(Value::as_str)
+                    == Some("homeboy/promotion-progress-frame/v1")
+            })
+            .expect("promotion progress is forwarded before process completion");
+        assert_eq!(progress["phase"], "promotion");
+        assert_eq!(
+            progress["metadata"]["promotion"]["message"],
+            "promotion progress: applying patch"
+        );
 
         std::fs::write(&release, "release").expect("release workload");
         wait_for_terminal_daemon_job(&client, &daemon_url, &job_id);
+        let late_events = fetch_daemon_events(&client, &daemon_url, &job_id)
+            .expect("late observer reads retained daemon events");
+        assert!(late_events.iter().any(|event| {
+            event.sequence > 0
+                && event
+                    .data
+                    .as_ref()
+                    .and_then(|data| data.pointer("/metadata/promotion/message"))
+                    .and_then(Value::as_str)
+                    == Some("promotion progress: applying patch")
+        }));
         let terminal_jobs: Value = client
             .get(format!("{daemon_url}/jobs"))
             .send()

--- a/crates/homeboy-lab-runner/src/progress.rs
+++ b/crates/homeboy-lab-runner/src/progress.rs
@@ -7,6 +7,7 @@ use homeboy_core::redaction::RedactionPolicy;
 
 pub(crate) const RUNNER_PROGRESS_LINE_PREFIX: &str = "HOMEBOY_RUNNER_PROGRESS ";
 pub(crate) const RUNNER_PROGRESS_SCHEMA: &str = "homeboy/runner-progress/v1";
+pub(crate) const PROMOTION_PROGRESS_FRAME_SCHEMA: &str = "homeboy/promotion-progress-frame/v1";
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -62,6 +63,21 @@ pub(crate) fn parse_child_progress_line(
         "metadata": envelope.metadata,
     });
     Some(redact_progress_value(value, env, secret_env_names))
+}
+
+/// Protocol frames are control data, not command output. Only remove a line
+/// after it passed the same strict parser used for durable progress events.
+pub(crate) fn remove_child_progress_lines(
+    stdout: &str,
+    env: &HashMap<String, String>,
+    secret_env_names: &[String],
+) -> String {
+    stdout
+        .split_inclusive('\n')
+        .filter(|line| {
+            parse_child_progress_line(line.trim_end_matches('\n'), env, secret_env_names).is_none()
+        })
+        .collect()
 }
 
 fn redact_progress_value(
@@ -143,5 +159,19 @@ mod tests {
             &[]
         )
         .is_none());
+    }
+
+    #[test]
+    fn removes_only_valid_protocol_frames_from_terminal_stdout() {
+        let env = HashMap::new();
+        let frame = format!(
+            "{RUNNER_PROGRESS_LINE_PREFIX}{{\"schema\":\"{RUNNER_PROGRESS_SCHEMA}\",\"phase\":\"promotion\",\"metadata\":{{\"promotion\":{{\"schema\":\"{PROMOTION_PROGRESS_FRAME_SCHEMA}\",\"message\":\"promotion progress\"}}}}}}\n"
+        );
+        let stdout = format!("{frame}result\n{RUNNER_PROGRESS_LINE_PREFIX}not-json\n");
+
+        assert_eq!(
+            remove_child_progress_lines(&stdout, &env, &[]),
+            format!("result\n{RUNNER_PROGRESS_LINE_PREFIX}not-json\n")
+        );
     }
 }


### PR DESCRIPTION
## Summary

- emit immediate promotion identity and phase/gate progress without corrupting JSON stdout
- preserve pinned controller-local runtime ownership for promotion
- carry typed, redacted, bounded progress frames across Lab routing
- replay ordered progress to foreground and late observers
- wire cancellation and terminal progress flush while excluding private gate commands

Closes #12841.
Closes #12860.

## Verification

- `cargo test -p homeboy-lab-runner promotion_progress --lib`
- `cargo test -p homeboy-cli promotion_review --lib`
- `cargo check -p homeboy-agents -p homeboy-lab-runner -p homeboy-cli`
- `cargo fmt --all -- --check`
- `git diff --check`

The routed slow-child test proves pre-terminal visibility and retained late replay.

## AI assistance

OpenAI GPT-5.6-sol via OpenCode and multiple OpenCode general coding/review subagents were used to trace controller and Lab routing, implement the typed progress protocol, harden redaction/cancellation, run tests, and review the diff. Chris Huber remains responsible for every line.