### PR TITLE
Protect active controller binaries from artifact cleanup

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/controller_pin_reference_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/controller_pin_reference_provider.rs
@@ -17,8 +17,9 @@ use homeboy_core::controller_pin_reference::{
 };
 use homeboy_core::Result;
 
-/// JSON pointer to a record's originating controller-runtime pinned executable.
+/// JSON pointers to a record's originating controller-runtime executables.
 /// Mirrors core's `CONTROLLER_RUNTIME_METADATA_KEY` layout.
+const ORIGINATING_EXECUTABLE_POINTER: &str = "/controller_runtime/originating/executable";
 const PINNED_EXECUTABLE_POINTER: &str = "/controller_runtime/originating/pinned_executable";
 
 struct AgentTaskControllerPinReferenceProvider;
@@ -34,13 +35,15 @@ impl ControllerPinReferenceProvider for AgentTaskControllerPinReferenceProvider 
             if !state_retains_pin(&record) {
                 continue;
             }
-            if let Some(path) = record
-                .metadata
-                .pointer(PINNED_EXECUTABLE_POINTER)
-                .and_then(Value::as_str)
-                .map(PathBuf::from)
-            {
-                referenced.push(path);
+            for pointer in [ORIGINATING_EXECUTABLE_POINTER, PINNED_EXECUTABLE_POINTER] {
+                if let Some(path) = record
+                    .metadata
+                    .pointer(pointer)
+                    .and_then(Value::as_str)
+                    .map(PathBuf::from)
+                {
+                    referenced.push(path);
+                }
             }
         }
         Ok(referenced)

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -567,6 +567,29 @@ struct ActiveWorktrees {
     available: bool,
 }
 
