### PR TITLE
fix(fanout): report durable detached admission

### DIFF
--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -578,6 +578,14 @@ where
         batch.state = AgentTaskBatchState::Failed;
         let commands = commands(&batch.batch_id);
         let admission_blocker = batch.metadata["terminal_failure"].clone();
+        let expected = batch.child_runs.len();
+        let admitted = batch
+            .child_runs
+            .iter()
+            .filter(|child| {
+                agent_task_lifecycle::run_record_exists_readonly(&child.run_id).unwrap_or(false)
+            })
+            .count();
         let mut next_actions = vec![commands.status.clone(), commands.artifacts.clone()];
         if let Some(command) = admission_blocker
             .pointer("/failure/next_action")
@@ -590,6 +598,12 @@ where
             status: "failed".to_string(),
             observation_fresh: true,
             totals: totals_for_children(&batch.child_runs),
+            admission: AgentTaskBatchAdmission {
+                expected,
+                admitted,
+                rejected: expected.saturating_sub(admitted),
+                absent: 0,
+            },
             batch,
             unavailable_child_runs: Vec::new(),
             admission_blocker: Some(admission_blocker),
@@ -606,12 +620,14 @@ where
     let mut resumable_child_runs = Vec::new();
     let mut timed_out_child_runs = HashSet::new();
     let mut observation_fresh = true;
