### PR TITLE
Retain provider diagnostics after Cook cancellation

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -3672,6 +3672,66 @@ pub fn record_provider_execution_terminal_in_store(
     Ok(record.unwrap_or(lifecycle_store.read_record(&run_id)?))
 }
 
+/// Attach stable, bounded provider stream references while the process is still
+/// running. Cancellation can win before the scheduler receives an outcome, so
+/// these references belong to the durable execution reservation rather than its
+/// eventual aggregate.
+pub fn record_provider_execution_runtime_evidence_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    task_id: &str,
+    attempt: u32,
+    stdout_uri: Option<String>,
+    stderr_uri: Option<String>,
+) -> Result<AgentTaskRunRecord> {
+    let run_id = sanitize_run_id(run_id);
+    let key = format!("{task_id}:{attempt}");
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
+        let Some(execution) = record.metadata["provider_executions"]
+            .as_array_mut()
+            .and_then(|executions| {
+                executions
+                    .iter_mut()
+                    .find(|execution| execution["key"] == key)
+            })
+        else {
+            return false;
+        };
+        execution["runtime_evidence"] = json!({
+            "stdout": stdout_uri,
+            "stderr": stderr_uri,
+            "capture": "bounded_incremental",
+        });
+        true
+    })?;
+    record.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "provider_execution",
+            "cannot attach runtime evidence to an unreserved provider execution",
+            Some(key),
+            None,
+        )
+    })
+}
+
+pub fn record_provider_execution_runtime_evidence(
+    run_id: &str,
+    task_id: &str,
+    attempt: u32,
+    stdout_uri: Option<String>,
+    stderr_uri: Option<String>,
+) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_provider_execution_runtime_evidence_in_store(
+        &lifecycle_store,
+        run_id,
+        task_id,
+        attempt,
+        stdout_uri,
+        stderr_uri,
+    )
+}
+
 // The ambient `has_active_provider_execution()` shim that used to sit here is gone;
 // its one scheduler test now asks the store it resolves (#7505).
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/logs_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/logs_projection.rs
@@ -60,7 +60,9 @@ pub fn logs_with_raw_in_store(
                 events.extend(local_provider_execution_events(&record));
                 events
             });
-            (progress, record.artifact_refs.clone(), raw_events)
+            let mut artifact_refs = record.artifact_refs.clone();
+            artifact_refs.extend(local_provider_execution_artifact_refs(&record));
+            (progress, artifact_refs, raw_events)
         }
     };
     let events = if raw_events.is_empty() {
@@ -80,12 +82,49 @@ pub fn logs_with_raw_in_store(
     })
 }
 