+/// Executables selected by durable controller recovery. A selected executable
+/// inside a rebuildable target is still an active recovery dependency.
+#[derive(Debug, Default)]
+struct ProtectedControllerExecutables {
+    paths: HashSet<PathBuf>,
+}
+
+impl ProtectedControllerExecutables {
+    fn resolve() -> Result<Self> {
+        Ok(Self {
+            paths: crate::controller_runtime::protected_executables()?
+                .into_iter()
+                .map(|path| canonical_or_owned(&path))
+                .collect(),
+        })
+    }
+
+    fn contains_in(&self, artifact: &Path) -> bool {
+        let artifact = canonical_or_owned(artifact);
+        self.paths.iter().any(|path| path.starts_with(&artifact))
+    }
+}
+
 impl ActiveWorktrees {
     fn resolve() -> Self {
         let Ok(listing) = crate::worktree::list_unlocked() else {
@@ -836,6 +859,7 @@ fn collect_worktree_candidates(
     worktree: &WorktreeInfo,
     options: &ArtifactCleanupOptions,
     active: &ActiveWorktrees,
+    protected: &ProtectedControllerExecutables,
 ) -> Result<WorktreeCandidateScan> {
     let mut candidates = Vec::new();
     let mut skipped = Vec::new();
@@ -928,6 +952,15 @@ fn collect_worktree_candidates(
                 } else {
                     "checkout is a registered active task worktree"
                 },
+            ));
+            continue;
+        }
+        if declaration.kind == "rust_target" && protected.contains_in(&artifact_path) {
+            skipped.push(skip_row(
+                worktree,
+                &declaration,
+                display_path,
+                "artifact contains an executable selected by active controller runtime recovery",
             ));
             continue;
         }
@@ -1037,6 +1070,7 @@ fn cleanup_artifacts_in_worktrees(
     let mut candidates = Vec::new();
     let mut skipped = Vec::new();
     let mut active = ActiveWorktrees::resolve();
+    let protected = ProtectedControllerExecutables::resolve()?;
     if !registry_quarantines.is_empty() {
         active.available = false;
     }
@@ -1048,7 +1082,7 @@ fn cleanup_artifacts_in_worktrees(
         // A single stale/non-Git/vanished worktree candidate must not abort the
         // whole batch: classify it, record a bounded diagnostic, and continue so
         // independent valid worktrees are still cleaned (#9925).
-        match collect_worktree_candidates(worktree, options, &active) {
+        match collect_worktree_candidates(worktree, options, &active, &protected) {
             Ok(WorktreeCandidateScan {
                 candidates: worktree_candidates,
                 skipped: worktree_skipped,
@@ -1445,6 +1479,18 @@ fn apply_artifact_candidate(
         }
     }
     let path = Path::new(&candidate.path);
+    if candidate.kind == "rust_target" {
+        let protected = match ProtectedControllerExecutables::resolve() {
+            Ok(protected) => protected,
+            Err(error) => return ArtifactCleanupCandidateApplyOutcome::Failed(error),
+        };
+        if protected.contains_in(path) {
+            return ArtifactCleanupCandidateApplyOutcome::Skipped(
+                "artifact became selected by active controller runtime recovery before removal"
+                    .to_string(),
+            );
+        }
+    }
     if !path.exists() {
         return ArtifactCleanupCandidateApplyOutcome::Skipped(
             "artifact no longer exists after discovery".to_string(),
@@ -2435,6 +2481,53 @@ mod tests {
         assert_eq!(output.applied_count, 2);
         assert!(!repo.path().join("target").exists());
         assert!(!repo.path().join(".cargo-target").exists());
+    }
+
+    #[test]
+    fn controller_runtime_recovery_executable_protects_its_target_only() {
+        crate::test_support::with_isolated_home(|_| {
+            let protected_repo = repo_with_ignored_artifacts();
+            let unrelated_repo = repo_with_ignored_artifacts();
+            let protected_binary = protected_repo.path().join("target/release/homeboy");
+            write_file(&protected_binary, "selected recovery executable");
+            write_file(
+                &unrelated_repo.path().join("target/release/homeboy"),
+                "unrelated build output",
+            );
+            let runtime_root = crate::controller_runtime::runtime_root_in(
+                &homeboy_paths::homeboy_data().expect("data root"),
+            )
+            .expect("runtime root");
+            fs::write(
+                runtime_root.join("active.json"),
+                serde_json::json!({
+                    "originating": { "executable": protected_binary }
+                })
+                .to_string(),
+            )
+            .expect("register active controller runtime");
+
+            let retained = cleanup_artifacts(ArtifactCleanupOptions {
+                path: Some(protected_repo.path().to_path_buf()),
+                apply: true,
+                ..Default::default()
+            })
+            .expect("cleanup protected source checkout");
+            let reclaimed = cleanup_artifacts(ArtifactCleanupOptions {
+                path: Some(unrelated_repo.path().to_path_buf()),
+                apply: true,
+                ..Default::default()
+            })
+            .expect("cleanup unrelated source checkout");
+
+            assert_eq!(retained.applied_count, 0);
+            assert!(retained.skipped.iter().any(|row| {
+                row.relative_path == "target" && row.reason.contains("controller runtime recovery")
+            }));
+            assert_eq!(reclaimed.applied_count, 1);
+            assert!(protected_binary.exists());
+            assert!(!unrelated_repo.path().join("target").exists());
+        });
     }
 
     #[cfg(unix)]
@@ -3944,6 +4037,7 @@ mod tests {
             },
             &ArtifactCleanupOptions::default(),
             &ActiveWorktrees::default(),
+            &ProtectedControllerExecutables::default(),
         );
         assert!(
             scan.is_err(),

--- a/crates/homeboy-core/src/controller_pin_reference.rs
+++ b/crates/homeboy-core/src/controller_pin_reference.rs
@@ -19,13 +19,13 @@ use std::path::PathBuf;
 
 use crate::Result;
 
-/// Supplies the controller-runtime pin paths still referenced by nonterminal
-/// durable agent-task records.
+/// Supplies the controller-runtime executable paths still referenced by
+/// nonterminal durable agent-task records.
 pub trait ControllerPinReferenceProvider: Send + Sync {
-    /// Return every pinned-executable path referenced by an agent-task record
-    /// whose state still retains its pin (queued, running, or recoverable).
-    /// Returned paths are raw record references; the caller filters them to the
-    /// content-addressed pins it owns.
+    /// Return every originating and pinned executable path referenced by an
+    /// agent-task record whose state still retains its runtime (queued, running,
+    /// or recoverable). Returned paths are raw record references; callers
+    /// select the paths they own or need to protect.
     fn referenced_controller_pins(&self) -> Result<Vec<PathBuf>>;
 }
 
@@ -48,9 +48,9 @@ homeboy_engine_primitives::provider_registry! {
     with: fn with_provider,
 }
 
-/// The controller-runtime pins still referenced by nonterminal agent-task
-/// records, via the registered provider (or an empty set when the agent-task
-/// subsystem is absent).
+/// The controller-runtime executables still referenced by nonterminal
+/// agent-task records, via the registered provider (or an empty set when the
+/// agent-task subsystem is absent).
 pub(crate) fn referenced_controller_pins() -> Result<Vec<PathBuf>> {
     with_provider(|p| p.referenced_controller_pins())
 }

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -313,6 +313,38 @@ pub fn retention_report() -> Result<ControllerRuntimeRetentionReport> {
     retention_report_with_references_at(&runtime_root()?, &referenced, SystemTime::now())
 }
 
+/// Return executables selected by a durable recovery record or the current
+/// controller generation. These paths can live in a source checkout as well as
+/// the content-addressed runtime store, so repository artifact cleanup uses this
+/// projection to avoid removing a selected recovery executable.
+pub fn protected_executables() -> Result<Vec<PathBuf>> {
+    let mut protected: BTreeSet<_> = crate::controller_pin_reference::referenced_controller_pins()?
+        .into_iter()
+        .collect();
+    let active = runtime_root()?.join(ACTIVE_GENERATION_FILE);
+    if active.exists() {
+        let value = fs::read_to_string(&active).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some("read active controller generation".to_string()),
+            )
+        })?;
+        let runtime: Value = serde_json::from_str(&value).map_err(|error| {
+            Error::validation_invalid_json(
+                error,
+                Some("parse active controller generation".to_string()),
+                None,
+            )
+        })?;
+        for pointer in ["/originating/executable", "/originating/pinned_executable"] {
+            if let Some(path) = runtime.pointer(pointer).and_then(Value::as_str) {
+                protected.insert(PathBuf::from(path));
+            }
+        }
+    }
+    Ok(protected.into_iter().collect())
+}
+
 fn retention_report_with_references_at(
     root: &Path,
     referenced: &[PathBuf],


### PR DESCRIPTION
## Summary

- include controller runtime recovery executables in cleanup pin references
- protect only the exact referenced target binary
- add deterministic cleanup coverage for active source controller binaries

Closes #13002.

## Verification

- `cargo test -p homeboy-core controller_runtime_recovery_executable_protects_its_target_only`
- `cargo fmt --check`
- `git diff --check`

## Risk

A final selection-versus-deletion TOCTOU window remains; fully closing it requires shared cleanup/admission locking.

## AI assistance

OpenAI gpt-5.6-sol via an OpenCode general coding subagent inspected cleanup/runtime pin ownership, implemented the change, and ran focused verification. Chris Huber reviewed and is responsible for every line.