### PR TITLE
fix(agents): persist resolved provider model provenance

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -3642,7 +3642,33 @@ pub fn record_provider_execution_terminal(
     state: &str,
 ) -> Result<AgentTaskRunRecord> {
     let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    record_provider_execution_terminal_in_store(&lifecycle_store, run_id, task_id, attempt, state)
+    record_provider_execution_terminal_with_model_in_store(
+        &lifecycle_store,
+        run_id,
+        task_id,
+        attempt,
+        state,
+        None,
+    )
+}
+
+/// Record a terminal provider result with its normalized concrete model.
+pub fn record_provider_execution_terminal_with_model(
+    run_id: &str,
+    task_id: &str,
+    attempt: u32,
+    state: &str,
+    model: Option<&str>,
+) -> Result<AgentTaskRunRecord> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    record_provider_execution_terminal_with_model_in_store(
+        &lifecycle_store,
+        run_id,
+        task_id,
+        attempt,
+        state,
+        model,
+    )
 }
 
 pub fn record_provider_execution_terminal_in_store(
@@ -3651,6 +3677,24 @@ pub fn record_provider_execution_terminal_in_store(
     task_id: &str,
     attempt: u32,
     state: &str,
+) -> Result<AgentTaskRunRecord> {
+    record_provider_execution_terminal_with_model_in_store(
+        lifecycle_store,
+        run_id,
+        task_id,
+        attempt,
+        state,
+        None,
+    )
+}
+
+pub fn record_provider_execution_terminal_with_model_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    task_id: &str,
+    attempt: u32,
+    state: &str,
+    model: Option<&str>,
 ) -> Result<AgentTaskRunRecord> {
     if !matches!(
         state,
@@ -3693,6 +3737,9 @@ pub fn record_provider_execution_terminal_in_store(
             return false;
         }
         execution["state"] = json!(state);
+        if let Some(model) = model.map(str::trim).filter(|model| !model.is_empty()) {
+            execution["model"] = json!(model);
+        }
         execution["finished_at"] = json!(now_timestamp());
         found = true;
         true

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -853,6 +853,11 @@ impl AgentTaskScheduler {
                     }
                     let mut outcome = result.outcome;
                     let provider_completed_at = result.completed_at;
+                    attach_candidate_adoption_provenance(
+                        &mut outcome,
+                        running_task.adoption.as_ref(),
+                    );
+                    persist_resolved_provider_model(&mut outcome, &running_task.request);
                     if let Some(run_id) = running_task.run_id.as_deref() {
                         let terminal_state = match outcome.status {
                             AgentTaskOutcomeStatus::Succeeded | AgentTaskOutcomeStatus::NoOp => {
@@ -864,18 +869,20 @@ impl AgentTaskScheduler {
                             _ => "failed",
                         };
                         let terminal = match self.lifecycle_store.as_ref() {
-                            Some(store) => store.record_provider_execution_terminal(
+                            Some(store) => store.record_provider_execution_terminal_with_model(
                                 run_id,
                                 &outcome.task_id,
                                 result.attempt,
                                 terminal_state,
+                                outcome.selected_model(),
                             ),
                             None => {
-                                crate::agent_task_lifecycle::record_provider_execution_terminal(
+                                crate::agent_task_lifecycle::record_provider_execution_terminal_with_model(
                                     run_id,
                                     &outcome.task_id,
                                     result.attempt,
                                     terminal_state,
+                                    outcome.selected_model(),
                                 )
                             }
                         };
@@ -895,16 +902,15 @@ impl AgentTaskScheduler {
                             });
                         }
                     }
-                    attach_candidate_adoption_provenance(
-                        &mut outcome,
-                        running_task.adoption.as_ref(),
-                    );
-                    persist_resolved_provider_model(&mut outcome, &running_task.request);
                     if let Err(error) = harvest_uncommitted_patch(&mut outcome, &running_task)
                         .and_then(|_| harvest_committed_patch(&mut outcome, &running_task))
                     {
                         outcome = committed_harvest_failure(outcome, error);
                     }
+                    // Harvest can add Homeboy-generated patch artifacts after the
+                    // provider result was normalized. Keep their provenance tied
+                    // to the same concrete model as the canonical outcome.
+                    persist_resolved_provider_model(&mut outcome, &running_task.request);
                     finalize_candidate_artifacts(&mut outcome, &running_task);
                     let outcome =
                         AgentTaskScheduleSupport::normalize_outcome(outcome, Some(&running_task));
@@ -1411,7 +1417,18 @@ pub(crate) fn persist_resolved_provider_model(
     outcome: &mut AgentTaskOutcome,
     request: &AgentTaskRequest,
 ) {
-    let provider_reported = outcome.selected_model().map(str::to_string);
+    // A second normalization pass runs after patch harvest. Once the first pass
+    // supplied a configured fallback in `metadata.model`, retain the original
+    // runtime-report boundary instead of mistaking that fallback for a report.
+    let provider_reported = outcome.metadata["model_identity"]["provider_reported"]
+        .as_str()
+        .filter(|model| !model.trim().is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            (!outcome.metadata["model_identity"].is_object())
+                .then(|| outcome.selected_model().map(str::to_string))
+                .flatten()
+        });
     let requested = request.metadata["model_selection"]["requested"]
         .as_str()
         .filter(|model| !model.trim().is_empty())
@@ -1420,7 +1437,16 @@ pub(crate) fn persist_resolved_provider_model(
         .executor
         .model()
         .filter(|model| !model.trim().is_empty())
-        .map(str::to_string);
+        .map(str::to_string)
+        .or_else(|| {
+            request.metadata["model_selection"]["selected"]
+                .as_str()
+                .filter(|model| !model.trim().is_empty())
+                .map(str::to_string)
+        });
+    // A runtime report is execution fact. When the runtime omits it, the
+    // dispatch-selected model is the only concrete identity available.
+    let actual = provider_reported.clone().or_else(|| resolved.clone());
     if !outcome.metadata.is_object() {
         outcome.metadata = serde_json::json!({});
     }
@@ -1439,11 +1465,21 @@ pub(crate) fn persist_resolved_provider_model(
             // Retained for consumers of the previous outcome metadata shape.
             "resolved": resolved,
             "provider_reported": provider_reported,
-            "actual": provider_reported,
+            "actual": actual,
         }),
     );
-    if let Some(actual) = provider_reported {
+    if let Some(actual) = actual {
         metadata.insert("model".to_string(), serde_json::json!(actual));
+    }
+    let actual = outcome.selected_model().map(str::to_string);
+    for artifact in &mut outcome.artifacts {
+        if artifact.kind != "patch" && artifact.role.as_deref() != Some("patch") {
+            continue;
+        }
+        if !artifact.metadata.is_object() {
+            artifact.metadata = serde_json::json!({});
+        }
+        artifact.metadata["provider_model"] = serde_json::json!(actual);
     }
 }
 

--- a/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
@@ -1381,7 +1381,10 @@ impl AgentTaskScheduleSupport {
                 .map(str::to_string)
                 .or_else(|| request.executor.model().map(str::to_string)),
             attempted_model: request.executor.model().map(str::to_string),
-            candidate_producing_model: outcome.selected_model().map(str::to_string),
+            candidate_producing_model: outcome.metadata["model_identity"]["provider_reported"]
+                .as_str()
+                .filter(|model| !model.trim().is_empty())
+                .map(str::to_string),
             status: outcome.status,
             failure_classification: outcome.failure_classification,
             summary: outcome.summary.clone(),

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/outcome_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/outcome_tests.rs
@@ -37,6 +37,48 @@ fn provider_reported_model_is_retained_separately_from_requested_and_resolved_mo
 }
 
 #[test]
+fn configured_model_becomes_actual_when_runtime_omits_provenance() {
+    let mut request = request("task-1");
+    request.metadata = json!({
+        "model_selection": { "selected": "openai/gpt-5.6-sol" }
+    });
+    let mut outcome = outcome("task-1".to_string(), AgentTaskOutcomeStatus::Succeeded);
+    outcome.artifacts.push(AgentTaskArtifact {
+        kind: "patch".to_string(),
+        metadata: json!({}),
+        ..Default::default()
+    });
+
+    crate::agent_task_scheduler::engine::persist_resolved_provider_model(&mut outcome, &request);
+
+    assert_eq!(outcome.selected_model(), Some("openai/gpt-5.6-sol"));
+    assert_eq!(
+        outcome.metadata["model_identity"]["provider_reported"],
+        json!(null)
+    );
+    assert_eq!(
+        outcome.artifacts[0].metadata["provider_model"],
+        json!("openai/gpt-5.6-sol")
+    );
+}
+
+#[test]
+fn runtime_reported_model_wins_over_conflicting_dispatch_selection() {
+    let mut request = request("task-1");
+    request.executor.model = Some("openai/gpt-5.6-terra".to_string());
+    let mut outcome = outcome("task-1".to_string(), AgentTaskOutcomeStatus::Succeeded);
+    outcome.metadata = json!({ "model": "openai/gpt-5.6-sol" });
+
+    crate::agent_task_scheduler::engine::persist_resolved_provider_model(&mut outcome, &request);
+
+    assert_eq!(outcome.selected_model(), Some("openai/gpt-5.6-sol"));
+    assert_eq!(
+        outcome.metadata["model_identity"]["attempted"],
+        json!("openai/gpt-5.6-terra")
+    );
+}
+
+#[test]
 fn nested_failed_executor_status_fails_succeeded_wrapper_outcome() {
     let scheduler = AgentTaskScheduler::new(Arc::new(NestedFailedStatusExecutor));
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -691,6 +691,30 @@ pub(crate) fn promote_or_load_attempt_in_store(
     options: &AgentTaskCookServiceOptions,
     run_id: &str,
 ) -> Result<AgentTaskPromotionReport> {
+    let aggregate = lifecycle_store.read_aggregate(run_id)?;
+    let outcome = aggregate
+        .selected_outcome()
+        .or_else(|| {
+            (aggregate.outcomes.len() == 1)
+                .then(|| aggregate.outcomes.first())
+                .flatten()
+        })
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "provider_model",
+                "Cook promotion has no selected provider outcome",
+                Some(run_id.to_string()),
+                None,
+            )
+        })?;
+    if concrete_provider_model(outcome.selected_model()).is_none() {
+        return Err(Error::validation_invalid_argument(
+            "provider_model",
+            "Cook promotion requires a concrete executed model",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
     if let Some(promotion) = persisted_promotion_for_attempt_in_store(lifecycle_store, run_id)? {
         if promotion.status == AgentTaskPromotionStatus::VerificationPending {
             let target_path = promotion.target.path.as_deref().or_else(|| {

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -303,6 +303,19 @@ impl AgentTaskLifecycleStore {
         )
     }
 
+    pub(crate) fn record_provider_execution_terminal_with_model(
+        &self,
+        run_id: &str,
+        task_id: &str,
+        attempt: u32,
+        state: &str,
+        model: Option<&str>,
+    ) -> Result<AgentTaskRunRecord> {
+        super::lifecycle_ops::record_provider_execution_terminal_with_model_in_store(
+            self, run_id, task_id, attempt, state, model,
+        )
+    }
+
     pub(crate) fn record_provider_execution_runtime_evidence(
         &self,
         run_id: &str,


### PR DESCRIPTION
## Summary
- persist provider-reported or dispatch-resolved model provenance before terminal lifecycle recording
- propagate the concrete model to canonical outcome, provider execution ledger, and patch metadata
- reject Cook promotion before candidate effects when executed-model provenance is unavailable

Closes #13045

## Verification
- `cargo fmt --check`
- `cargo check --workspace`
- focused `homeboy-agents` provenance and provider-rotation tests
- `cargo test -p homeboy-cli commands::agent_task::fanout::tests::dispatcher_fanout_terminalization_finalizes_success_and_failure_provider_records`

## AI assistance
OpenAI GPT-5.6-sol via OpenCode was used to trace the adapter/lifecycle provenance boundary, implement the generic fix, and run verification. Chris remains responsible for the change.