### PR TITLE
Supervise local Cook retries durably

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -22,8 +22,43 @@ pub fn record_pre_execution_failure_in_store(
     error: &Error,
 ) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
-    let mut record = lifecycle_store.read_record(&run_id)?;
+    // Cancellation and aggregate projection both own a terminal transition.
+    // Re-read and arbitrate while holding the record/aggregate transaction lock
+    // so a retry launcher failure cannot overwrite a cancellation winner.
+    let (mut record, aggregate) = lifecycle_store.with_config_lock(|| {
+        let record = lifecycle_store.read_record(&run_id)?;
+        // A completed provider candidate still needs its non-terminal transport
+        // follow-up marker. Bare cancellation and other terminal winners are
+        // returned unchanged rather than being overwritten by this aggregate.
+        if record.state.is_terminal() && !record.has_recorded_provider_progress() {
+            return Ok((record, None));
+        }
+        record_pre_execution_failure_locked(lifecycle_store, record, plan, phase, error)
+    })?;
 
+    // Projection acquires its own authority locks. It follows the locked
+    // arbitration/commit so a cancellation winner is never overwritten.
+    if let Some(aggregate) = aggregate {
+        record_terminal_artifact_projection_in_store(lifecycle_store, &mut record, &aggregate)?;
+        update_cook_candidate_after_completion_in_store(
+            lifecycle_store,
+            &record,
+            &aggregate,
+            None,
+        )?;
+    } else if record.state.is_terminal() {
+        lifecycle_store.project_terminal_record_after_unlock(&record.run_id)?;
+    }
+    Ok(record)
+}
+
+fn record_pre_execution_failure_locked(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    mut record: AgentTaskRunRecord,
+    plan: &AgentTaskPlan,
+    phase: &str,
+    error: &Error,
+) -> Result<(AgentTaskRunRecord, Option<AgentTaskAggregate>)> {
     // A transport/handoff error that arrives AFTER a provider attempt was
     // already dispatched (or completed) on a runner is not a pre-execution
     // failure. Terminalizing it here would overwrite a succeeded candidate with
@@ -33,7 +68,8 @@ pub fn record_pre_execution_failure_in_store(
     // controller reconciliation can adopt the completed candidate without
     // rerunning the provider.
     if record.has_recorded_provider_progress() {
-        return record_transport_follow_up_failure_in_store(lifecycle_store, record, phase, error);
+        return record_transport_follow_up_failure_in_store(lifecycle_store, record, phase, error)
+            .map(|record| (record, None));
     }
 
     let task_count = plan.tasks.len();
@@ -44,7 +80,7 @@ pub fn record_pre_execution_failure_in_store(
     let outcomes = plan
         .tasks
         .iter()
-        .map(|task| build_pre_execution_failure_outcome(&run_id, task, phase, error))
+        .map(|task| build_pre_execution_failure_outcome(&record.run_id, task, phase, error))
         .collect();
     let aggregate = AgentTaskAggregate {
         schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
@@ -77,8 +113,12 @@ pub fn record_pre_execution_failure_in_store(
             ..AgentTaskQueueStatus::default()
         },
     };
-    let mut failed_record =
-        record_aggregate_in_store(lifecycle_store, &mut record, plan, &aggregate)?;
+    let aggregate_path = lifecycle_store
+        .aggregate_path(&record.run_id)
+        .display()
+        .to_string();
+    apply_aggregate_to_record(&mut record, plan, &aggregate, aggregate_path);
+    let mut failed_record = record;
     let runner_id = failed_record.runner_id().map(str::to_string);
     let metadata = failed_record.ensure_metadata_object();
     if retryable {
@@ -106,8 +146,12 @@ pub fn record_pre_execution_failure_in_store(
             })).collect::<Vec<_>>(),
         }),
     );
-    lifecycle_store.write_record(&failed_record)?;
-    Ok(failed_record)
+    let failed_record = lifecycle_store
+        .write_aggregate_and_record_locked_without_terminal_projection(
+            &failed_record,
+            &aggregate,
+        )?;
+    Ok((failed_record, Some(aggregate)))
 }
 
 fn record_transport_follow_up_failure_in_store(
@@ -136,8 +180,7 @@ fn record_transport_follow_up_failure_in_store(
     // must not be reaped as a clean success when its follow-up failed.
     metadata.insert("candidate_preserved".to_string(), json!(true));
     metadata.insert(METADATA_KEY_RETRYABLE.to_string(), json!(true));
-    lifecycle_store.write_record(&record)?;
-    Ok(record)
+    lifecycle_store.write_record_locked_without_terminal_projection(&record)
 }
 
 pub(crate) fn build_pre_execution_failure_outcome(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -1223,6 +1223,231 @@ pub fn record_detached_cook_supervisor_in_store(
     Ok(())
 }
 
+/// Bind a daemon supervisor to an already-materialized Cook retry attempt.
+/// Retry reservations own their exact lifecycle record before a child is
+/// launched, unlike an initial detached Cook handoff.
+pub fn record_local_cook_retry_supervisor_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    cook_id: &str,
+    job_id: &str,
+) -> Result<()> {
+    let run_id = sanitize_run_id(run_id);
+    let cook_id = sanitize_run_id(cook_id);
+    let job_id = job_id.to_string();
+    let updated = lifecycle_store.mutate_record(&run_id, |record| {
+        if record.state.is_terminal()
+            || record.metadata["cook_id"].as_str() != Some(cook_id.as_str())
+        {
+            return false;
+        }
+        if record.metadata["local_cook_supervisor"]["pinned_run_id"].as_str()
+            != Some(run_id.as_str())
+        {
+            return false;
+        }
+        record.metadata["local_cook_supervisor"] = json!({
+            "state": "supervising",
+            "job_id": job_id,
+            "job_type": crate::agent_task_service::AGENT_TASK_COOK_JOB_TYPE,
+            "pinned_run_id": run_id,
+            "reattach_command": format!("homeboy agent-task status {run_id} --full"),
+        });
+        true
+    })?;
+    if updated.is_none() {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            "local Cook retry became terminal or is not owned by the expected Cook",
+            Some(run_id),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+/// Outcome of claiming the launcher side of a pending local Cook retry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LocalCookRetryLaunchClaim {
+    Acquired,
+    OwnedElsewhere,
+    RecoveryPending,
+    ChildSpawned {
+        pid: u32,
+        start_identity: homeboy_core::process::ProcessStartIdentity,
+        launch_token: String,
+        launch_token_path: String,
+    },
+    ChildExited,
+    NotPending,
+}
+
+/// Atomically fence the process allowed to spawn a pending local Cook retry.
+///
+/// A reservation is written before its child exists. The persisted launcher PID
+/// and start identity make that short interval recoverable after the launcher is
+/// killed, without allowing a second live launcher to spawn the same child.
+pub fn claim_local_cook_retry_launch_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    cook_id: &str,
+) -> Result<LocalCookRetryLaunchClaim> {
+    let run_id = sanitize_run_id(run_id);
+    let cook_id = sanitize_run_id(cook_id);
+    let launcher_pid = std::process::id();
+    let launcher_start_identity = homeboy_core::process::process_start_identity(launcher_pid)
+        .map_err(Error::internal_unexpected)?
+        .ok_or_else(|| {
+            Error::internal_unexpected(
+                "local Cook retry launcher exited before claiming its reservation",
+            )
+        })?;
+    let now = chrono::Utc::now();
+    let mut outcome = LocalCookRetryLaunchClaim::NotPending;
+    let updated = lifecycle_store.mutate_record(&run_id, |record| {
+        let supervisor = &record.metadata["local_cook_supervisor"];
+        if record.state != AgentTaskRunState::Queued
+            || record.metadata["cook_id"].as_str() != Some(cook_id.as_str())
+            || supervisor["pinned_run_id"] != run_id
+        {
+            return false;
+        }
+
+        if supervisor["state"] == "child_spawned" {
+            let child = supervisor["child_pid"]
+                .as_u64()
+                .and_then(|pid| u32::try_from(pid).ok())
+                .zip(serde_json::from_value(supervisor["child_start_identity"].clone()).ok())
+                .zip(supervisor["launch_token"].as_str())
+                .zip(supervisor["launch_token_path"].as_str());
+            let Some((((pid, start_identity), launch_token), launch_token_path)) = child else {
+                outcome = LocalCookRetryLaunchClaim::ChildExited;
+                return true;
+            };
+            outcome = if matches!(
+                homeboy_core::process::process_identity_state_with_start_identity(
+                    pid,
+                    None,
+                    Some(&start_identity),
+                ),
+                homeboy_core::process::ProcessIdentityState::Live
+            ) {
+                LocalCookRetryLaunchClaim::ChildSpawned {
+                    pid,
+                    start_identity,
+                    launch_token: launch_token.to_string(),
+                    launch_token_path: launch_token_path.to_string(),
+                }
+            } else {
+                LocalCookRetryLaunchClaim::ChildExited
+            };
+            return true;
+        }
+        if supervisor["state"] != "pending" {
+            return false;
+        }
+
+        let existing_pid = supervisor["launcher_pid"]
+            .as_u64()
+            .and_then(|pid| u32::try_from(pid).ok());
+        let existing_identity = supervisor["launcher_process_start_identity"].clone();
+        let is_current_launcher = existing_pid == Some(launcher_pid)
+            && existing_identity == json!(launcher_start_identity);
+        if is_current_launcher {
+            outcome = LocalCookRetryLaunchClaim::Acquired;
+            return true;
+        }
+
+        let owner_state = existing_pid
+            .zip(serde_json::from_value(existing_identity).ok())
+            .map(|(pid, identity)| {
+                homeboy_core::process::process_identity_state_with_start_identity(
+                    pid,
+                    None,
+                    Some(&identity),
+                )
+            });
+        match owner_state {
+            Some(homeboy_core::process::ProcessIdentityState::Live) => {
+                outcome = LocalCookRetryLaunchClaim::OwnedElsewhere;
+                return true;
+            }
+            Some(homeboy_core::process::ProcessIdentityState::Unverifiable)
+                if record.has_live_pending_local_cook_supervisor(now) =>
+            {
+                outcome = LocalCookRetryLaunchClaim::RecoveryPending;
+                return true;
+            }
+            None if record.has_live_pending_local_cook_supervisor(now) => {
+                outcome = LocalCookRetryLaunchClaim::RecoveryPending;
+                return true;
+            }
+            _ => {}
+        }
+
+        // A dead/mismatched identity is conclusively reclaimable. Ambiguous or
+        // malformed ownership is reclaimed only after its bounded lease expires.
+        let metadata = record.ensure_metadata_object();
+        metadata["local_cook_supervisor"]["launcher_pid"] = json!(launcher_pid);
+        metadata["local_cook_supervisor"]["launcher_process_start_identity"] =
+            json!(launcher_start_identity);
+        metadata["local_cook_supervisor"]["lease_started_at"] = json!(now.to_rfc3339());
+        metadata["local_cook_supervisor"]["lease_expires_at"] = json!((now
+            + chrono::Duration::seconds(LOCAL_COOK_SUPERVISOR_LEASE_SECONDS))
+        .to_rfc3339());
+        metadata["local_cook_supervisor"]["launcher_reclaimed_at"] = json!(now.to_rfc3339());
+        outcome = LocalCookRetryLaunchClaim::Acquired;
+        true
+    })?;
+    if updated.is_none() {
+        outcome = LocalCookRetryLaunchClaim::NotPending;
+    }
+    Ok(outcome)
+}
+
+/// Atomically record the one detached child that a retry launcher spawned.
+///
+/// The child remains blocked on its private readiness token until a controller
+/// job is durably projected. A takeover can therefore submit or re-submit the
+/// deterministic job for this exact child instead of spawning a replacement.
+pub fn record_local_cook_retry_child_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    cook_id: &str,
+    child_pid: u32,
+    child_start_identity: homeboy_core::process::ProcessStartIdentity,
+    launch_token: &str,
+    launch_token_path: &str,
+) -> Result<()> {
+    let run_id = sanitize_run_id(run_id);
+    let cook_id = sanitize_run_id(cook_id);
+    let updated = lifecycle_store.mutate_record(&run_id, |record| {
+        if record.state != AgentTaskRunState::Queued
+            || record.metadata["cook_id"].as_str() != Some(cook_id.as_str())
+            || record.metadata["local_cook_supervisor"]["state"] != "pending"
+            || record.metadata["local_cook_supervisor"]["pinned_run_id"] != run_id
+        {
+            return false;
+        }
+        let supervisor = &mut record.ensure_metadata_object()["local_cook_supervisor"];
+        supervisor["state"] = json!("child_spawned");
+        supervisor["child_pid"] = json!(child_pid);
+        supervisor["child_start_identity"] = json!(child_start_identity);
+        supervisor["launch_token"] = json!(launch_token);
+        supervisor["launch_token_path"] = json!(launch_token_path);
+        true
+    })?;
+    if updated.is_none() {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            "local Cook retry was no longer pending when its child was attached",
+            Some(run_id),
+            None,
+        ));
+    }
+    Ok(())
+}
+
 /// Reserve the first attempt identity before its lifecycle record is submitted.
 ///
 /// The record and Cook index are separate durable writes. This reservation keeps
