### PR TITLE
refactor(rig): root the rig install and source-metadata writers (#7505)

### DIFF
--- a/crates/homeboy-cli/src/commands/bench/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/bench/tests/mod.rs
@@ -226,8 +226,13 @@ fn install_rig_package(
     )
     .expect("write package rig");
 
-    homeboy::rig::install(package_root.to_string_lossy().as_ref(), Some(rig_id), false)
-        .expect("install rig package");
+    homeboy::rig::install(
+        &homeboy::core::paths::homeboy().expect("config root"),
+        package_root.to_string_lossy().as_ref(),
+        Some(rig_id),
+        false,
+    )
+    .expect("install rig package");
     package_root
 }
 
@@ -265,8 +270,13 @@ fn install_git_rig_package(
     let revision = git_fixture_output(&package_root, &["rev-parse", "--short", "HEAD"]);
     fs::write(package_root.join("untracked.txt"), "dirty\n").expect("dirty package");
 
-    homeboy::rig::install(package_root.to_string_lossy().as_ref(), Some(rig_id), false)
-        .expect("install rig package");
+    homeboy::rig::install(
+        &homeboy::core::paths::homeboy().expect("config root"),
+        package_root.to_string_lossy().as_ref(),
+        Some(rig_id),
+        false,
+    )
+    .expect("install rig package");
     (package_root, revision)
 }
 

