### PR TITLE
fix(release): recover orphaned v0.353.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "homeboy"
-version = "0.352.0"
+version = "0.353.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = ["crates/homeboy-*", "crates/contracts/homeboy-*"]
 
 [package]
 name = "homeboy"
-version = "0.352.0"
+version = "0.353.0"
 edition = "2021"
 default-run = "homeboy"
 license = "MIT"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,78 @@ All notable changes to Homeboy CLI are documented in this file.
 
 (This file is embedded into the CLI binary and is also viewable via `homeboy changelog`.)
 
+## [0.353.0] - 2026-08-22
+
+### Changed
+- format daemon control imports
+- Revert "fix(ci): converge required gates ruleset"
+- bound short deadline provider resolve
+- cover persistent resolve timeout recovery
+- remove blanket dead_code suppression and delete what it hid
+- root the recipe freeze boundary
+- free two tests the rooted admission unblocked
+- let the controller admission follow the store's root
+- give every controller-runtime entry point a rooted form
+- clear the last dead items, one verified name at a time
+- delete test-only functions and the tests that call them
+- delete pass-through shims, point tests at the real entry
+- stop suppressing dead_code and delete what it finds
+
+### Fixed
+- reconcile live Cook ownership during upgrade admission
+- lease isolated source build output
+- admit verified source upgrade targets
+- reject bypassable required gates
+- preserve private upload admission
+- isolate daemon projection test state
+- repair main after the dead_code suppression removals
+- remove unused evidence alias helper
+- rearm local placement admission
+- restore legacy deferred provision
+- bound watch and prompt parsing
+- stabilize runtime overlay snapshots
+- bound provider resolve by deadline
+- keep evidence aliases warning-clean
+- dispatch materialized provider workspace
+- preserve compatible Cargo lease
+- preflight and isolate evidence uploads
+- bind projected evidence prompt paths
+- harden chunk upload lifecycle
+- harden provider evidence paths
+- project detached reverse broker terminal state
+- bind provider evidence admission
+- plan issue-derived preview workspaces
+- harden chunk evidence uploads
+- bootstrap target admission recovery
+- bound component list inventory
+- select providers from project targets
+- rewrite macOS evidence path aliases
+- honor local continuation placement
+- persist deferred workspace provision
+- bound chunked evidence uploads
+- reject merged unpushed candidates
+- stream provider evidence handoff
+- tighten provider evidence aliases
+- stream bounded provider artifacts
+- mirror evidence into the home holding the run's lease
+- admit macOS provider evidence aliases
+- normalize repository identity
+- unify candidate inventory projections
+- drop the contract scenario a stale branch resurrected
+- detect rig service implementation instead of the word for it
+- authorize runner artifact paths against the store's root
+- restore the admission lock entry point as test-only scaffolding
+- complete command output fixtures
+- root the run observer's store at the rig entry points
+- bound inline stdin cleanup
+- supervise untimed child output
+- distinguish unstarted commands
+- preserve wait observation failures
+- report lost transport observation
+- bound raw output artifacts
+- retain typed raw transport state
+- flush raw output before terminal phases
+
 ## [0.352.0] - 2026-08-22
 
 ### Added


### PR DESCRIPTION
## Summary

Recovers the `v0.353.0` release commit that GitHub tagged successfully but rejected when pushing to `main` because the live ruleset expected eight checks on the newly-created release SHA.

- Merges existing release-bot commit `255ac5fb2` into current `main`, preserving its generated version, lockfile, and changelog changes.
- Makes `v0.353.0` reachable from `main`, so release planning can use its intended baseline instead of refusing the orphaned tag.

Fixes #6806.

## Evidence

- Failed push/release: https://github.com/Extra-Chill/homeboy/actions/runs/32572539487
- Current planner failure before recovery: https://github.com/Extra-Chill/homeboy/actions/runs/32573933708
- `git merge-base --is-ancestor v0.353.0 HEAD` succeeds after the merge.
- `cargo fmt --all -- --check` passes.
- `bash .github/validate-required-gates.sh --local` passes.
- `cargo test -p homeboy-release release::planning_semver::tests::current_version_tag_reachability_allows_reachable_tag --lib` and `cargo run --quiet -- release homeboy --dry-run` could not start because Cargo held shared package/artifact locks for ten minutes; neither produced a test or planner result.

## AI Assistance

OpenAI `openai/gpt-5.6-sol` via OpenCode inspected the current GitHub release failures and tag graph, implemented the non-destructive recovery merge, and ran available repository-native verification. Chris Huber remains responsible for this change.