### PR TITLE
Update two readiness tests to the fenced-recovery contract

### DIFF
--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_c.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_c.rs
@@ -120,9 +120,13 @@ fn refresh_readiness_blocks_a_post_refresh_binary_hash_mismatch() {
     assert!(!readiness.daemon_fresh);
     assert!(!readiness.accepting_jobs);
     assert_eq!(readiness.owners, ["lease-new"]);
+    // This fixture carries no typed repair plan, and a stale report without one
+    // is terminal even when its ownership proof is sufficient (#12797): there is
+    // no authorized mutation to prescribe. The readiness therefore falls back to
+    // the read-only status projection rather than a `runner doctor` action.
     assert_eq!(
         readiness.continuation.as_deref(),
-        Some("homeboy runner doctor homeboy-lab --scope lab-offload")
+        Some("homeboy runner status homeboy-lab --full")
     );
 }
 

--- a/crates/homeboy-lab-runner/src/lab/preparation_tests.rs
+++ b/crates/homeboy-lab-runner/src/lab/preparation_tests.rs
@@ -884,12 +884,14 @@ fn lab_runner_preparation_errors_for_explicit_stale_daemon_version() {
     .expect_err("explicit stale daemon should require an explicit refresh");
 
     assert!(err.message.contains("connected but is not ready"));
-    assert!(err.message.contains("daemon is stale"));
-    assert!(err.message.contains("homeboy 0.218.0"));
-    assert!(err.message.contains("homeboy 0.219.0"));
+    // A stale report whose ownership proof is incomplete takes the terminal
+    // ownership-blocker branch, which replaces the stale-daemon branch rather
+    // than adding to it: no severity line, no version drift pair, and no
+    // refresh command, because none of them are authorized without that proof.
     assert!(err
         .message
         .contains("typed ownership evidence is insufficient"));
+    assert!(!err.message.contains("daemon is stale"));
     assert!(!err
         .message
         .contains("homeboy runner doctor lab --scope lab-offload"));


### PR DESCRIPTION
`main` is red, and the required status checks have **no bypass actors** — so this blocks every merge in the repo, not just my stack.

## Both failures are stale tests, not regressions

They encode the contract that existed before recovery was fenced on ownership proof (`e9445e96b`, 2026-08-21). The expectations date from 2026-08-06.

### `refresh_readiness_blocks_a_post_refresh_binary_hash_mismatch`

Expected a `runner doctor --scope lab-offload` continuation from a fixture whose `repair_plan` is **empty**. Per the current contract:

> An empty plan is terminal **even when its ownership proof is sufficient**, because there is no authorized mutation to execute.

The fixture's `lease_id` + `pid` do make its ownership proof sufficient — which is precisely why the old expectation looks correct at a glance. It isn't: with no typed plan there is nothing to prescribe, so readiness falls back to the read-only status projection.

### `lab_runner_preparation_errors_for_explicit_stale_daemon_version`

Asserted text from **two mutually exclusive branches** of `connected_runner_not_ready_reason`:

```
branch 1  "typed ownership evidence is insufficient"     <- fires
branch 2  "daemon is stale (severity=...)" + version pair
```

Its fixture has a lease but **no pid**, so it takes the terminal ownership-blocker branch, which *replaces* the stale-daemon branch rather than adding to it. The test had already been given branch 1's assertion; branch 2's three were left behind. No fixture can satisfy both.

## A wrong turn worth recording

I first narrowed the `!freshness.fresh` fence in `admission_action`, reasoning it was broader than its own comment ("Missing typed ownership proof...") since the fixture *has* lease and pid.

That was wrong, and the test told me so. The fixture sets `stale_daemon: None`, so the fence was never on that code path at all — the `None` came from the terminal-blocker check above it. **Reverted.** The production fencing is correct as written; the tests are what drifted.

## Verification

Run, not just compiled — this is a fix to red main, so a green `cargo check` would prove nothing:

```
cargo test -p homeboy-lab-runner --lib
  refresh_readiness_blocks_a_post_refresh_binary_hash_mismatch ... ok
  lab_runner_preparation_errors_for_explicit_stale_daemon_version ... ok
```

- `nice -n 10 cargo check --workspace --tests -j2` — clean, **0 errors, 0 warnings**
- `cargo fmt --check` — clean

Two other tests fail in my sandbox (`daemon_exec_empty_envelope_over_http_is_actionable_not_null`, `materialize_failure_preserves_compiler_diagnostics_and_active_binary`). Neither appears in the main-branch CI failure set; both need real HTTP and a real compiler invocation, which this VPS does not give them. Flagging rather than hiding them.
