### PR TITLE
fix(cook): snapshot stdin prompts at ingress

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task.rs
+++ b/crates/homeboy-cli/src/commands/agent_task.rs
@@ -230,7 +230,11 @@ pub(crate) fn run_with_cook_progress_and_provenance(
 ) -> CmdResult<Value> {
     match args.command {
         AgentTaskCommand::Doctor(doctor_args) => doctor::doctor(doctor_args),
-        AgentTaskCommand::Cook(cook_args) => {
+        AgentTaskCommand::Cook(mut cook_args) => {
+            // Consume a redirected prompt before routing can hand Cook to another
+            // process. The captured value, rather than stdin, is then the input
+            // every preview and execution path compiles.
+            run::snapshot_cook_prompt(&mut cook_args)?;
             if cook_args.preview {
                 return run::preview_cook(*cook_args, provenance);
             }

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -1039,6 +1039,17 @@ pub struct AgentTaskCookArgs {
     /// Controller-resolved base provenance persisted with the Cook plan.
     #[arg(skip)]
     pub base_resolution: Option<serde_json::Value>,
+    /// Captured at CLI ingress when `--prompt -` is used. This survives route
+    /// handoff and plan compilation without asking a later phase to reread stdin.
+    #[arg(skip)]
+    pub prompt_snapshot: Option<CookPromptSnapshot>,
+}
+
+#[derive(Clone, Debug, serde::Serialize, PartialEq, Eq)]
+pub struct CookPromptSnapshot {
+    pub source: String,
+    pub sha256: String,
+    pub size_bytes: usize,
 }
 
 pub(crate) fn parse_provider_evidence_input(

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -234,6 +234,7 @@ fn aggregate_value_with_failure_reasons(aggregate: &AgentTaskAggregate) -> Value
 }
 
 pub(crate) fn run_cook(mut args: AgentTaskCookArgs) -> CmdResult<Value> {
+    snapshot_cook_prompt(&mut args)?;
     args.gates.snapshot_file_inputs()?;
     let args = resolve_cook_destination(args)?;
     validate_cook_request(&args)?;
@@ -249,6 +250,7 @@ pub(crate) fn preview_cook(
     mut args: AgentTaskCookArgs,
     provenance: Option<&crate::cli_surface::CommandArgumentProvenance>,
 ) -> CmdResult<Value> {
+    snapshot_cook_prompt(&mut args)?;
     args.gates.snapshot_file_inputs()?;
     // Source policy is a static validation and must apply to preview exactly as
     // it applies before an execution route can inspect the destination.
@@ -3559,6 +3561,7 @@ pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress(
     progress: super::CookProgress<'_>,
     provenance: Option<&crate::cli_surface::CommandArgumentProvenance>,
 ) -> CmdResult<Value> {
+    snapshot_cook_prompt(&mut args)?;
     args.gates.snapshot_file_inputs()?;
     let args = resolve_cook_destination(args)?;
     validate_cook_request_with_provenance(&args, provenance)?;
@@ -3650,6 +3653,15 @@ pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress(
     }
     if let Some(provenance) = provenance {
         record_cook_argument_provenance(&mut initial_plan, provenance);
+    }
+    if let Some(snapshot) = &args.prompt_snapshot {
+        for task in &mut initial_plan.tasks {
+            // The prompt is carried by `instructions`; metadata records the
+            // transport without duplicating private stdin content.
+            task.metadata["prompt_source"] = serde_json::json!(snapshot.source);
+        }
+        initial_plan.metadata["prompt_input"] = serde_json::to_value(snapshot)
+            .map_err(|error| homeboy::core::Error::internal_json(error.to_string(), None))?;
     }
     if args.require_acceptance {
         let authority = args.acceptance_authority.clone().ok_or_else(|| {
@@ -3862,6 +3874,34 @@ pub(super) fn resolve_dispatch_prompt(
     };
     let resolved = homeboy::agents::agent_task_prompts::read_prompt_input(spec)?;
     dispatch_args.prompt = Some(resolved);
+    Ok(())
+}
+
+/// Snapshot stdin at the Cook ingress boundary. Later compilation may happen in
+/// a detached child or retry a plan, neither of which owns the original stream.
+pub(crate) fn snapshot_cook_prompt(args: &mut AgentTaskCookArgs) -> homeboy::core::Result<()> {
+    if args.prompt_snapshot.is_some() || args.dispatch.prompt.as_deref() != Some("-") {
+        return Ok(());
+    }
+
+    let content = homeboy::agents::agent_task_prompts::read_prompt_input("-")?;
+    if content.is_empty() {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "prompt",
+            "agent-task cook --prompt - received empty stdin",
+            None,
+            Some(vec!["Pipe a non-empty prompt, for example: homeboy agent-task cook --prompt - < task.md".to_string()]),
+        ));
+    }
+    args.prompt_snapshot = Some(super::args::CookPromptSnapshot {
+        source: "stdin".to_string(),
+        sha256: format!(
+            "sha256:{}",
+            homeboy_engine_primitives::content_hash::sha256_hex(content.as_bytes())
+        ),
+        size_bytes: content.len(),
+    });
+    args.dispatch.prompt = Some(content);
     Ok(())
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -868,6 +868,7 @@ fn cook_preserves_successful_candidate_when_provider_response_has_wrong_schema()
                 acceptance_policy: None,
                 repository_identity: None,
                 base_resolution: None,
+                prompt_snapshot: None,
             },
             Arc::new(ExtensionProviderAgentTaskExecutor::default()),
         )
@@ -1269,6 +1270,7 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
                 acceptance_policy: None,
                 repository_identity: None,
                 base_resolution: None,
+                prompt_snapshot: None,
             },
             executor.clone(),
             Some(Arc::new(MirroredAttemptDispatcher {

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -2,6 +2,8 @@
 mod agent_task_provider_flag_diagnostic;
 #[path = "cli_binary/agent_tool_dispatch.rs"]
 mod agent_tool_dispatch;
+#[path = "cli_binary/cook_prompt_stdin.rs"]
+mod cook_prompt_stdin;
 #[path = "cli_binary/fanout_supervisor_cli.rs"]
 mod fanout_supervisor_cli;
 #[path = "cli_binary/output_dispatch.rs"]

--- a/tests/cli_binary/cook_prompt_stdin.rs
+++ b/tests/cli_binary/cook_prompt_stdin.rs
@@ -1,0 +1,141 @@
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+#[test]
+fn cook_rejects_empty_prompt_stdin_before_destination_or_provider_preflight() {
+    let output = Command::new(homeboy_bin())
+        .args([
+            "--placement",
+            "local",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "-",
+            "--backend",
+            "fixture",
+            "--no-finalize",
+        ])
+        .stdin(Stdio::piped())
+        .env("HOME", tempfile::tempdir().expect("home").path())
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .output()
+        .expect("run homeboy");
+
+    assert!(!output.status.success(), "{output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("agent-task cook --prompt - received empty stdin")
+            || stderr.contains("agent-task cook --prompt - received empty stdin"),
+        "stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        !stdout.contains("provider") && !stderr.contains("provider"),
+        "empty stdin must fail before provider preflight\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+#[test]
+fn cook_snapshots_multiline_stdin_once_in_the_durable_recipe() {
+    let home = tempfile::tempdir().expect("home");
+    let source = tempfile::tempdir().expect("source checkout");
+    git(source.path(), &["init"]);
+    git(
+        source.path(),
+        &["config", "user.email", "test@example.invalid"],
+    );
+    git(source.path(), &["config", "user.name", "Homeboy test"]);
+    std::fs::write(source.path().join("README.md"), "fixture\n").expect("write fixture");
+    git(source.path(), &["add", "README.md"]);
+    git(source.path(), &["commit", "-m", "fixture"]);
+    let target = source.path().join("cook-target");
+    git(
+        source.path(),
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "fix/stdin-snapshot",
+            target.to_str().expect("target path"),
+            "HEAD",
+        ],
+    );
+
+    let prompt = "# Preserve bytes\n\nUse `cargo test` and $HOME exactly.\n";
+    let mut child = Command::new(homeboy_bin())
+        .args([
+            "--placement",
+            "local",
+            "agent-task",
+            "cook",
+            "--run-id",
+            "stdin-snapshot",
+            "--prompt",
+            "-",
+            "--backend",
+            "fixture",
+            "--repo",
+            "stdin-fixture",
+            "--cwd",
+            target.to_str().expect("target path"),
+            "--to-worktree",
+            target.to_str().expect("target path"),
+            "--no-finalize",
+            "--no-progress",
+        ])
+        .stdin(Stdio::piped())
+        .env("HOME", home.path())
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .spawn()
+        .expect("run homeboy");
+    child
+        .stdin
+        .take()
+        .expect("piped stdin")
+        .write_all(prompt.as_bytes())
+        .expect("write prompt");
+    let output = child.wait_with_output().expect("wait for homeboy");
+    // The fixture provider executes successfully, then promotion refuses this
+    // unmanaged worktree. That terminal promotion result still proves the
+    // provider attempt consumed the durable plan we inspect below.
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+
+    let recipe = home
+        .path()
+        .join(".local/share/homeboy/agent-task-cooks/stdin-snapshot/recipe.json");
+    let recipe: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(recipe).expect("recipe")).expect("recipe JSON");
+    assert_eq!(
+        recipe["attempts"][0]["plan"]["tasks"][0]["instructions"],
+        prompt
+    );
+    assert_eq!(
+        recipe["attempts"][0]["plan"]["tasks"][0]["metadata"]["prompt_source"],
+        "stdin"
+    );
+    assert_eq!(
+        recipe["attempts"][0]["plan"]["metadata"]["prompt_input"]["source"],
+        "stdin"
+    );
+    assert_eq!(
+        recipe["attempts"][0]["plan"]["metadata"]["prompt_input"]["sha256"],
+        format!(
+            "sha256:{}",
+            homeboy_engine_primitives::content_hash::sha256_hex(prompt.as_bytes())
+        )
+    );
+}
+
+fn git(directory: &std::path::Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(directory)
+        .status()
+        .expect("run git");
+    assert!(status.success(), "git {args:?}");
+}
+
+fn homeboy_bin() -> PathBuf {
+    PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
+}


### PR DESCRIPTION
## Summary
- capture `agent-task cook --prompt -` before pinned-runtime, preview, and Lab routing consume stdin
- carry captured text as an explicit literal prompt contract through planning, so `-`, `@file`, and `@prompt:id` payloads are never reparsed
- preserve existing `prompt_source` metadata and add versioned `prompt_input_v1` provenance with source, SHA-256 digest, and byte count
- reuse the durable plan for retry and continuation; attempt-plan executions do not read stdin

Closes #12999.

## Verification
- `cargo fmt --check`
- `cargo test --test cli_binary cook_prompt_stdin --no-fail-fast`
- `cargo test -p homeboy-cli --lib commands::agent_task::run:: --no-fail-fast`
- `cargo test -p homeboy-agents agent_task_dispatch_plan --no-fail-fast`
- focused preview snapshot test

The Lab materialization regression test currently reaches an existing fixture base-resolution failure (`resolved Cook base main is unavailable before worktree provisioning`) before plan compilation.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagent was used to inspect prompt ingestion and lifecycle paths, reproduce the duplicate stdin read, implement the ingress snapshot, and add deterministic CLI/integration coverage. Chris Huber remains responsible for the change.