### PR TITLE
fix(cook): preserve provider repository identity

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -5577,7 +5577,7 @@ fn persistent_slow_provider_with_known_path_returns_exhausted_cwd_recovery() {
 
 #[cfg(unix)]
 #[test]
-fn pinned_missing_provider_ensures_an_unattached_branch_after_durable_admission() {
+fn pinned_missing_provider_ensures_canonical_repository_for_a_component_after_durable_admission() {
     use std::os::unix::fs::PermissionsExt;
 
     homeboy_core::test_support::with_isolated_home(|_| {
@@ -5630,13 +5630,25 @@ fn pinned_missing_provider_ensures_an_unattached_branch_after_durable_admission(
                 .expect("git runs")
                 .success());
         }
+        assert!(Command::new("git")
+            .args([
+                "-C",
+                source.to_str().expect("source path"),
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/example/blocks-engine.git",
+            ])
+            .status()
+            .expect("add canonical repository remote")
+            .success());
         let provider_dir = tempfile::tempdir().expect("provider directory");
         let created = provider_dir.path().join("created");
         let provider = provider_dir.path().join("provider");
         std::fs::write(
             &provider,
             format!(
-                "#!/bin/sh\ncase \"$1\" in\nresolve)\n  if test -f '{}'; then printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"fixture@durable-ensure\",\"path\":\"{}\",\"branch\":\"durable-ensure\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'; else printf '%s\\n' '{{\"worktrees\":[]}}' ; fi\n  ;;\nensure)\n  test \"$2\" = fixture && test \"$3\" = main && test \"$4\" = durable-ensure && test \"$5\" = https://example.test/issues/12601 && test \"$6\" = agent_task_cook && test \"$7\" = durable-ensure-run && test \"$8\" = remove_on_success || exit 9\n  git -C '{}' worktree add --quiet '{}' durable-ensure && touch '{}'\n  ;;\nesac\n",
+                "#!/bin/sh\ncase \"$1\" in\nresolve)\n  if test -f '{}'; then printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"fixture@durable-ensure\",\"path\":\"{}\",\"branch\":\"durable-ensure\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'; else printf '%s\\n' '{{\"worktrees\":[]}}' ; fi\n  ;;\nensure)\n  test \"$2\" = blocks-engine && test \"$3\" = main && test \"$4\" = durable-ensure && test \"$5\" = https://example.test/issues/12601 && test \"$6\" = agent_task_cook && test \"$7\" = durable-ensure-run && test \"$8\" = remove_on_success || exit 9\n  git -C '{}' worktree add --quiet '{}' durable-ensure && touch '{}'\n  ;;\nesac\n",
                 created.display(),
                 workspace.display(),
                 source.display(),
@@ -5708,7 +5720,7 @@ fn pinned_missing_provider_ensures_an_unattached_branch_after_durable_admission(
             "handle": options.to_worktree,
             "worktree_provider_id": "fixture",
             "provision_intent": {
-                "repo": "fixture",
+                "repo": "blocks-engine",
                 "base": "main",
                 "head": "durable-ensure",
                 "task_url": "https://example.test/issues/12601",
@@ -5717,6 +5729,10 @@ fn pinned_missing_provider_ensures_an_unattached_branch_after_durable_admission(
                 "purpose": "agent_task_cook",
                 "cleanup_policy": "remove_on_success",
             },
+        });
+        options.initial_plan.metadata["cook_repository_identity"] = serde_json::json!({
+            "component_id": "php-transformer",
+            "repository_name": "blocks-engine",
         });
 
         recipe_store

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -290,7 +290,8 @@ pub(crate) fn preview_cook(
                 "schema": "homeboy/agent-task-cook-preview/v1",
                 "mutates": false,
                 "resolved": {
-                    "repository": args.dispatch.repo,
+                    "repository": cook_provision_repository(&args),
+                    "component": args.dispatch.repo,
                     "repository_identity": args.repository_identity,
                     "worktree": args.to_worktree,
                     "base": args.base,
@@ -385,7 +386,8 @@ pub(crate) fn preview_cook(
             "schema": "homeboy/agent-task-cook-preview/v1",
             "mutates": false,
             "resolved": {
-                "repository": args.dispatch.repo,
+                "repository": cook_provision_repository(&args),
+                "component": args.dispatch.repo,
                 "repository_identity": args.repository_identity,
                 "worktree": args.to_worktree,
                 "base": args.base,
@@ -977,7 +979,7 @@ mod preview_tests {
             std::fs::write(
                 &provider,
                 format!(
-                    "#!/bin/sh\ncase \"$1\" in\nresolve) printf '%s\\n' '{{\"worktrees\":[]}}' ;;\nplan) printf '%s\\n' \"{{\\\"worktrees\\\":[{{\\\"handle\\\":\\\"$2\\\",\\\"path\\\":\\\"/provider/planned/$2\\\",\\\"branch\\\":\\\"$5\\\",\\\"safety\\\":{{\\\"dirty\\\":false,\\\"unpushed\\\":false,\\\"primary\\\":false}}}}]}}\" ;;\nensure) touch '{}' ;;\nesac\n",
+                    "#!/bin/sh\ncase \"$1\" in\nresolve) printf '%s\\n' '{{\"worktrees\":[]}}' ;;\nplan) test \"$3\" = blocks-engine || exit 9; printf '%s\\n' \"{{\\\"worktrees\\\":[{{\\\"handle\\\":\\\"$2\\\",\\\"path\\\":\\\"/provider/planned/$2\\\",\\\"branch\\\":\\\"$5\\\",\\\"safety\\\":{{\\\"dirty\\\":false,\\\"unpushed\\\":false,\\\"primary\\\":false}}}}]}}\" ;;\nensure) touch '{}' ;;\nesac\n",
                     marker.display(),
                 ),
             )
@@ -1031,6 +1033,16 @@ mod preview_tests {
                 },
             );
             homeboy::core::defaults::save_config(&config).expect("save provider config");
+            homeboy::core::component::write_standalone_component_config(
+                &homeboy::core::component::Component {
+                    id: "php-transformer".to_string(),
+                    aliases: vec!["blocks-engine".to_string()],
+                    local_path: temp.path().display().to_string(),
+                    remote_url: Some("https://github.com/example/blocks-engine.git".to_string()),
+                    ..Default::default()
+                },
+            )
+            .expect("register monorepo component");
             let before = std::fs::read_dir(home).expect("read isolated home").count();
 
             let (preview, exit_code) = preview_cook(
@@ -1044,9 +1056,9 @@ mod preview_tests {
                     "--prompt",
                     "implement the issue",
                     "--repo",
-                    "fixture",
+                    "blocks-engine",
                     "--task-url",
-                    "https://example.test/owner/repo/issues/12890",
+                    "https://example.test/owner/blocks-engine/issues/12890",
                     "--no-finalize",
                 ]),
                 None,
@@ -1056,18 +1068,24 @@ mod preview_tests {
             assert_eq!(exit_code, 0);
             assert_eq!(preview["resolved"]["workspace"]["action"], "planned_create");
             assert_eq!(preview["resolved"]["workspace"]["provider_id"], "fixture");
+            assert_eq!(preview["resolved"]["repository"], "blocks-engine");
+            assert_eq!(preview["resolved"]["component"], "php-transformer");
+            assert_eq!(
+                preview["resolved"]["workspace"]["intent"]["repo"],
+                "blocks-engine"
+            );
             assert_eq!(
                 preview["resolved"]["workspace"]["branch"],
-                "fix/issue-12890-repo"
+                "fix/issue-12890-blocks-engine"
             );
             assert_eq!(
                 preview["resolved"]["workspace"]["path"],
-                "/provider/planned/fixture@fix-issue-12890-repo"
+                "/provider/planned/php-transformer@fix-issue-12890-blocks-engine"
             );
             assert_eq!(preview["resolved"]["workspace"]["intent"]["base"], "main");
             assert_eq!(
                 preview["resolved"]["workspace"]["intent"]["head"],
-                "fix/issue-12890-repo"
+                "fix/issue-12890-blocks-engine"
             );
             assert!(!marker.exists(), "preview must not invoke ensure");
             assert_eq!(
@@ -2541,7 +2559,7 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
             "kind": "provider",
             "handle": to_worktree,
             "provision_intent": {
-                "repo": args.dispatch.repo,
+                "repo": cook_provision_repository(args),
                 "base": args.base,
                 "head": args.head,
                 "task_url": args.dispatch.task_url,
@@ -2638,7 +2656,7 @@ fn cook_workspace_create_intent(
                 "--to-worktree is required to create a missing Cook destination".to_string(),
             ])
         })?,
-        repo: args.dispatch.repo.clone().ok_or_else(|| {
+        repo: cook_provision_repository(args).ok_or_else(|| {
             homeboy::core::Error::validation_missing_argument(vec![
                 "--repo <repo> is required to create a missing --to-worktree destination"
                     .to_string(),
@@ -2661,6 +2679,18 @@ fn cook_workspace_create_intent(
             ])
         })?,
     })
+}
+
+/// Worktree providers operate on repository primaries, while Cook executes the
+/// selected component within the resulting checkout.
+fn cook_provision_repository(args: &AgentTaskCookArgs) -> Option<String> {
+    args.repository_identity
+        .as_ref()
+        .and_then(|identity| identity.get("repository_name"))
+        .and_then(Value::as_str)
+        .filter(|repository| !repository.trim().is_empty())
+        .map(str::to_string)
+        .or_else(|| args.dispatch.repo.clone())
 }
 
 fn cook_workspace_plan_identity(intent: &WorktreeProviderCreateIntent) -> Value {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -338,7 +338,7 @@ fn repo_only_cook_without_registered_component_persists_requested_repository_exp
 }
 
 #[test]
-fn cook_normalizes_repository_alias_to_component_identity_for_every_destination_form() {
+fn cook_preserves_repository_and_component_identity_for_every_destination_form() {
     with_isolated_home(|_| {
         let checkout = tempfile::tempdir().expect("repository checkout");
         init_runtime_component_checkout(checkout.path());
@@ -420,6 +420,34 @@ fn cook_normalizes_repository_alias_to_component_identity_for_every_destination_
         assert_eq!(
             plan.metadata["cook_repository_identity"]["component_id"],
             "php-transformer"
+        );
+
+        let mut config = homeboy::core::defaults::HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            homeboy::core::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: homeboy::core::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: homeboy::core::defaults::WorktreeProviderCommands {
+                    ensure: Some(vec!["worktree-provider".to_string(), "{repo}".to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: None,
+            },
+        );
+        homeboy::core::defaults::save_config(&config).expect("save provider config");
+        let mut provider_args = issue.clone();
+        provider_args.base = Some("main".to_string());
+        let provision = super::super::run::provision_cook_destination(&provider_args)
+            .expect("defer provider provisioning until Cook admission");
+        assert_eq!(provision["provision_intent"]["repo"], "blocks-engine");
+        assert_eq!(
+            provider_args.dispatch.repo.as_deref(),
+            Some("php-transformer")
         );
 
         let component_id = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![


### PR DESCRIPTION
## Summary

- keep configured component identity separate from canonical repository identity during Cook provisioning
- pass the canonical repository name to worktree-provider plan and ensure operations
- expose repository, component, and worktree identities independently in preview evidence
- cover a monorepo component whose slug differs from its DMC repository

Fixes #13073.

## Verification

- `cargo fmt -p homeboy-cli -p homeboy-agents --check`
- `cargo test -p homeboy-cli cook_preserves_repository_and_component_identity_for_every_destination_form --lib`
- `cargo test -p homeboy-cli preview_plans_an_absent_issue_workspace_without_ensuring_it --lib`
- `cargo test -p homeboy-agents pinned_missing_provider_ensures_canonical_repository_for_a_component_after_durable_admission --lib`
- `cargo check -p homeboy-cli -p homeboy-agents`
- `git diff --check origin/main...HEAD`

Workspace-wide `cargo fmt --check` currently fails on an unrelated pre-existing formatting difference in `tests/artifact_promotion_rooting_test.rs`; package-scoped formatting for touched crates passes.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the provisioning failure, implemented the identity separation and regression coverage, reviewed the diff, and ran verification. Chris Huber is responsible for every line.