### PR TITLE
fix(cook): honor local continuation placement

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1038,6 +1038,75 @@ pub fn record_execution_placement_outcome_in_store(
     lifecycle_store.write_record(&record)
 }
 
+/// Replace a failed pre-provider attempt's placement with an explicitly
+/// authorized local continuation. The immutable Cook recipe remains the source
+/// of work; this records only the next execution's routing authority.
+pub fn transition_execution_placement_for_continuation(
+    run_id: &str,
+    replacement: homeboy_lab_runner_contract::ExecutionPlacementDecision,
+) -> Result<()> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    transition_execution_placement_for_continuation_in_store(&lifecycle_store, run_id, replacement)
+}
+
+/// [`transition_execution_placement_for_continuation`] against an explicitly
+/// rooted lifecycle store.
+pub fn transition_execution_placement_for_continuation_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    replacement: homeboy_lab_runner_contract::ExecutionPlacementDecision,
+) -> Result<()> {
+    use homeboy_lab_runner_contract::ExecutionPlacementRequirement;
+
+    let mut record = lifecycle_store.read_record(&sanitize_run_id(run_id))?;
+    let prior: homeboy_lab_runner_contract::ExecutionPlacementDecision = serde_json::from_value(
+        record.metadata["execution_placement_decision"].clone(),
+    )
+    .map_err(|error| {
+        Error::validation_invalid_argument(
+            "execution_placement_decision",
+            format!("durable run has no valid canonical placement decision: {error}"),
+            Some(run_id.to_string()),
+            None,
+        )
+    })?;
+    let pre_provider_failure = record.metadata["pre_execution_failure"].is_object()
+        && record.metadata["provider_executions"]
+            .as_array()
+            .is_none_or(Vec::is_empty);
+    if prior.required == ExecutionPlacementRequirement::Lab
+        || !replacement.permits_local_execution()
+        || !pre_provider_failure
+    {
+        return Err(Error::validation_invalid_argument(
+            "placement",
+            "explicit local continuation is permitted only after a pre-provider failure from a non-Lab-required placement",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+
+    let mut plan = load_controller_plan_in_store(lifecycle_store, &record.run_id)?;
+    plan.metadata["execution_placement_decision"] =
+        serde_json::to_value(&replacement).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize continuation placement".to_string()),
+            )
+        })?;
+    persist_controller_plan_in_store(lifecycle_store, &record.run_id, &plan)?;
+    record.metadata["execution_placement_decision"] =
+        plan.metadata["execution_placement_decision"].clone();
+    record.metadata["execution_placement_outcome"] = Value::Null;
+    record.metadata["execution_placement_transition"] = json!({
+        "kind": "explicit_local_continuation",
+        "prior_decision_id": prior.decision_id,
+        "replacement_decision_id": replacement.decision_id,
+        "reason": "pre_provider_failure",
+    });
+    lifecycle_store.write_record(&record)
+}
+
 // The ambient `normalize_local_execution_placement()` shim that used to sit here is gone;
 // its two normalization tests now normalize inside a store they resolve (#7505).
 
@@ -1115,6 +1184,118 @@ mod execution_placement_tests {
                 authority: None,
             },
         )
