### PR TITLE
fix(ci): converge required gates ruleset

### DIFF
--- a/.github/manage-required-gates-ruleset.sh
+++ b/.github/manage-required-gates-ruleset.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Audit or converge the one repository-owned main ruleset to its versioned policy.
+set -euo pipefail
+
+repo='Extra-Chill/homeboy'
+ruleset_id='13680120'
+config='.github/required-gates-ruleset.json'
+operation=''
+evidence=''
+gh_bin="${GH_BIN:-gh}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --operation) operation="$2"; shift 2 ;;
+    --evidence) evidence="$2"; shift 2 ;;
+    *) echo "usage: $0 --operation <audit|reconcile> --evidence <path>" >&2; exit 2 ;;
+  esac
+done
+
+if [ "${operation}" != 'audit' ] && [ "${operation}" != 'reconcile' ]; then
+  echo "operation must be audit or reconcile" >&2
+  exit 2
+fi
+
+if [ ! -f "${config}" ] || [ -z "${evidence}" ]; then
+  echo "the versioned ruleset policy and an evidence path are required" >&2
+  exit 2
+fi
+
+project_ruleset() {
+  jq -S '{name, target, enforcement, conditions, rules}'
+}
+
+desired="$(project_ruleset < "${config}")"
+before="$(${gh_bin} api "repos/${repo}/rulesets/${ruleset_id}")"
+before_contract="$(project_ruleset <<< "${before}")"
+changed=false
+
+if [ "${before_contract}" != "${desired}" ] && [ "${operation}" = 'reconcile' ]; then
+  payload="$(mktemp)"
+  trap 'rm -f "${payload}"' EXIT
+  printf '%s\n' "${desired}" > "${payload}"
+  ${gh_bin} api --method PUT "repos/${repo}/rulesets/${ruleset_id}" --input "${payload}" >/dev/null
+  changed=true
+fi
+
+after="$(${gh_bin} api "repos/${repo}/rulesets/${ruleset_id}")"
+after_contract="$(project_ruleset <<< "${after}")"
+matched=false
+if [ "${after_contract}" = "${desired}" ]; then
+  matched=true
+fi
+
+jq -n \
+  --arg repository "${repo}" \
+  --arg ruleset_id "${ruleset_id}" \
+  --arg operation "${operation}" \
+  --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --argjson before "${before}" \
+  --argjson desired "${desired}" \
+  --argjson after "${after}" \
+  --argjson changed "${changed}" \
+  --argjson matched "${matched}" \
+  '{repository: $repository, ruleset_id: $ruleset_id, operation: $operation, timestamp: $timestamp, changed: $changed, matched: $matched, before: $before, desired: $desired, after: $after}' \
+  > "${evidence}"
+
+if [ "${matched}" != true ]; then
+  echo "ruleset ${ruleset_id} drifted from ${config}; evidence: ${evidence}" >&2
+  exit 1
+fi
+
+echo "required-gates-ruleset operation=${operation} ruleset=${ruleset_id} changed=${changed} matched=${matched} evidence=${evidence}"

--- a/.github/manage-required-gates-ruleset.sh
+++ b/.github/manage-required-gates-ruleset.sh
@@ -28,7 +28,7 @@ if [ ! -f "${config}" ] || [ -z "${evidence}" ]; then
 fi
 
 project_ruleset() {
-  jq -S '{name, target, enforcement, conditions, rules}'
+  jq -S '{name, target, enforcement, bypass_actors: (.bypass_actors // []), conditions, rules}'
 }
 
 desired="$(project_ruleset < "${config}")"

--- a/.github/required-gates-ruleset.json
+++ b/.github/required-gates-ruleset.json
@@ -2,6 +2,7 @@
   "name": "main",
   "target": "branch",
   "enforcement": "active",
