### PR TITLE
fix(finalization): quarantine publication drift

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -354,15 +354,36 @@ fn finalize_pr_with_backend_mode<B: AgentTaskPrFinalizationBackend>(
     });
     options.review_dossier.evidence.dedup();
     let body = render_review_dossier(&options.review_dossier, &options.review_profile);
-    let (action, pr, draft) = match existing {
-        Some(existing) => {
-            let draft = existing.is_draft;
-            (
-                "updated",
-                backend.update_pr(&options.path, existing.number, &options.title, &body)?,
-                draft,
-            )
-        }
+    // The lookup and base observation may take long enough for another writer to
+    // replace the branch. Bind the live remote again at the last safe point.
+    let observed_remote_sha = backend.verify_remote_candidate(&options.path, &head, commit_sha)?;
+    if observed_remote_sha != commit_sha {
+        return Err(publication_drift_error(
+            commit_sha,
+            &observed_remote_sha,
+            None,
+            "no PR mutation performed",
+        ));
+    }
+    let newly_created = existing.is_none();
+    let draft = existing.as_ref().is_some_and(|pr| pr.is_draft);
+    let quarantine_capability = backend.quarantine_capability(newly_created, draft)?;
+    if !quarantine_capability_is_safe(quarantine_capability, newly_created, draft) {
+        return Err(Error::validation_invalid_argument(
+            "publication_quarantine",
+            format!(
+                "refusing PR mutation without a guaranteed safe quarantine transition; cleanup_capability={}",
+                quarantine_capability_name(quarantine_capability)
+            ),
+            None,
+            None,
+        ));
+    }
+    let (action, pr) = match existing {
+        Some(existing) => (
+            "updated",
+            backend.update_pr(&options.path, existing.number, &options.title, &body)?,
+        ),
         None => (
             "created",
             backend.create_pr(
@@ -373,25 +394,54 @@ fn finalize_pr_with_backend_mode<B: AgentTaskPrFinalizationBackend>(
                 &body,
                 options.draft_pr,
             )?,
-            options.draft_pr,
         ),
     };
+    let published_draft = if newly_created {
+        options.draft_pr
+    } else {
+        draft
+    };
 
-    let binding = backend.verify_publication_binding(
+    let binding = match backend.verify_publication_binding(
         &options.path,
         &options.base,
         &head,
         commit_sha,
         &changed_files,
         &pr,
-    )?;
-    validate_publication_binding(&binding, commit_sha, &changed_files)?;
+    ) {
+        Ok(binding) => binding,
+        Err(error) => {
+            return Err(publication_drift_with_cleanup_error(
+                backend,
+                &options.path,
+                &pr,
+                commit_sha,
+                "not_observed",
+                None,
+                quarantine_capability,
+                &error.message,
+            ));
+        }
+    };
+    if let Err(_error) = validate_publication_binding(&binding, commit_sha, &changed_files) {
+        return Err(publication_drift_with_cleanup_error(
+            backend,
+            &options.path,
+            &pr,
+            commit_sha,
+            &binding.remote_sha,
+            Some(&binding.pr_head_sha),
+            quarantine_capability,
+            "binding tuple mismatch",
+        ));
+    }
 
     Ok(report(
         &options,
         intent,
         &head,
-        if draft {
+        if published_draft {
             "draft_published"
         } else {
             "review_ready"
@@ -818,6 +868,129 @@ fn validate_publication_binding(
         ));
     }
     Ok(())
+}
+
+const PUBLICATION_IDENTITY_DIAGNOSTIC_LIMIT: usize = 160;
+
+fn publication_drift_error(
+    expected_candidate_sha: &str,
+    observed_remote_sha: &str,
+    observed_pr_head_sha: Option<&str>,
+    cleanup_state: &str,
+) -> Error {
+    let bounded = |value: &str| {
+        let value = value.trim();
+        let characters = value.chars().count();
+        if characters <= PUBLICATION_IDENTITY_DIAGNOSTIC_LIMIT {
+            value.to_string()
+        } else {
+            format!(
+                "{}...(+{} chars)",
+                value
+                    .chars()
+                    .take(PUBLICATION_IDENTITY_DIAGNOSTIC_LIMIT)
+                    .collect::<String>(),
+                characters - PUBLICATION_IDENTITY_DIAGNOSTIC_LIMIT
+            )
+        }
+    };
+    Error::validation_invalid_argument(
+        "publication_binding",
+        format!(
+            "publication candidate drift refused: expected_candidate_sha={}; observed_remote_sha={}; observed_pr_head_sha={}; cleanup_state={}",
+            bounded(expected_candidate_sha),
+            bounded(observed_remote_sha),
+            observed_pr_head_sha.map(bounded).unwrap_or_else(|| "not_observed".to_string()),
+            bounded(cleanup_state),
+        ),
+        None,
+        None,
+    )
+}
+
+fn quarantine_capability_is_safe(
+    capability: AgentTaskPrQuarantineCapability,
+    newly_created: bool,
+    was_draft: bool,
+) -> bool {
+    matches!(
+        (capability, newly_created, was_draft),
+        (AgentTaskPrQuarantineCapability::CloseNewPr, true, _)
+            | (
+                AgentTaskPrQuarantineCapability::PreserveExistingDraft,
+                false,
+                true
+            )
+            | (
+                AgentTaskPrQuarantineCapability::ConvertExistingReadyPrToDraft,
+                false,
+                false
+            )
+    )
+}
+
+fn quarantine_capability_name(capability: AgentTaskPrQuarantineCapability) -> &'static str {
+    match capability {
+        AgentTaskPrQuarantineCapability::CloseNewPr => "close_new_pr",
+        AgentTaskPrQuarantineCapability::PreserveExistingDraft => "preserve_existing_draft",
+        AgentTaskPrQuarantineCapability::ConvertExistingReadyPrToDraft => {
+            "convert_existing_ready_pr_to_draft"
+        }
+        AgentTaskPrQuarantineCapability::Unsupported => "unsupported",
+    }
+}
+
+fn publication_drift_with_cleanup_error<B: AgentTaskPrFinalizationBackend>(
+    backend: &mut B,
+    path: &str,
+    pr: &AgentTaskPrRef,
+    expected_candidate_sha: &str,
+    observed_remote_sha: &str,
+    observed_pr_head_sha: Option<&str>,
+    capability: AgentTaskPrQuarantineCapability,
+    binding_error: &str,
+) -> Error {
+    let cleanup = match backend.quarantine_pr(path, pr, capability) {
+        Ok(state) => state,
+        Err(error) => format!(
+            "failed; cleanup_capability={}; cleanup_error={}",
+            quarantine_capability_name(capability),
+            bounded_publication_diagnostic(&error.message)
+        ),
+    };
+    let drift = publication_drift_error(
+        expected_candidate_sha,
+        observed_remote_sha,
+        observed_pr_head_sha,
+        &cleanup,
+    );
+    Error::validation_invalid_argument(
+        "publication_binding",
+        format!(
+            "{}; binding_error={}",
+            drift.message,
+            bounded_publication_diagnostic(binding_error)
+        ),
+        None,
+        None,
+    )
+}
+
+fn bounded_publication_diagnostic(value: &str) -> String {
+    let value = value.trim();
+    let characters = value.chars().count();
+    if characters <= PUBLICATION_IDENTITY_DIAGNOSTIC_LIMIT {
+        value.to_string()
+    } else {
+        format!(
+            "{}...(+{} chars)",
+            value
+                .chars()
+                .take(PUBLICATION_IDENTITY_DIAGNOSTIC_LIMIT)
+                .collect::<String>(),
+            characters - PUBLICATION_IDENTITY_DIAGNOSTIC_LIMIT
+        )
+    }
 }
 
 fn build_pr_publication_intent(

--- a/crates/homeboy-agents/src/agent_task_finalization/backend.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/backend.rs
@@ -1,7 +1,7 @@
 use super::{
     AgentTaskPrCandidateState, AgentTaskPrDurableGateProof, AgentTaskPrFinalizationBackend,
-    AgentTaskPrFinalizationOptions, AgentTaskPrRef, AgentTaskPrResolvedBase,
-    AgentTaskPublicationBinding, AgentTaskPublicationGitTracking,
+    AgentTaskPrFinalizationOptions, AgentTaskPrQuarantineCapability, AgentTaskPrRef,
+    AgentTaskPrResolvedBase, AgentTaskPublicationBinding, AgentTaskPublicationGitTracking,
 };
 use crate::agent_task_promotion::{AgentTaskPromotionCandidate, AgentTaskPromotionReport};
 use homeboy_core::error::{Error, Result};
@@ -417,6 +417,33 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
         }))
     }
 
