### PR TITLE
fix(cook): resolve stale remote bases

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4085,8 +4085,7 @@ fn run_cook_reported(
                     record = lifecycle_store.read_record(&failure_options.initial_run_id)?;
                 }
                 if error.retryable != Some(true)
-                    && record.metadata["pre_execution_failure"]["phase"].as_str()
-                        == Some("cook_pre_execution")
+                    && record.metadata.get("pre_execution_failure").is_some()
                 {
                     return Ok(pre_execution_failure_report(
                         failure_options.cook_id.clone(),
@@ -4471,6 +4470,7 @@ fn run_cook_spine(
         && (options.attempt_dispatcher.is_none() || options.source_worktree_path.is_some())
     {
         validate_cook_workspace(&options).map_err(|mut error| {
+            error = with_pre_execution_phase(error, "workspace_base_ancestry_preflight");
             error.details["cook_materialized_by_invocation"] = materialized_by_invocation.into();
             error
         })?;
@@ -6466,7 +6466,8 @@ fn validate_cook_workspace(options: &AgentTaskCookServiceOptions) -> Result<()> 
             ));
         }
     }
-    preflight_cook_workspace_base_ancestry(&target, &options.base)?;
+    preflight_cook_workspace_base_ancestry(&target, &options.base)
+        .map_err(|error| with_pre_execution_phase(error, "workspace_base_ancestry_preflight"))?;
     Ok(())
 }
 
