### PR TITLE
fix(ci): restore required gates on main

### DIFF
--- a/.github/test-manage-required-gates-ruleset.sh
+++ b/.github/test-manage-required-gates-ruleset.sh
@@ -119,8 +119,8 @@ if run_reconcile "${tmp}/missing-checks.json" "${tmp}/missing-check-failure.json
 fi
 jq -e '.outcome == "failed" and .stage == "check-run" and .reason == "canonical successful required check is absent"' "${tmp}/missing-check-failure.json" >/dev/null
 
-if GH_BIN="${tmp}/gh" GH_LOG="${tmp}/gh.log" GH_STATE="${tmp}/state.json" GITHUB_REPOSITORY=Extra-Chill/homeboy \
-  bash "${root}/.github/reconcile-required-gates-ruleset.sh" --evidence "${tmp}/token-failure.json"; then
+if env -u GH_TOKEN GH_BIN="${tmp}/gh" GH_LOG="${tmp}/gh.log" GH_STATE="${tmp}/state.json" GITHUB_REPOSITORY=Extra-Chill/homeboy \
+   bash "${root}/.github/reconcile-required-gates-ruleset.sh" --evidence "${tmp}/token-failure.json"; then
   echo 'reconcile accepted a missing administration token' >&2
   exit 1
 fi

--- a/tests/artifact_promotion_rooting_test.rs
+++ b/tests/artifact_promotion_rooting_test.rs
@@ -88,7 +88,9 @@ fn directory_child_promotion_guard_shares_the_promotion_store() {
 fn promotion_opens_no_ambient_store() {
     let source = promotion_source();
 
-    let opens = source.matches("ObservationStore::open_initialized()").count();
+    let opens = source
+        .matches("ObservationStore::open_initialized()")
+        .count();
     assert_eq!(
         opens, 0,
         "artifact_promotion.rs opens {opens} ambient store(s). Both production \


### PR DESCRIPTION
## Summary

- restore Rustfmt on the current `main` tree
- remove ambient `GH_TOKEN` from the fixture intended to exercise missing administration credentials
- resolve duplicate required contexts on the current head to their successful executed instance while preserving raw conclusions
- repair the mutually inherited CI failures in one normally gated stack

Fixes #13093.
Fixes #13103.
Fixes #13114.

## Verification

- `cargo +1.95.0 fmt --all -- --check`
- `bash .github/test-manage-required-gates-ruleset.sh`
- `cargo test --test required_gates_policy_test` (23 passed)
- focused commits independently proved their repaired gates in #13097 and the original #13110 run

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode correlated the inherited `main` failures, implemented head-scoped duplicate required-context aggregation, added fail-closed regression fixtures, and verified the local and CI evidence. Chris Huber is responsible for every line.