### PR TITLE
fix(lab): preserve tracked nested build sources

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -2105,14 +2105,19 @@ pub(super) fn materialize_snapshot_stage(
         )
     })?;
     let inputs = snapshot_manifest_tar_input(manifest);
-    // The manifest selects root inputs only. Tar still recurses through each
-    // selected directory, so every exclusion, including a root-anchored nested
-    // path, must be applied during archive construction.
-    let archive_excludes = excludes;
+    // The manifest has already removed excluded root inputs. Do not pass those
+    // patterns to tar, whose exclude matching would also remove legitimate
+    // nested directories with the same name. Nested root-anchored exclusions
+    // still need tar because their admitted root input is recursively archived.
+    let archive_excludes = excludes
+        .iter()
+        .filter(|pattern| !is_root_input_exclude(pattern))
+        .cloned()
+        .collect::<Vec<_>>();
     let source_archive = format!(
         "COPYFILE_DISABLE=1 tar --no-xattrs -C {src} {exclude} -cf - --null -T -",
         src = shell::quote_arg(&local_path.display().to_string()),
-        exclude = tar_exclude_args(archive_excludes),
+        exclude = tar_exclude_args(&archive_excludes),
     );
     let command = format!(
         "({inputs}) | {source_archive} | tar --no-xattrs -C {stage} -xf - && root={root} && stage={stage} && export root stage && find \"$stage\" -type l -exec sh -c {resolve} sh {{}} \\;",
@@ -2120,7 +2125,7 @@ pub(super) fn materialize_snapshot_stage(
         root = shell::quote_arg(&local_path.display().to_string()),
         resolve = shell::quote_arg(&format!(
             "stage_link=$1; relative=${{stage_link#\"$stage\"/}}; original=\"$root/$relative\"; target=$(realpath \"$original\") || exit; case \"$target\" in \"$root\"|\"$root\"/*) ;; *) rm -f \"$stage_link\" && mkdir -p \"$(dirname \"$stage_link\")\" && COPYFILE_DISABLE=1 tar --no-xattrs -h -C \"$root\" {} -cf - \"$relative\" | tar --no-xattrs -C \"$stage\" -xf - ;; esac",
-            tar_exclude_args(archive_excludes)
+            tar_exclude_args(&archive_excludes)
         )),
     );
     run_shell_command(&command, "construct workspace snapshot staging").map_err(|error| {
@@ -2148,6 +2153,14 @@ pub(super) fn materialize_snapshot_stage(
         }
     }
     Ok(stage)
+}
+
+fn is_root_input_exclude(pattern: &str) -> bool {
+    let Some(pattern) = pattern.strip_prefix("./") else {
+        return false;
+    };
+    let root = pattern.trim_end_matches("/**").trim_end_matches('/');
+    !root.is_empty() && !root.contains('/')
 }
 
 fn snapshot_manifest_tar_input(manifest: &SnapshotInputManifest) -> String {

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -1581,6 +1581,60 @@ fn snapshot_staging_keeps_nested_root_ignored_outputs_out_of_repeated_snapshots(
 }
 
 #[test]
+fn lab_snapshot_preacceptance_preserves_tracked_build_sources_before_provider_execution() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let source = workspace.path().join("source");
+    let tracked_build = source.join("crates/homeboy-extension/src/build");
+    fs::create_dir_all(&tracked_build).expect("tracked build source directory");
+    fs::create_dir_all(source.join("build")).expect("ignored root build directory");
+    fs::write(tracked_build.join("mod.rs"), "pub mod local_permissions;\n")
+        .expect("tracked build source");
+    fs::write(source.join("build/generated.bin"), "ignored\n").expect("ignored build output");
+    let excludes = vec!["./build".to_string(), "./build/**".to_string()];
+
+    let source_manifest = snapshot_stable_manifest(&source, &excludes).expect("source manifest");
+    let input_manifest = snapshot_input_manifest(&source, &excludes).expect("input manifest");
+    let stage = materialize_snapshot_stage(&source, &excludes, &input_manifest, None)
+        .expect("snapshot preacceptance stage");
+    let staged_source = stage.path().join("source");
+    let staged_manifest = snapshot_stable_manifest(&staged_source, &[]).expect("staged manifest");
+    let current_manifest = snapshot_stable_manifest(&source, &excludes).expect("current manifest");
+    assert_eq!(source_manifest, staged_manifest);
+    assert_eq!(staged_manifest, current_manifest);
+    assert!(staged_source
+        .join("crates/homeboy-extension/src/build/mod.rs")
+        .is_file());
+    assert!(!staged_source.join("build").exists());
+
+    let provider_workspace = workspace.path().join("provider-workspace");
+    let provider_marker = workspace.path().join("provider-executed");
+    fs::create_dir_all(&provider_workspace).expect("provider workspace");
+    let target_command = format!(
+        "tar -C {} -xf - && test -f {} && test ! -e {} && touch {}",
+        homeboy_core::engine::shell::quote_arg(&provider_workspace.display().to_string()),
+        homeboy_core::engine::shell::quote_arg(
+            &provider_workspace
+                .join("crates/homeboy-extension/src/build/mod.rs")
+                .display()
+                .to_string()
+        ),
+        homeboy_core::engine::shell::quote_arg(
+            &provider_workspace.join("build").display().to_string()
+        ),
+        homeboy_core::engine::shell::quote_arg(&provider_marker.display().to_string()),
+    );
+    materialize_snapshot_piped(
+        &source,
+        &target_command,
+        &excludes,
+        "test Lab provider execution",
+        None,
+    )
+    .expect("snapshot preacceptance reaches provider execution");
+    assert!(provider_marker.is_file());
+}
+
+#[test]
 fn snapshot_construction_failure_does_not_start_transport_or_accept_source_drift() {
     let source = tempfile::tempdir().expect("source");
     let scratch = tempfile::tempdir().expect("admitted scratch");


### PR DESCRIPTION
## Summary
Preserve legitimate tracked nested directories named build during Lab snapshot staging while continuing to exclude root build outputs.

## What changed
- Root-input exclusions are satisfied by the manifest and no longer passed recursively to tar; nested root-anchored exclusions still apply during archive construction. A provider-handoff regression test covers both sides of the contract.

## How to test
1. Run `cargo fmt --all -- --check`; expect Formatting exits successfully.
2. Run `cargo test -p homeboy-lab-runner workspace::tests::snapshot`; expect All 68 snapshot tests pass.

## Compatibility
Snapshot include/exclude semantics are unchanged for root outputs and nested root-anchored exclusions; tracked nested directories sharing a root exclusion name are now preserved.

## Evidence
- Base unchanged since verification: main remains at 77b46fc5b5c0b976e74527f5841ffdd5aea49d63.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/12963
- Reviewer-resolvable evidence from source\_refs\[1\]: https://github.com/Extra-Chill/homeboy/issues/12963#issuecomment-5383757339
- Verified finalization base: main at 77b46fc5b5c0b976e74527f5841ffdd5aea49d63
- fmt: passed (Passed)
- snapshot-tests: passed (68-passed) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the snapshot exclusion regression, generated the candidate, and verified the focused gates.

## Source relationships
- Closes #12963
