### PR TITLE
Authenticate Cook-promoted destination state

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -6404,7 +6404,14 @@ fn validate_cook_workspace(options: &AgentTaskCookServiceOptions) -> Result<()> 
             ));
         }
         let safety = homeboy_core::worktree_providers::attest_apply_enabled_worktree_provider_safety_from_config(&identity, &config)?;
-        if !safety.fresh || safety.dirty || safety.unpushed || identity.primary {
+        // A persisted identity must still be fresh, non-primary, and pushed.
+        // Its only admissible dirty state is authenticated below against this
+        // attempt's persisted promoted-candidate fingerprint.
+        if !safety.fresh
+            || safety.unpushed
+            || identity.primary
+            || (safety.dirty && continuation.is_none())
+        {
             return Err(Error::validation_invalid_argument(
                 "to_worktree",
                 "provider safety attestation is not current and safe for Cook execution",

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -12296,6 +12296,18 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
         homeboy_core::defaults::save_config(&config).expect("save provider config");
         crate::agent_task_candidate_baseline::register();
 
+        // Fanout coordinators re-resolve the destination from the identity
+        // persisted when their child was admitted; they do not retain a CWD.
+        options.source_worktree_path = None;
+        options.initial_plan.metadata["cook_provision"] = serde_json::json!({
+            "workspace_identity": homeboy_core::worktree_providers::resolve_apply_enabled_worktree_provider_identity_by_id_from_config(
+                &options.to_worktree,
+                "fixture",
+                &config,
+            )
+            .expect("persisted provider identity")
+        });
+
         assert!(
             tracked_promotion_continuation(&options).unwrap().is_some(),
             "a durably attributed gate-failed promotion re-enters without a route token"

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -541,6 +541,24 @@ pub fn resolve_apply_enabled_worktree_provider_by_id_from_config(
     provider_id: &str,
     config: &HomeboyConfig,
 ) -> Result<WorktreeProviderResolution> {
+    let resolution = resolve_apply_enabled_worktree_provider_by_id_unchecked_from_config(
+        handle,
+        provider_id,
+        config,
+    )?;
+    validate_provider_handle(provider_id, &resolution.worktree, None, None)?;
+    Ok(resolution)
+}
+
+/// Resolve a workspace through one persisted provider without admitting its
+/// safety state. Exact-identity and safety attestation callers need this
+/// observation boundary so Cook can attribute an owned promoted candidate
+/// before the normal dirty-worktree policy decides admission.
+fn resolve_apply_enabled_worktree_provider_by_id_unchecked_from_config(
+    handle: &str,
+    provider_id: &str,
+    config: &HomeboyConfig,
+) -> Result<WorktreeProviderResolution> {
     let provider = config.worktree_providers.get(provider_id).ok_or_else(|| {
         Error::validation_invalid_argument(
             "worktree_provider",
@@ -591,7 +609,6 @@ pub fn resolve_apply_enabled_worktree_provider_by_id_from_config(
         annotate_provider_lookup_error(&mut error, provider_id, command, operation, "not_found");
         error
     })?;
-    validate_provider_handle(provider_id, &worktree, None, None)?;
     Ok(WorktreeProviderResolution {
         provider_id: provider_id.to_string(),
         worktree,
@@ -717,8 +734,11 @@ pub fn resolve_apply_enabled_worktree_provider_identity_by_id_from_config(
         return Err(Error::validation_invalid_argument("worktree_providers.commands", format!("worktree provider `{provider_id}` must configure both resolve_identity and attest_safety"), Some(provider_id.to_string()), None));
     }
     let started = std::time::Instant::now();
-    let resolution =
-        resolve_apply_enabled_worktree_provider_by_id_from_config(handle, provider_id, config)?;
+    let resolution = resolve_apply_enabled_worktree_provider_by_id_unchecked_from_config(
+        handle,
+        provider_id,
+        config,
+    )?;
     let elapsed_ms = started.elapsed().as_millis();
     let token = compatibility_identity_token(&resolution);
     Ok(WorktreeProviderExactIdentity {
@@ -774,7 +794,7 @@ pub fn attest_apply_enabled_worktree_provider_safety_from_config(
         return Ok(safety);
     }
     let started = std::time::Instant::now();
-    let resolution = resolve_apply_enabled_worktree_provider_by_id_from_config(
+    let resolution = resolve_apply_enabled_worktree_provider_by_id_unchecked_from_config(
         &identity.handle,
         &identity.provider_id,
         config,


### PR DESCRIPTION
## Summary

- separate persisted provider identity lookup from initial safety admission
- admit dirty continuation state only when the exact tracked promotion fingerprint authenticates it
- retain fail-closed rejection for foreign drift, primary destinations, stale identity, and unpushed mismatches

Closes #13004.

## Verification

- `cargo test -p homeboy-agents cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate --lib`
- `cargo fmt --all --check`
- `git diff --check`

## AI assistance

OpenAI gpt-5.6-sol via an OpenCode general coding subagent traced fanout continuation admission, implemented the exact-fingerprint repair, and ran verification. Chris Huber reviewed and is responsible for every line.