### PR TITLE
fix(cook): expose safe notification route resolution

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/notification_transport_config.rs
+++ b/crates/contracts/homeboy-extension-contract/src/notification_transport_config.rs
@@ -38,6 +38,10 @@ pub struct NotificationRouteResolverResponse {
     pub status: NotificationRouteResolverStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub route: Option<String>,
+    /// Extension-owned names for caller context that would permit a match.
+    /// Values are never included, keeping resolver diagnostics safe to persist.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub missing_context: Vec<String>,
 }
 
 /// Safe, read-only transport metadata exposed by extension discovery surfaces.

--- a/crates/contracts/homeboy-lab-contract/src/notification_route.rs
+++ b/crates/contracts/homeboy-lab-contract/src/notification_route.rs
@@ -7,11 +7,67 @@ use serde::{Deserialize, Serialize};
 use homeboy_error::{Error, Result};
 
 pub const NOTIFICATION_ROUTE_METADATA_KEY: &str = "notification_route";
+pub const NOTIFICATION_RESOLUTION_METADATA_KEY: &str = "notification_resolution";
 pub const NOTIFICATION_TRANSPORT_ENV: &str = "HOMEBOY_NOTIFICATION_TRANSPORT";
 pub const NOTIFICATION_ROUTE_ENV: &str = "HOMEBOY_NOTIFICATION_ROUTE";
+pub const NOTIFICATION_RESOLUTION_ENV: &str = "HOMEBOY_NOTIFICATION_RESOLUTION";
 
 thread_local! {
     static CURRENT_NOTIFICATION_ROUTE: RefCell<Option<NotificationRoute>> = const { RefCell::new(None) };
+    static CURRENT_NOTIFICATION_RESOLUTION: RefCell<Option<NotificationRouteResolution>> = const { RefCell::new(None) };
+}
+
+/// Safe evidence of how a notification route was selected. This intentionally
+/// never includes the opaque route value.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NotificationRouteResolution {
+    pub schema: String,
+    pub classification: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transport: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolver_transport: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub missing_context: Vec<String>,
+}
+
+impl NotificationRouteResolution {
+    pub fn new(classification: impl Into<String>) -> Self {
+        Self {
+            schema: "homeboy/notification-route-resolution/v1".to_string(),
+            classification: classification.into(),
+            transport: None,
+            resolver_transport: None,
+            missing_context: Vec::new(),
+        }
+    }
+
+    pub fn insert_into_metadata(&self, metadata: &mut serde_json::Value) {
+        if !metadata.is_object() {
+            *metadata = serde_json::json!({});
+        }
+        metadata[NOTIFICATION_RESOLUTION_METADATA_KEY] =
+            serde_json::to_value(self).expect("notification resolution is serializable");
+    }
+
+    pub fn validate(&self) -> bool {
+        self.schema == "homeboy/notification-route-resolution/v1"
+            && matches!(
+                self.classification.as_str(),
+                "explicit" | "environment" | "resolver" | "route_less" | "invalid"
+            )
+            && self.transport.as_deref().is_none_or(valid_transport_id)
+            && self
+                .resolver_transport
+                .as_deref()
+                .is_none_or(valid_transport_id)
+            && self.missing_context.len() <= 32
+            && self
+                .missing_context
+                .iter()
+                .all(|field| valid_safe_identifier(field, 128))
+    }
 }
 
 /// An opaque, non-secret destination owned by an installed notification transport.
