### PR TITLE
fix(cook): preserve substantive promotion recovery

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -2661,6 +2661,10 @@ pub fn recover_cook_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
             )
         })?
     };
+    // A verified empty remediation is evidence about the already-applied
+    // candidate, not a replacement candidate. Recover the source promotion so
+    // an exact `--recover <remediation>` cannot hide that applied promotion.
+    let run_id = substantive_source_for_empty_remediation(&recipe, &run_id).unwrap_or(run_id);
     if persisted_promotion_for_attempt(&run_id)?.is_some_and(|promotion| {
         promotion.status == AgentTaskPromotionStatus::VerifiedNoChanges
             && promotion.changed_files.is_empty()
@@ -2912,6 +2916,7 @@ pub(crate) fn canonical_cook_recovery_run_id(cook_id: &str) -> Option<String> {
                             .pointer("/cook_follow_up/source_run_id")
                             .and_then(Value::as_str)
                             == Some(source_run_id.as_str())
+                            && !is_empty_verified_remediation(&promotion)
                     })
             {
                 return Some(attempt.run_id.clone());
@@ -2919,6 +2924,49 @@ pub(crate) fn canonical_cook_recovery_run_id(cook_id: &str) -> Option<String> {
         }
     }
     Some(source_run_id)
+}
+
+fn substantive_source_for_empty_remediation(
+    recipe: &super::cook_recipe::AgentTaskCookRecipe,
+    run_id: &str,
+) -> Option<String> {
+    let remediation = persisted_promotion_for_attempt(run_id).ok().flatten()?;
+    if !is_empty_verified_remediation(&remediation) {
+        return None;
+    }
+    let source_run_id = remediation
+        .provenance
+        .pointer("/cook_follow_up/source_run_id")
+        .and_then(Value::as_str)?;
+    if !recipe
+        .attempts
+        .iter()
+        .any(|attempt| attempt.run_id == source_run_id)
+        || canonical_cook_candidate(&recipe.cook_id)
+            .and_then(|candidate| candidate["run_id"].as_str().map(str::to_string))
+            .as_deref()
+            != Some(source_run_id)
+    {
+        return None;
+    }
+    persisted_promotion_for_attempt(source_run_id)
+        .ok()
+        .flatten()
+        .filter(|promotion| {
+            promotion.status == AgentTaskPromotionStatus::Applied
+                && !promotion.changed_files.is_empty()
+        })?;
+    Some(source_run_id.to_string())
+}
+
+fn is_empty_verified_remediation(promotion: &AgentTaskPromotionReport) -> bool {
+    promotion.status == AgentTaskPromotionStatus::VerifiedNoChanges
+        && promotion.changed_files.is_empty()
+        && promotion
+            .provenance
+            .pointer("/cook_follow_up/source_run_id")
+            .and_then(Value::as_str)
+            .is_some_and(|run_id| !run_id.is_empty())
 }
 
 /// Recover a standalone manual-finalization record. Unlike Cook attempts, a

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -14491,6 +14491,93 @@ fn verified_existing_candidate_no_change_recovery_finalizes_once() {
 }
 
 #[test]