+    fn verify_remote_candidate(
+        &mut self,
+        path: &str,
+        head: &str,
+        candidate_sha: &str,
+    ) -> Result<String> {
+        let observed = remote_branch_head(path, head)?.unwrap_or_default();
+        if observed != candidate_sha {
+            return Ok(observed);
+        }
+        Ok(candidate_sha.to_string())
+    }
+
+    fn quarantine_capability(
+        &mut self,
+        newly_created: bool,
+        was_draft: bool,
+    ) -> Result<AgentTaskPrQuarantineCapability> {
+        Ok(if newly_created {
+            AgentTaskPrQuarantineCapability::CloseNewPr
+        } else if was_draft {
+            AgentTaskPrQuarantineCapability::PreserveExistingDraft
+        } else {
+            AgentTaskPrQuarantineCapability::ConvertExistingReadyPrToDraft
+        })
+    }
+
     fn create_pr(
         &mut self,
         path: &str,
@@ -488,22 +515,6 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
         }
         let candidate_tree =
             git_output(path, &["rev-parse", &format!("{candidate_sha}^{{tree}}")])?;
-        let remote_sha = remote_branch_head(path, head)?.ok_or_else(|| {
-            Error::validation_invalid_argument(
-                "publication_binding",
-                "pushed remote head disappeared before PR verification",
-                None,
-                None,
-            )
-        })?;
-        if remote_sha != candidate_sha {
-            return Err(Error::validation_invalid_argument(
-                "publication_binding",
-                "pushed remote ref changed before PR verification",
-                None,
-                None,
-            ));
-        }
         let repository = gh_json(path, &["repo", "view", "--json", "nameWithOwner"])?
             ["nameWithOwner"]
             .as_str()
