### PR TITLE
fix(cook): preserve zero-execution retry budget

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4084,9 +4084,7 @@ fn run_cook_reported(
                     )?;
                     record = lifecycle_store.read_record(&failure_options.initial_run_id)?;
                 }
-                if error.retryable != Some(true)
-                    && record.metadata.get("pre_execution_failure").is_some()
-                {
+                if record.metadata.get("pre_execution_failure").is_some() {
                     return Ok(pre_execution_failure_report(
                         failure_options.cook_id.clone(),
                         vec![AgentTaskCookAttemptReport {
@@ -6553,7 +6551,7 @@ fn preflight_cook_workspace_base_ancestry(target: &Path, base: &str) -> Result<(
         "candidate_only_commits": ahead,
         "next_action": "converge_destination_before_provider",
     });
-    Err(error)
+    Err(error.with_retryable(true))
 }
 
 /// Admit a locally committed, unpushed provider checkout only when Cook can

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -4288,10 +4288,9 @@ pub fn cook_failure_context(
         &chronological_latest_run_id,
         recovery_legal,
         blocking_claim.is_some(),
-        provider_executions_consumed
-            < recipe.retry_budget["max_attempts"]
-                .as_u64()
-                .unwrap_or_default(),
+        record
+            .as_ref()
+            .is_some_and(|record| super::retry_admission(&record.run_id).is_ok()),
         exact_checkpoint_candidate_mismatch(&diagnostic),
         ambiguous_promotion_artifact_ids(record_run_id, promotion_diagnostic.as_ref(), &recipe),
         record.as_ref().and_then(lab_handoff_runtime_recovery),
@@ -4421,7 +4420,7 @@ fn cook_recovery_actions(
     run_id: &str,
     recovery_legal: bool,
     blocking_claim: bool,
-    provider_retry_available: bool,
+    retry_admitted: bool,
     exact_checkpoint_candidate_mismatch: bool,
     ambiguous_artifact_ids: Vec<String>,
     lab_runtime_recovery: Option<agent_task_lifecycle::AgentTaskLabRuntimeRecovery>,
@@ -4440,8 +4439,9 @@ fn cook_recovery_actions(
         | "green_no_finalize"
         | "intentional_no_change"
         | "execution_budget_exhausted"
-        | "retries_exhausted" => false,
-        "gate_failed" | "no_op_gate_failed" => provider_retry_available,
+        | "retries_exhausted"
+        | "pre_execution_failure" => false,
+        "gate_failed" | "no_op_gate_failed" => retry_admitted,
         _ => true,
     };
     let mut actions = vec![
@@ -4460,7 +4460,7 @@ fn cook_recovery_actions(
             command: super::cook_recovery_command(run_id, &["reconcile", run_id, "--dry-run"]),
         });
     }
-    if exact_checkpoint_candidate_mismatch {
+    if exact_checkpoint_candidate_mismatch && retry_admitted {
         // The checkpoint authenticates one exact destination candidate. A
         // replacement run preserves that immutable evidence without claiming it
         // can safely continue against a diverged worktree.
@@ -4484,6 +4484,11 @@ fn cook_recovery_actions(
                 ),
             }
         }));
+    } else if status == "pre_execution_failure" && retry_admitted {
+        actions.push(super::AgentTaskCookRecoveryAction {
+            action: "retry".to_string(),
+            command: super::cook_recovery_command(run_id, &["retry", run_id, "--run"]),
+        });
     } else if continuation_eligible {
         actions.push(super::AgentTaskCookRecoveryAction {
             action: "resume".to_string(),
@@ -4537,6 +4542,12 @@ mod recovery_action_tests {
                 vec!["status", "diagnose"],
             ),
             (
+                "pre_execution_failure",
+                true,
+                false,
+                vec!["status", "diagnose", "retry"],
+            ),
+            (
                 "verification_pending",
                 false,
                 false,
@@ -4578,7 +4589,10 @@ mod recovery_action_tests {
             );
             assert!(recovery.legal_actions.iter().all(|action| {
                 action.command.starts_with("homeboy agent-task ")
-                    && action.command.ends_with("cook-state-matrix-attempt-1")
+                    && (action.command.ends_with("cook-state-matrix-attempt-1")
+                        || action
+                            .command
+                            .ends_with("cook-state-matrix-attempt-1 --run"))
                     || action.command
                         == "homeboy agent-task status cook-state-matrix-attempt-1 --full"
             }));

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -1029,6 +1029,14 @@ pub fn record_recipe_attempt(
     default_store()?.record_recipe_attempt(cook_id, attempt, run_id, plan)
 }
 
+pub fn record_recipe_attempt_replacement(
+    cook_id: &str,
+    replaced_run_id: &str,
+    replacement_run_id: &str,
+) -> Result<AgentTaskCookRecipe> {
+    default_store()?.record_recipe_attempt_replacement(cook_id, replaced_run_id, replacement_run_id)
+}
+
 pub fn record_recipe_attempt_in_store(
     store: &CookRecipeStore,
     cook_id: &str,

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3914,6 +3914,7 @@ fn workspace_base_ancestry_preflight_rejects_behind_and_diverged_without_attribu
 
         let behind = preflight_cook_workspace_base_ancestry(&destination, "main")
             .expect_err("strictly behind destination is rejected before provider execution");
+        assert_eq!(behind.retryable, Some(true));
         assert_eq!(
             behind.details["workspace_base_ancestry"]["direction"],
             "behind"
@@ -3940,9 +3941,11 @@ fn workspace_base_ancestry_preflight_rejects_behind_and_diverged_without_attribu
         );
         options.to_worktree = destination.display().to_string();
         options.source_worktree_path = Some(destination.clone());
+        options.initial_plan.tasks[0].workspace.root = Some(destination.display().to_string());
         options.initial_plan.tasks[0].metadata = serde_json::json!({
             "worktree_provision": { "kind": "explicit_cwd" }
         });
+        options.attempt_dispatcher = None;
         let report = run_cook(CookContext::new(options.clone(), Arc::new(UnusedExecutor)))
             .expect("stale destination is a durable pre-execution failure");
         assert_eq!(report.value.status, "pre_execution_failure");
@@ -3957,7 +3960,30 @@ fn workspace_base_ancestry_preflight_rejects_behind_and_diverged_without_attribu
             .as_str()
             .expect("stale-base diagnostic")
             .contains("Cook destination is behind"));
+        assert_eq!(record.metadata["pre_execution_failure"]["retryable"], true);
         assert_eq!(record.metadata["provider_executions_consumed"], 0);
+        crate::agent_task_service::retry_admission(&options.initial_run_id)
+            .expect("stale-base retry admission");
+        let failure_context = report
+            .value
+            .failure_context
+            .as_ref()
+            .expect("stale-base recovery context");
+        assert!(
+            failure_context.next_actions.iter().any(|action| {
+                action.command
+                    == format!("homeboy agent-task retry {} --run", options.initial_run_id)
+            }),
+            "{failure_context:#?}"
+        );
+        assert!(report
+            .value
+            .failure_context
+            .as_ref()
+            .expect("stale-base recovery context")
+            .next_actions
+            .iter()
+            .all(|action| !action.command.contains("cook-continue")));
 
         git(
             &destination,
@@ -3970,6 +3996,27 @@ fn workspace_base_ancestry_preflight_rejects_behind_and_diverged_without_attribu
         git(&destination, &["merge", "--ff-only", "origin/main"]);
         preflight_cook_workspace_base_ancestry(&destination, "main")
             .expect("clean intentional no-change destination is equivalent to its resolved base");
+        let retry = crate::agent_task_service::retry(&options.initial_run_id, None, false, false)
+            .expect("converged zero-execution stale-base failure reuses its Cook attempt");
+        assert_eq!(retry.record.metadata["cook_id"], options.cook_id);
+        assert_eq!(retry.record.metadata["cook_attempt"], 1);
+        let provider_starts = Arc::new(AtomicUsize::new(0));
+        options.initial_run_id = retry.record.run_id;
+        options.initial_plan = agent_task_lifecycle::load_controller_plan(&options.initial_run_id)
+            .expect("load the retry's persisted Cook plan");
+        let continued = run_cook(CookContext::new(
+            options.clone(),
+            Arc::new(RecordingImmediateSuccessExecutor {
+                starts: Arc::clone(&provider_starts),
+            }),
+        ))
+        .expect("retried stale-base Cook reaches its provider");
+        assert_eq!(continued.value.cook_id, "cook-stale-origin-base");
+        assert_eq!(provider_starts.load(Ordering::SeqCst), 1, "{continued:#?}");
+        let retried_record = agent_task_lifecycle::status(&options.initial_run_id)
+            .expect("provider execution is durable on the replacement run");
+        assert_eq!(retried_record.metadata["provider_executions_consumed"], 1);
+
         std::fs::write(destination.join("candidate.txt"), "candidate only\n").unwrap();
         git(&destination, &["add", "candidate.txt"]);
         git(&destination, &["commit", "-m", "candidate"]);
@@ -7060,31 +7107,92 @@ fn retryable_pre_provider_retry_rejects_a_lifecycle_reservation_collision_withou
 }
 
 #[test]
-fn retryable_pre_provider_retry_enforces_the_persisted_attempt_budget() {
+fn retryable_zero_execution_pre_provider_failure_reuses_the_semantic_attempt_budget() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let options = retryable_pre_provider_cook("cook-retry-budget", 1);
 
-        let error = crate::agent_task_service::retry(&options.initial_run_id, None, false, false)
-            .expect_err("retry cannot exceed the persisted Cook budget");
+        let retry = crate::agent_task_service::retry(&options.initial_run_id, None, false, false)
+            .expect("zero-execution retry replaces the semantic Cook attempt");
 
-        assert_eq!(
-            error.details["field"],
-            "cook_recipe.retry_budget.max_attempts"
-        );
+        assert_eq!(retry.record.metadata["cook_attempt"], 1);
+        assert_eq!(retry.record.metadata["retry_of"], options.initial_run_id);
         assert_eq!(
             super::super::load_recipe(&options.cook_id)
-                .expect("recipe remains intact")
+                .expect("replacement is recorded")
                 .attempts
                 .len(),
-            1
+            2
         );
         assert_eq!(
             agent_task_lifecycle::cook_index(&options.cook_id)
-                .expect("index remains intact")
+                .expect("replacement is indexed")
                 .attempts
                 .len(),
-            1
+            2
         );
+    });
+}
+
+#[test]
+fn repeated_zero_execution_replacements_keep_one_semantic_attempt_and_unique_lineage() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let options = retryable_pre_provider_cook("cook-retry-replacements", 1);
+        let first = crate::agent_task_service::retry(&options.initial_run_id, None, false, false)
+            .expect("first zero-execution replacement");
+        agent_task_lifecycle::record_pre_execution_failure(
+            &first.record.run_id,
+            &options.initial_plan,
+            "gate_environment.preserve",
+            &Error::validation_invalid_argument("CARGO_HOME", "still unavailable", None, None)
+                .with_retryable(true),
+        )
+        .expect("record second zero-execution failure");
+        let second = crate::agent_task_service::retry(&first.record.run_id, None, false, false)
+            .expect("second zero-execution replacement");
+
+        assert_ne!(first.record.run_id, second.record.run_id);
+        assert_eq!(first.record.metadata["cook_attempt"], 1);
+        assert_eq!(second.record.metadata["cook_attempt"], 1);
+        assert_eq!(second.record.metadata["retry_of"], first.record.run_id);
+        let recipe = super::super::load_recipe(&options.cook_id).expect("replacement lineage");
+        assert_eq!(recipe.attempts.len(), 3);
+        assert!(recipe.attempts.iter().all(|attempt| attempt.attempt == 1));
+        assert_eq!(recipe.attempts[0].run_id, options.initial_run_id);
+        assert_eq!(recipe.attempts[1].run_id, first.record.run_id);
+        assert_eq!(recipe.attempts[2].run_id, second.record.run_id);
+        let stale_context = super::super::cook_failure_context(
+            &options.cook_id,
+            Some(&first.record.run_id),
+            "pre_execution_failure",
+        )
+        .expect("stale replacement failure context");
+        assert!(stale_context
+            .next_actions
+            .iter()
+            .all(|action| !action.command.contains("agent-task retry")));
+    });
+}
+
+#[test]
+fn non_retryable_pre_execution_failure_does_not_advertise_a_cook_losing_retry() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let options = retryable_pre_provider_cook("cook-non-retryable-pre-execution", 1);
+        agent_task_lifecycle::rewrite_record_for_test(&options.initial_run_id, |record| {
+            record.metadata["pre_execution_failure"]["retryable"] = serde_json::json!(false);
+        })
+        .expect("mark pre-execution failure non-retryable");
+
+        assert!(crate::agent_task_service::retry_admission(&options.initial_run_id).is_err());
+        let context = super::super::cook_failure_context(
+            &options.cook_id,
+            Some(&options.initial_run_id),
+            "pre_execution_failure",
+        )
+        .expect("Cook failure context");
+        assert!(context
+            .next_actions
+            .iter()
+            .all(|action| !action.command.contains("agent-task retry")));
     });
 }
 
