### PR TITLE
fix(cook): reenter owned promoted candidates

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -6320,12 +6320,16 @@ fn validate_cook_workspace(options: &AgentTaskCookServiceOptions) -> Result<()> 
         }
         PathBuf::from(identity.path)
     } else {
-        homeboy_core::worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
+        let trusted_unpushed = continuation
+            .as_ref()
+            .map(|continuation| cook_owned_unpushed_destination(continuation))
+            .transpose()?
+            .flatten();
+        homeboy_core::worktree_providers::resolve_apply_enabled_worktree_provider_with_trusted_unpushed_destination_from_config(
             &options.to_worktree,
             &homeboy_core::defaults::load_config(),
-            continuation
-                .as_ref()
-                .map(|continuation| &continuation.baseline),
+            continuation.as_ref().map(|continuation| &continuation.baseline),
+            trusted_unpushed.as_ref(),
         )?
         .worktree
         .path
@@ -6909,6 +6913,80 @@ struct TrackedPromotionContinuation {
     candidate: crate::agent_task_promotion::AgentTaskPromotionCandidate,
 }
 
+/// A gate-failed promotion may be committed by Cook's recovery path before its
+/// final push. Accept only one direct child of the recorded pre-promotion HEAD
+/// whose tree is the recorded promoted candidate; this proves the commit did
+/// not add unrelated work.
+fn cook_owned_unpushed_destination(
+    continuation: &TrackedPromotionContinuation,
+) -> Result<Option<homeboy_core::worktree_providers::TrustedUnpushedWorktree>> {
+    let crate::agent_task_promotion::AgentTaskPromotionCandidate::Git { fingerprint } =
+        &continuation.candidate
+    else {
+        return Ok(None);
+    };
+    let path = &continuation.path;
+    let clean = homeboy_core::git::run_git(
+        path,
+        &["status", "--porcelain=v1", "--untracked-files=all"],
+        "verify Cook-owned committed candidate cleanliness",
+    )?
+    .trim()
+    .is_empty();
+    if !clean {
+        return Ok(None);
+    }
+    let head = homeboy_core::git::run_git(
+        path,
+        &["rev-parse", "--verify", "HEAD^{commit}"],
+        "resolve Cook-owned committed candidate HEAD",
+    )?
+    .trim()
+    .to_string();
+    if head == fingerprint.head {
+        return Ok(None);
+    }
+    let parent = homeboy_core::git::run_git(
+        path,
+        &["rev-parse", "--verify", "HEAD^"],
+        "resolve Cook-owned committed candidate parent",
+    )?
+    .trim()
+    .to_string();
+    let tree = homeboy_core::git::run_git(
+        path,
+        &["rev-parse", "--verify", "HEAD^{tree}"],
+        "resolve Cook-owned committed candidate tree",
+    )?
+    .trim()
+    .to_string();
+    if parent != fingerprint.head || tree != fingerprint.tree {
+        let mut error = Error::validation_invalid_argument(
+            "to_worktree",
+            "clean unpushed checkout is not the exact one-commit Cook-owned promoted candidate",
+            Some(path.display().to_string()),
+            None,
+        );
+        error.details["workspace"] = serde_json::json!({
+            "classification": "workspace.cook_owned_unpushed_commit_mismatch",
+            "reason": if parent != fingerprint.head { "divergent_ancestry" } else { "unrelated_unpushed_commit" },
+            "owning_layer": "cook",
+            "path": path,
+            "expected_parent": fingerprint.head,
+            "actual_parent": parent,
+            "expected_tree": fingerprint.tree,
+            "actual_tree": tree,
+        });
+        return Err(error);
+    }
+    Ok(Some(
+        homeboy_core::worktree_providers::TrustedUnpushedWorktree {
+            path: path.clone(),
+            head,
+        },
+    ))
+}
+
 /// A dirty destination is reusable only for the exact post-apply candidate
 /// checkpoint owned by this Cook attempt. Core verifies the supplied baseline
 /// during provider resolution; Cook binds it to this attempt's target identity.
@@ -6935,12 +7013,12 @@ fn tracked_promotion_continuation(
         promotion.status,
         AgentTaskPromotionStatus::VerificationPending | AgentTaskPromotionStatus::Applied
     ) && (has_post_apply_checkpoint || authenticated_legacy_review);
-    // A gate-failed candidate remains eligible only when this exact lifecycle
-    // route selected its exact Cook attempt. Plan metadata is caller-controlled
-    // and is therefore never authorization for dirty-worktree reuse.
-    let route_authorized_gate_failure = promotion.status.gate_failed()
-        && has_post_apply_checkpoint
-        && has_cook_continue_route(options);
+    // A gate-failed candidate remains eligible only when its immutable recipe,
+    // indexed attempt, and run record all identify this Cook. This survives a
+    // failed controller process without treating caller-controlled route or
+    // plan metadata as authorization for dirty-worktree reuse.
+    let route_authorized_gate_failure =
+        promotion.status.gate_failed() && has_post_apply_checkpoint && cook_owns_attempt(options)?;
     if !(normal_continuation || route_authorized_gate_failure) {
         return Ok(None);
     }
@@ -7034,6 +7112,48 @@ fn tracked_promotion_continuation(
     }))
 }
 
