### PR TITLE
Fix duplicate required gate aggregation

### DIFF
--- a/.github/ci-required-gates-executed.sh
+++ b/.github/ci-required-gates-executed.sh
@@ -66,13 +66,15 @@
 #
 # REQUIRED_GATES_CONFIG overrides the declared-context payload;
 # REQUIRED_GATES_EXECUTED_JOBS substitutes a jobs-API payload file for the live
-# read; CI_GATE_RESULTS carries `toJSON(needs)`. All three make this runnable
-# without a network or a token.
+# read; REQUIRED_GATES_HEAD_SHA identifies the candidate the jobs must measure;
+# CI_GATE_RESULTS carries `toJSON(needs)`. All make this runnable without a
+# network or a token.
 
 set -euo pipefail
 
 config="${REQUIRED_GATES_CONFIG:-.github/required-gates-ruleset.json}"
 active="${CI_RUN_ACTIVE:-unknown}"
+head_sha="${REQUIRED_GATES_HEAD_SHA:-${GITHUB_SHA:-}}"
 
 if [ ! -f "${config}" ]; then
   echo "::error::required-gates execution check must run from the repository root"
@@ -83,6 +85,12 @@ fi
 if [ -z "${CI_GATE_RESULTS:-}" ]; then
   echo "::error::required-gates execution check requires CI_GATE_RESULTS=toJSON(needs)"
   echo "required-gates execution check requires CI_GATE_RESULTS=toJSON(needs)" >&2
+  exit 1
+fi
+
+if [ -z "${head_sha}" ]; then
+  echo "::error::required-gates execution check requires REQUIRED_GATES_HEAD_SHA"
+  echo "required-gates execution check requires REQUIRED_GATES_HEAD_SHA" >&2
   exit 1
 fi
 
@@ -164,14 +172,18 @@ if read_run_jobs; then
   # A skipped matrix job is reported under its UNEXPANDED name (#12573 observed
   # `${{ matrix.title }}`), so `homeboy / Audit` is simply absent rather than
   # present-and-skipped. Absent is therefore `not-executed`, which is exactly
