### PR TITLE
refactor(core): root controller admission and gate the ambient path (#7505)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2266,13 +2266,15 @@ where
     A: RuntimeAdmissionEvidence,
 {
     let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    let admission_status =
+        crate::agent_task_service::cook_pre_execution::store_admission_status(&lifecycle_store);
     submit_plan_with_runtime_admission_in_store(
         &lifecycle_store,
         plan,
         requested_run_id,
         execution_runner_id(),
         None,
-        Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
+        Some(&admission_status),
         admit_runtime,
     )
 }
@@ -2999,11 +3001,19 @@ pub fn runner_pinned_runtime_for_mutation(run_id: &str) -> Result<Option<RunnerP
 /// FIFO admission queue so concurrent seals wait their turn instead of
 /// fast-failing.
 pub fn pin_current_controller_runtime(
+    data_root: &std::path::Path,
     request_id: &str,
     cancellation_requested: impl Fn() -> Result<bool>,
 ) -> Result<std::path::PathBuf> {
-    let runtime =
-        homeboy_core::controller_runtime::pin_current_queued(request_id, cancellation_requested)?;
+    // The seal joins the FIFO admission queue, and that queue's lock lives under
+    // the runtime root. Taking the caller's data root is what keeps two
+    // installations from serializing against each other's queue (#7505).
+    let runtime_root = homeboy_core::controller_runtime::runtime_root_in(data_root)?;
+    let runtime = homeboy_core::controller_runtime::pin_current_queued_in_root(
+        &runtime_root,
+        request_id,
+        cancellation_requested,
+    )?;
     runtime
         .pointer("/originating/pinned_executable")
         .and_then(Value::as_str)

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -1273,7 +1273,9 @@ fn materialize_adoption_attempt_in_stores(
             .recover_for_adoption_with_runtime(
                 &recipe.cook_id,
                 &attempt.run_id,
-                Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
+                Some(&super::cook_pre_execution::store_admission_status(
+                    lifecycle_store,
+                )),
                 agent_task_lifecycle::execution_runner_id(),
                 super::cook_pre_execution::production_runtime_admission(lifecycle_store),
                 |cook_id| {

--- a/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
@@ -281,7 +281,7 @@ fn materialize_initial_cook_attempt_with_store_and_lifecycle(
         &options.cook_id,
         &options.initial_run_id,
         &options.initial_plan,
-        Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
+        Some(&store_admission_status(lifecycle_store)),
         agent_task_lifecycle::execution_runner_id(),
         production_runtime_admission(lifecycle_store),
         |cook_id| reconcile_reserved_cancellation_in_store(lifecycle_store, cook_id),
@@ -305,7 +305,7 @@ pub(crate) fn materialize_cook_attempt_with_stores(
         cook_id,
         run_id,
         plan,
-        Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
+        Some(&store_admission_status(lifecycle_store)),
         agent_task_lifecycle::execution_runner_id(),
         production_runtime_admission(lifecycle_store),
         |cook_id| reconcile_reserved_cancellation_in_store(lifecycle_store, cook_id),
@@ -365,6 +365,23 @@ pub(crate) fn reconcile_reserved_cancellation_in_store(
     lifecycle_store
         .cancel_reserved_detached_cook_handoff_attempt_if_cancelled(cook_id)
         .map(|_| ())
+}
+
+/// Probe admission status against the store's own runtime root.
+///
+/// The ambient `admission_status` resolves the data root itself, so a probe
+/// could read the admission lease of a *different* installation than the store
+/// it was passed alongside. Deriving the root from the store is what keeps a
+/// probe and the admission it is probing in one home (#7505).
+pub(crate) fn store_admission_status(
+    lifecycle_store: &AgentTaskLifecycleStore,
+) -> impl Fn(&str) -> Option<Value> + '_ {
+    move |run_id| {
+        let runtime_root =
+            homeboy_core::controller_runtime::runtime_root_in(lifecycle_store.roots().data())
+                .ok()?;
+        homeboy_core::controller_runtime::admission_status_at(&runtime_root, run_id).ok()
+    }
 }
 
 pub(crate) fn production_runtime_admission(
@@ -496,7 +513,7 @@ pub(crate) fn recover_recipe_attempt_with_stores(
 ) -> Result<Option<agent_task_lifecycle::AgentTaskRunRecord>> {
     CookExecutionPreparation::new(recipe_store, lifecycle_store).recover_with_runtime(
         cook_or_attempt_id,
-        Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
+        Some(&store_admission_status(lifecycle_store)),
         agent_task_lifecycle::execution_runner_id(),
         production_runtime_admission(lifecycle_store),
         |cook_id| reconcile_reserved_cancellation_in_store(lifecycle_store, cook_id),
@@ -515,7 +532,7 @@ pub(crate) fn recover_adoption_attempt_with_stores(
     CookExecutionPreparation::new(recipe_store, lifecycle_store).recover_for_adoption_with_runtime(
         cook_id,
         run_id,
-        Some(&|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok()),
+        Some(&store_admission_status(lifecycle_store)),
         agent_task_lifecycle::execution_runner_id(),
         production_runtime_admission(lifecycle_store),
         |cook_id| reconcile_reserved_cancellation_in_store(lifecycle_store, cook_id),

--- a/crates/homeboy-agents/src/agent_task_service/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_service/mod.rs
@@ -14,7 +14,7 @@ mod cook_batch_job;
 mod cook_budget;
 /// Daemon-owned durable lifecycle for a locally-placed detached Cook.
 mod cook_job;
-mod cook_pre_execution;
+pub(crate) mod cook_pre_execution;
 mod cook_promotion;
 mod cook_recipe;
 /// Resource supervision of a running Cook against its declared budgets.

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -199,9 +199,12 @@ impl AgentTaskLifecycleStore {
             plan,
             run_id,
             super::lifecycle_ops::execution_runner_id(),
-            &|run_id| homeboy_core::controller_runtime::admission_status(run_id).ok(),
+            &crate::agent_task_service::cook_pre_execution::store_admission_status(self),
             |run_id| {
-                homeboy_core::controller_runtime::admit_current_for_with_cancellation_check(
+                let runtime_root =
+                    homeboy_core::controller_runtime::runtime_root_in(self.roots().data())?;
+                homeboy_core::controller_runtime::admit_current_for_with_cancellation_check_in_root(
+                    &runtime_root,
                     run_id,
                     || Ok(self.read_record(run_id)?.state.is_terminal()),
                 )

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1015,11 +1015,14 @@ fn delegate_agent_task_cook_to_pinned_runtime(
     }
 
     let request_id = format!("seal-{}", Uuid::new_v4());
-    let pinned =
-        crate::agents::agent_tasks::lifecycle::pin_current_controller_runtime(&request_id, || {
-            Ok(false)
-        })
-        .map_err(|error| annotate_cook_seal_failure(error, &request_id, normalized_args))?;
+    // Boundary: sealing the controller for a cook is one unit of work (#7505).
+    let roots = homeboy::core::paths::PathRoots::from_environment()?;
+    let pinned = crate::agents::agent_tasks::lifecycle::pin_current_controller_runtime(
+        roots.data(),
+        &request_id,
+        || Ok(false),
+    )
+    .map_err(|error| annotate_cook_seal_failure(error, &request_id, normalized_args))?;
     let status = ProcessCommand::new(&pinned)
         .args(&normalized_args[1..])
         .env(COOK_PINNED_RUNTIME_ENV, &pinned)

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -724,6 +724,7 @@ fn pin_current_unlocked() -> Result<Value> {
 /// Pin the currently executing controller while participating in the FIFO
 /// admission queue.  Use this instead of `pin_current()` when concurrent cook
 /// requests must wait their turn rather than fast-fail.
+#[cfg(test)]
 pub fn pin_current_queued(
     request_id: &str,
     cancellation_requested: impl Fn() -> Result<bool>,
@@ -897,6 +898,23 @@ fn runtime_pin(
 /// active-generation pointer is diagnostic state only: every fresh run must
 /// retain the executable that created it, rather than inherit a previous
 /// controller's selection.
+/// Ambient admission entry points, retained for this module's own tests only.
+///
+/// These resolve the runtime root from process-global state. That is the exact
+/// split `tests/nextest_shard_parallelism_test.rs` recorded: a test holding a
+/// `HermeticTestContext` store while production code beneath it read the
+/// admission lease out of the real `$HOME`, so one test observed another's
+/// `controller_admission.owner`. `HermeticTestContext` does not mutate the
+/// environment, so process-per-test isolation cannot help there.
+///
+/// Every production caller now supplies a root, so the `#[cfg(test)]` gate below
+/// is the compiler enforcing that: production cannot reach ambient admission
+/// even by accident, and a future caller that tries will fail to build rather
+/// than fail a shard at random (#7505).
+///
+/// The module's own tests keep using them through `with_isolated_home`, which
+/// mutates `HOME` and is therefore safe under process-per-test.
+#[cfg(test)]
 pub fn admit_current() -> Result<RuntimeAdmission> {
     admit_current_for(&format!("controller-{}", Uuid::new_v4()))
 }
@@ -904,6 +922,7 @@ pub fn admit_current() -> Result<RuntimeAdmission> {
 /// Admit a durable controller request in FIFO order. The request ID is normally
 /// the agent-task run ID, which lets another controller observe or cancel a
 /// waiting admission after the original process has exited.
+#[cfg(test)]
 pub fn admit_current_for(request_id: &str) -> Result<RuntimeAdmission> {
     admit_current_for_with_cancellation_check(request_id, || Ok(false))
 }
@@ -911,6 +930,7 @@ pub fn admit_current_for(request_id: &str) -> Result<RuntimeAdmission> {
 /// Admit a request while checking the caller's durable lifecycle state at the
 /// queue claim boundary. The check runs under the queue lock, after the
 /// advisory lock is acquired and before ownership can be published.
+#[cfg(test)]
 pub fn admit_current_for_with_cancellation_check(
     request_id: &str,
     cancellation_requested: impl Fn() -> Result<bool>,
@@ -960,6 +980,7 @@ pub fn admit_current_for_with_cancellation_check_in_root(
 }
 
 /// Return the durable admission view used by lifecycle status output.
+#[cfg(test)]
 pub fn admission_status(request_id: &str) -> Result<Value> {
     admission_status_at(&runtime_root()?, request_id)
 }
@@ -1013,6 +1034,7 @@ fn admission_status_at_lock_path(lock_path: &Path, request_id: &str) -> Result<V
 
 /// Remove a waiting request. An owner is intentionally never force-released:
 /// the advisory lock remains the authority while a process is alive.
+#[cfg(test)]
 pub fn cancel_admission(request_id: &str) -> Result<()> {
     cancel_admission_at(&runtime_root()?, request_id)
 }

--- a/tests/controller_admission_rooting_test.rs
+++ b/tests/controller_admission_rooting_test.rs
@@ -1,0 +1,94 @@
+//! Pins ambient controller-runtime admission out of production code.
+//!
+//! `tests/nextest_shard_parallelism_test.rs` names two conditions for restoring
+//! `rust_nextest_shard_threads = 0`. This file guards the first one: the
+//! controller-runtime admission store must stop being machine-global for
+//! production callers.
+//!
+//! ## What went wrong, concretely
+//!
+//! Run `32294476539` failed `status_preserves_existing_terminal_runtime_evidence`
+//! on an `assert_eq!(before, after)` whose sides differed in one field:
+//!
+//! ```text
+//! before  metadata.controller_admission.owner = { request_id: "run_store-contract", .. }
+//! after   metadata.controller_admission.owner = Null
+//! ```
+//!
+//! `run_store-contract` is a different test in the same file. The mechanism is
+//! not shared memory and not a shared environment — it is a shared *directory*.
+//! That test builds a `HermeticTestContext`, which allocates temp roots and
+//! deliberately does **not** mutate `HOME`. Production code beneath it then
+//! resolved the admission lease ambiently, out of the real `$HOME`, while the
+//! record it was writing lived in the hermetic root. One operation, two homes.
+//!
+//! Process-per-test isolation is irrelevant to that: a fresh process is not a
+//! fresh disk, and nothing was reading process-global memory in the first place.
+//!
+//! ## What this test pins
+//!
+//! The ambient admission entry points in `homeboy_core::controller_runtime` are
+//! `#[cfg(test)]`. Production code physically cannot call them, so a regression
+//! is a build failure in the PR that introduces it rather than a red shard in
+//! somebody else's.
+//!
+//! If an ambient admission entry point is intentionally restored to production,
+//! delete or invert this test in the same commit, so the intent is recorded
+//! once rather than rediscovered from a flake.
+
+const CONTROLLER_RUNTIME_SOURCE: &str =
+    include_str!("../crates/homeboy-core/src/controller_runtime.rs");
+
+/// Entry points that resolve the admission root from process-global state.
+const AMBIENT_ADMISSION_ENTRY_POINTS: &[&str] = &[
+    "pub fn admit_current()",
+    "pub fn admit_current_for(",
+    "pub fn admit_current_for_with_cancellation_check(",
+    "pub fn admission_status(",
+    "pub fn cancel_admission(",
+    "pub fn pin_current_queued(",
+];
+
+#[test]
+fn ambient_admission_entry_points_are_test_only() {
+    for entry_point in AMBIENT_ADMISSION_ENTRY_POINTS {
+        let at = CONTROLLER_RUNTIME_SOURCE
+            .find(entry_point)
+            .unwrap_or_else(|| {
+                panic!(
+                "`{entry_point}` no longer exists in controller_runtime.rs. If it was renamed, \
+                 update this list; if it was deleted outright, that is strictly better than the \
+                 gate and this entry should be removed."
+            )
+            });
+
+        let preceding = &CONTROLLER_RUNTIME_SOURCE[..at];
+        assert!(
+            preceding.trim_end().ends_with("#[cfg(test)]"),
+            "`{entry_point}` must stay `#[cfg(test)]`. It resolves the controller-runtime \
+             admission root from process-global state, which is what let one test observe \
+             another's `controller_admission.owner` through the shared on-disk store (run \
+             32294476539). Production callers take an explicit root via the `_in_root` / `_at` \
+             siblings. See this file's module docs and #7505."
+        );
+    }
+}
+
+#[test]
+fn rooted_admission_siblings_exist_for_every_gated_entry_point() {
+    // The gate above is only tenable because a rooted form exists for each one.
+    // If a sibling disappears, the gate stops being a design boundary and starts
+    // being an obstacle, which is the point at which someone deletes it.
+    for sibling in [
+        "pub fn admit_current_for_with_cancellation_check_in_root(",
+        "pub fn admission_status_at(",
+        "pub fn cancel_admission_at(",
+        "pub fn pin_current_queued_in_root(",
+        "pub fn runtime_root_in(",
+    ] {
+        assert!(
+            CONTROLLER_RUNTIME_SOURCE.contains(sibling),
+            "rooted sibling `{sibling}` is missing; production callers have nowhere to go (#7505)"
+        );
+    }
+}


### PR DESCRIPTION
The second of the two conditions `tests/nextest_shard_parallelism_test.rs` names for restoring `rust_nextest_shard_threads = 0`. Follows #13011, #13019, #13030, #13032.

## What the recorded failure actually was

I went and read the evidence rather than assuming. Run `32294476539` failed `status_preserves_existing_terminal_runtime_evidence` on an `assert_eq!(before, after)` differing in exactly one field — `controller_admission.owner` carried a **peer test's** `request_id`.

The mechanism is specific and worth stating, because it changes what the fix has to be:

```
status_preserves_existing_terminal_runtime_evidence
  └─ HermeticTestContext::new()        allocates temp roots
                                       does NOT mutate HOME
  └─ AgentTaskLifecycleStore::new(context.path_roots())      -> hermetic root
       └─ submit_plan_with_runtime_admission_in_store
            └─ admission_status(run_id)   <-- ambient, reads the REAL $HOME
                                              ^^^^^^^ one operation, two homes
```

Process-per-test isolation was never going to help here. Nothing was reading process-global *memory*, and a fresh process is not a fresh disk.

## The fix

Six probe closures of this shape:

```rust
Some(&|run_id| controller_runtime::admission_status(run_id).ok())
```

now go through `cook_pre_execution::store_admission_status`, which derives the runtime root **from the lifecycle store it is passed alongside**. A probe and the admission it is probing are now provably in one home. `lifecycle_store::submit_plan_with_current_runtime` gets the same treatment for both its status probe and its admission call.

`pin_current_controller_runtime` takes a data root — the seal joins the FIFO admission queue, and that queue's lock lives under the runtime root, so an ambient root means two installations serializing against each other's queue. The cook seal in `cli_runtime` resolves it once.

**Production ambient admission calls: 0.**

## Gate rather than delete

After that, every ambient admission entry point had zero production callers — by the contract, dead ambient wrappers, deletable on sight.

I gated them `#[cfg(test)]` instead. Forty of this module's own tests use them through `with_isolated_home`, which mutates `HOME` and therefore *is* safe under process-per-test. Gating keeps those working while making the production boundary **compiler-enforced**: a future ambient caller is now a build failure in its own PR, not a red shard in somebody else's three weeks later.

`tests/controller_admission_rooting_test.rs` pins the gate — and also pins that a rooted sibling exists for each gated entry point, because a gate with nowhere to go is an obstacle rather than a boundary, and obstacles get deleted.

## Deliberately untouched

The content-addressed **executable cache** under the same root — retention, cleanup, prune, activate, migrate, recover. That sharing is an existing design decision, already documented at `recover_controller_runtime_in_store`:

> it is a content-addressed executable cache shared across homes, not durable lifecycle state, so it is not one of this store's roots

It is also not what the guard's evidence implicates. The failure was an admission lease, not a cached binary.

## `rust_nextest_shard_threads` still stays `1`

Both stores now take explicit roots for production callers, which is what the guard asked for. But the flip should carry a measured before/after, and test bodies that write these stores through `with_isolated_home` deserve their own look first. That is the next change and it should arrive with the number.

## Verification

`cargo check --workspace --tests -j2` — green, no warnings. New guard test passes (2/2).

Refs #7505.
