### PR TITLE
fix(ci): audit required gates ruleset drift

### DIFF
--- a/.github/ci-required-gates-executed.sh
+++ b/.github/ci-required-gates-executed.sh
@@ -31,9 +31,12 @@
 #   dependency results - every gate job `ci.yml` names as a dependency concluded
 #                        `success`. Tokenless, structural, and here `skipped`
 #                        and `cancelled` are failures rather than silence.
-#   observed execution - every context in `.github/required-gates-ruleset.json`
-#                        appears in this run's job list with conclusion
-#                        `success`. This is the claim the declaration check
+#   observed execution - every non-terminal context in
+#                        `.github/required-gates-ruleset.json` appears in this
+#                        run's job list with conclusion `success`. The terminal
+#                        job cannot observe its own conclusion while it runs;
+#                        GitHub enforces that final required context itself.
+#                        This is the claim the declaration check
 #                        cannot make: a context can be declared by a job that
 #                        never ran (#10997's vacuous-declaration shape) or by a
 #                        job the whole run skipped (#12573's shape).
@@ -111,6 +114,7 @@ declared_contexts="$(jq -c '
   | sort
 ' "${config}")"
 declared_count="$(jq 'length' <<< "${declared_contexts}")"
+execution_contexts="$(jq -c '[.[] | select(. != "homeboy / Required Gates Executed")]' <<< "${declared_contexts}")"
 
 if [ "${declared_count}" -eq 0 ]; then
   echo "::error::required-gates policy declares no required checks, so execution cannot be verified"
@@ -161,7 +165,7 @@ if read_run_jobs; then
   # `${{ matrix.title }}`), so `homeboy / Audit` is simply absent rather than
   # present-and-skipped. Absent is therefore `not-executed`, which is exactly
   # the verdict wanted: the context produced no measurement.
