### PR TITLE
Stabilize Lab runtime overlay snapshots

### DIFF
--- a/crates/homeboy-lab-runner/src/lab_workspaces/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces/mod.rs
@@ -526,7 +526,17 @@ pub(super) fn sync_lab_runtime_overlays(
                 allow_dirty_lab_workspace: false,
                 run_isolation_token: None,
             },
-        )?
+        )
+        .map_err(|mut error| {
+            // Generic workspace staging only knows filesystem children. Restore
+            // the configured overlay declaration at the owning boundary.
+            if error.details["classification"] == "snapshot_construction" {
+                error.details["declaration_id"] = serde_json::json!(overlay.workspace.role);
+                error.details["runtime_overlay_source"] =
+                    serde_json::json!(overlay.workspace.path.display().to_string());
+            }
+            error
+        })?
         .0;
         let entry = workspace_mapping_entry(&overlay.workspace.role, &synced);
         if !already_synced {

--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -2,7 +2,7 @@ use homeboy_engine_primitives::content_hash;
 use std::collections::BTreeMap;
 use std::fs;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use glob_match::glob_match;
 use sha2::{Digest, Sha256};
@@ -1841,15 +1841,292 @@ pub(crate) fn ensure_no_runner_workspace_metadata_collision(local_path: &Path) -
     Ok(())
 }
 