@@ -2470,9 +2695,15 @@ where
         }
         // Cook reports `provider_start` before a local executor or Lab runner
         // re-submits its materialized plan. That submission refreshes plan-owned
-        // fields but must not erase the durable lifecycle boundary that says
-        // provider work has started.
-        for key in ["cook_id", "cook_attempt", "cook_progress"] {
+        // fields but must not erase Cook-owned execution identity. In particular,
+        // a local retry's supervisor is reserved before the child re-enters this
+        // path, and its exact pinned run remains the owner through terminalization.
+        for key in [
+            "cook_id",
+            "cook_attempt",
+            "cook_progress",
+            "local_cook_supervisor",
+        ] {
             if let Some(value) = existing.metadata.get(key) {
                 record.metadata[key] = value.clone();
             }
@@ -5579,7 +5810,14 @@ pub(crate) fn retry_in_store(
     run_id: &str,
     requested_run_id: Option<&str>,
 ) -> Result<AgentTaskRunRecord> {
-    retry_with_force_inner_in_store(lifecycle_store, run_id, requested_run_id, false, false)
+    retry_with_force_inner_in_store(
+        lifecycle_store,
+        run_id,
+        requested_run_id,
+        false,
+        false,
+        None,
+    )
 }
 
 /// Whether a persisted plan contains enough source identity to offer a retry
@@ -5652,7 +5890,24 @@ pub(crate) fn retry_with_force_in_store(
     requested_run_id: Option<&str>,
     force: bool,
 ) -> Result<AgentTaskRunRecord> {
-    retry_with_force_inner_in_store(lifecycle_store, run_id, requested_run_id, force, true)
+    retry_with_force_inner_in_store(lifecycle_store, run_id, requested_run_id, force, true, None)
+}
+
+pub(crate) fn retry_with_force_and_metadata_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    requested_run_id: Option<&str>,
+    force: bool,
+    metadata: serde_json::Map<String, Value>,
+) -> Result<AgentTaskRunRecord> {
+    retry_with_force_inner_in_store(
+        lifecycle_store,
+        run_id,
+        requested_run_id,
+        force,
+        true,
+        Some(metadata),
+    )
 }
 
 fn retry_with_force_inner_in_store(
@@ -5661,15 +5916,17 @@ fn retry_with_force_inner_in_store(
     requested_run_id: Option<&str>,
     force: bool,
     enforce_lineage_reservation: bool,
+    reservation_metadata: Option<serde_json::Map<String, Value>>,
 ) -> Result<AgentTaskRunRecord> {
     let runtime_root =
         homeboy_core::controller_runtime::runtime_root_in(lifecycle_store.roots().data())?;
-    retry_with_runtime_admission_in_store(
+    retry_with_runtime_admission_with_metadata_in_store(
         lifecycle_store,
         run_id,
         requested_run_id,
         force,
         enforce_lineage_reservation,
+        reservation_metadata,
         Some(&|run_id| {
             homeboy_core::controller_runtime::admission_status_at(&runtime_root, run_id).ok()
         }),
@@ -5710,6 +5967,32 @@ pub(crate) fn retry_with_runtime_admission_in_store<F, A>(
     requested_run_id: Option<&str>,
     force: bool,
     enforce_lineage_reservation: bool,
+    admission_status: Option<&dyn Fn(&str) -> Option<Value>>,
+    admit_runtime: F,
+) -> Result<AgentTaskRunRecord>
+where
+    F: FnOnce(&str) -> Result<A>,
+    A: RuntimeAdmissionEvidence,
+{
+    retry_with_runtime_admission_with_metadata_in_store(
+        lifecycle_store,
+        run_id,
+        requested_run_id,
+        force,
+        enforce_lineage_reservation,
+        None,
+        admission_status,
+        admit_runtime,
+    )
+}
+
+fn retry_with_runtime_admission_with_metadata_in_store<F, A>(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    requested_run_id: Option<&str>,
+    force: bool,
+    enforce_lineage_reservation: bool,
+    reservation_metadata: Option<serde_json::Map<String, Value>>,
     admission_status: Option<&dyn Fn(&str) -> Option<Value>>,
     admit_runtime: F,
 ) -> Result<AgentTaskRunRecord>
@@ -5842,6 +6125,9 @@ where
         metadata.insert("retry_root".to_string(), json!(root_run_id));
     }
     metadata.insert("retry_requested_at".to_string(), json!(now_timestamp()));
+    if let Some(reservation_metadata) = reservation_metadata {
+        metadata.extend(reservation_metadata);
+    }
     let mut record = submit_plan_with_runtime_admission_in_store(
         lifecycle_store,
         &plan,
@@ -6358,18 +6644,20 @@ pub(crate) fn record_cook_attempt_locked_in_store(
     let metadata = record.ensure_metadata_object();
     metadata.insert("cook_id".to_string(), json!(&cook_id));
     metadata.insert("cook_attempt".to_string(), json!(attempt));
-    if let Ok(parent) = lifecycle_store.read_record(&cook_id) {
-        if let Some(supervisor) = parent.metadata["detached_cook_handoff"]
-            .get("supervisor_job_id")
-            .cloned()
-        {
-            metadata.insert(
-                "local_cook_supervisor".to_string(),
-                json!({
-                    "job_id": supervisor,
-                    "reattach_command": format!("homeboy agent-task status {cook_id} --full"),
-                }),
-            );
+    if !metadata.contains_key("local_cook_supervisor") {
+        if let Ok(parent) = lifecycle_store.read_record(&cook_id) {
+            if let Some(supervisor) = parent.metadata["detached_cook_handoff"]
+                .get("supervisor_job_id")
+                .cloned()
+            {
+                metadata.insert(
+                    "local_cook_supervisor".to_string(),
+                    json!({
+                        "job_id": supervisor,
+                        "reattach_command": format!("homeboy agent-task status {cook_id} --full"),
+                    }),
+                );
+            }
         }
     }
     let committed = lifecycle_store.write_record_locked_without_terminal_projection(&record)?;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -29,6 +29,7 @@ pub(crate) const METADATA_KEY_RUNNER_LIVENESS: &str = "runner_liveness";
 pub(crate) const METADATA_KEY_RETRYABLE: &str = "retryable";
 pub(crate) const METADATA_KEY_RECLAIMED_STALE_RUNNING: &str = "reclaimed_stale_running";
 pub(crate) const METADATA_KEY_CANCELLED_STALE_RUNNING: &str = "cancelled_stale_running";
+pub(crate) const LOCAL_COOK_SUPERVISOR_LEASE_SECONDS: i64 = 30;
 
 /// Reconciled local ownership evidence for a running record.
 ///
@@ -594,6 +595,14 @@ impl AgentTaskRunRecord {
             return;
         }
 
+        // A local Cook retry records its bounded supervisor admission in the
+        // same write that makes the queued successor visible. The daemon job id
+        // arrives later, so do not classify that intentional interval as an
+        // ownerless runner.
+        if self.has_live_pending_local_cook_supervisor(chrono::Utc::now()) {
+            return;
+        }
+
         // A reverse-broker job may begin before the daemon's accepted job/PID
         // projection arrives. Its complete, unexpired submission intent remains
         // the authoritative owner during that narrow handoff window.
@@ -666,6 +675,34 @@ impl AgentTaskRunRecord {
 
     pub(crate) fn owner_process_is_running(&self) -> bool {
         self.local_owner_liveness() == LocalOwnerLiveness::Live
+    }
+
+    pub(crate) fn has_live_pending_local_cook_supervisor(
+        &self,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> bool {
+        let supervisor = &self.metadata["local_cook_supervisor"];
+        let Some(started_at) = supervisor["lease_started_at"]
+            .as_str()
+            .and_then(parse_rfc3339)
+        else {
+            return false;
+        };
+        let Some(expires_at) = supervisor["lease_expires_at"]
+            .as_str()
+            .and_then(parse_rfc3339)
+        else {
+            return false;
+        };
+        supervisor["state"] == "pending"
+            && self.metadata["cook_id"]
+                .as_str()
+                .is_some_and(|cook_id| !cook_id.trim().is_empty())
+            && supervisor["pinned_run_id"] == self.run_id
+            && started_at <= now
+            && now < expires_at
+            && expires_at
+                <= started_at + chrono::Duration::seconds(LOCAL_COOK_SUPERVISOR_LEASE_SECONDS)
     }
 
     /// Reconcile every local ownership projection before a caller classifies a
@@ -1148,6 +1185,29 @@ mod tests {
             serde_json::from_value(serde_json::to_value(&record).expect("serialize"))
                 .expect("deserialize");
         assert_eq!(round_trip.lab_handoff, record.lab_handoff);
+    }
+
+    #[test]
+    fn pending_local_retry_supervisor_survives_reconciliation_before_job_projection() {
+        let lease_started_at = chrono::Utc::now();
+        let mut record = legacy_record(json!({
+            "cook_id": "cook",
+            "local_cook_supervisor": {
+                "state": "pending",
+                "pinned_run_id": "legacy-handoff",
+                "lease_started_at": lease_started_at.to_rfc3339(),
+                "lease_expires_at": (lease_started_at + chrono::Duration::seconds(LOCAL_COOK_SUPERVISOR_LEASE_SECONDS)).to_rfc3339(),
+            }
+        }));
+        record.state = AgentTaskRunState::Running;
+
+        record.annotate_stale_running();
+
+        assert!(record.metadata.get(METADATA_KEY_STALE_RUNNING).is_none());
+        assert!(record
+            .metadata
+            .get(METADATA_KEY_STALE_RUNNING_REASON)
+            .is_none());
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -15,6 +15,7 @@ use crate::agent_task_scheduler::{
 use homeboy_core::api_jobs::{Job, JobEvent, JobEventKind, JobStore, RemoteRunnerJobRequest};
 use homeboy_core::test_support::with_isolated_home;
 use sha2::{Digest, Sha256};
+use std::process::Command;
 use std::sync::{Arc, Mutex};
 
 fn seed_unmaterialized_admission_parent(store: &AgentTaskLifecycleStore, cook_id: &str) {
@@ -35,6 +36,116 @@ fn seed_unmaterialized_admission_parent(store: &AgentTaskLifecycleStore, cook_id
             true
         })
         .expect("seed admission parent");
+}
+
+#[test]
+fn pending_local_retry_launcher_claim_converges_live_owner_then_reclaims_dead_owner() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let store = AgentTaskLifecycleStore::new(context.path_roots());
+    let run_id = "pending-local-retry";
+    let cook_id = "pending-local-retry-cook";
+    store
+        .submit_plan_with_runtime_admission(&test_plan(), run_id, |_| Ok(json!({})))
+        .expect("submit pending retry");
+    let mut owner = Command::new("sleep")
+        .arg("30")
+        .spawn()
+        .expect("spawn distinct launcher owner");
+    let owner_identity = homeboy_core::process::process_start_identity(owner.id())
+        .expect("inspect launcher owner")
+        .expect("launcher owner identity");
+    store
+        .mutate_record(run_id, |record| {
+            record.metadata["cook_id"] = json!(cook_id);
+            record.metadata["local_cook_supervisor"] = json!({
+                "state": "pending",
+                "pinned_run_id": run_id,
+                "lease_started_at": chrono::Utc::now().to_rfc3339(),
+                "lease_expires_at": (chrono::Utc::now()
+                    + chrono::Duration::seconds(LOCAL_COOK_SUPERVISOR_LEASE_SECONDS))
+                    .to_rfc3339(),
+                "launcher_pid": owner.id(),
+                "launcher_process_start_identity": owner_identity,
+            });
+            true
+        })
+        .expect("persist pending launcher");
+
+    assert_eq!(
+        claim_local_cook_retry_launch_in_store(&store, run_id, cook_id).expect("live owner claim"),
+        LocalCookRetryLaunchClaim::OwnedElsewhere,
+        "a live launcher remains the sole process allowed to spawn"
+    );
+    owner.kill().expect("kill initial launcher");
+    owner.wait().expect("reap initial launcher");
+
+    assert_eq!(
+        claim_local_cook_retry_launch_in_store(&store, run_id, cook_id)
+            .expect("dead owner takeover"),
+        LocalCookRetryLaunchClaim::Acquired,
+        "a dead launcher is atomically replaced by this caller"
+    );
+    let record = store.read_record(run_id).expect("read reclaimed retry");
+    assert_eq!(
+        record.metadata["local_cook_supervisor"]["launcher_pid"].as_u64(),
+        Some(u64::from(std::process::id()))
+    );
+    assert!(
+        !record.metadata["local_cook_supervisor"]["launcher_reclaimed_at"].is_null(),
+        "takeover remains durable evidence"
+    );
+}
+
+#[test]
+fn spawned_local_retry_child_is_reclaimed_without_a_second_spawn() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let store = AgentTaskLifecycleStore::new(context.path_roots());
+    let run_id = "spawned-local-retry";
+    let cook_id = "spawned-local-retry-cook";
+    store
+        .submit_plan_with_runtime_admission(&test_plan(), run_id, |_| Ok(json!({})))
+        .expect("submit pending retry");
+    store
+        .mutate_record(run_id, |record| {
+            record.metadata["cook_id"] = json!(cook_id);
+            record.metadata["local_cook_supervisor"] = json!({
+                "state": "pending",
+                "pinned_run_id": run_id,
+            });
+            true
+        })
+        .expect("seed pending retry");
+    let mut child = Command::new("sleep")
+        .arg("30")
+        .spawn()
+        .expect("spawn retry child");
+    let identity = homeboy_core::process::process_start_identity(child.id())
+        .expect("inspect retry child")
+        .expect("retry child identity");
+    record_local_cook_retry_child_in_store(
+        &store,
+        run_id,
+        cook_id,
+        child.id(),
+        identity.clone(),
+        "one-child-token",
+        "/tmp/one-child-token",
+    )
+    .expect("persist retry child before submission");
+
+    assert!(matches!(
+        claim_local_cook_retry_launch_in_store(&store, run_id, cook_id)
+            .expect("recover spawned child"),
+        LocalCookRetryLaunchClaim::ChildSpawned { pid, start_identity, .. }
+            if pid == child.id() && start_identity == identity
+    ));
+    child.kill().expect("kill retry child");
+    child.wait().expect("reap retry child");
+    assert_eq!(
+        claim_local_cook_retry_launch_in_store(&store, run_id, cook_id)
+            .expect("observe dead child"),
+        LocalCookRetryLaunchClaim::ChildExited,
+    );
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -18,7 +18,7 @@ use homeboy_core::api_jobs::{Job, JobEvent, JobEventKind, JobStore, RemoteRunner
 use homeboy_core::test_support::with_isolated_home;
 use sha2::{Digest, Sha256};
 use std::process::Command;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 use tempfile::TempDir;
 
 struct TerminalSnapshotProvider {
@@ -27,6 +27,23 @@ struct TerminalSnapshotProvider {
 
 struct ServiceRunnerFixture {
     commands: Arc<Mutex<Vec<Vec<String>>>>,
+}
+
+static CONFIG_LOCK_STRICT_TEST: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+fn with_strict_config_lock(test: impl FnOnce()) {
+    let _guard = CONFIG_LOCK_STRICT_TEST
+        .lock()
+        .expect("strict lock test guard");
+    std::env::set_var(homeboy_core::config::CONFIG_LOCK_STRICT_ENV, "1");
+    struct StrictLockEnv;
+    impl Drop for StrictLockEnv {
+        fn drop(&mut self) {
+            std::env::remove_var(homeboy_core::config::CONFIG_LOCK_STRICT_ENV);
+        }
+    }
+    let _env = StrictLockEnv;
+    test();
 }
 
 struct FixtureAcceptanceVerifier;
@@ -3729,6 +3746,63 @@ fn run_status_reports_bridge_envelope_and_cursor_filtered_events() {
     );
     assert_eq!(status.normalized_events[0].artifact_refs.len(), 1);
     assert_eq!(status.artifact_refs[0].kind, "artifact-bundle");
+}
+
+#[test]
+fn cancellation_wins_the_retry_pre_execution_failure_race() {
+    with_isolated_home(|_| {
+        let run_id = "cook-retry-cancellation-race";
+        let plan = test_plan();
+        submit_plan(&plan, Some(run_id)).expect("submit retry reservation");
+        cancel_run(run_id, Some("operator cancellation")).expect("cancel retry");
+
+        let failure = record_pre_execution_failure_in_store(
+            &AgentTaskLifecycleStore::from_current_environment().expect("lifecycle store"),
+            run_id,
+            &plan,
+            "local_retry_supervisor",
+            &Error::internal_unexpected("supervisor exited before execution"),
+        )
+        .expect("terminal arbitration preserves cancellation");
+
+        assert_eq!(failure.state, AgentTaskRunState::Cancelled);
+        assert!(failure.metadata.get("pre_execution_failure").is_none());
+    });
+}
+
+#[test]
+fn dead_retry_launcher_persists_terminal_failure_under_strict_config_locking() {
+    with_strict_config_lock(|| {
+        with_isolated_home(|_| {
+            let run_id = "cook-dead-retry-launcher-strict-attempt-2";
+            let plan = test_plan();
+            submit_plan(&plan, Some(run_id)).expect("persist retry reservation");
+
+            let store =
+                AgentTaskLifecycleStore::from_current_environment().expect("lifecycle store");
+            let failed = record_pre_execution_failure_in_store(
+                &store,
+                run_id,
+                &plan,
+                "local_retry_supervisor",
+                &Error::internal_unexpected(
+                    "local Cook retry launcher exited before provider execution",
+                ),
+            )
+            .expect("strict lock must not re-enter during terminal persistence");
+
+            assert_eq!(failed.state, AgentTaskRunState::Failed);
+            assert_eq!(
+                store.read_aggregate(run_id).expect("aggregate").status,
+                AgentTaskAggregateStatus::Failed
+            );
+            assert_eq!(
+                store.read_record(run_id).expect("durable record").metadata["artifact_projection"]
+                    ["status"],
+                "complete"
+            );
+        })
+    });
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_service/cook_job.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_job.rs
@@ -73,6 +73,14 @@ pub struct AgentTaskCookJobRequest {
     pub cook_id: String,
     pub child_pid: u32,
     pub child_start_identity: ProcessStartIdentity,
+    /// A retry has an existing Cook alias but needs a fresh durable supervisor.
+    /// Initial Cook jobs retain the Cook id as their owner identity.
+    #[serde(default)]
+    pub supervisor_id: Option<String>,
+    /// The retry run this supervisor is allowed to observe. Unlike the Cook
+    /// alias, it never advances when a later retry becomes the index latest.
+    #[serde(default)]
+    pub pinned_retry_run_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -120,15 +128,25 @@ impl AgentTaskCookJob {
                 "cook jobs require the detached child's process id",
             ));
         }
+        let run_id = request.pinned_retry_run_id.clone();
         Ok(Self {
             schema: AGENT_TASK_COOK_JOB_SCHEMA.to_string(),
             // The cook id is already unique and is the durable identity of this
             // work, so replaying a submit converges on one job rather than
             // creating a second supervisor for the same child.
-            idempotency_key: format!("agent-task-cook:{}", request.cook_id),
+            idempotency_key: format!(
+                "agent-task-cook:{}",
+                request
+                    .pinned_retry_run_id
+                    .as_deref()
+                    .unwrap_or_else(|| request
+                        .supervisor_id
+                        .as_deref()
+                        .unwrap_or(&request.cook_id))
+            ),
             request,
             phase: AgentTaskCookJobPhase::Queued,
-            run_id: None,
+            run_id,
             terminal_state: None,
         })
     }
@@ -314,8 +332,14 @@ impl ControllerJobDriver for CookJobDriver {
         if job.phase == AgentTaskCookJobPhase::Completed {
             return Ok(());
         }
-        agent_task_lifecycle::cancel_run(&job.request.cook_id, Some("controller job cancelled"))
-            .map(|_| ())
+        // A retry supervisor owns one immutable attempt. Resolving its Cook
+        // alias here could instead cancel a later retry that became latest.
+        let run_id = job
+            .request
+            .pinned_retry_run_id
+            .as_deref()
+            .unwrap_or(&job.request.cook_id);
+        agent_task_lifecycle::cancel_run(run_id, Some("controller job cancelled")).map(|_| ())
     }
 }
 
@@ -357,6 +381,9 @@ impl CookJobDriver {
                 let lifecycle_store =
                     agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
                 let mut record = lifecycle_store.read_record(run_id)?;
+                if record.state.is_terminal() {
+                    return job.observe_terminal(Some(record.run_id));
+                }
                 if record.runner_id().is_some() && record.runner_job_id().is_some() {
                     agent_task_lifecycle::reconcile_runner_job_state_in_store(
                         &lifecycle_store,
@@ -419,12 +446,36 @@ impl AgentTaskCookJob {
     /// as `Failed` rather than dressed up as a success, mirroring the launcher's
     /// existing `exited_before_handoff` honesty.
     fn observe_terminal(&mut self, run_id: Option<String>) -> Result<Value> {
-        let run_id = run_id.or_else(|| latest_run_id(&self.request.cook_id));
+        let run_id = run_id
+            .or_else(|| self.request.pinned_retry_run_id.clone())
+            .or_else(|| latest_run_id(&self.request.cook_id));
         if run_id.is_none() {
             agent_task_lifecycle::fail_detached_cook_handoff_parent(
                 &self.request.cook_id,
                 "detached Cook exited before materializing its first attempt",
             )?;
+        }
+        // A retry supervisor is attached to an existing queued attempt rather
+        // than an initial handoff parent. If its launcher exits before provider
+        // execution, retain the normal zero-provider terminal outcome.
+        if self.request.supervisor_id.is_some() {
+            if let Some(run_id) = run_id.as_deref() {
+                let lifecycle_store =
+                    agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+                let record = lifecycle_store.read_record(run_id)?;
+                if !record.state.is_terminal() {
+                    let plan = lifecycle_store.read_controller_plan(run_id)?;
+                    agent_task_lifecycle::record_pre_execution_failure_in_store(
+                        &lifecycle_store,
+                        run_id,
+                        &plan,
+                        "local_retry_supervisor",
+                        &homeboy_core::Error::internal_unexpected(
+                            "local Cook retry launcher exited before provider execution",
+                        ),
+                    )?;
+                }
+            }
         }
         let observed = run_id
             .as_deref()
@@ -490,6 +541,32 @@ pub fn cook_job_submission(
         cook_id: cook_id.to_string(),
         child_pid,
         child_start_identity: child_start_identity.clone(),
+        supervisor_id: None,
+        pinned_retry_run_id: None,
+    })?;
+    Ok(json!({
+        "type": AGENT_TASK_COOK_JOB_TYPE,
+        "version": AGENT_TASK_COOK_JOB_VERSION,
+        "idempotency_key": job.idempotency_key,
+        "request": job.to_checkpoint()?,
+    }))
+}
+
+/// Build a retry-specific supervisor submission. The Cook alias remains the
+/// cancellation target while the retry run is the one-shot supervisor owner.
+pub fn cook_retry_job_submission(
+    cook_id: &str,
+    run_id: &str,
+    child_pid: u32,
+    child_start_identity: &ProcessStartIdentity,
+) -> Result<Value> {
+    let job = AgentTaskCookJob::new(AgentTaskCookJobRequest {
+        schema: AGENT_TASK_COOK_JOB_SCHEMA.to_string(),
+        cook_id: cook_id.to_string(),
+        child_pid,
+        child_start_identity: child_start_identity.clone(),
+        supervisor_id: Some(run_id.to_string()),
+        pinned_retry_run_id: Some(run_id.to_string()),
     })?;
     Ok(json!({
         "type": AGENT_TASK_COOK_JOB_TYPE,
@@ -510,6 +587,37 @@ mod tests {
 
     fn submission(cook_id: &str, pid: u32) -> Value {
         cook_job_submission(cook_id, pid, &IDENTITY).expect("build cook job submission")
+    }
+
+    #[test]
+    fn retry_supervisors_are_owned_by_the_exact_retry_run() {
+        let first = cook_retry_job_submission("cook-retry", "cook-retry-attempt-2", 1, &IDENTITY)
+            .expect("first retry submission");
+        let replay = cook_retry_job_submission("cook-retry", "cook-retry-attempt-2", 2, &IDENTITY)
+            .expect("replayed retry submission");
+        let successor =
+            cook_retry_job_submission("cook-retry", "cook-retry-attempt-3", 3, &IDENTITY)
+                .expect("successor retry submission");
+
+        assert_eq!(
+            first["idempotency_key"],
+            "agent-task-cook:cook-retry-attempt-2"
+        );
+        assert_eq!(first["idempotency_key"], replay["idempotency_key"]);
+        assert_ne!(first["idempotency_key"], successor["idempotency_key"]);
+        let first_job = AgentTaskCookJob::parse(first["request"].clone()).expect("first job");
+        let successor_job =
+            AgentTaskCookJob::parse(successor["request"].clone()).expect("successor job");
+        assert_eq!(first_job.run_id.as_deref(), Some("cook-retry-attempt-2"));
+        assert_eq!(
+            successor_job.run_id.as_deref(),
+            Some("cook-retry-attempt-3")
+        );
+        assert_ne!(first_job.run_id, successor_job.run_id);
+        assert_eq!(
+            first_job.request.pinned_retry_run_id.as_deref(),
+            first_job.run_id.as_deref()
+        );
     }
 
     fn request_of(cook_id: &str, pid: u32) -> Value {
@@ -755,6 +863,45 @@ mod tests {
                     homeboy_core::process::ProcessIdentityState::Dead
                 ),
                 "a cancelled cook job must leave no live child"
+            );
+        });
+    }
+
+    #[test]
+    fn cancelling_a_retry_supervisor_targets_its_pinned_attempt_not_the_latest() {
+        with_isolated_home(|_| {
+            let cook_id = "cook-retry-cancel";
+            let plan = crate::agent_task_scheduler::AgentTaskPlan::new("retry-cancel", Vec::new());
+            agent_task_lifecycle::record_detached_cook_handoff_parent(cook_id)
+                .expect("persist handoff parent");
+            for (attempt, run_id) in [
+                (1, "cook-retry-cancel-attempt-1"),
+                (2, "cook-retry-cancel-attempt-2"),
+                (3, "cook-retry-cancel-attempt-3"),
+            ] {
+                agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("persist attempt");
+                agent_task_lifecycle::record_cook_attempt(cook_id, attempt, run_id)
+                    .expect("index attempt");
+            }
+
+            let submission =
+                cook_retry_job_submission(cook_id, "cook-retry-cancel-attempt-2", 4242, &IDENTITY)
+                    .expect("build retry supervisor submission");
+            CookJobDriver
+                .cancel(&submission["request"])
+                .expect("cancel pinned retry supervisor");
+
+            assert_eq!(
+                agent_task_lifecycle::exact_record("cook-retry-cancel-attempt-2")
+                    .expect("read cancelled pinned attempt")
+                    .state,
+                agent_task_lifecycle::AgentTaskRunState::Cancelled
+            );
+            assert_eq!(
+                agent_task_lifecycle::exact_record("cook-retry-cancel-attempt-3")
+                    .expect("read latest attempt")
+                    .state,
+                agent_task_lifecycle::AgentTaskRunState::Queued
             );
         });
     }

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -7207,10 +7207,9 @@ fn retryable_pre_provider_retry_concurrently_claims_one_successor() {
                 let run_id = options.initial_run_id.clone();
                 std::thread::spawn(move || {
                     barrier.wait();
-                    crate::agent_task_service::retry(&run_id, None, false, false)
-                        .expect("concurrent retry converges")
-                        .record
-                        .run_id
+                    let retry = crate::agent_task_service::retry(&run_id, None, false, false)
+                        .expect("concurrent retry converges");
+                    (retry.record.run_id, retry.created)
                 })
             })
             .collect::<Vec<_>>();
@@ -7219,13 +7218,18 @@ fn retryable_pre_provider_retry_concurrently_claims_one_successor() {
             .map(|retry| retry.join().expect("retry thread"))
             .collect::<Vec<_>>();
 
-        assert!(run_ids.iter().all(|run_id| run_id == &run_ids[0]));
+        assert!(run_ids.iter().all(|(run_id, _)| run_id == &run_ids[0].0));
+        assert_eq!(
+            run_ids.iter().filter(|(_, created)| *created).count(),
+            1,
+            "only the reservation owner may launch the local retry child"
+        );
         let recipe = super::super::load_recipe(&options.cook_id).expect("bound recipe");
         let index = agent_task_lifecycle::cook_index(&options.cook_id).expect("bound index");
         assert_eq!(recipe.attempts.len(), 2);
-        assert_eq!(recipe.attempts[1].run_id, run_ids[0]);
+        assert_eq!(recipe.attempts[1].run_id, run_ids[0].0.as_str());
         assert_eq!(index.attempts.len(), 2);
-        assert_eq!(index.latest_run_id, run_ids[0]);
+        assert_eq!(index.latest_run_id, run_ids[0].0.as_str());
         assert_eq!(
             agent_task_lifecycle::list_records()
                 .expect("durable lifecycle records")

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -4,6 +4,7 @@
 use crate::agent_task::{AgentTaskRequest, AgentTaskSourceRef};
 use crate::agent_task_lifecycle::{self, AgentTaskRecordHealthSummary, AgentTaskRunRecord};
 use crate::agent_task_scheduler::AgentTaskState;
+use homeboy_core::api_jobs::{JobStatus, JobStore};
 use std::collections::{BTreeMap, BTreeSet};
 // `agent-task active` treats a `Running` record that has gone this long without
 // an `updated_at` heartbeat as suspect even when its owner process/runner-job
@@ -667,6 +668,20 @@ fn classify_liveness(
     if record.lab_handoff_validation_error().is_some() {
         return AgentTaskLiveness::Unreconciled;
     }
+    // Retry reservation publishes a short, exact-run lease before its daemon
+    // job id can be projected. Honor only that bounded, well-formed window so
+    // discovery cannot cancel the queued successor between those two writes.
+    if record.state == agent_task_lifecycle::AgentTaskRunState::Queued
+        && record.has_live_pending_local_cook_supervisor(now)
+    {
+        return AgentTaskLiveness::Active;
+    }
+    // A local Cook retry owns a queued lifecycle reservation before its child
+    // begins provider execution. Its current daemon job is the authoritative
+    // owner, so test it before generic queued-record staleness.
+    if live_local_cook_retry_supervisor(record) {
+        return AgentTaskLiveness::Active;
+    }
     if record.state != agent_task_lifecycle::AgentTaskRunState::Running {
         if agent_task_lifecycle::has_expired_pending_runner_submission_intent(record, now) {
             return AgentTaskLiveness::Unreconciled;
@@ -741,6 +756,48 @@ fn classify_liveness(
         // we genuinely cannot confirm this run either way.
         (false, false) => AgentTaskLiveness::Unreconciled,
     }
+}
+
+fn live_local_cook_retry_supervisor(record: &AgentTaskRunRecord) -> bool {
+    let supervisor = &record.metadata["local_cook_supervisor"];
+    if supervisor["job_type"].as_str() != Some(crate::agent_task_service::AGENT_TASK_COOK_JOB_TYPE)
+    {
+        return false;
+    }
+    let Some(job_id) = supervisor["job_id"].as_str() else {
+        return false;
+    };
+    let Ok(job_id) = uuid::Uuid::parse_str(job_id) else {
+        return false;
+    };
+    let Ok(daemon) = homeboy_core::daemon::read_status() else {
+        return false;
+    };
+    let Some(lease) = daemon.state.map(|state| state.lease_id) else {
+        return false;
+    };
+    if !daemon.reachable || !daemon.fresh {
+        return false;
+    }
+    let Ok(path) = homeboy_core::paths::daemon_jobs_file() else {
+        return false;
+    };
+    let Ok(store) = JobStore::open_without_reconciliation(path) else {
+        return false;
+    };
+    let Ok(job) = store.get(job_id) else {
+        return false;
+    };
+    // Controller jobs retain their transport namespace in durable storage.
+    // The retry metadata carries the submitted job type, not that stored
+    // operation name, so compare against the authoritative controller form.
+    job.operation
+        == format!(
+            "controller.{}",
+            crate::agent_task_service::AGENT_TASK_COOK_JOB_TYPE
+        )
+        && job.daemon_lease_id.as_deref() == Some(lease.as_str())
+        && matches!(job.status, JobStatus::Queued | JobStatus::Running)
 }
 
 /// Label where a run executes so an operator can trace the runner process.
@@ -919,4 +976,66 @@ fn metadata_string(metadata: &Value, key: &str) -> Option<String> {
 
 fn metadata_bool(metadata: &Value, key: &str) -> Option<bool> {
     metadata.get(key).and_then(Value::as_bool)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn queued_record(supervisor: Value) -> AgentTaskRunRecord {
+        serde_json::from_value(json!({
+            "schema": "homeboy/agent-task-run/v1",
+            "run_id": "retry-attempt",
+            "plan_id": "plan",
+            "state": "queued",
+            "submitted_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "plan_path": "plan.json",
+            "metadata": {
+                "cook_id": "cook",
+                "local_cook_supervisor": supervisor,
+            },
+        }))
+        .expect("queued record")
+    }
+
+    #[test]
+    fn queued_retry_honors_only_a_valid_bounded_pending_supervisor_lease() {
+        let now = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:01:00Z")
+            .expect("timestamp")
+            .with_timezone(&chrono::Utc);
+        let valid = queued_record(json!({
+            "state": "pending",
+            "pinned_run_id": "retry-attempt",
+            "lease_started_at": "2026-01-01T00:00:45Z",
+            "lease_expires_at": "2026-01-01T00:01:15Z",
+        }));
+        assert_eq!(
+            classify_liveness(&valid, Some(10), now),
+            AgentTaskLiveness::Active
+        );
+
+        let expired = queued_record(json!({
+            "state": "pending",
+            "pinned_run_id": "retry-attempt",
+            "lease_started_at": "2026-01-01T00:00:00Z",
+            "lease_expires_at": "2026-01-01T00:00:30Z",
+        }));
+        assert_eq!(
+            classify_liveness(&expired, Some(10), now),
+            AgentTaskLiveness::Stale
+        );
+
+        let invalid = queued_record(json!({
+            "state": "pending",
+            "pinned_run_id": "retry-attempt",
+            "lease_started_at": "2026-01-01T00:00:00Z",
+            "lease_expires_at": "2026-01-01T00:10:00Z",
+        }));
+        assert_eq!(
+            classify_liveness(&invalid, Some(10), now),
+            AgentTaskLiveness::Stale
+        );
+    }
 }

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -1157,7 +1157,11 @@ pub fn retry(
     })?;
     if let Some(record) = recovered_replacement {
         let run = run && !record.state.is_terminal();
-        return Ok(AgentTaskRetryServiceResult { record, run });
+        return Ok(AgentTaskRetryServiceResult {
+            record,
+            run,
+            created: false,
+        });
     }
     let cook_retry = retryable_cook_attempt(&lifecycle_store, &source)?;
     let record = match cook_retry {
@@ -1194,6 +1198,11 @@ pub fn retry(
                     &cook_retry.plan,
                     &retry_run_id,
                 )?
+                && !is_pending_local_cook_retry_reservation(
+                    &lifecycle_store,
+                    &source,
+                    &retry_run_id,
+                )?
             {
                 return Err(Error::validation_invalid_argument(
                     "new_run_id",
@@ -1205,14 +1214,17 @@ pub fn retry(
             // The lifecycle record is the durable reservation. It writes retry_of
             // before recipe/index binding, so recovery can prove ownership without
             // adopting an unrelated same-plan run.
+            let mut created = false;
             if !retry_exists {
-                retry_run_id = reserve_cook_retry_lifecycle(
+                let reservation = reserve_cook_retry_lifecycle(
                     &lifecycle_store,
                     &source,
                     &cook_retry,
                     &retry_run_id,
                     force,
                 )?;
+                retry_run_id = reservation.run_id;
+                created = reservation.created;
             }
             // Recipe and index are one Cook-owned binding boundary. Serialize
             // concurrent claim observers so neither can overwrite the other's
@@ -1250,9 +1262,17 @@ pub fn retry(
             )?
             .record;
             if record.state.is_terminal() {
-                return Ok(AgentTaskRetryServiceResult { record, run: false });
+                return Ok(AgentTaskRetryServiceResult {
+                    record,
+                    run: false,
+                    created,
+                });
             }
-            record
+            return Ok(AgentTaskRetryServiceResult {
+                record,
+                run,
+                created,
+            });
         }
         None => agent_task_lifecycle::retry_with_force_in_store(
             &lifecycle_store,
@@ -1261,7 +1281,16 @@ pub fn retry(
             force,
         )?,
     };
-    Ok(AgentTaskRetryServiceResult { record, run })
+    Ok(AgentTaskRetryServiceResult {
+        record,
+        run,
+        created: false,
+    })
+}
+
+struct CookRetryReservation {
+    run_id: String,
+    created: bool,
 }
 
 fn reserve_cook_retry_lifecycle(
@@ -1270,7 +1299,7 @@ fn reserve_cook_retry_lifecycle(
     retry: &CookRetryAttempt,
     retry_run_id: &str,
     force: bool,
-) -> Result<String> {
+) -> Result<CookRetryReservation> {
     let operation_key = format!("retry:{}:{}", retry.cook_id, retry.attempt);
     match agent_task_lifecycle::claim_cook_operation_in_store(
         lifecycle_store,
@@ -1282,11 +1311,34 @@ fn reserve_cook_retry_lifecycle(
             // The Cook operation claim coordinates recipe/index binding; the
             // lifecycle retry lock also makes the first durable successor
             // idempotent across concurrent controllers and processes.
-            agent_task_lifecycle::retry_with_force_in_store(
+            let existed_before_claim =
+                agent_task_lifecycle::run_record_exists_in_store(lifecycle_store, retry_run_id)?;
+            let lease_started_at = chrono::Utc::now();
+            let launcher_pid = std::process::id();
+            let launcher_start_identity =
+                homeboy_core::process::process_start_identity(launcher_pid)
+                    .map_err(Error::internal_unexpected)?
+                    .ok_or_else(|| {
+                        Error::internal_unexpected(
+                            "local Cook retry launcher exited before its reservation was persisted",
+                        )
+                    })?;
+            let reserved = agent_task_lifecycle::retry_with_force_and_metadata_in_store(
                 lifecycle_store,
                 &source.run_id,
                 Some(retry_run_id),
                 force,
+                serde_json::Map::from_iter([(
+                    "local_cook_supervisor".to_string(),
+                    json!({
+                        "state": "pending",
+                        "pinned_run_id": retry_run_id,
+                        "lease_started_at": lease_started_at.to_rfc3339(),
+                        "lease_expires_at": (lease_started_at + chrono::Duration::seconds(agent_task_lifecycle::LOCAL_COOK_SUPERVISOR_LEASE_SECONDS)).to_rfc3339(),
+                        "launcher_pid": launcher_pid,
+                        "launcher_process_start_identity": launcher_start_identity,
+                    }),
+                )]),
             )?;
             let result = json!({ "run_id": retry_run_id });
             if let Err(error) = agent_task_lifecycle::complete_cook_operation_in_store(
@@ -1312,13 +1364,19 @@ fn reserve_cook_retry_lifecycle(
                     result,
                 )?;
             }
-            Ok(retry_run_id.to_string())
+            Ok(CookRetryReservation {
+                run_id: retry_run_id.to_string(),
+                created: !existed_before_claim && reserved.run_id == retry_run_id,
+            })
         }
         agent_task_lifecycle::ClaimOutcome::AlreadyCompleted(result) => {
             let recorded_run_id = result["run_id"].as_str().ok_or_else(|| {
                 Error::internal_unexpected("completed Cook retry claim has no run id")
             })?;
-            Ok(recorded_run_id.to_string())
+            Ok(CookRetryReservation {
+                run_id: recorded_run_id.to_string(),
+                created: false,
+            })
         }
         agent_task_lifecycle::ClaimOutcome::LeaseHeld => {
             // The winner writes its lifecycle reservation before completing the
@@ -1337,7 +1395,10 @@ fn reserve_cook_retry_lifecycle(
                         &retry.plan,
                     )?
                 {
-                    return Ok(record.run_id);
+                    return Ok(CookRetryReservation {
+                        run_id: record.run_id,
+                        created: false,
+                    });
                 }
                 std::thread::sleep(Duration::from_millis(10));
             }
@@ -1590,6 +1651,29 @@ fn is_exact_retry_reservation(
         ))
 }
 
+/// A pending local retry has already passed recipe binding and has not yet
+/// materialized a child. Its pinned launcher lease is durable retry proof even
+/// when a restarted caller rebuilds a plan with non-execution metadata changed.
+fn is_pending_local_cook_retry_reservation(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    source: &agent_task_lifecycle::AgentTaskRunRecord,
+    run_id: &str,
+) -> Result<bool> {
+    let record = agent_task_lifecycle::exact_record_in_store(lifecycle_store, run_id)?;
+    let supervisor = &record.metadata["local_cook_supervisor"];
+    Ok(
+        record.state == agent_task_lifecycle::AgentTaskRunState::Queued
+            && record.metadata["retry_of"] == source.run_id
+            && matches!(
+                supervisor["state"].as_str(),
+                Some("pending") | Some("child_spawned")
+            )
+            && supervisor["pinned_run_id"] == run_id
+            && supervisor["launcher_pid"].as_u64().is_some()
+            && !supervisor["launcher_process_start_identity"].is_null(),
+    )
+}
+
 pub(super) fn cook_retry_plans_match(expected: &AgentTaskPlan, observed: &AgentTaskPlan) -> bool {
     if expected == observed {
         return true;
@@ -1638,6 +1722,8 @@ struct CookRetryAttempt {
 pub struct AgentTaskRetryServiceResult {
     pub record: AgentTaskRunRecord,
     pub run: bool,
+    /// True only for the caller that durably reserved this Cook successor.
+    pub created: bool,
 }
 
 pub fn status(run_id: &str) -> Result<AgentTaskRunRecord> {

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -302,6 +302,7 @@ pub mod gate {
 pub mod lifecycle {
     pub use super::super::agent_task_lifecycle::{
         aggregate_source, artifacts, cancel, cancel_run, claim_cook_operation,
+        claim_local_cook_retry_launch_in_store,
         claim_next_eligible_queued_run_with_preflight_and_filter,
         claim_next_eligible_queued_run_with_preflight_and_filter_and_limit, claim_next_queued_run,
         complete_cook_operation, consume_unmaterialized_cook_replay_claim, cook_attempt_run_id,
@@ -322,8 +323,10 @@ pub mod lifecycle {
         record_detached_cook_handoff_child_in_store, record_detached_cook_handoff_parent,
         record_detached_cook_handoff_parent_in_store, record_detached_cook_supervisor,
         record_detached_cook_supervisor_in_store, record_detached_lab_run, record_health_summary,
-        record_lab_offload_phase, record_lab_offload_planned, record_pre_dispatch_failure,
-        record_pre_execution_failure, record_promotion, record_remote_dispatch_failure,
+        record_lab_offload_phase, record_lab_offload_planned,
+        record_local_cook_retry_child_in_store, record_local_cook_retry_supervisor_in_store,
+        record_pre_dispatch_failure, record_pre_execution_failure,
+        record_pre_execution_failure_in_store, record_promotion, record_remote_dispatch_failure,
         record_run_aggregate, record_runner_job_identity, record_unmaterialized_cook_admission,
         recover_unmaterialized_cook_input_publication, register_acceptance_verifier,
         register_acceptance_verifier_from_config,
@@ -351,8 +354,9 @@ pub mod lifecycle {
         AgentTaskRunStatus, AgentTaskRunTask, AgentTaskRunnerDiagnosticProbe, AgentTaskRunnerProbe,
         AgentTaskRunnerProbePlan, AgentTaskStatusOptions, AgentTaskStatusOutcome, ClaimOutcome,
         ControllerRuntimePruneResult, DetachedCookMaterializingAttempt, DetachedLabRunRecord,
-        LabOffloadProxyPlan, RunnerPinnedRuntime, RUNNER_PROBE_SKIPPED_CALLER_OPTED_OUT,
-        RUNNER_PROBE_SKIPPED_CONTROLLER_LOCAL, RUNNER_PROBE_SKIPPED_NOT_RUNNING,
+        LabOffloadProxyPlan, LocalCookRetryLaunchClaim, RunnerPinnedRuntime,
+        RUNNER_PROBE_SKIPPED_CALLER_OPTED_OUT, RUNNER_PROBE_SKIPPED_CONTROLLER_LOCAL,
+        RUNNER_PROBE_SKIPPED_NOT_RUNNING,
     };
     #[cfg(feature = "test-support")]
     pub use super::super::agent_task_lifecycle::{

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -829,6 +829,30 @@ impl AgentTaskLifecycleStore {
         )
     }
 
+    /// Commit the authoritative record/aggregate pair while the caller owns
+    /// this store's config lock. Artifact and workspace authority projection
+    /// must happen only after releasing that lock.
+    pub(crate) fn write_aggregate_and_record_locked_without_terminal_projection(
+        &self,
+        record: &AgentTaskRunRecord,
+        aggregate: &AgentTaskAggregate,
+    ) -> Result<AgentTaskRunRecord> {
+        let committed = write_record_with_aggregate_without_workspace_authority(
+            self,
+            record,
+            Some(aggregate.clone()),
+        )?;
+        #[cfg(test)]
+        if INTERRUPT_AFTER_TERMINAL_COMMIT.swap(false, Ordering::SeqCst) {
+            return Err(Error::internal_io(
+                "injected interruption after terminal lifecycle commit",
+                Some(record.run_id.clone()),
+            ));
+        }
+        self.write_aggregate(&record.run_id, aggregate)?;
+        Ok(committed)
+    }
+
     pub fn mutate_record(
         &self,
         run_id: &str,

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -66,6 +66,11 @@ pub(crate) fn route_after_parse_with_provenance(
     // runner-side bail-out because the request needs a verdict — detach here,
     // or an explicit rejection there — in both contexts.
     if runner_side || cli.placement == homeboy::cli_surface::Placement::Local {
+        if let Some(exit_code) =
+            local_detach::intercept_local_cook_retry(cli, normalized_args, runner_side)?
+        {
+            return Ok(Some(exit_code));
+        }
         if let Some(exit_code) = local_detach::intercept_local_detached_cook(
             cli,
             normalized_args,

--- a/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
@@ -65,6 +65,421 @@ const HANDOFF_POLL: Duration = Duration::from_millis(100);
 const HANDOFF_TIMEOUT_ENV: &str = "HOMEBOY_COOK_DETACH_HANDOFF_TIMEOUT_MS";
 const LOCAL_COOK_LAUNCH_TOKEN_ENV: &str = "HOMEBOY_LOCAL_COOK_LAUNCH_TOKEN";
 const LOCAL_COOK_LAUNCH_TOKEN_PATH_ENV: &str = "HOMEBOY_LOCAL_COOK_LAUNCH_TOKEN_PATH";
+// Hermetic E2E control: keep the launcher observable after ownership was
+// accepted so the test can signal it. Normal invocations still return at handoff.
+const TEST_LOCAL_COOK_RETRY_FOLLOW_ENV: &str = "HOMEBOY_TEST_LOCAL_COOK_RETRY_FOLLOW";
+const TEST_LOCAL_COOK_RETRY_PAUSE_AFTER_RESERVATION_ENV: &str =
+    "HOMEBOY_TEST_LOCAL_COOK_RETRY_PAUSE_AFTER_RESERVATION";
+const TEST_LOCAL_COOK_RETRY_PAUSE_AFTER_SPAWN_ENV: &str =
+    "HOMEBOY_TEST_LOCAL_COOK_RETRY_PAUSE_AFTER_SPAWN";
+const TEST_LOCAL_COOK_RETRY_PAUSE_AFTER_SUBMIT_ENV: &str =
+    "HOMEBOY_TEST_LOCAL_COOK_RETRY_PAUSE_AFTER_SUBMIT";
+
+/// Serve the one local retry route that has an existing Cook owner. Generic
+/// retries, Lab retries, runner-side commands, and a retry that only reserves
+/// a successor retain their established routes.
+pub(super) fn intercept_local_cook_retry(
+    cli: &Cli,
+    normalized_args: &[String],
+    runner_side: bool,
+) -> homeboy::core::Result<Option<i32>> {
+    let Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
+        command: crate::commands::agent_task::AgentTaskCommand::Retry(retry),
+    }) = &cli.command
+    else {
+        return Ok(None);
+    };
+    if !retry.run || runner_side || cli.placement != homeboy::cli_surface::Placement::Local {
+        return Ok(None);
+    }
+    // The child cannot route the retry until its parent has atomically published
+    // this unique readiness token after recording the exact-run supervisor.
+    if local_cook_launch_token_is_present() {
+        return if await_local_cook_launch_token(handoff_timeout()) {
+            Ok(None)
+        } else {
+            Err(Error::validation_invalid_argument(
+                "retry",
+                "local Cook retry readiness token was not published before the bounded handoff deadline",
+                None,
+                None,
+            ))
+        };
+    }
+    let source = match agent_task_lifecycle::status(&retry.run_id) {
+        Ok(record) => record,
+        Err(_) => return Ok(None),
+    };
+    let Some(cook_id) = source.metadata["cook_id"].as_str() else {
+        return Ok(None);
+    };
+    if source.runner_id().is_some() || source.runner_job_id().is_some() {
+        return Ok(None);
+    }
+    // This guard must precede retry reservation: unsupported hosts retain the
+    // ordinary retry path without leaving an unowned queued successor behind.
+    if !local_cook_supervision_supported() {
+        return Err(Error::validation_invalid_argument(
+            "placement",
+            "local Cook retry supervision requires a platform with session detachment and exact process start identity support",
+            Some(source.run_id),
+            None,
+        ));
+    }
+
+    // Every fallible resource needed to launch is prepared before reserving a
+    // successor. A preflight error must not leave an ownerless queued retry.
+    let controller_client =
+        homeboy::core::daemon::LocalControllerJobClient::connect_current_build()?;
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    let session_root = detached_session_root(&format!(
+        "{}-retry-launch-{}",
+        source.run_id,
+        uuid::Uuid::new_v4()
+    ))?;
+    let launch_token = new_local_cook_launch_token(&session_root);
+    let _launch_token_cleanup = LocalCookLaunchTokenCleanup(launch_token.1.clone());
+    let log_path = session_root.join("cook-retry.log");
+
+    // A crashed launcher can leave its successor queued in `child_spawned`.
+    // Recover that exact durable reservation before asking normal retry
+    // admission, which correctly rejects a generic request while work is queued.
+    let existing_retry = agent_task_lifecycle::list_records()?
+        .into_iter()
+        .find(|record| {
+            record.metadata["retry_of"].as_str() == Some(retry.run_id.as_str())
+                && record.state == agent_task_lifecycle::AgentTaskRunState::Queued
+                && matches!(
+                    record.metadata["local_cook_supervisor"]["state"].as_str(),
+                    Some("pending") | Some("child_spawned")
+                )
+        });
+    let (retry_runs, retry_record) = match existing_retry {
+        Some(record) => (true, record),
+        None => {
+            let result = homeboy::agents::agent_task_service::retry(
+                &retry.run_id,
+                retry.new_run_id.as_deref(),
+                true,
+                retry.force,
+            )?;
+            (result.run, result.record)
+        }
+    };
+    if !retry_runs || retry_record.state.is_terminal() {
+        println!(
+            "{}",
+            serde_json::to_string(&retry_record).unwrap_or_default()
+        );
+        return Ok(Some(0));
+    }
+    let run_id = retry_record.run_id;
+    let child = match agent_task_lifecycle::claim_local_cook_retry_launch_in_store(
+        &lifecycle_store,
+        &run_id,
+        cook_id,
+    )? {
+        agent_task_lifecycle::LocalCookRetryLaunchClaim::Acquired => None,
+        agent_task_lifecycle::LocalCookRetryLaunchClaim::ChildSpawned {
+            pid,
+            start_identity,
+            launch_token,
+            launch_token_path,
+        } => Some((
+            pid,
+            start_identity,
+            (launch_token, PathBuf::from(launch_token_path)),
+        )),
+        agent_task_lifecycle::LocalCookRetryLaunchClaim::ChildExited => {
+            record_retry_launcher_failure_for_run(
+                &run_id,
+                "local Cook retry child exited before durable supervision",
+            );
+            return Ok(Some(0));
+        }
+        // A live owner has the same pinned reservation and will establish the
+        // supervisor. Returning success makes concurrent retries converge.
+        agent_task_lifecycle::LocalCookRetryLaunchClaim::OwnedElsewhere
+        | agent_task_lifecycle::LocalCookRetryLaunchClaim::RecoveryPending
+        | agent_task_lifecycle::LocalCookRetryLaunchClaim::NotPending => {
+            println!(
+                "{}",
+                serde_json::to_string(
+                    &agent_task_lifecycle::status_in_store(
+                        &lifecycle_store,
+                        &run_id,
+                        agent_task_lifecycle::AgentTaskStatusOptions::default(),
+                        false,
+                    )?
+                    .record
+                )
+                .unwrap_or_default()
+            );
+            return Ok(Some(0));
+        }
+    };
+    // A takeover must continue through the recovered stage, not reproduce the
+    // crash fixture that stopped its dead predecessor.
+    let is_initial_launcher = lifecycle_store.read_record(&run_id)?.metadata
+        ["local_cook_supervisor"]["launcher_reclaimed_at"]
+        .is_null();
+    if is_initial_launcher
+        && std::env::var_os(TEST_LOCAL_COOK_RETRY_PAUSE_AFTER_RESERVATION_ENV).is_some()
+    {
+        loop {
+            std::thread::sleep(Duration::from_secs(1));
+        }
+    }
+    let plan = match agent_task_lifecycle::load_plan(&run_id) {
+        Ok(plan) => plan,
+        Err(error) => {
+            record_retry_launcher_failure_for_run(
+                &run_id,
+                "local Cook retry plan could not be loaded",
+            );
+            return Err(error);
+        }
+    };
+    let (pid, start_identity, launch_token) = match child {
+        Some(child) => child,
+        None => {
+            let route = detached_route(cli);
+            let child_args = retry_child_args(normalized_args, &run_id);
+            let mut child =
+                match spawn_detached_cook(&child_args, &log_path, route.as_ref(), &launch_token) {
+                    Ok(child) => child,
+                    Err(error) => {
+                        record_retry_launcher_failure(
+                            &lifecycle_store,
+                            &run_id,
+                            &plan,
+                            "local Cook retry could not be spawned",
+                        );
+                        return Err(error);
+                    }
+                };
+            let pid = child.id();
+            let start_identity = match detached_child_start_identity(pid) {
+                Ok(identity) => identity,
+                Err(error) => {
+                    terminate_and_reap_detached_child(&mut child);
+                    record_retry_launcher_failure(
+                        &lifecycle_store,
+                        &run_id,
+                        &plan,
+                        "local Cook retry child start identity could not be captured",
+                    );
+                    return Err(error);
+                }
+            };
+            if let Err(error) = agent_task_lifecycle::record_local_cook_retry_child_in_store(
+                &lifecycle_store,
+                &run_id,
+                cook_id,
+                pid,
+                start_identity.clone(),
+                &launch_token.0,
+                &launch_token.1.display().to_string(),
+            ) {
+                terminate_and_reap_detached_child(&mut child);
+                record_retry_launcher_failure(
+                    &lifecycle_store,
+                    &run_id,
+                    &plan,
+                    "local Cook retry child identity could not be persisted",
+                );
+                return Err(error);
+            }
+            if is_initial_launcher
+                && std::env::var_os(TEST_LOCAL_COOK_RETRY_PAUSE_AFTER_SPAWN_ENV).is_some()
+            {
+                loop {
+                    std::thread::sleep(Duration::from_secs(1));
+                }
+            }
+            (pid, start_identity, launch_token)
+        }
+    };
+    let controller_job = match submit_cook_retry_controller_job(
+        &controller_client,
+        cook_id,
+        &run_id,
+        pid,
+        &start_identity,
+    ) {
+        Ok(job) => job,
+        Err(error) => {
+            record_retry_launcher_failure(
+                &lifecycle_store,
+                &run_id,
+                &plan,
+                "durable local Cook retry supervision could not be established",
+            );
+            return Err(error);
+        }
+    };
+    if is_initial_launcher
+        && std::env::var_os(TEST_LOCAL_COOK_RETRY_PAUSE_AFTER_SUBMIT_ENV).is_some()
+    {
+        loop {
+            std::thread::sleep(Duration::from_secs(1));
+        }
+    }
+    if let Err(error) = agent_task_lifecycle::record_local_cook_retry_supervisor_in_store(
+        &lifecycle_store,
+        &run_id,
+        cook_id,
+        controller_job.job_id(),
+    ) {
+        let _ = controller_client.cancel(
+            controller_job.job_id(),
+            "local Cook retry supervisor projection failed",
+        );
+        record_retry_launcher_failure(
+            &lifecycle_store,
+            &run_id,
+            &plan,
+            "local Cook retry supervisor projection failed",
+        );
+        return Err(error);
+    }
+    if let Err(error) = publish_local_cook_launch_token(&launch_token) {
+        let _ = controller_client.cancel(
+            controller_job.job_id(),
+            "local Cook retry readiness publication failed",
+        );
+        record_retry_launcher_failure(
+            &lifecycle_store,
+            &run_id,
+            &plan,
+            "local Cook retry readiness publication failed",
+        );
+        return Err(error);
+    }
+    if let Err(error) = await_consumed_retry_launch_token_by_identity(
+        pid,
+        &start_identity,
+        &launch_token.1,
+        handoff_timeout(),
+    ) {
+        let _ = controller_client.cancel(
+            controller_job.job_id(),
+            "local Cook retry did not consume its launch readiness token",
+        );
+        record_retry_launcher_failure(
+            &lifecycle_store,
+            &run_id,
+            &plan,
+            "local Cook retry did not consume its launch readiness token",
+        );
+        return Err(error);
+    }
+    println!(
+        "{}",
+        serde_json::to_string(&json!({
+            "run_id": run_id,
+            "controller_job": controller_job.projection(),
+            "state": "accepted",
+        }))
+        .unwrap_or_default()
+    );
+    if std::env::var_os(TEST_LOCAL_COOK_RETRY_FOLLOW_ENV).as_deref()
+        == Some(std::ffi::OsStr::new("1"))
+    {
+        // A recovered launcher no longer owns a `Child` handle. The durable
+        // supervisor is the authority, so normal retry handoff returns here.
+        return Ok(Some(0));
+    }
+    Ok(Some(0))
+}
+
+fn await_consumed_retry_launch_token_by_identity(
+    pid: u32,
+    start_identity: &homeboy::core::process::ProcessStartIdentity,
+    token_path: &Path,
+    timeout: Duration,
+) -> homeboy::core::Result<()> {
+    let deadline = Instant::now() + timeout;
+    while token_path.exists() {
+        if !matches!(
+            homeboy::core::process::process_identity_state_with_start_identity(
+                pid,
+                None,
+                Some(start_identity)
+            ),
+            homeboy::core::process::ProcessIdentityState::Live
+        ) {
+            return Err(Error::validation_invalid_argument(
+                "retry",
+                "local Cook retry child exited before consuming its readiness token",
+                None,
+                None,
+            ));
+        }
+        if Instant::now() >= deadline {
+            return Err(Error::validation_invalid_argument("retry", "local Cook retry launcher did not consume its readiness token before the bounded handoff deadline", None, None));
+        }
+        std::thread::sleep(HANDOFF_POLL);
+    }
+    Ok(())
+}
+
+fn record_retry_launcher_failure_for_run(run_id: &str, reason: &str) {
+    let Ok(lifecycle_store) =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()
+    else {
+        return;
+    };
+    if let Ok(plan) = agent_task_lifecycle::load_plan(run_id) {
+        record_retry_launcher_failure(&lifecycle_store, run_id, &plan, reason);
+    } else {
+        // A corrupt or missing retry plan cannot produce an aggregate, but the
+        // reserved successor must still stop looking runnable.
+        let _ = agent_task_lifecycle::cancel_run(run_id, Some(reason));
+    }
+}
+
+fn record_retry_launcher_failure(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    run_id: &str,
+    plan: &homeboy::agents::agent_tasks::scheduler::AgentTaskPlan,
+    reason: &str,
+) {
+    let _ = agent_task_lifecycle::record_pre_execution_failure_in_store(
+        lifecycle_store,
+        run_id,
+        plan,
+        "local_retry_supervisor",
+        &Error::internal_unexpected(reason),
+    );
+}
+
+/// Pin the detached child to the reservation its parent won. Replaying an
+/// unpinned retry can otherwise resolve a later Cook successor after a
+/// concurrent caller advances the recipe.
+fn retry_child_args(normalized_args: &[String], run_id: &str) -> Vec<String> {
+    let mut args = Vec::with_capacity(normalized_args.len() + 2);
+    let mut index = usize::from(
+        normalized_args
+            .first()
+            .is_some_and(|arg| arg == "homeboy" || arg.ends_with("/homeboy")),
+    );
+    while index < normalized_args.len() {
+        let arg = &normalized_args[index];
+        if arg == "--new-run-id" {
+            index += 2;
+            continue;
+        }
+        if !arg.starts_with("--new-run-id=") {
+            args.push(arg.clone());
+        }
+        index += 1;
+    }
+    args.push("--new-run-id".to_string());
+    args.push(run_id.to_string());
+    args
+}
 
 /// Whether this is an unsupervised Cook requesting detached supervision.
 ///
@@ -103,13 +518,36 @@ fn consume_local_cook_launch_token() -> bool {
     consume_local_cook_launch_token_at(&token, &PathBuf::from(path))
 }
 
+fn local_cook_launch_token_is_present() -> bool {
+    std::env::var_os(LOCAL_COOK_LAUNCH_TOKEN_ENV).is_some()
+        && std::env::var_os(LOCAL_COOK_LAUNCH_TOKEN_PATH_ENV).is_some()
+}
+
+fn await_local_cook_launch_token(timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if consume_local_cook_launch_token() {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            if let Some(path) = std::env::var_os(LOCAL_COOK_LAUNCH_TOKEN_PATH_ENV) {
+                let _ = std::fs::remove_file(PathBuf::from(path));
+            }
+            return false;
+        }
+        std::thread::sleep(HANDOFF_POLL);
+    }
+}
+
 fn consume_local_cook_launch_token_at(token: &std::ffi::OsStr, path: &Path) -> bool {
-    let valid = std::fs::read_to_string(path)
+    let claimed = path.with_extension(format!("consumed-{}", uuid::Uuid::new_v4()));
+    if std::fs::rename(path, &claimed).is_err() {
+        return false;
+    }
+    let valid = std::fs::read_to_string(&claimed)
         .ok()
         .is_some_and(|stored| stored.trim_end() == token);
-    if valid {
-        let _ = std::fs::remove_file(path);
-    }
+    let _ = std::fs::remove_file(claimed);
     valid
 }
 
@@ -504,6 +942,25 @@ fn submit_cook_controller_job_inner(
     Ok(job_id)
 }
 
+fn submit_cook_retry_controller_job(
+    client: &homeboy::core::daemon::LocalControllerJobClient,
+    cook_id: &str,
+    run_id: &str,
+    pid: u32,
+    start_identity: &homeboy::core::process::ProcessStartIdentity,
+) -> homeboy::core::Result<ControllerJobHandoff> {
+    let submission = homeboy::agents::agent_task_service::cook_retry_job_submission(
+        cook_id,
+        run_id,
+        pid,
+        start_identity,
+    )?;
+    let job = client.submit(submission)?;
+    Ok(ControllerJobHandoff::Owned {
+        job_id: job.id.to_string(),
+    })
+}
+
 /// The one context where local detachment stays a rejection.
 fn runner_side_detach_error() -> Error {
     Error::validation_invalid_argument(
@@ -670,19 +1127,48 @@ fn detached_session_root(cook_id: &str) -> homeboy::core::Result<PathBuf> {
 /// that came from argv or from the launcher's own environment. Setting both
 /// variables together also normalizes a half-set pair inherited from the
 /// launcher, which the child would otherwise reject as a validation error.
-fn create_local_cook_launch_token(session_root: &Path) -> homeboy::core::Result<(String, PathBuf)> {
+fn new_local_cook_launch_token(session_root: &Path) -> (String, PathBuf) {
     let token = uuid::Uuid::new_v4().to_string();
-    let path = session_root.join("launch-token");
-    std::fs::write(&path, &token)
-        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
+    let path = session_root.join(format!("launch-token-{token}"));
+    (token, path)
+}
+
+fn publish_local_cook_launch_token(launch_token: &(String, PathBuf)) -> homeboy::core::Result<()> {
+    let pending = launch_token.1.with_extension("pending");
+    std::fs::write(&pending, &launch_token.0).map_err(|error| {
+        Error::internal_io(error.to_string(), Some(pending.display().to_string()))
+    })?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).map_err(
-            |error| Error::internal_io(error.to_string(), Some(path.display().to_string())),
+        std::fs::set_permissions(&pending, std::fs::Permissions::from_mode(0o600)).map_err(
+            |error| Error::internal_io(error.to_string(), Some(pending.display().to_string())),
         )?;
     }
-    Ok((token, path))
+    std::fs::rename(&pending, &launch_token.1).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(launch_token.1.display().to_string()),
+        )
+    })?;
+    Ok(())
+}
+
+/// Retry readiness is valid only while its parent is still establishing the
+/// handoff. Always remove it when that parent returns, including timeout paths.
+struct LocalCookLaunchTokenCleanup(PathBuf);
+
+impl Drop for LocalCookLaunchTokenCleanup {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+        let _ = std::fs::remove_file(self.0.with_extension("pending"));
+    }
+}
+
+fn create_local_cook_launch_token(session_root: &Path) -> homeboy::core::Result<(String, PathBuf)> {
+    let launch_token = new_local_cook_launch_token(session_root);
+    publish_local_cook_launch_token(&launch_token)?;
+    Ok(launch_token)
 }
 
 fn spawn_detached_cook(
@@ -1171,6 +1657,90 @@ mod tests {
         let (token, path) = create_local_cook_launch_token(directory.path()).expect("launch token");
         assert!(consume_local_cook_launch_token_at(token.as_ref(), &path));
         assert!(!consume_local_cook_launch_token_at(token.as_ref(), &path));
+    }
+
+    #[test]
+    fn retry_launch_tokens_are_unique_and_unpublished_until_supervisor_ready() {
+        let directory = tempfile::tempdir().expect("temporary token directory");
+        let first = new_local_cook_launch_token(directory.path());
+        let second = new_local_cook_launch_token(directory.path());
+        assert_ne!(first.1, second.1);
+        assert!(
+            !first.1.exists(),
+            "preflight reserves no readable readiness token"
+        );
+
+        publish_local_cook_launch_token(&first).expect("atomically publish readiness");
+        assert!(consume_local_cook_launch_token_at(
+            first.0.as_ref(),
+            &first.1
+        ));
+        assert!(
+            !second.1.exists(),
+            "one launch cannot release another child"
+        );
+    }
+
+    #[test]
+    fn retry_child_args_pin_the_parent_reservation() {
+        let rewritten = retry_child_args(
+            &args(&[
+                "homeboy",
+                "--placement",
+                "local",
+                "agent-task",
+                "retry",
+                "source",
+                "--run",
+                "--new-run-id=untrusted",
+            ]),
+            "reserved-retry",
+        );
+
+        assert_eq!(
+            rewritten
+                .iter()
+                .filter(|arg| arg.as_str() == "--new-run-id")
+                .count(),
+            1
+        );
+        assert_eq!(rewritten.last(), Some(&"reserved-retry".to_string()));
+        assert!(!rewritten.iter().any(|arg| arg == "--new-run-id=untrusted"));
+    }
+
+    #[test]
+    fn retry_interceptor_leaves_no_reservation_when_controller_connect_fails() {
+        homeboy::core::test_support::with_isolated_home(|_| {
+            let source = "retry-interceptor-connect-failure";
+            agent_task_lifecycle::submit_plan(
+                &homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new("retry-plan", vec![]),
+                Some(source),
+            )
+            .expect("persist source record");
+            agent_task_lifecycle::record_cook_attempt("retry-interceptor-cook", 1, source)
+                .expect("bind source to Cook");
+            let normalized = args(&[
+                "homeboy",
+                "--placement",
+                "local",
+                "agent-task",
+                "retry",
+                source,
+                "--run",
+            ]);
+            let cli = Cli::try_parse_from(&normalized).expect("parse retry invocation");
+
+            intercept_local_cook_retry(&cli, &normalized, false)
+                .expect_err("an isolated home has no controller daemon");
+
+            assert_eq!(
+                agent_task_lifecycle::list_records()
+                    .expect("list lifecycle records")
+                    .len(),
+                1,
+                "controller preflight must fail before reserving a retry"
+            );
+        });
     }
 
     #[test]

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -2,6 +2,8 @@ use std::path::Path;
 use std::process::{Output, Stdio};
 use std::time::{Duration, Instant};
 
+use homeboy::agents::agent_task_lifecycle::AgentTaskLifecycleStore;
+use homeboy_core::api_jobs::{JobStatus, JobStore};
 use homeboy_core::observation::{NewRunRecord, ObservationStore, RunListFilter};
 use homeboy_core::test_support::{bounded_output, HermeticTestContext, TestBinary};
 
@@ -566,7 +568,7 @@ fn foreground_local_cook_survives_client_termination_with_artifacts() {
     client
         // This test exercises automatic placement, not live host pressure.
         .env("GITHUB_ACTIONS", "true")
-        .env("HOMEBOY_FIXTURE_PROVIDER_DELAY_MS", "20000")
+        .env("HOMEBOY_FIXTURE_PROVIDER_DELAY_MS", "5000")
         .env("HOMEBOY_FIXTURE_PROVIDER_STARTED_FILE", &provider_started)
         .args([
             "agent-task",
@@ -680,6 +682,321 @@ fn foreground_local_cook_survives_client_termination_with_artifacts() {
     assert!(
         completed.contains("changes.patch"),
         "terminal artifacts retained: {completed}"
+    );
+}
+
+/// A retry can die after reserving its successor but before it spawns the
+/// detached child. A later retry must reclaim that dead launcher, rather than
+/// stranding the queued reservation or launching duplicate provider work.
+fn local_retry_reclaims_a_dead_launcher_at_handoff_stage(crash_env: &str) {
+    let context = HermeticTestContext::new();
+    let (_checkout_guard, checkout) =
+        homeboy_core::test_support::shared_committed_git_repo_fixture("local-retry-durability");
+    let component_id = "local-retry-durability";
+    let mut register = context.command(TestBinary::HomeboyFixture);
+    register.args([
+        "component",
+        "create",
+        "--local-path",
+        checkout.to_str().expect("checkout path"),
+    ]);
+    assert!(
+        bounded_output(register).status.success(),
+        "register component"
+    );
+    let task_worktree = context.root().join("local-retry-durability-worktree");
+    homeboy_core::test_support::run_git_fixture_command(
+        &checkout,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "local-retry-durability",
+            task_worktree.to_str().expect("task worktree path"),
+        ],
+    );
+    std::fs::write(
+        context.config_dir().join("homeboy.json"),
+        r#"{"retention":{"reconstructable_artifact_reserve_bytes":0}}"#,
+    )
+    .expect("disable host-capacity admission for fixture worktree");
+
+    let cook_id = format!(
+        "local-retry-durability-{}",
+        crash_env
+            .strip_prefix("HOMEBOY_TEST_LOCAL_COOK_RETRY_PAUSE_AFTER_")
+            .unwrap_or("handoff")
+            .to_ascii_lowercase()
+    );
+    let source_started = context.root().join("source-provider-started");
+    let mut source = context.controller_runtime_command(TestBinary::HomeboyFixture);
+    source
+        .env("GITHUB_ACTIONS", "true")
+        .env("HOMEBOY_FIXTURE_PROVIDER_DELAY_MS", "20000")
+        .env("HOMEBOY_FIXTURE_PROVIDER_STARTED_FILE", &source_started)
+        .args([
+            "agent-task",
+            "cook",
+            "--run-id",
+            &cook_id,
+            "--repo",
+            component_id,
+            "--backend",
+            "fixture",
+            "--prompt",
+            "make the retry durable",
+            "--cwd",
+            task_worktree.to_str().expect("task worktree path"),
+            "--to-worktree",
+            task_worktree.to_str().expect("task worktree path"),
+            "--verify",
+            "true",
+            "--max-attempts",
+            "2",
+            "--no-finalize",
+        ]);
+    let mut source = source.spawn().expect("start source Cook");
+    let deadline = Instant::now() + Duration::from_secs(60);
+    while !source_started.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "source Cook did not reserve provider work"
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    let mut source_status = context.controller_runtime_command(TestBinary::HomeboyFixture);
+    source_status.args(["agent-task", "status", &cook_id, "--full"]);
+    let source_status = bounded_output(source_status);
+    let source_status_json = serde_json::from_slice::<serde_json::Value>(&source_status.stdout)
+        .expect("source status JSON");
+    let source_run_id = source_status_json
+        .pointer("/data/action_eligibility/run_id")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_else(|| panic!("source durable run id: {source_status_json}"))
+        .to_string();
+    let mut cancel = context.controller_runtime_command(TestBinary::HomeboyFixture);
+    cancel.args([
+        "agent-task",
+        "cancel",
+        &source_run_id,
+        "--reason",
+        "prepare retry fixture",
+    ]);
+    assert!(
+        bounded_output(cancel).status.success(),
+        "cancel source Cook attempt"
+    );
+    source.wait().expect("reap source client");
+    let lifecycle_store = AgentTaskLifecycleStore::new(context.path_roots());
+    assert!(
+        lifecycle_store
+            .read_record(&source_run_id)
+            .expect("read cancelled source")
+            .state
+            .is_terminal(),
+        "source must terminalize before its retry is reserved"
+    );
+
+    let retry_started = context.root().join("retry-provider-started");
+    let retry_stdout = context.root().join("retry-client.stdout");
+    let mut retry = context.controller_runtime_command(TestBinary::HomeboyFixture);
+    retry
+        .env("GITHUB_ACTIONS", "true")
+        .env(crash_env, "1")
+        .args([
+            "--placement",
+            "local",
+            "agent-task",
+            "retry",
+            &source_run_id,
+            "--run",
+        ])
+        .stdout(Stdio::from(
+            std::fs::File::create(&retry_stdout).expect("create retry stdout"),
+        ));
+    let mut retry = retry.spawn().expect("start local retry client");
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let retry_run_id = format!("{cook_id}-attempt-2-retry");
+    let expected_handoff_state =
+        if crash_env == "HOMEBOY_TEST_LOCAL_COOK_RETRY_PAUSE_AFTER_RESERVATION" {
+            "pending"
+        } else {
+            "child_spawned"
+        };
+    while lifecycle_store
+        .read_record(&retry_run_id)
+        .ok()
+        .is_none_or(|record| {
+            record.metadata["local_cook_supervisor"]["state"].as_str()
+                != Some(expected_handoff_state)
+                || record.metadata["local_cook_supervisor"]["launcher_pid"]
+                    .as_u64()
+                    .is_none()
+                || record.metadata["local_cook_supervisor"]["launcher_process_start_identity"]
+                    .is_null()
+        })
+    {
+        assert!(
+            Instant::now() < deadline,
+            "local retry did not persist a verifiable pending launcher: {}",
+            std::fs::read_to_string(&retry_stdout).unwrap_or_default(),
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    let launcher_pid = lifecycle_store
+        .read_record(&retry_run_id)
+        .expect("read persisted retry launcher")
+        .metadata["local_cook_supervisor"]["launcher_pid"]
+        .as_u64()
+        .and_then(|pid| i32::try_from(pid).ok())
+        .expect("persisted retry launcher pid");
+
+    // The launcher is deliberately paused after the durable reservation, before
+    // it can spawn a child or project a supervisor.
+    assert!(
+        retry.try_wait().expect("observe retry client").is_none(),
+        "retry client returned before the reservation could be interrupted"
+    );
+    assert_eq!(
+        unsafe { libc::kill(launcher_pid, libc::SIGKILL) },
+        0,
+        "terminate only the persisted retry launcher",
+    );
+    let _ = retry.wait();
+
+    let mut takeover = context.controller_runtime_command(TestBinary::HomeboyFixture);
+    takeover
+        .env("GITHUB_ACTIONS", "true")
+        .env("HOMEBOY_FIXTURE_PROVIDER_DELAY_MS", "10000")
+        .env("HOMEBOY_FIXTURE_PROVIDER_STARTED_FILE", &retry_started)
+        .args([
+            "--placement",
+            "local",
+            "agent-task",
+            "retry",
+            &source_run_id,
+            "--run",
+        ]);
+    let takeover = bounded_output(takeover);
+    assert!(
+        takeover.status.success(),
+        "retry takeover failed: {}",
+        String::from_utf8_lossy(&takeover.stdout)
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let running_record = loop {
+        let record = lifecycle_store
+            .read_record(&retry_run_id)
+            .expect("read retry record at provider boundary");
+        if record.metadata["local_cook_supervisor"]["state"].as_str() == Some("supervising") {
+            break record;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "retry did not project its pinned supervisor: {record:?}"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    };
+    assert_eq!(
+        running_record.metadata["local_cook_supervisor"]["state"].as_str(),
+        Some("supervising"),
+        "retry must replace its queued pending owner with the pinned supervisor",
+    );
+    assert!(
+        running_record.metadata["local_cook_supervisor"]["job_id"]
+            .as_str()
+            .is_some(),
+        "retry supervisor must have a durable job id"
+    );
+    let supervisor_job_id = running_record.metadata["local_cook_supervisor"]["job_id"]
+        .as_str()
+        .expect("retry supervisor job id")
+        .parse()
+        .expect("retry supervisor UUID");
+
+    let mut reconcile = context.controller_runtime_command(TestBinary::HomeboyFixture);
+    reconcile.args(["agent-task", "reconcile", &retry_run_id, "--apply"]);
+    let reconciled = bounded_output(reconcile);
+    assert!(
+        !String::from_utf8_lossy(&reconciled.stdout).contains("missing_runner_pid"),
+        "pinned supervisor must prevent ownerless cancellation: {}",
+        String::from_utf8_lossy(&reconciled.stdout),
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        let mut status = context.controller_runtime_command(TestBinary::HomeboyFixture);
+        status.args(["agent-task", "status", &retry_run_id, "--full"]);
+        let output = bounded_output(status);
+        let record = lifecycle_store
+            .read_record(&retry_run_id)
+            .expect("read retry record");
+        if record.state == homeboy::agents::agent_task_lifecycle::AgentTaskRunState::Succeeded
+            && record.aggregate_path.is_some()
+            && !record.artifact_refs.is_empty()
+        {
+            assert!(output.status.success());
+            assert!(
+                record.aggregate_path.is_some(),
+                "terminal aggregate retained"
+            );
+            assert!(
+                !record.artifact_refs.is_empty(),
+                "terminal artifacts retained"
+            );
+            assert_eq!(
+                record.metadata["provider_executions_consumed"].as_u64(),
+                Some(1),
+                "only the reclaimed launcher may execute the provider"
+            );
+            assert!(
+                !String::from_utf8_lossy(&output.stdout).contains("missing_runner_pid"),
+                "terminal retry must retain its supervisor-owned finalization"
+            );
+            assert_eq!(
+                record.metadata["local_cook_supervisor"]["pinned_run_id"].as_str(),
+                Some(retry_run_id.as_str()),
+                "terminal retry must retain its exact supervisor identity"
+            );
+            break;
+        }
+        assert!(Instant::now() < deadline, "local retry did not complete");
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let store = JobStore::open_without_reconciliation(context.daemon_dir().join("jobs.json"))
+            .expect("open supervisor job store");
+        if store
+            .get(supervisor_job_id)
+            .expect("read retry supervisor job")
+            .status
+            == JobStatus::Succeeded
+        {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "retry supervisor did not complete"
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+#[test]
+fn local_retry_reclaims_a_dead_launcher_after_spawn_before_submit() {
+    local_retry_reclaims_a_dead_launcher_at_handoff_stage(
+        "HOMEBOY_TEST_LOCAL_COOK_RETRY_PAUSE_AFTER_SPAWN",
+    );
+}
+
+#[test]
+fn local_retry_reclaims_a_dead_launcher_after_submit_before_projection() {
+    local_retry_reclaims_a_dead_launcher_at_handoff_stage(
+        "HOMEBOY_TEST_LOCAL_COOK_RETRY_PAUSE_AFTER_SUBMIT",
     );
 }
 


### PR DESCRIPTION
## Summary

- route Cook-owned local `agent-task retry --run` through durable detached Cook supervision while preserving ordinary, Lab, runner-side, and non-run retry behavior
- make retry reservation, launcher ownership, child readiness, supervisor job, and terminal arbitration exact-run and crash-recoverable
- preserve cancellation winners, strict config-lock ordering, zero-provider terminal evidence, and authoritative controller-job liveness
- recover dead launchers before spawn, after spawn, and after supervisor submission without duplicate provider execution
- pin supervision and cancellation to the retry run rather than mutable latest Cook identity

Fixes #12970

## Verification

- `cargo test --test cook_lab_handoff_test local_retry_reclaims_a_dead_launcher -- --nocapture` (2 passed)
- local-detach route suite (63 passed)
- serial retry suite (88 passed in focused verification)
- Cook-job suite (13 passed)
- terminal/reconcile suite (60 passed in parallel and serial focused verification)
- strict config-lock, cancellation-race, queued pending lease, concurrent reservation, pinned successor, dead-child, and exact cancellation regressions
- `cargo check --workspace`
- `cargo fmt --check`
- `git diff --check`

Broader retry filtering still encounters pre-existing baseline/capacity-reserve failures; the exact crash-window and ownership suites for this change are green.

## AI assistance

OpenCode with `openai/gpt-5.6-sol` was used to reproduce the missing-PID and retry hang failures, implement the durable handoff state machine, repeatedly adversarially review race windows, and run crash-window verification. Chris Huber reviewed the resulting change and remains responsible for every line.