### PR TITLE
fix(cook): reject merged unpushed candidates

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4681,12 +4681,20 @@ fn run_cook_spine(
         ));
     }
     if let Some(latest_attempt) = recipe.attempts.last() {
+        // Recipe attempts retain logical input provenance. The controller plan
+        // is the canonical dispatch contract once pending workspace resolution
+        // has authenticated and projected a concrete root into it.
+        let plan = if lifecycle_store.record_exists(&latest_attempt.run_id)? {
+            lifecycle_store.read_controller_plan(&latest_attempt.run_id)?
+        } else {
+            latest_attempt.plan.clone()
+        };
         materialize_cook_attempt_with_stores(
             store,
             lifecycle_store,
             &recipe.cook_id,
             &latest_attempt.run_id,
-            &latest_attempt.plan,
+            &plan,
         )?;
     }
     // The recipe alone is resumable input, not a status-addressable run. Publish

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -7217,13 +7217,31 @@ fn cook_owned_unpushed_destination(
     if head == fingerprint.head {
         return Ok(None);
     }
-    let parent = homeboy_core::git::run_git(
+    let parents = homeboy_core::git::run_git(
         path,
-        &["rev-parse", "--verify", "HEAD^"],
-        "resolve Cook-owned committed candidate parent",
+        &["rev-list", "--parents", "-n", "1", "HEAD"],
+        "resolve Cook-owned committed candidate parents",
     )?
-    .trim()
-    .to_string();
+    .split_whitespace()
+    .map(str::to_string)
+    .collect::<Vec<_>>();
+    if parents.len() != 2 {
+        let mut error = Error::validation_invalid_argument(
+            "to_worktree",
+            "clean unpushed checkout is not a single-parent Cook-owned promoted candidate",
+            Some(path.display().to_string()),
+            None,
+        );
+        error.details["workspace"] = serde_json::json!({
+            "classification": "workspace.cook_owned_unpushed_commit_mismatch",
+            "reason": "merge_commit",
+            "owning_layer": "cook",
+            "path": path,
+            "parents": parents,
+        });
+        return Err(error);
+    }
+    let parent = &parents[1];
     let tree = homeboy_core::git::run_git(
         path,
         &["rev-parse", "--verify", "HEAD^{tree}"],
@@ -7231,7 +7249,7 @@ fn cook_owned_unpushed_destination(
     )?
     .trim()
     .to_string();
-    if parent != fingerprint.head || tree != fingerprint.tree {
+    if parent != &fingerprint.head || tree != fingerprint.tree {
         let mut error = Error::validation_invalid_argument(
             "to_worktree",
             "clean unpushed checkout is not the exact one-commit Cook-owned promoted candidate",
@@ -7240,7 +7258,7 @@ fn cook_owned_unpushed_destination(
         );
         error.details["workspace"] = serde_json::json!({
             "classification": "workspace.cook_owned_unpushed_commit_mismatch",
-            "reason": if parent != fingerprint.head { "divergent_ancestry" } else { "unrelated_unpushed_commit" },
+            "reason": if parent != &fingerprint.head { "divergent_ancestry" } else { "unrelated_unpushed_commit" },
             "owning_layer": "cook",
             "path": path,
             "expected_parent": fingerprint.head,

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -11565,15 +11565,45 @@ fn cook_owned_unpushed_candidate_requires_one_exact_promoted_commit() {
             .unwrap()
             .is_some());
 
-        std::fs::write(target.path().join("unrelated.txt"), "drift\n").unwrap();
+        let base = Command::new("git")
+            .args(["rev-parse", "HEAD^"])
+            .current_dir(target.path())
+            .output()
+            .unwrap();
+        let base = String::from_utf8(base.stdout).unwrap().trim().to_string();
         assert!(Command::new("git")
-            .args(["add", "unrelated.txt"])
+            .args(["branch", "side", &base])
             .current_dir(target.path())
             .status()
             .unwrap()
             .success());
         assert!(Command::new("git")
-            .args(["commit", "--quiet", "-m", "unrelated"])
+            .args(["checkout", "--quiet", "side"])
+            .current_dir(target.path())
+            .status()
+            .unwrap()
+            .success());
+        std::fs::write(target.path().join("side.txt"), "side\n").unwrap();
+        assert!(Command::new("git")
+            .args(["add", "side.txt"])
+            .current_dir(target.path())
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args(["commit", "--quiet", "-m", "side"])
+            .current_dir(target.path())
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args(["checkout", "--quiet", "cook-candidate"])
+            .current_dir(target.path())
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args(["merge", "--quiet", "--no-ff", "-s", "ours", "side", "-m", "merge"])
             .current_dir(target.path())
             .status()
             .unwrap()
@@ -11583,7 +11613,7 @@ fn cook_owned_unpushed_candidate_requires_one_exact_promoted_commit() {
             error.details["workspace"]["classification"],
             "workspace.cook_owned_unpushed_commit_mismatch"
         );
-        assert_eq!(error.details["workspace"]["reason"], "divergent_ancestry");
+        assert_eq!(error.details["workspace"]["reason"], "merge_commit");
     });
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3145,6 +3145,37 @@ impl AgentTaskCookAttemptDispatcher for RecordingDetachedAttemptDispatcher {
     }
 }
 
+#[derive(Debug)]
+struct WorkspaceCapturingDetachedAttemptDispatcher {
+    plan: Arc<Mutex<Option<AgentTaskPlan>>>,
+}
+
+impl AgentTaskCookAttemptDispatcher for WorkspaceCapturingDetachedAttemptDispatcher {
+    fn durable_recipe(&self) -> Result<Value> {
+        Ok(serde_json::json!({ "kind": "test-workspace-capturing-detached" }))
+    }
+
+    fn dispatch_attempt(
+        &self,
+        plan: AgentTaskPlan,
+        run_id: &str,
+        _derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
+    ) -> Result<()> {
+        *self.plan.lock().expect("captured dispatch plan") = Some(plan.clone());
+        agent_task_lifecycle::submit_plan(&plan, Some(run_id))?;
+        agent_task_lifecycle::record_detached_lab_run(
+            agent_task_lifecycle::DetachedLabRunRecord {
+                run_id,
+                runner_id: "fixture-lab",
+                runner_job_id: "workspace-capturing-daemon-job",
+                remote_workspace: "/runner/workspace",
+                remote_command: &["homeboy".to_string(), "agent-task".to_string()],
+            },
+        )?;
+        Ok(())
+    }
+}
+
 #[derive(Clone)]
 struct UnusedExecutor;
 
@@ -6000,6 +6031,46 @@ fn pending_cook_workspace_lookup_remains_bound_to_timed_out_provider() {
         assert_eq!(
             options.initial_plan.tasks[0].workspace.root.as_deref(),
             canonical_original.to_str()
+        );
+
+        let captured = Arc::new(Mutex::new(None));
+        let mut dispatch_options = batch_cook_options(
+            "provider-bound-dispatch",
+            Arc::new(WorkspaceCapturingDetachedAttemptDispatcher {
+                plan: Arc::clone(&captured),
+            }),
+        );
+        dispatch_options.to_worktree = "fixture@provider-bound".to_string();
+        dispatch_options.initial_plan.metadata["cook_provision"] = serde_json::json!({
+            "action": "lookup_pending", "kind": "provider",
+            "handle": dispatch_options.to_worktree,
+            "worktree_provider_id": "z-original",
+        });
+
+        let report = run_cook(CookContext::new(dispatch_options, Arc::new(UnusedExecutor)))
+            .expect("Cook dispatches the materialized provider workspace");
+        assert_eq!(report.value.status, "in_flight");
+        let dispatched = captured
+            .lock()
+            .expect("captured dispatch plan")
+            .clone()
+            .expect("provider dispatch received a plan");
+        assert_eq!(
+            dispatched.tasks[0].workspace.root.as_deref(),
+            canonical_original.to_str(),
+            "provider resolution projects its concrete path into the canonical dispatch plan"
+        );
+        assert_eq!(
+            dispatched.metadata["cook_provision"]["workspace_identity"]["handle"],
+            "fixture@provider-bound",
+            "the logical handle remains the authenticated provider identity"
+        );
+        let recipe = super::super::load_recipe("provider-bound-dispatch")
+            .expect("logical Cook recipe remains durable");
+        assert!(recipe.attempts[0].plan.tasks[0].workspace.root.is_none());
+        assert_eq!(
+            recipe.attempts[0].plan.metadata["cook_provision"]["action"],
+            "lookup_pending"
         );
     });
 }


### PR DESCRIPTION
## Summary

- correct merged PR #12885 by requiring the Cook-owned unpushed exception to have exactly one parent
- reject a two-parent merge even when its tree exactly matches the promoted candidate
- preserve #12857 as the separate authenticated merge-candidate adoption path
- dispatch the lifecycle-materialized provider workspace plan so pending resolution projects its verified root while the Cook recipe retains logical-handle provenance

## Tests

- `cargo fmt --check`
- `cargo check -p homeboy-agents`
- `cargo test -p homeboy-agents pending_cook_workspace_lookup_remains_bound_to_timed_out_provider -- --nocapture`
- Cook suite: `197 passed`, `6 ignored`; one pre-existing filesystem-race fixture failed under suite concurrency and passed in isolation.

## AI assistance

OpenAI openai/gpt-5.6-terra via OpenCode traced the Cook materialization boundary, implemented the canonical dispatch-plan projection, added the direct regression, and ran the listed verification. Chris Huber directed and remains responsible for the change.