### PR TITLE
fix(lab): preserve root-anchored snapshot excludes

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -1,5 +1,5 @@
 use homeboy_engine_primitives::content_hash;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -125,6 +125,7 @@ const INCREMENTAL_PREPARE_COMMAND_MAX_BYTES: usize = 16 * 1024;
 // preflight deliberately overestimates so it can reject before allocating a
 // command proportional to the manifest.
 const INCREMENTAL_PREPARE_COMMAND_FIXED_OVERHEAD_BYTES: usize = 4 * 1024;
+const SNAPSHOT_MANIFEST_DIFFERENCE_LIMIT: usize = 8;
 
 pub(crate) fn snapshot_identity(
     local_path: &Path,
@@ -1926,8 +1927,95 @@ pub(super) fn validate_snapshot_stability(
         "workspace_snapshot",
         source,
         Some(staging_output),
-        "source and staged snapshot manifests differ; refusing a mixed snapshot",
+        &format!(
+            "source and staged snapshot manifests differ; refusing a mixed snapshot; {}",
+            snapshot_manifest_difference(before, staged, after)
+        ),
     ))
+}
+
+fn snapshot_manifest_difference(
+    before: &SnapshotStableManifest,
+    staged: &SnapshotStableManifest,
+    after: &SnapshotStableManifest,
+) -> String {
+    let mut differences = Vec::new();
+    append_snapshot_manifest_difference("source-to-staged", before, staged, &mut differences);
+    append_snapshot_manifest_difference("staged-to-current", staged, after, &mut differences);
+    if differences.is_empty() {
+        "content identities differ outside the bounded manifest metadata".to_string()
+    } else {
+        format!(
+            "bounded differing entries (up to {SNAPSHOT_MANIFEST_DIFFERENCE_LIMIT}): {}",
+            differences.join(", ")
+        )
+    }
+}
+
+fn append_snapshot_manifest_difference(
+    label: &str,
+    expected: &SnapshotStableManifest,
+    actual: &SnapshotStableManifest,
+    differences: &mut Vec<String>,
+) {
+    let expected_entries = expected
+        .inventory
+        .entries
+        .iter()
+        .map(|entry| (&entry.path, entry))
+        .collect::<BTreeMap<_, _>>();
+    let actual_entries = actual
+        .inventory
+        .entries
+        .iter()
+        .map(|entry| (&entry.path, entry))
+        .collect::<BTreeMap<_, _>>();
+    let paths = expected_entries
+        .keys()
+        .chain(actual_entries.keys())
+        .copied()
+        .collect::<BTreeSet<_>>();
+    for path in paths {
+        if differences.len() == SNAPSHOT_MANIFEST_DIFFERENCE_LIMIT {
+            return;
+        }
+        match (expected_entries.get(path), actual_entries.get(path)) {
+            (Some(expected), Some(actual)) if expected == actual => {}
+            (Some(expected), Some(actual)) => differences.push(format!(
+                "{label}:{path} ({})",
+                snapshot_manifest_entry_difference(expected, actual)
+            )),
+            (Some(_), None) => differences.push(format!("{label}:{path} (missing)")),
+            (None, Some(_)) => differences.push(format!("{label}:{path} (unexpected)")),
+            (None, None) => unreachable!("entry key came from one manifest"),
+        }
+    }
+    if differences.is_empty() && expected.content_identity != actual.content_identity {
+        differences.push(format!("{label}:content identity changed"));
+    }
+}
+
+fn snapshot_manifest_entry_difference(
+    expected: &WorkspaceContentManifestEntry,
+    actual: &WorkspaceContentManifestEntry,
+) -> String {
+    let mut fields = Vec::new();
+    if expected.kind != actual.kind {
+        fields.push("kind");
+    }
+    if expected.sha256 != actual.sha256 {
+        fields.push("sha256");
+    }
+    if expected.bytes != actual.bytes {
+        fields.push("bytes");
+    }
+    if expected.owner_executable != actual.owner_executable {
+        fields.push("owner_executable");
+    }
+    if fields.is_empty() {
+        fields.push("metadata");
+    }
+    format!("changed fields: {}", fields.join(", "))
 }
 
 /// One controller-side input and its corresponding private staging output.
@@ -2017,17 +2105,14 @@ pub(super) fn materialize_snapshot_stage(
         )
     })?;
     let inputs = snapshot_manifest_tar_input(manifest);
