### PR TITLE
fix: bound component list inventory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build artifacts
 /target/
+/crates/*/target/
 /.cargo-target/
 /build/
 dist-manifest.json

--- a/crates/homeboy-cli/src/commands/component.rs
+++ b/crates/homeboy-cli/src/commands/component.rs
@@ -2,6 +2,7 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 use serde_json::Value;
 use std::path::Path;
+use std::time::Instant;
 
 use homeboy::core::component::{self, Component};
 use homeboy::core::project::{self, Project};
@@ -122,8 +123,12 @@ enum ComponentCommand {
         /// New component ID (should match repository directory name)
         new_id: String,
     },
-    /// List all available components
-    List,
+    /// List registered components without opening their checkouts
+    List {
+        /// Enrich every row from its checkout, including portable and Git metadata
+        #[arg(long)]
+        full: bool,
+    },
     /// List projects using this component
     Projects {
         /// Component ID
@@ -199,6 +204,24 @@ pub struct ComponentExtra {
     pub projects: Option<Vec<Project>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shared: Option<std::collections::HashMap<String, Vec<String>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inventory: Option<ComponentInventorySummary>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ComponentInventorySummary {
+    pub status: String,
+    pub registered_count: usize,
+    pub enriched_count: usize,
+    pub omitted_enrichment_count: usize,
+    pub phases: Vec<ComponentInventoryPhase>,
+    pub continue_command: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ComponentInventoryPhase {
+    pub name: String,
+    pub elapsed_ms: u128,
 }
 
 pub type ComponentOutput = EntityCrudOutput<Value, ComponentExtra>;
@@ -345,7 +368,7 @@ pub fn run(args: ComponentArgs) -> CmdResult<ComponentOutput> {
         ),
         ComponentCommand::Delete { id } => delete(&id),
         ComponentCommand::Rename { id, new_id } => rename(&id, &new_id),
-        ComponentCommand::List => list(),
+        ComponentCommand::List { full } => list(full),
         ComponentCommand::Projects { id } => projects(&id),
         ComponentCommand::Shared { id } => shared(id.as_deref()),
         ComponentCommand::Env { id, path } => env::env(id.as_deref(), path.as_deref()),
@@ -768,16 +791,68 @@ fn rename(id: &str, new_id: &str) -> CmdResult<ComponentOutput> {
     ))
 }
 
-fn list() -> CmdResult<ComponentOutput> {
-    let components: Vec<Value> = component::inventory()?
+fn list(full: bool) -> CmdResult<ComponentOutput> {
+    let started = Instant::now();
+    let components = if full {
+        component::inventory()?
+    } else {
+        component::inventory::registered_base()?
+    };
+    let discovery_elapsed_ms = started.elapsed().as_millis();
+    let component_count = components.len();
+    let rendering_started = Instant::now();
+    let components: Vec<Value> = components
         .into_iter()
-        .map(|component| component_discovery_value(&component, None))
+        .map(|component| {
+            let mut value = component_discovery_value_with_diagnostics(&component, None, full)?;
+            if let Value::Object(ref mut map) = value {
+                map.insert(
+                    "inventory_enrichment".to_string(),
+                    if full {
+                        serde_json::json!({ "status": "complete" })
+                    } else {
+                        serde_json::json!({
+                            "status": "omitted",
+                            "reason": "default_bounded_inventory",
+                            "continue_command": "homeboy component list --full"
+                        })
+                    },
+                );
+            }
+            Ok(value)
+        })
         .collect::<homeboy::core::Result<Vec<Value>>>()?;
+    let rendering_elapsed_ms = rendering_started.elapsed().as_millis();
 
     Ok((
         ComponentOutput {
             command: "component.list".to_string(),
             entities: components,
+            hint: (!full).then(|| {
+                "Registry rows are shown without checkout enrichment; run `homeboy component list --full` for portable and Git metadata."
+                    .to_string()
+            }),
+            extra: ComponentExtra {
+                inventory: Some(ComponentInventorySummary {
+                    status: if full { "complete" } else { "partial" }.to_string(),
+                    registered_count: component_count,
+                    enriched_count: if full { component_count } else { 0 },
+                    omitted_enrichment_count: if full { 0 } else { component_count },
+                    phases: vec![
+                        ComponentInventoryPhase {
+                            name: if full { "discovery_and_enrichment" } else { "registry_rows" }
+                                .to_string(),
+                            elapsed_ms: discovery_elapsed_ms,
+                        },
+                        ComponentInventoryPhase {
+                            name: "render_rows".to_string(),
+                            elapsed_ms: rendering_elapsed_ms,
+                        },
+                    ],
+                    continue_command: "homeboy component list --full".to_string(),
+                }),
+                ..Default::default()
+            },
             ..Default::default()
         },
         0,
@@ -787,6 +862,14 @@ fn list() -> CmdResult<ComponentOutput> {
 fn component_discovery_value(
     component: &Component,
     drift_files: Option<Vec<String>>,
+) -> homeboy::core::Result<Value> {
+    component_discovery_value_with_diagnostics(component, drift_files, true)
+}
+
+fn component_discovery_value_with_diagnostics(
+    component: &Component,
+    drift_files: Option<Vec<String>>,
+    include_diagnostics: bool,
 ) -> homeboy::core::Result<Value> {
     let mut value = serde_json::to_value(component).map_err(|error| {
         homeboy::core::Error::validation_invalid_argument(
@@ -800,19 +883,21 @@ fn component_discovery_value(
         map.insert("id".to_string(), Value::String(component.id.clone()));
         // Always surface remote_owner so missing config is visible (#602).
         map.entry("remote_owner".to_string()).or_insert(Value::Null);
-        let local_path_diagnostic = component::inventory::local_path_diagnostic(component);
-        if local_path_diagnostic.status != "ok" {
-            map.insert(
-                "local_path_diagnostic".to_string(),
-                serde_json::to_value(local_path_diagnostic).map_err(|error| {
-                    homeboy::core::Error::validation_invalid_argument(
-                        "component",
-                        "Failed to serialize local_path diagnostic",
-                        Some(error.to_string()),
-                        None,
-                    )
-                })?,
-            );
+        if include_diagnostics {
+            let local_path_diagnostic = component::inventory::local_path_diagnostic(component);
+            if local_path_diagnostic.status != "ok" {
+                map.insert(
+                    "local_path_diagnostic".to_string(),
+                    serde_json::to_value(local_path_diagnostic).map_err(|error| {
+                        homeboy::core::Error::validation_invalid_argument(
+                            "component",
+                            "Failed to serialize local_path diagnostic",
+                            Some(error.to_string()),
+                            None,
+                        )
+                    })?,
+                );
+            }
         }
         summarize_large_component_metadata(map);
         if let Some(drift_files) = drift_files {
@@ -966,6 +1051,17 @@ mod tests {
             }
             _ => panic!("expected component show command"),
         }
+    }
+
+    #[test]
+    fn parses_component_list_full_flag() {
+        let cli = TestCli::try_parse_from(["component", "list", "--full"])
+            .expect("component list --full should parse");
+
+        assert!(matches!(
+            cli.component.command,
+            ComponentCommand::List { full: true }
+        ));
     }
 
     #[test]

--- a/crates/homeboy-core/src/component/inventory/listing.rs
+++ b/crates/homeboy-core/src/component/inventory/listing.rs
@@ -124,6 +124,16 @@ pub fn registered() -> Result<Vec<Component>> {
     registered_core(None)
 }
 
+/// List persisted component registrations without opening their checkouts.
+///
+/// This is the inventory boundary for broad, interactive readers. It only reads
+/// Homeboy's registry files, so a stale mount or a wedged Git helper in one
+/// checkout cannot delay rows for every other registered component. Callers
+/// that need repo-owned portable fields must explicitly use [`registered`].
+pub fn registered_base() -> Result<Vec<Component>> {
+    registered_base_core(None)
+}
+
 /// [`registered`] against an already-resolved config root (#7505).
 pub fn registered_in_root(config_root: &Path) -> Result<Vec<Component>> {
     registered_core(Some(config_root))
@@ -165,6 +175,56 @@ fn registered_core(config_root: Option<&Path>) -> Result<Vec<Component>> {
     }
 
     components.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(components)
+}
+
+fn registered_base_core(config_root: Option<&Path>) -> Result<Vec<Component>> {
+    let projects = projects_at(config_root).unwrap_or_default();
+    let mut components = Vec::new();
+    let mut seen = HashSet::new();
+
+    for project in projects {
+        for attachment in project.components {
+            if seen.insert(attachment.id.clone()) {
+                let mut component = Component::new(
+                    attachment.id,
+                    attachment.local_path,
+                    attachment.remote_path.unwrap_or_default(),
+                    None,
+                );
+                component.deployment_provider = attachment.deployment_provider;
+                components.push(component);
+            }
+        }
+    }
+
+    let dir = components_dir(config_root)?;
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+                continue;
+            }
+            let Some(id) = path.file_stem().and_then(|stem| stem.to_str()) else {
+                continue;
+            };
+            if seen.contains(id) {
+                continue;
+            }
+            let Ok(content) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
+                continue;
+            };
+            if let Some(component) = component_from_standalone_config(id, json) {
+                seen.insert(component.id.clone());
+                components.push(component);
+            }
+        }
+    }
+
+    components.sort_by(|left, right| left.id.cmp(&right.id));
     Ok(components)
 }
 

--- a/crates/homeboy-core/src/component/inventory/tests.rs
+++ b/crates/homeboy-core/src/component/inventory/tests.rs
@@ -6,6 +6,7 @@ use crate::project::{Project, ProjectComponentAttachment};
 use std::fs;
 use std::process::Command;
 use std::sync::MutexGuard;
+use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 // Tests that override `HOME` to redirect `paths::components()` are
@@ -536,6 +537,71 @@ fn load_resolves_the_selected_registration_without_requiring_global_inventory() 
         !discovery_paths.iter().any(|path| path == &unrelated_repo),
         "targeted load inspected the unrelated component: {discovery_paths:?}"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn registered_base_returns_before_a_sleeping_git_enrichment_probe() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let home = temp_home_dir();
+    let repo = home.path().join("repo");
+    fs::create_dir_all(&repo).expect("repo directory");
+    write_portable_id(&repo, "sleeping-probe");
+    let components = home
+        .path()
+        .join(".config")
+        .join("homeboy")
+        .join("components");
+    fs::create_dir_all(&components).expect("components directory");
+    write_standalone_json(&components, "sleeping-probe", &repo.to_string_lossy());
+
+    let bin = tempfile::tempdir().expect("fake git bin");
+    let git = bin.path().join("git");
+    fs::write(&git, "#!/bin/sh\nsleep 30\n").expect("fake git");
+    let mut permissions = fs::metadata(&git).expect("git metadata").permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&git, permissions).expect("make fake git executable");
+    let started = Instant::now();
+    let test_name = crate::test_support::harness_test_name(
+        module_path!(),
+        "registered_base_sleeping_git_enrichment_probe_child",
+    );
+    let output = crate::test_support::run_child_test(
+        Command::new(std::env::current_exe().expect("current test executable"))
+            .arg("--exact")
+            .arg(&test_name)
+            .arg("--ignored")
+            .env("HOME", home.path())
+            .env(
+                "PATH",
+                format!(
+                    "{}:{}",
+                    bin.path().display(),
+                    std::env::var_os("PATH")
+                        .as_deref()
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                ),
+            ),
+        &test_name,
+    );
+
+    assert!(
+        output.status.success(),
+        "sleeping probe child failed: {output:?}"
+    );
+    assert!(started.elapsed() < Duration::from_secs(2));
+}
+
+#[cfg(unix)]
+#[test]
+#[ignore = "runs under the parent test with an isolated sleeping Git probe"]
+fn registered_base_sleeping_git_enrichment_probe_child() {
+    let rows = registered_base().expect("base registry rows");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, "sleeping-probe");
+    assert!(rows[0].local_path.ends_with("/repo"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- return configured component registry rows without opening registered checkouts by default
- retain checkout, portable, Git, and path diagnostics behind homeboy component list --full
- disclose inventory phase timing, partial/enrichment counts, row-level omitted enrichment, and the continuation command

Closes #12894

## Verification
- cargo fmt --check
- cargo test -p homeboy-core component::inventory::tests (26 passed, 1 subprocess helper intentionally ignored)
- cargo test -p homeboy-cli commands::component::tests (10 passed)
- sleeping-Git probe: a child process has a fake git that runs sleep 30; base inventory returned in under 2 seconds (observed 0.03 seconds)

## AI assistance
OpenAI gpt-5.6-sol used through OpenCode inspected component discovery, Git enrichment, cancellation behavior, implemented the bounded registry inventory and test, and ran verification. Chris Huber reviewed and is responsible for every line.