+    }
+
+    fn local_continuation(
+        prior: &homeboy_lab_runner_contract::ExecutionPlacementDecision,
+    ) -> homeboy_lab_runner_contract::ExecutionPlacementDecision {
+        homeboy_lab_runner_contract::ExecutionPlacementDecision::new(
+            prior.policy_id.clone(),
+            prior.policy_revision.clone(),
+            prior.identity.clone(),
+            Placement::Local,
+            ExecutionPlacementRequirement::Either,
+            EffectiveExecutionPlacement::Local,
+            None,
+            ExecutionPlacementFallback {
+                local_allowed: false,
+                reason: None,
+            },
+            ExecutionPlacementOverrideAuthorization {
+                authorized: true,
+                authority: Some("operator --placement local".to_string()),
+            },
+        )
+    }
+
+    #[test]
+    fn explicit_local_continuation_replaces_only_pre_provider_auto_lab_placement() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut plan = super::super::tests::test_plan();
+            let lab = decision();
+            let prior = homeboy_lab_runner_contract::ExecutionPlacementDecision::new(
+                lab.policy_id,
+                lab.policy_revision,
+                lab.identity,
+                Placement::Auto,
+                ExecutionPlacementRequirement::Either,
+                EffectiveExecutionPlacement::Lab,
+                lab.runner,
+                ExecutionPlacementFallback {
+                    local_allowed: true,
+                    reason: None,
+                },
+                lab.override_authorization,
+            );
+            plan.metadata = json!({ "execution_placement_decision": prior });
+            submit_plan_with_runtime_admission(&plan, Some("local-continuation"), |_| {
+                Ok(json!({}))
+            })
+            .expect("submit routed Lab attempt");
+            record_pre_execution_failure(
+                "local-continuation",
+                &plan,
+                "lab_handoff_preacceptance",
+                &Error::internal_unexpected("Lab disconnected before provider start"),
+            )
+            .expect("record pre-provider failure");
+
+            let replacement = local_continuation(&prior);
+            transition_execution_placement_for_continuation(
+                "local-continuation",
+                replacement.clone(),
+            )
+            .expect("explicit local continuation is authorized");
+
+            let record = status("local-continuation").expect("read transitioned attempt");
+            assert_eq!(
+                record.metadata["execution_placement_decision"]["decision_id"],
+                replacement.decision_id
+            );
+            assert_eq!(
+                record.metadata["execution_placement_transition"]["prior_decision_id"],
+                prior.decision_id
+            );
+            assert_eq!(
+                load_controller_plan("local-continuation")
+                    .expect("read transitioned controller plan")
+                    .metadata["execution_placement_decision"]["decision_id"],
+                replacement.decision_id
+            );
+        });
+    }
+
+    #[test]
+    fn explicit_local_continuation_rejects_lab_required_policy() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut plan = super::super::tests::test_plan();
+            let prior = decision();
+            plan.metadata = json!({ "execution_placement_decision": prior });
+            submit_plan_with_runtime_admission(&plan, Some("lab-only-continuation"), |_| {
+                Ok(json!({}))
+            })
+            .expect("submit Lab-required attempt");
+            record_pre_execution_failure(
+                "lab-only-continuation",
+                &plan,
+                "lab_handoff_preacceptance",
+                &Error::internal_unexpected("Lab disconnected before provider start"),
+            )
+            .expect("record pre-provider failure");
+
+            let error = transition_execution_placement_for_continuation(
+                "lab-only-continuation",
+                local_continuation(&prior),
+            )
+            .expect_err("Lab-required policy fails closed");
+            assert!(error.message.contains("non-Lab-required"));
+            assert_eq!(
+                status("lab-only-continuation")
+                    .expect("read unchanged attempt")
+                    .metadata["execution_placement_decision"]["decision_id"],
+                prior.decision_id
+            );
+        });
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1077,10 +1077,15 @@ pub fn transition_execution_placement_for_continuation_in_store(
     if prior.required == ExecutionPlacementRequirement::Lab
         || !replacement.permits_local_execution()
         || !pre_provider_failure
+        || prior.identity != replacement.identity
+        || prior.policy_id != replacement.policy_id
+        || prior.policy_revision != replacement.policy_revision
+        || record.metadata["execution_placement_transition"].is_object()
+        || record.metadata["transport_admission_reset"].is_object()
     {
         return Err(Error::validation_invalid_argument(
             "placement",
-            "explicit local continuation is permitted only after a pre-provider failure from a non-Lab-required placement",
+            "explicit local continuation is permitted once after a pre-provider failure from a non-Lab-required placement with the same execution identity",
             Some(run_id.to_string()),
             None,
         ));
@@ -1103,6 +1108,14 @@ pub fn transition_execution_placement_for_continuation_in_store(
         "prior_decision_id": prior.decision_id,
         "replacement_decision_id": replacement.decision_id,
         "reason": "pre_provider_failure",
+    });
+    // This is a one-shot admission reset, not a retry-budget reset. The
+    // replacement run consumes it by receiving a new transport identity.
+    record.metadata["transport_admission_reset"] = json!({
+        "kind": "placement_transition",
+        "prior_decision_id": prior.decision_id,
+        "replacement_decision_id": replacement.decision_id,
+        "reason": "explicit_local_continuation_after_pre_provider_failure",
     });
     lifecycle_store.write_record(&record)
 }
