### PR TITLE
fix(lab): preserve prepared cache ownership

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/hydration.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/hydration.rs
@@ -55,6 +55,8 @@ pub struct LabWorkspaceHydrationOutput {
     pub(crate) steps: Vec<LabWorkspaceHydrationStep>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) cache_source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) prepared_source_cache_observations: Option<Vec<String>>,
 }
 
 impl LabWorkspaceHydrationOutput {
@@ -65,6 +67,7 @@ impl LabWorkspaceHydrationOutput {
             workspace: workspace.to_string(),
             steps: Vec::new(),
             cache_source: None,
+            prepared_source_cache_observations: None,
         }
     }
 
@@ -75,6 +78,7 @@ impl LabWorkspaceHydrationOutput {
             workspace: workspace.to_string(),
             steps: Vec::new(),
             cache_source: Some("runner_prepared_source".to_string()),
+            prepared_source_cache_observations: None,
         }
     }
 
@@ -195,6 +199,7 @@ fn hydrate_lab_workspace_dependencies_with_policy(
                 workspace: remote_path.to_string(),
                 steps: Vec::new(),
                 cache_source: Some("controller_package".to_string()),
+                prepared_source_cache_observations: None,
             });
         }
     }
@@ -246,6 +251,7 @@ fn hydrate_lab_workspace_dependencies_with_policy(
         workspace: remote_path.to_string(),
         steps,
         cache_source: None,
+        prepared_source_cache_observations: None,
     })
 }
 
