### PR TITLE
fix(deploy): select explicit artifact version targets

### DIFF
--- a/crates/homeboy-deploy/src/execution/mod.rs
+++ b/crates/homeboy-deploy/src/execution/mod.rs
@@ -798,6 +798,84 @@ mod tests {
     }
 
     #[test]
+    fn predeploy_artifact_version_inspection_ignores_repository_only_targets_when_archive_paths_are_declared(
+    ) {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let artifact = temp.path().join("wp-codebox.zip");
+        write_zip(
+            &artifact,
+            &[
+                (
+                    "wp-codebox/wp-codebox.php",
+                    "<?php\n/* Version: 0.22.0 */\n",
+                ),
+                (
+                    "wp-codebox/packages/cli/package.json",
+                    r#"{"version":"0.22.0"}"#,
+                ),
+            ],
+        );
+        let component = Component {
+            id: "wp-codebox".to_string(),
+            local_path: temp.path().to_string_lossy().to_string(),
+            version_targets: Some(vec![
+                VersionTarget {
+                    file: "npm-shrinkwrap.json".to_string(),
+                    pattern: Some(r#""version"\s*:\s*"([0-9.]+)""#.to_string()),
+                    artifact_path: None,
+                },
+                VersionTarget {
+                    file: "wp-codebox.php".to_string(),
+                    pattern: Some(r"Version:\s*([0-9.]+)".to_string()),
+                    artifact_path: Some("wp-codebox/wp-codebox.php".to_string()),
+                },
+                VersionTarget {
+                    file: "packages/cli/package.json".to_string(),
+                    pattern: Some(r#""version"\s*:\s*"([0-9.]+)""#.to_string()),
+                    artifact_path: Some("wp-codebox/packages/cli/package.json".to_string()),
+                },
+            ]),
+            ..Component::default()
+        };
+
+        validate_predeploy_artifact_version(&component, &artifact, "0.22.0")
+            .expect("archive targets, not the repository lockfile, verify the release asset");
+    }
+
+    #[test]
+    fn predeploy_artifact_version_inspection_rejects_contradictory_archive_targets() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let artifact = temp.path().join("fixture.zip");
+        write_zip(
+            &artifact,
+            &[
+                ("plugin/plugin.php", "Version: 1.2.3\n"),
+                ("plugin/package.json", r#"{"version":"1.2.4"}"#),
+            ],
+        );
+        let component = Component {
+            id: "fixture".to_string(),
+            version_targets: Some(vec![
+                VersionTarget {
+                    file: "plugin.php".to_string(),
+                    pattern: Some(r"Version:\s*([0-9.]+)".to_string()),
+                    artifact_path: Some("plugin/plugin.php".to_string()),
+                },
+                VersionTarget {
+                    file: "package.json".to_string(),
+                    pattern: Some(r#""version"\s*:\s*"([0-9.]+)""#.to_string()),
+                    artifact_path: Some("plugin/package.json".to_string()),
+                },
+            ]),
+            ..Component::default()
+        };
+
+        let error = validate_predeploy_artifact_version(&component, &artifact, "1.2.3")
+            .expect_err("contradictory archive target must fail closed");
+        assert!(error.contains("1.2.4") && error.contains("expected '1.2.3'"));
+    }
+
+    #[test]
     fn predeploy_artifact_version_inspection_reports_artifact_path_when_missing() {
         // When artifact_path is set but absent from the ZIP, the error should name the
         // artifact path (what ships), not the source bump path.

--- a/crates/homeboy-deploy/src/execution/preflight.rs
+++ b/crates/homeboy-deploy/src/execution/preflight.rs
@@ -165,7 +165,13 @@ pub(super) fn resolve_preflight_artifact_path(
         artifact_path
     };
 
-    if let Some(expected_version) = local_version.as_deref() {
+    // An explicit --version identifies the requested release asset and must be
+    // the archive assertion too. Otherwise retain the inferred local version.
+    if let Some(expected_version) = config
+        .expected_version
+        .as_deref()
+        .or(local_version.as_deref())
+    {
         if let Err(error) =
             validate_predeploy_artifact_version(component, &artifact_path, expected_version)
         {
@@ -307,9 +313,10 @@ pub(super) fn validate_predeploy_artifact_version(
         return Ok(());
     }
 
-    let Some(targets) = component.version_targets.as_ref() else {
+    let Some(_) = component.version_targets.as_ref() else {
         return Ok(());
     };
+    let targets = crate::types::artifact_version_targets(component).collect::<Vec<_>>();
     if targets.is_empty() {
         return Ok(());
     }

--- a/crates/homeboy-deploy/src/orchestration/mod.rs
+++ b/crates/homeboy-deploy/src/orchestration/mod.rs
@@ -1120,6 +1120,58 @@ mod tests {
     }
 
     #[test]
+    fn deploy_modes_report_the_explicit_archive_version_source() {
+        let component = Component {
+            id: "wp-codebox".to_string(),
+            local_path: "/source/wp-codebox".to_string(),
+            build_artifact: Some("build/wp-codebox.zip".to_string()),
+            version_targets: Some(vec![
+                homeboy_core::component::VersionTarget {
+                    file: "npm-shrinkwrap.json".to_string(),
+                    pattern: None,
+                    artifact_path: None,
+                },
+                homeboy_core::component::VersionTarget {
+                    file: "wp-codebox.php".to_string(),
+                    pattern: None,
+                    artifact_path: Some("wp-codebox/wp-codebox.php".to_string()),
+                },
+            ]),
+            ..Component::default()
+        };
+        let result_for = |status| {
+            ComponentDeployResult::new(&component, "/srv/site")
+                .with_status(status)
+                .with_versions(Some("0.22.0".to_string()), None)
+        };
+        let mut result = DeployOrchestrationResult {
+            results: vec![
+                result_for("checked"),
+                result_for("planned"),
+                result_for("success"),
+            ],
+            summary: DeploySummary {
+                total: 3,
+                succeeded: 1,
+                failed: 0,
+                skipped: 0,
+            },
+            deploy_run_id: None,
+        };
+
+        attach_version_sources(&mut result, std::slice::from_ref(&component));
+
+        for row in result.results {
+            let source = row
+                .version_sources
+                .and_then(|sources| sources.artifact)
+                .expect("artifact source");
+            assert_eq!(source.file, "wp-codebox/wp-codebox.php");
+            assert_eq!(source.path, "wp-codebox/wp-codebox.php");
+        }
+    }
+
+    #[test]
     fn deploy_tag_for_version_formats_regular_release_tag() {
         let component = make_component("sample-plugin", "/tmp/not-a-git-repo");
 

--- a/crates/homeboy-deploy/src/orchestration/modes.rs
+++ b/crates/homeboy-deploy/src/orchestration/modes.rs
@@ -143,6 +143,11 @@ pub(super) fn run_check_mode(input: CheckModeInput<'_>) -> DeployOrchestrationRe
                 .with_component_status(status)
                 .with_content_manifest(manifest)
                 .with_source_identity(c, config.head);
+            if let Some(package) = canonical_packages.get(&c.id) {
+                result = result
+                    .with_artifact_path(Some(package.path.display().to_string()))
+                    .with_artifact_source(DeployArtifactSource::ReleaseAsset);
+            }
             if let Some(state) = release_state {
                 result = result.with_release_state(state);
             }

--- a/crates/homeboy-deploy/src/types.rs
+++ b/crates/homeboy-deploy/src/types.rs
@@ -474,9 +474,9 @@ pub struct VersionSource {
 ///
 /// This and `artifact_version_source` used to live in the release crate's
 /// `version` module even though they return deploy types and only deploy calls
-/// them — one of the edges that made release and deploy circular (#11144). They
-/// resolve through `homeboy_version::version::canonical_version_target`, so the
-/// canonical-target policy still has exactly one definition.
+/// them — one of the edges that made release and deploy circular (#11144).
+/// Local source keeps the shared canonical-target policy; artifacts select their
+/// explicitly mapped shipped targets below.
 pub fn local_version_source(component: &Component) -> Option<VersionSource> {
     let target = homeboy_version::version::canonical_version_target(component)?;
     Some(VersionSource {
@@ -490,7 +490,7 @@ pub fn local_version_source(component: &Component) -> Option<VersionSource> {
 
 /// The path a component's version is read from inside a built artifact.
 pub fn artifact_version_source(component: &Component) -> Option<VersionSource> {
-    let target = homeboy_version::version::canonical_version_target(component)?;
+    let target = artifact_version_targets(component).next()?;
     let file = target
         .artifact_path
         .clone()
@@ -499,6 +499,24 @@ pub fn artifact_version_source(component: &Component) -> Option<VersionSource> {
         path: file.clone(),
         file,
     })
+}
+
+/// Version targets that describe files carried by a deploy artifact.
+///
+/// An explicit `artifact_path` maps a source version target to its shipped
+/// location. Once a component declares such mappings, repository-only targets
+/// are not archive requirements. Components without mappings retain the legacy
+/// behavior of validating every declared target, including single-package npm
+/// artifacts.
+pub(crate) fn artifact_version_targets(
+    component: &Component,
+) -> impl Iterator<Item = &homeboy_core::component::VersionTarget> {
+    let targets = component.version_targets.as_deref().unwrap_or_default();
+    let has_artifact_paths = targets.iter().any(|target| target.artifact_path.is_some());
+
+    targets
+        .iter()
+        .filter(move |target| !has_artifact_paths || target.artifact_path.is_some())
 }
 
 /// Version-target provenance for deploy output. Every populated source follows
@@ -816,9 +834,9 @@ fn detect_linked_worktree(path: &Path) -> Option<bool> {
 #[cfg(test)]
 mod tests {
     use super::{
-        compare_deployed_versions, parse_bulk_component_ids, ComponentDeployResult,
-        ComponentStatus, DeployConfig, DeployResult, DeploymentProvenanceEvidence,
-        PreparedDeployArtifact, ReleaseState, ReleaseStateStatus,
+        artifact_version_source, compare_deployed_versions, parse_bulk_component_ids,
+        ComponentDeployResult, ComponentStatus, DeployConfig, DeployResult,
+        DeploymentProvenanceEvidence, PreparedDeployArtifact, ReleaseState, ReleaseStateStatus,
     };
     use homeboy_core::component::{Component, ScopedExtensionConfig};
     use homeboy_core::project::Project;
@@ -1247,6 +1265,29 @@ mod tests {
 
         std::fs::write(&artifact_path, "changed bytes").expect("changed artifact");
         assert!(artifact.validate("fixture", Some("1.2.3")).is_err());
+    }
+
+    #[test]
+    fn artifact_version_source_prefers_an_explicit_archive_path_over_a_repository_lockfile() {
+        let component = Component {
+            version_targets: Some(vec![
+                homeboy_core::component::VersionTarget {
+                    file: "npm-shrinkwrap.json".to_string(),
+                    pattern: None,
+                    artifact_path: None,
+                },
+                homeboy_core::component::VersionTarget {
+                    file: "wp-codebox.php".to_string(),
+                    pattern: None,
+                    artifact_path: Some("wp-codebox/wp-codebox.php".to_string()),
+                },
+            ]),
+            ..Component::default()
+        };
+
+        let source = artifact_version_source(&component).expect("archive version source");
+        assert_eq!(source.file, "wp-codebox/wp-codebox.php");
+        assert_eq!(source.path, "wp-codebox/wp-codebox.php");
     }
 
     #[test]


### PR DESCRIPTION
Closes #12951

## Summary
- Select explicitly mapped artifact version targets for archive validation and deploy evidence, rather than allowing a repository-only target to become the archive authority.
- Keep all declared targets as the artifact contract when no `artifact_path` mappings exist, preserving npm single-package behavior.
- Use `--version` as the archive assertion when supplied, and report the same artifact source for check, dry-run, and apply.

## Evidence
- `cargo fmt --check`
- `cargo check -p homeboy-deploy`
- `cargo test -p homeboy-deploy execution::tests::predeploy_artifact_version_inspection_ignores_repository_only_targets_when_archive_paths_are_declared --lib -- --exact`
- `cargo test -p homeboy-deploy orchestration::tests::deploy_modes_report_the_explicit_archive_version_source --lib -- --exact`
- `cargo test -p homeboy-deploy types::tests::artifact_version_source_prefers_an_explicit_archive_path_over_a_repository_lockfile --lib -- --exact`
- `cargo test -p homeboy-deploy --lib -- --test-threads=1`: 306 passed; 4 pre-existing local adapter tests fail at `chmod directories` in the macOS temporary-directory environment.
- `cargo clippy -p homeboy-deploy --lib --tests -- -D warnings` is blocked by 19 existing `homeboy-core` warnings under the installed Rust/Clippy version; this change introduces no reported deploy lint.

## AI Assistance
OpenAI gpt-5.6-sol through OpenCode inspected the deploy/version-resolution paths, implemented the generic artifact-target selection and focused tests, and ran the verification commands. Chris Huber remains responsible for every line.