### PR TITLE
fix(cook): attest root for component execution

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -664,7 +664,8 @@ fn run_materialized_provider_command_once_contained(
     // baseline replacement. A component-relative cwd is resolved only after
     // that identity is established, so nested packages execute correctly in
     // both the original worktree and isolated retry baselines.
-    let cwd = match request.request.workspace.root.as_deref() {
+    let attestation_root = request.request.workspace.root.as_deref().map(PathBuf::from);
+    let cwd = match attestation_root.as_deref() {
         Some(root) => match homeboy_core::resolve_contained_local_path(
             root,
             request
@@ -690,8 +691,12 @@ fn run_materialized_provider_command_once_contained(
         },
         None => provider_cwd,
     };
-    let cwd_identity = cwd.as_deref().map(workspace_identity).transpose();
-    let cwd_identity = match cwd_identity {
+    let attestation_identity = attestation_root
+        .as_deref()
+        .or(cwd.as_deref())
+        .map(workspace_identity)
+        .transpose();
+    let attestation_identity = match attestation_identity {
         Ok(identity) => identity,
         Err(message) => {
             return failure_outcome(
@@ -821,7 +826,7 @@ fn run_materialized_provider_command_once_contained(
             .or_else(|| request.request.metadata.get("cook_workspace_identity"))
         {
             let identity_match = crate::agent_task_workspace_identity::workspace_attestation_match(
-                &cwd,
+                attestation_root.as_deref().unwrap_or(&cwd),
                 attestation,
             );
             if identity_match
@@ -843,18 +848,24 @@ fn run_materialized_provider_command_once_contained(
                     } else {
                         "provider workspace no longer matches its Cook attempt identity attestation; refusing execution".to_string()
                     },
-                    json!({ "provider": provider.id, "workspace": cwd }),
+                    json!({ "provider": provider.id, "workspace": attestation_root.as_deref().unwrap_or(&cwd), "execution_cwd": cwd }),
                 );
             }
         }
-        if workspace_identity(&cwd).as_ref().ok() != cwd_identity.as_ref() {
+        if attestation_root
+            .as_deref()
+            .or(Some(&cwd))
+            .and_then(|path| workspace_identity(path).ok())
+            .as_ref()
+            != attestation_identity.as_ref()
+        {
             return failure_outcome(
                 request,
                 AgentTaskOutcomeStatus::ProviderError,
                 AgentTaskFailureClassification::InvalidInput,
                 "agent_task.workspace_identity_changed",
                 "provider workspace changed after validation; refusing execution".to_string(),
-                json!({ "provider": provider.id, "workspace": cwd }),
+                json!({ "provider": provider.id, "workspace": attestation_root.as_deref().unwrap_or(&cwd), "execution_cwd": cwd }),
             );
         }
         command_builder.current_dir(cwd);

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -65,6 +65,35 @@ fn component_workspace_path(options: &AgentTaskCookServiceOptions) -> Option<Pat
     homeboy_core::resolve_contained_local_path(source, component_cwd, "component_cwd").ok()
 }
 
+fn replacement_component_workspace(
+    original: &AgentTaskPromotionReport,
+    target: &std::path::Path,
+) -> Result<Option<PathBuf>> {
+    let Some(cwd) = original
+        .deterministic_gates
+        .iter()
+        .find_map(|gate| gate.cwd.as_ref())
+    else {
+        return Ok(None);
+    };
+    let relative = PathBuf::from(&cwd.effective)
+        .strip_prefix(&cwd.requested)
+        .map_err(|_| {
+            Error::validation_invalid_argument(
+                "replacement_gate.cwd",
+                "persisted effective gate cwd is outside its requested worktree root",
+                Some(cwd.effective.clone()),
+                None,
+            )
+        })?
+        .to_path_buf();
+    Ok(Some(homeboy_core::resolve_contained_local_path(
+        target,
+        relative,
+        "replacement_gate.cwd",
+    )?))
+}
+
 pub fn promotion_source(spec: &str) -> Result<(String, Option<PathBuf>)> {
     if spec != "-" {
         let path = PathBuf::from(spec.strip_prefix('@').unwrap_or(spec));
@@ -1088,12 +1117,13 @@ fn verify_replacement_gates_owned(
     // side effects, so a dead owner after this point must recover with external
     // candidate-bound proof rather than replaying an unknown partial execution.
     mark_replacement_gate_execution_started(lifecycle_store, run_id)?;
+    let replacement_workspace = replacement_component_workspace(&original, &target_path)?;
     let mut replacement = resume_promoted_patch_replacement_gates_in_observation_store(
         AgentTaskPromotionOptions {
             source,
             source_run_id: Some(run_id.to_string()),
             source_path,
-            source_worktree_path: None,
+            source_worktree_path: replacement_workspace,
             base_ref: Some(verified_base.base.clone()),
             task_base_sha: inputs
                 .and_then(|value| value.get("task_base_sha"))


### PR DESCRIPTION
## Summary
- attest provider workspaces at the repository or isolated attempt root while executing commands in the contained component cwd
- recover replacement-gate component cwd from persisted requested/effective gate evidence for hydration and execution
- cover nested provider execution with root workspace attestation

Follow-up to merged #13017 and #13033. Closes #13001.

## Testing
- `cargo fmt --all`
- `cargo check -p homeboy-agents`
- `cargo test -p homeboy-agents provider_attests_worktree_root_and_executes_nested_component --lib --no-fail-fast` (1 passed)
- `cargo test -p homeboy-agents verify_replacement_gates_replays_completed_proof_without_rerunning_gates --lib --no-fail-fast` (1 passed)

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagent traced the root-attestation and replacement-gate recovery regressions, implemented the corrective path handling, added focused regression coverage, and ran verification. Chris Huber remains responsible for every line.