@@ -529,26 +540,16 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
             .to_string();
         if pr_value["baseRefName"].as_str() != Some(base)
             || pr_value["headRefName"].as_str() != Some(head)
-            || repository.is_empty()
-            || head_repository != repository
-            || pr_head_sha != candidate_sha
         {
             return Err(Error::validation_invalid_argument(
                 "publication_binding",
-                "GitHub PR does not match the requested same-repository head or verified candidate SHA",
+                "GitHub PR does not match the requested base and head refs",
                 None,
                 None,
             ));
         }
         // Re-read after GitHub observation to reject a force-update race.
-        if remote_branch_head(path, head)?.as_deref() != Some(candidate_sha) {
-            return Err(Error::validation_invalid_argument(
-                "publication_binding",
-                "pushed remote ref changed while verifying the GitHub PR head",
-                None,
-                None,
-            ));
-        }
+        let remote_sha = remote_branch_head(path, head)?.unwrap_or_default();
         Ok(AgentTaskPublicationBinding {
             candidate_sha: candidate_sha.to_string(),
             candidate_tree,
@@ -558,6 +559,53 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
             head_repository,
             changed_files: super::normalize_changed_files(changed_files),
         })
+    }
+
+    fn quarantine_pr(
+        &mut self,
+        path: &str,
+        pr: &AgentTaskPrRef,
+        capability: AgentTaskPrQuarantineCapability,
+    ) -> Result<String> {
+        let (args, state) = match capability {
+            AgentTaskPrQuarantineCapability::CloseNewPr => (
+                vec!["pr".to_string(), "close".to_string(), pr.number.to_string()],
+                "new_pr_closed",
+            ),
+            AgentTaskPrQuarantineCapability::PreserveExistingDraft => {
+                return Ok("existing_pr_already_draft".to_string())
+            }
+            AgentTaskPrQuarantineCapability::ConvertExistingReadyPrToDraft => (
+                vec![
+                    "pr".to_string(),
+                    "ready".to_string(),
+                    pr.number.to_string(),
+                    "--undo".to_string(),
+                ],
+                "existing_pr_converted_to_draft",
+            ),
+            AgentTaskPrQuarantineCapability::Unsupported => {
+                return Err(Error::validation_invalid_argument(
+                    "publication_quarantine",
+                    "backend does not support a safe PR quarantine transition",
+                    None,
+                    None,
+                ))
+            }
+        };
+        let output = std::process::Command::new("gh")
+            .args(&args)
+            .current_dir(path)
+            .output()
+            .map_err(|error| Error::git_command_failed(error.to_string()))?;
+        if !output.status.success() {
+            return Err(Error::git_command_failed(format!(
+                "gh {} failed while quarantining publication drift: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&output.stderr).trim()
+            )));
+        }
+        Ok(state.to_string())
     }
 }
 

