### PR TITLE
fix(cook): restore resolve deadline evidence

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -456,6 +456,7 @@ const COOK_PROVIDER_TERMINAL_POLL_INTERVAL: Duration = Duration::from_millis(250
 const COOK_PROVIDER_RESOLVE_ATTEMPTS: u32 = 2;
 const COOK_PROVIDER_RESOLVE_BACKOFF: Duration = Duration::from_millis(100);
 const COOK_PROVIDER_RESOLVE_DEADLINE: Duration = Duration::from_secs(90);
+const COOK_PROVIDER_RESOLVE_MIN_BUDGET: Duration = Duration::from_millis(50);
 
 /// One Cook progress event, as delivered to a foreground observer.
 ///
@@ -6677,6 +6678,7 @@ fn cook_workspace_lookup_pending(plan: &AgentTaskPlan) -> bool {
 fn materialize_pending_cook_workspace(
     lifecycle_store: &AgentTaskLifecycleStore,
     options: &mut AgentTaskCookServiceOptions,
+    effective_lookup_timeout_ms: Option<u64>,
 ) -> Result<()> {
     let provider_id = options
         .initial_plan
@@ -6690,7 +6692,12 @@ fn materialize_pending_cook_workspace(
                 .pointer("/cook_provision/worktree_provider_id")
                 .and_then(Value::as_str)
         });
-    let config = homeboy_core::defaults::load_config();
+    let mut config = homeboy_core::defaults::load_config();
+    if let Some(timeout_ms) = effective_lookup_timeout_ms {
+        for provider in config.worktree_providers.values_mut() {
+            provider.lookup_timeout_ms = provider.lookup_timeout_ms.min(timeout_ms);
+        }
+    }
     let resolve = || {
         match provider_id {
         Some(provider_id) => homeboy_core::worktree_providers::resolve_apply_enabled_worktree_provider_identity_by_id_from_config(
@@ -6808,7 +6815,12 @@ fn materialize_pending_cook_workspace_with_retry(
 
     for attempt in 1..=COOK_PROVIDER_RESOLVE_ATTEMPTS {
         let remaining_ms = deadline_ms.saturating_sub(now_unix_ms());
-        if remaining_ms == 0 {
+        let reserve_ms = if attempt < COOK_PROVIDER_RESOLVE_ATTEMPTS {
+            COOK_PROVIDER_RESOLVE_BACKOFF.as_millis() as u64
+        } else {
+            0
+        };
+        if remaining_ms < COOK_PROVIDER_RESOLVE_MIN_BUDGET.as_millis() as u64 + reserve_ms {
             let mut error = Error::validation_invalid_argument(
                 "to_worktree",
                 "Cook pre-execution deadline expired before worktree provider resolve could start",
@@ -6828,21 +6840,35 @@ fn materialize_pending_cook_workspace_with_retry(
                 attempt,
                 deadline_ms,
                 remaining_ms,
+                configured_provider_lookup_timeout_ms(options),
+                0,
+                "deadline_expired",
                 None,
                 None,
             )?;
             return Err(error);
         }
+        let configured_timeout_ms = configured_provider_lookup_timeout_ms(options);
+        let effective_timeout_ms =
+            configured_timeout_ms.min(remaining_ms.saturating_sub(reserve_ms));
         record_provider_resolve_evidence(
             lifecycle_store,
             options,
             attempt,
             deadline_ms,
             remaining_ms,
+            configured_timeout_ms,
+            effective_timeout_ms,
+            "running",
             None,
             None,
         )?;
-        match materialize_pending_cook_workspace(lifecycle_store, options) {
+        let started_ms = now_unix_ms();
+        match materialize_pending_cook_workspace(
+            lifecycle_store,
+            options,
+            Some(effective_timeout_ms),
+        ) {
             Ok(()) => return Ok(()),
             Err(mut error)
                 if provider_resolve_timeout(&error) && attempt < COOK_PROVIDER_RESOLVE_ATTEMPTS =>
@@ -6856,6 +6882,9 @@ fn materialize_pending_cook_workspace_with_retry(
                     attempt,
                     deadline_ms,
                     deadline_ms.saturating_sub(now_unix_ms()),
+                    configured_timeout_ms,
+                    effective_timeout_ms,
+                    "retrying",
                     Some(next_retry_ms),
                     recovery.as_deref(),
                 )?;
@@ -6876,9 +6905,24 @@ fn materialize_pending_cook_workspace_with_retry(
                     attempt,
                     deadline_ms,
                     deadline_ms.saturating_sub(now_unix_ms()),
+                    configured_timeout_ms,
+                    effective_timeout_ms,
+                    if provider_resolve_timeout(&error) {
+                        "exhausted"
+                    } else {
+                        "fail_closed"
+                    },
                     None,
                     recovery.as_deref(),
                 )?;
+                error.details["worktree_provider_resolve"] = lifecycle_store
+                    .read_controller_plan(&options.initial_run_id)?
+                    .metadata["worktree_provider_resolve"]
+                    .clone();
+                error.details["worktree_provider_resolve"]["started_unix_ms"] =
+                    Value::from(started_ms);
+                error.details["worktree_provider_resolve"]["elapsed_ms"] =
+                    Value::from(now_unix_ms().saturating_sub(started_ms));
                 if let Some(recovery) = recovery {
                     error.details["worktree_provider_cwd_recovery_command"] =
                         Value::String(recovery);
@@ -6928,12 +6972,61 @@ fn known_cwd_recovery_command(options: &AgentTaskCookServiceOptions) -> Option<S
     ))
 }
 
+fn configured_provider_id(options: &AgentTaskCookServiceOptions) -> Option<String> {
+    options
+        .initial_plan
+        .metadata
+        .pointer("/cook_provision/worktree_provider_id")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            options
+                .initial_plan
+                .metadata
+                .pointer("/cook_provision/workspace_identity/provider_id")
+                .and_then(Value::as_str)
+        })
+        .map(str::to_string)
+        .or_else(|| {
+            let config = homeboy_core::defaults::load_config();
+            let mut ids = config
+                .worktree_providers
+                .iter()
+                .filter(|(_, provider)| provider.enabled && provider.apply_enabled)
+                .map(|(id, _)| id.clone());
+            let provider_id = ids.next()?;
+            ids.next().is_none().then_some(provider_id)
+        })
+}
+
+fn configured_provider_lookup_timeout_ms(options: &AgentTaskCookServiceOptions) -> u64 {
+    let config = homeboy_core::defaults::load_config();
+    configured_provider_id(options)
+        .and_then(|id| {
+            config
+                .worktree_providers
+                .get(&id)
+                .map(|provider| provider.lookup_timeout_ms)
+        })
+        .or_else(|| {
+            config
+                .worktree_providers
+                .values()
+                .filter(|provider| provider.enabled && provider.apply_enabled)
+                .map(|provider| provider.lookup_timeout_ms)
+                .min()
+        })
+        .unwrap_or(0)
+}
+
 fn record_provider_resolve_evidence(
     lifecycle_store: &AgentTaskLifecycleStore,
     options: &mut AgentTaskCookServiceOptions,
     attempt: u32,
     deadline_ms: u64,
     remaining_ms: u64,
+    configured_timeout_ms: u64,
+    effective_timeout_ms: u64,
+    retry_disposition: &str,
     next_retry_ms: Option<u64>,
     recovery_command: Option<&str>,
 ) -> Result<()> {
@@ -6947,24 +7040,7 @@ fn record_provider_resolve_evidence(
                     .map(str::to_string)
             })
     });
-    let timeout_ms = options
-        .initial_plan
-        .metadata
-        .pointer("/cook_provision/worktree_provider_id")
-        .and_then(Value::as_str)
-        .or_else(|| {
-            options
-                .initial_plan
-                .metadata
-                .pointer("/cook_provision/workspace_identity/provider_id")
-                .and_then(Value::as_str)
-        })
-        .and_then(|provider_id| {
-            homeboy_core::defaults::load_config()
-                .worktree_providers
-                .get(provider_id)
-                .map(|provider| provider.lookup_timeout_ms)
-        });
+    let provider_id = configured_provider_id(options);
     let mut events = lifecycle_store
         .read_record(&options.initial_run_id)
         .ok()
@@ -6977,7 +7053,12 @@ fn record_provider_resolve_evidence(
     events.push(serde_json::json!({
         "attempt": attempt,
         "phase": "worktree_provider_lookup",
-        "timeout_ms": timeout_ms,
+        "provider_id": provider_id,
+        "configured_timeout_ms": configured_timeout_ms,
+        "effective_timeout_ms": effective_timeout_ms,
+        "started_unix_ms": now_unix_ms(),
+        "elapsed_ms": 0,
+        "retry_disposition": retry_disposition,
         "next_retry_unix_ms": next_retry_ms,
     }));
     let evidence = serde_json::json!({
@@ -6987,7 +7068,10 @@ fn record_provider_resolve_evidence(
         "max_attempts": COOK_PROVIDER_RESOLVE_ATTEMPTS,
         "deadline_unix_ms": deadline_ms,
         "remaining_ms": remaining_ms,
-        "timeout_ms": timeout_ms,
+        "provider_id": provider_id,
+        "configured_timeout_ms": configured_timeout_ms,
+        "effective_timeout_ms": effective_timeout_ms,
+        "retry_disposition": retry_disposition,
         "next_retry_unix_ms": next_retry_ms,
         "cwd_recovery_command": recovery_command,
         "events": events,

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -6846,6 +6846,10 @@ fn materialize_pending_cook_workspace_with_retry(
                 None,
                 None,
             )?;
+            error.details["worktree_provider_resolve"] = lifecycle_store
+                .read_controller_plan(&options.initial_run_id)?
+                .metadata["worktree_provider_resolve"]
+                .clone();
             return Err(error);
         }
         let configured_timeout_ms = configured_provider_lookup_timeout_ms(options);

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -5314,7 +5314,7 @@ fn deferred_provider_ensure_materializes_injected_lifecycle_plan_after_its_postc
             .expect("persist recipe in the injected recipe store");
         materialize_initial_cook_attempt_with_stores(&recipe_store, &lifecycle_store, &options)
             .expect("materialize run in the injected lifecycle store");
-        materialize_pending_cook_workspace(&lifecycle_store, &mut options)
+        materialize_pending_cook_workspace(&lifecycle_store, &mut options, None)
             .expect("materialize the ensured workspace in the injected lifecycle store");
 
         assert!(created.exists(), "ensure ran after durable Cook admission");
@@ -5985,7 +5985,7 @@ fn pending_cook_workspace_lookup_remains_bound_to_timed_out_provider() {
 
         let lifecycle_store =
             AgentTaskLifecycleStore::from_current_environment().expect("ambient lifecycle store");
-        materialize_pending_cook_workspace(&lifecycle_store, &mut options)
+        materialize_pending_cook_workspace(&lifecycle_store, &mut options, None)
             .expect("materialize original provider workspace");
 
         assert_eq!(

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -5011,7 +5011,7 @@ fn cook_persists_controller_admission_timeout_before_provider_execution() {
 
 #[cfg(unix)]
 #[test]
-fn provider_resolve_timeout_retries_with_durable_deadline_and_cwd_recovery() {
+fn persistent_slow_provider_with_known_path_returns_exhausted_cwd_recovery() {
     use std::os::unix::fs::PermissionsExt;
 
     homeboy_core::test_support::with_isolated_home(|_| {
@@ -5065,13 +5065,10 @@ fn provider_resolve_timeout_retries_with_durable_deadline_and_cwd_recovery() {
         let workspace = workspace.canonicalize().expect("canonical workspace");
         let provider_dir = tempfile::tempdir().expect("provider directory");
         let provider = provider_dir.path().join("provider");
-        let first_resolve = provider_dir.path().join("first-resolve");
         std::fs::write(
             &provider,
             format!(
-                "#!/bin/sh\nif test \"$1\" = identity; then\n  if test ! -f '{}'; then : > '{}'; sleep 1; fi\n  printf '%s\\n' '{{\"schema\":\"homeboy/worktree-provider-identity/v1\",\"provider_id\":\"fixture\",\"token\":\"recovered-identity\",\"handle\":\"fixture@cook-slow-worktree-lookup\",\"path\":\"{}\",\"branch\":\"cook-slow-worktree-lookup\",\"primary\":false,\"latency_ms\":0,\"budget_ms\":0}}'\nelse\n  printf '%s\\n' '{{\"schema\":\"homeboy/worktree-provider-safety/v1\",\"identity_token\":\"recovered-identity\",\"observed_at\":\"2026-01-01T00:00:00Z\",\"dirty\":false,\"unpushed\":false,\"fresh\":true,\"latency_ms\":0,\"budget_ms\":0}}'\nfi\n",
-                first_resolve.display(),
-                first_resolve.display(),
+                "#!/bin/sh\nsleep 1\nprintf '%s\\n' '{{\"schema\":\"homeboy/worktree-provider-identity/v1\",\"provider_id\":\"fixture\",\"token\":\"unreachable\",\"handle\":\"fixture@cook-slow-worktree-lookup\",\"path\":\"{}\",\"branch\":\"cook-slow-worktree-lookup\",\"primary\":false,\"latency_ms\":0,\"budget_ms\":0}}'\n",
                 workspace.display(),
             ),
         )
@@ -5138,9 +5135,9 @@ fn provider_resolve_timeout_retries_with_durable_deadline_and_cwd_recovery() {
 
         options.source_worktree_path = Some(workspace.clone());
         let result = run_cook(CookContext::new(options.clone(), Arc::new(UnusedExecutor)))
-            .expect("Cook retries and materializes the provider workspace");
+            .expect("Cook records exhausted provider timeout");
 
-        assert_eq!(result.exit_code, 0, "{:?}", result.value);
+        assert_eq!(result.exit_code, 1, "{:?}", result.value);
         assert_eq!(result.value.cook_id, cook_id);
         assert_eq!(result.value.latest_run_id.as_deref(), Some(run_id));
         let record = agent_task_lifecycle::status(run_id).expect("durable lookup record");
@@ -5153,6 +5150,10 @@ fn provider_resolve_timeout_retries_with_durable_deadline_and_cwd_recovery() {
         assert_eq!(
             persisted_plan.metadata["worktree_provider_resolve"]["attempt"],
             2
+        );
+        assert_eq!(
+            persisted_plan.metadata["worktree_provider_resolve"]["retry_disposition"],
+            "exhausted"
         );
         assert!(
             persisted_plan.metadata["worktree_provider_resolve"]["deadline_unix_ms"]
@@ -5179,10 +5180,7 @@ fn provider_resolve_timeout_retries_with_durable_deadline_and_cwd_recovery() {
             persisted_plan.metadata["cook_provision"]["handle"],
             exact_handle
         );
-        assert_eq!(
-            persisted_plan.tasks[0].workspace.root.as_deref(),
-            Some(workspace.to_str().expect("utf8 workspace"))
-        );
+        assert_eq!(persisted_plan.tasks[0].workspace.root, None);
     });
 }
 
@@ -5683,6 +5681,15 @@ fn split_identity_timeout_persists_legacy_lookup_pending_recipe_and_retry() {
             .as_str()
             .expect("replay command")
             .contains(provider.to_string_lossy().as_ref()));
+        let plan = agent_task_lifecycle::load_plan(run_id).expect("durable timeout plan");
+        assert_eq!(plan.metadata["worktree_provider_resolve"]["attempt"], 2);
+        assert_eq!(
+            plan.metadata["worktree_provider_resolve"]["retry_disposition"],
+            "exhausted"
+        );
+        assert!(plan.metadata["worktree_provider_resolve"]["cwd_recovery_command"].is_null());
+        assert_eq!(record.metadata["provider_executions_consumed"], 0);
+        assert!(record.metadata["provider_executions"].is_null());
         assert!(phases
             .lock()
             .expect("phase lock")

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -5600,7 +5600,8 @@ fn review_12349_deferred_lookup_cancellation_preserves_cancelled_state() {
 
 #[cfg(unix)]
 #[test]
-fn split_identity_timeout_persists_legacy_lookup_pending_recipe_and_retry() {
+fn short_cook_deadline_caps_resolve_timeout_without_starting_retry() {
+    use crate::agent_task_timeout::{now_unix_ms, with_current_cook_deadline, CookDeadline};
     use std::os::unix::fs::PermissionsExt;
     use std::sync::Mutex;
 
@@ -5620,7 +5621,7 @@ fn split_identity_timeout_persists_legacy_lookup_pending_recipe_and_retry() {
                 enabled: true,
                 kind: homeboy_core::defaults::WorktreeProviderKind::Command,
                 apply_enabled: true,
-                lookup_timeout_ms: 25,
+                lookup_timeout_ms: 5_000,
                 mutation_timeout_ms: 30_000,
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy_core::defaults::WorktreeProviderCommands {
@@ -5654,11 +5655,23 @@ fn split_identity_timeout_persists_legacy_lookup_pending_recipe_and_retry() {
                 .push((event.phase.to_string(), event.detail.map(str::to_string)));
             Ok(())
         };
-        let result = run_cook(CookContext {
-            durable_observer: Some(&observer),
-            ..CookContext::new(options, Arc::new(UnusedExecutor))
-        })
-        .expect("Cook records split lookup timeout");
+        let started = std::time::Instant::now();
+        let result = with_current_cook_deadline(
+            Some(CookDeadline::from_unix_ms(
+                now_unix_ms().saturating_add(200),
+            )),
+            || {
+                run_cook(CookContext {
+                    durable_observer: Some(&observer),
+                    ..CookContext::new(options, Arc::new(UnusedExecutor))
+                })
+            },
+        )
+        .expect("Cook records short-deadline lookup timeout");
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(2),
+            "effective lookup timeout must cap total pre-execution time"
+        );
         assert_eq!(result.value.status, "pre_execution_failure");
         let record = agent_task_lifecycle::status(run_id).expect("durable timeout record");
         assert_eq!(record.metadata["provider_executions_consumed"], 0);
@@ -5668,28 +5681,37 @@ fn split_identity_timeout_persists_legacy_lookup_pending_recipe_and_retry() {
             "timed_out"
         );
         assert_eq!(
-            record.metadata["pre_execution_failure"]["details"]["worktree_provider_id"],
-            "fixture"
-        );
-        assert_eq!(
             record.metadata["pre_execution_failure"]["details"]
                 ["worktree_provider_call_classification"],
             "timeout"
         );
-        assert!(record.metadata["pre_execution_failure"]["details"]
-            ["worktree_provider_replay_command"]
-            .as_str()
-            .expect("replay command")
-            .contains(provider.to_string_lossy().as_ref()));
         let plan = agent_task_lifecycle::load_plan(run_id).expect("durable timeout plan");
-        assert_eq!(plan.metadata["worktree_provider_resolve"]["attempt"], 2);
+        assert_eq!(plan.metadata["worktree_provider_resolve"]["attempt"], 1);
         assert_eq!(
             plan.metadata["worktree_provider_resolve"]["retry_disposition"],
-            "exhausted"
+            "deadline_expired"
         );
+        assert_eq!(
+            plan.metadata["worktree_provider_resolve"]["configured_timeout_ms"],
+            5_000
+        );
+        assert_eq!(
+            plan.metadata["worktree_provider_resolve"]["provider_id"],
+            "fixture"
+        );
+        assert!(plan.metadata["worktree_provider_resolve"]["events"]
+            .as_array()
+            .expect("resolve events")
+            .iter()
+            .any(|event| event["attempt"] == 1
+                && event["effective_timeout_ms"].as_u64().unwrap_or(u64::MAX) < 5_000));
         assert!(plan.metadata["worktree_provider_resolve"]["cwd_recovery_command"].is_null());
         assert_eq!(record.metadata["provider_executions_consumed"], 0);
         assert!(record.metadata["provider_executions"].is_null());
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["details"]["worktree_provider_resolve"],
+            plan.metadata["worktree_provider_resolve"]
+        );
         assert!(phases
             .lock()
             .expect("phase lock")


### PR DESCRIPTION
## Summary
- restore the omitted Cook resolve deadline cap and durable evidence corrections from merged #12895
- retain canonical --cwd recovery for known paths and fail-closed no-path behavior
- cover persistent and short-deadline resolve timeouts with zero provider executions

## Verification
- cargo fmt --check
- cargo check -p homeboy-agents
- cargo test -p homeboy-agents short_cook_deadline_caps_resolve_timeout_without_starting_retry --no-default-features
- cargo test -p homeboy-agents persistent_slow_provider_with_known_path_returns_exhausted_cwd_recovery --no-default-features
- cargo test -p homeboy-agents nonretryable_provider_failures_cannot_enter_the_resolve_retry_path --no-default-features

Related to #12825. Corrects omitted follow-up commits from merged #12895.

## AI assistance
OpenAI GPT-5.6-terra via OpenCode cherry-picked the omitted validated corrections onto current main, verified them with the declared shared Cargo target, and prepared this corrective PR. Chris Huber remains responsible for every line.