-fn materialize_snapshot_piped(
+pub(super) fn materialize_snapshot_piped(
     local_path: &Path,
     target_command: &str,
     excludes: &[String],
     action: &str,
     scratch: Option<&Path>,
 ) -> Result<()> {
-    let command = snapshot_materialization_command(local_path, target_command, excludes, scratch)?;
+    // Complete the controller-side archive staging before starting the target
+    // command. In particular, an SSH target must never observe a partial or
+    // second read of a controller workspace whose overlay artifacts changed.
+    let source_manifest = snapshot_stable_manifest(local_path, excludes).map_err(|error| {
+        snapshot_construction_failure(
+            "workspace_snapshot",
+            local_path,
+            None,
+            &format!(
+                "{action}: {}; diagnostics: {}",
+                error.message, error.details
+            ),
+        )
+    })?;
+    let mut manifest = snapshot_input_manifest(local_path, excludes)?;
+    let stage = materialize_snapshot_stage(local_path, excludes, &manifest, scratch).map_err(
+        |mut error| {
+            error.message = format!("{action}: {}", error.message);
+            error
+        },
+    )?;
+    // A group that produced no staging output was entirely excluded by the
+    // selected snapshot policy. It is optional transport input, so omit it
+    // rather than giving tar a path that the same staging operation did not
+    // create.
+    manifest
+        .entries
+        .retain(|entry| stage.path().join(&entry.staging_output).exists());
+    let staged_manifest = snapshot_stable_manifest(&stage.path().join("source"), &[])?;
+    let current_manifest = snapshot_stable_manifest(local_path, excludes)?;
+    validate_snapshot_stability(
+        &source_manifest,
+        &staged_manifest,
+        &current_manifest,
+        local_path,
+        &stage.path().join("source"),
+    )?;
+    let command = snapshot_staged_materialization_command(
+        &stage.path().join("source"),
+        &manifest,
+        target_command,
+        scratch,
+    );
     run_shell_command(&command, action)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SnapshotStableManifest {
+    inventory: WorkspaceContentManifest,
+    content_identity: String,
+}
+
+pub(super) fn snapshot_stable_manifest(
+    path: &Path,
+    excludes: &[String],
+) -> Result<SnapshotStableManifest> {
+    Ok(SnapshotStableManifest {
+        inventory: workspace_content_manifest_for_policy(
+            path,
+            excludes,
+            WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
+        )?,
+        content_identity: workspace_content_hash(path, excludes)?,
+    })
+}
+
+pub(super) fn validate_snapshot_stability(
+    before: &SnapshotStableManifest,
+    staged: &SnapshotStableManifest,
+    after: &SnapshotStableManifest,
+    source: &Path,
+    staging_output: &Path,
+) -> Result<()> {
+    if before == staged && staged == after {
+        return Ok(());
+    }
+    Err(snapshot_construction_failure(
+        "workspace_snapshot",
+        source,
+        Some(staging_output),
+        "source and staged snapshot manifests differ; refusing a mixed snapshot",
+    ))
+}
+
+/// One controller-side input and its corresponding private staging output.
+/// The archive transfer consumes only `staging_output`, never `source`.
+#[derive(Debug, Clone)]
+pub(super) struct SnapshotInputManifestEntry {
+    pub(super) declaration_id: String,
+    pub(super) source: PathBuf,
+    pub(super) archive_path: String,
+    pub(super) staging_output: PathBuf,
+}
+
+/// The typed input contract for one snapshot staging operation.
+#[derive(Debug, Clone)]
+pub(super) struct SnapshotInputManifest {
+    pub(super) entries: Vec<SnapshotInputManifestEntry>,
+}
+
+pub(super) fn snapshot_input_manifest(
+    local_path: &Path,
+    excludes: &[String],
+) -> Result<SnapshotInputManifest> {
+    let entries = fs::read_dir(local_path)
+        .map_err(|err| Error::internal_io(err.to_string(), Some("read snapshot root".to_string())))?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|err| {
+            Error::internal_io(
+                err.to_string(),
+                Some("read snapshot root entry".to_string()),
+            )
+        })?;
+    let mut manifest_entries = Vec::new();
+    for entry in entries {
+        let source = entry.path();
+        if is_excluded(local_path, &source, excludes, &[]) {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().to_string();
+        let declaration_id = format!("root:{name}");
+        // `read_dir` is not a presence guarantee. Validate each required input
+        // immediately and report its durable declaration identity before SSH.
+        if let Err(error) = fs::symlink_metadata(&source) {
+            return Err(snapshot_construction_failure(
+                &declaration_id,
+                &source,
+                None,
+                &error.to_string(),
+            ));
+        }
+        manifest_entries.push(SnapshotInputManifestEntry {
+            declaration_id,
+            source,
+            archive_path: format!("./{name}"),
+            staging_output: PathBuf::from("source").join(name),
+        });
+    }
+    Ok(SnapshotInputManifest {
+        entries: manifest_entries,
+    })
+}
+
+/// Materialize every required manifest entry into one private staging tree.
+/// The returned directory is kept alive through transfer, making the staging
+/// output the sole tar input after validation succeeds.
+pub(super) fn materialize_snapshot_stage(
+    local_path: &Path,
+    excludes: &[String],
+    manifest: &SnapshotInputManifest,
+    scratch: Option<&Path>,
+) -> Result<tempfile::TempDir> {
+    let stage = scratch
+        .map_or_else(tempfile::tempdir, |path| {
+            tempfile::Builder::new()
+                .prefix("homeboy-snapshot-stage-")
+                .tempdir_in(path)
+        })
+        .map_err(|error| {
+            snapshot_construction_failure("staging", local_path, None, &error.to_string())
+        })?;
+    let stage_source = stage.path().join("source");
+    fs::create_dir_all(&stage_source).map_err(|error| {
+        snapshot_construction_failure(
+            "staging",
+            local_path,
+            Some(&stage_source),
+            &error.to_string(),
+        )
+    })?;
+    let inputs = snapshot_manifest_tar_input(manifest);
+    // Root-anchored exclusions have already shaped the manifest. Passing them
+    // to tar again would make a root-only exclusion match nested paths.
+    let archive_excludes = excludes
+        .iter()
+        .filter(|pattern| !pattern.starts_with("./"))
+        .cloned()
+        .collect::<Vec<_>>();
+    let source_archive = format!(
+        "COPYFILE_DISABLE=1 tar --no-xattrs -C {src} {exclude} -cf - --null -T -",
+        src = shell::quote_arg(&local_path.display().to_string()),
+        exclude = tar_exclude_args(&archive_excludes),
+    );
+    let command = format!(
+        "({inputs}) | {source_archive} | tar --no-xattrs -C {stage} -xf - && root={root} && stage={stage} && export root stage && find \"$stage\" -type l -exec sh -c {resolve} sh {{}} \\;",
+        stage = shell::quote_arg(&stage_source.display().to_string()),
+        root = shell::quote_arg(&local_path.display().to_string()),
+        resolve = shell::quote_arg(&format!(
+            "stage_link=$1; relative=${{stage_link#\"$stage\"/}}; original=\"$root/$relative\"; target=$(realpath \"$original\") || exit; case \"$target\" in \"$root\"|\"$root\"/*) ;; *) rm -f \"$stage_link\" && mkdir -p \"$(dirname \"$stage_link\")\" && COPYFILE_DISABLE=1 tar --no-xattrs -h -C \"$root\" {} -cf - \"$relative\" | tar --no-xattrs -C \"$stage\" -xf - ;; esac",
+            tar_exclude_args(&archive_excludes)
+        )),
+    );
+    run_shell_command(&command, "construct workspace snapshot staging").map_err(|error| {
+        let missing = manifest.entries.iter().find(|entry| !entry.source.exists());
+        snapshot_construction_failure(
+            missing
+                .map(|entry| entry.declaration_id.as_str())
+                .unwrap_or("staging"),
+            missing
+                .map(|entry| entry.source.as_path())
+                .unwrap_or(local_path),
+            Some(&stage_source),
+            &error.message,
+        )
+    })?;
+    for entry in &manifest.entries {
+        let output = stage.path().join(&entry.staging_output);
+        if !output.exists() && !entry.source.exists() {
+            return Err(snapshot_construction_failure(
+                &entry.declaration_id,
+                &entry.source,
+                Some(&output),
+                "required staging output was not materialized",
+            ));
+        }
+    }
+    Ok(stage)
+}
+
+fn snapshot_manifest_tar_input(manifest: &SnapshotInputManifest) -> String {
+    if manifest.entries.is_empty() {
+        "printf ''".to_string()
+    } else {
+        format!(
+            "printf '%s\\0' {}",
+            manifest
+                .entries
+                .iter()
+                .map(|entry| shell::quote_arg(&entry.archive_path))
+                .collect::<Vec<_>>()
+                .join(" ")
+        )
+    }
+}
+
+fn snapshot_staged_materialization_command(
+    stage: &Path,
+    manifest: &SnapshotInputManifest,
+    target_command: &str,
+    scratch: Option<&Path>,
+) -> String {
+    let inputs = snapshot_manifest_tar_input(manifest);
+    let command = format!(
+        "({inputs}) | COPYFILE_DISABLE=1 tar --no-xattrs -C {stage} -cf - --null -T - | {target_command}",
+        stage = shell::quote_arg(&stage.display().to_string()),
+    );
+    scratch.map_or(command.clone(), |scratch| {
+        scratch_scoped_command(&command, scratch)
+    })
+}
+
+fn snapshot_construction_failure(
+    declaration_id: &str,
+    source: &Path,
+    staging_output: Option<&Path>,
+    reason: &str,
+) -> Error {
+    let mut error = Error::validation_invalid_argument(
+        "workspace_snapshot",
+        format!("Lab workspace snapshot construction failed before SSH transport: {reason}"),
+        Some(format!("{declaration_id}: {}", source.display())),
+        Some(vec![
+            "Rebuild the Homeboy snapshot staging set, then replay the Cook; component dependency installation cannot repair controller-side snapshot inputs.".to_string(),
+        ]),
+    )
+    .with_retryable(false);
+    error.details["classification"] = serde_json::json!("snapshot_construction");
+    error.details["declaration_id"] = serde_json::json!(declaration_id);
+    error.details["source_identity"] = serde_json::json!(source.display().to_string());
+    error.details["staging_output"] = staging_output
+        .map(|path| serde_json::json!(path.display().to_string()))
+        .unwrap_or(serde_json::Value::Null);
+    error.details["reason"] = serde_json::json!(reason);
+    error.details["recovery"] = serde_json::json!({
+        "owner": "homeboy_snapshot_staging",
+        "action": "rebuild_snapshot_staging_and_replay_cook",
+        "command": "homeboy agent-task retry <run-id> --run",
+    });
+    error
 }
 
 /// Build the exact shell program a snapshot materialization hands to `sh -c`.

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -6,10 +6,12 @@ use std::sync::{Mutex, OnceLock};
 
 use crate::workspace::snapshot::{
     copy_snapshot_to_directory, ensure_no_runner_workspace_metadata_collision,
+    materialize_snapshot_piped, materialize_snapshot_stage,
     register_after_snapshot_directory_discovery_hook, scratch_scoped_command,
-    snapshot_archive_command, snapshot_install_command, snapshot_materialization_command,
-    snapshot_overlay_install_command, synthetic_checkout_value, workspace_content_hash,
-    workspace_content_hash_algorithm, workspace_content_hash_for_policy, workspace_content_hash_v1,
+    snapshot_archive_command, snapshot_input_manifest, snapshot_install_command,
+    snapshot_overlay_install_command, snapshot_stable_manifest, synthetic_checkout_value,
+    validate_snapshot_stability, workspace_content_hash, workspace_content_hash_algorithm,
+    workspace_content_hash_for_policy, workspace_content_hash_v1,
     workspace_content_manifest_for_policy, WORKSPACE_CONTENT_PERMISSION_PORTABLE,
     WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE,
     WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE,
@@ -1498,51 +1500,6 @@ fn scratch_scoped_snapshot_command_parses_under_posix_sh() {
     }
 }
 
-/// Cover the command production actually executes, not a re-composition of its
-/// parts. `materialize_snapshot_piped` used to assemble the archive pipeline and
-/// the scratch prefix inline, so no test observed the assembled program; the
-/// scratch branch is taken unconditionally by `sync_workspace`, which is why a
-/// malformed composition took out every workspace-prune behavior test at once
-/// instead of a single targeted assertion (#10399).
-#[test]
-fn snapshot_materialization_command_parses_under_posix_shells() {
-    use homeboy_core::engine::shell;
-
-    let source = tempfile::tempdir().expect("snapshot source");
-    let local_target = format!(
-        "sh -c {}",
-        shell::quote_arg(&snapshot_install_command(
-            "/var/lib/sampleplugin/workspace/_lab_workspaces/homeboy-abc"
-        ))
-    );
-
-    for excludes in [
-        vec![],
-        vec!["node_modules".to_string()],
-        vec!["./target".to_string(), "node_modules".to_string()],
-    ] {
-        for target in [local_target.as_str(), "ssh runner 'tar -xf -'"] {
-            for scratch in [
-                None,
-                Some(Path::new("/var/lib/homeboy/scratch dir")),
-                Some(Path::new("/var/lib/homeboy/scratch")),
-            ] {
-                let command =
-                    snapshot_materialization_command(source.path(), target, &excludes, scratch)
-                        .expect("snapshot materialization command");
-
-                assert_eq!(
-                    scratch.is_some(),
-                    command.starts_with("export TMPDIR="),
-                    "scratch scoping must be applied exactly when a scratch filesystem is admitted: {command}"
-                );
-
-                assert_parses_under_posix_shells(&command, "snapshot materialization command");
-            }
-        }
-    }
-}
-
 /// The install commands cross the same `sh -c` boundary as the archive
 /// pipeline, on both the local and the SSH runner path, so hold them to the
 /// same portability contract (#10399).
@@ -1586,6 +1543,117 @@ fn snapshot_archive_command_selectively_dereferences_external_symlinked_dependen
         command.contains("tar --no-xattrs -C \"$stage/source\""),
         "the final snapshot archive must preserve internal symlink entries: {command}"
     );
+}
+
+#[test]
+fn snapshot_staging_rejects_a_disappearing_runtime_overlay_before_ssh() {
+    let source = tempfile::tempdir().expect("snapshot source");
+    let overlay = source.path().join("runtime-overlays");
+    fs::create_dir_all(&overlay).expect("runtime overlay source");
+    fs::write(overlay.join("runtime.js"), "runtime").expect("runtime artifact");
+
+    // This is the race that previously became `tar: ./runtime-overlays: Cannot
+    // stat` in a pipeline whose SSH side had already started. The typed manifest
+    // preserves the declaration identity and staging now fails before transport.
+    let manifest = snapshot_input_manifest(source.path(), &[]).expect("input manifest");
+    fs::remove_dir_all(&overlay).expect("remove overlay after manifest creation");
+    let error = materialize_snapshot_stage(source.path(), &[], &manifest, None)
+        .expect_err("missing declared overlay must fail during local staging");
+
+    assert_eq!(error.retryable, Some(false));
+    assert_eq!(error.details["classification"], "snapshot_construction");
+    assert_eq!(error.details["declaration_id"], "root:runtime-overlays");
+    assert_eq!(
+        error.details["source_identity"],
+        serde_json::json!(overlay.display().to_string())
+    );
+    assert!(error.details["staging_output"]
+        .as_str()
+        .is_some_and(|path| path.ends_with("/source")));
+    assert!(error.details["reason"]
+        .as_str()
+        .is_some_and(|reason| reason.contains("tar: ./runtime-overlays: Cannot stat")));
+    assert_eq!(
+        error.details["recovery"]["action"],
+        "rebuild_snapshot_staging_and_replay_cook"
+    );
+}
+
+#[test]
+fn snapshot_transport_archives_only_the_admitted_scratch_stage() {
+    let source = tempfile::tempdir().expect("source");
+    let scratch = tempfile::tempdir().expect("admitted scratch");
+    let archive_list = tempfile::NamedTempFile::new().expect("archive list");
+    fs::write(source.path().join("runtime-overlays"), "runtime").expect("overlay");
+    fs::write(source.path().join("other"), "other").expect("other input");
+    let manifest = snapshot_input_manifest(source.path(), &[]).expect("input manifest");
+    let stage = materialize_snapshot_stage(source.path(), &[], &manifest, Some(scratch.path()))
+        .expect("stage in admitted scratch");
+    assert!(stage.path().starts_with(scratch.path()));
+
+    materialize_snapshot_piped(
+        source.path(),
+        &format!(
+            "tar -tf - > {}",
+            homeboy_core::engine::shell::quote_arg(&archive_list.path().display().to_string())
+        ),
+        &[],
+        "test SSH snapshot transport",
+        Some(scratch.path()),
+    )
+    .expect("stage then transport snapshot");
+
+    let entries = fs::read_to_string(archive_list.path()).expect("tar input list");
+    assert!(entries.contains("runtime-overlays"));
+    assert!(entries.contains("other"));
+}
+
+#[test]
+fn snapshot_construction_failure_does_not_start_transport_or_accept_source_drift() {
+    let source = tempfile::tempdir().expect("source");
+    let scratch = tempfile::tempdir().expect("admitted scratch");
+    let marker = tempfile::NamedTempFile::new().expect("marker");
+    fs::remove_file(marker.path()).expect("remove marker");
+    let missing_source = source.path().join("missing-workspace");
+    let error = materialize_snapshot_piped(
+        &missing_source,
+        &format!("touch {}", marker.path().display()),
+        &[],
+        "test SSH snapshot transport",
+        Some(scratch.path()),
+    )
+    .expect_err("construction failure must reject transport");
+    assert_eq!(error.details["classification"], "snapshot_construction");
+    assert!(
+        !marker.path().exists(),
+        "transport must not start after staging failure"
+    );
+}
+
+#[test]
+fn snapshot_stability_rejects_a_mixed_staged_tree_even_if_source_is_restored() {
+    let source = tempfile::tempdir().expect("source");
+    let scratch = tempfile::tempdir().expect("scratch");
+    fs::write(source.path().join("runtime-overlays"), "before").expect("overlay");
+    let before = snapshot_stable_manifest(source.path(), &[]).expect("before manifest");
+    let manifest = snapshot_input_manifest(source.path(), &[]).expect("input manifest");
+    let stage = materialize_snapshot_stage(source.path(), &[], &manifest, Some(scratch.path()))
+        .expect("stage");
+    fs::write(stage.path().join("source/runtime-overlays"), "mixed").expect("mutate stage");
+    fs::write(source.path().join("runtime-overlays"), "after").expect("mutate source");
+    fs::write(source.path().join("runtime-overlays"), "before").expect("restore source");
+    let staged =
+        snapshot_stable_manifest(&stage.path().join("source"), &[]).expect("staged manifest");
+    let after = snapshot_stable_manifest(source.path(), &[]).expect("after manifest");
+    let error = validate_snapshot_stability(
+        &before,
+        &staged,
+        &after,
+        source.path(),
+        &stage.path().join("source"),
+    )
+    .expect_err("mixed staged tree must fail even after source ABA restoration");
+    assert_eq!(error.details["classification"], "snapshot_construction");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- construct portable snapshots in admitted scratch space instead of mutating the source workspace
- compare source-before, staged, and source-after content manifests before transport
- reject mixed staged trees and source drift with bounded diagnostics while preserving transport retry behavior

## Verification
- `cargo test -p homeboy-lab-runner snapshot_transport_archives_only_the_admitted_scratch_stage --lib`
- `cargo test -p homeboy-lab-runner snapshot_construction_failure_does_not_start_transport_or_accept_source_drift --lib`
- `cargo test -p homeboy-lab-runner snapshot_stability_rejects_a_mixed_staged_tree_even_if_source_is_restored --lib`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

Closes #12896.

## AI assistance
OpenAI gpt-5.6-sol via OpenCode was used to diagnose the snapshot race, implement scratch-stage stability checks and regressions, and run verification. Chris Huber reviewed and is responsible for the change.