### PR TITLE
Keep agent-task review scoped to its run

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -260,6 +260,7 @@ pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
         aggregate_review.as_ref(),
         args.to_worktree.as_deref(),
     );
+    let (review_record, cleanup_evidence) = review_record_projection(&record);
 
     let mut value = serde_json::json!({
             "schema": "homeboy/agent-task-review/v1",
@@ -268,7 +269,7 @@ pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
             "plan_id": record.plan_id,
             "plan_path": record.plan_path,
             "aggregate_path": record.aggregate_path,
-            "record": record,
+            "record": review_record,
             "logs": log,
             "artifacts": artifacts,
             "aggregate": aggregate,
@@ -278,6 +279,7 @@ pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
             "execution_states": execution_states,
             "promotion_candidates": promotion_candidates,
             "next_actions": next_actions,
+            "cleanup_evidence": cleanup_evidence,
             "transport": {
                 "authoritative": "homeboy-agent-task-lifecycle",
                 "chat_state_required": false
@@ -314,6 +316,34 @@ pub(crate) fn review(args: ReviewArgs) -> CmdResult<Value> {
         value["candidate_selection"] = selection;
     }
     Ok((compact_review(value, args.full), 0))
+}
+
+/// Cleanup retention is persisted with a run because it happened while that
+/// run completed, but its inventory can cover sibling worktrees. Keep that
+/// operational evidence addressable without making it review evidence.
+fn review_record_projection(
+    record: &homeboy::agents::agent_tasks::lifecycle::AgentTaskRunRecord,
+) -> (Value, Vec<Value>) {
+    let mut value = serde_json::to_value(record).unwrap_or(Value::Null);
+    let Some(metadata) = value.get_mut("metadata").and_then(Value::as_object_mut) else {
+        return (value, Vec::new());
+    };
+    let mut cleanup_evidence = Vec::new();
+    for key in [
+        "automatic_artifact_retention",
+        "automatic_artifact_retention_inaccessible_roots",
+    ] {
+        if metadata.remove(key).is_some() {
+            cleanup_evidence.push(serde_json::json!({
+                "kind": key,
+                "details_omitted": true,
+                "ref": format!("homeboy://agent-task/run/{}/status#metadata.{key}", record.run_id),
+                "command": format!("homeboy agent-task status {} --full", record.run_id),
+                "export_command": format!("homeboy agent-task status {} --full --output <path>", record.run_id),
+            }));
+        }
+    }
+    (value, cleanup_evidence)
 }
 
 /// Default review output is an actionable handoff, not a second copy of every

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -202,6 +202,60 @@ fn default_review_is_bounded_and_points_to_full_evidence() {
 }
 
 #[test]
+fn full_review_excludes_unrelated_worktree_cleanup_inventory() {
+    with_temp_home(|| {
+        let run_id = "run-review-scoped-cleanup";
+        run_loaded_plan(test_plan(), Some(run_id), Arc::new(ApplyArtifactExecutor))
+            .expect("run completed");
+        let unrelated_worktrees = (0..59)
+            .map(|index| format!("/workspace/unrelated-worktree-{index}"))
+            .collect::<Vec<_>>();
+        agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+            record.metadata["automatic_artifact_retention"] = json!({
+                "status": "completed",
+                "worktree_count": unrelated_worktrees.len(),
+                "worktrees": unrelated_worktrees,
+            });
+        })
+        .expect("persist unrelated cleanup inventory");
+
+        let (review_value, exit_code) = review::review(ReviewArgs {
+            run_id: run_id.to_string(),
+            full: true,
+            to_worktree: None,
+            provider_command: None,
+            provider_argv: Vec::new(),
+        })
+        .expect("review loaded");
+
+        assert_eq!(exit_code, 0);
+        assert!(review_value["record"]["metadata"]
+            .get("automatic_artifact_retention")
+            .is_none());
+        assert_eq!(
+            review_value["cleanup_evidence"][0]["kind"],
+            "automatic_artifact_retention"
+        );
+        assert_eq!(
+            review_value["cleanup_evidence"][0]["command"],
+            format!("homeboy agent-task status {run_id} --full")
+        );
+        assert_eq!(
+            review_value["cleanup_evidence"][0]["export_command"],
+            format!("homeboy agent-task status {run_id} --full --output <path>")
+        );
+        assert!(!review_value.to_string().contains("unrelated-worktree-58"));
+        let persisted = agent_task_lifecycle::status(run_id).expect("cleanup evidence persists");
+        assert_eq!(
+            persisted.metadata["automatic_artifact_retention"]["worktrees"]
+                .as_array()
+                .map(Vec::len),
+            Some(59)
+        );
+    });
+}
+
+#[test]
 fn cook_readers_keep_the_substantive_candidate_after_a_no_change_retry() {
     struct PatchExecutor {
         path: String,


### PR DESCRIPTION
## Summary

- exclude global automatic-retention inventory from `agent-task review --full`
- retain separately addressable cleanup status and export evidence
- prove unrelated worktrees stay out of requested-run review output

Closes #12838.

## Verification

- `cargo test -p homeboy-cli full_review_excludes_unrelated_worktree_cleanup_inventory`
- `cargo fmt --check`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6-sol via OpenCode and OpenCode general coding/review subagents were used to reproduce the review projection, implement the scoped evidence projection, run tests, and review the diff. Chris Huber remains responsible for every line.