--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -51,6 +51,12 @@ struct MockBackend {
     last_body: String,
     publication_binding: Option<AgentTaskPublicationBinding>,
     publication_binding_calls: u8,
+    remote_candidate_sha: Option<String>,
+    remote_candidate_checks: u8,
+    quarantine_capability: Option<AgentTaskPrQuarantineCapability>,
+    quarantine_state: Option<String>,
+    quarantine_error: bool,
+    quarantine_calls: u8,
     candidate_validation_calls: u8,
     rooted_candidate_validation_calls: u8,
 }
@@ -281,6 +287,33 @@ impl AgentTaskPrFinalizationBackend for MockBackend {
         Ok(self.existing_pr.clone())
     }
 
+    fn verify_remote_candidate(
+        &mut self,
+        _path: &str,
+        _head: &str,
+        candidate_sha: &str,
+    ) -> Result<String> {
+        self.remote_candidate_checks += 1;
+        Ok(self
+            .remote_candidate_sha
+            .clone()
+            .unwrap_or_else(|| candidate_sha.to_string()))
+    }
+
+    fn quarantine_capability(
+        &mut self,
+        newly_created: bool,
+        was_draft: bool,
+    ) -> Result<AgentTaskPrQuarantineCapability> {
+        Ok(self.quarantine_capability.unwrap_or(if newly_created {
+            AgentTaskPrQuarantineCapability::CloseNewPr
+        } else if was_draft {
+            AgentTaskPrQuarantineCapability::PreserveExistingDraft
+        } else {
+            AgentTaskPrQuarantineCapability::ConvertExistingReadyPrToDraft
+        }))
+    }
+
     fn create_pr(
         &mut self,
         _path: &str,
@@ -341,6 +374,31 @@ impl AgentTaskPrFinalizationBackend for MockBackend {
                 repository: "Extra-Chill/homeboy".to_string(),
                 head_repository: "Extra-Chill/homeboy".to_string(),
                 changed_files: changed_files.to_vec(),
+            }))
+    }
+
+    fn quarantine_pr(
+        &mut self,
+        _path: &str,
+        _pr: &AgentTaskPrRef,
+        capability: AgentTaskPrQuarantineCapability,
+    ) -> Result<String> {
+        self.quarantine_calls += 1;
+        if self.quarantine_error {
+            return Err(Error::git_command_failed("quarantine command failed"));
+        }
+        Ok(self
+            .quarantine_state
+            .clone()
+            .unwrap_or_else(|| match capability {
+                AgentTaskPrQuarantineCapability::CloseNewPr => "new_pr_closed".to_string(),
+                AgentTaskPrQuarantineCapability::PreserveExistingDraft => {
+                    "existing_pr_already_draft".to_string()
+                }
+                AgentTaskPrQuarantineCapability::ConvertExistingReadyPrToDraft => {
+                    "existing_pr_converted_to_draft".to_string()
+                }
+                AgentTaskPrQuarantineCapability::Unsupported => "unsupported".to_string(),
             }))
     }
 }
@@ -459,13 +517,14 @@ fn finalization_rejects_candidate_remote_pr_and_fork_binding_mismatches() {
         };
         let error =
             finalize_pr_with_backend(options(), &mut backend).expect_err("binding mismatch");
-        assert!(
-            error.message.contains("candidate SHA") || error.message.contains("same-repository")
-        );
+        assert!(error
+            .message
+            .contains("publication candidate drift refused"));
         assert!(
             backend.created,
             "PR mutation precedes the authoritative re-read"
         );
+        assert_eq!(backend.quarantine_calls, 1, "drift quarantines the PR");
         binding.candidate_sha.clear();
     };
     let binding =
