### PR TITLE
Preflight review test capabilities before admission

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -2040,7 +2040,13 @@ fn preflight_review_test_capability(cli: &Cli) -> homeboy::core::Result<()> {
         &args.extension_override,
         Some(homeboy_extension::ExtensionCapability::Test),
     )
-    .map(|_| ())
+	.and_then(|context| {
+		homeboy::core::extension_execution::resolve_execution_context(
+			&context.component,
+			homeboy_extension::ExtensionCapability::Test,
+		)
+		.map(|_| ())
+	})
     .map_err(|mut error| {
         error.details["review_capability_preflight"] = serde_json::json!({
             "capability": "test",
@@ -2691,9 +2697,27 @@ mod tests {
                 ] {
                     let mut argv = vec!["homeboy"];
                     argv.extend(placement.iter().copied());
-                    argv.extend(["review", "test", "--path", script_path]);
-                    argv.extend(test_mode.iter().copied());
+                    argv.extend(["review", "test"]);
+                    if test_mode.first().copied() != Some("--") {
+                        argv.extend(test_mode.iter().copied());
+                    }
+                    argv.extend(["--path", script_path]);
+                    if test_mode.first().copied() == Some("--") {
+                        argv.extend(test_mode.iter().copied());
+                    }
                     let cli = Cli::parse_from(argv);
+
+                    let result = preflight_review_test_capability(&cli);
+                    assert!(
+						result.is_err(),
+						"modified test mode requires an extension test provider: {test_mode:?}, {placement:?}"
+					);
+                    let error = result.expect_err("error checked above");
+                    assert!(
+                        error.message.contains("No extension provider configured"),
+                        "{test_mode:?}, {placement:?}: {}",
+                        error.message
+                    );
 
                     assert_eq!(
                         preflight_hot_command_with(
@@ -2707,10 +2731,6 @@ mod tests {
                         Some(2),
                         "{test_mode:?}, {placement:?}"
                     );
-                    assert!(preflight_review_test_capability(&cli)
-                        .expect_err("modified test mode requires an extension test provider")
-                        .message
-                        .contains("No extension provider configured"));
                 }
             }
 

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1779,6 +1779,10 @@ fn preflight_hot_command_with(
     if controller_owned_unmaterialized_resume(cli) {
         return None;
     }
+    if let Err(err) = preflight_review_test_capability(cli) {
+        output_runtime::emit_json_result_for_identity(Err(err), output_file, 2, command_identity);
+        return Some(2);
+    }
     if let Some(hot_command) = resource_policy::hot_command(&cli.command) {
         if let Ok((resources, _)) = preflight() {
             let mut lab_readiness = if hot_command.lab_offload_supported {
@@ -2000,6 +2004,70 @@ fn detached_cook_unmaterialized_admission_eligible(cli: &Cli) -> bool {
                 command: crate::commands::agent_task::AgentTaskCommand::Cook(_),
             })
         )
+}
+
+/// Verify `review test` can execute without creating work, admitting controller
+/// capacity, selecting a runner, or preparing a Lab workspace.
+fn preflight_review_test_capability(cli: &Cli) -> homeboy::core::Result<()> {
+    let Commands::Review(review) = &cli.command else {
+        return Ok(());
+    };
+    let Some(crate::commands::review::ReviewCommand::Test(args)) = review.command.as_ref() else {
+        return Ok(());
+    };
+
+    let source = crate::commands::source_command::resolve_source_context(
+        &args.comp,
+        &args.setting_args,
+        &args.extension_override,
+        None,
+    )?;
+    let passthrough_args = crate::commands::utils::args::filter_passthrough_args(
+        crate::commands::utils::args::PassthroughCommand::Test,
+        &args.args,
+    );
+    if args.should_use_self_check_dispatch(&passthrough_args)
+        && source
+            .component
+            .has_script(homeboy_extension::ExtensionCapability::Test)
+    {
+        return Ok(());
+    }
+
+    crate::commands::source_command::resolve_source_context(
+        &args.comp,
+        &args.setting_args,
+        &args.extension_override,
+        Some(homeboy_extension::ExtensionCapability::Test),
+    )
+    .map(|_| ())
+    .map_err(|mut error| {
+        error.details["review_capability_preflight"] = serde_json::json!({
+            "capability": "test",
+            "effective_component": {
+                "id": source.component_id,
+                "source_path": source.source_path,
+                "config_provenance": review_test_config_provenance(&source),
+            },
+        });
+        error.with_hint(
+            "Review capability preflight failed before resource admission or Lab routing; repair the component capability, then retry the same command.",
+        )
+    })
+}
+
+fn review_test_config_provenance(
+    source: &homeboy::core::engine::execution_context::ExecutionContext,
+) -> String {
+    let portable_config = source.source_path.join("homeboy.json");
+    if portable_config.is_file() {
+        return format!("portable component config: {}", portable_config.display());
+    }
+    format!(
+        "resolved component '{}' without a portable homeboy.json at {} (registry or synthetic target)",
+        source.component_id,
+        source.source_path.display()
+    )
 }
 
 fn review_test_runner_requirements(
@@ -2538,6 +2606,197 @@ mod tests {
                     ["local_fallback"],
                 false
             );
+        });
+    }
+
+    #[test]
+    fn review_test_missing_capability_fails_before_resource_admission_for_all_placements() {
+        crate::test_support::with_isolated_home(|_| {
+            let component = tempfile::tempdir().expect("component directory");
+            std::fs::write(
+                component.path().join("homeboy.json"),
+                r#"{"id":"unconfigured-review-test"}"#,
+            )
+            .expect("write component config");
+            let path = component.path().to_str().expect("component path");
+
+            for placement in [
+                vec!["--placement", "local"],
+                vec!["--placement", "auto"],
+                vec!["--placement", "lab"],
+                vec!["--runner", "homeboy-lab"],
+            ] {
+                let mut argv = vec!["homeboy"];
+                argv.extend(placement.iter().copied());
+                argv.extend(["review", "test", "--path", path]);
+                let cli = Cli::parse_from(argv);
+
+                assert_eq!(
+                    preflight_hot_command_with(
+                        &cli,
+                        None,
+                        &output::CommandIdentity::with_operation("review", "test"),
+                        || -> crate::commands::CmdResult<crate::commands::resources::DoctorOutput> {
+                            panic!("capability preflight must run before resource admission")
+                        },
+                    ),
+                    Some(2),
+                    "{placement:?}"
+                );
+
+                let error = preflight_review_test_capability(&cli)
+                    .expect_err("unconfigured review test must fail capability preflight");
+                assert!(error.message.contains("No extension provider configured"));
+                assert_eq!(
+                    error.details["review_capability_preflight"]["effective_component"]["id"],
+                    "unconfigured-review-test"
+                );
+                assert!(
+                    error.details["review_capability_preflight"]["effective_component"]
+                        ["config_provenance"]
+                        .as_str()
+                        .expect("config provenance")
+                        .contains("homeboy.json")
+                );
+                assert!(error.hints.iter().any(|hint| hint
+                    .message
+                    .contains("component set unconfigured-review-test --extension")));
+            }
+        });
+    }
+
+    #[test]
+    fn review_test_capability_preflight_only_accepts_eligible_component_scripts() {
+        crate::test_support::with_isolated_home(|home| {
+            let script_component = tempfile::tempdir().expect("script component directory");
+            std::fs::write(
+                script_component.path().join("homeboy.json"),
+                r#"{"id":"script-review-test","scripts":{"test":["./test.sh"]}}"#,
+            )
+            .expect("write script component config");
+            let script_path = script_component
+                .path()
+                .to_str()
+                .expect("script component path");
+            let script_cli = Cli::parse_from(["homeboy", "review", "test", "--path", script_path]);
+            preflight_review_test_capability(&script_cli)
+                .expect("component-owned test script remains supported");
+
+            for test_mode in [vec!["--skip-lint"], vec!["--", "--testsuite=imports"]] {
+                for placement in [
+                    vec!["--placement", "local"],
+                    vec!["--placement", "auto"],
+                    vec!["--placement", "lab"],
+                    vec!["--runner", "homeboy-lab"],
+                ] {
+                    let mut argv = vec!["homeboy"];
+                    argv.extend(placement.iter().copied());
+                    argv.extend(["review", "test", "--path", script_path]);
+                    argv.extend(test_mode.iter().copied());
+                    let cli = Cli::parse_from(argv);
+
+                    assert_eq!(
+                        preflight_hot_command_with(
+                            &cli,
+                            None,
+                            &output::CommandIdentity::with_operation("review", "test"),
+                            || -> crate::commands::CmdResult<crate::commands::resources::DoctorOutput> {
+                                panic!("unsupported scripted test mode must fail before resource admission")
+                            },
+                        ),
+                        Some(2),
+                        "{test_mode:?}, {placement:?}"
+                    );
+                    assert!(preflight_review_test_capability(&cli)
+                        .expect_err("modified test mode requires an extension test provider")
+                        .message
+                        .contains("No extension provider configured"));
+                }
+            }
+
+            let extension_component = tempfile::tempdir().expect("extension component directory");
+            std::fs::write(
+                extension_component.path().join("homeboy.json"),
+                r#"{"id":"extension-review-test","extensions":{"fixture-test":{}}}"#,
+            )
+            .expect("write extension component config");
+            let extension_dir = home.path().join(".config/homeboy/extensions/fixture-test");
+            std::fs::create_dir_all(&extension_dir).expect("extension directory");
+            std::fs::write(
+                extension_dir.join("fixture-test.json"),
+                r#"{"name":"fixture-test","version":"1.0.0","test":{"extension_script":"test.sh"}}"#,
+            )
+            .expect("write extension manifest");
+            let extension_path = extension_component
+                .path()
+                .to_str()
+                .expect("extension component path");
+            let extension_cli =
+                Cli::parse_from(["homeboy", "review", "test", "--path", extension_path]);
+            preflight_review_test_capability(&extension_cli)
+                .expect("configured extension test support remains valid");
+        });
+    }
+
+    #[test]
+    fn review_test_capability_preflight_preserves_extension_override_diagnostics() {
+        crate::test_support::with_isolated_home(|home| {
+            let component = tempfile::tempdir().expect("component directory");
+            std::fs::write(
+                component.path().join("homeboy.json"),
+                r#"{"id":"override-review-test","extensions":{"fixture-without-test":{}}}"#,
+            )
+            .expect("write component config");
+            let extension_dir = home
+                .path()
+                .join(".config/homeboy/extensions/fixture-without-test");
+            std::fs::create_dir_all(&extension_dir).expect("extension directory");
+            std::fs::write(
+                extension_dir.join("fixture-without-test.json"),
+                r#"{"name":"fixture-without-test","version":"1.0.0"}"#,
+            )
+            .expect("write extension manifest");
+            let path = component.path().to_str().expect("component path");
+
+            for placement in [
+                vec!["--placement", "local"],
+                vec!["--placement", "auto"],
+                vec!["--placement", "lab"],
+                vec!["--runner", "homeboy-lab"],
+            ] {
+                let mut argv = vec!["homeboy"];
+                argv.extend(placement.iter().copied());
+                argv.extend([
+                    "review",
+                    "test",
+                    "--path",
+                    path,
+                    "--extension",
+                    "fixture-without-test",
+                ]);
+                let cli = Cli::parse_from(argv);
+
+                assert_eq!(
+                    preflight_hot_command_with(
+                        &cli,
+                        None,
+                        &output::CommandIdentity::with_operation("review", "test"),
+                        || -> crate::commands::CmdResult<crate::commands::resources::DoctorOutput> {
+                            panic!("invalid extension override must fail before resource admission")
+                        },
+                    ),
+                    Some(2),
+                    "{placement:?}"
+                );
+                let error = preflight_review_test_capability(&cli)
+                    .expect_err("override without test support must fail capability preflight");
+                assert!(error
+                    .message
+                    .contains("explicit extension override 'fixture-without-test'"));
+                assert!(error.hints.iter().any(|hint| hint
+                    .message
+                    .contains("Upgrade or refresh the runner extension")));
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- validate `review test` capability before resource admission and Lab routing
- allow component scripts only for self-check-compatible test modes
- preserve actionable extension-override diagnostics

Fixes #12985

## Verification
- `cargo test -p homeboy-cli review_test_`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI assistance
OpenAI `gpt-5.6-sol` was used through OpenCode to inspect the review routing flow, implement the preflight, and add focused tests. Chris Huber reviewed the resulting changes and remains responsible for every line.