### PR TITLE
fix(cook): preserve compatible Cargo leases

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -1971,34 +1971,11 @@ impl SelectedGateEnvironment {
             .get("CARGO_TARGET_DIR")
             .cloned()
             .or_else(|| std::env::var("CARGO_TARGET_DIR").ok());
-        let compatibility = [
-            (
-                "CARGO_BUILD_TARGET",
-                self.values
-                    .get("CARGO_BUILD_TARGET")
-                    .map(String::as_str)
-                    .unwrap_or(""),
-            ),
-            (
-                "RUSTFLAGS",
-                self.values
-                    .get("RUSTFLAGS")
-                    .map(String::as_str)
-                    .unwrap_or(""),
-            ),
-            (
-                "CARGO_PROFILE",
-                self.values
-                    .get("CARGO_PROFILE")
-                    .map(String::as_str)
-                    .unwrap_or(""),
-            ),
-        ];
-        let target = homeboy_core::cleanup::acquire_managed_cargo_target_with_compatibility(
+        let target = homeboy_core::cleanup::acquire_managed_cargo_target_for_environment(
             "agent-task-cargo",
             cwd,
             explicit_target.as_deref(),
-            &compatibility,
+            &self.values,
         )?;
         // Store sizing is evidence only. A concurrent gate may update the
         // shared target while this observation walks it.

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -715,7 +715,7 @@ fn run_materialized_provider_command_once_contained(
     // The lease remains alive through the provider process. This lets provider
     // attempts and controller gates share only the same compatibility-keyed
     // Cargo output directory while preserving their isolated HOME/XDG roots.
-    let cargo_target = match provider_cargo_target(request, cwd.as_deref()) {
+    let cargo_target = match provider_cargo_target(request, cwd.as_deref(), &env) {
         Ok(target) => target,
         Err(error) => {
             return failure_outcome(
@@ -1133,6 +1133,7 @@ fn run_materialized_provider_command_once_contained(
 fn provider_cargo_target(
     _request: &AgentTaskExecutorRequest,
     cwd: Option<&Path>,
+    environment: &[(String, String)],
 ) -> homeboy_core::Result<Option<homeboy_core::ManagedCargoTarget>> {
     let Some(cwd) = cwd else { return Ok(None) };
     let enabled =
@@ -1142,26 +1143,12 @@ fn provider_cargo_target(
     if !enabled {
         return Ok(None);
     }
-    let compatibility = [
-        (
-            "CARGO_BUILD_TARGET",
-            std::env::var("CARGO_BUILD_TARGET").unwrap_or_default(),
-        ),
-        ("RUSTFLAGS", std::env::var("RUSTFLAGS").unwrap_or_default()),
-        (
-            "CARGO_PROFILE",
-            std::env::var("CARGO_PROFILE").unwrap_or_default(),
-        ),
-    ];
-    let compatibility = compatibility
-        .iter()
-        .map(|(name, value)| (*name, value.as_str()))
-        .collect::<Vec<_>>();
-    homeboy_core::acquire_managed_cargo_target_with_compatibility(
+    let environment = environment.iter().cloned().collect();
+    homeboy_core::acquire_managed_cargo_target_for_environment(
         "agent-task-cargo",
         cwd,
         None,
-        &compatibility,
+        &environment,
     )
     .map(Some)
 }

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -21,10 +21,12 @@ use crate::{git, Error, Result};
 
 mod cargo_targets;
 pub use cargo_targets::{
-    acquire_managed_cargo_target, acquire_managed_cargo_target_with_compatibility,
-    acquire_shared_cargo_target, cleanup_shared_cargo_targets, shared_cargo_target_inventory,
+    acquire_managed_cargo_target, acquire_managed_cargo_target_for_environment,
+    acquire_managed_cargo_target_with_compatibility, acquire_shared_cargo_target,
+    cargo_target_compatibility, cleanup_shared_cargo_targets, shared_cargo_target_inventory,
     shared_cargo_target_root, shared_cargo_target_storage_status, CargoTargetCleanupOptions,
-    CargoTargetCleanupOutput, CargoTargetStorageStatus, ManagedCargoTarget, SharedCargoTargetLease,
+    CargoTargetCleanupOutput, CargoTargetCompatibility, CargoTargetStorageStatus,
+    ManagedCargoTarget, SharedCargoTargetLease,
 };
 mod automatic_retention;
 pub use automatic_retention::{

--- a/crates/homeboy-core/src/cleanup/cargo_targets.rs
+++ b/crates/homeboy-core/src/cleanup/cargo_targets.rs
@@ -87,7 +87,7 @@ pub struct CargoTargetStorageStatus {
 /// liveness evidence for inventory after the producer exits.
 pub struct SharedCargoTargetLease {
     target_dir: PathBuf,
-    _lock: File,
+    lock: File,
 }
 
 /// The Cargo target selected for a managed child process. Holding this value
@@ -97,6 +97,20 @@ pub struct ManagedCargoTarget {
     resolution: &'static str,
     owner: String,
     _lease: Option<SharedCargoTargetLease>,
+}
+
+/// The complete, non-secret compatibility surface used to select a shared
+/// Cargo target. Callers must collect this from the environment they pass to
+/// the child, rather than from Homeboy's ambient process environment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CargoTargetCompatibility {
+    identity: String,
+}
+
+impl CargoTargetCompatibility {
+    pub fn identity(&self) -> &str {
+        &self.identity
+    }
 }
 
 impl ManagedCargoTarget {
@@ -133,8 +147,23 @@ impl SharedCargoTargetLease {
 
 impl Drop for SharedCargoTargetLease {
     fn drop(&mut self) {
-        let _ = fs::remove_file(self.target_dir.join(LEASE_FILE));
-        let _ = write_last_used(&self.target_dir, SystemTime::now());
+        // A provider attempt, its retry, and controller gates can all hold a
+        // shared lease. Only the final holder may clear liveness; otherwise a
+        // cleaner can reclaim an actively compiling target between phases.
+        let _ = FileExt::unlock(&self.lock);
+        let final_holder = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(self.target_dir.join(LOCK_FILE))
+            .ok()
+            .and_then(|lock| match lock.try_lock_exclusive() {
+                Ok(true) => Some(lock),
+                Ok(false) | Err(_) => None,
+            });
+        if final_holder.is_some() {
+            let _ = fs::remove_file(self.target_dir.join(LEASE_FILE));
+            let _ = write_last_used(&self.target_dir, SystemTime::now());
+        }
     }
 }
 
@@ -167,6 +196,44 @@ pub fn acquire_managed_cargo_target_with_compatibility(
     explicit_target: Option<&str>,
     declared_environment: &[(&str, &str)],
 ) -> Result<ManagedCargoTarget> {
+    let compatibility = cargo_target_compatibility(source_path, declared_environment);
+    acquire_managed_cargo_target_for_compatibility(
+        owner,
+        source_path,
+        explicit_target,
+        &compatibility,
+    )
+}
+
+/// Acquire a target using compatibility collected from the exact child
+/// environment. This keeps provider attempts, retries, and controller gates in
+/// the same store when their execution declarations are the same.
+pub fn acquire_managed_cargo_target_for_environment(
+    owner: &str,
+    source_path: &Path,
+    explicit_target: Option<&str>,
+    environment: &BTreeMap<String, String>,
+) -> Result<ManagedCargoTarget> {
+    let declared = environment
+        .iter()
+        .filter(|(name, _)| cargo_compatibility_environment_name(name))
+        .map(|(name, value)| (name.as_str(), value.as_str()))
+        .collect::<Vec<_>>();
+    let compatibility = cargo_target_compatibility(source_path, &declared);
+    acquire_managed_cargo_target_for_compatibility(
+        owner,
+        source_path,
+        explicit_target,
+        &compatibility,
+    )
+}
+
+fn acquire_managed_cargo_target_for_compatibility(
+    owner: &str,
+    source_path: &Path,
+    explicit_target: Option<&str>,
+    compatibility: &CargoTargetCompatibility,
+) -> Result<ManagedCargoTarget> {
     if let Some(target) = explicit_target.filter(|target| !target.trim().is_empty()) {
         let target_dir = PathBuf::from(target);
         let target_dir = if target_dir.is_absolute() {
@@ -182,8 +249,7 @@ pub fn acquire_managed_cargo_target_with_compatibility(
         });
     }
 
-    let compatibility = cargo_target_compatibility_identity(source_path, declared_environment);
-    let lease = acquire_shared_cargo_target(&format!("{owner}:{compatibility}"))?;
+    let lease = acquire_shared_cargo_target(&format!("{owner}:{}", compatibility.identity()))?;
     Ok(ManagedCargoTarget {
         target_dir: lease.target_dir().to_path_buf(),
         resolution: "shared",
@@ -192,10 +258,13 @@ pub fn acquire_managed_cargo_target_with_compatibility(
     })
 }
 
-fn cargo_target_compatibility_identity(
+/// Collect the target identity from repository inputs and the declared child
+/// environment. Cargo fingerprints individual crates within the selected
+/// target, while this boundary prevents incompatible build universes sharing it.
+pub fn cargo_target_compatibility(
     source_path: &Path,
     declared_environment: &[(&str, &str)],
-) -> String {
+) -> CargoTargetCompatibility {
     let mut inputs = BTreeMap::new();
     inputs.insert(
         "repository".to_string(),
@@ -219,11 +288,33 @@ fn cargo_target_compatibility_identity(
         inputs.insert(format!("input:{name}"), digest);
     }
     for (name, value) in declared_environment {
-        inputs.insert(format!("env:{name}"), (*value).to_string());
+        if cargo_compatibility_environment_name(name) {
+            inputs.insert(format!("env:{name}"), (*value).to_string());
+        }
     }
-    content_hash::sha256_hex(
-        &serde_json::to_vec(&inputs).expect("Cargo compatibility inputs serialize"),
-    )
+    CargoTargetCompatibility {
+        identity: content_hash::sha256_hex(
+            &serde_json::to_vec(&inputs).expect("Cargo compatibility inputs serialize"),
+        ),
+    }
+}
+
+fn cargo_compatibility_environment_name(name: &str) -> bool {
+    matches!(
+        name,
+        "CARGO_BUILD_TARGET"
+            | "CARGO_BUILD_RUSTFLAGS"
+            | "CARGO_ENCODED_RUSTFLAGS"
+            | "CARGO_INCREMENTAL"
+            | "CARGO_PROFILE"
+            | "CARGO_TARGET_DIR"
+            | "RUSTC"
+            | "RUSTC_WRAPPER"
+            | "RUSTC_WORKSPACE_WRAPPER"
+            | "RUSTDOCFLAGS"
+            | "RUSTFLAGS"
+    ) || name.starts_with("CARGO_FEATURE_")
+        || name == "HOMEBOY_CARGO_FEATURES"
 }
 
 /// Cargo itself separates compatible crate fingerprints inside one target
@@ -314,10 +405,7 @@ pub(crate) fn acquire_shared_cargo_target_in(
     lock.lock_shared()
         .map_err(|error| io_error(error, "lock shared Cargo target"))?;
     write_lifecycle(&target_dir, Some(owner), now)?;
-    Ok(SharedCargoTargetLease {
-        target_dir,
-        _lock: lock,
-    })
+    Ok(SharedCargoTargetLease { target_dir, lock })
 }
 
 pub fn cleanup_shared_cargo_targets(
@@ -1110,14 +1198,14 @@ mod tests {
             "channel = 'stable'",
         )
         .unwrap();
-        let first = cargo_target_compatibility_identity(
+        let first = cargo_target_compatibility(
             workspace.path(),
             &[
                 ("CARGO_BUILD_TARGET", "x86_64-unknown-linux-gnu"),
                 ("RUSTFLAGS", ""),
             ],
         );
-        let warm = cargo_target_compatibility_identity(
+        let warm = cargo_target_compatibility(
             workspace.path(),
             &[
                 ("CARGO_BUILD_TARGET", "x86_64-unknown-linux-gnu"),
@@ -1128,7 +1216,7 @@ mod tests {
         fs::write(workspace.path().join("Cargo.lock"), "lock-b").unwrap();
         assert_ne!(
             first,
-            cargo_target_compatibility_identity(
+            cargo_target_compatibility(
                 workspace.path(),
                 &[
                     ("CARGO_BUILD_TARGET", "x86_64-unknown-linux-gnu"),
@@ -1143,7 +1231,7 @@ mod tests {
         .unwrap();
         assert_ne!(
             warm,
-            cargo_target_compatibility_identity(
+            cargo_target_compatibility(
                 workspace.path(),
                 &[
                     ("CARGO_BUILD_TARGET", "aarch64-apple-darwin"),
@@ -1151,6 +1239,110 @@ mod tests {
                 ],
             )
         );
+    }
+
+    #[test]
+    fn compatibility_collector_uses_effective_environment_and_feature_declarations() {
+        let workspace = TempDir::new().unwrap();
+        fs::write(workspace.path().join("Cargo.lock"), "lock-a").unwrap();
+        let provider_environment = BTreeMap::from([
+            (
+                "CARGO_BUILD_TARGET".to_string(),
+                "x86_64-unknown-linux-gnu".to_string(),
+            ),
+            ("CARGO_PROFILE".to_string(), "release".to_string()),
+            ("RUSTFLAGS".to_string(), "-Dwarnings".to_string()),
+            (
+                "HOMEBOY_CARGO_FEATURES".to_string(),
+                "server,metrics".to_string(),
+            ),
+            ("UNRELATED".to_string(), "ignored".to_string()),
+        ]);
+        let gate_environment = provider_environment.clone();
+
+        let provider =
+            cargo_target_compatibility_for_environment(workspace.path(), &provider_environment);
+        let gate = cargo_target_compatibility_for_environment(workspace.path(), &gate_environment);
+        assert_eq!(
+            provider, gate,
+            "the same effective child environment reuses the store"
+        );
+
+        let mut incompatible = gate_environment;
+        incompatible.insert("HOMEBOY_CARGO_FEATURES".to_string(), "server".to_string());
+        assert_ne!(
+            provider,
+            cargo_target_compatibility_for_environment(workspace.path(), &incompatible),
+            "feature declarations are a cache compatibility boundary"
+        );
+    }
+
+    #[test]
+    fn provider_retry_controller_matrix_reuses_one_durable_lease() {
+        let root = TempDir::new().unwrap();
+        let workspace = TempDir::new().unwrap();
+        fs::write(workspace.path().join("Cargo.lock"), "lock-a").unwrap();
+        let environment = BTreeMap::from([(
+            "CARGO_BUILD_TARGET".to_string(),
+            "x86_64-unknown-linux-gnu".to_string(),
+        )]);
+        let compatibility =
+            cargo_target_compatibility_for_environment(workspace.path(), &environment);
+        let provider = acquire_shared_cargo_target_in(
+            root.path(),
+            &format!("agent-task-cargo:{}", compatibility.identity()),
+            SystemTime::now(),
+        )
+        .unwrap();
+        let target = provider.target_dir().to_path_buf();
+        fs::write(target.join("provider-artifact"), "warm output").unwrap();
+        assert!(
+            target.join(LEASE_FILE).is_file(),
+            "provider holds the live lease"
+        );
+
+        let retry = acquire_shared_cargo_target_in(
+            root.path(),
+            &format!("agent-task-cargo:{}", compatibility.identity()),
+            SystemTime::now(),
+        )
+        .unwrap();
+        assert_eq!(retry.target_dir(), target, "retry observes provider output");
+        assert!(retry.target_dir().join("provider-artifact").is_file());
+
+        let controller = acquire_shared_cargo_target_in(
+            root.path(),
+            &format!("agent-task-cargo:{}", compatibility.identity()),
+            SystemTime::now(),
+        )
+        .unwrap();
+        assert_eq!(
+            controller.target_dir(),
+            target,
+            "controller gate reuses retry target"
+        );
+        drop(provider);
+        drop(retry);
+        assert!(
+            target.join(LEASE_FILE).is_file(),
+            "controller keeps the lease durable"
+        );
+        drop(controller);
+        assert!(
+            !target.join(LEASE_FILE).exists(),
+            "terminal controller release clears liveness"
+        );
+    }
+
+    fn cargo_target_compatibility_for_environment(
+        source_path: &Path,
+        environment: &BTreeMap<String, String>,
+    ) -> CargoTargetCompatibility {
+        let declared = environment
+            .iter()
+            .map(|(name, value)| (name.as_str(), value.as_str()))
+            .collect::<Vec<_>>();
+        cargo_target_compatibility(source_path, &declared)
     }
 
     #[test]

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -36,8 +36,9 @@ pub use lab_contract as command_contract;
 // Stable domain facades for new command/core integrations.
 pub mod artifacts;
 pub use cleanup::{
-    acquire_managed_cargo_target, acquire_managed_cargo_target_with_compatibility,
-    ManagedCargoTarget,
+    acquire_managed_cargo_target, acquire_managed_cargo_target_for_environment,
+    acquire_managed_cargo_target_with_compatibility, cargo_target_compatibility,
+    CargoTargetCompatibility, ManagedCargoTarget,
 };
 pub use homeboy_engine_primitives::cargo_target::CargoTargetEvidence;
 

--- a/crates/homeboy-extension/src/component_script.rs
+++ b/crates/homeboy-extension/src/component_script.rs
@@ -91,10 +91,12 @@ fn run_component_scripts_with_env_and_timeout(
             .find(|(key, _)| key == "CARGO_TARGET_DIR")
             .map(|(_, value)| value.clone())
             .or_else(|| std::env::var("CARGO_TARGET_DIR").ok());
-        let target = homeboy_core::cleanup::acquire_managed_cargo_target(
+        let environment = env.iter().cloned().collect();
+        let target = homeboy_core::cleanup::acquire_managed_cargo_target_for_environment(
             &format!("component:{}", component.id),
             source_path,
             explicit_target.as_deref(),
+            &environment,
         )?;
         env.push((
             "CARGO_TARGET_DIR".to_string(),


### PR DESCRIPTION
## Summary
- collect Cargo compatibility from each child process effective environment, including target, profile, rustflags, wrappers, and declared features
- preserve the shared target lease until the final provider/retry/controller holder exits
- add compatibility and provider -> retry -> controller durable-lease matrix coverage
- merge current `origin/main` without rebase after CI artifact review

Relates to #12648 and #12888.

## Verification
- `cargo fmt --all -- --check` (blocked by formatting drift in merged `origin/main`: `tests/core/daemon/control_test.rs` and `crates/homeboy-lab-runner/src/evidence/tests/mod.rs`)
- `cargo check -p homeboy-agents -p homeboy-extension`
- `cargo test -p homeboy-core cleanup::cargo_targets::tests::compatibility --lib`
- `cargo test -p homeboy-core cleanup::cargo_targets::tests::provider_retry_controller_matrix_reuses_one_durable_lease --lib`

## Benchmark
Before the merge, the targeted provider -> retry -> controller durable-lease matrix completed in 29.78s on a cold test-profile build and 1.73s warm (test body 0.06s). After merging current `origin/main`, it completed in 1.13s warm (test body 0.12s). It proves cache-store path continuity and active lease preservation across all three phases; it does not claim a representative full Cargo compilation speedup.

## CI Investigation
Run 32553853741 failed because its aggregate `homeboy / Test` artifact recorded inconsistent failures in every shard (5, 6, 11, and 12), even though all four candidate shard jobs passed. `homeboy / Required Gates Executed` correctly failed because that aggregate context failed. This is not a deterministic branch-specific cache failure.

## Workflow Note
This worktree remains unmanaged by Data Machine Code metadata under Chris Huber's explicit control-plane bypass authorization.

## Known Limitation
The existing agent gate cache tests cannot run on this host because shared-cache admission correctly rejects its configured 99 GB reserve with 20 GB free.

## AI Assistance
OpenAI `openai/gpt-5.6-terra` via OpenCode inspected CI artifacts and gate verdicts, merged current main without rebase, revalidated the cache compatibility and durable lease matrix, and preserved reviewer-facing evidence. Chris Huber directed and remains responsible for the change.