### PR TITLE
Separate attempt and Cook status scope

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -266,6 +266,27 @@ mod tests {
     }
 
     #[test]
+    fn bridge_status_accepts_a_positional_attempt_without_exact() {
+        let cli = Cli::try_parse_from([
+            "homeboy",
+            "agent-task",
+            "status",
+            "cook-attempt-2",
+            "--bridge",
+        ])
+        .expect("bridge status with positional attempt parses");
+        let Commands::AgentTask(agent_task) = cli.command else {
+            panic!("expected agent-task command");
+        };
+        let AgentTaskCommand::Status(args) = agent_task.command else {
+            panic!("expected status command");
+        };
+        assert_eq!(args.run_id, "cook-attempt-2");
+        assert!(args.bridge);
+        assert!(!args.exact);
+    }
+
+    #[test]
     fn strict_subject_exit_is_status_only() {
         let cli = Cli::try_parse_from([
             "homeboy",

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -169,6 +169,7 @@ fn status_once(args: StatusArgs) -> CmdResult<Value> {
         if let Some(selection) = target.selection {
             value["candidate_selection"] = selection;
         }
+        attach_status_scope(&mut value, &target.run_id);
         return Ok((value, 0));
     }
 
@@ -275,6 +276,7 @@ fn status_once(args: StatusArgs) -> CmdResult<Value> {
     if let Some(selection) = target.selection.as_ref() {
         value["candidate_selection"] = selection.clone();
     }
+    attach_status_scope(&mut value, run_id);
     if args.full {
         let aggregate = completed_run_aggregate(run_id).and_then(Result::ok);
         attach_full_status_candidate(&mut value, aggregate.as_ref(), run_id);
@@ -1170,6 +1172,10 @@ fn normalized_full_status(
                 "label": bounded_value(action.get("label").unwrap_or(&Value::Null)),
             })),
         },
+        "status_scope": value
+            .get("status_scope")
+            .map(compact_status_scope)
+            .unwrap_or(Value::Null),
         "evidence_graph": normalized_evidence_graph(run_id, aggregate, artifact_count, evidence_count),
         "details": {
             "status": { "ref": status_ref, "command": format!("homeboy agent-task status {} --full", quote_arg(run_id)) },
@@ -1212,6 +1218,10 @@ fn normalized_full_status(
                 "state": bounded_value(value.get("state").unwrap_or(&Value::Null)),
                 "terminal_status": bounded_value(value.get("terminal_status").unwrap_or(&Value::Null)),
             },
+            "status_scope": value
+                .get("status_scope")
+                .map(compact_status_scope)
+                .unwrap_or(Value::Null),
             "output_budget": {
                 "max_bytes": BOUNDED_FULL_STATUS_BYTE_LIMIT,
                 "truncated": true,
@@ -1361,6 +1371,37 @@ mod bounded_full_status_tests {
             .windows(2)
             .all(|pair| { pair[0]["ref"].as_str().unwrap() < pair[1]["ref"].as_str().unwrap() }));
         assert_eq!(full["details"]["artifacts"]["total_items"], 10_000);
+    }
+
+    #[test]
+    fn bounded_full_status_preserves_attempt_and_cook_scope() {
+        let full = normalized_full_status(
+            json!({
+                "run_id": "cancelled-retry",
+                "state": "cancelled",
+                "status_scope": {
+                    "schema": "homeboy/agent-task-status-scope/v1",
+                    "queried_attempt": { "run_id": "cancelled-retry", "candidate": { "state": "unknown" }, "unbounded": "x".repeat(BOUNDED_FULL_STATUS_BYTE_LIMIT * 2) },
+                    "cook": { "selection": { "status": "selected", "run_id": "historical-finalized", "candidate": { "state": "finalized" } }, "finalization": { "status": "review_ready", "pr_url": "x".repeat(BOUNDED_FULL_STATUS_BYTE_LIMIT * 2) } }
+                }
+            }),
+            "cancelled-retry",
+            None,
+        );
+
+        assert!(serialized_len(&full) <= BOUNDED_FULL_STATUS_BYTE_LIMIT);
+        assert_eq!(
+            full["status_scope"]["queried_attempt"]["run_id"],
+            "cancelled-retry"
+        );
+        assert_eq!(
+            full["status_scope"]["cook"]["selection"]["status"],
+            "selected"
+        );
+        assert_eq!(
+            full["status_scope"]["cook"]["selection"]["candidate"]["state"],
+            "finalized"
+        );
     }
 }
 
@@ -2434,7 +2475,12 @@ fn attach_cook_completion(value: &mut Value, record: &AgentTaskRunRecord) {
         record.metadata.get("cook_finalization"),
         Some(&record.run_id),
     ) {
-        value["cook_completion"] = serde_json::to_value(completion).expect("completion serializes");
+        let mut completion = serde_json::to_value(completion).expect("completion serializes");
+        // This legacy top-level field remains for existing consumers, but its
+        // candidate fact belongs to the Cook rather than this queried attempt.
+        completion["scope"] = json!("cook");
+        completion["context"] = json!("selected_cook_candidate");
+        value["cook_completion"] = completion;
     }
     // The completion projection answers whether a PR exists; it does not carry
     // the PR's identity. Project that beside it so `status` can answer "is there
@@ -2454,6 +2500,132 @@ fn cook_finalization_pr_url(record: &AgentTaskRunRecord) -> Option<&str> {
         .and_then(Value::as_str)?
         .trim();
     (!url.is_empty()).then_some(url)
+}
+
+/// Versioned semantic boundary between one queried lifecycle attempt and the
+/// Cook-wide candidate that can survive later empty or cancelled retries.
+/// Legacy top-level fields intentionally retain their historical projection.
+fn attach_status_scope(value: &mut Value, queried_run_id: &str) {
+    // The bridge status projection intentionally omits record metadata and the
+    // aggregate. Rehydrate both from the controller before classifying so every
+    // status mode describes the same durable attempt, not its transient view.
+    let queried_record = agent_task_service_direct::persisted_status(queried_run_id).ok();
+    let queried_aggregate = completed_run_aggregate(queried_run_id).and_then(Result::ok);
+    let queried_payload = queried_record
+        .as_ref()
+        .and_then(|record| serde_json::to_value(record).ok())
+        .unwrap_or_else(|| value.clone());
+    let queried_candidate = canonical_candidate_projection(classify_candidates(
+        &candidate_result_payload(&queried_payload, queried_aggregate.as_ref()),
+    ));
+    let cook_id = queried_record
+        .as_ref()
+        .and_then(|record| record.metadata.get("cook_id"))
+        .and_then(Value::as_str);
+    // A status scope distinguishes a queried Cook attempt from its selected
+    // candidate. Do not invent that distinction for ordinary lifecycle runs:
+    // a synthetic unavailable Cook selection changes their human summary.
+    let has_cook_evidence = cook_id.is_some_and(|cook_id| !cook_id.is_empty())
+        || value
+            .get("cook_completion")
+            .is_some_and(|completion| !completion.is_null())
+        || value
+            .pointer("/metadata/cook_finalization")
+            .is_some_and(|finalization| !finalization.is_null());
+    if !has_cook_evidence {
+        return;
+    }
+    let mut cook = json!({
+        "selection": {
+            "status": "unavailable",
+            "diagnostics": [{ "code": "cook_identity_unavailable" }],
+        },
+        "completion": Value::Null,
+        "finalization": Value::Null,
+    });
+    if let Some(cook_id) = cook_id.filter(|cook_id| !cook_id.is_empty()) {
+        cook["cook_id"] = bounded_value(&Value::String(cook_id.to_string()));
+        match agent_task_service_direct::select_cook_candidate(cook_id) {
+            Ok(selection) if selection.incomplete => {
+                cook["selection"] = json!({
+                    "status": "unavailable",
+                    "reason": selection.reason,
+                    "latest_attempt_run_id": bounded_value(&Value::String(selection.latest_attempt_run_id)),
+                    "diagnostics": [{ "code": "selection_incomplete", "skipped_attempts": selection.skipped_newer_run_ids.len() }],
+                });
+            }
+            Ok(selection) if selection.selected_artifact_id.is_none() => {
+                cook["selection"] = json!({
+                    "status": "none",
+                    "reason": selection.reason,
+                    "latest_attempt_run_id": bounded_value(&Value::String(selection.latest_attempt_run_id)),
+                });
+            }
+            Ok(selection) => {
+                let selected_run_id = selection.run_id;
+                let selected = agent_task_service_direct::persisted_status(&selected_run_id)
+                    .ok()
+                    .map(|record| {
+                        let aggregate =
+                            completed_run_aggregate(&selected_run_id).and_then(Result::ok);
+                        let mut payload = serde_json::to_value(&record).unwrap_or(Value::Null);
+                        attach_cook_completion(&mut payload, &record);
+                        (
+                            canonical_candidate_projection(classify_candidates(
+                                &candidate_result_payload(&payload, aggregate.as_ref()),
+                            )),
+                            payload
+                                .get("cook_completion")
+                                .cloned()
+                                .unwrap_or(Value::Null),
+                            payload
+                                .pointer("/metadata/cook_finalization")
+                                .cloned()
+                                .unwrap_or(Value::Null),
+                        )
+                    });
+                let selection_available = selected.is_some();
+                let (candidate, completion, finalization) = selected.unwrap_or_else(|| {
+                    (
+                        json!({ "schema": "homeboy/agent-task-candidate/v1", "state": "unknown" }),
+                        Value::Null,
+                        Value::Null,
+                    )
+                });
+                cook["completion"] = completion;
+                cook["finalization"] = finalization;
+                cook["selection"] = json!({
+                    "status": if selection_available { "selected" } else { "unavailable" },
+                    "run_id": bounded_value(&Value::String(selected_run_id)),
+                    "attempt": selection.attempt,
+                    "latest_attempt_run_id": bounded_value(&Value::String(selection.latest_attempt_run_id)),
+                    "reason": selection.reason,
+                    "selected_task_id": selection.selected_task_id.map(Value::String).unwrap_or(Value::Null),
+                    "selected_artifact_id": selection.selected_artifact_id.map(Value::String).unwrap_or(Value::Null),
+                    "candidate": candidate,
+                    "diagnostics": if selection_available { Value::Array(Vec::new()) } else { json!([{ "code": "selected_attempt_unavailable" }]) },
+                });
+            }
+            Err(error) => {
+                cook["selection"] = json!({
+                    "status": "unavailable",
+                    "diagnostics": [{ "code": "selection_read_failed", "message": bounded_value(&Value::String(error.message)) }],
+                });
+            }
+        }
+    }
+    value["status_scope"] = json!({
+        "schema": "homeboy/agent-task-status-scope/v1",
+        "queried_attempt": {
+            "run_id": bounded_value(&Value::String(queried_run_id.to_string())),
+            "state": value.get("state").cloned().unwrap_or(Value::Null),
+            "child_run_state": value.get("child_run_state").cloned().unwrap_or(Value::Null),
+            "totals": value.get("totals").cloned().unwrap_or(Value::Null),
+            "artifacts": { "count": value.get("artifact_refs").and_then(Value::as_array).map_or(0, Vec::len) },
+            "candidate": queried_candidate,
+        },
+        "cook": cook,
+    });
 }
 
 /// Basis marker for `next_actions`: the diagnosis mapped a typed failure
@@ -3790,7 +3962,7 @@ mod diagnose_actionable_tests {
             vec![
                 "homeboy agent-task status run-1 --full",
                 "homeboy runner status homeboy-lab",
-                "homeboy runner doctor homeboy-lab --repair",
+                "homeboy runner doctor homeboy-lab --scope lab-offload --repair",
                 "homeboy --runner homeboy-lab agent-task retry run-1 --run",
             ]
         );
@@ -5281,6 +5453,9 @@ fn compact_status_summary_with_aggregate(
             summary["pr_url"] = pr_url.clone();
         }
     }
+    if let Some(status_scope) = record.get("status_scope") {
+        summary["status_scope"] = compact_status_scope(status_scope);
+    }
     if let Some(delivery) = record.get("notification_delivery") {
         summary["notification_delivery"] = compact_fields(
             delivery,
@@ -5393,6 +5568,74 @@ fn compact_cook_status(cook: Option<&Value>, run_id: &str) -> Value {
     summary
 }
 
+fn compact_status_scope(scope: &Value) -> Value {
+    let selection = scope.pointer("/cook/selection").unwrap_or(&Value::Null);
+    let candidate = |value: &Value| {
+        let mut result = compact_status_scope_fields(value, &["schema", "state"]);
+        result["scan"] = compact_status_scope_fields(
+            value.get("scan").unwrap_or(&Value::Null),
+            &[
+                "degraded",
+                "attempts_omitted",
+                "outcomes_omitted",
+                "artifacts_omitted",
+            ],
+        );
+        result
+    };
+    json!({
+            "schema": bounded_status_scope_value(scope.get("schema").unwrap_or(&Value::Null)),
+        "queried_attempt": {
+            "run_id": bounded_status_scope_value(scope.pointer("/queried_attempt/run_id").unwrap_or(&Value::Null)),
+            "state": bounded_status_scope_value(scope.pointer("/queried_attempt/state").unwrap_or(&Value::Null)),
+            "child_run_state": bounded_status_scope_value(scope.pointer("/queried_attempt/child_run_state").unwrap_or(&Value::Null)),
+            "totals": compact_status_scope_fields(scope.pointer("/queried_attempt/totals").unwrap_or(&Value::Null), &["queued", "running", "blocked", "skipped", "succeeded", "failed", "cancelled", "timed_out"]),
+            "artifacts": compact_status_scope_fields(scope.pointer("/queried_attempt/artifacts").unwrap_or(&Value::Null), &["count"]),
+            "candidate": candidate(scope.pointer("/queried_attempt/candidate").unwrap_or(&Value::Null)),
+        },
+        "cook": {
+            "cook_id": bounded_status_scope_value(scope.pointer("/cook/cook_id").unwrap_or(&Value::Null)),
+            "selection": {
+                "status": bounded_status_scope_value(selection.get("status").unwrap_or(&Value::Null)),
+                "run_id": bounded_status_scope_value(selection.get("run_id").unwrap_or(&Value::Null)),
+                "attempt": bounded_status_scope_value(selection.get("attempt").unwrap_or(&Value::Null)),
+                "latest_attempt_run_id": bounded_status_scope_value(selection.get("latest_attempt_run_id").unwrap_or(&Value::Null)),
+                "reason": bounded_status_scope_value(selection.get("reason").unwrap_or(&Value::Null)),
+                "selected_task_id": bounded_status_scope_value(selection.get("selected_task_id").unwrap_or(&Value::Null)),
+                "selected_artifact_id": bounded_status_scope_value(selection.get("selected_artifact_id").unwrap_or(&Value::Null)),
+                "candidate": candidate(selection.get("candidate").unwrap_or(&Value::Null)),
+                "diagnostics": selection.get("diagnostics").and_then(Value::as_array).map(|diagnostics| diagnostics.iter().take(COMPACT_REF_LIMIT).map(|diagnostic| compact_status_scope_fields(diagnostic, &["code", "skipped_attempts", "message"])).collect::<Vec<_>>()),
+            },
+            "completion": compact_status_scope_fields(scope.pointer("/cook/completion").unwrap_or(&Value::Null), &["scope", "context", "candidate_produced", "finalization_requested", "pr_finalized", "state"]),
+            "finalization": {
+                "status": bounded_status_scope_value(scope.pointer("/cook/finalization/status").unwrap_or(&Value::Null)),
+                "pr_number": bounded_status_scope_value(scope.pointer("/cook/finalization/pr_number").unwrap_or(&Value::Null)),
+                "pr_url": bounded_status_scope_value(scope.pointer("/cook/finalization/pr_url").or_else(|| scope.pointer("/cook/finalization/pull_request_url")).unwrap_or(&Value::Null)),
+            },
+        },
+    })
+}
+
+fn compact_status_scope_fields(value: &Value, fields: &[&str]) -> Value {
+    let mut object = serde_json::Map::new();
+    for field in fields {
+        if let Some(value) = value.get(*field) {
+            object.insert((*field).to_string(), bounded_status_scope_value(value));
+        }
+    }
+    Value::Object(object)
+}
+
+fn bounded_status_scope_value(value: &Value) -> Value {
+    if serialized_len(value) <= COMPACT_TEXT_LIMIT {
+        return value.clone();
+    }
+    Value::String(format!(
+        "sha256:{}",
+        content_hash::sha256_hex(&serde_json::to_vec(value).unwrap_or_default())
+    ))
+}
+
 fn compact_gate_summaries(gates: &[Value]) -> (Value, usize) {
     let summaries = gates
         .iter()
@@ -5406,6 +5649,12 @@ fn compact_gate_summaries(gates: &[Value]) -> (Value, usize) {
 }
 
 fn enforce_compact_status_budget(mut value: Value) -> Value {
+    // Callers may add scope after producing their compact projection. Normalize
+    // it here as well so the mandatory semantic boundary cannot consume the
+    // budget or be removed by overflow handling.
+    if let Some(scope) = value.get("status_scope").cloned() {
+        value["status_scope"] = compact_status_scope(&scope);
+    }
     if serialized_len(&value) <= COMPACT_STATUS_BYTE_LIMIT {
         return value;
     }
@@ -5547,6 +5796,7 @@ fn compact_mandatory_field(field: &str) -> bool {
             | "latest_run_id"
             | "status"
             | "state"
+            | "status_scope"
             | "full_command"
     )
 }
@@ -7829,6 +8079,20 @@ mod tests {
             "candidate_selection": { "evidence": large },
             "identity": { "cook_alias": { "evidence": large } },
             "runner_probe": { "evidence": large },
+            "status_scope": {
+                "schema": "homeboy/agent-task-status-scope/v1",
+                "queried_attempt": { "run_id": "retry", "state": "cancelled", "candidate": { "state": "unknown", "scan": { "degraded": false, "unbounded": large } } },
+                "cook": {
+                    "cook_id": "cook",
+                    "selection": {
+                        "status": "selected",
+                        "run_id": "historical",
+                        "candidate": { "state": "finalized", "scan": { "degraded": false, "unbounded": large } },
+                        "diagnostics": [{ "code": large, "message": large, "skipped_attempts": large }]
+                    },
+                    "finalization": { "status": large, "pr_number": large, "pr_url": large }
+                }
+            },
             ACTIONABLE_METADATA_KEY: { "next_actions": [{ "command": large }] },
             "unknown_future_enrichment": { "evidence": large }
         });
@@ -7866,6 +8130,30 @@ mod tests {
             "unknown_future_enrichment",
         ] {
             assert!(compact.get(section).is_none(), "{section}");
+        }
+        assert_eq!(
+            compact["status_scope"]["queried_attempt"]["state"],
+            "cancelled"
+        );
+        assert_eq!(
+            compact["status_scope"]["cook"]["selection"]["candidate"]["state"],
+            "finalized"
+        );
+        for field in ["status", "pr_number", "pr_url"] {
+            assert!(
+                compact["status_scope"]["cook"]["finalization"][field]
+                    .as_str()
+                    .is_some_and(|value| value.starts_with("sha256:")),
+                "{field}"
+            );
+        }
+        for field in ["code", "message", "skipped_attempts"] {
+            assert!(
+                compact["status_scope"]["cook"]["selection"]["diagnostics"][0][field]
+                    .as_str()
+                    .is_some_and(|value| value.starts_with("sha256:")),
+                "{field}"
+            );
         }
         assert!(compact["omitted_sections"]
             .as_array()
@@ -8009,6 +8297,8 @@ mod tests {
                 }},
                 "cook_completion": {
                     "schema": "homeboy/agent-task-cook-completion/v1",
+                    "scope": "cook",
+                    "context": "selected_cook_candidate",
                     "candidate_produced": true,
                     "finalization_requested": true,
                     "pr_finalized": false,
@@ -8024,6 +8314,11 @@ mod tests {
             "candidate_awaiting_finalization"
         );
         assert_eq!(summary["cook_completion"]["pr_finalized"], false);
+        assert_eq!(summary["cook_completion"]["scope"], "cook");
+        assert_eq!(
+            summary["cook_completion"]["context"],
+            "selected_cook_candidate"
+        );
         assert_eq!(summary["pr_url"], "https://example.test/pull/1");
         assert_eq!(summary["canonical_candidate"]["state"], "promoted");
 
@@ -8235,7 +8530,7 @@ mod tests {
         assert!(rendered.contains("Patch candidates: 1 non-empty / 0 empty"));
         assert!(!rendered.contains("Patch candidates: 1 non-empty / 0 empty /"));
         assert!(rendered.contains("Diff bytes: 32318"));
-        assert!(rendered.contains("Changed files: unknown"));
+        assert!(rendered.contains("Changed files: 7"));
         assert!(rendered.contains("Next: homeboy agent-task review agent-task-durable-patch"));
         assert!(compact[ACTIONABLE_METADATA_KEY]["next_actions"]
             .as_array()

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -73,6 +73,256 @@ fn bounded_full_status_refs_hydrate_through_the_agent_task_resolver() {
 }
 
 #[test]
+fn status_scope_keeps_the_historical_finalized_candidate_for_a_cancelled_retry() {
+    with_isolated_home(|_| {
+        let cook_id = "status-scope-cook";
+        let source_run_id = "status-scope-attempt-1";
+        let retry_run_id = "status-scope-attempt-2";
+        let plan = test_plan();
+        let task_id = plan.tasks[0].task_id.clone();
+        let artifact_dir = tempfile::tempdir().expect("artifact directory");
+        let patch = "diff --git a/a b/a\n--- a/a\n+++ b/a\n@@ -1 +1 @@\n-old\n+new\n";
+        let patch_path = artifact_dir.path().join("candidate.patch");
+        std::fs::write(&patch_path, patch).expect("candidate patch");
+
+        agent_task_lifecycle::submit_plan(&plan, Some(source_run_id)).expect("source attempt");
+        agent_task_lifecycle::submit_plan(&plan, Some(retry_run_id)).expect("retry attempt");
+        agent_task_lifecycle::record_cook_attempt(cook_id, 1, source_run_id)
+            .expect("source Cook identity");
+        agent_task_lifecycle::record_cook_attempt(cook_id, 2, retry_run_id)
+            .expect("retry Cook identity");
+        let artifact = AgentTaskArtifact {
+            id: "historical-patch".to_string(),
+            kind: "patch".to_string(),
+            path: Some(patch_path.display().to_string()),
+            size_bytes: Some(patch.len() as u64),
+            sha256: Some(format!("{:x}", Sha256::digest(patch.as_bytes()))),
+            metadata: json!({
+                "task_id": task_id,
+                "run_id": source_run_id,
+                "producer_attempt": 1,
+                "base_ref": "main",
+                "provider_backend": "fixture",
+                "repository_identity": "fixture",
+                "workspace_identity": "fixture",
+            }),
+            ..Default::default()
+        };
+        let aggregate = AgentTaskAggregate {
+            schema: "homeboy/agent-task-aggregate/v1".to_string(),
+            plan_id: plan.plan_id.clone(),
+            status: homeboy::agents::agent_tasks::scheduler::AgentTaskAggregateStatus::Succeeded,
+            totals: Default::default(),
+            outcomes: vec![AgentTaskOutcome {
+                schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                task_id: task_id.clone(),
+                status: AgentTaskOutcomeStatus::Succeeded,
+                summary: Some("historical patch".to_string()),
+                failure_classification: None,
+                artifacts: vec![artifact.clone()],
+                typed_artifacts: Vec::new(),
+                evidence_refs: Vec::new(),
+                diagnostics: Vec::new(),
+                outputs: Value::Null,
+                workflow: None,
+                follow_up: None,
+                metadata: Value::Null,
+            }],
+            events: Vec::new(),
+            artifact_lineage: Vec::new(),
+            child_runs: Vec::new(),
+            artifact_bindings: Vec::new(),
+            queue: Default::default(),
+        };
+        agent_task_lifecycle::record_run_aggregate(source_run_id, &plan, &aggregate)
+            .expect("source aggregate");
+        let mut hash = Sha256::new();
+        hash.update(source_run_id.as_bytes());
+        hash.update([0]);
+        hash.update(task_id.as_bytes());
+        hash.update([0]);
+        hash.update(b"historical-patch");
+        let artifact_id = format!("agent-task-{:x}", hash.finalize());
+        homeboy::core::observation::ObservationStore::open_initialized()
+            .expect("observation store")
+            .record_verified_artifact_with_id(
+                source_run_id,
+                "patch",
+                &patch_path,
+                &artifact_id,
+                Some(patch.len() as i64),
+                Some(&format!("{:x}", Sha256::digest(patch.as_bytes()))),
+                json!({"agent_task":{"task_id":task_id,"logical_artifact_id":"historical-patch"}}),
+            )
+            .expect("controller artifact");
+        homeboy::agents::agent_tasks::lifecycle::reconcile_terminal_artifact_projection(
+            source_run_id,
+        )
+        .expect("controller projection");
+        agent_task_lifecycle::record_cook_finalization(
+            source_run_id,
+            json!({"status":"review_ready","pr_url":"https://example.test/pull/12971"}),
+        )
+        .expect("historical finalization");
+        agent_task_lifecycle::rewrite_record_for_test(retry_run_id, |record| {
+            record.state = AgentTaskRunState::Cancelled;
+        })
+        .expect("cancel retry");
+
+        let status_args = |full: bool, bridge: bool| StatusArgs {
+            run_id: retry_run_id.to_string(),
+            // `--bridge` and `--exact` conflict in Clap. A positional attempt
+            // still resolves its Cook identity and candidate selection.
+            exact: !bridge,
+            bridge,
+            since_cursor: None,
+            full,
+            bounded: false,
+            no_runner_probe: false,
+            strict_subject_exit: false,
+            watch: false,
+            interval: "5s".to_string(),
+            timeout: "30m".to_string(),
+        };
+        for value in [
+            status(status_args(false, false)).expect("compact status").0,
+            status(status_args(true, false)).expect("full status").0,
+            status(status_args(false, true)).expect("bridge status").0,
+        ] {
+            assert_eq!(
+                value["status_scope"]["queried_attempt"]["state"],
+                "cancelled"
+            );
+            assert_eq!(
+                value["status_scope"]["cook"]["selection"]["status"],
+                "selected"
+            );
+            assert_eq!(
+                value["status_scope"]["cook"]["selection"]["run_id"],
+                source_run_id
+            );
+            assert_eq!(
+                value["status_scope"]["cook"]["selection"]["candidate"]["state"],
+                "finalized"
+            );
+            assert_eq!(
+                value["status_scope"]["cook"]["finalization"]["pr_url"],
+                "https://example.test/pull/12971"
+            );
+        }
+    });
+}
+
+#[test]
+fn status_scope_reports_a_bounded_cook_selection_as_unavailable() {
+    with_isolated_home(|_| {
+        let cook_id = "status-scope-degraded-cook";
+        let plan = test_plan();
+        let run_ids = (1..=65)
+            .map(|attempt| format!("status-scope-degraded-{attempt}"))
+            .collect::<Vec<_>>();
+        for (index, run_id) in run_ids.iter().enumerate() {
+            agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("Cook attempt");
+            agent_task_lifecycle::record_cook_attempt(cook_id, (index + 1) as u32, run_id)
+                .expect("Cook index attempt");
+        }
+        let retry_run_id = run_ids.last().expect("latest attempt");
+        agent_task_lifecycle::rewrite_record_for_test(retry_run_id, |record| {
+            record.state = AgentTaskRunState::Cancelled;
+        })
+        .expect("cancel retry");
+
+        for value in [
+            status(StatusArgs {
+                run_id: retry_run_id.clone(),
+                exact: true,
+                bridge: false,
+                since_cursor: None,
+                full: false,
+                bounded: false,
+                no_runner_probe: false,
+                strict_subject_exit: false,
+                watch: false,
+                interval: "5s".to_string(),
+                timeout: "30m".to_string(),
+            })
+            .expect("compact status")
+            .0,
+            status(StatusArgs {
+                run_id: retry_run_id.clone(),
+                exact: true,
+                bridge: false,
+                since_cursor: None,
+                full: true,
+                bounded: false,
+                no_runner_probe: false,
+                strict_subject_exit: false,
+                watch: false,
+                interval: "5s".to_string(),
+                timeout: "30m".to_string(),
+            })
+            .expect("full status")
+            .0,
+            status(StatusArgs {
+                run_id: retry_run_id.clone(),
+                // Bridge resolution starts from the supplied attempt ID; Clap
+                // rejects pairing `--bridge` with `--exact`.
+                exact: false,
+                bridge: true,
+                since_cursor: None,
+                full: false,
+                bounded: false,
+                no_runner_probe: false,
+                strict_subject_exit: false,
+                watch: false,
+                interval: "5s".to_string(),
+                timeout: "30m".to_string(),
+            })
+            .expect("bridge status")
+            .0,
+        ] {
+            assert_eq!(
+                value["status_scope"]["queried_attempt"]["state"],
+                "cancelled"
+            );
+            assert_eq!(
+                value["status_scope"]["cook"]["selection"]["status"],
+                "unavailable"
+            );
+            assert_eq!(
+                value["status_scope"]["cook"]["selection"]["diagnostics"][0]["code"],
+                "selection_incomplete"
+            );
+        }
+    });
+}
+
+#[test]
+fn status_omits_scope_for_an_ordinary_non_cook_attempt() {
+    with_isolated_home(|_| {
+        let run_id = "ordinary-status-attempt";
+        agent_task_lifecycle::submit_plan(&test_plan(), Some(run_id)).expect("submitted");
+
+        let (value, _) = status(StatusArgs {
+            run_id: run_id.to_string(),
+            exact: false,
+            bridge: false,
+            since_cursor: None,
+            full: false,
+            bounded: false,
+            no_runner_probe: false,
+            strict_subject_exit: false,
+            watch: false,
+            interval: "5s".to_string(),
+            timeout: "30m".to_string(),
+        })
+        .expect("status");
+
+        assert!(value.get("status_scope").is_none());
+    });
+}
+
+#[test]
 fn full_status_bounds_unrelated_high_cardinality_cleanup_inventory() {
     with_isolated_home(|_| {
         let run_id = "status-scoped-cleanup";

--- a/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
@@ -1,4 +1,4 @@
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use super::agent_task::candidate::{
     changed_files_for_artifact, classify_candidates, CandidateState,
@@ -117,22 +117,34 @@ fn render_status_summary(payload: &Value) -> Option<String> {
         .provider_executions
         .unwrap_or_else(|| status_attempted_task_count(payload));
     let metrics = code_production_metrics(payload);
-    let state = string_value(payload, &["cook", "state"]).unwrap_or_else(|| {
-        effective_run_state(
-            raw_state,
-            tasks_attempted,
-            metrics.candidate_state,
-            metrics.candidate_scan_degraded,
-        )
-    });
+    let candidate_state = status_scope_candidate(payload).unwrap_or(metrics.candidate_state);
+    let state = string_value(payload, &["cook", "state"])
+        .or_else(|| string_value(payload, &["status_scope", "cook", "finalization", "status"]))
+        .or_else(|| string_value(payload, &["status_scope", "cook", "completion", "state"]))
+        .unwrap_or_else(|| {
+            effective_run_state(
+                raw_state,
+                tasks_attempted,
+                candidate_state,
+                metrics.candidate_scan_degraded,
+            )
+        });
     let completion = cook_completion_summary(payload);
-    let cook = cook_outcome_summary(payload, state, metrics.candidate_state, completion.as_ref());
+    let cook = cook_outcome_summary(payload, state, candidate_state, completion.as_ref());
     let artifact_count = array_len(payload, &["artifact_refs"]).unwrap_or(0);
     let aggregate_path = string_value(payload, &["aggregate_path"]);
 
     let mut lines = vec!["Agent task status".to_string()];
     if let Some(cook) = cook.as_ref() {
         lines.extend(cook.lines());
+        if let Some(scope) = payload.get("status_scope") {
+            let queried_state = string_value(scope, &["queried_attempt", "candidate", "state"])
+                .unwrap_or("unknown");
+            let queried_run = string_value(scope, &["queried_attempt", "run_id"]).unwrap_or(run_id);
+            lines.push(format!(
+                "Queried attempt candidate: {queried_state} (run {queried_run})"
+            ));
+        }
         lines.push(format!("Run: {run_id}"));
         lines.push("Provider/task evidence:".to_string());
     } else {
@@ -177,6 +189,7 @@ struct CookOutcomeSummary<'a> {
     candidate_state: CandidateState,
     gate_state: Option<&'a str>,
     completion: Option<&'a CookCompletionSummary<'a>>,
+    candidate_context: String,
 }
 
 impl CookOutcomeSummary<'_> {
@@ -192,7 +205,11 @@ impl CookOutcomeSummary<'_> {
             .unwrap_or("unknown");
         let mut lines = vec![
             format!("Cook outcome: {}", self.state),
-            format!("Candidate: {candidate} ({})", self.candidate_state.as_str()),
+            format!(
+                "Candidate: {candidate} ({}; {})",
+                self.candidate_state.as_str(),
+                self.candidate_context
+            ),
             format!("Gates: {}", self.gate_state.unwrap_or("not_run")),
             format!("PR finalization: {finalization}"),
         ];
@@ -226,7 +243,8 @@ fn cook_outcome_summary<'a>(
     completion: Option<&'a CookCompletionSummary<'a>>,
 ) -> Option<CookOutcomeSummary<'a>> {
     let cook = value_at(payload, &["cook"]).filter(|cook| !cook.is_null());
-    if cook.is_none() && completion.is_none() {
+    let scoped_cook = value_at(payload, &["status_scope", "cook"]).filter(|cook| !cook.is_null());
+    if cook.is_none() && scoped_cook.is_none() && completion.is_none() {
         return None;
     }
     Some(CookOutcomeSummary {
@@ -246,7 +264,32 @@ fn cook_outcome_summary<'a>(
         candidate_state,
         gate_state: string_value(payload, &["execution_states", "gate", "state"]),
         completion,
+        candidate_context: status_scope_candidate_context(payload),
     })
+}
+
+fn status_scope_candidate(payload: &Value) -> Option<CandidateState> {
+    let scope = payload.get("status_scope")?;
+    (string_value(scope, &["cook", "selection", "status"]) == Some("selected")).then(|| {
+        classify_candidates(&json!({
+            "canonical_candidate": scope.pointer("/cook/selection/candidate").unwrap_or(&Value::Null),
+        }))
+        .state()
+    })
+}
+
+fn status_scope_candidate_context(payload: &Value) -> String {
+    let Some(scope) = payload.get("status_scope") else {
+        return "legacy canonical".to_string();
+    };
+    match string_value(scope, &["cook", "selection", "status"]).unwrap_or("unavailable") {
+        "selected" => format!(
+            "Cook-wide selected candidate run {}",
+            string_value(scope, &["cook", "selection", "run_id"]).unwrap_or("unknown")
+        ),
+        "none" => "Cook-wide selection: none".to_string(),
+        _ => "Cook-wide selection: unavailable".to_string(),
+    }
 }
 
 /// The Cook-level publication facts, projected from the `cook_completion`
@@ -274,12 +317,14 @@ impl CookCompletionSummary<'_> {
 }
 
 fn cook_completion_summary(payload: &Value) -> Option<CookCompletionSummary<'_>> {
-    let completion = value_at(payload, &["cook_completion"])?;
+    let completion = value_at(payload, &["cook_completion"])
+        .or_else(|| value_at(payload, &["status_scope", "cook", "completion"]))?;
     Some(CookCompletionSummary {
         state: string_value(completion, &["state"]).unwrap_or("unknown"),
         finalization_state: string_value(payload, &["execution_states", "finalization", "state"])
             .or_else(|| string_value(payload, &["cook_finalization", "status"]))
-            .or_else(|| string_value(payload, &["metadata", "cook_finalization", "status"])),
+            .or_else(|| string_value(payload, &["metadata", "cook_finalization", "status"]))
+            .or_else(|| string_value(payload, &["status_scope", "cook", "finalization", "status"])),
         finalization_requested: value_at(completion, &["finalization_requested"])
             .and_then(Value::as_bool)
             .unwrap_or(false),
@@ -298,7 +343,8 @@ fn cook_pr_url(payload: &Value) -> Option<&str> {
     let url = string_value(payload, &["pr_url"])
         .or_else(|| receipt_pr_url(payload, &["cook_finalization"]))
         .or_else(|| receipt_pr_url(payload, &["metadata", "cook_finalization"]))
-        .or_else(|| receipt_pr_url(payload, &["finalization"]))?
+        .or_else(|| receipt_pr_url(payload, &["finalization"]))
+        .or_else(|| receipt_pr_url(payload, &["status_scope", "cook", "finalization"]))?
         .trim();
     (!url.is_empty()).then_some(url)
 }
@@ -1350,7 +1396,7 @@ mod tests {
 
         assert!(
             summary.starts_with(
-                "Agent task status\nCook outcome: finalization_failed\nCandidate: yes (promoted)\nGates: passed\nPR finalization: finalization_failed"
+                "Agent task status\nCook outcome: finalization_failed\nCandidate: yes (promoted; legacy canonical)\nGates: passed\nPR finalization: finalization_failed"
             ),
             "{summary}"
         );
@@ -1395,10 +1441,91 @@ mod tests {
         let summary = render_agent_task_summary(AgentTaskSummaryKind::Status, &payload).unwrap();
 
         assert!(summary.starts_with(
-            "Agent task status\nCook outcome: review_ready\nCandidate: yes (finalized)\nGates: passed\nPR finalization: finalized\nPull request: https://example.test/pull/1"
+            "Agent task status\nCook outcome: review_ready\nCandidate: yes (finalized; legacy canonical)\nGates: passed\nPR finalization: finalized\nPull request: https://example.test/pull/1"
         ));
         assert!(summary.contains("Pull request: https://example.test/pull/1\n"));
         assert!(summary.contains("Next: homeboy agent-task review agent-task-finalized\n"));
+    }
+
+    #[test]
+    fn status_summary_separates_selected_cook_candidate_from_cancelled_retry() {
+        let payload = json!({
+            "run_id": "retry-run",
+            "state": "cancelled",
+            "tasks": [],
+            "artifact_refs": [],
+            "cook": { "state": "review_ready", "publication": "completed" },
+            "canonical_candidate": { "schema": "homeboy/agent-task-candidate/v1", "state": "unknown", "counts": {}, "scan": {} },
+            "cook_completion": { "candidate_produced": true, "finalization_requested": true, "pr_finalized": true, "state": "pr_finalized" },
+            "status_scope": {
+                "schema": "homeboy/agent-task-status-scope/v1",
+                "queried_attempt": { "run_id": "retry-run", "candidate": { "schema": "homeboy/agent-task-candidate/v1", "state": "unknown", "counts": {}, "scan": {} } },
+                "cook": { "selection": { "status": "selected", "run_id": "historical-run", "candidate": { "schema": "homeboy/agent-task-candidate/v1", "state": "finalized", "counts": {}, "scan": {} } } }
+            }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Status, &payload).unwrap();
+
+        assert!(summary.contains(
+            "Candidate: yes (finalized; Cook-wide selected candidate run historical-run)"
+        ));
+        assert!(summary.contains("Queried attempt candidate: unknown (run retry-run)"));
+    }
+
+    #[test]
+    fn status_command_payload_without_cook_evidence_keeps_the_ordinary_summary() {
+        let payload = json!({
+            "run_id": "ordinary-run",
+            "state": "queued",
+            "tasks": [],
+            "artifact_refs": []
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Status, &payload).unwrap();
+
+        assert!(summary.starts_with("Agent task status\nStatus: queued\nRun: ordinary-run\n"));
+        assert!(!summary.contains("Cook outcome:"), "{summary}");
+        assert!(!summary.contains("Queried attempt candidate:"), "{summary}");
+    }
+
+    #[test]
+    fn bridge_status_summary_uses_scope_without_legacy_cook_fields() {
+        let payload = json!({
+            "run_id": "retry-run",
+            "state": "cancelled",
+            "tasks": [],
+            "artifact_refs": [],
+            "status_scope": {
+                "schema": "homeboy/agent-task-status-scope/v1",
+                "queried_attempt": { "run_id": "retry-run", "candidate": { "schema": "homeboy/agent-task-candidate/v1", "state": "unknown", "counts": {}, "scan": {} } },
+                "cook": {
+                    "selection": { "status": "selected", "run_id": "historical-run", "candidate": { "schema": "homeboy/agent-task-candidate/v1", "state": "finalized", "counts": {}, "scan": {} } },
+                    "completion": { "scope": "cook", "candidate_produced": true, "finalization_requested": true, "pr_finalized": true, "state": "pr_finalized" },
+                    "finalization": { "status": "review_ready", "pr_url": "https://example.test/pull/12971" }
+                }
+            }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Status, &payload).unwrap();
+
+        assert!(
+            summary.contains("Cook outcome: review_ready\n"),
+            "{summary}"
+        );
+        assert!(
+            summary.contains(
+                "Candidate: yes (finalized; Cook-wide selected candidate run historical-run)"
+            ),
+            "{summary}"
+        );
+        assert!(
+            summary.contains("Queried attempt candidate: unknown (run retry-run)"),
+            "{summary}"
+        );
+        assert!(
+            summary.contains("Pull request: https://example.test/pull/12971\n"),
+            "{summary}"
+        );
     }
 
     #[test]

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -45,6 +45,17 @@ see [`docs/architecture/provider-fanout-boundary.md`](../architecture/provider-f
 
 `agent-task status <run-id> --watch` follows the same durable status abstraction used by one-shot status reads, including `--bridge` runner reconciliation. Every material state change is emitted immediately as one bounded `homeboy/agent-task-status-watch-event/v2` JSONL event on stderr. Its `change.change_basis` contains the same state, task, progress, and liveness fields that caused the event, including a complete task-state digest beyond the compact task page. Stdout is the bounded `homeboy/agent-task-status-watch/v2` final envelope: it retains at most 12 changed records, reports omissions and continuation commands, and has one total size budget covering changes and fixed sections. `latest` is always the final observed compact status; terminal conclusions additionally include `terminal_summary`, while timeout/nonterminal conclusions leave it null. `--full` supplies bounded change records with stable `full_status_ref`/continuation commands for durable retrieval rather than expanding the live stream. This is an explicit v2 migration from the former v1 `latest` snapshot contract. Polls default to every `5s` and stop after `30m`; `--interval <duration>` and `--timeout <duration>` require `--watch`. The shared watcher caps each sleep to the remaining timeout, so its wall-clock bound is not extended by the polling interval. A terminal failure exits nonzero; a timeout returns the latest partial status and exits `124`.
 
+Status keeps established top-level machine fields for compatibility and adds
+`status_scope` with schema `homeboy/agent-task-status-scope/v1`. Its
+`queried_attempt` describes the exact attempt's state, counts, artifacts, and
+candidate classification. Its `cook` section describes the Cook-wide selected
+candidate identity/classification, completion, and finalization. The selection
+state is explicitly `selected`, `none`, or `unavailable`; unavailable includes
+diagnostics so a bounded or degraded scan is never reported as proof of no
+candidate. The human `Candidate:` line identifies Cook-wide selected context and
+prints the queried-attempt candidate separately. Legacy records without this
+envelope are qualified as `legacy canonical`.
+
 ### Resource Behavior
 
 Resource admission follows command capability rather than command names. Bounded


### PR DESCRIPTION
## Summary

- add an additive versioned `status_scope` envelope separating queried-attempt evidence from Cook-wide selected-candidate state
- preserve historical candidate classification, finalization, and completion across cancelled retries, compact/full status, and positional bridge output
- distinguish selected, none, and unavailable/degraded Cook selection with bounded diagnostics
- preserve legacy machine fields and human `Candidate:` compatibility while explicitly qualifying scope
- retain semantic scope under compact, bounded, and overflow budgets

Fixes #12971

## Verification

- `cargo test -p homeboy-cli commands::agent_task::status::tests --lib` (50 passed)
- `cargo test -p homeboy-cli agent_task_summary --lib` (42 passed)
- focused lifecycle/status-scope bridge, aggregate, bounded, and cancelled-retry tests
- `git diff --check`

Repository-wide `cargo fmt --check` is currently blocked by a pre-existing formatting difference in `tests/artifact_promotion_rooting_test.rs`; changed files are formatted.

## AI assistance

OpenCode with `openai/gpt-5.6-sol` was used to reproduce the mixed-scope status contradiction, implement and repeatedly review the structured/human compatibility contract, and run verification. Chris Huber reviewed the resulting change and remains responsible for every line.