### PR TITLE
perf(cook): reuse compatible Cargo targets

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -1971,10 +1971,34 @@ impl SelectedGateEnvironment {
             .get("CARGO_TARGET_DIR")
             .cloned()
             .or_else(|| std::env::var("CARGO_TARGET_DIR").ok());
-        let target = homeboy_core::cleanup::acquire_managed_cargo_target(
-            "agent-task-gate",
+        let compatibility = [
+            (
+                "CARGO_BUILD_TARGET",
+                self.values
+                    .get("CARGO_BUILD_TARGET")
+                    .map(String::as_str)
+                    .unwrap_or(""),
+            ),
+            (
+                "RUSTFLAGS",
+                self.values
+                    .get("RUSTFLAGS")
+                    .map(String::as_str)
+                    .unwrap_or(""),
+            ),
+            (
+                "CARGO_PROFILE",
+                self.values
+                    .get("CARGO_PROFILE")
+                    .map(String::as_str)
+                    .unwrap_or(""),
+            ),
+        ];
+        let target = homeboy_core::cleanup::acquire_managed_cargo_target_with_compatibility(
+            "agent-task-cargo",
             cwd,
             explicit_target.as_deref(),
+            &compatibility,
         )?;
         // Store sizing is evidence only. A concurrent gate may update the
         // shared target while this observation walks it.

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -683,7 +683,7 @@ fn run_materialized_provider_command_once_contained(
             )
         }
     };
-    let env = match provider_command_env(request, provider) {
+    let mut env = match provider_command_env(request, provider) {
         Ok(env) => env,
         Err(ProviderCommandEnvError::Secret(error)) => {
             return failure_outcome(
@@ -712,6 +712,32 @@ fn run_materialized_provider_command_once_contained(
             )
         }
     };
+    // The lease remains alive through the provider process. This lets provider
+    // attempts and controller gates share only the same compatibility-keyed
+    // Cargo output directory while preserving their isolated HOME/XDG roots.
+    let cargo_target = match provider_cargo_target(request, cwd.as_deref()) {
+        Ok(target) => target,
+        Err(error) => {
+            return failure_outcome(
+                request,
+                AgentTaskOutcomeStatus::ProviderError,
+                AgentTaskFailureClassification::InvalidInput,
+                "agent_task.cargo_cache_unavailable",
+                error.to_string(),
+                json!({ "provider": provider.id }),
+            )
+        }
+    };
+    if let Some(target) = &cargo_target {
+        env.push((
+            "CARGO_TARGET_DIR".to_string(),
+            target.target_dir().display().to_string(),
+        ));
+        env.push((
+            "HOMEBOY_CARGO_TARGET_RESOLUTION".to_string(),
+            target.resolution().to_string(),
+        ));
+    }
 
     let mut command_builder = Command::new(&program);
     command_builder.args(&args).envs(
@@ -1102,6 +1128,42 @@ fn run_materialized_provider_command_once_contained(
             ),
         ),
     }
+}
+
+fn provider_cargo_target(
+    _request: &AgentTaskExecutorRequest,
+    cwd: Option<&Path>,
+) -> homeboy_core::Result<Option<homeboy_core::ManagedCargoTarget>> {
+    let Some(cwd) = cwd else { return Ok(None) };
+    let enabled =
+        homeboy_core::component::resolve_effective(None, Some(&cwd.to_string_lossy()), None)
+            .map(|component| component.managed_execution.shared_cargo_target)
+            .unwrap_or(false);
+    if !enabled {
+        return Ok(None);
+    }
+    let compatibility = [
+        (
+            "CARGO_BUILD_TARGET",
+            std::env::var("CARGO_BUILD_TARGET").unwrap_or_default(),
+        ),
+        ("RUSTFLAGS", std::env::var("RUSTFLAGS").unwrap_or_default()),
+        (
+            "CARGO_PROFILE",
+            std::env::var("CARGO_PROFILE").unwrap_or_default(),
+        ),
+    ];
+    let compatibility = compatibility
+        .iter()
+        .map(|(name, value)| (*name, value.as_str()))
+        .collect::<Vec<_>>();
+    homeboy_core::acquire_managed_cargo_target_with_compatibility(
+        "agent-task-cargo",
+        cwd,
+        None,
+        &compatibility,
+    )
+    .map(Some)
 }
 
 // Provider adapters that predate the top-level declaration field consume the

