### PR TITLE
fix(agent-task): preserve gate evidence ownership

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -1972,7 +1972,7 @@ impl SelectedGateEnvironment {
             .cloned()
             .or_else(|| std::env::var("CARGO_TARGET_DIR").ok());
         let target = homeboy_core::cleanup::acquire_managed_cargo_target_for_environment(
-            "agent-task-cargo",
+            "agent-task-gate",
             cwd,
             explicit_target.as_deref(),
             &self.values,

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -380,6 +380,24 @@ fn aggregate_promotion_forwards_canonical_gate_feedback_baseline() {
 #[test]
 fn follow_up_promotion_records_and_forwards_verified_chain_baseline() {
     let temp = tempfile::tempdir().expect("tempdir");
+    let remote = temp.path().join("origin.git");
+    let target = temp.path().join("target");
+    std::fs::create_dir(&target).expect("create target");
+    git(&target, &["init", "--initial-branch=main"]);
+    git(&target, &["config", "user.email", "test@example.com"]);
+    git(&target, &["config", "user.name", "Test"]);
+    std::fs::write(target.join("base.txt"), "base\n").expect("write base");
+    git(&target, &["add", "base.txt"]);
+    git(&target, &["commit", "-m", "base"]);
+    git(
+        temp.path(),
+        &["init", "--bare", "--initial-branch=main", "origin.git"],
+    );
+    git(
+        &target,
+        &["remote", "add", "origin", remote.to_str().unwrap()],
+    );
+    git(&target, &["push", "-u", "origin", "main"]);
     let patch_path = temp.path().join("follow-up.patch");
     std::fs::write(&patch_path, VALID_PATCH).expect("write follow-up patch");
     let prior_sha256 = "b".repeat(64);
@@ -409,7 +427,7 @@ fn follow_up_promotion_records_and_forwards_verified_chain_baseline() {
     })
     .to_string();
     let mut provider = FakePromotionWorkspaceProvider {
-        workspace_path: Some(temp.path().to_path_buf()),
+        workspace_path: Some(target),
         ..Default::default()
     };
 


### PR DESCRIPTION
## Summary
- restore the `agent-task-gate` owner in shared Cargo target evidence without changing compatibility-key target reuse
- give the verified promotion-chain forwarding fixture a real `origin/main` snapshot, matching the declared-base contract

## Investigation
The failures did not share an evidence-metadata root. Cargo reporting regressed its evidence owner independently; the promotion test failed before provenance forwarding because its fixture requested `main` without an `origin` remote.

## Verification
- `cargo test -p homeboy-agents declared_shared_cargo_target_is_reported_without_parsing_gate_shell_text`
- `cargo test -p homeboy-agents follow_up_promotion_records_and_forwards_verified_chain_baseline`
- `cargo fmt --check`
- `cargo check -p homeboy-agents`

`cargo test -p homeboy-agents agent_task_promotion::tests::part_b` has three unrelated pre-existing controller-scratch lease failures (34 passed, 3 failed). Full Clippy with `-D warnings` is also baseline-blocked by existing warnings (19 in `homeboy-core`, 27 in `homeboy-agents`), including pre-existing findings in `agent_task_gate.rs`.

## AI Assistance
OpenAI gpt-5.6-terra via OpenCode investigated the two regressions, implemented the scoped fix, and ran the listed verification. Chris Huber remains responsible for the change.