### PR TITLE
test(cook): cover nested component cwd

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
@@ -726,6 +726,41 @@ fn linked_workspace(temp: &tempfile::TempDir) -> (std::path::PathBuf, std::path:
 
 #[cfg(unix)]
 #[test]
+fn provider_attests_worktree_root_and_executes_nested_component() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let (workspace, _) = linked_workspace(&temp);
+    let component = workspace.join("packages/component");
+    std::fs::create_dir_all(&component).expect("component directory");
+    let attestation = workspace_attestation(&workspace);
+    let script = script(
+        r#"const fs = require('fs'); let input = ''; process.stdin.on('data', c => input += c); process.stdin.on('end', () => { const request = JSON.parse(input); fs.writeFileSync('provider-observation.json', JSON.stringify({ cwd: process.cwd(), workspace: request.workspace.root })); process.stdout.write(JSON.stringify({ schema: 'homeboy/agent-task-outcome/v1', task_id: request.task_id, status: 'succeeded', summary: 'nested component executed' })); });"#,
+    );
+    let (mut request, provider) = request("nested-component", format!("node {script}"));
+    request.workspace.root = Some(workspace.display().to_string());
+    request.executor.config = json!({ "component_cwd": "packages/component" });
+    request.metadata = json!({ "cook_attempt_workspace_identity": attestation });
+
+    let outcome = run_provider_command_once(&request, &provider);
+
+    assert_eq!(outcome.status, AgentTaskOutcomeStatus::Succeeded);
+    let observation: Value = serde_json::from_slice(
+        &std::fs::read(component.join("provider-observation.json")).expect("provider observation"),
+    )
+    .expect("observation json");
+    assert_eq!(
+        observation["cwd"],
+        component
+            .canonicalize()
+            .expect("canonical component")
+            .display()
+            .to_string()
+    );
+    assert_eq!(observation["workspace"], workspace.display().to_string());
+    assert!(!workspace.join("provider-observation.json").exists());
+}
+
+#[cfg(unix)]
+#[test]
 fn provider_refuses_legacy_source_attestation_git_file_replaced_before_spawn() {
     let temp = tempfile::tempdir().expect("tempdir");
     let (workspace, _) = linked_workspace(&temp);


### PR DESCRIPTION
## Summary
- add a behavior-level regression proving a provider attests the repository worktree root while executing from its nested component cwd
- retain replacement-gate replay coverage against the component-cwd recovery path

Follow-up to merged #13017, #13033, and #13047. Closes #13001.

## Testing
- `cargo fmt --all`
- `cargo check -p homeboy-agents`
- `cargo test -p homeboy-agents provider_attests_worktree_root_and_executes_nested_component --lib --no-fail-fast` (1 passed)
- `cargo test -p homeboy-agents verify_replacement_gates_replays_completed_proof_without_rerunning_gates --lib --no-fail-fast` (1 passed)

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode general coding subagent rebased the post-merge regression test, reran focused verification, and prepared this test-only follow-up. Chris Huber remains responsible for every line.