### PR TITLE
refactor(rig): root the stack registry and the rig lease store (#7505)

### DIFF
--- a/crates/homeboy-cli/src/commands/bench/matrix.rs
+++ b/crates/homeboy-cli/src/commands/bench/matrix.rs
@@ -49,8 +49,15 @@ fn prepare_rig_bench_context(
     source.spec = spec.clone();
     rig::preflight_effective_component_checkouts(&spec)?;
     let prepare_settings = bench_prepare_settings(args);
-    let lease =
-        rig::lease::acquire_active_run_lease_with_settings(&spec, "bench", &prepare_settings)?;
+    // Boundary: one rig bench run is one unit of work, and the lease must release
+    // into the same home it acquired from (#7505).
+    let roots = homeboy::core::paths::PathRoots::from_environment()?;
+    let lease = rig::lease::acquire_active_run_lease_with_settings(
+        roots.config(),
+        &spec,
+        "bench",
+        &prepare_settings,
+    )?;
     if let Some(prepare) = rig::run_bench_prepare(&spec, &prepare_settings)? {
         if !prepare.success {
             return Err(homeboy::core::Error::rig_pipeline_failed(

--- a/crates/homeboy-cli/src/commands/resources/mod.rs
+++ b/crates/homeboy-cli/src/commands/resources/mod.rs
@@ -297,8 +297,11 @@ fn compare_cpu_desc(a: &ProcessRow, b: &ProcessRow) -> Ordering {
 }
 
 fn collect_rig_leases() -> Result<RigLeaseSummary, String> {
-    let leases =
-        homeboy::rig::active_run_leases().map_err(|e| format!("rig lease probe failed: {e}"))?;
+    // Boundary: one resource probe is one unit of work (#7505).
+    let roots = homeboy::core::paths::PathRoots::from_environment()
+        .map_err(|e| format!("rig lease probe failed: {e}"))?;
+    let leases = homeboy::rig::active_run_leases(roots.config())
+        .map_err(|e| format!("rig lease probe failed: {e}"))?;
     let rows: Vec<RigLeaseRow> = leases
         .into_iter()
         .map(|lease| RigLeaseRow {

--- a/crates/homeboy-cli/src/commands/rig/mod.rs
+++ b/crates/homeboy-cli/src/commands/rig/mod.rs
@@ -26,6 +26,7 @@ use crate::command_contract::{
     RIG_RUN_LAB_LABEL, RIG_SOURCE_MANAGEMENT_LAB_LABEL,
     RIG_SOURCE_MANAGEMENT_LAB_UNSUPPORTED_REASON, RIG_UP_LAB_UNSUPPORTED_REASON,
 };
+use std::path::Path;
 
 #[derive(Args)]
 pub struct RigArgs {
@@ -483,7 +484,10 @@ fn rig_package_lint_root(path: &std::path::Path) -> std::path::PathBuf {
 }
 
 fn release_lock(rig_id: &str, force: bool) -> CmdResult<RigCommandOutput> {
-    let outcome = rig::release_active_run_lease(rig_id, force)?;
+    // Boundary: this is the entry point for one unit of work, so the config
+    // root is resolved once here rather than inside the helpers below (#7505).
+    let roots = homeboy::core::paths::PathRoots::from_environment()?;
+    let outcome = rig::release_active_run_lease(roots.config(), rig_id, force)?;
     Ok((
         RigCommandOutput::ReleaseLock(RigReleaseLockOutput {
             command: "rig.release_lock",
@@ -572,6 +576,10 @@ fn install(
 }
 
 fn update(rig_id: Option<&str>, all: bool) -> CmdResult<RigCommandOutput> {
+    // Boundary: this is the entry point for one unit of work, so the config
+    // root is resolved once here rather than inside the helpers below (#7505).
+    let roots = homeboy::core::paths::PathRoots::from_environment()?;
+    let config_root = roots.config();
     let report = match (rig_id, all) {
         (Some(_), true) => {
             return Err(homeboy::core::Error::validation_invalid_argument(
@@ -581,8 +589,8 @@ fn update(rig_id: Option<&str>, all: bool) -> CmdResult<RigCommandOutput> {
                 None,
             ))
         }
-        (Some(id), false) => rig::update_source_for_rig(id)?,
-        (None, true) => rig::update_all_sources()?,
+        (Some(id), false) => rig::update_source_for_rig(config_root, id)?,
+        (None, true) => rig::update_all_sources(config_root)?,
         (None, false) => {
             return Err(homeboy::core::Error::validation_invalid_argument(
                 "rig_id",
@@ -964,7 +972,9 @@ fn sync(rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
 }
 
 fn run_profile(args: RigRunArgs) -> CmdResult<RigCommandOutput> {
-    let source_update = refresh_rig_source_if_materialized(&args.rig_id)?;
+    // Boundary: one rig run is one unit of work (#7505).
+    let roots = homeboy::core::paths::PathRoots::from_environment()?;
+    let source_update = refresh_rig_source_if_materialized(roots.config(), &args.rig_id)?;
     let rig = rig::load(&args.rig_id)?;
     let sync_report = rig::run_sync(&rig, false)?;
     let bench_options = rig_run_bench_options(args);
@@ -1002,6 +1012,7 @@ fn run_profile(args: RigRunArgs) -> CmdResult<RigCommandOutput> {
 }
 
 fn refresh_rig_source_if_materialized(
+    config_root: &Path,
     rig_id: &str,
 ) -> homeboy::core::Result<Option<rig::RigSourceUpdateResult>> {
     let Some(metadata) = rig::read_source_metadata(rig_id) else {
@@ -1010,7 +1021,7 @@ fn refresh_rig_source_if_materialized(
     if metadata.linked {
         return Ok(None);
     }
-    Ok(Some(rig::update_source_for_rig(rig_id)?))
+    Ok(Some(rig::update_source_for_rig(config_root, rig_id)?))
 }
 
 fn rig_run_bench_options(args: RigRunArgs) -> RigRunBenchOptions {

--- a/crates/homeboy-cli/src/commands/rig/sources.rs
+++ b/crates/homeboy-cli/src/commands/rig/sources.rs
@@ -4,6 +4,7 @@ use homeboy::rig;
 use super::output::{RigSourcesOutput, RigSourcesReport};
 use super::RigCommandOutput;
 use crate::commands::CmdResult;
+use std::path::Path;
 
 #[derive(Subcommand)]
 pub(super) enum RigSourcesCommand {
@@ -23,38 +24,41 @@ pub(super) enum RigSourcesCommand {
 }
 
 pub(super) fn run(command: Option<RigSourcesCommand>) -> CmdResult<RigCommandOutput> {
+    // Boundary: one `homeboy rig sources` invocation is one unit of work (#7505).
+    let roots = homeboy::core::paths::PathRoots::from_environment()?;
+    let config_root = roots.config();
     match command {
-        None | Some(RigSourcesCommand::List) => list(),
-        Some(RigSourcesCommand::Remove { source }) => remove(&source),
-        Some(RigSourcesCommand::Refresh { source }) => refresh(source.as_deref()),
+        None | Some(RigSourcesCommand::List) => list(config_root),
+        Some(RigSourcesCommand::Remove { source }) => remove(config_root, &source),
+        Some(RigSourcesCommand::Refresh { source }) => refresh(config_root, source.as_deref()),
     }
 }
 
-fn list() -> CmdResult<RigCommandOutput> {
+fn list(config_root: &Path) -> CmdResult<RigCommandOutput> {
     Ok((
         RigCommandOutput::Sources(RigSourcesOutput {
             command: "rig.sources.list",
-            report: RigSourcesReport::List(rig::list_sources()?),
+            report: RigSourcesReport::List(rig::list_sources(config_root)?),
         }),
         0,
     ))
 }
 
-fn remove(source: &str) -> CmdResult<RigCommandOutput> {
+fn remove(config_root: &Path, source: &str) -> CmdResult<RigCommandOutput> {
     Ok((
         RigCommandOutput::Sources(RigSourcesOutput {
             command: "rig.sources.remove",
-            report: RigSourcesReport::Remove(Box::new(rig::remove_source(source)?)),
+            report: RigSourcesReport::Remove(Box::new(rig::remove_source(config_root, source)?)),
         }),
         0,
     ))
 }
 
-fn refresh(source: Option<&str>) -> CmdResult<RigCommandOutput> {
+fn refresh(config_root: &Path, source: Option<&str>) -> CmdResult<RigCommandOutput> {
     Ok((
         RigCommandOutput::Sources(RigSourcesOutput {
             command: "rig.sources.refresh",
-            report: RigSourcesReport::Refresh(rig::update_source(source)?),
+            report: RigSourcesReport::Refresh(rig::update_source(config_root, source)?),
         }),
         0,
     ))

--- a/crates/homeboy-cli/src/commands/runs/resources.rs
+++ b/crates/homeboy-cli/src/commands/runs/resources.rs
@@ -474,10 +474,13 @@ fn load_indexes(args: &RunsResourcesArgs) -> Result<Vec<LoadedResourceIndex>> {
     }
 
     let store = ObservationStore::open_initialized()?;
-    load_observation_store_index(&store, args.run_id.as_deref())
+    // Boundary: one `runs resources` load is one unit of work (#7505).
+    let roots = homeboy::core::paths::PathRoots::from_environment()?;
+    load_observation_store_index(roots.config(), &store, args.run_id.as_deref())
 }
 
 fn load_observation_store_index(
+    config_root: &Path,
     store: &ObservationStore,
     run_id: Option<&str>,
 ) -> Result<Vec<LoadedResourceIndex>> {
@@ -507,7 +510,9 @@ fn load_observation_store_index(
     index
         .resources
         .extend(executor_evidence_resources(store, run_id)?);
-    index.resources.extend(rig_lease_resources(run_id)?);
+    index
+        .resources
+        .extend(rig_lease_resources(config_root, run_id)?);
 
     if index.resources.is_empty() {
         return Ok(Vec::new());
@@ -524,9 +529,12 @@ fn load_observation_store_index(
     }])
 }
 
-fn rig_lease_resources(run_id: Option<&str>) -> Result<Vec<ResourceLifecycleRecord>> {
+fn rig_lease_resources(
+    config_root: &Path,
+    run_id: Option<&str>,
+) -> Result<Vec<ResourceLifecycleRecord>> {
     let mut resources = Vec::new();
-    for diagnostic in homeboy::rig::lease::run_lease_diagnostics()? {
+    for diagnostic in homeboy::rig::lease::run_lease_diagnostics(config_root)? {
         if run_id.is_some_and(|run_id| diagnostic.run_id.as_deref() != Some(run_id)) {
             continue;
         }
@@ -610,7 +618,9 @@ fn load_runtime_diagnostics(
 
     let store = ObservationStore::open_initialized()?;
     let mut outputs = Vec::new();
-    for diagnostic in homeboy::rig::lease::run_lease_diagnostics()? {
+    // Boundary: one resource-lifecycle report is one unit of work (#7505).
+    let roots = homeboy::core::paths::PathRoots::from_environment()?;
+    for diagnostic in homeboy::rig::lease::run_lease_diagnostics(roots.config())? {
         if args
             .run_id
             .as_deref()
@@ -847,6 +857,18 @@ mod tests {
 
     use super::*;
 
+    /// The isolated home each test below installs, named as a config root.
+    ///
+    /// A test is the entry point for its own unit of work, so resolving here is
+    /// a boundary resolution. What matters is that the production path beneath
+    /// it resolves nothing (#7505).
+    fn test_config_root() -> std::path::PathBuf {
+        homeboy::core::paths::PathRoots::from_environment()
+            .expect("path roots")
+            .config()
+            .to_path_buf()
+    }
+
     fn temp_store(tempdir: &tempfile::TempDir) -> ObservationStore {
         ObservationStore::open_initialized_at(tempdir.path().join("homeboy.sqlite"))
             .expect("temp observation store")
@@ -1039,7 +1061,8 @@ mod tests {
             };
             record_store_resource(&store, &run.id, &artifact_path, resource.clone());
 
-            let indexes = load_observation_store_index(&store, None).expect("store index");
+            let indexes = load_observation_store_index(&test_config_root(), &store, None)
+                .expect("store index");
 
             assert_eq!(indexes.len(), 1);
             assert_eq!(indexes[0].source, "observation-store");
@@ -1064,7 +1087,8 @@ mod tests {
             std::fs::write(evidence_dir.join("task-1/executor-input.json"), "{}")
                 .expect("evidence file");
 
-            let indexes = load_observation_store_index(&store, Some(&run.id)).expect("store index");
+            let indexes = load_observation_store_index(&test_config_root(), &store, Some(&run.id))
+                .expect("store index");
             assert_eq!(indexes.len(), 1);
             assert_eq!(indexes[0].source, format!("observation-store:{}", run.id));
             assert_eq!(indexes[0].index.resources.len(), 1);
@@ -1110,7 +1134,8 @@ mod tests {
                 Some(run.id.clone()),
             ));
 
-            let indexes = load_observation_store_index(&store, Some(&run.id)).expect("store index");
+            let indexes = load_observation_store_index(&test_config_root(), &store, Some(&run.id))
+                .expect("store index");
             let resources = &indexes[0].index.resources;
             assert_eq!(resources.len(), 4);
             assert!(resources
@@ -1127,7 +1152,7 @@ mod tests {
 
             let diagnostic = rig_lease_diagnostic_output(
                 &store,
-                homeboy::rig::lease::run_lease_diagnostics()
+                homeboy::rig::lease::run_lease_diagnostics(&test_config_root())
                     .expect("lease diagnostics")
                     .remove(0),
             )
@@ -1145,8 +1170,8 @@ mod tests {
         crate::test_support::with_isolated_home(|_| {
             write_rig_lease(rig_lease("studio", u32::MAX, Some("stale-run".to_string())));
 
-            let diagnostics =
-                homeboy::rig::lease::run_lease_diagnostics().expect("lease diagnostics");
+            let diagnostics = homeboy::rig::lease::run_lease_diagnostics(&test_config_root())
+                .expect("lease diagnostics");
             assert_eq!(diagnostics.len(), 1);
             assert!(diagnostics[0].reclaimable_without_force);
             assert_eq!(
@@ -1154,7 +1179,8 @@ mod tests {
                 Some("homeboy rig release-lock studio")
             );
 
-            let resources = rig_lease_resources(None).expect("rig lease resources");
+            let resources =
+                rig_lease_resources(&test_config_root(), None).expect("rig lease resources");
             assert_eq!(resources.len(), 4);
             assert!(
                 resources
@@ -1174,15 +1200,16 @@ mod tests {
         crate::test_support::with_isolated_home(|_| {
             write_rig_lease(rig_lease("studio", std::process::id(), None));
 
-            let resources = rig_lease_resources(None).expect("rig lease resources");
+            let resources =
+                rig_lease_resources(&test_config_root(), None).expect("rig lease resources");
             assert_eq!(resources[0].run_id, "rig-lease:studio");
             assert_eq!(
                 resources[0].cleanup_command.as_deref(),
                 Some("homeboy runs resources --actionable")
             );
 
-            let diagnostics =
-                homeboy::rig::lease::run_lease_diagnostics().expect("lease diagnostics");
+            let diagnostics = homeboy::rig::lease::run_lease_diagnostics(&test_config_root())
+                .expect("lease diagnostics");
             assert!(diagnostics[0].inspect_command.is_none());
             assert!(diagnostics[0].safe_cleanup_command.is_none());
             assert!(diagnostics[0]
@@ -1211,7 +1238,8 @@ mod tests {
             std::fs::write(evidence_dir.join("task-1/executor-result.json"), "{}")
                 .expect("evidence file");
 
-            let indexes = load_observation_store_index(&store, Some(&run.id)).expect("store index");
+            let indexes = load_observation_store_index(&test_config_root(), &store, Some(&run.id))
+                .expect("store index");
             let resource = &indexes[0].index.resources[0];
 
             assert_eq!(
@@ -1240,7 +1268,8 @@ mod tests {
                 .expect("evidence file");
 
             let mut indexes =
-                load_observation_store_index(&store, Some(run_id)).expect("store index");
+                load_observation_store_index(&test_config_root(), &store, Some(run_id))
+                    .expect("store index");
             let mut resource = indexes.remove(0).index.resources.remove(0);
             resource.ttl = Some("0s".to_string());
 
@@ -1291,7 +1320,8 @@ mod tests {
             ..record(ResourceLifecycleResourceStatus::CleanupPending)
         };
         record_store_resource(&store, &run.id, &artifact_path, resource);
-        let indexes = load_observation_store_index(&store, Some(&run.id)).expect("store index");
+        let indexes = load_observation_store_index(&test_config_root(), &store, Some(&run.id))
+            .expect("store index");
 
         let cleanup = build_cleanup_output(
             &indexes[0].index.resources,
@@ -1326,7 +1356,8 @@ mod tests {
             ..record(ResourceLifecycleResourceStatus::CleanupPending)
         };
         record_store_resource(&store, &run.id, &artifact_path, resource);
-        let indexes = load_observation_store_index(&store, Some(&run.id)).expect("store index");
+        let indexes = load_observation_store_index(&test_config_root(), &store, Some(&run.id))
+            .expect("store index");
 
         let cleanup = build_cleanup_output(
             &indexes[0].index.resources,
@@ -1546,7 +1577,8 @@ mod tests {
             )
             .expect("artifact with resource lifecycle metadata");
 
-        let indexes = load_observation_store_index(&store, Some(&run.id)).expect("store index");
+        let indexes = load_observation_store_index(&test_config_root(), &store, Some(&run.id))
+            .expect("store index");
 
         let transitioned = &indexes[0].index.resources[0];
         assert_eq!(

--- a/crates/homeboy-cli/src/commands/stack.rs
+++ b/crates/homeboy-cli/src/commands/stack.rs
@@ -12,6 +12,7 @@ use homeboy_stack::stack::{
 };
 
 use super::{CmdResult, CommandReport};
+use std::path::Path;
 
 #[derive(Args)]
 pub struct StackArgs {
@@ -224,10 +225,15 @@ pub type StackDiffOutput = CommandReport<DiffOutput>;
 pub type StackInspectOutput = CommandReport<InspectOutput>;
 
 pub fn run(args: StackArgs) -> CmdResult<StackCommandOutput> {
+    // Boundary: one `homeboy stack` invocation is one unit of work, so the
+    // config root is resolved exactly once here and handed to every handler
+    // below. Nothing under this point resolves again (#7505).
+    let roots = homeboy::core::paths::PathRoots::from_environment()?;
+    let config_root = roots.config();
     match args.command {
-        StackCommand::List => list(),
-        StackCommand::Show { stack_id } => show(&stack_id),
-        StackCommand::Candidates { stack_id } => candidates(&stack_id),
+        StackCommand::List => list(config_root),
+        StackCommand::Show { stack_id } => show(config_root, &stack_id),
+        StackCommand::Candidates { stack_id } => candidates(config_root, &stack_id),
         StackCommand::Create {
             stack_id,
             component,
@@ -236,6 +242,7 @@ pub fn run(args: StackArgs) -> CmdResult<StackCommandOutput> {
             target,
             description,
         } => create(
+            config_root,
             &stack_id,
             &component,
             &component_path,
@@ -248,16 +255,17 @@ pub fn run(args: StackArgs) -> CmdResult<StackCommandOutput> {
             repo,
             number,
             note,
-        } => add_pr(&stack_id, &repo, number, note),
+        } => add_pr(config_root, &stack_id, &repo, number, note),
         StackCommand::RemovePr {
             stack_id,
             number,
             repo,
-        } => remove_pr(&stack_id, number, repo.as_deref()),
+        } => remove_pr(config_root, &stack_id, number, repo.as_deref()),
         StackCommand::Apply {
             stack_id,
             abort_on_conflict,
         } => apply(
+            config_root,
             &stack_id,
             ConflictPolicy::from_abort_flag(abort_on_conflict),
         ),
@@ -265,21 +273,23 @@ pub fn run(args: StackArgs) -> CmdResult<StackCommandOutput> {
             stack_id,
             abort_on_conflict,
         } => rebase(
+            config_root,
             &stack_id,
             ConflictPolicy::from_abort_flag(abort_on_conflict),
         ),
-        StackCommand::Status { stack_id } => status(&stack_id),
+        StackCommand::Status { stack_id } => status(config_root, &stack_id),
         StackCommand::Sync {
             stack_id,
             dry_run,
             abort_on_conflict,
         } => sync(
+            config_root,
             &stack_id,
             dry_run,
             ConflictPolicy::from_abort_flag(abort_on_conflict),
         ),
-        StackCommand::Push { stack_id } => push(&stack_id),
-        StackCommand::Diff { stack_id } => diff(&stack_id),
+        StackCommand::Push { stack_id } => push(config_root, &stack_id),
+        StackCommand::Diff { stack_id } => diff(config_root, &stack_id),
         StackCommand::Inspect {
             component_id,
             base,
@@ -290,9 +300,9 @@ pub fn run(args: StackArgs) -> CmdResult<StackCommandOutput> {
     }
 }
 
-fn candidates(stack_id: &str) -> CmdResult<StackCommandOutput> {
-    let spec = stack::load(stack_id)?;
-    let candidates = stack::discover_candidates(&spec)?;
+fn candidates(config_root: &Path, stack_id: &str) -> CmdResult<StackCommandOutput> {
+    let spec = stack::load(config_root, stack_id)?;
+    let candidates = stack::discover_candidates(config_root, &spec)?;
     Ok((
         StackCommandOutput::Candidates(StackCandidatesOutput {
             command: "stack.candidates",
@@ -303,8 +313,8 @@ fn candidates(stack_id: &str) -> CmdResult<StackCommandOutput> {
     ))
 }
 
-fn list() -> CmdResult<StackCommandOutput> {
-    let stacks = stack::list()?;
+fn list(config_root: &Path) -> CmdResult<StackCommandOutput> {
+    let stacks = stack::list(config_root)?;
     let summaries = stacks
         .into_iter()
         .map(|s| StackSummary {
@@ -326,8 +336,8 @@ fn list() -> CmdResult<StackCommandOutput> {
     ))
 }
 
-fn show(stack_id: &str) -> CmdResult<StackCommandOutput> {
-    let stack = stack::load(stack_id)?;
+fn show(config_root: &Path, stack_id: &str) -> CmdResult<StackCommandOutput> {
+    let stack = stack::load(config_root, stack_id)?;
     Ok((
         StackCommandOutput::Show(StackShowOutput {
             command: "stack.show",
@@ -338,6 +348,7 @@ fn show(stack_id: &str) -> CmdResult<StackCommandOutput> {
 }
 
 fn create(
+    config_root: &Path,
     stack_id: &str,
     component: &str,
     component_path: &str,
@@ -347,7 +358,7 @@ fn create(
 ) -> CmdResult<StackCommandOutput> {
     // Refuse to silently overwrite an existing stack — `add-pr`/`remove-pr`
     // are the right verbs for editing a live spec.
-    if stack::exists(stack_id)? {
+    if stack::exists(config_root, stack_id)? {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "stack_id",
             format!("Stack '{}' already exists", stack_id),
@@ -373,7 +384,7 @@ fn create(
         provenance: None,
         requirements: Default::default(),
     };
-    stack::save(&spec)?;
+    stack::save(config_root, &spec)?;
     Ok((
         StackCommandOutput::Create(StackMutationOutput {
             command: "stack.create",
@@ -384,12 +395,13 @@ fn create(
 }
 
 fn add_pr(
+    config_root: &Path,
     stack_id: &str,
     repo: &str,
     number: u64,
     note: Option<String>,
 ) -> CmdResult<StackCommandOutput> {
-    let mut spec = stack::load(stack_id)?;
+    let mut spec = stack::load(config_root, stack_id)?;
 
     // Refuse to silently double-add the same PR — keeps the spec tidy and
     // makes "did I already add this?" obvious.
@@ -414,7 +426,7 @@ fn add_pr(
         number,
         note,
     });
-    stack::save(&spec)?;
+    stack::save(config_root, &spec)?;
     Ok((
         StackCommandOutput::AddPr(StackMutationOutput {
             command: "stack.add_pr",
@@ -424,8 +436,13 @@ fn add_pr(
     ))
 }
 
-fn remove_pr(stack_id: &str, number: u64, repo: Option<&str>) -> CmdResult<StackCommandOutput> {
-    let mut spec = stack::load(stack_id)?;
+fn remove_pr(
+    config_root: &Path,
+    stack_id: &str,
+    number: u64,
+    repo: Option<&str>,
+) -> CmdResult<StackCommandOutput> {
+    let mut spec = stack::load(config_root, stack_id)?;
 
     let matches: Vec<usize> = spec
         .prs
@@ -464,7 +481,7 @@ fn remove_pr(stack_id: &str, number: u64, repo: Option<&str>) -> CmdResult<Stack
     }
 
     spec.prs.remove(matches[0]);
-    stack::save(&spec)?;
+    stack::save(config_root, &spec)?;
     Ok((
         StackCommandOutput::RemovePr(StackMutationOutput {
             command: "stack.remove_pr",
@@ -474,9 +491,13 @@ fn remove_pr(stack_id: &str, number: u64, repo: Option<&str>) -> CmdResult<Stack
     ))
 }
 
-fn apply(stack_id: &str, conflict_policy: ConflictPolicy) -> CmdResult<StackCommandOutput> {
-    let spec = stack::load(stack_id)?;
-    let report = stack::apply(&spec, conflict_policy)?;
+fn apply(
+    config_root: &Path,
+    stack_id: &str,
+    conflict_policy: ConflictPolicy,
+) -> CmdResult<StackCommandOutput> {
+    let spec = stack::load(config_root, stack_id)?;
+    let report = stack::apply(config_root, &spec, conflict_policy)?;
     let exit_code = if report.success { 0 } else { 1 };
     Ok((
         StackCommandOutput::Apply(StackApplyOutput {
@@ -487,9 +508,13 @@ fn apply(stack_id: &str, conflict_policy: ConflictPolicy) -> CmdResult<StackComm
     ))
 }
 
-fn rebase(stack_id: &str, conflict_policy: ConflictPolicy) -> CmdResult<StackCommandOutput> {
-    let spec = stack::load(stack_id)?;
-    let report = stack::rebase(&spec, conflict_policy)?;
+fn rebase(
+    config_root: &Path,
+    stack_id: &str,
+    conflict_policy: ConflictPolicy,
+) -> CmdResult<StackCommandOutput> {
+    let spec = stack::load(config_root, stack_id)?;
+    let report = stack::rebase(config_root, &spec, conflict_policy)?;
     let exit_code = if report.success { 0 } else { 1 };
     Ok((
         StackCommandOutput::Rebase(StackRebaseOutput {
@@ -500,8 +525,8 @@ fn rebase(stack_id: &str, conflict_policy: ConflictPolicy) -> CmdResult<StackCom
     ))
 }
 
-fn status(stack_id: &str) -> CmdResult<StackCommandOutput> {
-    let spec = stack::load(stack_id)?;
+fn status(config_root: &Path, stack_id: &str) -> CmdResult<StackCommandOutput> {
+    let spec = stack::load(config_root, stack_id)?;
     let report = stack::status(&spec)?;
     Ok((
         StackCommandOutput::Status(StackStatusOutput {
@@ -513,12 +538,13 @@ fn status(stack_id: &str) -> CmdResult<StackCommandOutput> {
 }
 
 fn sync(
+    config_root: &Path,
     stack_id: &str,
     dry_run: bool,
     conflict_policy: ConflictPolicy,
 ) -> CmdResult<StackCommandOutput> {
-    let mut spec = stack::load(stack_id)?;
-    let report = stack::sync(&mut spec, dry_run, conflict_policy)?;
+    let mut spec = stack::load(config_root, stack_id)?;
+    let report = stack::sync(config_root, &mut spec, dry_run, conflict_policy)?;
     let exit_code = if report.success { 0 } else { 1 };
     Ok((
         StackCommandOutput::Sync(StackSyncOutput {
@@ -529,8 +555,8 @@ fn sync(
     ))
 }
 
-fn push(stack_id: &str) -> CmdResult<StackCommandOutput> {
-    let spec = stack::load(stack_id)?;
+fn push(config_root: &Path, stack_id: &str) -> CmdResult<StackCommandOutput> {
+    let spec = stack::load(config_root, stack_id)?;
     let report = stack::push(&spec)?;
     Ok((
         StackCommandOutput::Push(StackPushOutput {
@@ -541,8 +567,8 @@ fn push(stack_id: &str) -> CmdResult<StackCommandOutput> {
     ))
 }
 
-fn diff(stack_id: &str) -> CmdResult<StackCommandOutput> {
-    let spec = stack::load(stack_id)?;
+fn diff(config_root: &Path, stack_id: &str) -> CmdResult<StackCommandOutput> {
+    let spec = stack::load(config_root, stack_id)?;
     let report = stack::diff(&spec)?;
     Ok((
         StackCommandOutput::Diff(StackDiffOutput {

--- a/crates/homeboy-cli/src/commands/trace.rs
+++ b/crates/homeboy-cli/src/commands/trace.rs
@@ -599,9 +599,14 @@ fn execute_trace_run_impl(args: TraceArgs) -> homeboy::core::Result<TraceRunExec
             rig::RigWorkloadKind::Trace,
         )?;
     }
+    // Boundary: one trace run is one unit of work, and the lease must release
+    // into the same home it acquired from (#7505).
+    let lease_roots = homeboy::core::paths::PathRoots::from_environment()?;
     let _lease = rig_context
         .as_ref()
-        .map(|context| rig::lease::acquire_active_run_lease(&context.rig_spec, "trace"))
+        .map(|context| {
+            rig::lease::acquire_active_run_lease(lease_roots.config(), &context.rig_spec, "trace")
+        })
         .transpose()?
         .flatten();
     let span_definitions = span_definitions_for_args(

--- a/crates/homeboy-cli/src/commands/trace/compare_targets.rs
+++ b/crates/homeboy-cli/src/commands/trace/compare_targets.rs
@@ -35,10 +35,17 @@ pub(super) fn run_compare_targets(args: TraceArgs) -> CmdResult<TraceCommandOutp
     let baseline = required_target(args.baseline_target.as_deref(), "--baseline-target")?;
     let candidate = required_target(args.candidate.as_deref(), "--candidate")?;
     let (component_id, base_component) = compare_target_component(&args)?;
+    // Boundary: one trace compare is one unit of work, and the lease must release
+    // into the same home it acquired from (#7505).
+    let lease_roots = homeboy::core::paths::PathRoots::from_environment()?;
     let _compare_lease = if let Some(rig_id) = args.rig.as_deref() {
         load_rig_context(Some(rig_id))?
             .map(|context| {
-                homeboy::rig::lease::acquire_active_run_lease(&context.rig_spec, "trace compare")
+                homeboy::rig::lease::acquire_active_run_lease(
+                    lease_roots.config(),
+                    &context.rig_spec,
+                    "trace compare",
+                )
             })
             .transpose()?
             .flatten()
@@ -1126,9 +1133,13 @@ mod tests {
             assert_eq!(compare.proof_run_order[1].group, "candidate");
             assert_eq!(compare.proof_run_order[2].group, "baseline");
             assert_eq!(compare.proof_run_order[3].group, "candidate");
-            assert!(homeboy::rig::lease::active_run_leases()
-                .expect("active leases")
-                .is_empty());
+            assert!(homeboy::rig::lease::active_run_leases(
+                homeboy::core::paths::PathRoots::from_environment()
+                    .expect("path roots")
+                    .config()
+            )
+            .expect("active leases")
+            .is_empty());
             let store = ObservationStore::open_initialized().expect("store");
             let runs = store
                 .list_runs(homeboy::core::observation::RunListFilter {

--- a/crates/homeboy-cli/src/commands/trace/rig_tests.rs
+++ b/crates/homeboy-cli/src/commands/trace/rig_tests.rs
@@ -95,7 +95,7 @@ fn rig_trace_run_fails_fast_on_active_default_namespace_resource_lease() {
         set_trace_rig_resources(home, "studio-alt", resources);
 
         let active_spec = rig::load("studio-rig").expect("load active rig");
-        let _lease = rig::lease::acquire_active_run_lease(&active_spec, "trace")
+        let _lease = rig::lease::acquire_active_run_lease(home.path(), &active_spec, "trace")
             .expect("acquire active trace lease")
             .expect("resourceful trace rig leases");
 

--- a/crates/homeboy-rig/src/lease.rs
+++ b/crates/homeboy-rig/src/lease.rs
@@ -71,18 +71,23 @@ pub struct RigRunLeaseDiagnostic {
 /// error. Process crashes are handled by stale-PID cleanup on the next acquire.
 #[derive(Debug)]
 pub struct ActiveRigRunLease {
+    /// The config root the lease was acquired against.
+    ///
+    /// The guard must release into the same home it acquired from. Resolving
+    /// ambiently in `Drop` would let a guard delete a lease in whatever home is
+    /// current at teardown, which is a different home whenever the acquiring
+    /// work owned an explicit root (#7505).
+    config_root: PathBuf,
     rig_id: String,
     pid: u32,
 }
 
 impl Drop for ActiveRigRunLease {
     fn drop(&mut self) {
-        let Ok(_lock) = acquire_lease_index_lock() else {
+        let Ok(_lock) = acquire_lease_index_lock(&self.config_root) else {
             return;
         };
-        let Ok(path) = lease_path(&self.rig_id) else {
-            return;
-        };
+        let path = lease_path(&self.config_root, &self.rig_id);
         let Ok(Some(lease)) = read_lease(&path) else {
             return;
         };
@@ -93,13 +98,18 @@ impl Drop for ActiveRigRunLease {
 }
 
 /// Acquire an active-run lease for a mutating rig command.
-pub fn acquire_active_run_lease(rig: &RigSpec, command: &str) -> Result<Option<ActiveRigRunLease>> {
-    acquire_active_run_lease_with_settings(rig, command, &[])
+pub fn acquire_active_run_lease(
+    config_root: &Path,
+    rig: &RigSpec,
+    command: &str,
+) -> Result<Option<ActiveRigRunLease>> {
+    acquire_active_run_lease_with_settings(config_root, rig, command, &[])
 }
 
 /// Acquire an active-run lease after materializing rig settings as env values
 /// for resource interpolation.
 pub fn acquire_active_run_lease_with_settings(
+    config_root: &Path,
     rig: &RigSpec,
     command: &str,
     settings: &[(String, String)],
@@ -109,16 +119,16 @@ pub fn acquire_active_run_lease_with_settings(
         return Ok(None);
     }
 
-    let _lock = acquire_lease_index_lock()?;
-    fs::create_dir_all(paths::rig_leases_dir()?).map_err(|e| {
+    let _lock = acquire_lease_index_lock(config_root)?;
+    fs::create_dir_all(paths::rig_leases_dir_in_root(config_root)).map_err(|e| {
         Error::internal_unexpected(format!("Failed to create rig lease directory: {}", e))
     })?;
 
-    prune_stale_leases()?;
-    if has_covering_parent_lease(rig, command)? {
+    prune_stale_leases(config_root)?;
+    if has_covering_parent_lease(config_root, rig, command)? {
         return Ok(None);
     }
-    if let Some(conflict) = find_conflict(rig, command, &resources)? {
+    if let Some(conflict) = find_conflict(config_root, rig, command, &resources)? {
         let held_age_seconds = lease_age_seconds(&conflict.lease.started_at);
         return Err(Error::rig_resource_conflict(RigResourceConflictInfo {
             rig_id: rig.id.clone(),
@@ -147,11 +157,12 @@ pub fn acquire_active_run_lease_with_settings(
     };
     let json = serde_json::to_string_pretty(&lease)
         .map_err(|e| Error::internal_unexpected(format!("Failed to serialize rig lease: {}", e)))?;
-    fs::write(lease_path(&rig.id)?, json).map_err(|e| {
+    fs::write(lease_path(config_root, &rig.id), json).map_err(|e| {
         Error::internal_unexpected(format!("Failed to write rig lease for '{}': {}", rig.id, e))
     })?;
 
     Ok(Some(ActiveRigRunLease {
+        config_root: config_root.to_path_buf(),
         rig_id: rig.id.clone(),
         pid,
     }))
@@ -164,11 +175,12 @@ struct ResourceConflict {
 }
 
 fn find_conflict(
+    config_root: &Path,
     rig: &RigSpec,
     command: &str,
     resources: &RigResourcesSpec,
 ) -> Result<Option<ResourceConflict>> {
-    for lease in live_leases()? {
+    for lease in live_leases(config_root)? {
         if lease.rig_id == rig.id {
             if lease_allows_child_command(&lease, command) {
                 continue;
@@ -190,8 +202,8 @@ fn find_conflict(
     Ok(None)
 }
 
-fn has_covering_parent_lease(rig: &RigSpec, command: &str) -> Result<bool> {
-    Ok(live_leases()?
+fn has_covering_parent_lease(config_root: &Path, rig: &RigSpec, command: &str) -> Result<bool> {
+    Ok(live_leases(config_root)?
         .iter()
         .any(|lease| lease.rig_id == rig.id && lease_allows_child_command(lease, command)))
 }
@@ -312,8 +324,8 @@ fn lease_is_reclaimable(lease: &RigRunLease) -> bool {
     false
 }
 
-fn prune_stale_leases() -> Result<()> {
-    for path in lease_files()? {
+fn prune_stale_leases(config_root: &Path) -> Result<()> {
+    for path in lease_files(config_root)? {
         let Some(lease) = read_lease(&path)? else {
             continue;
         };
@@ -330,9 +342,9 @@ fn prune_stale_leases() -> Result<()> {
     Ok(())
 }
 
-fn live_leases() -> Result<Vec<RigRunLease>> {
+fn live_leases(config_root: &Path) -> Result<Vec<RigRunLease>> {
     let mut leases = Vec::new();
-    for path in lease_files()? {
+    for path in lease_files(config_root)? {
         if let Some(lease) = read_lease(&path)? {
             if !lease_is_reclaimable(&lease) {
                 leases.push(lease);
@@ -370,9 +382,13 @@ pub enum ReleaseLeaseOutcome {
 /// Releasing the lock does not terminate the holder process; it only frees the
 /// local guardrail so a new run can proceed. With `force`, the caller is
 /// asserting the holder is dead or wedged.
-pub fn release_active_run_lease(rig_id: &str, force: bool) -> Result<ReleaseLeaseOutcome> {
-    let _lock = acquire_lease_index_lock()?;
-    let path = lease_path(rig_id)?;
+pub fn release_active_run_lease(
+    config_root: &Path,
+    rig_id: &str,
+    force: bool,
+) -> Result<ReleaseLeaseOutcome> {
+    let _lock = acquire_lease_index_lock(config_root)?;
+    let path = lease_path(config_root, rig_id);
     let Some(lease) = read_lease(&path)? else {
         return Ok(ReleaseLeaseOutcome::NoLease {
             rig_id: rig_id.to_string(),
@@ -414,13 +430,13 @@ pub fn release_active_run_lease(rig_id: &str, force: bool) -> Result<ReleaseLeas
 }
 
 /// List active rig run leases without acquiring or mutating leases.
-pub fn active_run_leases() -> Result<Vec<RigRunLease>> {
-    live_leases()
+pub fn active_run_leases(config_root: &Path) -> Result<Vec<RigRunLease>> {
+    live_leases(config_root)
 }
 
-pub fn run_lease_diagnostics() -> Result<Vec<RigRunLeaseDiagnostic>> {
+pub fn run_lease_diagnostics(config_root: &Path) -> Result<Vec<RigRunLeaseDiagnostic>> {
     let mut diagnostics = Vec::new();
-    for path in lease_files()? {
+    for path in lease_files(config_root)? {
         let Some(lease) = read_lease(&path)? else {
             continue;
         };
@@ -461,8 +477,8 @@ fn run_lease_diagnostic(lease: RigRunLease) -> RigRunLeaseDiagnostic {
     }
 }
 
-fn lease_files() -> Result<Vec<PathBuf>> {
-    let dir = paths::rig_leases_dir()?;
+fn lease_files(config_root: &Path) -> Result<Vec<PathBuf>> {
+    let dir = paths::rig_leases_dir_in_root(config_root);
     if !dir.exists() {
         return Ok(Vec::new());
     }
@@ -505,8 +521,9 @@ fn read_lease(path: &Path) -> Result<Option<RigRunLease>> {
     })
 }
 
-fn lease_path(rig_id: &str) -> Result<PathBuf> {
-    Ok(paths::rig_leases_dir()?.join(format!("{}.json", paths::sanitize_path_segment(rig_id))))
+fn lease_path(config_root: &Path, rig_id: &str) -> PathBuf {
+    paths::rig_leases_dir_in_root(config_root)
+        .join(format!("{}.json", paths::sanitize_path_segment(rig_id)))
 }
 
 #[cfg(test)]

--- a/crates/homeboy-rig/src/lease/lock.rs
+++ b/crates/homeboy-rig/src/lease/lock.rs
@@ -7,6 +7,7 @@
 use homeboy_core::error::Result;
 use homeboy_core::paths;
 use homeboy_engine_primitives::fs_index_lock::{FsIndexLock, FsIndexLockConfig};
+use std::path::Path;
 
 const CONFIG: FsIndexLockConfig = FsIndexLockConfig::index("rig lease");
 
@@ -14,6 +15,6 @@ pub(super) type LeaseIndexLock = FsIndexLock;
 
 /// Block until the rig lease index lock is held. Released when the returned
 /// guard drops.
-pub(super) fn acquire() -> Result<LeaseIndexLock> {
-    FsIndexLock::acquire_in(&paths::rig_leases_dir()?, CONFIG)
+pub(super) fn acquire(config_root: &Path) -> Result<LeaseIndexLock> {
+    FsIndexLock::acquire_in(&paths::rig_leases_dir_in_root(config_root), CONFIG)
 }

--- a/crates/homeboy-rig/src/runner.rs
+++ b/crates/homeboy-rig/src/runner.rs
@@ -201,10 +201,12 @@ pub enum SymlinkStatusState {
 /// Materialize a rig: run the `up` pipeline, stash timestamp in state.
 pub fn run_up(rig: &RigSpec) -> Result<UpReport> {
     preflight_effective_component_checkouts(rig)?;
-    let _lease = acquire_active_run_lease(rig, "up")?;
     // One rig run is one unit of work, so the entry point resolves the roots
-    // once and the observer carries them for the rest of it (#7505).
+    // once and the lease and observer both carry them for the rest of it
+    // (#7505). The lease in particular must release into the same home it
+    // acquired from, which only holds if it is handed this root.
     let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let _lease = acquire_active_run_lease(roots.config(), rig, "up")?;
     let observer = RigRunObserver::start(rig, "up", &roots);
 
     let execute = || {
@@ -687,7 +689,14 @@ pub fn run_down(rig: &RigSpec) -> Result<DownReport> {
 /// Tear down a rig with invocation settings available to resource expansion and
 /// the `down` pipeline as `HOMEBOY_SETTINGS_<KEY>` env vars.
 pub fn run_down_with_settings(rig: &RigSpec, settings: &[(String, String)]) -> Result<DownReport> {
-    let _lease = super::lease::acquire_active_run_lease_with_settings(rig, "down", settings)?;
+    // Boundary: one rig teardown is one unit of work (#7505).
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let _lease = super::lease::acquire_active_run_lease_with_settings(
+        roots.config(),
+        rig,
+        "down",
+        settings,
+    )?;
     let pipeline = if rig.pipeline.contains_key("down") {
         Some(run_pipeline_with_settings(rig, "down", false, settings)?)
     } else {
@@ -742,7 +751,9 @@ pub fn run_down_with_settings(rig: &RigSpec, settings: &[(String, String)]) -> R
 /// handle no declared step still owns is reported `blocked`, because that is
 /// drift needing manual attention, not something repair may silently discard.
 pub fn run_repair(rig: &RigSpec) -> Result<RepairReport> {
-    let _lease = acquire_active_run_lease(rig, "repair")?;
+    // Boundary: one rig repair is one unit of work (#7505).
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let _lease = acquire_active_run_lease(roots.config(), rig, "repair")?;
     let mut resources = Vec::new();
 
     for link in &rig.symlinks {

--- a/crates/homeboy-rig/src/source.rs
+++ b/crates/homeboy-rig/src/source.rs
@@ -21,12 +21,13 @@ pub use types::{
     SkippedRigSourceUpdate,
 };
 
-pub fn list_sources() -> Result<RigSourceListResult> {
-    read_source_entries().and_then(group_source_entries)
+pub fn list_sources(config_root: &Path) -> Result<RigSourceListResult> {
+    let entries = read_source_entries(config_root)?;
+    group_source_entries(config_root, entries)
 }
 
-pub fn remove_source(selector: &str) -> Result<RigSourceRemoveResult> {
-    let list = list_sources()?;
+pub fn remove_source(config_root: &Path, selector: &str) -> Result<RigSourceRemoveResult> {
+    let list = list_sources(config_root)?;
     let matches = list
         .sources
         .into_iter()
@@ -63,7 +64,7 @@ pub fn remove_source(selector: &str) -> Result<RigSourceRemoveResult> {
     let mut skipped = Vec::new();
     let mut skipped_stacks = Vec::new();
     for rig in &source.rigs {
-        let metadata_path = paths::rig_source_metadata(&rig.id)?;
+        let metadata_path = paths::rig_source_metadata_in_root(config_root, &rig.id);
         let config_path = PathBuf::from(&rig.config_path);
         let remove_config = rig.config_present && rig.config_owned;
         if remove_config {
@@ -83,7 +84,7 @@ pub fn remove_source(selector: &str) -> Result<RigSourceRemoveResult> {
         }
     }
     for stack in &source.stacks {
-        let metadata_path = paths::stack_source_metadata(&stack.id)?;
+        let metadata_path = paths::stack_source_metadata_in_root(config_root, &stack.id);
         let config_path = PathBuf::from(&stack.config_path);
         let remove_config = stack.config_present && stack.config_owned;
         if remove_config {
@@ -133,7 +134,7 @@ pub fn remove_source(selector: &str) -> Result<RigSourceRemoveResult> {
     })
 }
 
-pub fn update_source_for_rig(id: &str) -> Result<RigSourceUpdateResult> {
+pub fn update_source_for_rig(config_root: &Path, id: &str) -> Result<RigSourceUpdateResult> {
     let metadata = super::install::read_source_metadata(id).ok_or_else(|| {
         Error::validation_invalid_argument(
             "rig_id",
@@ -151,7 +152,7 @@ pub fn update_source_for_rig(id: &str) -> Result<RigSourceUpdateResult> {
         ));
     }
 
-    let list = list_sources()?;
+    let list = list_sources(config_root)?;
     let source = list
         .sources
         .into_iter()
@@ -165,17 +166,17 @@ pub fn update_source_for_rig(id: &str) -> Result<RigSourceUpdateResult> {
             )
         })?;
 
-    update_group(source)
+    update_group(config_root, source)
 }
 
-pub fn update_all_sources() -> Result<RigSourceUpdateResult> {
+pub fn update_all_sources(config_root: &Path) -> Result<RigSourceUpdateResult> {
     let mut aggregate = RigSourceUpdateResult {
         updated: Vec::new(),
         updated_stacks: Vec::new(),
         skipped: Vec::new(),
         failed: Vec::new(),
     };
-    for source in list_sources()?.sources {
+    for source in list_sources(config_root)?.sources {
         if source.linked {
             for rig in source.rigs {
                 aggregate.skipped.push(SkippedRigSourceUpdate {
@@ -193,7 +194,7 @@ pub fn update_all_sources() -> Result<RigSourceUpdateResult> {
             }
             continue;
         }
-        match update_group(source.clone()) {
+        match update_group(config_root, source.clone()) {
             Ok(result) => {
                 aggregate.updated.extend(result.updated);
                 aggregate.updated_stacks.extend(result.updated_stacks);
@@ -213,12 +214,12 @@ pub fn update_all_sources() -> Result<RigSourceUpdateResult> {
     Ok(aggregate)
 }
 
-pub fn update_source(selector: Option<&str>) -> Result<RigSourceUpdateResult> {
+pub fn update_source(config_root: &Path, selector: Option<&str>) -> Result<RigSourceUpdateResult> {
     let Some(selector) = selector else {
-        return update_all_sources();
+        return update_all_sources(config_root);
     };
 
-    let matches = list_sources()?
+    let matches = list_sources(config_root)?
         .sources
         .into_iter()
         .filter(|source| source_matches(source, selector))
@@ -273,10 +274,10 @@ pub fn update_source(selector: Option<&str>) -> Result<RigSourceUpdateResult> {
         });
     }
 
-    update_group(source)
+    update_group(config_root, source)
 }
 
-fn update_group(source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
+fn update_group(config_root: &Path, source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
     if source.discovery_path.trim().is_empty() {
         return Err(Error::validation_invalid_argument(
             "source",
@@ -375,7 +376,7 @@ fn update_group(source: RigSourceGroup) -> Result<RigSourceUpdateResult> {
         super::install::package_content_hash(Path::new(&source.package_path))?;
     for stack in current_stacks {
         let existing = source.stacks.iter().find(|entry| entry.id == stack.id);
-        let config_path = paths::stack_config(&stack.id)?;
+        let config_path = paths::stack_config_in_root(config_root, &stack.id);
         if config_path.exists() || fs::symlink_metadata(&config_path).is_ok() {
             if existing.is_none_or(|entry| !entry.config_owned) {
                 skipped.push(SkippedRigSourceUpdate {
@@ -461,8 +462,8 @@ struct StackSourceEntry {
     metadata: StackSourceMetadata,
 }
 
-fn read_source_entries() -> Result<SourceEntries> {
-    let dir = paths::rig_sources()?;
+fn read_source_entries(config_root: &Path) -> Result<SourceEntries> {
+    let dir = paths::rig_sources_in_root(config_root);
     let rig_entries = super::json_config::read_json_configs::<RigSourceMetadata>(
         &dir,
         "read rig sources dir",
@@ -482,7 +483,7 @@ fn read_source_entries() -> Result<SourceEntries> {
         })
         .collect::<Vec<_>>();
 
-    let valid_stacks = read_stack_source_entries(&mut invalid)?;
+    let valid_stacks = read_stack_source_entries(config_root, &mut invalid)?;
     invalid.sort_by(|a, b| a.id.cmp(&b.id));
     Ok(SourceEntries {
         valid,
@@ -492,9 +493,10 @@ fn read_source_entries() -> Result<SourceEntries> {
 }
 
 fn read_stack_source_entries(
+    config_root: &Path,
     invalid: &mut Vec<InvalidRigSourceMetadata>,
 ) -> Result<Vec<StackSourceEntry>> {
-    let dir = paths::stack_sources()?;
+    let dir = paths::stack_sources_in_root(config_root);
     let entries = super::json_config::read_json_configs::<StackSourceMetadata>(
         &dir,
         "read stack sources dir",
@@ -521,7 +523,7 @@ fn invalid_source_metadata(
     }
 }
 
-fn group_source_entries(entries: SourceEntries) -> Result<RigSourceListResult> {
+fn group_source_entries(config_root: &Path, entries: SourceEntries) -> Result<RigSourceListResult> {
     let managed_stack_ids = entries
         .valid_stacks
         .iter()
@@ -530,7 +532,7 @@ fn group_source_entries(entries: SourceEntries) -> Result<RigSourceListResult> {
     let mut groups: BTreeMap<String, RigSourceGroup> = BTreeMap::new();
     for entry in entries.valid {
         let key = format!("{}\0{}", entry.metadata.source, entry.metadata.package_path);
-        let config_path = paths::rig_config(&entry.id).ok();
+        let config_path = Some(paths::rig_config_in_root(config_root, &entry.id));
         let config_present = config_path.as_ref().is_some_and(|path| path.exists());
         let config_owned = config_path.as_ref().is_some_and(|path| {
             entry.metadata.materialized || rig_config_matches_source(path, &entry.metadata.rig_path)
@@ -545,7 +547,7 @@ fn group_source_entries(entries: SourceEntries) -> Result<RigSourceListResult> {
 
     for entry in entries.valid_stacks {
         let key = format!("{}\0{}", entry.metadata.source, entry.metadata.package_path);
-        let config_path = paths::stack_config(&entry.id).ok();
+        let config_path = Some(paths::stack_config_in_root(config_root, &entry.id));
         let config_present = config_path.as_ref().is_some_and(|path| path.exists());
         let config_owned = config_path
             .as_ref()
@@ -556,6 +558,7 @@ fn group_source_entries(entries: SourceEntries) -> Result<RigSourceListResult> {
             .or_insert_with(|| new_stack_source_group(&entry.metadata))
             .stacks
             .push(source_stack(
+                config_root,
                 entry,
                 config_path,
                 config_present,
@@ -569,7 +572,8 @@ fn group_source_entries(entries: SourceEntries) -> Result<RigSourceListResult> {
         source.stacks.sort_by(|a, b| a.id.cmp(&b.id));
     }
 
-    let orphaned_stacks = installed_stacks_without_source_metadata(&managed_stack_ids)?;
+    let orphaned_stacks =
+        installed_stacks_without_source_metadata(config_root, &managed_stack_ids)?;
 
     Ok(RigSourceListResult {
         sources,
@@ -671,13 +675,14 @@ fn source_rig(
 }
 
 fn source_stack(
+    config_root: &Path,
     entry: StackSourceEntry,
     config_path: Option<PathBuf>,
     config_present: bool,
     config_owned: bool,
 ) -> RigSourceStack {
     let stack_present = Path::new(&entry.metadata.stack_path).is_file();
-    let (component_path, component_path_present) = stack_component_path(&entry.id);
+    let (component_path, component_path_present) = stack_component_path(config_root, &entry.id);
     RigSourceStack {
         id: entry.id,
         stack_path: entry.metadata.stack_path,
@@ -692,9 +697,10 @@ fn source_stack(
 }
 
 fn installed_stacks_without_source_metadata(
+    config_root: &Path,
     managed_stack_ids: &HashSet<String>,
 ) -> Result<Vec<OrphanedRigSourceStack>> {
-    let dir = paths::stacks()?;
+    let dir = paths::stacks_in_root(config_root);
     let entries = super::json_config::sorted_json_config_entries(
         &dir,
         "read stacks dir",
@@ -706,16 +712,19 @@ fn installed_stacks_without_source_metadata(
         .into_iter()
         .filter(|entry| !managed_stack_ids.contains(&entry.id))
         .map(|entry| {
-            orphaned_stack(InstalledStack {
-                id: entry.id,
-                path: entry.path,
-            })
+            orphaned_stack(
+                config_root,
+                InstalledStack {
+                    id: entry.id,
+                    path: entry.path,
+                },
+            )
         })
         .collect())
 }
 
-fn orphaned_stack(stack: InstalledStack) -> OrphanedRigSourceStack {
-    let (component_path, component_path_present) = stack_component_path(&stack.id);
+fn orphaned_stack(config_root: &Path, stack: InstalledStack) -> OrphanedRigSourceStack {
+    let (component_path, component_path_present) = stack_component_path(config_root, &stack.id);
     let content_identity = fs::read(&stack.path)
         .map(|content| {
             format!(
@@ -740,8 +749,8 @@ fn orphaned_stack(stack: InstalledStack) -> OrphanedRigSourceStack {
     }
 }
 
-fn stack_component_path(id: &str) -> (Option<String>, Option<bool>) {
-    let Ok(spec) = homeboy_stack::stack::load(id) else {
+fn stack_component_path(config_root: &Path, id: &str) -> (Option<String>, Option<bool>) {
+    let Ok(spec) = homeboy_stack::stack::load(config_root, id) else {
         return (None, None);
     };
     let component_path = homeboy_stack::stack::expand_path(&spec.component_path);

--- a/crates/homeboy-rig/src/stack.rs
+++ b/crates/homeboy-rig/src/stack.rs
@@ -69,10 +69,15 @@ pub fn plan_stack_sync(rig: &RigSpec) -> Vec<RigStackPlanEntry> {
 }
 
 pub fn run_sync(rig: &RigSpec, dry_run: bool) -> Result<RigStackSyncReport> {
+    // Boundary: one rig stack sync is one unit of work (#7505).
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let config_root = roots.config();
     Ok(run_sync_with(
         rig,
         dry_run,
-        |component_id, stack_id, dry_run| sync_checked(rig, component_id, stack_id, dry_run),
+        |component_id, stack_id, dry_run| {
+            sync_checked(config_root, rig, component_id, stack_id, dry_run)
+        },
     ))
 }
 
@@ -99,11 +104,16 @@ pub fn run_component_sync(
         )
     })?;
 
+    // Boundary: one component stack sync is one unit of work (#7505).
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let config_root = roots.config();
     let entry = run_one(
         component_id,
         stack_id,
         dry_run,
-        |component_id, stack_id, dry_run| sync_checked(rig, component_id, stack_id, dry_run),
+        |component_id, stack_id, dry_run| {
+            sync_checked(config_root, rig, component_id, stack_id, dry_run)
+        },
     );
 
     if entry.status == "changed" || entry.status == "no-op" {
@@ -195,16 +205,17 @@ where
 }
 
 fn sync_checked(
+    config_root: &Path,
     rig: &RigSpec,
     component_id: &str,
     stack_id: &str,
     dry_run: bool,
 ) -> Result<SyncOutput> {
-    let mut spec = stack::load(stack_id)?;
+    let mut spec = stack::load(config_root, stack_id)?;
     validate_component_stack_path(rig, component_id, &spec)?;
     // Rig sync inherits the default conflict policy: pause with the
     // conflicted pick intact so the operator can resolve it in the checkout.
-    stack::sync(&mut spec, dry_run, ConflictPolicy::default())
+    stack::sync(config_root, &mut spec, dry_run, ConflictPolicy::default())
 }
 
 pub(crate) fn validate_component_stack_path(

--- a/crates/homeboy-stack/src/provider.rs
+++ b/crates/homeboy-stack/src/provider.rs
@@ -3,27 +3,38 @@
 //! Core owns the HTTP API surface; this supplies the stack data by loading and
 //! inspecting stack specs and serializing them to JSON.
 
+use homeboy_core::paths;
 use homeboy_core::stack_provider::{register_stack_provider, StackProvider};
 use homeboy_core::Result;
 use serde_json::Value;
+use std::path::PathBuf;
 
 use crate::stack;
 
 struct StackProviderImpl;
 
+/// Each provider method answers one HTTP request, which is one unit of work, so
+/// this is a boundary resolution rather than an ambient one (#7505). It is
+/// deliberately per-call: the provider is a long-lived singleton and capturing a
+/// root at registration would pin it to whatever home happened to be current
+/// then.
+fn config_root() -> Result<PathBuf> {
+    paths::homeboy()
+}
+
 impl StackProvider for StackProviderImpl {
     fn stack_list_json(&self) -> Result<Value> {
-        let stacks = stack::list()?;
+        let stacks = stack::list(&config_root()?)?;
         Ok(serde_json::to_value(stacks).unwrap_or(Value::Null))
     }
 
     fn stack_show_json(&self, id: &str) -> Result<Value> {
-        let spec = stack::load(id)?;
+        let spec = stack::load(&config_root()?, id)?;
         Ok(serde_json::to_value(spec).unwrap_or(Value::Null))
     }
 
     fn stack_status_json(&self, id: &str) -> Result<Value> {
-        let spec = stack::load(id)?;
+        let spec = stack::load(&config_root()?, id)?;
         let report = stack::status(&spec)?;
         Ok(serde_json::to_value(report).unwrap_or(Value::Null))
     }

--- a/crates/homeboy-stack/src/stack/apply.rs
+++ b/crates/homeboy-stack/src/stack/apply.rs
@@ -39,6 +39,7 @@ use super::candidates::{preflight, stale_stack_error, StackCandidate};
 use super::git::run_git;
 use super::pr_meta::{fetch_pr_meta, PrHead};
 use super::spec::{resolve_existing_component_path, StackPrEntry, StackSpec};
+use std::path::Path;
 
 /// Per-PR outcome from a single `apply` run.
 #[derive(Debug, Clone, Serialize)]
@@ -118,17 +119,26 @@ pub struct ApplyOutput {
 pub type RebaseOutput = ApplyOutput;
 
 /// Apply a stack spec: build `target` from `base + prs`.
-pub fn apply(spec: &StackSpec, conflict_policy: ConflictPolicy) -> Result<ApplyOutput> {
-    rebuild(spec, "apply", conflict_policy)
+pub fn apply(
+    config_root: &Path,
+    spec: &StackSpec,
+    conflict_policy: ConflictPolicy,
+) -> Result<ApplyOutput> {
+    rebuild(config_root, spec, "apply", conflict_policy)
 }
 
 /// Rebase a stack spec: rebuild `target` from `base + prs` without editing the
 /// stack spec, even when some listed PRs have merged upstream.
-pub fn rebase(spec: &StackSpec, conflict_policy: ConflictPolicy) -> Result<RebaseOutput> {
-    rebuild(spec, "rebase", conflict_policy)
+pub fn rebase(
+    config_root: &Path,
+    spec: &StackSpec,
+    conflict_policy: ConflictPolicy,
+) -> Result<RebaseOutput> {
+    rebuild(config_root, spec, "rebase", conflict_policy)
 }
 
 fn rebuild(
+    config_root: &Path,
     spec: &StackSpec,
     rerun_verb: &str,
     conflict_policy: ConflictPolicy,
@@ -146,7 +156,7 @@ fn rebuild(
     let _ = fetch_remote_branch(&path, &spec.target.remote, &spec.target.branch);
 
     let base_ref = format!("{}/{}", spec.base.remote, spec.base.branch);
-    let preflight = preflight(spec, &path, &base_ref)?;
+    let preflight = preflight(config_root, spec, &path, &base_ref)?;
     if preflight.blocked {
         return Err(stale_stack_error(spec, &preflight));
     }

--- a/crates/homeboy-stack/src/stack/candidates.rs
+++ b/crates/homeboy-stack/src/stack/candidates.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use super::spec::{list, GitRef, StackPrEntry, StackProvenance, StackRequirements, StackSpec};
 use super::status::{count_revs, git_ref_exists};
 use homeboy_core::error::Result;
+use std::path::Path;
 
 /// A compatible installed stack that requires explicit operator selection.
 #[derive(Debug, Clone, Serialize)]
@@ -35,9 +36,9 @@ pub struct StackPreflight {
 ///
 /// Ranking is deterministic: declared base compatibility first, then the
 /// number of overlapping PR coordinates, and finally stack ID.
-pub fn discover(spec: &StackSpec) -> Result<Vec<StackCandidate>> {
+pub fn discover(config_root: &Path, spec: &StackSpec) -> Result<Vec<StackCandidate>> {
     let source_repositories = repositories(&spec.prs);
-    let mut candidates = list()?
+    let mut candidates = list(config_root)?
         .into_iter()
         .filter(|candidate| candidate.id != spec.id && candidate.component == spec.component)
         .filter_map(|candidate| {
@@ -96,7 +97,12 @@ pub fn discover(spec: &StackSpec) -> Result<Vec<StackCandidate>> {
 /// We stop only when a distinct-base candidate explicitly declares that it is
 /// compatible with this stack's base; that is actionable evidence that the
 /// operator may be using an obsolete stack definition.
-pub fn preflight(spec: &StackSpec, path: &str, base_ref: &str) -> Result<StackPreflight> {
+pub fn preflight(
+    config_root: &Path,
+    spec: &StackSpec,
+    path: &str,
+    base_ref: &str,
+) -> Result<StackPreflight> {
     let target_exists = git_ref_exists(path, &spec.target.branch);
     let (target_ahead, target_behind) = if target_exists {
         (
@@ -106,7 +112,7 @@ pub fn preflight(spec: &StackSpec, path: &str, base_ref: &str) -> Result<StackPr
     } else {
         (None, None)
     };
-    let candidates = discover(spec)?;
+    let candidates = discover(config_root, spec)?;
     let blocked = target_behind.unwrap_or_default() > 0
         && candidates
             .iter()

--- a/crates/homeboy-stack/src/stack/spec.rs
+++ b/crates/homeboy-stack/src/stack/spec.rs
@@ -144,11 +144,14 @@ pub(crate) fn resolve_existing_component_path(spec: &StackSpec) -> Result<String
     ))
 }
 
-/// Load a stack spec by ID from `~/.config/homeboy/stacks/{id}.json`.
-pub fn load(id: &str) -> Result<StackSpec> {
-    let path = paths::stack_config(id)?;
+/// Load a stack spec by ID from `<config_root>/stacks/{id}.json`.
+///
+/// The caller supplies the config root it already resolved, so one unit of work
+/// cannot straddle two Homeboy homes (#7505).
+pub fn load(config_root: &Path, id: &str) -> Result<StackSpec> {
+    let path = paths::stack_config_in_root(config_root, id);
     if !path.exists() {
-        let suggestions = list_ids().unwrap_or_default();
+        let suggestions = list_ids(config_root).unwrap_or_default();
         return Err(Error::stack_not_found(id, suggestions));
     }
     let content = fs::read_to_string(&path).map_err(|e| {
@@ -167,9 +170,9 @@ pub fn load(id: &str) -> Result<StackSpec> {
     Ok(spec)
 }
 
-/// List all stack specs in `~/.config/homeboy/stacks/`.
-pub fn list() -> Result<Vec<StackSpec>> {
-    let dir = paths::stacks()?;
+/// List all stack specs in `<config_root>/stacks/`.
+pub fn list(config_root: &Path) -> Result<Vec<StackSpec>> {
+    let dir = paths::stacks_in_root(config_root);
     if !dir.exists() {
         return Ok(Vec::new());
     }
@@ -188,7 +191,7 @@ pub fn list() -> Result<Vec<StackSpec>> {
             Some(s) => s.to_string(),
             None => continue,
         };
-        if let Ok(spec) = load(&stem) {
+        if let Ok(spec) = load(config_root, &stem) {
             stacks.push(spec);
         }
     }
@@ -198,8 +201,8 @@ pub fn list() -> Result<Vec<StackSpec>> {
 
 /// Return sorted stack IDs (cheaper than load+collect when you only need IDs,
 /// e.g. for error suggestions).
-pub fn list_ids() -> Result<Vec<String>> {
-    let dir = paths::stacks()?;
+pub fn list_ids(config_root: &Path) -> Result<Vec<String>> {
+    let dir = paths::stacks_in_root(config_root);
     if !dir.exists() {
         return Ok(Vec::new());
     }
@@ -223,14 +226,14 @@ pub fn list_ids() -> Result<Vec<String>> {
 }
 
 /// Whether a stack spec with this ID already exists on disk.
-pub fn exists(id: &str) -> Result<bool> {
-    Ok(paths::stack_config(id)?.exists())
+pub fn exists(config_root: &Path, id: &str) -> Result<bool> {
+    Ok(paths::stack_config_in_root(config_root, id).exists())
 }
 
 /// Write a spec to disk. Creates the stacks directory if missing. Pretty-printed
 /// so humans can edit by hand.
-pub fn save(spec: &StackSpec) -> Result<()> {
-    let dir = paths::stacks()?;
+pub fn save(config_root: &Path, spec: &StackSpec) -> Result<()> {
+    let dir = paths::stacks_in_root(config_root);
     fs::create_dir_all(&dir).map_err(|e| {
         Error::internal_unexpected(format!(
             "Failed to create stacks dir {}: {}",
@@ -238,7 +241,7 @@ pub fn save(spec: &StackSpec) -> Result<()> {
             e
         ))
     })?;
-    let path = paths::stack_config(&spec.id)?;
+    let path = paths::stack_config_in_root(config_root, &spec.id);
     let json = serde_json::to_string_pretty(spec).map_err(|e| {
         Error::internal_unexpected(format!("Failed to serialize stack spec: {}", e))
     })?;

--- a/crates/homeboy-stack/src/stack/sync.rs
+++ b/crates/homeboy-stack/src/stack/sync.rs
@@ -51,6 +51,7 @@ use super::pr_meta::fetch_pr_meta;
 pub(crate) use super::pr_meta::StackPrMeta as PrMeta;
 use super::spec::{resolve_existing_component_path, save, StackPrEntry, StackSpec};
 use super::status::{commit_reachable, count_revs, git_ref_exists, patch_in_base};
+use std::path::Path;
 
 /// Output envelope for `homeboy stack sync`.
 #[derive(Debug, Clone, Serialize)]
@@ -573,6 +574,7 @@ pub fn diff(spec: &StackSpec) -> Result<DiffOutput> {
 /// Sync a stack: rebuild target from base, auto-drop merged PRs, replay
 /// the rest.
 pub fn sync(
+    config_root: &Path,
     spec: &mut StackSpec,
     dry_run: bool,
     conflict_policy: ConflictPolicy,
@@ -607,7 +609,7 @@ pub fn sync(
     )?;
 
     let base_ref = format!("{}/{}", spec.base.remote, spec.base.branch);
-    let preflight = preflight(spec, &plan.preview.component_path, &base_ref)?;
+    let preflight = preflight(config_root, spec, &plan.preview.component_path, &base_ref)?;
     if preflight.blocked {
         return Err(stale_stack_error(spec, &preflight));
     }
@@ -617,7 +619,7 @@ pub fn sync(
     //    cleanly rebuilds.
     if plan.preview.dropped_count > 0 {
         spec.prs = plan.kept_entries.clone();
-        save(spec)?;
+        save(config_root, spec)?;
     } else {
         // No spec mutation needed — but keep `spec.prs` aligned with the
         // plan so the pick loop has consistent indexing.

--- a/tests/core/rig/bench_resource_lease_test.rs
+++ b/tests/core/rig/bench_resource_lease_test.rs
@@ -37,9 +37,10 @@ fn run_single_rig_bench_fails_fast_on_active_resource_lease() {
         set_rig_resources(home, "studio-bfb", resources);
 
         let active_spec = crate::rig::load("studio").expect("load active rig");
-        let _lease = crate::rig::lease::acquire_active_run_lease(&active_spec, "bench")
-            .expect("acquire active lease")
-            .expect("resourceful rig leases");
+        let _lease =
+            crate::rig::lease::acquire_active_run_lease(home.path(), &active_spec, "bench")
+                .expect("acquire active lease")
+                .expect("resourceful rig leases");
 
         let error = match run(run_args(None, vec!["studio-bfb".to_string()], Vec::new())) {
             Ok(_) => panic!("bench should fail before running with conflicting rig resources"),
@@ -65,7 +66,7 @@ fn run_single_rig_bench_without_resources_does_not_create_lease() {
             .expect("non-resourceful rig bench should run");
 
         assert_eq!(exit_code, 0);
-        assert!(crate::rig::lease::active_run_leases()
+        assert!(crate::rig::lease::active_run_leases(home.path())
             .expect("list active leases")
             .is_empty());
         assert!(!crate::core::paths::rig_leases_dir()

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -382,11 +382,19 @@ mod install_flows {
         assert!(installed.exists());
         #[cfg(unix)]
         assert_eq!(fs::read_link(&installed).expect("symlink"), stack_path);
-        assert_eq!(homeboy_stack::stack::list().expect("stack list").len(), 1);
         assert_eq!(
-            homeboy_stack::stack::load("studio-combined")
-                .expect("load stack")
-                .component,
+            homeboy_stack::stack::list(&homeboy_core::paths::homeboy().expect("config root"))
+                .expect("stack list")
+                .len(),
+            1
+        );
+        assert_eq!(
+            homeboy_stack::stack::load(
+                &homeboy_core::paths::homeboy().expect("config root"),
+                "studio-combined",
+            )
+            .expect("load stack")
+            .component,
             "studio"
         );
         let metadata = read_stack_source_metadata("studio-combined").expect("stack metadata");

--- a/tests/core/rig/lease_test.rs
+++ b/tests/core/rig/lease_test.rs
@@ -9,6 +9,18 @@ use crate::{run_up, RigRunLease};
 use homeboy_core::error::ErrorCode;
 use homeboy_core::test_support::with_isolated_home;
 
+/// The isolated home each test below installs, named as a config root.
+///
+/// A test is the entry point for its own unit of work, so resolving once here is
+/// a boundary resolution, not an ambient one. What matters is that the
+/// production path beneath it resolves nothing (#7505).
+fn test_config_root() -> std::path::PathBuf {
+    homeboy_core::paths::PathRoots::from_environment()
+        .expect("path roots")
+        .config()
+        .to_path_buf()
+}
+
 struct EnvVarGuard {
     name: &'static str,
     previous: Option<String>,
@@ -85,19 +97,21 @@ fn test_acquire_active_run_lease_blocks_overlapping_resources_until_drop() {
         let studio = rig("studio", resources());
         let studio_bfb = rig("studio-bfb", resources());
 
-        let lease = acquire_active_run_lease(&studio, "up")
+        let lease = acquire_active_run_lease(&test_config_root(), &studio, "up")
             .expect("first lease")
             .expect("resourceful rig leases");
-        let conflict =
-            acquire_active_run_lease(&studio_bfb, "up").expect_err("second lease conflicts");
+        let conflict = acquire_active_run_lease(&test_config_root(), &studio_bfb, "up")
+            .expect_err("second lease conflicts");
         assert_eq!(conflict.code, ErrorCode::RigResourceConflict);
         assert!(conflict.message.contains("studio-runtime"));
         assert!(conflict.message.contains("studio"));
 
         drop(lease);
-        assert!(acquire_active_run_lease(&studio_bfb, "up")
-            .expect("lease after drop")
-            .is_some());
+        assert!(
+            acquire_active_run_lease(&test_config_root(), &studio_bfb, "up")
+                .expect("lease after drop")
+                .is_some()
+        );
     });
 }
 
@@ -115,11 +129,11 @@ fn test_resource_conflict_reports_active_run_context_when_available() {
         let studio = rig("studio", resources());
         let studio_bfb = rig("studio-bfb", resources());
 
-        let lease = acquire_active_run_lease(&studio, "trace")
+        let lease = acquire_active_run_lease(&test_config_root(), &studio, "trace")
             .expect("first lease")
             .expect("resourceful rig leases");
-        let conflict =
-            acquire_active_run_lease(&studio_bfb, "trace").expect_err("second lease conflicts");
+        let conflict = acquire_active_run_lease(&test_config_root(), &studio_bfb, "trace")
+            .expect_err("second lease conflicts");
 
         assert_eq!(conflict.details["held_by"]["run_id"], "trace-run-123");
         assert_eq!(conflict.details["held_by"]["runner_id"], "lab-runner-1");
@@ -144,11 +158,11 @@ fn test_acquire_active_run_lease_blocks_env_expanded_exclusive_resources() {
         let studio = rig("studio", namespaced_resources("RIG_LEASE_NAMESPACE"));
         let studio_bfb = rig("studio-bfb", namespaced_resources("RIG_LEASE_NAMESPACE"));
 
-        let lease = acquire_active_run_lease(&studio, "up")
+        let lease = acquire_active_run_lease(&test_config_root(), &studio, "up")
             .expect("first lease")
             .expect("resourceful rig leases");
-        let conflict =
-            acquire_active_run_lease(&studio_bfb, "up").expect_err("expanded token conflicts");
+        let conflict = acquire_active_run_lease(&test_config_root(), &studio_bfb, "up")
+            .expect_err("expanded token conflicts");
 
         match previous {
             Some(value) => std::env::set_var("RIG_LEASE_NAMESPACE", value),
@@ -174,11 +188,21 @@ fn test_acquire_active_run_lease_expands_settings_in_resources() {
         let studio_bfb = rig("studio-bfb", resources);
         let settings = vec![("fixture_namespace".to_string(), "bench-a".to_string())];
 
-        let lease = acquire_active_run_lease_with_settings(&studio, "bench", &settings)
-            .expect("first lease")
-            .expect("resourceful rig leases");
-        let conflict = acquire_active_run_lease_with_settings(&studio_bfb, "bench", &settings)
-            .expect_err("settings-expanded token conflicts");
+        let lease = acquire_active_run_lease_with_settings(
+            &test_config_root(),
+            &studio,
+            "bench",
+            &settings,
+        )
+        .expect("first lease")
+        .expect("resourceful rig leases");
+        let conflict = acquire_active_run_lease_with_settings(
+            &test_config_root(),
+            &studio_bfb,
+            "bench",
+            &settings,
+        )
+        .expect_err("settings-expanded token conflicts");
 
         assert_eq!(conflict.code, ErrorCode::RigResourceConflict);
         assert!(conflict.message.contains("fixture:bench-a"));
@@ -196,10 +220,10 @@ fn test_acquire_active_run_lease_uses_default_namespace_for_empty_exclusive_reso
         let studio = rig("studio", namespaced_resources("RIG_LEASE_NAMESPACE"));
         let studio_bfb = rig("studio-bfb", namespaced_resources("RIG_LEASE_NAMESPACE"));
 
-        let lease = acquire_active_run_lease(&studio, "trace")
+        let lease = acquire_active_run_lease(&test_config_root(), &studio, "trace")
             .expect("first lease")
             .expect("resourceful rig leases");
-        let conflict = acquire_active_run_lease(&studio_bfb, "trace")
+        let conflict = acquire_active_run_lease(&test_config_root(), &studio_bfb, "trace")
             .expect_err("default namespace token conflicts");
 
         match previous {
@@ -219,10 +243,10 @@ fn test_active_run_leases_lists_live_leases_without_mutating_them() {
     with_isolated_home(|_| {
         let studio = rig("studio", resources());
 
-        let lease = acquire_active_run_lease(&studio, "up")
+        let lease = acquire_active_run_lease(&test_config_root(), &studio, "up")
             .expect("first lease")
             .expect("resourceful rig leases");
-        let leases = active_run_leases().expect("list active leases");
+        let leases = active_run_leases(&test_config_root()).expect("list active leases");
 
         assert_eq!(leases.len(), 1);
         assert_eq!(leases[0].rig_id, "studio");
@@ -230,7 +254,7 @@ fn test_active_run_leases_lists_live_leases_without_mutating_them() {
         assert_eq!(leases[0].pid, std::process::id());
 
         drop(lease);
-        assert!(active_run_leases()
+        assert!(active_run_leases(&test_config_root())
             .expect("list active leases after drop")
             .is_empty());
     });
@@ -241,16 +265,21 @@ fn test_trace_compare_lease_allows_same_process_child_trace() {
     with_isolated_home(|_| {
         let studio = rig("studio", resources());
 
-        let compare_lease = acquire_active_run_lease(&studio, "trace compare")
+        let compare_lease = acquire_active_run_lease(&test_config_root(), &studio, "trace compare")
             .expect("compare lease")
             .expect("resourceful rig leases");
-        let child_lease = acquire_active_run_lease(&studio, "trace")
+        let child_lease = acquire_active_run_lease(&test_config_root(), &studio, "trace")
             .expect("child trace lease should be allowed under compare");
 
         assert!(child_lease.is_none());
-        assert_eq!(active_run_leases().expect("list active leases").len(), 1);
+        assert_eq!(
+            active_run_leases(&test_config_root())
+                .expect("list active leases")
+                .len(),
+            1
+        );
         drop(compare_lease);
-        assert!(active_run_leases()
+        assert!(active_run_leases(&test_config_root())
             .expect("list active leases after drop")
             .is_empty());
     });
@@ -277,9 +306,11 @@ fn test_acquire_active_run_lease_prunes_stale_pid() {
         .expect("write stale lease");
 
         let studio_bfb = rig("studio-bfb", resources());
-        assert!(acquire_active_run_lease(&studio_bfb, "up")
-            .expect("stale pid ignored")
-            .is_some());
+        assert!(
+            acquire_active_run_lease(&test_config_root(), &studio_bfb, "up")
+                .expect("stale pid ignored")
+                .is_some()
+        );
     });
 }
 
@@ -315,7 +346,7 @@ fn test_ttl_reclaims_live_but_stale_lease() {
 
         let studio_bfb = rig("studio-bfb", resources());
         assert!(
-            acquire_active_run_lease(&studio_bfb, "bench")
+            acquire_active_run_lease(&test_config_root(), &studio_bfb, "bench")
                 .expect("ttl-stale lease is reclaimable")
                 .is_some(),
             "a live-but-stale holder past its TTL must be reclaimable"
@@ -328,12 +359,12 @@ fn test_live_holder_within_ttl_still_conflicts() {
     with_isolated_home(|_| {
         let _ttl = EnvVarGuard::set(RIG_LEASE_TTL_ENV, "100000");
         let studio = rig("studio", resources());
-        let lease = acquire_active_run_lease(&studio, "bench")
+        let lease = acquire_active_run_lease(&test_config_root(), &studio, "bench")
             .expect("first lease")
             .expect("resourceful rig leases");
 
         let studio_bfb = rig("studio-bfb", resources());
-        let conflict = acquire_active_run_lease(&studio_bfb, "bench")
+        let conflict = acquire_active_run_lease(&test_config_root(), &studio_bfb, "bench")
             .expect_err("a live, recent holder within its TTL must still conflict");
         assert_eq!(conflict.code, ErrorCode::RigResourceConflict);
 
@@ -349,7 +380,7 @@ fn test_no_ttl_keeps_live_holder_locked() {
         write_lease(&live_lease("studio", "2020-01-01T00:00:00Z"));
 
         let studio_bfb = rig("studio-bfb", resources());
-        let conflict = acquire_active_run_lease(&studio_bfb, "bench")
+        let conflict = acquire_active_run_lease(&test_config_root(), &studio_bfb, "bench")
             .expect_err("without a TTL a live holder is never stolen");
         assert_eq!(conflict.code, ErrorCode::RigResourceConflict);
     });
@@ -361,7 +392,7 @@ fn test_resource_conflict_includes_age_and_reclaim_command() {
         write_lease(&live_lease("studio", "2020-01-01T00:00:00Z"));
 
         let studio_bfb = rig("studio-bfb", resources());
-        let conflict = acquire_active_run_lease(&studio_bfb, "bench")
+        let conflict = acquire_active_run_lease(&test_config_root(), &studio_bfb, "bench")
             .expect_err("live holder conflicts without a TTL");
 
         let age = conflict.details["held_by"]["age_seconds"]
@@ -381,7 +412,8 @@ fn test_resource_conflict_includes_age_and_reclaim_command() {
 #[test]
 fn test_release_lock_reports_no_lease_when_absent() {
     with_isolated_home(|_| {
-        let outcome = release_active_run_lease("studio", false).expect("release with no lease");
+        let outcome = release_active_run_lease(&test_config_root(), "studio", false)
+            .expect("release with no lease");
         assert!(matches!(outcome, ReleaseLeaseOutcome::NoLease { .. }));
     });
 }
@@ -400,7 +432,8 @@ fn test_release_lock_frees_dead_holder_without_force() {
         };
         write_lease(&dead);
 
-        let outcome = release_active_run_lease("studio", false).expect("release dead holder");
+        let outcome = release_active_run_lease(&test_config_root(), "studio", false)
+            .expect("release dead holder");
         match outcome {
             ReleaseLeaseOutcome::Released {
                 was_reclaimable,
@@ -412,7 +445,9 @@ fn test_release_lock_frees_dead_holder_without_force() {
             }
             other => panic!("expected Released, got {other:?}"),
         }
-        assert!(active_run_leases().expect("list").is_empty());
+        assert!(active_run_leases(&test_config_root())
+            .expect("list")
+            .is_empty());
     });
 }
 
@@ -422,12 +457,12 @@ fn test_release_lock_requires_force_for_live_holder() {
         std::env::remove_var(RIG_LEASE_TTL_ENV);
         write_lease(&live_lease("studio", "2020-01-01T00:00:00Z"));
 
-        let err = release_active_run_lease("studio", false)
+        let err = release_active_run_lease(&test_config_root(), "studio", false)
             .expect_err("a live holder must not be released without force");
         assert_eq!(err.code, ErrorCode::RigResourceConflict);
 
-        let outcome =
-            release_active_run_lease("studio", true).expect("force releases the live holder");
+        let outcome = release_active_run_lease(&test_config_root(), "studio", true)
+            .expect("force releases the live holder");
         match outcome {
             ReleaseLeaseOutcome::Released {
                 was_reclaimable,
@@ -450,7 +485,7 @@ fn test_run_up_acquires_active_run_lease() {
     with_isolated_home(|_| {
         let studio = rig("studio", resources());
         let studio_bfb = rig("studio-bfb", resources());
-        let _lease = acquire_active_run_lease(&studio, "up")
+        let _lease = acquire_active_run_lease(&test_config_root(), &studio, "up")
             .expect("first lease")
             .expect("resourceful rig leases");
 

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -12,6 +12,18 @@ use crate::rig_test_support::{
     bare_source_path, minimal_rig, minimal_stack, run_git, write_rig, write_stack, GitFixture,
 };
 
+/// The isolated home each test below installs, named as a config root.
+///
+/// A test is the entry point for its own unit of work, so resolving once here is
+/// a boundary resolution, not an ambient one. What matters is that the
+/// production path beneath it resolves nothing (#7505).
+fn test_config_root() -> std::path::PathBuf {
+    homeboy_core::paths::PathRoots::from_environment()
+        .expect("path roots")
+        .config()
+        .to_path_buf()
+}
+
 /// Source-update-only fixture helpers. These live here rather than in the
 /// shared `support.rs` because only the source-update tests attach to an
 /// existing repo and push back to a bare source; keeping them in the shared
@@ -49,7 +61,7 @@ fn test_list_sources() {
 
     install(package.path().to_str().unwrap(), None, true).expect("install all");
 
-    let result = list_sources().expect("sources");
+    let result = list_sources(&test_config_root()).expect("sources");
     assert_eq!(result.invalid.len(), 0);
     assert_eq!(result.sources.len(), 1);
     assert_eq!(result.sources[0].source, package.path().to_string_lossy());
@@ -116,7 +128,7 @@ fn list_sources_reports_stack_specs_from_package() {
 
     install(package.path().to_str().unwrap(), None, false).expect("install");
 
-    let result = list_sources().expect("sources");
+    let result = list_sources(&test_config_root()).expect("sources");
     assert_eq!(result.sources.len(), 1);
     assert_eq!(result.sources[0].stacks.len(), 1);
     assert_eq!(result.sources[0].stacks[0].id, "alpha-combined");
@@ -135,7 +147,7 @@ fn sources_list_reports_legacy_stack_without_inferring_or_mutating_provenance() 
         .replace("${env.DEV_ROOT}/legacy", "/definitely/missing/legacy");
     fs::write(&config, &content).expect("legacy stack");
 
-    let result = list_sources().expect("sources");
+    let result = list_sources(&test_config_root()).expect("sources");
 
     assert!(result.sources.is_empty());
     assert_eq!(result.orphaned_stacks.len(), 1);
@@ -184,7 +196,8 @@ fn test_remove_source() {
     let manual = homeboy_core::paths::rig_config("manual").expect("manual rig path");
     fs::write(&manual, minimal_rig("manual")).expect("manual rig");
 
-    let result = remove_source(&package.path().to_string_lossy()).expect("remove source");
+    let result = remove_source(&test_config_root(), &package.path().to_string_lossy())
+        .expect("remove source");
     assert_eq!(result.removed.len(), 2);
     assert!(result.skipped.is_empty());
     assert!(result.removed_package_path.is_none());
@@ -211,7 +224,8 @@ fn remove_source_preserves_replaced_config_but_drops_metadata() {
     fs::remove_file(&config).expect("remove symlink");
     fs::write(&config, minimal_rig("replacement")).expect("replacement rig");
 
-    let result = remove_source(&package.path().to_string_lossy()).expect("remove source");
+    let result = remove_source(&test_config_root(), &package.path().to_string_lossy())
+        .expect("remove source");
     assert!(result.removed.is_empty());
     assert_eq!(result.skipped.len(), 1);
     assert!(config.exists());
@@ -232,7 +246,8 @@ fn remove_source_preserves_replaced_stack_config_but_drops_metadata() {
     fs::remove_file(&config).expect("remove symlink");
     fs::write(&config, minimal_stack("alpha-combined", "manual")).expect("replacement stack");
 
-    let result = remove_source(&package.path().to_string_lossy()).expect("remove source");
+    let result = remove_source(&test_config_root(), &package.path().to_string_lossy())
+        .expect("remove source");
 
     assert!(result.removed_stacks.is_empty());
     assert_eq!(result.skipped_stacks.len(), 1);
@@ -255,10 +270,11 @@ fn remove_source_treats_copied_config_as_owned_when_contents_match() {
     fs::remove_file(&config).expect("remove symlink");
     fs::copy(&source, &config).expect("copy rig config");
 
-    let listed = list_sources().expect("sources");
+    let listed = list_sources(&test_config_root()).expect("sources");
     assert!(listed.sources[0].rigs[0].config_owned);
 
-    let result = remove_source(&package.path().to_string_lossy()).expect("remove source");
+    let result = remove_source(&test_config_root(), &package.path().to_string_lossy())
+        .expect("remove source");
     assert_eq!(result.removed.len(), 1);
     assert!(result.skipped.is_empty());
     assert!(!config.exists());
@@ -288,7 +304,7 @@ fn sources_list_reports_corrupt_metadata_and_missing_configs() {
     )
     .expect("missing metadata");
 
-    let result = list_sources().expect("sources");
+    let result = list_sources(&test_config_root()).expect("sources");
     assert_eq!(result.invalid.len(), 1);
     assert_eq!(result.invalid[0].id, "broken");
     assert_eq!(result.sources.len(), 1);
@@ -306,7 +322,7 @@ fn sources_list_reports_missing_linked_source_paths() {
     install(package.path().to_str().unwrap(), None, false).expect("install linked");
     fs::remove_dir_all(package.path()).expect("remove linked source");
 
-    let result = list_sources().expect("sources");
+    let result = list_sources(&test_config_root()).expect("sources");
 
     assert_eq!(result.sources.len(), 1);
     let source = &result.sources[0];
@@ -377,7 +393,7 @@ fn sources_list_skips_non_json_and_collects_invalid_stack_metadata() {
     )
     .expect("installed stack");
 
-    let result = list_sources().expect("sources");
+    let result = list_sources(&test_config_root()).expect("sources");
 
     assert!(result.sources.is_empty());
     assert_eq!(result.invalid.len(), 1);
@@ -410,7 +426,7 @@ fn update_git_source_fast_forwards_package_and_refreshes_metadata() {
     commit_package(package.path(), "update alpha");
     GitFixture::attach(package.path()).push_main(&source);
 
-    let result = update_source_for_rig("alpha").expect("update rig source");
+    let result = update_source_for_rig(&test_config_root(), "alpha").expect("update rig source");
 
     assert_eq!(result.updated.len(), 1);
     assert!(result.skipped.is_empty());
@@ -455,7 +471,7 @@ fn update_git_source_refreshes_owned_stack_specs() {
     commit_package(package.path(), "update alpha stack");
     GitFixture::attach(package.path()).push_main(&source);
 
-    let result = update_source_for_rig("alpha").expect("update rig source");
+    let result = update_source_for_rig(&test_config_root(), "alpha").expect("update rig source");
 
     assert_eq!(result.updated_stacks.len(), 1);
     assert_eq!(result.updated_stacks[0].id, "alpha-combined");
@@ -498,7 +514,8 @@ fn legacy_source_without_a_valid_discovery_path_fails_before_refresh_mutation() 
     commit_package(package.path(), "remote update");
     GitFixture::attach(package.path()).push_main(&source);
 
-    let error = update_source_for_rig("alpha").expect_err("invalid provenance must fail closed");
+    let error = update_source_for_rig(&test_config_root(), "alpha")
+        .expect_err("invalid provenance must fail closed");
 
     assert!(error.message.contains("no validated discovery path"));
     assert_eq!(
@@ -537,7 +554,8 @@ fn update_all_reports_broken_sources_and_continues() {
     commit_package(good_package.path(), "update good rig");
     GitFixture::attach(good_package.path()).push_main(&good_source);
 
-    let result = update_all_sources().expect("update all continues after broken source");
+    let result =
+        update_all_sources(&test_config_root()).expect("update all continues after broken source");
 
     assert_eq!(result.failed.len(), 1);
     assert_eq!(result.failed[0].source, broken_source);
@@ -570,10 +588,10 @@ fn refresh_source_selector_updates_recorded_package() {
     commit_package(package.path(), "refresh alpha");
     GitFixture::attach(package.path()).push_main(&source);
 
-    let package_id = list_sources().expect("sources").sources[0]
+    let package_id = list_sources(&test_config_root()).expect("sources").sources[0]
         .package_id
         .clone();
-    let result = update_source(Some(&package_id)).expect("refresh source");
+    let result = update_source(&test_config_root(), Some(&package_id)).expect("refresh source");
 
     assert_eq!(result.updated.len(), 1);
     assert_eq!(result.updated[0].id, "alpha");
@@ -610,7 +628,7 @@ fn refresh_without_selector_updates_all_sources() {
     commit_package(package.path(), "refresh alpha");
     GitFixture::attach(package.path()).push_main(&source);
 
-    let result = update_source(None).expect("refresh all sources");
+    let result = update_source(&test_config_root(), None).expect("refresh all sources");
 
     assert_eq!(result.updated.len(), 1);
     assert_eq!(result.updated[0].id, "alpha");
@@ -639,7 +657,7 @@ fn update_git_source_skips_user_replaced_stack_specs() {
     commit_package(package.path(), "update alpha stack");
     GitFixture::attach(package.path()).push_main(&source);
 
-    let result = update_source_for_rig("alpha").expect("update rig source");
+    let result = update_source_for_rig(&test_config_root(), "alpha").expect("update rig source");
 
     assert!(result.updated_stacks.is_empty());
     assert_eq!(result.skipped.len(), 1);
@@ -657,7 +675,7 @@ fn update_all_skips_linked_local_sources() {
     write_rig(package.path(), "alpha", &minimal_rig("alpha"));
 
     install(package.path().to_str().unwrap(), None, false).expect("install linked");
-    let result = update_all_sources().expect("update all");
+    let result = update_all_sources(&test_config_root()).expect("update all");
 
     assert!(result.updated.is_empty());
     assert_eq!(result.skipped.len(), 1);
@@ -673,7 +691,7 @@ fn update_all_skips_linked_local_stack_sources() {
     write_stack(package.path(), "alpha-combined", "alpha");
 
     install(package.path().to_str().unwrap(), None, false).expect("install linked");
-    let result = update_all_sources().expect("update all");
+    let result = update_all_sources(&test_config_root()).expect("update all");
 
     assert!(result.updated.is_empty());
     assert!(result.updated_stacks.is_empty());
@@ -691,7 +709,7 @@ fn update_single_linked_local_source_errors() {
     write_rig(package.path(), "alpha", &minimal_rig("alpha"));
 
     install(package.path().to_str().unwrap(), None, false).expect("install linked");
-    let err = update_source_for_rig("alpha").expect_err("linked update error");
+    let err = update_source_for_rig(&test_config_root(), "alpha").expect_err("linked update error");
 
     assert!(err.message.contains("linked local source"));
 }

--- a/tests/core/stack/apply_test.rs
+++ b/tests/core/stack/apply_test.rs
@@ -790,13 +790,19 @@ fn rebase_rebuilds_target_without_editing_spec() {
             provenance: None,
             requirements: Default::default(),
         };
-        save(&spec).expect("save stack spec");
+        save(&homeboy_core::paths::homeboy().expect("config root"), &spec)
+            .expect("save stack spec");
         let spec_path = home
             .path()
             .join(".config/homeboy/stacks/rebase-no-edit.json");
         let before = fs::read_to_string(&spec_path).expect("read spec before rebase");
 
-        let output = rebase(&spec, ConflictPolicy::default()).expect("rebase stack");
+        let output = rebase(
+            &homeboy_core::paths::homeboy().expect("config root"),
+            &spec,
+            ConflictPolicy::default(),
+        )
+        .expect("rebase stack");
         assert!(output.success);
         assert_eq!(output.picked_count, 0);
         assert_eq!(output.skipped_count, 0);

--- a/tests/core/stack/candidates_test.rs
+++ b/tests/core/stack/candidates_test.rs
@@ -9,6 +9,18 @@ use std::process::Command;
 mod support;
 use support::{commit_file, git, init_repo, rev_parse};
 
+/// The isolated home each test below installs, named as a config root.
+///
+/// A test is the entry point for its own unit of work, so resolving once here is
+/// a boundary resolution, not an ambient one. What matters is that the
+/// production path beneath it resolves nothing (#7505).
+fn test_config_root() -> std::path::PathBuf {
+    homeboy_core::paths::PathRoots::from_environment()
+        .expect("path roots")
+        .config()
+        .to_path_buf()
+}
+
 fn stack(id: &str, component: &str, base: &str, prs: &[(&str, u64)]) -> StackSpec {
     StackSpec {
         id: id.to_string(),
@@ -59,10 +71,11 @@ fn stale_trunk_stack_ranks_compatible_pr_based_candidate_first() {
             .requirements
             .compatible_bases
             .push(stale.base.clone());
-        save(&stale).expect("save stale stack");
-        save(&candidate).expect("save candidate stack");
+        save(&test_config_root(), &stale).expect("save stale stack");
+        save(&test_config_root(), &candidate).expect("save candidate stack");
 
-        let candidates = discover_candidates(&stale).expect("discover candidates");
+        let candidates =
+            discover_candidates(&test_config_root(), &stale).expect("discover candidates");
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].stack_id, "abi-pr");
         assert!(candidates[0].base_compatible);
@@ -119,12 +132,12 @@ fn ambiguous_candidates_are_ranked_by_overlap_then_id() {
             .requirements
             .compatible_bases
             .push(source.base.clone());
-        save(&source).unwrap();
-        save(&beta).unwrap();
-        save(&overlap).unwrap();
-        save(&alpha).unwrap();
+        save(&test_config_root(), &source).unwrap();
+        save(&test_config_root(), &beta).unwrap();
+        save(&test_config_root(), &overlap).unwrap();
+        save(&test_config_root(), &alpha).unwrap();
 
-        let candidates = discover_candidates(&source).unwrap();
+        let candidates = discover_candidates(&test_config_root(), &source).unwrap();
         assert_eq!(
             candidates
                 .iter()
@@ -167,10 +180,10 @@ fn stale_target_with_compatible_candidate_is_blocked_without_mutation() {
             .requirements
             .compatible_bases
             .push(source.base.clone());
-        save(&source).unwrap();
-        save(&alternative).unwrap();
+        save(&test_config_root(), &source).unwrap();
+        save(&test_config_root(), &alternative).unwrap();
 
-        let report = preflight(&source, &path, "main").expect("preflight");
+        let report = preflight(&test_config_root(), &source, &path, "main").expect("preflight");
         assert!(report.blocked);
         assert_eq!(report.target_behind, Some(1));
         assert_eq!(report.candidates[0].stack_id, "topic-stack");
@@ -217,12 +230,12 @@ fn unrelated_stacks_are_excluded_and_missing_provenance_is_null() {
             "topic",
             &[("Automattic/wordpress", 10)],
         );
-        save(&source).unwrap();
-        save(&matching).unwrap();
-        save(&other_component).unwrap();
-        save(&other_repository).unwrap();
+        save(&test_config_root(), &source).unwrap();
+        save(&test_config_root(), &matching).unwrap();
+        save(&test_config_root(), &other_component).unwrap();
+        save(&test_config_root(), &other_repository).unwrap();
 
-        let candidates = discover_candidates(&source).unwrap();
+        let candidates = discover_candidates(&test_config_root(), &source).unwrap();
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].stack_id, "matching");
         assert!(candidates[0].provenance.is_none());


### PR DESCRIPTION
Roots the stack registry and the rig lease store, the first of the two halves `tests/nextest_shard_parallelism_test.rs` names as the release condition for `rust_nextest_shard_threads`.

## Why this slice

The guard test states its own condition verbatim:

> `rust_nextest_shard_threads` must stay 1 while the controller-runtime admission store and the rig registry live in machine-global directories. ... Restore 0 only after those stores take explicit roots (#7505).

nextest already runs every test in its own process, so process-global environment is not what forces this pin. The filesystem is: both stores sit beneath the real `$HOME`, so concurrent test *processes* share them exactly as thoroughly as concurrent threads would. Run `32294476539` caught ten `workspace::tests::prune::*` failures traced to shared rig-registry writes.

That makes this the actionable half of #7505. It is ~86 call sites across two named stores, not the 2,587 `with_isolated_home` sites the issue headline implies — and the rooted APIs in `homeboy-paths` were already written.

## What changed

**`homeboy-stack` reaches 0 ambient.** `load`, `list`, `list_ids`, `exists`, and `save` take the config root the caller already resolved. The ambient forms are **deleted**, not kept as `_in_root` siblings — per the contract, a change that only adds rooted variants has added plumbing. `sync`, `apply`, `rebase`, `rebuild`, `preflight`, and `discover` thread it down from `commands/stack.rs::run`, a single match over every `StackCommand` variant and therefore one boundary for the entire surface.

**The rig lease guard carries its own root.** This is the substantive find. `ActiveRigRunLease::drop` resolved ambiently, so the guard released into whatever home was current at teardown — a *different* home whenever the acquiring work owned an explicit root:

```rust
pub struct ActiveRigRunLease {
    /// The config root the lease was acquired against.
    ///
    /// The guard must release into the same home it acquired from. Resolving
    /// ambiently in `Drop` would let a guard delete a lease in whatever home is
    /// current at teardown, which is a different home whenever the acquiring
    /// work owned an explicit root (#7505).
    config_root: PathBuf,
    ...
}
```

Same split-root shape as #12623, in a `Drop` impl where it is invisible at the call site.

**`homeboy-rig` source listing/update** is rooted through `list_sources`, `remove_source`, `update_source`, `update_source_for_rig`, and `update_all_sources`.

## Reporting

Decomposed as the contract requires — a correct boundary is also a call, so raw counts mislead:

| | before | after |
|---|---:|---:|
| ambient resolutions, `homeboy-rig` + `homeboy-stack` | 41 | **23** |
| ambient resolutions, repo-wide | 133 | **115** |
| boundary resolutions added | — | 14 |
| test helpers added | — | 6 |

Each of the 14 boundaries is one named unit of work: one `homeboy stack` invocation, one rig up / down / repair, one rig stack sync, one trace run, one trace compare, one bench run, one resource probe.

## Deliberately not done

- **`rust_nextest_shard_threads` stays `1`** and the guard test is untouched. The controller-runtime admission store is the other half of its condition. Flipping now would reintroduce the exact contamination the guard exists to catch.
- **`rust_cargo_test_threads` untouched** — different race, different release condition.
- **No test freed from `with_isolated_home`.** The contract is explicit that a scan over test bodies cannot prove a test stopped reaching the filesystem through an ambient root, and that a prior scan of that kind returned 97 candidates that were noise. Freeing zero is the expected outcome for a slice that roots production APIs.
- `install.rs`, `lib.rs`, `service.rs`, and `state.rs` still resolve ambiently (23 sites). Next slice.

## Verification

`cargo check --workspace --tests -j2` — green.

Two collisions surfaced as failed pre-write assertions rather than bad edits, both of the shapes the contract pre-empts: a `fn test_list_sources()` definition matching a `list_sources()` call pattern, and an auto-inserted import landing inside a multi-line `use` block.

Refs #7505.