@@ -1241,6 +1254,27 @@ mod execution_placement_tests {
             .expect("record pre-provider failure");
 
             let replacement = local_continuation(&prior);
+            let mut stale_identity = prior.identity.clone();
+            stale_identity.candidate = Some("candidate-b".to_string());
+            let stale = homeboy_lab_runner_contract::ExecutionPlacementDecision::new(
+                prior.policy_id.clone(),
+                prior.policy_revision.clone(),
+                stale_identity,
+                Placement::Local,
+                ExecutionPlacementRequirement::Either,
+                EffectiveExecutionPlacement::Local,
+                None,
+                ExecutionPlacementFallback {
+                    local_allowed: false,
+                    reason: None,
+                },
+                ExecutionPlacementOverrideAuthorization {
+                    authorized: true,
+                    authority: Some("operator --placement local".to_string()),
+                },
+            );
+            transition_execution_placement_for_continuation("local-continuation", stale)
+                .expect_err("a stale placement decision is rejected");
             transition_execution_placement_for_continuation(
                 "local-continuation",
                 replacement.clone(),
@@ -1262,6 +1296,12 @@ mod execution_placement_tests {
                     .metadata["execution_placement_decision"]["decision_id"],
                 replacement.decision_id
             );
+            assert_eq!(
+                record.metadata["transport_admission_reset"]["replacement_decision_id"],
+                replacement.decision_id
+            );
+            transition_execution_placement_for_continuation("local-continuation", replacement)
+                .expect_err("the placement transition cannot mint another admission reset");
         });
     }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -198,6 +198,24 @@ fn transport_retry_available(store: &CookRecipeStore, cook_id: &str, attempt: u3
         <= MAX_TRANSPORT_RETRIES_PER_ATTEMPT)
 }
 