--- a/crates/homeboy-cli/src/commands/bench/tests/run_list_tests.rs
+++ b/crates/homeboy-cli/src/commands/bench/tests/run_list_tests.rs
@@ -150,6 +150,7 @@ fn run_list_filters_installed_rig_workloads_discovered_under_a_component_alias()
         )
         .expect("write rig");
         homeboy::rig::install(
+            &homeboy::core::paths::homeboy().expect("config root"),
             package_root.to_string_lossy().as_ref(),
             Some("installed-alias-rig"),
             false,

--- a/crates/homeboy-cli/src/commands/fuzz/tests/workload_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/workload_tests.rs
@@ -522,6 +522,7 @@ fn fuzz_list_reports_stale_installed_rig_package_provenance() {
             assert!(status.success(), "git command should succeed");
         }
         homeboy::rig::install(
+            &homeboy::core::paths::homeboy().expect("config root"),
             package.path().to_string_lossy().as_ref(),
             Some("package-fuzz"),
             false,

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -166,7 +166,8 @@ pub(crate) fn route_after_parse_with_provenance(
                 // Lab routing resolves rig components and path inputs on the
                 // controller before dispatch, so runner-targeted installs must
                 // keep the controller registry pointed at the same source.
-                homeboy::rig::install(source, id, all)?;
+                let roots = homeboy::core::paths::PathRoots::from_environment()?;
+                homeboy::rig::install(roots.config(), source, id, all)?;
             }
             let (stdout, stderr, exit_code) =
                 run_rig_source_management_on_runner(runner_id, normalized_args, output_file)?;

--- a/crates/homeboy-cli/src/commands/rig/mod.rs
+++ b/crates/homeboy-cli/src/commands/rig/mod.rs
@@ -538,7 +538,9 @@ fn install(
     all: bool,
     _reinstall: bool,
 ) -> CmdResult<RigCommandOutput> {
-    let result = rig::install(source, id, all)?;
+    // Boundary: one `homeboy rig install` is one unit of work (#7505).
+    let roots = homeboy::core::paths::PathRoots::from_environment()?;
+    let result = rig::install(roots.config(), source, id, all)?;
     Ok((
         RigCommandOutput::Install(RigInstallOutput {
             command: "rig.install",

--- a/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
@@ -2272,6 +2272,7 @@ mod tests {
             std::fs::create_dir_all(homeboy_core::paths::rig_sources().expect("rig sources"))
                 .expect("create rig sources");
             homeboy_rig::install::write_source_metadata(
+                &homeboy_core::paths::homeboy().expect("config root"),
                 "studio-web-product-matrix",
                 &homeboy_rig::install::RigSourceMetadata {
                     source: checkout.display().to_string(),

--- a/crates/homeboy-rig/src/install.rs
+++ b/crates/homeboy-rig/src/install.rs
@@ -114,8 +114,13 @@ struct RigPackageMetadata {
     package_dependencies: Vec<String>,
 }
 
-pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallResult> {
-    let mut prepared = prepare_source(source)?;
+pub fn install(
+    config_root: &Path,
+    source: &str,
+    id: Option<&str>,
+    all: bool,
+) -> Result<RigInstallResult> {
+    let mut prepared = prepare_source(config_root, source)?;
     let discovered = discover_rigs_for_install(&prepared.discovery_path, id, all)?;
     let selected = select_rigs(discovered, id, all, source)?;
     let dependency_roots = package_source_roots_for_dependencies(&prepared, &selected)?;
@@ -133,32 +138,32 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
     if all {
         preflight_all_install(&selected, &prepared.package_path)?;
         for rig in &selected {
-            let target = paths::rig_config(&rig.id)?;
+            let target = paths::rig_config_in_root(config_root, &rig.id);
             if target.exists() || fs::symlink_metadata(&target).is_ok() {
                 ensure_rig_refreshable(rig, &target)?;
             }
         }
     }
 
-    fs::create_dir_all(paths::rigs()?)
+    fs::create_dir_all(paths::rigs_in_root(config_root))
         .map_err(|e| Error::internal_io(e.to_string(), Some("create rigs dir".into())))?;
-    fs::create_dir_all(paths::stacks()?)
+    fs::create_dir_all(paths::stacks_in_root(config_root))
         .map_err(|e| Error::internal_io(e.to_string(), Some("create stacks dir".into())))?;
-    fs::create_dir_all(paths::rig_sources()?)
+    fs::create_dir_all(paths::rig_sources_in_root(config_root))
         .map_err(|e| Error::internal_io(e.to_string(), Some("create rig sources dir".into())))?;
-    fs::create_dir_all(paths::stack_sources()?)
+    fs::create_dir_all(paths::stack_sources_in_root(config_root))
         .map_err(|e| Error::internal_io(e.to_string(), Some("create stack sources dir".into())))?;
 
     for stack in &discovered_stacks {
-        let target = paths::stack_config(&stack.id)?;
+        let target = paths::stack_config_in_root(config_root, &stack.id);
         if target.exists() || fs::symlink_metadata(&target).is_ok() {
-            ensure_stack_refreshable(stack, &target)?;
+            ensure_stack_refreshable(config_root, stack, &target)?;
         }
     }
 
     let mut installed = Vec::new();
     for rig in selected {
-        let target = paths::rig_config(&rig.id)?;
+        let target = paths::rig_config_in_root(config_root, &rig.id);
         if !all {
             validate_rig_spec_file(&rig.rig_path, &prepared.package_path, &rig.id)?;
         }
@@ -183,7 +188,7 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
             source_dirty: prepared.source_dirty,
             source_content_hash: Some(prepared.source_content_hash.clone()),
         };
-        write_source_metadata(&rig.id, &metadata)?;
+        write_source_metadata(config_root, &rig.id, &metadata)?;
 
         installed.push(InstalledRig {
             id: rig.id,
@@ -196,7 +201,7 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
 
     let mut installed_stacks = Vec::new();
     for stack in discovered_stacks {
-        let target = paths::stack_config(&stack.id)?;
+        let target = paths::stack_config_in_root(config_root, &stack.id);
         if target.exists() || fs::symlink_metadata(&target).is_ok() {
             remove_existing_config(&target, "replace stack config link")?;
         }
@@ -214,7 +219,7 @@ pub fn install(source: &str, id: Option<&str>, all: bool) -> Result<RigInstallRe
             source_dirty: prepared.source_dirty,
             source_content_hash: Some(prepared.source_content_hash.clone()),
         };
-        write_stack_source_metadata(&stack.id, &metadata)?;
+        write_stack_source_metadata(config_root, &stack.id, &metadata)?;
 
         installed_stacks.push(InstalledStack {
             id: stack.id,
@@ -1013,12 +1018,16 @@ fn ensure_rig_refreshable(rig: &DiscoveredRig, target: &Path) -> Result<()> {
     ))
 }
 
-fn ensure_stack_refreshable(stack: &DiscoveredStack, target: &Path) -> Result<()> {
+fn ensure_stack_refreshable(
+    config_root: &Path,
+    stack: &DiscoveredStack,
+    target: &Path,
+) -> Result<()> {
     if !target.exists() && fs::symlink_metadata(target).is_ok() {
         return Ok(());
     }
 
-    if read_stack_source_metadata(&stack.id)
+    if read_stack_source_metadata_in_root(config_root, &stack.id)
         .is_some_and(|metadata| config_matches_source(target, Path::new(&metadata.stack_path)))
     {
         return Ok(());
@@ -1083,27 +1092,42 @@ fn remove_existing_config(target: &Path, context: &'static str) -> Result<()> {
     fs::remove_file(target).map_err(|e| Error::internal_io(e.to_string(), Some(context.into())))
 }
 
+pub fn read_source_metadata_in_root(config_root: &Path, id: &str) -> Option<RigSourceMetadata> {
+    let path = paths::rig_source_metadata_in_root(config_root, id);
+    let content = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+/// Ambient wrapper retained deliberately.
+///
+/// The remaining readers are `expand::resolve_token` and
+/// `component_resolution::expand_component_path` — spec token expansion, several
+/// frames below anything that holds a root and with no carrier passing through.
+/// Rooting them today would relocate one resolution into many, which the
+/// PathRoots injection contract calls out as a regression rather than progress.
+/// Delete this when token expansion gains a carrier (#7505).
 pub fn read_source_metadata(id: &str) -> Option<RigSourceMetadata> {
-    let path = paths::rig_source_metadata(id).ok()?;
+    read_source_metadata_in_root(&paths::homeboy().ok()?, id)
+}
+
+pub fn read_stack_source_metadata_in_root(
+    config_root: &Path,
+    id: &str,
+) -> Option<StackSourceMetadata> {
+    let path = paths::stack_source_metadata_in_root(config_root, id);
     let content = fs::read_to_string(path).ok()?;
     serde_json::from_str(&content).ok()
 }
 
-pub fn read_stack_source_metadata(id: &str) -> Option<StackSourceMetadata> {
-    let path = paths::stack_source_metadata(id).ok()?;
-    let content = fs::read_to_string(path).ok()?;
-    serde_json::from_str(&content).ok()
-}
-
-pub(crate) fn prepare_source(source: &str) -> Result<PreparedSource> {
+pub(crate) fn prepare_source(config_root: &Path, source: &str) -> Result<PreparedSource> {
     if extension::is_git_url(source) || source.contains(".git//") {
-        prepare_git_source(source)
+        prepare_git_source(config_root, source)
     } else {
         prepare_local_source(source)
     }
 }
 
-fn prepare_git_source(source: &str) -> Result<PreparedSource> {
+fn prepare_git_source(config_root: &Path, source: &str) -> Result<PreparedSource> {
     let (root_source, subpath) = split_git_source_subpath(source)?;
     let trimmed = root_source.trim_end_matches('/').trim_end_matches(".git");
     let parts = trimmed.rsplit(['/', ':']).take(2).collect::<Vec<_>>();
@@ -1112,7 +1136,7 @@ fn prepare_git_source(source: &str) -> Result<PreparedSource> {
     } else {
         extension::slugify_id(parts.first().copied().unwrap_or(trimmed))?
     };
-    let package_path = paths::rig_package(&package_id)?;
+    let package_path = paths::rig_package_in_root(config_root, &package_id);
     if package_path.exists() {
         return Err(Error::validation_invalid_argument(
             "source",
@@ -1125,7 +1149,7 @@ fn prepare_git_source(source: &str) -> Result<PreparedSource> {
             None,
         ));
     }
-    fs::create_dir_all(paths::rig_packages()?)
+    fs::create_dir_all(paths::rig_packages_in_root(config_root))
         .map_err(|e| Error::internal_io(e.to_string(), Some("create rig packages dir".into())))?;
     git::clone_repo(root_source, &package_path)?;
     let source_revision = git::short_head_revision(&package_path);
@@ -1279,18 +1303,26 @@ fn collect_package_files(root: &Path, directory: &Path, files: &mut Vec<PathBuf>
     Ok(())
 }
 
-pub fn write_source_metadata(id: &str, metadata: &RigSourceMetadata) -> Result<()> {
-    let path = paths::rig_source_metadata(id)?;
+pub fn write_source_metadata(
+    config_root: &Path,
+    id: &str,
+    metadata: &RigSourceMetadata,
+) -> Result<()> {
+    let path = paths::rig_source_metadata_in_root(config_root, id);
     let content = serde_json::to_string_pretty(metadata)
         .map_err(|e| Error::internal_json(e.to_string(), Some("serialize rig source".into())))?;
     fs::write(&path, format!("{}\n", content))
         .map_err(|e| Error::internal_io(e.to_string(), Some("write rig source".into())))
 }
 
-pub(crate) fn write_stack_source_metadata(id: &str, metadata: &StackSourceMetadata) -> Result<()> {
-    fs::create_dir_all(paths::stack_sources()?)
+pub(crate) fn write_stack_source_metadata(
+    config_root: &Path,
+    id: &str,
+    metadata: &StackSourceMetadata,
+) -> Result<()> {
+    fs::create_dir_all(paths::stack_sources_in_root(config_root))
         .map_err(|e| Error::internal_io(e.to_string(), Some("create stack sources dir".into())))?;
-    let path = paths::stack_source_metadata(id)?;
+    let path = paths::stack_source_metadata_in_root(config_root, id);
     let content = serde_json::to_string_pretty(metadata)
         .map_err(|e| Error::internal_json(e.to_string(), Some("serialize stack source".into())))?;
     fs::write(&path, format!("{}\n", content))

--- a/crates/homeboy-rig/src/lib.rs
+++ b/crates/homeboy-rig/src/lib.rs
@@ -61,8 +61,8 @@ pub use component_resolution::{component_ref, resolve_component, resolve_compone
 pub use install::{
     default_materialize_source_root, discover_rigs, discover_stacks, install, materialize_rig_spec,
     materialize_rig_spec_with_default_source_root, package_content_hash, read_source_metadata,
-    read_stack_source_metadata, DiscoveredRig, DiscoveredStack, InstalledStack, RigInstallResult,
-    RigSourceMetadata, StackSourceMetadata,
+    read_source_metadata_in_root, read_stack_source_metadata_in_root, DiscoveredRig,
+    DiscoveredStack, InstalledStack, RigInstallResult, RigSourceMetadata, StackSourceMetadata,
 };
 pub use lease::{
     acquire_active_run_lease, acquire_active_run_lease_with_settings, active_run_leases,
@@ -658,8 +658,13 @@ impl RigSourceContext {
 
         // Confirm the active checkout declares this rig before refreshing its
         // global registration. `install` then enforces existing ID ownership.
+        //
+        // Boundary: loading a rig for an invocation is one unit of work, and the
+        // refresh below writes into the registry, so it resolves once here
+        // instead of letting `install` resolve on its own (#7505).
+        let roots = homeboy_core::paths::PathRoots::from_environment()?;
         load_local_source(component_path, Some(id))?;
-        install(component_path, Some(id), false)?;
+        install(roots.config(), component_path, Some(id), false)?;
         Self::load(id)
     }
 }

--- a/crates/homeboy-rig/src/source.rs
+++ b/crates/homeboy-rig/src/source.rs
@@ -135,14 +135,15 @@ pub fn remove_source(config_root: &Path, selector: &str) -> Result<RigSourceRemo
 }
 
 pub fn update_source_for_rig(config_root: &Path, id: &str) -> Result<RigSourceUpdateResult> {
-    let metadata = super::install::read_source_metadata(id).ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "rig_id",
-            format!("Rig '{}' has no installed source metadata", id),
-            Some(id.to_string()),
-            None,
-        )
-    })?;
+    let metadata =
+        super::install::read_source_metadata_in_root(config_root, id).ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "rig_id",
+                format!("Rig '{}' has no installed source metadata", id),
+                Some(id.to_string()),
+                None,
+            )
+        })?;
     if metadata.linked {
         return Err(Error::validation_invalid_argument(
             "rig_id",
@@ -359,7 +360,7 @@ fn update_group(config_root: &Path, source: RigSourceGroup) -> Result<RigSourceU
                 &source.package_path,
             ))?),
         };
-        write_source_metadata(&rig.id, &metadata)?;
+        write_source_metadata(config_root, &rig.id, &metadata)?;
 
         updated.push(RigSourceUpdatedRig {
             id: rig.id,
@@ -404,7 +405,7 @@ fn update_group(config_root: &Path, source: RigSourceGroup) -> Result<RigSourceU
             source_dirty,
             source_content_hash: Some(source_content_hash.clone()),
         };
-        write_stack_source_metadata(&stack.id, &metadata)?;
+        write_stack_source_metadata(config_root, &stack.id, &metadata)?;
 
         updated_stacks.push(RigSourceUpdatedStack {
             id: stack.id,

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -4,12 +4,24 @@ use crate::install::local_package_source_root_for_dependencies;
 use crate::{
     declared_id, default_materialize_source_root, discover_rigs, install, list, list_ids, load,
     load_local_source, materialize_rig_spec, materialize_rig_spec_with_default_source_root,
-    read_source_metadata, read_stack_source_metadata, run_check, run_lint,
+    read_source_metadata_in_root, read_stack_source_metadata_in_root, run_check, run_lint,
 };
 use homeboy_core::test_support::HomeGuard;
 use homeboy_core::ErrorCode;
 use std::fs;
 use std::path::Path;
+
+/// The isolated home each test below installs, named as a config root.
+///
+/// A test is the entry point for its own unit of work, so resolving once here is
+/// a boundary resolution, not an ambient one. What matters is that the
+/// production path beneath it resolves nothing (#7505).
+fn test_config_root() -> std::path::PathBuf {
+    homeboy_core::paths::PathRoots::from_environment()
+        .expect("path roots")
+        .config()
+        .to_path_buf()
+}
 
 use crate::rig_test_support::{minimal_rig, minimal_stack, write_rig, write_stack, GitFixture};
 
@@ -60,7 +72,13 @@ mod discovery {
         let package = tempfile::tempdir().expect("package");
         let source = write_rig(package.path(), "alpha", &minimal_rig("alpha"));
 
-        let result = install(package.path().to_str().unwrap(), None, false).expect("install");
+        let result = install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            None,
+            false,
+        )
+        .expect("install");
         assert!(result.linked);
         assert_eq!(result.installed.len(), 1);
         assert_eq!(result.installed[0].id, "alpha");
@@ -74,7 +92,8 @@ mod discovery {
         assert!(installed_content.contains("${env.DEV_ROOT}/alpha"));
         assert!(installed_content.contains("${components.app.path}"));
 
-        let metadata = read_source_metadata("alpha").expect("metadata");
+        let metadata =
+            read_source_metadata_in_root(&test_config_root(), "alpha").expect("metadata");
         assert!(metadata.linked);
         assert_eq!(metadata.rig_path, source.to_string_lossy());
     }
@@ -373,7 +392,13 @@ mod install_flows {
         write_rig(package.path(), "studio", &minimal_rig("studio"));
         let stack_path = write_stack(package.path(), "studio-combined", "studio");
 
-        let result = install(package.path().to_str().unwrap(), None, false).expect("install");
+        let result = install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            None,
+            false,
+        )
+        .expect("install");
 
         assert_eq!(result.installed.len(), 1);
         assert_eq!(result.installed_stacks.len(), 1);
@@ -397,7 +422,8 @@ mod install_flows {
             .component,
             "studio"
         );
-        let metadata = read_stack_source_metadata("studio-combined").expect("stack metadata");
+        let metadata = read_stack_source_metadata_in_root(&test_config_root(), "studio-combined")
+            .expect("stack metadata");
         assert!(metadata.linked);
         assert_eq!(metadata.stack_path, stack_path.to_string_lossy());
     }
@@ -409,7 +435,13 @@ mod install_flows {
             let first_package = tempfile::tempdir().expect("first package");
             write_rig(first_package.path(), "studio", &minimal_rig("studio"));
             write_stack(first_package.path(), "studio-combined", "studio");
-            install(first_package.path().to_str().unwrap(), None, false).expect("install first");
+            install(
+                &test_config_root(),
+                first_package.path().to_str().unwrap(),
+                None,
+                false,
+            )
+            .expect("install first");
             if remove_original_source {
                 fs::remove_dir_all(first_package.path()).expect("remove stale source");
             }
@@ -426,8 +458,13 @@ mod install_flows {
                 .expect("update stack content");
             }
 
-            let result = install(second_package.path().to_str().unwrap(), None, false)
-                .expect("reinstall replaces owned stack link");
+            let result = install(
+                &test_config_root(),
+                second_package.path().to_str().unwrap(),
+                None,
+                false,
+            )
+            .expect("reinstall replaces owned stack link");
 
             assert_eq!(result.installed_stacks.len(), 1);
             let installed =
@@ -464,10 +501,13 @@ mod install_flows {
         );
         GitFixture::init(repo.path()).commit("nested package with shared dependency");
 
-        let result =
-            install(nested.to_str().unwrap(), None, false).expect("install nested package");
-        let metadata =
-            read_source_metadata("static-site-importer-fixture-matrix").expect("metadata");
+        let result = install(&test_config_root(), nested.to_str().unwrap(), None, false)
+            .expect("install nested package");
+        let metadata = read_source_metadata_in_root(
+            &test_config_root(),
+            "static-site-importer-fixture-matrix",
+        )
+        .expect("metadata");
         let repo_root = repo.path().canonicalize().expect("canonical repo root");
         let package_root = nested.canonicalize().expect("canonical package root");
         let rigs = discover_rigs(&nested).expect("discover local rigs");
@@ -512,10 +552,13 @@ mod install_flows {
             }"#,
         );
 
-        let result =
-            install(nested.to_str().unwrap(), None, false).expect("install materialized package");
-        let metadata =
-            read_source_metadata("static-site-importer-fixture-matrix").expect("metadata");
+        let result = install(&test_config_root(), nested.to_str().unwrap(), None, false)
+            .expect("install materialized package");
+        let metadata = read_source_metadata_in_root(
+            &test_config_root(),
+            "static-site-importer-fixture-matrix",
+        )
+        .expect("metadata");
         let source_root = snapshot.canonicalize().expect("canonical source root");
         let package_root = nested.canonicalize().expect("canonical package root");
         let rigs = discover_rigs(&nested).expect("discover materialized rigs");
@@ -550,7 +593,7 @@ mod install_flows {
             }"#,
         );
 
-        let err = install(nested.to_str().unwrap(), None, false)
+        let err = install(&test_config_root(), nested.to_str().unwrap(), None, false)
             .expect_err("dependency outside snapshot should fail");
 
         assert!(err
@@ -577,7 +620,7 @@ mod install_flows {
         );
         GitFixture::init(&repo).commit("bad dependency");
 
-        let err = install(nested.to_str().unwrap(), None, false)
+        let err = install(&test_config_root(), nested.to_str().unwrap(), None, false)
             .expect_err("dependency outside repo should fail");
 
         assert!(err
@@ -601,7 +644,7 @@ mod install_flows {
         );
         GitFixture::init(repo.path()).commit("bad dependency");
 
-        let err = install(nested.to_str().unwrap(), None, false)
+        let err = install(&test_config_root(), nested.to_str().unwrap(), None, false)
             .expect_err("absolute dependency should fail");
 
         assert!(err.message.contains("non-empty relative paths"));
@@ -619,7 +662,13 @@ mod install_flows {
         )
         .expect("conflict fixture");
 
-        install(package.path().to_str().unwrap(), None, false).expect("install");
+        install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            None,
+            false,
+        )
+        .expect("install");
         let rig = load("lint-fixture").expect("load rig");
         let report = run_check(&rig).expect("check report");
 
@@ -661,7 +710,7 @@ mod install_flows {
         let report = run_check(&rig).expect("check local package rig");
 
         assert!(report.success, "local package check should pass");
-        assert!(read_source_metadata("local-alpha").is_none());
+        assert!(read_source_metadata_in_root(&test_config_root(), "local-alpha").is_none());
         assert!(load("local-alpha").is_err(), "rig should not be installed");
     }
 
@@ -719,7 +768,7 @@ mod install_flows {
             crate::expand::expand_vars(&rig, "${package.root}/marker.txt"),
             package.path().join("marker.txt").to_string_lossy()
         );
-        assert!(read_source_metadata("direct-alpha").is_none());
+        assert!(read_source_metadata_in_root(&test_config_root(), "direct-alpha").is_none());
     }
 
     #[test]
@@ -755,7 +804,13 @@ mod install_flows {
         }"#,
         );
 
-        let result = install(package.path().to_str().unwrap(), None, false).expect("install");
+        let result = install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            None,
+            false,
+        )
+        .expect("install");
 
         assert_eq!(result.installed.len(), 1);
         let installed_path = homeboy_core::paths::rig_config("alpha").expect("rig config");
@@ -769,7 +824,7 @@ mod install_flows {
         assert_eq!(rig.components["app"].branch.as_deref(), Some("main"));
         assert_eq!(rig.pipeline["check"].len(), 1);
         assert!(
-            read_source_metadata("alpha")
+            read_source_metadata_in_root(&test_config_root(), "alpha")
                 .expect("metadata")
                 .materialized
         );
@@ -795,8 +850,13 @@ mod install_flows {
         }"#,
         );
 
-        let result = install(package.path().to_str().unwrap(), None, false)
-            .expect("install registry-backed component rig");
+        let result = install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            None,
+            false,
+        )
+        .expect("install registry-backed component rig");
 
         assert_eq!(result.installed.len(), 1);
         let rig = load("registry-backed").expect("load registry-backed rig");
@@ -823,8 +883,13 @@ mod install_flows {
         )
         .expect("rig json");
 
-        let err = install(package.path().to_str().unwrap(), None, false)
-            .expect_err("schema error should fail install discovery");
+        let err = install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            None,
+            false,
+        )
+        .expect_err("schema error should fail install discovery");
 
         assert_eq!(err.code, ErrorCode::ValidationInvalidArgument);
         assert_eq!(err.details["field"], "rig_spec");
@@ -847,7 +912,8 @@ mod install_flows {
         )
         .expect("rig json");
 
-        let err = install(package.to_str().unwrap(), None, false).expect_err("outside extends");
+        let err = install(&test_config_root(), package.to_str().unwrap(), None, false)
+            .expect_err("outside extends");
 
         assert_eq!(err.details["field"], "extends");
         assert!(err.message.contains("inside the rig package source root"));
@@ -884,7 +950,13 @@ mod install_flows {
         }"#,
         );
 
-        install(package.path().to_str().unwrap(), None, false).expect("install");
+        install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            None,
+            false,
+        )
+        .expect("install");
         let rig = load("trace-defaults").expect("load rig");
         let workloads = rig
             .trace_workloads
@@ -928,7 +1000,13 @@ mod install_flows {
         }"#,
         );
 
-        install(package.path().to_str().unwrap(), None, false).expect("install");
+        install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            None,
+            false,
+        )
+        .expect("install");
         let rig = load("lint-only").expect("load rig");
 
         // Full check fails: the requirement file and probe file are both absent.
@@ -965,7 +1043,13 @@ mod install_flows {
         )
         .expect("conflict fixture");
 
-        install(package.path().to_str().unwrap(), None, false).expect("install");
+        install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            None,
+            false,
+        )
+        .expect("install");
         let rig = load("lint-conflict").expect("load rig");
         let lint = run_lint(&rig).expect("lint report");
 
@@ -996,7 +1080,13 @@ mod install_flows {
         fs::write(datamachine.join("notes.txt"), "<<<<<<< ours\n")
             .expect("conflict inside ignored dir");
 
-        install(package.path().to_str().unwrap(), None, false).expect("install");
+        install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            None,
+            false,
+        )
+        .expect("install");
         let rig = load("lint-dm").expect("load rig");
         let lint = run_lint(&rig).expect("lint report");
 
@@ -1064,7 +1154,13 @@ mod install_flows {
                 ),
             );
 
-            install(package.path().to_str().unwrap(), None, false).expect("install");
+            install(
+                &test_config_root(),
+                package.path().to_str().unwrap(),
+                None,
+                false,
+            )
+            .expect("install");
 
             let installed_path = homeboy_core::paths::rig_config(id).expect("rig config");
             let installed = fs::read_to_string(&installed_path).expect("installed rig");
@@ -1123,7 +1219,13 @@ mod install_flows {
         }"#,
         );
 
-        install(package.path().to_str().unwrap(), None, false).expect("install");
+        install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            None,
+            false,
+        )
+        .expect("install");
         let installed_path = homeboy_core::paths::rig_config("replacer").expect("rig config");
         let installed = fs::read_to_string(&installed_path).expect("installed rig");
         let value: serde_json::Value = serde_json::from_str(&installed).expect("materialized json");
@@ -1183,8 +1285,13 @@ mod install_flows {
                 ),
             );
 
-            let err = install(package.path().to_str().unwrap(), None, false)
-                .expect_err("invalid directive should fail");
+            let err = install(
+                &test_config_root(),
+                package.path().to_str().unwrap(),
+                None,
+                false,
+            )
+            .expect_err("invalid directive should fail");
 
             assert_eq!(err.code, ErrorCode::ValidationInvalidArgument);
             assert_eq!(err.details["field"], expected_field);
@@ -1212,7 +1319,13 @@ mod multi_rig {
         write_rig(package.path(), "alpha", &minimal_rig("alpha"));
         write_rig(package.path(), "beta", &minimal_rig("beta"));
 
-        let err = install(package.path().to_str().unwrap(), None, false).expect_err("error");
+        let err = install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            None,
+            false,
+        )
+        .expect_err("error");
         assert!(err.message.contains("multiple rigs"));
         assert!(err.message.contains("alpha"));
         assert!(err.message.contains("beta"));
@@ -1225,8 +1338,13 @@ mod multi_rig {
         write_rig(package.path(), "alpha", &minimal_rig("alpha"));
         write_rig(package.path(), "beta", &minimal_rig("beta"));
 
-        let result =
-            install(package.path().to_str().unwrap(), Some("beta"), false).expect("install");
+        let result = install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            Some("beta"),
+            false,
+        )
+        .expect("install");
         assert_eq!(result.installed.len(), 1);
         assert_eq!(result.installed[0].id, "beta");
         assert!(homeboy_core::paths::rig_config("beta").unwrap().exists());
@@ -1240,7 +1358,13 @@ mod multi_rig {
         let stale_source = tempfile::tempdir().expect("stale source");
         write_rig(stale_source.path(), "stale-rig", &minimal_rig("stale-rig"));
         let stale_stack = write_stack(stale_source.path(), "stale-stack", "stale-component");
-        install(stale_source.path().to_str().unwrap(), None, false).expect("install stale source");
+        install(
+            &test_config_root(),
+            stale_source.path().to_str().unwrap(),
+            None,
+            false,
+        )
+        .expect("install stale source");
         fs::remove_dir_all(stale_source.path()).expect("remove stale source");
 
         let package = tempfile::tempdir().expect("package");
@@ -1248,8 +1372,13 @@ mod multi_rig {
         write_rig(package.path(), "beta", &minimal_rig("beta"));
         write_stack(package.path(), "stale-stack", "other-component");
 
-        let result = install(package.path().to_str().unwrap(), Some("alpha"), false)
-            .expect("install requested rig despite stale unrelated stack source");
+        let result = install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            Some("alpha"),
+            false,
+        )
+        .expect("install requested rig despite stale unrelated stack source");
 
         assert_eq!(result.installed.len(), 1);
         assert_eq!(result.installed[0].id, "alpha");
@@ -1276,8 +1405,13 @@ mod multi_rig {
         )
         .expect("broken rig json");
 
-        let result =
-            install(package.path().to_str().unwrap(), Some("alpha"), false).expect("install");
+        let result = install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            Some("alpha"),
+            false,
+        )
+        .expect("install");
 
         assert_eq!(result.installed.len(), 1);
         assert_eq!(result.installed[0].id, "alpha");
@@ -1291,8 +1425,13 @@ mod multi_rig {
         let package = tempfile::tempdir().expect("package");
         write_rig(package.path(), "alpha", &minimal_rig("alpha"));
 
-        let err = install(package.path().to_str().unwrap(), Some("missing"), false)
-            .expect_err("missing rig should error");
+        let err = install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            Some("missing"),
+            false,
+        )
+        .expect_err("missing rig should error");
 
         assert_eq!(err.details["field"], "id");
         assert!(err.message.contains("missing"));
@@ -1306,7 +1445,13 @@ mod multi_rig {
         write_rig(package.path(), "alpha", &minimal_rig("alpha"));
         write_rig(package.path(), "beta", &minimal_rig("beta"));
 
-        let result = install(package.path().to_str().unwrap(), None, true).expect("install");
+        let result = install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            None,
+            true,
+        )
+        .expect("install");
         assert_eq!(result.installed.len(), 2);
         assert!(homeboy_core::paths::rig_config("alpha").unwrap().exists());
         assert!(homeboy_core::paths::rig_config("beta").unwrap().exists());
@@ -1324,8 +1469,13 @@ mod multi_rig {
             r#"{"id":"unsupported-cleanup","lifecycle":{"cleanup":42}}"#,
         );
 
-        let error = install(package.path().to_str().unwrap(), None, true)
-            .expect_err("package preflight should reject incompatible member");
+        let error = install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            None,
+            true,
+        )
+        .expect_err("package preflight should reject incompatible member");
 
         assert_eq!(error.code, ErrorCode::ValidationMultipleErrors);
         assert_eq!(error.details["atomic"], true);
@@ -1363,14 +1513,22 @@ mod refresh_and_identity {
         )
         .expect("stale installed rig");
 
-        let result = install(package.path().to_str().unwrap(), None, false).expect("refresh");
+        let result = install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            None,
+            false,
+        )
+        .expect("refresh");
 
         assert_eq!(result.installed.len(), 1);
         let installed = fs::read_to_string(homeboy_core::paths::rig_config("alpha").unwrap())
             .expect("installed rig");
         assert!(installed.contains("alpha rig refreshed"));
         assert_eq!(
-            read_source_metadata("alpha").expect("metadata").rig_path,
+            read_source_metadata_in_root(&test_config_root(), "alpha")
+                .expect("metadata")
+                .rig_path,
             package.path().join("rigs/alpha/rig.json").to_string_lossy()
         );
     }
@@ -1388,7 +1546,13 @@ mod refresh_and_identity {
         std::os::unix::fs::symlink(package.path().join("missing-rig.json"), &installed)
             .expect("broken rig symlink");
 
-        let result = install(package.path().to_str().unwrap(), None, false).expect("refresh");
+        let result = install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            None,
+            false,
+        )
+        .expect("refresh");
 
         assert_eq!(result.installed.len(), 1);
         assert_eq!(fs::read_link(&installed).expect("updated symlink"), source);
@@ -1409,7 +1573,13 @@ mod refresh_and_identity {
         )
         .expect("conflicting installed rig");
 
-        let err = install(package.path().to_str().unwrap(), None, false).expect_err("collision");
+        let err = install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            None,
+            false,
+        )
+        .expect_err("collision");
         assert!(err.message.contains("refusing to replace"));
     }
 
@@ -1427,11 +1597,18 @@ mod refresh_and_identity {
         )
         .expect("existing stack");
 
-        let result = install(package.path().to_str().unwrap(), None, false).expect("refresh");
+        let result = install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            None,
+            false,
+        )
+        .expect("refresh");
 
         assert_eq!(result.installed_stacks.len(), 1);
         assert_eq!(result.installed_stacks[0].id, "studio-combined");
-        let metadata = read_stack_source_metadata("studio-combined").expect("stack metadata");
+        let metadata = read_stack_source_metadata_in_root(&test_config_root(), "studio-combined")
+            .expect("stack metadata");
         assert_eq!(metadata.stack_path, stack_path.to_string_lossy());
     }
 