+  "bypass_actors": [],
   "conditions": {
     "ref_name": {
       "include": ["~DEFAULT_BRANCH"],

--- a/.github/test-manage-required-gates-ruleset.sh
+++ b/.github/test-manage-required-gates-ruleset.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+workflow="${root}/.github/workflows/required-gates-ruleset.yml"
+grep -Fq 'schedule:' "${workflow}"
+grep -Fq 'environment: main-ruleset-administration' "${workflow}"
+grep -Fq -- '--operation audit' "${workflow}"
+grep -Fq -- '--operation reconcile' "${workflow}"
+grep -Fq 'bash .github/validate-required-gates.sh --github' "${workflow}"
+
+jq 'del(.rules[] | select(.type == "required_status_checks"))' \
+  "${root}/.github/required-gates-ruleset.json" > "${tmp}/state.json"
+
+cat > "${tmp}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${GH_LOG}"
+if [[ " $* " == *" --method PUT "* ]]; then
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = '--input' ]; then cp "$2" "${GH_STATE}"; exit 0; fi
+    shift
+  done
+fi
+cat "${GH_STATE}"
+EOF
+chmod +x "${tmp}/gh"
+
+run() {
+  GH_BIN="${tmp}/gh" GH_LOG="${tmp}/gh.log" GH_STATE="${tmp}/state.json" \
+    bash "${root}/.github/manage-required-gates-ruleset.sh" "$@"
+}
+
+if run --operation audit --evidence "${tmp}/audit.json"; then
+  echo 'audit accepted a drifted ruleset' >&2
+  exit 1
+fi
+jq -e '.operation == "audit" and .changed == false and .matched == false' "${tmp}/audit.json" >/dev/null
+test ! -s "${tmp}/gh.log" || ! grep -Fq -- '--method PUT' "${tmp}/gh.log"
+
+: > "${tmp}/gh.log"
+run --operation reconcile --evidence "${tmp}/reconcile.json"
+jq -e '.operation == "reconcile" and .changed == true and .matched == true' "${tmp}/reconcile.json" >/dev/null
+grep -Fq -- '--method PUT' "${tmp}/gh.log"
+jq -e '[.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]] | length == 8' "${tmp}/state.json" >/dev/null
+
+: > "${tmp}/gh.log"
+run --operation audit --evidence "${tmp}/converged.json"
+jq -e '.operation == "audit" and .changed == false and .matched == true' "${tmp}/converged.json" >/dev/null
+test ! -s "${tmp}/gh.log" || ! grep -Fq -- '--method PUT' "${tmp}/gh.log"

--- a/.github/test-manage-required-gates-ruleset.sh
+++ b/.github/test-manage-required-gates-ruleset.sh
@@ -46,6 +46,7 @@ run --operation reconcile --evidence "${tmp}/reconcile.json"
 jq -e '.operation == "reconcile" and .changed == true and .matched == true' "${tmp}/reconcile.json" >/dev/null
 grep -Fq -- '--method PUT' "${tmp}/gh.log"
 jq -e '[.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]] | length == 8' "${tmp}/state.json" >/dev/null
+jq -e '.bypass_actors == []' "${tmp}/state.json" >/dev/null
 
 : > "${tmp}/gh.log"
 run --operation audit --evidence "${tmp}/converged.json"

--- a/.github/validate-required-gates.sh
+++ b/.github/validate-required-gates.sh
@@ -421,7 +421,7 @@ if [ "${mode}" = "--report" ]; then
 fi
 
 case "${outcome}" in
-  enforced | bypassable)
+  enforced)
     exit 0
     ;;
   *)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,9 @@ jobs:
       - name: Validate required check contexts and report live enforcement
         env:
           GH_TOKEN: ${{ github.token }}
-        run: bash .github/validate-required-gates.sh --report
+        run: |
+          bash .github/validate-required-gates.sh --report
+          bash .github/test-manage-required-gates-ruleset.sh
       # A reusable-workflow pin must be a COMMIT. Pinning an annotated tag's ref
       # object kills every run at startup with zero jobs scheduled, which is how
       # #12152 broke `main` until #12153 repinned the dereferenced commit.

--- a/.github/workflows/required-gates-ruleset.yml
+++ b/.github/workflows/required-gates-ruleset.yml
@@ -1,0 +1,62 @@
+name: Required Gates Ruleset
+
+on:
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: Audit the live ruleset or reconcile it to the versioned policy.
+        required: true
+        default: audit
+        type: choice
+        options: [audit, reconcile]
+
+concurrency:
+  group: required-gates-ruleset-Extra-Chill-homeboy
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Audit required gates ruleset
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+      - name: Audit the existing ruleset against the versioned policy
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/manage-required-gates-ruleset.sh --operation audit --evidence required-gates-ruleset-audit.json
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: required-gates-ruleset-audit
+          path: required-gates-ruleset-audit.json
+          if-no-files-found: error
+
+  reconcile:
+    if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.operation == 'reconcile' }}
+    needs: audit
+    runs-on: ubuntu-latest
+    environment: main-ruleset-administration
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+      - name: Reconcile the existing ruleset and verify effective enforcement
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBOY_RULESET_ADMIN_TOKEN }}
+        run: |
+          test -n "${GH_TOKEN}"
+          bash .github/manage-required-gates-ruleset.sh --operation reconcile --evidence required-gates-ruleset-reconcile.json
+          bash .github/validate-required-gates.sh --github
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: required-gates-ruleset-reconcile
+          path: required-gates-ruleset-reconcile.json
+          if-no-files-found: error

