### PR TITLE
Persist deferred cleanup ownership atomically

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -94,6 +94,26 @@ pub(crate) fn reconcile_deferred_candidate_in_store(
         };
         let raw = match fs::read_to_string(path) {
             Ok(raw) => raw,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                if !outcome
+                    .diagnostics
+                    .iter()
+                    .any(|entry| entry.class == "agent_task.deferred_cleanup_descriptor_missing")
+                {
+                    outcome.diagnostics.push(AgentTaskDiagnostic {
+                        class: "agent_task.deferred_cleanup_descriptor_missing".to_string(),
+                        message: "deferred cleanup descriptor is missing; its workspace receipt cannot be reconciled".to_string(),
+                        data: json!({
+                            "path": path,
+                            "safe_next_action": format!(
+                                "homeboy agent-task diagnose {run_id} --full"
+                            ),
+                        }),
+                    });
+                    changed = true;
+                }
+                continue;
+            }
             Err(_) => continue,
         };
         let action_value: Value = match serde_json::from_str(&raw) {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -30,6 +30,61 @@ fn candidate_recoverable_provider_projection_is_failed_not_timed_out() {
     );
 }
 
+#[test]
+fn deferred_cleanup_missing_descriptor_is_persisted_as_actionable_diagnosis() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let run_id = "deferred-cleanup-missing-descriptor";
+    let plan = test_plan();
+    lifecycle_store
+        .submit_plan_with_runtime_admission(&plan, run_id, |_| Ok(json!({})))
+        .expect("submit run");
+    let mut aggregate = succeeded_aggregate(&plan);
+    aggregate.status = AgentTaskAggregateStatus::Failed;
+    aggregate.outcomes[0].status = AgentTaskOutcomeStatus::Timeout;
+    aggregate.outcomes[0].artifacts.push(AgentTaskArtifact {
+        schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+        id: "deferred-cleanup".to_string(),
+        kind: "cleanup_action".to_string(),
+        name: Some("deferred-cleanup.json".to_string()),
+        label: None,
+        role: Some("cleanup_action".to_string()),
+        semantic_key: None,
+        path: Some(
+            lifecycle_store
+                .artifact_root()
+                .join("agent-task/deferred-cleanup/missing.json")
+                .display()
+                .to_string(),
+        ),
+        url: None,
+        mime: Some("application/json".to_string()),
+        size_bytes: None,
+        sha256: None,
+        metadata: json!({ "run_id": run_id, "task_id": "task-a", "attempt": 1 }),
+    });
+    record_run_aggregate_in_store(&lifecycle_store, run_id, &plan, &aggregate)
+        .expect("persist timeout aggregate");
+
+    assert!(
+        reconcile_deferred_candidate_in_store(&lifecycle_store, run_id)
+            .expect("reconcile missing descriptor")
+    );
+    let reconciled = lifecycle_store
+        .read_aggregate(run_id)
+        .expect("read aggregate");
+    let diagnostic = reconciled.outcomes[0]
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.class == "agent_task.deferred_cleanup_descriptor_missing")
+        .expect("missing descriptor diagnosis");
+    assert_eq!(
+        diagnostic.data["safe_next_action"],
+        json!(format!("homeboy agent-task diagnose {run_id} --full"))
+    );
+}
+
 /// Rooted in an explicit store rather than a mutated process environment
 /// (#7505). Cook alias projection is a decision made *across* records — which
 /// indexed attempt is latest, and which attempt owns the active adoption — so

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -1554,9 +1554,13 @@ pub(super) fn deferred_cleanup_action_artifact(
         "safe_next_action": "Wait for cleanup completion; mutable workspace recovery is intentionally deferred until provider exit.",
     });
     let content = serde_json::to_vec_pretty(&action).expect("cleanup action serializes");
