### PR TITLE
Retain bounded provider timeout evidence

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -45,6 +45,53 @@ const IMMEDIATE_FAILURE_WINDOW: Duration = Duration::from_secs(10);
 const IMMEDIATE_FAILURE_SIGNATURE_TEXT_LIMIT: usize = 4 * 1024;
 const IMMEDIATE_FAILURE_ERROR_REF_LIMIT: usize = 8;
 
+/// Bounded pipe activity retained until a provider reaches a terminal state.
+/// The runner owns this rather than relying on provider-specific event formats.
+#[derive(Default)]
+struct ProviderOutputCapture {
+    tail: Vec<u8>,
+    full_output: Option<Vec<u8>>,
+    total_bytes: u64,
+    events: u64,
+    last_activity_ms: u64,
+}
+
+impl ProviderOutputCapture {
+    fn with_full_output() -> Self {
+        Self {
+            full_output: Some(Vec::new()),
+            ..Self::default()
+        }
+    }
+
+    fn record(&mut self, bytes: &[u8], elapsed_ms: u64) {
+        self.total_bytes = self.total_bytes.saturating_add(bytes.len() as u64);
+        self.events = self.events.saturating_add(1);
+        self.last_activity_ms = elapsed_ms;
+        if let Some(full_output) = &mut self.full_output {
+            full_output.extend_from_slice(bytes);
+        }
+        self.tail.extend_from_slice(bytes);
+        if self.tail.len() > EXECUTOR_OUTPUT_CAPTURE_LIMIT_BYTES {
+            let excess = self.tail.len() - EXECUTOR_OUTPUT_CAPTURE_LIMIT_BYTES;
+            self.tail.drain(..excess);
+        }
+    }
+
+    fn text(&self) -> String {
+        String::from_utf8_lossy(&self.tail).trim().to_string()
+    }
+
+    fn full_text(&self) -> String {
+        self.full_output
+            .as_deref()
+            .map(String::from_utf8_lossy)
+            .unwrap_or_else(|| String::from_utf8_lossy(&self.tail))
+            .trim()
+            .to_string()
+    }
+}
+
 /// Run the provider command with a bounded retry on transient provider/network
 /// failures.
 ///
@@ -864,24 +911,26 @@ fn run_materialized_provider_command_once_contained(
     }
 
     let started = Instant::now();