@@ -7132,6 +7240,10 @@ fn retryable_pre_provider_retry_repairs_lifecycle_reserved_attempts_idempotently
 fn retryable_pre_provider_retry_materializes_orphaned_transport_replacement() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let options = retryable_pre_provider_cook("cook-retry-orphaned-replacement", 2);
+        agent_task_lifecycle::rewrite_record_for_test(&options.initial_run_id, |record| {
+            record.metadata["provider_executions_consumed"] = serde_json::json!(1);
+        })
+        .expect("make the predecessor budget-consuming");
         let first_retry =
             crate::agent_task_service::retry(&options.initial_run_id, None, false, false)
                 .expect("reserve second attempt");

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -1159,7 +1159,7 @@ pub fn retry(
         let run = run && !record.state.is_terminal();
         return Ok(AgentTaskRetryServiceResult { record, run });
     }
-    let cook_retry = retryable_cook_attempt(&lifecycle_store, &source)?;
+    let cook_retry = retry_admission_in_store(&lifecycle_store, &source, false)?;
     let record = match cook_retry {
         Some(cook_retry) => {
             let discovered_run_id =
@@ -1180,10 +1180,7 @@ pub fn retry(
                 .unwrap_or_else(|| {
                     // All concurrent retries of one Cook attempt must reserve
                     // the same lifecycle successor before claim reconciliation.
-                    format!(
-                        "{}-attempt-{}-retry",
-                        cook_retry.cook_id, cook_retry.attempt
-                    )
+                    format!("{}-retry", source.run_id)
                 });
             let retry_exists =
                 agent_task_lifecycle::run_record_exists_in_store(&lifecycle_store, &retry_run_id)?;
@@ -1211,7 +1208,7 @@ pub fn retry(
                     &source,
                     &cook_retry,
                     &retry_run_id,
-                    force,
+                    force || cook_retry.replaces_source_attempt,
                 )?;
             }
             // Recipe and index are one Cook-owned binding boundary. Serialize
@@ -1226,12 +1223,20 @@ pub fn retry(
                     &retry_run_id,
                     &cook_retry.plan,
                 )?;
-                super::record_recipe_attempt(
-                    &cook_retry.cook_id,
-                    cook_retry.attempt,
-                    &retry_run_id,
-                    &cook_retry.plan,
-                )?;
+                if cook_retry.replaces_source_attempt {
+                    super::record_recipe_attempt_replacement(
+                        &cook_retry.cook_id,
+                        &source.run_id,
+                        &retry_run_id,
+                    )?;
+                } else {
+                    super::record_recipe_attempt(
+                        &cook_retry.cook_id,
+                        cook_retry.attempt,
+                        &retry_run_id,
+                        &cook_retry.plan,
+                    )?;
+                }
                 agent_task_lifecycle::record_cook_attempt_locked_in_store(
                     &lifecycle_store,
                     &cook_retry.cook_id,
@@ -1395,6 +1400,9 @@ fn retryable_cook_attempt(
     };
     let retryable_pre_execution_failure =
         source.metadata["pre_execution_failure"]["retryable"] == serde_json::Value::Bool(true);
+    if source.metadata["pre_execution_failure"].is_object() && !retryable_pre_execution_failure {
+        return Ok(None);
+    }
     let acceptance_repair = source.acceptance.as_ref().is_some_and(|acceptance| {
         acceptance.verdict == agent_task_lifecycle::AgentTaskAcceptanceVerdict::Rejected
             && acceptance.repair_attempts == 1
@@ -1415,6 +1423,26 @@ fn retryable_cook_attempt(
     if !retryable_pre_execution_failure && !failed_provider_without_candidate && !acceptance_repair
     {
         return Ok(None);
+    }
+    let replaces_source_attempt = source.metadata["pre_execution_failure"].is_object()
+        && source.metadata["provider_executions_consumed"]
+            .as_u64()
+            .unwrap_or_default()
+            == 0;
+    if replaces_source_attempt
+        && !recipe
+            .attempts
+            .iter()
+            .any(|recipe_attempt| recipe_attempt.attempt > attempt)
+    {
+        return Ok(Some(CookRetryAttempt {
+            cook_id: cook_id.to_string(),
+            attempt,
+            pending_run_id: None,
+            plan: source_recipe_attempt.plan.clone(),
+            recipe_replacement: false,
+            replaces_source_attempt: true,
+        }));
     }
     let mut pending_attempt = None;
     let mut materialized_attempt_seen = false;
@@ -1487,6 +1515,7 @@ fn retryable_cook_attempt(
                     pending_run_id: Some(recipe_attempt.run_id.clone()),
                     plan: recipe_attempt.plan.clone(),
                     recipe_replacement: materialized_attempt_seen,
+                    replaces_source_attempt: false,
                 }));
             }
             materialized_attempt_seen = true;
@@ -1513,6 +1542,7 @@ fn retryable_cook_attempt(
             pending_run_id: Some(pending_attempt.run_id.clone()),
             plan: pending_attempt.plan.clone(),
             recipe_replacement: materialized_attempt_seen,
+            replaces_source_attempt: false,
         }));
     }
     let max_attempts = recipe