@@ -6478,16 +6479,15 @@ fn preflight_cook_workspace_base_ancestry(target: &Path, base: &str) -> Result<(
     else {
         return Ok(());
     };
-    // A destination can be a valid local Git workspace without an origin base
-    // to compare. Preserve that provider-owned contract; when origin already
-    // resolves the declared base, capture its current immutable snapshot below.
-    let tracking_ref = format!("refs/remotes/origin/{base}");
-    let tracking_base = std::process::Command::new("git")
-        .args(["show-ref", "--verify", "--quiet", &tracking_ref])
+    // A provider-owned Git destination can intentionally have no origin. When
+    // origin is configured, resolve its authoritative base directly instead of
+    // trusting a potentially absent shallow or single-branch tracking ref.
+    let origin = std::process::Command::new("git")
+        .args(["remote", "get-url", "origin"])
         .current_dir(target)
-        .status()
+        .output()
         .map_err(|error| Error::git_command_failed(error.to_string()))?;
-    if !tracking_base.success() {
+    if !origin.status.success() {
         return Ok(());
     }
     let Some(resolved_base) =

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3848,101 +3848,175 @@ fn batch_cook_options(
 
 #[test]
 fn workspace_base_ancestry_preflight_rejects_behind_and_diverged_without_attributing_base_files() {
-    let remote = tempfile::tempdir().expect("bare origin");
-    let workspace = tempfile::tempdir().expect("workspace");
-    let git = |cwd: &std::path::Path, args: &[&str]| {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let remote = tempfile::tempdir().expect("bare origin");
+        let workspace = tempfile::tempdir().expect("workspace");
+        let git = |cwd: &std::path::Path, args: &[&str]| {
+            let output = Command::new("git")
+                .args(args)
+                .current_dir(cwd)
+                .output()
+                .expect("run git");
+            assert!(
+                output.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        git(remote.path(), &["init", "--bare"]);
         let output = Command::new("git")
-            .args(args)
-            .current_dir(cwd)
+            .args([
+                "clone",
+                remote.path().to_str().unwrap(),
+                workspace.path().to_str().unwrap(),
+            ])
             .output()
-            .expect("run git");
+            .expect("clone origin");
         assert!(
             output.status.success(),
-            "git {:?} failed: {}",
-            args,
+            "clone failed: {}",
             String::from_utf8_lossy(&output.stderr)
         );
+        git(
+            workspace.path(),
+            &["config", "user.email", "test@example.com"],
+        );
+        git(workspace.path(), &["config", "user.name", "Test"]);
+        git(workspace.path(), &["checkout", "-b", "main"]);
+        std::fs::write(workspace.path().join("base.txt"), "base\n").unwrap();
+        git(workspace.path(), &["add", "base.txt"]);
+        git(workspace.path(), &["commit", "-m", "base"]);
+        git(workspace.path(), &["push", "-u", "origin", "main"]);
+        let destination_root = tempfile::tempdir().expect("candidate worktree root");
+        let destination = destination_root.path().join("candidate");
+        git(
+            workspace.path(),
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "candidate",
+                destination.to_str().expect("candidate path"),
+                "main",
+            ],
+        );
+        std::fs::write(workspace.path().join("newer-base.txt"), "base only\n").unwrap();
+        git(workspace.path(), &["add", "newer-base.txt"]);
+        git(workspace.path(), &["commit", "-m", "advance base"]);
+        git(workspace.path(), &["push"]);
+        // Shallow and single-branch checkouts may not retain this local ref. The
+        // admission check must still resolve the authoritative origin base.
+        git(
+            &destination,
+            &["update-ref", "-d", "refs/remotes/origin/main"],
+        );
+
+        let behind = preflight_cook_workspace_base_ancestry(&destination, "main")
+            .expect_err("strictly behind destination is rejected before provider execution");
+        assert_eq!(
+            behind.details["workspace_base_ancestry"]["direction"],
+            "behind"
+        );
+        assert_eq!(
+            behind.details["workspace_base_ancestry"]["base_only_commits"],
+            1
+        );
+        assert_eq!(
+            behind.details["workspace_base_ancestry"]["candidate_only_commits"],
+            0
+        );
+        assert_eq!(
+            behind.details["workspace_base_ancestry"]["next_action"],
+            "converge_destination_before_provider"
+        );
+
+        let dispatches = Arc::new(AtomicUsize::new(0));
+        let mut options = batch_cook_options(
+            "cook-stale-origin-base",
+            Arc::new(RecordingDetachedAttemptDispatcher {
+                dispatches: Arc::clone(&dispatches),
+            }),
+        );
+        options.to_worktree = destination.display().to_string();
+        options.source_worktree_path = Some(destination.clone());
+        options.initial_plan.tasks[0].metadata = serde_json::json!({
+            "worktree_provision": { "kind": "explicit_cwd" }
+        });
+        let report = run_cook(CookContext::new(options.clone(), Arc::new(UnusedExecutor)))
+            .expect("stale destination is a durable pre-execution failure");
+        assert_eq!(report.value.status, "pre_execution_failure");
+        assert_eq!(dispatches.load(Ordering::SeqCst), 0);
+        let record = agent_task_lifecycle::status(&options.initial_run_id)
+            .expect("durable stale-base failure record");
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["phase"],
+            "workspace_base_ancestry_preflight"
+        );
+        assert!(record.metadata["pre_execution_failure"]["message"]
+            .as_str()
+            .expect("stale-base diagnostic")
+            .contains("Cook destination is behind"));
+        assert_eq!(record.metadata["provider_executions_consumed"], 0);
+
+        git(
+            &destination,
+            &[
+                "fetch",
+                "origin",
+                "refs/heads/main:refs/remotes/origin/main",
+            ],
+        );
+        git(&destination, &["merge", "--ff-only", "origin/main"]);
+        preflight_cook_workspace_base_ancestry(&destination, "main")
+            .expect("clean intentional no-change destination is equivalent to its resolved base");
+        std::fs::write(destination.join("candidate.txt"), "candidate only\n").unwrap();
+        git(&destination, &["add", "candidate.txt"]);
+        git(&destination, &["commit", "-m", "candidate"]);
+        preflight_cook_workspace_base_ancestry(&destination, "main")
+            .expect("ahead destination retains a candidate relative to the resolved base");
+
+        std::fs::write(workspace.path().join("newer-base-2.txt"), "base only\n").unwrap();
+        git(workspace.path(), &["add", "newer-base-2.txt"]);
+        git(workspace.path(), &["commit", "-m", "advance base again"]);
+        git(workspace.path(), &["push"]);
+        let diverged = preflight_cook_workspace_base_ancestry(&destination, "main")
+            .expect_err("diverged destination is rejected before provider execution");
+        assert_eq!(
+            diverged.details["workspace_base_ancestry"]["direction"],
+            "diverged"
+        );
+        assert_eq!(
+            diverged.details["workspace_base_ancestry"]["base_only_commits"],
+            1
+        );
+        assert_eq!(
+            diverged.details["workspace_base_ancestry"]["candidate_only_commits"],
+            1
+        );
+    });
+}
+
+#[test]
+fn workspace_base_ancestry_preflight_preserves_provider_owned_non_origin_targets() {
+    let workspace = tempfile::tempdir().expect("provider-owned Git workspace");
+    let git = |args: &[&str]| {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(workspace.path())
+            .output()
+            .expect("run git");
+        assert!(output.status.success(), "git {:?} failed", args);
     };
-    git(remote.path(), &["init", "--bare"]);
-    let output = Command::new("git")
-        .args([
-            "clone",
-            remote.path().to_str().unwrap(),
-            workspace.path().to_str().unwrap(),
-        ])
-        .output()
-        .expect("clone origin");
-    assert!(
-        output.status.success(),
-        "clone failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    git(
-        workspace.path(),
-        &["config", "user.email", "test@example.com"],
-    );
-    git(workspace.path(), &["config", "user.name", "Test"]);
-    git(workspace.path(), &["checkout", "-b", "main"]);
-    std::fs::write(workspace.path().join("base.txt"), "base\n").unwrap();
-    git(workspace.path(), &["add", "base.txt"]);
-    git(workspace.path(), &["commit", "-m", "base"]);
-    git(workspace.path(), &["push", "-u", "origin", "main"]);
-    git(workspace.path(), &["checkout", "-b", "candidate"]);
-    git(workspace.path(), &["checkout", "main"]);
-    std::fs::write(workspace.path().join("newer-base.txt"), "base only\n").unwrap();
-    git(workspace.path(), &["add", "newer-base.txt"]);
-    git(workspace.path(), &["commit", "-m", "advance base"]);
-    git(workspace.path(), &["push"]);
-    git(workspace.path(), &["checkout", "candidate"]);
+    git(&["init", "--initial-branch=main"]);
+    git(&["config", "user.email", "test@example.com"]);
+    git(&["config", "user.name", "Test"]);
+    std::fs::write(workspace.path().join("provider.txt"), "provider owned\n").unwrap();
+    git(&["add", "provider.txt"]);
+    git(&["commit", "-m", "provider base"]);
 
-    let behind = preflight_cook_workspace_base_ancestry(workspace.path(), "main")
-        .expect_err("strictly behind destination is rejected before provider execution");
-    assert_eq!(
-        behind.details["workspace_base_ancestry"]["direction"],
-        "behind"
-    );
-    assert_eq!(
-        behind.details["workspace_base_ancestry"]["base_only_commits"],
-        1
-    );
-    assert_eq!(
-        behind.details["workspace_base_ancestry"]["candidate_only_commits"],
-        0
-    );
-    assert_eq!(
-        behind.details["workspace_base_ancestry"]["next_action"],
-        "converge_destination_before_provider"
-    );
-
-    git(workspace.path(), &["merge", "--ff-only", "origin/main"]);
     preflight_cook_workspace_base_ancestry(workspace.path(), "main")
-        .expect("clean intentional no-change destination is equivalent to its resolved base");
-    std::fs::write(workspace.path().join("candidate.txt"), "candidate only\n").unwrap();
-    git(workspace.path(), &["add", "candidate.txt"]);
-    git(workspace.path(), &["commit", "-m", "candidate"]);
-    preflight_cook_workspace_base_ancestry(workspace.path(), "main")
-        .expect("ahead destination retains a candidate relative to the resolved base");
-
-    git(workspace.path(), &["checkout", "main"]);
-    std::fs::write(workspace.path().join("newer-base-2.txt"), "base only\n").unwrap();
-    git(workspace.path(), &["add", "newer-base-2.txt"]);
-    git(workspace.path(), &["commit", "-m", "advance base again"]);
-    git(workspace.path(), &["push"]);
-    git(workspace.path(), &["checkout", "candidate"]);
-    let diverged = preflight_cook_workspace_base_ancestry(workspace.path(), "main")
-        .expect_err("diverged destination is rejected before provider execution");
-    assert_eq!(
-        diverged.details["workspace_base_ancestry"]["direction"],
-        "diverged"
-    );
-    assert_eq!(
-        diverged.details["workspace_base_ancestry"]["base_only_commits"],
-        1
-    );
-    assert_eq!(
-        diverged.details["workspace_base_ancestry"]["candidate_only_commits"],
-        1
-    );
+        .expect("a provider-owned Git workspace without origin has no remote base to converge");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Follow-up

Follow-up to merged #13027, which landed before its corrective ancestry commit. Closes #13000.

## Summary
- Resolve configured `origin` directly when a shallow or single-branch destination lacks `refs/remotes/origin/<base>`.
- Preserve provider-owned Git destinations that intentionally have no `origin`.
- Persist `workspace_base_ancestry_preflight` only for ancestry rejection; other workspace, provider, and authorization validation failures retain their existing phases.
- Report every durable pre-execution failure through the pre-execution report contract.

## Verification
- `cargo fmt`
- `cargo test -p homeboy-agents workspace_base_ancestry_preflight --lib`
- `cargo test -p homeboy-agents non_ancestry_workspace_validation_retains_the_generic_pre_execution_phase --lib`
- `cargo test -p homeboy-agents provider_dispatch_observes_a_durable_provider_start_boundary --lib`

The ancestry regression uses a linked destination strictly behind origin main after deleting its local tracking ref. It proves remote-base resolution, zero dispatcher/provider reservations, durable phase and diagnostic evidence, and covers equivalent no-change, ahead, diverged, and non-origin provider-owned targets. The non-ancestry regression proves a primary-checkout validation failure remains `cook_pre_execution` with its original linked-worktree diagnostic.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagent was used to inspect Cook validation phases, implement the precise ancestry-only tagging, add durable phase regressions, and run focused verification. Chris Huber reviewed and remains responsible for this change.