-  execution="$(jq -c --argjson required "${declared_contexts}" '
+  execution="$(jq -c --argjson required "${execution_contexts}" '
     . as $jobs
     | [ $required[]
         | . as $context

--- a/.github/manage-required-gates-ruleset.sh
+++ b/.github/manage-required-gates-ruleset.sh
@@ -2,9 +2,10 @@
 # Audit or converge the one repository-owned main ruleset to its versioned policy.
 set -euo pipefail
 
-repo='Extra-Chill/homeboy'
-ruleset_id='13680120'
-config='.github/required-gates-ruleset.json'
+policy_version='required-gates-ruleset/v1'
+repo="${GITHUB_REPOSITORY:-Extra-Chill/homeboy}"
+ruleset_id="${GH_RULESET_ID:-13680120}"
+config="${REQUIRED_GATES_CONFIG:-.github/required-gates-ruleset.json}"
 operation=''
 evidence=''
 gh_bin="${GH_BIN:-gh}"
@@ -32,6 +33,8 @@ project_ruleset() {
 }
 
 desired="$(project_ruleset < "${config}")"
+policy_revision="$(git rev-parse HEAD)"
+policy_sha256="$(printf '%s\n' "${desired}" | shasum -a 256 | awk '{print $1}')"
 before="$(${gh_bin} api "repos/${repo}/rulesets/${ruleset_id}")"
 before_contract="$(project_ruleset <<< "${before}")"
 changed=false
@@ -54,6 +57,9 @@ fi
 jq -n \
   --arg repository "${repo}" \
   --arg ruleset_id "${ruleset_id}" \
+  --arg policy_version "${policy_version}" \
+  --arg policy_revision "${policy_revision}" \
+  --arg policy_sha256 "${policy_sha256}" \
   --arg operation "${operation}" \
   --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   --argjson before "${before}" \
@@ -61,7 +67,7 @@ jq -n \
   --argjson after "${after}" \
   --argjson changed "${changed}" \
   --argjson matched "${matched}" \
-  '{repository: $repository, ruleset_id: $ruleset_id, operation: $operation, timestamp: $timestamp, changed: $changed, matched: $matched, before: $before, desired: $desired, after: $after}' \
+  '{repository: $repository, ruleset_id: $ruleset_id, policy_version: $policy_version, policy_revision: $policy_revision, policy_sha256: $policy_sha256, operation: $operation, timestamp: $timestamp, changed: $changed, matched: $matched, before: $before, desired: $desired, after: $after}' \
   > "${evidence}"
 
 if [ "${matched}" != true ]; then

--- a/.github/test-manage-required-gates-ruleset.sh
+++ b/.github/test-manage-required-gates-ruleset.sh
@@ -7,7 +7,8 @@ trap 'rm -rf "${tmp}"' EXIT
 
 workflow="${root}/.github/workflows/required-gates-ruleset.yml"
 grep -Fq 'workflow_dispatch:' "${workflow}"
-! grep -Fq 'schedule:' "${workflow}"
+grep -Fq 'schedule:' "${workflow}"
+grep -Fq "cron: '17 * * * *'" "${workflow}"
 grep -Fq 'environment: main-ruleset-administration' "${workflow}"
 grep -Fq -- '--operation audit' "${workflow}"
 grep -Fq -- '--operation reconcile' "${workflow}"
@@ -48,7 +49,7 @@ if run --operation audit --evidence "${tmp}/audit.json"; then
   echo 'audit accepted a drifted ruleset' >&2
   exit 1
 fi
-jq -e '.operation == "audit" and .changed == false and .matched == false' "${tmp}/audit.json" >/dev/null
+jq -e '.operation == "audit" and .policy_version == "required-gates-ruleset/v1" and (.policy_revision | length == 40) and (.policy_sha256 | length == 64) and .changed == false and .matched == false' "${tmp}/audit.json" >/dev/null
 test ! -s "${tmp}/gh.log" || ! grep -Fq -- '--method PUT' "${tmp}/gh.log"
 
 : > "${tmp}/gh.log"

--- a/.github/test-manage-required-gates-ruleset.sh
+++ b/.github/test-manage-required-gates-ruleset.sh
@@ -17,11 +17,19 @@ grep -Fq 'environments/main-ruleset-administration' "${workflow}"
 grep -Fq 'required_reviewers' "${workflow}"
 grep -Fq 'can_admins_bypass == false' "${workflow}"
 grep -Fq 'commits/${head}/check-runs' "${workflow}"
+grep -Fq '.name == "homeboy / Test" and .app.id == 15368 and .conclusion == "success"' "${workflow}"
 grep -Fq 'commits/main' "${workflow}"
 grep -Fq 'test "${head}" = "${current_main}"' "${workflow}"
 grep -Fq 'bash .github/validate-required-gates.sh --github' "${workflow}"
 ! grep -Fq 'gh api --method PUT' "${root}/docs/operations/required-ci-gates.md"
 ! grep -Fq 'gh api --method PUT' "${root}/.github/validate-required-gates.sh"
+
+preflight_query='any(.check_runs[]; .name == "homeboy / Test" and .app.id == 15368 and .conclusion == "success")'
+if jq -e "${preflight_query}" <<<'{"check_runs":[{"name":"homeboy / Test","app":{"id":99999},"conclusion":"success"}]}' >/dev/null; then
+  echo 'ruleset preflight accepted a spoofed successful Test check' >&2
+  exit 1
+fi
+jq -e "${preflight_query}" <<<'{"check_runs":[{"name":"homeboy / Test","app":{"id":15368},"conclusion":"success"}]}' >/dev/null
 
 jq 'del(.rules[] | select(.type == "required_status_checks"))' \
   "${root}/.github/required-gates-ruleset.json" > "${tmp}/state.json"

--- a/.github/workflows/required-gates-ruleset.yml
+++ b/.github/workflows/required-gates-ruleset.yml
@@ -60,7 +60,7 @@ jobs:
           current_main="$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq '.sha')"
           test "${head}" = "${current_main}"
           gh api "repos/${GITHUB_REPOSITORY}/commits/${head}/check-runs?per_page=100" \
-            --jq 'any(.check_runs[]; .name == "homeboy / Test" and .conclusion == "success")' \
+            --jq 'any(.check_runs[]; .name == "homeboy / Test" and .app.id == 15368 and .conclusion == "success")' \
             | grep -qx true
           current_main="$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq '.sha')"
           test "${head}" = "${current_main}"

--- a/.github/workflows/required-gates-ruleset.yml
+++ b/.github/workflows/required-gates-ruleset.yml
@@ -1,6 +1,9 @@
 name: Required Gates Ruleset
 
 on:
+  schedule:
+    # Audit only. Reconciliation remains an explicit approved dispatch.
+    - cron: '17 * * * *'
   workflow_dispatch:
     inputs:
       operation:

--- a/docs/operations/required-ci-gates.md
+++ b/docs/operations/required-ci-gates.md
@@ -1,28 +1,18 @@
 # Required CI Gates
 
 > [!IMPORTANT]
-> **Branch protection deliberately requires NO status checks (2026-08-22).**
+> **The checked-in policy requires the eight status checks below.**
 >
-> The `main` ruleset (`13680120`) carries only `deletion` and
-> `non_fast_forward`. Making the eight contexts below *required* was an
-> unwanted change: with 35 pre-existing test failures on `main`, `homeboy /
-> Test` fails on every pull request, so a required-checks rule blocks the
-> entire merge queue rather than protecting it.
+> The live `main` ruleset (`13680120`) is audited hourly against that policy.
+> Audit is read-only and fails closed with a replayable before/desired/after
+> artifact when the ruleset drifts. It never changes GitHub state.
 >
-> **Do not reconcile the live ruleset to the declaration in
-> `.github/required-gates-ruleset.json`.** That is exactly what #12904 added
-> and why it was reverted — its own live verification re-added the rule 75
-> minutes after it was deliberately removed, and the merge queue stopped again.
->
-> The declaration below is retained as a *description of which contexts CI
-> emits*, which is what `validate-required-gates.sh --report` measures and what
-> `required-gates-executed` enforces inside a run. Neither makes GitHub require
-> anything, and `--report` is non-blocking by construction
-> (`reporting_never_blocks_a_pull_request`). Reporting `unenforced` is the
-> intended steady state, not drift to repair.
->
-> Re-enabling required checks is a deliberate decision that belongs to the
-> repository owner, and it should follow a green suite, not precede one.
+> Reconciliation is a separate, explicit `workflow_dispatch` operation from
+> `main`, protected by the `main-ruleset-administration` environment. It only
+> updates the existing ruleset ID after the exact current `main` revision has a
+> successful `homeboy / Test`; it then verifies the effective branch rule. The
+> evidence records a policy version, source revision, and canonical policy
+> fingerprint so an operator can replay the decision.
 
 
 Three different things can be true or false here, and conflating them is what
@@ -83,9 +73,9 @@ Prior to #11084 this job was named `homeboy / Required Gates Policy` and ran
 that green tick, because `repos/Extra-Chill/homeboy/rules/branches/main` carried
 no required-status-check rule at all.
 
-This is a reporting fix on purpose. The repository merges fast by design and a
-post-merge guard was removed by design; the defect was the false assurance, not
-the absence of a block.
+This reporting check does not itself merge-protect a pull request. The active
+ruleset must require these contexts; the audit and approved reconciliation path
+keep that repository state converged with the reviewed declaration.
 
 ## Execution: What A Green Run Has To Mean
 
@@ -104,7 +94,7 @@ two independent things and fails unless both hold:
 | direction | claim |
 | --- | --- |
 | dependency results | every gate job `ci.yml` names in its `needs` concluded `success`; `skipped` and `cancelled` are failures here, not silence |
-| observed execution | every declared context appears in this run's job list with conclusion `success`, read back from `actions/runs/<id>/jobs` |
+| observed execution | every non-terminal declared context appears in this run's job list with conclusion `success`, read back from `actions/runs/<id>/jobs`; the terminal context is enforced by GitHub after this job succeeds |
 
 | outcome | meaning |
 | --- | --- |
@@ -130,8 +120,9 @@ without wiring it into the terminal job turns `Required Gates Declaration` red.
 ## Apply And Verify
 
 The GitHub ruleset is repository state, so it cannot be changed by a pull
-request. `Required Gates Ruleset` is an approved manual operation from `main`.
-It does not create another ruleset. Reconciliation first requires a successful
+request. `Required Gates Ruleset` audits hourly and supports an approved manual
+reconciliation operation from `main`. It does not create another ruleset.
+Reconciliation first requires a successful
 `homeboy / Test` check on the current `main` SHA, so it cannot re-enable strict
 required checks while the main suite is red. Configure the `main-ruleset-administration`
 environment with required reviewers, administrator bypass disabled, and a

--- a/docs/operations/required-ci-gates.md
+++ b/docs/operations/required-ci-gates.md
@@ -122,12 +122,14 @@ without wiring it into the terminal job turns `Required Gates Declaration` red.
 The GitHub ruleset is repository state, so it cannot be changed by a pull
 request. `Required Gates Ruleset` audits hourly and supports an approved manual
 reconciliation operation from `main`. It does not create another ruleset.
-Reconciliation first requires a successful
-`homeboy / Test` check on the current `main` SHA, so it cannot re-enable strict
-required checks while the main suite is red. Configure the `main-ruleset-administration`
-environment with required reviewers, administrator bypass disabled, and a
-repository-administration token named `HOMEBOY_RULESET_ADMIN_TOKEN`; only the
-approved manual reconciliation job can use that credential.
+Reconciliation first requires a successful `homeboy / Test` check from GitHub
+Actions app `15368` on the current `main` SHA, so a same-named external check
+cannot satisfy the preflight and strict required checks are not re-enabled while
+the main suite is red. Issue #12833 remains open until the
+`main-ruleset-administration` environment is provisioned with required
+reviewers and administrator bypass disabled, its scoped
+`HOMEBOY_RULESET_ADMIN_TOKEN` is available only to the approved manual job, and
+reconciliation succeeds with verified evidence.
 
 After reviewing the audit artifact, dispatch reconciliation from `main`:
 

--- a/tests/required_gates_policy_test.rs
+++ b/tests/required_gates_policy_test.rs
@@ -124,6 +124,38 @@ fn run_validator(mode: &str, env: &[(&str, &str)]) -> Output {
         .expect("required-gates validator should run")
 }
 
+fn run_execution_gate(env: &[(&str, &str)]) -> Output {
+    let mut command = Command::new("bash");
+    command.arg(".github/ci-required-gates-executed.sh");
+    command.env_remove("GITHUB_STEP_SUMMARY");
+    command.env("CI_GATE_RESULTS", r#"{"gates":{"result":"success"}}"#);
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    command
+        .output()
+        .expect("required-gates execution gate should run")
+}
+
+fn execution_jobs(contexts: &[String], exception: Option<(&str, serde_json::Value)>) -> String {
+    serde_json::to_string(
+        &contexts
+            .iter()
+            .map(|context| {
+                serde_json::json!({
+                    "name": context,
+                    "conclusion": exception
+                        .as_ref()
+                        .filter(|(candidate, _)| *candidate == context)
+                        .map(|(_, conclusion)| conclusion.clone())
+                        .unwrap_or_else(|| serde_json::json!("success")),
+                })
+            })
+            .collect::<Vec<_>>(),
+    )
+    .expect("execution jobs fixture")
+}
+
 fn stdout_of(output: &Output) -> String {
     String::from_utf8_lossy(&output.stdout).into_owned()
 }
@@ -531,6 +563,83 @@ fn github_mode_rejects_rulesets_that_omit_the_terminal_execution_verdict() {
         stderr_of(&output).contains("enforcement is divergent"),
         "{}",
         stderr_of(&output)
+    );
+}
+
+/// GitHub only allows a merge once a required context succeeds. These fixtures
+/// exercise the terminal context's fail-closed contract for every non-success
+/// check state that could otherwise leave a candidate unverified.
+#[test]
+fn terminal_execution_verdict_rejects_pending_skipped_cancelled_failed_and_absent_contexts() {
+    let contexts = declared_contexts();
+    let target = "homeboy / Test";
+
+    for (state, conclusion, expected_outcome) in [
+        ("pending", serde_json::Value::Null, "failed"),
+        ("skipped", serde_json::json!("skipped"), "failed"),
+        ("cancelled", serde_json::json!("cancelled"), "failed"),
+        ("failed", serde_json::json!("failure"), "failed"),
+    ] {
+        let scratch = Scratch::new(state);
+        let jobs = scratch.write(
+            "jobs.json",
+            &execution_jobs(&contexts, Some((target, conclusion))),
+        );
+        let output = run_execution_gate(&[("REQUIRED_GATES_EXECUTED_JOBS", jobs.as_str())]);
+
+        assert!(
+            !output.status.success(),
+            "a {state} terminal context must leave the PR unmergeable: {}",
+            stdout_of(&output)
+        );
+        assert!(
+            stdout_of(&output).contains(&format!(
+                "required-gates-executed-status={expected_outcome}"
+            )),
+            "a {state} terminal context must have a fail-closed verdict: {}",
+            stdout_of(&output)
+        );
+    }
+
+    let absent: Vec<String> = contexts
+        .iter()
+        .filter(|context| context.as_str() != target)
+        .cloned()
+        .collect();
+    let scratch = Scratch::new("absent-terminal-context");
+    let jobs = scratch.write("jobs.json", &execution_jobs(&absent, None));
+    let output = run_execution_gate(&[("REQUIRED_GATES_EXECUTED_JOBS", jobs.as_str())]);
+    assert!(
+        !output.status.success()
+            && stdout_of(&output).contains("required-gates-executed-status=skipped"),
+        "an absent terminal context must leave the PR unmergeable: {}",
+        stdout_of(&output)
+    );
+}
+
+/// The terminal job has no conclusion until this script exits. Its own required
+/// context is enforced by GitHub after that exit, so observing it as a running
+/// job would make every otherwise-green run fail cyclically.
+#[test]
+fn terminal_execution_verdict_does_not_require_its_own_in_progress_conclusion() {
+    let jobs: Vec<String> = declared_contexts()
+        .into_iter()
+        .filter(|context| context != "homeboy / Required Gates Executed")
+        .collect();
+    let scratch = Scratch::new("terminal-self-observation");
+    let jobs = scratch.write("jobs.json", &execution_jobs(&jobs, None));
+    let output = run_execution_gate(&[("REQUIRED_GATES_EXECUTED_JOBS", jobs.as_str())]);
+
+    assert!(
+        output.status.success(),
+        "the terminal context is enforced by GitHub after this job exits: {}\n{}",
+        stdout_of(&output),
+        stderr_of(&output)
+    );
+    assert!(
+        stdout_of(&output).contains("required-gates-executed-status=executed"),
+        "{}",
+        stdout_of(&output)
     );
 }
 

--- a/tests/required_gates_policy_test.rs
+++ b/tests/required_gates_policy_test.rs
@@ -622,12 +622,15 @@ fn terminal_execution_verdict_rejects_pending_skipped_cancelled_failed_and_absen
 /// job would make every otherwise-green run fail cyclically.
 #[test]
 fn terminal_execution_verdict_does_not_require_its_own_in_progress_conclusion() {
-    let jobs: Vec<String> = declared_contexts()
-        .into_iter()
-        .filter(|context| context != "homeboy / Required Gates Executed")
-        .collect();
+    let contexts = declared_contexts();
     let scratch = Scratch::new("terminal-self-observation");
-    let jobs = scratch.write("jobs.json", &execution_jobs(&jobs, None));
+    let jobs = scratch.write(
+        "jobs.json",
+        &execution_jobs(
+            &contexts,
+            Some(("homeboy / Required Gates Executed", serde_json::Value::Null)),
+        ),
+    );
     let output = run_execution_gate(&[("REQUIRED_GATES_EXECUTED_JOBS", jobs.as_str())]);
 
     assert!(


### PR DESCRIPTION
## Summary

Refs #12833. The issue remains open until the protected reconciliation environment is provisioned and live convergence succeeds.

- Restore hourly, read-only audit of the existing `main` ruleset against the checked-in required-context policy.
- Keep reconciliation explicit, environment-approved, exact-main-SHA-gated, idempotent, and limited to existing ruleset `13680120`.
- Require the exact-main `homeboy / Test` preflight to be a successful check from GitHub Actions app `15368`, matching the declared ruleset integration ID; same-named external checks cannot authorize reconciliation.
- Bind before/desired/after evidence to `required-gates-ruleset/v1`, the source revision, and a canonical policy SHA-256.
- Keep `homeboy / Required Gates Executed` as a required context while correcting its self-observation cycle: it verifies every other required context, and GitHub verifies the terminal context after it exits.
- Add hermetic policy coverage for pending, skipped, cancelled, failed, and absent required contexts, the terminal in-progress self-cycle, and a spoofed Test check with the wrong app ID.

## Verification

- `cargo test --test required_gates_policy_test` (22 passed)
- `cargo test --test pr_ci_lifecycle_test` (3 passed)
- `bash .github/test-manage-required-gates-ruleset.sh`
- `bash .github/validate-required-gates.sh --local`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash -n .github/test-manage-required-gates-ruleset.sh .github/ci-required-gates-executed.sh`
- `actionlint .github/workflows/required-gates-ruleset.yml`

## Operator Action

#12833 remains open until `main-ruleset-administration` is provisioned with required reviewers and administrator bypass disabled, its scoped `HOMEBOY_RULESET_ADMIN_TOKEN` is available only to the approved job, and an approved operator dispatches `Required Gates Ruleset` from `main` with `operation=reconcile`. The workflow then requires a successful app-`15368` `homeboy / Test` on the exact current `main` SHA and writes replayable reconciliation evidence. This PR does not mutate live settings.

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode general coding subagent investigated the issue and related evidence, implemented the workflow/script/test/documentation changes, and ran the listed verification. Chris Huber remains responsible for every line.