### PR TITLE
fix(daemon): mirror evidence into the home holding the run's lease

### DIFF
--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -241,11 +241,15 @@ fn validate_controller_artifact(artifact: &ArtifactRecord) -> Result<()> {
     Ok(())
 }
 
+/// Takes the caller's roots because the evidence this mirrors describes the run
+/// whose lease the caller is already holding. Resolving a second set here let
+/// the lease live in one installation and its evidence land in another (#7505).
 pub(crate) fn mirror_daemon_evidence(
     request: MirrorEvidenceRequest<'_>,
+    roots: &homeboy_core::paths::PathRoots,
 ) -> Result<Option<MirroredDaemonEvidence>> {
     classify_terminal_result(request.job, request.result, "direct-daemon")?;
-    let store = ObservationStore::open_initialized()?;
+    let store = ObservationStore::open_initialized_in_roots(roots)?;
     let local_job_run = mirror_job_run_request(&store, request)?;
     let result = (|| {
         let remote_runs = mirror_remote_observation_runs(

--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -10,6 +10,14 @@ use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::{Runner, RunnerKind};
+
+/// These cases run inside `with_isolated_home`, so reading the environment here
+/// observes that isolated home. Naming the roots keeps the call sites explicit
+/// about which installation the evidence is being mirrored into.
+fn test_roots() -> homeboy_core::paths::PathRoots {
+    homeboy_core::paths::PathRoots::from_environment().expect("path roots")
+}
+
 use homeboy_core::api_jobs::{
     Job, JobArtifactMetadata, JobEvent, JobEventKind, JobStatus, RemoteRunnerObservationRunDetail,
     RunnerJobLifecycleMetadata, RunnerJobProjection,
@@ -567,7 +575,7 @@ fn direct_failure_mirror_projects_bounded_typed_diagnostics_without_artifacts() 
             }),
             None,
             None,
-        ))
+        ), &test_roots())
         .expect("direct failure mirror")
         .expect("mirrored failure");
 
@@ -621,6 +629,7 @@ fn explicit_generic_runner_exec_run_skips_missing_remote_run_projection() {
                 None,
             )
             .with_generic_runner_exec_run(),
+            &test_roots(),
         )
         .expect("controller-owned run does not require a remote run lookup")
         .expect("terminal evidence");
@@ -2008,7 +2017,7 @@ fn direct_result_refresh_treats_preterminal_absence_as_pending() {
             &json!({}),
             None,
             None,
-        ))
+        ), &test_roots())
         .expect("preterminal direct result is pending")
         .expect("pending direct evidence");
 

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -247,9 +247,13 @@ pub(super) fn exec_via_daemon(
     // The renewal also sits inside the `while !job.status.is_terminal()` poll
     // below, so a five-minute daemon exec opened SQLite and walked the
     // migration ladder roughly 1,500 times to renew a lease it already held.
+    // The lease below and the evidence mirror further down describe the same
+    // run, so one resolution serves both rather than each reading the
+    // environment on its own (#7505).
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
     let lease_store = run_id
         .as_deref()
-        .map(|_| ObservationStore::open_initialized())
+        .map(|_| ObservationStore::open_initialized_in_roots(&roots))
         .transpose()?;
     let foreground_source_lease = run_id
         .as_deref()
@@ -408,7 +412,7 @@ pub(super) fn exec_via_daemon(
         } else {
             request
         };
-        mirror_daemon_evidence(request).map_err(|error| {
+        mirror_daemon_evidence(request, &roots).map_err(|error| {
             if run_id_owns_generic_exec {
                 if let Some(run_id) = run_id.as_deref() {
                     let _ =


### PR DESCRIPTION
Part of #7505.

## The lease and its evidence resolved separately

`exec_via_daemon` opens a store to hold the run's lease:

```rust
let lease_store = run_id.as_deref().map(|_| ObservationStore::open_initialized()).transpose()?;
```

and later mirrors that run's evidence:

```rust
mirror_daemon_evidence(request)   // opened its own store from the environment
```

Two independent resolutions for one execution. The comment already sitting above the lease states the invariant plainly:

> a lease claimed against one home and released against another leaves the source stuck `running` with nothing alive holding it (#7505)

Evidence for the same run had no equivalent guarantee. A repoint between the two — or any caller that later hands `exec_via_daemon` injected roots — puts the lease in one installation and the artifacts, job runs, and terminal status describing it in another. The run then looks abandoned in the home that holds its lease, while its evidence sits somewhere nobody is reading.

## Fix

`exec_via_daemon` resolves once and shares:

```rust
let roots = homeboy_core::paths::PathRoots::from_environment()?;
let lease_store = run_id.as_deref()
    .map(|_| ObservationStore::open_initialized_in_roots(&roots))
    .transpose()?;
...
mirror_daemon_evidence(request, &roots)
```

`mirror_daemon_evidence` takes the roots rather than resolving its own. It has one production caller.

## A note on how the test edits went

I inserted the new argument at three test call sites with a paren-matching script, which placed it after an existing trailing comma at one of them:

```rust
    .with_generic_runner_exec_run(),
, &test_roots())
```

`cargo check --workspace --tests -j2` caught it (`expected expression, found ,`) and it is fixed. Worth recording because the two other sites had a different shape and were fine — a script that is right twice can still be wrong once, which is the argument for running the gate rather than trusting the edit.

## Verification

`cargo check --workspace --tests -j2` — clean, 3m20s, zero errors.

## Remaining in this file

`evidence/mirror.rs` still has seven ambient entry points (`mirror_reverse_broker_evidence`, `mirror_daemon_job_progress`, `refresh_mirrored_daemon_evidence`, and others). Each is reachable from a different caller, so they want their own increments rather than one sweep — this one is the pair where the split was demonstrably load-bearing.