### PR TITLE
fix(cook): reattest Lab baseline workspaces

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4990,7 +4990,10 @@ fn run_cook_spine(
                         });
                     }
                 }
-                if options.attempt_dispatcher.is_none() {
+                // A controller-owned baseline replaces the admitted workspace
+                // for both local and detached dispatch. Attest that exact
+                // replacement before either path can persist or hand it off.
+                if effective_baseline.is_some() || options.attempt_dispatcher.is_none() {
                     bind_dispatch_workspace_attestations(&mut dispatch_plan)?;
                 }
                 failed_dispatch_plan = Some(dispatch_plan.clone());

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3535,6 +3535,11 @@ struct RetryableTransportFailingAttemptDispatcher {
 }
 
 #[derive(Debug)]
+struct AttestingRetryableTransportDispatcher {
+    observations: Arc<Mutex<Vec<(String, Value, Value, bool)>>>,
+}
+
+#[derive(Debug)]
 struct FlakyPreparationDispatcher {
     failures_remaining: AtomicUsize,
 }
@@ -3702,6 +3707,42 @@ impl AgentTaskCookAttemptDispatcher for RetryableTransportFailingAttemptDispatch
         _derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
     ) -> Result<()> {
         self.dispatches.fetch_add(1, Ordering::SeqCst);
+        Err(Error::new(
+            homeboy_core::error::ErrorCode::RunnerLabTransportFailure,
+            "fixture transport disconnected",
+            serde_json::json!({ "phase": "lab_handoff" }),
+        )
+        .with_retryable(true))
+    }
+}
+
+impl AgentTaskCookAttemptDispatcher for AttestingRetryableTransportDispatcher {
+    fn durable_recipe(&self) -> Result<Value> {
+        Ok(serde_json::json!({ "kind": "test-attesting-transport-failure" }))
+    }
+
+    fn dispatch_attempt(
+        &self,
+        plan: AgentTaskPlan,
+        _run_id: &str,
+        _derived_cook_baseline: Option<&DerivedCookBaselineCapability>,
+    ) -> Result<()> {
+        let task = &plan.tasks[0];
+        let root = task
+            .workspace
+            .root
+            .as_deref()
+            .expect("baseline workspace root");
+        let identity = task.metadata["cook_workspace_identity"].clone();
+        let predecessor = task.metadata["cook_workspace_identity_predecessor"].clone();
+        let matches = crate::agent_task_workspace_identity::workspace_matches_attestation(
+            std::path::Path::new(root),
+            &identity,
+        );
+        self.observations
+            .lock()
+            .expect("baseline observations")
+            .push((root.to_string(), identity, predecessor, matches));
         Err(Error::new(
             homeboy_core::error::ErrorCode::RunnerLabTransportFailure,
             "fixture transport disconnected",
@@ -8422,6 +8463,68 @@ fn cook_retries_retryable_pre_provider_transport_failures_within_attempt_budget(
                 "transient"
             );
         }
+    });
+}
+
+#[test]
+fn cook_reattests_each_initial_baseline_before_detached_transport_retry() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("temporary repository root");
+        let primary = temp.path().join("primary");
+        let source = temp.path().join("source");
+        std::fs::create_dir(&primary).expect("create primary repository");
+        let git = |cwd: &std::path::Path, args: &[&str]| {
+            let output = Command::new("git")
+                .args(args)
+                .current_dir(cwd)
+                .output()
+                .expect("run git fixture command");
+            assert!(output.status.success(), "git {:?} failed", args);
+        };
+        git(&primary, &["init", "--initial-branch=main"]);
+        git(&primary, &["config", "user.email", "agent@example.test"]);
+        git(&primary, &["config", "user.name", "Agent"]);
+        std::fs::write(primary.join("fixture.txt"), "base\n").expect("write base fixture");
+        git(&primary, &["add", "fixture.txt"]);
+        git(&primary, &["commit", "-m", "base"]);
+        git(
+            &primary,
+            &[
+                "worktree",
+                "add",
+                "--detach",
+                source.to_str().expect("UTF-8 source path"),
+                "HEAD",
+            ],
+        );
+        std::fs::write(source.join("fixture.txt"), "candidate\n").expect("write candidate fixture");
+
+        let observations = Arc::new(Mutex::new(Vec::new()));
+        let mut options = batch_cook_options(
+            "cook-baseline-attestation",
+            Arc::new(AttestingRetryableTransportDispatcher {
+                observations: Arc::clone(&observations),
+            }),
+        );
+        options.initial_run_id = "cook-baseline-attestation-attempt-1".to_string();
+        options.source_worktree_path = Some(source.clone());
+        options.provider_command = Some("fixture-provider".to_string());
+        options.initial_plan.tasks[0].workspace.root = Some(source.display().to_string());
+        let source_identity = crate::agent_task_workspace_identity::attest_workspace(&source)
+            .expect("attest admitted source workspace");
+        options.initial_plan.tasks[0].metadata["cook_workspace_identity"] = source_identity.clone();
+
+        let result = run_cook(CookContext::new(options, Arc::new(UnusedExecutor)))
+            .expect("record bounded transport retry");
+
+        assert_eq!(result.value.attempts.len(), 2);
+        let observations = observations.lock().expect("baseline observations");
+        assert_eq!(observations.len(), 2);
+        assert!(observations.iter().all(|(_, _, _, matches)| *matches));
+        assert_ne!(observations[0].0, observations[1].0);
+        assert!(observations
+            .iter()
+            .all(|(_, _, predecessor, _)| predecessor == &source_identity));
     });
 }
 

