### PR TITLE
fix(cook): align gates with component cwd

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -619,6 +619,10 @@ pub struct AgentTaskGateReport {
     pub stderr: String,
     #[serde(default)]
     pub capture: AgentTaskGateCapture,
+    /// The workspace requested by Cook and the component workspace that
+    /// actually executed this gate. Root components retain identical paths.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<AgentTaskGateCwdEvidence>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failure_evidence: Option<AgentTaskGateFailureEvidence>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -640,6 +644,12 @@ pub struct AgentTaskGateReport {
     pub candidate_checkout: Option<AgentTaskGateCandidateCheckout>,
     #[serde(default, skip_serializing_if = "AgentTaskGateEnvironment::is_empty")]
     pub environment: AgentTaskGateEnvironment,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskGateCwdEvidence {
+    pub requested: String,
+    pub effective: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1181,6 +1191,7 @@ impl AgentTaskGateReport {
             stdout: stdout.into(),
             stderr: stderr.into(),
             capture: AgentTaskGateCapture::default(),
+            cwd: None,
             failure_evidence,
             test_result: None,
             cargo_selection: None,
@@ -1234,6 +1245,7 @@ impl AgentTaskGateReport {
             stdout: String::new(),
             stderr: String::new(),
             capture: AgentTaskGateCapture::default(),
+            cwd: None,
             failure_evidence: None,
             test_result: None,
             cargo_selection: None,

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -1766,9 +1766,10 @@ fn run_promotion_gates(
     // setup is intentionally destination-only: gates must consume the exact
     // executable projection this report describes.
     let candidate_setup = Vec::new();
-    let destination_gate_setup = if worktree_path.is_dir() {
+    let gate_workspace = gate_workspace_path(options, worktree_path);
+    let destination_gate_setup = if gate_workspace.is_dir() {
         crate::agent_task_gate::hydrate_gate_dependency_roots(
-            worktree_path,
+            &gate_workspace,
             options.gates.hydrate_dependencies,
             "destination_gate_workspace",
         )
@@ -1823,7 +1824,7 @@ fn run_promotion_gates(
             run_promotion_gate(
                 options,
                 provider,
-                worktree_path,
+                &gate_workspace,
                 index + 1,
                 command,
                 visibility,
@@ -1836,6 +1837,11 @@ fn run_promotion_gates(
         {
             blocking_gate_id = Some(gate.id.clone());
         }
+        let mut gate = gate;
+        gate.cwd = Some(crate::agent_task_gate::AgentTaskGateCwdEvidence {
+            requested: worktree_path.display().to_string(),
+            effective: gate_workspace.display().to_string(),
+        });
         deterministic_gates.push(gate);
     }
     emit_promotion_progress(
@@ -1869,6 +1875,15 @@ fn run_promotion_gates(
         destination_gate_setup,
         candidate_checkout,
     })
+}
+
+fn gate_workspace_path(options: &AgentTaskPromotionOptions, worktree_path: &Path) -> PathBuf {
+    options
+        .source_worktree_path
+        .as_ref()
+        .filter(|source| source.is_dir())
+        .cloned()
+        .unwrap_or_else(|| worktree_path.to_path_buf())
 }
 
 fn bounded_setup_error_text(value: &str) -> String {

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -3777,6 +3777,33 @@ pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress(
     ))
 }
 
+fn cook_component_workspace(
+    args: &AgentTaskCookArgs,
+    workspace: &Path,
+) -> homeboy::core::Result<PathBuf> {
+    let Some(component_id) = args.dispatch.repo.as_deref() else {
+        return Ok(workspace.to_path_buf());
+    };
+    let Some(component) = homeboy::core::component::registered_by_id(component_id)? else {
+        return Ok(workspace.to_path_buf());
+    };
+    let effective = homeboy::core::component::resolution::rebase_component_path_to_checkout(
+        &component, workspace,
+    );
+    if !effective.is_dir() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "component workspace",
+            format!(
+                "resolved component `{component_id}` is not present in Cook workspace: {}",
+                effective.display()
+            ),
+            Some(effective.display().to_string()),
+            None,
+        ));
+    }
+    Ok(effective)
+}
+
 pub(crate) fn record_cook_argument_provenance(
     plan: &mut AgentTaskPlan,
     provenance: &crate::cli_surface::CommandArgumentProvenance,
@@ -4029,7 +4056,7 @@ pub(crate) fn compile_cook_plan(
         provision.get("action").and_then(Value::as_str),
         Some("lookup_pending" | "attestation_pending" | "planned_create")
     );
-    let workspace = (!pending_lookup)
+    let requested_workspace = (!pending_lookup)
         .then(|| {
             provision
                 .get("path")
@@ -4037,12 +4064,12 @@ pub(crate) fn compile_cook_plan(
                 .map(str::to_string)
         })
         .flatten();
-    if workspace.is_none() && !pending_lookup {
+    if requested_workspace.is_none() && !pending_lookup {
         return Err(homeboy::core::Error::internal_unexpected(
             "Cook destination provisioning did not return a task worktree path".to_string(),
         ));
     }
-    if !args.provider_evidence_inputs.is_empty() && workspace.is_none() {
+    if !args.provider_evidence_inputs.is_empty() && requested_workspace.is_none() {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "provider-evidence",
             "provider evidence requires a bound Cook workspace",
@@ -4050,6 +4077,14 @@ pub(crate) fn compile_cook_plan(
             None,
         ));
     }
+    if let Some(workspace) = requested_workspace.as_deref() {
+        validate_cook_destination_identity(args, Path::new(workspace))?;
+    }
+    let workspace = requested_workspace
+        .as_deref()
+        .map(|workspace| cook_component_workspace(args, Path::new(workspace)))
+        .transpose()?
+        .map(|workspace| workspace.display().to_string());
     let mut dispatch = dispatch_args_for_cook(args);
     resolve_dispatch_prompt(&mut dispatch)?;
     // Provisioning makes an explicit --cwd authoritative, otherwise this is the
@@ -4074,9 +4109,6 @@ pub(crate) fn compile_cook_plan(
         workspace.as_deref(),
         &projected_paths,
     )?;
-    if let Some(workspace) = workspace.as_deref() {
-        validate_cook_destination_identity(args, Path::new(workspace))?;
-    }
     let mut request = dispatch_service::resolve_dispatch_request(dispatch.into())?;
     let mut plan = match dispatch_service::build_controller_dispatch_plan(&mut request) {
         Ok(plan) => plan,
@@ -4096,6 +4128,15 @@ pub(crate) fn compile_cook_plan(
     };
     plan.options.candidate_completion = args.candidate_completion;
     record_cook_provision(&mut plan, provision);
+    if let (Some(requested), Some(effective)) =
+        (requested_workspace.as_deref(), workspace.as_deref())
+    {
+        plan.metadata["gate_workspace"] = serde_json::json!({
+            "requested_cwd": requested,
+            "effective_cwd": effective,
+            "component_id": args.dispatch.repo,
+        });
+    }
     if let Some(identity) = &args.repository_identity {
         plan.metadata["cook_repository_identity"] = identity.clone();
     }

--- a/crates/homeboy-core/src/component/resolution.rs
+++ b/crates/homeboy-core/src/component/resolution.rs
@@ -595,6 +595,16 @@ fn rebase_registered_path_to_checkout(registered_path: &Path, cwd_git_root: &Pat
     }
 }
 
+/// Project a registered component path into a checkout of its repository.
+///
+/// A component can be registered at a package below the Git root while Cook's
+/// managed worktree is necessarily the repository root. Keeping this mapping
+/// here makes provider, dependency, and gate callers share the same component
+/// path contract.
+pub fn rebase_component_path_to_checkout(component: &Component, checkout: &Path) -> PathBuf {
+    rebase_registered_path_to_checkout(Path::new(&component.local_path), checkout)
+}
+
 fn is_named_component_worktree(
     component_id: &str,
     registered_path: &Path,
@@ -2354,6 +2364,13 @@ mod tests {
                     crate::git::MonorepoContext::detect(&target.component.local_path, "foo")
                         .expect("package path should still be monorepo-scoped");
                 assert_eq!(monorepo.path_prefix, "packages/foo");
+                let registered = crate::component::registered_by_id("foo")
+                    .expect("registered component lookup")
+                    .expect("registered component");
+                assert_eq!(
+                    rebase_component_path_to_checkout(&registered, &repo),
+                    canonical_package
+                );
                 assert!(!target.synthetic);
             });
         });
@@ -2392,6 +2409,13 @@ mod tests {
                     crate::git::MonorepoContext::detect(&target.component.local_path, "foo")
                         .expect("package path should still be monorepo-scoped");
                 assert_eq!(monorepo.path_prefix, "packages/foo");
+                let registered = crate::component::registered_by_id("foo")
+                    .expect("registered component lookup")
+                    .expect("registered component");
+                assert_eq!(
+                    rebase_component_path_to_checkout(&registered, &worktree),
+                    canonical_package
+                );
                 assert!(!target.synthetic);
             });
         });


### PR DESCRIPTION
## Summary
- project a resolved registered component into the Cook checkout before provider dispatch
- use that same component workspace for dependency hydration, gate preflight, and deterministic gates
- record requested and effective gate cwd in the Cook plan and gate evidence

Closes #13001.

## Testing
- `cargo fmt --all`
- focused Cargo test commands were blocked by concurrent workspace Cargo builds holding the shared target lock

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagent inspected component resolution, Cook planning, dependency hydration, gate execution, and evidence; implemented the cwd contract and tests. Chris Huber remains responsible for every line.