### PR TITLE
fix(lab): stabilize snapshot manifests

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -1912,7 +1912,7 @@ pub(super) fn validate_snapshot_stability(
     if before == staged && staged == after {
         return Ok(());
     }
-    let mut error = snapshot_construction_failure(
+    Err(snapshot_construction_failure(
         "workspace_snapshot",
         source,
         Some(staging_output),
@@ -1920,8 +1920,7 @@ pub(super) fn validate_snapshot_stability(
             "source and staged snapshot manifests differ; refusing a mixed snapshot; {}",
             snapshot_manifest_difference(before, staged, after)
         ),
-    ));
-    error
+    ))
 }
 
 fn snapshot_manifest_difference(

--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -220,6 +220,17 @@ pub(crate) fn workspace_content_hash_for_policy(
     excludes: &[String],
     policy: &str,
 ) -> Result<String> {
+    Ok(workspace_content_manifest_and_hash_for_policy(path, excludes, policy)?.1)
+}
+
+/// Collect the content manifest and digest in one traversal. Snapshot staging
+/// must never compare an inventory from one filesystem instant with a digest
+/// from another while runner-owned cleanup is active.
+pub(crate) fn workspace_content_manifest_and_hash_for_policy(
+    path: &Path,
+    excludes: &[String],
+    policy: &str,
+) -> Result<(WorkspaceContentManifest, String)> {
     let (algorithm, executable_capability) =
         workspace_content_hash_contract(policy).ok_or_else(|| {
             Error::validation_invalid_argument(
@@ -233,15 +244,19 @@ pub(crate) fn workspace_content_hash_for_policy(
     hasher.update(algorithm.as_bytes());
     hasher.update(b"\0");
     let root = content_hash_root(path)?;
+    let mut manifest = WorkspaceContentManifest {
+        entry_count: 0,
+        entries: Vec::new(),
+    };
     ContentHashTraversal {
         root: &root,
         excludes,
         hasher: &mut hasher,
         executable_capability,
-        manifest: None,
+        manifest: Some(&mut manifest),
     }
     .collect(&root, Path::new(""), &mut vec![root.clone()])?;
-    Ok(format!("sha256:{:x}", hasher.finalize()))
+    Ok((manifest, format!("sha256:{:x}", hasher.finalize())))
 }
 
 /// A deterministic, content-free inventory of every path a snapshot materializes.
@@ -252,34 +267,7 @@ pub(crate) fn workspace_content_manifest_for_policy(
     excludes: &[String],
     policy: &str,
 ) -> Result<WorkspaceContentManifest> {
-    let executable_capability = match workspace_content_hash_contract(policy) {
-        Some((_, capability)) => capability,
-        None => {
-            return Err(Error::validation_invalid_argument(
-                "permission_policy",
-                "workspace content hash policy is unsupported on this platform",
-                Some(policy.to_string()),
-                None,
-            ));
-        }
-    };
-    let root = content_hash_root(path)?;
-    let mut manifest = WorkspaceContentManifest {
-        entry_count: 0,
-        entries: Vec::new(),
-    };
-    // Use the authoritative v2 traversal so diagnostics and the content hash
-    // have identical symlink, exclusion, and metadata behavior.
-    let mut hasher = Sha256::new();
-    ContentHashTraversal {
-        root: &root,
-        excludes,
-        hasher: &mut hasher,
-        executable_capability,
-        manifest: Some(&mut manifest),
-    }
-    .collect(&root, Path::new(""), &mut vec![root.clone()])?;
-    Ok(manifest)
+    Ok(workspace_content_manifest_and_hash_for_policy(path, excludes, policy)?.0)
 }
 
 /// Exact historical v1 algorithm for controllers that emitted
@@ -1903,13 +1891,14 @@ pub(super) fn snapshot_stable_manifest(
     path: &Path,
     excludes: &[String],
 ) -> Result<SnapshotStableManifest> {
+    let (inventory, content_identity) = workspace_content_manifest_and_hash_for_policy(
+        path,
+        excludes,
+        WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
+    )?;
     Ok(SnapshotStableManifest {
-        inventory: workspace_content_manifest_for_policy(
-            path,
-            excludes,
-            WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
-        )?,
-        content_identity: workspace_content_hash(path, excludes)?,
+        inventory,
+        content_identity,
     })
 }
 
@@ -1923,7 +1912,7 @@ pub(super) fn validate_snapshot_stability(
     if before == staged && staged == after {
         return Ok(());
     }
-    Err(snapshot_construction_failure(
+    let mut error = snapshot_construction_failure(
         "workspace_snapshot",
         source,
         Some(staging_output),
@@ -1931,7 +1920,8 @@ pub(super) fn validate_snapshot_stability(
             "source and staged snapshot manifests differ; refusing a mixed snapshot; {}",
             snapshot_manifest_difference(before, staged, after)
         ),
-    ))
+    ));
+    error
 }
 
 fn snapshot_manifest_difference(

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -11,8 +11,8 @@ use crate::workspace::snapshot::{
     snapshot_install_command, snapshot_overlay_install_command, snapshot_stable_manifest,
     synthetic_checkout_value, validate_snapshot_stability, workspace_content_hash,
     workspace_content_hash_algorithm, workspace_content_hash_for_policy, workspace_content_hash_v1,
-    workspace_content_manifest_for_policy, WORKSPACE_CONTENT_PERMISSION_PORTABLE,
-    WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE,
+    workspace_content_manifest_and_hash_for_policy, workspace_content_manifest_for_policy,
+    WORKSPACE_CONTENT_PERMISSION_PORTABLE, WORKSPACE_CONTENT_PERMISSION_UNIX_EXECUTABLE,
     WORKSPACE_CONTENT_PERMISSION_UNIX_OWNER_EXECUTABLE,
 };
 
@@ -780,6 +780,43 @@ fn workspace_content_hash_skips_runner_metadata_removed_after_discovery() {
             "legacy verification must tolerate the same runner metadata race"
         );
     }
+}
+
+#[test]
+fn workspace_content_manifest_and_hash_share_one_traversal_instant() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let first = workspace.path().join("a-first.txt");
+    let trigger = workspace.path().join("z-trigger.txt");
+    fs::write(&first, "before\n").expect("first file");
+    fs::write(&trigger, "trigger\n").expect("trigger file");
+
+    let first_to_mutate = first.clone();
+    let _hook = register_after_snapshot_directory_discovery_hook(trigger, move || {
+        fs::write(first_to_mutate, "after\n").expect("mutate first file after its traversal");
+    });
+    let (manifest, identity) = workspace_content_manifest_and_hash_for_policy(
+        workspace.path(),
+        &[],
+        WORKSPACE_CONTENT_PERMISSION_PORTABLE,
+    )
+    .expect("collect manifest and identity");
+
+    let first_entry = manifest
+        .entries
+        .iter()
+        .find(|entry| entry.path == "a-first.txt")
+        .expect("first file manifest entry");
+    assert_eq!(first_entry.bytes, Some(7));
+    assert_ne!(
+        identity,
+        workspace_content_hash_for_policy(
+            workspace.path(),
+            &[],
+            WORKSPACE_CONTENT_PERMISSION_PORTABLE,
+        )
+        .expect("identity after mutation"),
+        "the source mutation happened after the shared traversal read the first file"
+    );
 }
 
 #[test]
@@ -1631,6 +1668,74 @@ fn snapshot_stability_rejects_a_mixed_staged_tree_even_if_source_is_restored() {
         "{error:?}"
     );
     assert!(error.message.contains("runtime-overlays"), "{error:?}");
+}
+
+#[test]
+fn snapshot_staging_is_stable_with_sibling_worktrees_and_ignored_outputs() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let workspace_root = tempfile::tempdir().expect("workspace root");
+        let source = workspace_root.path().join("homeboy@task");
+        let runner_root = tempfile::tempdir().expect("runner root");
+        fs::create_dir_all(&source).expect("source directory");
+        fs::write(source.join("tracked.txt"), "source\n").expect("tracked source");
+        fs::write(source.join(".gitignore"), "generated/\ntarget/\n").expect("gitignore");
+        git(&source, &["init", "-b", "main"]);
+        git(&source, &["config", "user.email", "test@example.com"]);
+        git(&source, &["config", "user.name", "Test User"]);
+        git(&source, &["add", "."]);
+        git(&source, &["commit", "-m", "baseline"]);
+        for index in 0..16 {
+            let sibling = workspace_root
+                .path()
+                .join(format!("homeboy@sibling-{index}"));
+            let output = std::process::Command::new("git")
+                .args(["worktree", "add", "--detach"])
+                .arg(&sibling)
+                .arg("HEAD")
+                .current_dir(&source)
+                .output()
+                .expect("create sibling worktree");
+            assert!(
+                output.status.success(),
+                "create sibling worktree: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        fs::create_dir_all(source.join("generated/runtime")).expect("generated directory");
+        fs::create_dir_all(source.join("target/debug")).expect("target directory");
+        fs::write(source.join("generated/runtime/output.js"), "generated\n")
+            .expect("generated output");
+        fs::write(source.join("target/debug/homeboy"), "binary\n").expect("target output");
+
+        crate::create(
+            &format!(
+                r#"{{"id":"lab-stable-clean-worktree","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+        let options = RunnerWorkspaceSyncOptions {
+            path: source.display().to_string(),
+            mode: RunnerWorkspaceSyncMode::Snapshot,
+            controller_routed_git: false,
+            changed_since_base: None,
+            git_fetch_refs: Vec::new(),
+            snapshot_includes: Vec::new(),
+            allow_dirty_lab_workspace: false,
+            run_isolation_token: None,
+        };
+
+        for attempt in 0..3 {
+            let (synced, exit_code) = sync_workspace("lab-stable-clean-worktree", options.clone())
+                .expect("clean worktree snapshot must remain stable");
+            assert_eq!(exit_code, 0, "attempt {attempt}");
+            let staged = Path::new(&synced.remote_path);
+            assert!(staged.join("tracked.txt").is_file());
+            assert!(!staged.join("generated/runtime/output.js").exists());
+            assert!(!staged.join("target/debug/homeboy").exists());
+        }
+    });
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- collect each snapshot content manifest and identity in one traversal
- report bounded, path-level manifest differences for real mixed snapshots
- cover stable clean-worktree staging and the traversal-boundary race

Closes #12963

## Testing
- cargo fmt --check
- cargo test -p homeboy-lab-runner workspace::tests::snapshot:: -- --nocapture

## AI assistance
OpenAI gpt-5.6-sol via OpenCode used for implementation and verification; Chris Huber remains responsible.