### PR TITLE
fix(cook): carry stdin snapshots as literals

### DIFF
--- a/crates/homeboy-agents/src/agent_task_controller_service/request.rs
+++ b/crates/homeboy-agents/src/agent_task_controller_service/request.rs
@@ -29,6 +29,7 @@ pub fn controller_request_dispatch_command(
     let dispatch = request.get("dispatch").unwrap_or(request);
     let mut command = AgentTaskDispatchCommand {
         prompt: optional_string(dispatch, "prompt"),
+        prompt_is_literal: false,
         tasks: optional_string_array(dispatch, "tasks")?,
         cwd: optional_string(dispatch, "cwd")
             .or_else(|| optional_string(request, "cwd"))

--- a/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
@@ -141,7 +141,11 @@ pub fn build_dispatch_plan_with_provider_requirements(
         });
     let mut prompt_specs = Vec::new();
     if let Some(prompt) = &request.prompt {
-        prompt_specs.push(DispatchPromptSpec::new(prompt.clone()));
+        prompt_specs.push(DispatchPromptSpec {
+            prompt: prompt.clone(),
+            task_id: None,
+            is_literal: request.prompt_is_literal,
+        });
     }
     prompt_specs.extend(request.tasks.iter().cloned().map(DispatchPromptSpec::new));
     prompt_specs.extend(read_dispatch_tasks_json(
@@ -199,7 +203,14 @@ pub fn build_dispatch_plan_with_provider_requirements(
     let command_policy = resolve_dispatch_command_policy(request)?;
     let mut tasks = Vec::new();
     for (index, prompt_spec) in prompt_specs.iter().enumerate() {
-        let resolved_prompt = read_prompt_spec(&prompt_spec.prompt)?;
+        let resolved_prompt = if prompt_spec.is_literal {
+            prompt_spec::ResolvedPromptSpec {
+                content: prompt_spec.prompt.clone(),
+                stored_prompt: None,
+            }
+        } else {
+            read_prompt_spec(&prompt_spec.prompt)?
+        };
         let instructions = dispatch_instructions(
             resolved_prompt.content.clone(),
             request.task_url.as_deref(),
@@ -2215,6 +2226,7 @@ mod tests {
     fn dispatch_request(overrides: DispatchRequestOverrides) -> AgentTaskDispatchRequest {
         AgentTaskDispatchRequest {
             prompt: overrides.prompt,
+            prompt_is_literal: false,
             tasks: overrides.tasks,
             cwd: overrides.cwd,
             workspace: overrides.workspace,

--- a/crates/homeboy-agents/src/agent_task_dispatch_plan/prompt_spec.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_plan/prompt_spec.rs
@@ -59,6 +59,7 @@ pub(crate) fn read_prompt_spec(spec: &str) -> Result<ResolvedPromptSpec> {
 pub(crate) struct DispatchPromptSpec {
     pub(crate) prompt: String,
     pub(crate) task_id: Option<String>,
+    pub(crate) is_literal: bool,
 }
 
 impl DispatchPromptSpec {
@@ -66,6 +67,7 @@ impl DispatchPromptSpec {
         Self {
             prompt,
             task_id: None,
+            is_literal: false,
         }
     }
 }
@@ -151,7 +153,11 @@ fn task_prompt_from_json_item(item: Value, index: usize) -> Result<DispatchPromp
                     })
                 })
                 .transpose()?;
-            Ok(DispatchPromptSpec { prompt, task_id })
+            Ok(DispatchPromptSpec {
+                prompt,
+                task_id,
+                is_literal: false,
+            })
         }
         _ => Err(Error::validation_invalid_argument(
             "tasks",

--- a/crates/homeboy-agents/src/agent_task_dispatch_service.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_service.rs
@@ -129,6 +129,9 @@ pub struct DispatchCoreInputs {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentTaskDispatchRequest {
     pub prompt: Option<String>,
+    /// The CLI captured this prompt from a structured source already. Treat it
+    /// as literal task text rather than parsing it as another source spec.
+    pub prompt_is_literal: bool,
     pub tasks: Vec<String>,
     pub cwd: Option<String>,
     pub workspace: Option<String>,
@@ -345,6 +348,7 @@ fn dispatch_report(
 #[derive(Debug, Clone, Default)]
 pub struct AgentTaskDispatchCommand {
     pub prompt: Option<String>,
+    pub prompt_is_literal: bool,
     pub tasks: Vec<String>,
     pub cwd: Option<String>,
     pub workspace: Option<String>,
@@ -666,6 +670,7 @@ fn resolve_dispatch_request_with_sources(
 
     Ok(AgentTaskDispatchRequest {
         prompt: command.prompt,
+        prompt_is_literal: command.prompt_is_literal,
         tasks: command.tasks,
         cwd: command.cwd,
         workspace: command.workspace,
@@ -757,6 +762,7 @@ mod tests {
         };
         let request = AgentTaskDispatchRequest {
             prompt: Some("Cook the task.".to_string()),
+            prompt_is_literal: false,
             tasks: Vec::new(),
             cwd: None,
             workspace: None,

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1,5 +1,5 @@
 use clap::{ArgMatches, Command};
-use std::io::IsTerminal;
+use std::io::{IsTerminal, Write};
 use std::process::Command as ProcessCommand;
 use std::sync::OnceLock;
 use uuid::Uuid;
@@ -593,6 +593,21 @@ impl CliRuntime {
         commands::set_skip_deps_hydration(cli.skip_deps_hydration);
         normalize_runs_runner_options(&mut cli, &normalized);
         normalize_cook_runner_option(&mut cli, &normalized);
+        if let Commands::AgentTask(agent_task) = &mut cli.command {
+            if let crate::commands::agent_task::AgentTaskCommand::Cook(cook) =
+                &mut agent_task.command
+            {
+                if let Err(err) = crate::commands::agent_task::run::snapshot_cook_prompt(cook) {
+                    output_runtime::emit_json_result_for_identity(
+                        Err(err),
+                        output_file.as_deref(),
+                        2,
+                        &command_identity,
+                    );
+                    return std::process::ExitCode::from(2);
+                }
+            }
+        }
         if let Commands::Fuzz(args) = &mut cli.command {
             match args.absorb_planning_runner(cli.runner.take()) {
                 Ok(runner) => cli.runner = runner,
@@ -1023,11 +1038,23 @@ fn delegate_agent_task_cook_to_pinned_runtime(
         || Ok(false),
     )
     .map_err(|error| annotate_cook_seal_failure(error, &request_id, normalized_args))?;
-    let status = ProcessCommand::new(&pinned)
+    let prompt_snapshot = match &cli.command {
+        Commands::AgentTask(agent_task) => match &agent_task.command {
+            crate::commands::agent_task::AgentTaskCommand::Cook(cook) => cook
+                .prompt_snapshot
+                .as_ref()
+                .map(|snapshot| snapshot.content.clone()),
+            _ => None,
+        },
+        _ => None,
+    };
+    let mut command = ProcessCommand::new(&pinned);
+    command
         .args(&normalized_args[1..])
-        .env(COOK_PINNED_RUNTIME_ENV, &pinned)
-        .status()
-        .map_err(|error| {
+        .env(COOK_PINNED_RUNTIME_ENV, &pinned);
+    let status = if let Some(prompt) = prompt_snapshot {
+        command.stdin(std::process::Stdio::piped());
+        let mut child = command.spawn().map_err(|error| {
             homeboy::core::Error::internal_io(
                 error.to_string(),
                 Some(format!(
@@ -1036,6 +1063,38 @@ fn delegate_agent_task_cook_to_pinned_runtime(
                 )),
             )
         })?;
+        child
+            .stdin
+            .take()
+            .ok_or_else(|| {
+                homeboy::core::Error::internal_unexpected(
+                    "pinned Cook runtime stdin was not piped".to_string(),
+                )
+            })?
+            .write_all(prompt.as_bytes())
+            .map_err(|error| {
+                homeboy::core::Error::internal_io(
+                    error.to_string(),
+                    Some("write captured Cook prompt to pinned runtime stdin".to_string()),
+                )
+            })?;
+        child.wait().map_err(|error| {
+            homeboy::core::Error::internal_io(
+                error.to_string(),
+                Some("wait for pinned Cook runtime".to_string()),
+            )
+        })?
+    } else {
+        command.status().map_err(|error| {
+            homeboy::core::Error::internal_io(
+                error.to_string(),
+                Some(format!(
+                    "execute pinned controller runtime {}",
+                    pinned.display()
+                )),
+            )
+        })?
+    };
     Ok(Some(status.code().unwrap_or(1)))
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -1070,6 +1070,8 @@ pub struct AgentTaskCookArgs {
 
 #[derive(Clone, Debug, serde::Serialize, PartialEq, Eq)]
 pub struct CookPromptSnapshot {
+    #[serde(skip)]
+    pub content: String,
     pub source: String,
     pub sha256: String,
     pub size_bytes: usize,

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -3528,6 +3528,7 @@ impl BatchCookSpec {
         }
         let dispatch = AgentTaskDispatchCommand {
             prompt,
+            prompt_is_literal: false,
             tasks: self.tasks.clone(),
             cwd: self.cwd.clone(),
             workspace: self

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -335,8 +335,7 @@ pub(crate) fn preview_cook(
                 None,
             )
         })?;
-        let mut dispatch = dispatch_args_for_cook(&args);
-        resolve_dispatch_prompt(&mut dispatch)?;
+        let dispatch = resolved_dispatch_args_for_cook(&args)?;
         let admitted_evidence = admit_provider_evidence_inputs(&args.provider_evidence_inputs)?;
         compile_args.dispatch.prompt = dispatch.prompt;
         let evidence =
@@ -1468,7 +1467,7 @@ mod preview_tests {
                 "--backend".to_string(),
                 "fixture".to_string(),
                 "--prompt".to_string(),
-                "inspect the task".to_string(),
+                "-".to_string(),
                 "--to-worktree".to_string(),
                 workspace,
                 "--no-finalize".to_string(),
@@ -1479,9 +1478,15 @@ mod preview_tests {
             let Commands::AgentTask(agent_task) = cli.command else {
                 panic!("agent-task command");
             };
-            let super::super::AgentTaskCommand::Cook(args) = agent_task.command else {
+            let super::super::AgentTaskCommand::Cook(mut args) = agent_task.command else {
                 panic!("Cook command");
             };
+            args.prompt_snapshot = Some(super::super::args::CookPromptSnapshot {
+                content: "@/not/a/prompt/file".to_string(),
+                source: "stdin".to_string(),
+                sha256: "sha256:fixture".to_string(),
+                size_bytes: "@/not/a/prompt/file".len(),
+            });
             let (preview, exit_code) = preview_cook(*args, None).expect("compile preview");
 
             assert_eq!(exit_code, 0);
@@ -3821,10 +3826,7 @@ pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress(
         project_provider_evidence_inputs(&args.provider_evidence_inputs, workspace, None)?;
     }
 
-    let mut dispatch_args = dispatch_args_for_cook(&args);
-    // Resolve @file / stdin / stored-ref prompts before anything consumes the
-    // prompt, so the executor receives the exact bytes (#10100).
-    resolve_dispatch_prompt(&mut dispatch_args)?;
+    let mut dispatch_args = resolved_dispatch_args_for_cook(&args)?;
     let requested_cook_id = dispatch_args.run_id.clone();
     if let Some(cook_id) = requested_cook_id.as_deref() {
         dispatch_args.run_id = Some(
@@ -3873,15 +3875,6 @@ pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress(
     }
     if let Some(provenance) = provenance {
         record_cook_argument_provenance(&mut initial_plan, provenance);
-    }
-    if let Some(snapshot) = &args.prompt_snapshot {
-        for task in &mut initial_plan.tasks {
-            // The prompt is carried by `instructions`; metadata records the
-            // transport without duplicating private stdin content.
-            task.metadata["prompt_source"] = serde_json::json!(snapshot.source);
-        }
-        initial_plan.metadata["prompt_input"] = serde_json::to_value(snapshot)
-            .map_err(|error| homeboy::core::Error::internal_json(error.to_string(), None))?;
     }
     if args.require_acceptance {
         let authority = args.acceptance_authority.clone().ok_or_else(|| {
@@ -4054,6 +4047,22 @@ pub(super) fn dispatch_args_for_cook(args: &AgentTaskCookArgs) -> DispatchArgs {
     dispatch_args
 }
 
+/// Resolve a Cook prompt without treating an ingress snapshot as another
+/// structured spec. The original `dispatch.prompt` remains source provenance;
+/// the typed snapshot supplies literal task content.
+fn resolved_dispatch_args_for_cook(
+    args: &AgentTaskCookArgs,
+) -> homeboy::core::Result<DispatchArgs> {
+    let mut dispatch = dispatch_args_for_cook(args);
+    if let Some(snapshot) = &args.prompt_snapshot {
+        dispatch.prompt = Some(snapshot.content.clone());
+        dispatch.prompt_is_literal = true;
+    } else {
+        resolve_dispatch_prompt(&mut dispatch)?;
+    }
+    Ok(dispatch)
+}
+
 fn resolve_cook_execution_budget(
     args: &AgentTaskCookArgs,
     plan: &mut AgentTaskPlan,
@@ -4127,7 +4136,10 @@ pub(super) fn resolve_dispatch_prompt(
 /// Snapshot stdin at the Cook ingress boundary. Later compilation may happen in
 /// a detached child or retry a plan, neither of which owns the original stream.
 pub(crate) fn snapshot_cook_prompt(args: &mut AgentTaskCookArgs) -> homeboy::core::Result<()> {
-    if args.prompt_snapshot.is_some() || args.dispatch.prompt.as_deref() != Some("-") {
+    if args.prompt_snapshot.is_some()
+        || args.attempt_plan.is_some()
+        || args.dispatch.prompt.as_deref() != Some("-")
+    {
         return Ok(());
     }
 
@@ -4140,15 +4152,17 @@ pub(crate) fn snapshot_cook_prompt(args: &mut AgentTaskCookArgs) -> homeboy::cor
             Some(vec!["Pipe a non-empty prompt, for example: homeboy agent-task cook --prompt - < task.md".to_string()]),
         ));
     }
+    let size_bytes = content.len();
+    let sha256 = format!(
+        "sha256:{}",
+        homeboy_engine_primitives::content_hash::sha256_hex(content.as_bytes())
+    );
     args.prompt_snapshot = Some(super::args::CookPromptSnapshot {
+        content,
         source: "stdin".to_string(),
-        sha256: format!(
-            "sha256:{}",
-            homeboy_engine_primitives::content_hash::sha256_hex(content.as_bytes())
-        ),
-        size_bytes: content.len(),
+        sha256,
+        size_bytes,
     });
-    args.dispatch.prompt = Some(content);
     Ok(())
 }
 
@@ -4231,10 +4245,13 @@ mod rotation_disclosure_tests {
 #[cfg(test)]
 mod prompt_input_tests {
     use super::*;
+    use crate::cli_surface::{Cli, Commands};
+    use clap::Parser;
 
     fn dispatch_with_prompt(prompt: Option<&str>) -> DispatchArgs {
         DispatchArgs {
             prompt: prompt.map(str::to_string),
+            prompt_is_literal: false,
             tasks: Vec::new(),
             cwd: None,
             workspace: None,
@@ -4325,6 +4342,40 @@ mod prompt_input_tests {
         resolve_dispatch_prompt(&mut args).expect("no prompt is fine");
         assert!(args.prompt.is_none());
     }
+
+    #[test]
+    fn stdin_snapshot_literals_are_never_reparsed_as_structured_prompt_specs() {
+        for literal in ["-", "@/missing/prompt.md", "@prompt:missing", " \n\t"] {
+            let cli = Cli::try_parse_from([
+                "homeboy",
+                "agent-task",
+                "cook",
+                "--prompt",
+                "-",
+                "--backend",
+                "fixture",
+                "--no-finalize",
+            ])
+            .expect("parse Cook");
+            let Commands::AgentTask(agent_task) = cli.command else {
+                panic!("agent-task command");
+            };
+            let crate::commands::agent_task::AgentTaskCommand::Cook(mut cook) = agent_task.command
+            else {
+                panic!("Cook command");
+            };
+            cook.prompt_snapshot = Some(super::super::args::CookPromptSnapshot {
+                content: literal.to_string(),
+                source: "stdin".to_string(),
+                sha256: "sha256:test".to_string(),
+                size_bytes: literal.len(),
+            });
+
+            let dispatch = resolved_dispatch_args_for_cook(&cook).expect("literal snapshot");
+            assert_eq!(dispatch.prompt.as_deref(), Some(literal));
+            assert_eq!(cook.dispatch.prompt.as_deref(), Some("-"));
+        }
+    }
 }
 
 /// Compile the one durable provider-cell plan used by local Cook and Lab handoff.
@@ -4379,8 +4430,7 @@ pub(crate) fn compile_cook_plan(
                 .map(|path| path.display().to_string())
         })
         .transpose()?;
-    let mut dispatch = dispatch_args_for_cook(args);
-    resolve_dispatch_prompt(&mut dispatch)?;
+    let mut dispatch = resolved_dispatch_args_for_cook(args)?;
     // Provisioning makes an explicit --cwd authoritative, otherwise this is the
     // resolved managed destination. Pass that exact linked worktree downstream.
     dispatch.cwd = None;
@@ -4437,6 +4487,13 @@ pub(crate) fn compile_cook_plan(
     }
     if let Some(resolution) = &args.base_resolution {
         plan.metadata["cook_base_resolution"] = resolution.clone();
+    }
+    if let Some(snapshot) = &args.prompt_snapshot {
+        for task in &mut plan.tasks {
+            task.metadata["prompt_source"] = serde_json::json!(args.dispatch.prompt);
+        }
+        plan.metadata["prompt_input_v1"] = serde_json::to_value(snapshot)
+            .map_err(|error| homeboy::core::Error::internal_json(error.to_string(), None))?;
     }
     for task in &mut plan.tasks {
         if pending_lookup {

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -4138,7 +4138,11 @@ pub(super) fn resolve_dispatch_prompt(
 pub(crate) fn snapshot_cook_prompt(args: &mut AgentTaskCookArgs) -> homeboy::core::Result<()> {
     if args.prompt_snapshot.is_some()
         || args.attempt_plan.is_some()
-        || args.dispatch.prompt.as_deref() != Some("-")
+        || !args
+            .dispatch
+            .prompt
+            .as_deref()
+            .is_some_and(|spec| spec.trim() == "-")
     {
         return Ok(());
     }

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -780,6 +780,7 @@ fn cook_preserves_successful_candidate_when_provider_response_has_wrong_schema()
                 provider_evidence_inputs: Vec::new(),
                 dispatch: DispatchArgs {
                     prompt: None,
+                    prompt_is_literal: false,
                     tasks: Vec::new(),
                     cwd: None,
                     workspace: None,
@@ -1191,6 +1192,7 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
                 provider_evidence_inputs: Vec::new(),
                 dispatch: DispatchArgs {
                     prompt: Some("commit a change".to_string()),
+                    prompt_is_literal: false,
                     tasks: Vec::new(),
                     cwd: Some(target.display().to_string()),
                     workspace: None,

--- a/crates/homeboy-cli/src/commands/agent_task_dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_dispatch.rs
@@ -151,6 +151,8 @@ pub struct DispatchArgs {
     ///   cat task.md | homeboy agent-task cook --prompt - ...
     #[arg(long, value_name = "PROMPT")]
     pub prompt: Option<String>,
+    #[arg(skip)]
+    pub prompt_is_literal: bool,
 
     /// Reserved batch input retained for forward-compatible command decoding.
     #[arg(long = "task", value_name = "PROMPT", hide = true)]
@@ -221,6 +223,7 @@ impl From<DispatchArgs> for AgentTaskDispatchCommand {
     fn from(args: DispatchArgs) -> Self {
         AgentTaskDispatchCommand {
             prompt: args.prompt,
+            prompt_is_literal: args.prompt_is_literal,
             tasks: args.tasks,
             cwd: args.cwd,
             workspace: args.workspace,
@@ -333,6 +336,7 @@ mod tests {
         let request = dispatch_service::resolve_dispatch_request_with_default(
             DispatchArgs {
                 prompt: Some("run with default".to_string()),
+                prompt_is_literal: false,
                 tasks: Vec::new(),
                 cwd: None,
                 workspace: None,
@@ -373,6 +377,7 @@ mod tests {
         let error = dispatch_service::resolve_dispatch_request_with_default(
             DispatchArgs {
                 prompt: Some("run without default".to_string()),
+                prompt_is_literal: false,
                 tasks: Vec::new(),
                 cwd: None,
                 workspace: None,
@@ -481,6 +486,7 @@ mod tests {
     fn dispatch_args(overrides: DispatchArgOverrides) -> DispatchArgs {
         DispatchArgs {
             prompt: overrides.prompt,
+            prompt_is_literal: false,
             tasks: Vec::new(),
             cwd: overrides.cwd,
             workspace: overrides.workspace,

--- a/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
@@ -643,7 +643,7 @@ fn materialize_prompt_from(
 /// following element, an attached `--prompt=-` names itself.
 fn stdin_prompt_index(args: &[String]) -> Option<usize> {
     args.iter().enumerate().find_map(|(index, arg)| {
-        if arg == "--prompt" && args.get(index + 1).is_some_and(|value| value == "-") {
+        if arg == "--prompt" && args.get(index + 1).is_some_and(|value| value.trim() == "-") {
             Some(index + 1)
         } else if arg == "--prompt=-" {
             Some(index)

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -1812,7 +1812,7 @@ fn lab_cook_materializes_goal_and_prompt_as_one_durable_cell() {
         let linked = homeboy::core::test_support::bounded_output(command);
         assert!(linked.status.success(), "{linked:?}");
         let workspace = workspace.display().to_string();
-        let cook = Cli::parse_from([
+        let mut cook = Cli::parse_from([
             "homeboy",
             "agent-task",
             "cook",
@@ -1821,7 +1821,7 @@ fn lab_cook_materializes_goal_and_prompt_as_one_durable_cell() {
             // `--goal` frames the work and `--prompt` is its one source.
             // Pairing `--goal` with `--task` is a rejected conflict (#10070).
             "--prompt",
-            "Repair the Lab Cook compiler",
+            "-",
             "--cwd",
             &workspace,
             "--to-worktree",
@@ -1832,6 +1832,20 @@ fn lab_cook_materializes_goal_and_prompt_as_one_durable_cell() {
             "--run-id",
             "cook-lab-goal-task",
         ]);
+        let Commands::AgentTask(agent_task) = &mut cook.command else {
+            panic!("agent-task command");
+        };
+        let crate::commands::agent_task::AgentTaskCommand::Cook(cook_args) =
+            &mut agent_task.command
+        else {
+            panic!("Cook command");
+        };
+        cook_args.prompt_snapshot = Some(crate::commands::agent_task::args::CookPromptSnapshot {
+            content: "@/does/not/exist\n\t".to_string(),
+            source: "stdin".to_string(),
+            sha256: "sha256:fixture".to_string(),
+            size_bytes: "@/does/not/exist\n\t".len(),
+        });
 
         let plan = materialize_agent_task_cook_plan(&cook, None)
             .expect("materialize Lab Cook plan")
@@ -1839,7 +1853,9 @@ fn lab_cook_materializes_goal_and_prompt_as_one_durable_cell() {
         assert_eq!(plan.tasks.len(), 1);
         assert_eq!(plan.options.execution_budget.max_provider_executions, 1);
         assert_eq!(plan.metadata["cook_goal"], "Preserve one provider cell");
-        assert_eq!(plan.tasks[0].instructions, "Repair the Lab Cook compiler");
+        assert_eq!(plan.tasks[0].instructions, "@/does/not/exist\n\t");
+        assert_eq!(plan.tasks[0].metadata["prompt_source"], "-");
+        assert_eq!(plan.metadata["prompt_input_v1"]["source"], "stdin");
         assert_eq!(
             plan.tasks[0].metadata["cook_goal"],
             "Preserve one provider cell"

--- a/tests/cli_binary/cook_prompt_stdin.rs
+++ b/tests/cli_binary/cook_prompt_stdin.rs
@@ -112,14 +112,14 @@ fn cook_snapshots_multiline_stdin_once_in_the_durable_recipe() {
     );
     assert_eq!(
         recipe["attempts"][0]["plan"]["tasks"][0]["metadata"]["prompt_source"],
+        "-"
+    );
+    assert_eq!(
+        recipe["attempts"][0]["plan"]["metadata"]["prompt_input_v1"]["source"],
         "stdin"
     );
     assert_eq!(
-        recipe["attempts"][0]["plan"]["metadata"]["prompt_input"]["source"],
-        "stdin"
-    );
-    assert_eq!(
-        recipe["attempts"][0]["plan"]["metadata"]["prompt_input"]["sha256"],
+        recipe["attempts"][0]["plan"]["metadata"]["prompt_input_v1"]["sha256"],
         format!(
             "sha256:{}",
             homeboy_engine_primitives::content_hash::sha256_hex(prompt.as_bytes())

--- a/tests/cli_binary/cook_prompt_stdin.rs
+++ b/tests/cli_binary/cook_prompt_stdin.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 #[test]
-fn cook_rejects_empty_prompt_stdin_before_destination_or_provider_preflight() {
+fn cook_rejects_empty_whitespace_padded_prompt_stdin_before_destination_or_provider_preflight() {
     let output = Command::new(homeboy_bin())
         .args([
             "--placement",
@@ -11,7 +11,7 @@ fn cook_rejects_empty_prompt_stdin_before_destination_or_provider_preflight() {
             "agent-task",
             "cook",
             "--prompt",
-            "-",
+            " \t-\n ",
             "--backend",
             "fixture",
             "--no-finalize",
@@ -37,7 +37,7 @@ fn cook_rejects_empty_prompt_stdin_before_destination_or_provider_preflight() {
 }
 
 #[test]
-fn cook_snapshots_multiline_stdin_once_in_the_durable_recipe() {
+fn cook_snapshots_multiline_whitespace_padded_stdin_once_in_the_durable_recipe() {
     let home = tempfile::tempdir().expect("home");
     let source = tempfile::tempdir().expect("source checkout");
     git(source.path(), &["init"]);
@@ -72,7 +72,7 @@ fn cook_snapshots_multiline_stdin_once_in_the_durable_recipe() {
             "--run-id",
             "stdin-snapshot",
             "--prompt",
-            "-",
+            " \t-\n ",
             "--backend",
             "fixture",
             "--repo",
@@ -112,7 +112,7 @@ fn cook_snapshots_multiline_stdin_once_in_the_durable_recipe() {
     );
     assert_eq!(
         recipe["attempts"][0]["plan"]["tasks"][0]["metadata"]["prompt_source"],
-        "-"
+        " \t-\n "
     );
     assert_eq!(
         recipe["attempts"][0]["plan"]["metadata"]["prompt_input_v1"]["source"],


### PR DESCRIPTION
## Follow-up
Follow-up to merged #13021.

- capture stdin before pinned-runtime, preview, and Lab routing
- normalize structured stdin markers with the established `trim() == "-"` contract
- carry captured text as a typed literal so `-`, `@file`, and `@prompt:id` payloads are never reparsed
- preserve `prompt_source` and add `prompt_input_v1` provenance
- attempt-plan retry and continuation paths do not read stdin

Closes #12999.

## Verification
- `cargo fmt --check`
- `cargo test --test cli_binary cook_prompt_stdin --no-fail-fast`
- `cargo test -p homeboy-cli --lib commands::agent_task::run::prompt_input_tests --no-fail-fast`
- `cargo test -p homeboy-agents agent_task_dispatch_plan --no-fail-fast`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagent was used to rebase the corrective stdin handling onto current main, resolve conflicts, normalize whitespace marker handling, and run focused verification. Chris Huber remains responsible for the change.