+fn empty_intentional_no_change_remediation_preserves_applied_candidate_recovery() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-8307-preserve-applied";
+        let source_run_id = "cook-8307-preserve-applied-attempt-1";
+        let remediation_run_id = "cook-8307-preserve-applied-attempt-2";
+        let target = tempfile::tempdir().expect("fixture target");
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = source_run_id.to_string();
+        options.initial_plan.tasks[0].executor.model = Some("fixture-model".to_string());
+        persist_initial_recipe(&options).expect("persist recipe");
+        super::super::record_recipe_attempt(cook_id, 2, remediation_run_id, &options.initial_plan)
+            .expect("persist remediation recipe attempt");
+        for (attempt, run_id) in [(1, source_run_id), (2, remediation_run_id)] {
+            agent_task_lifecycle::submit_plan(&options.initial_plan, Some(run_id))
+                .expect("submit attempt");
+            agent_task_lifecycle::record_cook_attempt(cook_id, attempt, run_id)
+                .expect("record Cook attempt");
+        }
+        seed_substantive_candidate_aggregate(
+            source_run_id,
+            &options.initial_plan,
+            &target.path().join("candidate.patch"),
+            "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n",
+        );
+        let mut source_aggregate = agent_task_lifecycle::read_attempt_aggregate(source_run_id)
+            .expect("read source aggregate");
+        source_aggregate.outcomes[0].outputs = serde_json::json!({
+            "review_form": test_review_form(),
+        });
+        agent_task_lifecycle::record_run_aggregate(
+            source_run_id,
+            &options.initial_plan,
+            &source_aggregate,
+        )
+        .expect("persist source review form");
+        let source_promotion = promotion_with_existing_path(source_run_id, target.path());
+        agent_task_lifecycle::record_promotion(
+            source_run_id,
+            serde_json::to_value(&source_promotion).unwrap(),
+        )
+        .expect("persist applied source promotion");
+
+        seed_review_form_aggregate(remediation_run_id, &options.initial_plan);
+        let mut remediation_promotion =
+            promotion_with_existing_path(remediation_run_id, target.path());
+        remediation_promotion.status = AgentTaskPromotionStatus::VerifiedNoChanges;
+        remediation_promotion.changed_files.clear();
+        remediation_promotion.provenance["cook_follow_up"] = serde_json::json!({
+            "kind": "gate_remediation",
+            "source_run_id": source_run_id,
+        });
+        agent_task_lifecycle::record_promotion(
+            remediation_run_id,
+            serde_json::to_value(remediation_promotion).unwrap(),
+        )
+        .expect("persist empty intentional no-change remediation");
+
+        let selection = agent_task_lifecycle::select_cook_candidate(cook_id)
+            .expect("select substantive source candidate");
+        assert_eq!(selection.run_id, source_run_id);
+        assert_eq!(
+            canonical_cook_recovery_run_id(cook_id).as_deref(),
+            Some(source_run_id),
+            "empty remediation cannot replace the source promotion recovery owner"
+        );
+
+        let mut backend = CaptureBackend {
+            synthetic_gate_proof: Some(source_promotion),
+            ..Default::default()
+        };
+        let published =
+            recover_cook_pr_with_backend(remediation_run_id, Vec::new(), false, &mut backend)
+                .expect("exact remediation recovery uses the preserved applied promotion");
+        assert_eq!(published["status"], "review_ready");
+        assert!(backend.created);
+
+        let mut repeated = CaptureBackend::default();
+        assert_eq!(
+            recover_cook_pr_with_backend(cook_id, Vec::new(), false, &mut repeated)
+                .expect("Cook alias recovery remains idempotent"),
+            published
+        );
+        assert!(!repeated.created);
+    });
+}
+
+#[test]
 fn manual_preflight_intent_does_not_block_normal_cook_finalization() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let cook_id = "cook-10980-normal";


### PR DESCRIPTION
## Summary
- treat a verified empty gate-remediation promotion as evidence about its substantive source candidate
- recover the source attempt's applied promotion for both exact remediation IDs and Cook aliases
- prevent an empty intentional-no-change retry from hiding an already-applied candidate

Closes #8307

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-agents empty_intentional_no_change_remediation_preserves_applied_candidate_recovery`
- `cargo test -p homeboy-agents verified_existing_candidate_no_change_recovery_finalizes_once`
- `git diff --check`

## Evidence boundary
The regression test covers substantive applied promotion, a later empty verified remediation linked by `cook_follow_up.source_run_id`, exact remediation recovery, Cook-alias recovery, and idempotent PR finalization. Full workspace CI remains authoritative for unrelated surfaces.

## AI assistance
OpenAI GPT-5.6-sol via OpenCode traced the live Cook failure, implemented the recovery boundary and regression coverage, and ran focused verification. Chris Huber reviewed the diff and remains responsible for every line.