### PR TITLE
fix: restore Warning Clean on main

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -4,7 +4,6 @@ use std::fs::OpenOptions;
 use std::hash::{Hash, Hasher};
 use std::io::Write;
 use std::path::Path;
-use std::process::Command;
 use std::time::{Duration, Instant, SystemTime};
 
 use base64::Engine;


### PR DESCRIPTION
## Summary

Removes the unconditional `std::process::Command` import that makes the current main build fail under `RUSTFLAGS=-Dwarnings`. The live call sites in `workspace/sync/mod.rs` are fully qualified.

Closes #12923

## Investigation context

The reported daemon admission symbols are required behavior, not dead code:

- #12439 (`b54931da`, `1c4008ee`) uses an exclusive admission fence while `reconcile_unleased_candidates(..., apply = true)` proves state, signals candidates, and starts a replacement.
- Durable admissions take the shared side of the same lock.
- `reverse_runner_submission_cannot_persist_while_reconciliation_holds_admission_fence` asserts the Linux concurrency contract.
- #12912 exposed warnings after removing broad suppression; #12916 fixed other concurrent warning regressions. `3ed7602c` reintroduced this stale import after that repair.

## Verification

- `cargo fmt --all --check`
- `cargo check --locked -p homeboy --bin homeboy`
- `RUSTFLAGS=-Dwarnings cargo build --locked -p homeboy --bin homeboy`
- `cargo test --locked -p homeboy reverse_runner_submission_cannot_persist_while_reconciliation_holds_admission_fence -- --exact` (the test is `cfg(target_os = "linux")`; macOS compiled zero matching tests)

## Merge order

Standalone one-line fix based on `origin/main` at `8cdb0fa`; no prerequisite PR and no daemon behavior change.

## AI assistance

OpenAI gpt-5.6-sol via OpenCode traced the history and runtime semantics, identified the current warning-clean root, implemented the minimal fix, and ran verification. Chris Huber reviewed and remains responsible for every line.