### PR TITLE
fix(finalization): preserve recoverable candidate lineage

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -941,6 +941,7 @@ fn report(
         acceptance,
         review_dossier: options.review_dossier.clone(),
         manual_finalization: options.manual_finalization,
+        manual_candidate_binding: None,
         evidence: options.evidence.clone(),
     }
 }

--- a/crates/homeboy-agents/src/agent_task_finalization/types.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/types.rs
@@ -4,6 +4,20 @@ use super::*;
 use crate::agent_task_review_dossier::{AgentTaskPublicContract, AgentTaskPublicContractEvidence};
 use homeboy_core::git::GitIdentityProof;
 
+pub const AGENT_TASK_MANUAL_CANDIDATE_BINDING_SCHEMA: &str =
+    "homeboy/agent-task-manual-candidate-binding/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentTaskManualCandidateBinding {
+    pub schema: String,
+    pub selection: crate::agent_task_lifecycle::AgentTaskCookCandidateSelection,
+    pub candidate: crate::agent_task_promotion::AgentTaskCandidateFingerprint,
+    pub source: crate::agent_task_promotion::AgentTaskPromotionSource,
+    pub model: String,
+    pub replacement_gate_proof: serde_json::Value,
+    pub gates: Vec<HomeboyGateResult>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskGateResult {
     pub name: String,
@@ -44,6 +58,8 @@ pub struct AgentTaskPrFinalizationReport {
     pub acceptance: Option<crate::agent_task_lifecycle::AgentTaskAcceptanceRecord>,
     pub review_dossier: AgentTaskReviewDossier,
     pub manual_finalization: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manual_candidate_binding: Option<AgentTaskManualCandidateBinding>,
     #[serde(flatten)]
     pub evidence: AgentTaskPrEvidence,
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -2448,7 +2448,13 @@ pub fn persist_manual_finalization_intent(
     run_id: &str,
     report: &AgentTaskPrFinalizationReport,
 ) -> Result<crate::agent_task_lifecycle::AgentTaskRunRecord> {
-    validate_manual_preflight_report(report, run_id)?;
+    let mut report = report.clone();
+    if crate::agent_task_lifecycle::persisted_status(run_id)?.state
+        == crate::agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable
+    {
+        report.manual_candidate_binding = Some(manual_candidate_binding(run_id, &report)?);
+    }
+    validate_manual_preflight_report(&report, run_id)?;
     agent_task_lifecycle::record_manual_finalization_intent(
         run_id,
         serde_json::to_value(report).expect("finalization report serializes"),
@@ -2475,6 +2481,18 @@ pub fn prepare_manual_finalization_identity(requested_id: &str) -> Result<String
                     None,
                 )
             })?;
+        if crate::agent_task_lifecycle::persisted_status(&run_id)?.state
+            == crate::agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable
+        {
+            let candidate = crate::agent_task_lifecycle::select_cook_candidate(requested_id)?;
+            if candidate.incomplete
+                || candidate.selected_task_id.is_none()
+                || candidate.selected_artifact_id.is_none()
+            {
+                return Err(Error::validation_invalid_argument("run_id", "candidate-recoverable manual finalization requires the complete controller-selected Cook candidate", Some(run_id), None));
+            }
+            return require_manual_finalization_run(&candidate.run_id);
+        }
         return require_manual_finalization_run(&run_id);
     }
 