--- a/crates/homeboy-agents/src/agent_task_workspace_identity.rs
+++ b/crates/homeboy-agents/src/agent_task_workspace_identity.rs
@@ -113,6 +113,43 @@ pub fn workspace_matches_attestation(path: &Path, attestation: &Value) -> bool {
     workspace_attestation_match(path, attestation) == WorkspaceAttestationMatch::Matched
 }
 
+/// Return the exact identity values compared during a failed handoff admission.
+/// This evidence is diagnostic only; callers must still use
+/// [`workspace_matches_attestation`] for the admission decision.
+#[cfg(unix)]
+pub fn workspace_attestation_diagnostics(path: &Path, attestation: &Value) -> Value {
+    const FIELDS: [&str; 10] = [
+        "canonical_path",
+        "device",
+        "inode",
+        "git_representation",
+        "git_file_content",
+        "gitdir_target",
+        "git_dir_canonical_path",
+        "git_dir_device",
+        "git_dir_inode",
+        "git_file_is_file",
+    ];
+
+    match attest_workspace(path) {
+        Ok(observed) => serde_json::json!({
+            "match": format!("{:?}", workspace_attestation_match(path, attestation)),
+            "expected": attestation,
+            "observed": observed,
+            "compared_fields": FIELDS.into_iter().map(|field| serde_json::json!({
+                "field": field,
+                "expected": attestation[field],
+                "observed": observed[field],
+            })).collect::<Vec<_>>(),
+        }),
+        Err(error) => serde_json::json!({
+            "match": "Mismatched",
+            "expected": attestation,
+            "observed_error": error.message,
+        }),
+    }
+}
+
 #[cfg(unix)]
 pub fn workspace_attestation_match(path: &Path, attestation: &Value) -> WorkspaceAttestationMatch {
     use std::os::unix::fs::MetadataExt;
@@ -206,6 +243,27 @@ pub fn workspace_matches_attestation(path: &Path, attestation: &Value) -> bool {
         .and_then(|path| path.to_str().map(str::to_string))
         .as_deref()
         == attestation["canonical_path"].as_str()
+}
+
+#[cfg(not(unix))]
+pub fn workspace_attestation_diagnostics(path: &Path, attestation: &Value) -> Value {
+    match attest_workspace(path) {
+        Ok(observed) => serde_json::json!({
+            "match": format!("{:?}", workspace_attestation_match(path, attestation)),
+            "expected": attestation,
+            "observed": observed,
+            "compared_fields": [{
+                "field": "canonical_path",
+                "expected": attestation["canonical_path"],
+                "observed": observed["canonical_path"],
+            }],
+        }),
+        Err(error) => serde_json::json!({
+            "match": "Mismatched",
+            "expected": attestation,
+            "observed_error": error.message,
+        }),
+    }
 }
 
 #[cfg(not(unix))]

--- a/crates/homeboy-lab-runner/src/lab_args/agent_task_specs.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/agent_task_specs.rs
@@ -103,15 +103,21 @@ pub(crate) fn verify_cook_workspace_attestations_in_args(
                 Path::new(root),
                 attestation,
             ) {
-                return Err(Error::validation_invalid_argument(
+                let mut error = Error::validation_invalid_argument(
                     "workspace",
-                    "Cook source workspace no longer matches its admission identity attestation before Lab snapshotting",
+                    "Cook workspace identity does not match its admission attestation before Lab snapshotting",
                     Some(root.to_string()),
                     Some(vec![
-                        "Restore the admitted worktree or start a new Cook so Lab can snapshot the verified source."
+                        "Resolve the reported identity mismatch in the managed source, then start a new Cook; Homeboy recreates dispatch baselines."
                             .to_string(),
                     ]),
-                ));
+                );
+                error.details["identity_attestation"] =
+                    homeboy_agents::agent_task_workspace_identity::workspace_attestation_diagnostics(
+                        Path::new(root),
+                        attestation,
+                    );
+                return Err(error);
             }
         }
     }

