### PR TITLE
fix(test): restore nextest shard parallelism (#7505)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/managed_services.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/managed_services.rs
@@ -1488,11 +1488,27 @@ mod tests {
             first.socket_handoff = false;
             first.readiness = None;
             first.cleanup_deadline_ms = 3_000;
+            // The service stamps the wall-clock window it spends inside its own
+            // SIGTERM handler. Concurrency is then proved by those windows
+            // overlapping, which is what `thread::scope` in `cleanup` actually
+            // guarantees — and unlike a total-elapsed bound it does not become a
+            // statement about how loaded the host is (#7505).
             first.command = vec![
                 "python3".to_string(),
                 "-u".to_string(),
                 "-c".to_string(),
-                "import signal,time; signal.signal(signal.SIGTERM, lambda *_: time.sleep(2.1)); print('ready', flush=True); signal.pause()".to_string(),
+                concat!(
+                    "import signal,sys,time; ",
+                    "w=lambda m:(sys.stdout.write(m+chr(10)),sys.stdout.flush()); ",
+                    "signal.signal(signal.SIGTERM, lambda *_:(",
+                    "w('term_start %.6f'%time.time()),",
+                    "time.sleep(1.0),",
+                    "w('term_end %.6f'%time.time()),",
+                    "sys.exit(0))); ",
+                    "print('ready',flush=True); ",
+                    "signal.pause()",
+                )
+                .to_string(),
             ];
             let mut second = first.clone();
             second.id = "second".to_string();
@@ -1508,15 +1524,54 @@ mod tests {
                 }
                 assert!(std::fs::read_to_string(&log_path).is_ok_and(|log| log.contains("ready")));
             }
-            let started = Instant::now();
+            let log_paths = services
+                .records()
+                .into_iter()
+                .map(|record| record.log_path.expect("service log"))
+                .collect::<Vec<_>>();
             let records = services.cleanup("test");
 
-            assert!(started.elapsed() < Duration::from_secs(4));
             assert_eq!(records.len(), 2);
-            assert!(records.iter().all(|record| {
-                record.cleanup_outcome.as_deref() == Some("graceful")
-                    && record.cleanup.as_deref() == Some("cleaned_up:test")
-            }));
+            let outcomes = records
+                .iter()
+                .map(|record| (record.cleanup_outcome.clone(), record.cleanup.clone()))
+                .collect::<Vec<_>>();
+            assert!(
+                records.iter().all(|record| {
+                    record.cleanup_outcome.as_deref() == Some("graceful")
+                        && record.cleanup.as_deref() == Some("cleaned_up:test")
+                }),
+                "expected both services to clean up gracefully, got {outcomes:?}"
+            );
+
+            // Both services were inside their SIGTERM handler at the same
+            // instant. Serial cleanup cannot produce overlapping windows however
+            // slow or fast the host is; this is the property the test name
+            // claims, asserted directly.
+            let windows = log_paths
+                .iter()
+                .map(|path| {
+                    let log = std::fs::read_to_string(path).expect("read service log");
+                    let stamp = |prefix: &str| {
+                        log.lines()
+                            .find_map(|line| line.strip_prefix(prefix))
+                            .unwrap_or_else(|| {
+                                panic!("`{prefix}` missing from service log:\n{log}")
+                            })
+                            .trim()
+                            .parse::<f64>()
+                            .expect("service stamp parses")
+                    };
+                    (stamp("term_start "), stamp("term_end "))
+                })
+                .collect::<Vec<_>>();
+            let latest_start = windows[0].0.max(windows[1].0);
+            let earliest_end = windows[0].1.min(windows[1].1);
+            assert!(
+                latest_start < earliest_end,
+                "service SIGTERM handler windows did not overlap, so cleanup ran \
+                 serially: {windows:?}"
+            );
         });
     }
 

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/concurrency.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/concurrency.rs
@@ -659,9 +659,14 @@ pub(super) mod concurrency_tests {
         plan.tasks[1].workspace.root = Some(workspace.display().to_string());
         plan.tasks[2].workspace.root = Some(unrelated.display().to_string());
 
-        let started = Instant::now();
+        // No wall-clock bound here. "Without starving unrelated work" is asserted
+        // structurally further down — `task-3-started` proves the unrelated
+        // workspace ran, and the absence of `task-2-started` proves the shared
+        // workspace was quarantined. A 2s bound restated that as a claim about
+        // host load, and under eight-way contention it failed while both
+        // event assertions still held. Same reasoning as the deferred-cleanup
+        // bound below, which was already relaxed for exactly this (#7505).
         let aggregate = scheduler.run(plan);
-        assert!(started.elapsed() < Duration::from_secs(2));
         wait_until("the late-mutating executor to finish", || {
             finished.load(Ordering::SeqCst)
         });

--- a/crates/homeboy-core/src/process.rs
+++ b/crates/homeboy-core/src/process.rs
@@ -1649,6 +1649,26 @@ fn linux_scope_pids(scope: &str) -> Result<LinuxScopeDiscovery> {
         };
         let environment = match std::fs::read(entry.path().join("environ")) {
             Ok(environment) => environment,
+            // A `/proc/<pid>` that disappears between `read_dir` and this read is
+            // a process that exited, which is the state cleanup is trying to
+            // reach — not a gap in discovery. Counting it as unreadable made the
+            // report `incomplete` whenever any unrelated process on the machine
+            // happened to exit mid-scan, which is constant under load and was
+            // reproducible as soon as tests ran concurrently (#7505).
+            //
+            // Permission denied is different and still counts: another user's
+            // process is one we cannot prove is outside our scope.
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::NotFound | std::io::ErrorKind::PermissionDenied
+                ) =>
+            {
+                if error.kind() == std::io::ErrorKind::PermissionDenied {
+                    unreadable_environments += 1;
+                }
+                continue;
+            }
             Err(_) => {
                 unreadable_environments += 1;
                 continue;

--- a/docs/internals/test-tiers.md
+++ b/docs/internals/test-tiers.md
@@ -59,22 +59,25 @@ One thread per test binary closes that window on the Cargo fallback. Nextest
 closes it more directly by running each test in its own process.
 
 The Cargo cap is a fallback workaround for a race that is specific to sharing
-one process across threads. Sharded nextest replay does not have that race — but
-it sets `rust_nextest_shard_threads = 1` anyway, for a second and independent
-reason.
+one process across threads. Sharded nextest replay does not have that race, and
+`rust_nextest_shard_threads` is now `0` — nextest's num-cpus parallelism.
 
-Process-per-test isolates environment. It does not isolate the filesystem. The
-controller-runtime admission store and the rig registry are machine-global
-directories beneath the real `$HOME`, so concurrent test *processes* share them
-just as thoroughly as concurrent threads would. Run `32294476539` caught one
-test reading another's admission lease — the two sides of an "unchanged record"
-assertion differed only in `controller_admission.owner`, which carried a peer
-test's `request_id` — and ten `workspace::tests::prune::*` failures traced to
-shared rig-registry writes.
+It was `1` for a second and independent reason, which no longer holds. Process-
+per-test isolates environment but not the filesystem, and the controller-runtime
+admission store and the rig registry used to be machine-global directories
+beneath the real `$HOME`. Run `32294476539` caught one test reading another's
+admission lease, and ten `workspace::tests::prune::*` failures traced to shared
+rig-registry writes.
 
-The two settings are therefore both `1` and clear on different conditions. The
-Cargo cap lifts when `HomeGuard` stops mutating process-global environment; the
-nextest cap lifts when those stores take explicit roots. Both are #7505.
+Both stores now take explicit roots for every production caller (#7505), and
+both failure families pass in parallel. Measured on an 8-core host,
+`homeboy-lab-runner --lib` went from 410.3s serial to 98.5s parallel with an
+identical failure set, and neither it nor `homeboy-agents --lib` has any
+parallel-only failure. `tests/nextest_shard_parallelism_test.rs` pins the `0` and
+carries the measurement.
+
+The two settings therefore now differ. The Cargo cap stays `1` until `HomeGuard`
+stops mutating process-global environment; the nextest cap is lifted.
 
 Unsharded nextest runs were previously unmeasurable — they emit no
 `test result:` lines, so the cargo-test adapter matched nothing and produced no

--- a/homeboy.json
+++ b/homeboy.json
@@ -1820,7 +1820,7 @@
       "settings": {
         "rust_test_runner": "nextest",
         "rust_cargo_test_threads": 1,
-        "rust_nextest_shard_threads": 1
+        "rust_nextest_shard_threads": 0
       }
     }
   },

--- a/tests/nextest_shard_parallelism_test.rs
+++ b/tests/nextest_shard_parallelism_test.rs
@@ -1,4 +1,4 @@
-//! Pins nextest shard replay to serial execution.
+//! Pins nextest shard replay to parallel execution.
 //!
 //! `extensions.rust.settings.rust_nextest_shard_threads` is the `--test-threads`
 //! value the rust extension passes to `cargo nextest run` during shard replay
@@ -40,60 +40,51 @@
 //! the shared rig registry, where a peer's `create` leaves the registry in a
 //! state the assertions were not written for.
 //!
-//! ## What has to be true before this goes back to `0`
+//! ## That condition was met, and the value is back at `0`
 //!
-//! Not "the flakes stopped". The stores have to stop being machine-global:
-//! controller admission and the rig registry need the same explicit-root
-//! treatment #7505 is applying everywhere else, so that a test's writes land in
-//! its own `HermeticTestContext` rather than in a directory every concurrent
-//! test can see.
+//! The stores stopped being machine-global. The rig registry reached zero
+//! ambient production resolutions across #13011/#13019/#13030/#13032, and
+//! controller admission reached zero in #13035, where the ambient entry points
+//! were additionally gated `#[cfg(test)]` so production cannot reach them even
+//! by accident.
 //!
-//! Until then a parallel value is not faster, it is red. Serial is slower and
-//! correct, and slower-and-correct is the side to err on for a gate whose
-//! entire job is to be believed.
+//! Measured on an 8-core Linux host, `cargo nextest`, repeated runs:
 //!
-//! ### Status of that condition, measured 2026-08-23
+//! | scope | serial | parallel |
+//! |---|---|---|
+//! | `workspace::tests::prune::*` (the 10 named above) | 26.5s, 30/30 | 5.6s, 30/30 |
+//! | `status_and_recovery` (holds both tests named above) | 20.3s, 53/53 | 4.7s, 53/53 |
+//! | `homeboy-lab-runner --lib` (1881 tests) | 410.3s | 98.5s |
+//! | `homeboy-agents --lib` (1946 tests) | — | 164.0s |
 //!
-//! **Both named stores are done, and both named failure families now pass in
-//! parallel.** The rig registry reached zero ambient production resolutions
-//! across #13011/#13019/#13030/#13032, and controller admission reached zero in
-//! #13035, where the ambient entry points were additionally gated `#[cfg(test)]`
-//! so production cannot reach them at all.
-//!
-//! Reproduced locally against `c747bec09` on an 8-core Linux host, `cargo
-//! nextest`, three consecutive runs each:
-//!
-//! | scope | serial | parallel | verdict |
-//! |---|---|---|---|
-//! | `workspace::tests::prune::*` (the 10 named here) | 26.5s, 30/30 | 5.6s, 30/30 | passes |
-//! | `status_and_recovery` (holds both named tests) | 20.3s, 53/53 | 4.7s, 53/53 | passes |
-//! | `homeboy-lab-runner --lib` (1881 tests) | 410.3s, 7 failed | 98.5s, 7 failed | **identical failure set** |
-//!
-//! For `homeboy-lab-runner` the parallel-only failure count is **zero**: every
+//! For both crates the parallel-only failure count is zero: every remaining
 //! failure reproduces serially in isolation and is environmental to that host.
+//! `homeboy-lab-runner` is a 4.2x improvement.
 //!
-//! ### Why this still says `1`
+//! ### Two things had to be fixed first, and neither was a store
 //!
-//! `homeboy-agents --lib` (1945 tests, 165.5s parallel) had 7 failures, and
-//! re-running those 7 serially in isolation cleared only 5. Two fail *only*
-//! under parallelism:
+//! Restoring parallelism surfaced two defects that serialization had been
+//! hiding, which is the argument for not serializing:
 //!
-//! - `agent_task_scheduler::managed_services::tests::cleanup_runs_multiple_service_grace_periods_concurrently`
-//! - `agent_task_scheduler::tests::scheduling_tests::concurrency::concurrency_tests::timeout_quarantines_only_its_workspace_without_starving_unrelated_work`
+//! - `linux_scope_pids` counted *every* unreadable `/proc/<pid>/environ` as
+//!   incomplete discovery, including `ENOENT` — a process that exited between
+//!   `read_dir` and the read. That is the state cleanup is trying to reach, not
+//!   a gap in it. Any concurrent load made managed-service cleanup report
+//!   `incomplete` spuriously, in production as much as in tests. Now only
+//!   `EPERM`/`EACCES` counts, because only that is a real blind spot.
+//! - Two scheduler tests asserted concurrency and non-starvation with total
+//!   wall-clock bounds, which restate a structural property as a claim about
+//!   host load. Both now assert the property directly: overlapping SIGTERM
+//!   handler windows, and the task-start events that were already there.
 //!
-//! Both assert on grace periods and timeouts. They are wall-clock sensitive, so
-//! eight-way CPU contention starves them — a different defect class from the
-//! shared-directory contamination this file was written about, and one that
-//! rooting a store cannot fix. **The release condition above is met; this is a
-//! new and separate blocker.** Restoring `0` needs those two given deadlines
-//! that do not depend on how loaded the host is.
+//! ### Cautions for whoever measures this next
 //!
-//! Two cautions for whoever measures next, both of which produced false results
-//! here before being caught:
+//! Both of these produced false results here before being caught:
 //!
-//! - A host under disk pressure can have cleanup delete `/var/tmp/.homeboy-test-tmp`
-//!   mid-run. That presents as ~1000 failures reading `No such file or
-//!   directory`, not as a race. Check free space before believing a bad run.
+//! - A host under disk pressure can have cleanup delete
+//!   `/var/tmp/.homeboy-test-tmp` mid-run. That presents as ~1000 failures
+//!   reading `No such file or directory`, not as a race. Check free space
+//!   before believing a bad run.
 //! - `/dev/null` on that host had been replaced by a regular file containing 99
 //!   bytes of git error text, which makes `git` fail with `bad config line 1 in
 //!   file /dev/null` in whichever tests happen to run while it is broken. That
@@ -122,9 +113,10 @@
 //! invisible in review either way. That is what makes a test the right
 //! instrument here.
 //!
-//! If shard parallelism is intentionally restored, delete or invert this test in
-//! the same commit that changes the value, so the intent is recorded once rather
-//! than argued a fourth time.
+//! Shard parallelism has now been intentionally restored, and this test was
+//! inverted in the same commit that changed the value rather than deleted — so a
+//! silent re-serialization fails here too. The failure mode this file exists to
+//! prevent is a one-token numeric edit that nobody argues about.
 
 use serde_json::Value;
 
@@ -136,7 +128,7 @@ fn rust_settings() -> Value {
 }
 
 #[test]
-fn nextest_shard_replay_stays_serial_while_stores_are_machine_global() {
+fn nextest_shard_replay_stays_parallel_now_that_the_stores_take_roots() {
     let settings = rust_settings();
 
     let threads = settings
@@ -145,14 +137,15 @@ fn nextest_shard_replay_stays_serial_while_stores_are_machine_global() {
         .expect("extensions.rust.settings.rust_nextest_shard_threads is present and numeric");
 
     assert_eq!(
-        threads, 1,
-        "rust_nextest_shard_threads must stay 1 while the controller-runtime \
-         admission store and the rig registry live in machine-global directories. \
-         nextest gives every test its own process, which isolates env but not the \
-         filesystem those stores sit on, so concurrent tests observe each other's \
-         leases and registry writes. See this file's module docs for the observed \
-         cross-test contamination (run 32294476539). Restore 0 only after those \
-         stores take explicit roots (#7505)."
+        threads, 0,
+        "rust_nextest_shard_threads must stay 0. It was 1 for a real reason and that \
+         reason is gone: the controller-runtime admission store and the rig registry \
+         now take explicit roots for every production caller, and both failure \
+         families this file documented pass in parallel. Serializing again costs \
+         roughly 4x wall clock and buys nothing measured. If a shared-directory race \
+         returns, fix the store rather than re-serializing the suite, or invert this \
+         test in the same commit and say which store — the one thing this value has \
+         never survived is being changed quietly. See this file's module docs and #7505."
     );
 }
 

--- a/tests/nextest_shard_parallelism_test.rs
+++ b/tests/nextest_shard_parallelism_test.rs
@@ -52,6 +52,53 @@
 //! correct, and slower-and-correct is the side to err on for a gate whose
 //! entire job is to be believed.
 //!
+//! ### Status of that condition, measured 2026-08-23
+//!
+//! **Both named stores are done, and both named failure families now pass in
+//! parallel.** The rig registry reached zero ambient production resolutions
+//! across #13011/#13019/#13030/#13032, and controller admission reached zero in
+//! #13035, where the ambient entry points were additionally gated `#[cfg(test)]`
+//! so production cannot reach them at all.
+//!
+//! Reproduced locally against `c747bec09` on an 8-core Linux host, `cargo
+//! nextest`, three consecutive runs each:
+//!
+//! | scope | serial | parallel | verdict |
+//! |---|---|---|---|
+//! | `workspace::tests::prune::*` (the 10 named here) | 26.5s, 30/30 | 5.6s, 30/30 | passes |
+//! | `status_and_recovery` (holds both named tests) | 20.3s, 53/53 | 4.7s, 53/53 | passes |
+//! | `homeboy-lab-runner --lib` (1881 tests) | 410.3s, 7 failed | 98.5s, 7 failed | **identical failure set** |
+//!
+//! For `homeboy-lab-runner` the parallel-only failure count is **zero**: every
+//! failure reproduces serially in isolation and is environmental to that host.
+//!
+//! ### Why this still says `1`
+//!
+//! `homeboy-agents --lib` (1945 tests, 165.5s parallel) had 7 failures, and
+//! re-running those 7 serially in isolation cleared only 5. Two fail *only*
+//! under parallelism:
+//!
+//! - `agent_task_scheduler::managed_services::tests::cleanup_runs_multiple_service_grace_periods_concurrently`
+//! - `agent_task_scheduler::tests::scheduling_tests::concurrency::concurrency_tests::timeout_quarantines_only_its_workspace_without_starving_unrelated_work`
+//!
+//! Both assert on grace periods and timeouts. They are wall-clock sensitive, so
+//! eight-way CPU contention starves them — a different defect class from the
+//! shared-directory contamination this file was written about, and one that
+//! rooting a store cannot fix. **The release condition above is met; this is a
+//! new and separate blocker.** Restoring `0` needs those two given deadlines
+//! that do not depend on how loaded the host is.
+//!
+//! Two cautions for whoever measures next, both of which produced false results
+//! here before being caught:
+//!
+//! - A host under disk pressure can have cleanup delete `/var/tmp/.homeboy-test-tmp`
+//!   mid-run. That presents as ~1000 failures reading `No such file or
+//!   directory`, not as a race. Check free space before believing a bad run.
+//! - `/dev/null` on that host had been replaced by a regular file containing 99
+//!   bytes of git error text, which makes `git` fail with `bad config line 1 in
+//!   file /dev/null` in whichever tests happen to run while it is broken. That
+//!   looks exactly like an intermittent race and is not one.
+//!
 //! ## Why this is pinned rather than commented
 //!
 //! The value has now moved three times, and only one of those moves announced


### PR DESCRIPTION
`rust_nextest_shard_threads` goes back to **0**. Both conditions the guard set are met, and this carries the measurement so the value isn't changed quietly a fourth time.

## The measurement

8-core Linux host, `cargo nextest`, repeated runs:

| scope | serial | parallel |
|---|---|---|
| `workspace::tests::prune::*` — the 10 named in the guard | 26.5s, 30/30 | **5.6s, 30/30** |
| `status_and_recovery` — holds both named tests | 20.3s, 53/53 | **4.7s, 53/53** |
| `homeboy-lab-runner --lib` (1881) | 410.3s | **98.5s** |
| `homeboy-agents --lib` (1946) | — | **164.0s** |

**Parallel-only failure count is zero for both crates.** Every remaining failure reproduces serially in isolation and is environmental to that host. lab-runner is **4.2×**.

## Two defects had to be fixed first, and neither was a store

Serialization had been hiding both. That's the argument against serializing.

### 1. A real product bug in `/proc` scanning

`linux_scope_pids` counted **every** unreadable `/proc/<pid>/environ` as incomplete discovery — including `ENOENT`, which just means the process exited between `read_dir` and the read. That is *the state cleanup is trying to reach*, not a gap in it.

Any concurrent load made managed-service cleanup report `incomplete` spuriously — **in production as much as under test**:

```
cleanup_incomplete:test:process-scope discovery was incomplete:
  1 /proc environment entries could not be read
```

Nothing was wrong. Now only `EPERM`/`EACCES` counts, because only that is a blind spot we cannot see past.

### 2. Two structural properties asserted as wall-clock bounds

- `cleanup_runs_multiple_service_grace_periods_concurrently` proved concurrency with `elapsed < 2s`. Now each service **stamps the window it spends inside its own SIGTERM handler** and the test asserts those windows overlap — which is exactly what `thread::scope` in `cleanup` guarantees, and is true regardless of host speed. Grace sleep also drops 2.1s → 1.0s since the proof no longer needs the margin.
- `timeout_quarantines_only_its_workspace_without_starving_unrelated_work` loses its 2s bound entirely. Non-starvation was **already** asserted structurally below it by `task-3-started` and the absence of `task-2-started`. The sibling deferred-cleanup bound in the same file had already been relaxed for this exact reason.

## Guard inverted, not deleted

Per the file's own instruction. A silent **re**-serialization now fails too — that's the failure mode this file exists to catch.

It also records two measurement traps that produced false results during this work, because each is indistinguishable from a race:

1. Disk-pressure cleanup deleting `/var/tmp/.homeboy-test-tmp` mid-run → ~1000 `No such file or directory` failures. My first serial baseline reported 1052 failures and was pure artifact.
2. **`/dev/null` had been replaced by a regular file** containing 99 bytes of git error text, making git fail `bad config line 1 in file /dev/null` in whichever tests ran while it was broken. Repairing the device node took `upgrade_runners` from 4/6/5 failures to 48/48 passing, three times.

## Scope

`rust_cargo_test_threads` untouched, stays `1` — different race, different release condition.

`cargo check --workspace --tests -j2` green. Guard test 3/3.

Refs #7505.