### PR TITLE
fix(cook): preserve scheduler workspace root

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -613,16 +613,36 @@ fn run_materialized_provider_command_once_contained(
         );
     };
 
-    // The scheduler may replace a task workspace with an isolated attempt
-    // worktree. That task root is the execution cwd; a manifest cwd is only a
-    // fallback for requests without a workspace.
-    let cwd = request
-        .request
-        .workspace
-        .root
-        .as_deref()
-        .map(PathBuf::from)
-        .or(provider_cwd);
+    // Workspace identity stays at the Git root for scheduler admission and
+    // baseline replacement. A component-relative cwd is resolved only after
+    // that identity is established, so nested packages execute correctly in
+    // both the original worktree and isolated retry baselines.
+    let cwd = match request.request.workspace.root.as_deref() {
+        Some(root) => match homeboy_core::resolve_contained_local_path(
+            root,
+            request
+                .request
+                .executor
+                .config
+                .get("component_cwd")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("."),
+            "component_cwd",
+        ) {
+            Ok(cwd) => Some(cwd),
+            Err(error) => {
+                return failure_outcome(
+                    request,
+                    AgentTaskOutcomeStatus::ProviderError,
+                    AgentTaskFailureClassification::InvalidInput,
+                    "agent_task.component_cwd_invalid",
+                    error.to_string(),
+                    json!({ "provider": provider.id }),
+                )
+            }
+        },
+        None => provider_cwd,
+    };
     let cwd_identity = cwd.as_deref().map(workspace_identity).transpose();
     let cwd_identity = match cwd_identity {
         Ok(identity) => identity,

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -55,6 +55,16 @@ pub fn source_worktree_path(cwd: Option<String>, workspace: Option<String>) -> O
     .map(PathBuf::from)
 }
 