-    let stdout_buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
-    let stderr_buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    // Provider stdout may be a large valid JSON outcome, so retain it for
+    // parsing while the timeout diagnostic persists only its bounded tail.
+    let stdout_capture = Arc::new(Mutex::new(ProviderOutputCapture::with_full_output()));
+    let stderr_capture = Arc::new(Mutex::new(ProviderOutputCapture::default()));
     // Progress and the wall timeout must share a monotonic clock. A system-clock
     // adjustment must never turn a stale provider into a live one.
     let last_progress_ms: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
 
     let stdout_reader = child.stdout.take().map(|stdout| {
-        spawn_output_reader(
+        spawn_provider_output_reader(
             stdout,
-            Arc::clone(&stdout_buffer),
+            Arc::clone(&stdout_capture),
             Arc::clone(&last_progress_ms),
             started,
         )
     });
     let stderr_reader = child.stderr.take().map(|stderr| {
-        spawn_output_reader(
+        spawn_provider_output_reader(
             stderr,
-            Arc::clone(&stderr_buffer),
+            Arc::clone(&stderr_capture),
             Arc::clone(&last_progress_ms),
             started,
         )
@@ -940,6 +989,7 @@ fn run_materialized_provider_command_once_contained(
     } else {
         containment.reap_after_exit()
     };
+    let cancellation_acknowledged = containment_cleanup.is_ok();
     containment_report.record(&containment, containment_cleanup);
 
     if let Some(handle) = stdout_reader {
@@ -949,10 +999,10 @@ fn run_materialized_provider_command_once_contained(
         let _ = handle.join();
     }
 
-    let stdout_bytes = stdout_buffer.lock().expect("stdout buffer").clone();
-    let stderr_bytes = stderr_buffer.lock().expect("stderr buffer").clone();
-    let stdout = String::from_utf8_lossy(&stdout_bytes).trim().to_string();
-    let stderr = String::from_utf8_lossy(&stderr_bytes).trim().to_string();
+    let stdout_capture = stdout_capture.lock().expect("stdout capture");
+    let stderr_capture = stderr_capture.lock().expect("stderr capture");
+    let stdout = stdout_capture.full_text();
+    let stderr = stderr_capture.text();
 
     if killed_for_liveness {
         let (status, classification, message) = classify_stall_or_rate_limit(
@@ -976,8 +1026,8 @@ fn run_materialized_provider_command_once_contained(
                 "timeout_ms": requested_timeout_ms,
                 "process_timeout_ms": process_timeout.as_millis(),
                 "liveness_timeout_ms": request.limits.liveness_timeout_ms,
-                "stdout_bytes": stdout_bytes.len(),
-                "stderr_bytes": stderr_bytes.len(),
+                "stdout_bytes": stdout_capture.total_bytes,
+                "stderr_bytes": stderr_capture.total_bytes,
             }),
         );
     }
@@ -999,14 +1049,17 @@ fn run_materialized_provider_command_once_contained(
                 "provider '{}' exceeded timeout_ms={}",
                 provider.id, requested_timeout_ms
             ),
-            json!({
-                "provider": provider.id,
-                "command": command,
-                "deadline": "wall_clock",
-                "timeout_ms": requested_timeout_ms,
-                "process_timeout_ms": process_timeout.as_millis(),
-                "liveness_timeout_ms": request.limits.liveness_timeout_ms,
-            }),
+            provider_timeout_diagnostic_data(
+                request,
+                provider,
+                &command,
+                run_id,
+                requested_timeout_ms,
+                process_timeout.as_millis(),
+                cancellation_acknowledged,
+                &stdout_capture,
+                &stderr_capture,
+            ),
         );
     }
     let Some(status) = status else {
@@ -1465,6 +1518,91 @@ where
                 Ordering::SeqCst,
             );
         }
+    })
+}
+
+fn spawn_provider_output_reader<R>(
+    mut reader: R,
+    capture: Arc<Mutex<ProviderOutputCapture>>,
+    last_progress_ms: Arc<AtomicU64>,
+    started: Instant,
+) -> std::thread::JoinHandle<()>
+where
+    R: Read + Send + 'static,
+{
+    std::thread::spawn(move || {
+        let mut chunk = [0; 4096];
+        while let Ok(read) = reader.read(&mut chunk) {
+            if read == 0 {
+                break;
+            }
+            let elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+            capture
+                .lock()
+                .expect("provider output capture")
+                .record(&chunk[..read], elapsed_ms);
+            last_progress_ms.store(elapsed_ms, Ordering::SeqCst);
+        }
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn provider_timeout_diagnostic_data(
+    request: &AgentTaskExecutorRequest,
+    provider: &AgentTaskExecutorProvider,
+    command: &str,
+    run_id: Option<&str>,
+    timeout_ms: u64,
+    process_timeout_ms: u128,
+    cancellation_acknowledged: bool,
+    stdout: &ProviderOutputCapture,
+    stderr: &ProviderOutputCapture,
+) -> Value {
+    let last_activity = match (stdout.events > 0, stderr.events > 0) {
+        (false, false) => Value::Null,
+        (true, false) => json!({ "kind": "stdout", "elapsed_ms": stdout.last_activity_ms }),
+        (false, true) => json!({ "kind": "stderr", "elapsed_ms": stderr.last_activity_ms }),
+        (true, true) if stdout.last_activity_ms >= stderr.last_activity_ms => {
+            json!({ "kind": "stdout", "elapsed_ms": stdout.last_activity_ms })
+        }
+        (true, true) => json!({ "kind": "stderr", "elapsed_ms": stderr.last_activity_ms }),
+    };
+    let redactions = provider_output_redactions(request, provider);
+    let command = redact_sensitive_text(command, &redactions);
+    let stdout_text = stdout.text();
+    let stderr_text = stderr.text();
+    let stdout_tail = redact_sensitive_text(&stdout_text, &redactions);
+    let stderr_tail = redact_sensitive_text(&stderr_text, &redactions);
+    let log_lookup = run_id.map_or_else(
+        || "homeboy agent-task logs <run-id> --task <task-id>".to_string(),
+        |run_id| {
+            format!(
+                "homeboy agent-task logs {run_id} --task {}",
+                request.task_id
+            )
+        },
+    );
+
+    json!({
+        "provider": provider.id,
+        "provider_backend": provider.backend,
+        "command": command,
+        "deadline": "wall_clock",
+        "timeout_ms": timeout_ms,
+        "process_timeout_ms": process_timeout_ms,
+        "liveness_timeout_ms": request.limits.liveness_timeout_ms,
+        "output_event_count": stdout.events.saturating_add(stderr.events),
+        "stdout_bytes": stdout.total_bytes,
+        "stderr_bytes": stderr.total_bytes,
+        "last_activity": last_activity,
+        "stdout_tail": bounded_executor_output(&stdout_tail),
+        "stderr_tail": bounded_executor_output(&stderr_tail),
+        "stdout_tail_truncated": stdout.total_bytes > EXECUTOR_OUTPUT_CAPTURE_LIMIT_BYTES as u64,
+        "stderr_tail_truncated": stderr.total_bytes > EXECUTOR_OUTPUT_CAPTURE_LIMIT_BYTES as u64,
+        "cancellation_requested": true,
+        "cancellation_acknowledged": cancellation_acknowledged,
+        "provider_boundary_evidence": "executor-result",
+        "log_lookup": log_lookup,
     })
 }
 

--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -648,6 +648,63 @@ fn provider_timeout_returns_structured_outcome() {
 }
 
 #[test]
+fn provider_timeout_persists_bounded_redacted_last_activity() {
+    const SECRET_ENV: &str = "HOMEBOY_TIMEOUT_TEST_SECRET";
+    const SECRET: &str = "timeout-secret-value";
+    std::env::set_var(SECRET_ENV, SECRET);
+    struct ClearSecret;
+    impl Drop for ClearSecret {
+        fn drop(&mut self) {
+            std::env::remove_var(SECRET_ENV);
+        }
+    }
+    let _clear_secret = ClearSecret;
+
+    let command = format!(
+        "node {}",
+        script("process.stderr.write('x'.repeat(20000) + process.env.HOMEBOY_TIMEOUT_TEST_SECRET); setInterval(() => {}, 1000);")
+    );
+    let (mut request, provider) = request("task-timeout-evidence", command);
+    request.limits.timeout_ms = Some(50);
+    request.executor.secret_env = vec![SECRET_ENV.to_string()];
+
+    let outcome = run_provider_command(&request, &provider, Some("run-timeout-evidence"));
+
+    let diagnostic = outcome
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.class == "agent_task.provider_timeout")
+        .expect("timeout diagnostic");
+    assert!(
+        diagnostic.data["output_event_count"]
+            .as_u64()
+            .unwrap_or_default()
+            >= 1
+    );
+    assert_eq!(diagnostic.data["stdout_bytes"], json!(0));
+    assert!(diagnostic.data["stderr_bytes"].as_u64().unwrap_or_default() > 16 * 1024);
+    assert_eq!(diagnostic.data["last_activity"]["kind"], json!("stderr"));
+    assert_eq!(diagnostic.data["stderr_tail_truncated"], json!(true));
+    assert!(
+        diagnostic.data["stderr_tail"]
+            .as_str()
+            .unwrap_or_default()
+            .len()
+            <= 16 * 1024
+    );
+    assert!(!diagnostic.data.to_string().contains(SECRET));
+    assert!(diagnostic.data.to_string().contains("[redacted]"));
+    assert_eq!(
+        diagnostic.data["log_lookup"],
+        json!("homeboy agent-task logs run-timeout-evidence --task task-timeout-evidence")
+    );
+    assert_eq!(
+        diagnostic.data["provider_boundary_evidence"],
+        json!("executor-result")
+    );
+}
+
+#[test]
 fn expired_execution_deadline_returns_typed_outcome_without_spawning_provider() {
     let (mut request, provider) = request("task-deadline", "missing-provider-command".to_string());
     request.limits.execution_deadline_unix_ms = Some(0);


### PR DESCRIPTION
## Summary

- retain bounded stdout and stderr activity on provider timeout
- persist byte/event counts, last stream activity, cancellation acknowledgement, and redacted tails
- expose replayable executor-result evidence without weakening output parsing or secret redaction

Closes #13005.

## Verification

- `cargo test -p homeboy-agents provider_timeout_persists_bounded_redacted_last_activity --lib`
- `rustfmt --edition 2021 --check crates/homeboy-agents/src/agent_task_provider/command_runner.rs crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs`
- `git diff --check`

## AI assistance

OpenAI gpt-5.6-sol via an OpenCode general coding subagent inspected provider execution capture, implemented bounded timeout evidence, and ran verification. Chris Huber reviewed and is responsible for every line.