--- a/crates/homeboy-lab-runner/src/lab_args/tests.rs
+++ b/crates/homeboy-lab-runner/src/lab_args/tests.rs
@@ -1789,6 +1789,66 @@ mod materialize_specs_tests {
     }
 
     #[test]
+    fn cook_attestation_failure_reports_compared_identities_without_scratch_restore_advice() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let admitted = temp.path().join("admitted");
+        let replacement = temp.path().join("replacement");
+        std::fs::create_dir_all(admitted.join(".git")).expect("admitted workspace");
+        std::fs::create_dir_all(replacement.join(".git")).expect("replacement workspace");
+        let plan = serde_json::json!({
+            "schema": "homeboy/agent-task-plan/v1",
+            "plan_id": "controller-plan",
+            "tasks": [{
+                "task_id": "task-1",
+                "instructions": "test",
+                "executor": { "backend": "fixture" },
+                "workspace": { "root": replacement },
+                "metadata": {
+                    "cook_workspace_identity": {
+                        "canonical_path": admitted,
+                        "device": 1,
+                        "inode": 1,
+                        "git_representation": "directory"
+                    }
+                }
+            }]
+        })
+        .to_string();
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--attempt-plan".to_string(),
+            plan,
+        ];
+
+        let error =
+            agent_task_specs::verify_cook_workspace_attestations_in_args(&args, temp.path())
+                .expect_err("replacement identity must not satisfy the admitted attestation");
+
+        assert_eq!(
+            error.details["identity_attestation"]["expected"]["canonical_path"],
+            serde_json::json!(admitted)
+        );
+        assert_eq!(
+            error.details["identity_attestation"]["observed"]["canonical_path"],
+            serde_json::json!(replacement.canonicalize().expect("canonical replacement"))
+        );
+        assert_eq!(
+            error.details["identity_attestation"]["compared_fields"]
+                .as_array()
+                .expect("compared fields")
+                .len(),
+            10
+        );
+        assert!(error.details["tried"]
+            .as_array()
+            .expect("recovery guidance")
+            .iter()
+            .all(|value| !value.as_str().unwrap_or_default().contains("Restore")));
+    }
+
+    #[test]
     fn controller_attempt_plan_ignores_truncated_legacy_tasks_json() {
         let temp = tempfile::tempdir().expect("tempdir");
         let plan = serde_json::json!({


### PR DESCRIPTION
## Summary

- re-attest each controller-owned immutable baseline before local or detached Cook dispatch
- preserve the admitted source identity as predecessor evidence across transport retry
- report expected and observed workspace identity fields without telling operators to restore Homeboy scratch

Closes #12996.

## Verification

- `cargo test -p homeboy-agents cook_reattests_each_initial_baseline_before_detached_transport_retry --lib`
- `cargo test -p homeboy-lab-runner cook_attestation_failure_reports_compared_identities_without_scratch_restore_advice --lib`
- `cargo fmt --check`
- `git diff --check`

## AI assistance

OpenAI gpt-5.6-sol via OpenCode was used to diagnose the Lab preacceptance failure, implement the identity lifecycle repair, add regression coverage, and verify the change. Chris Huber remains responsible for every line.