### PR TITLE
fix(fanout): ensure typed provider misses

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -6182,7 +6182,7 @@ fi
             std::fs::write(
                 &provider,
                 format!(
-                    "#!/bin/sh\ncase \"$1\" in\nresolve)\n  path='{}/'$2\n  if [ -d \"$path\" ]; then\n    branch=$(git -C \"$path\" branch --show-current)\n    printf '{{\"worktrees\":[{{\"handle\":\"%s\",\"path\":\"%s\",\"branch\":\"%s\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}\\n' \"$2\" \"$path\" \"$branch\"\n  else\n    exit 1\n  fi\n  ;;\nensure)\n  path='{}/'$2\n  git init --quiet -b \"$5\" \"$path\"\n  printf '%s|%s|%s|%s\\n' \"$2\" \"$8\" \"$9\" \"${{10}}\" >> '{}'\n  ;;\nesac\n",
+                    "#!/bin/sh\ncase \"$1\" in\nresolve)\n  path='{}/'$2\n  if [ -d \"$path\" ]; then\n    branch=$(git -C \"$path\" branch --show-current)\n    printf '{{\"worktrees\":[{{\"handle\":\"%s\",\"path\":\"%s\",\"branch\":\"%s\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}\\n' \"$2\" \"$path\" \"$branch\"\n  else\n    printf '{{\"status\":\"error\",\"error\":{{\"code\":\"worktree_not_found\"}}}}\\n'\n  fi\n  ;;\nensure)\n  path='{}/'$2\n  git init --quiet -b \"$5\" \"$path\"\n  printf '%s|%s|%s|%s\\n' \"$2\" \"$8\" \"$9\" \"${{10}}\" >> '{}'\n  ;;\nesac\n",
                     workspace_root.display(),
                     workspace_root.display(),
                     ensured.display(),
@@ -6244,6 +6244,9 @@ fi
             homeboy::core::defaults::save_config(&config).expect("save provider config");
 
             let mut args = cook_batch_args();
+            args.issues = (6453..=6458)
+                .map(|number| format!("https://github.com/Extra-Chill/homeboy/issues/{number}"))
+                .collect();
             args.dry_run = false;
             let mut plan = build_cook_batch_plan(&args).expect("fanout plan");
             let worktrees =
@@ -6255,9 +6258,13 @@ fi
                         path.starts_with(workspace_root.to_string_lossy().as_ref())
                     })
             }));
-            assert!(std::fs::read_to_string(&ensured)
-                .expect("provider ensure records")
-                .contains("agent_task_cook"));
+            let ensured = std::fs::read_to_string(&ensured).expect("provider ensure records");
+            assert_eq!(ensured.lines().count(), 6, "{ensured}");
+            assert!(ensured.contains("agent_task_cook"));
+            assert!(plan
+                .cooks
+                .iter()
+                .all(|cook| ensured.contains(&cook.to_worktree)));
             assert!(worktrees.rows.iter().all(|row| {
                 row.command.first() == Some(&provider.display().to_string())
                     && !row
@@ -6267,6 +6274,7 @@ fi
             }));
 
             bind_materialized_worktree_paths(&mut plan, &worktrees);
+            assert_eq!(plan.cooks.len(), 6);
             assert!(plan.cooks.iter().all(|cook| cook.workspace.is_some()));
 
             let mut blocked = worktrees.clone();

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -2190,6 +2190,9 @@ fn run_provider_lookup_command(
             false,
         )
     })?;
+    if provider_declared_lookup_not_found(&value) {
+        return Ok(Vec::new());
+    }
     if let Some(attribution) = provider_failed_lookup_timeout_attribution(&value) {
         let mut error = Error::validation_invalid_argument(
             "to_worktree",
@@ -2227,6 +2230,22 @@ fn run_provider_lookup_command(
         annotate_provider_lookup_error(&mut error, provider_id, command, operation, "malformed");
         error
     })
+}
+
+/// Command providers may report an absent handle in a successful typed response.
+/// This is a lookup result, unlike a failed command or a malformed response, so
+/// callers can converge it through their configured ensure lifecycle.
+fn provider_declared_lookup_not_found(value: &Value) -> bool {
+    matches!(
+        value.get("status").and_then(Value::as_str),
+        Some("not_found")
+    ) || matches!(
+        value.get("code").and_then(Value::as_str),
+        Some("worktree_not_found")
+    ) || matches!(
+        value.pointer("/error/code").and_then(Value::as_str),
+        Some("worktree_not_found")
+    )
 }
 
 #[derive(Serialize)]
@@ -6599,6 +6618,18 @@ mod tests {
         .expect("write script");
         make_executable(&script);
         script.to_string_lossy().to_string()
+    }
+
+    #[test]
+    fn typed_worktree_not_found_is_distinct_from_provider_execution_failure() {
+        assert!(provider_declared_lookup_not_found(&serde_json::json!({
+            "status": "error",
+            "error": { "code": "worktree_not_found" }
+        })));
+        assert!(!provider_declared_lookup_not_found(&serde_json::json!({
+            "status": "error",
+            "error": { "code": "provider_execution_failed" }
+        })));
     }
 
     fn fake_list_provider_script(output: Value) -> String {


### PR DESCRIPTION
## Summary
- classify provider-returned typed `worktree_not_found` lookup envelopes as an absent destination
- let provider-backed fanout invoke the selected ensure command and bind the resulting workspace without legacy fallback
- cover six absent fanout destinations through a deterministic command-provider fixture

Closes #12950.

## Verification
- `cargo fmt --check`
- `cargo check -p homeboy-core -p homeboy-cli`
- `cargo test -p homeboy-core typed_worktree_not_found_is_distinct_from_provider_execution_failure`
- `cargo test -p homeboy-cli fanout_uses_an_ensure_resolve_provider_without_a_finalizer_for_creation_binding_and_repair`

## AI assistance
OpenAI GPT-5.6-terra via OpenCode inspected the prior partial work, reviewed #12816, #12835, and #9908, completed the typed provider-miss handling and deterministic regressions, and ran the listed checks. Chris Huber remains responsible for every line.