### PR TITLE
refactor(cli): open one observation store per `runs` invocation (#7505)

### DIFF
--- a/crates/homeboy-cli/src/commands/runs/artifact_index_tests.rs
+++ b/crates/homeboy-cli/src/commands/runs/artifact_index_tests.rs
@@ -5,6 +5,14 @@ use serde_json::Value;
 use super::types::RunsArtifactsArgs;
 use super::{handlers, list_runs, RunsListArgs, RunsOutput};
 
+/// The observation store the enclosing isolated home installs.
+///
+/// A test is the entry point for its own unit of work, so opening once here
+/// is a boundary open, not an ambient one inside production code (#7505).
+fn test_store() -> homeboy::core::observation::ObservationStore {
+    homeboy::core::observation::ObservationStore::open_initialized().expect("observation store")
+}
+
 struct XdgGuard(Option<String>);
 
 struct PublicArtifactBaseGuard(Option<String>);
@@ -93,6 +101,7 @@ fn runs_list_rig_filter_surfaces_compact_artifact_index() {
             .expect("record report");
 
         let (output, _) = list_runs(
+            &test_store(),
             RunsListArgs {
                 active: false,
                 task_url: None,

--- a/crates/homeboy-cli/src/commands/runs/bundle.rs
+++ b/crates/homeboy-cli/src/commands/runs/bundle.rs
@@ -93,7 +93,7 @@ pub struct RunsImportOutput {
     pub imported: ObservationBundleImportSummary,
 }
 
-pub(super) fn export_runs(args: RunsExportArgs) -> CmdResult<RunsOutput> {
+pub(super) fn export_runs(store: &ObservationStore, args: RunsExportArgs) -> CmdResult<RunsOutput> {
     if args
         .output
         .extension()
@@ -108,7 +108,6 @@ pub(super) fn export_runs(args: RunsExportArgs) -> CmdResult<RunsOutput> {
         ));
     }
 
-    let store = ObservationStore::open_initialized()?;
     let runs = if let Some(run_id) = args.run.as_deref() {
         vec![require_run(&store, run_id)?]
     } else if let Some(since) = args.since.as_deref() {
@@ -139,7 +138,7 @@ pub(super) fn export_runs(args: RunsExportArgs) -> CmdResult<RunsOutput> {
     ))
 }
 
-pub(super) fn import_runs(args: RunsImportArgs) -> CmdResult<RunsOutput> {
+pub(super) fn import_runs(store: &ObservationStore, args: RunsImportArgs) -> CmdResult<RunsOutput> {
     if args.from_gh_actions {
         return import_via_gh_actions(args);
     }
@@ -149,7 +148,6 @@ pub(super) fn import_runs(args: RunsImportArgs) -> CmdResult<RunsOutput> {
         ])
     })?;
     let mut bundle = read_bundle_dir(&input)?;
-    let store = ObservationStore::open_initialized()?;
     for index in 0..bundle.runs.len() {
         let original_run_id = bundle.runs[index].id.clone();
         let imported_run_id = import_bundle_run(&store, &mut bundle.runs[index])?;

--- a/crates/homeboy-cli/src/commands/runs/bundle_import_tests.rs
+++ b/crates/homeboy-cli/src/commands/runs/bundle_import_tests.rs
@@ -12,6 +12,14 @@ use super::bundle::{export_runs, import_runs, RunsExportArgs, RunsImportArgs};
 use super::dead_owned_run;
 use super::RunsOutput;
 
+/// The observation store the enclosing isolated home installs.
+///
+/// A test is the entry point for its own unit of work, so opening once here
+/// is a boundary open, not an ambient one inside production code (#7505).
+fn test_store() -> homeboy::core::observation::ObservationStore {
+    homeboy::core::observation::ObservationStore::open_initialized().expect("observation store")
+}
+
 struct XdgGuard(Option<String>);
 
 impl XdgGuard {
@@ -68,11 +76,14 @@ fn lab_bundle_run_id_conflicts_are_remapped_idempotently() {
             .expect("finding");
 
         let bundle = home.path().join("lab-conflict-bundle");
-        export_runs(RunsExportArgs {
-            run: Some(run.id.clone()),
-            since: None,
-            output: bundle.clone(),
-        })
+        export_runs(
+            &test_store(),
+            RunsExportArgs {
+                run: Some(run.id.clone()),
+                since: None,
+                output: bundle.clone(),
+            },
+        )
         .expect("export");
 
         let conflicting_id = "runner-exec-conflict-fixture";
@@ -137,15 +148,21 @@ fn lab_bundle_run_id_conflicts_are_remapped_idempotently() {
             .expect("rewrite findings");
         }
 
-        import_runs(RunsImportArgs {
-            input: Some(bundle.clone()),
-            ..RunsImportArgs::default()
-        })
+        import_runs(
+            &test_store(),
+            RunsImportArgs {
+                input: Some(bundle.clone()),
+                ..RunsImportArgs::default()
+            },
+        )
         .expect("import remaps conflict");
-        import_runs(RunsImportArgs {
-            input: Some(bundle),
-            ..RunsImportArgs::default()
-        })
+        import_runs(
+            &test_store(),
+            RunsImportArgs {
+                input: Some(bundle),
+                ..RunsImportArgs::default()
+            },
+        )
         .expect("second import remains idempotent");
 
         let store = ObservationStore::open_initialized().expect("store");
@@ -206,11 +223,14 @@ fn runs_export_import_preserves_file_artifact_bytes_with_checksum_refs() {
             .record_artifact(&run.id, "fuzz_result_envelope", &artifact_path)
             .expect("artifact");
 
-        let (output, exit) = export_runs(RunsExportArgs {
-            run: Some(run.id.clone()),
-            since: None,
-            output: bundle.clone(),
-        })
+        let (output, exit) = export_runs(
+            &test_store(),
+            RunsExportArgs {
+                run: Some(run.id.clone()),
+                since: None,
+                output: bundle.clone(),
+            },
+        )
         .expect("export");
         assert_eq!(exit, 0);
         let RunsOutput::Export(exported) = output else {
@@ -238,10 +258,13 @@ fn runs_export_import_preserves_file_artifact_bytes_with_checksum_refs() {
 
     with_isolated_home(|_| {
         let _xdg = XdgGuard::unset();
-        import_runs(RunsImportArgs {
-            input: Some(bundle.clone()),
-            ..RunsImportArgs::default()
-        })
+        import_runs(
+            &test_store(),
+            RunsImportArgs {
+                input: Some(bundle.clone()),
+                ..RunsImportArgs::default()
+            },
+        )
         .expect("import");
         let store = ObservationStore::open_initialized().expect("store");
         let imported_artifact = store
@@ -285,11 +308,14 @@ fn runs_export_import_preserves_directory_artifact_as_checksumed_archive() {
             .record_directory_artifact(&run.id, "fuzz_artifacts", &artifact_dir)
             .expect("directory artifact");
 
-        let (output, exit) = export_runs(RunsExportArgs {
-            run: Some(run.id.clone()),
-            since: None,
-            output: bundle.clone(),
-        })
+        let (output, exit) = export_runs(
+            &test_store(),
+            RunsExportArgs {
+                run: Some(run.id.clone()),
+                since: None,
+                output: bundle.clone(),
+            },
+        )
         .expect("export");
         assert_eq!(exit, 0);
         let RunsOutput::Export(exported) = output else {
@@ -318,10 +344,13 @@ fn runs_export_import_preserves_directory_artifact_as_checksumed_archive() {
 
     with_isolated_home(|_| {
         let _xdg = XdgGuard::unset();
-        import_runs(RunsImportArgs {
-            input: Some(bundle.clone()),
-            ..RunsImportArgs::default()
-        })
+        import_runs(
+            &test_store(),
+            RunsImportArgs {
+                input: Some(bundle.clone()),
+                ..RunsImportArgs::default()
+            },
+        )
         .expect("import");
         let store = ObservationStore::open_initialized().expect("store");
         let imported_artifact = store

--- a/crates/homeboy-cli/src/commands/runs/compare.rs
+++ b/crates/homeboy-cli/src/commands/runs/compare.rs
@@ -69,8 +69,8 @@ pub(crate) fn is_table_mode(args: &RunsCompareArgs) -> bool {
     args.format == RunsCompareFormat::Table
 }
 
-pub(crate) fn run_markdown(args: RunsCompareArgs) -> CmdResult<String> {
-    let (output, exit_code) = compare_runs(args)?;
+pub(crate) fn run_markdown(store: &ObservationStore, args: RunsCompareArgs) -> CmdResult<String> {
+    let (output, exit_code) = compare_runs(store, args)?;
     match output {
         RunsOutput::Compare(output) => Ok((render_compare_table(&output), exit_code)),
         _ => Err(Error::validation_invalid_argument(
@@ -82,8 +82,10 @@ pub(crate) fn run_markdown(args: RunsCompareArgs) -> CmdResult<String> {
     }
 }
 
-pub(super) fn compare_runs(args: RunsCompareArgs) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
+pub(super) fn compare_runs(
+    store: &ObservationStore,
+    args: RunsCompareArgs,
+) -> CmdResult<RunsOutput> {
     let limit = args.limit.clamp(1, 1000);
     let runs = store.list_runs(RunListFilter {
         kind: Some(args.kind.clone()),
@@ -270,6 +272,14 @@ fn fmt_metric(value: Option<f64>) -> String {
 
 #[cfg(test)]
 mod tests {
+
+    /// The observation store the enclosing isolated home installs.
+    ///
+    /// A test is the entry point for its own unit of work, so opening once here
+    /// is a boundary open, not an ambient one inside production code (#7505).
+    fn test_store() -> homeboy::core::observation::ObservationStore {
+        homeboy::core::observation::ObservationStore::open_initialized().expect("observation store")
+    }
     use super::*;
     use homeboy::core::observation::{NewRunRecord, RunStatus};
     use homeboy::test_support::with_isolated_home;
@@ -351,16 +361,19 @@ mod tests {
                 .finish_run(&other.id, RunStatus::Pass, None)
                 .expect("finish trace");
 
-            let (output, _) = compare_runs(RunsCompareArgs {
-                kind: "bench".to_string(),
-                component_id: Some("studio".to_string()),
-                rig: Some("studio-bfb".to_string()),
-                scenario_id: Some("site-build".to_string()),
-                status: None,
-                metrics: vec!["total_elapsed_ms".to_string(), "p95_ms".to_string()],
-                limit: 20,
-                format: RunsCompareFormat::Json,
-            })
+            let (output, _) = compare_runs(
+                &test_store(),
+                RunsCompareArgs {
+                    kind: "bench".to_string(),
+                    component_id: Some("studio".to_string()),
+                    rig: Some("studio-bfb".to_string()),
+                    scenario_id: Some("site-build".to_string()),
+                    status: None,
+                    metrics: vec!["total_elapsed_ms".to_string(), "p95_ms".to_string()],
+                    limit: 20,
+                    format: RunsCompareFormat::Json,
+                },
+            )
             .expect("compare");
 
             let RunsOutput::Compare(output) = output else {

--- a/crates/homeboy-cli/src/commands/runs/corpus_tests.rs
+++ b/crates/homeboy-cli/src/commands/runs/corpus_tests.rs
@@ -14,6 +14,14 @@ use serde_json::Value;
 use super::bundle::{RunsExportArgs, RunsImportArgs};
 use super::{bundle::import_runs, drift, query, RunsOutput};
 
+/// The observation store the enclosing isolated home installs.
+///
+/// A test is the entry point for its own unit of work, so opening once here
+/// is a boundary open, not an ambient one inside production code (#7505).
+fn test_store() -> homeboy::core::observation::ObservationStore {
+    homeboy::core::observation::ObservationStore::open_initialized().expect("observation store")
+}
+
 /// Restore `XDG_DATA_HOME` for the test scope so the observation store
 /// resolves under the temporary home created by `with_isolated_home`.
 struct XdgGuard(Option<String>);
@@ -87,16 +95,19 @@ fn runs_query_projects_select_jsonpath_over_artifact_corpus() {
             "design-distribution",
         );
 
-        let (output, _) = query::runs_query(query::RunsQueryArgs {
-            component_id: Some("wc-site-generator".into()),
-            kind: Some("gh-actions".into()),
-            since: None,
-            select: vec!["$.theme".into()],
-            group_by: None,
-            count: false,
-            format: query::QueryFormat::Json,
-            limit: 200,
-        })
+        let (output, _) = query::runs_query(
+            &test_store(),
+            query::RunsQueryArgs {
+                component_id: Some("wc-site-generator".into()),
+                kind: Some("gh-actions".into()),
+                since: None,
+                select: vec!["$.theme".into()],
+                group_by: None,
+                count: false,
+                format: query::QueryFormat::Json,
+                limit: 200,
+            },
+        )
         .expect("query");
 
         let RunsOutput::Query(output) = output else {
@@ -130,16 +141,19 @@ fn runs_query_groups_by_jsonpath_with_count() {
             );
         }
 
-        let (output, _) = query::runs_query(query::RunsQueryArgs {
-            component_id: Some("wc-site-generator".into()),
-            kind: Some("gh-actions".into()),
-            since: None,
-            select: vec!["$.theme".into()],
-            group_by: Some("$.theme".into()),
-            count: true,
-            format: query::QueryFormat::Json,
-            limit: 200,
-        })
+        let (output, _) = query::runs_query(
+            &test_store(),
+            query::RunsQueryArgs {
+                component_id: Some("wc-site-generator".into()),
+                kind: Some("gh-actions".into()),
+                since: None,
+                select: vec!["$.theme".into()],
+                group_by: Some("$.theme".into()),
+                count: true,
+                format: query::QueryFormat::Json,
+                limit: 200,
+            },
+        )
         .expect("query");
 
         let RunsOutput::Query(output) = output else {
@@ -170,15 +184,18 @@ fn runs_drift_reports_dominant_value_above_threshold() {
             );
         }
 
-        let (output, _) = drift::runs_drift(drift::RunsDriftArgs {
-            component_id: Some("wc-site-generator".into()),
-            kind: Some("gh-actions".into()),
-            metric: "$.theme".into(),
-            window: "30d".into(),
-            threshold: 0.6,
-            baseline: None,
-            format: drift::DriftFormat::Json,
-        })
+        let (output, _) = drift::runs_drift(
+            &test_store(),
+            drift::RunsDriftArgs {
+                component_id: Some("wc-site-generator".into()),
+                kind: Some("gh-actions".into()),
+                metric: "$.theme".into(),
+                window: "30d".into(),
+                threshold: 0.6,
+                baseline: None,
+                format: drift::DriftFormat::Json,
+            },
+        )
         .expect("drift");
 
         let RunsOutput::Drift(output) = output else {
@@ -206,11 +223,14 @@ fn import_from_gh_actions_requires_gh_specific_arguments() {
         let _xdg = XdgGuard::unset();
         // Without --component, --repo, --workflow/--run-id, --artifact-glob, the
         // gh-actions branch must reject with a missing-argument error.
-        let err = import_runs(RunsImportArgs {
-            input: None,
-            from_gh_actions: true,
-            ..RunsImportArgs::default()
-        })
+        let err = import_runs(
+            &test_store(),
+            RunsImportArgs {
+                input: None,
+                from_gh_actions: true,
+                ..RunsImportArgs::default()
+            },
+        )
         .err()
         .expect("must fail without required gh-actions args");
         assert_eq!(err.code.as_str(), "validation.missing_argument");
@@ -221,14 +241,17 @@ fn import_from_gh_actions_requires_gh_specific_arguments() {
 fn import_from_gh_actions_requires_workflow_or_run_id() {
     with_isolated_home(|_home| {
         let _xdg = XdgGuard::unset();
-        let err = import_runs(RunsImportArgs {
-            input: None,
-            from_gh_actions: true,
-            component_id: Some("wp-site-generator".into()),
-            repo: Some("example-org/wp-site-generator".into()),
-            artifact_glob: Some("php-transformer-iterator-transcript-*".into()),
-            ..RunsImportArgs::default()
-        })
+        let err = import_runs(
+            &test_store(),
+            RunsImportArgs {
+                input: None,
+                from_gh_actions: true,
+                component_id: Some("wp-site-generator".into()),
+                repo: Some("example-org/wp-site-generator".into()),
+                artifact_glob: Some("php-transformer-iterator-transcript-*".into()),
+                ..RunsImportArgs::default()
+            },
+        )
         .err()
         .expect("must fail without workflow or run id");
         assert_eq!(err.code.as_str(), "validation.missing_argument");
@@ -255,20 +278,26 @@ fn bundle_import_restores_file_artifacts_and_query_reads_embedded_bytes() {
         );
         run_id = run.id.clone();
 
-        super::bundle::export_runs(RunsExportArgs {
-            run: Some(run.id),
-            since: None,
-            output: bundle_dir.path().to_path_buf(),
-        })
+        super::bundle::export_runs(
+            &test_store(),
+            RunsExportArgs {
+                run: Some(run.id),
+                since: None,
+                output: bundle_dir.path().to_path_buf(),
+            },
+        )
         .expect("export bundle");
     });
 
     with_isolated_home(|_home| {
         let _xdg = XdgGuard::unset();
-        let (output, _) = import_runs(RunsImportArgs {
-            input: Some(bundle_dir.path().to_path_buf()),
-            ..RunsImportArgs::default()
-        })
+        let (output, _) = import_runs(
+            &test_store(),
+            RunsImportArgs {
+                input: Some(bundle_dir.path().to_path_buf()),
+                ..RunsImportArgs::default()
+            },
+        )
         .expect("import bundle");
         let RunsOutput::Import(output) = output else {
             panic!("expected import output");
@@ -283,16 +312,19 @@ fn bundle_import_restores_file_artifacts_and_query_reads_embedded_bytes() {
         assert!(!artifacts[0].path.contains(&source_home_path));
         assert!(std::path::Path::new(&artifacts[0].path).is_absolute());
 
-        let (output, _) = query::runs_query(query::RunsQueryArgs {
-            component_id: Some("homeboy".into()),
-            kind: Some("observe".into()),
-            since: None,
-            select: vec!["$.component_id".into()],
-            group_by: None,
-            count: false,
-            format: query::QueryFormat::Json,
-            limit: 200,
-        })
+        let (output, _) = query::runs_query(
+            &test_store(),
+            query::RunsQueryArgs {
+                component_id: Some("homeboy".into()),
+                kind: Some("observe".into()),
+                since: None,
+                select: vec!["$.component_id".into()],
+                group_by: None,
+                count: false,
+                format: query::QueryFormat::Json,
+                limit: 200,
+            },
+        )
         .expect("query");
         let RunsOutput::Query(output) = output else {
             panic!("expected query output");
@@ -307,16 +339,19 @@ fn bundle_import_restores_file_artifacts_and_query_reads_embedded_bytes() {
 fn runs_query_rejects_invalid_jsonpath() {
     with_isolated_home(|_home| {
         let _xdg = XdgGuard::unset();
-        let err = query::runs_query(query::RunsQueryArgs {
-            component_id: None,
-            kind: None,
-            since: None,
-            select: vec!["definitely not a jsonpath".into()],
-            group_by: None,
-            count: false,
-            format: query::QueryFormat::Json,
-            limit: 10,
-        })
+        let err = query::runs_query(
+            &test_store(),
+            query::RunsQueryArgs {
+                component_id: None,
+                kind: None,
+                since: None,
+                select: vec!["definitely not a jsonpath".into()],
+                group_by: None,
+                count: false,
+                format: query::QueryFormat::Json,
+                limit: 10,
+            },
+        )
         .err()
         .expect("must reject invalid jsonpath");
         assert_eq!(err.code.as_str(), "validation.invalid_argument");
@@ -327,15 +362,18 @@ fn runs_query_rejects_invalid_jsonpath() {
 fn runs_drift_rejects_threshold_outside_unit_interval() {
     with_isolated_home(|_home| {
         let _xdg = XdgGuard::unset();
-        let err = drift::runs_drift(drift::RunsDriftArgs {
-            component_id: None,
-            kind: None,
-            metric: "$.theme".into(),
-            window: "7d".into(),
-            threshold: 1.5,
-            baseline: None,
-            format: drift::DriftFormat::Json,
-        })
+        let err = drift::runs_drift(
+            &test_store(),
+            drift::RunsDriftArgs {
+                component_id: None,
+                kind: None,
+                metric: "$.theme".into(),
+                window: "7d".into(),
+                threshold: 1.5,
+                baseline: None,
+                format: drift::DriftFormat::Json,
+            },
+        )
         .err()
         .expect("must reject threshold > 1");
         assert_eq!(err.code.as_str(), "validation.invalid_argument");

--- a/crates/homeboy-cli/src/commands/runs/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/runs/dispatch.rs
@@ -3,6 +3,7 @@
 //! Routes parsed subcommands to their handlers and provides the global
 //! `--runner` guidance surfaced when operators misuse the top-level flag.
 
+use homeboy::core::observation::ObservationStore;
 use homeboy::core::Error;
 
 use super::types::{
@@ -178,19 +179,24 @@ impl RunsArgs {
 }
 
 pub fn run(args: RunsArgs) -> CmdResult<RunsOutput> {
+    // Boundary: one `homeboy runs` invocation is one unit of work, so the
+    // observation store is opened exactly once here and handed to the handlers
+    // below. Each of those used to open its own, which made a single command
+    // several independently-resolved stores (#7505).
+    let store = ObservationStore::open_initialized()?;
     match args.command {
-        RunsCommand::List(args) => handlers::list_runs(args, "runs.list"),
+        RunsCommand::List(args) => handlers::list_runs(&store, args, "runs.list"),
         RunsCommand::Distribution(args) => {
-            distribution::runs_distribution(args, "runs.distribution")
+            distribution::runs_distribution(&store, args, "runs.distribution")
         }
         RunsCommand::LatestRun(args) => latest::latest_run(args),
-        RunsCommand::Compare(args) => compare::compare_runs(args),
+        RunsCommand::Compare(args) => compare::compare_runs(&store, args),
         RunsCommand::BenchCompare(args) => bench::bench_compare_from_args(args),
-        RunsCommand::FuzzCompare(args) => fuzz_compare::fuzz_compare_from_args(args),
-        RunsCommand::Hotspots(args) => hotspots::runs_hotspots(args),
-        RunsCommand::Reconcile(args) => reconcile::reconcile_runs(args),
-        RunsCommand::Watch(args) => watch::watch_run(args),
-        RunsCommand::Cancel { run_id } => handlers::cancel_run(&run_id),
+        RunsCommand::FuzzCompare(args) => fuzz_compare::fuzz_compare_from_args(&store, args),
+        RunsCommand::Hotspots(args) => hotspots::runs_hotspots(&store, args),
+        RunsCommand::Reconcile(args) => reconcile::reconcile_runs(&store, args),
+        RunsCommand::Watch(args) => watch::watch_run(&store, args),
+        RunsCommand::Cancel { run_id } => handlers::cancel_run(&store, &run_id),
         RunsCommand::Show {
             run_id,
             json: _,
@@ -208,7 +214,7 @@ pub fn run(args: RunsArgs) -> CmdResult<RunsOutput> {
             run_id,
             json: _,
             presentation: _,
-        } => proof::proof(&run_id),
+        } => proof::proof(&store, &run_id),
         RunsCommand::Dossier {
             run_id,
             json: _,
@@ -220,7 +226,7 @@ pub fn run(args: RunsArgs) -> CmdResult<RunsOutput> {
             full,
             field,
         } => {
-            let (output, exit_code) = evidence::evidence_projection(&run_id, full)?;
+            let (output, exit_code) = evidence::evidence_projection(&store, &run_id, full)?;
             if field.is_empty() {
                 Ok((output, exit_code))
             } else {
@@ -230,15 +236,15 @@ pub fn run(args: RunsArgs) -> CmdResult<RunsOutput> {
         RunsCommand::Env { run_id } => handlers::env(&run_id),
         RunsCommand::Artifacts(args) => handlers::artifacts_from_args(args),
         RunsCommand::Artifact(args) => handlers::artifact_command(args),
-        RunsCommand::Findings(args) => findings::findings(args),
-        RunsCommand::Finding { finding_id } => findings::finding(&finding_id),
+        RunsCommand::Findings(args) => findings::findings(&store, args),
+        RunsCommand::Finding { finding_id } => findings::finding(&store, &finding_id),
         RunsCommand::LatestFinding(args) => findings::latest_finding(args),
-        RunsCommand::Export(args) => super::bundle::export_runs(args),
-        RunsCommand::Import(args) => super::bundle::import_runs(args),
-        RunsCommand::Query(args) => query::runs_query(args),
-        RunsCommand::Refs(args) => refs::runs_refs(args),
+        RunsCommand::Export(args) => super::bundle::export_runs(&store, args),
+        RunsCommand::Import(args) => super::bundle::import_runs(&store, args),
+        RunsCommand::Query(args) => query::runs_query(&store, args),
+        RunsCommand::Refs(args) => refs::runs_refs(&store, args),
         RunsCommand::Resources(args) => resources::runs_resources(args),
-        RunsCommand::Drift(args) => drift::runs_drift(args),
+        RunsCommand::Drift(args) => drift::runs_drift(&store, args),
         RunsCommand::LoopSync(args) => loop_sync::loop_sync(args),
         RunsCommand::Report(args) => {
             report::run(args).map(|(output, exit_code)| (RunsOutput::Report(output), exit_code))
@@ -252,8 +258,10 @@ pub(crate) fn global_runner_error(args: &RunsArgs, runner_id: &str) -> Error {
 }
 
 pub(crate) fn run_markdown(args: RunsArgs) -> CmdResult<String> {
+    // Same boundary rule as `run`: one invocation, one store (#7505).
+    let store = ObservationStore::open_initialized()?;
     match args.command {
-        RunsCommand::Compare(args) => compare::run_markdown(args),
+        RunsCommand::Compare(args) => compare::run_markdown(&store, args),
         RunsCommand::Report(args) => report::run_markdown(args),
         _ => Err(Error::validation_invalid_argument(
             "output_mode",

--- a/crates/homeboy-cli/src/commands/runs/distribution.rs
+++ b/crates/homeboy-cli/src/commands/runs/distribution.rs
@@ -73,10 +73,10 @@ pub struct CategoryDistributionValue {
 }
 
 pub(crate) fn runs_distribution(
+    store: &ObservationStore,
     args: RunsDistributionArgs,
     command: &'static str,
 ) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
     let limit = args.limit.clamp(1, 1000);
     let runs = store
         .list_runs(RunListFilter {
@@ -211,6 +211,14 @@ fn scalar_metadata_label(value: &Value) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+
+    /// The observation store the enclosing isolated home installs.
+    ///
+    /// A test is the entry point for its own unit of work, so opening once here
+    /// is a boundary open, not an ambient one inside production code (#7505).
+    fn test_store() -> homeboy::core::observation::ObservationStore {
+        homeboy::core::observation::ObservationStore::open_initialized().expect("observation store")
+    }
     use super::*;
 
     use homeboy::core::observation::{NewRunRecord, RunStatus};
@@ -519,7 +527,8 @@ mod tests {
     }
 
     fn distribution_output(args: RunsDistributionArgs) -> RunsDistributionOutput {
-        let (output, _) = runs_distribution(args, "runs.distribution").expect("distribution");
+        let (output, _) =
+            runs_distribution(&test_store(), args, "runs.distribution").expect("distribution");
         let RunsOutput::Distribution(output) = output else {
             panic!("expected distribution output");
         };

--- a/crates/homeboy-cli/src/commands/runs/drift.rs
+++ b/crates/homeboy-cli/src/commands/runs/drift.rs
@@ -97,7 +97,7 @@ pub struct DriftValue {
     pub share_delta: Option<f64>,
 }
 
-pub(crate) fn runs_drift(args: RunsDriftArgs) -> CmdResult<RunsOutput> {
+pub(crate) fn runs_drift(store: &ObservationStore, args: RunsDriftArgs) -> CmdResult<RunsOutput> {
     if args.metric.trim().is_empty() {
         return Err(Error::validation_invalid_argument(
             "metric",
@@ -116,7 +116,6 @@ pub(crate) fn runs_drift(args: RunsDriftArgs) -> CmdResult<RunsOutput> {
     }
 
     let metric_path = compile_jsonpath(&args.metric)?;
-    let store = ObservationStore::open_initialized()?;
 
     let filter = RunListFilter {
         kind: args.kind.clone(),

--- a/crates/homeboy-cli/src/commands/runs/evidence.rs
+++ b/crates/homeboy-cli/src/commands/runs/evidence.rs
@@ -88,11 +88,14 @@ pub fn evidence(run_id: &str) -> CmdResult<RunsOutput> {
 
 /// Render the full core report or a bounded CLI projection without changing the
 /// reusable report schema used by non-CLI consumers.
-pub(crate) fn evidence_projection(run_id: &str, full: bool) -> CmdResult<RunsOutput> {
+pub(crate) fn evidence_projection(
+    store: &ObservationStore,
+    run_id: &str,
+    full: bool,
+) -> CmdResult<RunsOutput> {
     if full {
         return evidence(run_id);
     }
-    let store = ObservationStore::open_initialized()?;
     let run = require_run(&store, run_id)?;
     let mut run_ids = vec![run.id.clone()];
     run_ids.extend(runs_service::related_lab_run_ids(&store, &run)?);
@@ -264,6 +267,14 @@ fn bounded_string(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+
+    /// The observation store the enclosing isolated home installs.
+    ///
+    /// A test is the entry point for its own unit of work, so opening once here
+    /// is a boundary open, not an ambient one inside production code (#7505).
+    fn test_store() -> homeboy::core::observation::ObservationStore {
+        homeboy::core::observation::ObservationStore::open_initialized().expect("observation store")
+    }
     use homeboy::core::artifact_address::ArtifactAddressKind;
     use homeboy::core::artifact_links::PUBLIC_ARTIFACT_BASE_URL_ENV;
     use homeboy::core::observation::{NewRunRecord, ObservationStore, RunStatus};
@@ -784,7 +795,8 @@ mod tests {
                 .expect("omitted artifact");
             std::fs::remove_file(&omitted.path).expect("remove omitted artifact bytes");
 
-            let (output, _) = evidence_projection(&run.id, false).expect("bounded evidence");
+            let (output, _) =
+                evidence_projection(&test_store(), &run.id, false).expect("bounded evidence");
             let RunsOutput::EvidenceSummary(summary) = output else {
                 panic!("expected bounded evidence summary");
             };
@@ -867,7 +879,8 @@ mod tests {
                 "the bounded output must not leak omitted artifact IDs"
             );
 
-            let (full, _) = evidence_projection(&run.id, true).expect("full evidence");
+            let (full, _) =
+                evidence_projection(&test_store(), &run.id, true).expect("full evidence");
             let RunsOutput::Evidence(full) = full else {
                 panic!("expected full evidence report");
             };
@@ -919,7 +932,8 @@ mod tests {
                 )
                 .expect("directory artifact");
 
-            let (output, _) = evidence_projection(&run.id, false).expect("bounded evidence");
+            let (output, _) =
+                evidence_projection(&test_store(), &run.id, false).expect("bounded evidence");
             let RunsOutput::EvidenceSummary(summary) = output else {
                 panic!("expected bounded evidence summary");
             };
@@ -1365,7 +1379,8 @@ mod tests {
             assert_eq!(output.failure.status, "running");
             assert!(!output.failure.failed);
 
-            let (bounded, _) = evidence_projection(&run.id, false).expect("bounded evidence");
+            let (bounded, _) =
+                evidence_projection(&test_store(), &run.id, false).expect("bounded evidence");
             let RunsOutput::EvidenceSummary(bounded) = bounded else {
                 panic!("expected bounded evidence");
             };

--- a/crates/homeboy-cli/src/commands/runs/findings.rs
+++ b/crates/homeboy-cli/src/commands/runs/findings.rs
@@ -72,7 +72,7 @@ pub struct RunsFindingOutput {
     pub finding: RecordedHomeboyFinding,
 }
 
-pub fn findings(args: RunsFindingsArgs) -> CmdResult<RunsOutput> {
+pub fn findings(store: &ObservationStore, args: RunsFindingsArgs) -> CmdResult<RunsOutput> {
     if let Some(command) = args.command {
         let (output, exit_code) = issues::run(issues::IssuesArgs { command })?;
         return Ok((RunsOutput::FindingsReconcile(output), exit_code));
@@ -81,7 +81,6 @@ pub fn findings(args: RunsFindingsArgs) -> CmdResult<RunsOutput> {
     let run_id = args
         .run_id
         .ok_or_else(|| Error::validation_missing_argument(vec!["run_id".to_string()]))?;
-    let store = ObservationStore::open_initialized()?;
     // Route run lookup through the observation facade so `runs findings` shares
     // the one activity-aware surface: durable label aliases, Lab mirror
     // resolution, and the stable missing-run error with runner guidance (#6768).
@@ -110,8 +109,7 @@ pub fn findings(args: RunsFindingsArgs) -> CmdResult<RunsOutput> {
     ))
 }
 
-pub fn finding(finding_id: &str) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
+pub fn finding(store: &ObservationStore, finding_id: &str) -> CmdResult<RunsOutput> {
     let finding = store.get_finding(finding_id)?.ok_or_else(|| {
         Error::validation_invalid_argument(
             "finding_id",
@@ -169,6 +167,14 @@ pub fn latest_finding(args: RunsLatestFindingArgs) -> CmdResult<RunsOutput> {
 
 #[cfg(test)]
 mod tests {
+
+    /// The observation store the enclosing isolated home installs.
+    ///
+    /// A test is the entry point for its own unit of work, so opening once here
+    /// is a boundary open, not an ambient one inside production code (#7505).
+    fn test_store() -> homeboy::core::observation::ObservationStore {
+        homeboy::core::observation::ObservationStore::open_initialized().expect("observation store")
+    }
     use homeboy::core::observation::{NewFindingRecord, NewRunRecord, ObservationStore};
     use homeboy::test_support::with_isolated_home;
     use serde_json::json;
@@ -240,11 +246,14 @@ mod tests {
             let run_id = labeled_run(&store, "findings-label");
             record_finding(&store, &run_id);
 
-            let (output, exit) = findings(RunsFindingsArgs {
-                run_id: Some("findings-label".to_string()),
-                limit: 100,
-                ..Default::default()
-            })
+            let (output, exit) = findings(
+                &test_store(),
+                RunsFindingsArgs {
+                    run_id: Some("findings-label".to_string()),
+                    limit: 100,
+                    ..Default::default()
+                },
+            )
             .expect("durable run label resolves through runs_service::require_run");
 
             assert_eq!(exit, 0);
@@ -266,11 +275,14 @@ mod tests {
             let run_id = labeled_run(&store, "findings-exact");
             record_finding(&store, &run_id);
 
-            let (output, _) = findings(RunsFindingsArgs {
-                run_id: Some(run_id.clone()),
-                limit: 100,
-                ..Default::default()
-            })
+            let (output, _) = findings(
+                &test_store(),
+                RunsFindingsArgs {
+                    run_id: Some(run_id.clone()),
+                    limit: 100,
+                    ..Default::default()
+                },
+            )
             .expect("record id resolves");
 
             let RunsOutput::Findings(output) = output else {
@@ -287,11 +299,14 @@ mod tests {
             let _xdg = XdgGuard::unset();
             let _store = ObservationStore::open_initialized().expect("store");
             // `RunsOutput` is not `Debug`, so match rather than `expect_err`.
-            let error = match findings(RunsFindingsArgs {
-                run_id: Some("definitely-missing-run".to_string()),
-                limit: 100,
-                ..Default::default()
-            }) {
+            let error = match findings(
+                &test_store(),
+                RunsFindingsArgs {
+                    run_id: Some("definitely-missing-run".to_string()),
+                    limit: 100,
+                    ..Default::default()
+                },
+            ) {
                 Ok(_) => panic!("expected a missing-run error"),
                 Err(error) => error,
             };

--- a/crates/homeboy-cli/src/commands/runs/fuzz_compare.rs
+++ b/crates/homeboy-cli/src/commands/runs/fuzz_compare.rs
@@ -30,8 +30,10 @@ pub struct RunsFuzzCompareArgs {
     pub hotspot_policy: FuzzCompareHotspotPolicy,
 }
 
-pub(crate) fn fuzz_compare_from_args(args: RunsFuzzCompareArgs) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
+pub(crate) fn fuzz_compare_from_args(
+    store: &ObservationStore,
+    args: RunsFuzzCompareArgs,
+) -> CmdResult<RunsOutput> {
     let baseline = resolve_run_fuzz_envelope(&store, &args.from_run)?;
     let candidate = resolve_run_fuzz_envelope(&store, &args.to_run)?;
     let output = compare_envelopes(
@@ -178,6 +180,14 @@ fn is_related_fuzz_json(value: &Value) -> bool {
 
 #[cfg(test)]
 mod tests {
+
+    /// The observation store the enclosing isolated home installs.
+    ///
+    /// A test is the entry point for its own unit of work, so opening once here
+    /// is a boundary open, not an ambient one inside production code (#7505).
+    fn test_store() -> homeboy::core::observation::ObservationStore {
+        homeboy::core::observation::ObservationStore::open_initialized().expect("observation store")
+    }
     use homeboy::core::observation::{NewRunRecord, ObservationStore, RunStatus};
     use homeboy::test_support::with_isolated_home;
 
@@ -241,11 +251,14 @@ mod tests {
                 .record_artifact(&candidate.id, "fuzz_result_envelope", &candidate_path)
                 .expect("candidate artifact");
 
-            let (_, exit_code) = fuzz_compare_from_args(RunsFuzzCompareArgs {
-                from_run: baseline.id.clone(),
-                to_run: candidate.id.clone(),
-                hotspot_policy: FuzzCompareHotspotPolicy::Advisory,
-            })
+            let (_, exit_code) = fuzz_compare_from_args(
+                &test_store(),
+                RunsFuzzCompareArgs {
+                    from_run: baseline.id.clone(),
+                    to_run: candidate.id.clone(),
+                    hotspot_policy: FuzzCompareHotspotPolicy::Advisory,
+                },
+            )
             .expect("fuzz compare");
 
             assert_eq!(exit_code, 0);

--- a/crates/homeboy-cli/src/commands/runs/handlers.rs
+++ b/crates/homeboy-cli/src/commands/runs/handlers.rs
@@ -38,7 +38,21 @@ use super::types::{
 };
 use super::{reconcile, remote, remote_artifact, CmdResult};
 
-pub fn list_runs(args: RunsListArgs, command: &'static str) -> CmdResult<RunsOutput> {
+#[cfg(test)]
+/// The observation store the enclosing isolated home installs.
+///
+/// At file scope so every `#[cfg(test)]` module here reaches it the same way.
+/// A test is the entry point for its own unit of work, so opening once here is
+/// a boundary open, not an ambient one inside production code (#7505).
+fn test_store() -> homeboy::core::observation::ObservationStore {
+    homeboy::core::observation::ObservationStore::open_initialized().expect("observation store")
+}
+
+pub fn list_runs(
+    store: &ObservationStore,
+    args: RunsListArgs,
+    command: &'static str,
+) -> CmdResult<RunsOutput> {
     if args.active {
         return list_active_runs(args);
     }
@@ -47,7 +61,6 @@ pub fn list_runs(args: RunsListArgs, command: &'static str) -> CmdResult<RunsOut
         return remote::list_runner_runs(&runner_id, args, command);
     }
 
-    let store = ObservationStore::open_initialized()?;
     // `--running` is shorthand for `--status running`; the two are mutually
     // exclusive at the CLI layer so this never overrides an explicit status.
     let status = if args.running {
@@ -129,8 +142,7 @@ fn list_active_runs(args: RunsListArgs) -> CmdResult<RunsOutput> {
     Ok((RunsOutput::Active(Box::new(report)), 0))
 }
 
-pub fn cancel_run(run_id: &str) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
+pub fn cancel_run(store: &ObservationStore, run_id: &str) -> CmdResult<RunsOutput> {
     let run = runs_service::require_run(&store, run_id)?;
     if run.status != RunStatus::Running.as_str() {
         return Err(Error::validation_invalid_argument(
@@ -602,6 +614,7 @@ fn stale_run_summary(
 
 #[cfg(test)]
 mod runner_enrichment_tests {
+
     use super::*;
 
     #[test]
@@ -1740,7 +1753,8 @@ mod pull_tests {
                 )
                 .expect("run");
 
-            let (output, exit_code) = cancel_run(&run.id).expect("cancel run");
+            let (output, exit_code) =
+                cancel_run(&super::test_store(), &run.id).expect("cancel run");
 
             assert_eq!(exit_code, 0);
             let RunsOutput::Cancel(output) = output else {

--- a/crates/homeboy-cli/src/commands/runs/hotspots.rs
+++ b/crates/homeboy-cli/src/commands/runs/hotspots.rs
@@ -89,10 +89,12 @@ struct HotspotAccumulator {
     sources: BTreeSet<String>,
 }
 
-pub(crate) fn runs_hotspots(args: RunsHotspotsArgs) -> CmdResult<RunsOutput> {
+pub(crate) fn runs_hotspots(
+    store: &ObservationStore,
+    args: RunsHotspotsArgs,
+) -> CmdResult<RunsOutput> {
     let limit = args.limit.clamp(1, 500);
     validate_hotspot_args(&args)?;
-    let store = ObservationStore::open_initialized()?;
     let ranking_run_ids = if args.run_ids.is_empty() {
         combined_run_ids(&args.baseline_runs, &args.candidate_runs)
     } else {
@@ -760,6 +762,14 @@ fn severity_score(value: &Value) -> Option<f64> {
 
 #[cfg(test)]
 mod tests {
+
+    /// The observation store the enclosing isolated home installs.
+    ///
+    /// A test is the entry point for its own unit of work, so opening once here
+    /// is a boundary open, not an ambient one inside production code (#7505).
+    fn test_store() -> homeboy::core::observation::ObservationStore {
+        homeboy::core::observation::ObservationStore::open_initialized().expect("observation store")
+    }
     use homeboy::core::observation::{NewRunRecord, ObservationStore, RunStatus};
     use homeboy::test_support::with_isolated_home;
     use serde_json::json;
@@ -864,12 +874,15 @@ mod tests {
                 .record_directory_artifact(&run.id, "fuzz_artifacts", &directory)
                 .expect("directory artifact");
 
-            let (output, _) = runs_hotspots(RunsHotspotsArgs {
-                run_ids: vec![run.id.clone()],
-                baseline_runs: Vec::new(),
-                candidate_runs: Vec::new(),
-                limit: 20,
-            })
+            let (output, _) = runs_hotspots(
+                &test_store(),
+                RunsHotspotsArgs {
+                    run_ids: vec![run.id.clone()],
+                    baseline_runs: Vec::new(),
+                    candidate_runs: Vec::new(),
+                    limit: 20,
+                },
+            )
             .expect("hotspots");
 
             let RunsOutput::Hotspots(output) = output else {
@@ -918,12 +931,15 @@ mod tests {
                 .record_directory_artifact(&run.id, "fuzz_artifacts", &directory)
                 .expect("directory artifact");
 
-            let (output, _) = runs_hotspots(RunsHotspotsArgs {
-                run_ids: vec!["hotspot-label".to_string()],
-                baseline_runs: Vec::new(),
-                candidate_runs: Vec::new(),
-                limit: 20,
-            })
+            let (output, _) = runs_hotspots(
+                &test_store(),
+                RunsHotspotsArgs {
+                    run_ids: vec!["hotspot-label".to_string()],
+                    baseline_runs: Vec::new(),
+                    candidate_runs: Vec::new(),
+                    limit: 20,
+                },
+            )
             .expect("durable run label resolves through runs_service::require_run");
 
             let RunsOutput::Hotspots(output) = output else {
@@ -945,12 +961,15 @@ mod tests {
         with_isolated_home(|_home| {
             let _xdg = XdgGuard::unset();
             // `RunsOutput` is not `Debug`, so match rather than `expect_err`.
-            let error = match runs_hotspots(RunsHotspotsArgs {
-                run_ids: vec!["definitely-missing-run".to_string()],
-                baseline_runs: Vec::new(),
-                candidate_runs: Vec::new(),
-                limit: 20,
-            }) {
+            let error = match runs_hotspots(
+                &test_store(),
+                RunsHotspotsArgs {
+                    run_ids: vec!["definitely-missing-run".to_string()],
+                    baseline_runs: Vec::new(),
+                    candidate_runs: Vec::new(),
+                    limit: 20,
+                },
+            ) {
                 Ok(_) => panic!("expected a missing-run error"),
                 Err(error) => error,
             };

--- a/crates/homeboy-cli/src/commands/runs/proof.rs
+++ b/crates/homeboy-cli/src/commands/runs/proof.rs
@@ -57,8 +57,7 @@ pub struct RunsProofOutput {
     pub fuzz: Option<FuzzProof>,
 }
 
-pub fn proof(run_id: &str) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
+pub fn proof(store: &ObservationStore, run_id: &str) -> CmdResult<RunsOutput> {
     reconcile::reconcile_owned_stale_running_runs(&store, 1000)?;
     runs_service::require_run(&store, run_id)?;
     runs_service::refresh_mirrored_daemon_evidence_best_effort(run_id);

--- a/crates/homeboy-cli/src/commands/runs/query.rs
+++ b/crates/homeboy-cli/src/commands/runs/query.rs
@@ -112,7 +112,7 @@ pub struct QueryGroup {
     pub count: usize,
 }
 
-pub(crate) fn runs_query(args: RunsQueryArgs) -> CmdResult<RunsOutput> {
+pub(crate) fn runs_query(store: &ObservationStore, args: RunsQueryArgs) -> CmdResult<RunsOutput> {
     if args.select.iter().any(|s| s.trim().is_empty()) {
         return Err(Error::validation_invalid_argument(
             "select",
@@ -132,7 +132,6 @@ pub(crate) fn runs_query(args: RunsQueryArgs) -> CmdResult<RunsOutput> {
         .map(|expr| compile_jsonpath(expr).map(|p| (expr.to_string(), p)))
         .transpose()?;
 
-    let store = ObservationStore::open_initialized()?;
     let filter = RunListFilter {
         kind: args.kind.clone(),
         component_id: args.component_id.clone(),

--- a/crates/homeboy-cli/src/commands/runs/reconcile.rs
+++ b/crates/homeboy-cli/src/commands/runs/reconcile.rs
@@ -68,8 +68,10 @@ pub struct ReconciledRunSummary {
     pub remote_job_status: Option<String>,
 }
 
-pub(crate) fn reconcile_runs(args: RunsReconcileArgs) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
+pub(crate) fn reconcile_runs(
+    store: &ObservationStore,
+    args: RunsReconcileArgs,
+) -> CmdResult<RunsOutput> {
     let running = running_runs(&store, args.limit)?;
     let inspected = running.len();
     let reconciled =

--- a/crates/homeboy-cli/src/commands/runs/refs.rs
+++ b/crates/homeboy-cli/src/commands/runs/refs.rs
@@ -111,8 +111,7 @@ pub struct RunsRefsArtifactRef {
     pub get_command: String,
 }
 
-pub(crate) fn runs_refs(args: RunsRefsArgs) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
+pub(crate) fn runs_refs(store: &ObservationStore, args: RunsRefsArgs) -> CmdResult<RunsOutput> {
     let filter = RunListFilter {
         kind: args.kind.clone(),
         component_id: args.component_id.clone(),
@@ -254,6 +253,14 @@ fn shell_arg(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+
+    /// The observation store the enclosing isolated home installs.
+    ///
+    /// A test is the entry point for its own unit of work, so opening once here
+    /// is a boundary open, not an ambient one inside production code (#7505).
+    fn test_store() -> homeboy::core::observation::ObservationStore {
+        homeboy::core::observation::ObservationStore::open_initialized().expect("observation store")
+    }
     use super::*;
     use homeboy::core::observation::{NewRunRecord, RunStatus};
     use homeboy::test_support::with_isolated_home;
@@ -280,16 +287,19 @@ mod tests {
                 .record_artifact(&run.id, "trace_aggregate", &aggregate_path)
                 .expect("record artifact");
 
-            let (output, _) = runs_refs(RunsRefsArgs {
-                component_id: Some("homeboy".to_string()),
-                kind: Some("bench".to_string()),
-                rig: Some("matrix-rig".to_string()),
-                status: Some("pass".to_string()),
-                since: None,
-                limit: 20,
-                artifact_kinds: Vec::new(),
-                aggregate_artifact_kinds: Vec::new(),
-            })
+            let (output, _) = runs_refs(
+                &test_store(),
+                RunsRefsArgs {
+                    component_id: Some("homeboy".to_string()),
+                    kind: Some("bench".to_string()),
+                    rig: Some("matrix-rig".to_string()),
+                    status: Some("pass".to_string()),
+                    since: None,
+                    limit: 20,
+                    artifact_kinds: Vec::new(),
+                    aggregate_artifact_kinds: Vec::new(),
+                },
+            )
             .expect("refs");
 
             let RunsOutput::Refs(output) = output else {

--- a/crates/homeboy-cli/src/commands/runs/tests/export_import.rs
+++ b/crates/homeboy-cli/src/commands/runs/tests/export_import.rs
@@ -14,6 +14,14 @@ use serde_json::Value;
 use super::super::{export_runs, import_runs, RunsExportArgs, RunsImportArgs, RunsOutput};
 use super::{sample_run, XdgGuard};
 
+/// The observation store the enclosing isolated home installs.
+///
+/// A test is the entry point for its own unit of work, so opening once here
+/// is a boundary open, not an ambient one inside production code (#7505).
+fn test_store() -> homeboy::core::observation::ObservationStore {
+    homeboy::core::observation::ObservationStore::open_initialized().expect("observation store")
+}
+
 fn read_bundle_test_json<T: for<'de> Deserialize<'de>>(path: &Path) -> T {
     serde_json::from_str(&std::fs::read_to_string(path).expect("read json")).expect("json")
 }
@@ -31,11 +39,14 @@ fn export_one_run_writes_directory_bundle() {
             .expect("finish");
         let output = home.path().join("bundle");
 
-        let (result, _) = export_runs(RunsExportArgs {
-            run: Some(run.id.clone()),
-            since: None,
-            output: output.clone(),
-        })
+        let (result, _) = export_runs(
+            &test_store(),
+            RunsExportArgs {
+                run: Some(run.id.clone()),
+                since: None,
+                output: output.clone(),
+            },
+        )
         .expect("export");
 
         let RunsOutput::Export(result) = result else {
@@ -95,11 +106,14 @@ fn export_includes_findings_and_test_failures() {
             .expect("test failure");
         let output = home.path().join("findings-bundle");
 
-        let (result, _) = export_runs(RunsExportArgs {
-            run: Some(run.id),
-            since: None,
-            output: output.clone(),
-        })
+        let (result, _) = export_runs(
+            &test_store(),
+            RunsExportArgs {
+                run: Some(run.id),
+                since: None,
+                output: output.clone(),
+            },
+        )
         .expect("export");
 
         let RunsOutput::Export(result) = result else {
@@ -129,11 +143,14 @@ fn export_since_writes_multiple_runs() {
             .expect("second");
         let output = home.path().join("recent-bundle");
 
-        export_runs(RunsExportArgs {
-            run: None,
-            since: Some("1d".to_string()),
-            output: output.clone(),
-        })
+        export_runs(
+            &test_store(),
+            RunsExportArgs {
+                run: None,
+                since: Some("1d".to_string()),
+                output: output.clone(),
+            },
+        )
         .expect("export recent");
 
         let runs: Vec<RunRecord> = read_bundle_test_json(&output.join("runs.json"));
@@ -160,11 +177,14 @@ fn export_embeds_local_file_artifact_bytes() {
             .expect("record artifact");
         let output = home.path().join("artifact-bundle");
 
-        export_runs(RunsExportArgs {
-            run: Some(run.id),
-            since: None,
-            output: output.clone(),
-        })
+        export_runs(
+            &test_store(),
+            RunsExportArgs {
+                run: Some(run.id),
+                since: None,
+                output: output.clone(),
+            },
+        )
         .expect("export");
 
         let artifacts: Vec<ArtifactRecord> = read_bundle_test_json(&output.join("artifacts.json"));
@@ -208,11 +228,14 @@ fn export_rewrites_unproven_remote_artifact_paths_as_metadata_only() {
             .expect("artifact");
         let output = home.path().join("remote-artifact-bundle");
 
-        export_runs(RunsExportArgs {
-            run: Some(run.id),
-            since: None,
-            output: output.clone(),
-        })
+        export_runs(
+            &test_store(),
+            RunsExportArgs {
+                run: Some(run.id),
+                since: None,
+                output: output.clone(),
+            },
+        )
         .expect("export");
 
         let artifacts: Vec<ArtifactRecord> = read_bundle_test_json(&output.join("artifacts.json"));
@@ -242,11 +265,14 @@ fn export_trace_spans_when_present() {
             .expect("span");
         let output = home.path().join("trace-bundle");
 
-        export_runs(RunsExportArgs {
-            run: Some(run.id),
-            since: None,
-            output: output.clone(),
-        })
+        export_runs(
+            &test_store(),
+            RunsExportArgs {
+                run: Some(run.id),
+                since: None,
+                output: output.clone(),
+            },
+        )
         .expect("export");
 
         let spans: Vec<TraceSpanRecord> = read_bundle_test_json(&output.join("trace_spans.json"));
@@ -291,26 +317,35 @@ fn import_into_empty_db_and_reimport_is_idempotent() {
                     metadata_json: serde_json::json!({ "record_kind": "failure" }),
                 })
                 .expect("finding");
-            export_runs(RunsExportArgs {
-                run: Some(run.id.clone()),
-                since: None,
-                output: bundle.clone(),
-            })
+            export_runs(
+                &test_store(),
+                RunsExportArgs {
+                    run: Some(run.id.clone()),
+                    since: None,
+                    output: bundle.clone(),
+                },
+            )
             .expect("export");
             run.id
         };
         std::fs::remove_file(home.path().join(".local/share/homeboy/homeboy.sqlite"))
             .expect("remove db");
 
-        import_runs(RunsImportArgs {
-            input: Some(bundle.clone()),
-            ..RunsImportArgs::default()
-        })
+        import_runs(
+            &test_store(),
+            RunsImportArgs {
+                input: Some(bundle.clone()),
+                ..RunsImportArgs::default()
+            },
+        )
         .expect("import");
-        import_runs(RunsImportArgs {
-            input: Some(bundle.clone()),
-            ..RunsImportArgs::default()
-        })
+        import_runs(
+            &test_store(),
+            RunsImportArgs {
+                input: Some(bundle.clone()),
+                ..RunsImportArgs::default()
+            },
+        )
         .expect("second import is idempotent");
 
         let store = ObservationStore::open_initialized().expect("store");
@@ -338,10 +373,13 @@ fn malformed_bundle_validation_fails_clearly() {
         std::fs::create_dir_all(&bundle).expect("bundle dir");
         std::fs::write(bundle.join("manifest.json"), "not json").expect("manifest");
 
-        let err = match import_runs(RunsImportArgs {
-            input: Some(bundle),
-            ..RunsImportArgs::default()
-        }) {
+        let err = match import_runs(
+            &test_store(),
+            RunsImportArgs {
+                input: Some(bundle),
+                ..RunsImportArgs::default()
+            },
+        ) {
             Ok(_) => panic!("malformed bundle should fail"),
             Err(err) => err,
         };
@@ -359,11 +397,14 @@ fn conflicting_existing_rows_fail_clearly() {
             .start_run(sample_run("bench", "homeboy", "studio", Value::Null))
             .expect("run");
         let bundle = home.path().join("conflict-bundle");
-        export_runs(RunsExportArgs {
-            run: Some(run.id.clone()),
-            since: None,
-            output: bundle.clone(),
-        })
+        export_runs(
+            &test_store(),
+            RunsExportArgs {
+                run: Some(run.id.clone()),
+                since: None,
+                output: bundle.clone(),
+            },
+        )
         .expect("export");
         let mut runs: Vec<RunRecord> = read_bundle_test_json(&bundle.join("runs.json"));
         runs[0].status = "pass".to_string();
@@ -373,10 +414,13 @@ fn conflicting_existing_rows_fail_clearly() {
         )
         .expect("rewrite runs");
 
-        let err = match import_runs(RunsImportArgs {
-            input: Some(bundle),
-            ..RunsImportArgs::default()
-        }) {
+        let err = match import_runs(
+            &test_store(),
+            RunsImportArgs {
+                input: Some(bundle),
+                ..RunsImportArgs::default()
+            },
+        ) {
             Ok(_) => panic!("conflicting import should fail"),
             Err(err) => err,
         };

--- a/crates/homeboy-cli/src/commands/runs/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/runs/tests/mod.rs
@@ -1,5 +1,13 @@
 //! Tests for the `runs` command dispatch, handlers, and output shaping.
 
+/// The observation store the enclosing isolated home installs.
+///
+/// A test is the entry point for its own unit of work, so opening once here
+/// is a boundary open, not an ambient one inside production code (#7505).
+fn test_store() -> homeboy::core::observation::ObservationStore {
+    homeboy::core::observation::ObservationStore::open_initialized().expect("observation store")
+}
+
 mod export_import;
 
 use super::bench::bench_compare;
@@ -100,6 +108,7 @@ fn run_list_filters_kind_component_rig_and_status() {
             .expect("finish trace");
 
         let (output, _) = list_runs(
+            &test_store(),
             RunsListArgs {
                 active: false,
                 task_url: None,
@@ -143,6 +152,7 @@ fn run_list_reads_durable_record_without_reconciliation() {
             .expect("import stale fixture");
 
         let (output, _) = list_runs(
+            &test_store(),
             RunsListArgs {
                 active: false,
                 task_url: None,
@@ -223,7 +233,7 @@ fn run_list_does_not_classify_terminal_runs_as_stale() {
             store.finish_run(&run.id, status, None).expect("finish run");
         }
 
-        let (output, _) = list_runs(list_args(), "runs.list").expect("list");
+        let (output, _) = list_runs(&test_store(), list_args(), "runs.list").expect("list");
         let RunsOutput::List(output) = output else {
             panic!("expected list output");
         };
@@ -242,6 +252,7 @@ fn active_list_uses_the_unified_activity_projection_without_changing_runs_list()
             .expect("active run");
 
         let (output, _) = list_runs(
+            &test_store(),
             RunsListArgs {
                 active: true,
                 limit: 20,
@@ -258,7 +269,8 @@ fn active_list_uses_the_unified_activity_projection_without_changing_runs_list()
         assert_eq!(report.command, "runs.list_active");
         assert!(report.items.iter().any(|item| item.id == active.id));
 
-        let (ordinary, _) = list_runs(list_args(), "runs.list").expect("ordinary list");
+        let (ordinary, _) =
+            list_runs(&test_store(), list_args(), "runs.list").expect("ordinary list");
         assert!(matches!(ordinary, RunsOutput::List(_)));
     });
 }
@@ -285,7 +297,7 @@ fn active_list_identity_filters_parse_and_reject_observation_only_combinations()
 #[test]
 fn ordinary_runs_list_stays_in_its_existing_serialized_variant() {
     with_isolated_home(|_| {
-        let output = list_runs(list_args(), "runs.list")
+        let output = list_runs(&test_store(), list_args(), "runs.list")
             .expect("ordinary list")
             .0;
         let value = serde_json::to_value(output).expect("serialize ordinary list");
@@ -351,7 +363,7 @@ fn run_list_collapses_runner_execution_mirrors_by_default() {
             .finish_run(&caller.id, RunStatus::Pass, None)
             .expect("finish caller");
 
-        let (output, _) = list_runs(list_args(), "runs.list").expect("list");
+        let (output, _) = list_runs(&test_store(), list_args(), "runs.list").expect("list");
         let RunsOutput::List(output) = output else {
             panic!("expected list output");
         };
@@ -365,6 +377,7 @@ fn run_list_collapses_runner_execution_mirrors_by_default() {
         assert_eq!(output.hidden_mirrors, 2);
 
         let (all, _) = list_runs(
+            &test_store(),
             RunsListArgs {
                 include_mirrors: true,
                 ..list_args()
@@ -409,6 +422,7 @@ fn run_list_applies_command_and_id_filters() {
             .expect("finish other");
 
         let (by_command, _) = list_runs(
+            &test_store(),
             RunsListArgs {
                 command_contains: Some("gutenberg".to_string()),
                 ..list_args()
@@ -423,6 +437,7 @@ fn run_list_applies_command_and_id_filters() {
         assert_eq!(by_command.runs[0].id, keep.id);
 
         let (by_id, _) = list_runs(
+            &test_store(),
             RunsListArgs {
                 id: Some("cook-79020".to_string()),
                 ..list_args()
@@ -511,7 +526,7 @@ fn run_list_rediscovers_lab_agent_task_lineage_from_canonical_metadata() {
                 ..list_args()
             },
         ] {
-            let (output, _) = list_runs(args, "runs.list").expect("rediscover run");
+            let (output, _) = list_runs(&test_store(), args, "runs.list").expect("rediscover run");
             let RunsOutput::List(output) = output else {
                 panic!("expected list output");
             };
@@ -557,6 +572,7 @@ fn run_discovery_uses_named_provenance_and_normalized_workspace_boundaries() {
             .expect("run");
 
         let (workspace, _) = list_runs(
+            &test_store(),
             RunsListArgs {
                 workspace: Some("/work/wp-build".to_string()),
                 ..list_args()
@@ -587,6 +603,7 @@ fn run_discovery_uses_named_provenance_and_normalized_workspace_boundaries() {
             .expect("boundary run");
 
         let (path_boundary, _) = list_runs(
+            &test_store(),
             RunsListArgs {
                 workspace: Some("wp-build".to_string()),
                 ..list_args()
@@ -606,6 +623,7 @@ fn run_discovery_uses_named_provenance_and_normalized_workspace_boundaries() {
         );
 
         let (secret, _) = list_runs(
+            &test_store(),
             RunsListArgs {
                 command_contains: Some("super-secret-value".to_string()),
                 ..list_args()
@@ -619,6 +637,7 @@ fn run_discovery_uses_named_provenance_and_normalized_workspace_boundaries() {
         assert!(secret.runs.is_empty());
 
         let (provider, _) = list_runs(
+            &test_store(),
             RunsListArgs {
                 correlation: Some("provider-session-11958".to_string()),
                 ..list_args()
@@ -664,6 +683,7 @@ fn run_discovery_walks_beyond_legacy_prefetch_prefix() {
                 .expect("run");
         }
         let (output, _) = list_runs(
+            &test_store(),
             RunsListArgs {
                 command_contains: Some("target-command".to_string()),
                 limit: 1,
@@ -691,10 +711,13 @@ fn runs_reconcile_explicitly_reconciles_owned_dead_running_runs() {
             .import_run(&dead_owned_run("dead-owned-run"))
             .expect("import stale fixture");
 
-        let (output, _) = reconcile_runs(RunsReconcileArgs {
-            dry_run: false,
-            limit: 20,
-        })
+        let (output, _) = reconcile_runs(
+            &test_store(),
+            RunsReconcileArgs {
+                dry_run: false,
+                limit: 20,
+            },
+        )
         .expect("reconcile");
 
         let RunsOutput::Reconcile(output) = output else {
@@ -751,10 +774,13 @@ fn runs_reconcile_immediately_terminalizes_dead_deploy_observation_owner() {
             .expect("record child owner");
         child.wait().expect("child exits");
 
-        let (output, _) = reconcile_runs(RunsReconcileArgs {
-            dry_run: false,
-            limit: 20,
-        })
+        let (output, _) = reconcile_runs(
+            &test_store(),
+            RunsReconcileArgs {
+                dry_run: false,
+                limit: 20,
+            },
+        )
         .expect("reconcile");
         let RunsOutput::Reconcile(output) = output else {
             panic!("expected reconcile output");
@@ -1951,14 +1977,17 @@ fn findings_commands_list_and_show_records() {
             })
             .expect("finding");
 
-        let (output, _) = findings::findings(findings::RunsFindingsArgs {
-            command: None,
-            run_id: Some(run.id),
-            tool: Some("lint".to_string()),
-            file: Some("src/foo.php".to_string()),
-            fingerprint: None,
-            limit: 20,
-        })
+        let (output, _) = findings::findings(
+            &test_store(),
+            findings::RunsFindingsArgs {
+                command: None,
+                run_id: Some(run.id),
+                tool: Some("lint".to_string()),
+                file: Some("src/foo.php".to_string()),
+                fingerprint: None,
+                limit: 20,
+            },
+        )
         .expect("list findings");
         let RunsOutput::Findings(output) = output else {
             panic!("expected findings output");
@@ -1967,7 +1996,7 @@ fn findings_commands_list_and_show_records() {
         assert_eq!(output.findings[0].id, recorded.id);
         assert_eq!(output.findings[0].finding.message, "Missing escaping");
 
-        let (output, _) = findings::finding(&recorded.id).expect("show finding");
+        let (output, _) = findings::finding(&test_store(), &recorded.id).expect("show finding");
         let RunsOutput::Finding(output) = output else {
             panic!("expected finding output");
         };
@@ -2109,6 +2138,7 @@ fn bench_history_orders_and_filters_by_scenario() {
             .expect("finish new");
 
         let (output, _) = list_runs(
+            &test_store(),
             RunsListArgs {
                 active: false,
                 task_url: None,

--- a/crates/homeboy-cli/src/commands/runs/watch.rs
+++ b/crates/homeboy-cli/src/commands/runs/watch.rs
@@ -103,14 +103,13 @@ impl WatchPoller for StorePoller<'_> {
     }
 }
 
-pub(crate) fn watch_run(args: RunsWatchArgs) -> CmdResult<RunsOutput> {
+pub(crate) fn watch_run(store: &ObservationStore, args: RunsWatchArgs) -> CmdResult<RunsOutput> {
     let interval = parse_duration(&args.interval)?;
     let timeout = (!args.forever)
         .then(|| parse_duration(&args.timeout))
         .transpose()?;
     let config = WatchConfig { interval, timeout };
 
-    let store = ObservationStore::open_initialized()?;
     let poller = StorePoller { store: &store };
 
     let started = Instant::now();


### PR DESCRIPTION
`homeboy runs` opened a fresh `ObservationStore` **in every handler**. One command was therefore several independently-resolved stores — the same defect the rig and admission work removed, and invisible at the call site.

`dispatch::run` and `dispatch::run_markdown` now open **one store each** and hand `&ObservationStore` to the seventeen handlers they dispatch to.

## Reporting

Decomposed as the contract asks, because a correct boundary is also a call:

| | before | after |
|---|---:|---:|
| **ambient resolution points** | 28 | **12** |
| boundary opens | 0 | 2 |
| test helpers | 0 | 13 |

Two of the twelve remaining are the new boundaries themselves.

## What's left, and why it isn't in here

The other ten are all **more than one hop** from the boundary: `remote_artifact`'s attach/capture/preview, the `resources` index loaders, `latest_run_context`, `bench_compare`, the `gh_actions` import, and two report internals. Each needs its own caller rooted first. Threading a store down to them from here would be pushing plumbing outward, which the contract calls a regression rather than progress.

## On the raw grep count

`open_initialized()` under `runs/` only moves 151 → 149, and that is expected. Test bodies call these handlers directly, so each test module gained a `test_store()` helper — a test is the entry point for its own unit of work, so that open is a boundary open. The **ambient** count halves while the total stays flat.

That gap is exactly why the contract asks for the decomposition instead of the total.

## Verification

`cargo check --workspace --tests -j2` — green, no warnings.

Anchored every signature edit on `fn <name>(` rather than a bare `(`, after the previous attempt at this collided with `pub(super)`. Three further collisions were caught before writing: helpers inserted above `//!` module docs, one above a `#![cfg(test)]` inner attribute, and a `(?<![\w:.])` lookbehind that skipped every `module::handler(` call.

Refs #7505.