### PR TITLE
refactor(rig): root the rig spec loader — production reaches zero (#7505)

### DIFF
--- a/crates/homeboy-cli/src/commands/bench.rs
+++ b/crates/homeboy-cli/src/commands/bench.rs
@@ -32,6 +32,20 @@ mod matrix;
 mod observation;
 mod settings_matrix;
 
+/// Config root for rig-registry reads on the bench command surface.
+///
+/// The bench surface has no `PathRoots` carrier: `BenchRunArgs` threads through
+/// a dozen helpers that each need a rig spec, and none of them has another
+/// reason to know about paths. Adding a root parameter to all of them to remove
+/// these reads is the plumbing the PathRoots injection contract warns against.
+///
+/// The resolution stays, but it is named and greppable here instead of hidden
+/// inside `rig::load`, which every other caller now reaches with an explicit
+/// root. Delete this when the bench surface gains a carrier (#7505).
+pub(super) fn bench_config_root() -> homeboy::core::Result<PathBuf> {
+    homeboy::core::paths::homeboy()
+}
+
 use default_baseline::{
     add_default_baseline_failure_hint, apply_default_baseline_failure_context,
     default_baseline_notice, maybe_expand_default_baseline,
@@ -790,7 +804,7 @@ fn run_cross_rig_bench(
 }
 
 fn rig_axes(rig_id: &str) -> homeboy::core::Result<Option<BTreeMap<String, String>>> {
-    let spec = rig::RigSourceContext::load_for_invocation(rig_id)?.spec;
+    let spec = rig::RigSourceContext::load_for_invocation(&bench_config_root()?, rig_id)?.spec;
     let Some(bench) = spec.bench else {
         return Ok(None);
     };
@@ -972,7 +986,7 @@ fn bench_list_empty_hints(
 }
 
 fn compatible_bench_rig_hints(component_id: &str) -> Vec<String> {
-    let Ok(rigs) = rig::list() else {
+    let Ok(Ok(rigs)) = bench_config_root().map(|root| rig::list(&root)) else {
         return Vec::new();
     };
 
@@ -1090,7 +1104,10 @@ type ListRigContext = rig::RigSourceContext;
 fn load_list_rig(args: &BenchListArgs) -> homeboy::core::Result<Option<ListRigContext>> {
     match args.rig.as_slice() {
         [] => Ok(None),
-        [rig_id] => Ok(Some(rig::RigSourceContext::load_for_invocation(rig_id)?)),
+        [rig_id] => Ok(Some(rig::RigSourceContext::load_for_invocation(
+            &bench_config_root()?,
+            rig_id,
+        )?)),
         _ => Err(homeboy::core::Error::validation_invalid_argument(
             "--rig",
             "bench list accepts exactly one rig id",

--- a/crates/homeboy-cli/src/commands/bench/default_baseline.rs
+++ b/crates/homeboy-cli/src/commands/bench/default_baseline.rs
@@ -116,8 +116,12 @@ pub(super) fn maybe_expand_default_baseline(
     }
 
     let candidate = &args.rig[0];
-    let candidate_spec =
-        rig::RigSourceContext::load_for_invocation_at(candidate, args.comp.path.as_deref())?.spec;
+    let candidate_spec = rig::RigSourceContext::load_for_invocation_at(
+        &super::bench_config_root()?,
+        candidate,
+        args.comp.path.as_deref(),
+    )?
+    .spec;
     if args.comp.id().is_none()
         && candidate_spec
             .bench

--- a/crates/homeboy-cli/src/commands/bench/fanout.rs
+++ b/crates/homeboy-cli/src/commands/bench/fanout.rs
@@ -144,7 +144,7 @@ pub(super) fn run_matrix_fanout(
 fn declared_result_gates(run_args: &BenchRunArgs) -> homeboy::core::Result<Vec<BenchGate>> {
     let mut gates = Vec::new();
     for rig_id in &run_args.rig {
-        let spec = homeboy::rig::load(rig_id)?;
+        let spec = homeboy::rig::load(&super::bench_config_root()?, rig_id)?;
         gates.extend(result_gates_for_rig(&spec));
     }
     Ok(gates)
@@ -261,7 +261,7 @@ fn effective_matrix_component(run_args: &BenchRunArgs) -> homeboy::core::Result<
     }
 
     if run_args.rig.len() == 1 {
-        let spec = homeboy::rig::load(&run_args.rig[0])?;
+        let spec = homeboy::rig::load(&super::bench_config_root()?, &run_args.rig[0])?;
         if let Some(component) = spec
             .bench
             .as_ref()

--- a/crates/homeboy-cli/src/commands/bench/matrix.rs
+++ b/crates/homeboy-cli/src/commands/bench/matrix.rs
@@ -40,8 +40,14 @@ fn prepare_rig_bench_context(
     rig_id: &str,
     args: &BenchRunArgs,
 ) -> homeboy::core::Result<RigBenchContext> {
-    let mut source =
-        rig::RigSourceContext::load_for_invocation_at(rig_id, args.comp.path.as_deref())?;
+    // Boundary: one rig bench run is one unit of work; the roots resolved here
+    // also bind the lease below (#7505).
+    let roots = homeboy::core::paths::PathRoots::from_environment()?;
+    let mut source = rig::RigSourceContext::load_for_invocation_at(
+        roots.config(),
+        rig_id,
+        args.comp.path.as_deref(),
+    )?;
     report_rig_source(&source);
     let mut spec = source.spec.clone();
     let declared_spec = spec.clone();
@@ -49,9 +55,6 @@ fn prepare_rig_bench_context(
     source.spec = spec.clone();
     rig::preflight_effective_component_checkouts(&spec)?;
     let prepare_settings = bench_prepare_settings(args);
-    // Boundary: one rig bench run is one unit of work, and the lease must release
-    // into the same home it acquired from (#7505).
-    let roots = homeboy::core::paths::PathRoots::from_environment()?;
     let lease = rig::lease::acquire_active_run_lease_with_settings(
         roots.config(),
         &spec,
@@ -163,8 +166,12 @@ pub(super) fn validate_profile_available_for_rigs(
     let mut available_by_rig = Vec::new();
 
     for rig_id in &args.rig {
-        let spec =
-            rig::RigSourceContext::load_for_invocation_at(rig_id, args.comp.path.as_deref())?.spec;
+        let spec = rig::RigSourceContext::load_for_invocation_at(
+            &super::bench_config_root()?,
+            rig_id,
+            args.comp.path.as_deref(),
+        )?
+        .spec;
         if !spec.bench_profiles.contains_key(profile) {
             missing.push(rig_id.clone());
         }

--- a/crates/homeboy-cli/src/commands/fuzz/workloads.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/workloads.rs
@@ -25,7 +25,9 @@ pub(super) fn load_rig(
     let Some(rig_id) = rig_id else {
         return Ok(None);
     };
-    let mut context = rig::RigSourceContext::load(rig_id)?;
+    // The fuzz surface has no roots carrier either; same reasoning as
+    // `bench_config_root` (#7505).
+    let mut context = rig::RigSourceContext::load(&homeboy::core::paths::homeboy()?, rig_id)?;
     apply_fuzz_rig_setting_overrides(&mut context.spec, settings)?;
     Ok(Some(context))
 }

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -148,7 +148,9 @@ pub(crate) fn route_after_parse_with_provenance(
 
     if let (Some(runner_id), Commands::Rig(args)) = (cli.runner.as_deref(), &cli.command) {
         if let Some(rig_id) = args.up_dry_run_rig_id() {
-            let (output, exit_code) = crate::commands::rig::up_runner_exec_plan(rig_id, runner_id)?;
+            let roots = homeboy::core::paths::PathRoots::from_environment()?;
+            let (output, exit_code) =
+                crate::commands::rig::up_runner_exec_plan(roots.config(), rig_id, runner_id)?;
             let stdout = serde_json::to_string_pretty(&output).map_err(|err| {
                 Error::internal_io(
                     err.to_string(),

--- a/crates/homeboy-cli/src/commands/rig/mod.rs
+++ b/crates/homeboy-cli/src/commands/rig/mod.rs
@@ -370,30 +370,37 @@ struct RigRunArgs {
 }
 
 pub fn run(args: RigArgs) -> CmdResult<RigCommandOutput> {
+    // Boundary: one `homeboy rig` invocation is one unit of work, so the config
+    // root is resolved exactly once here and handed to the handlers that read
+    // the rig registry. Nothing under this point resolves again (#7505).
+    let roots = homeboy::core::paths::PathRoots::from_environment()?;
+    let config_root = roots.config();
     match args.command {
-        RigCommand::List => list(),
-        RigCommand::Show { rig_id } => show(&rig_id),
+        RigCommand::List => list(config_root),
+        RigCommand::Show { rig_id } => show(config_root, &rig_id),
         RigCommand::Materialize {
             rig_path,
             source_root,
         } => materialize(&rig_path, source_root.as_deref()),
-        RigCommand::Up { rig_id, dry_run } => up(&rig_id, dry_run),
-        RigCommand::Check { target, id, path } => check(&target, id.as_deref(), path.as_deref()),
+        RigCommand::Up { rig_id, dry_run } => up(config_root, &rig_id, dry_run),
+        RigCommand::Check { target, id, path } => {
+            check(config_root, &target, id.as_deref(), path.as_deref())
+        }
         RigCommand::Lint {
             target,
             id,
             all,
             format,
-        } => lint(&target, id.as_deref(), all, format),
+        } => lint(config_root, &target, id.as_deref(), all, format),
         RigCommand::Package { command } => package(command),
         RigCommand::Down {
             rig_id,
             setting_args,
-        } => down(&rig_id, &setting_args),
-        RigCommand::Repair { rig_id } => repair(&rig_id),
-        RigCommand::Sync { rig_id, dry_run } => sync(&rig_id, dry_run),
-        RigCommand::Run(args) => run_profile(args),
-        RigCommand::Status { rig_id } => status(&rig_id),
+        } => down(config_root, &rig_id, &setting_args),
+        RigCommand::Repair { rig_id } => repair(config_root, &rig_id),
+        RigCommand::Sync { rig_id, dry_run } => sync(config_root, &rig_id, dry_run),
+        RigCommand::Run(args) => run_profile(config_root, args),
+        RigCommand::Status { rig_id } => status(config_root, &rig_id),
         RigCommand::ReleaseLock { rig_id, force } => release_lock(&rig_id, force),
         RigCommand::Install {
             source,
@@ -403,7 +410,7 @@ pub fn run(args: RigArgs) -> CmdResult<RigCommandOutput> {
         } => install(&source, id.as_deref(), all, reinstall),
         RigCommand::Update { rig_id, all } => update(rig_id.as_deref(), all),
         RigCommand::Sources { command } => sources::run(command),
-        RigCommand::App { command } => app(command),
+        RigCommand::App { command } => app(config_root, command),
         RigCommand::Artifact { command } => artifact(command),
     }
 }
@@ -497,14 +504,14 @@ fn release_lock(rig_id: &str, force: bool) -> CmdResult<RigCommandOutput> {
     ))
 }
 
-fn list() -> CmdResult<RigCommandOutput> {
-    let rigs = rig::list()?;
+fn list(config_root: &Path) -> CmdResult<RigCommandOutput> {
+    let rigs = rig::list(config_root)?;
     let summaries = rigs
         .into_iter()
         .map(|r| {
             let mut pipelines: Vec<String> = r.pipeline.keys().cloned().collect();
             pipelines.sort();
-            let declared_id = rig::declared_id(&r.id)?;
+            let declared_id = rig::declared_id(config_root, &r.id)?;
             Ok(RigSummary {
                 source: rig::read_source_metadata(&r.id).map(|source| RigSourceSummary {
                     source: source.source,
@@ -612,8 +619,8 @@ fn update(rig_id: Option<&str>, all: bool) -> CmdResult<RigCommandOutput> {
     ))
 }
 
-fn show(rig_id: &str) -> CmdResult<RigCommandOutput> {
-    let rig = rig::load(rig_id)?;
+fn show(config_root: &Path, rig_id: &str) -> CmdResult<RigCommandOutput> {
+    let rig = rig::load(config_root, rig_id)?;
     let resources = rig::expand::expand_resources(&rig);
     Ok((
         RigCommandOutput::Show(Box::new(RigShowOutput {
@@ -625,8 +632,8 @@ fn show(rig_id: &str) -> CmdResult<RigCommandOutput> {
     ))
 }
 
-fn up(rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
-    let rig = rig::load(rig_id)?;
+fn up(config_root: &Path, rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
+    let rig = rig::load(config_root, rig_id)?;
     if dry_run {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "dry_run",
@@ -646,8 +653,12 @@ fn up(rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
     ))
 }
 
-pub(crate) fn up_runner_exec_plan(rig_id: &str, runner_id: &str) -> CmdResult<RigCommandOutput> {
-    let rig = rig::load(rig_id)?;
+pub(crate) fn up_runner_exec_plan(
+    config_root: &Path,
+    rig_id: &str,
+    runner_id: &str,
+) -> CmdResult<RigCommandOutput> {
+    let rig = rig::load(config_root, rig_id)?;
     let homeboy_binary = runners::runner_homeboy_path_for_command(
         runner_id,
         "rig up --dry-run --runner command plan",
@@ -758,6 +769,7 @@ fn shell_join(args: &[String]) -> String {
 }
 
 fn check(
+    config_root: &Path,
     target: &str,
     id: Option<&str>,
     path_override: Option<&str>,
@@ -773,7 +785,7 @@ fn check(
                 None,
             ));
         }
-        rig::load(target)?
+        rig::load(config_root, target)?
     };
     if let Some(path) = path_override {
         apply_check_path_override(&mut rig, path)?;
@@ -799,6 +811,7 @@ fn check(
 }
 
 fn lint(
+    config_root: &Path,
     target: &str,
     id: Option<&str>,
     all: bool,
@@ -850,7 +863,7 @@ fn lint(
                 None,
             ));
         }
-        rig::load(target)?
+        rig::load(config_root, target)?
     };
     let report = rig::run_lint(&rig)?;
     let exit_code = if report.success { 0 } else { 1 };
@@ -913,8 +926,12 @@ fn apply_check_path_override(rig: &mut rig::RigSpec, path: &str) -> homeboy::cor
     Ok(())
 }
 
-fn down(rig_id: &str, setting_args: &SettingArgs) -> CmdResult<RigCommandOutput> {
-    let rig = rig::load(rig_id)?;
+fn down(
+    config_root: &Path,
+    rig_id: &str,
+    setting_args: &SettingArgs,
+) -> CmdResult<RigCommandOutput> {
+    let rig = rig::load(config_root, rig_id)?;
     let settings = materialized_setting_env_args(setting_args)?;
     let report = rig::run_down_with_settings(&rig, &settings)?;
     let exit_code = if report.success { 0 } else { 1 };
@@ -947,8 +964,8 @@ fn materialized_setting_env_args(
     Ok(settings)
 }
 
-fn repair(rig_id: &str) -> CmdResult<RigCommandOutput> {
-    let rig = rig::load(rig_id)?;
+fn repair(config_root: &Path, rig_id: &str) -> CmdResult<RigCommandOutput> {
+    let rig = rig::load(config_root, rig_id)?;
     let report = rig::run_repair(&rig)?;
     let exit_code = if report.success { 0 } else { 1 };
     Ok((
@@ -960,8 +977,8 @@ fn repair(rig_id: &str) -> CmdResult<RigCommandOutput> {
     ))
 }
 
-fn sync(rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
-    let rig = rig::load(rig_id)?;
+fn sync(config_root: &Path, rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
+    let rig = rig::load(config_root, rig_id)?;
     let report = rig::run_sync(&rig, dry_run)?;
     let exit_code = if report.success { 0 } else { 1 };
     Ok((
@@ -973,11 +990,11 @@ fn sync(rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
     ))
 }
 
-fn run_profile(args: RigRunArgs) -> CmdResult<RigCommandOutput> {
+fn run_profile(config_root: &Path, args: RigRunArgs) -> CmdResult<RigCommandOutput> {
     // Boundary: one rig run is one unit of work (#7505).
     let roots = homeboy::core::paths::PathRoots::from_environment()?;
     let source_update = refresh_rig_source_if_materialized(roots.config(), &args.rig_id)?;
-    let rig = rig::load(&args.rig_id)?;
+    let rig = rig::load(config_root, &args.rig_id)?;
     let sync_report = rig::run_sync(&rig, false)?;
     let bench_options = rig_run_bench_options(args);
     let profile = bench_options.profile.clone();
@@ -1044,8 +1061,8 @@ fn rig_run_bench_options(args: RigRunArgs) -> RigRunBenchOptions {
     }
 }
 
-fn status(rig_id: &str) -> CmdResult<RigCommandOutput> {
-    let rig = rig::load(rig_id)?;
+fn status(config_root: &Path, rig_id: &str) -> CmdResult<RigCommandOutput> {
+    let rig = rig::load(config_root, rig_id)?;
     let report = rig::run_status(&rig)?;
     Ok((
         RigCommandOutput::Status(RigStatusOutput {
@@ -1056,16 +1073,18 @@ fn status(rig_id: &str) -> CmdResult<RigCommandOutput> {
     ))
 }
 
-fn app(command: RigAppCommand) -> CmdResult<RigCommandOutput> {
+fn app(config_root: &Path, command: RigAppCommand) -> CmdResult<RigCommandOutput> {
     match command {
-        RigAppCommand::Install { rig_id, dry_run } => app_install(&rig_id, dry_run),
-        RigAppCommand::Update { rig_id, dry_run } => app_update(&rig_id, dry_run),
-        RigAppCommand::Uninstall { rig_id, dry_run } => app_uninstall(&rig_id, dry_run),
+        RigAppCommand::Install { rig_id, dry_run } => app_install(config_root, &rig_id, dry_run),
+        RigAppCommand::Update { rig_id, dry_run } => app_update(config_root, &rig_id, dry_run),
+        RigAppCommand::Uninstall { rig_id, dry_run } => {
+            app_uninstall(config_root, &rig_id, dry_run)
+        }
     }
 }
 
-fn app_install(rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
-    let rig = rig::load(rig_id)?;
+fn app_install(config_root: &Path, rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
+    let rig = rig::load(config_root, rig_id)?;
     let report = rig::app::install(&rig, rig::AppLauncherOptions { dry_run })?;
     Ok((
         RigCommandOutput::App(RigAppOutput {
@@ -1076,8 +1095,8 @@ fn app_install(rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
     ))
 }
 
-fn app_update(rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
-    let rig = rig::load(rig_id)?;
+fn app_update(config_root: &Path, rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
+    let rig = rig::load(config_root, rig_id)?;
     let report = rig::app::update(&rig, rig::AppLauncherOptions { dry_run })?;
     Ok((
         RigCommandOutput::App(RigAppOutput {
@@ -1088,8 +1107,8 @@ fn app_update(rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
     ))
 }
 
-fn app_uninstall(rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
-    let rig = rig::load(rig_id)?;
+fn app_uninstall(config_root: &Path, rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
+    let rig = rig::load(config_root, rig_id)?;
     let report = rig::app::uninstall(&rig, rig::AppLauncherOptions { dry_run })?;
     Ok((
         RigCommandOutput::App(RigAppOutput {
@@ -1102,6 +1121,14 @@ fn app_uninstall(rig_id: &str, dry_run: bool) -> CmdResult<RigCommandOutput> {
 
 #[cfg(test)]
 mod tests {
+    /// The isolated home each test below installs, named as a config root.
+    ///
+    /// A test is the entry point for its own unit of work, so resolving once
+    /// here is a boundary resolution (#7505).
+    fn test_config_root() -> std::path::PathBuf {
+        homeboy::core::paths::homeboy().expect("config root")
+    }
+
     use super::*;
     use clap::Parser;
     use std::fs;
@@ -1332,6 +1359,7 @@ mod tests {
             );
 
             let (_output, exit_code) = check(
+                &test_config_root(),
                 "studio-bfb",
                 None,
                 Some(&override_component.path().to_string_lossy()),
@@ -1359,6 +1387,7 @@ mod tests {
             );
 
             let err = match check(
+                &test_config_root(),
                 "multi-component",
                 None,
                 Some(&component.path().to_string_lossy()),
@@ -1479,12 +1508,19 @@ mod tests {
             );
 
             // Full check fails on the missing requirement file.
-            let (_check, check_exit) = check("lint-cmd", None, None).expect("rig check runs");
+            let (_check, check_exit) =
+                check(&test_config_root(), "lint-cmd", None, None).expect("rig check runs");
             assert_eq!(check_exit, 1, "missing requirement should fail rig check");
 
             // The lint command skips requirements entirely and succeeds.
-            let (output, exit_code) =
-                lint("lint-cmd", None, false, Some(RigLintFormat::Json)).expect("rig lint runs");
+            let (output, exit_code) = lint(
+                &test_config_root(),
+                "lint-cmd",
+                None,
+                false,
+                Some(RigLintFormat::Json),
+            )
+            .expect("rig lint runs");
             assert_eq!(exit_code, 0);
             let json = serde_json::to_value(output).expect("serialize lint output");
             assert_eq!(json["payload"]["command"], "rig.lint");
@@ -1501,7 +1537,13 @@ mod tests {
                 serde_json::json!({ "id": "lint-id-guard" }),
             );
 
-            let err = match lint("lint-id-guard", Some("alpha"), false, None) {
+            let err = match lint(
+                &test_config_root(),
+                "lint-id-guard",
+                Some("alpha"),
+                false,
+                None,
+            ) {
                 Ok(_) => panic!("--id against an installed rig id should fail"),
                 Err(err) => err,
             };
@@ -1524,6 +1566,7 @@ mod tests {
         }
 
         let (output, exit_code) = lint(
+            &test_config_root(),
             &temp.path().to_string_lossy(),
             None,
             true,
@@ -1559,6 +1602,7 @@ mod tests {
         .expect("write conflict");
 
         let (output, exit_code) = lint(
+            &test_config_root(),
             &temp.path().to_string_lossy(),
             None,
             true,
@@ -1620,8 +1664,9 @@ mod tests {
                 }),
             );
 
-            let (output, exit_code) = up_runner_exec_plan("script-matrix", "homeboy-lab")
-                .expect("command-only rig should plan");
+            let (output, exit_code) =
+                up_runner_exec_plan(&test_config_root(), "script-matrix", "homeboy-lab")
+                    .expect("command-only rig should plan");
 
             assert_eq!(exit_code, 0);
             let json = serde_json::to_value(output).expect("serialize plan");
@@ -1668,7 +1713,8 @@ mod tests {
                 }),
             );
 
-            let err = match up_runner_exec_plan("resource-rig", "homeboy-lab") {
+            let err = match up_runner_exec_plan(&test_config_root(), "resource-rig", "homeboy-lab")
+            {
                 Ok(_) => panic!("resource rig should not plan"),
                 Err(err) => err,
             };

--- a/crates/homeboy-cli/src/commands/trace.rs
+++ b/crates/homeboy-cli/src/commands/trace.rs
@@ -1021,7 +1021,7 @@ fn resolve_trace_profile_args(args: &mut TraceArgs) -> homeboy::core::Result<()>
     }
     if args.comp.component.is_none() {
         if let Some(rig_id) = args.rig.as_deref() {
-            let rig_spec = rig::load(rig_id)?;
+            let rig_spec = rig::load(&trace_config_root()?, rig_id)?;
             if let Some(component) = rig_spec.trace.default_component.as_deref() {
                 if !rig_spec.components.contains_key(component) {
                     return Err(homeboy::core::Error::validation_invalid_argument(
@@ -1134,7 +1134,7 @@ fn resolve_trace_profile(
     rig_id: Option<&str>,
 ) -> homeboy::core::Result<ResolvedTraceProfile> {
     if let Some(rig_id) = rig_id {
-        let rig_spec = rig::load(rig_id)?;
+        let rig_spec = rig::load(&trace_config_root()?, rig_id)?;
         let profile = rig_spec.trace_profiles.get(profile_id).ok_or_else(|| {
             let available = rig_spec.trace_profiles.keys().cloned().collect::<Vec<_>>();
             homeboy::core::Error::validation_invalid_argument(
@@ -1152,7 +1152,7 @@ fn resolve_trace_profile(
         });
     }
 
-    let matches = rig::list()?
+    let matches = rig::list(&trace_config_root()?)?
         .into_iter()
         .filter_map(|rig_spec| {
             rig_spec
@@ -1225,8 +1225,8 @@ fn attach_profile_output(
 
 fn run_list_profiles(rig_id: Option<&str>) -> homeboy::core::Result<TraceCommandOutput> {
     let rigs = match rig_id {
-        Some(rig_id) => vec![rig::load(rig_id)?],
-        None => rig::list()?,
+        Some(rig_id) => vec![rig::load(&trace_config_root()?, rig_id)?],
+        None => rig::list(&trace_config_root()?)?,
     };
     let mut profiles = Vec::new();
     for rig_spec in rigs {
@@ -1250,16 +1250,28 @@ fn run_list_profiles(rig_id: Option<&str>) -> homeboy::core::Result<TraceCommand
     }))
 }
 
+/// Config root for rig-registry reads on the trace command surface.
+///
+/// Same situation as `bench_config_root`: the trace surface threads `TraceArgs`
+/// through profile resolution and rig-context loading, and none of those
+/// helpers has another reason to hold a path. Named here so the resolution is
+/// greppable rather than hidden inside `rig::load`. Delete when the trace
+/// surface gains a carrier (#7505).
+fn trace_config_root() -> homeboy::core::Result<PathBuf> {
+    homeboy::core::paths::homeboy()
+}
+
 fn load_rig_context(rig_id: Option<&str>) -> homeboy::core::Result<Option<TraceRigContext>> {
     let Some(rig_id) = rig_id else {
         return Ok(None);
     };
-    let spec = rig::load(rig_id)?;
-    let package_root =
-        rig::read_source_metadata(&spec.id).map(|metadata| PathBuf::from(metadata.package_path));
-    let config_root = crate::core::paths::rig_config(&spec.id)
-        .ok()
-        .and_then(|path| path.parent().map(Path::to_path_buf));
+    let registry_root = trace_config_root()?;
+    let spec = rig::load(&registry_root, rig_id)?;
+    let package_root = rig::read_source_metadata_in_root(&registry_root, &spec.id)
+        .map(|metadata| PathBuf::from(metadata.package_path));
+    let config_root = crate::core::paths::rig_config_in_root(&registry_root, &spec.id)
+        .parent()
+        .map(Path::to_path_buf);
     Ok(Some(TraceRigContext {
         rig_spec: spec,
         rig_package_root: package_root,

--- a/crates/homeboy-cli/src/commands/trace/rig_tests.rs
+++ b/crates/homeboy-cli/src/commands/trace/rig_tests.rs
@@ -94,7 +94,7 @@ fn rig_trace_run_fails_fast_on_active_default_namespace_resource_lease() {
         set_trace_rig_resources(home, "studio-rig", resources.clone());
         set_trace_rig_resources(home, "studio-alt", resources);
 
-        let active_spec = rig::load("studio-rig").expect("load active rig");
+        let active_spec = rig::load(home.path(), "studio-rig").expect("load active rig");
         let _lease = rig::lease::acquire_active_run_lease(home.path(), &active_spec, "trace")
             .expect("acquire active trace lease")
             .expect("resourceful trace rig leases");

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -5672,15 +5672,19 @@ pub(crate) fn artifact_response_for_path(path: &str) -> Option<HttpResponse> {
 }
 
 fn config_paths_body() -> Result<serde_json::Value> {
+    // Boundary: one `GET /config/paths` request is one unit of work, so the rig
+    // and stack directories are joined onto the same root this response already
+    // reports rather than resolved again (#7505).
+    let config_root = paths::homeboy()?;
     Ok(json!({
-        "homeboy": paths::homeboy()?.display().to_string(),
+        "homeboy": config_root.display().to_string(),
         "homeboy_json": paths::homeboy_json()?.display().to_string(),
         "projects": paths::projects()?.display().to_string(),
         "servers": paths::servers()?.display().to_string(),
         "components": paths::components()?.display().to_string(),
         "extensions": paths::extensions()?.display().to_string(),
-        "rigs": paths::rigs()?.display().to_string(),
-        "stacks": paths::stacks()?.display().to_string(),
+        "rigs": paths::rigs_in_root(&config_root).display().to_string(),
+        "stacks": paths::stacks_in_root(&config_root).display().to_string(),
         "daemon_state": paths::daemon_state_file()?.display().to_string(),
         "daemon_jobs": paths::daemon_jobs_file()?.display().to_string(),
     }))

--- a/crates/homeboy-extension/src/trace/run/runner.rs
+++ b/crates/homeboy-extension/src/trace/run/runner.rs
@@ -133,12 +133,13 @@ pub(super) fn trace_probes_with_fswatch_attachments(
 /// `example-org/studio`) never creates or mutates a `homeboy.json` inside that
 /// repo. See Extra-Chill/homeboy#2329.
 pub(super) fn resolve_trace_baseline_root(
+    config_root: &Path,
     component_path: &str,
     rig_id: Option<&str>,
 ) -> Result<PathBuf> {
     match rig_id {
         Some(id) => {
-            let root = paths::rig_baseline_root(id)?;
+            let root = paths::rig_baseline_root_in_root(config_root, id);
             std::fs::create_dir_all(&root).map_err(|e| {
                 Error::internal_io(
                     format!(

--- a/crates/homeboy-extension/src/trace/run/tests/workflow.rs
+++ b/crates/homeboy-extension/src/trace/run/tests/workflow.rs
@@ -184,7 +184,12 @@ fn test_trace_is_unclaimed() {
 fn resolve_trace_baseline_root_without_rig_returns_component_path() {
     let temp = tempfile::tempdir().unwrap();
     let component_path = temp.path().to_string_lossy().to_string();
-    let root = resolve_trace_baseline_root(&component_path, None).unwrap();
+    let root = resolve_trace_baseline_root(
+        &homeboy_core::paths::homeboy().expect("config root"),
+        &component_path,
+        None,
+    )
+    .unwrap();
     assert_eq!(root, PathBuf::from(&component_path));
     // Crucially, no homeboy.json gets created in the component checkout
     // just by resolving — that only happens when a baseline is saved.
@@ -197,7 +202,12 @@ fn resolve_trace_baseline_root_with_rig_uses_rig_state_dir_and_skips_component_p
     let component_path = temp.path().to_string_lossy().to_string();
     let rig_id = format!("__hb-trace-baseline-test-{}", std::process::id());
 
-    let root = resolve_trace_baseline_root(&component_path, Some(&rig_id)).unwrap();
+    let root = resolve_trace_baseline_root(
+        &homeboy_core::paths::homeboy().expect("config root"),
+        &component_path,
+        Some(&rig_id),
+    )
+    .unwrap();
 
     assert!(
         root.ends_with(format!("{}.state/baselines", rig_id)),
@@ -232,7 +242,12 @@ fn rig_save_baseline_does_not_write_component_homeboy_json() {
     let component_path = temp.path().to_string_lossy().to_string();
     let rig_id = format!("__hb-trace-save-test-{}", std::process::id());
 
-    let baseline_root = resolve_trace_baseline_root(&component_path, Some(&rig_id)).unwrap();
+    let baseline_root = resolve_trace_baseline_root(
+        &homeboy_core::paths::homeboy().expect("config root"),
+        &component_path,
+        Some(&rig_id),
+    )
+    .unwrap();
 
     let results = TraceResults {
         component_id: "studio".to_string(),

--- a/crates/homeboy-extension/src/trace/run/workflow.rs
+++ b/crates/homeboy-extension/src/trace/run/workflow.rs
@@ -332,7 +332,9 @@ pub(super) fn run_trace_workflow_with_context(
         runner_output.exit_code
     };
     let rig_id = args.rig_id.as_deref();
-    let baseline_root = resolve_trace_baseline_root(&component_path, rig_id)?;
+    // Boundary: one trace workflow run is one unit of work (#7505).
+    let roots = homeboy_core::paths::PathRoots::from_environment()?;
+    let baseline_root = resolve_trace_baseline_root(roots.config(), &component_path, rig_id)?;
     let mut baseline_comparison = None;
     let mut baseline_exit_override = None;
     let mut hints = non_canonical_evidence_hints(&evidence);

--- a/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
@@ -589,6 +589,21 @@ fn selected_rig_component_remote_path(
     ))
 }
 
+/// Config root for rig-registry reads on the lab-offload path.
+///
+/// The lab offload stack holds no `PathRoots` anywhere — not in
+/// `lab/offload/inner.rs`, not in `lab/workspace_plan.rs`, not on any carrier
+/// passing through. Threading a root down to the three readers below would mean
+/// adding a path parameter to functions whose job is parsing offload arguments,
+/// which the PathRoots injection contract calls out as adding plumbing.
+///
+/// So the resolution stays here for now — but it is *visible* here, rather than
+/// hidden inside `homeboy_rig::load`, which 27 other callers now reach with an
+/// explicit root. Delete this when lab offload gains a carrier (#7505).
+fn rig_registry_config_root() -> Result<PathBuf> {
+    homeboy_core::paths::homeboy()
+}
+
 fn default_rig_component_selector(args: &[String]) -> Result<Option<String>> {
     let rig_ids = lab_offload_rig_ids(args);
     let [rig_id] = rig_ids.as_slice() else {
@@ -599,7 +614,7 @@ fn default_rig_component_selector(args: &[String]) -> Result<Option<String>> {
         Some("fuzz") => homeboy_rig::RigWorkloadKind::Fuzz,
         _ => return Ok(None),
     };
-    let spec = homeboy_rig::load(rig_id)?;
+    let spec = homeboy_rig::load(&rig_registry_config_root()?, rig_id)?;
     let component_ids = homeboy_rig::component_ids_for_workload(&spec, kind, None);
     Ok((component_ids.len() == 1).then(|| component_ids[0].clone()))
 }
@@ -833,7 +848,7 @@ pub(super) fn lab_offload_rig_component_checkout_root(args: &[String]) -> Result
     if rig_ids.len() != 1 {
         return Ok(None);
     }
-    let spec = homeboy_rig::load(&rig_ids[0])?;
+    let spec = homeboy_rig::load(&rig_registry_config_root()?, &rig_ids[0])?;
     if spec.components.len() != 1 {
         return Ok(None);
     }
@@ -858,7 +873,7 @@ pub(super) fn lab_offload_rig_component_dependencies(
     let mut dependencies = Vec::new();
     let component_path_override = component_path_override(args);
     for rig_id in lab_offload_rig_ids(args) {
-        let spec = homeboy_rig::load(&rig_id)?;
+        let spec = homeboy_rig::load(&rig_registry_config_root()?, &rig_id)?;
         let single_component = spec.components.len() == 1;
         for (component_id, component) in &spec.components {
             if let Some(lab_stack) = &component.lab_stack {

--- a/crates/homeboy-rig/src/lib.rs
+++ b/crates/homeboy-rig/src/lib.rs
@@ -351,13 +351,13 @@ fn component_with_unrecognized_schema(value: &serde_json::Value) -> Option<Strin
         .map(|(name, _)| name.clone())
 }
 
-fn read_config(id: &str) -> Result<(RigSpec, Option<String>)> {
-    let path = paths::rig_config(id)?;
+fn read_config(config_root: &Path, id: &str) -> Result<(RigSpec, Option<String>)> {
+    let path = paths::rig_config_in_root(config_root, id);
     if !path.exists() {
-        if let Some(error) = stale_source_error(id, &path) {
+        if let Some(error) = stale_source_error(config_root, id, &path) {
             return Err(error);
         }
-        let suggestions = list_ids().unwrap_or_default();
+        let suggestions = list_ids(config_root).unwrap_or_default();
         return Err(Error::rig_not_found(id, suggestions));
     }
     let content = fs::read_to_string(&path).map_err(|e| {
@@ -480,8 +480,8 @@ fn apply_trace_workload_defaults(spec: &mut RigSpec) -> Result<()> {
     Ok(())
 }
 
-fn stale_source_error(id: &str, config_path: &Path) -> Option<Error> {
-    let metadata = read_source_metadata(id)?;
+fn stale_source_error(config_root: &Path, id: &str, config_path: &Path) -> Option<Error> {
+    let metadata = read_source_metadata_in_root(config_root, id)?;
     let package_present = Path::new(&metadata.package_path).exists();
     let rig_present = Path::new(&metadata.rig_path).is_file();
     let config_entry_present = fs::symlink_metadata(config_path).is_ok();
@@ -521,9 +521,12 @@ fn stale_source_error(id: &str, config_path: &Path) -> Option<Error> {
     )
 }
 
-/// Load a rig spec by ID from `~/.config/homeboy/rigs/{id}.json`.
-pub fn load(id: &str) -> Result<RigSpec> {
-    read_config(id).map(|(spec, _)| spec)
+/// Load a rig spec by ID from `<config_root>/rigs/{id}.json`.
+///
+/// The caller supplies the config root it already resolved, so one unit of work
+/// cannot straddle two Homeboy homes (#7505).
+pub fn load(config_root: &Path, id: &str) -> Result<RigSpec> {
+    read_config(config_root, id).map(|(spec, _)| spec)
 }
 
 /// Load a rig spec directly from a local package directory or `rig.json` path
@@ -614,30 +617,30 @@ pub struct RigSourceContext {
 impl RigSourceContext {
     /// Build a source context from an already-loaded spec, resolving the
     /// package root from the rig's recorded source metadata.
-    pub fn from_spec(spec: RigSpec) -> Self {
+    pub fn from_spec(config_root: &Path, spec: RigSpec) -> Self {
         let package_root = local_package_root(&spec.id).or_else(|| {
-            read_source_metadata(&spec.id)
+            read_source_metadata_in_root(config_root, &spec.id)
                 .map(|metadata| std::path::PathBuf::from(metadata.package_path))
         });
         Self { spec, package_root }
     }
 
     /// Load a rig spec by ID and resolve its package root.
-    pub fn load(id: &str) -> Result<Self> {
-        Ok(Self::from_spec(load(id)?))
+    pub fn load(config_root: &Path, id: &str) -> Result<Self> {
+        Ok(Self::from_spec(config_root, load(config_root, id)?))
     }
 
     /// Load a rig for a command invocation, preferring an enclosing local rig
     /// package checkout that contains the requested rig ID over the globally
     /// installed rig registry.
-    pub fn load_for_invocation(id: &str) -> Result<Self> {
+    pub fn load_for_invocation(config_root: &Path, id: &str) -> Result<Self> {
         if let Some(package_root) = enclosing_local_package_for_rig(id)? {
-            return Ok(Self::from_spec(load_local_source(
-                package_root.to_string_lossy().as_ref(),
-                Some(id),
-            )?));
+            return Ok(Self::from_spec(
+                config_root,
+                load_local_source(package_root.to_string_lossy().as_ref(), Some(id))?,
+            ));
         }
-        Self::load(id)
+        Self::load(config_root, id)
     }
 
     /// Load a rig for an invocation with an explicit component checkout.
@@ -645,27 +648,29 @@ impl RigSourceContext {
     /// A linked rig source can disappear when its managed worktree is cleaned
     /// up. When the active checkout contains the same rig declaration, refresh
     /// the installed link through the normal install ownership checks.
-    pub fn load_for_invocation_at(id: &str, component_path: Option<&str>) -> Result<Self> {
+    /// This used to resolve its own roots. It now receives them: a boundary is
+    /// only a boundary while nothing above it can supply one, and every caller
+    /// can (#7505).
+    pub fn load_for_invocation_at(
+        config_root: &Path,
+        id: &str,
+        component_path: Option<&str>,
+    ) -> Result<Self> {
         let Some(component_path) = component_path else {
-            return Self::load_for_invocation(id);
+            return Self::load_for_invocation(config_root, id);
         };
-        let Some(metadata) = read_source_metadata(id) else {
-            return Self::load_for_invocation(id);
+        let Some(metadata) = read_source_metadata_in_root(config_root, id) else {
+            return Self::load_for_invocation(config_root, id);
         };
         if !metadata.linked || Path::new(&metadata.package_path).is_dir() {
-            return Self::load_for_invocation(id);
+            return Self::load_for_invocation(config_root, id);
         }
 
         // Confirm the active checkout declares this rig before refreshing its
         // global registration. `install` then enforces existing ID ownership.
-        //
-        // Boundary: loading a rig for an invocation is one unit of work, and the
-        // refresh below writes into the registry, so it resolves once here
-        // instead of letting `install` resolve on its own (#7505).
-        let roots = homeboy_core::paths::PathRoots::from_environment()?;
         load_local_source(component_path, Some(id))?;
-        install(roots.config(), component_path, Some(id), false)?;
-        Self::load(id)
+        install(config_root, component_path, Some(id), false)?;
+        Self::load(config_root, id)
     }
 }
 
@@ -687,13 +692,13 @@ fn enclosing_local_package_for_rig(id: &str) -> Result<Option<PathBuf>> {
 }
 
 /// Return the JSON-declared rig ID when it differs from the installed ID.
-pub fn declared_id(id: &str) -> Result<Option<String>> {
-    read_config(id).map(|(_, declared_id)| declared_id)
+pub fn declared_id(config_root: &Path, id: &str) -> Result<Option<String>> {
+    read_config(config_root, id).map(|(_, declared_id)| declared_id)
 }
 
-/// List all rig specs in `~/.config/homeboy/rigs/`.
-pub fn list() -> Result<Vec<RigSpec>> {
-    let dir = paths::rigs()?;
+/// List all rig specs in `<config_root>/rigs/`.
+pub fn list(config_root: &Path) -> Result<Vec<RigSpec>> {
+    let dir = paths::rigs_in_root(config_root);
     let mut rigs = Vec::new();
     for entry in json_config::sorted_json_config_entries(
         &dir,
@@ -701,7 +706,7 @@ pub fn list() -> Result<Vec<RigSpec>> {
         "read rig entry",
         |e, context| Error::internal_unexpected(format!("Failed to {}: {}", context, e)),
     )? {
-        if let Ok(spec) = load(&entry.id) {
+        if let Ok(spec) = load(config_root, &entry.id) {
             rigs.push(spec);
         }
     }
@@ -710,8 +715,8 @@ pub fn list() -> Result<Vec<RigSpec>> {
 
 /// Return sorted rig IDs (cheaper than load+collect when you only need IDs,
 /// e.g. for error suggestions).
-pub fn list_ids() -> Result<Vec<String>> {
-    let dir = paths::rigs()?;
+pub fn list_ids(config_root: &Path) -> Result<Vec<String>> {
+    let dir = paths::rigs_in_root(config_root);
     json_config::sorted_json_config_entries(&dir, "list rigs", "read rig entry", |e, context| {
         Error::internal_unexpected(format!("Failed to {}: {}", context, e))
     })

--- a/crates/homeboy-rig/src/provider.rs
+++ b/crates/homeboy-rig/src/provider.rs
@@ -7,34 +7,46 @@
 use std::path::Path;
 
 use homeboy_core::component::{self, Component};
+use homeboy_core::paths;
 use homeboy_core::rig_provider::{register_rig_provider, RigProvider};
 use homeboy_core::rig_toolchain_provider::{register_rig_toolchain_provider, RigToolchainProvider};
 use homeboy_core::scope::ScopeComponentRef;
 use homeboy_core::Result;
 use serde_json::{json, Value};
 
+/// Each provider method answers one HTTP request, which is one unit of work,
+/// so this is a boundary resolution rather than an ambient one (#7505). It is
+/// per-call: the provider is a long-lived singleton and capturing a root at
+/// registration would pin it to whatever home happened to be current then.
+fn config_root() -> Result<std::path::PathBuf> {
+    paths::homeboy()
+}
+
 struct RigProviderImpl;
 
 impl RigProvider for RigProviderImpl {
     fn rig_list_json(&self) -> Result<Value> {
-        Ok(json!(crate::list()?))
+        Ok(json!(crate::list(&config_root()?)?))
     }
 
     fn rig_show_json(&self, id: &str) -> Result<Value> {
-        Ok(json!(crate::load(id)?))
+        Ok(json!(crate::load(&config_root()?, id)?))
     }
 
     fn rig_check_json(&self, id: &str) -> Result<Value> {
-        let rig = crate::load(id)?;
+        let rig = crate::load(&config_root()?, id)?;
         Ok(json!(crate::runner::run_check(&rig)?))
     }
 
     fn rig_ids(&self) -> Result<Vec<String>> {
-        Ok(crate::list()?.into_iter().map(|rig| rig.id).collect())
+        Ok(crate::list(&config_root()?)?
+            .into_iter()
+            .map(|rig| rig.id)
+            .collect())
     }
 
     fn resolve_rig_scope(&self, rig_id: &str) -> Result<Vec<ScopeComponentRef>> {
-        let spec = crate::load(rig_id)?;
+        let spec = crate::load(&config_root()?, rig_id)?;
         let mut refs = Vec::new();
         for (component_id, component_spec) in spec.components.iter() {
             let path = crate::expand::expand_vars(&spec, &component_spec.path);
@@ -53,7 +65,7 @@ impl RigProvider for RigProviderImpl {
     }
 
     fn resolve_rig_component_records(&self, rig_id: &str) -> Result<Vec<Component>> {
-        let spec = crate::load(rig_id)?;
+        let spec = crate::load(&config_root()?, rig_id)?;
         let mut components = Vec::new();
         for (component_id, component_spec) in spec.components.iter() {
             let local_path = crate::expand::expand_vars(&spec, &component_spec.path);
@@ -85,7 +97,9 @@ impl RigToolchainProvider for RigToolchainProviderImpl {
         // A named rig contributes its own `toolchain` declaration. An unknown or
         // unloadable id degrades to the built-in default rather than failing an
         // exec-env build over PATH assembly.
-        let rig = rig_id.and_then(|rig_id| crate::load(rig_id).ok());
+        let rig = rig_id
+            .and_then(|rig_id| config_root().ok().map(|root| (root, rig_id)))
+            .and_then(|(root, rig_id)| crate::load(&root, rig_id).ok());
         crate::toolchain::command_step_path(rig.as_ref())
     }
 }

--- a/tests/core/rig/bench_resource_lease_test.rs
+++ b/tests/core/rig/bench_resource_lease_test.rs
@@ -36,7 +36,7 @@ fn run_single_rig_bench_fails_fast_on_active_resource_lease() {
         set_rig_resources(home, "studio", resources.clone());
         set_rig_resources(home, "studio-bfb", resources);
 
-        let active_spec = crate::rig::load("studio").expect("load active rig");
+        let active_spec = crate::rig::load(home.path(), "studio").expect("load active rig");
         let _lease =
             crate::rig::lease::acquire_active_run_lease(home.path(), &active_spec, "bench")
                 .expect("acquire active lease")

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -669,7 +669,7 @@ mod install_flows {
             false,
         )
         .expect("install");
-        let rig = load("lint-fixture").expect("load rig");
+        let rig = load(&test_config_root(), "lint-fixture").expect("load rig");
         let report = run_check(&rig).expect("check report");
 
         assert!(
@@ -711,7 +711,10 @@ mod install_flows {
 
         assert!(report.success, "local package check should pass");
         assert!(read_source_metadata_in_root(&test_config_root(), "local-alpha").is_none());
-        assert!(load("local-alpha").is_err(), "rig should not be installed");
+        assert!(
+            load(&test_config_root(), "local-alpha").is_err(),
+            "rig should not be installed"
+        );
     }
 
     #[test]
@@ -818,7 +821,7 @@ mod install_flows {
         assert!(fs::read_link(&installed_path).is_err());
         let installed = fs::read_to_string(&installed_path).expect("installed rig");
         assert!(!installed.contains("extends"));
-        let rig = load("alpha").expect("load rig");
+        let rig = load(&test_config_root(), "alpha").expect("load rig");
         assert_eq!(rig.description, "alpha rig");
         assert_eq!(rig.components["app"].path, "${env.DEV_ROOT}/alpha");
         assert_eq!(rig.components["app"].branch.as_deref(), Some("main"));
@@ -859,7 +862,7 @@ mod install_flows {
         .expect("install registry-backed component rig");
 
         assert_eq!(result.installed.len(), 1);
-        let rig = load("registry-backed").expect("load registry-backed rig");
+        let rig = load(&test_config_root(), "registry-backed").expect("load registry-backed rig");
         let component = &rig.components["app"];
         assert!(component.path.is_empty());
         assert_eq!(component.component_id.as_deref(), Some("registry-app"));
@@ -957,7 +960,7 @@ mod install_flows {
             false,
         )
         .expect("install");
-        let rig = load("trace-defaults").expect("load rig");
+        let rig = load(&test_config_root(), "trace-defaults").expect("load rig");
         let workloads = rig
             .trace_workloads
             .get("trace-runner")
@@ -1007,7 +1010,7 @@ mod install_flows {
             false,
         )
         .expect("install");
-        let rig = load("lint-only").expect("load rig");
+        let rig = load(&test_config_root(), "lint-only").expect("load rig");
 
         // Full check fails: the requirement file and probe file are both absent.
         let check = run_check(&rig).expect("check report");
@@ -1050,7 +1053,7 @@ mod install_flows {
             false,
         )
         .expect("install");
-        let rig = load("lint-conflict").expect("load rig");
+        let rig = load(&test_config_root(), "lint-conflict").expect("load rig");
         let lint = run_lint(&rig).expect("lint report");
 
         assert!(!lint.success, "conflict markers should fail rig lint");
@@ -1087,7 +1090,7 @@ mod install_flows {
             false,
         )
         .expect("install");
-        let rig = load("lint-dm").expect("load rig");
+        let rig = load(&test_config_root(), "lint-dm").expect("load rig");
         let lint = run_lint(&rig).expect("lint report");
 
         assert!(
@@ -1185,7 +1188,7 @@ mod install_flows {
                 assert_eq!(build["metadata"]["timeout"], expected_timeout);
             }
 
-            load(id).expect("load materialized rig");
+            load(&test_config_root(), id).expect("load materialized rig");
         }
     }
 
@@ -1649,23 +1652,25 @@ mod refresh_and_identity {
         )
         .expect("replacement rig");
 
-        let ids = list_ids().expect("list ids");
+        let ids = list_ids(&test_config_root()).expect("list ids");
         assert_eq!(ids, vec!["replacement"]);
 
-        let rigs = list().expect("list rigs");
+        let rigs = list(&test_config_root()).expect("list rigs");
         assert_eq!(rigs.len(), 1);
         assert_eq!(rigs[0].id, "replacement");
         assert_eq!(
-            declared_id("replacement").expect("declared id"),
+            declared_id(&test_config_root(), "replacement").expect("declared id"),
             Some("alpha".to_string())
         );
 
         assert_eq!(
-            load("replacement").expect("load replacement").id,
+            load(&test_config_root(), "replacement")
+                .expect("load replacement")
+                .id,
             "replacement"
         );
 
-        let err = load("alpha").expect_err("alpha should not resolve");
+        let err = load(&test_config_root(), "alpha").expect_err("alpha should not resolve");
         assert_eq!(err.message, "Rig not found");
         assert_eq!(err.details["id"], "alpha");
         let hints = err
@@ -1695,8 +1700,11 @@ mod refresh_and_identity {
         )
         .expect("non-json rig sidecar");
 
-        assert_eq!(list_ids().expect("list ids"), vec!["alpha"]);
-        assert_eq!(list().expect("list rigs").len(), 1);
+        assert_eq!(
+            list_ids(&test_config_root()).expect("list ids"),
+            vec!["alpha"]
+        );
+        assert_eq!(list(&test_config_root()).expect("list rigs").len(), 1);
     }
 }
 

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -405,7 +405,7 @@ fn missing_linked_source_gets_rig_source_diagnostic_not_not_found_hint() {
     .expect("install linked");
     fs::remove_dir_all(package.path()).expect("remove linked source");
 
-    let err = load("alpha").expect_err("stale source error");
+    let err = load(&test_config_root(), "alpha").expect_err("stale source error");
 
     assert!(err.message.contains("linked rig source"));
     assert!(err.message.contains("source path is missing"));
@@ -417,7 +417,9 @@ fn missing_linked_source_gets_rig_source_diagnostic_not_not_found_hint() {
         .hints
         .iter()
         .any(|hint| hint.message.contains("homeboy rig sources remove")));
-    assert!(!list_ids().expect("list ids").contains(&"alpha".to_string()));
+    assert!(!list_ids(&test_config_root())
+        .expect("list ids")
+        .contains(&"alpha".to_string()));
 }
 
 #[test]


### PR DESCRIPTION
Last slice of the rig-registry half. **Production ambient rig/stack registry resolution reaches zero.**

`load`, `list`, `list_ids`, `declared_id`, and the private `read_config` / `stale_source_error` now take the config root the caller resolved. `homeboy-rig` goes 3 → **0**.

Every remaining ambient rig/stack registry resolution under `crates/` is inside a `#[cfg(test)]` body. Verified by walking each hit to its enclosing function and comparing against the file's first `#[cfg(test)]`.

## Where the roots come from

**`RigSourceContext`** carries the root through its four loaders. `load_for_invocation_at` **stopped resolving and started receiving** — the shape the contract says to expect near the end:

> A boundary is only a boundary while nothing above it can supply one.

**`homeboy rig`** follows `homeboy stack` from #13011: one resolution in `commands/rig/mod.rs::run`, threaded to fifteen handlers through the single `RigCommand` match. Same for the `rig app` subcommand dispatch.

**The rig provider** takes the per-call boundary shape the stack provider already uses — each method answers one HTTP request, and the provider is a long-lived singleton, so capturing a root at registration would pin it to whatever home was current then.

## Three surfaces that still resolve, and why

Each now says so in one named, greppable place instead of hiding it inside `rig::load`:

| helper | why it can't be threaded yet |
|---|---|
| `rig_materialization::rig_registry_config_root` | the lab offload stack has **no `PathRoots` anywhere**, on any carrier |
| `bench::bench_config_root` | `BenchRunArgs` threads through a dozen helpers that each want a rig spec, none of which otherwise touch paths |
| `trace::trace_config_root` | same shape |

Threading roots into those means adding a path parameter to functions whose job has nothing to do with paths — the plumbing the contract explicitly warns against, and the `agent_task/fanout.rs` counter-example almost exactly.

**The progress is moving the resolution out of a leaf that 27 callers share and into three named sites.** Deleting them needs a carrier that does not exist yet, and each doc comment says so with its deletion condition.

## Stragglers closed

- `daemon::config_paths_body` — was resolving `rigs()` and `stacks()` independently of the `homeboy()` root it reports in the same JSON object. Now joins onto that root.
- `resolve_trace_baseline_root` — takes the root from the trace workflow boundary.

That takes `homeboy-core` and `homeboy-extension` to zero on these paths too.

## Reporting

| | before | after |
|---|---:|---:|
| `homeboy-rig` ambient | 3 | **0** |
| production ambient, all crates | 3 | **0** |
| repo-wide (incl. test bodies) | 95 | **91** |

Cumulative across #13011, #13019, #13030 and this: **133 → 91**, and the production half is done.

## Not done

`rust_nextest_shard_threads` stays `1`. The rig-registry half of that guard's condition is now met *for production code*, but the controller-runtime admission store is untouched and test bodies still write the registry through `with_isolated_home`.

## Verification

`cargo check --workspace --tests -j2` — green, no warnings.

Two more collisions caught before writing: `(?<![\w:])load\("` matched `state_store.load("...")` because the lookbehind excluded `:` but not `.` (4 sites, reverted); and `fn test_list_sources()`-style function-definition matches, same class as #13019.

Refs #7505.
