### PR TITLE
fix(runner): clarify Lab binary diagnostics

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
@@ -265,20 +265,13 @@ pub fn lab_homeboy_path_checks(
     ));
 
     if let Some(candidate) = candidate {
-        let configured_version = configured_probe.version.trim();
-        if configured_version != candidate.version.trim() {
-            checks.push(checks::warning_with_details(
-                "lab.homeboy.path_drift",
-                format!(
-                    "Configured runner Homeboy {configured_version} differs from preferred runner binary {} at {}",
-                    candidate.version, candidate.path
-                ),
-                Some(format!(
-                    "Point runner `{runner_id}` at the preferred binary with `homeboy runner set {runner_id} --json '{{\"homeboy_path\":\"{}\"}}'`",
-                    candidate.path
-                )),
-                configured_details.clone(),
-            ));
+        if let Some(check) = lab_homeboy_path_drift_check(
+            runner_id,
+            configured_probe,
+            &candidate,
+            configured_details.clone(),
+        ) {
+            checks.push(check);
         }
     }
 
@@ -295,6 +288,66 @@ pub fn lab_homeboy_path_checks(
     }
 
     checks
+}
+
+pub(super) fn lab_homeboy_path_drift_check(
+    runner_id: &str,
+    configured: &HomeboyProbe,
+    preferred: &RemoteHomeboyCandidate,
+    details: BTreeMap<String, String>,
+) -> Option<RunnerCheck> {
+    let configured_version = configured.version.trim();
+    let preferred_version = preferred.version.trim();
+    if configured_version == preferred_version {
+        return None;
+    }
+
+    let preferred_is_dirty = preferred_version.contains("dirty");
+    let preferred_precedence = (!preferred_is_dirty)
+        .then(|| {
+            let configured =
+                semver::Version::parse(configured_version.trim_start_matches('v')).ok()?;
+            let preferred =
+                semver::Version::parse(preferred_version.trim_start_matches('v')).ok()?;
+            Some(preferred.cmp_precedence(&configured))
+        })
+        .flatten();
+
+    if preferred_precedence.is_some_and(|precedence| precedence.is_gt()) {
+        return Some(checks::warning_with_details(
+            "lab.homeboy.path_drift",
+            format!(
+                "Preferred runner Homeboy {preferred_version} at {} is newer than configured runner Homeboy {configured_version}",
+                preferred.path
+            ),
+            Some(format!(
+                "Point runner `{runner_id}` at the newer preferred binary with `homeboy runner set {runner_id} --json '{{\"homeboy_path\":\"{}\"}}'`",
+                preferred.path
+            )),
+            details,
+        ));
+    }
+
+    let reason = if preferred_is_dirty {
+        "is a dirty build"
+    } else if preferred_precedence.is_some_and(|precedence| precedence.is_lt()) {
+        "is older than configured"
+    } else {
+        "has a different build identity from configured"
+    };
+    Some(checks::warning_with_details(
+        "lab.homeboy.path_drift",
+        format!(
+            "Preferred runner Homeboy {preferred_version} at {} {reason}; configured Homeboy {configured_version} remains selected",
+            preferred.path
+        ),
+        Some(format!(
+            "Update or remove stale preferred binary at {}; keep runner `{runner_id}` on configured homeboy_path `{}`",
+            preferred.path,
+            configured.path.as_deref().unwrap_or("homeboy")
+        )),
+        details,
+    ))
 }
 
 pub(super) fn homeboy_path_shadow_check(
@@ -1304,9 +1357,9 @@ pub(super) fn provider_env_path_readiness_check_from_probe(
     )
 }
 
