### PR TITLE
fix(cli): run `runner exec` against one observation store (#7505)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
@@ -107,6 +107,7 @@ const COMMAND_RESULT_RUN_REF_LIMIT: usize = 32;
 const DESCENDANT_RUN_GRAPH_LIMIT: usize = 64;
 
 fn ensure_runner_exec_observation_run(
+    lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     runner_id: &str,
     remote_workspace: &str,
@@ -114,7 +115,7 @@ fn ensure_runner_exec_observation_run(
     runner_job_id: Option<&str>,
 ) -> Result<homeboy_core::observation::RunRecord> {
     let run_id = sanitize_run_id(run_id);
-    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    let store = lifecycle_store.open_observation_maintained()?;
     let mut run = match store.get_run(&run_id)? {
         Some(run)
             if run.metadata_json.get("kind").and_then(Value::as_str)
@@ -190,6 +191,7 @@ pub fn record_runner_exec_job_identity(
     remote_command: &[String],
 ) -> Result<homeboy_core::observation::RunRecord> {
     ensure_runner_exec_observation_run(
+        &AgentTaskLifecycleStore::from_current_environment()?,
         run_id,
         runner_id,
         remote_workspace,
@@ -205,7 +207,29 @@ pub fn record_runner_exec_execution_record(
     run_id: &str,
     execution_record: &homeboy_core::runner_execution_envelope::RunnerExecutionRecord,
 ) -> Result<()> {
-    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    record_runner_exec_execution_record_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        run_id,
+        execution_record,
+    )
+}
+
+/// The store-rooted counterpart of [`record_runner_exec_execution_record`].
+///
+/// This is a read-modify-write of one observation row: read, `kind`-checked,
+/// mutated, written back. Read and write are the same row, so they have to
+/// be the same installation (#7505).
+///
+/// Opened through [`AgentTaskLifecycleStore::open_observation_maintained`]
+/// rather than the lifecycle opener: the ambient body used
+/// `ObservationStore::open_initialized()`, and the two differ in startup
+/// artifact maintenance.
+pub fn record_runner_exec_execution_record_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    execution_record: &homeboy_core::runner_execution_envelope::RunnerExecutionRecord,
+) -> Result<()> {
+    let store = lifecycle_store.open_observation_maintained()?;
     let Some(mut run) = store.get_run(&sanitize_run_id(run_id))? else {
         return Ok(());
     };
@@ -266,7 +290,37 @@ pub fn ensure_generic_runner_exec_run(
     remote_workspace: &str,
     remote_command: &[String],
 ) -> Result<homeboy_core::observation::RunRecord> {
-    ensure_runner_exec_observation_run(run_id, runner_id, remote_workspace, remote_command, None)
+    ensure_generic_runner_exec_run_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        run_id,
+        runner_id,
+        remote_workspace,
+        remote_command,
+    )
+}
+
+/// The store-rooted counterpart of [`ensure_generic_runner_exec_run`].
+///
+/// This is the run's first durable write. Everything the caller records after
+/// it — declarations, execution record, promotions, terminal result — addresses
+/// the row created here, so creating it in one installation and appending to it
+/// from another would leave the later writes silently addressing nothing
+/// (#7505).
+pub fn ensure_generic_runner_exec_run_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    runner_id: &str,
+    remote_workspace: &str,
+    remote_command: &[String],
+) -> Result<homeboy_core::observation::RunRecord> {
+    ensure_runner_exec_observation_run(
+        lifecycle_store,
+        run_id,
+        runner_id,
+        remote_workspace,
+        remote_command,
+        None,
+    )
 }
 
 /// Record a controller-side phase before work can reach a runner. This local
@@ -357,7 +411,33 @@ pub fn record_runner_exec_artifact_declarations(
     artifact_dirs: &[String],
     summaries: &[String],
 ) -> Result<()> {
-    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    record_runner_exec_artifact_declarations_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        run_id,
+        artifacts,
+        artifact_dirs,
+        summaries,
+    )
+}
+
+/// The store-rooted counterpart of [`record_runner_exec_artifact_declarations`].
+///
+/// This is a read-modify-write of one observation row: read, `kind`-checked,
+/// mutated, written back. Read and write are the same row, so they have to
+/// be the same installation (#7505).
+///
+/// Opened through [`AgentTaskLifecycleStore::open_observation_maintained`]
+/// rather than the lifecycle opener: the ambient body used
+/// `ObservationStore::open_initialized()`, and the two differ in startup
+/// artifact maintenance.
+pub fn record_runner_exec_artifact_declarations_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    artifacts: &[String],
+    artifact_dirs: &[String],
+    summaries: &[String],
+) -> Result<()> {
+    let store = lifecycle_store.open_observation_maintained()?;
     let run_id = sanitize_run_id(run_id);
     let Some(mut run) = store.get_run(&run_id)? else {
         return Err(Error::validation_invalid_argument(
@@ -1003,7 +1083,26 @@ fn bounded_required_string<'a>(value: &'a Value, field: &str, limit: usize) -> O
 /// Finish a synchronous transport that has no daemon job identity (diagnostic
 /// SSH/local execution) after its declared evidence is safely retained.
 pub fn finish_runner_exec_direct(run_id: &str, transport: &str, exit_code: i32) -> Result<bool> {
-    let store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    finish_runner_exec_direct_in_store(
+        &AgentTaskLifecycleStore::from_current_environment()?,
+        run_id,
+        transport,
+        exit_code,
+    )
+}
+
+/// The store-rooted counterpart of [`finish_runner_exec_direct`].
+///
+/// This is the run's terminal commit. It reads the row, refuses if already
+/// terminal, and finishes it — the guard and the write are the same row, so a
+/// split root could finish a run the guard never inspected (#7505).
+pub fn finish_runner_exec_direct_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    transport: &str,
+    exit_code: i32,
+) -> Result<bool> {
+    let store = lifecycle_store.open_observation_maintained()?;
     let Some(mut run) = store.get_run(&sanitize_run_id(run_id))? else {
         return Ok(false);
     };

--- a/crates/homeboy-cli/src/commands/runner/exec.rs
+++ b/crates/homeboy-cli/src/commands/runner/exec.rs
@@ -117,19 +117,37 @@ pub(super) fn exec_with_hydration(
             remote_path,
         )?;
     }
-    if let Some(run_id) = validated_run_id.as_deref() {
+    // One `runner exec` invocation is one unit of work over one installation.
+    // The eleven durable writes below used to open eleven independent ambient
+    // stores, so the run this command created and the run it finished were only
+    // the same row by coincidence of environment (#7505).
+    // Resolved only when there is a run to record against. `PathRoots` is
+    // fallible, and an invocation without `--run-id` writes nothing durable, so
+    // resolving unconditionally would fail commands that never needed a home.
+    let lifecycle_store = validated_run_id
+        .as_deref()
+        .map(|_| {
+            homeboy_agents::agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment(
+            )
+        })
+        .transpose()?;
+    if let (Some(run_id), Some(lifecycle_store)) =
+        (validated_run_id.as_deref(), lifecycle_store.as_ref())
+    {
         let runner_config = runner::load(runner_id)?;
         let remote_cwd = cwd
             .as_deref()
             .or(runner_config.workspace_root.as_deref())
             .unwrap_or(".");
-        homeboy_agents::agent_task_lifecycle::ensure_generic_runner_exec_run(
+        homeboy_agents::agent_task_lifecycle::ensure_generic_runner_exec_run_in_store(
+            lifecycle_store,
             run_id,
             runner_id,
             remote_cwd,
             &prepared_command,
         )?;
-        homeboy_agents::agent_task_lifecycle::record_runner_exec_artifact_declarations(
+        homeboy_agents::agent_task_lifecycle::record_runner_exec_artifact_declarations_in_store(
+            lifecycle_store,
             run_id,
             &artifact_outputs,
             &artifact_dir_outputs,
@@ -142,7 +160,8 @@ pub(super) fn exec_with_hydration(
             .with_orchestration_provenance(Some(
                 runner::runner_exec_orchestration_provenance(runner_id)?,
             ));
-        homeboy_agents::agent_task_lifecycle::record_runner_exec_execution_record(
+        homeboy_agents::agent_task_lifecycle::record_runner_exec_execution_record_in_store(
+            lifecycle_store,
             run_id,
             &execution_record,
         )?;
@@ -189,15 +208,19 @@ pub(super) fn exec_with_hydration(
             read_only_artifact_access: read_only_artifact,
         },
     )?;
-    if let Some(run_id) = validated_run_id.as_deref() {
+    if let (Some(run_id), Some(lifecycle_store)) =
+        (validated_run_id.as_deref(), lifecycle_store.as_ref())
+    {
         if let Some(execution_record) = output.execution_record.as_ref() {
-            homeboy_agents::agent_task_lifecycle::record_runner_exec_execution_record(
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_execution_record_in_store(
+                lifecycle_store,
                 run_id,
                 execution_record,
             )?;
         }
         if let (Some(job), Some(events)) = (output.job.as_ref(), output.job_events.as_ref()) {
-            homeboy_agents::agent_task_lifecycle::record_runner_exec_terminal_checkpoint(
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_terminal_checkpoint_in_store(
+                lifecycle_store,
                 run_id,
                 &homeboy::core::api_jobs::RunnerJobLogSnapshot {
                     job: job.clone(),
@@ -212,7 +235,8 @@ pub(super) fn exec_with_hydration(
                 &output,
                 std::slice::from_ref(declaration),
             )?;
-            homeboy_agents::agent_task_lifecycle::record_runner_exec_declaration_promotion(
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_declaration_promotion_in_store(
+                lifecycle_store,
                 run_id,
                 "artifact",
                 declaration,
@@ -231,7 +255,8 @@ pub(super) fn exec_with_hydration(
                 &output,
                 std::slice::from_ref(declaration),
             )?;
-            homeboy_agents::agent_task_lifecycle::record_runner_exec_declaration_promotion(
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_declaration_promotion_in_store(
+                lifecycle_store,
                 run_id,
                 "artifact_dir",
                 declaration,
@@ -250,7 +275,8 @@ pub(super) fn exec_with_hydration(
                 &output,
                 std::slice::from_ref(declaration),
             )?;
-            homeboy_agents::agent_task_lifecycle::record_runner_exec_declaration_promotion(
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_declaration_promotion_in_store(
+                lifecycle_store,
                 run_id,
                 "summary",
                 declaration,
@@ -278,9 +304,14 @@ pub(super) fn exec_with_hydration(
             .chain(summaries.iter())
             .cloned()
             .collect::<Vec<_>>();
-        homeboy_agents::agent_task_lifecycle::record_runner_exec_artifact_refs(run_id, &retained)?;
+        homeboy_agents::agent_task_lifecycle::record_runner_exec_artifact_refs_in_store(
+            lifecycle_store,
+            run_id,
+            &retained,
+        )?;
         if let (Some(job), Some(events)) = (output.job.as_ref(), output.job_events.as_ref()) {
-            homeboy_agents::agent_task_lifecycle::project_terminal_runner_result(
+            homeboy_agents::agent_task_lifecycle::project_terminal_runner_result_in_store(
+                lifecycle_store,
                 run_id,
                 &homeboy::core::api_jobs::RunnerJobLogSnapshot {
                     job: job.clone(),
@@ -291,7 +322,8 @@ pub(super) fn exec_with_hydration(
             output.mode,
             runner::RunnerExecMode::DiagnosticSsh | runner::RunnerExecMode::Local
         ) {
-            homeboy_agents::agent_task_lifecycle::finish_runner_exec_direct(
+            homeboy_agents::agent_task_lifecycle::finish_runner_exec_direct_in_store(
+                lifecycle_store,
                 run_id,
                 match output.mode {
                     runner::RunnerExecMode::DiagnosticSsh => "diagnostic_ssh",

--- a/tests/runner_exec_cli_rooting_test.rs
+++ b/tests/runner_exec_cli_rooting_test.rs
@@ -1,0 +1,110 @@
+//! Pins `runner exec` onto a single observation store per invocation.
+//!
+//! ## What went wrong, concretely
+//!
+//! `exec_with_hydration` is the whole of `homeboy runner exec`. Against a
+//! `--run-id` it performed eleven durable writes, in this order:
+//!
+//! ```text
+//! ensure_generic_runner_exec_run          creates the run row
+//! record_runner_exec_artifact_declarations
+//! record_runner_exec_execution_record     (planned)
+//!   ... the command actually runs ...
+//! record_runner_exec_execution_record     (observed)
+//! record_runner_exec_terminal_checkpoint
+//! record_runner_exec_declaration_promotion  x3
+//! record_runner_exec_artifact_refs
+//! project_terminal_runner_result / finish_runner_exec_direct
+//! ```
+//!
+//! Every one of those opened its own ambient `ObservationStore`. The first call
+//! *creates* the row that all ten later calls address. So the run this command
+//! created and the run it finished were the same row only by coincidence of
+//! environment — nothing in the code made them the same installation.
+//!
+//! That coincidence holds right up until something moves `HOME` mid-invocation,
+//! which is exactly what a hermetic test context does: it allocates temp roots
+//! and deliberately leaves `HOME` alone. Under it the creating write and the
+//! finishing write can land in different databases, and the later writes then
+//! silently address a row that does not exist — every one of these helpers
+//! returns `Ok` on a missing run rather than failing.
+//!
+//! ## What this test pins
+//!
+//! One invocation resolves at most one lifecycle store, and every lifecycle
+//! write goes through it.
+//!
+//! ## Why the store is an `Option`
+//!
+//! `PathRoots` resolution is fallible. An invocation without `--run-id` writes
+//! nothing durable, so resolving unconditionally would have made `runner exec`
+//! fail in environments where it previously worked. The store is therefore
+//! resolved only when there is a run to record against, which is also the exact
+//! condition the two write blocks already tested.
+
+use std::path::PathBuf;
+
+fn exec_source() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("crates/homeboy-cli/src/commands/runner/exec.rs");
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
+}
+
+/// Every lifecycle write in `runner exec` names the invocation's own store.
+#[test]
+fn runner_exec_writes_through_the_invocation_store() {
+    let source = exec_source();
+
+    let ambient = source
+        .lines()
+        .filter(|line| line.contains("agent_task_lifecycle::"))
+        .filter(|line| {
+            // A call, not a type path or an import.
+            line.contains('(') && !line.contains("_in_store(")
+        })
+        .filter(|line| !line.contains("AgentTaskLifecycleStore"))
+        .map(str::trim)
+        .collect::<Vec<_>>();
+
+    assert!(
+        ambient.is_empty(),
+        "runner exec performs {} ambient lifecycle write(s): {ambient:#?}\n\n\
+         The first durable write in this command creates the run row that every \
+         later write addresses. An ambient opener here means the row created and \
+         the row finished are the same only by coincidence of environment, and \
+         these helpers return Ok on a missing run rather than failing (#7505). \
+         Use the `_in_store` counterpart with `lifecycle_store`.",
+        ambient.len()
+    );
+}
+
+/// One invocation is one unit of work, so it resolves one store.
+#[test]
+fn runner_exec_resolves_at_most_one_lifecycle_store() {
+    let source = exec_source();
+
+    let resolutions = source
+        .matches("AgentTaskLifecycleStore::from_current_environment")
+        .count();
+    assert_eq!(
+        resolutions, 1,
+        "runner exec resolves {resolutions} lifecycle stores. Resolving per \
+         write is what this change removed; doing it again with an explicit \
+         argument would be the same defect wearing a parameter (#7505)."
+    );
+}
+
+/// The resolution stays gated on there being a run to record against.
+#[test]
+fn runner_exec_resolves_no_store_without_a_run_id() {
+    let source = exec_source();
+
+    assert!(
+        source.contains("let lifecycle_store = validated_run_id"),
+        "runner exec no longer gates lifecycle-store resolution on \
+         `validated_run_id`. `PathRoots` resolution is fallible and an \
+         invocation without `--run-id` writes nothing durable, so resolving \
+         unconditionally makes commands fail that never needed a home (#7505)."
+    );
+}


### PR DESCRIPTION
## The command created a run and finished a different one

`exec_with_hydration` is the whole of `homeboy runner exec`. Against a `--run-id` it performed **eleven durable writes, each opening its own ambient store**:

```
ensure_generic_runner_exec_run            <- creates the run row
record_runner_exec_artifact_declarations
record_runner_exec_execution_record       (planned)
  ... the command actually runs ...
record_runner_exec_execution_record       (observed)
record_runner_exec_terminal_checkpoint
record_runner_exec_declaration_promotion  x3
record_runner_exec_artifact_refs
project_terminal_runner_result / finish_runner_exec_direct
```

**The first call creates the row that the other ten address.** So the run this command created and the run it finished were the same row *only by coincidence of environment* — nothing in the code made them the same installation.

That coincidence holds until something moves `HOME` mid-invocation, which is exactly what a hermetic context does: temp roots, `HOME` deliberately untouched. The creating write and the finishing write then land in different databases — and the later writes **silently address a row that does not exist**, because these helpers return `Ok` on a missing run rather than failing.

That last part is why this never showed up as a crash. It shows up as a run that is missing its promotions, or one that never leaves `running`.

## The fix

One lifecycle store per invocation; every write names it.

Five helpers gain `_in_store` counterparts, opened through `open_observation_maintained` to preserve the startup artifact maintenance the ambient opener performs (the #12618 hazard):

- `ensure_generic_runner_exec_run`
- `record_runner_exec_execution_record`
- `record_runner_exec_artifact_declarations`
- `finish_runner_exec_direct`
- the private `ensure_runner_exec_observation_run` beneath the first

| | before | after |
|---|--:|--:|
| `cli/commands/runner/exec.rs` ambient writes | 11 | **0** |
| `runner_exec.rs` production ambient opens | 11 | **7** |

## One deliberate subtlety

The store is resolved **only when `--run-id` is present**. `PathRoots` resolution is fallible, and an invocation without a run id writes nothing durable — resolving unconditionally would have made `runner exec` fail in environments where it previously worked. That is also the exact condition the two write blocks already tested, so it costs nothing.

I hoisted it unconditionally first, noticed it while checking fallibility, and gated it.

## Verification

- `cargo check --workspace --tests -j2` — green, no warnings
- `tests/runner_exec_cli_rooting_test.rs` pins three properties: no ambient writes, exactly one resolution, resolution stays gated
- **Each assertion verified non-vacuous independently** — reintroduced its specific regression and confirmed that one, and only that one, failed:

| injected regression | test that caught it |
|---|---|
| ambient `record_runner_exec_artifact_refs` | `..._writes_through_the_invocation_store` |
| a second `from_current_environment` | `..._resolves_at_most_one_lifecycle_store` |
| ungated resolution | `..._resolves_no_store_without_a_run_id` |

Refs #7505.