### PR TITLE
fix(ci): compare Test candidates to base

### DIFF
--- a/.github/ci-capacity.json
+++ b/.github/ci-capacity.json
@@ -1,6 +1,6 @@
 {
   "schema": "homeboy/ci-capacity/v1",
-  "test_shards": 4,
+  "test_shards": 1,
   "queue_delay_slo_seconds": {
     "window_days": 7,
     "p95": 300,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,8 +225,8 @@ jobs:
           comment-section-title: ${{ matrix.section_title }}
 
   # The caller job name plus the called reconciliation job name preserves the
-  # required `homeboy / Test` context. PRs execute the affected test closure;
-  # ambiguous source changes fail closed or use Homeboy's full-scope fallback.
+  # required `homeboy / Test` context. Differential Test runs use one candidate
+  # and one base execution so inherited failures remain attributable.
   homeboy:
     name: homeboy
     needs: [pr-state, ci-capacity-admission]
@@ -265,7 +265,7 @@ jobs:
       source: .
       scope: auto
       differential-gating: 'true'
-      baseline-commands: none
+      baseline-commands: review test
       test-shards: ${{ needs.ci-capacity-admission.outputs.test-shards }}
       execution-timeout-seconds: '2100'
       test-timeout-seconds: '1800'

--- a/tests/pr_ci_lifecycle_test.rs
+++ b/tests/pr_ci_lifecycle_test.rs
@@ -124,17 +124,18 @@ fn non_pr_ci_invocations_remain_admitted() {
 }
 
 #[test]
-fn ci_admits_only_the_configured_shard_budget_and_publishes_timing_evidence() {
+fn ci_uses_a_baseline_capable_test_execution_and_publishes_timing_evidence() {
     let config: serde_json::Value =
         serde_json::from_str(include_str!("../.github/ci-capacity.json")).expect("capacity config");
     assert_eq!(config["schema"], "homeboy/ci-capacity/v1");
-    assert_eq!(config["test_shards"], 4);
+    assert_eq!(config["test_shards"], 1);
     assert_eq!(config["queue_delay_slo_seconds"]["window_days"], 7);
     assert_eq!(config["queue_delay_slo_seconds"]["p95"], 300);
     assert_eq!(config["queue_delay_slo_seconds"]["p99"], 600);
 
     let workflow = ci_workflow();
     let test = job_section(workflow, "homeboy");
+    assert!(test.contains("baseline-commands: review test"));
     let shard_p95 = config["execution_slo_seconds"]["test_shard_p95"]
         .as_u64()
         .expect("Test shard p95");

--- a/tests/required_gates_policy_test.rs
+++ b/tests/required_gates_policy_test.rs
@@ -209,15 +209,11 @@ fn required_gate_policy_is_complete_and_emitted_by_every_pr_ci_run() {
         .expect("reusable Test gate");
     assert!(test_gate.contains("      scope: auto"));
     assert!(test_gate.contains("      differential-gating: 'true'"));
-    assert!(test_gate.contains("      baseline-commands: none"));
+    assert!(test_gate.contains("      baseline-commands: review test"));
     assert!(test_gate
         .contains("      test-shards: ${{ needs.ci-capacity-admission.outputs.test-shards }}"));
     assert!(test_gate.contains("      execution-timeout-seconds: '2100'"));
     assert!(test_gate.contains("      test-timeout-seconds: '1800'"));
-    assert!(
-        !test_gate.contains("baseline-commands: review test"),
-        "Test differential gating expands changed PRs to an unbounded full-workspace run"
-    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- run the required Test gate through the existing unsharded candidate/base reconciliation path
- enable `review test` baseline evidence so inherited failures are attributed separately
- retain the required gate and lifecycle tests for the selected execution contract

Fixes #12962.

## Verification

- `cargo fmt --check`
- `cargo test --test pr_ci_lifecycle_test --test required_gates_policy_test` (23 passed)
- `cargo clippy --workspace --all-targets -- -D warnings` (blocked by 19 pre-existing `homeboy-core` warnings in untouched files)

## AI assistance

- **Tool:** OpenCode
- **Model:** OpenAI GPT-5.6 Sol
- **Used for:** Compared the CI candidate and baseline execution contracts, preserved and integrated the interrupted patch with current main, added policy coverage, ran verification, and drafted this PR. Chris remains responsible for every line.