@@ -493,6 +552,199 @@ fn finalization_rejects_candidate_remote_pr_and_fork_binding_mismatches() {
         "candidate-sha",
         "contributor/homeboy",
     ));
+}
+
+#[test]
+fn finalization_refuses_remote_drift_immediately_before_pr_mutation() {
+    let mut backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        remote_candidate_sha: Some("foreign-remote-sha".to_string()),
+        ..Default::default()
+    };
+
+    let error = finalize_pr_with_backend(options(), &mut backend).expect_err("remote drift blocks");
+
+    assert!(error
+        .message
+        .contains("expected_candidate_sha=candidate-sha"));
+    assert!(error
+        .message
+        .contains("observed_remote_sha=foreign-remote-sha"));
+    assert!(error.message.contains("observed_pr_head_sha=not_observed"));
+    assert!(error
+        .message
+        .contains("cleanup_state=no PR mutation performed"));
+    assert_eq!(backend.remote_candidate_checks, 1);
+    assert!(
+        !backend.created && !backend.updated,
+        "PR mutation is refused"
+    );
+    assert_eq!(backend.quarantine_calls, 0);
+}
+
+#[test]
+fn post_mutation_drift_closes_new_pr_and_refuses_a_receipt() {
+    let mut backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        publication_binding: Some(AgentTaskPublicationBinding {
+            candidate_sha: "candidate-sha".to_string(),
+            candidate_tree: "candidate-tree".to_string(),
+            remote_sha: "foreign-remote-sha".to_string(),
+            pr_head_sha: "foreign-pr-head".to_string(),
+            repository: "Extra-Chill/homeboy".to_string(),
+            head_repository: "Extra-Chill/homeboy".to_string(),
+            changed_files: vec!["src/lib.rs".to_string()],
+        }),
+        ..Default::default()
+    };
+
+    let result = finalize_pr_with_backend(options(), &mut backend);
+    let error = result.expect_err("post-mutation drift refuses finalization receipt");
+
+    assert!(backend.created);
+    assert_eq!(backend.quarantine_calls, 1);
+    assert!(error
+        .message
+        .contains("expected_candidate_sha=candidate-sha"));
+    assert!(error
+        .message
+        .contains("observed_remote_sha=foreign-remote-sha"));
+    assert!(error
+        .message
+        .contains("observed_pr_head_sha=foreign-pr-head"));
+    assert!(error.message.contains("cleanup_state=new_pr_closed"));
+}
+
+#[test]
+fn post_mutation_drift_quarantines_existing_ready_pr_as_draft() {
+    let mut backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        existing_pr: Some(AgentTaskPrRef {
+            number: 77,
+            url: "https://github.com/Extra-Chill/homeboy/pull/77".to_string(),
+            is_draft: false,
+        }),
+        publication_binding: Some(AgentTaskPublicationBinding {
+            candidate_sha: "candidate-sha".to_string(),
+            candidate_tree: "candidate-tree".to_string(),
+            remote_sha: "foreign-remote-sha".to_string(),
+            pr_head_sha: "foreign-pr-head".to_string(),
+            repository: "Extra-Chill/homeboy".to_string(),
+            head_repository: "Extra-Chill/homeboy".to_string(),
+            changed_files: vec!["src/lib.rs".to_string()],
+        }),
+        ..Default::default()
+    };
+
+    let error = finalize_pr_with_backend(options(), &mut backend)
+        .expect_err("post-mutation drift refuses finalization receipt");
+
+    assert!(backend.updated);
+    assert!(!backend.created);
+    assert_eq!(backend.quarantine_calls, 1);
+    assert!(error
+        .message
+        .contains("cleanup_state=existing_pr_converted_to_draft"));
+}
+
+#[test]
+fn unsupported_existing_ready_pr_quarantine_refuses_update_before_mutation() {
+    let mut backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        existing_pr: Some(AgentTaskPrRef {
+            number: 77,
+            url: "https://github.com/Extra-Chill/homeboy/pull/77".to_string(),
+            is_draft: false,
+        }),
+        quarantine_capability: Some(AgentTaskPrQuarantineCapability::Unsupported),
+        ..Default::default()
+    };
+
+    let error = finalize_pr_with_backend(options(), &mut backend)
+        .expect_err("unsupported quarantine blocks update and receipt");
+
+    assert!(error.message.contains("cleanup_capability=unsupported"));
+    assert!(!backend.updated && !backend.created);
+    assert_eq!(backend.quarantine_calls, 0);
+}
+
+#[test]
+fn failed_new_pr_close_preserves_drift_and_cleanup_evidence_without_receipt() {
+    let mut backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        publication_binding: Some(AgentTaskPublicationBinding {
+            candidate_sha: "candidate-sha".to_string(),
+            candidate_tree: "candidate-tree".to_string(),
+            remote_sha: "foreign-remote-sha".to_string(),
+            pr_head_sha: "foreign-pr-head".to_string(),
+            repository: "Extra-Chill/homeboy".to_string(),
+            head_repository: "Extra-Chill/homeboy".to_string(),
+            changed_files: vec!["src/lib.rs".to_string()],
+        }),
+        quarantine_error: true,
+        ..Default::default()
+    };
+
+    let error = finalize_pr_with_backend(options(), &mut backend)
+        .expect_err("failed close still refuses receipt");
+
+    assert!(backend.created);
+    assert_eq!(backend.quarantine_calls, 1);
+    for expected in [
+        "expected_candidate_sha=candidate-sha",
+        "observed_remote_sha=foreign-remote-sha",
+        "observed_pr_head_sha=foreign-pr-head",
+        "cleanup_state=failed",
+        "cleanup_capability=close_new_pr",
+        "cleanup_error=quarantine command failed",
+    ] {
+        assert!(
+            error.message.contains(expected),
+            "missing {expected}: {error}"
+        );
+    }
+}
+
+#[test]
+fn failed_existing_pr_draft_conversion_preserves_drift_and_cleanup_evidence_without_receipt() {
+    let mut backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        existing_pr: Some(AgentTaskPrRef {
+            number: 77,
+            url: "https://github.com/Extra-Chill/homeboy/pull/77".to_string(),
+            is_draft: false,
+        }),
+        publication_binding: Some(AgentTaskPublicationBinding {
+            candidate_sha: "candidate-sha".to_string(),
+            candidate_tree: "candidate-tree".to_string(),
+            remote_sha: "foreign-remote-sha".to_string(),
+            pr_head_sha: "foreign-pr-head".to_string(),
+            repository: "Extra-Chill/homeboy".to_string(),
+            head_repository: "Extra-Chill/homeboy".to_string(),
+            changed_files: vec!["src/lib.rs".to_string()],
+        }),
+        quarantine_error: true,
+        ..Default::default()
+    };
+
+    let error = finalize_pr_with_backend(options(), &mut backend)
+        .expect_err("failed draft conversion still refuses receipt");
+
+    assert!(backend.updated);
+    assert_eq!(backend.quarantine_calls, 1);
+    for expected in [
+        "expected_candidate_sha=candidate-sha",
+        "observed_remote_sha=foreign-remote-sha",
+        "observed_pr_head_sha=foreign-pr-head",
+        "cleanup_state=failed",
+        "cleanup_capability=convert_existing_ready_pr_to_draft",
+        "cleanup_error=quarantine command failed",
+    ] {
+        assert!(
+            error.message.contains(expected),
+            "missing {expected}: {error}"
+        );
+    }
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_finalization/types.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/types.rs
@@ -275,6 +275,15 @@ pub struct AgentTaskPrRef {
     pub is_draft: bool,
 }
 