@@ -32,12 +88,7 @@ impl NotificationRoute {
     }
 
     pub fn validate(&self) -> Result<()> {
-        let valid_transport = !self.transport.is_empty()
-            && self.transport.len() <= 64
-            && self
-                .transport
-                .bytes()
-                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'));
+        let valid_transport = valid_transport_id(&self.transport);
         if !valid_transport {
             return Err(Error::validation_invalid_argument(
                 "notification_transport",
@@ -54,7 +105,7 @@ impl NotificationRoute {
             return Err(Error::validation_invalid_argument(
                 "notification_route",
                 "must be a non-empty, at most 4096-character opaque non-secret value without control characters or credential syntax",
-                Some(self.route.clone()),
+                None,
                 None,
             ));
         }
@@ -133,14 +184,48 @@ pub fn from_cli_or_env(
 /// through the environment therefore adds no exposure the delivery path did not
 /// already have.
 pub fn child_env(route: Option<&NotificationRoute>) -> Vec<(&'static str, String)> {
-    route
+    let mut environment = route
         .map(|route| {
             vec![
                 (NOTIFICATION_TRANSPORT_ENV, route.transport.clone()),
                 (NOTIFICATION_ROUTE_ENV, route.route.clone()),
             ]
         })
-        .unwrap_or_default()
+        .unwrap_or_default();
+    if let Some(resolution) = current_resolution().filter(NotificationRouteResolution::validate) {
+        environment.push((
+            NOTIFICATION_RESOLUTION_ENV,
+            serde_json::to_string(&resolution).expect("notification resolution is serializable"),
+        ));
+    }
+    environment
+}
+
+pub fn propagated_resolution_from_env(
+    route: Option<&NotificationRoute>,
+) -> Option<NotificationRouteResolution> {
+    let resolution = serde_json::from_str::<NotificationRouteResolution>(
+        &std::env::var(NOTIFICATION_RESOLUTION_ENV).ok()?,
+    )
+    .ok()?;
+    let matching_transport = match (resolution.transport.as_deref(), route) {
+        (Some(transport), Some(route)) => transport == route.transport,
+        (None, None) => true,
+        _ => false,
+    };
+    (resolution.validate() && matching_transport).then_some(resolution)
+}
+
+fn valid_transport_id(transport: &str) -> bool {
+    valid_safe_identifier(transport, 64)
+}
+
+fn valid_safe_identifier(value: &str, max_len: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= max_len
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
 }
 
 fn contains_credential_syntax(route: &str) -> bool {
@@ -166,6 +251,23 @@ pub fn with_current<T>(route: Option<NotificationRoute>, operation: impl FnOnce(
 
 pub fn current() -> Option<NotificationRoute> {
     CURRENT_NOTIFICATION_ROUTE.with(|current| current.borrow().clone())
+}
+
+/// Bind route-resolution evidence for the command lifetime.
+pub fn with_current_resolution<T>(
+    resolution: Option<NotificationRouteResolution>,
+    operation: impl FnOnce() -> T,
+) -> T {
+    CURRENT_NOTIFICATION_RESOLUTION.with(|current| {
+        let previous = current.replace(resolution);
+        let result = operation();
+        current.replace(previous);
+        result
+    })
+}
+
+pub fn current_resolution() -> Option<NotificationRouteResolution> {
+    CURRENT_NOTIFICATION_RESOLUTION.with(|current| current.borrow().clone())
 }
 
 /// A route captured from one thread so it can be re-bound on another.
@@ -212,11 +314,30 @@ mod tests {
     }
 
     #[test]
+    fn resolution_evidence_persists_without_the_opaque_route() {
+        let resolution = NotificationRouteResolution {
+            schema: "homeboy/notification-route-resolution/v1".to_string(),
+            classification: "route_less".to_string(),
+            transport: None,
+            resolver_transport: Some("example.completed".to_string()),
+            missing_context: vec!["CALLER_THREAD_ID".to_string()],
+        };
+        let mut metadata = serde_json::json!({});
+        resolution.insert_into_metadata(&mut metadata);
+        let serialized = serde_json::to_string(&metadata).unwrap();
+        assert!(serialized.contains("CALLER_THREAD_ID"));
+        assert!(!serialized.contains("opaque-destination"));
+    }
+
+    #[test]
     fn malformed_route_is_rejected() {
         assert!(NotificationRoute::new("bad transport", "route").is_err());
         assert!(NotificationRoute::new("extension", "").is_err());
         assert!(NotificationRoute::new("extension", "line\nbreak").is_err());
         assert!(NotificationRoute::new("extension", "token=credential").is_err());
+        let error = NotificationRoute::new("extension", "opaque\ndestination").unwrap_err();
+        assert!(error.details.get("id").is_none());
+        assert!(!error.details.to_string().contains("destination"));
     }
 
     #[test]
@@ -272,6 +393,52 @@ mod tests {
                 (NOTIFICATION_ROUTE_ENV, "opaque/thread 42".to_string()),
             ]
         );
+    }
+
+    #[test]
+    fn child_env_carries_safe_resolution_evidence_without_the_route() {
+        let route = NotificationRoute::new("generic.completed", "opaque-destination").unwrap();
+        let mut resolution = NotificationRouteResolution::new("resolver");
+        resolution.transport = Some("generic.completed".to_string());
+        resolution.resolver_transport = Some("generic.completed".to_string());
+
+        let environment =
+            with_current_resolution(Some(resolution.clone()), || child_env(Some(&route)));
+        let serialized = environment
+            .iter()
+            .find_map(|(name, value)| (*name == NOTIFICATION_RESOLUTION_ENV).then_some(value))
+            .expect("resolution environment");
+
+        assert_eq!(
+            serde_json::from_str::<NotificationRouteResolution>(serialized).unwrap(),
+            resolution
+        );
+        assert!(!serialized.contains("opaque-destination"));
+    }
+
+    #[test]
+    fn propagated_resolution_requires_the_same_transport() {
+        let _lock = env_lock().lock().unwrap();
+        let old_resolution = std::env::var(NOTIFICATION_RESOLUTION_ENV).ok();
+        let route = NotificationRoute::new("generic.completed", "opaque-destination").unwrap();
+        let mut resolution = NotificationRouteResolution::new("resolver");
+        resolution.transport = Some("generic.completed".to_string());
+        std::env::set_var(
+            NOTIFICATION_RESOLUTION_ENV,
+            serde_json::to_string(&resolution).unwrap(),
+        );
+
+        assert_eq!(
+            propagated_resolution_from_env(Some(&route)),
+            Some(resolution)
+        );
+        let other_route = NotificationRoute::new("other.completed", "other-route").unwrap();
+        assert!(propagated_resolution_from_env(Some(&other_route)).is_none());
+
+        match old_resolution {
+            Some(value) => std::env::set_var(NOTIFICATION_RESOLUTION_ENV, value),
+            None => std::env::remove_var(NOTIFICATION_RESOLUTION_ENV),
+        }
     }
 
     /// A half-set pair is a hard error in `from_cli_or_env`, so an absent route

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1761,6 +1761,9 @@ where
     if let Some(route) = homeboy_core::notification_route::current() {
         route.insert_into_metadata(&mut metadata);
     }
+    if let Some(resolution) = homeboy_core::notification_route::current_resolution() {
+        resolution.insert_into_metadata(&mut metadata);
+    }
     if let Some(submission_metadata) = submission_metadata {
         metadata
             .as_object_mut()

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -254,6 +254,30 @@ fn submit_plan_persists_queued_status() {
     });
 }
 
+#[test]
+fn submit_plan_persists_safe_route_resolution_without_a_destination() {
+    with_isolated_home(|_| {
+        let mut resolution =
+            homeboy_core::notification_route::NotificationRouteResolution::new("route_less");
+        resolution.resolver_transport = Some("generic.completed".to_string());
+        resolution.missing_context = vec!["CALLER_THREAD_ID".to_string()];
+
+        let record = homeboy_core::notification_route::with_current_resolution(
+            Some(resolution.clone()),
+            || submit_plan(&test_plan(), Some("route-less-cook")).expect("submitted"),
+        );
+
+        assert_eq!(
+            record.metadata["notification_resolution"],
+            serde_json::to_value(resolution).unwrap()
+        );
+        assert!(record.metadata.get("notification_route").is_none());
+        assert!(!serde_json::to_string(&record.metadata)
+            .unwrap()
+            .contains("opaque-destination"));
+    });
+}
+
 #[cfg(unix)]
 #[test]
 fn controller_runtime_retention_keeps_mutable_and_retained_terminal_runs() {

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -573,12 +573,12 @@ impl CliRuntime {
         };
         let mut cli = compiled.value;
         let command_provenance = compiled.provenance;
-        let mut notification_route =
-            match crate::core::notification_route_resolver::resolve_from_cli_or_env(
+        let mut notification_resolution =
+            match crate::core::notification_route_resolver::resolve_from_cli_or_env_with_evidence(
                 cli.notification_transport.as_deref(),
                 cli.notification_route.as_deref(),
             ) {
-                Ok(route) => route,
+                Ok(resolution) => resolution,
                 Err(err) => {
                     output_runtime::emit_json_result_for_identity(
                         Err(err),
@@ -589,6 +589,7 @@ impl CliRuntime {
                     return std::process::ExitCode::from(2);
                 }
             };
+        let mut notification_route = notification_resolution.route.clone();
         if let Some(route) = &notification_route {
             // Placement routing happens before the thread-local command scope.
             // Mirror the selected route into its existing durable handoff input.
@@ -668,22 +669,42 @@ impl CliRuntime {
                 )
         ) && notification_route.is_none()
         {
-            notification_route = match crate::core::notification_route_resolver::resolve_installed()
-            {
-                Ok(route) => route,
-                Err(err) => {
-                    output_runtime::emit_json_result_for_identity(
-                        Err(err),
-                        output_file.as_deref(),
-                        2,
-                        &command_identity,
-                    );
-                    return std::process::ExitCode::from(2);
-                }
-            };
+            notification_resolution =
+                match crate::core::notification_route_resolver::resolve_installed_with_evidence() {
+                    Ok(resolution) => resolution,
+                    Err(err) => {
+                        output_runtime::emit_json_result_for_identity(
+                            Err(err),
+                            output_file.as_deref(),
+                            2,
+                            &command_identity,
+                        );
+                        return std::process::ExitCode::from(2);
+                    }
+                };
+            notification_route = notification_resolution.route.clone();
             if let Some(route) = &notification_route {
                 cli.notification_transport = Some(route.transport.clone());
                 cli.notification_route = Some(route.route.clone());
+            }
+        }
+        if cli.detach_after_handoff
+            && notification_route.is_none()
+            && matches!(
+                &cli.command,
+                Commands::AgentTask(agent_task)
+                    if matches!(
+                        &agent_task.command,
+                        crate::commands::agent_task::AgentTaskCommand::Cook(_)
+                    )
+            )
+        {
+            if let Some(warning) =
+                crate::commands::agent_task::run::detached_cook_route_less_warning(
+                    &notification_resolution.evidence,
+                )
+            {
+                eprintln!("{warning}");
             }
         }
 
@@ -742,11 +763,18 @@ impl CliRuntime {
         // placement routing can consume controller transport markers.
         crate::commands::utils::execution_provenance::capture(&cli, &normalized);
 
-        let route_result = crate::commands::route::route_after_parse_with_provenance(
-            &cli,
-            &normalized,
-            output_file.as_deref(),
-            Some(&command_provenance),
+        let route_result = crate::core::notification_route::with_current_resolution(
+            Some(notification_resolution.evidence.clone()),
+            || {
+                crate::core::notification_route::with_current(notification_route.clone(), || {
+                    crate::commands::route::route_after_parse_with_provenance(
+                        &cli,
+                        &normalized,
+                        output_file.as_deref(),
+                        Some(&command_provenance),
+                    )
+                })
+            },
         );
         if managed_runner_placement {
             resource_policy::clear_managed_runner_placement_context();
@@ -773,18 +801,23 @@ impl CliRuntime {
 
         run_startup_update_checks(&cli.command);
 
-        let exit_code = crate::core::notification_route::with_current(notification_route, || {
-            #[cfg(test)]
-            record_marker_context_before_run_command();
-            commands::output_runtime::run_command(
-                cli.command,
-                command_spec,
-                output_file.as_deref(),
-                &command_identity,
-                command_provenance,
-                cli.placement,
-            )
-        });
+        let exit_code = crate::core::notification_route::with_current_resolution(
+            Some(notification_resolution.evidence),
+            || {
+                crate::core::notification_route::with_current(notification_route, || {
+                    #[cfg(test)]
+                    record_marker_context_before_run_command();
+                    commands::output_runtime::run_command(
+                        cli.command,
+                        command_spec,
+                        output_file.as_deref(),
+                        &command_identity,
+                        command_provenance,
+                        cli.placement,
+                    )
+                })
+            },
+        );
         // The command's initial outcome is now durable and returned. Historical
         // runner evidence is a separately owned
         // best-effort recovery concern and cannot delay that boundary.

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -155,6 +155,30 @@ pub(crate) fn cook_attached_local_placement_disclosure(
     })
 }
 
+/// Warn before a detached Cook becomes observable only through durable status.
+pub(crate) fn detached_cook_route_less_warning(
+    resolution: &homeboy::core::notification_route::NotificationRouteResolution,
+) -> Option<String> {
+    if resolution.classification != "route_less" {
+        return None;
+    }
+    let resolver = resolution
+        .resolver_transport
+        .as_deref()
+        .map(|transport| format!(" installed resolver transport {transport}"))
+        .unwrap_or_else(|| " no installed resolver transport matched".to_string());
+    let missing = (!resolution.missing_context.is_empty()).then(|| {
+        format!(
+            "; provide caller context: {}",
+            resolution.missing_context.join(", ")
+        )
+    });
+    Some(format!(
+        "cook: detached notification route is route-less;{resolver}{missing}. Terminal updates will not return to the launching notification destination; inspect them with `homeboy agent-task status <cook-id>`",
+        missing = missing.unwrap_or_default(),
+    ))
+}
+
 fn cook_resolved_policy_disclosure(max_attempts: u32, plan: &AgentTaskPlan) -> String {
     let budget = &plan.options.execution_budget;
     format!(
@@ -231,6 +255,7 @@ pub(crate) fn preview_cook(
     let (args, provision) = resolve_cook_preview_destination(args)?;
     let replay = cook_preview_replay_argv(&args);
     let placement = preview_placement_policy_with_admission(&replay.argv);
+    let notification_resolution = homeboy::core::notification_route::current_resolution();
     if matches!(
         provision["action"].as_str(),
         Some("materialization_required" | "unresolved_provider")
@@ -247,6 +272,7 @@ pub(crate) fn preview_cook(
                     "head": args.head,
                     "placement": placement,
                     "workspace": provision,
+                    "notification_resolution": notification_resolution,
                 },
                 "replay_argv": replay.argv,
                 "replay_requires": replay.requires,
@@ -353,6 +379,7 @@ pub(crate) fn preview_cook(
                     "draft": args.draft_pr,
                     "ai_tool": args.ai_tool,
                 },
+                "notification_resolution": notification_resolution,
             },
             "replay_argv": replay.argv,
             "replay_requires": replay.requires,
@@ -5842,7 +5869,8 @@ mod tests {
     use super::{
         cook_attached_local_placement_disclosure, cook_continuation_status,
         cook_provider_timeout_disclosure, cook_report_with_continuation,
-        cook_resolved_policy_disclosure, durable_cook_identity_lines, preflight_continue_cook,
+        cook_resolved_policy_disclosure, detached_cook_route_less_warning,
+        durable_cook_identity_lines, preflight_continue_cook,
     };
     use crate::commands::agent_task::args::CookContinueArgs;
 
@@ -5928,6 +5956,22 @@ mod tests {
             None
         );
         assert_eq!(cook_attached_local_placement_disclosure(None, false), None);
+    }
+
+    #[test]
+    fn detached_route_less_warning_names_only_safe_resolver_diagnostics() {
+        let mut resolution =
+            homeboy::core::notification_route::NotificationRouteResolution::new("route_less");
+        resolution.resolver_transport = Some("generic.completed".to_string());
+        resolution.missing_context = vec!["CALLER_THREAD_ID".to_string()];
+
+        let warning = detached_cook_route_less_warning(&resolution).expect("warning");
+        assert!(warning.contains("generic.completed"));
+        assert!(warning.contains("CALLER_THREAD_ID"));
+        assert!(!warning.contains("opaque-destination"));
+
+        resolution.classification = "resolver".to_string();
+        assert!(detached_cook_route_less_warning(&resolution).is_none());
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -220,6 +220,7 @@ fn status_once(args: StatusArgs) -> CmdResult<Value> {
     // and the flag says so instead of leaving the caller to guess (#W3-15).
     attach_reconciled(&mut value, false);
     attach_status_identity(&mut value, &args.run_id, &target);
+    attach_notification_resolution(&mut value, &record);
     attach_cook_notification_delivery(&mut value, &record, &target);
     attach_durable_read_availability(&mut value, &durable_read.unavailable_sources);
     attach_cook_completion(&mut value, &record);
@@ -779,6 +780,15 @@ fn attach_cook_notification_delivery(
     }
     if let Value::Object(fields) = value {
         fields.insert("notification_delivery".to_string(), outcome);
+    }
+}
+
+fn attach_notification_resolution(value: &mut Value, record: &AgentTaskRunRecord) {
+    let Some(resolution) = record.metadata.get("notification_resolution") else {
+        return;
+    };
+    if let Value::Object(fields) = value {
+        fields.insert("notification_resolution".to_string(), resolution.clone());
     }
 }
 
@@ -5055,6 +5065,18 @@ fn compact_status_summary_with_aggregate(
             ],
         );
     }
+    if let Some(resolution) = record.get("notification_resolution") {
+        summary["notification_resolution"] = compact_fields(
+            resolution,
+            &[
+                "schema",
+                "classification",
+                "transport",
+                "resolver_transport",
+                "missing_context",
+            ],
+        );
+    }
     enforce_compact_status_budget(summary)
 }
 
@@ -5162,6 +5184,7 @@ fn enforce_compact_status_budget(mut value: Value) -> Value {
     // state, and the full-output command always survive this final pass.
     for section in [
         "notification_delivery",
+        "notification_resolution",
         "transport_recovery",
         "diagnostic_summary",
         "failure_reasons",
@@ -7663,6 +7686,35 @@ mod tests {
         assert!(summary["notification_delivery"]
             .get("raw_destination")
             .is_none());
+    }
+
+    #[test]
+    fn compact_status_surfaces_route_less_resolver_diagnostics_without_destination() {
+        let summary = compact_status_summary(
+            &json!({
+                "run_id": "cook-attempt-1",
+                "state": "queued",
+                "tasks": [],
+                "notification_resolution": {
+                    "schema": "homeboy/notification-route-resolution/v1",
+                    "classification": "route_less",
+                    "resolver_transport": "generic.completed",
+                    "missing_context": ["CALLER_THREAD_ID"],
+                    "route": "opaque-destination"
+                }
+            }),
+            "cook-attempt-1",
+        );
+
+        assert_eq!(
+            summary["notification_resolution"]["classification"],
+            "route_less"
+        );
+        assert_eq!(
+            summary["notification_resolution"]["missing_context"],
+            json!(["CALLER_THREAD_ID"])
+        );
+        assert!(summary["notification_resolution"].get("route").is_none());
     }
 
     #[test]

--- a/crates/homeboy-core/src/notification_route_resolver.rs
+++ b/crates/homeboy-core/src/notification_route_resolver.rs
@@ -17,10 +17,14 @@ use homeboy_extension_contract::{
     NOTIFICATION_ROUTE_RESOLVER_REQUEST_SCHEMA, NOTIFICATION_ROUTE_RESOLVER_SCHEMA,
 };
 
-use crate::{extension_store::load_all_extensions, notification_route::NotificationRoute};
+use crate::{
+    extension_store::load_all_extensions,
+    notification_route::{NotificationRoute, NotificationRouteResolution},
+};
 
 const AMBIENT_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(2);
 const RESOLVER_OUTPUT_LIMIT: usize = 16 * 1024;
+const MAX_MISSING_CONTEXT_FIELDS: usize = 32;
 
 /// Ask installed transport resolvers for a route. One match is selected; zero
 /// matches retains route-less behavior. Ambient discovery has one aggregate
@@ -28,12 +32,25 @@ const RESOLVER_OUTPUT_LIMIT: usize = 16 * 1024;
 /// A resolver that cannot start or exceeds that deadline is skipped with a
 /// bounded diagnostic; malformed, invalid, and ambiguous results fail closed.
 pub fn resolve_installed() -> Result<Option<NotificationRoute>> {
+    Ok(resolve_installed_with_evidence()?.route)
+}
+
+/// Resolve installed extension routes while retaining safe admission evidence.
+pub fn resolve_installed_with_evidence() -> Result<ResolvedNotificationRoute> {
     resolve_installed_with_timeout(AMBIENT_DISCOVERY_TIMEOUT)
 }
 
-fn resolve_installed_with_timeout(timeout: Duration) -> Result<Option<NotificationRoute>> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedNotificationRoute {
+    pub route: Option<NotificationRoute>,
+    pub evidence: NotificationRouteResolution,
+}
+
+fn resolve_installed_with_timeout(timeout: Duration) -> Result<ResolvedNotificationRoute> {
     let extensions = load_all_extensions()?;
     let mut matches = Vec::new();
+    let mut missing_context = Vec::new();
+    let mut resolver_transports = Vec::new();
     let started = Instant::now();
     for extension in extensions {
         for transport in &extension.notification_transports {
@@ -42,7 +59,7 @@ fn resolve_installed_with_timeout(timeout: Duration) -> Result<Option<Notificati
             };
             let Some(remaining) = timeout.checked_sub(started.elapsed()) else {
                 ambient_discovery_warning("notification route resolver discovery timed out");
-                return select_match(matches);
+                return select_match(matches, resolver_transports, missing_context);
             };
             match invoke(
                 resolver,
@@ -50,25 +67,51 @@ fn resolve_installed_with_timeout(timeout: Duration) -> Result<Option<Notificati
                 extension.extension_path.as_deref().unwrap_or_default(),
                 remaining,
             ) {
-                Ok(Some(route)) => matches.push(route),
-                Ok(None) => {}
+                Ok(ResolverResult::Matched(route)) => matches.push(route),
+                Ok(ResolverResult::Unmatched {
+                    missing_context: missing,
+                }) => {
+                    resolver_transports.push(transport.id.clone());
+                    missing_context.extend(missing);
+                }
                 Err(InvokeError::Optional(message)) => {
                     ambient_discovery_warning(message);
                     if started.elapsed() >= timeout {
-                        return select_match(matches);
+                        return select_match(matches, resolver_transports, missing_context);
                     }
                 }
                 Err(InvokeError::Fatal(error)) => return Err(error),
             }
         }
     }
-    select_match(matches)
+    select_match(matches, resolver_transports, missing_context)
 }
 
-fn select_match(mut matches: Vec<NotificationRoute>) -> Result<Option<NotificationRoute>> {
+fn select_match(
+    mut matches: Vec<NotificationRoute>,
+    resolver_transports: Vec<String>,
+    mut missing_context: Vec<String>,
+) -> Result<ResolvedNotificationRoute> {
     match matches.len() {
-        0 => Ok(None),
-        1 => Ok(matches.pop()),
+        0 => {
+            missing_context.sort();
+            missing_context.dedup();
+            let mut evidence = NotificationRouteResolution::new("route_less");
+            evidence.resolver_transport =
+                (resolver_transports.len() == 1).then(|| resolver_transports[0].clone());
+            evidence.missing_context = missing_context;
+            Ok(ResolvedNotificationRoute {
+                route: None,
+                evidence,
+            })
+        }
+        1 => {
+            let route = matches.pop();
+            let mut evidence = NotificationRouteResolution::new("resolver");
+            evidence.transport = route.as_ref().map(|route| route.transport.clone());
+            evidence.resolver_transport = evidence.transport.clone();
+            Ok(ResolvedNotificationRoute { route, evidence })
+        }
         _ => Err(resolver_error(
             "more than one installed notification route resolver matched",
         )),
@@ -87,9 +130,39 @@ pub fn resolve_from_cli_or_env(
     }
 }
 
+/// Resolve explicit argv or propagated environment context with its source.
+pub fn resolve_from_cli_or_env_with_evidence(
+    cli_transport: Option<&str>,
+    cli_route: Option<&str>,
+) -> Result<ResolvedNotificationRoute> {
+    let route = resolve_from_cli_or_env(cli_transport, cli_route)
+        .map_err(with_invalid_resolution_evidence)?;
+    let mut evidence = NotificationRouteResolution::new(if cli_transport.is_some() {
+        "explicit"
+    } else if route.is_some() {
+        "environment"
+    } else {
+        "route_less"
+    });
+    evidence.transport = route.as_ref().map(|route| route.transport.clone());
+    if cli_transport.is_none() {
+        if let Some(propagated) =
+            crate::notification_route::propagated_resolution_from_env(route.as_ref())
+        {
+            evidence = propagated;
+        }
+    }
+    Ok(ResolvedNotificationRoute { route, evidence })
+}
+
 enum InvokeError {
     Optional(&'static str),
     Fatal(Error),
+}
+
+enum ResolverResult {
+    Matched(NotificationRoute),
+    Unmatched { missing_context: Vec<String> },
 }
 
 fn invoke(
@@ -97,7 +170,7 @@ fn invoke(
     transport: &str,
     extension_path: &str,
     timeout: Duration,
-) -> std::result::Result<Option<NotificationRoute>, InvokeError> {
+) -> std::result::Result<ResolverResult, InvokeError> {
     let argv: Vec<String> = resolver
         .command
         .iter()
@@ -189,11 +262,25 @@ fn invoke(
             "notification route resolver returned an unsupported schema",
         )));
     }
+    if response.missing_context.len() > MAX_MISSING_CONTEXT_FIELDS
+        || response
+            .missing_context
+            .iter()
+            .any(|field| !valid_context_field_name(field))
+    {
+        return Err(InvokeError::Fatal(resolver_error(
+            "notification route resolver returned invalid missing context field names",
+        )));
+    }
     match (response.status, response.route) {
-        (NotificationRouteResolverStatus::Unmatched, None) => Ok(None),
-        (NotificationRouteResolverStatus::Matched, Some(route)) => {
+        (NotificationRouteResolverStatus::Unmatched, None) => Ok(ResolverResult::Unmatched {
+            missing_context: response.missing_context,
+        }),
+        (NotificationRouteResolverStatus::Matched, Some(route))
+            if response.missing_context.is_empty() =>
+        {
             NotificationRoute::new(transport, route)
-                .map(Some)
+                .map(ResolverResult::Matched)
                 .map_err(|_| {
                     InvokeError::Fatal(resolver_error(
                         "notification route resolver returned an invalid route",
@@ -204,6 +291,14 @@ fn invoke(
             "notification route resolver returned an invalid result shape",
         ))),
     }
+}
+
+fn valid_context_field_name(field: &str) -> bool {
+    !field.is_empty()
+        && field.len() <= 128
+        && field
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
 }
 
 fn terminate(child: &mut std::process::Child, reader: Option<thread::JoinHandle<(Vec<u8>, bool)>>) {
@@ -256,7 +351,23 @@ fn read_bounded(mut reader: impl Read) -> (Vec<u8>, bool) {
 }
 
 fn resolver_error(message: &str) -> Error {
-    Error::validation_invalid_argument("notification_route_resolver", message, None, None)
+    with_invalid_resolution_evidence(Error::validation_invalid_argument(
+        "notification_route_resolver",
+        message,
+        None,
+        None,
+    ))
+}
+
+fn with_invalid_resolution_evidence(mut error: Error) -> Error {
+    if let Some(details) = error.details.as_object_mut() {
+        details.insert(
+            "notification_resolution".to_string(),
+            serde_json::to_value(NotificationRouteResolution::new("invalid"))
+                .expect("notification resolution is serializable"),
+        );
+    }
+    error
 }
 
 #[cfg(test)]
@@ -365,7 +476,9 @@ mod tests {
             install_resolver("resolver-two", "sleep 1");
             let started = Instant::now();
             assert_eq!(
-                resolve_installed_with_timeout(Duration::from_millis(100)).unwrap(),
+                resolve_installed_with_timeout(Duration::from_millis(100))
+                    .unwrap()
+                    .route,
                 None
             );
             assert!(started.elapsed() < Duration::from_millis(500));
@@ -388,5 +501,55 @@ mod tests {
                 Some(NotificationRoute::new("chosen.transport", "chosen-route").unwrap())
             );
         });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unmatched_resolver_reports_safe_missing_caller_context() {
+        crate::test_support::with_isolated_home(|_| {
+            install_resolver(
+                "resolver-test",
+                "cat >/dev/null; printf '%s' '{\"schema\":\"homeboy/notification-route-resolver/v1\",\"status\":\"unmatched\",\"missing_context\":[\"CALLER_THREAD_ID\"]}'",
+            );
+            let resolution = resolve_installed_with_evidence().unwrap();
+            assert!(resolution.route.is_none());
+            assert_eq!(resolution.evidence.classification, "route_less");
+            assert_eq!(
+                resolution.evidence.resolver_transport.as_deref(),
+                Some("synthetic.completed")
+            );
+            assert_eq!(resolution.evidence.missing_context, ["CALLER_THREAD_ID"]);
+            assert!(serde_json::to_string(&resolution.evidence)
+                .unwrap()
+                .contains("CALLER_THREAD_ID"));
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unsafe_missing_context_diagnostics_fail_closed() {
+        crate::test_support::with_isolated_home(|_| {
+            install_resolver(
+                "resolver-test",
+                "cat >/dev/null; printf '%s' '{\"schema\":\"homeboy/notification-route-resolver/v1\",\"status\":\"unmatched\",\"missing_context\":[\"token=opaque-destination\"]}'",
+            );
+            let error = resolve_installed_with_evidence().unwrap_err();
+            assert!(error.to_string().contains("invalid missing context"));
+            assert!(!error.to_string().contains("opaque-destination"));
+        });
+    }
+
+    #[test]
+    fn explicit_and_environment_context_have_distinct_evidence() {
+        let explicit = resolve_from_cli_or_env_with_evidence(Some("chosen"), Some("route"))
+            .expect("explicit route");
+        assert_eq!(explicit.evidence.classification, "explicit");
+        assert_eq!(explicit.evidence.transport.as_deref(), Some("chosen"));
+
+        let invalid = resolve_from_cli_or_env_with_evidence(Some("chosen"), None).unwrap_err();
+        assert_eq!(
+            invalid.details["notification_resolution"]["classification"],
+            "invalid"
+        );
     }
 }

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -880,6 +880,19 @@ identifiers in core lifecycle state. Provider-specific execution settings belong
 in `--provider-config`; durable lifecycle commands remain headless and can be
 inspected later with `agent-task status`, `agent-task logs`, or `agent-task review`.
 
+To verify that an installed notification resolver receives the current bridge
+context without launching provider work, run the normal read-only Cook preview:
+
+```bash
+homeboy agent-task cook --preview --repo <repo> --task-url <issue-url> --prompt "verify notification resolver context" --no-finalize
+```
+
+Inspect `resolved.notification_resolution`: `resolver` proves the context selected
+a route, while `route_less`, `resolver_transport`, and `missing_context` provide
+safe remediation without exposing the opaque destination. Detached route-less
+submissions emit the same diagnosis before durable handoff, and `agent-task
+status <cook-id>` preserves it with the latest notification delivery outcome.
+
 `--backend` selects the generic executor backend, `--dispatch-provider-id` (also
 accepted as `--selector`) selects a specific provider id for that backend, and
 `--model` is only a provider-owned model override. Provider ids come from

--- a/docs/reference/schemas/extension-manifest-schema.md
+++ b/docs/reference/schemas/extension-manifest-schema.md
@@ -283,6 +283,13 @@ It must write exactly one JSON result to stdout:
 {"schema":"homeboy/notification-route-resolver/v1","status":"unmatched"}
 ```
 
+An unmatched resolver may name the caller-context fields that would permit a
+match. Names are bounded ASCII identifiers; values must never be returned:
+
+```json
+{"schema":"homeboy/notification-route-resolver/v1","status":"unmatched","missing_context":["CALLER_THREAD_ID"]}
+```
+
 or:
 
 ```json
@@ -300,6 +307,9 @@ typed `notification_route_resolver` diagnostic. Timed-out Unix resolvers are
 killed as a process group so descendants cannot retain their pipes. A selected
 route is validated and bound before durable submission, so detached, fanout,
 resume, daemon, and delivery paths reuse their existing route persistence.
+Route resolution evidence persists the classification, transport identity, and
+missing context names, but never the opaque route value. A detached route-less
+Cook warns before handoff and `agent-task status` retains the same safe evidence.
 Cook seals to its pinned controller runtime before ambient discovery, so exactly
 that executing runtime resolves and persists the selected route once.
 


### PR DESCRIPTION
## Summary

Make detached Cook notification route resolution visible, persistent, and diagnosable without exposing transport-owned opaque destination values.

## Changes

- Add transport-neutral resolution classifications for explicit, environment, resolver, route-less, and invalid outcomes.
- Let unmatched resolvers declare bounded safe caller-context field names while rejecting values or credential-like diagnostics.
- Persist safe resolution evidence through detached/Lab handoff and continuation.
- Surface route-less warnings during submission and compact status, including latest safe delivery outcome.
- Document a read-only Cook preview flow for resolver-context diagnosis.

## Verification

- Notification route contract suite: 15 passed.
- Notification resolver suite: 10 passed.
- Lifecycle persistence test: 1 passed.
- Detached route-less warning test: 1 passed.
- Compact status diagnostics test: 1 passed.
- `cargo fmt --all -- --check` passed.
- `git diff --check` passed.

Fixes #12925

## AI Assistance

OpenAI `openai/gpt-5.6-sol` via OpenCode general coding subagents completed the generic contracts, persistence, diagnostics, and behavioral verification. Chris Huber remains responsible for every line.