@@ -2505,17 +2523,117 @@ fn require_manual_finalization_run(run_id: &str) -> Result<String> {
     if record.metadata["manual_finalization_identity"] == true {
         return Ok(run_id.to_string());
     }
+    if record.state == crate::agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable {
+        if record.acceptance.is_some() || record.metadata.get("acceptance_requirement").is_some() {
+            return Err(Error::validation_invalid_argument("acceptance", "candidate-recoverable manual finalization cannot replace a durable acceptance decision", Some(run_id.to_string()), None));
+        }
+        let cook_id = record.metadata["cook_id"].as_str().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "run_id",
+                "candidate-recoverable manual finalization requires a Cook-bound candidate",
+                Some(run_id.to_string()),
+                None,
+            )
+        })?;
+        let candidate = crate::agent_task_lifecycle::select_cook_candidate(cook_id)?;
+        if !candidate.incomplete
+            && candidate.run_id == run_id
+            && candidate.selected_task_id.is_some()
+            && candidate.selected_artifact_id.is_some()
+        {
+            return Ok(run_id.to_string());
+        }
+        return Err(Error::validation_invalid_argument("run_id", "candidate-recoverable manual finalization requires the complete controller-selected Cook candidate", Some(run_id.to_string()), None));
+    }
     if record.lifecycle.execution.state
         != homeboy_core::run_lifecycle_record::RunExecutionState::Failed
     {
         return Err(Error::validation_invalid_argument(
             "run_id",
-            "manual finalization accepts an existing failed attempt or an unused ID for a new durable manual-finalization record",
+            "manual finalization accepts an existing failed attempt, the complete controller-selected candidate-recoverable attempt, or an unused ID for a new durable manual-finalization record",
             Some(run_id.to_string()),
             None,
         ));
     }
     Ok(run_id.to_string())
+}
+
+fn manual_candidate_binding(
+    run_id: &str,
+    report: &AgentTaskPrFinalizationReport,
+) -> Result<crate::agent_task_finalization::AgentTaskManualCandidateBinding> {
+    let record = crate::agent_task_lifecycle::persisted_status(run_id)?;
+    if record.state != crate::agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable
+        || record.acceptance.is_some()
+        || record.metadata.get("acceptance_requirement").is_some()
+    {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            "manual candidate binding requires an unblocked candidate-recoverable run",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+    let cook_id = record.metadata["cook_id"].as_str().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "run_id",
+            "candidate-recoverable manual finalization requires a Cook-bound candidate",
+            Some(run_id.to_string()),
+            None,
+        )
+    })?;
+    let selection = crate::agent_task_lifecycle::select_cook_candidate(cook_id)?;
+    if selection.incomplete
+        || selection.run_id != run_id
+        || selection.selected_task_id.is_none()
+        || selection.selected_artifact_id.is_none()
+    {
+        return Err(Error::validation_invalid_argument("run_id", "candidate-recoverable manual finalization requires the complete controller-selected Cook candidate", Some(run_id.to_string()), None));
+    }
+    let promotion = persisted_promotion_for_attempt(run_id)?.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "latest_promotion",
+            "candidate-recoverable manual finalization requires a persisted replacement gate proof",
+            Some(run_id.to_string()),
+            None,
+        )
+    })?;
+    let candidate: crate::agent_task_promotion::AgentTaskPromotionCandidate = serde_json::from_value(promotion.provenance["candidate"].clone()).map_err(|_| Error::validation_invalid_argument("latest_promotion.provenance.candidate", "candidate-recoverable manual finalization requires a durable Git candidate fingerprint", Some(run_id.to_string()), None))?;
+    let crate::agent_task_promotion::AgentTaskPromotionCandidate::Git { fingerprint } = candidate
+    else {
+        return Err(Error::validation_invalid_argument("latest_promotion.provenance.candidate", "candidate-recoverable manual finalization requires a durable Git candidate fingerprint", Some(run_id.to_string()), None));
+    };
+    let model = record.lifecycle.provider_runtime.iter().rev().find_map(|runtime| runtime.metadata["model"].as_str()).filter(|model| !model.trim().is_empty()).ok_or_else(|| Error::validation_invalid_argument("run_id", "candidate-recoverable manual finalization requires concrete provider model provenance", Some(run_id.to_string()), None))?;
+    let commit = report
+        .publication_proof
+        .git_identity
+        .as_ref()
+        .and_then(|identity| identity.commit_sha.as_deref())
+        .unwrap_or_default();
+    if promotion.source.run_id.as_deref() != Some(run_id)
+        || selection.selected_task_id.as_deref() != Some(promotion.source.task_id.as_str())
+        || promotion.provenance.get("replacement_gate_proof").is_none()
+        || !promotion.finalization_eligible(false)
+        || fingerprint.head != commit
+        || fingerprint.changed_files != report.changed_files
+        || report.evidence.ai_model.as_deref() != Some(model)
+        || report.review_dossier.ai_assistance.model != model
+        || promotion.gate_results != report.normalized_gate_results
+    {
+        return Err(Error::validation_invalid_argument("manual_finalization_intent", "manual finalization dossier does not match the selected candidate, model provenance, and replacement gate proof", Some(run_id.to_string()), None));
+    }
+    Ok(
+        crate::agent_task_finalization::AgentTaskManualCandidateBinding {
+            schema: crate::agent_task_finalization::AGENT_TASK_MANUAL_CANDIDATE_BINDING_SCHEMA
+                .to_string(),
+            selection,
+            candidate: fingerprint,
+            source: promotion.source,
+            model: model.to_string(),
+            replacement_gate_proof: promotion.provenance["replacement_gate_proof"].clone(),
+            gates: promotion.gate_results,
+        },
+    )
 }
 
 /// Persist only a controller-published manual receipt bound to its preflight dossier.