+/// An authorized placement transition gets one new transport admission after a
+/// failed route exhausted its own connection budget. Provider execution and the
+/// semantic Cook attempt remain untouched; the replacement run consumes this
+/// authority because it does not inherit this record metadata.
+fn transport_admission_reset_available(
+    record: Option<&agent_task_lifecycle::AgentTaskRunRecord>,
+) -> bool {
+    record.is_some_and(|record| {
+        record.metadata["transport_admission_reset"]["kind"] == "placement_transition"
+            && record.metadata["transport_admission_reset"]["replacement_decision_id"]
+                == record.metadata["execution_placement_decision"]["decision_id"]
+            && record.metadata["execution_placement_transition"]["kind"]
+                == "explicit_local_continuation"
+            && record.metadata["execution_placement_transition"]["replacement_decision_id"]
+                == record.metadata["execution_placement_decision"]["decision_id"]
+    })
+}
+
 /// Durable operation key for the dispatch of one retry attempt. A retry is
 /// one-per-generated-`run_id`, so the next run id is the stable identity (#8357).
 fn retry_dispatch_operation_key(next_run_id: &str) -> String {
@@ -4383,12 +4401,19 @@ fn run_cook_spine(
     // Resume from the validated durable inputs so ambient transport state cannot
     // turn replay into a conflicting new cook.
     let requested_run_id = options.initial_run_id.clone();
+    let local_placement_override = options.attempt_dispatcher.is_none()
+        && lifecycle_store
+            .read_record(&requested_run_id)
+            .ok()
+            .is_some_and(|record| transport_admission_reset_available(Some(&record)));
     let mut options = if existing_recipe {
         let mut reconstructed = if adopted_model.is_some() || allow_historical_terminal {
             super::reconstruct_adoption_options_with_dispatcher(
                 &recipe,
                 options.attempt_dispatcher,
             )?
+        } else if local_placement_override {
+            super::cook_recipe::reconstruct_options_with_local_placement_override(&recipe)?
         } else {
             super::reconstruct_options_with_dispatcher(&recipe, options.attempt_dispatcher)?
         };
@@ -5251,7 +5276,9 @@ fn run_cook_spine(
                         Some(&run_id),
                     ));
                 }
-                if !transport_retry_available(store, &cook_id, attempt)? {
+                if !transport_retry_available(store, &cook_id, attempt)?
+                    && !transport_admission_reset_available(record.as_ref())
+                {
                     return Ok(pre_execution_failure_report(
                         cook_id,
                         attempts,
@@ -5391,7 +5418,9 @@ fn run_cook_spine(
                         1,
                     ));
                 }
-                if replace_semantic_attempt && !transport_retry_available(store, &cook_id, attempt)?
+                if replace_semantic_attempt
+                    && !transport_retry_available(store, &cook_id, attempt)?
+                    && !transport_admission_reset_available(Some(&record))
                 {
                     return Ok(pre_artifact_interruption_report(
                         cook_id,

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -1695,6 +1695,15 @@ pub fn reconstruct_options_with_dispatcher(
     reconstruct_recipe_options(recipe, attempt_dispatcher, true, true)
 }
 
+/// Reconstruct immutable Cook inputs for a lifecycle-validated local placement
+/// transition. The caller proves the transition against the durable run record;
+/// this only relaxes reconstruction of the superseded Lab transport.
+pub(crate) fn reconstruct_options_with_local_placement_override(
+    recipe: &AgentTaskCookRecipe,
+) -> Result<AgentTaskCookServiceOptions> {
+    reconstruct_recipe_options(recipe, None, true, false)
+}
+
 /// Reconstruct the policy used to adopt an already-prepared candidate. Adoption
 /// never replays provider work, so it may use a validated historical recipe
 /// after a controller runtime upgrade.

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3186,6 +3186,22 @@ impl AgentTaskExecutorAdapter for ImmediateSuccessExecutor {
 }
 
 #[derive(Clone)]
+struct RecordingImmediateSuccessExecutor {
+    starts: Arc<AtomicUsize>,
+}
+
+impl AgentTaskExecutorAdapter for RecordingImmediateSuccessExecutor {
+    fn execute(
+        &self,
+        request: crate::agent_task::AgentTaskRequest,
+        context: crate::agent_task_scheduler::AgentTaskExecutionContext,
+    ) -> crate::agent_task::AgentTaskOutcome {
+        self.starts.fetch_add(1, Ordering::SeqCst);
+        ImmediateSuccessExecutor.execute(request, context)
+    }
+}
+
+#[derive(Clone)]
 struct SucceedingExecutor;
 
 impl AgentTaskExecutorAdapter for SucceedingExecutor {
@@ -8203,6 +8219,177 @@ fn cook_retries_retryable_pre_provider_transport_failures_within_attempt_budget(
                 "transient"
             );
         }
+    });
+}
+
+#[test]
+fn explicit_local_continuation_replaces_exhausted_auto_lab_transport_without_replaying_lab() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let config_root = homeboy_core::paths::homeboy().expect("resolve isolated config root");
+        std::fs::create_dir_all(&config_root).expect("create isolated config root");
+        std::fs::write(
+            config_root.join("homeboy.json"),
+            r#"{"retention":{"reconstructable_artifact_reserve_bytes":0}}"#,
+        )
+        .expect("disable host-capacity admission for local continuation");
+        let (_checkout_guard, checkout) =
+            homeboy_core::test_support::shared_committed_git_repo_fixture(
+                "local-placement-override",
+            );
+        let worktree_parent = tempfile::tempdir().expect("create worktree parent");
+        let worktree = worktree_parent.path().join("candidate");
+        homeboy_core::test_support::run_git_fixture_command(
+            &checkout,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "local-placement-override",
+                worktree.to_str().expect("worktree path"),
+            ],
+        );
+        let lab_dispatches = Arc::new(AtomicUsize::new(0));
+        let local_starts = Arc::new(AtomicUsize::new(0));
+        let cook_id = "cook-local-placement-override";
+        let mut options = batch_cook_options(
+            cook_id,
+            Arc::new(RetryableTransportFailingAttemptDispatcher {
+                dispatches: Arc::clone(&lab_dispatches),
+            }),
+        );
+        options.provider_command = Some("fixture-provider".to_string());
+        options.initial_run_id = format!("{cook_id}-attempt-1");
+        options.to_worktree = "fixture@local-placement-override".to_string();
+        options.source_worktree_path = Some(worktree.clone());
+        options.initial_plan.tasks[0].workspace.root = Some(worktree.display().to_string());
+        options.initial_plan.tasks[0].workspace.kind = Some("homeboy-worktree".to_string());
+        options.initial_plan.tasks[0].workspace.materialization = serde_json::json!({
+            "kind": "homeboy-worktree",
+            "id": options.to_worktree,
+            "root": worktree,
+            "branch": "local-placement-override",
+        });
+        homeboy_core::worktree::adopt(homeboy_core::worktree::WorktreeAdoptOptions {
+            handle: options.to_worktree.clone(),
+            path: worktree.display().to_string(),
+            kind: Some("test-fixture".to_string()),
+            provenance: None,
+        })
+        .expect("register original Cook worktree");
+        let prior = homeboy_lab_runner_contract::ExecutionPlacementDecision::new(
+            "fixture-policy",
+            "v1",
+            homeboy_lab_runner_contract::ExecutionPlacementIdentity {
+                repository: "fixture".to_string(),
+                workspace: "fixture-worktree".to_string(),
+                task: "provider".to_string(),
+                candidate: Some("candidate-a".to_string()),
+                base: Some("base-a".to_string()),
+            },
+            homeboy_lab_runner_contract::Placement::Auto,
+            homeboy_lab_runner_contract::ExecutionPlacementRequirement::Either,
+            homeboy_lab_runner_contract::EffectiveExecutionPlacement::Lab,
+            Some(
+                homeboy_lab_runner_contract::ExecutionPlacementRunnerSelection {
+                    runner_id: "fixture-lab".to_string(),
+                    source: homeboy_lab_runner_contract::RunnerSelectionSource::Policy,
+                },
+            ),
+            homeboy_lab_runner_contract::ExecutionPlacementFallback {
+                local_allowed: true,
+                reason: Some("fixture policy allows local recovery".to_string()),
+            },
+            homeboy_lab_runner_contract::ExecutionPlacementOverrideAuthorization {
+                authorized: false,
+                authority: None,
+            },
+        );
+        options.initial_plan.metadata["execution_placement_decision"] =
+            serde_json::to_value(&prior).expect("serialize auto Lab decision");
+
+        let exhausted = run_cook(CookContext::new(options.clone(), Arc::new(UnusedExecutor)))
+            .expect("exhaust the bounded Lab transport retry");
+        assert_eq!(exhausted.value.status, "pre_execution_failure");
+        assert_eq!(lab_dispatches.load(Ordering::SeqCst), 2);
+        let exhausted_run_id = exhausted
+            .value
+            .latest_run_id
+            .expect("exhausted transport attempt is durable");
+        let recipe_before = super::super::load_recipe(cook_id).expect("durable recipe");
+
+        let local = homeboy_lab_runner_contract::ExecutionPlacementDecision::new(
+            prior.policy_id.clone(),
+            prior.policy_revision.clone(),
+            prior.identity.clone(),
+            homeboy_lab_runner_contract::Placement::Local,
+            homeboy_lab_runner_contract::ExecutionPlacementRequirement::Either,
+            homeboy_lab_runner_contract::EffectiveExecutionPlacement::Local,
+            None,
+            homeboy_lab_runner_contract::ExecutionPlacementFallback {
+                local_allowed: false,
+                reason: None,
+            },
+            homeboy_lab_runner_contract::ExecutionPlacementOverrideAuthorization {
+                authorized: true,
+                authority: Some("operator --placement local".to_string()),
+            },
+        );
+        agent_task_lifecycle::transition_execution_placement_for_continuation(
+            &exhausted_run_id,
+            local.clone(),
+        )
+        .expect("authorize local continuation after auto Lab preacceptance failure");
+
+        options.initial_run_id = exhausted_run_id.clone();
+        options.initial_plan = agent_task_lifecycle::load_controller_plan(&exhausted_run_id)
+            .expect("load transitioned plan");
+        options.attempt_dispatcher = None;
+        let continued = run_cook(CookContext::new(
+            options,
+            Arc::new(RecordingImmediateSuccessExecutor {
+                starts: Arc::clone(&local_starts),
+            }),
+        ))
+        .expect("local continuation starts provider work");
+
+        assert_eq!(
+            lab_dispatches.load(Ordering::SeqCst),
+            2,
+            "no Lab connection after override"
+        );
+        assert_eq!(
+            local_starts.load(Ordering::SeqCst),
+            1,
+            "one local provider start: {continued:#?}"
+        );
+        assert_eq!(continued.value.cook_id, cook_id);
+        let recipe_after =
+            super::super::load_recipe(cook_id).expect("durable recipe after override");
+        assert_eq!(
+            recipe_after.promotion_transport,
+            recipe_before.promotion_transport
+        );
+        assert_eq!(recipe_after.gate_policy, recipe_before.gate_policy);
+        assert_eq!(recipe_after.retry_budget, recipe_before.retry_budget);
+        assert_eq!(recipe_after.finalization, recipe_before.finalization);
+        assert_eq!(
+            recipe_after.attempts[0].plan.tasks[0].instructions,
+            recipe_before.attempts[0].plan.tasks[0].instructions
+        );
+        let transitioned =
+            agent_task_lifecycle::status(&exhausted_run_id).expect("transition evidence");
+        assert_eq!(
+            transitioned.metadata["execution_placement_decision"]["decision_id"],
+            local.decision_id
+        );
+        assert_eq!(
+            transitioned.metadata["execution_placement_decision"]["identity"]["candidate"],
+            "candidate-a"
+        );
+        assert_eq!(
+            transitioned.metadata["transport_admission_reset"]["kind"],
+            "placement_transition"
+        );
     });
 }
 

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -330,6 +330,7 @@ pub mod lifecycle {
         run_record_exists_resolved, run_status, runner_diagnostic_probe,
         runner_pinned_runtime_for_mutation, runner_probe_plan, select_cook_candidate_from_attempts,
         status, status_in_store, status_with_options, submit_plan,
+        transition_execution_placement_for_continuation,
         verified_controller_artifact_projection_path, AgentTaskAcceptanceAttestation,
         AgentTaskAcceptanceRecord, AgentTaskAcceptanceRequirement, AgentTaskAcceptanceVerdict,
         AgentTaskAcceptanceVerificationRequest, AgentTaskAcceptanceVerifier,

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -1253,6 +1253,63 @@ where
     continue_cook_with_queued_execution(args, executor, reconstruct_dispatcher, false)
 }
 
