### PR TITLE
fix(cook): recover orphaned retry replacements

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -6273,7 +6273,10 @@ pub(crate) fn record_cook_attempt_locked_in_store(
     if let Ok(parent) = lifecycle_store.read_record(&cook_id) {
         let handoff = &parent.metadata["detached_cook_handoff"];
         let reserved_child = handoff["materializing_attempt_run_id"] == run_id;
-        if handoff["cook_id"] == cook_id
+        // An existing index proves this is later-attempt materialization; a
+        // terminal first-handoff placeholder no longer owns that boundary.
+        if !lifecycle_store.cook_index_exists(&cook_id)
+            && handoff["cook_id"] == cook_id
             && (((parent.state.is_terminal() && handoff["state"] != "redirected")
                 || handoff["cancellation_fence"]["state"] == "cancelled")
                 && !reserved_child

--- a/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
@@ -324,11 +324,15 @@ fn materialize_cook_attempt_with_stores_and_runtime(
     reconcile_reserved_cancellation: impl FnOnce(&str) -> Result<()>,
 ) -> Result<()> {
     if !lifecycle_store.record_exists(run_id)? {
-        agent_task_lifecycle::reserve_detached_cook_handoff_materialization_in_store(
-            lifecycle_store,
-            cook_id,
-            run_id,
-        )?;
+        // The detached handoff placeholder only owns first-attempt admission.
+        // Once indexed, later attempts derive ownership from the Cook index.
+        if !agent_task_lifecycle::cook_index_exists_in_store(lifecycle_store, cook_id)? {
+            agent_task_lifecycle::reserve_detached_cook_handoff_materialization_in_store(
+                lifecycle_store,
+                cook_id,
+                run_id,
+            )?;
+        }
         let submission = match admission_status {
             Some(project) => lifecycle_store.submit_plan_with_runtime_admission_status(
                 plan,

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -241,7 +241,7 @@ impl CookRecipeStore {
     }
 }
 
-fn default_store() -> Result<CookRecipeStore> {
+pub(crate) fn default_store() -> Result<CookRecipeStore> {
     CookRecipeStore::from_current_data_root()
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -7129,6 +7129,74 @@ fn retryable_pre_provider_retry_repairs_lifecycle_reserved_attempts_idempotently
 }
 
 #[test]
+fn retryable_pre_provider_retry_materializes_orphaned_transport_replacement() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let options = retryable_pre_provider_cook("cook-retry-orphaned-replacement", 2);
+        let first_retry =
+            crate::agent_task_service::retry(&options.initial_run_id, None, false, false)
+                .expect("reserve second attempt");
+        agent_task_lifecycle::record_pre_execution_failure(
+            &first_retry.record.run_id,
+            &options.initial_plan,
+            "lab_handoff",
+            &Error::internal_io("snapshot failed", None).with_retryable(true),
+        )
+        .expect("terminalize the materialized second attempt");
+        let orphaned_run_id = format!("{}-transport-retry", first_retry.record.run_id);
+        super::super::cook_recipe::default_store()
+            .expect("Cook recipe store")
+            .record_recipe_attempt_replacement(
+                &options.cook_id,
+                &first_retry.record.run_id,
+                &orphaned_run_id,
+            )
+            .expect("persist replacement before interrupted lifecycle materialization");
+        assert!(!agent_task_lifecycle::run_record_exists(&orphaned_run_id)
+            .expect("probe missing lifecycle reservation"));
+
+        let barrier = Arc::new(Barrier::new(4));
+        let retries = (0..4)
+            .map(|_| {
+                let barrier = Arc::clone(&barrier);
+                let run_id = options.initial_run_id.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    crate::agent_task_service::retry(&run_id, None, true, true)
+                        .expect("materialize the recipe-owned replacement")
+                })
+            })
+            .collect::<Vec<_>>();
+        let recovered = retries
+            .into_iter()
+            .map(|retry| retry.join().expect("retry thread"))
+            .collect::<Vec<_>>();
+
+        assert!(recovered
+            .iter()
+            .all(|retry| retry.record.run_id == orphaned_run_id && retry.run));
+        let recovered_record = agent_task_lifecycle::exact_record(&orphaned_run_id)
+            .expect("recovered lifecycle record");
+        assert_eq!(recovered_record.metadata["cook_id"], options.cook_id);
+        assert_eq!(recovered_record.metadata["cook_attempt"], 2);
+        assert_eq!(
+            recovered_record.metadata["cook_retry_recipe_recovery"],
+            serde_json::json!({
+                "schema": "homeboy/cook-retry-recipe-recovery/v1",
+                "status": "materialized_orphaned_replacement",
+                "source_run_id": options.initial_run_id,
+                "recovered_run_id": orphaned_run_id,
+            })
+        );
+        assert_eq!(
+            agent_task_lifecycle::cook_index(&options.cook_id)
+                .expect("recovered Cook index")
+                .latest_run_id,
+            orphaned_run_id
+        );
+    });
+}
+
+#[test]
 fn retryable_pre_provider_retry_concurrently_claims_one_successor() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let options = retryable_pre_provider_cook("cook-retry-concurrent", 2);

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -1111,6 +1111,54 @@ pub fn retry(
         &lifecycle_store,
         run_id,
     )?;
+    let recovered_replacement = config::with_config_lock(|| {
+        let Some(cook_retry) = retryable_cook_attempt(&lifecycle_store, &source)? else {
+            return Ok(None);
+        };
+        if !cook_retry.recipe_replacement {
+            return Ok(None);
+        }
+        let retry_run_id = cook_retry
+            .pending_run_id
+            .as_deref()
+            .expect("recipe replacement has a run id");
+        let lifecycle_missing =
+            !agent_task_lifecycle::run_record_exists_in_store(&lifecycle_store, retry_run_id)?;
+        if lifecycle_missing {
+            let recipe_store = super::cook_recipe::default_store()?;
+            super::cook_pre_execution::materialize_cook_attempt_with_stores(
+                &recipe_store,
+                &lifecycle_store,
+                &cook_retry.cook_id,
+                retry_run_id,
+                &cook_retry.plan,
+            )?;
+            agent_task_lifecycle::record_metadata_value_in_store(
+                &lifecycle_store,
+                retry_run_id,
+                "cook_retry_recipe_recovery",
+                json!({
+                    "schema": "homeboy/cook-retry-recipe-recovery/v1",
+                    "status": "materialized_orphaned_replacement",
+                    "source_run_id": source.run_id,
+                    "recovered_run_id": retry_run_id,
+                }),
+            )?;
+        }
+        Ok(Some(
+            agent_task_lifecycle::status_in_store(
+                &lifecycle_store,
+                retry_run_id,
+                agent_task_lifecycle::AgentTaskStatusOptions::default(),
+                false,
+            )?
+            .record,
+        ))
+    })?;
+    if let Some(record) = recovered_replacement {
+        let run = run && !record.state.is_terminal();
+        return Ok(AgentTaskRetryServiceResult { record, run });
+    }
     let cook_retry = retryable_cook_attempt(&lifecycle_store, &source)?;
     let record = match cook_retry {
         Some(cook_retry) => {
@@ -1369,6 +1417,7 @@ fn retryable_cook_attempt(
         return Ok(None);
     }
     let mut pending_attempt = None;
+    let mut materialized_attempt_seen = false;
     for recipe_attempt in recipe
         .attempts
         .iter()
@@ -1378,6 +1427,10 @@ fn retryable_cook_attempt(
             lifecycle_store,
             &recipe_attempt.run_id,
         )? {
+            if materialized_attempt_seen {
+                pending_attempt = Some(recipe_attempt);
+                break;
+            }
             return Err(Error::validation_invalid_argument(
                 "cook_recipe.attempts",
                 "pending Cook retry recipe entry has no durable lifecycle reservation",
@@ -1385,9 +1438,29 @@ fn retryable_cook_attempt(
                 None,
             ));
         }
-        let record =
+        let mut record =
             agent_task_lifecycle::exact_record_in_store(lifecycle_store, &recipe_attempt.run_id)?;
-        if record.metadata["retry_of"] != source.run_id {
+        let mut owned_replacement = materialized_attempt_seen
+            && record.metadata["cook_id"] == cook_id
+            && record.metadata["cook_attempt"] == recipe_attempt.attempt;
+        if materialized_attempt_seen
+            && !owned_replacement
+            && record.state == agent_task_lifecycle::AgentTaskRunState::Queued
+        {
+            for _ in 0..100 {
+                std::thread::sleep(Duration::from_millis(10));
+                record = agent_task_lifecycle::exact_record_in_store(
+                    lifecycle_store,
+                    &recipe_attempt.run_id,
+                )?;
+                owned_replacement = record.metadata["cook_id"] == cook_id
+                    && record.metadata["cook_attempt"] == recipe_attempt.attempt;
+                if owned_replacement {
+                    break;
+                }
+            }
+        }
+        if !owned_replacement && record.metadata["retry_of"] != source.run_id {
             return Err(Error::validation_invalid_argument(
                 "cook_recipe.attempts",
                 "pending Cook retry run is not the durable retry of its source attempt",
@@ -1413,8 +1486,10 @@ fn retryable_cook_attempt(
                     attempt: recipe_attempt.attempt,
                     pending_run_id: Some(recipe_attempt.run_id.clone()),
                     plan: recipe_attempt.plan.clone(),
+                    recipe_replacement: materialized_attempt_seen,
                 }));
             }
+            materialized_attempt_seen = true;
             // A terminal failed successor is authoritative evidence. It cannot
             // be resumed; a later attempt may be allocated below if the durable
             // retry budget permits it.
@@ -1437,6 +1512,7 @@ fn retryable_cook_attempt(
             attempt: pending_attempt.attempt,
             pending_run_id: Some(pending_attempt.run_id.clone()),
             plan: pending_attempt.plan.clone(),
+            recipe_replacement: materialized_attempt_seen,
         }));
     }
     let max_attempts = recipe
@@ -1496,6 +1572,7 @@ fn retryable_cook_attempt(
         attempt: next_attempt,
         pending_run_id: None,
         plan,
+        recipe_replacement: false,
     }))
 }
 
@@ -1554,6 +1631,7 @@ struct CookRetryAttempt {
     attempt: u32,
     pending_run_id: Option<String>,
     plan: AgentTaskPlan,
+    recipe_replacement: bool,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary

- recognize a missing lifecycle record as recoverable only when it is a same-attempt replacement following a valid materialized Cook attempt
- materialize that exact append-only recipe replacement instead of allocating a competing semantic attempt
- serialize concurrent recovery, preserve ownership checks, and record `homeboy/cook-retry-recipe-recovery/v1` provenance
- keep missing first-attempt reservations and conflicting lifecycle ownership fail-closed

Closes #13054.

## Verification

- `cargo test -p homeboy-agents retryable_pre_provider_retry` (14 passed)
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p homeboy-agents --lib` reached 1,926 passing tests with 22 unrelated concurrency/fixture failures; the changed retry subset passed in that run
- `cargo clippy -p homeboy-agents --lib -- -D warnings` is baseline-red on unrelated Rust 1.95 lints in `homeboy-core`

## AI assistance

OpenAI `gpt-5.6-sol` via OpenCode diagnosed the orphaned durable lineage, implemented the retry recovery boundary and concurrent regression coverage, and ran verification. Chris Huber is responsible for every line and the final review.