### PR TITLE
fix(ssh): reap descendants before stream drain

### DIFF
--- a/crates/homeboy-core/src/server/client/ssh_client.rs
+++ b/crates/homeboy-core/src/server/client/ssh_client.rs
@@ -98,6 +98,15 @@ fn collect_ssh_child_output(
     let deadline = Instant::now() + PROCESS_CLEANUP_ALLOWANCE;
     if wait_failed {
         let _ = terminate_process_group_with_deadline(child, pid, deadline);
+    } else if status
+        .as_ref()
+        .and_then(|status| status.as_ref().ok())
+        .is_some_and(std::process::ExitStatus::success)
+    {
+        // A remote shell can exit successfully while a descendant still owns
+        // the SSH pipes. Reap our process group before waiting for EOF so that
+        // successful bounded commands cannot become false transport failures.
+        terminate_unreaped_process_group(pid);
     }
     let (stdout, mut stderr, streams_stalled) = collect_streams_before(stdout, stderr, deadline);
     if streams_stalled {

--- a/crates/homeboy-core/src/server/client/tests.rs
+++ b/crates/homeboy-core/src/server/client/tests.rs
@@ -871,10 +871,50 @@ fn managed_session_connect_builds_master_command() {
 
 #[cfg(unix)]
 #[test]
-fn timed_command_does_not_wait_for_a_pipe_holding_descendant() {
+fn successful_ssh_child_with_delayed_eof_reaps_descendant_before_drain() {
+    let marker =
+        std::env::temp_dir().join(format!("homeboy-ssh-stream-drain-{}", std::process::id()));
+    let _ = std::fs::remove_file(&marker);
     let mut command = Command::new("sh");
     command
-        .args(["-c", "sleep 5 & exit 0"])
+        .args([
+            "-c",
+            &format!(
+                "sleep 5 & printf '%s' \"$!\" > {}; printf snapshot-output",
+                crate::engine::shell::quote_path(&marker.to_string_lossy())
+            ),
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    crate::server::process_cleanup::configure_process_group_cleanup(&mut command);
+    let started = Instant::now();
+
+    let output = run_ssh_with_child(command);
+
+    assert!(output.success, "{}", output.stderr);
+    assert_eq!(output.stdout, "snapshot-output");
+    assert!(
+        started.elapsed() < Duration::from_millis(750),
+        "successful output collection must not wait for a pipe-holding descendant"
+    );
+    std::thread::sleep(Duration::from_millis(100));
+    let pid = std::fs::read_to_string(&marker)
+        .expect("pipe-holding descendant pid")
+        .parse()
+        .expect("numeric descendant pid");
+    assert!(
+        !crate::process::pid_is_running(pid),
+        "successful SSH child leaked its descendant"
+    );
+    let _ = std::fs::remove_file(marker);
+}
+
+#[cfg(unix)]
+#[test]
+fn timed_ssh_child_with_stuck_streams_fails_within_its_cleanup_bound() {
+    let mut command = Command::new("sh");
+    command
+        .args(["-c", "sleep 5"])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     crate::server::process_cleanup::configure_process_group_cleanup(&mut command);
@@ -886,9 +926,9 @@ fn timed_command_does_not_wait_for_a_pipe_holding_descendant() {
     assert_eq!(output.exit_code, 124);
     assert!(
         started.elapsed() < Duration::from_millis(750),
-        "timeout plus its single cleanup allowance must remain bounded"
+        "stuck SSH child must remain bounded by its deadline and cleanup allowance"
     );
-    assert!(output.stderr.contains("stream drain exceeded"));
+    assert!(output.stderr.contains("timed out after 50ms"));
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- reap the owned SSH process group after a successful direct child exit and before waiting for stream EOF
- prevent pipe-holding descendants from converting successful Lab snapshot scans into transport failures
- retain bounded timeout behavior and process-group cleanup for genuinely stuck commands

## Root cause
A remote shell could exit successfully while a descendant retained stdout or stderr. Homeboy waited for EOF before cleaning up its process group, exhausted the stream-drain deadline, and reported a false snapshot failure.

## Verification
- `cargo test -p homeboy-core successful_ssh_child_with_delayed_eof_reaps_descendant_before_drain`
- `cargo test -p homeboy-core timed_ssh_child_with_stuck_streams_fails_within_its_cleanup_bound`
- `cargo test -p homeboy-lab-runner ssh_snapshot_listing_preserves_entries_and_isolates_invalid_metadata`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

Fixes #13044

## AI assistance
- **Model:** OpenAI GPT-5.6 Sol
- **Tool:** OpenCode general coding subagent
- **Used for:** SSH lifecycle tracing, implementation, deterministic process tests, and compatibility review

Chris Huber reviewed the diff and remains responsible for every line.