### PR TITLE
fix(lab-runner): reconcile runner-exec recovery through one store (#7505)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
@@ -401,10 +401,34 @@ pub fn record_runner_exec_terminal_checkpoint(
     run_id: &str,
     snapshot: &RunnerJobLogSnapshot,
 ) -> Result<()> {
+    record_runner_exec_terminal_checkpoint_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        run_id,
+        snapshot,
+    )
+}
+
+/// The store-rooted counterpart of [`record_runner_exec_terminal_checkpoint`].
+///
+/// This is a read-modify-write of one observation row: the row is read,
+/// its `kind` is checked, its metadata is mutated, and it is written back.
+/// Read and write are the same row, so they have to be the same
+/// installation (#7505).
+///
+/// Opened through [`AgentTaskLifecycleStore::open_observation_maintained`]
+/// rather than the lifecycle opener, because the ambient body used
+/// `ObservationStore::open_initialized()` and the two differ in startup
+/// artifact maintenance. Rooting through the lifecycle opener would change
+/// behaviour, not just its home.
+pub fn record_runner_exec_terminal_checkpoint_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    snapshot: &RunnerJobLogSnapshot,
+) -> Result<()> {
     if !snapshot.job.status.is_terminal() {
         return Ok(());
     }
-    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    let store = lifecycle_store.open_observation_maintained()?;
     let run_id = sanitize_run_id(run_id);
     let Some(mut run) = store.get_run(&run_id)? else {
         return Ok(());
@@ -466,7 +490,31 @@ pub fn record_runner_exec_artifact_refs(
     run_id: &str,
     artifacts: &[homeboy_core::observation::ArtifactRecord],
 ) -> Result<()> {
-    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    record_runner_exec_artifact_refs_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        run_id,
+        artifacts,
+    )
+}
+
+/// The store-rooted counterpart of [`record_runner_exec_artifact_refs`].
+///
+/// This is a read-modify-write of one observation row: the row is read,
+/// its `kind` is checked, its metadata is mutated, and it is written back.
+/// Read and write are the same row, so they have to be the same
+/// installation (#7505).
+///
+/// Opened through [`AgentTaskLifecycleStore::open_observation_maintained`]
+/// rather than the lifecycle opener, because the ambient body used
+/// `ObservationStore::open_initialized()` and the two differ in startup
+/// artifact maintenance. Rooting through the lifecycle opener would change
+/// behaviour, not just its home.
+pub fn record_runner_exec_artifact_refs_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    artifacts: &[homeboy_core::observation::ArtifactRecord],
+) -> Result<()> {
+    let store = lifecycle_store.open_observation_maintained()?;
     let run_id = sanitize_run_id(run_id);
     let Some(mut run) = store.get_run(&run_id)? else {
         return Ok(());
@@ -512,7 +560,35 @@ pub fn record_runner_exec_declaration_promotion(
     declaration: &str,
     artifacts: &[homeboy_core::observation::ArtifactRecord],
 ) -> Result<()> {
-    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    record_runner_exec_declaration_promotion_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        run_id,
+        role,
+        declaration,
+        artifacts,
+    )
+}
+
+/// The store-rooted counterpart of [`record_runner_exec_declaration_promotion`].
+///
+/// This is a read-modify-write of one observation row: the row is read,
+/// its `kind` is checked, its metadata is mutated, and it is written back.
+/// Read and write are the same row, so they have to be the same
+/// installation (#7505).
+///
+/// Opened through [`AgentTaskLifecycleStore::open_observation_maintained`]
+/// rather than the lifecycle opener, because the ambient body used
+/// `ObservationStore::open_initialized()` and the two differ in startup
+/// artifact maintenance. Rooting through the lifecycle opener would change
+/// behaviour, not just its home.
+pub fn record_runner_exec_declaration_promotion_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    role: &str,
+    declaration: &str,
+    artifacts: &[homeboy_core::observation::ArtifactRecord],
+) -> Result<()> {
+    let store = lifecycle_store.open_observation_maintained()?;
     let run_id = sanitize_run_id(run_id);
     let Some(mut run) = store.get_run(&run_id)? else {
         return Ok(());

--- a/crates/homeboy-lab-runner/src/execution/recovery.rs
+++ b/crates/homeboy-lab-runner/src/execution/recovery.rs
@@ -167,6 +167,12 @@ fn reconcile_terminal_runner_exec_runs_with_owner(
     // Reconciliation runs under the caller's child lock and writes the same
     // runs the caller already opened, so it shares the caller's roots (#7505).
     let store = ObservationStore::open_initialized_in_roots(roots)?;
+    // The checkpoint, promotion, and artifact-ref writes below used to each open
+    // their own ambient store, so a pass that read through these injected roots
+    // wrote through whatever the environment happened to name. Reads and writes
+    // in one reconciliation are the same rows, so they share one store (#7505).
+    let lifecycle_store =
+        homeboy_agents::agent_task_lifecycle::AgentTaskLifecycleStore::new(roots.clone());
     let mut reconciled = 0;
     let mut deferred = 0;
     let mut unavailable_endpoints = BTreeSet::new();
@@ -263,8 +269,10 @@ fn reconcile_terminal_runner_exec_runs_with_owner(
             continue;
         }
         worker.renew(&store)?;
-        homeboy_agents::agent_task_lifecycle::record_runner_exec_terminal_checkpoint(
-            &run.id, &snapshot,
+        homeboy_agents::agent_task_lifecycle::record_runner_exec_terminal_checkpoint_in_store(
+            &lifecycle_store,
+            &run.id,
+            &snapshot,
         )?;
         let declarations = run
             .metadata_json
@@ -300,7 +308,8 @@ fn reconcile_terminal_runner_exec_runs_with_owner(
                 &output,
                 std::slice::from_ref(&declaration),
             )?;
-            homeboy_agents::agent_task_lifecycle::record_runner_exec_declaration_promotion(
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_declaration_promotion_in_store(
+                &lifecycle_store,
                 &run.id,
                 "artifact",
                 &declaration,
@@ -323,7 +332,8 @@ fn reconcile_terminal_runner_exec_runs_with_owner(
                 &output,
                 std::slice::from_ref(&declaration),
             )?;
-            homeboy_agents::agent_task_lifecycle::record_runner_exec_declaration_promotion(
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_declaration_promotion_in_store(
+                &lifecycle_store,
                 &run.id,
                 "artifact_dir",
                 &declaration,
@@ -346,7 +356,8 @@ fn reconcile_terminal_runner_exec_runs_with_owner(
                 &output,
                 std::slice::from_ref(&declaration),
             )?;
-            homeboy_agents::agent_task_lifecycle::record_runner_exec_declaration_promotion(
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_declaration_promotion_in_store(
+                &lifecycle_store,
                 &run.id,
                 "summary",
                 &declaration,
@@ -361,7 +372,11 @@ fn reconcile_terminal_runner_exec_runs_with_owner(
             .cloned()
             .collect::<Vec<_>>();
         worker.renew(&store)?;
-        homeboy_agents::agent_task_lifecycle::record_runner_exec_artifact_refs(&run.id, &retained)?;
+        homeboy_agents::agent_task_lifecycle::record_runner_exec_artifact_refs_in_store(
+            &lifecycle_store,
+            &run.id,
+            &retained,
+        )?;
         worker.renew(&store)?;
         homeboy_agents::agent_task_lifecycle::project_terminal_runner_result(&run.id, &snapshot)?;
         reconciled += 1;

--- a/tests/runner_exec_recovery_rooting_test.rs
+++ b/tests/runner_exec_recovery_rooting_test.rs
@@ -1,0 +1,105 @@
+//! Pins the runner-exec recovery reconciliation onto a single observation store.
+//!
+//! ## What went wrong, concretely
+//!
+//! `reconcile_terminal_runner_exec_runs_with_owner` takes `roots: &PathRoots`
+//! and opens its candidate reader through them:
+//!
+//! ```text
+//! let store = ObservationStore::open_initialized_in_roots(roots)?;
+//! ```
+//!
+//! It then selected candidates from that store and wrote its results through
+//! five calls that each opened their own *ambient* store:
+//!
+//! ```text
+//! record_runner_exec_terminal_checkpoint(..)     // 1 ambient open
+//! record_runner_exec_declaration_promotion(..)   // 3 ambient opens
+//! record_runner_exec_artifact_refs(..)           // 1 ambient open
+//! ```
+//!
+//! So a pass that *read* through injected roots *wrote* through whatever the
+//! environment happened to name. Under a `HermeticTestContext` — which
+//! allocates temp roots and deliberately does not mutate `HOME` — the read side
+//! saw the hermetic root and the write side saw the real one. The reconciler
+//! would select a run, promote its artifacts, and record the outcome against a
+//! row in a different database than the one it had just decided from.
+//!
+//! This is the same split-root shape as `ActiveRigRunLease::drop` (#13011):
+//! injection applied to one half of an operation is not injection, it is a
+//! guarantee that the two halves can disagree.
+//!
+//! ## What this test pins
+//!
+//! Inside `recovery.rs`, the three write helpers are reached only through their
+//! `_in_store` counterparts. The ambient names remain exported — other callers
+//! are not yet rooted and deleting them would be a bottom-up migration — but
+//! they must not reappear in the one caller that already holds roots.
+//!
+//! A source-level assertion is the right instrument here. The defect is not
+//! observable from behaviour under a single root: both stores resolve, both
+//! writes succeed, and the split only shows up as a lost update when the two
+//! roots differ. What is being pinned is the *provenance* of the store, which
+//! is a property of the call, not of its result.
+
+use std::path::PathBuf;
+
+fn recovery_source() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("crates/homeboy-lab-runner/src/execution/recovery.rs");
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
+}
+
+/// The reconciler holds `roots`, so every observation write it performs has to
+/// name the store built from those roots.
+#[test]
+fn recovery_reconciliation_writes_through_the_injected_store() {
+    let source = recovery_source();
+
+    for helper in [
+        "record_runner_exec_terminal_checkpoint",
+        "record_runner_exec_declaration_promotion",
+        "record_runner_exec_artifact_refs",
+    ] {
+        let ambient = format!("{helper}(");
+        assert!(
+            !source.contains(&ambient),
+            "recovery.rs calls the ambient `{helper}`. This function already \
+             holds `roots: &PathRoots` and opens its reader through them, so an \
+             ambient write here reads one installation and writes another \
+             (#7505). Use `{helper}_in_store` with the `lifecycle_store` built \
+             from the same roots."
+        );
+        assert!(
+            source.contains(&format!("{helper}_in_store(")),
+            "recovery.rs no longer calls `{helper}_in_store`. If this write was \
+             removed on purpose, drop it from this list; if it was re-routed \
+             through an ambient opener, that is the split-root regression this \
+             test exists to catch (#7505)."
+        );
+    }
+}
+
+/// One reconciliation pass is one unit of work, so it builds one lifecycle
+/// store — not one per write.
+#[test]
+fn recovery_reconciliation_builds_exactly_one_lifecycle_store() {
+    let source = recovery_source();
+
+    let constructions = source.matches("AgentTaskLifecycleStore::new(").count();
+    assert_eq!(
+        constructions, 1,
+        "recovery.rs constructs {constructions} lifecycle stores. The \
+         reconciler is one unit of work over one set of roots; constructing a \
+         store per write would restore the per-call resolution this change \
+         removed, just with an explicit argument (#7505)."
+    );
+
+    assert!(
+        !source.contains("AgentTaskLifecycleStore::from_current_environment"),
+        "recovery.rs resolves a lifecycle store from the environment. It is \
+         handed `roots` by its caller; resolving again here would reintroduce \
+         an ambient root below an injected one (#7505)."
+    );
+}


### PR DESCRIPTION
## A split-root bug, not just a count

`reconcile_terminal_runner_exec_runs_with_owner` takes `roots: &PathRoots` and opens its candidate reader through them. It then wrote its results through **five calls that each opened their own ambient store**:

```
read:   ObservationStore::open_initialized_in_roots(roots)   <- injected
write:  record_runner_exec_terminal_checkpoint(..)     1 ambient open
write:  record_runner_exec_declaration_promotion(..)   3 ambient opens
write:  record_runner_exec_artifact_refs(..)           1 ambient open
```

A pass that **read through injected roots wrote through whatever the environment named.** Under a `HermeticTestContext` — which allocates temp roots and deliberately does not mutate `HOME` — the read side saw the hermetic root and the write side saw the real one. The reconciler selected a run, promoted its artifacts, and recorded the outcome against a row **in a different database than the one it decided from**.

This is the same shape as `ActiveRigRunLease::drop` in #13011. Injection applied to one half of an operation is not injection; it is a guarantee that the two halves can disagree.

## The fix

The three helpers gain `_in_store` counterparts opened through `open_observation_maintained` — matching the existing pairs in this file, and preserving the startup artifact maintenance the ambient opener performs. Rooting through the lifecycle opener instead would have changed behaviour rather than just its home (the #12618 hazard).

The reconciler builds **one** lifecycle store from its own roots and passes it to all five calls.

Ambient names are kept and still exported. Their other callers are not yet rooted, and deleting them now would be a bottom-up migration.

`runner_exec.rs` production ambient opens: **14 → 11**.

## Readiness, since only part of this file was ready

I checked caller depth before converting rather than converting all 14. Of the callers of these functions:

| caller | holds roots? |
|---|---|
| `reconcile_terminal_runner_exec_runs_with_owner` | **yes** |
| `schedule_terminal_runner_exec_recovery` | yes |
| `record_scheduled_..._spawn_failure` | yes |
| 8 others in `recovery.rs` | no |
| `cli/commands/runner/exec.rs` | no |

Converting the rest now would make every unrooted caller resolve its own store — more resolutions than today, which is the regression the contract warns about. Only the ready ones are converted here.

Also worth noting: the file's "15 sites" includes a **doc-comment mention**, not a call. The real figure was 14.

## Verification

- `cargo check --workspace --tests -j2` — green, no warnings
- `tests/runner_exec_recovery_rooting_test.rs` pins both halves: ambient names absent from the rooted caller, and exactly one lifecycle store constructed
- **Verified non-vacuous** — reintroduced the ambient call and confirmed the test fails with the intended message, then restored

Refs #7505.