### PR TITLE
fix(agent-task): fence planned runner publication

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
@@ -785,6 +785,10 @@ fn record_lab_offload_proxy_in_store(
 ) -> Result<AgentTaskRunRecord> {
     validate_lab_handoff_plan(durable_plan)?;
     let run_id = sanitize_run_id(requested_run_id);
+    // Planning and stale cleanup race for this controller-owned proxy. Use the
+    // same fence as acceptance and expiry so cleanup cannot terminalize a
+    // snapshot taken before this planned execution is durably published.
+    let _lock = LabHandoffLock::lock_in_store(lifecycle_store, &run_id)?;
     let input = DetachedLabRunRecord {
         run_id: &run_id,
         runner_id,

--- a/crates/homeboy-agents/src/agent_task_service/reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_service/reconcile.rs
@@ -226,6 +226,23 @@ pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileRe
                     .unwrap_or(authoritative_state)
             })
         } else {
+            // Discovery is a fleet snapshot. A Lab planner can publish its
+            // run-bound execution after that snapshot but before this cleanup
+            // reaches cancellation. Share the handoff fence with that writer,
+            // then decide from the fenced record so a fresh planned submission
+            // remains alive until normal expiry/acceptance reconciliation.
+            let _lock =
+                agent_task_lifecycle::LabHandoffLock::lock_in_store(&lifecycle_store, &run.run_id)?;
+            let fenced = lifecycle_store.read_record(&run.run_id)?;
+            if fenced.state.is_terminal()
+                || (fenced.has_planned_runner_execution() && fenced.has_fresh_update())
+                || agent_task_lifecycle::has_live_pending_runner_submission_intent(
+                    &fenced,
+                    chrono::Utc::now(),
+                )
+            {
+                continue;
+            }
             agent_task_lifecycle::cancel_run_in_store(&lifecycle_store, &run.run_id, Some(&reason))
                 .map(|record| record.state)
         };
@@ -669,6 +686,90 @@ mod tests {
                 agent_task_lifecycle::AgentTaskRunState::Cancelled
             );
             assert_eq!(terminal.metadata["cancel_reason"], "missing_runner_pid");
+        });
+    }
+
+    #[test]
+    fn concurrent_planned_submissions_survive_delayed_runner_identity_publication() {
+        use std::sync::{Arc, Barrier};
+
+        with_isolated_home(|_| {
+            register_orchestration_driver();
+            let run_ids = [
+                "reconcile-concurrent-planned-1",
+                "reconcile-concurrent-planned-2",
+                "reconcile-concurrent-planned-3",
+                "reconcile-concurrent-planned-4",
+            ];
+            for run_id in run_ids {
+                orphaned_running_run(run_id);
+                agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+                    record
+                        .metadata
+                        .as_object_mut()
+                        .expect("metadata object")
+                        .remove("runner_pid");
+                })
+                .expect("remove controller owner identity");
+            }
+
+            let published = Arc::new(Barrier::new(run_ids.len() + 1));
+            let release = Arc::new(Barrier::new(run_ids.len() + 1));
+            let mut planners = Vec::new();
+            for run_id in run_ids {
+                let published = Arc::clone(&published);
+                let release = Arc::clone(&release);
+                planners.push(std::thread::spawn(move || {
+                    let plan = AgentTaskPlan::new("concurrent-planned-runner", Vec::new());
+                    agent_task_lifecycle::record_lab_offload_phase(
+                        run_id,
+                        "homeboy-lab",
+                        "materializing",
+                        None,
+                        None,
+                        None,
+                        Some(&plan),
+                    )
+                    .expect("planned runner submission");
+                    published.wait();
+                    release.wait();
+                }));
+            }
+            published.wait();
+
+            let report = homeboy_core::daemon::orchestration::reconcile_stale_active_runs()
+                .expect("cleanup during delayed identity publication");
+            assert_eq!(report["reconciled"], 0, "{report}");
+            for run_id in run_ids {
+                let record = agent_task_lifecycle::status(run_id).expect("planned record");
+                assert!(!record.state.is_terminal(), "{run_id} was terminalized");
+                assert_eq!(
+                    record.metadata["runner_execution_record"]["status"],
+                    "planned"
+                );
+                assert!(record.metadata.get("cancel_reason").is_none());
+            }
+
+            release.wait();
+            for planner in planners {
+                planner.join().expect("planner thread");
+            }
+            for run_id in run_ids {
+                let accepted = agent_task_lifecycle::record_detached_lab_run(
+                    agent_task_lifecycle::DetachedLabRunRecord {
+                        run_id,
+                        runner_id: "homeboy-lab",
+                        runner_job_id: &format!("delayed-{run_id}"),
+                        remote_workspace: "/runner/workspace/homeboy",
+                        remote_command: &[],
+                    },
+                )
+                .expect("delayed identity publication");
+                assert_eq!(
+                    accepted.runner_job_id(),
+                    Some(format!("delayed-{run_id}").as_str())
+                );
+            }
         });
     }
 

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -4,7 +4,6 @@ use std::fs::OpenOptions;
 use std::hash::{Hash, Hasher};
 use std::io::Write;
 use std::path::Path;
-use std::process::Command;
 use std::time::{Duration, Instant, SystemTime};
 
 use base64::Engine;


### PR DESCRIPTION
## Summary
- fence controller-side Lab proxy planning with the existing handoff lock
- re-read stale cleanup candidates under that fence before terminalization
- cover four concurrent planned submissions with deliberately delayed daemon identity publication

Fixes #12926.

## Race And Contract
A cleanup sweep could classify a PID-less running record as stale, then a concurrent Lab planner would persist the fresh run-bound `planned` execution, and cleanup would still terminalize its old snapshot as `missing_runner_pid`. Planned publication and cleanup now share the Lab handoff fence. Cleanup decides from the fenced durable record and leaves fresh planned submissions, plus live pending submission intents, active until normal acceptance or expiry reconciliation. Genuine PID-less orphans still terminalize, and accepted-job identity validation remains unchanged.

## Verification
- `cargo test -p homeboy-agents agent_task_service::reconcile::tests -- --test-threads=1`
- `cargo test -p homeboy-agents status_keeps_fresh_planned_runner_submission_live -- --test-threads=1`
- `cargo fmt --check`
- `git diff --check`

## AI Assistance
OpenAI `openai/gpt-5.6-sol` via the OpenCode general coding subagent traced the lifecycle race, implemented the ordering fence and deterministic regressions, and ran focused verification. Chris Huber reviewed and remains responsible for every line.