@@ -1573,6 +1603,7 @@ fn retryable_cook_attempt(
         pending_run_id: None,
         plan,
         recipe_replacement: false,
+        replaces_source_attempt: false,
     }))
 }
 
@@ -1632,6 +1663,64 @@ struct CookRetryAttempt {
     pending_run_id: Option<String>,
     plan: AgentTaskPlan,
     recipe_replacement: bool,
+    replaces_source_attempt: bool,
+}
+
+/// Verify retry admission before advertising a retry as executable.
+///
+/// Recipe-backed Cook runs cannot fall back to generic lifecycle retry because
+/// that would lose the Cook's authenticated lineage.
+pub fn retry_admission(run_id: &str) -> Result<()> {
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    let source = agent_task_lifecycle::normalize_local_execution_placement_in_store(
+        &lifecycle_store,
+        run_id,
+    )?;
+    let _ = retry_admission_in_store(&lifecycle_store, &source, true)?;
+    Ok(())
+}
+
+fn retry_admission_in_store(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    source: &agent_task_lifecycle::AgentTaskRunRecord,
+    require_latest_attempt: bool,
+) -> Result<Option<CookRetryAttempt>> {
+    let has_cook_ownership = source
+        .metadata
+        .get("cook_id")
+        .and_then(serde_json::Value::as_str)
+        .map(super::recipe_exists)
+        .transpose()?
+        .unwrap_or(false);
+    let retry = retryable_cook_attempt(lifecycle_store, source)?;
+    if require_latest_attempt && has_cook_ownership {
+        let cook_id = source.metadata["cook_id"]
+            .as_str()
+            .expect("recipe-backed Cook ownership has a cook id");
+        if super::load_recipe(cook_id)?
+            .attempts
+            .last()
+            .map(|attempt| attempt.run_id.as_str())
+            != Some(source.run_id.as_str())
+        {
+            return Err(Error::validation_invalid_argument(
+                "cook_recipe.attempts",
+                "only the latest durable Cook attempt can be retried",
+                Some(source.run_id.clone()),
+                None,
+            ));
+        }
+    }
+    if has_cook_ownership && retry.is_none() {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            "Cook-owned run is not eligible for a durable Cook retry",
+            Some(source.run_id.clone()),
+            None,
+        ));
+    }
+    Ok(retry)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -6983,6 +6983,12 @@ fn retry_replay_action(record: &AgentTaskRunRecord) -> RetryReplayAction {
             );
         }
     }
+    if let Err(error) = agent_task_service_direct::retry_admission(&record.run_id) {
+        return RetryReplayAction::unavailable(
+            owner,
+            format!("retry admission is unavailable: {}", error.message),
+        );
+    }
     if !plan_has_retry_materialization_identity(&plan) {
         return RetryReplayAction::unavailable(
             owner,


### PR DESCRIPTION
## Summary

- replace zero-execution pre-provider failures without consuming semantic Cook attempts
- allocate collision-free durable retry lineage across repeated replacements
- use real retry admission for status, diagnose, and failure-context actions

## Verification

- focused semantic-budget, repeated-replacement, non-retryable, stale-base, concurrency, and recovery-action tests
- `cargo check -p homeboy-cli`
- targeted `rustfmt --check`
- `git diff --check`

Closes #13062

## AI assistance

OpenAI GPT-5.6 Sol through OpenCode reproduced the impossible recovery path, implemented retry-lineage and admission fixes, and performed independent review. Chris Huber reviewed and remains responsible for every line.