### PR TITLE
style: format artifact promotion rooting test

### DIFF
--- a/tests/artifact_promotion_rooting_test.rs
+++ b/tests/artifact_promotion_rooting_test.rs
@@ -88,7 +88,9 @@ fn directory_child_promotion_guard_shares_the_promotion_store() {
 fn promotion_opens_no_ambient_store() {
     let source = promotion_source();
 
-    let opens = source.matches("ObservationStore::open_initialized()").count();
+    let opens = source
+        .matches("ObservationStore::open_initialized()")
+        .count();
     assert_eq!(
         opens, 0,
         "artifact_promotion.rs opens {opens} ambient store(s). Both production \


### PR DESCRIPTION
## Summary

Apply the canonical Rustfmt output that current `main` is missing in the artifact-promotion rooting test.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`

Closes #13101
Relates to #12833

## AI assistance

OpenAI GPT-5.6 Sol through OpenCode identified the shared baseline failure and applied the canonical one-file formatting correction. Chris Huber reviewed and remains responsible for every line.