### PR TITLE
fix(fanout): bound authoritative workspace lookup

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -3928,9 +3928,7 @@ fn validate_batch_cook_gates(
 }
 
 fn batch_gate_workspace(args: &AgentTaskFanoutCookBatchArgs) -> Result<Option<std::path::PathBuf>> {
-    let component = homeboy::core::component::registered()?
-        .into_iter()
-        .find(|component| component.id == args.repo);
+    let component = homeboy::core::component::registered_by_id(&args.repo)?;
     let Some(component) = component else {
         return Ok(None);
     };
@@ -3948,9 +3946,7 @@ fn batch_plan_gate_workspace(plan: &BatchCookFanoutPlan) -> Result<Option<std::p
         return Ok(None);
     }
     let repository = repositories.into_iter().next().expect("one repository");
-    let component = homeboy::core::component::registered()?
-        .into_iter()
-        .find(|component| component.id == repository);
+    let component = homeboy::core::component::registered_by_id(repository)?;
     let Some(component) = component else {
         return Ok(None);
     };
@@ -5911,6 +5907,58 @@ fi
     }
 
     #[test]
+    fn fanout_dry_run_bounds_gate_workspace_lookup_in_a_large_registry() {
+        with_isolated_home(|home| {
+            let target = home.path().join("target");
+            std::fs::create_dir(&target).expect("target workspace");
+            std::fs::write(target.join("homeboy.json"), r#"{"id":"fixture"}"#)
+                .expect("target manifest");
+            write_component_registration(home.path(), "fixture", &target);
+
+            for index in 0..300 {
+                let id = format!("unrelated-{index}");
+                let workspace = home.path().join(&id);
+                std::fs::create_dir(&workspace).expect("unrelated workspace");
+                std::fs::write(
+                    workspace.join("homeboy.json"),
+                    serde_json::json!({ "id": id }).to_string(),
+                )
+                .expect("unrelated manifest");
+                write_component_registration(home.path(), &id, &workspace);
+            }
+
+            let mut args = cook_batch_args();
+            args.repo = "fixture".to_string();
+            args.issues = (1..=4)
+                .map(|issue| format!("https://github.com/Extra-Chill/homeboy/issues/{issue}"))
+                .collect();
+            let started = Instant::now();
+            let (value, exit_code) = cook_batch(args).expect("bounded four-child dry run");
+            let rows = value["worktrees"]["rows"]
+                .as_array()
+                .expect("worktree rows");
+            let planned_handles = value["plan"]["cooks"]
+                .as_array()
+                .expect("planned cooks")
+                .iter()
+                .map(|cook| cook["to_worktree"].as_str().expect("planned handle"))
+                .collect::<BTreeSet<_>>();
+            let projected_handles = rows
+                .iter()
+                .map(|row| row["handle"].as_str().expect("projected handle"))
+                .collect::<BTreeSet<_>>();
+
+            assert_eq!(exit_code, 0, "{value}");
+            assert!(
+                started.elapsed() < DRY_RUN_PHASE_TIMEOUT,
+                "targeted registry lookup exceeded the normal planner deadline"
+            );
+            assert_eq!(rows.len(), 4);
+            assert_eq!(projected_handles, planned_handles);
+        });
+    }
+
+    #[test]
     fn cook_batch_repo_normalization_accepts_slugs_and_registered_primary_paths() {
         with_isolated_home(|home| {
             let primary = home.path().join("primary");
@@ -7106,6 +7154,32 @@ fi
             .as_str()
             .expect("replay command")
             .contains("--dry-run"));
+    }
+
+    #[test]
+    fn dry_run_planner_attributes_a_slow_workspace_lookup_to_its_exact_phase() {
+        let args = cook_batch_args();
+        let mut planner = DryRunPlanner::new(&args);
+        planner.phase_timeout = Duration::from_millis(20);
+
+        let error = planner
+            .run_bounded(
+                "gate_workspace",
+                "authoritative registered workspace",
+                || {
+                    std::thread::sleep(Duration::from_secs(2));
+                    Ok(())
+                },
+            )
+            .expect_err("slow workspace lookup must be bounded");
+
+        assert_eq!(error.details["reason"], "planner_deadline_exceeded");
+        assert_eq!(error.details["phase"], "gate_workspace");
+        assert!(error.details["phase_elapsed_ms"].as_u64().unwrap() >= 20);
+        assert_eq!(
+            error.details["unresolved_dependency"],
+            "authoritative registered workspace"
+        );
     }
 
     #[test]

--- a/crates/homeboy-core/src/component/inventory/tests.rs
+++ b/crates/homeboy-core/src/component/inventory/tests.rs
@@ -539,6 +539,35 @@ fn load_resolves_the_selected_registration_without_requiring_global_inventory() 
     );
 }
 
+#[test]
+fn registered_by_id_inspects_only_the_selected_workspace_in_a_large_registry() {
+    let dir = temp_home_dir();
+    let target_repo = dir.path().join("target-repo");
+    fs::create_dir_all(&target_repo).unwrap();
+    write_portable_id(&target_repo, "target");
+    let _home = with_home_override(dir.path());
+    let components = crate::paths::components().unwrap();
+    fs::create_dir_all(&components).unwrap();
+    write_standalone_json(&components, "target", &target_repo.to_string_lossy());
+
+    for index in 0..300 {
+        let id = format!("unrelated-{index}");
+        let repo = dir.path().join(&id);
+        fs::create_dir_all(&repo).unwrap();
+        write_portable_id(&repo, &id);
+        write_standalone_json(&components, &id, &repo.to_string_lossy());
+    }
+
+    crate::component::portable::take_discovery_paths_for_test();
+    let component = registered_by_id("target")
+        .unwrap()
+        .expect("target component");
+    let discovery_paths = crate::component::portable::take_discovery_paths_for_test();
+
+    assert_eq!(component.local_path, target_repo.to_string_lossy());
+    assert_eq!(discovery_paths, vec![target_repo]);
+}
+
 #[cfg(unix)]
 #[test]
 fn registered_base_returns_before_a_sleeping_git_enrichment_probe() {


### PR DESCRIPTION
## Summary

Bound fanout authoritative gate-workspace resolution to the selected component registration so unrelated high-cardinality workspace entries cannot consume the dry-run planner deadline.

## Changes

- Resolve both argument-backed and persisted-plan gate workspaces with `registered_by_id` instead of expanding the full registered component inventory.
- Add a 300-registration, four-child dry-run regression that completes within the normal planner phase deadline and projects only the four planned issue-owned worktree handles.
- Add component-inventory coverage proving targeted lookup opens only the selected registered workspace.
- Add timeout coverage asserting `gate_workspace`, elapsed phase cost, and `authoritative registered workspace` dependency evidence.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-core registered_by_id_inspects_only_the_selected_workspace_in_a_large_registry`
- `cargo test -p homeboy-cli fanout_dry_run_bounds_gate_workspace_lookup_in_a_large_registry`
- `cargo test -p homeboy-cli dry_run_planner_attributes_a_slow_workspace_lookup_to_its_exact_phase`
- `cargo check -p homeboy-core -p homeboy-cli --all-targets`
- `git diff --check origin/main...HEAD`

Fixes #12924

## AI Assistance

OpenAI `openai/gpt-5.6-sol` via OpenCode general coding subagents traced the planner dependency, completed the implementation and tests, and prepared this pull request. Chris Huber reviewed the outcome and remains responsible for every line.