### PR TITLE
Recover detached Cook daemon preflight

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1163,14 +1163,18 @@ pub fn record_detached_cook_handoff_child_in_store(
 ) -> Result<AgentTaskRunRecord> {
     let cook_id = sanitize_run_id(cook_id);
     let record = lifecycle_store.mutate_record(&cook_id, |record| {
-        let cancelled = record.state == AgentTaskRunState::Cancelled;
-        let state = if cancelled { "cancelled" } else { "pending" };
+        // A concurrent observer may have already terminalized the handoff
+        // before this attachment write acquired the record lock. Keep that
+        // classification intact for the launcher to report.
+        if record.state.is_terminal() {
+            return false;
+        }
         let cancellation_fence =
             record.metadata["detached_cook_handoff"]["cancellation_fence"].clone();
         let metadata = record.ensure_metadata_object();
         metadata["detached_cook_handoff"] = json!({
-            "state": state,
-        "admission_state": if cancelled { "cancelled" } else { "child_attached" },
+            "state": "pending",
+        "admission_state": "child_attached",
         "child_supervisor_deadline_at": (chrono::Utc::now()
             + chrono::Duration::seconds(DETACHED_COOK_ADMISSION_LEASE_SECONDS))
             .to_rfc3339(),
@@ -1182,7 +1186,7 @@ pub fn record_detached_cook_handoff_child_in_store(
         record.updated_at = Some(now_timestamp());
         true
     })?;
-    Ok(record.expect("detached handoff parent exists"))
+    Ok(record.unwrap_or(lifecycle_store.read_record(&cook_id)?))
 }
 
 /// Persist the daemon job that supervises this locally launched Cook.

--- a/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
@@ -1768,6 +1768,45 @@ mod tests {
     }
 
     #[test]
+    fn attaching_a_child_preserves_an_exited_before_handoff_terminal_parent() {
+        crate::test_support::with_isolated_home(|_| {
+            let cook_id = "cook-exited-before-child-attachment";
+            agent_task_lifecycle::record_detached_cook_handoff_parent(cook_id)
+                .expect("persist handoff parent");
+            agent_task_lifecycle::fail_detached_cook_handoff_parent(
+                cook_id,
+                "detached Cook exited before materializing its first attempt",
+            )
+            .expect("terminalize handoff before delayed child attachment");
+
+            let mut child = Command::new("sh")
+                .args(["-c", "sleep 30"])
+                .spawn()
+                .expect("spawn child for delayed attachment");
+            let parent = agent_task_lifecycle::record_detached_cook_handoff_child(
+                cook_id,
+                child.id(),
+                detached_child_start_identity(child.id()).expect("capture child identity"),
+            )
+            .expect("read terminal handoff parent");
+            terminate_and_reap_detached_child(&mut child);
+
+            assert_eq!(
+                parent.state,
+                agent_task_lifecycle::AgentTaskRunState::Failed
+            );
+            assert_eq!(
+                parent.metadata["detached_cook_handoff"]["state"],
+                "exited_before_handoff"
+            );
+            assert_eq!(
+                parent.metadata["detached_cook_handoff"]["admission_state"],
+                "failed"
+            );
+        });
+    }
+
+    #[test]
     fn an_explicit_cook_id_cannot_overwrite_a_non_handoff_run() {
         crate::test_support::with_isolated_home(|_| {
             let cook_id = "existing-non-handoff-run";

--- a/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
@@ -335,6 +335,14 @@ pub(super) fn intercept_local_detached_cook(
     // materialize an attempt after cancellation.
     if handoff_parent.state.is_terminal() {
         terminate_and_reap_detached_child(&mut child);
+        if handoff_parent.metadata["detached_cook_handoff"]["state"] == "exited_before_handoff" {
+            return Err(Error::validation_invalid_argument(
+                "detach-after-handoff",
+                "detached Cook exited before materializing its first attempt",
+                Some(cook_id),
+                None,
+            ));
+        }
         return Err(Error::validation_invalid_argument(
             "detach-after-handoff",
             "detached Cook became terminal before durable controller ownership could be established",

--- a/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
@@ -235,6 +235,14 @@ pub(super) fn intercept_local_detached_cook(
     materialize_stdin_prompt(&mut child_args, &session_root)?;
     let log_path = session_root.join("cook.log");
 
+    // A daemon build mismatch cannot be resumed from the handoff parent: it has
+    // no materialized Cook recipe yet. Reject it before the first durable write
+    // so the supplied repair command can be followed by the same invocation.
+    let preflight_controller_client = cli
+        .detach_after_handoff
+        .then(homeboy::core::daemon::LocalControllerJobClient::connect_current_build)
+        .transpose()?;
+
     // One store for the whole handoff. The parent record, the child record, the
     // supervisor projection, and every compensating failure below are one
     // transaction: a parent opened in one installation and failed in another
@@ -258,15 +266,13 @@ pub(super) fn intercept_local_detached_cook(
     // A daemon-owned job is the authority that outlives this launcher. Prove it
     // is reachable before a provider-capable child exists, so unsupported
     // detachment is rejected before dispatch.
-    let controller_client =
-        match homeboy::core::daemon::LocalControllerJobClient::connect_current_build() {
+    let controller_client = match preflight_controller_client {
+        Some(client) => client,
+        None => match homeboy::core::daemon::LocalControllerJobClient::connect_current_build() {
             Ok(client) => client,
-            Err(error)
-                if controller_job_daemon_build_mismatch(&error) && !cli.detach_after_handoff =>
-            {
-                // An attached caller can retain foreground ownership. This keeps a
-                // newer client useful without letting an older resident daemon
-                // interpret and terminate lifecycle records it does not understand.
+            Err(error) if controller_job_daemon_build_mismatch(&error) => {
+                // Attached callers retain foreground ownership when the resident
+                // daemon is an older build; #12581 owns that wait-policy path.
                 return Ok(None);
             }
             Err(error) => {
@@ -277,7 +283,8 @@ pub(super) fn intercept_local_detached_cook(
                 );
                 return Err(error);
             }
-        };
+        },
+    };
     let route = detached_route(cli);
     let launch_token = create_local_cook_launch_token(&session_root)?;
     let mut child = match spawn_detached_cook(&child_args, &log_path, route.as_ref(), &launch_token)

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -187,6 +187,9 @@ impl LocalControllerJobClient {
                 .state
                 .as_ref()
                 .map(|state| state.build_identity.display.clone());
+            let recovery_command = (status.freshness.restartable
+                && status.freshness.active_jobs == 0)
+                .then_some("homeboy daemon recover --yes");
             let mut error = Error::validation_invalid_argument(
                 "daemon_build_identity",
                 "controller jobs require the resident daemon to match the invoking Homeboy build",
@@ -198,6 +201,9 @@ impl LocalControllerJobClient {
                         .to_string(),
                 ]),
             );
+            if let Some(recovery_command) = recovery_command {
+                error = error.with_hint(format!("Next: {recovery_command}"));
+            }
             error.details = json!({
                 "classification": "controller_job_daemon_build_mismatch",
                 "daemon_build_identity": daemon_identity,
@@ -205,6 +211,7 @@ impl LocalControllerJobClient {
                 "stale_reason": status.stale_reason,
                 "stale_reason_code": status.freshness.stale_reason_code,
                 "active_jobs": status.freshness.active_jobs,
+                "recovery_command": recovery_command,
             });
             return Err(error);
         }

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -277,6 +277,80 @@ fn cook_rejects_local_detachment_when_the_child_exits_before_attempt_materializa
     );
 }
 
+/// A detached Cook cannot resume a handoff parent without a materialized recipe.
+/// A mismatched daemon is therefore rejected, with its lease-bound repair, before
+/// the launcher announces or persists that parent (#12982).
+#[test]
+fn cook_rejects_daemon_build_mismatch_before_durable_handoff_announcement() {
+    let context = HermeticTestContext::new();
+    let state_path = context.daemon_dir().join("state.json");
+    // The test process is a live local PID from the Cook subprocess's point of
+    // view. A stale lease reaches the build-mismatch preflight without a daemon
+    // process or network timing in the fixture.
+    let state = serde_json::json!({
+        "schema": "homeboy.daemon.session_lease.v1",
+        "lease_id": "stale-fixture-lease",
+        "startup_token": "stale-fixture-token",
+        "address": "127.0.0.1:49152",
+        "pid": std::process::id(),
+        "state_path": state_path.display().to_string(),
+        "started_at": "2026-01-01T00:00:00Z",
+        "last_seen_at": "2026-01-01T00:00:00Z",
+        "build_identity": {
+            "version": "0.0.0-stale",
+            "display": "homeboy 0.0.0-stale+fixture"
+        },
+        "binary_sha256": null,
+        "runtime_paths": { "loaded_at": "2026-01-01T00:00:00Z", "paths": [] }
+    });
+    std::fs::write(
+        &state_path,
+        serde_json::to_vec(&state).expect("serialize mismatched daemon state"),
+    )
+    .expect("write mismatched daemon state");
+
+    let cook_id = "local-detach-daemon-build-mismatch";
+    let mut command = context.controller_runtime_command(TestBinary::HomeboyFixture);
+    command.args([
+        "--placement",
+        "local",
+        "--detach-after-handoff",
+        "agent-task",
+        "cook",
+        "--run-id",
+        cook_id,
+        "--backend",
+        "fixture",
+        "--prompt",
+        "reject stale daemon before handoff",
+        "--to-worktree",
+        "missing@worktree",
+        "--verify",
+        "true",
+    ]);
+    let output = bounded_output(command);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "{stdout}\n{stderr}");
+    assert!(
+        stdout.contains("Next: homeboy daemon recover --yes"),
+        "{stdout}"
+    );
+    assert!(
+        !stderr.contains(&format!("durable run id `{cook_id}`")),
+        "a failed preflight must not announce a durable handoff: {stderr}"
+    );
+
+    let mut status = context.controller_runtime_command(TestBinary::HomeboyFixture);
+    status.args(["agent-task", "status", cook_id, "--full"]);
+    let status = bounded_output(status);
+    assert!(
+        !status.status.success(),
+        "mismatch preflight must not persist a handoff: {}",
+        String::from_utf8_lossy(&status.stdout)
+    );
+}
+
 /// A successful local detach exposes accepted only after the child has written
 /// an attempt that status can resolve, rather than merely its zero-task parent.
 #[test]

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -224,13 +224,13 @@ fn cook_rejects_local_detachment_when_the_child_exits_before_attempt_materializa
         if stderr.contains("durable run id `local-detach-exits-before-attempt`") {
             assert!(
                 child.try_wait().expect("poll detached Cook launcher").is_none(),
-                "the launcher must still be crossing daemon/child admission after it emits the durable parent identity"
+                "the launcher must still be crossing child admission after it emits the durable parent identity"
             );
             break;
         }
         assert!(
             Instant::now() < deadline,
-            "the parent identity was not emitted before detached admission completed: {stderr}"
+            "the parent identity was not emitted after daemon compatibility admission completed: {stderr}"
         );
         std::thread::sleep(Duration::from_millis(10));
     }

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -1260,6 +1260,14 @@ fn controller_job_client_rejects_a_live_daemon_from_another_build() {
         "homeboy 0.0.0-stale+fixture"
     );
     assert_eq!(error.details["active_jobs"], 0);
+    assert_eq!(
+        error.details["recovery_command"],
+        "homeboy daemon recover --yes"
+    );
+    assert!(error
+        .hints
+        .iter()
+        .any(|hint| hint.message == "Next: homeboy daemon recover --yes"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- reject idle daemon build mismatch before announcing a durable Cook ID
- return an exact non-destructive daemon recovery command
- preserve terminal `exited_before_handoff` classification when delayed child attachment races terminalization
- cover stale-daemon preflight and terminal-parent attachment ordering

## Verification

- `cargo test -p homeboy --test cook_lab_handoff_test cook_rejects_daemon_build_mismatch_before_durable_handoff_announcement` passed
- `cargo test -p homeboy-core controller_job_client_rejects_a_live_daemon_from_another_build` passed
- `cargo fmt --all -- --check` passed after the final race fix and rebase
- full CI pending

This is a draft because the child-exit integration test exposed the attachment race before the final correction; CI must verify the corrected ordering on the current base.

Closes #12982.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode general coding subagents implemented and diagnosed the lifecycle changes; OpenCode inspected the cancelled agent's partial fix, committed it, rebased the branch, and prepared this PR under Chris Huber's direction. Chris remains responsible for every line.