+fn cook_owns_attempt(options: &AgentTaskCookServiceOptions) -> Result<bool> {
+    let recipe_store = CookRecipeStore::from_current_data_root()?;
+    let recipe = match recipe_store.load_recipe(&options.cook_id) {
+        Ok(recipe) => recipe,
+        Err(_) => return Ok(false),
+    };
+    let Some(attempt) = recipe
+        .attempts
+        .iter()
+        .find(|attempt| attempt.run_id == options.initial_run_id)
+    else {
+        return Ok(false);
+    };
+    let recipe_tasks = attempt
+        .plan
+        .tasks
+        .iter()
+        .map(|task| task.workspace.task_url.as_deref())
+        .collect::<Vec<_>>();
+    let option_tasks = options
+        .initial_plan
+        .tasks
+        .iter()
+        .map(|task| task.workspace.task_url.as_deref())
+        .collect::<Vec<_>>();
+    if recipe_tasks != option_tasks
+        || recipe
+            .finalization
+            .get("to_worktree")
+            .and_then(Value::as_str)
+            != Some(options.to_worktree.as_str())
+    {
+        return Ok(false);
+    }
+    let record = agent_task_lifecycle::exact_record(&options.initial_run_id)?;
+    Ok(
+        record.metadata.get("cook_id").and_then(Value::as_str) == Some(options.cook_id.as_str())
+            && record.metadata.get("cook_attempt").and_then(Value::as_u64)
+                == Some(u64::from(attempt.attempt)),
+    )
+}
+
 fn authenticate_tracked_promotion_continuation(
     target: &std::path::Path,
     continuation: &TrackedPromotionContinuation,
@@ -7070,7 +7190,8 @@ fn authenticate_tracked_promotion_continuation(
     }
     let actual =
         crate::agent_task_promotion::candidate_fingerprint(target.to_string_lossy().as_ref())?;
-    if actual != continuation.candidate {
+    if actual != continuation.candidate && cook_owned_unpushed_destination(continuation)?.is_none()
+    {
         return Err(Error::validation_invalid_argument(
             "to_worktree",
             "Cook continuation destination differs from its exact tracked post-apply candidate",

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -11119,6 +11119,8 @@ fn tracked_promotion_continuation_options(
     target: &std::path::Path,
 ) -> AgentTaskCookServiceOptions {
     let mut options = promotion_claim_options(cook_id, run_id);
+    options.initial_plan =
+        batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher)).initial_plan;
     options.to_worktree = target.display().to_string();
     options.source_worktree_path = Some(target.to_path_buf());
     options
@@ -11128,7 +11130,20 @@ fn record_tracked_promotion_continuation(
     options: &AgentTaskCookServiceOptions,
     target: &std::path::Path,
 ) {
+    if !CookRecipeStore::from_current_data_root()
+        .unwrap()
+        .recipe_exists(&options.cook_id)
+    {
+        persist_initial_recipe(options).unwrap();
+    }
     agent_task_lifecycle::submit_plan(&options.initial_plan, Some(&options.initial_run_id))
+        .unwrap();
+    agent_task_lifecycle::rewrite_record_for_test(&options.initial_run_id, |record| {
+        record.metadata["cook_id"] = serde_json::json!(options.cook_id);
+        record.metadata["cook_attempt"] = serde_json::json!(1);
+    })
+    .unwrap();
+    agent_task_lifecycle::record_cook_attempt(&options.cook_id, 1, &options.initial_run_id)
         .unwrap();
     let mut checkpoint = serde_json::to_value(promotion(&options.initial_run_id)).unwrap();
     checkpoint["status"] = serde_json::json!("gate_failed");
@@ -11192,6 +11207,89 @@ fn fresh_cook_has_no_tracked_promotion_before_lifecycle_materialization() {
 
         assert!(!agent_task_lifecycle::run_record_exists(&options.initial_run_id).unwrap());
         assert!(tracked_promotion_continuation(&options).unwrap().is_none());
+    });
+}
+
+#[test]
+fn cook_owned_unpushed_candidate_requires_one_exact_promoted_commit() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let target = tempfile::tempdir().expect("target");
+        for args in [
+            vec!["init", "--quiet", "-b", "main"],
+            vec!["config", "user.email", "test@example.com"],
+            vec!["config", "user.name", "Homeboy Test"],
+        ] {
+            assert!(Command::new("git")
+                .args(args)
+                .current_dir(target.path())
+                .status()
+                .unwrap()
+                .success());
+        }
+        std::fs::write(target.path().join("tracked.txt"), "base\n").unwrap();
+        assert!(Command::new("git")
+            .args(["add", "tracked.txt"])
+            .current_dir(target.path())
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args(["commit", "--quiet", "-m", "base"])
+            .current_dir(target.path())
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args(["checkout", "--quiet", "-b", "cook-candidate"])
+            .current_dir(target.path())
+            .status()
+            .unwrap()
+            .success());
+        std::fs::write(target.path().join("tracked.txt"), "promoted\n").unwrap();
+        let options = tracked_promotion_continuation_options(
+            "cook-owned-unpushed",
+            "run-cook-owned-unpushed",
+            target.path(),
+        );
+        record_tracked_promotion_continuation(&options, target.path());
+        assert!(Command::new("git")
+            .args(["add", "tracked.txt"])
+            .current_dir(target.path())
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args(["commit", "--quiet", "-m", "cook: retain candidate"])
+            .current_dir(target.path())
+            .status()
+            .unwrap()
+            .success());
+        let continuation = tracked_promotion_continuation(&options)
+            .unwrap()
+            .expect("durable Cook attribution");
+        assert!(cook_owned_unpushed_destination(&continuation)
+            .unwrap()
+            .is_some());
+
+        std::fs::write(target.path().join("unrelated.txt"), "drift\n").unwrap();
+        assert!(Command::new("git")
+            .args(["add", "unrelated.txt"])
+            .current_dir(target.path())
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args(["commit", "--quiet", "-m", "unrelated"])
+            .current_dir(target.path())
+            .status()
+            .unwrap()
+            .success());
+        let error = cook_owned_unpushed_destination(&continuation).unwrap_err();
+        assert_eq!(
+            error.details["workspace"]["classification"],
+            "workspace.cook_owned_unpushed_commit_mismatch"
+        );
+        assert_eq!(error.details["workspace"]["reason"], "divergent_ancestry");
     });
 }
 