@@ -3076,6 +3194,29 @@ fn manual_finalization_intent_for_run(
             Some(run_id.to_string()),
             None,
         ));
+    }
+    let candidate_recoverable = crate::agent_task_lifecycle::persisted_status(run_id)?.state
+        == crate::agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable;
+    if candidate_recoverable && report.manual_candidate_binding.is_none() {
+        return Err(Error::validation_invalid_argument(
+            "manual_finalization_intent",
+            "candidate-recoverable manual finalization intent has no controller candidate binding",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+    if let Some(binding) = report.manual_candidate_binding.as_ref() {
+        if binding.schema
+            != crate::agent_task_finalization::AGENT_TASK_MANUAL_CANDIDATE_BINDING_SCHEMA
+            || manual_candidate_binding(run_id, &report)? != *binding
+        {
+            return Err(Error::validation_invalid_argument(
+                "manual_finalization_intent",
+                "persisted manual finalization intent no longer matches the selected Cook candidate",
+                Some(run_id.to_string()),
+                None,
+            ));
+        }
     }
     Ok(report)
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -14517,6 +14517,243 @@ fn manual_preflight_intent_does_not_block_normal_cook_finalization() {
 }
 
 #[test]
+fn candidate_recoverable_manual_preflight_binds_canonical_candidate_and_recovers_once() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-13060";
+        let run_id = "cook-13060-attempt-1";
+        let target = tempfile::tempdir().expect("fixture target");
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = run_id.to_string();
+        options.head = Some("fix/8058".to_string());
+        options.initial_plan.tasks[0].task_id = "task".to_string();
+        options.initial_plan.tasks[0].executor.model = Some("fixture-model".to_string());
+        options.ai_model = Some("fixture-model".to_string());
+        options.gates = VerifyGateOptions {
+            verify: vec!["cargo test --locked agent_task_promotion --lib".to_string()],
+            ..Default::default()
+        };
+        persist_initial_recipe(&options).expect("persist recipe");
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id)).expect("submit run");
+        agent_task_lifecycle::record_cook_attempt(cook_id, 1, run_id).expect("link Cook attempt");
+
+        let mut aggregate = review_form_aggregate(&options.initial_plan);
+        aggregate.status =
+            crate::agent_task_scheduler::AgentTaskAggregateStatus::CandidateRecoverable;
+        aggregate.totals = crate::agent_task_scheduler::AgentTaskAggregateTotals {
+            recoverable_candidates: 1,
+            ..Default::default()
+        };
+        aggregate.outcomes[0].status =
+            crate::agent_task::AgentTaskOutcomeStatus::CandidateRecoverable;
+        let candidate_patch = target.path().join("candidate.patch");
+        let candidate_bytes = b"diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n";
+        std::fs::write(&candidate_patch, candidate_bytes).expect("write candidate patch");
+        aggregate.outcomes[0].artifacts = vec![crate::agent_task::AgentTaskArtifact {
+            id: "candidate".to_string(),
+            kind: "patch".to_string(),
+            path: Some(candidate_patch.display().to_string()),
+            size_bytes: Some(candidate_bytes.len() as u64),
+            sha256: Some(homeboy_engine_primitives::content_hash::sha256_hex(
+                candidate_bytes,
+            )),
+            ..Default::default()
+        }];
+        agent_task_lifecycle::record_run_aggregate(run_id, &options.initial_plan, &aggregate)
+            .expect("persist candidate-recoverable aggregate");
+        agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+            record
+                .lifecycle
+                .provider_runtime
+                .push(ProviderRuntimeLifecycle {
+                    task_id: "task".to_string(),
+                    backend: "fixture".to_string(),
+                    state: ProviderRuntimeState::Succeeded,
+                    stream_uri: None,
+                    external_runtime_ids: Vec::new(),
+                    metadata: serde_json::json!({ "model": "fixture-model" }),
+                });
+        })
+        .expect("persist provider model provenance");
+        assert_eq!(
+            agent_task_lifecycle::status(run_id)
+                .expect("candidate status")
+                .state,
+            AgentTaskRunState::CandidateRecoverable
+        );
+
+        let mut promotion = promotion_with_existing_path(run_id, target.path());
+        promotion.provenance["candidate"] = serde_json::json!({
+            "kind": "git",
+            "fingerprint": {
+                "schema": "homeboy/agent-task-candidate-fingerprint/v1",
+                "target_path": target.path(),
+                "head": "candidate-sha",
+                "base": "main",
+                "tree": "candidate-tree",
+                "sha256": "candidate-sha",
+                "changed_files": ["src/lib.rs"]
+            }
+        });
+        promotion.provenance["replacement_gate_proof"] = serde_json::json!({
+            "schema": "homeboy/agent-task-replacement-gate-proof/v1",
+            "status": "passed"
+        });
+        agent_task_lifecycle::record_promotion(run_id, serde_json::to_value(&promotion).unwrap())
+            .expect("persist promotion evidence");
+        promotion = persisted_promotion_for_attempt(run_id)
+            .expect("read persisted promotion")
+            .expect("persisted promotion");
+        let selection = agent_task_lifecycle::select_cook_candidate(cook_id)
+            .expect("select canonical candidate");
+        assert_eq!(selection.selected_task_id.as_deref(), Some("task"));
+        assert_eq!(selection.selected_artifact_id.as_deref(), Some("candidate"));
+        assert!(promotion.finalization_eligible(false));
+
+        assert_eq!(
+            prepare_manual_finalization_identity(cook_id).expect("Cook selects candidate"),
+            run_id
+        );
+        let mut finalization = cook_finalization_options(&options, run_id, &promotion, Vec::new())
+            .expect("manual finalization options");
+        finalization.manual_finalization = true;
+        let preflight = crate::agent_task_finalization::preflight_pr_with_backend(
+            finalization,
+            &mut CaptureBackend {
+                candidate_state: Some(
+                    crate::agent_task_finalization::AgentTaskPrCandidateState::Committed {
+                        changed_files: vec!["src/lib.rs".to_string()],
+                        push_required: false,
+                    },
+                ),
+                committed_sha: Some("candidate-sha".to_string()),
+                hydrate_run_id: Some(run_id.to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("manual preflight");
+        assert_eq!(
+            preflight.evidence.ai_model.as_deref(),
+            Some("fixture-model")
+        );
+        assert_eq!(
+            preflight.review_dossier.ai_assistance.model,
+            "fixture-model"
+        );
+        assert_eq!(preflight.normalized_gate_results, promotion.gate_results);
+        assert_eq!(promotion.source.run_id.as_deref(), Some(run_id));
+        assert_eq!(promotion.source.task_id, "task");
+        assert!(promotion.provenance.get("replacement_gate_proof").is_some());
+        let candidate: crate::agent_task_promotion::AgentTaskPromotionCandidate =
+            serde_json::from_value(promotion.provenance["candidate"].clone())
+                .expect("parse promotion candidate");
+        let crate::agent_task_promotion::AgentTaskPromotionCandidate::Git { fingerprint } =
+            candidate
+        else {
+            panic!("fixture promotion has a Git candidate");
+        };
+        assert_eq!(fingerprint.head, "candidate-sha");
+        assert_eq!(fingerprint.changed_files, preflight.changed_files);
+        assert_eq!(
+            preflight
+                .publication_proof
+                .git_identity
+                .as_ref()
+                .and_then(|identity| identity.commit_sha.as_deref()),
+            Some("candidate-sha")
+        );
+        assert_eq!(
+            agent_task_lifecycle::status(run_id)
+                .expect("read provider provenance")
+                .lifecycle
+                .provider_runtime
+                .last()
+                .and_then(|runtime| runtime.metadata["model"].as_str()),
+            Some("fixture-model")
+        );
+        persist_manual_finalization_intent(run_id, &preflight).expect("persist bound intent");
+        let intent = agent_task_lifecycle::status(run_id)
+            .expect("read bound intent")
+            .metadata["manual_finalization_intent"]
+            .clone();
+        assert_eq!(
+            intent["manual_candidate_binding"]["schema"],
+            crate::agent_task_finalization::AGENT_TASK_MANUAL_CANDIDATE_BINDING_SCHEMA
+        );
+        assert_eq!(
+            intent["manual_candidate_binding"]["selection"]["run_id"],
+            run_id
+        );
+        assert_eq!(
+            intent["manual_candidate_binding"]["selection"]["selected_task_id"],
+            "task"
+        );
+        assert_eq!(
+            intent["manual_candidate_binding"]["selection"]["selected_artifact_id"],
+            "candidate"
+        );
+        assert_eq!(
+            intent["manual_candidate_binding"]["candidate"]["head"],
+            "candidate-sha"
+        );
+        assert_eq!(
+            intent["manual_candidate_binding"]["source"]["run_id"],
+            run_id
+        );
+        assert_eq!(intent["manual_candidate_binding"]["model"], "fixture-model");
+        assert_eq!(
+            intent["manual_candidate_binding"]["gates"],
+            serde_json::to_value(&promotion.gate_results).unwrap()
+        );
+
+        let mut tampered = promotion.clone();
+        tampered.provenance["candidate"]["fingerprint"]["head"] =
+            serde_json::json!("tampered-candidate-sha");
+        agent_task_lifecycle::record_promotion(run_id, serde_json::to_value(&tampered).unwrap())
+            .expect("persist candidate tampering");
+        let error = recover_cook_pr_with_backend(
+            cook_id,
+            Vec::new(),
+            false,
+            &mut CaptureBackend::default(),
+        )
+        .expect_err("candidate tampering fails closed");
+        assert_eq!(error.code.as_str(), "validation.invalid_argument");
+        agent_task_lifecycle::record_promotion(run_id, serde_json::to_value(&promotion).unwrap())
+            .expect("restore promotion evidence");
+
+        let mut publish_backend = CaptureBackend {
+            candidate_state: Some(
+                crate::agent_task_finalization::AgentTaskPrCandidateState::Committed {
+                    changed_files: vec!["src/lib.rs".to_string()],
+                    push_required: false,
+                },
+            ),
+            committed_sha: Some("candidate-sha".to_string()),
+            hydrate_run_id: Some(run_id.to_string()),
+            ..Default::default()
+        };
+        let published =
+            recover_cook_pr_with_backend(cook_id, Vec::new(), false, &mut publish_backend)
+                .expect("recover bound candidate through fake publication");
+        assert_eq!(published["status"], "review_ready");
+        assert!(publish_backend.created);
+        let receipt = agent_task_lifecycle::status(run_id).expect("read receipt");
+        assert_eq!(
+            receipt.metadata["cook_finalization"]["manual_finalization"],
+            true
+        );
+
+        let mut repeated_backend = CaptureBackend::default();
+        assert_eq!(
+            recover_cook_pr_with_backend(cook_id, Vec::new(), false, &mut repeated_backend)
+                .expect("recovery receipt is idempotent"),
+            published
+        );
+        assert!(!repeated_backend.created);
+    });
+}
+
+#[test]
 fn manual_preflight_recovers_without_a_persisted_promotion_and_rejects_tampering() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let cook_id = "cook-10980";


### PR DESCRIPTION
## Summary

- allow complete canonical candidate-recoverable Cooks to own manual-finalization identity
- persist a typed versioned binding for candidate SHA/tree/files, source lineage, model, and replacement gates
- fail closed on ambiguous state, transition, or tampering and preserve idempotent recovery

## Verification

- `cargo test -p homeboy-agents candidate_recoverable_manual_preflight_binds_canonical_candidate_and_recovers_once --lib`
- focused manual identity, tamper, and idempotent recovery tests
- `cargo fmt -p homeboy-agents -- --check`
- `git diff --check`

Closes #13060

## AI assistance

OpenAI GPT-5.6 Sol through OpenCode implemented the typed candidate lineage contract and end-to-end recovery test, with independent safety review. Chris Huber reviewed and remains responsible for every line.