### PR TITLE
refactor(rig): give rig state its root at construction (#7505)

### DIFF
--- a/crates/homeboy-rig/src/lib.rs
+++ b/crates/homeboy-rig/src/lib.rs
@@ -120,7 +120,7 @@ pub use stack::{
 };
 pub use state::{
     ComponentSnapshot, LifecycleSnapshotState, MaterializedRigState, RigState, RigStateSnapshot,
-    ServiceState,
+    RigStateStore, ServiceState,
 };
 pub use workloads::{
     check_groups_for_bench_scenarios, check_groups_for_extension_workloads,

--- a/crates/homeboy-rig/src/pipeline/fs_step.rs
+++ b/crates/homeboy-rig/src/pipeline/fs_step.rs
@@ -4,11 +4,12 @@ use std::path::{Path, PathBuf};
 
 use super::super::expand::expand_vars;
 use super::super::spec::{RigSpec, SharedPathOp, SharedPathSpec, SymlinkOp, SymlinkSpec};
+use super::super::state::RigStateStore;
 use super::super::state::{now_rfc3339, RigState, SharedPathState};
 use homeboy_core::error::{Error, Result};
 
-pub(super) fn cleanup_shared_paths(rig: &RigSpec) -> Result<()> {
-    run_shared_path_step(rig, SharedPathOp::Cleanup)
+pub(super) fn cleanup_shared_paths(state_store: &RigStateStore, rig: &RigSpec) -> Result<()> {
+    run_shared_path_step(state_store, rig, SharedPathOp::Cleanup)
 }
 
 pub(super) fn run_symlink_step(rig: &RigSpec, op: SymlinkOp) -> Result<()> {
@@ -111,7 +112,11 @@ fn verify_symlink(rig: &RigSpec, link: &SymlinkSpec) -> Result<()> {
     Ok(())
 }
 
-pub(super) fn run_shared_path_step(rig: &RigSpec, op: SharedPathOp) -> Result<()> {
+pub(super) fn run_shared_path_step(
+    state_store: &RigStateStore,
+    rig: &RigSpec,
+    op: SharedPathOp,
+) -> Result<()> {
     if rig.shared_paths.is_empty() {
         return Ok(());
     }
@@ -123,7 +128,7 @@ pub(super) fn run_shared_path_step(rig: &RigSpec, op: SharedPathOp) -> Result<()
         return Ok(());
     }
 
-    let mut state = RigState::load(&rig.id)?;
+    let mut state = state_store.load(&rig.id)?;
     let mut state_changed = false;
 
     for shared in &rig.shared_paths {
@@ -139,7 +144,7 @@ pub(super) fn run_shared_path_step(rig: &RigSpec, op: SharedPathOp) -> Result<()
     }
 
     if state_changed {
-        state.save(&rig.id)?;
+        state_store.save(&rig.id, &state)?;
     }
     Ok(())
 }
@@ -363,12 +368,15 @@ pub(crate) struct SharedPathRepair {
 /// `SharedPathOp::Cleanup`: only links this rig created and still owns are
 /// removed, real files and directories are never touched, and a symlink owned
 /// by something else is reported rather than replaced.
-pub(crate) fn repair_shared_paths(rig: &RigSpec) -> Result<Vec<SharedPathRepair>> {
+pub(crate) fn repair_shared_paths(
+    state_store: &RigStateStore,
+    rig: &RigSpec,
+) -> Result<Vec<SharedPathRepair>> {
     if rig.shared_paths.is_empty() {
         return Ok(Vec::new());
     }
 
-    let mut state = RigState::load(&rig.id)?;
+    let mut state = state_store.load(&rig.id)?;
     let mut state_changed = false;
     let mut repairs = Vec::with_capacity(rig.shared_paths.len());
 
@@ -382,7 +390,7 @@ pub(crate) fn repair_shared_paths(rig: &RigSpec) -> Result<Vec<SharedPathRepair>
     }
 
     if state_changed {
-        state.save(&rig.id)?;
+        state_store.save(&rig.id, &state)?;
     }
     Ok(repairs)
 }

--- a/crates/homeboy-rig/src/pipeline/lifecycle_step.rs
+++ b/crates/homeboy-rig/src/pipeline/lifecycle_step.rs
@@ -19,7 +19,8 @@ use super::super::spec::{
     LifecyclePhaseStatus, LifecycleResultMetadata, LifecycleSnapshotRef, LifecycleWorkloadRef,
     RigSpec,
 };
-use super::super::state::{now_rfc3339, LifecycleSnapshotState, RigState};
+use super::super::state::RigStateStore;
+use super::super::state::{now_rfc3339, LifecycleSnapshotState};
 use super::super::toolchain;
 use super::labels::serialize_lifecycle_op;
 use homeboy_core::error::{Error, Result};
@@ -38,6 +39,7 @@ const DEFAULT_SNAPSHOT_KIND: &str = "lifecycle_snapshot";
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn run_lifecycle_step(
+    state_store: &RigStateStore,
     rig: &RigSpec,
     step_id: Option<&str>,
     component: Option<&str>,
@@ -52,7 +54,14 @@ pub(super) fn run_lifecycle_step(
     // Persist before propagating a phase failure: a handle captured before the
     // failure is a live environment, and dropping it would leak exactly what
     // this primitive exists to make reapable.
-    persist_snapshots(rig, &step_key(step_id, component), component, op, &result)?;
+    persist_snapshots(
+        state_store,
+        rig,
+        &step_key(step_id, component),
+        component,
+        op,
+        &result,
+    )?;
 
     match failure {
         Some(error) => Err(error),
@@ -101,6 +110,7 @@ pub(crate) fn step_key(step_id: Option<&str>, component: Option<&str>) -> String
 /// Record captured handles in rig state, and reap the ones this step owns when
 /// the op is `teardown`.
 fn persist_snapshots(
+    state_store: &RigStateStore,
     rig: &RigSpec,
     step_key: &str,
     component: Option<&str>,
@@ -112,7 +122,7 @@ fn persist_snapshots(
         return Ok(());
     }
 
-    let mut state = RigState::load(&rig.id)?;
+    let mut state = state_store.load(&rig.id)?;
     let mut changed = false;
 
     if teardown {
@@ -137,7 +147,7 @@ fn persist_snapshots(
     }
 
     if changed {
-        state.save(&rig.id)?;
+        state_store.save(&rig.id, &state)?;
     }
     Ok(())
 }

--- a/crates/homeboy-rig/src/pipeline/mod.rs
+++ b/crates/homeboy-rig/src/pipeline/mod.rs
@@ -23,6 +23,7 @@ use std::collections::BTreeSet;
 
 use super::check;
 use super::spec::{PipelineStep, RigSpec};
+use super::state::RigStateStore;
 use homeboy_core::error::Result;
 
 pub use outcome::{PipelineOutcome, PipelineStepOutcome};
@@ -33,11 +34,17 @@ pub(super) use command_step::run_command_step;
 /// writes, instead of a second copy that can drift.
 pub(super) use lifecycle_step::step_key as lifecycle_step_key;
 
-pub fn run_pipeline(rig: &RigSpec, name: &str, fail_fast: bool) -> Result<PipelineOutcome> {
-    run_pipeline_with_settings(rig, name, fail_fast, &[])
+pub fn run_pipeline(
+    state_store: &RigStateStore,
+    rig: &RigSpec,
+    name: &str,
+    fail_fast: bool,
+) -> Result<PipelineOutcome> {
+    run_pipeline_with_settings(state_store, rig, name, fail_fast, &[])
 }
 
 pub fn run_pipeline_with_settings(
+    state_store: &RigStateStore,
     rig: &RigSpec,
     name: &str,
     fail_fast: bool,
@@ -45,10 +52,19 @@ pub fn run_pipeline_with_settings(
 ) -> Result<PipelineOutcome> {
     let steps = rig.pipeline.get(name).cloned().unwrap_or_default();
     let ordered_indices = ordering::order_pipeline_steps(rig, name, &steps)?;
-    run_ordered_steps(rig, name, &steps, ordered_indices, fail_fast, settings)
+    run_ordered_steps(
+        state_store,
+        rig,
+        name,
+        &steps,
+        ordered_indices,
+        fail_fast,
+        settings,
+    )
 }
 
 pub fn run_pipeline_check_groups(
+    state_store: &RigStateStore,
     rig: &RigSpec,
     groups: &[String],
     fail_fast: bool,
@@ -64,7 +80,15 @@ pub fn run_pipeline_check_groups(
         .filter(|step| ordering::step_matches_groups(step, &wanted))
         .collect::<Vec<_>>();
     let ordered_indices = ordering::order_pipeline_steps(rig, "check", &steps)?;
-    run_ordered_steps(rig, "check", &steps, ordered_indices, fail_fast, settings)
+    run_ordered_steps(
+        state_store,
+        rig,
+        "check",
+        &steps,
+        ordered_indices,
+        fail_fast,
+        settings,
+    )
 }
 
 pub fn run_prepare_requirement_steps(
@@ -141,13 +165,14 @@ fn is_prepare_requirement_step(step: &PipelineStep, phase: &str) -> bool {
     )
 }
 
-pub fn cleanup_shared_paths(rig: &RigSpec) -> Result<()> {
-    fs_step::cleanup_shared_paths(rig)
+pub fn cleanup_shared_paths(state_store: &RigStateStore, rig: &RigSpec) -> Result<()> {
+    fs_step::cleanup_shared_paths(state_store, rig)
 }
 
 pub(super) use fs_step::{repair_shared_paths, SharedPathRepair, SharedPathRepairStatus};
 
 fn run_ordered_steps(
+    state_store: &RigStateStore,
     rig: &RigSpec,
     name: &str,
     steps: &[PipelineStep],
@@ -178,7 +203,7 @@ fn run_ordered_steps(
 
         let result = runner_capabilities
             .validate_step(&rig.id, &label, step)
-            .and_then(|()| run_step(rig, name, step, settings));
+            .and_then(|()| run_step(state_store, rig, name, step, settings));
 
         let outcome = match &result {
             Ok(()) => PipelineStepOutcome {
@@ -291,13 +316,16 @@ fn runner_id() -> String {
 }
 
 fn run_step(
+    state_store: &RigStateStore,
     rig: &RigSpec,
     pipeline_name: &str,
     step: &PipelineStep,
     settings: &[(String, String)],
 ) -> Result<()> {
     match step {
-        PipelineStep::Service { id, op, .. } => service_step::run_service_step(rig, id, *op),
+        PipelineStep::Service { id, op, .. } => {
+            service_step::run_service_step(state_store, rig, id, *op)
+        }
         PipelineStep::Build { component, .. } => component::run_build_step(rig, component),
         PipelineStep::Extension { component, op, .. } => {
             component::run_extension_step(rig, component, op)
@@ -321,7 +349,7 @@ fn run_step(
             requirement_step::run_requirement_step(rig, pipeline_name, step, settings)
         }
         PipelineStep::Symlink { op, .. } => fs_step::run_symlink_step(rig, *op),
-        PipelineStep::SharedPath { op, .. } => fs_step::run_shared_path_step(rig, *op),
+        PipelineStep::SharedPath { op, .. } => fs_step::run_shared_path_step(state_store, rig, *op),
         PipelineStep::Patch {
             component,
             file,
@@ -347,6 +375,7 @@ fn run_step(
             op,
             ..
         } => lifecycle_step::run_lifecycle_step(
+            state_store,
             rig,
             step_id.as_deref(),
             component.as_deref(),

--- a/crates/homeboy-rig/src/pipeline/service_step.rs
+++ b/crates/homeboy-rig/src/pipeline/service_step.rs
@@ -3,15 +3,21 @@
 use super::super::check;
 use super::super::service;
 use super::super::spec::{RigSpec, ServiceOp};
+use super::super::state::RigStateStore;
 use homeboy_core::error::{Error, Result};
 
-pub(super) fn run_service_step(rig: &RigSpec, service_id: &str, op: ServiceOp) -> Result<()> {
+pub(super) fn run_service_step(
+    state_store: &RigStateStore,
+    rig: &RigSpec,
+    service_id: &str,
+    op: ServiceOp,
+) -> Result<()> {
     match op {
         ServiceOp::Start => {
-            service::start(rig, service_id)?;
+            service::start(state_store, rig, service_id)?;
             Ok(())
         }
-        ServiceOp::Stop => service::stop(rig, service_id),
+        ServiceOp::Stop => service::stop(state_store, rig, service_id),
         ServiceOp::Health => {
             let spec = rig.services.get(service_id).ok_or_else(|| {
                 Error::rig_service_failed(&rig.id, service_id, "service not declared in rig spec")
@@ -19,7 +25,7 @@ pub(super) fn run_service_step(rig: &RigSpec, service_id: &str, op: ServiceOp) -
             if let Some(health) = &spec.health {
                 check::evaluate(rig, health)?;
             }
-            match service::status(&rig.id, service_id)? {
+            match service::status(state_store, &rig.id, service_id)? {
                 service::ServiceStatus::Running(_) => Ok(()),
                 service::ServiceStatus::Stopped => Err(Error::rig_service_failed(
                     &rig.id,

--- a/crates/homeboy-rig/src/runner.rs
+++ b/crates/homeboy-rig/src/runner.rs
@@ -32,7 +32,7 @@ use super::spec::{
     RIG_RESOURCE_CLASS_LIFECYCLE_SNAPSHOTS,
 };
 use super::state::{
-    now_rfc3339, ComponentSnapshot, MaterializedRigState, RigState, RigStateSnapshot,
+    now_rfc3339, ComponentSnapshot, MaterializedRigState, RigState, RigStateSnapshot, RigStateStore,
 };
 use homeboy_core::engine::command::run_in_optional;
 use homeboy_core::error::{Error, Result};
@@ -207,13 +207,14 @@ pub fn run_up(rig: &RigSpec) -> Result<UpReport> {
     // acquired from, which only holds if it is handed this root.
     let roots = homeboy_core::paths::PathRoots::from_environment()?;
     let _lease = acquire_active_run_lease(roots.config(), rig, "up")?;
+    let state_store = RigStateStore::in_roots(&roots);
     let observer = RigRunObserver::start(rig, "up", &roots);
 
     let execute = || {
-        let outcome = run_pipeline(rig, "up", true)?;
+        let outcome = run_pipeline(&state_store, rig, "up", true)?;
 
         if outcome.is_success() {
-            let mut state = RigState::load(&rig.id)?;
+            let mut state = state_store.load(&rig.id)?;
             let materialized_at = now_rfc3339();
             let snapshot = snapshot_state(rig);
             state.last_up = Some(materialized_at.clone());
@@ -223,7 +224,7 @@ pub fn run_up(rig: &RigSpec) -> Result<UpReport> {
                 resources: expand_resources(rig),
                 components: snapshot.components,
             });
-            state.save(&rig.id)?;
+            state_store.save(&rig.id, &state)?;
         }
 
         Ok(UpReport {
@@ -266,19 +267,21 @@ pub fn run_check_with_settings(
 ) -> Result<CheckReport> {
     preflight_effective_component_checkouts(rig)?;
     let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let state_store = RigStateStore::in_roots(&roots);
     let observer = RigRunObserver::start(rig, "check", &roots);
 
     let execute = || {
         let requirements = evaluate_requirements(rig);
         let package_lint = run_package_lint(rig)?;
-        let check_outcome = run_pipeline_with_settings(rig, "check", false, settings)?;
+        let check_outcome =
+            run_pipeline_with_settings(&state_store, rig, "check", false, settings)?;
         let outcome = merge_check_outcomes(vec![requirements, package_lint, check_outcome]);
 
-        let mut state = RigState::load(&rig.id)?;
+        let mut state = state_store.load(&rig.id)?;
         state.last_check = Some(now_rfc3339());
         state.last_check_result =
             Some(if outcome.is_success() { "pass" } else { "fail" }.to_string());
-        state.save(&rig.id)?;
+        state_store.save(&rig.id, &state)?;
 
         Ok(CheckReport {
             rig_id: rig.id.clone(),
@@ -367,7 +370,10 @@ pub fn run_check_groups_with_settings(
     settings: &[(String, String)],
 ) -> Result<CheckReport> {
     preflight_effective_component_checkouts(rig)?;
-    let outcome = run_pipeline_check_groups(rig, groups, false, settings)?;
+    // Boundary: one grouped rig check is one unit of work (#7505).
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let state_store = RigStateStore::in_roots(&roots);
+    let outcome = run_pipeline_check_groups(&state_store, rig, groups, false, settings)?;
 
     Ok(CheckReport {
         rig_id: rig.id.clone(),
@@ -387,6 +393,9 @@ pub fn run_bench_prepare(
     rig: &RigSpec,
     settings: &[(String, String)],
 ) -> Result<Option<BenchPrepareReport>> {
+    // Boundary: one bench prepare is one unit of work (#7505).
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let state_store = RigStateStore::in_roots(&roots);
     let prepare_requirements = run_prepare_requirement_steps(rig, "bench_prepare", settings)?;
     if !rig.pipeline.contains_key("bench_prepare") && prepare_requirements.steps.is_empty() {
         return Ok(None);
@@ -394,7 +403,7 @@ pub fn run_bench_prepare(
 
     let pipeline_outcome =
         if prepare_requirements.is_success() && rig.pipeline.contains_key("bench_prepare") {
-            run_pipeline_with_settings(rig, "bench_prepare", true, settings)?
+            run_pipeline_with_settings(&state_store, rig, "bench_prepare", true, settings)?
         } else {
             PipelineOutcome {
                 name: "bench_prepare".to_string(),
@@ -425,6 +434,9 @@ pub fn run_fuzz_prepare(
     {
         return Ok(None);
     }
+    // Boundary: one fuzz prepare is one unit of work (#7505).
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let state_store = RigStateStore::in_roots(&roots);
 
     // Dependency-cache evidence must belong to a real, completed run rather
     // than depending on a caller to have installed a rig observer.
@@ -435,7 +447,7 @@ pub fn run_fuzz_prepare(
             run_dependency_materialization_steps(rig, "fuzz_prepare", settings)?;
         let pipeline_outcome =
             if dependency_outcome.is_success() && rig.pipeline.contains_key("fuzz_prepare") {
-                run_pipeline_with_settings(rig, "fuzz_prepare", true, settings)?
+                run_pipeline_with_settings(&state_store, rig, "fuzz_prepare", true, settings)?
             } else {
                 PipelineOutcome {
                     name: "fuzz_prepare".to_string(),
@@ -691,6 +703,7 @@ pub fn run_down(rig: &RigSpec) -> Result<DownReport> {
 pub fn run_down_with_settings(rig: &RigSpec, settings: &[(String, String)]) -> Result<DownReport> {
     // Boundary: one rig teardown is one unit of work (#7505).
     let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let state_store = RigStateStore::in_roots(&roots);
     let _lease = super::lease::acquire_active_run_lease_with_settings(
         roots.config(),
         rig,
@@ -698,24 +711,30 @@ pub fn run_down_with_settings(rig: &RigSpec, settings: &[(String, String)]) -> R
         settings,
     )?;
     let pipeline = if rig.pipeline.contains_key("down") {
-        Some(run_pipeline_with_settings(rig, "down", false, settings)?)
+        Some(run_pipeline_with_settings(
+            &state_store,
+            rig,
+            "down",
+            false,
+            settings,
+        )?)
     } else {
         None
     };
 
-    cleanup_shared_paths(rig)?;
+    cleanup_shared_paths(&state_store, rig)?;
 
     let mut stopped = Vec::new();
     for service_id in rig.services.keys() {
-        service::stop(rig, service_id)?;
+        service::stop(&state_store, rig, service_id)?;
         stopped.push(service_id.clone());
     }
     stopped.sort();
 
     let success = pipeline.as_ref().is_none_or(|p| p.is_success());
-    let mut state = RigState::load(&rig.id)?;
+    let mut state = state_store.load(&rig.id)?;
     state.materialized = None;
-    state.save(&rig.id)?;
+    state_store.save(&rig.id, &state)?;
 
     Ok(DownReport {
         rig_id: rig.id.clone(),
@@ -754,15 +773,16 @@ pub fn run_repair(rig: &RigSpec) -> Result<RepairReport> {
     // Boundary: one rig repair is one unit of work (#7505).
     let roots = homeboy_core::paths::PathRoots::from_environment()?;
     let _lease = acquire_active_run_lease(roots.config(), rig, "repair")?;
+    let state_store = RigStateStore::in_roots(&roots);
     let mut resources = Vec::new();
 
     for link in &rig.symlinks {
         resources.push(repair_symlink(rig, link)?);
     }
-    resources.extend(repair_rig_shared_paths(rig)?);
-    resources.extend(repair_services(rig)?);
+    resources.extend(repair_rig_shared_paths(&state_store, rig)?);
+    resources.extend(repair_services(&state_store, rig)?);
     resources.extend(report_declared_resources(rig));
-    resources.extend(report_lifecycle_snapshots(rig)?);
+    resources.extend(report_lifecycle_snapshots(&state_store, rig)?);
 
     let mut repaired = 0;
     let mut unchanged = 0;
@@ -790,8 +810,11 @@ pub fn run_repair(rig: &RigSpec) -> Result<RepairReport> {
 }
 
 /// Repair declared shared paths through the shared-path ops.
-fn repair_rig_shared_paths(rig: &RigSpec) -> Result<Vec<RepairResourceReport>> {
-    Ok(repair_shared_paths(rig)?
+fn repair_rig_shared_paths(
+    state_store: &RigStateStore,
+    rig: &RigSpec,
+) -> Result<Vec<RepairResourceReport>> {
+    Ok(repair_shared_paths(state_store, rig)?
         .into_iter()
         .map(|repair: SharedPathRepair| RepairResourceReport {
             kind: "shared_path".to_string(),
@@ -816,7 +839,10 @@ fn repair_rig_shared_paths(rig: &RigSpec) -> Result<Vec<RepairResourceReport>> {
 /// process is gone, and the record is drift. Running services are left alone,
 /// stopped services are reported (starting them is `up`'s job), and adopted
 /// `external` services are never signalled — this rig does not own them.
-fn repair_services(rig: &RigSpec) -> Result<Vec<RepairResourceReport>> {
+fn repair_services(
+    state_store: &RigStateStore,
+    rig: &RigSpec,
+) -> Result<Vec<RepairResourceReport>> {
     let mut service_ids = rig.services.keys().cloned().collect::<Vec<_>>();
     service_ids.sort();
 
@@ -834,7 +860,7 @@ fn repair_services(rig: &RigSpec) -> Result<Vec<RepairResourceReport>> {
             continue;
         }
 
-        match service::status(&rig.id, &service_id)? {
+        match service::status(state_store, &rig.id, &service_id)? {
             ServiceStatus::Running(pid) => reports.push(service_resource(
                 &service_id,
                 REPAIR_STATUS_UNCHANGED,
@@ -844,7 +870,7 @@ fn repair_services(rig: &RigSpec) -> Result<Vec<RepairResourceReport>> {
             )),
             ServiceStatus::Stale(pid) => {
                 // `stop` on a dead PID only drops the stale state record.
-                service::stop(rig, &service_id)?;
+                service::stop(state_store, rig, &service_id)?;
                 reports.push(service_resource(
                     &service_id,
                     REPAIR_STATUS_REPAIRED,
@@ -954,8 +980,11 @@ fn report_declared_resources(rig: &RigSpec) -> Vec<RepairResourceReport> {
 ///   command that reaps it
 /// - a handle no declared step owns any more is `blocked` — the rig captured an
 ///   environment and then lost the step that could tear it down
-fn report_lifecycle_snapshots(rig: &RigSpec) -> Result<Vec<RepairResourceReport>> {
-    let snapshots = RigState::load(&rig.id)?.lifecycle_snapshots;
+fn report_lifecycle_snapshots(
+    state_store: &RigStateStore,
+    rig: &RigSpec,
+) -> Result<Vec<RepairResourceReport>> {
+    let snapshots = state_store.load(&rig.id)?.lifecycle_snapshots;
     if snapshots.is_empty() {
         return Ok(Vec::new());
     }
@@ -1150,18 +1179,21 @@ fn create_symlink(_target: &Path, _link: &Path) -> std::io::Result<()> {
 
 /// Summarize current rig state (no mutations).
 pub fn run_status(rig: &RigSpec) -> Result<RigStatusReport> {
-    let state = RigState::load(&rig.id)?;
+    // Boundary: one rig status report is one unit of work (#7505).
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let state_store = RigStateStore::in_roots(&roots);
+    let state = state_store.load(&rig.id)?;
     let mut services = Vec::with_capacity(rig.services.len());
 
     for (id, spec) in &rig.services {
-        let live = service::status(&rig.id, id)?;
+        let live = service::status(&state_store, &rig.id, id)?;
         let (status_str, pid) = match live {
             ServiceStatus::Running(pid) => ("running", Some(pid)),
             ServiceStatus::Stopped => ("stopped", None),
             ServiceStatus::Stale(pid) => ("stale", Some(pid)),
         };
         let started_at = state.services.get(id).and_then(|s| s.started_at.clone());
-        let log_path = service::log_path(&rig.id, id)?
+        let log_path = service::log_path(&state_store, &rig.id, id)?
             .to_string_lossy()
             .into_owned();
         services.push(ServiceStatusReport {
@@ -1223,8 +1255,11 @@ pub fn preflight_effective_component_checkouts(rig: &RigSpec) -> Result<()> {
 
 /// Persist a caller-selected effective checkout for later status reporting.
 pub fn record_effective_component_path(rig_id: &str, component_id: &str, path: &str) -> Result<()> {
+    // Boundary: recording an effective checkout is one unit of work (#7505).
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let state_store = RigStateStore::in_roots(&roots);
     let (sha, branch) = head_sha_and_branch(path);
-    let mut state = RigState::load(rig_id)?;
+    let mut state = state_store.load(rig_id)?;
     state.last_effective_components.insert(
         component_id.to_string(),
         ComponentSnapshot {
@@ -1234,7 +1269,7 @@ pub fn record_effective_component_path(rig_id: &str, component_id: &str, path: &
             branch,
         },
     );
-    state.save(rig_id)
+    state_store.save(rig_id, &state)
 }
 
 fn component_status(
@@ -1375,6 +1410,11 @@ pub fn head_sha_and_branch(path: &str) -> (Option<String>, Option<String>) {
 
 struct RigRunObserver {
     store: ObservationStore,
+    /// Rig state for this run, bound to the same home as `store`.
+    ///
+    /// The observer already spans the whole run; giving it the state store keeps
+    /// the run's observation records and its rig state in one home (#7505).
+    state_store: RigStateStore,
     run_id: String,
     command: String,
     artifact_manifest: tempfile::NamedTempFile,
@@ -1404,6 +1444,7 @@ impl RigRunObserver {
 
         Some(Self {
             store,
+            state_store: RigStateStore::in_roots(roots),
             run_id: run.id,
             command: command.to_string(),
             artifact_manifest,
@@ -1431,7 +1472,7 @@ impl RigRunObserver {
             Err(_) => RunStatus::Error,
         };
         let error = result.as_ref().err().map(ToString::to_string);
-        let state = RigState::load(&rig.id).ok();
+        let state = observer.state_store.load(&rig.id).ok();
         let metadata =
             rig_observation_metadata(rig, &observer.command, state, pipeline, error.as_deref());
         observer.record_registered_artifacts();
@@ -1489,7 +1530,9 @@ impl RigRunObserver {
             "up" if status == RunStatus::Pass => super::expand::expand_resources(rig),
             "up" => super::expand::expand_resources(rig),
             "check" | "fuzz_prepare" => super::expand::expand_resources(rig),
-            "down" => RigState::load(&rig.id)
+            "down" => self
+                .state_store
+                .load(&rig.id)
                 .ok()
                 .and_then(|state| {
                     state
@@ -1506,7 +1549,9 @@ impl RigRunObserver {
             .any(|step| !step.cache_key_inputs.is_empty() && !step.expected_outputs.is_empty());
         // Live lifecycle snapshot handles are produced at run time, not
         // declared, so they are read back from state rather than from the spec.
-        let snapshots = RigState::load(&rig.id)
+        let snapshots = self
+            .state_store
+            .load(&rig.id)
             .map(|state| state.lifecycle_snapshots)
             .unwrap_or_default();
         if resources.is_empty() && !cache_enabled && snapshots.is_empty() {

--- a/crates/homeboy-rig/src/service.rs
+++ b/crates/homeboy-rig/src/service.rs
@@ -18,6 +18,7 @@
 //! returns `RigServiceFailed` so the crate still builds everywhere.
 
 use super::spec::{DiscoverSpec, RigSpec};
+use super::state::RigStateStore;
 use homeboy_core::error::Result;
 
 /// Size at which a supervised service log is rotated.
@@ -134,23 +135,31 @@ pub struct DiscoveredProcess {
 /// Start a service if it isn't already running. Idempotent.
 ///
 /// Returns the PID of the running (or newly started) process.
-pub fn start(rig: &RigSpec, service_id: &str) -> Result<u32> {
-    platform::start(rig, service_id)
+pub fn start(state_store: &RigStateStore, rig: &RigSpec, service_id: &str) -> Result<u32> {
+    platform::start(state_store, rig, service_id)
 }
 
 /// Stop a running service. Idempotent — if not running, returns immediately.
-pub fn stop(rig: &RigSpec, service_id: &str) -> Result<()> {
-    platform::stop(rig, service_id)
+pub fn stop(state_store: &RigStateStore, rig: &RigSpec, service_id: &str) -> Result<()> {
+    platform::stop(state_store, rig, service_id)
 }
 
 /// Report current service status, cross-referencing rig state with live PID.
-pub fn status(rig_id: &str, service_id: &str) -> Result<ServiceStatus> {
-    platform::status(rig_id, service_id)
+pub fn status(
+    state_store: &RigStateStore,
+    rig_id: &str,
+    service_id: &str,
+) -> Result<ServiceStatus> {
+    platform::status(state_store, rig_id, service_id)
 }
 
 /// Log file path for a supervised service.
-pub fn log_path(rig_id: &str, service_id: &str) -> Result<std::path::PathBuf> {
-    platform::log_file_path(rig_id, service_id)
+pub fn log_path(
+    state_store: &RigStateStore,
+    rig_id: &str,
+    service_id: &str,
+) -> Result<std::path::PathBuf> {
+    Ok(state_store.log_file(rig_id, service_id))
 }
 
 /// Find the newest process whose command line contains `pattern`.
@@ -200,12 +209,11 @@ mod platform {
 
     use super::super::expand::expand_vars;
     use super::super::spec::{RigSpec, ServiceKind, ServiceSpec};
-    use super::super::state::{now_rfc3339, ServiceState};
+    use super::super::state::{now_rfc3339, RigStateStore, ServiceState};
     use super::ServiceStatus;
     use homeboy_core::error::{Error, Result};
-    use homeboy_core::paths;
 
-    pub fn start(rig: &RigSpec, service_id: &str) -> Result<u32> {
+    pub fn start(state_store: &RigStateStore, rig: &RigSpec, service_id: &str) -> Result<u32> {
         let spec = rig.services.get(service_id).ok_or_else(|| {
             Error::rig_service_failed(&rig.id, service_id, "service not declared in rig spec")
         })?;
@@ -223,7 +231,7 @@ mod platform {
         }
 
         // Idempotency: if we have a PID and it's live, no-op.
-        let mut state = super::super::state::RigState::load(&rig.id)?;
+        let mut state = state_store.load(&rig.id)?;
         if let Some(svc_state) = state.services.get(service_id) {
             if let Some(pid) = svc_state.pid {
                 if pid_alive(pid) {
@@ -234,7 +242,7 @@ mod platform {
 
         let (program, args) = build_command(rig, service_id, spec)?;
         let cwd = resolve_cwd(rig, spec)?;
-        let log_path = log_file_for(&rig.id, service_id)?;
+        let log_path = log_file_for(state_store, &rig.id, service_id)?;
         let log_file = open_log(&log_path)?;
         let err_file = log_file
             .try_clone()
@@ -284,16 +292,16 @@ mod platform {
                 status: "running".to_string(),
             },
         );
-        state.save(&rig.id)?;
+        state_store.save(&rig.id, &state)?;
 
         Ok(pid)
     }
 
-    pub fn stop(rig: &RigSpec, service_id: &str) -> Result<()> {
+    pub fn stop(state_store: &RigStateStore, rig: &RigSpec, service_id: &str) -> Result<()> {
         let spec = rig.services.get(service_id).ok_or_else(|| {
             Error::rig_service_failed(&rig.id, service_id, "service not declared in rig spec")
         })?;
-        let mut state = super::super::state::RigState::load(&rig.id)?;
+        let mut state = state_store.load(&rig.id)?;
 
         // For external services, the PID isn't in rig state — we discover it
         // via the configured pattern. No discovery hit ⇒ nothing to stop;
@@ -320,7 +328,7 @@ mod platform {
 
         if !pid_alive(pid) {
             state.services.remove(service_id);
-            state.save(&rig.id)?;
+            state_store.save(&rig.id, &state)?;
             return Ok(());
         }
 
@@ -346,12 +354,16 @@ mod platform {
         }
 
         state.services.remove(service_id);
-        state.save(&rig.id)?;
+        state_store.save(&rig.id, &state)?;
         Ok(())
     }
 
-    pub fn status(rig_id: &str, service_id: &str) -> Result<ServiceStatus> {
-        let state = super::super::state::RigState::load(rig_id)?;
+    pub fn status(
+        state_store: &RigStateStore,
+        rig_id: &str,
+        service_id: &str,
+    ) -> Result<ServiceStatus> {
+        let state = state_store.load(rig_id)?;
         let pid = match state.services.get(service_id).and_then(|s| s.pid) {
             Some(pid) => pid,
             None => return Ok(ServiceStatus::Stopped),
@@ -434,12 +446,20 @@ mod platform {
         }
     }
 
-    pub(super) fn log_file_path(rig_id: &str, service_id: &str) -> Result<PathBuf> {
-        Ok(paths::rig_logs_dir(rig_id)?.join(format!("{}.log", service_id)))
+    pub(super) fn log_file_path(
+        state_store: &RigStateStore,
+        rig_id: &str,
+        service_id: &str,
+    ) -> Result<PathBuf> {
+        Ok(state_store.log_file(rig_id, service_id))
     }
 
-    fn log_file_for(rig_id: &str, service_id: &str) -> Result<PathBuf> {
-        let dir = paths::rig_logs_dir(rig_id)?;
+    fn log_file_for(
+        state_store: &RigStateStore,
+        rig_id: &str,
+        service_id: &str,
+    ) -> Result<PathBuf> {
+        let dir = state_store.logs_dir(rig_id);
         std::fs::create_dir_all(&dir).map_err(|e| {
             Error::internal_unexpected(format!(
                 "Failed to create logs dir {}: {}",
@@ -447,7 +467,7 @@ mod platform {
                 e
             ))
         })?;
-        log_file_path(rig_id, service_id)
+        log_file_path(state_store, rig_id, service_id)
     }
 
     fn open_log(path: &PathBuf) -> Result<File> {
@@ -647,24 +667,33 @@ mod platform {
     //! `RigServiceFailed` with the same message so callers get a clear
     //! reason instead of a compile error.
     use super::super::spec::RigSpec;
+    use super::super::state::RigStateStore;
     use super::ServiceStatus;
     use homeboy_core::error::{Error, Result};
 
     const UNSUPPORTED: &str = "rig services are not supported on this platform (Unix only)";
 
-    pub fn start(rig: &RigSpec, service_id: &str) -> Result<u32> {
+    pub fn start(_state_store: &RigStateStore, rig: &RigSpec, service_id: &str) -> Result<u32> {
         Err(Error::rig_service_failed(&rig.id, service_id, UNSUPPORTED))
     }
 
-    pub fn stop(rig: &RigSpec, service_id: &str) -> Result<()> {
+    pub fn stop(_state_store: &RigStateStore, rig: &RigSpec, service_id: &str) -> Result<()> {
         Err(Error::rig_service_failed(&rig.id, service_id, UNSUPPORTED))
     }
 
-    pub fn status(rig_id: &str, service_id: &str) -> Result<ServiceStatus> {
+    pub fn status(
+        _state_store: &RigStateStore,
+        rig_id: &str,
+        service_id: &str,
+    ) -> Result<ServiceStatus> {
         Err(Error::rig_service_failed(rig_id, service_id, UNSUPPORTED))
     }
 
-    pub fn log_file_path(rig_id: &str, service_id: &str) -> Result<std::path::PathBuf> {
+    pub fn log_file_path(
+        _state_store: &RigStateStore,
+        rig_id: &str,
+        service_id: &str,
+    ) -> Result<std::path::PathBuf> {
         Err(Error::rig_service_failed(rig_id, service_id, UNSUPPORTED))
     }
 

--- a/crates/homeboy-rig/src/state.rs
+++ b/crates/homeboy-rig/src/state.rs
@@ -6,6 +6,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
+use std::path::{Path, PathBuf};
 
 use homeboy_core::error::{Error, Result};
 use homeboy_core::paths;
@@ -120,14 +121,61 @@ pub struct SharedPathState {
     pub created_at: String,
 }
 
-impl RigState {
+/// Storage for rig runtime state, bound to one Homeboy home.
+///
+/// `RigState::load`/`save` previously resolved the config root on every call,
+/// which made the resolution invisible at the call site and let a single rig run
+/// read state from one home and persist it into another. Every one of those
+/// call sites is a read-modify-write against the same file, so the root belongs
+/// on the store rather than on seventeen free functions (#7505).
+///
+/// Service logs live beneath the same per-rig state directory, so the store owns
+/// those paths too.
+#[derive(Debug, Clone)]
+pub struct RigStateStore {
+    config_root: PathBuf,
+}
+
+impl RigStateStore {
+    /// Bind the store to an already-resolved config root.
+    pub fn in_root(config_root: impl Into<PathBuf>) -> Self {
+        Self {
+            config_root: config_root.into(),
+        }
+    }
+
+    /// Bind the store to the config root of an already-resolved [`PathRoots`].
+    pub fn in_roots(roots: &paths::PathRoots) -> Self {
+        Self::in_root(roots.config())
+    }
+
+    /// The config root this store reads and writes beneath.
+    pub fn config_root(&self) -> &Path {
+        &self.config_root
+    }
+
+    /// Per-rig state directory (`<config_root>/rigs/{id}.state/`).
+    pub fn state_dir(&self, rig_id: &str) -> PathBuf {
+        paths::rig_state_dir_in_root(&self.config_root, rig_id)
+    }
+
+    /// Per-rig service log directory.
+    pub fn logs_dir(&self, rig_id: &str) -> PathBuf {
+        paths::rig_logs_dir_in_root(&self.config_root, rig_id)
+    }
+
+    /// Log file for one supervised service.
+    pub fn log_file(&self, rig_id: &str, service_id: &str) -> PathBuf {
+        self.logs_dir(rig_id).join(format!("{}.log", service_id))
+    }
+
     /// Load state for a rig, returning a default (empty) state if the file
     /// doesn't exist. Missing state is not an error — it just means the rig
     /// hasn't been brought up yet on this machine.
-    pub fn load(rig_id: &str) -> Result<Self> {
-        let path = paths::rig_state_file(rig_id)?;
+    pub fn load(&self, rig_id: &str) -> Result<RigState> {
+        let path = paths::rig_state_file_in_root(&self.config_root, rig_id);
         if !path.exists() {
-            return Ok(Self::default());
+            return Ok(RigState::default());
         }
         let content = fs::read_to_string(&path).map_err(|e| {
             Error::internal_unexpected(format!(
@@ -137,7 +185,7 @@ impl RigState {
             ))
         })?;
         if content.trim().is_empty() {
-            return Ok(Self::default());
+            return Ok(RigState::default());
         }
         serde_json::from_str(&content).map_err(|e| {
             Error::validation_invalid_json(
@@ -149,8 +197,8 @@ impl RigState {
     }
 
     /// Persist state to disk. Creates the state directory if needed.
-    pub fn save(&self, rig_id: &str) -> Result<()> {
-        let dir = paths::rig_state_dir(rig_id)?;
+    pub fn save(&self, rig_id: &str, state: &RigState) -> Result<()> {
+        let dir = self.state_dir(rig_id);
         fs::create_dir_all(&dir).map_err(|e| {
             Error::internal_unexpected(format!(
                 "Failed to create rig state dir {}: {}",
@@ -158,8 +206,8 @@ impl RigState {
                 e
             ))
         })?;
-        let path = paths::rig_state_file(rig_id)?;
-        let json = serde_json::to_string_pretty(self).map_err(|e| {
+        let path = paths::rig_state_file_in_root(&self.config_root, rig_id);
+        let json = serde_json::to_string_pretty(state).map_err(|e| {
             Error::internal_unexpected(format!("Failed to serialize rig state: {}", e))
         })?;
         fs::write(&path, json).map_err(|e| {
@@ -171,6 +219,17 @@ impl RigState {
         })?;
         Ok(())
     }
+}
+
+/// A [`RigStateStore`] bound to the isolated home a test installs.
+///
+/// A test is the entry point for its own unit of work, so resolving once here
+/// is a boundary resolution. What matters is that the production path beneath
+/// it resolves nothing (#7505). Lives here rather than in each test file so
+/// nested test modules can reach it by path.
+#[cfg(test)]
+pub(crate) fn test_state_store() -> RigStateStore {
+    RigStateStore::in_roots(&paths::PathRoots::from_environment().expect("path roots"))
 }
 
 /// RFC3339 timestamp for state fields.

--- a/tests/core/rig/pipeline_test.rs
+++ b/tests/core/rig/pipeline_test.rs
@@ -31,8 +31,14 @@ fn test_run_pipeline_check_groups() {
     )
     .expect("parse rig");
 
-    let outcome = run_pipeline_check_groups(&rig, &["desktop-app".to_string()], false, &[])
-        .expect("scoped pipeline runs");
+    let outcome = run_pipeline_check_groups(
+        &crate::state::test_state_store(),
+        &rig,
+        &["desktop-app".to_string()],
+        false,
+        &[],
+    )
+    .expect("scoped pipeline runs");
 
     assert!(outcome.is_success());
     assert_eq!(outcome.steps.len(), 1);
@@ -66,7 +72,13 @@ fn test_command_if_missing_runs_only_when_guard_path_is_missing() {
         ))
         .expect("parse rig");
 
-        let out = run_pipeline(&rig, "bench_prepare", true).expect("pipeline runs");
+        let out = run_pipeline(
+            &crate::state::test_state_store(),
+            &rig,
+            "bench_prepare",
+            true,
+        )
+        .expect("pipeline runs");
         assert!(out.is_success(), "outcomes: {:?}", out.steps);
         assert_eq!(marker.exists(), !guard_exists);
     }
@@ -95,8 +107,14 @@ fn test_command_step_exposes_pipeline_settings_env() {
         "sample_runtime_source_root".to_string(),
         "/tmp/sample-runtime".to_string(),
     )];
-    let out =
-        run_pipeline_with_settings(&rig, "bench_prepare", true, &settings).expect("pipeline runs");
+    let out = run_pipeline_with_settings(
+        &crate::state::test_state_store(),
+        &rig,
+        "bench_prepare",
+        true,
+        &settings,
+    )
+    .expect("pipeline runs");
 
     assert!(out.is_success(), "outcomes: {:?}", out.steps);
     assert_eq!(
@@ -126,7 +144,13 @@ fn test_command_step_fails_with_structured_runner_capability_missing() {
     )
     .expect("parse rig");
 
-    let out = run_pipeline(&rig, "bench_prepare", true).expect("pipeline reports failure");
+    let out = run_pipeline(
+        &crate::state::test_state_store(),
+        &rig,
+        "bench_prepare",
+        true,
+    )
+    .expect("pipeline reports failure");
 
     assert!(!out.is_success());
     let error = out.steps[0].error.as_deref().unwrap_or_default();
@@ -175,7 +199,13 @@ fn test_bootstrap_step_provides_required_runner_capability_before_consumer() {
     ))
     .expect("parse rig");
 
-    let out = run_pipeline(&rig, "bench_prepare", true).expect("pipeline runs");
+    let out = run_pipeline(
+        &crate::state::test_state_store(),
+        &rig,
+        "bench_prepare",
+        true,
+    )
+    .expect("pipeline runs");
 
     assert!(out.is_success(), "outcomes: {:?}", out.steps);
     assert_eq!(out.steps[0].label, "bootstrap");
@@ -206,7 +236,8 @@ fn test_host_mutation_step_reports_contract_validation_failure() {
     )
     .expect("parse rig");
 
-    let out = run_pipeline(&rig, "up", true).expect("pipeline reports failure");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+        .expect("pipeline reports failure");
 
     assert!(!out.is_success());
     assert_eq!(out.steps[0].kind, "host-mutation");
@@ -247,7 +278,8 @@ fn test_host_mutation_step_dry_run_does_not_mutate_filesystem() {
     ))
     .expect("parse rig");
 
-    let out = run_pipeline(&rig, "up", true).expect("pipeline runs");
+    let out =
+        run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("pipeline runs");
 
     assert!(out.is_success(), "outcomes: {:?}", out.steps);
     assert!(
@@ -333,13 +365,15 @@ fn test_host_mutation_step_applies_and_reverts_package_manifest_rewrite() {
     ))
     .expect("parse rig");
 
-    let up = run_pipeline(&rig, "up", true).expect("up pipeline runs");
+    let up = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+        .expect("up pipeline runs");
     assert!(up.is_success(), "outcomes: {:?}", up.steps);
     let rewritten = std::fs::read_to_string(&manifest).expect("read rewritten");
     assert!(rewritten.contains("2.0.0"), "manifest: {rewritten}");
     assert!(backup.exists(), "apply should create revert backup");
 
-    let down = run_pipeline(&rig, "down", true).expect("down pipeline runs");
+    let down = run_pipeline(&crate::state::test_state_store(), &rig, "down", true)
+        .expect("down pipeline runs");
     assert!(down.is_success(), "outcomes: {:?}", down.steps);
     let restored = std::fs::read_to_string(&manifest).expect("read restored");
     assert!(restored.contains("1.0.0"), "manifest: {restored}");
@@ -462,7 +496,8 @@ fn test_host_mutation_step_applies_and_reverts_filesystem_mutations() {
     ))
     .expect("parse rig");
 
-    let up = run_pipeline(&rig, "up", true).expect("up pipeline runs");
+    let up = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+        .expect("up pipeline runs");
     assert!(up.is_success(), "outcomes: {:?}", up.steps);
     assert_eq!(std::fs::read_link(&link).expect("read link"), target);
     assert!(temp_dir.is_dir(), "temp dir should be created");
@@ -472,7 +507,8 @@ fn test_host_mutation_step_applies_and_reverts_filesystem_mutations() {
     );
 
     std::fs::write(&original, "changed").expect("change original");
-    let down = run_pipeline(&rig, "down", true).expect("down pipeline runs");
+    let down = run_pipeline(&crate::state::test_state_store(), &rig, "down", true)
+        .expect("down pipeline runs");
     assert!(down.is_success(), "outcomes: {:?}", down.steps);
     assert!(!link.exists(), "revert should remove symlink");
     assert!(!temp_dir.exists(), "revert should remove temp dir");
@@ -534,7 +570,8 @@ fn test_requirement_passes_when_declared_file_exists() {
     ))
     .expect("parse rig");
 
-    let out = run_pipeline(&rig, "check", true).expect("pipeline runs");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "check", true)
+        .expect("pipeline runs");
     assert!(out.is_success(), "outcomes: {:?}", out.steps);
 }
 
@@ -559,7 +596,13 @@ fn test_requirement_prepare_command_runs_only_in_declared_phase() {
     ))
     .expect("parse rig");
 
-    let out = run_pipeline(&rig, "bench_prepare", true).expect("pipeline runs");
+    let out = run_pipeline(
+        &crate::state::test_state_store(),
+        &rig,
+        "bench_prepare",
+        true,
+    )
+    .expect("pipeline runs");
     assert!(out.is_success(), "outcomes: {:?}", out.steps);
     assert_eq!(std::fs::read_to_string(marker).expect("marker"), "prepared");
 }
@@ -586,7 +629,8 @@ fn test_requirement_fails_with_remediation_without_prepare_phase() {
     ))
     .expect("parse rig");
 
-    let out = run_pipeline(&rig, "check", true).expect("pipeline runs");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "check", true)
+        .expect("pipeline runs");
     assert!(!out.is_success());
     let error = out.steps[0].error.as_deref().unwrap_or_default();
     assert!(error.contains("run bench_prepare"), "error: {error}");
@@ -617,7 +661,8 @@ fn test_requirement_validates_component_path_contains() {
     ))
     .expect("parse rig");
 
-    let out = run_pipeline(&rig, "check", true).expect("pipeline runs");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "check", true)
+        .expect("pipeline runs");
     assert!(out.is_success(), "outcomes: {:?}", out.steps);
 }
 
@@ -649,7 +694,8 @@ fn test_requirement_executable_falls_back_to_path_when_env_override_missing() {
     ))
     .expect("parse rig");
 
-    let out = run_pipeline(&rig, "check", true).expect("pipeline runs");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "check", true)
+        .expect("pipeline runs");
     assert!(out.is_success(), "outcomes: {:?}", out.steps);
 }
 
@@ -682,7 +728,8 @@ fn test_requirement_executable_uses_ordered_env_aliases_before_path() {
     ))
     .expect("parse rig");
 
-    let out = run_pipeline(&rig, "check", true).expect("pipeline runs");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "check", true)
+        .expect("pipeline runs");
     assert!(out.is_success(), "outcomes: {:?}", out.steps);
 }
 
@@ -712,7 +759,8 @@ fn test_requirement_executable_falls_back_to_path_when_env_override_is_unusable(
     ))
     .expect("parse rig");
 
-    let out = run_pipeline(&rig, "check", true).expect("pipeline runs");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "check", true)
+        .expect("pipeline runs");
     assert!(out.is_success(), "outcomes: {:?}", out.steps);
 }
 
@@ -738,7 +786,8 @@ fn test_requirement_executable_reports_resolution_sources() {
     )
     .expect("parse rig");
 
-    let out = run_pipeline(&rig, "check", true).expect("pipeline runs");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "check", true)
+        .expect("pipeline runs");
     assert!(!out.is_success());
     let error = out.steps[0].error.as_deref().unwrap_or_default();
     assert!(
@@ -772,7 +821,8 @@ fn test_requirement_executable_reports_missing_tool() {
     )
     .expect("parse rig");
 
-    let out = run_pipeline(&rig, "check", true).expect("pipeline runs");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "check", true)
+        .expect("pipeline runs");
     assert!(!out.is_success());
     let error = out.steps[0].error.as_deref().unwrap_or_default();
     assert!(
@@ -902,7 +952,8 @@ mod dag {
             HashMap::new(),
         );
 
-        let out = run_pipeline(&rig, "up", true).expect("pipeline");
+        let out =
+            run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("pipeline");
         assert!(out.is_success(), "outcomes: {:?}", out.steps);
         assert_eq!(
             fs::read_to_string(&log).expect("read log"),
@@ -929,7 +980,8 @@ mod dag {
             HashMap::new(),
         );
 
-        let err = run_pipeline(&rig, "up", true).expect_err("missing dependency errors");
+        let err = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+            .expect_err("missing dependency errors");
         let msg = err.to_string();
         assert!(msg.contains("missing step id 'missing-step'"), "{msg}");
     }
@@ -944,7 +996,8 @@ mod dag {
             HashMap::new(),
         );
 
-        let err = run_pipeline(&rig, "up", true).expect_err("cycle errors");
+        let err = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+            .expect_err("cycle errors");
         let msg = err.to_string();
         assert!(msg.contains("dependency cycle"), "{msg}");
         assert!(msg.contains("'a'"), "{msg}");
@@ -970,7 +1023,8 @@ mod dag {
             HashMap::new(),
         );
 
-        let out = run_pipeline(&rig, "up", true).expect("pipeline");
+        let out =
+            run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("pipeline");
         assert!(out.is_success());
         assert_eq!(
             fs::read_to_string(&log).expect("read log"),
@@ -1016,7 +1070,8 @@ mod dag {
             components,
         );
 
-        let out = run_pipeline(&rig, "up", true).expect("pipeline report");
+        let out = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+            .expect("pipeline report");
         assert!(!out.is_success());
         assert_eq!(out.failed, 1);
         assert_eq!(out.steps[0].kind, "stack");
@@ -1089,7 +1144,8 @@ mod dag {
             components,
         );
 
-        let out = run_pipeline(&rig, "up", true).expect("pipeline");
+        let out =
+            run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("pipeline");
         assert!(out.is_success(), "outcomes: {:?}", out.steps);
         assert_eq!(
             fs::read_to_string(component_b.join("ready.txt")).expect("ready"),
@@ -1224,7 +1280,8 @@ mod git_steps {
         assert!(status.success(), "update-index failed");
 
         let rig = rig_with_git_step(repo.to_string_lossy().into_owned(), GitOp::Status);
-        let outcome = run_pipeline(&rig, "up", true).expect("pipeline outcome");
+        let outcome = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+            .expect("pipeline outcome");
 
         assert!(!outcome.is_success());
         assert_eq!(outcome.steps[0].status, "fail");
@@ -1354,7 +1411,8 @@ mod extension_lifecycle {
                 },
             );
 
-            let out = run_pipeline(&rig, "up", true).expect("pipeline");
+            let out = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+                .expect("pipeline");
             assert!(out.is_success(), "outcomes: {:?}", out.steps);
             assert_eq!(out.steps[0].kind, "extension");
 
@@ -1383,7 +1441,8 @@ mod extension_lifecycle {
             },
         );
 
-        let out = run_pipeline(&rig, "up", true).expect("pipeline");
+        let out =
+            run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("pipeline");
         assert!(!out.is_success());
         assert_eq!(out.steps[0].kind, "extension");
         let error = out.steps[0].error.as_deref().expect("error");
@@ -1465,7 +1524,8 @@ mod command_env {
             format!("printf '%s' \"$PATH\" > {}", path_file.to_string_lossy()),
             env,
         );
-        let outcome = run_pipeline(&rig, "up", true).expect("pipeline");
+        let outcome =
+            run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("pipeline");
 
         assert!(outcome.is_success(), "outcomes: {:?}", outcome.steps);
         assert_eq!(
@@ -1489,7 +1549,8 @@ mod command_env {
             "fixture must exercise the built-in default"
         );
         let expected = toolchain::command_step_path(Some(&rig)).expect("toolchain path");
-        let outcome = run_pipeline(&rig, "up", true).expect("pipeline");
+        let outcome =
+            run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("pipeline");
 
         assert!(outcome.is_success(), "outcomes: {:?}", outcome.steps);
         assert_eq!(
@@ -1515,7 +1576,8 @@ mod command_env {
             ..Default::default()
         });
 
-        let outcome = run_pipeline(&rig, "up", true).expect("pipeline");
+        let outcome =
+            run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("pipeline");
 
         assert!(outcome.is_success(), "outcomes: {:?}", outcome.steps);
         let observed = fs::read_to_string(path_file).expect("path file");
@@ -1534,7 +1596,8 @@ mod command_env {
             "definitely-not-a-homeboy-test-command-1758 2>/dev/null".to_string(),
             HashMap::new(),
         );
-        let outcome = run_pipeline(&rig, "up", true).expect("pipeline report");
+        let outcome = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+            .expect("pipeline report");
 
         assert!(!outcome.is_success());
         let error = outcome.steps[0].error.as_deref().expect("error");

--- a/tests/core/rig/pipeline_test/lifecycle.rs
+++ b/tests/core/rig/pipeline_test/lifecycle.rs
@@ -9,7 +9,6 @@ use std::fs;
 
 use crate::pipeline::run_pipeline;
 use crate::spec::RigSpec;
-use crate::state::RigState;
 use homeboy_core::test_support::with_isolated_home;
 
 fn rig_from_json(json: &str) -> RigSpec {
@@ -42,7 +41,8 @@ fn test_lifecycle_step_runs_matching_phases_in_declared_order() {
         log = log_arg
     ));
 
-    let out = run_pipeline(&rig, "up", true).expect("pipeline runs");
+    let out =
+        run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("pipeline runs");
 
     assert!(out.is_success(), "outcomes: {:?}", out.steps);
     assert_eq!(out.steps[0].kind, "lifecycle");
@@ -77,7 +77,8 @@ fn test_lifecycle_step_exposes_phase_identity_to_commands() {
         marker = marker_arg
     ));
 
-    let out = run_pipeline(&rig, "up", true).expect("pipeline runs");
+    let out =
+        run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("pipeline runs");
 
     assert!(out.is_success(), "outcomes: {:?}", out.steps);
     assert_eq!(
@@ -115,7 +116,8 @@ fn test_lifecycle_snapshot_handle_is_visible_to_later_phases() {
             marker = marker_arg
         ));
 
-        let out = run_pipeline(&rig, "up", true).expect("pipeline runs");
+        let out = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+            .expect("pipeline runs");
 
         assert!(out.is_success(), "outcomes: {:?}", out.steps);
         assert_eq!(
@@ -148,10 +150,13 @@ fn test_lifecycle_snapshot_handle_lands_in_rig_state() {
             }"#,
         );
 
-        let out = run_pipeline(&rig, "up", true).expect("pipeline runs");
+        let out = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+            .expect("pipeline runs");
         assert!(out.is_success(), "outcomes: {:?}", out.steps);
 
-        let state = RigState::load(&rig.id).expect("state");
+        let state = crate::state::test_state_store()
+            .load(&rig.id)
+            .expect("state");
         let entry = state
             .lifecycle_snapshots
             .get("capture")
@@ -190,10 +195,13 @@ fn test_lifecycle_snapshot_handle_can_be_a_full_contract_ref() {
             }"#,
         );
 
-        let out = run_pipeline(&rig, "up", true).expect("pipeline runs");
+        let out = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+            .expect("pipeline runs");
         assert!(out.is_success(), "outcomes: {:?}", out.steps);
 
-        let state = RigState::load(&rig.id).expect("state");
+        let state = crate::state::test_state_store()
+            .load(&rig.id)
+            .expect("state");
         let entry = state
             .lifecycle_snapshots
             .get("sandbox-7f3")
@@ -238,20 +246,24 @@ fn test_lifecycle_teardown_reaps_the_handles_its_step_owns() {
             }"#,
         );
 
-        let up = run_pipeline(&rig, "up", true).expect("up runs");
+        let up =
+            run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("up runs");
         assert!(up.is_success(), "outcomes: {:?}", up.steps);
         assert_eq!(
-            RigState::load(&rig.id)
+            crate::state::test_state_store()
+                .load(&rig.id)
                 .expect("state")
                 .lifecycle_snapshots
                 .len(),
             1
         );
 
-        let down = run_pipeline(&rig, "down", true).expect("down runs");
+        let down =
+            run_pipeline(&crate::state::test_state_store(), &rig, "down", true).expect("down runs");
         assert!(down.is_success(), "outcomes: {:?}", down.steps);
         assert!(
-            RigState::load(&rig.id)
+            crate::state::test_state_store()
+                .load(&rig.id)
                 .expect("state")
                 .lifecycle_snapshots
                 .is_empty(),
@@ -277,7 +289,8 @@ fn test_lifecycle_step_rejects_unknown_contract_schema() {
         }"#,
     );
 
-    let out = run_pipeline(&rig, "up", true).expect("pipeline reports failure");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+        .expect("pipeline reports failure");
 
     assert!(!out.is_success());
     assert_eq!(out.steps[0].kind, "lifecycle");
@@ -305,7 +318,8 @@ fn test_lifecycle_step_fails_when_op_has_no_declared_phase() {
         }"#,
     );
 
-    let out = run_pipeline(&rig, "down", true).expect("pipeline reports failure");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "down", true)
+        .expect("pipeline reports failure");
 
     assert!(!out.is_success());
     let error = out.steps[0].error.as_deref().unwrap_or_default();
@@ -328,7 +342,8 @@ fn test_lifecycle_step_rejects_phase_without_hook_or_command() {
         }"#,
     );
 
-    let out = run_pipeline(&rig, "up", true).expect("pipeline reports failure");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+        .expect("pipeline reports failure");
 
     assert!(!out.is_success());
     let error = out.steps[0].error.as_deref().unwrap_or_default();
@@ -362,7 +377,8 @@ fn test_lifecycle_step_fails_on_required_phase_failure() {
         marker = marker_arg
     ));
 
-    let out = run_pipeline(&rig, "up", true).expect("pipeline reports failure");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+        .expect("pipeline reports failure");
 
     assert!(!out.is_success());
     let error = out.steps[0].error.as_deref().unwrap_or_default();
@@ -394,7 +410,8 @@ fn test_lifecycle_step_continues_past_optional_phase_failure() {
         marker = marker_arg
     ));
 
-    let out = run_pipeline(&rig, "up", true).expect("pipeline runs");
+    let out =
+        run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("pipeline runs");
 
     assert!(out.is_success(), "outcomes: {:?}", out.steps);
     assert!(marker.exists(), "an optional phase failure is not fatal");
@@ -417,7 +434,8 @@ fn test_lifecycle_step_fails_on_undeclared_component() {
         }"#,
     );
 
-    let out = run_pipeline(&rig, "up", true).expect("pipeline reports failure");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+        .expect("pipeline reports failure");
 
     assert!(!out.is_success());
     let error = out.steps[0].error.as_deref().unwrap_or_default();
@@ -444,7 +462,8 @@ fn test_lifecycle_step_rejects_malformed_extension_hook() {
         }"#,
     );
 
-    let out = run_pipeline(&rig, "up", true).expect("pipeline reports failure");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+        .expect("pipeline reports failure");
 
     assert!(!out.is_success());
     let error = out.steps[0].error.as_deref().unwrap_or_default();
@@ -469,7 +488,8 @@ fn test_pipeline_without_lifecycle_step_is_unchanged() {
         marker = marker_arg
     ));
 
-    let out = run_pipeline(&rig, "up", true).expect("pipeline runs");
+    let out =
+        run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("pipeline runs");
 
     assert!(out.is_success(), "outcomes: {:?}", out.steps);
     assert_eq!(out.steps[0].kind, "command");
@@ -524,11 +544,13 @@ fn test_lifecycle_step_resolves_a_workload_declared_contract() {
             log = log_arg
         ));
 
-        let up = run_pipeline(&rig, "up", true).expect("up runs");
+        let up =
+            run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("up runs");
         assert!(up.is_success(), "outcomes: {:?}", up.steps);
         assert_eq!(up.steps[0].kind, "lifecycle");
 
-        let down = run_pipeline(&rig, "down", true).expect("down runs");
+        let down =
+            run_pipeline(&crate::state::test_state_store(), &rig, "down", true).expect("down runs");
         assert!(down.is_success(), "outcomes: {:?}", down.steps);
 
         assert_eq!(
@@ -569,7 +591,8 @@ fn test_lifecycle_workload_ref_resolves_bench_and_trace_maps() {
             marker = marker_arg
         ));
 
-        let out = run_pipeline(&rig, "up", true).expect("pipeline runs");
+        let out = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+            .expect("pipeline runs");
         assert!(out.is_success(), "{kind} outcomes: {:?}", out.steps);
         assert_eq!(fs::read_to_string(&marker).expect("marker"), kind);
     }
@@ -614,7 +637,8 @@ fn test_lifecycle_workload_ref_disambiguates_by_path() {
         marker = marker_arg
     ));
 
-    let out = run_pipeline(&rig, "up", true).expect("pipeline runs");
+    let out =
+        run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("pipeline runs");
     assert!(out.is_success(), "outcomes: {:?}", out.steps);
     assert_eq!(fs::read_to_string(&marker).expect("marker"), "b");
 }
@@ -646,7 +670,8 @@ fn test_lifecycle_workload_ref_rejects_ambiguous_selection() {
         }"#,
     );
 
-    let out = run_pipeline(&rig, "up", true).expect("pipeline reports failure");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+        .expect("pipeline reports failure");
 
     assert!(!out.is_success());
     let error = out.steps[0].error.as_deref().unwrap_or_default();
@@ -675,7 +700,8 @@ fn test_lifecycle_workload_ref_rejects_unknown_extension() {
         }"#,
     );
 
-    let out = run_pipeline(&rig, "up", true).expect("pipeline reports failure");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+        .expect("pipeline reports failure");
 
     assert!(!out.is_success());
     let error = out.steps[0].error.as_deref().unwrap_or_default();
@@ -707,7 +733,8 @@ fn test_lifecycle_workload_ref_rejects_unknown_path() {
         }"#,
     );
 
-    let out = run_pipeline(&rig, "up", true).expect("pipeline reports failure");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+        .expect("pipeline reports failure");
 
     assert!(!out.is_success());
     let error = out.steps[0].error.as_deref().unwrap_or_default();
@@ -733,7 +760,8 @@ fn test_lifecycle_workload_ref_rejects_workload_without_contract() {
         }"#,
     );
 
-    let out = run_pipeline(&rig, "up", true).expect("pipeline reports failure");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+        .expect("pipeline reports failure");
 
     assert!(!out.is_success());
     let error = out.steps[0].error.as_deref().unwrap_or_default();
@@ -761,7 +789,8 @@ fn test_lifecycle_step_rejects_both_inline_and_workload_sources() {
         }"#,
     );
 
-    let out = run_pipeline(&rig, "up", true).expect("pipeline reports failure");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+        .expect("pipeline reports failure");
 
     assert!(!out.is_success());
     let error = out.steps[0].error.as_deref().unwrap_or_default();
@@ -779,7 +808,8 @@ fn test_lifecycle_step_rejects_neither_inline_nor_workload_source() {
         }"#,
     );
 
-    let out = run_pipeline(&rig, "up", true).expect("pipeline reports failure");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+        .expect("pipeline reports failure");
 
     assert!(!out.is_success());
     let error = out.steps[0].error.as_deref().unwrap_or_default();

--- a/tests/core/rig/pipeline_test/patch.rs
+++ b/tests/core/rig/pipeline_test/patch.rs
@@ -77,7 +77,7 @@ fn test_patch_appends_when_no_anchor() {
         label: None,
     };
     let rig = rig_with_patch(&tmp.path().to_string_lossy(), step);
-    let out = run_pipeline(&rig, "up", true).expect("pipeline");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("pipeline");
     assert!(out.is_success(), "outcomes: {:?}", out.steps);
 
     let body = fs::read_to_string(&file).expect("read");
@@ -104,7 +104,7 @@ fn test_patch_idempotent_when_marker_present() {
         label: None,
     };
     let rig = rig_with_patch(&tmp.path().to_string_lossy(), step);
-    run_pipeline(&rig, "up", true).expect("pipeline");
+    run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("pipeline");
 
     let after = fs::read_to_string(&file).expect("read after");
     assert_eq!(before, after, "second apply should be a no-op");
@@ -128,7 +128,7 @@ fn test_patch_inserts_after_anchor() {
         label: None,
     };
     let rig = rig_with_patch(&tmp.path().to_string_lossy(), step);
-    run_pipeline(&rig, "up", true).expect("pipeline");
+    run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("pipeline");
 
     let body = fs::read_to_string(&file).expect("read");
     // Patch goes on the line after the anchor, so the anchor's line
@@ -154,7 +154,8 @@ fn test_patch_fails_when_anchor_missing() {
         label: None,
     };
     let rig = rig_with_patch(&tmp.path().to_string_lossy(), step);
-    let out = run_pipeline(&rig, "up", true).expect("pipeline runs");
+    let out =
+        run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("pipeline runs");
     assert!(!out.is_success(), "missing anchor must fail");
     let err = out.steps[0].error.as_deref().unwrap_or("");
     assert!(err.contains("anchor"), "error must mention anchor: {}", err);
@@ -179,7 +180,8 @@ fn test_patch_rejects_content_missing_marker() {
         label: None,
     };
     let rig = rig_with_patch(&tmp.path().to_string_lossy(), step);
-    let out = run_pipeline(&rig, "up", true).expect("pipeline runs");
+    let out =
+        run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("pipeline runs");
     assert!(!out.is_success(), "must reject re-apply-forever shape");
 }
 
@@ -201,7 +203,7 @@ fn test_patch_verify_passes_when_marker_present() {
         label: None,
     };
     let rig = rig_with_patch(&tmp.path().to_string_lossy(), step);
-    let out = run_pipeline(&rig, "up", true).expect("pipeline");
+    let out = run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("pipeline");
     assert!(out.is_success());
 }
 
@@ -224,7 +226,8 @@ fn test_patch_verify_fails_when_marker_absent_and_does_not_mutate() {
         label: None,
     };
     let rig = rig_with_patch(&tmp.path().to_string_lossy(), step);
-    let out = run_pipeline(&rig, "up", true).expect("pipeline runs");
+    let out =
+        run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("pipeline runs");
     assert!(!out.is_success());
 
     let after = fs::read_to_string(&file).expect("read after");

--- a/tests/core/rig/pipeline_test/shared_path.rs
+++ b/tests/core/rig/pipeline_test/shared_path.rs
@@ -8,7 +8,6 @@ use std::fs;
 
 use crate::pipeline::{cleanup_shared_paths, run_pipeline};
 use crate::spec::{PipelineStep, RigSpec, SharedPathOp, SharedPathSpec};
-use crate::state::RigState;
 use homeboy_core::test_support::with_isolated_home;
 
 fn rig_with_shared_path(id: &str, shared: SharedPathSpec, op: SharedPathOp) -> RigSpec {
@@ -71,12 +70,15 @@ fn test_shared_path_ensure_creates_missing_symlink_and_records_state() {
             shared(&link, &target),
             SharedPathOp::Ensure,
         );
-        let out = run_pipeline(&rig, "up", true).expect("pipeline");
+        let out =
+            run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("pipeline");
         assert!(out.is_success(), "outcomes: {:?}", out.steps);
         assert!(link.is_symlink(), "missing path becomes symlink");
         assert_eq!(fs::read_link(&link).expect("read link"), target);
 
-        let state = RigState::load(&rig.id).expect("state");
+        let state = crate::state::test_state_store()
+            .load(&rig.id)
+            .expect("state");
         let key = link.to_string_lossy().into_owned();
         assert_eq!(
             state.shared_paths.get(&key).unwrap().target,
@@ -96,12 +98,15 @@ fn test_shared_path_ensure_leaves_existing_local_directory_unowned() {
 
         let rig =
             rig_with_shared_path("shared-local", shared(&link, &target), SharedPathOp::Ensure);
-        let out = run_pipeline(&rig, "up", true).expect("pipeline");
+        let out =
+            run_pipeline(&crate::state::test_state_store(), &rig, "up", true).expect("pipeline");
         assert!(out.is_success(), "existing local directory should pass");
         assert!(link.is_dir());
         assert!(!link.is_symlink());
 
-        let state = RigState::load(&rig.id).expect("state");
+        let state = crate::state::test_state_store()
+            .load(&rig.id)
+            .expect("state");
         assert!(
             state.shared_paths.is_empty(),
             "local deps are not rig-owned"
@@ -143,20 +148,23 @@ fn test_shared_path_symlink_ownership_cases() {
             }
 
             let rig = rig_with_shared_path(id, shared(&link, &target), SharedPathOp::Ensure);
-            let out = run_pipeline(&rig, "up", true).expect("pipeline runs");
+            let out = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+                .expect("pipeline runs");
 
             match case {
                 Case::OwnedCleanup => {
                     assert!(out.is_success(), "outcomes: {:?}", out.steps);
                     assert!(link.is_symlink());
-                    cleanup_shared_paths(&rig).expect("cleanup");
+                    cleanup_shared_paths(&crate::state::test_state_store(), &rig).expect("cleanup");
                     assert!(!link.exists(), "owned symlink removed");
-                    let state = RigState::load(&rig.id).expect("state");
+                    let state = crate::state::test_state_store()
+                        .load(&rig.id)
+                        .expect("state");
                     assert!(state.shared_paths.is_empty(), "ownership marker cleared");
                 }
                 Case::UnownedMatchingCleanup => {
                     assert!(out.is_success(), "existing matching symlink should pass");
-                    cleanup_shared_paths(&rig).expect("cleanup");
+                    cleanup_shared_paths(&crate::state::test_state_store(), &rig).expect("cleanup");
                     assert!(link.is_symlink(), "unowned symlink is left alone");
                 }
                 Case::WrongTargetRefused => {
@@ -181,7 +189,8 @@ fn test_shared_path_ensure_rejects_broken_matching_symlink() {
             shared(&link, &target),
             SharedPathOp::Ensure,
         );
-        let out = run_pipeline(&rig, "up", true).expect("pipeline runs");
+        let out = run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+            .expect("pipeline runs");
         assert!(!out.is_success(), "broken dependency symlink should fail");
         assert!(link.is_symlink(), "ensure must not remove broken symlink");
     });
@@ -202,7 +211,8 @@ fn test_shared_path_verify_accepts_local_directory_and_rejects_missing() {
             shared(&local, &target),
             SharedPathOp::Verify,
         );
-        let local_out = run_pipeline(&local_rig, "up", true).expect("local verify");
+        let local_out = run_pipeline(&crate::state::test_state_store(), &local_rig, "up", true)
+            .expect("local verify");
         assert!(local_out.is_success(), "local deps satisfy verify");
 
         let missing_rig = rig_with_shared_path(
@@ -210,7 +220,8 @@ fn test_shared_path_verify_accepts_local_directory_and_rejects_missing() {
             shared(&missing, &target),
             SharedPathOp::Verify,
         );
-        let missing_out = run_pipeline(&missing_rig, "up", true).expect("missing verify");
+        let missing_out = run_pipeline(&crate::state::test_state_store(), &missing_rig, "up", true)
+            .expect("missing verify");
         assert!(!missing_out.is_success(), "missing deps should fail verify");
     });
 }

--- a/tests/core/rig/runner_observation_test.rs
+++ b/tests/core/rig/runner_observation_test.rs
@@ -9,7 +9,7 @@ use crate::spec::{
     DependencyMaterializationSafety, DependencyMaterializationStepSpec, PipelineStep,
     RigRequirementsSpec, RigResourcesSpec, RigSpec,
 };
-use crate::{RigSourceMetadata, RigState};
+use crate::RigSourceMetadata;
 use homeboy_core::observation::{ObservationStore, RunListFilter};
 use homeboy_core::paths;
 use homeboy_core::resource_lifecycle_index::{
@@ -399,7 +399,8 @@ fn test_observation_store_failure_does_not_fail_rig_check() {
 
         assert!(report.success);
         assert_eq!(
-            RigState::load(&rig.id)
+            crate::state::test_state_store()
+                .load(&rig.id)
                 .expect("state still writes")
                 .last_check_result
                 .as_deref(),

--- a/tests/core/rig/runner_test.rs
+++ b/tests/core/rig/runner_test.rs
@@ -193,7 +193,9 @@ fn test_run_up() {
         assert_eq!(report.pipeline.passed, 0);
         assert_eq!(report.pipeline.failed, 0);
 
-        let state = RigState::load(&rig.id).expect("state loads");
+        let state = crate::state::test_state_store()
+            .load(&rig.id)
+            .expect("state loads");
         let materialized = state.materialized.expect("materialized ownership");
         assert_eq!(materialized.rig_id, "run-up-fixture");
         assert_eq!(materialized.resources.exclusive, vec!["run-up-exclusive"]);
@@ -230,7 +232,9 @@ fn test_failed_run_up_does_not_write_materialized_ownership() {
         let report = run_up(&rig).expect("run_up returns a failed report");
         assert!(!report.success, "failing step should fail up");
 
-        let state = RigState::load(&rig.id).expect("state loads");
+        let state = crate::state::test_state_store()
+            .load(&rig.id)
+            .expect("state loads");
         assert!(
             state.materialized.is_none(),
             "failed up must not persist materialized ownership"
@@ -430,7 +434,8 @@ fn test_run_down() {
         let rig = minimal_spec("run-down-fixture");
         run_up(&rig).expect("seed materialized ownership");
         assert!(
-            RigState::load(&rig.id)
+            crate::state::test_state_store()
+                .load(&rig.id)
                 .expect("state loads")
                 .materialized
                 .is_some(),
@@ -449,7 +454,8 @@ fn test_run_down() {
         );
         assert!(report.success, "empty teardown is trivially successful");
         assert!(
-            RigState::load(&rig.id)
+            crate::state::test_state_store()
+                .load(&rig.id)
                 .expect("state loads")
                 .materialized
                 .is_none(),
@@ -705,7 +711,9 @@ fn test_run_repair_creates_missing_shared_path() {
         assert_eq!(std::fs::read_link(&link).expect("read link"), target);
 
         // Ownership is recorded, so `down` / a later repair can clean it up.
-        let state = RigState::load("repair-missing-shared-path-fixture").expect("state");
+        let state = crate::state::test_state_store()
+            .load("repair-missing-shared-path-fixture")
+            .expect("state");
         assert!(state
             .shared_paths
             .contains_key(link.to_string_lossy().as_ref()));
@@ -788,7 +796,9 @@ fn test_run_repair_removes_rig_owned_dangling_shared_path() {
         assert_eq!(resource(&report, "shared_path").status, "repaired");
         assert!(!link.is_symlink(), "dangling rig-owned link is removed");
 
-        let state = RigState::load("repair-dangling-shared-path-fixture").expect("state");
+        let state = crate::state::test_state_store()
+            .load("repair-dangling-shared-path-fixture")
+            .expect("state");
         assert!(state.shared_paths.is_empty(), "ownership record is dropped");
     });
 }
@@ -886,7 +896,9 @@ fn test_run_repair_clears_stale_service_state() {
                 status: "running".to_string(),
             },
         );
-        state.save("repair-stale-service-fixture").expect("state");
+        crate::state::test_state_store()
+            .save("repair-stale-service-fixture", &state)
+            .expect("state");
 
         let report = run_repair(&rig).expect("repair succeeds");
 
@@ -897,7 +909,9 @@ fn test_run_repair_clears_stale_service_state() {
         assert_eq!(service.path, "web");
         assert_eq!(service.previous_target.as_deref(), Some("4294967295"));
 
-        let state = RigState::load("repair-stale-service-fixture").expect("state");
+        let state = crate::state::test_state_store()
+            .load("repair-stale-service-fixture")
+            .expect("state");
         assert!(
             !state.services.contains_key("web"),
             "stale service record is cleared"
@@ -923,7 +937,9 @@ fn test_run_repair_does_not_start_stopped_services() {
             .unwrap_or_default()
             .contains("does not start services"));
 
-        let state = RigState::load("repair-stopped-service-fixture").expect("state");
+        let state = crate::state::test_state_store()
+            .load("repair-stopped-service-fixture")
+            .expect("state");
         assert!(state.services.is_empty(), "repair started nothing");
     });
 }
@@ -1053,7 +1069,8 @@ fn test_run_down_cleans_state_owned_shared_paths() {
             toolchain: None,
         };
 
-        let up = crate::pipeline::run_pipeline(&rig, "up", true).expect("up pipeline");
+        let up = crate::pipeline::run_pipeline(&crate::state::test_state_store(), &rig, "up", true)
+            .expect("up pipeline");
         assert!(up.is_success());
         assert!(link.is_symlink());
 
@@ -1889,7 +1906,9 @@ fn lifecycle_snapshot_rig(id: &str, step_id: Option<&str>) -> RigSpec {
 }
 
 fn record_snapshot(rig_id: &str, snapshot_id: &str, step: &str) {
-    let mut state = RigState::load(rig_id).expect("state");
+    let mut state = crate::state::test_state_store()
+        .load(rig_id)
+        .expect("state");
     state.lifecycle_snapshots.insert(
         snapshot_id.to_string(),
         LifecycleSnapshotState {
@@ -1909,7 +1928,9 @@ fn record_snapshot(rig_id: &str, snapshot_id: &str, step: &str) {
             },
         },
     );
-    state.save(rig_id).expect("save state");
+    crate::state::test_state_store()
+        .save(rig_id, &state)
+        .expect("save state");
 }
 
 #[test]
@@ -1943,7 +1964,8 @@ fn test_run_repair_reports_owned_lifecycle_snapshot_as_skipped() {
 
         // Report-only: the record survives.
         assert_eq!(
-            RigState::load(&rig.id)
+            crate::state::test_state_store()
+                .load(&rig.id)
                 .expect("state")
                 .lifecycle_snapshots
                 .len(),
@@ -1975,7 +1997,8 @@ fn test_run_repair_blocks_on_orphaned_lifecycle_snapshot() {
             .contains("orphaned lifecycle snapshot"));
 
         assert_eq!(
-            RigState::load(&rig.id)
+            crate::state::test_state_store()
+                .load(&rig.id)
                 .expect("state")
                 .lifecycle_snapshots
                 .len(),

--- a/tests/core/rig/service_test.rs
+++ b/tests/core/rig/service_test.rs
@@ -125,7 +125,8 @@ mod lifecycle {
                 },
             );
 
-            let pid = service::start(&rig, "svc").expect("start http-static service");
+            let pid = service::start(&crate::state::test_state_store(), &rig, "svc")
+                .expect("start http-static service");
             assert!(
                 wait_until(Duration::from_secs(5), || std::net::TcpStream::connect((
                     "127.0.0.1",
@@ -135,13 +136,15 @@ mod lifecycle {
                 "http-static listener should accept connections"
             );
             assert_eq!(
-                service::status(&rig.id, "svc").expect("status"),
+                service::status(&crate::state::test_state_store(), &rig.id, "svc").expect("status"),
                 ServiceStatus::Running(pid)
             );
 
-            service::stop(&rig, "svc").expect("stop http-static service");
+            service::stop(&crate::state::test_state_store(), &rig, "svc")
+                .expect("stop http-static service");
             assert_eq!(
-                service::status(&rig.id, "svc").expect("status after stop"),
+                service::status(&crate::state::test_state_store(), &rig.id, "svc")
+                    .expect("status after stop"),
                 ServiceStatus::Stopped
             );
         });
@@ -166,15 +169,17 @@ mod lifecycle {
                 },
             );
 
-            let err = service::start(&rig, "svc").expect_err("external start rejected");
+            let err = service::start(&crate::state::test_state_store(), &rig, "svc")
+                .expect_err("external start rejected");
             assert!(
                 err.message.contains("adopted, not spawned"),
                 "unexpected error: {}",
                 err.message
             );
-            service::stop(&rig, "svc").expect("external stop with no match is idempotent");
+            service::stop(&crate::state::test_state_store(), &rig, "svc")
+                .expect("external stop with no match is idempotent");
             assert_eq!(
-                service::status(&rig.id, "svc").expect("status"),
+                service::status(&crate::state::test_state_store(), &rig.id, "svc").expect("status"),
                 ServiceStatus::Stopped
             );
         });
@@ -244,16 +249,19 @@ mod lifecycle {
     fn test_command_service_start_status_stop_lifecycle() {
         with_isolated_home(|_home| {
             let rig = command_rig("service-lifecycle", "sleep 30", None);
-            let pid = service::start(&rig, "cmd").expect("start command service");
+            let pid = service::start(&crate::state::test_state_store(), &rig, "cmd")
+                .expect("start command service");
 
             assert_eq!(
-                service::status(&rig.id, "cmd").expect("status"),
+                service::status(&crate::state::test_state_store(), &rig.id, "cmd").expect("status"),
                 ServiceStatus::Running(pid)
             );
 
-            service::stop(&rig, "cmd").expect("stop command service");
+            service::stop(&crate::state::test_state_store(), &rig, "cmd")
+                .expect("stop command service");
             assert_eq!(
-                service::status(&rig.id, "cmd").expect("status after stop"),
+                service::status(&crate::state::test_state_store(), &rig.id, "cmd")
+                    .expect("status after stop"),
                 ServiceStatus::Stopped
             );
         });
@@ -263,7 +271,8 @@ mod lifecycle {
     fn test_command_service_stop_kills_process_group_children() {
         with_isolated_home(|_home| {
             let rig = command_rig("service-process-group", "sleep 30 & wait", None);
-            let pid = service::start(&rig, "cmd").expect("start command service");
+            let pid = service::start(&crate::state::test_state_store(), &rig, "cmd")
+                .expect("start command service");
             assert!(
                 wait_until(Duration::from_secs(2), || unsafe {
                     libc::kill(-(pid as libc::pid_t), 0) == 0
@@ -271,7 +280,8 @@ mod lifecycle {
                 "process group should exist after start"
             );
 
-            service::stop(&rig, "cmd").expect("stop command service");
+            service::stop(&crate::state::test_state_store(), &rig, "cmd")
+                .expect("stop command service");
             assert!(
                 !wait_until(Duration::from_secs(2), || {
                     homeboy_core::process::process_group_is_running(pid as i32)
@@ -294,20 +304,25 @@ mod lifecycle {
                     status: "running".to_string(),
                 },
             );
-            state.save(&rig.id).expect("save stale state");
+            crate::state::test_state_store()
+                .save(&rig.id, &state)
+                .expect("save stale state");
 
             assert_eq!(
-                service::status(&rig.id, "cmd").expect("stale status"),
+                service::status(&crate::state::test_state_store(), &rig.id, "cmd")
+                    .expect("stale status"),
                 ServiceStatus::Stale(999_999)
             );
-            let pid = service::start(&rig, "cmd").expect("start replaces stale pid");
+            let pid = service::start(&crate::state::test_state_store(), &rig, "cmd")
+                .expect("start replaces stale pid");
             assert_ne!(pid, 999_999);
             assert_eq!(
-                service::status(&rig.id, "cmd").expect("fresh status"),
+                service::status(&crate::state::test_state_store(), &rig.id, "cmd")
+                    .expect("fresh status"),
                 ServiceStatus::Running(pid)
             );
 
-            service::stop(&rig, "cmd").expect("cleanup");
+            service::stop(&crate::state::test_state_store(), &rig, "cmd").expect("cleanup");
         });
     }
 
@@ -320,8 +335,10 @@ mod lifecycle {
                 "printf supervisor-log-marker; sleep 30",
                 Some(tmp.path().to_string_lossy().into_owned()),
             );
-            let pid = service::start(&rig, "cmd").expect("start command service");
-            let log_path = service::log_path(&rig.id, "cmd").expect("log path");
+            let pid = service::start(&crate::state::test_state_store(), &rig, "cmd")
+                .expect("start command service");
+            let log_path = service::log_path(&crate::state::test_state_store(), &rig.id, "cmd")
+                .expect("log path");
             assert!(
                 wait_until(Duration::from_secs(2), || std::fs::read_to_string(
                     &log_path
@@ -333,10 +350,10 @@ mod lifecycle {
             );
 
             assert_eq!(
-                service::status(&rig.id, "cmd").expect("status"),
+                service::status(&crate::state::test_state_store(), &rig.id, "cmd").expect("status"),
                 ServiceStatus::Running(pid)
             );
-            service::stop(&rig, "cmd").expect("cleanup");
+            service::stop(&crate::state::test_state_store(), &rig, "cmd").expect("cleanup");
         });
     }
 }


### PR DESCRIPTION
The `RigState` store slice I deferred out of #13019, done as a rooted store rather than a parameter on seventeen free functions.

## The defect

`RigState::load(rig_id)` and `state.save(rig_id)` each resolved the config root **on every call**. Seventeen call sites, every one a read-modify-write against the same file, and the resolution invisible at the call site — a rig run could read state from one home and persist it into another with nothing in the code to show it.

The contract names this exact shape:

> A store with associated (`Self::`) methods that each resolve a root is the worst version of this defect, because the per-call resolution is invisible at the call site. ... Give the store the root at construction.

## The fix

```rust
pub struct RigStateStore { config_root: PathBuf }

impl RigStateStore {
    pub fn in_root(config_root: impl Into<PathBuf>) -> Self
    pub fn in_roots(roots: &paths::PathRoots) -> Self
    pub fn load(&self, rig_id: &str) -> Result<RigState>
    pub fn save(&self, rig_id: &str, state: &RigState) -> Result<()>
    pub fn state_dir(&self, rig_id: &str) -> PathBuf
    pub fn logs_dir(&self, rig_id: &str) -> PathBuf
    pub fn log_file(&self, rig_id: &str, service_id: &str) -> PathBuf
}
```

**Service logs fold in.** They live beneath the same per-rig state directory, so `service::log_path` and the platform `log_file_path` / `log_file_for` helpers now come off the store instead of resolving separately. That pair was two independent answers to the same question.

**`RigRunObserver` holds it.** The observer already spans a whole rig run and already receives `&PathRoots`, so per the contract it is *the struct that models the lifetime of the work*. Its observation records and the run's rig state now provably land in one home.

## Why `&RigStateStore` and not `&Path`

A function that takes a state store states what it does. A function that takes a bare config root is carrying a path it has no other reason to know about — the plumbing the contract warns against. This mattered for the pipeline chain (`run_pipeline` → `run_ordered_steps` → `run_step` → the service / shared-path / lifecycle steps), which has no carrier of its own. Threading a `&Path` through it would have been six functions gaining a path parameter for no stated reason; threading the store says "these steps persist rig state," which is true.

That chain was only eligible because its entry points now hold the store — the readiness test, not the call count.

## Reporting

| | before | after |
|---|---:|---:|
| `homeboy-rig` ambient | 8 | **3** |
| repo-wide ambient | 100 | **95** |
| boundary resolutions added | — | 6 |
| test helpers added | — | 1 |

Six boundaries, each one unit of work: rig up, down, repair, status, grouped check, bench prepare, fuzz prepare, and recording an effective component path.

The single test helper is `crate::state::test_state_store()`, deliberately placed in `state.rs` rather than duplicated per test file so nested test modules can reach it by path.

## What's left

The three remaining ambient sites are `lib.rs::read_config` / `list` / `list_ids`, which sit under `rig::load` — 33 call sites across three crates. Separate slice.

`rust_nextest_shard_threads` stays `1`. The controller-runtime admission store is untouched and is the other half of that guard's condition.

## Verification

`cargo check --workspace --tests -j2` — green, no warnings.

Three collisions caught by pre-write assertions rather than shipping: `pub fn start(rig: &RigSpec, ...)` matched **3** times because `service.rs` carries `#[cfg(unix)]` and `#[cfg(not(unix))]` platform modules (switched to line-targeted edits); `state.save(&rig.id)?;` matched 3 where 2 were expected; and an auto-inserted import landed inside a multi-line `use homeboy_core::server::{`.

Refs #7505.
