### PR TITLE
fix(cook): preserve pre-provider ownership

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -3473,7 +3473,9 @@ pub fn record_cook_progress_with_activity_in_store(
             }
             metadata.insert("cook_progress".to_string(), progress);
         }
-        if !record.state.is_terminal() && !record.is_runner_backed() {
+        if !record.state.is_terminal()
+            && (!record.is_runner_backed() || record.has_fresh_controller_pre_provider_heartbeat())
+        {
             record.updated_at = Some(now_timestamp());
             update_lifecycle_heartbeat(record);
         }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -586,6 +586,14 @@ impl AgentTaskRunRecord {
             return;
         }
 
+        // Worktree lookup and materialization run in the controller before a
+        // runner job can exist. Their fresh Cook heartbeat is therefore the
+        // ownership evidence; applying the runner-PID watchdog here would
+        // cancel a healthy provider command before its declared timeout.
+        if self.has_fresh_controller_pre_provider_heartbeat() {
+            return;
+        }
+
         // A reverse-broker job may begin before the daemon's accepted job/PID
         // projection arrives. Its complete, unexpired submission intent remains
         // the authoritative owner during that narrow handoff window.
@@ -850,6 +858,21 @@ impl AgentTaskRunRecord {
                 .and_then(|value| value.get("runner_id"))
                 .and_then(Value::as_str)
                 .is_some_and(|runner_id| self.runner_id() == Some(runner_id))
+    }
+
+    /// A controller-owned pre-provider phase is live only while its heartbeat
+    /// is fresh. Once runner submission begins, runner identity remains the
+    /// fail-closed ownership boundary.
+    pub(crate) fn has_fresh_controller_pre_provider_heartbeat(&self) -> bool {
+        self.runner_job_id().is_none()
+            && self.provider_handles.is_empty()
+            && matches!(
+                self.metadata
+                    .pointer("/cook_progress/phase")
+                    .and_then(Value::as_str),
+                Some("worktree_provider_lookup" | "worktree_provider_ensure")
+            )
+            && self.has_fresh_update()
     }
 
     /// A run is runner-backed when its durable record carries a runner id or

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4536,12 +4536,27 @@ fn run_cook_spine(
                     }
                     if Instant::now() >= next_heartbeat {
                         next_heartbeat = Instant::now() + COOK_HEARTBEAT_INTERVAL;
+                        let phase = lookup_lifecycle_store
+                            .read_record(&lookup_run_id)
+                            .ok()
+                            .and_then(|record| {
+                                record.metadata["cook_progress"]["phase"]
+                                    .as_str()
+                                    .map(str::to_string)
+                            })
+                            .filter(|phase| {
+                                matches!(
+                                    phase.as_str(),
+                                    "worktree_provider_lookup" | "worktree_provider_ensure"
+                                )
+                            })
+                            .unwrap_or_else(|| "worktree_provider_lookup".to_string());
                         let _ = report_cook_progress(
                             lookup_lifecycle_store,
                             durable_observer,
                             &lookup_cook_id,
                             &lookup_run_id,
-                            "worktree_provider_lookup",
+                            &phase,
                             1,
                             Some("bounded provider workspace lookup is still running"),
                         );
@@ -6877,6 +6892,13 @@ fn materialize_pending_cook_workspace(
     let mut identity = match resolve(options) {
         Ok(identity) => identity,
         Err(error) if error.details["worktree_provider_lookup"] == "not_found" => {
+            agent_task_lifecycle::record_cook_progress_in_store(
+                lifecycle_store,
+                &options.initial_run_id,
+                "worktree_provider_ensure",
+                1,
+                Some("starting controller-owned provider workspace materialization"),
+            )?;
             let provision = provision_pending_cook_workspace(lifecycle_store, options, &config)?;
             // Pin the provider that performed the durable mutation. A later
             // continuation re-resolves this exact destination through its owner.

--- a/crates/homeboy-agents/src/agent_task_service/reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_service/reconcile.rs
@@ -1237,6 +1237,101 @@ mod tests {
     }
 
     #[test]
+    fn controller_heartbeat_keeps_slow_pre_provider_materialization_out_of_runner_pid_watchdog() {
+        with_isolated_home(|_| {
+            register_orchestration_driver();
+            let run_id = "reconcile-controller-pre-provider-heartbeat";
+            let plan = AgentTaskPlan::new("reconcile-tick-plan", Vec::new());
+            agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("submitted");
+            agent_task_lifecycle::mark_running(run_id).expect("running");
+            agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+                record
+                    .metadata
+                    .as_object_mut()
+                    .expect("metadata object")
+                    .remove("runner_pid");
+                record.metadata["runner_id"] = serde_json::json!("homeboy-lab");
+            })
+            .expect("runner has not been submitted yet");
+            agent_task_lifecycle::record_cook_progress_in_store(
+                &agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()
+                    .expect("lifecycle store"),
+                run_id,
+                "worktree_provider_ensure",
+                1,
+                Some("provider budget is 120 seconds; ensure remains active after 20 seconds"),
+            )
+            .expect("controller heartbeat");
+            agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+                record.metadata["cook_progress"]["started_at"] = serde_json::json!(
+                    (chrono::Utc::now() - chrono::Duration::seconds(21)).to_rfc3339()
+                );
+                record.metadata["cook_progress"]["provider_budget_ms"] =
+                    serde_json::json!(120_000u64);
+            })
+            .expect("record slow provider evidence");
+
+            let status = agent_task_lifecycle::status(run_id).expect("status while ensure runs");
+            assert!(status.metadata.get("stale_running").is_none());
+            assert_eq!(
+                status.metadata["cook_progress"]["phase"],
+                "worktree_provider_ensure"
+            );
+            assert_eq!(
+                status.metadata["cook_progress"]["provider_budget_ms"],
+                120_000
+            );
+
+            let report = homeboy_core::daemon::orchestration::reconcile_stale_active_runs()
+                .expect("watchdog pass");
+            assert_eq!(report["reconciled"], 0, "{report}");
+            let retained = agent_task_lifecycle::status(run_id).expect("retained run");
+            assert_eq!(
+                retained.state,
+                agent_task_lifecycle::AgentTaskRunState::Running
+            );
+            assert!(retained.metadata.get("cancel_reason").is_none());
+        });
+    }
+
+    #[test]
+    fn missing_runner_pid_after_runner_submission_still_cancels() {
+        with_isolated_home(|_| {
+            register_orchestration_driver();
+            let run_id = "reconcile-missing-post-submission-runner-pid";
+            let plan = AgentTaskPlan::new("reconcile-tick-plan", Vec::new());
+            agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("submitted");
+            agent_task_lifecycle::mark_running(run_id).expect("running");
+            agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+                record
+                    .metadata
+                    .as_object_mut()
+                    .expect("metadata object")
+                    .remove("runner_pid");
+                record.metadata["runner_id"] = serde_json::json!("homeboy-lab");
+                record.metadata["cook_progress"] = serde_json::json!({
+                    "phase": "runner_submission",
+                    "attempt": 1,
+                });
+            })
+            .expect("runner submission without PID");
+
+            let stale = agent_task_lifecycle::status(run_id).expect("status after submission");
+            assert_eq!(stale.metadata["stale_running_reason"], "missing_runner_pid");
+
+            let report = homeboy_core::daemon::orchestration::reconcile_stale_active_runs()
+                .expect("watchdog pass");
+            assert_eq!(report["reconciled"], 1, "{report}");
+            let cancelled = agent_task_lifecycle::status(run_id).expect("cancelled run");
+            assert_eq!(
+                cancelled.state,
+                agent_task_lifecycle::AgentTaskRunState::Cancelled
+            );
+            assert_eq!(cancelled.metadata["cancel_reason"], "missing_runner_pid");
+        });
+    }
+
+    #[test]
     fn concurrent_planned_submissions_survive_delayed_runner_identity_publication() {
         use std::sync::{Arc, Barrier};
 


### PR DESCRIPTION
## Summary
- keep fresh controller heartbeats authoritative during worktree-provider lookup and ensure
- distinguish provider lookup/ensure from actual runner submission in durable Cook progress
- preserve fail-closed missing-runner-PID cancellation after submission begins

## Root cause
Runner-backed Cook records suppressed controller heartbeat updates before a runner job could exist. The stale-run watchdog therefore interpreted a healthy controller-owned worktree ensure as a missing runner PID and cancelled it before the provider budget expired.

## Verification
- `cargo test -p homeboy-agents agent_task_service::reconcile::tests -- --nocapture` (23 passed)
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

Fixes #13046

## AI assistance
- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode general coding subagent
- **Used for:** root-cause tracing, implementation, focused regression tests, and compatibility review

Chris Huber reviewed the diff and remains responsible for every line.