+    let mut admitted = 0;
     for child in &mut batch.child_runs {
         if terminal_preflight_or_admission_failure(&batch.metadata, &child.run_id) {
             continue;
         }
         match child_status(&child.run_id) {
             Ok(record) => {
+                admitted += 1;
                 if child.state != record.state {
                     child.state = record.state;
                 }
@@ -688,6 +704,7 @@ where
     next_actions.truncate(8);
     let resumable = !resumable_child_runs.is_empty();
     let commands = commands(&batch.batch_id);
+    let expected = batch.child_runs.len();
     Ok(AgentTaskBatchStatusReport {
         schema: AGENT_TASK_BATCH_STATUS_SCHEMA,
         status: state.outcome_status().to_string(),
@@ -697,6 +714,12 @@ where
         commands,
         batch,
         totals,
+        admission: AgentTaskBatchAdmission {
+            expected,
+            admitted,
+            rejected: 0,
+            absent: expected.saturating_sub(admitted),
+        },
         unavailable_child_runs,
         admission_blocker: None,
         projection_pending_child_runs,

--- a/crates/homeboy-agents/src/agent_task_batch/types.rs
+++ b/crates/homeboy-agents/src/agent_task_batch/types.rs
@@ -78,6 +78,9 @@ pub struct AgentTaskBatchStatusReport {
     pub observation_fresh: bool,
     pub batch: AgentTaskBatchRecord,
     pub totals: AgentTaskBatchTotals,
+    /// Durable admission progress. `rejected` counts children terminalized by
+    /// the coordinator before a lifecycle record existed; `absent` have neither.
+    pub admission: AgentTaskBatchAdmission,
     /// The controller-side blocker that prevented any child admission. This
     /// projects the typed failure persisted before a child lifecycle record
     /// exists, rather than making callers inspect batch metadata.
@@ -105,6 +108,13 @@ pub struct AgentTaskBatchStatusReport {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub next_actions: Vec<String>,
     pub commands: AgentTaskBatchCommands,
+}
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AgentTaskBatchAdmission {
+    pub expected: usize,
+    pub admitted: usize,
+    pub rejected: usize,
+    pub absent: usize,
 }
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct AgentTaskBatchResumableChild {

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -366,8 +366,15 @@ fn submit_fanout_batch(args: AgentTaskFanoutSubmitBatchArgs) -> CmdResult<Value>
 }
 
 fn batch_status(args: AgentTaskFanoutBatchStatusArgs) -> CmdResult<Value> {
-    let observations = reconcile_fanout_pr_states(&args.batch_id, false)?;
     let mut report = batch::status(&args.batch_id)?;
+    // A terminal coordinator failure is the authoritative outcome even when it
+    // happened before the first child record existed. Reconciling children first
+    // would turn that diagnostic into a misleading "run record not found".
+    let observations = if report.admission_blocker.is_some() {
+        BTreeMap::new()
+    } else {
+        reconcile_fanout_pr_states(&args.batch_id, false)?
+    };
     if !observations.is_empty() {
         report.dependency_graph = batch::fanout_dependency_graph_with_finalization_statuses(
             &args.batch_id,

--- a/crates/homeboy-cli/src/commands/infra/route/local_detach_fanout.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach_fanout.rs
@@ -524,7 +524,10 @@ fn detached_child_start_identity(
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DetachedFanoutHandoff {
     state: DetachedHandoffState,
-    children: Option<usize>,
+    expected: Option<usize>,
+    admitted: Option<usize>,
+    rejected: Option<usize>,
+    absent: Option<usize>,
     waited_ms: u64,
 }
 
@@ -533,10 +536,11 @@ enum DetachedHandoffState {
     /// The coordinator published its durable batch record; `fanout status` and
     /// `fanout resume` resolve now.
     Accepted,
-    /// The coordinator is alive but has not written its batch record yet. The
-    /// fanout id is still the correct handle — it is pinned on the child's argv
-    /// and is the controller job's idempotency key.
-    Pending,
+    /// The controller job owns a coordinator, but child admission is not yet
+    /// durable for every expected child.
+    CoordinatorStarted,
+    /// The coordinator wrote a terminal failure before completing admission.
+    CoordinatorFailed,
     /// The coordinator exited before publishing durable batch state. The log is
     /// the only evidence, and this is reported rather than dressed up as a
     /// successful handoff.
@@ -547,7 +551,8 @@ impl DetachedHandoffState {
     fn as_str(self) -> &'static str {
         match self {
             Self::Accepted => "accepted",
-            Self::Pending => "pending",
+            Self::CoordinatorStarted => "coordinator_started",
+            Self::CoordinatorFailed => "coordinator_failed",
             Self::ExitedBeforeHandoff => "exited_before_handoff",
         }
     }
@@ -575,29 +580,68 @@ fn await_durable_handoff(
 ) -> DetachedFanoutHandoff {
     let started = Instant::now();
     loop {
-        if let Ok(record) = homeboy::agents::agent_tasks::batch::read_batch_record(fanout_id) {
-            return DetachedFanoutHandoff {
-                state: DetachedHandoffState::Accepted,
-                children: Some(record.child_runs.len()),
-                waited_ms: started.elapsed().as_millis() as u64,
-            };
+        if let Some(mut handoff) = durable_handoff(fanout_id) {
+            handoff.waited_ms = started.elapsed().as_millis() as u64;
+            return handoff;
         }
         if matches!(child.try_wait(), Ok(Some(_)) | Err(_)) {
             return DetachedFanoutHandoff {
                 state: DetachedHandoffState::ExitedBeforeHandoff,
-                children: None,
+                expected: None,
+                admitted: None,
+                rejected: None,
+                absent: None,
                 waited_ms: started.elapsed().as_millis() as u64,
             };
         }
         if started.elapsed() >= timeout {
             return DetachedFanoutHandoff {
-                state: DetachedHandoffState::Pending,
-                children: None,
+                state: DetachedHandoffState::CoordinatorStarted,
+                expected: None,
+                admitted: None,
+                rejected: None,
+                absent: None,
                 waited_ms: started.elapsed().as_millis() as u64,
             };
         }
         std::thread::sleep(HANDOFF_POLL);
     }
+}
+
+/// Read admission only from durable records. A batch roster alone is merely a
+/// coordinator start: it must not be reported as accepted before every child is
+/// either admitted or durably rejected.
+fn durable_handoff(fanout_id: &str) -> Option<DetachedFanoutHandoff> {
+    let record = homeboy::agents::agent_tasks::batch::read_batch_record(fanout_id).ok()?;
+    let expected = record.child_runs.len();
+    let terminal_failure = record.metadata["terminal_failure"].is_object();
+    let admitted = record
+        .child_runs
+        .iter()
+        .filter(|child| {
+            homeboy::agents::agent_tasks::lifecycle::run_record_exists_readonly(&child.run_id)
+                .unwrap_or(false)
+        })
+        .count();
+    let rejected = terminal_failure
+        .then_some(expected.saturating_sub(admitted))
+        .unwrap_or(0);
+    let absent = expected.saturating_sub(admitted + rejected);
+    let state = if terminal_failure {
+        DetachedHandoffState::CoordinatorFailed
+    } else if absent == 0 {
+        DetachedHandoffState::Accepted
+    } else {
+        DetachedHandoffState::CoordinatorStarted
+    };
+    Some(DetachedFanoutHandoff {
+        state,
+        expected: Some(expected),
+        admitted: Some(admitted),
+        rejected: Some(rejected),
+        absent: Some(absent),
+        waited_ms: 0,
+    })
 }
 
 /// The launcher's only output: a bounded, machine-readable handoff naming the
@@ -618,7 +662,12 @@ fn handoff_envelope(
         "launcher_log": log_path.display().to_string(),
         "handoff": {
             "state": handoff.state.as_str(),
-            "children": handoff.children,
+            "admission": {
+                "expected": handoff.expected,
+                "admitted": handoff.admitted,
+                "rejected": handoff.rejected,
+                "absent": handoff.absent,
+            },
             "waited_ms": handoff.waited_ms,
         },
         // The daemon-owned durable job that now supervises this wave, making it
@@ -1048,7 +1097,10 @@ mod tests {
             Path::new("/tmp/fanout.log"),
             &DetachedFanoutHandoff {
                 state: DetachedHandoffState::Accepted,
-                children: Some(3),
+                expected: Some(3),
+                admitted: Some(3),
+                rejected: Some(0),
+                absent: Some(0),
                 waited_ms: 12,
             },
             &ControllerJobHandoff::Owned {
@@ -1060,7 +1112,8 @@ mod tests {
         assert_eq!(envelope["fanout_id"], "wave-7");
         assert_eq!(envelope["detached"], true);
         assert_eq!(envelope["handoff"]["state"], "accepted");
-        assert_eq!(envelope["handoff"]["children"], 3);
+        assert_eq!(envelope["handoff"]["admission"]["expected"], 3);
+        assert_eq!(envelope["handoff"]["admission"]["admitted"], 3);
         assert_eq!(envelope["controller_job"]["state"], "owned");
         assert_eq!(
             envelope["commands"]["status"],
@@ -1070,6 +1123,30 @@ mod tests {
             envelope["commands"]["resume"],
             "homeboy agent-task fanout resume wave-7"
         );
+    }
+
+    #[test]
+    fn a_persisted_roster_without_child_records_is_only_coordinator_started() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            homeboy::agents::agent_tasks::batch::persist_fanout_run_batch(
+                "wave-pre-admission",
+                "wave-pre-admission",
+                &[homeboy::agents::agent_tasks::batch::FanoutRunBatchChild {
+                    task_id: "child".to_string(),
+                    run_id: "child-run".to_string(),
+                }],
+                json!({}),
+            )
+            .expect("persist coordinator roster");
+
+            let handoff = durable_handoff("wave-pre-admission").expect("read handoff");
+
+            assert_eq!(handoff.state, DetachedHandoffState::CoordinatorStarted);
+            assert_eq!(handoff.expected, Some(1));
+            assert_eq!(handoff.admitted, Some(0));
+            assert_eq!(handoff.rejected, Some(0));
+            assert_eq!(handoff.absent, Some(1));
+        });
     }
 
     #[test]

--- a/tests/cli_binary/fanout_supervisor_cli.rs
+++ b/tests/cli_binary/fanout_supervisor_cli.rs
@@ -1,7 +1,10 @@
 use std::path::PathBuf;
 use std::process::Command;
 
-use homeboy::agents::agent_tasks::batch::{persist_fanout_run_batch, FanoutRunBatchChild};
+use homeboy::agents::agent_tasks::batch::{
+    claim_fanout_run_batch, persist_fanout_run_batch, record_fanout_run_batch_failure,
+    FanoutRunBatchChild,
+};
 use homeboy::agents::agent_tasks::fanout_supervisor::{portfolio_exists, read_portfolio};
 use homeboy::agents::agent_tasks::lifecycle::submit_plan;
 use homeboy::agents::agent_tasks::scheduler::AgentTaskPlan;
@@ -116,6 +119,58 @@ fn fanout_resume_runs_and_persists_the_production_supervisor_across_restart() {
             assert!(portfolio.revision >= expected_minimum_revision);
             assert_eq!(portfolio.children["child"].child_id, "child");
         }
+    });
+}
+
+#[test]
+fn fanout_status_reports_a_pre_child_coordinator_failure() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        persist_fanout_run_batch(
+            "failed-before-admission",
+            "failed-before-admission",
+            &[FanoutRunBatchChild {
+                task_id: "child".to_string(),
+                run_id: "missing-child-record".to_string(),
+            }],
+            serde_json::json!({}),
+        )
+        .expect("persist fanout batch");
+        let claim_id = claim_fanout_run_batch("failed-before-admission")
+            .expect("claim batch")
+            .expect("coordinator claim");
+        record_fanout_run_batch_failure(
+            "failed-before-admission",
+            &claim_id,
+            "worktree_preflight",
+            serde_json::json!({ "message": "fixture failure before first child" }),
+        )
+        .expect("persist coordinator failure");
+
+        let output = Command::new(homeboy_bin())
+            .args(["agent-task", "fanout", "status", "failed-before-admission"])
+            .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+            .output()
+            .expect("run Homeboy fanout status");
+        assert!(
+            !output.status.success(),
+            "terminal coordinator failure exits nonzero"
+        );
+        let output: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("fanout status JSON output");
+        assert_eq!(output["data"]["batch"]["status"], "failed");
+        assert_eq!(
+            output["data"]["batch"]["admission_blocker"]["stage"],
+            "worktree_preflight"
+        );
+        assert_eq!(
+            output["data"]["batch"]["admission"],
+            serde_json::json!({
+                "expected": 1,
+                "admitted": 0,
+                "rejected": 1,
+                "absent": 0,
+            })
+        );
     });
 }
 


### PR DESCRIPTION
## Summary
- require every expected child to have a durable lifecycle record before detached fanout reports `accepted`
- expose expected, admitted, rejected, and absent admission counts in detached handoff and fanout status
- preserve and return terminal coordinator failures before child creation

Fixes #12948

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-cli local_detach_fanout::tests`
- `cargo test --test cli_binary fanout_status_reports_a_pre_child_coordinator_failure`
- `cargo test -p homeboy-agents agent_task_batch::tests`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode inspected the aborted worktree, completed the durable-admission/status implementation, and ran the focused Rust tests. Chris Huber remains responsible for every line.