@@ -11485,18 +11583,13 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
         crate::agent_task_candidate_baseline::register();
 
         assert!(
-            tracked_promotion_continuation(&options).unwrap().is_none(),
-            "gate-failed promotion requires cook-continue context"
+            tracked_promotion_continuation(&options).unwrap().is_some(),
+            "a durably attributed gate-failed promotion re-enters without a route token"
         );
         options.initial_plan.metadata["cook_continue_context"] = serde_json::json!({
             "schema": "homeboy/agent-task-cook-continue-context/v1",
             "run_id": options.initial_run_id,
         });
-        assert!(
-            tracked_promotion_continuation(&options).unwrap().is_none(),
-            "forged plan metadata cannot authorize a gate-failed continuation"
-        );
-        authorize_cook_continue_route(&options).unwrap();
         let continuation = tracked_promotion_continuation(&options)
             .unwrap()
             .expect("tracked promotion continuation");


### PR DESCRIPTION
## Summary

- recognize a gate-failed promoted destination from the immutable Cook recipe, indexed attempt, and run attribution rather than requiring a continuation route token
- permit Cook to complete final push for one clean unpushed commit that is a direct child of the recorded pre-promotion HEAD and reproduces the recorded candidate tree
- retain typed refusals for dirty/unattributed state, wrong task ownership, divergent ancestry, and unrelated unpushed commits

Closes #11075.

## Dependencies

No merge dependency on #12855 or #12856: this branch is based on current `main`. It complements #12855 (existing-candidate finalization) and #12856 (verified no-change recovery) by covering the remaining gate-failed promoted-state and Cook-owned unpushed-branch admission path.

## Tests

- `cargo fmt --check`
- `cargo check -p homeboy-agents`
- `cargo test -p homeboy-agents --lib agent_task_service::cook::tests -- --nocapture`

## AI assistance

OpenAI openai/gpt-5.6-sol via OpenCode general coding subagent implemented and verified this change; Chris Huber directed and remains responsible for the change.