@@ -1448,8 +1625,13 @@ mod refresh_and_identity {
             homeboy_core::paths::stack_config("studio-combined").expect("stack path");
         fs::write(&stack_config, &manual_stack).expect("conflicting stack");
 
-        let err =
-            install(package.path().to_str().unwrap(), None, false).expect_err("stack collision");
+        let err = install(
+            &test_config_root(),
+            package.path().to_str().unwrap(),
+            None,
+            false,
+        )
+        .expect_err("stack collision");
         assert!(err.message.contains("different content"));
         assert_eq!(
             fs::read_to_string(stack_config).expect("manual stack preserved"),
@@ -1538,7 +1720,7 @@ mod git_url {
 
         let root_source = bare.path().join("rig-package.git");
         let source = format!("{}//packages/studio", root_source.to_string_lossy());
-        let result = install(&source, None, false).expect("install subpath");
+        let result = install(&test_config_root(), &source, None, false).expect("install subpath");
 
         assert!(!result.linked);
         assert_eq!(result.source, root_source.to_string_lossy());
@@ -1558,7 +1740,8 @@ mod git_url {
             .unwrap()
             .exists());
 
-        let metadata = read_source_metadata("studio").expect("metadata");
+        let metadata =
+            read_source_metadata_in_root(&test_config_root(), "studio").expect("metadata");
         assert_eq!(metadata.source, root_source.to_string_lossy());
         assert!(metadata.rig_path.ends_with("packages/studio/rig.json"));
     }
@@ -1566,8 +1749,13 @@ mod git_url {
     #[test]
     fn git_url_subpath_rejects_invalid_relative_path() {
         let _home = HomeGuard::new();
-        let err = install("https://example.com/rigs.git//../secrets", None, false)
-            .expect_err("invalid subpath");
+        let err = install(
+            &test_config_root(),
+            "https://example.com/rigs.git//../secrets",
+            None,
+            false,
+        )
+        .expect_err("invalid subpath");
 
         assert!(err.message.contains("non-empty relative path"));
     }

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -59,7 +59,13 @@ fn test_list_sources() {
     write_rig(package.path(), "alpha", &minimal_rig("alpha"));
     write_rig(package.path(), "beta", &minimal_rig("beta"));
 
-    install(package.path().to_str().unwrap(), None, true).expect("install all");
+    install(
+        &test_config_root(),
+        package.path().to_str().unwrap(),
+        None,
+        true,
+    )
+    .expect("install all");
 
     let result = list_sources(&test_config_root()).expect("sources");
     assert_eq!(result.invalid.len(), 0);
@@ -81,8 +87,13 @@ fn linked_package_provenance_tracks_execution_time_content_and_dirty_state() {
     let rig = write_rig(package.path(), "alpha", &minimal_rig("alpha"));
     GitFixture::init(package.path()).commit("initial rig");
 
-    let installed = install(package.path().to_str().unwrap(), Some("alpha"), false)
-        .expect("install linked rig");
+    let installed = install(
+        &test_config_root(),
+        package.path().to_str().unwrap(),
+        Some("alpha"),
+        false,
+    )
+    .expect("install linked rig");
     assert!(installed.linked);
     assert!(!installed.source_dirty);
     let metadata = crate::read_source_metadata("alpha").expect("source metadata");
@@ -126,7 +137,13 @@ fn list_sources_reports_stack_specs_from_package() {
     write_rig(package.path(), "alpha", &minimal_rig("alpha"));
     write_stack(package.path(), "alpha-combined", "alpha");
 
-    install(package.path().to_str().unwrap(), None, false).expect("install");
+    install(
+        &test_config_root(),
+        package.path().to_str().unwrap(),
+        None,
+        false,
+    )
+    .expect("install");
 
     let result = list_sources(&test_config_root()).expect("sources");
     assert_eq!(result.sources.len(), 1);
@@ -192,7 +209,13 @@ fn test_remove_source() {
     write_rig(package.path(), "alpha", &minimal_rig("alpha"));
     write_rig(package.path(), "beta", &minimal_rig("beta"));
 
-    install(package.path().to_str().unwrap(), None, true).expect("install all");
+    install(
+        &test_config_root(),
+        package.path().to_str().unwrap(),
+        None,
+        true,
+    )
+    .expect("install all");
     let manual = homeboy_core::paths::rig_config("manual").expect("manual rig path");
     fs::write(&manual, minimal_rig("manual")).expect("manual rig");
 
@@ -219,7 +242,13 @@ fn remove_source_preserves_replaced_config_but_drops_metadata() {
     let package = tempfile::tempdir().expect("package");
     write_rig(package.path(), "alpha", &minimal_rig("alpha"));
 
-    install(package.path().to_str().unwrap(), None, false).expect("install");
+    install(
+        &test_config_root(),
+        package.path().to_str().unwrap(),
+        None,
+        false,
+    )
+    .expect("install");
     let config = homeboy_core::paths::rig_config("alpha").expect("rig config");
     fs::remove_file(&config).expect("remove symlink");
     fs::write(&config, minimal_rig("replacement")).expect("replacement rig");
@@ -241,7 +270,13 @@ fn remove_source_preserves_replaced_stack_config_but_drops_metadata() {
     write_rig(package.path(), "alpha", &minimal_rig("alpha"));
     write_stack(package.path(), "alpha-combined", "alpha");
 
-    install(package.path().to_str().unwrap(), None, false).expect("install");
+    install(
+        &test_config_root(),
+        package.path().to_str().unwrap(),
+        None,
+        false,
+    )
+    .expect("install");
     let config = homeboy_core::paths::stack_config("alpha-combined").expect("stack config");
     fs::remove_file(&config).expect("remove symlink");
     fs::write(&config, minimal_stack("alpha-combined", "manual")).expect("replacement stack");
@@ -265,7 +300,13 @@ fn remove_source_treats_copied_config_as_owned_when_contents_match() {
     let package = tempfile::tempdir().expect("package");
     let source = write_rig(package.path(), "alpha", &minimal_rig("alpha"));
 
-    install(package.path().to_str().unwrap(), None, false).expect("install");
+    install(
+        &test_config_root(),
+        package.path().to_str().unwrap(),
+        None,
+        false,
+    )
+    .expect("install");
     let config = homeboy_core::paths::rig_config("alpha").expect("rig config");
     fs::remove_file(&config).expect("remove symlink");
     fs::copy(&source, &config).expect("copy rig config");
@@ -319,7 +360,13 @@ fn sources_list_reports_missing_linked_source_paths() {
     let package = tempfile::tempdir().expect("package");
     write_rig(package.path(), "alpha", &minimal_rig("alpha"));
 
-    install(package.path().to_str().unwrap(), None, false).expect("install linked");
+    install(
+        &test_config_root(),
+        package.path().to_str().unwrap(),
+        None,
+        false,
+    )
+    .expect("install linked");
     fs::remove_dir_all(package.path()).expect("remove linked source");
 
     let result = list_sources(&test_config_root()).expect("sources");
@@ -349,7 +396,13 @@ fn missing_linked_source_gets_rig_source_diagnostic_not_not_found_hint() {
     let package = tempfile::tempdir().expect("package");
     write_rig(package.path(), "alpha", &minimal_rig("alpha"));
 
-    install(package.path().to_str().unwrap(), None, false).expect("install linked");
+    install(
+        &test_config_root(),
+        package.path().to_str().unwrap(),
+        None,
+        false,
+    )
+    .expect("install linked");
     fs::remove_dir_all(package.path()).expect("remove linked source");
 
     let err = load("alpha").expect_err("stale source error");
@@ -413,7 +466,7 @@ fn update_git_source_fast_forwards_package_and_refreshes_metadata() {
     let bare = create_bare_source(package.path());
     let source = bare_source_path(&bare).to_string_lossy().to_string();
 
-    install(&source, None, false).expect("install");
+    install(&test_config_root(), &source, None, false).expect("install");
     let before = crate::read_source_metadata("alpha")
         .expect("metadata")
         .source_revision;
@@ -453,9 +506,10 @@ fn update_git_source_refreshes_owned_stack_specs() {
     let bare = create_bare_source(package.path());
     let source = bare_source_path(&bare).to_string_lossy().to_string();
 
-    install(&source, None, false).expect("install");
+    install(&test_config_root(), &source, None, false).expect("install");
     let installed_metadata =
-        crate::read_stack_source_metadata("alpha-combined").expect("stack metadata");
+        crate::read_stack_source_metadata_in_root(&test_config_root(), "alpha-combined")
+            .expect("stack metadata");
     let before = installed_metadata.source_revision;
     fs::write(
         Path::new(&installed_metadata.package_path).join("local-untracked"),
@@ -480,8 +534,8 @@ fn update_git_source_refreshes_owned_stack_specs() {
         fs::read_to_string(homeboy_core::paths::stack_config("alpha-combined").unwrap())
             .expect("installed stack");
     assert!(installed.contains("updated stack"));
-    let metadata =
-        crate::read_stack_source_metadata("alpha-combined").expect("refreshed stack metadata");
+    let metadata = crate::read_stack_source_metadata_in_root(&test_config_root(), "alpha-combined")
+        .expect("refreshed stack metadata");
     assert_eq!(metadata.source_ref.as_deref(), Some("main"));
     assert!(metadata.source_dirty);
 }
@@ -494,7 +548,7 @@ fn legacy_source_without_a_valid_discovery_path_fails_before_refresh_mutation() 
     let bare = create_bare_source(package.path());
     let source = bare_source_path(&bare).to_string_lossy().to_string();
 
-    install(&source, None, false).expect("install");
+    install(&test_config_root(), &source, None, false).expect("install");
     let mut metadata = crate::read_source_metadata("alpha").expect("metadata");
     let installed_root = metadata.source_root.clone().expect("source root");
     let installed_revision = homeboy_core::git::short_head_revision_at(Path::new(&installed_root));
@@ -537,7 +591,7 @@ fn update_all_reports_broken_sources_and_continues() {
     write_rig(broken_package.path(), "broken", &minimal_rig("broken"));
     let broken_bare = create_bare_source(broken_package.path());
     let broken_source = bare_source_path(&broken_bare).to_string_lossy().to_string();
-    install(&broken_source, None, false).expect("install broken source");
+    install(&test_config_root(), &broken_source, None, false).expect("install broken source");
     let broken_metadata = crate::read_source_metadata("broken").expect("broken metadata");
     fs::remove_dir_all(&broken_metadata.package_path).expect("remove installed package clone");
 
@@ -545,7 +599,7 @@ fn update_all_reports_broken_sources_and_continues() {
     let good_rig = write_rig(good_package.path(), "good", &minimal_rig("good"));
     let good_bare = create_bare_source(good_package.path());
     let good_source = bare_source_path(&good_bare).to_string_lossy().to_string();
-    install(&good_source, None, false).expect("install good source");
+    install(&test_config_root(), &good_source, None, false).expect("install good source");
     fs::write(
         &good_rig,
         minimal_rig("good").replace("good rig", "good rig updated"),
@@ -575,7 +629,7 @@ fn refresh_source_selector_updates_recorded_package() {
     let bare = create_bare_source(package.path());
     let source = bare_source_path(&bare).to_string_lossy().to_string();
 
-    install(&source, None, false).expect("install");
+    install(&test_config_root(), &source, None, false).expect("install");
     let before = crate::read_source_metadata("alpha")
         .expect("metadata")
         .source_revision;
@@ -619,7 +673,7 @@ fn refresh_without_selector_updates_all_sources() {
     let bare = create_bare_source(package.path());
     let source = bare_source_path(&bare).to_string_lossy().to_string();
 
-    install(&source, None, false).expect("install");
+    install(&test_config_root(), &source, None, false).expect("install");
     fs::write(
         &source_rig,
         minimal_rig("alpha").replace("alpha rig", "alpha rig refreshed"),
@@ -645,7 +699,7 @@ fn update_git_source_skips_user_replaced_stack_specs() {
     let bare = create_bare_source(package.path());
     let source = bare_source_path(&bare).to_string_lossy().to_string();
 
-    install(&source, None, false).expect("install");
+    install(&test_config_root(), &source, None, false).expect("install");
     let config = homeboy_core::paths::stack_config("alpha-combined").expect("stack config");
     fs::remove_file(&config).expect("remove symlink");
     fs::write(&config, minimal_stack("alpha-combined", "manual")).expect("manual stack");
@@ -674,7 +728,13 @@ fn update_all_skips_linked_local_sources() {
     let package = tempfile::tempdir().expect("package");
     write_rig(package.path(), "alpha", &minimal_rig("alpha"));
 
-    install(package.path().to_str().unwrap(), None, false).expect("install linked");
+    install(
+        &test_config_root(),
+        package.path().to_str().unwrap(),
+        None,
+        false,
+    )
+    .expect("install linked");
     let result = update_all_sources(&test_config_root()).expect("update all");
 
     assert!(result.updated.is_empty());
@@ -690,7 +750,13 @@ fn update_all_skips_linked_local_stack_sources() {
     write_rig(package.path(), "alpha", &minimal_rig("alpha"));
     write_stack(package.path(), "alpha-combined", "alpha");
 
-    install(package.path().to_str().unwrap(), None, false).expect("install linked");
+    install(
+        &test_config_root(),
+        package.path().to_str().unwrap(),
+        None,
+        false,
+    )
+    .expect("install linked");
     let result = update_all_sources(&test_config_root()).expect("update all");
 
     assert!(result.updated.is_empty());
@@ -708,7 +774,13 @@ fn update_single_linked_local_source_errors() {
     let package = tempfile::tempdir().expect("package");
     write_rig(package.path(), "alpha", &minimal_rig("alpha"));
 
-    install(package.path().to_str().unwrap(), None, false).expect("install linked");
+    install(
+        &test_config_root(),
+        package.path().to_str().unwrap(),
+        None,
+        false,
+    )
+    .expect("install linked");
     let err = update_source_for_rig(&test_config_root(), "alpha").expect_err("linked update error");
 
     assert!(err.message.contains("linked local source"));


### PR DESCRIPTION
Second slice of the rig-registry half of the `rust_nextest_shard_threads` unblock condition. Follows #13011.

## What this covers

`crates/homeboy-rig/src/install.rs` owns **every write into the registry** — rig configs, stack configs, source metadata, and the cloned package tree — and it resolved the config root **fifteen separate times across a single install**. Nothing tied those fifteen answers together.

Rooted here: `install`, `prepare_source`, `prepare_git_source`, `ensure_stack_refreshable`, `write_source_metadata`, `write_stack_source_metadata`.

| | before | after |
|---|---:|---:|
| `homeboy-rig/src/install.rs` | 15 | **2** |
| `homeboy-rig` (crate) | 23 | **8** |
| repo-wide | 115 | **100** |

Three boundaries, each one unit of work:
- `commands/rig/mod.rs::install` — one `homeboy rig install`
- `commands/infra/route.rs` — runner-targeted installs, which must keep the controller registry pointed at the same source
- `RigSourceContext::load_for_invocation_at` — refreshes a linked rig's registration, so it writes

## One ambient wrapper kept on purpose

`read_source_metadata`'s remaining readers are `expand::resolve_token` and `component_resolution::expand_component_path` — spec token expansion, several frames below anything that holds a root, with no carrier passing through. The contract is explicit that converting a callee whose callers cannot supply a root **relocates one resolution into many**, and calls that a regression rather than progress badly measured.

So the wrapper stays, and now says why and when it goes:

```rust
/// Ambient wrapper retained deliberately.
///
/// The remaining readers are `expand::resolve_token` and
/// `component_resolution::expand_component_path` — spec token expansion, several
/// frames below anything that holds a root and with no carrier passing through.
/// Rooting them today would relocate one resolution into many, which the
/// PathRoots injection contract calls out as a regression rather than progress.
/// Delete this when token expansion gains a carrier (#7505).
pub fn read_source_metadata(id: &str) -> Option<RigSourceMetadata> {
    read_source_metadata_in_root(&paths::homeboy().ok()?, id)
}
```

`read_source_metadata_in_root` is the rooted sibling, and every caller that *does* hold a root uses it.

## Deliberately not in this PR

**`RigState::load`/`save` and the service log paths.** I started these and backed them out. Their seventeen call sites are all read-modify-write against the same rig state file, which makes them a **rooted-store** question — give `RigState` its root at construction, the way `OperationRecordStore` and `CookRecipeStore` did — not a parameter on seventeen free functions. Threading a parameter through `service::platform` and the pipeline steps to dodge that design call is exactly the plumbing the contract warns against. It deserves its own review.

**`lib.rs::read_config` / `list` / `list_ids`.** These sit under `rig::load`, which has 33 call sites across three crates. Separate slice.

**`rust_nextest_shard_threads` stays `1`.** The controller-runtime admission store is untouched and is the other half of that guard's condition.

## Verification

`cargo check --workspace --tests -j2` — green.

Two pattern collisions were caught by pre-write match-count assertions rather than shipping as bad edits, both flagged in the contract: an indentation-substring mismatch on `write_stack_source_metadata`, and `= install(` re-matching text already rewritten by a ` install(` pass (22 double-applications, collapsed). The second is why the test-file rewrite switched to `(?<![\w:])install\(`.

Refs #7505.
