### PR TITLE
Fix detached Cook handoff output parity

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
@@ -405,7 +405,9 @@ pub(super) fn intercept_local_detached_cook(
                 return Err(error);
             }
         };
-        println!("{stdout}");
+        // `--output` owns the serialized acknowledgement until this point. Emit
+        // those exact bytes so both requested destinations carry one contract.
+        print!("{stdout}");
         return Ok(Some(0));
     }
 

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -314,6 +314,7 @@ fn cook_accepts_local_detachment_after_materializing_an_executable_attempt() {
     )
     .expect("disable host-capacity admission for fixture worktree");
     let cook_id = "local-detach-materializes-attempt";
+    let output_path = context.root().join("local-detach-handoff.json");
     let mut command = context.controller_runtime_command(TestBinary::HomeboyFixture);
     command.args([
         "--placement",
@@ -338,10 +339,17 @@ fn cook_accepts_local_detachment_after_materializing_an_executable_attempt() {
         "--max-attempts",
         "1",
         "--no-finalize",
+        "--output",
+        output_path.to_str().expect("handoff output path"),
     ]);
     let output = bounded_output(command);
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(output.status.success(), "{stdout}");
+    assert_eq!(
+        std::fs::read_to_string(&output_path).expect("read atomic handoff output"),
+        stdout,
+        "stdout and --output must receive the identical terminal handoff envelope"
+    );
     let handoff: serde_json::Value = serde_json::from_str(
         &stdout[stdout
             .find('{')


### PR DESCRIPTION
## Summary
- emit the detached Cook handoff envelope as identical bytes on stdout and `--output`
- cover atomic output-file parity through the real detached local Cook acceptance path

Closes #11090

## Verification
- `cargo fmt --check`
- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-cli local_detach`
- `cargo test --test cook_lab_handoff_test cook_accepts_local_detachment_after_materializing_an_executable_attempt -- --exact`

`cargo test --test reverse_cook_queue_acceptance pinned_runner_route_persists_the_verified_lab_outcome_through_detached_cook_lifecycle -- --exact` failed in the existing Lab fixture: the controller did not project the terminal broker result, followed by fixture cleanup permission errors.

AI assistance: OpenAI openai/gpt-5.6-terra via OpenCode general coding subagent implemented and verified this change; Chris Huber directed and remains responsible for the change.