### PR TITLE
Extend the bounded Cook review-form timeout

### DIFF
--- a/crates/homeboy-agents/src/agent_task_cook_loop.rs
+++ b/crates/homeboy-agents/src/agent_task_cook_loop.rs
@@ -23,8 +23,8 @@ const MAX_DIAGNOSTIC_FIELD_BYTES: usize = 512;
 const MAX_DIAGNOSTIC_ACTIONS: usize = 4;
 /// A review form is metadata, not a coding attempt. Callers may lower this via
 /// `metadata.cook_loop.review_form_timeout_ms`; the cap keeps it bounded.
-const DEFAULT_REVIEW_FORM_TIMEOUT_MS: u64 = 60_000;
-const MAX_REVIEW_FORM_TIMEOUT_MS: u64 = 120_000;
+const DEFAULT_REVIEW_FORM_TIMEOUT_MS: u64 = 300_000;
+const MAX_REVIEW_FORM_TIMEOUT_MS: u64 = 600_000;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentTaskCookLoopOptions {
@@ -1874,11 +1874,13 @@ mod tests {
 
     #[test]
     fn review_form_timeout_is_configurable_but_capped() {
+        assert_eq!(review_form_timeout_ms(&source_request()), 300_000);
+
         let mut request = source_request();
         request.metadata = json!({
             "cook_loop": { "review_form_timeout_ms": MAX_REVIEW_FORM_TIMEOUT_MS + 1 }
         });
-        assert_eq!(review_form_timeout_ms(&request), MAX_REVIEW_FORM_TIMEOUT_MS);
+        assert_eq!(review_form_timeout_ms(&request), 600_000);
 
         request.metadata["cook_loop"]["review_form_timeout_ms"] = json!(5_000);
         assert_eq!(review_form_timeout_ms(&request), 5_000);


### PR DESCRIPTION
## Summary

- raise the review-form default timeout from 60 seconds to 5 minutes
- raise the hard configurable cap from 2 minutes to 10 minutes
- pin both production policy values in deterministic Cook-loop coverage

Review forms remain independently bounded below the normal 20-minute coding execution default.

Closes #12977.

## Evidence

The following promoted, gate-passing cooks independently timed out during review-form-only execution at exactly 60 seconds:

- `cook-cook-batch-blocks-engine-issue-1004-3-b64b55b53682-issue-1004-attempt-2-e303480f`
- `cook-cook-batch-blocks-engine-issue-1004-3-b64b55b53682-issue-1005-attempt-2-7920d240`

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-agents review_form_timeout_is_configurable_but_capped`
- `cargo test -p homeboy-agents review_form_retries_retain_the_normalized_timeout`
- `git diff --check`

## AI assistance

OpenAI gpt-5.6-sol via OpenCode was used to inspect durable Cook evidence, trace the timeout policy, implement the bounded change, and run verification. Chris Huber reviewed and is responsible for every line.