@@ -518,7 +524,7 @@ fn hydrate_for_lab_workspace_exec_internal(
     plan: HomeboyPlan,
     agent_task_run_id: Option<&str>,
 ) -> Result<LabOffloadDependencyHydration> {
-    let record = if skip_deps_hydration {
+    let mut record = if skip_deps_hydration {
         LabWorkspaceHydrationRecord::NotApplied { reason: "opt_out" }
     } else {
         LabWorkspaceHydrationRecord::Applied(hydrate_lab_workspace_dependencies_for_run(
@@ -531,8 +537,11 @@ fn hydrate_for_lab_workspace_exec_internal(
 
     // Persist a source/dependency preparation only after hydration has completed.
     // The next same-commit job receives a private view of this immutable cache.
-    if matches!(&record, LabWorkspaceHydrationRecord::Applied(_)) {
-        crate::workspace::save_prepared_source_cache(runner_id, local_path, remote_path)?;
+    if let LabWorkspaceHydrationRecord::Applied(output) = &mut record {
+        output.prepared_source_cache_observations = Some(
+            crate::workspace::save_prepared_source_cache(runner_id, local_path, remote_path)?
+                .observations,
+        );
     }
 
     let plan = match &record {

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -538,31 +538,45 @@ pub fn sync_workspace_in_roots(
 /// Cache only a source that has completed dependency hydration. The cache lives
 /// outside `_lab_workspaces`, is never handed to a job, and has no terminal-job
 /// cleanup owner. A private job view is copied from it on a same-commit hit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PreparedSourceCacheLifecycle {
+    pub observations: Vec<String>,
+}
+
 pub(crate) fn save_prepared_source_cache(
     runner_id: &str,
     local_path: &str,
     remote_path: &str,
-) -> Result<()> {
+) -> Result<PreparedSourceCacheLifecycle> {
     let runner = load(runner_id)?;
     // The cache is a pure optimization: a hit lets the next same-commit job skip
     // dependency hydration. A runner with no configured `workspace_root` has
     // nowhere to keep it, which is a reason to skip caching — not to fail an
     // otherwise-successful offload that has already hydrated its workspace.
     let Some(workspace_root) = runner.workspace_root.as_deref() else {
-        return Ok(());
+        return Ok(PreparedSourceCacheLifecycle {
+            observations: vec![
+                "homeboy_prepared_source_cache event=skipped reason=no_workspace_root".to_string(),
+            ],
+        });
     };
     let local_path = canonical_workspace_path(local_path)?;
     let commit = git_output(&local_path, &["rev-parse", "HEAD"])?;
     let cache = prepared_source_cache_path(workspace_root, &local_path, &commit);
     let cache_root = prepared_source_cache_root(workspace_root);
-    let command = format!(
-        "cache={cache}; cache_root={cache_root}; source={source}; lock=\"$cache.lock\"; mkdir -p \"$cache_root\"; test -f \"$cache/.homeboy/prepared-source-ready\" || {{ mkdir \"$lock\" 2>/dev/null || exit 0; trap 'rmdir \"$lock\"' EXIT; tmp=\"$cache.tmp.$$\"; rm -rf \"$tmp\"; cp -a \"$source\" \"$tmp\"; mkdir -p \"$tmp/.homeboy\"; : > \"$tmp/.homeboy/prepared-source-ready\"; chmod -R a-w \"$tmp\"; mv \"$tmp\" \"$cache\"; }}; kept=0; ls -1dt \"$cache_root\"/* 2>/dev/null | while IFS= read -r candidate; do test -f \"$candidate/.homeboy/prepared-source-ready\" || continue; if [ \"$kept\" -lt {max_entries} ]; then kept=$((kept + 1)); continue; fi; test -e \"$candidate.lock\" && continue; ls \"$candidate\".lease.* >/dev/null 2>&1 && continue; chmod -R u+w \"$candidate\" && rm -rf \"$candidate\"; done",
-        cache = shell::quote_arg(&cache),
-        cache_root = shell::quote_arg(&cache_root),
-        source = shell::quote_arg(remote_path),
-        max_entries = PREPARED_SOURCE_CACHE_MAX_ENTRIES,
-    );
-    run_workspace_shell_command(&runner, &command, "save prepared Lab source cache")
+    let output = run_workspace_shell_command(
+        &runner,
+        &prepared_source_cache_command(&cache, &cache_root, remote_path),
+        "save prepared Lab source cache",
+    )?;
+    Ok(prepared_source_cache_lifecycle(&output))
+}
+
+pub(super) fn prepared_source_cache_command(cache: &str, cache_root: &str, source: &str) -> String {
+    format!(
+        "cache={cache}; cache_root={cache_root}; source={source}; lock=\"$cache.lock\"; {capture_owner}; mkdir -p \"$cache_root\"; if test -f \"$cache/.homeboy/prepared-source-ready\"; then printf 'homeboy_prepared_source_cache event=hit cache=%s\n' \"$cache\"; elif mkdir \"$lock\" 2>/dev/null; then trap 'rmdir \"$lock\"' EXIT; tmp=\"$cache.tmp.$$\"; rm -rf \"$tmp\"; cp -a \"$source\" \"$tmp\" && mkdir -p \"$tmp/.homeboy\" && : > \"$tmp/.homeboy/prepared-source-ready\" && chmod -R a-w \"$tmp\" && mv \"$tmp\" \"$cache\" && printf 'homeboy_prepared_source_cache event=created cache=%s\n' \"$cache\" || exit 1; else printf 'homeboy_prepared_source_cache event=skipped cache=%s reason=busy\n' \"$cache\"; fi; {restore_owner}; kept=0; failures=0; ls -1dt \"$cache_root\"/* 2>/dev/null | while IFS= read -r candidate; do test -f \"$candidate/.homeboy/prepared-source-ready\" || continue; if [ \"$kept\" -lt {max_entries} ]; then kept=$((kept + 1)); continue; fi; candidate_lock=\"$candidate.lock\"; mkdir \"$candidate_lock\" 2>/dev/null || continue; if test -f \"$candidate/.homeboy/prepared-source-ready\"; then if ! chmod -R u+w \"$candidate\" >/dev/null 2>&1 || ! rm -rf \"$candidate\" >/dev/null 2>&1; then failures=$((failures + 1)); if [ \"$failures\" -le {max_failures} ]; then printf 'homeboy_prepared_source_cache event=prune_failed cache=%s reason=undeletable\n' \"$candidate\" >&2; elif [ \"$failures\" -eq $(({max_failures} + 1)) ]; then printf 'homeboy_prepared_source_cache event=prune_failed_summary reason=additional_failures_suppressed\n' >&2; fi; else printf 'homeboy_prepared_source_cache event=pruned cache=%s\n' \"$candidate\"; fi; fi; rmdir \"$candidate_lock\"; done",
+        cache = shell::quote_arg(cache), cache_root = shell::quote_arg(cache_root), source = shell::quote_arg(source), capture_owner = super::util::owner_capture_shell("$cache_root"), restore_owner = super::util::owner_restore_path_shell("$cache_root"), max_entries = PREPARED_SOURCE_CACHE_MAX_ENTRIES, max_failures = 8,
+    )
 }
 
 fn prepared_source_cache_path(workspace_root: &str, local_path: &Path, commit: &str) -> String {
@@ -586,28 +600,61 @@ fn materialize_prepared_source_view(
     cache: &str,
     remote_path: &str,
 ) -> Result<bool> {
-    let command = format!(
-        "cache={cache}; destination={destination}; test -f \"$cache/.homeboy/prepared-source-ready\" && test ! -e \"$destination\" || exit 1; lease=\"$cache.lease.$$\"; : > \"$lease\" || exit 1; trap 'rm -f \"$lease\"' EXIT HUP INT TERM; test -f \"$cache/.homeboy/prepared-source-ready\" && mkdir -p \"$(dirname \"$destination\")\" && cp -a \"$cache\" \"$destination\" && chmod -R u+w \"$destination\" || {{ rm -rf \"$destination\"; exit 1; }}",
-        cache = shell::quote_arg(cache),
-        destination = shell::quote_arg(remote_path),
-    );
+    let command = prepared_source_view_command(cache, remote_path);
     run_workspace_shell_success(runner, &command, "materialize prepared Lab source view")
+        .map(|output| output.success)
+}
+
+pub(super) fn prepared_source_view_command(cache: &str, destination: &str) -> String {
+    format!(
+        "cache={cache}; destination={destination}; lock=\"$cache.lock\"; test -f \"$cache/.homeboy/prepared-source-ready\" && test ! -e \"$destination\" && mkdir \"$lock\" 2>/dev/null || exit 1; trap 'rmdir \"$lock\"' EXIT HUP INT TERM; test -f \"$cache/.homeboy/prepared-source-ready\" && mkdir -p \"$(dirname \"$destination\")\" && cp -a \"$cache\" \"$destination\" && chmod -R u+w \"$destination\" || {{ rm -rf \"$destination\"; exit 1; }}",
+        cache = shell::quote_arg(cache), destination = shell::quote_arg(destination),
+    )
+}
+
+struct WorkspaceShellOutput {
+    success: bool,
+    stdout: String,
+    stderr: String,
+}
+fn prepared_source_cache_lifecycle(output: &WorkspaceShellOutput) -> PreparedSourceCacheLifecycle {
+    PreparedSourceCacheLifecycle {
+        observations: output
+            .stdout
+            .lines()
+            .chain(output.stderr.lines())
+            .filter(|line| line.starts_with("homeboy_prepared_source_cache "))
+            .take(32)
+            .map(str::to_string)
+            .collect(),
+    }
 }
 
 fn run_workspace_shell_success(
     runner: &super::super::Runner,
     command: &str,
     action: &str,
-) -> Result<bool> {
+) -> Result<WorkspaceShellOutput> {
     match runner.kind {
-        RunnerKind::Local => Ok(std::process::Command::new("sh")
-            .args(["-c", command])
-            .status()
-            .map_err(|error| Error::internal_io(error.to_string(), Some(action.to_string())))?
-            .success()),
+        RunnerKind::Local => {
+            let output = std::process::Command::new("sh")
+                .args(["-c", command])
+                .output()
+                .map_err(|error| Error::internal_io(error.to_string(), Some(action.to_string())))?;
+            Ok(WorkspaceShellOutput {
+                success: output.status.success(),
+                stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+                stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            })
+        }
         RunnerKind::Ssh => {
             let (_server, client) = ssh_client_for_runner(runner)?;
-            Ok(client.execute(command).success)
+            let output = client.execute(command);
+            Ok(WorkspaceShellOutput {
+                success: output.success,
+                stdout: output.stdout,
+                stderr: output.stderr,
+            })
         }
     }
 }
@@ -616,11 +663,15 @@ fn run_workspace_shell_command(
     runner: &super::super::Runner,
     command: &str,
     action: &str,
-) -> Result<()> {
-    if run_workspace_shell_success(runner, command, action)? {
-        Ok(())
+) -> Result<WorkspaceShellOutput> {
+    let output = run_workspace_shell_success(runner, command, action)?;
+    if output.success {
+        Ok(output)
     } else {
-        Err(Error::internal_unexpected(format!("{action} failed")))
+        Err(Error::internal_unexpected(format!(
+            "{action} failed: {}",
+            output.stderr.trim()
+        )))
     }
 }
 

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshots.rs
@@ -1,9 +1,11 @@
 use std::fs;
+use std::process::Command;
 use std::sync::{Mutex, OnceLock};
 
 use super::git;
 use crate::workspace::snapshot::{incremental_prepare_command_fits, snapshot_manifest_delta};
 use crate::workspace::sync::{
+    prepared_source_cache_command, prepared_source_view_command,
     reuse_compatible_snapshot_workspace, save_prepared_source_cache, sync_workspace,
     workspace_snapshot_scan_command, workspace_snapshots,
 };
@@ -13,6 +15,33 @@ use crate::workspace::types::{
 use crate::workspace::{WorkspaceContentManifest, WorkspaceContentManifestEntry};
 
 static PATH_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+#[cfg(unix)]
+fn make_cache_fixture_writable(root: &std::path::Path) {
+    let status = Command::new("chmod")
+        .args(["-R", "u+w"])
+        .arg(root)
+        .status()
+        .expect("restore fixture permissions");
+    assert!(status.success(), "restore fixture permissions");
+}
+
+#[cfg(not(unix))]
+fn make_cache_fixture_writable(root: &std::path::Path) {
+    fn restore(path: &std::path::Path) -> std::io::Result<()> {
+        let mut permissions = std::fs::metadata(path)?.permissions();
+        permissions.set_readonly(false);
+        std::fs::set_permissions(path, permissions)?;
+        if path.is_dir() {
+            for entry in std::fs::read_dir(path)? {
+                restore(&entry?.path())?;
+            }
+        }
+        Ok(())
+    }
+
+    restore(root).expect("restore fixture permissions");
+}
 
 #[test]
 fn workspace_snapshot_scan_skips_a_child_removed_during_atomic_promotion() {
@@ -413,12 +442,16 @@ fn same_commit_prepared_source_cache_creates_private_job_views() {
             "hydrated\n",
         )
         .expect("simulate dependency hydration");
-        save_prepared_source_cache(
+        let lifecycle = save_prepared_source_cache(
             "lab-local-prepared-cache",
             &first.local_path,
             &first.remote_path,
         )
         .expect("save immutable prepared source");
+        assert!(lifecycle
+            .observations
+            .iter()
+            .any(|entry| entry.contains("event=created")));
 
         options.run_isolation_token = Some("job-two".to_string());
         let (second, _) = sync_workspace("lab-local-prepared-cache", options)
@@ -462,6 +495,7 @@ fn same_commit_prepared_source_cache_creates_private_job_views() {
             .expect("prepared cache directory")
             .next()
             .is_some());
+        make_cache_fixture_writable(&runner_root.path().join("_lab_prepared_sources"));
     });
 }
 
@@ -520,7 +554,77 @@ fn prepared_source_cache_retains_a_bounded_completed_working_set() {
             })
             .count();
         assert_eq!(completed, 8);
+        make_cache_fixture_writable(&cache_root);
     });
+}
+
+#[test]
+#[cfg(unix)]
+fn prepared_source_cache_uses_one_lock_for_views_and_pruning() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let _path_guard = PATH_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("PATH lock");
+    let root = tempfile::tempdir().expect("cache root");
+    let cache_root = root.path().join("_lab_prepared_sources");
+    let cache = cache_root.join("cache-locked");
+    fs::create_dir_all(cache.join(".homeboy")).expect("cache");
+    fs::write(cache.join(".homeboy/prepared-source-ready"), "").expect("ready marker");
+    fs::write(cache.join("marker"), "cached\n").expect("cache marker");
+    for index in 0..8 {
+        let entry = cache_root.join(format!("cache-new-{index}"));
+        fs::create_dir_all(entry.join(".homeboy")).expect("newer cache");
+        fs::write(entry.join(".homeboy/prepared-source-ready"), "").expect("ready marker");
+    }
+    let tools = tempfile::tempdir().expect("tool shims");
+    let started = root.path().join("copy-started");
+    let release = root.path().join("copy-release");
+    let cp = tools.path().join("cp");
+    fs::write(&cp, "#!/bin/sh\n: > \"$HOMEBOY_COPY_STARTED\"\nwhile [ ! -f \"$HOMEBOY_COPY_RELEASE\" ]; do sleep 0.01; done\nexec /bin/cp \"$@\"\n").expect("cp shim");
+    fs::set_permissions(&cp, fs::Permissions::from_mode(0o755)).expect("cp shim permissions");
+    let destination = root.path().join("view");
+    let mut view = Command::new("sh")
+        .args([
+            "-c",
+            &prepared_source_view_command(cache.to_str().unwrap(), destination.to_str().unwrap()),
+        ])
+        .env(
+            "PATH",
+            format!(
+                "{}:{}",
+                tools.path().display(),
+                std::env::var("PATH").unwrap_or_default()
+            ),
+        )
+        .env("HOMEBOY_COPY_STARTED", &started)
+        .env("HOMEBOY_COPY_RELEASE", &release)
+        .spawn()
+        .expect("start materialization");
+    for _ in 0..100 {
+        if started.exists() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert!(started.exists(), "materialization acquired the cache lock");
+    let prune = Command::new("sh")
+        .args([
+            "-c",
+            &prepared_source_cache_command(
+                cache.to_str().unwrap(),
+                cache_root.to_str().unwrap(),
+                cache.to_str().unwrap(),
+            ),
+        ])
+        .output()
+        .expect("run concurrent prune");
+    assert!(prune.status.success(), "{prune:?}");
+    assert!(cache.exists(), "prune must defer a lock-owned cache");
+    fs::write(&release, "").expect("release copy");
+    assert!(view.wait().expect("wait materialization").success());
+    assert!(destination.join("marker").is_file());
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/workspace/util.rs
+++ b/crates/homeboy-lab-runner/src/workspace/util.rs
@@ -116,7 +116,14 @@ pub(super) fn owner_capture_shell(reference: &str) -> String {
 
 pub(super) fn owner_restore_shell(parent: &str, dest: &str) -> String {
     format!(
-        "if [ \"$(id -u)\" = \"0\" ] && [ -n \"$owner\" ] && [ \"$owner\" != \"0:0\" ]; then chown \"$owner\" {parent} && chown -R \"$owner\" {dest}; fi",
+        "if [ \"$(id -u)\" = \"0\" ] && [ -n \"$owner\" ] && [ \"$owner\" != \"0:0\" ]; then chown \"$owner\" {parent} && {}; fi",
+        owner_restore_path_shell(dest),
+    )
+}
+
+pub(super) fn owner_restore_path_shell(path: &str) -> String {
+    format!(
+        "if [ \"$(id -u)\" = \"0\" ] && [ -n \"$owner\" ] && [ \"$owner\" != \"0:0\" ]; then chown -R \"$owner\" {path}; fi",
     )
 }
 


### PR DESCRIPTION
## Summary

- restore configured workspace ownership while preserving immutable ready caches
- synchronize cache creation, materialization, and pruning through one lock protocol
- persist bounded cache lifecycle observations in durable Lab hydration metadata
- continue pruning after bounded failed-removal diagnostics

## Verification

- 16 Lab hydration tests passed
- 3 prepared-source cache tests passed
- focused snapshot/materializer and lock-race coverage passed
- targeted Rust formatting and `git diff --check`

Closes #13061

## AI assistance

OpenAI GPT-5.6 Sol through OpenCode diagnosed the ownership leak, implemented cache synchronization and observability, and performed independent review. Chris Huber reviewed and remains responsible for every line.