+/// The safe state transition available if a PR binding drifts after mutation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentTaskPrQuarantineCapability {
+    CloseNewPr,
+    PreserveExistingDraft,
+    ConvertExistingReadyPrToDraft,
+    Unsupported,
+}
+
 /// The complete Git candidate classification, determined before finalization
 /// mutates the worktree or remote.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -405,6 +414,23 @@ pub trait AgentTaskPrFinalizationBackend {
         base: &str,
         head: &str,
     ) -> Result<Option<AgentTaskPrRef>>;
+    /// Re-reads the live candidate branch immediately before a GitHub mutation.
+    /// This is separate from post-mutation binding verification because a remote
+    /// writer can advance the branch between Homeboy's push and PR mutation.
+    fn verify_remote_candidate(
+        &mut self,
+        path: &str,
+        head: &str,
+        candidate_sha: &str,
+    ) -> Result<String>;
+    /// Declares the safe post-mutation state transition before the mutation is
+    /// admitted. A ready existing PR may only be updated when conversion to a
+    /// draft is supported.
+    fn quarantine_capability(
+        &mut self,
+        newly_created: bool,
+        was_draft: bool,
+    ) -> Result<AgentTaskPrQuarantineCapability>;
     fn create_pr(
         &mut self,
         path: &str,
@@ -430,4 +456,11 @@ pub trait AgentTaskPrFinalizationBackend {
         changed_files: &[String],
         pr: &AgentTaskPrRef,
     ) -> Result<AgentTaskPublicationBinding>;
+    /// Applies the safe transition declared by [`Self::quarantine_capability`].
+    fn quarantine_pr(
+        &mut self,
+        path: &str,
+        pr: &AgentTaskPrRef,
+        capability: AgentTaskPrQuarantineCapability,
+    ) -> Result<String>;
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -12078,6 +12078,27 @@ impl AgentTaskPrFinalizationBackend for CaptureBackend {
     ) -> Result<Option<AgentTaskPrRef>> {
         Ok(None)
     }
+    fn verify_remote_candidate(
+        &mut self,
+        _path: &str,
+        _head: &str,
+        candidate_sha: &str,
+    ) -> Result<String> {
+        Ok(candidate_sha.to_string())
+    }
+    fn quarantine_capability(
+        &mut self,
+        newly_created: bool,
+        was_draft: bool,
+    ) -> Result<crate::agent_task_finalization::AgentTaskPrQuarantineCapability> {
+        Ok(if newly_created {
+            crate::agent_task_finalization::AgentTaskPrQuarantineCapability::CloseNewPr
+        } else if was_draft {
+            crate::agent_task_finalization::AgentTaskPrQuarantineCapability::PreserveExistingDraft
+        } else {
+            crate::agent_task_finalization::AgentTaskPrQuarantineCapability::ConvertExistingReadyPrToDraft
+        })
+    }
     fn create_pr(
         &mut self,
         _path: &str,
@@ -12122,6 +12143,27 @@ impl AgentTaskPrFinalizationBackend for CaptureBackend {
             repository: "Extra-Chill/homeboy".to_string(),
             head_repository: "Extra-Chill/homeboy".to_string(),
             changed_files: changed_files.to_vec(),
+        })
+    }
+    fn quarantine_pr(
+        &mut self,
+        _path: &str,
+        _pr: &AgentTaskPrRef,
+        capability: crate::agent_task_finalization::AgentTaskPrQuarantineCapability,
+    ) -> Result<String> {
+        Ok(match capability {
+            crate::agent_task_finalization::AgentTaskPrQuarantineCapability::CloseNewPr => {
+                "new_pr_closed".to_string()
+            }
+            crate::agent_task_finalization::AgentTaskPrQuarantineCapability::PreserveExistingDraft => {
+                "existing_pr_already_draft".to_string()
+            }
+            crate::agent_task_finalization::AgentTaskPrQuarantineCapability::ConvertExistingReadyPrToDraft => {
+                "existing_pr_converted_to_draft".to_string()
+            }
+            crate::agent_task_finalization::AgentTaskPrQuarantineCapability::Unsupported => {
+                "unsupported".to_string()
+            }
         })
     }
 }


### PR DESCRIPTION
## Summary
- revalidate live remote candidate identity immediately before PR mutation
- require an explicit safe quarantine capability before creating or updating a PR
- close drifted new PRs and convert drifted existing ready PRs to draft
- preserve expected/observed SHA evidence when quarantine itself fails
- refuse finalization receipts for every drift and cleanup-failure path

## Verification
- `cargo check -p homeboy-agents`
- `cargo test -p homeboy-agents agent_task_finalization --lib` (72 passed; one shared-environment protected-branch assertion passed in isolated rerun)
- `git diff --check origin/main...HEAD`

Closes #13092

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode identified the mutation-order race during independent review, implemented fail-closed quarantine capabilities, added backend-driven coverage, and ran focused verification. Chris Huber is responsible for every line.