+fn explicit_local_continuation_decision(
+    plan: &homeboy::agents::agent_task_scheduler::AgentTaskPlan,
+) -> homeboy::core::Result<Option<homeboy_lab_runner_contract::ExecutionPlacementDecision>> {
+    if !homeboy::core::resource_policy_context::captured_context()
+        .is_some_and(|context| context.local_override)
+    {
+        return Ok(None);
+    }
+    let prior: homeboy_lab_runner_contract::ExecutionPlacementDecision = serde_json::from_value(
+        plan.metadata["execution_placement_decision"].clone(),
+    )
+    .map_err(|error| {
+        homeboy::core::Error::validation_invalid_argument(
+            "execution_placement_decision",
+            format!("durable Cook attempt has no valid placement decision: {error}"),
+            None,
+            None,
+        )
+    })?;
+    Ok(Some(
+        homeboy_lab_runner_contract::ExecutionPlacementDecision::new(
+            prior.policy_id,
+            prior.policy_revision,
+            prior.identity,
+            homeboy_lab_runner_contract::Placement::Local,
+            homeboy_lab_runner_contract::ExecutionPlacementRequirement::Either,
+            homeboy_lab_runner_contract::EffectiveExecutionPlacement::Local,
+            None,
+            homeboy_lab_runner_contract::ExecutionPlacementFallback {
+                local_allowed: false,
+                reason: None,
+            },
+            homeboy_lab_runner_contract::ExecutionPlacementOverrideAuthorization {
+                authorized: true,
+                authority: Some("operator --placement local".to_string()),
+            },
+        ),
+    ))
+}
+
+fn apply_explicit_local_continuation(
+    run_id: &str,
+    options: &mut homeboy::agents::agent_task_service::AgentTaskCookServiceOptions,
+) -> homeboy::core::Result<()> {
+    let Some(decision) = explicit_local_continuation_decision(&options.initial_plan)? else {
+        return Ok(());
+    };
+    homeboy::agents::agent_tasks::lifecycle::transition_execution_placement_for_continuation(
+        run_id,
+        decision.clone(),
+    )?;
+    options.initial_plan.metadata["execution_placement_decision"] = serde_json::to_value(decision)
+        .map_err(|error| homeboy::core::Error::internal_json(error.to_string(), None))?;
+    options.attempt_dispatcher = None;
+    Ok(())
+}
+
 /// `retry --run` owns a fresh queued replacement attempt. It may dispatch that
 /// attempt through the immutable Cook recipe; ordinary `cook-continue` remains
 /// observation-only until the attempt becomes terminal.
