### PR TITLE
Refactor audit vacuous-test detector ownership

### DIFF
--- a/crates/homeboy-code-audit/src/descriptor_runtime.rs
+++ b/crates/homeboy-code-audit/src/descriptor_runtime.rs
@@ -47,6 +47,9 @@ pub(super) struct DetectorRunContext<'a> {
     /// root-only fast path when no snapshot-backed detector is enabled.
     pub(super) source_snapshot: Option<&'a CodebaseSnapshot>,
     pub(super) dead_code_references: Option<&'a DeadCodeReferenceAnalysis>,
+    /// The Rust test-quality walk is shared by topology and coverage so a full
+    /// audit classifies each test file once before descriptor fan-out.
+    pub(super) test_quality_findings: Option<&'a [Finding]>,
 }
 
 fn run_fingerprint_descriptor(
@@ -86,7 +89,10 @@ fn run_root_descriptor(
     context: &DetectorRunContext<'_>,
 ) -> Vec<Finding> {
     match runner {
-        RootDetectorRunner::TestTopology => test_topology::run(context.root),
+        RootDetectorRunner::TestTopology => context.test_quality_findings.map_or_else(
+            || test_topology::run(context.root),
+            test_topology::run_from_shared,
+        ),
         RootDetectorRunner::TestWiring => test_wiring::run(context.root, context.audit_config),
     }
 }
@@ -195,17 +201,27 @@ fn run_dead_code(context: &DetectorRunContext<'_>) -> Vec<Finding> {
 /// that declares a `test_mapping` for the component, matching the prior
 /// hand-wired loop's "first extension wins, then stop" behavior.
 fn run_test_coverage(context: &DetectorRunContext<'_>) -> Vec<Finding> {
+    let standalone_vacuity = context.test_quality_findings.map_or_else(
+        || test_coverage::run_vacuity(context.root),
+        test_coverage::run_vacuity_from_shared,
+    );
     let Some(comp) = super::component_provider::resolve_by_id(context.component_id) else {
-        return Vec::new();
+        return standalone_vacuity;
     };
     for ext_id in &comp.extension_ids {
         if let Some(ext_manifest) = super::extension_manifests::load_audit_manifest(ext_id) {
             if let Some(test_mapping) = &ext_manifest.test_mapping {
-                return test_coverage::run(context.root, context.all_fingerprints, test_mapping);
+                let mut findings = standalone_vacuity;
+                findings.extend(test_coverage::analyze_test_coverage(
+                    context.root,
+                    context.all_fingerprints,
+                    test_mapping,
+                ));
+                return findings;
             }
         }
     }
-    Vec::new()
+    standalone_vacuity
 }
 
 fn extend_descriptor_findings(
@@ -481,6 +497,7 @@ mod tests {
             policy_fingerprints: &[],
             source_snapshot: None,
             dead_code_references: None,
+            test_quality_findings: None,
         };
 
         let plan = AuditExecutionPlan::from_profile_and_filters(AuditProfile::Full, &[], &[]);
@@ -531,6 +548,7 @@ mod tests {
             policy_fingerprints: &fingerprints,
             source_snapshot: None,
             dead_code_references: None,
+            test_quality_findings: None,
         };
         let plan = AuditExecutionPlan::from_profile_and_filters(AuditProfile::Full, &[], &[]);
         let mut timing = AuditTiming::default();
@@ -578,6 +596,7 @@ mod tests {
             policy_fingerprints: &fingerprints,
             source_snapshot: None,
             dead_code_references: None,
+            test_quality_findings: None,
         };
         let plan = AuditExecutionPlan::from_profile_and_filters(AuditProfile::Full, &[], &[]);
 

--- a/crates/homeboy-code-audit/src/detectors/test_coverage.rs
+++ b/crates/homeboy-code-audit/src/detectors/test_coverage.rs
@@ -31,12 +31,19 @@ use super::test_mapping::{
 use super::test_vacuity::{find_vacuous_test_methods, resolve_package_name};
 use homeboy_audit_contract::TestMappingConfig;
 
-pub(crate) fn run(
-    root: &Path,
-    fingerprints: &[&FileFingerprint],
-    config: &TestMappingConfig,
-) -> Vec<Finding> {
-    analyze_test_coverage(root, fingerprints, config)
+/// Run vacuity checks that do not need an extension test mapping. The descriptor
+/// runtime invokes this when no mapping is declared, preserving standalone Rust
+/// test-quality findings while keeping `VacuousTest` under one owner.
+pub(crate) fn run_vacuity(root: &Path) -> Vec<Finding> {
+    crate::test_quality::run_vacuity(root)
+}
+
+pub(crate) fn run_vacuity_from_shared(findings: &[Finding]) -> Vec<Finding> {
+    findings
+        .iter()
+        .filter(|finding| finding.kind == AuditFinding::VacuousTest)
+        .cloned()
+        .collect()
 }
 
 /// Analyze test coverage gaps given source fingerprints and a test mapping config.

--- a/crates/homeboy-code-audit/src/detectors/test_topology.rs
+++ b/crates/homeboy-code-audit/src/detectors/test_topology.rs
@@ -1,6 +1,8 @@
 //! Test topology audit.
 //!
-//! This detector emits standalone `vacuous_test` findings via `test_quality`.
+//! Vacuity findings are owned by `test_coverage`, which runs the shared
+//! `test_quality` scan alongside policy-driven vacuity checks. This root-only
+//! detector retains the topology-specific findings used by the PR profile.
 //!
 //! It used to carry a second, script-driven branch: extensions were meant to
 //! classify files as source/test through a `scripts.topology` manifest key, and
@@ -22,13 +24,18 @@ use std::path::Path;
 
 use super::findings::Finding;
 
-#[path = "../test_quality.rs"]
-mod test_quality;
-
 pub(crate) fn run(root: &Path) -> Vec<Finding> {
-    let mut findings = test_quality::run(root);
+    let mut findings = crate::test_quality::run_without_vacuity(root);
     findings.sort_by(|a, b| a.file.cmp(&b.file).then(a.description.cmp(&b.description)));
     findings
+}
+
+pub(crate) fn run_from_shared(findings: &[Finding]) -> Vec<Finding> {
+    findings
+        .iter()
+        .filter(|finding| finding.kind != crate::conventions::AuditFinding::VacuousTest)
+        .cloned()
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/homeboy-code-audit/src/engine.rs
+++ b/crates/homeboy-code-audit/src/engine.rs
@@ -390,6 +390,9 @@ pub(super) fn audit_internal(
         plan.detector_enabled("dead_code")
             .then(|| DeadCodeReferenceAnalysis::build(root, reference_paths))
     });
+    let test_quality_findings = (plan.detector_enabled("test_coverage")
+        || plan.detector_enabled("test_topology"))
+    .then(|| crate::test_quality::run(root));
     let detector_context = DetectorRunContext {
         root,
         component_id,
@@ -399,6 +402,7 @@ pub(super) fn audit_internal(
         policy_fingerprints: policy_scan_fingerprints,
         source_snapshot: Some(&source_snapshot),
         dead_code_references: dead_code_references.as_ref(),
+        test_quality_findings: test_quality_findings.as_deref(),
     };
 
     // The duplication family stays hand-sequenced: it runs five timing spans and
@@ -924,6 +928,9 @@ fn audit_root_only(
     } else {
         None
     };
+    let test_quality_findings = (plan.detector_enabled("test_coverage")
+        || plan.detector_enabled("test_topology"))
+    .then(|| crate::test_quality::run(root));
 
     let detector_context = DetectorRunContext {
         root,
@@ -936,6 +943,7 @@ fn audit_root_only(
         policy_fingerprints: &[],
         source_snapshot: source_snapshot.as_ref(),
         dead_code_references: None,
+        test_quality_findings: test_quality_findings.as_deref(),
     };
 
     run_descriptor_detectors(

--- a/crates/homeboy-code-audit/src/execution_plan.rs
+++ b/crates/homeboy-code-audit/src/execution_plan.rs
@@ -274,6 +274,8 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
             AuditFinding::MissingTestFile,
             AuditFinding::MissingTestMethod,
             AuditFinding::OrphanedTest,
+            // This descriptor owns all vacuity findings: policy-driven methods
+            // in `test_vacuity` and standalone Rust test-quality checks.
             AuditFinding::VacuousTest,
         ],
         access: DetectorAccess::Discovery,
@@ -296,7 +298,6 @@ const DETECTOR_DESCRIPTORS: &[DetectorDescriptor] = &[
         findings: &[
             AuditFinding::InlineTestModule,
             AuditFinding::ScatteredTestFile,
-            AuditFinding::VacuousTest,
             AuditFinding::RedundantTestWrapper,
             AuditFinding::IgnoredTestWithoutReason,
         ],

--- a/crates/homeboy-code-audit/src/lib.rs
+++ b/crates/homeboy-code-audit/src/lib.rs
@@ -54,6 +54,7 @@ mod signatures;
 mod source_locations;
 mod structural;
 pub(crate) mod test_mapping;
+mod test_quality;
 pub mod walker;
 
 mod doc_drift;
@@ -174,17 +175,14 @@ mod tests {
     }
 
     #[test]
-    fn only_vacuous_test_keeps_all_vacuous_detector_families_enabled() {
+    fn only_vacuous_test_selects_test_coverage_as_its_single_owner() {
         let plan = AuditExecutionPlan::from_filters(&[AuditFinding::VacuousTest], &[]);
 
         assert!(
             plan.detector_enabled("test_coverage"),
-            "coverage detector also emits vacuous_test for mapped tests"
+            "test coverage owns both policy-driven and Rust test-quality vacuity findings"
         );
-        assert!(
-            plan.detector_enabled("test_topology"),
-            "test topology/test quality detector emits standalone vacuous_test findings"
-        );
+        assert!(!plan.detector_enabled("test_topology"));
     }
 
     #[test]

--- a/crates/homeboy-code-audit/src/test_quality.rs
+++ b/crates/homeboy-code-audit/src/test_quality.rs
@@ -13,7 +13,21 @@ use crate::conventions::AuditFinding;
 use crate::findings::{Finding, Severity};
 use crate::walker::is_test_path;
 
-pub(super) fn run(root: &Path) -> Vec<Finding> {
+pub(crate) fn run_vacuity(root: &Path) -> Vec<Finding> {
+    run(root)
+        .into_iter()
+        .filter(|finding| finding.kind == AuditFinding::VacuousTest)
+        .collect()
+}
+
+pub(crate) fn run_without_vacuity(root: &Path) -> Vec<Finding> {
+    run(root)
+        .into_iter()
+        .filter(|finding| finding.kind != AuditFinding::VacuousTest)
+        .collect()
+}
+
+pub(crate) fn run(root: &Path) -> Vec<Finding> {
     let config = ScanConfig {
         extensions: ExtensionFilter::Only(vec!["rs".to_string()]),
         ..Default::default()


### PR DESCRIPTION
## Summary
- Make `test_coverage` the sole descriptor owner of `VacuousTest`.
- Preserve standalone Rust test-quality vacuity findings without a test mapping.
- Share one test-quality scan between coverage and topology, partitioning findings before descriptor fan-out.

Closes #6789

## Verification
- `cargo fmt --check`
- `cargo check -p homeboy-code-audit`
- `cargo test -p homeboy-code-audit --lib` (934 passed, 1 ignored)
- `cargo test -p homeboy-code-audit only_vacuous_test --lib`
- `cargo test -p homeboy-code-audit test_vacuity --lib`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode was used to inspect detector ownership, implement the refactor, and run verification. Chris reviewed and is responsible for the change.