### PR TITLE
Resolve prompt files before evidence validation

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -3425,11 +3425,17 @@ pub(crate) fn validate_cook_request_with_provenance(
             ]),
         ));
     }
-    validate_provider_evidence_inputs(
-        &args.provider_evidence_inputs,
-        args.dispatch.prompt.as_deref(),
-    )?;
-    let dispatch = dispatch_args_for_cook(args);
+    // Resolve @file input before scanning its provider-visible content. The
+    // host path is an ingestion detail, not evidence. Stdin remains unread
+    // until execution so this preflight cannot consume its prompt bytes.
+    let mut dispatch = dispatch_args_for_cook(args);
+    if dispatch.prompt.as_deref().is_some_and(|spec| {
+        spec.starts_with('@')
+            && homeboy::agents::agent_task_prompts::stored_prompt_ref_id(spec).is_none()
+    }) {
+        resolve_dispatch_prompt(&mut dispatch)?;
+    }
+    validate_provider_evidence_inputs(&args.provider_evidence_inputs, dispatch.prompt.as_deref())?;
     dispatch_service::validate_single_cook_prompt_source(
         dispatch.prompt.as_deref(),
         &dispatch.tasks,
@@ -3989,6 +3995,26 @@ mod prompt_input_tests {
         resolve_dispatch_prompt(&mut args).expect("resolve @file prompt");
 
         assert_eq!(args.prompt.as_deref(), Some(body));
+    }
+
+    #[test]
+    fn relative_and_absolute_at_file_prompts_resolve_to_equivalent_bytes() {
+        let cwd = std::env::current_dir().expect("current directory");
+        let file = tempfile::NamedTempFile::new_in(&cwd).expect("prompt file");
+        let body = "Preserve these prompt bytes.\n\n";
+        std::fs::write(file.path(), body).expect("write prompt");
+        let relative = file
+            .path()
+            .strip_prefix(&cwd)
+            .expect("prompt file is in the current directory");
+
+        let mut relative_args = dispatch_with_prompt(Some(&format!("@{}", relative.display())));
+        let mut absolute_args = dispatch_with_prompt(Some(&format!("@{}", file.path().display())));
+        resolve_dispatch_prompt(&mut relative_args).expect("resolve relative @file prompt");
+        resolve_dispatch_prompt(&mut absolute_args).expect("resolve absolute @file prompt");
+
+        assert_eq!(relative_args.prompt, absolute_args.prompt);
+        assert_eq!(absolute_args.prompt.as_deref(), Some(body));
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -385,6 +385,33 @@ fn goal_and_prompt_remain_a_valid_single_source_cook_shape() {
 }
 
 #[test]
+fn cook_preflight_scans_at_file_content_not_its_absolute_source_path() {
+    let file = tempfile::NamedTempFile::new().expect("prompt file");
+    std::fs::write(file.path(), "Implement the outcome.\n").expect("write prompt");
+    let args = cook_args_from_cli(vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "cook".to_string(),
+        "--prompt".to_string(),
+        format!("@{}", file.path().display()),
+        "--to-worktree".to_string(),
+        "sample-plugin@fix-issue".to_string(),
+        "--backend".to_string(),
+        "fixture".to_string(),
+        "--no-finalize".to_string(),
+    ]);
+
+    validate_cook_request(&args).expect("absolute @file source is not provider evidence");
+
+    std::fs::write(file.path(), "Read /private/evidence.json before editing.\n")
+        .expect("rewrite prompt");
+    let error =
+        validate_cook_request(&args).expect_err("absolute path in prompt content is evidence");
+    assert_eq!(error.details["field"], "prompt");
+    assert!(error.message.contains("undeclared absolute evidence path"));
+}
+
+#[test]
 fn cook_preflight_rejects_contradictory_retry_budget_with_corrected_command() {
     let args = cook_args_from_cli(vec![
         "homeboy".to_string(),


### PR DESCRIPTION
## Summary

- resolve `@file` prompt input before provider-evidence validation
- make relative and absolute prompt files produce equivalent prompt bytes
- continue validating absolute paths contained inside resolved prompt content

## Tests

- `cargo test -p homeboy-cli --lib relative_and_absolute_at_file_prompts_resolve_to_equivalent_bytes`
- `cargo test -p homeboy-cli --lib cook_preflight_scans_at_file_content_not_its_absolute_source_path`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

Closes #12981.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode general coding subagents implemented the fix and focused regression coverage; OpenCode then reviewed, rebased, and verified the branch under Chris Huber's direction. Chris remains responsible for every line.