--- a/crates/homeboy-agents/src/agent_task_review_dossier.rs
+++ b/crates/homeboy-agents/src/agent_task_review_dossier.rs
@@ -55,6 +55,9 @@ pub struct AgentTaskReviewEvidence {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AiReviewVerificationClaim {
     pub command: String,
+    /// Provider-measured wall time. Controller gate timing is retained separately.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub elapsed_ms: Option<u128>,
     pub total: u64,
     pub passed: u64,
     pub failed: u64,
@@ -329,7 +332,7 @@ impl AiFilledReviewForm {
     pub fn requirement_feedback() -> &'static str {
         "Return a `review_form` object in your task outputs with: `summary` (what is changing and why), \
 `what_changed` (a non-empty list of concrete change bullets), `compatibility` (a qualitative impact/compatibility \
-assessment), optional `verification` entries with an exact command and total/passed/failed/ignored counts, and \
+ assessment), optional `verification` entries with an exact command, elapsed_ms, and total/passed/failed/ignored counts, and \
 `used_for` (a concise, self-reflective description of the process you took — distinct from the summary of what \
 changed). Homeboy derives reviewer-visible verification from its durable candidate gate evidence. A successful \
 `used_for` is a genuine process reflection."
@@ -1646,6 +1649,7 @@ mod tests {
         let mut form = valid_form();
         form.verification.push(AiReviewVerificationClaim {
             command: "cargo test connection::tests".into(),
+            elapsed_ms: None,
             total: 127,
             passed: 124,
             failed: 3,
@@ -1653,6 +1657,7 @@ mod tests {
         });
         form.verification.push(AiReviewVerificationClaim {
             command: "cargo test connection".into(),
+            elapsed_ms: None,
             total: 127,
             passed: 124,
             failed: 2,
@@ -1674,6 +1679,7 @@ mod tests {
         let mut form = valid_form();
         form.verification.push(AiReviewVerificationClaim {
             command: "cargo test connection".into(),
+            elapsed_ms: None,
             total: 177,
             passed: 175,
             failed: 2,
@@ -1692,6 +1698,7 @@ mod tests {
         let mut form = valid_form();
         form.verification.push(AiReviewVerificationClaim {
             command: "php artisan test".into(),
+            elapsed_ms: None,
             total: 7,
             passed: 7,
             failed: 0,

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -21,10 +21,10 @@ use crate::{git, Error, Result};
 
 mod cargo_targets;
 pub use cargo_targets::{
-    acquire_managed_cargo_target, acquire_shared_cargo_target, cleanup_shared_cargo_targets,
-    shared_cargo_target_inventory, shared_cargo_target_root, shared_cargo_target_storage_status,
-    CargoTargetCleanupOptions, CargoTargetCleanupOutput, CargoTargetStorageStatus,
-    ManagedCargoTarget, SharedCargoTargetLease,
+    acquire_managed_cargo_target, acquire_managed_cargo_target_with_compatibility,
+    acquire_shared_cargo_target, cleanup_shared_cargo_targets, shared_cargo_target_inventory,
+    shared_cargo_target_root, shared_cargo_target_storage_status, CargoTargetCleanupOptions,
+    CargoTargetCleanupOutput, CargoTargetStorageStatus, ManagedCargoTarget, SharedCargoTargetLease,
 };
 mod automatic_retention;
 pub use automatic_retention::{

--- a/crates/homeboy-core/src/cleanup/cargo_targets.rs
+++ b/crates/homeboy-core/src/cleanup/cargo_targets.rs
@@ -154,6 +154,19 @@ pub fn acquire_managed_cargo_target(
     source_path: &Path,
     explicit_target: Option<&str>,
 ) -> Result<ManagedCargoTarget> {
+    acquire_managed_cargo_target_with_compatibility(owner, source_path, explicit_target, &[])
+}
+
+/// Acquire a target store whose identity is bound to the repository and the
+/// declared build compatibility surface.  Cargo still owns fine-grained crate
+/// fingerprints inside this directory; this boundary prevents unrelated build
+/// universes from sharing the directory at all.
+pub fn acquire_managed_cargo_target_with_compatibility(
+    owner: &str,
+    source_path: &Path,
+    explicit_target: Option<&str>,
+    declared_environment: &[(&str, &str)],
+) -> Result<ManagedCargoTarget> {
     if let Some(target) = explicit_target.filter(|target| !target.trim().is_empty()) {
         let target_dir = PathBuf::from(target);
         let target_dir = if target_dir.is_absolute() {
@@ -169,7 +182,7 @@ pub fn acquire_managed_cargo_target(
         });
     }
 
-    let compatibility = cargo_target_repository_identity(source_path);
+    let compatibility = cargo_target_compatibility_identity(source_path, declared_environment);
     let lease = acquire_shared_cargo_target(&format!("{owner}:{compatibility}"))?;
     Ok(ManagedCargoTarget {
         target_dir: lease.target_dir().to_path_buf(),
@@ -177,6 +190,40 @@ pub fn acquire_managed_cargo_target(
         owner: owner.to_string(),
         _lease: Some(lease),
     })
+}
+
+fn cargo_target_compatibility_identity(
+    source_path: &Path,
+    declared_environment: &[(&str, &str)],
+) -> String {
+    let mut inputs = BTreeMap::new();
+    inputs.insert(
+        "repository".to_string(),
+        cargo_target_repository_identity(source_path),
+    );
+    inputs.insert(
+        "platform".to_string(),
+        format!("{}/{}", std::env::consts::OS, std::env::consts::ARCH),
+    );
+    for name in [
+        "Cargo.lock",
+        "rust-toolchain",
+        "rust-toolchain.toml",
+        ".cargo/config",
+        ".cargo/config.toml",
+    ] {
+        let path = source_path.join(name);
+        let digest = fs::read(&path)
+            .map(|bytes| content_hash::sha256_hex(&bytes))
+            .unwrap_or_else(|_| "absent".to_string());
+        inputs.insert(format!("input:{name}"), digest);
+    }
+    for (name, value) in declared_environment {
+        inputs.insert(format!("env:{name}"), (*value).to_string());
+    }
+    content_hash::sha256_hex(
+        &serde_json::to_vec(&inputs).expect("Cargo compatibility inputs serialize"),
+    )
 }
 
 /// Cargo itself separates compatible crate fingerprints inside one target
@@ -1052,6 +1099,58 @@ mod tests {
             "homeboy cleanup --include shared-cargo-targets --apply"
         );
         assert!(protected.target_dir().exists());
+    }
+
+    #[test]
+    fn compatibility_identity_reuses_matching_inputs_and_rejects_changes() {
+        let workspace = TempDir::new().unwrap();
+        fs::write(workspace.path().join("Cargo.lock"), "lock-a").unwrap();
+        fs::write(
+            workspace.path().join("rust-toolchain.toml"),
+            "channel = 'stable'",
+        )
+        .unwrap();
+        let first = cargo_target_compatibility_identity(
+            workspace.path(),
+            &[
+                ("CARGO_BUILD_TARGET", "x86_64-unknown-linux-gnu"),
+                ("RUSTFLAGS", ""),
+            ],
+        );
+        let warm = cargo_target_compatibility_identity(
+            workspace.path(),
+            &[
+                ("CARGO_BUILD_TARGET", "x86_64-unknown-linux-gnu"),
+                ("RUSTFLAGS", ""),
+            ],
+        );
+        assert_eq!(first, warm);
+        fs::write(workspace.path().join("Cargo.lock"), "lock-b").unwrap();
+        assert_ne!(
+            first,
+            cargo_target_compatibility_identity(
+                workspace.path(),
+                &[
+                    ("CARGO_BUILD_TARGET", "x86_64-unknown-linux-gnu"),
+                    ("RUSTFLAGS", "")
+                ],
+            )
+        );
+        fs::write(
+            workspace.path().join("rust-toolchain.toml"),
+            "channel = 'nightly'",
+        )
+        .unwrap();
+        assert_ne!(
+            warm,
+            cargo_target_compatibility_identity(
+                workspace.path(),
+                &[
+                    ("CARGO_BUILD_TARGET", "aarch64-apple-darwin"),
+                    ("RUSTFLAGS", "-Dwarnings")
+                ],
+            )
+        );
     }
 
     #[test]

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -35,7 +35,10 @@ pub use lab_contract as command_contract;
 
 // Stable domain facades for new command/core integrations.
 pub mod artifacts;
-pub use cleanup::{acquire_managed_cargo_target, ManagedCargoTarget};
+pub use cleanup::{
+    acquire_managed_cargo_target, acquire_managed_cargo_target_with_compatibility,
+    ManagedCargoTarget,
+};
 pub use homeboy_engine_primitives::cargo_target::CargoTargetEvidence;
 
 // Public extensions (config first — exports entity_crud! macro used by entity extensions)


### PR DESCRIPTION
## Summary
- bind managed Cargo targets to repository, lockfile, toolchain/config, platform, and declared build environment
- retain the shared target lease for provider process lifetime and pass its target directory to provider attempts
- reuse the same target owner for controller deterministic gates and add provider verification elapsed-time evidence

Closes #12648

## Verification
- `cargo fmt --all -- --check`
- `cargo check -p homeboy-agents`
- `cargo test -p homeboy-core cleanup::cargo_targets::tests::compatibility_identity_reuses_matching_inputs_and_rejects_changes --lib`
- `cargo test -p homeboy-agents agent_task_review_dossier::tests --lib`

## AI Assistance
OpenAI `openai/gpt-5.6-terra` via OpenCode implemented the compatible Cargo-target lease integration, added compatibility and additive evidence coverage, and ran the listed checks. Chris Huber directed and remains responsible for the change.