-struct RemoteHomeboyCandidate {
-    path: String,
-    version: String,
+pub(super) struct RemoteHomeboyCandidate {
+    pub(super) path: String,
+    pub(super) version: String,
 }
 
 fn remote_homeboy_probe(client: &SshClient, command: &str) -> RemoteHomeboyCandidateProbe {

--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/homeboy_path.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/homeboy_path.rs
@@ -2,6 +2,99 @@ use super::super::*;
 use std::collections::BTreeMap;
 use types::{HomeboyProbe, RunnerDoctorStatus};
 
+fn configured_homeboy(version: &str) -> HomeboyProbe {
+    HomeboyProbe {
+        version: version.to_string(),
+        path: Some("/runner/configured/homeboy".to_string()),
+    }
+}
+
+fn preferred_homeboy(version: &str) -> probes::RemoteHomeboyCandidate {
+    probes::RemoteHomeboyCandidate {
+        path: "/runner/preferred/homeboy".to_string(),
+        version: version.to_string(),
+    }
+}
+
+#[test]
+fn lab_homeboy_path_drift_keeps_a_newer_configured_binary() {
+    let check = probes::lab_homeboy_path_drift_check(
+        "lab",
+        &configured_homeboy("0.354.1+current"),
+        &preferred_homeboy("0.284.0+old"),
+        BTreeMap::new(),
+    )
+    .expect("stale preferred binary is diagnosed");
+
+    assert_eq!(check.status, RunnerDoctorStatus::Warning);
+    assert!(check.message.contains("older than configured"));
+    assert!(check.message.contains("remains selected"));
+    assert!(check.remediation.as_deref().is_some_and(|value| {
+        value.contains("Update or remove stale preferred binary") && !value.contains("runner set")
+    }));
+}
+
+#[test]
+fn lab_homeboy_path_drift_recommends_a_clean_newer_preferred_binary() {
+    let check = probes::lab_homeboy_path_drift_check(
+        "lab",
+        &configured_homeboy("0.353.1+current"),
+        &preferred_homeboy("0.354.1+new"),
+        BTreeMap::new(),
+    )
+    .expect("newer preferred binary is diagnosed");
+
+    assert_eq!(check.status, RunnerDoctorStatus::Warning);
+    assert!(check.message.contains("newer than configured"));
+    assert_eq!(
+        check.remediation.as_deref(),
+        Some("Point runner `lab` at the newer preferred binary with `homeboy runner set lab --json '{\"homeboy_path\":\"/runner/preferred/homeboy\"}'`")
+    );
+}
+
+#[test]
+fn lab_homeboy_path_drift_rejects_dirty_preferred_binary() {
+    let check = probes::lab_homeboy_path_drift_check(
+        "lab",
+        &configured_homeboy("0.353.1+current"),
+        &preferred_homeboy("0.354.1+candidate-dirty"),
+        BTreeMap::new(),
+    )
+    .expect("dirty preferred binary is diagnosed");
+
+    assert!(check.message.contains("dirty build"));
+    assert!(check.remediation.as_deref().is_some_and(|value| {
+        value.contains("Update or remove stale preferred binary") && !value.contains("runner set")
+    }));
+}
+
+#[test]
+fn lab_homeboy_path_drift_is_absent_for_exact_match() {
+    assert!(probes::lab_homeboy_path_drift_check(
+        "lab",
+        &configured_homeboy("0.354.1+exact"),
+        &preferred_homeboy("0.354.1+exact"),
+        BTreeMap::new(),
+    )
+    .is_none());
+}
+
+#[test]
+fn lab_homeboy_path_drift_keeps_configured_binary_for_different_build_identity() {
+    let check = probes::lab_homeboy_path_drift_check(
+        "lab",
+        &configured_homeboy("0.354.1+current"),
+        &preferred_homeboy("0.354.1+different-build"),
+        BTreeMap::new(),
+    )
+    .expect("different build identity is diagnosed");
+
+    assert!(check.message.contains("different build identity"));
+    assert!(check.remediation.as_deref().is_some_and(|value| {
+        value.contains("Update or remove stale preferred binary") && !value.contains("runner set")
+    }));
+}
+
 #[test]
 fn lab_homeboy_path_shadow_is_ok_when_configured_homeboy_is_current() {
     let mut details = BTreeMap::new();

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1699,22 +1699,8 @@ pub(crate) fn run_lab_offload_inner(
         .build(),
     );
     eprintln!(
-        "Lab offload: runner `{}` Homeboy binary `{}`; active daemon {}; refresh with `{}`.",
-        runner_id,
-        homeboy_path,
-        runner_homeboy_daemon_display(&runner_homeboy),
-        runner_homeboy["refresh_commands"]
-            .as_array()
-            .map(|commands| commands
-                .iter()
-                .filter_map(|command| command.as_str())
-                .collect::<Vec<_>>()
-                .join(" && "))
-            .unwrap_or_else(|| format!(
-                "homeboy runner disconnect {} && homeboy runner connect {}",
-                shell::quote_arg(runner_id),
-                shell::quote_arg(runner_id)
-            ))
+        "{}",
+        lab_offload_runner_homeboy_progress(runner_id, homeboy_path, &runner_homeboy)
     );
     if blocking_runner_homeboy_drift {
         return Err(stale_runner_homeboy_error(
@@ -2505,6 +2491,31 @@ pub(crate) fn run_lab_offload_inner(
     })
 }
 
+fn lab_offload_runner_homeboy_progress(
+    runner_id: &str,
+    homeboy_path: &str,
+    runner_homeboy: &serde_json::Value,
+) -> String {
+    let prefix = format!(
+        "Lab offload: runner `{runner_id}` Homeboy binary `{homeboy_path}`; active daemon {}",
+        runner_homeboy_daemon_display(runner_homeboy),
+    );
+    let refresh_commands = runner_homeboy["refresh_commands"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(serde_json::Value::as_str)
+        .collect::<Vec<_>>();
+    if refresh_commands.is_empty() {
+        format!("{prefix}; controller and daemon identities match.")
+    } else {
+        format!(
+            "{prefix}; refresh with `{}`.",
+            refresh_commands.join(" && ")
+        )
+    }
+}
+
 fn runner_workspace_ttl() -> String {
     homeboy_core::defaults::load_config()
         .lab
@@ -2854,6 +2865,44 @@ mod tests {
         RunnerActiveJobState, RunnerSessionState, RunnerStaleDaemonWarning, RunnerTunnelMode,
     };
     use std::sync::{Arc, Barrier, Mutex};
+
+    #[test]
+    fn lab_offload_progress_omits_refresh_when_identities_match() {
+        let progress = lab_offload_runner_homeboy_progress(
+            "lab",
+            "/runner/homeboy",
+            &serde_json::json!({
+                "active_daemon_build_identity": "homeboy 0.354.1+exact",
+                "refresh_commands": [],
+            }),
+        );
+
+        assert_eq!(
+            progress,
+            "Lab offload: runner `lab` Homeboy binary `/runner/homeboy`; active daemon homeboy 0.354.1+exact; controller and daemon identities match."
+        );
+        assert!(!progress.contains("refresh with"));
+    }
+
+    #[test]
+    fn lab_offload_progress_renders_complete_refresh_command_when_needed() {
+        let progress = lab_offload_runner_homeboy_progress(
+            "lab",
+            "/runner/homeboy",
+            &serde_json::json!({
+                "active_daemon_build_identity": "homeboy 0.353.1+old",
+                "refresh_commands": [
+                    "homeboy runner refresh-homeboy lab --ref abc --reconnect",
+                    "homeboy runner connect lab"
+                ],
+            }),
+        );
+
+        assert_eq!(
+            progress,
+            "Lab offload: runner `lab` Homeboy binary `/runner/homeboy`; active daemon homeboy 0.353.1+old; refresh with `homeboy runner refresh-homeboy lab --ref abc --reconnect && homeboy runner connect lab`."
+        );
+    }
 
     #[test]
     fn concurrent_same_id_rigs_dispatch_from_their_admitted_registry_after_promotion() {


### PR DESCRIPTION
## Summary
- retain the configured runner binary when the preferred binary is older, dirty, or has a different build identity
- recommend a preferred binary only when it is clean and semantically newer
- report matching controller and daemon identities without an empty refresh command

Closes #12965
Closes #12966

## Tests
- `cargo test -p homeboy-cli lab_homeboy_path_drift`
- `cargo test -p homeboy-lab-runner lab_offload_progress`
- `cargo fmt --check`

## AI assistance
OpenAI gpt-5.6-sol via OpenCode reviewed the candidate, implemented and tested the diagnostics changes, and drafted this PR. Chris Huber reviewed and remains responsible for every line.