-/// Synthesize progress events from the durable running provider executions of a
-/// local (in-process) cook. `reserve_provider_execution` records each attempt
+fn local_provider_execution_artifact_refs(
+    record: &AgentTaskRunRecord,
+) -> Vec<AgentTaskArtifactRef> {
+    record.metadata["provider_executions"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .flat_map(|execution| {
+            let task_id = execution
+                .get("task_id")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .or_else(|| record.tasks.first().map(|task| task.task_id.clone()))
+                .unwrap_or_else(|| record.run_id.clone());
+            [
+                ("provider-runtime-stdout", "stdout"),
+                ("provider-runtime-stderr", "stderr"),
+            ]
+            .into_iter()
+            .filter_map(move |(kind, stream)| {
+                execution
+                    .pointer(&format!("/runtime_evidence/{stream}"))
+                    .and_then(Value::as_str)
+                    .filter(|uri| !uri.trim().is_empty())
+                    .map(|uri| AgentTaskArtifactRef {
+                        task_id: task_id.clone(),
+                        kind: kind.to_string(),
+                        uri: uri.to_string(),
+                        role: None,
+                        label: Some(format!("provider {stream} (bounded capture)")),
+                        semantic_key: None,
+                        size_bytes: None,
+                    })
+            })
+        })
+        .collect()
+}
+
+/// Synthesize progress events from durable local provider executions. `reserve_provider_execution` records each attempt
 /// (backend, model, started_at, `state:"running"`) before the scheduler blocks
 /// on the backend, but until an aggregate exists `agent-task logs` shows only
-/// "task submitted". Surface the running executions so logs reflect active
-/// provider work rather than a stalled preflight (#8396).
+/// "task submitted". Terminal reservations are also projected because a
+/// cancellation can complete before an aggregate imports the provider outcome.
 pub(super) fn local_provider_execution_events(
     record: &AgentTaskRunRecord,
 ) -> Vec<AgentTaskProgressEvent> {
@@ -98,8 +137,14 @@ pub(super) fn local_provider_execution_events(
     };
     executions
         .iter()
-        .filter(|execution| execution.get("state").and_then(Value::as_str) == Some("running"))
-        .map(|execution| {
+        .filter_map(|execution| {
+            let state = match execution.get("state").and_then(Value::as_str) {
+                Some("running") => AgentTaskState::Running,
+                Some("cancelled") => AgentTaskState::Cancelled,
+                Some("timed_out") => AgentTaskState::TimedOut,
+                Some("failed") => AgentTaskState::Failed,
+                _ => return None,
+            };
             let task_id = execution
                 .get("task_id")
                 .and_then(Value::as_str)
@@ -110,7 +155,10 @@ pub(super) fn local_provider_execution_events(
                 .get("backend")
                 .and_then(Value::as_str)
                 .unwrap_or("provider");
-            let mut message = format!("provider execution running: {backend}");
+            let mut message = format!(
+                "provider execution {}: {backend}",
+                execution["state"].as_str().unwrap_or("unknown")
+            );
             if let Some(model) = execution.get("model").and_then(Value::as_str) {
                 if !model.is_empty() {
                     message.push_str(&format!(" ({model})"));
@@ -119,15 +167,15 @@ pub(super) fn local_provider_execution_events(
             if let Some(started_at) = execution.get("started_at").and_then(Value::as_str) {
                 message.push_str(&format!("; started {started_at}"));
             }
-            AgentTaskProgressEvent {
+            Some(AgentTaskProgressEvent {
                 task_id,
-                state: AgentTaskState::Running,
+                state,
                 attempt: execution
                     .get("attempt")
                     .and_then(Value::as_u64)
                     .unwrap_or(1) as u32,
                 message: Some(message),
-            }
+            })
         })
         .collect()
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -2527,6 +2527,67 @@ fn local_cook_logs_surface_running_provider_execution_before_aggregate() {
     );
 }
 
+#[test]
+fn cancelled_local_provider_retains_runtime_evidence_in_terminal_logs() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let run_id = "local-cook-cancelled-with-output";
+    let plan = test_plan();
+    lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, run_id, |_| Ok(json!({})))
+        .expect("submitted");
+    reserve_provider_execution_in_store(&lifecycle_store, run_id, &plan.tasks[0], 1)
+        .expect("reserved provider execution");
+
+    // This simulates a provider that emitted output before controller cancellation.
+    let stdout = context
+        .path_roots()
+        .artifacts()
+        .join("provider-runtime-stdout-1.log");
+    std::fs::write(&stdout, "provider emitted diagnostic output\n").expect("provider output");
+    record_provider_execution_runtime_evidence_in_store(
+        &lifecycle_store,
+        run_id,
+        &plan.tasks[0].task_id,
+        1,
+        Some(format!("file://{}", stdout.display())),
+        None,
+    )
+    .expect("runtime evidence recorded before cancellation");
+
+    super::super::cancellation::cancel_run_in_store(
+        &lifecycle_store,
+        run_id,
+        Some("deterministic test cancellation"),
+    )
+    .expect("cancelled");
+
+    let log = logs_in_store(&lifecycle_store, run_id).expect("terminal logs");
+    let terminal = log
+        .events
+        .iter()
+        .find(|event| {
+            event.status == AgentTaskState::Cancelled
+                && event
+                    .message
+                    .as_deref()
+                    .is_some_and(|message| message.contains("provider execution cancelled"))
+        })
+        .expect("cancelled provider event");
+    let stdout_ref = terminal
+        .artifact_refs
+        .iter()
+        .find(|reference| reference.kind == "provider-runtime-stdout")
+        .expect("bounded stdout reference");
+    assert_eq!(stdout_ref.uri, format!("file://{}", stdout.display()));
+    assert_eq!(
+        std::fs::read_to_string(stdout_ref.uri.strip_prefix("file://").expect("file uri"))
+            .expect("retained provider output"),
+        "provider emitted diagnostic output\n"
+    );
+}
+
 /// Rooted in an explicit store rather than a mutated process environment
 /// (#7505). The liveness predicate is a read of the same durable provider
 /// execution the reservation and terminalization wrote, so answering it from an

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -870,12 +870,25 @@ fn run_materialized_provider_command_once_contained(
     // adjustment must never turn a stale provider into a live one.
     let last_progress_ms: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
 
+    let (stdout_capture, stderr_capture) = runtime_output_captures(request, run_id, attempt);
+    if let Some(run_id) = run_id {
+        // The files exist before any output arrives, so a controller-side
+        // cancellation retains resolvable diagnostics even if it interrupts us.
+        let _ = crate::agent_task_lifecycle::record_provider_execution_runtime_evidence(
+            run_id,
+            &request.request.task_id,
+            attempt,
+            stdout_capture.as_ref().map(|capture| capture.uri.clone()),
+            stderr_capture.as_ref().map(|capture| capture.uri.clone()),
+        );
+    }
     let stdout_reader = child.stdout.take().map(|stdout| {
         spawn_output_reader(
             stdout,
             Arc::clone(&stdout_buffer),
             Arc::clone(&last_progress_ms),
             started,
+            stdout_capture.map(|capture| capture.file),
         )
     });
     let stderr_reader = child.stderr.take().map(|stderr| {
@@ -884,6 +897,7 @@ fn run_materialized_provider_command_once_contained(
             Arc::clone(&stderr_buffer),
             Arc::clone(&last_progress_ms),
             started,
+            stderr_capture.map(|capture| capture.file),
         )
     });
 
@@ -1449,23 +1463,61 @@ fn spawn_output_reader<R>(
     buffer: Arc<Mutex<Vec<u8>>>,
     last_progress_ms: Arc<AtomicU64>,
     started: Instant,
+    capture: Option<std::fs::File>,
 ) -> std::thread::JoinHandle<()>
 where
     R: Read + Send + 'static,
 {
     std::thread::spawn(move || {
+        let mut capture = capture;
+        let mut captured = 0;
         let mut chunk = [0; 4096];
         while let Ok(read) = reader.read(&mut chunk) {
             if read == 0 {
                 break;
             }
             buffer.lock().expect("output buffer").extend(&chunk[..read]);
+            if let Some(file) = capture.as_mut() {
+                let remaining = EXECUTOR_OUTPUT_CAPTURE_LIMIT_BYTES.saturating_sub(captured);
+                let written = remaining.min(read);
+                if written > 0 && file.write_all(&chunk[..written]).is_ok() {
+                    captured += written;
+                }
+            }
             last_progress_ms.store(
                 u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
                 Ordering::SeqCst,
             );
         }
     })
+}
+
+struct RuntimeOutputCapture {
+    uri: String,
+    file: std::fs::File,
+}
+
+fn runtime_output_captures(
+    request: &AgentTaskExecutorRequest,
+    run_id: Option<&str>,
+    attempt: u32,
+) -> (Option<RuntimeOutputCapture>, Option<RuntimeOutputCapture>) {
+    if run_id.is_none() || std::fs::create_dir_all(&request.artifacts_path).is_err() {
+        return (None, None);
+    }
+    let capture = |name: &str| {
+        let path = request.artifacts_path.join(name);
+        std::fs::File::create(&path)
+            .ok()
+            .map(|file| RuntimeOutputCapture {
+                uri: format!("file://{}", path.display()),
+                file,
+            })
+    };
+    (
+        capture(&format!("provider-runtime-stdout-{attempt}.log")),
+        capture(&format!("provider-runtime-stderr-{attempt}.log")),
+    )
 }
 
 fn classify_stall_or_rate_limit(
@@ -2097,7 +2149,13 @@ pub fn run_provider_readiness_invocation(
     let last_progress = Arc::new(AtomicU64::new(0));
     let started = Instant::now();
     let stdout_reader = child.stdout.take().map(|stdout| {
-        spawn_output_reader(stdout, Arc::clone(&stdout_buffer), last_progress, started)
+        spawn_output_reader(
+            stdout,
+            Arc::clone(&stdout_buffer),
+            last_progress,
+            started,
+            None,
+        )
     });
     let status = loop {
         match child.try_wait() {

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -300,6 +300,19 @@ impl AgentTaskLifecycleStore {
         )
     }
 
+    pub(crate) fn record_provider_execution_runtime_evidence(
+        &self,
+        run_id: &str,
+        task_id: &str,
+        attempt: u32,
+        stdout_uri: Option<String>,
+        stderr_uri: Option<String>,
+    ) -> Result<AgentTaskRunRecord> {
+        super::lifecycle_ops::record_provider_execution_runtime_evidence_in_store(
+            self, run_id, task_id, attempt, stdout_uri, stderr_uri,
+        )
+    }
+
     pub(crate) fn record_provider_execution_cleanup_elapsed(
         &self,
         run_id: &str,


### PR DESCRIPTION
## Summary

- persist bounded provider stdout/stderr incrementally during local execution
- retain stable stream references when cancellation terminalizes before aggregate creation
- project cancelled provider execution and diagnostics through `agent-task logs`

## Tests

- `cargo test -p homeboy-agents cancelled_local_provider_retains_runtime_evidence_in_terminal_logs --lib`
- `cargo test -p homeboy-agents local_cook_logs_surface_running_provider_execution_before_aggregate --lib`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

Closes #12980.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode general coding subagents implemented the fix and focused regression coverage; OpenCode then reviewed, rebased, and verified the branch under Chris Huber's direction. Chris remains responsible for every line.