-    std::fs::write(&path, &content).map_err(|error| HarvestError::ArtifactWrite {
-        path: path.clone(),
-        message: error.to_string(),
+    // The aggregate may expose this path as soon as this function returns, so
+    // publish only a complete descriptor.
+    write_deferred_cleanup_action(&path, &content).map_err(|error| {
+        HarvestError::ArtifactWrite {
+            path: path.clone(),
+            message: error.to_string(),
+        }
     })?;
     Ok(AgentTaskArtifact {
         schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
@@ -1592,15 +1596,34 @@ pub(super) fn artifact_root_for_running(running: &RunningTask) -> Result<PathBuf
     }
 }
 
+fn write_deferred_cleanup_action(path: &Path, content: &[u8]) -> std::io::Result<()> {
+    let parent = path
+        .parent()
+        .expect("cleanup action has a parent directory");
+    let temporary = parent.join(format!(
+        ".{}.{}.tmp",
+        path.file_name()
+            .expect("cleanup action has a file name")
+            .to_string_lossy(),
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::write(&temporary, content)?;
+    if let Err(error) = std::fs::rename(&temporary, path) {
+        let _ = std::fs::remove_file(&temporary);
+        return Err(error);
+    }
+    Ok(())
+}
+
 pub(super) fn complete_deferred_cleanup_recovery(
     path: &Path,
     outcome: &AgentTaskOutcome,
     cleanup: Result<(), String>,
-) {
-    let mut action = std::fs::read_to_string(path)
-        .ok()
-        .and_then(|raw| serde_json::from_str(&raw).ok())
-        .unwrap_or_else(|| serde_json::json!({}));
+) -> Result<(), String> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|error| format!("cannot read deferred cleanup descriptor: {error}"))?;
+    let mut action: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|error| format!("cannot parse deferred cleanup descriptor: {error}"))?;
     let candidates = outcome
         .artifacts
         .iter()
@@ -1629,7 +1652,10 @@ pub(super) fn complete_deferred_cleanup_recovery(
                 serde_json::to_value(candidates).unwrap_or(serde_json::Value::Null);
         }
     }
-    let _ = std::fs::write(path, serde_json::to_vec_pretty(&action).unwrap_or_default());
+    let content = serde_json::to_vec_pretty(&action)
+        .map_err(|error| format!("cannot serialize deferred cleanup receipt: {error}"))?;
+    write_deferred_cleanup_action(path, &content)
+        .map_err(|error| format!("cannot persist deferred cleanup receipt: {error}"))
 }
 
 fn retry_attempt_evidence(outcome: &AgentTaskOutcome, running: &RunningTask) -> serde_json::Value {
@@ -2100,6 +2126,28 @@ mod executor_erasure_tests {
             calls.load(Ordering::SeqCst),
             2,
             "both the original and its clone must dispatch to the same executor"
+        );
+    }
+
+    #[test]
+    fn deferred_cleanup_descriptor_replaces_only_complete_content() {
+        let directory = tempfile::tempdir().expect("descriptor directory");
+        let descriptor = directory.path().join("deferred-cleanup.json");
+        std::fs::write(&descriptor, b"old receipt").expect("seed descriptor");
+
+        write_deferred_cleanup_action(&descriptor, br#"{"status":"pending"}"#)
+            .expect("atomically publish descriptor");
+
+        assert_eq!(
+            std::fs::read(&descriptor).expect("published descriptor"),
+            br#"{"status":"pending"}"#
+        );
+        assert_eq!(
+            std::fs::read_dir(directory.path())
+                .expect("descriptor directory entries")
+                .count(),
+            1,
+            "temporary descriptor files must not be exposed"
         );
     }
 }

--- a/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
@@ -769,22 +769,27 @@ impl AgentTaskScheduleSupport {
                             );
                             super::finalize_candidate_artifacts(&mut recovered, &task);
                         }
-                        let _ = super::engine::release_scratch(
-                            &task.scratch,
-                            "scheduler_timeout_completion",
-                            &recovered,
-                        );
                         let cleanup = harvest.and_then(|_| {
                             task._attempt_workspace
                                 .as_ref()
                                 .map(|workspace| workspace.cleanup())
                                 .unwrap_or(Ok(()))
                         });
-                        super::complete_deferred_cleanup_recovery(
+                        let receipt = super::complete_deferred_cleanup_recovery(
                             &action_path,
                             &recovered,
                             cleanup,
                         );
+                        // Keep the scratch lease active until both checkout
+                        // cleanup and its durable receipt have reached a
+                        // terminal state. A released lease is reclaimable.
+                        if receipt.is_ok() {
+                            let _ = super::engine::release_scratch(
+                                &task.scratch,
+                                "scheduler_timeout_completion",
+                                &recovered,
+                            );
+                        }
                     })
                 });
             }


### PR DESCRIPTION
## Summary

- atomically publish and update deferred cleanup descriptors
- retain controller scratch ownership through cleanup and terminal receipt persistence
- persist a typed actionable diagnosis when a descriptor is genuinely missing

Closes #13003.

## Verification

- `cargo test -p homeboy-agents deferred_cleanup_descriptor_replaces_only_complete_content --lib`
- `cargo test -p homeboy-agents deferred_cleanup_missing_descriptor_is_persisted_as_actionable_diagnosis --lib`
- `cargo fmt --check`
- `git diff --check`

An existing timing-sensitive scheduler test failed before reaching deferred-cleanup assertions because its deliberate three-second fixture exceeded a two-second scheduler bound; the focused regressions pass.

## AI assistance

OpenAI gpt-5.6-sol via an OpenCode general coding subagent traced deferred cleanup ownership and persistence, implemented the repair, and ran verification. Chris Huber reviewed and is responsible for every line.