### PR TITLE
fix(ci): gate manual ruleset reconciliation on green main

### DIFF
--- a/.github/test-manage-required-gates-ruleset.sh
+++ b/.github/test-manage-required-gates-ruleset.sh
@@ -6,10 +6,11 @@ tmp="$(mktemp -d)"
 trap 'rm -rf "${tmp}"' EXIT
 
 workflow="${root}/.github/workflows/required-gates-ruleset.yml"
-grep -Fq 'schedule:' "${workflow}"
+grep -Fq 'workflow_dispatch:' "${workflow}"
 grep -Fq 'environment: main-ruleset-administration' "${workflow}"
 grep -Fq -- '--operation audit' "${workflow}"
 grep -Fq -- '--operation reconcile' "${workflow}"
+grep -Fq 'commits/${head}/check-runs' "${workflow}"
 grep -Fq 'bash .github/validate-required-gates.sh --github' "${workflow}"
 
 jq 'del(.rules[] | select(.type == "required_status_checks"))' \

--- a/.github/workflows/required-gates-ruleset.yml
+++ b/.github/workflows/required-gates-ruleset.yml
@@ -1,8 +1,6 @@
 name: Required Gates Ruleset
 
 on:
-  schedule:
-    - cron: '17 * * * *'
   workflow_dispatch:
     inputs:
       operation:
@@ -52,6 +50,10 @@ jobs:
           GH_TOKEN: ${{ secrets.HOMEBOY_RULESET_ADMIN_TOKEN }}
         run: |
           test -n "${GH_TOKEN}"
+          head="$(git rev-parse HEAD)"
+          gh api "repos/${GITHUB_REPOSITORY}/commits/${head}/check-runs" \
+            --jq 'any(.check_runs[]; .name == "homeboy / Test" and .conclusion == "success")' \
+            | grep -qx true
           bash .github/manage-required-gates-ruleset.sh --operation reconcile --evidence required-gates-ruleset-reconcile.json
           bash .github/validate-required-gates.sh --github
       - uses: actions/upload-artifact@v4

--- a/docs/operations/required-ci-gates.md
+++ b/docs/operations/required-ci-gates.md
@@ -130,9 +130,10 @@ without wiring it into the terminal job turns `Required Gates Declaration` red.
 ## Apply And Verify
 
 The GitHub ruleset is repository state, so it cannot be changed by a pull
-request. `Required Gates Ruleset` audits the existing ruleset every hour from
-`main`, fails on drift, and uploads its before/desired/after evidence. It does
-not create another ruleset. Configure the `main-ruleset-administration`
+request. `Required Gates Ruleset` is an approved manual operation from `main`.
+It does not create another ruleset. Reconciliation first requires a successful
+`homeboy / Test` check on the current `main` SHA, so it cannot re-enable strict
+required checks while the main suite is red. Configure the `main-ruleset-administration`
 environment with required reviewers and a repository-administration token named
 `HOMEBOY_RULESET_ADMIN_TOKEN`; only the approved manual reconciliation job can
 use that credential.


### PR DESCRIPTION
## Summary

Reapplies corrective commit `58914f6a2` against current `main` without changing the live ruleset.

- Removes the scheduled ruleset workflow trigger; audit and reconcile remain manual operations.
- Keeps reconciliation behind the `main-ruleset-administration` environment and requires a successful `homeboy / Test` check run for the exact checked-out `main` SHA before any reconcile request.
- Preserves the documented deliberate `unenforced` live state.

References `d7617f6`, #12922, and #12833.

## Verification

- `bash .github/test-manage-required-gates-ruleset.sh`
- `cargo test --test required_gates_policy_test` (20 passed)
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `bash .github/validate-required-gates.sh --report` (read-only; reports the intentional `unenforced` state)
- Read-only GitHub API inspection of ruleset `13680120` and check runs for current `main` SHA

## AI assistance

OpenAI `gpt-5.6-sol` via OpenCode re-applied the corrective patch, resolved it against current `main`, ran the listed validation, and prepared this PR. Chris Huber remains responsible for every line.