@@ -1322,6 +1379,8 @@ where
         let dispatcher = reconstruct_dispatcher;
         let executor = executor.clone();
         let execute = |options| {
+            let mut options = options;
+            apply_explicit_local_continuation(&run_id, &mut options)?;
             agent_task_service::authorize_cook_continue_route_with_artifact(
                 &options,
                 args.artifact_id.as_deref(),
@@ -1359,7 +1418,21 @@ where
         ));
     }
 
-    let dispatcher = reconstruct_dispatcher(&recipe.promotion_transport["attempt_dispatch"])?;
+    let local_override = explicit_local_continuation_decision(
+        &recipe
+            .attempts
+            .iter()
+            .find(|attempt| attempt.run_id == run_id)
+            .ok_or_else(|| {
+                homeboy::core::Error::internal_unexpected("selected Cook attempt is absent")
+            })?
+            .plan,
+    )?;
+    let dispatcher = if local_override.is_some() {
+        None
+    } else {
+        reconstruct_dispatcher(&recipe.promotion_transport["attempt_dispatch"])?
+    };
     let attempt = recipe
         .attempts
         .iter()
@@ -1381,6 +1454,9 @@ where
     };
     options.initial_run_id = attempt.run_id.clone();
     options.initial_plan = attempt.plan.clone();