--- a/docs/operations/required-ci-gates.md
+++ b/docs/operations/required-ci-gates.md
@@ -105,8 +105,24 @@ without wiring it into the terminal job turns `Required Gates Declaration` red.
 ## Apply And Verify
 
 The GitHub ruleset is repository state, so it cannot be changed by a pull
-request. A repository administrator applies the versioned payload to the
-existing `main` ruleset and verifies the result:
+request. `Required Gates Ruleset` audits the existing ruleset every hour from
+`main`, fails on drift, and uploads its before/desired/after evidence. It does
+not create another ruleset. Configure the `main-ruleset-administration`
+environment with required reviewers and a repository-administration token named
+`HOMEBOY_RULESET_ADMIN_TOKEN`; only the approved manual reconciliation job can
+use that credential.
+
+After reviewing the audit artifact, dispatch reconciliation from `main`:
+
+```bash
+gh workflow run required-gates-ruleset.yml --repo Extra-Chill/homeboy --ref main \
+  -f operation=reconcile
+```
+
+The reconciliation job applies the versioned payload only when the existing
+ruleset differs, records the before/desired/after documents, and fails unless
+they exactly match. It then runs the same fail-closed effective-enforcement
+verification used below. For an administrator recovery outside Actions:
 
 ```bash
 gh api --method PUT repos/Extra-Chill/homeboy/rulesets/13680120 \

--- a/tests/cleanup_next_actions.rs
+++ b/tests/cleanup_next_actions.rs
@@ -285,6 +285,11 @@ fn run_homeboy(home: &Path, cwd: &Path, args: &[&str], path: &str) -> Value {
         .env("HOME", home)
         .env("HOMEBOY_NO_UPDATE_CHECK", "1")
         .env("PATH", path)
+        // This fixture inventories its isolated local runner. A parent Lab
+        // handoff is unrelated ambient provenance and would add a second runner
+        // with the same fixture workspace root.
+        .env_remove("HOMEBOY_LAB_EXECUTION_RUNNER_ID")
+        .env_remove("HOMEBOY_RUNNER_HOSTED_EXEC")
         .output()
         .expect("run cleanup");
     serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {

--- a/tests/required_gates_policy_test.rs
+++ b/tests/required_gates_policy_test.rs
@@ -539,6 +539,39 @@ fn github_mode_rejects_rulesets_that_omit_the_terminal_execution_verdict() {
 }
 
 #[test]
+fn github_mode_fails_closed_when_the_live_ruleset_has_bypass_actors() {
+    let scratch = Scratch::new("github-bypassable");
+    let rules = scratch.write("rules.json", &live_rules(&declared_contexts(), true));
+    let detail = scratch.write(
+        "ruleset.json",
+        &ruleset_detail(
+            serde_json::json!([
+                { "actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always" }
+            ]),
+            "always",
+        ),
+    );
+    let output = run_validator(
+        "--github",
+        &[
+            ("REQUIRED_GATES_LIVE_RULES", rules.as_str()),
+            ("REQUIRED_GATES_LIVE_RULESET", detail.as_str()),
+        ],
+    );
+
+    assert!(
+        !output.status.success(),
+        "a bypassable ruleset is not enforced: {}",
+        stdout_of(&output)
+    );
+    assert!(
+        stderr_of(&output).contains("enforcement is bypassable"),
+        "{}",
+        stderr_of(&output)
+    );
+}
+
+#[test]
 fn github_mode_fails_closed_when_live_state_cannot_be_read() {
     let scratch = Scratch::new("github-unverified");
     let output = run_validator(


### PR DESCRIPTION
## Summary

Make the versioned `.github/required-gates-ruleset.json` converge the existing main ruleset rather than merely reporting drift.

- Add a scheduled, fail-closed audit with before/desired/after JSON evidence.
- Add an environment-scoped manual reconciliation path that updates ruleset `13680120` only when it differs, then verifies effective enforcement.
- Exercise drift, repair, and no-op audit behavior with a fake GitHub API fixture.

Closes #12833

## Verification

- `bash .github/test-manage-required-gates-ruleset.sh`
- `bash .github/validate-required-gates.sh --local`
- `cargo test --test required_gates_policy_test`
- `git diff --check`
- Live: `bash .github/manage-required-gates-ruleset.sh --operation reconcile --evidence /tmp/homeboy-required-gates-live-reconcile.json`
- Live: `bash .github/validate-required-gates.sh --github`

The live API verification reports ruleset `13680120` active with exactly eight contexts, strict checks enabled, and zero bypass actors.

## AI assistance

OpenAI `openai/gpt-5.6-terra` via OpenCode investigated GitHub ruleset history and workflow provenance, implemented the audit/reconciliation workflow and fixture coverage, and performed the documented live verification. Chris Huber reviewed the evidence and remains responsible for this change.