### PR TITLE
fix(cook): retain workspace validation phases

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4470,7 +4470,6 @@ fn run_cook_spine(
         && (options.attempt_dispatcher.is_none() || options.source_worktree_path.is_some())
     {
         validate_cook_workspace(&options).map_err(|mut error| {
-            error = with_pre_execution_phase(error, "workspace_base_ancestry_preflight");
             error.details["cook_materialized_by_invocation"] = materialized_by_invocation.into();
             error
         })?;
@@ -4883,9 +4882,7 @@ fn run_cook_spine(
             let mut failed_dispatch_plan = None;
             let execution = (|| {
                 if options.attempt_dispatcher.is_none() || options.source_worktree_path.is_some() {
-                    validate_cook_workspace(&options).map_err(|error| {
-                        with_pre_execution_phase(error, "workspace_base_ancestry_preflight")
-                    })?;
+                    validate_cook_workspace(&options)?;
                 }
                 if options.attempt_dispatcher.is_none() {
                     homeboy_core::cleanup::admit_reconstructable_artifact_work(

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -4019,6 +4019,55 @@ fn workspace_base_ancestry_preflight_preserves_provider_owned_non_origin_targets
         .expect("a provider-owned Git workspace without origin has no remote base to converge");
 }
 
+#[test]
+fn non_ancestry_workspace_validation_retains_the_generic_pre_execution_phase() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let primary = tempfile::tempdir().expect("primary checkout");
+        let git = |args: &[&str]| {
+            let output = Command::new("git")
+                .args(args)
+                .current_dir(primary.path())
+                .output()
+                .expect("run git");
+            assert!(output.status.success(), "git {:?} failed", args);
+        };
+        git(&["init", "--initial-branch=main"]);
+        git(&["config", "user.email", "test@example.com"]);
+        git(&["config", "user.name", "Test"]);
+        std::fs::write(primary.path().join("base.txt"), "base\n").unwrap();
+        git(&["add", "base.txt"]);
+        git(&["commit", "-m", "base"]);
+
+        let dispatches = Arc::new(AtomicUsize::new(0));
+        let mut options = batch_cook_options(
+            "cook-primary-workspace-validation",
+            Arc::new(RecordingDetachedAttemptDispatcher {
+                dispatches: Arc::clone(&dispatches),
+            }),
+        );
+        options.to_worktree = primary.path().display().to_string();
+        options.source_worktree_path = Some(primary.path().to_path_buf());
+        options.initial_plan.tasks[0].metadata = serde_json::json!({
+            "worktree_provision": { "kind": "explicit_cwd" }
+        });
+
+        let report = run_cook(CookContext::new(options.clone(), Arc::new(UnusedExecutor)))
+            .expect("primary checkout is a durable pre-execution failure");
+        assert_eq!(report.value.status, "pre_execution_failure");
+        assert_eq!(dispatches.load(Ordering::SeqCst), 0);
+        let record = agent_task_lifecycle::status(&options.initial_run_id)
+            .expect("durable primary-checkout failure record");
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["phase"],
+            "cook_pre_execution"
+        );
+        assert!(record.metadata["pre_execution_failure"]["message"]
+            .as_str()
+            .expect("primary-checkout diagnostic")
+            .contains("primary or non-linked checkout"));
+    });
+}
+
 #[cfg(unix)]
 #[test]
 fn initial_cook_adopts_only_clean_issue_owned_unpushed_provider_worktree() {


### PR DESCRIPTION
## Follow-up

Follow-up to merged #13027 and #13037, which both landed before their subsequent corrective commits. Closes #13000.

## Summary
- Keep `workspace_base_ancestry_preflight` attached only by the Cook ancestry helper.
- Preserve truthful phases for all other `validate_cook_workspace` failures, including provider, workspace, and authorization failures.
- Add a durable Cook regression proving a primary/non-linked checkout failure remains `cook_pre_execution` with its original diagnostic and zero provider dispatches.

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-agents workspace_base_ancestry_preflight --lib`
- `cargo test -p homeboy-agents non_ancestry_workspace_validation_retains_the_generic_pre_execution_phase --lib`
- `cargo test -p homeboy-agents provider_dispatch_observes_a_durable_provider_start_boundary --lib`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagent was used to inspect the merged and corrective ancestry lifecycle paths, preserve the post-merge diagnostic correction through rebase, add the Cook-level phase regression, and run focused verification. Chris Huber reviewed and remains responsible for this change.