+    if local_override.is_some() {
+        apply_explicit_local_continuation(&run_id, &mut options)?;
+    }
     agent_task_service::authorize_cook_continue_route_with_artifact(
         &options,
         args.artifact_id.as_deref(),

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -1842,6 +1842,26 @@ fn cook_continuation_status(
         .get("runner_liveness")
         .and_then(Value::as_str)
         == Some("disconnected");
+    let placement_authority = record
+        .metadata
+        .get("execution_placement_decision")
+        .and_then(|decision| {
+            let requested = decision.get("requested").and_then(Value::as_str);
+            let runner_source = decision.pointer("/runner/source").and_then(Value::as_str);
+            let operator_override = decision
+                .pointer("/override_authorization/authorized")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            Some(if operator_override {
+                "operator_overridable"
+            } else if runner_source == Some("explicit") {
+                "operator_pinned"
+            } else if requested == Some("auto") || runner_source == Some("policy") {
+                "policy_pinned"
+            } else {
+                "recipe_pinned"
+            })
+        });
     let (status, guidance) = if runner_disconnected {
         (
             "recovery_required",
@@ -1890,6 +1910,7 @@ fn cook_continuation_status(
             "runner_id": runner_id,
             "runner_job_status": record.metadata.get("runner_job_status"),
         },
+        "placement_authority": placement_authority,
         "remaining_phases": ["harvest", "review", "gates", "promotion", "finalization"],
         "guidance": guidance,
     })
@@ -4494,6 +4515,11 @@ mod tests {
                         "runner_id": "fixture-lab",
                         "runner_job_status": "queued",
                         "runner_queue": { "state": "waiting_for_capacity" },
+                        "execution_placement_decision": {
+                            "requested": "auto",
+                            "runner": { "source": "policy" },
+                            "override_authorization": { "authorized": false }
+                        },
                     });
                 },
             )
@@ -4510,6 +4536,7 @@ mod tests {
                 "homeboy runner status fixture-lab"
             );
             assert!(report.get("continuation_command").is_none());
+            assert_eq!(report["placement_authority"], "policy_pinned");
         });
     }
 


### PR DESCRIPTION
## Summary
- allow an explicit local `cook-continue` placement to replace an auto Lab placement after a pre-provider failure
- persist the replacement decision and transition evidence on the lifecycle record and controller plan
- preserve Lab-required placement as a fail-closed policy boundary

Closes #12893

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-agents explicit_local_continuation --no-default-features`
- `cargo clippy -p homeboy-cli -p homeboy-agents --no-default-features -- -D warnings` (blocked by pre-existing `homeboy-core` warnings under the current Clippy toolchain)

## AI assistance
OpenAI gpt-5.6-sol used through OpenCode to inspect the Cook placement/rearm lifecycle, implement the scoped continuation transition, and run targeted verification. Chris Huber reviewed the change and remains responsible for every line.