### PR TITLE
Fix Cook worktree destination convergence

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -473,7 +473,10 @@ const COOK_PROVIDER_TERMINAL_POLL_INTERVAL: Duration = Duration::from_millis(250
 /// before Cook can start any provider mutation or execution.
 const COOK_PROVIDER_RESOLVE_ATTEMPTS: u32 = 2;
 const COOK_PROVIDER_RESOLVE_BACKOFF: Duration = Duration::from_millis(100);
-const COOK_PROVIDER_RESOLVE_DEADLINE: Duration = Duration::from_secs(90);
+// Leave a small, explicit grace window around a provider's maximum supported
+// lookup budget so a configured 120-second exact-handle lookup is not cut off
+// by Cook before the provider can return its authoritative answer.
+const COOK_PROVIDER_RESOLVE_DEADLINE: Duration = Duration::from_secs(121);
 const COOK_PROVIDER_RESOLVE_MIN_BUDGET: Duration = Duration::from_millis(50);
 
 /// One Cook progress event, as delivered to a foreground observer.
@@ -6794,10 +6797,7 @@ fn materialize_pending_cook_workspace(
     };
     let mut identity = match resolve(options) {
         Ok(identity) => identity,
-        Err(error)
-            if provider_id(options).is_none()
-                && error.details["worktree_provider_lookup"] == "not_found" =>
-        {
+        Err(error) if error.details["worktree_provider_lookup"] == "not_found" => {
             let provision = provision_pending_cook_workspace(lifecycle_store, options, &config)?;
             // Pin the provider that performed the durable mutation. A later
             // continuation re-resolves this exact destination through its owner.

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -5355,7 +5355,7 @@ fn persistent_slow_provider_with_known_path_returns_exhausted_cwd_recovery() {
 
 #[cfg(unix)]
 #[test]
-fn deferred_provider_ensure_materializes_injected_lifecycle_plan_after_its_postcondition() {
+fn pinned_missing_provider_ensures_an_unattached_branch_after_durable_admission() {
     use std::os::unix::fs::PermissionsExt;
 
     homeboy_core::test_support::with_isolated_home(|_| {
@@ -5414,7 +5414,7 @@ fn deferred_provider_ensure_materializes_injected_lifecycle_plan_after_its_postc
         std::fs::write(
             &provider,
             format!(
-                "#!/bin/sh\ncase \"$1\" in\nresolve)\n  if test -f '{}'; then printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"fixture@durable-ensure\",\"path\":\"{}\",\"branch\":\"durable-ensure\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'; else printf '%s\\n' '{{\"worktrees\":[]}}' ; fi\n  ;;\nensure)\n  test \"$2\" = fixture && test \"$3\" = main && test \"$4\" = durable-ensure && test \"$5\" = https://example.test/issues/12601 && test \"$6\" = agent_task_cook && test \"$7\" = durable-ensure-run && test \"$8\" = remove_on_success || exit 9\n  git -C '{}' worktree add --quiet -b durable-ensure '{}' HEAD && touch '{}'\n  ;;\nesac\n",
+                "#!/bin/sh\ncase \"$1\" in\nresolve)\n  if test -f '{}'; then printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"fixture@durable-ensure\",\"path\":\"{}\",\"branch\":\"durable-ensure\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'; else printf '%s\\n' '{{\"worktrees\":[]}}' ; fi\n  ;;\nensure)\n  test \"$2\" = fixture && test \"$3\" = main && test \"$4\" = durable-ensure && test \"$5\" = https://example.test/issues/12601 && test \"$6\" = agent_task_cook && test \"$7\" = durable-ensure-run && test \"$8\" = remove_on_success || exit 9\n  git -C '{}' worktree add --quiet '{}' durable-ensure && touch '{}'\n  ;;\nesac\n",
                 created.display(),
                 workspace.display(),
                 source.display(),
@@ -5469,6 +5469,12 @@ fn deferred_provider_ensure_materializes_injected_lifecycle_plan_after_its_postc
             },
         );
         homeboy_core::defaults::save_config(&config).expect("save provider config");
+        assert!(Command::new("git")
+            .args(["branch", "durable-ensure", "HEAD"])
+            .current_dir(&source)
+            .status()
+            .expect("create unattached branch")
+            .success());
 
         let cook_id = "durable-ensure";
         let run_id = "durable-ensure-run";
@@ -5478,6 +5484,7 @@ fn deferred_provider_ensure_materializes_injected_lifecycle_plan_after_its_postc
             "action": "lookup_pending",
             "kind": "provider",
             "handle": options.to_worktree,
+            "worktree_provider_id": "fixture",
             "provision_intent": {
                 "repo": "fixture",
                 "base": "main",


### PR DESCRIPTION
## Summary
- allow a pinned provider to ensure an unambiguous missing Cook destination after its exact-handle lookup reports not found
- retain the full configured 120-second lookup budget with a bounded one-second Cook grace window
- cover reuse of an existing unattached branch through the provider ensure contract

Fixes #12134
Refs #9908

## Verification
- `cargo test -p homeboy-agents pinned_missing_provider_ensures --lib`
- `cargo test -p homeboy-agents short_cook_deadline_caps --lib`
- `cargo test -p homeboy-core path_resolution_retries_a_transient_resolve_path_timeout --lib`
- `cargo fmt --all --check`

## AI assistance
OpenAI gpt-5.6-sol via OpenCode was used to inspect the Cook/provider resolution path, implement the bounded convergence repair, and run focused Rust tests. Chris Huber reviewed and remains responsible for the change.