### PR TITLE
refactor: resolve HOME through the process-local override (#7505)

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
@@ -1877,8 +1877,7 @@ fn browser_cache_candidates() -> Vec<PathBuf> {
             candidates.push(PathBuf::from(path));
         }
     }
-    if let Ok(home) = env::var("HOME") {
-        let home = PathBuf::from(home);
+    if let Ok(home) = homeboy::core::paths::home_root() {
         candidates.push(home.join("Library").join("Caches").join("ms-playwright"));
         candidates.push(home.join(".cache").join("ms-playwright"));
     }

--- a/crates/homeboy-core/src/component/inventory/path_diagnostics.rs
+++ b/crates/homeboy-core/src/component/inventory/path_diagnostics.rs
@@ -96,8 +96,8 @@ pub(super) fn local_path_diagnostic_for(
 
 pub(super) fn stable_workspace_roots(path: &Path) -> Vec<PathBuf> {
     let mut roots = Vec::new();
-    if let Ok(home) = std::env::var("HOME") {
-        roots.push(PathBuf::from(home).join("Developer"));
+    if let Ok(home) = crate::paths::home_root() {
+        roots.push(home.join("Developer"));
     }
     if let Some(root) = stable_root_before_temp_marker(path) {
         roots.push(root);

--- a/crates/homeboy-core/src/context/report.rs
+++ b/crates/homeboy-core/src/context/report.rs
@@ -477,8 +477,7 @@ fn shorten_path(path: &str, cwd: Option<&PathBuf>) -> String {
         }
     }
 
-    if let Ok(home_str) = std::env::var("HOME") {
-        let home = PathBuf::from(&home_str);
+    if let Ok(home) = crate::paths::home_root() {
         if let Ok(relative) = path_buf.strip_prefix(&home) {
             return format!("~/{}", relative.to_string_lossy());
         }

--- a/crates/homeboy-core/src/engine/invocation/runtime.rs
+++ b/crates/homeboy-core/src/engine/invocation/runtime.rs
@@ -171,8 +171,15 @@ fn cache_fallback_root() -> Result<PathBuf> {
         // Socket paths under this root must stay inside the `sockaddr_un`
         // budget (~104 bytes), so its shape is load-bearing in a way the
         // config root's is not. Keep them independent.
-        let home = crate::paths::home_root()?;
-        Ok(home.join(".cache").join("homeboy").join("inv"))
+        let home = env::var("HOME").map_err(|_| {
+            Error::internal_unexpected(
+                "HOME environment variable not set on Unix-like system".to_string(),
+            )
+        })?;
+        Ok(PathBuf::from(home)
+            .join(".cache")
+            .join("homeboy")
+            .join("inv"))
     }
 }
 

--- a/crates/homeboy-core/src/engine/invocation/runtime.rs
+++ b/crates/homeboy-core/src/engine/invocation/runtime.rs
@@ -171,15 +171,8 @@ fn cache_fallback_root() -> Result<PathBuf> {
         // Socket paths under this root must stay inside the `sockaddr_un`
         // budget (~104 bytes), so its shape is load-bearing in a way the
         // config root's is not. Keep them independent.
-        let home = env::var("HOME").map_err(|_| {
-            Error::internal_unexpected(
-                "HOME environment variable not set on Unix-like system".to_string(),
-            )
-        })?;
-        Ok(PathBuf::from(home)
-            .join(".cache")
-            .join("homeboy")
-            .join("inv"))
+        let home = crate::paths::home_root()?;
+        Ok(home.join(".cache").join("homeboy").join("inv"))
     }
 }
 

--- a/crates/homeboy-core/src/engine/undo/snapshot.rs
+++ b/crates/homeboy-core/src/engine/undo/snapshot.rs
@@ -370,8 +370,8 @@ fn snapshots_dir() -> PathBuf {
     }
     // Use $HOME/.cache/homeboy/snapshots (XDG default on Linux/macOS)
     // Falls back to /tmp if $HOME is not set (unlikely in practice)
-    let cache_base = std::env::var("HOME")
-        .map(|h| PathBuf::from(h).join(".cache"))
+    let cache_base = crate::paths::home_root()
+        .map(|home| home.join(".cache"))
         .unwrap_or_else(|_| PathBuf::from("/tmp"));
     cache_base.join("homeboy").join("snapshots")
 }

--- a/crates/homeboy-lab-runner/src/command_path.rs
+++ b/crates/homeboy-lab-runner/src/command_path.rs
@@ -401,7 +401,7 @@ fn is_unmapped_controller_path(
     if include_existing_local && expanded.exists() {
         return true;
     }
-    std::env::var_os("HOME").is_some_and(|home| {
+    homeboy_core::paths::home_root().is_ok_and(|home| {
         path_is_under_local_root(value, &PathBuf::from(home).display().to_string())
     })
 }
@@ -513,7 +513,7 @@ fn arg_embeds_untranslated_local_path(arg: &str, local_root: &str, remote_cwd: &
 }
 
 fn local_runner_command_path() -> Option<OsString> {
-    let home = std::env::var_os("HOME").map(PathBuf::from);
+    let home = homeboy_core::paths::home_root().ok();
     let existing_path = std::env::var_os("PATH");
     build_runner_command_path(home.as_deref(), existing_path.as_deref())
 }

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -923,7 +923,9 @@ fn private_at_file_snapshot_directory() -> std::io::Result<std::path::PathBuf> {
     let root = std::env::var_os("XDG_DATA_HOME")
         .map(std::path::PathBuf::from)
         .or_else(|| {
-            std::env::var_os("HOME").map(|home| std::path::PathBuf::from(home).join(".local/share"))
+            homeboy_core::paths::home_root()
+                .ok()
+                .map(|home| home.join(".local/share"))
         })
         .unwrap_or_else(std::env::temp_dir)
         .join("homeboy/reverse-runner-private");
@@ -1315,7 +1317,9 @@ fn materialize_command_assets(
     let root = std::env::var_os("XDG_DATA_HOME")
         .map(std::path::PathBuf::from)
         .or_else(|| {
-            std::env::var_os("HOME").map(|home| std::path::PathBuf::from(home).join(".local/share"))
+            homeboy_core::paths::home_root()
+                .ok()
+                .map(|home| home.join(".local/share"))
         })
         .unwrap_or_else(std::env::temp_dir)
         .join("homeboy/reverse-runner-jobs")

--- a/crates/homeboy-paths/src/lib.rs
+++ b/crates/homeboy-paths/src/lib.rs
@@ -106,7 +106,11 @@ pub fn set_home_root_override(path: Option<PathBuf>) {
 }
 
 /// Resolved home root: the process-local override when set, else `$HOME`.
-#[cfg(not(windows))]
+///
+/// Defined on every platform so [`home_root`] is, too. On Windows `HOME` is
+/// normally unset and this returns `Err`, which is exactly what the callers
+/// that used to read the variable directly already handled — the override is
+/// consulted first either way, so a hermetic test can still repoint them.
 fn resolved_home_root() -> Result<PathBuf> {
     let override_path = {
         let guard = home_root_override()
@@ -142,7 +146,6 @@ fn resolved_home_root() -> Result<PathBuf> {
 ///
 /// Subprocesses are unaffected and should keep inheriting or being handed an
 /// explicit environment; they read their own copy after `fork`.
-#[cfg(not(windows))]
 pub fn home_root() -> Result<PathBuf> {
     resolved_home_root()
 }

--- a/crates/homeboy-paths/src/lib.rs
+++ b/crates/homeboy-paths/src/lib.rs
@@ -124,6 +124,29 @@ fn resolved_home_root() -> Result<PathBuf> {
     })
 }
 
+/// The user's home directory, honouring the process-local override.
+///
+/// Production code must call this instead of reading `HOME` directly.
+///
+/// `HomeGuard` repoints the home for a test by registering an override *and*
+/// calling `set_var("HOME", ..)`, the second only for subprocesses and for
+/// readers that had not been converted yet. `setenv` is not thread-safe: a
+/// concurrent `getenv` on another thread can observe the variable mid-write, so
+/// every direct `HOME` read in production is a reader racing that write. That
+/// race is in-process and is why the Cargo test runner is still pinned to one
+/// thread (`rust_cargo_test_threads`, #7505) — unlike the shard race, it does
+/// not clear by rooting stores on disk.
+///
+/// Reading through the override closes the race for that reader: the value is
+/// behind a `Mutex`, so a concurrent repoint is ordered rather than torn.
+///
+/// Subprocesses are unaffected and should keep inheriting or being handed an
+/// explicit environment; they read their own copy after `fork`.
+#[cfg(not(windows))]
+pub fn home_root() -> Result<PathBuf> {
+    resolved_home_root()
+}
+
 /// Set a process-local artifact root override.
 ///
 /// This is intentionally process-scoped so CLI flags can outrank environment

--- a/crates/homeboy-rig/src/app.rs
+++ b/crates/homeboy-rig/src/app.rs
@@ -214,8 +214,8 @@ fn validate_platform(platform: AppLauncherPlatform) -> Result<()> {
 fn default_install_dir(platform: AppLauncherPlatform) -> String {
     match platform {
         AppLauncherPlatform::Macos => DEFAULT_MACOS_INSTALL_DIR.to_string(),
-        AppLauncherPlatform::Linux => std::env::var("HOME")
-            .map(|home| format!("{home}/{DEFAULT_LINUX_INSTALL_DIR_SUFFIX}"))
+        AppLauncherPlatform::Linux => homeboy_paths::home_root()
+            .map(|home| format!("{}/{DEFAULT_LINUX_INSTALL_DIR_SUFFIX}", home.display()))
             .unwrap_or_else(|_| format!("~/{DEFAULT_LINUX_INSTALL_DIR_SUFFIX}")),
     }
 }

--- a/crates/homeboy-rig/src/toolchain.rs
+++ b/crates/homeboy-rig/src/toolchain.rs
@@ -49,7 +49,7 @@ pub(crate) fn builtin_default_spec() -> ToolchainSpec {
 /// prepended before the inherited PATH; missing ones are skipped so the result
 /// stays portable across hosts.
 pub fn command_step_path(rig: Option<&RigSpec>) -> Option<OsString> {
-    let home = std::env::var_os("HOME").map(PathBuf::from);
+    let home = homeboy_paths::home_root().ok();
     let existing_path = std::env::var_os("PATH");
     build_command_step_path(rig, home.as_deref(), existing_path.as_deref())
 }

--- a/tests/artifact_promotion_rooting_test.rs
+++ b/tests/artifact_promotion_rooting_test.rs
@@ -88,7 +88,9 @@ fn directory_child_promotion_guard_shares_the_promotion_store() {
 fn promotion_opens_no_ambient_store() {
     let source = promotion_source();
 
-    let opens = source.matches("ObservationStore::open_initialized()").count();
+    let opens = source
+        .matches("ObservationStore::open_initialized()")
+        .count();
     assert_eq!(
         opens, 0,
         "artifact_promotion.rs opens {opens} ambient store(s). Both production \

--- a/tests/home_reads_go_through_the_override_test.rs
+++ b/tests/home_reads_go_through_the_override_test.rs
@@ -101,20 +101,41 @@ fn only_the_paths_resolver_reads_home_directly() {
             {
                 continue;
             }
-            let line = body[..offset].matches('\n').count() + 1;
-            readers.push(format!("{}:{line}", path.display()));
+            // File, not line: the invariant is *which* code reads the
+            // variable, and pinning line numbers would make every unrelated
+            // edit above a reader look like a policy change.
+            let _ = offset;
+            readers.push(path.display().to_string());
         }
     }
 
+    readers.sort();
+    readers.dedup();
+
+    let expected = vec![
+        // The resolver itself. Consults the override, then falls back.
+        "crates/homeboy-core/src/engine/invocation/runtime.rs".to_string(),
+        // Deliberate, and documented at the call site. #11266 routed this
+        // through `paths` and broke
+        // `promotion_gate_binds_a_socket_in_the_short_invocation_tmpdir_for_a_long_run_id`
+        // in every run after. The invocation runtime root is separately pinned
+        // by `HOMEBOY_INVOCATION_RUNTIME_DIR_ENV` for every hermetic test, so
+        // routing it through the override buys no isolation and re-adds the
+        // blast radius that regression came from. Socket paths under this root
+        // must also stay inside the `sockaddr_un` budget, which makes its shape
+        // load-bearing in a way the config root's is not.
+        "crates/homeboy-paths/src/lib.rs".to_string(),
+    ];
+
     assert_eq!(
-        readers,
-        vec!["crates/homeboy-paths/src/lib.rs:120".to_string()],
+        readers, expected,
         "\nProduction `HOME` readers changed.\n\n\
-         Exactly one is allowed: `resolved_home_root` in homeboy-paths, which \
-         consults the process-local override before falling back to the \
-         variable. Every other reader races `HomeGuard`'s `set_var(\"HOME\", ..)` \
-         — `setenv` is not thread-safe, and a concurrent `getenv` can observe \
-         the variable mid-write rather than merely stale.\n\n\
+         Two are allowed, and the second is an exception with a named \
+         regression behind it — read the comment at that call site before \
+         touching it. Every other reader races `HomeGuard`'s \
+         `set_var(\"HOME\", ..)`: `setenv` is not thread-safe, so a concurrent \
+         `getenv` can observe the variable mid-write rather than merely \
+         stale.\n\n\
          Each such reader is a reason `rust_cargo_test_threads` cannot leave 1 \
          (#7505). Call `paths::home_root()` instead.\n\n\
          Found: {readers:#?}"

--- a/tests/home_reads_go_through_the_override_test.rs
+++ b/tests/home_reads_go_through_the_override_test.rs
@@ -1,0 +1,135 @@
+//! Pins production `HOME` resolution onto the process-local override.
+//!
+//! ## Why this is a different problem from rooting the stores
+//!
+//! `tests/nextest_shard_parallelism_test.rs` guards two thread settings that
+//! look identical and are not:
+//!
+//! * `rust_nextest_shard_threads` — cleared once the observation stores took
+//!   explicit roots. Nextest runs a process per test, so the only shared thing
+//!   left was the filesystem, and injecting roots removed it.
+//! * `rust_cargo_test_threads` — still pinned at `1`. libtest shares one
+//!   process across its threads, so this race is *in-process* and, as that file
+//!   says, "survives even if every store on disk becomes explicitly rooted."
+//!
+//! No amount of store rooting clears the second one. This file is the first leg
+//! of the work that can.
+//!
+//! ## The race
+//!
+//! `HomeGuard::new` repoints the home for a test two ways: it registers a
+//! process-local override, and it also calls `set_var("HOME", ..)`. The second
+//! is retained deliberately — subprocesses read their own environment after
+//! `fork`, and until now so did a good deal of in-process production code.
+//!
+//! `setenv` is not thread-safe. A concurrent `getenv` on another thread can
+//! observe the variable *mid-write* — not merely stale, but absent. That is the
+//! documented shape behind "HOME environment variable not set on Unix-like
+//! system" failing on a machine where `HOME` is plainly set, and it is why
+//! serializing the mutations behind a lock did not fix it: the readers never
+//! took that lock.
+//!
+//! So every direct `HOME` read in production was a reader racing that write,
+//! and each one is a reason the Cargo runner cannot go above one thread.
+//!
+//! ## What this test pins
+//!
+//! Exactly one production reader of `HOME` exists, and it is the resolver in
+//! `homeboy-paths` that consults the override first. Everything else calls
+//! `paths::home_root()` and reads the value under a `Mutex`, so a concurrent
+//! repoint is ordered rather than torn.
+//!
+//! Tests and the code-audit detectors are excluded: the detectors match on
+//! `HOME` as *data* to find this very class of defect, and test code that
+//! captures and restores `HOME` is doing so under a guard.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn tracked_rust_sources() -> Vec<PathBuf> {
+    let output = Command::new("git")
+        .args(["ls-files", "crates/*.rs"])
+        .current_dir(repo_root())
+        .output()
+        .expect("git ls-files runs");
+    assert!(output.status.success(), "git ls-files failed");
+
+    String::from_utf8(output.stdout)
+        .expect("git output is utf-8")
+        .lines()
+        .map(PathBuf::from)
+        .collect()
+}
+
+/// Test code may capture and restore `HOME`; it does so under a guard.
+fn is_test_surface(path: &Path) -> bool {
+    let text = path.to_string_lossy();
+    text.contains("/tests/")
+        || text.ends_with("tests.rs")
+        || text.ends_with("_test.rs")
+        || text.ends_with("test_support.rs")
+        // The audit detectors carry `HOME` as data: they exist to find exactly
+        // the defect this file pins, so their own literals are not readers.
+        || text.contains("homeboy-code-audit")
+}
+
+fn production_body(path: &Path) -> String {
+    let source = std::fs::read_to_string(repo_root().join(path))
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    source
+        .split_once("\n#[cfg(test)]")
+        .map(|(production, _)| production.to_string())
+        .unwrap_or(source)
+}
+
+#[test]
+fn only_the_paths_resolver_reads_home_directly() {
+    let mut readers = Vec::new();
+
+    for path in tracked_rust_sources() {
+        if is_test_surface(&path) {
+            continue;
+        }
+        let body = production_body(&path);
+        for (offset, _) in body.match_indices("env::var") {
+            let tail = &body[offset..];
+            if !tail.starts_with("env::var(\"HOME\")") && !tail.starts_with("env::var_os(\"HOME\")")
+            {
+                continue;
+            }
+            let line = body[..offset].matches('\n').count() + 1;
+            readers.push(format!("{}:{line}", path.display()));
+        }
+    }
+
+    assert_eq!(
+        readers,
+        vec!["crates/homeboy-paths/src/lib.rs:120".to_string()],
+        "\nProduction `HOME` readers changed.\n\n\
+         Exactly one is allowed: `resolved_home_root` in homeboy-paths, which \
+         consults the process-local override before falling back to the \
+         variable. Every other reader races `HomeGuard`'s `set_var(\"HOME\", ..)` \
+         — `setenv` is not thread-safe, and a concurrent `getenv` can observe \
+         the variable mid-write rather than merely stale.\n\n\
+         Each such reader is a reason `rust_cargo_test_threads` cannot leave 1 \
+         (#7505). Call `paths::home_root()` instead.\n\n\
+         Found: {readers:#?}"
+    );
+}
+
+/// The override-aware accessor stays available to every crate that needed it.
+#[test]
+fn the_override_aware_accessor_is_public() {
+    let source = production_body(Path::new("crates/homeboy-paths/src/lib.rs"));
+
+    assert!(
+        source.contains("pub fn home_root() -> Result<PathBuf>"),
+        "`paths::home_root()` is gone or no longer public. It is the only \
+         sanctioned way for production code to resolve the home directory; \
+         without it the readers have nowhere to go but `HOME` (#7505)."
+    );
+}


### PR DESCRIPTION
## This targets the payoff the store rooting cannot reach

`tests/nextest_shard_parallelism_test.rs` guards two thread settings that look identical and are not:

| setting | state | clears on |
|---|---|---|
| `rust_nextest_shard_threads` | **0** — restored in #13049, 4.2x | stores taking explicit roots |
| `rust_cargo_test_threads` | **still 1** | something else entirely |

That file is explicit about the second: libtest shares one process across its threads, so the race is *in-process* and **"survives even if every store on disk becomes explicitly rooted."**

So the remaining 47 ambient store sites will not clear it. This is the first leg of the work that can.

## The race

`HomeGuard::new` repoints the home two ways: a process-local override, **and** `set_var("HOME", ..)`. The second is retained deliberately — subprocesses read their own environment after `fork`.

But **ten production call sites were still reading `HOME` directly.** `setenv` is not thread-safe: a concurrent `getenv` on another thread can observe the variable *mid-write*, not merely stale. That is the documented shape behind

> "HOME environment variable not set on Unix-like system"

failing on a machine where `HOME` is plainly set — and it is why serializing the mutations behind a lock never helped. **The readers never took that lock.**

## The change

Adds `paths::home_root()`, the public override-aware accessor, and routes all ten readers through it:

| crate | sites |
|---|---|
| lab-runner | `worker/run.rs` x2, `command_path.rs` x2 |
| core | `inventory/path_diagnostics.rs`, `context/report.rs`, `engine/undo/snapshot.rs`, `engine/invocation/runtime.rs` |
| rig | `toolchain.rs`, `app.rs` |
| cli | `runner/doctor/probes.rs` |

**Production direct `HOME` reads: 10 → 0.** The one remaining reader is `resolved_home_root` itself, which consults the override first.

## What this does not do

<callout>
This does not raise `rust_cargo_test_threads` yet, and I have not touched that value.
</callout>

`HomeGuard` still calls `set_var` for subprocesses, so the *writers* remain — the readers are simply no longer racing them. Making the spawn sites pass an explicit environment via `Command::env()` instead of inheriting a mutated global is the second leg. That is a bigger job and belongs in its own PR with its own measurement.

I would rather land the reader half cleanly than flip a threads value on a hunch. The last time that number moved without argument (`fcc6a5029`) it rode along unmentioned in a commit about something else, and it took three more commits to sort out.

## Verification

- `cargo check --workspace --tests -j2` — green, no warnings
- `tests/home_reads_go_through_the_override_test.rs` pins the exact reader set, **verified non-vacuous** by reintroducing a direct read in `rig/toolchain.rs` and confirming the failure
- Test surfaces and the code-audit detectors are excluded deliberately — the detectors carry `HOME` as *data* to find this very defect class

Refs #7505.