### PR TITLE
fix(daemon): converge concurrent startup waits

### DIFF
--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -39,6 +39,11 @@ use super::{
 };
 
 const TEST_KEEP_DAEMON_IN_PROCESS_GROUP_ENV: &str = "HOMEBOY_TEST_KEEP_DAEMON_IN_PROCESS_GROUP";
+// A launcher can observe two five-second lease-publication attempts and clean
+// up the first attempt before returning. Followers must wait through that
+// bounded startup lifecycle, then re-read the durable lease rather than timing
+// out halfway through the winning launch.
+const ENSURE_RUNNING_STARTUP_WAIT: Duration = Duration::from_secs(15);
 
 /// Enumerate foreground daemon processes without inferring ownership from a
 /// command substring. A candidate is an owner only when its explicit state
@@ -1318,7 +1323,7 @@ pub fn start_background(addr: &str) -> Result<DaemonStartResult> {
 /// Return a live daemon under the lifecycle lock, or start one when its lease
 /// is absent or its recorded PID is dead.
 pub fn ensure_running(addr: &str) -> Result<DaemonStartResult> {
-    ensure_running_with_wait(addr, Duration::from_secs(5))
+    ensure_running_with_wait(addr, ENSURE_RUNNING_STARTUP_WAIT)
 }
 
 /// The optional controller operation id is intentionally additive. Existing
@@ -1332,7 +1337,7 @@ pub fn ensure_running_with_replacement_operation(
         return ensure_running(addr);
     };
     parse_bind_addr(addr)?;
-    let _lock = acquire_daemon_operation_lock_for_ensure(Duration::from_secs(5))?;
+    let _lock = acquire_daemon_operation_lock_for_ensure(ENSURE_RUNNING_STARTUP_WAIT)?;
     let status = read_status()?;
     if let Some(state) = status
         .state

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -1140,6 +1140,47 @@ fn ensure_running_concurrent_callers_converge_on_same_daemon() {
 }
 
 #[test]
+fn ensure_running_concurrent_callers_wait_for_slow_startup() {
+    with_isolated_home(|_| {
+        let daemon = fake_daemon(4242, "lease-slow");
+        let state = Arc::new(Mutex::new(FakeEnsureState::default()));
+        let barrier = Arc::new(Barrier::new(3));
+        let first = ensure_with_slow_fake_operations(
+            Arc::clone(&barrier),
+            Arc::clone(&state),
+            daemon.clone(),
+        );
+        let second =
+            ensure_with_slow_fake_operations(Arc::clone(&barrier), Arc::clone(&state), daemon);
+        barrier.wait();
+
+        let first = first.join().expect("first thread").expect("first ensure");
+        let second = second
+            .join()
+            .expect("second thread")
+            .expect("second ensure");
+        assert_eq!(first, second);
+        assert_eq!(state.lock().expect("state").starts, 1);
+    });
+}
+
+#[test]
+fn ensure_running_returns_the_startup_failure() {
+    with_isolated_home(|_| {
+        let err = ensure_running_with_operations(
+            Duration::from_millis(50),
+            super::super::acquire_daemon_operation_lock_for_ensure,
+            || Ok(fake_status(None, false)),
+            |_| false,
+            || Err(crate::error::Error::internal_unexpected("startup failed")),
+        )
+        .expect_err("startup failure must be returned to the caller");
+
+        assert_eq!(err.message, "startup failed");
+    });
+}
+
+#[test]
 fn startup_observation_requires_a_live_attempt_token() {
     let expected = "attempt-token";
     let wrong = fake_status(Some(fake_daemon(4242, "other-lease")), true);
@@ -1352,6 +1393,37 @@ fn ensure_with_fake_operations(
             },
             move |pid| pid == daemon_pid,
             move || {
+                let mut state = start_state.lock().expect("state");
+                state.starts += 1;
+                state.daemon = Some(daemon.clone());
+                Ok(daemon)
+            },
+        )
+    })
+}
+
+fn ensure_with_slow_fake_operations(
+    barrier: Arc<Barrier>,
+    state: Arc<Mutex<FakeEnsureState>>,
+    daemon: super::DaemonStartResult,
+) -> std::thread::JoinHandle<crate::error::Result<super::DaemonStartResult>> {
+    std::thread::spawn(move || {
+        barrier.wait();
+        let read_state = Arc::clone(&state);
+        let start_state = Arc::clone(&state);
+        let daemon_pid = daemon.pid;
+        ensure_running_with_operations(
+            Duration::from_secs(1),
+            super::super::acquire_daemon_operation_lock_for_ensure,
+            move || {
+                Ok(fake_status(
+                    read_state.lock().expect("state").daemon.clone(),
+                    true,
+                ))
+            },
+            move |pid| pid == daemon_pid,
+            move || {
+                std::thread::sleep(Duration::from_millis(100));
                 let mut state = start_state.lock().expect("state");
                 state.starts += 1;
                 state.daemon = Some(daemon.clone());


### PR DESCRIPTION
## Summary
- wait through the bounded daemon startup lifecycle before a concurrent ensure-running caller times out
- reuse the durable daemon lease after the winning startup publishes it
- cover delayed concurrent startup and startup-failure propagation alongside existing stale/live coverage

## Tests
- `CARGO_TARGET_DIR=target cargo test -p homeboy-core daemon::control --lib`
- `cargo fmt --check`
- `CARGO_TARGET_DIR=target cargo clippy -p homeboy-core --lib --tests -- -D warnings` (blocked by 19 existing unrelated warnings in `cleanup.rs`, `controller_runtime.rs`, `daemon/runner_files.rs`, `git/release_download.rs`, `http_api.rs`, `notify_outbox.rs`, and `server/*`)

Closes #12949

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode inspected the daemon lifecycle implementation, implemented the bounded startup convergence change, and added focused tests. Chris Huber reviewed the task direction and remains responsible for this PR.