### PR TITLE
fix(status): bound unrelated cleanup evidence

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -329,24 +329,7 @@ fn review_record_projection(
     record: &homeboy::agents::agent_tasks::lifecycle::AgentTaskRunRecord,
 ) -> (Value, Vec<Value>) {
     let mut value = serde_json::to_value(record).unwrap_or(Value::Null);
-    let Some(metadata) = value.get_mut("metadata").and_then(Value::as_object_mut) else {
-        return (value, Vec::new());
-    };
-    let mut cleanup_evidence = Vec::new();
-    for key in [
-        "automatic_artifact_retention",
-        "automatic_artifact_retention_inaccessible_roots",
-    ] {
-        if metadata.remove(key).is_some() {
-            cleanup_evidence.push(serde_json::json!({
-                "kind": key,
-                "details_omitted": true,
-                "ref": format!("homeboy://agent-task/run/{}/status#metadata.{key}", record.run_id),
-                "command": format!("homeboy agent-task status {} --full", record.run_id),
-                "export_command": format!("homeboy agent-task status {} --full --output <path>", record.run_id),
-            }));
-        }
-    }
+    let cleanup_evidence = super::status::cleanup_evidence_projection(&mut value, &record.run_id);
     (value, cleanup_evidence)
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -281,6 +281,10 @@ fn status_once(args: StatusArgs) -> CmdResult<Value> {
         attach_runner_probe(&mut value, &runner_probe);
         attach_agent_task_status_actionable(&mut value, run_id);
         preserve_controller_owner_placement_with_prefix(&mut value, run_id, &recovery_prefix);
+        let cleanup_evidence = cleanup_evidence_projection(&mut value, run_id);
+        if !cleanup_evidence.is_empty() {
+            value["cleanup_evidence"] = Value::Array(cleanup_evidence);
+        }
         if args.bounded {
             value = bounded_full_status(value, run_id);
         }
@@ -300,6 +304,39 @@ fn status_once(args: StatusArgs) -> CmdResult<Value> {
     let summary = enforce_compact_status_budget(summary);
     let exit_code = subject_exit_code(&summary, args.strict_subject_exit);
     Ok((summary, exit_code))
+}
+
+/// Automatic retention runs while a task completes but can inventory every
+/// workspace sharing its roots. Keep that global operational evidence durable
+/// and addressable without allowing it to obscure this run's diagnosis.
+pub(crate) fn cleanup_evidence_projection(value: &mut Value, run_id: &str) -> Vec<Value> {
+    let Some(metadata) = value.get_mut("metadata").and_then(Value::as_object_mut) else {
+        return Vec::new();
+    };
+    let run_ref = homeboy::core::execution_contract::encode_uri_component(run_id);
+    [
+        "automatic_artifact_retention",
+        "automatic_artifact_retention_inaccessible_roots",
+    ]
+    .into_iter()
+    .filter_map(|key| {
+        let details = metadata.remove(key)?;
+        let count = details
+            .get("worktree_count")
+            .and_then(Value::as_u64)
+            .or_else(|| details.as_array().map(|items| items.len() as u64))
+            .or_else(|| details.get("worktrees").and_then(Value::as_array).map(|items| items.len() as u64))
+            .unwrap_or(0);
+        Some(json!({
+            "kind": key,
+            "count": count,
+            "details_omitted": true,
+            "ref": format!("homeboy://agent-task/run/{run_ref}/status#metadata.{key}"),
+            "command": format!("homeboy agent-task status {} --full", quote_arg(run_id)),
+            "export_command": format!("homeboy agent-task status {} --full --output <path>", quote_arg(run_id)),
+        }))
+    })
+    .collect()
 }
 
 struct StatusPoller {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -72,6 +72,62 @@ fn bounded_full_status_refs_hydrate_through_the_agent_task_resolver() {
     });
 }
 
+#[test]
+fn full_status_bounds_unrelated_high_cardinality_cleanup_inventory() {
+    with_isolated_home(|_| {
+        let run_id = "status-scoped-cleanup";
+        agent_task_lifecycle::submit_plan(&test_plan(), Some(run_id)).expect("submitted");
+        let worktrees = (0..10_000)
+            .map(|index| format!("/workspace/unrelated-{index}"))
+            .collect::<Vec<_>>();
+        agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+            record.metadata["automatic_artifact_retention"] = json!({
+                "status": "completed",
+                "worktree_count": worktrees.len(),
+                "worktrees": worktrees,
+            });
+        })
+        .expect("persist unrelated cleanup inventory");
+
+        let (value, _) = status(StatusArgs {
+            run_id: run_id.to_string(),
+            exact: false,
+            bridge: false,
+            since_cursor: None,
+            full: true,
+            bounded: false,
+            no_runner_probe: false,
+            strict_subject_exit: false,
+            watch: false,
+            interval: "5s".to_string(),
+            timeout: "30m".to_string(),
+        })
+        .expect("full status");
+
+        assert!(value["metadata"]
+            .get("automatic_artifact_retention")
+            .is_none());
+        assert_eq!(value["cleanup_evidence"][0]["count"], 10_000);
+        assert_eq!(
+            value["cleanup_evidence"][0]["ref"],
+            format!(
+                "homeboy://agent-task/run/{run_id}/status#metadata.automatic_artifact_retention"
+            )
+        );
+        assert!(value["tasks"].is_array());
+        assert!(!value.to_string().contains("/workspace/unrelated-9999"));
+        assert!(value.to_string().len() < 16 * 1024);
+
+        let persisted = agent_task_lifecycle::status(run_id).expect("persisted record");
+        assert_eq!(
+            persisted.metadata["automatic_artifact_retention"]["worktrees"]
+                .as_array()
+                .map(Vec::len),
+            Some(10_000)
+        );
+    });
+}
+
 #[derive(Debug)]
 struct RecoverableRunnerDispatcher {
     unavailable: AtomicBool,


### PR DESCRIPTION
## Summary
- scope `agent-task status <run> --full` to selected-run evidence by replacing automatic retention inventories with counts and durable status references
- preserve the durable lifecycle record and reuse the projection in `agent-task review`
- add a 10,000-worktree regression proving the rendered full status remains bounded while the persisted inventory remains available

Closes #12989.

## Verification
- `cargo fmt --all --check` passed
- focused `homeboy-cli` test compiled and reached the regression at runtime; the final assertion-only adjustment was not rerun because concurrent workspace Cargo builds repeatedly exhausted the 300s/900s local gate windows
- `cargo check --workspace --locked` and full lint did not complete locally under concurrent Cargo target contention; CI remains required

AI assistance: OpenAI gpt-5.6-sol via OpenCode assisted implementation and verification; Chris Huber remains responsible.