-    // Root-anchored exclusions have already shaped the manifest. Passing them
-    // to tar again would make a root-only exclusion match nested paths.
-    let archive_excludes = excludes
-        .iter()
-        .filter(|pattern| !pattern.starts_with("./"))
-        .cloned()
-        .collect::<Vec<_>>();
+    // The manifest selects root inputs only. Tar still recurses through each
+    // selected directory, so every exclusion, including a root-anchored nested
+    // path, must be applied during archive construction.
+    let archive_excludes = excludes;
     let source_archive = format!(
         "COPYFILE_DISABLE=1 tar --no-xattrs -C {src} {exclude} -cf - --null -T -",
         src = shell::quote_arg(&local_path.display().to_string()),
-        exclude = tar_exclude_args(&archive_excludes),
+        exclude = tar_exclude_args(archive_excludes),
     );
     let command = format!(
         "({inputs}) | {source_archive} | tar --no-xattrs -C {stage} -xf - && root={root} && stage={stage} && export root stage && find \"$stage\" -type l -exec sh -c {resolve} sh {{}} \\;",
@@ -2035,7 +2120,7 @@ pub(super) fn materialize_snapshot_stage(
         root = shell::quote_arg(&local_path.display().to_string()),
         resolve = shell::quote_arg(&format!(
             "stage_link=$1; relative=${{stage_link#\"$stage\"/}}; original=\"$root/$relative\"; target=$(realpath \"$original\") || exit; case \"$target\" in \"$root\"|\"$root\"/*) ;; *) rm -f \"$stage_link\" && mkdir -p \"$(dirname \"$stage_link\")\" && COPYFILE_DISABLE=1 tar --no-xattrs -h -C \"$root\" {} -cf - \"$relative\" | tar --no-xattrs -C \"$stage\" -xf - ;; esac",
-            tar_exclude_args(&archive_excludes)
+            tar_exclude_args(archive_excludes)
         )),
     );
     run_shell_command(&command, "construct workspace snapshot staging").map_err(|error| {

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -1547,6 +1547,40 @@ fn snapshot_transport_archives_only_the_admitted_scratch_stage() {
 }
 
 #[test]
+fn snapshot_staging_keeps_nested_root_ignored_outputs_out_of_repeated_snapshots() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let source = workspace.path().join("source");
+    fs::create_dir_all(source.join("src/generated-output")).expect("generated output directory");
+    fs::write(source.join("src/lib.rs"), "pub fn stable() {}\n").expect("source file");
+    fs::write(source.join("src/generated-output/state.json"), "ignored\n").expect("ignored output");
+    for index in 0..128 {
+        let sibling = source.join(format!("worktrees/sibling-{index}"));
+        fs::create_dir_all(&sibling).expect("sibling directory");
+        fs::write(sibling.join("build-output"), "ignored\n").expect("sibling output");
+    }
+
+    let excludes = vec![
+        "./src/generated-output".to_string(),
+        "./worktrees".to_string(),
+    ];
+    let baseline = snapshot_stable_manifest(&source, &excludes).expect("baseline manifest");
+    for destination in [
+        workspace.path().join("first"),
+        workspace.path().join("second"),
+    ] {
+        copy_snapshot_to_directory(&source, &destination, &excludes)
+            .expect("ignored outputs must not enter the staging archive");
+        assert_eq!(
+            snapshot_stable_manifest(&destination, &[]).expect("staged manifest"),
+            baseline,
+            "repeated snapshot must preserve the source manifest"
+        );
+        assert!(!destination.join("src/generated-output").exists());
+        assert!(!destination.join("worktrees").exists());
+    }
+}
+
+#[test]
 fn snapshot_construction_failure_does_not_start_transport_or_accept_source_drift() {
     let source = tempfile::tempdir().expect("source");
     let scratch = tempfile::tempdir().expect("admitted scratch");
@@ -1592,6 +1626,11 @@ fn snapshot_stability_rejects_a_mixed_staged_tree_even_if_source_is_restored() {
     )
     .expect_err("mixed staged tree must fail even after source ABA restoration");
     assert_eq!(error.details["classification"], "snapshot_construction");
+    assert!(
+        error.message.contains("bounded differing entries"),
+        "{error:?}"
+    );
+    assert!(error.message.contains("runtime-overlays"), "{error:?}");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- apply every snapshot exclusion while tar recursively stages admitted root inputs
- include bounded source/staged manifest differences in real mutation failures
- cover repeated snapshots with nested root-anchored ignored output

Fixes #12963

## Verification
- `cargo test -p homeboy-lab-runner snapshot_staging_keeps_nested_root_ignored_outputs_out_of_repeated_snapshots --lib`
- `cargo test -p homeboy-lab-runner snapshot_stability_rejects_a_mixed_staged_tree_even_if_source_is_restored --lib`
- `cargo fmt --check`
- `cargo check -p homeboy-lab-runner`

`cargo clippy -p homeboy-lab-runner -- -D warnings` is blocked by existing Clippy findings on `main`, outside this patch.

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode inspected, rebased, verified, and prepared this change. Chris Huber reviewed and remains responsible for every line.