### PR TITLE
fix(ci): restore rustfmt on main

### DIFF
--- a/tests/artifact_promotion_rooting_test.rs
+++ b/tests/artifact_promotion_rooting_test.rs
@@ -88,7 +88,9 @@ fn directory_child_promotion_guard_shares_the_promotion_store() {
 fn promotion_opens_no_ambient_store() {
     let source = promotion_source();
 
-    let opens = source.matches("ObservationStore::open_initialized()").count();
+    let opens = source
+        .matches("ObservationStore::open_initialized()")
+        .count();
     assert_eq!(
         opens, 0,
         "artifact_promotion.rs opens {opens} ambient store(s). Both production \


### PR DESCRIPTION
## Summary

- format the root artifact-promotion guard introduced by #13082
- restore `cargo fmt --all --check` on current main
- unblock independent PRs whose required-gates aggregation currently inherits the formatting failure

Fixes #13093.

## Verification

- `cargo fmt --all --check`
- `cargo test --test artifact_promotion_rooting_test` (3 passed)

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode correlated the failing CI runs, traced the introducing commit, applied the one-line formatting repair, and ran verification. Chris Huber is responsible for every line.