### PR TITLE
Fix Cook worktree provider convergence

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -6748,29 +6748,32 @@ fn materialize_pending_cook_workspace(
     effective_lookup_timeout_ms: Option<u64>,
 ) -> Result<()> {
     restore_legacy_cook_provision(&mut options.initial_plan)?;
-    let provider_id = options
-        .initial_plan
-        .metadata
-        .pointer("/cook_provision/workspace_identity/provider_id")
-        .and_then(Value::as_str)
-        .or_else(|| {
-            options
-                .initial_plan
-                .metadata
-                .pointer("/cook_provision/worktree_provider_id")
-                .and_then(Value::as_str)
-        });
+    let provider_id = |options: &AgentTaskCookServiceOptions| {
+        options
+            .initial_plan
+            .metadata
+            .pointer("/cook_provision/workspace_identity/provider_id")
+            .and_then(Value::as_str)
+            .or_else(|| {
+                options
+                    .initial_plan
+                    .metadata
+                    .pointer("/cook_provision/worktree_provider_id")
+                    .and_then(Value::as_str)
+            })
+            .map(str::to_string)
+    };
     let mut config = homeboy_core::defaults::load_config();
     if let Some(timeout_ms) = effective_lookup_timeout_ms {
         for provider in config.worktree_providers.values_mut() {
             provider.lookup_timeout_ms = provider.lookup_timeout_ms.min(timeout_ms);
         }
     }
-    let resolve = || {
-        match provider_id {
+    let resolve = |options: &AgentTaskCookServiceOptions| {
+        match provider_id(options) {
         Some(provider_id) => homeboy_core::worktree_providers::resolve_apply_enabled_worktree_provider_identity_by_id_from_config(
             &options.to_worktree,
-            provider_id,
+            &provider_id,
             &config,
         ),
         None => homeboy_core::worktree_providers::resolve_apply_enabled_worktree_provider_identity_from_config(
@@ -6779,14 +6782,23 @@ fn materialize_pending_cook_workspace(
         ),
     }
     };
-    let mut identity = match resolve() {
+    let mut identity = match resolve(options) {
         Ok(identity) => identity,
         Err(error)
-            if provider_id.is_none()
+            if provider_id(options).is_none()
                 && error.details["worktree_provider_lookup"] == "not_found" =>
         {
-            provision_pending_cook_workspace(options, &config)?;
-            resolve()?
+            let provision = provision_pending_cook_workspace(lifecycle_store, options, &config)?;
+            // Pin the provider that performed the durable mutation. A later
+            // continuation re-resolves this exact destination through its owner.
+            options.initial_plan.metadata["cook_provision"]["worktree_provider_id"] =
+                Value::String(provision.resolution.provider_id);
+            agent_task_lifecycle::persist_controller_plan_in_store(
+                lifecycle_store,
+                &options.initial_run_id,
+                &options.initial_plan,
+            )?;
+            resolve(options)?
         }
         Err(error) => return Err(error),
     };
@@ -7170,9 +7182,10 @@ fn record_provider_resolve_evidence(
 /// identity. In that case, execute the unchanged configured ensure contract and
 /// resolve its postcondition through the same provider boundary.
 fn provision_pending_cook_workspace(
-    options: &AgentTaskCookServiceOptions,
+    lifecycle_store: &AgentTaskLifecycleStore,
+    options: &mut AgentTaskCookServiceOptions,
     config: &homeboy_core::defaults::HomeboyConfig,
-) -> Result<()> {
+) -> Result<homeboy_core::worktree_providers::WorktreeProviderProvision> {
     let intent = &options.initial_plan.metadata["cook_provision"]["provision_intent"];
     let required = |field: &str| {
         intent.get(field).and_then(Value::as_str).filter(|value| !value.trim().is_empty()).ok_or_else(|| {
@@ -7182,17 +7195,70 @@ fn provision_pending_cook_workspace(
             )])
         })
     };
-    homeboy_core::worktree_providers::provision_apply_enabled_worktree_provider_from_config(
-        &homeboy_core::worktree_providers::WorktreeProviderCreateIntent {
-            handle: options.to_worktree.clone(),
-            repo: required("repo")?.to_string(),
-            base: required("base")?.to_string(),
-            head: required("head")?.to_string(),
-            task_url: required("task_url")?.to_string(),
+    let create_intent = homeboy_core::worktree_providers::WorktreeProviderCreateIntent {
+        handle: options.to_worktree.clone(),
+        repo: required("repo")?.to_string(),
+        base: required("base")?.to_string(),
+        head: required("head")?.to_string(),
+        task_url: required("task_url")?.to_string(),
+    };
+    let Some(lifecycle) = options
+        .initial_plan
+        .metadata
+        .pointer("/cook_provision/lifecycle_intent")
+        .filter(|value| value.is_object())
+    else {
+        // Historical recipes did not declare ownership fields. Keep their
+        // existing provider contract intact; new Cook plans always persist it.
+        return homeboy_core::worktree_providers::provision_apply_enabled_worktree_provider_from_config(
+            &create_intent,
+            config,
+        );
+    };
+    let purpose = lifecycle
+        .get("purpose")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("agent_task_cook")
+        .to_string();
+    let cleanup_policy = match lifecycle.get("cleanup_policy").and_then(Value::as_str) {
+        None | Some("remove_on_success") => {
+            homeboy_core::worktree_providers::WorktreeProviderCleanupPolicy::RemoveOnSuccess
+        }
+        Some("preserve_on_failure") => {
+            homeboy_core::worktree_providers::WorktreeProviderCleanupPolicy::PreserveOnFailure
+        }
+        Some(value) => {
+            return Err(Error::validation_invalid_argument(
+                "cook_provision.lifecycle_intent.cleanup_policy",
+                "Cook provider lifecycle cleanup policy is invalid",
+                Some(value.to_string()),
+                None,
+            ));
+        }
+    };
+    // Bind the pending lifecycle intent to its stable durable run before the
+    // mutation so configured templates have complete context and continuation
+    // observes the same provider ownership.
+    options.initial_plan.metadata["cook_provision"]["lifecycle_intent"] = serde_json::json!({
+        "purpose": purpose,
+        "owner_run_ref": options.initial_run_id,
+        "cleanup_policy": cleanup_policy.as_str(),
+    });
+    agent_task_lifecycle::persist_controller_plan_in_store(
+        lifecycle_store,
+        &options.initial_run_id,
+        &options.initial_plan,
+    )?;
+    homeboy_core::worktree_providers::provision_apply_enabled_worktree_provider_with_lifecycle_from_config(
+        &create_intent,
+        &homeboy_core::worktree_providers::WorktreeProviderLifecycleIntent {
+            purpose,
+            owner_run_ref: options.initial_run_id.clone(),
+            cleanup_policy,
         },
         config,
-    )?;
-    Ok(())
+    )
 }
 
 fn validate_pending_cook_repository_identity(plan: &AgentTaskPlan, target: &Path) -> Result<()> {

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -5373,7 +5373,7 @@ fn deferred_provider_ensure_materializes_injected_lifecycle_plan_after_its_postc
         std::fs::write(
             &provider,
             format!(
-                "#!/bin/sh\ncase \"$1\" in\nresolve)\n  if test -f '{}'; then printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"fixture@durable-ensure\",\"path\":\"{}\",\"branch\":\"durable-ensure\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'; else printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"fixture@durable-ensure\",\"path\":\"remote://fixture/durable-ensure\",\"branch\":\"durable-ensure\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'; fi\n  ;;\nensure)\n  git -C '{}' worktree add --quiet -b durable-ensure '{}' HEAD && touch '{}'\n  ;;\nesac\n",
+                "#!/bin/sh\ncase \"$1\" in\nresolve)\n  if test -f '{}'; then printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"fixture@durable-ensure\",\"path\":\"{}\",\"branch\":\"durable-ensure\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'; else printf '%s\\n' '{{\"worktrees\":[]}}' ; fi\n  ;;\nensure)\n  test \"$2\" = fixture && test \"$3\" = main && test \"$4\" = durable-ensure && test \"$5\" = https://example.test/issues/12601 && test \"$6\" = agent_task_cook && test \"$7\" = durable-ensure-run && test \"$8\" = remove_on_success || exit 9\n  git -C '{}' worktree add --quiet -b durable-ensure '{}' HEAD && touch '{}'\n  ;;\nesac\n",
                 created.display(),
                 workspace.display(),
                 source.display(),
@@ -5400,7 +5400,17 @@ fn deferred_provider_ensure_materializes_injected_lifecycle_plan_after_its_postc
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy_core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![provider.display().to_string(), "resolve".to_string()]),
-                    ensure: Some(vec![provider.display().to_string(), "ensure".to_string()]),
+                    ensure: Some(vec![
+                        provider.display().to_string(),
+                        "ensure".to_string(),
+                        "{repo}".to_string(),
+                        "{base}".to_string(),
+                        "{head}".to_string(),
+                        "{task_url}".to_string(),
+                        "{purpose}".to_string(),
+                        "{owner_run_ref}".to_string(),
+                        "{cleanup_policy}".to_string(),
+                    ]),
                     ..Default::default()
                 },
                 list_result_mapping: Some(
@@ -5433,6 +5443,10 @@ fn deferred_provider_ensure_materializes_injected_lifecycle_plan_after_its_postc
                 "head": "durable-ensure",
                 "task_url": "https://example.test/issues/12601",
             },
+            "lifecycle_intent": {
+                "purpose": "agent_task_cook",
+                "cleanup_policy": "remove_on_success",
+            },
         });
 
         recipe_store
@@ -5453,6 +5467,14 @@ fn deferred_provider_ensure_materializes_injected_lifecycle_plan_after_its_postc
             .read_controller_plan(run_id)
             .expect("injected lifecycle store has the materialized plan");
         assert_eq!(plan.metadata["cook_provision"]["action"], "existing");
+        assert_eq!(
+            plan.metadata["cook_provision"]["lifecycle_intent"]["owner_run_ref"],
+            run_id
+        );
+        assert_eq!(
+            plan.metadata["cook_provision"]["worktree_provider_id"],
+            "fixture"
+        );
         assert_eq!(
             options.source_worktree_path.as_deref(),
             Some(workspace.as_path())

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -2328,6 +2328,12 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
                 "head": args.head,
                 "task_url": args.dispatch.task_url,
             },
+            // Cook owns this destination's terminal lifecycle. Its exact run id
+            // is assigned during durable materialization, before ensure runs.
+            "lifecycle_intent": {
+                "purpose": "agent_task_cook",
+                "cleanup_policy": "remove_on_success",
+            },
         }));
     }
     match homeboy::core::worktree_providers::resolve_apply_enabled_worktree_provider_identity_from_config(to_worktree, &config) {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -2254,6 +2254,13 @@ fn cook_defers_an_issue_destination_with_an_ensure_only_provider() {
             .expect("ensure-only provider is deferred until durable Cook admission");
 
         assert_eq!(provision["action"], "lookup_pending");
+        assert_eq!(
+            provision["lifecycle_intent"],
+            serde_json::json!({
+                "purpose": "agent_task_cook",
+                "cleanup_policy": "remove_on_success",
+            })
+        );
         let plan = super::super::run::compile_cook_plan(&args, provision.clone())
             .expect("compile issue-derived Cook with its deferred provision intent");
         assert_eq!(plan.metadata["cook_provision"], provision);


### PR DESCRIPTION
Closes #9908

## Summary
- persist lifecycle provisioning intent for deferred single-Cook destinations
- bind the durable run before provider ensure and pin the selected provider for continuation
- cover lifecycle placeholder expansion and provider adoption

## Verification
- `cargo test -p homeboy-agents deferred_ensure_only_provider_fails_after_durable_cook_admission`
- `cargo test -p homeboy-agents deferred_ensure_only_failure_uses_injected_recipe_and_lifecycle_stores`
- `cargo test -p homeboy-agents deferred_provider_ensure_materializes_injected_lifecycle_plan_after_its_postcondition`
- `cargo test -p homeboy-cli cook_defers_an_issue_destination_with_an_ensure_only_provider`
- `cargo fmt --check`

## AI assistance
OpenAI GPT-5.6-sol via OpenCode general coding subagent was used to inspect the Cook/provider lifecycle, implement the durable provisioning change, and run focused verification. Chris reviewed and remains responsible for this change.