+fn component_workspace_path(options: &AgentTaskCookServiceOptions) -> Option<PathBuf> {
+    let source = options.source_worktree_path.as_ref()?;
+    let component_cwd = options
+        .initial_plan
+        .metadata
+        .pointer("/gate_workspace/component_cwd")
+        .and_then(Value::as_str)?;
+    homeboy_core::resolve_contained_local_path(source, component_cwd, "component_cwd").ok()
+}
+
 pub fn promotion_source(spec: &str) -> Result<(String, Option<PathBuf>)> {
     if spec != "-" {
         let path = PathBuf::from(spec.strip_prefix('@').unwrap_or(spec));
@@ -117,7 +127,8 @@ pub(crate) fn promote_attempt_in_store(
             source,
             source_run_id: Some(run_id.to_string()),
             source_path,
-            source_worktree_path: options.source_worktree_path.clone(),
+            source_worktree_path: component_workspace_path(options)
+                .or_else(|| options.source_worktree_path.clone()),
             base_ref: Some(options.base.clone()),
             task_base_sha: options.task_base_sha.clone(),
             candidate_ref: None,
@@ -176,7 +187,8 @@ pub(crate) fn canonical_cook_patch_artifact_id_in_store(
         source,
         source_run_id: Some(run_id.to_string()),
         source_path,
-        source_worktree_path: options.source_worktree_path.clone(),
+        source_worktree_path: component_workspace_path(options)
+            .or_else(|| options.source_worktree_path.clone()),
         base_ref: Some(options.base.clone()),
         task_base_sha: options.task_base_sha.clone(),
         candidate_ref: None,
@@ -674,7 +686,8 @@ pub(crate) fn promote_or_load_attempt_in_store(
                     source,
                     source_run_id: Some(run_id.to_string()),
                     source_path,
-                    source_worktree_path: options.source_worktree_path.clone(),
+                    source_worktree_path: component_workspace_path(options)
+                        .or_else(|| options.source_worktree_path.clone()),
                     base_ref: Some(options.base.clone()),
                     task_base_sha: options.task_base_sha.clone(),
                     candidate_ref: None,
@@ -1602,7 +1615,8 @@ pub(crate) fn recover_moving_base_cook_candidate_in_store(
             source,
             source_run_id: Some(recovery.run_id.clone()),
             source_path,
-            source_worktree_path: options.source_worktree_path.clone(),
+            source_worktree_path: component_workspace_path(options)
+                .or_else(|| options.source_worktree_path.clone()),
             base_ref: Some(options.base.clone()),
             task_base_sha: options.task_base_sha.clone(),
             candidate_ref: None,

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -4106,19 +4106,33 @@ pub(crate) fn compile_cook_plan(
     if let Some(workspace) = requested_workspace.as_deref() {
         validate_cook_destination_identity(args, Path::new(workspace))?;
     }
-    let workspace = requested_workspace
+    let component_cwd = requested_workspace
         .as_deref()
         .map(|workspace| cook_component_workspace(args, Path::new(workspace)))
         .transpose()?
-        .map(|workspace| workspace.display().to_string());
+        .map(|workspace| {
+            workspace
+                .strip_prefix(
+                    requested_workspace
+                        .as_deref()
+                        .expect("component workspace has root"),
+                )
+                .map_err(|_| {
+                    homeboy::core::Error::internal_unexpected(
+                        "resolved component workspace escapes the Cook workspace".to_string(),
+                    )
+                })
+                .map(|path| path.display().to_string())
+        })
+        .transpose()?;
     let mut dispatch = dispatch_args_for_cook(args);
     resolve_dispatch_prompt(&mut dispatch)?;
     // Provisioning makes an explicit --cwd authoritative, otherwise this is the
     // resolved managed destination. Pass that exact linked worktree downstream.
     dispatch.cwd = None;
-    dispatch.workspace = workspace.clone();
+    dispatch.workspace = requested_workspace.clone();
     let admitted_evidence = admit_provider_evidence_inputs(&args.provider_evidence_inputs)?;
-    let evidence = if let Some(workspace) = workspace.as_deref() {
+    let evidence = if let Some(workspace) = requested_workspace.as_deref() {
         project_admitted_provider_evidence_inputs(
             &args.provider_evidence_inputs,
             &admitted_evidence,
@@ -4132,7 +4146,7 @@ pub(crate) fn compile_cook_plan(
         &mut dispatch.prompt,
         &args.provider_evidence_inputs,
         &admitted_evidence,
-        workspace.as_deref(),
+        requested_workspace.as_deref(),
         &projected_paths,
     )?;
     let mut request = dispatch_service::resolve_dispatch_request(dispatch.into())?;
@@ -4154,12 +4168,13 @@ pub(crate) fn compile_cook_plan(
     };
     plan.options.candidate_completion = args.candidate_completion;
     record_cook_provision(&mut plan, provision);
-    if let (Some(requested), Some(effective)) =
-        (requested_workspace.as_deref(), workspace.as_deref())
+    if let (Some(requested), Some(component_cwd)) =
+        (requested_workspace.as_deref(), component_cwd.as_deref())
     {
         plan.metadata["gate_workspace"] = serde_json::json!({
             "requested_cwd": requested,
-            "effective_cwd": effective,
+            "effective_cwd": Path::new(requested).join(component_cwd),
+            "component_cwd": component_cwd,
             "component_id": args.dispatch.repo,
         });
     }
@@ -4182,6 +4197,12 @@ pub(crate) fn compile_cook_plan(
             )
         })?;
         task.metadata["cook_workspace_identity"] = workspace_identity_attestation(Path::new(root))?;
+        if let Some(component_cwd) = component_cwd.as_deref() {
+            if !task.executor.config.is_object() {
+                task.executor.config = serde_json::json!({});
+            }
+            task.executor.config["component_cwd"] = serde_json::json!(component_cwd);
+        }
     }
     homeboy::agents::agent_task_provider::AgentTaskProviderCatalog::discover()
         .validate_explicit_models(&plan)?;


### PR DESCRIPTION
## Summary
- preserve the Git worktree root as Cook scheduler and admission identity
- carry the registered nested component path as a contained provider execution cwd
- derive the same durable component path for promotion dependency hydration and deterministic gates

Follow-up to merged #13017. Fixes reopened #13001.

## Testing
- `cargo fmt --all`
- `cargo check -p homeboy-cli -p homeboy-agents`
- `cargo test -p homeboy-agents agent_task_provider::tests::manifest_tests --lib --no-fail-fast`
- `cargo test -p homeboy-cli commands::agent_task::run --lib --no-fail-fast`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagent traced the post-merge scheduler identity regression, implemented the separate component cwd contract, and ran focused verification. Chris Huber remains responsible for every line.