-  # the verdict wanted: the context produced no measurement.
-  execution="$(jq -c --argjson required "${execution_contexts}" '
+  # the verdict wanted: the context produced no measurement. Jobs are scoped to
+  # the PR head because a matching context from another candidate is not proof
+  # that this candidate executed.
+  execution="$(jq -c --argjson required "${execution_contexts}" --arg head_sha "${head_sha}" '
     . as $jobs
     | [ $required[]
         | . as $context
-        | ($jobs | map(select(.name == $context))) as $matches
+        | ($jobs | map(select(.name == $context and .head_sha == $head_sha))) as $matches
         | {
             context: $context,
+            head_sha: $head_sha,
+            raw_conclusions: ($matches | map(.conclusion // "in-progress")),
             state: (
               if ($matches | length) == 0 then "not-executed"
               # The workflow can emit a skipped planning job with the same
@@ -184,6 +196,16 @@ if read_run_jobs; then
               elif ($matches | any(.conclusion != "success"))
                 then ($matches | map(.conclusion // "in-progress") | unique | join(","))
               else "success"
+              end
+            ),
+            selected_conclusion: (
+              if ($matches | length) == 0 then "not-executed"
+              elif ($matches | any(.conclusion == "success"))
+                and ($matches | all(.conclusion == "success" or .conclusion == "skipped"))
+                then "success"
+              elif ($matches | any(.conclusion != "success" and .conclusion != "skipped"))
+                then ($matches | map(select(.conclusion != "success" and .conclusion != "skipped") | .conclusion // "in-progress") | unique | join(","))
+              else "skipped"
               end
             )
           }
@@ -204,7 +226,9 @@ fi
 
 executed_count='unknown'
 if [ "${execution}" != 'unknown' ]; then
-  executed_count="$(jq '[.[] | select(.state != "not-executed")] | length' <<< "${execution}")"
+  # This terminal job is executing by definition. Its conclusion is enforced by
+  # GitHub after this script exits, so it is not part of the jobs observation.
+  executed_count="$(( $(jq '[.[] | select(.state != "not-executed")] | length' <<< "${execution}") + 1 ))"
 fi
 
 if [ "${execution}" = 'unknown' ]; then
@@ -222,6 +246,9 @@ fi
 # code — the same reason `validate-required-gates.sh` emits its enforcement basis
 # before its verdict.
 echo "::notice::required-gates-executed basis=needs-results+run-jobs run=${GITHUB_RUN_ID:-unknown} attempt=${GITHUB_RUN_ATTEMPT:-unknown} pr_state_active=${active} declared=${declared_count} executed=${executed_count} dependencies=${dependency_count} dependencies_skipped=${dependency_skipped} outcome=${outcome}"
+if [ "${execution}" != 'unknown' ]; then
+  echo "::notice::required-gates-executed contexts=$(jq -c '.' <<< "${execution}")"
+fi
 
 closure_note=''
 if [ "${active}" = 'false' ]; then
@@ -259,12 +286,12 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     echo
     echo "${headline}"
     echo
-    echo "| context | state |"
-    echo "| --- | --- |"
+    echo "| context | head SHA | raw conclusions | selected result | state |"
+    echo "| --- | --- | --- | --- | --- |"
     if [ "${execution}" = 'unknown' ]; then
-      jq -r '.[] | "| `\(.)` | `unverified` |"' <<< "${declared_contexts}"
+      jq -r '.[] | "| `\(.)` | `\(env.REQUIRED_GATES_HEAD_SHA)` | `unverified` | `unverified` | `unverified` |"' <<< "${declared_contexts}"
     else
-      jq -r '.[] | "| `\(.context)` | `\(.state)` |"' <<< "${execution}"
+      jq -r '.[] | "| `\(.context)` | `\(.head_sha)` | `\(.raw_conclusions | join(","))` | `\(.selected_conclusion)` | `\(.state)` |"' <<< "${execution}"
     fi
     echo
     echo "| dependency | result |"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,4 +327,5 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           CI_GATE_RESULTS: ${{ toJSON(needs) }}
           CI_RUN_ACTIVE: ${{ needs.pr-state.outputs.active }}
+          REQUIRED_GATES_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: bash .github/ci-required-gates-executed.sh

--- a/tests/required_gates_policy_test.rs
+++ b/tests/required_gates_policy_test.rs
@@ -129,6 +129,10 @@ fn run_execution_gate(env: &[(&str, &str)]) -> Output {
     command.arg(".github/ci-required-gates-executed.sh");
     command.env_remove("GITHUB_STEP_SUMMARY");
     command.env("CI_GATE_RESULTS", r#"{"gates":{"result":"success"}}"#);
+    command.env(
+        "REQUIRED_GATES_HEAD_SHA",
+        "0000000000000000000000000000000000000000",
+    );
     for (key, value) in env {
         command.env(key, value);
     }
@@ -144,6 +148,7 @@ fn execution_jobs(contexts: &[String], exception: Option<(&str, serde_json::Valu
             .map(|context| {
                 serde_json::json!({
                     "name": context,
+                    "head_sha": "0000000000000000000000000000000000000000",
                     "conclusion": exception
                         .as_ref()
                         .filter(|(candidate, _)| *candidate == context)
@@ -659,6 +664,7 @@ fn terminal_execution_verdict_accepts_a_skipped_planning_duplicate_after_success
         serde_json::from_str(&execution_jobs(&contexts, None)).expect("execution jobs");
     jobs.push(serde_json::json!({
         "name": "homeboy / Test",
+        "head_sha": "0000000000000000000000000000000000000000",
         "conclusion": "skipped",
     }));
     let jobs = scratch.write(
@@ -672,6 +678,109 @@ fn terminal_execution_verdict_accepts_a_skipped_planning_duplicate_after_success
         "a successful canonical Test context remains valid when its planning duplicate is skipped: {}\n{}",
         stdout_of(&output),
         stderr_of(&output)
+    );
+    assert!(
+        stdout_of(&output).contains("\"raw_conclusions\":[\"success\",\"skipped\"]")
+            && stdout_of(&output).contains("\"selected_conclusion\":\"success\""),
+        "duplicate diagnostics must retain both results and the selected success: {}",
+        stdout_of(&output)
+    );
+    assert!(
+        stdout_of(&output).contains("declared=8 executed=8"),
+        "the terminal gate counts itself after observing the other seven: {}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn terminal_execution_verdict_keeps_duplicate_failures_and_cancellations_fail_closed() {
+    let contexts = declared_contexts();
+
+    for (name, conclusion) in [("failure", "failure"), ("cancelled", "cancelled")] {
+        let scratch = Scratch::new(name);
+        let mut jobs: Vec<serde_json::Value> =
+            serde_json::from_str(&execution_jobs(&contexts, None)).expect("execution jobs");
+        jobs.push(serde_json::json!({
+            "name": "homeboy / Test",
+            "head_sha": "0000000000000000000000000000000000000000",
+            "conclusion": conclusion,
+        }));
+        let jobs = scratch.write(
+            "jobs.json",
+            &serde_json::to_string(&jobs).expect("duplicate jobs"),
+        );
+        let output = run_execution_gate(&[("REQUIRED_GATES_EXECUTED_JOBS", jobs.as_str())]);
+
+        assert!(
+            !output.status.success()
+                && stdout_of(&output).contains("required-gates-executed-status=failed"),
+            "a {name} duplicate must not be masked by success: {}",
+            stdout_of(&output)
+        );
+        assert!(
+            stdout_of(&output).contains(&format!("\"selected_conclusion\":\"{conclusion}\"")),
+            "the selected fail-closed result must be diagnosable: {}",
+            stdout_of(&output)
+        );
+    }
+}
+
+#[test]
+fn terminal_execution_verdict_rejects_skipped_only_and_ignores_other_head_duplicates() {
+    let contexts = declared_contexts();
+    let scratch = Scratch::new("skipped-only-other-head");
+    let mut jobs: Vec<serde_json::Value> = serde_json::from_str(&execution_jobs(
+        &contexts,
+        Some(("homeboy / Test", serde_json::json!("skipped"))),
+    ))
+    .expect("execution jobs");
+    jobs.push(serde_json::json!({
+        "name": "homeboy / Test",
+        "head_sha": "1111111111111111111111111111111111111111",
+        "conclusion": "success",
+    }));
+    let jobs = scratch.write(
+        "jobs.json",
+        &serde_json::to_string(&jobs).expect("duplicate jobs"),
+    );
+    let output = run_execution_gate(&[("REQUIRED_GATES_EXECUTED_JOBS", jobs.as_str())]);
+
+    assert!(
+        !output.status.success()
+            && stdout_of(&output).contains("required-gates-executed-status=failed"),
+        "a success for another head must not satisfy a skipped candidate: {}",
+        stdout_of(&output)
+    );
+    assert!(
+        stdout_of(&output).contains("\"raw_conclusions\":[\"skipped\"]")
+            && stdout_of(&output).contains("\"selected_conclusion\":\"skipped\""),
+        "the candidate-head result must be diagnosable: {}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn terminal_execution_verdict_accepts_duplicate_success() {
+    let contexts = declared_contexts();
+    let scratch = Scratch::new("duplicate-success");
+    let mut jobs: Vec<serde_json::Value> =
+        serde_json::from_str(&execution_jobs(&contexts, None)).expect("execution jobs");
+    jobs.push(serde_json::json!({
+        "name": "homeboy / Test",
+        "head_sha": "0000000000000000000000000000000000000000",
+        "conclusion": "success",
+    }));
+    let jobs = scratch.write(
+        "jobs.json",
+        &serde_json::to_string(&jobs).expect("duplicate jobs"),
+    );
+    let output = run_execution_gate(&[("REQUIRED_GATES_EXECUTED_JOBS", jobs.as_str())]);
+
+    assert!(output.status.success(), "{}", stdout_of(&output));
+    assert!(
+        stdout_of(&output).contains("\"raw_conclusions\":[\"success\",\"success\"]"),
+        "duplicate successes must remain visible in diagnostics: {}",
+        stdout_of(&output)
     );
 }
 


### PR DESCRIPTION
## Summary

- aggregate terminal required-gate jobs by logical context and candidate head SHA
- accept a successful executed instance alongside skipped conditional duplicates
- preserve fail-closed handling for skipped-only, failed, cancelled, pending, and absent contexts
- retain raw duplicate conclusions and selected-result diagnostics

## Verification

- `cargo fmt --check`
- `bash -n .github/ci-required-gates-executed.sh`
- `cargo test --test required_gates_policy_test` (26 passed)
- independent review found no findings

Closes #13114

## AI assistance

OpenAI GPT-5.6 Sol through OpenCode identified the live CI failure, implemented the aggregation repair with a general coding subagent, ran focused verification, and performed an independent review. Chris Huber reviewed and remains responsible for every line.