### PR TITLE
fix(runner): scope bare doctor repairs

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -2551,7 +2551,7 @@ fn lost_runner_actions(runner_id: Option<&str>) -> Vec<CommandNextAction> {
         .with_kind(CommandNextActionKind::Show),
         CommandNextAction::new(
             format!("diagnose and repair runner {runner_id}"),
-            format!("homeboy runner doctor {runner} --repair"),
+            format!("homeboy runner doctor {runner} --scope lab-offload --repair"),
         )
         .with_kind(CommandNextActionKind::Repair),
     ]
@@ -3321,7 +3321,7 @@ mod diagnose_actionable_tests {
             vec![
                 "homeboy agent-task reconcile run-1 --dry-run",
                 "homeboy runner status homeboy-lab",
-                "homeboy runner doctor homeboy-lab --repair",
+                "homeboy runner doctor homeboy-lab --scope lab-offload --repair",
                 "homeboy agent-task evidence run-1 --task task-a --failure-only",
                 "homeboy --placement local agent-task retry run-1 --run",
             ]
@@ -3330,7 +3330,7 @@ mod diagnose_actionable_tests {
             repair_commands(&actions),
             vec![
                 "homeboy agent-task reconcile run-1 --dry-run",
-                "homeboy runner doctor homeboy-lab --repair",
+                "homeboy runner doctor homeboy-lab --scope lab-offload --repair",
                 "homeboy --placement local agent-task retry run-1 --run",
             ]
         );

--- a/crates/homeboy-cli/src/commands/runner/cli.rs
+++ b/crates/homeboy-cli/src/commands/runner/cli.rs
@@ -211,7 +211,7 @@ pub(super) enum RunnerCommand {
         #[arg(long, value_enum, default_value_t = RunnerDoctorScopeArg::General)]
         scope: RunnerDoctorScopeArg,
 
-        /// Safely repair issues in the selected scope, such as reconnecting a stale Lab daemon.
+        /// Safely repair issues in the selected scope, such as reconnecting a stale Lab daemon. Without --scope, repairs use lab-offload.
         #[arg(long)]
         repair: bool,
     },
@@ -823,6 +823,28 @@ mod tests {
             "--unknown"
         ])
         .is_err());
+    }
+
+    #[test]
+    fn doctor_repair_without_scope_selects_lab_offload_repair() {
+        let cli = Cli::try_parse_from(["homeboy", "runner", "doctor", "lab", "--repair"])
+            .expect("generated runner recovery command parses");
+        let Commands::Runner(RunnerArgs {
+            command:
+                RunnerCommand::Doctor {
+                    scope,
+                    repair: true,
+                    ..
+                },
+        }) = cli.command
+        else {
+            panic!("expected runner doctor repair command");
+        };
+
+        assert_eq!(
+            super::doctor::repair_scope(scope.into(), true),
+            doctor::RunnerDoctorScope::LabOffload
+        );
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
@@ -54,8 +54,9 @@ pub fn run(runner_id: &str) -> CmdResult<RunnerDoctorOutput> {
 
 pub fn run_with_options(
     runner_id: &str,
-    options: RunnerDoctorOptions,
+    mut options: RunnerDoctorOptions,
 ) -> CmdResult<RunnerDoctorOutput> {
+    options.scope = repair_scope(options.scope, options.repair);
     let target = target::resolve(runner_id)?;
     let mut report = match &target {
         target::RunnerTarget::Local { id, runner } => {
@@ -101,6 +102,17 @@ pub fn run_with_options(
     }
     let exit_code = report.status.operational_exit_code();
     Ok((report, exit_code))
+}
+
+/// A bare `--repair` is the Lab daemon recovery request emitted by runner
+/// recovery guidance. Resolve it before probing so that command both diagnoses
+/// and applies the repair it advertises.
+pub(super) fn repair_scope(scope: RunnerDoctorScope, repair: bool) -> RunnerDoctorScope {
+    if repair && scope == RunnerDoctorScope::General {
+        RunnerDoctorScope::LabOffload
+    } else {
+        scope
+    }
 }
 
 fn runner_summary(

--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/shape.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/shape.rs
@@ -27,6 +27,22 @@ fn doctor_options_default_to_general_read_only_scope() {
 }
 
 #[test]
+fn bare_repair_deterministically_selects_the_lab_offload_scope() {
+    assert_eq!(
+        repair_scope(RunnerDoctorScope::General, true),
+        RunnerDoctorScope::LabOffload
+    );
+    assert_eq!(
+        repair_scope(RunnerDoctorScope::General, false),
+        RunnerDoctorScope::General
+    );
+    assert_eq!(
+        repair_scope(RunnerDoctorScope::SecretEnv, true),
+        RunnerDoctorScope::SecretEnv
+    );
+}
+
+#[test]
 fn doctor_output_omits_empty_repairs() {
     let (report, _) = run("local").expect("local doctor report");
     let value = serde_json::to_value(report).expect("serialize report");


### PR DESCRIPTION
## Summary
- emit the Lab-scoped runner doctor repair command from generated stalled-run recovery guidance
- infer lab-offload before probes for legacy bare runner doctor repair invocations
- preserve read-only general doctor behavior and explicit secret-env repair scope

## Verification
- cargo fmt --check
- cargo test -p homeboy-cli doctor_repair_without_scope_selects_lab_offload_repair --lib
- cargo test -p homeboy-cli bare_repair_deterministically_selects_the_lab_offload_scope --lib
- cargo test -p homeboy-cli a_stalled_run_reconciles_and_repairs_the_runner_that_went_quiet --lib

Closes #12928

## AI Assistance
OpenAI openai/gpt-5.6-terra via an OpenCode general coding subagent traced the command path, implemented the scoped repair inference and regression tests, and ran the listed checks. Chris Huber remains responsible for every line.