### PR TITLE
refactor(runner): unify daemon and broker job flow

### DIFF
--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -1,22 +1,20 @@
 use homeboy_engine_primitives::content_hash;
 use std::collections::HashMap;
 use std::path::Path;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use base64::Engine;
 use homeboy_core::api_jobs::{
-    Job, JobStatus, RemoteRunnerJobRequest, RemoteRunnerSubmissionLookup,
-    RunnerJobLifecycleMetadata,
+    Job, RemoteRunnerJobRequest, RemoteRunnerSubmissionLookup, RunnerJobLifecycleMetadata,
 };
 use homeboy_core::error::{Error, Result};
 use homeboy_core::lab_contract::LabRunnerWorkload;
-use homeboy_core::redaction::redact_argv;
 use homeboy_core::source_snapshot::SourceSnapshot;
 use reqwest::blocking::Client;
 
 use super::super::broker_http;
 use super::super::evidence::mirror_reverse_broker_evidence;
-use super::super::{Runner, RunnerJob};
+use super::super::Runner;
 
 #[allow(unused_imports)]
 use super::*;
@@ -265,318 +263,95 @@ pub(super) fn exec_via_reverse_broker(
     let job_value = data
         .get("job")
         .ok_or_else(|| Error::internal_unexpected("reverse broker submit returned no job"))?;
-    let mut job: Job = serde_json::from_value(job_value.clone()).map_err(|err| {
+    let job: Job = serde_json::from_value(job_value.clone()).map_err(|err| {
         Error::internal_json(
             err.to_string(),
             Some("parse reverse broker job".to_string()),
         )
     })?;
-    if let Some(run_id) = run_id.as_deref() {
-        // The broker has accepted this job. Persist that boundary before local
-        // follow-up work can fail, preserving the authoritative remote identity.
-        let binding = if !run_id_owns_generic_exec {
-            homeboy_agents::agent_task_lifecycle::bind_accepted_lab_runner_job(
-                &homeboy_core::lab_contract::RunnerJobIdentity::new(
-                    run_id,
-                    &runner.id,
-                    job.id.to_string(),
-                ),
-                &cwd,
-                &command,
-            )
-            .map(|_| ())
-        } else {
-            homeboy_agents::agent_task_lifecycle::record_runner_exec_job_identity(
-                run_id,
-                &runner.id,
-                &job.id.to_string(),
-                &cwd,
-                &command,
-            )
-            .map(|_| ())
-        };
-        binding.map_err(|error| {
-            super::accepted_handoff_persistence_error(error, &runner.id, &job.id.to_string())
-        })?;
-    }
-    persist_runner_execution_transition(
-        &RunnerExecutionRecord::in_flight(job.id.to_string(), runner.id.clone(), "reverse_broker")
-            .with_job_id(job.id.to_string())
-            .with_path_materialization_plan(path_materialization_plan.clone())
-            .with_orchestration_provenance(orchestration_target_provenance(
-                runner,
-                None,
-                Some(&source_snapshot),
-                &[],
-            ))
-            .with_next_actions(runner_execution_next_actions(
-                &runner.id,
-                &job.id.to_string(),
-            )),
-        &cwd,
-        &command,
-    )?;
-    let persisted_run_id = mirror_evidence
-        .then(|| {
-            persist_lab_offload_handoff_run(
-                runner,
-                &cwd,
-                &command,
-                &job,
-                run_id.as_deref(),
-                Some(broker_url),
-            )
-        })
-        .flatten();
-    validate_generic_exec_mirror_run_id(
-        run_id_owns_generic_exec,
-        run_id.as_deref(),
-        persisted_run_id.as_deref(),
-    )?;
-    if detach_after_handoff {
-        return Ok(detached_handoff_output(
+    return complete_submitted_runner_job(
+        SubmittedRunnerJobFlow {
             runner,
-            RunnerExecMode::ReverseBroker,
-            cwd,
-            command,
-            source_snapshot,
-            job,
-            path_materialization_plan,
-            require_paths,
-            run_id,
-            persisted_run_id,
-        ));
-    }
-
-    let deadline = Instant::now() + runner_exec_wait_timeout();
-    let mut reported_progress_sequence = 0;
-    while !matches!(
-        job.status,
-        JobStatus::Succeeded | JobStatus::Failed | JobStatus::Cancelled
-    ) {
-        if Instant::now() >= deadline {
-            let events = fetch_daemon_events(&client, broker_url, &job.id.to_string())
-                .map(|events| {
-                    redact_runner_job_events(&events, &redaction_env, &redaction_secret_env_names)
-                })
-                .unwrap_or_default();
-            return Err(daemon_job_wait_timeout(
-                runner,
-                &cwd,
-                &command,
-                &job,
-                &events,
-                "reverse runner job",
-                true,
-            ));
-        }
-        std::thread::sleep(Duration::from_millis(200));
-        let job_id = job.id.to_string();
-        job = fetch_daemon_job_resilient(&client, broker_url, &job_id).map_err(|err| {
-            terminal_runner_poll_failure(
-                runner,
-                &cwd,
-                &command,
-                &job,
-                "reverse_broker",
-                path_materialization_plan.as_ref(),
-                &source_snapshot,
-                &require_paths,
-                persisted_run_id.as_deref(),
-                None,
-                err,
-            )
-        })?;
-        if let Ok(events) = fetch_daemon_events(&client, broker_url, &job_id) {
-            let events =
-                redact_runner_job_events(&events, &redaction_env, &redaction_secret_env_names);
-            super::daemon::record_and_report_promotion_progress_frames(
-                run_id.as_deref(),
-                &job_id,
-                &events,
-                &mut reported_progress_sequence,
-            );
-        }
-    }
-    let events = redact_runner_job_events(
-        &fetch_daemon_events(&client, broker_url, &job.id.to_string())?,
-        &redaction_env,
-        &redaction_secret_env_names,
-    );
-    super::daemon::record_and_report_promotion_progress_frames(
-        run_id.as_deref(),
-        &job.id.to_string(),
-        &events,
-        &mut reported_progress_sequence,
-    );
-
-    let RunnerJobResultFields {
-        result,
-        stdout,
-        stderr,
-        metrics,
-        capture,
-        exit_code,
-    } = runner_job_result_fields(
-        &events,
-        job.status,
-        &redaction_env,
-        &redaction_secret_env_names,
-    );
-    let terminal_snapshot = homeboy_core::api_jobs::RunnerJobLogSnapshot {
-        job: job.clone(),
-        events: events.clone(),
-    };
-    if run_id_owns_generic_exec {
-        if let Some(run_id) = run_id.as_deref() {
-            homeboy_agents::agent_task_lifecycle::record_runner_exec_terminal_checkpoint(
-                run_id,
-                &terminal_snapshot,
-            )?;
-        }
-    }
-    let mirror = if mirror_evidence {
-        let request = crate::evidence::MirrorEvidenceRequest::new(
-            runner,
-            &cwd,
-            &command,
-            &job,
-            &events,
-            &result,
-            run_id.as_deref(),
-            lab_runner_workload
-                .as_ref()
-                .and_then(|workload| workload.notification_route.as_ref()),
-        );
-        let request = if run_id_owns_generic_exec {
-            request.with_generic_runner_exec_run()
-        } else {
-            request
-        };
-        mirror_reverse_broker_evidence(crate::evidence::ReverseBrokerEvidenceContext {
-            request,
-            broker_url,
-        })
-        .map_err(|error| {
-            if run_id_owns_generic_exec {
-                if let Some(run_id) = run_id.as_deref() {
-                    let _ =
-                        homeboy_agents::agent_task_lifecycle::record_runner_exec_projection_failure(
-                            run_id,
-                            &terminal_snapshot,
-                            &error,
-                        );
-                }
-            }
-            error
-        })?
-    } else {
-        None
-    };
-    let patch = mirror.as_ref().and_then(|evidence| evidence.patch.clone());
-    let mirror_run_id = mirror.as_ref().map(|evidence| evidence.run.id.clone());
-    validate_generic_exec_mirror_run_id(
-        run_id_owns_generic_exec,
-        run_id.as_deref(),
-        mirror_run_id.as_deref(),
-    )?;
-    fire_runner_direct_notification(
-        run_id.as_deref(),
-        &job,
-        lab_runner_workload
-            .as_ref()
-            .and_then(|workload| workload.notification_route.as_ref()),
-    );
-    let artifacts = mirror
-        .as_ref()
-        .map(|evidence| crate::evidence::controller_artifact_metadata(&evidence.runs))
-        .transpose()?
-        .unwrap_or_default();
-    let mutation_artifacts = mutation_artifacts_from_job(&job, &result);
-
-    if print_handoff_output {
-        print_lab_offload_handoff(
-            &runner.id,
-            Some(&cwd),
-            &job.id.to_string(),
-            mirror_run_id.as_deref(),
-            DaemonJobHandoffState::Terminal(job.status),
-        );
-    }
-
-    let runner_job = RunnerJob::from_job(&runner.id, "broker", &command, Some(cwd.clone()), &job);
-    let mut runner_result = runner_result(
-        Some(&job),
-        exit_code,
-        &stdout,
-        &stderr,
-        mirror_run_id.as_deref(),
-        mutation_artifacts.clone(),
-    );
-    runner_result.artifact_refs = artifacts
-        .iter()
-        .map(crate::session::runner_artifact_ref_from_metadata)
-        .collect();
-    let provenance_extensions = required_extensions_for_command(
-        &command,
-        &super::super::workload::merge_lab_runner_workload_required_extensions(
-            Vec::new(),
-            lab_runner_workload.as_ref(),
-        ),
-    );
-    let handoff = lab_runner_handoff(
-        runner,
-        "reverse_broker",
-        Some(runner_job.clone()),
-        Some(runner_result.clone()),
-    );
-    let execution_record = runner_execution_record_for_output(
-        runner,
-        "reverse_broker",
-        exit_code,
-        Some(job.id.to_string()),
-        mirror_run_id.clone(),
-        Some(&source_snapshot),
-        path_materialization_plan,
-        &require_paths,
-        &provenance_extensions,
-        &artifacts,
-        Some(&runner_result),
-    );
-    persist_runner_execution_transition(&execution_record, &cwd, &command)?;
-
-    Ok((
-        RunnerExecOutput {
-            variant: "exec",
-            command: "runner.exec",
-            runner_id: runner.id.clone(),
-            dry_run: false,
             mode: RunnerExecMode::ReverseBroker,
-            argv: redact_argv(&command),
-            remote_cwd: cwd,
-            exit_code,
-            stdout,
-            stderr,
-            source_snapshot: Some(source_snapshot.clone()),
-            job_id: Some(job.id.to_string()),
-            job: Some(job),
-            runner_job: Some(runner_job),
-            job_events: Some(events),
-            mirror_run_id,
-            patch,
-            mutation_artifacts,
-            artifacts,
-            promoted_outputs: Vec::new(),
-            structured_summaries: Vec::new(),
-            metrics,
-            capture,
-            execution_record: Some(execution_record),
-            runner_result: Some(runner_result),
-            handoff: Some(handoff),
-            diagnostics: runner_exec_diagnostics(runner, Some(&source_snapshot), &require_paths),
+            transport: "reverse_broker",
+            runner_job_transport: "broker",
+            timeout_label: "reverse runner job",
+            cwd: cwd.clone(),
+            command: command.clone(),
+            redaction_env: &redaction_env,
+            secret_env_names: &redaction_secret_env_names,
+            source_snapshot: source_snapshot.clone(),
+            path_materialization_plan: path_materialization_plan.clone(),
+            require_paths: require_paths.clone(),
+            lab_runner_workload: lab_runner_workload.clone(),
+            run_id: run_id.clone(),
+            run_id_owns_generic_exec,
+            detach_after_handoff,
+            mirror_evidence,
+            print_handoff_output,
+            handoff_endpoint: Some(broker_url),
         },
-        exit_code,
-    ))
+        job,
+        |_| Ok(()),
+        |current| {
+            fetch_daemon_job_resilient(&client, broker_url, &current.id.to_string()).map_err(
+                |err| {
+                    terminal_runner_poll_failure(
+                        runner,
+                        &cwd,
+                        &command,
+                        current,
+                        "reverse_broker",
+                        path_materialization_plan.as_ref(),
+                        &source_snapshot,
+                        &require_paths,
+                        None,
+                        None,
+                        err,
+                    )
+                },
+            )
+        },
+        |job_id| fetch_daemon_events(&client, broker_url, job_id),
+        |job, events, result| {
+            let request = crate::evidence::MirrorEvidenceRequest::new(
+                runner,
+                &cwd,
+                &command,
+                job,
+                events,
+                result,
+                run_id.as_deref(),
+                lab_runner_workload
+                    .as_ref()
+                    .and_then(|workload| workload.notification_route.as_ref()),
+            );
+            let request = if run_id_owns_generic_exec {
+                request.with_generic_runner_exec_run()
+            } else {
+                request
+            };
+            mirror_reverse_broker_evidence(crate::evidence::ReverseBrokerEvidenceContext {
+                request,
+                broker_url,
+            })
+            .and_then(|evidence| {
+                evidence
+                    .map(|evidence| {
+                        Ok(MirroredJobEvidence {
+                            run_id: evidence.run.id,
+                            patch: evidence.patch,
+                            artifacts: crate::evidence::controller_artifact_metadata(
+                                &evidence.runs,
+                            )?,
+                        })
+                    })
+                    .transpose()
+            })
+        },
+        || Ok(()),
+        |_, _| Ok(()),
+    );
 }
 
 /// Preserve file-backed argv values past controller cleanup. Values are content

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -175,404 +175,168 @@ pub(super) fn exec_via_daemon(
     let job_value = body
         .get("job")
         .ok_or_else(|| Error::internal_unexpected("daemon exec returned no job"))?;
-    let mut job: Job = serde_json::from_value(job_value.clone()).map_err(|err| {
+    let job: Job = serde_json::from_value(job_value.clone()).map_err(|err| {
         Error::internal_json(err.to_string(), Some("parse daemon exec job".to_string()))
     })?;
-    if let Some(run_id) = run_id.as_deref() {
-        // `/exec` has accepted the job. Bind this fact before any local
-        // bookkeeping can fail so a later error never misclassifies an accepted
-        // handoff as a controller-only pre-handoff failure.
-        let binding = if !run_id_owns_generic_exec {
-            homeboy_agents::agent_task_lifecycle::bind_accepted_lab_runner_job(
-                &homeboy_core::lab_contract::RunnerJobIdentity::new(
-                    run_id,
-                    &runner.id,
-                    job.id.to_string(),
-                ),
-                &cwd,
-                &command,
-            )
-            .map(|_| ())
-        } else {
-            homeboy_agents::agent_task_lifecycle::record_runner_exec_job_identity(
-                run_id,
-                &runner.id,
-                &job.id.to_string(),
-                &cwd,
-                &command,
-            )
-            .map(|_| ())
-        };
-        binding.map_err(|error| {
-            super::accepted_handoff_persistence_error(error, &runner.id, &job.id.to_string())
-        })?;
-    }
-    if let Some(session) = accepted_session.as_ref() {
-        // Persist the endpoint selected at admission before any controller-side
-        // wait or evidence work can fail. Follow-up operations route by this
-        // durable job identity while an older generation drains.
-        super::super::generation_store::record_job(&runner.id, session, &job.id.to_string())?;
-        if let Some(durable_run_id) = run_id.as_deref() {
-            super::super::generation_store::record_job_run(
-                &runner.id,
-                session,
-                &job.id.to_string(),
-                durable_run_id,
-            )?;
-        }
-    }
-    persist_runner_execution_transition(
-        &RunnerExecutionRecord::in_flight(job.id.to_string(), runner.id.clone(), "daemon")
-            .with_job_id(job.id.to_string())
-            .with_path_materialization_plan(path_materialization_plan.clone())
-            .with_orchestration_provenance(orchestration_target_provenance(
-                runner,
-                None,
-                Some(&source_snapshot),
-                &[],
-            ))
-            .with_next_actions(runner_execution_next_actions(
-                &runner.id,
-                &job.id.to_string(),
-            )),
-        &cwd,
-        &command,
-    )?;
-    // One store for the whole foreground lease: claim, every renewal, and the
-    // release. Each step used to open its own, which split the lease's identity
-    // across three independent reads of process state -- a claim taken in one
-    // home and released against another leaves the source stuck `running` with
-    // nothing alive holding it (#7505).
-    //
-    // The renewal also sits inside the `while !job.status.is_terminal()` poll
-    // below, so a five-minute daemon exec opened SQLite and walked the
-    // migration ladder roughly 1,500 times to renew a lease it already held.
-    // The lease below and the evidence mirror further down describe the same
-    // run, so one resolution serves both rather than each reading the
-    // environment on its own (#7505).
     let roots = homeboy_core::paths::PathRoots::from_environment()?;
     let lease_store = run_id
         .as_deref()
         .map(|_| ObservationStore::open_initialized_in_roots(&roots))
         .transpose()?;
-    let foreground_source_lease = run_id
-        .as_deref()
-        .map(|run_id| {
-            let token = uuid::Uuid::new_v4().to_string();
-            let store = lease_store
-                .as_ref()
-                .expect("lease store is opened whenever run_id is present");
-            if !store.claim_running_runner_exec_recovery_source(
-                run_id,
-                "foreground-runner-exec",
-                &token,
-                &job.id.to_string(),
-            )? {
-                return Err(runner_exec_source_claim_error(
-                    store,
-                    run_id,
+    let foreground_source_lease = std::cell::RefCell::new(None);
+    let daemon_endpoint = std::cell::RefCell::new(local_url.to_string());
+    return complete_submitted_runner_job(
+        SubmittedRunnerJobFlow {
+            runner,
+            mode: RunnerExecMode::Daemon,
+            transport: "daemon",
+            runner_job_transport: "daemon",
+            timeout_label: "runner daemon job",
+            cwd: cwd.clone(),
+            command: command.clone(),
+            redaction_env: &env,
+            secret_env_names: &secret_env_names,
+            source_snapshot: source_snapshot.clone(),
+            path_materialization_plan: path_materialization_plan.clone(),
+            require_paths: require_paths.clone(),
+            lab_runner_workload: lab_runner_workload.clone(),
+            run_id: run_id.clone(),
+            run_id_owns_generic_exec,
+            detach_after_handoff,
+            mirror_evidence,
+            print_handoff_output,
+            handoff_endpoint: None,
+        },
+        job,
+        |job| {
+            if let Some(session) = accepted_session.as_ref() {
+                super::super::generation_store::record_job(
+                    &runner.id,
+                    session,
                     &job.id.to_string(),
-                )?);
-            }
-            Ok::<_, Error>((run_id.to_string(), token))
-        })
-        .transpose()?;
-    let persisted_run_id = mirror_evidence
-        .then(|| {
-            persist_lab_offload_handoff_run(runner, &cwd, &command, &job, run_id.as_deref(), None)
-        })
-        .flatten();
-    validate_generic_exec_mirror_run_id(
-        run_id_owns_generic_exec,
-        run_id.as_deref(),
-        persisted_run_id.as_deref(),
-    )?;
-    if detach_after_handoff {
-        return Ok(detached_handoff_output(
-            runner,
-            RunnerExecMode::Daemon,
-            cwd,
-            command,
-            source_snapshot,
-            job,
-            path_materialization_plan,
-            require_paths,
-            run_id,
-            persisted_run_id,
-        ));
-    }
-
-    let deadline = Instant::now() + runner_exec_wait_timeout();
-    let mut daemon_endpoint = local_url.to_string();
-    let mut reported_progress_sequence = 0;
-    while !job.status.is_terminal() {
-        if Instant::now() >= deadline {
-            let events = fetch_daemon_events(&client, &daemon_endpoint, &job.id.to_string())
-                .map(|events| redact_runner_job_events(&events, &env, &secret_env_names))
-                .unwrap_or_default();
-            record_and_report_promotion_progress_frames(
-                run_id.as_deref(),
-                &job.id.to_string(),
-                &events,
-                &mut reported_progress_sequence,
-            );
-            return Err(daemon_job_wait_timeout(
-                runner,
-                &cwd,
-                &command,
-                &job,
-                &events,
-                "runner daemon job",
-                true,
-            ));
-        }
-        std::thread::sleep(Duration::from_millis(200));
-        if let Some((run_id, token)) = &foreground_source_lease {
-            let _ = lease_store
-                .as_ref()
-                .expect("lease store is opened whenever a lease is held")
-                .renew_running_runner_exec_source_lease(run_id, token)?;
-        }
-        let job_id = job.id.to_string();
-        let (refreshed_job, refreshed_endpoint) = fetch_daemon_job_resilient_with_endpoint_reload(
-            &client,
-            &daemon_endpoint,
-            &job_id,
-            || refreshed_daemon_endpoint(&runner.id, &job_id, accepted_daemon_identity.as_deref()),
-        )
-        .map_err(|err| {
-            terminal_runner_poll_failure(
-                runner,
-                &cwd,
-                &command,
-                &job,
-                "daemon",
-                path_materialization_plan.as_ref(),
-                &source_snapshot,
-                &require_paths,
-                persisted_run_id.as_deref(),
-                accepted_daemon_identity.as_deref(),
-                err,
-            )
-        })?;
-        daemon_endpoint = refreshed_endpoint;
-        job = refreshed_job;
-        if let Ok(events) = fetch_daemon_events(&client, &daemon_endpoint, &job_id) {
-            let events = redact_runner_job_events(&events, &env, &secret_env_names);
-            record_and_report_promotion_progress_frames(
-                run_id.as_deref(),
-                &job_id,
-                &events,
-                &mut reported_progress_sequence,
-            );
-        }
-    }
-    let job_id = job.id.to_string();
-    let mut events = match fetch_daemon_events(&client, &daemon_endpoint, &job_id) {
-        Ok(events) => redact_runner_job_events(&events, &env, &secret_env_names),
-        Err(err) => {
-            return Err(lab_terminal_result_transport_error(
-                runner, &cwd, &command, &job, err,
-            ))
-        }
-    };
-    record_and_report_promotion_progress_frames(
-        run_id.as_deref(),
-        &job_id,
-        &events,
-        &mut reported_progress_sequence,
-    );
-    append_agent_task_lifecycle_workload_event(
-        &mut events,
-        lab_runner_workload.as_ref(),
-        &runner.id,
-        &job_id,
-    )?;
-    append_agent_task_dispatch_handoff_workload_event(
-        &mut events,
-        lab_runner_workload.as_ref(),
-        &runner.id,
-        &job_id,
-    );
-
-    let RunnerJobResultFields {
-        result,
-        stdout,
-        stderr,
-        metrics,
-        capture,
-        exit_code,
-    } = runner_job_result_fields(&events, job.status, &env, &secret_env_names);
-
-    let terminal_snapshot = homeboy_core::api_jobs::RunnerJobLogSnapshot {
-        job: job.clone(),
-        events: events.clone(),
-    };
-    if run_id_owns_generic_exec {
-        if let Some(run_id) = run_id.as_deref() {
-            homeboy_agents::agent_task_lifecycle::record_runner_exec_terminal_checkpoint(
-                run_id,
-                &terminal_snapshot,
-            )?;
-        }
-    }
-    let mirror = if mirror_evidence {
-        let request = crate::evidence::MirrorEvidenceRequest::new(
-            runner,
-            &cwd,
-            &command,
-            &job,
-            &events,
-            &result,
-            run_id.as_deref(),
-            lab_runner_workload
-                .as_ref()
-                .and_then(|workload| workload.notification_route.as_ref()),
-        );
-        let request = if run_id_owns_generic_exec {
-            request.with_generic_runner_exec_run()
-        } else {
-            request
-        };
-        mirror_daemon_evidence(request, &roots).map_err(|error| {
-            if run_id_owns_generic_exec {
-                if let Some(run_id) = run_id.as_deref() {
-                    let _ =
-                        homeboy_agents::agent_task_lifecycle::record_runner_exec_projection_failure(
-                            run_id,
-                            &terminal_snapshot,
-                            &error,
-                        );
+                )?;
+                if let Some(durable_run_id) = run_id.as_deref() {
+                    super::super::generation_store::record_job_run(
+                        &runner.id,
+                        session,
+                        &job.id.to_string(),
+                        durable_run_id,
+                    )?;
                 }
             }
-            error
-        })?
-    } else {
-        None
-    };
-    if let Some((run_id, token)) = &foreground_source_lease {
-        let _ = lease_store
-            .as_ref()
-            .expect("lease store is opened whenever a lease is held")
-            .release_running_runner_exec_source_lease(run_id, token)?;
-    }
-    let patch = mirror.as_ref().and_then(|evidence| evidence.patch.clone());
-    let mirror_run_id = mirror.as_ref().map(|evidence| evidence.run.id.clone());
-    validate_generic_exec_mirror_run_id(
-        run_id_owns_generic_exec,
-        run_id.as_deref(),
-        mirror_run_id.as_deref(),
-    )?;
-    fire_runner_direct_notification(
-        run_id.as_deref(),
-        &job,
-        lab_runner_workload
-            .as_ref()
-            .and_then(|workload| workload.notification_route.as_ref()),
+            if let Some(run_id) = run_id.as_deref() {
+                let token = uuid::Uuid::new_v4().to_string();
+                let store = lease_store
+                    .as_ref()
+                    .expect("lease store is opened whenever run_id is present");
+                if !store.claim_running_runner_exec_recovery_source(
+                    run_id,
+                    "foreground-runner-exec",
+                    &token,
+                    &job.id.to_string(),
+                )? {
+                    return Err(runner_exec_source_claim_error(
+                        store,
+                        run_id,
+                        &job.id.to_string(),
+                    )?);
+                }
+                *foreground_source_lease.borrow_mut() = Some((run_id.to_string(), token));
+            }
+            Ok(())
+        },
+        |current| {
+            if let Some((run_id, token)) = foreground_source_lease.borrow().as_ref() {
+                lease_store
+                    .as_ref()
+                    .expect("lease store is opened whenever a lease is held")
+                    .renew_running_runner_exec_source_lease(run_id, token)?;
+            }
+            let job_id = current.id.to_string();
+            let (refreshed, endpoint) = fetch_daemon_job_resilient_with_endpoint_reload(
+                &client,
+                &daemon_endpoint.borrow(),
+                &job_id,
+                || {
+                    refreshed_daemon_endpoint(
+                        &runner.id,
+                        &job_id,
+                        accepted_daemon_identity.as_deref(),
+                    )
+                },
+            )
+            .map_err(|err| {
+                terminal_runner_poll_failure(
+                    runner,
+                    &cwd,
+                    &command,
+                    current,
+                    "daemon",
+                    path_materialization_plan.as_ref(),
+                    &source_snapshot,
+                    &require_paths,
+                    None,
+                    accepted_daemon_identity.as_deref(),
+                    err,
+                )
+            })?;
+            *daemon_endpoint.borrow_mut() = endpoint;
+            Ok(refreshed)
+        },
+        |job_id| fetch_daemon_events(&client, &daemon_endpoint.borrow(), job_id),
+        |job, events, result| {
+            let request = crate::evidence::MirrorEvidenceRequest::new(
+                runner,
+                &cwd,
+                &command,
+                job,
+                events,
+                result,
+                run_id.as_deref(),
+                lab_runner_workload
+                    .as_ref()
+                    .and_then(|workload| workload.notification_route.as_ref()),
+            );
+            let request = if run_id_owns_generic_exec {
+                request.with_generic_runner_exec_run()
+            } else {
+                request
+            };
+            mirror_daemon_evidence(request, &roots).and_then(|evidence| {
+                evidence
+                    .map(|evidence| {
+                        Ok(MirroredJobEvidence {
+                            run_id: evidence.run.id,
+                            patch: evidence.patch,
+                            artifacts: crate::evidence::controller_artifact_metadata(
+                                &evidence.runs,
+                            )?,
+                        })
+                    })
+                    .transpose()
+            })
+        },
+        || {
+            if let Some((run_id, token)) = foreground_source_lease.borrow_mut().take() {
+                lease_store
+                    .as_ref()
+                    .expect("lease store is opened whenever a lease is held")
+                    .release_running_runner_exec_source_lease(&run_id, &token)?;
+            }
+            Ok(())
+        },
+        |job, artifacts| {
+            if let Some(session) = accepted_session.as_ref() {
+                super::super::generation_store::record_job_artifacts(
+                    &runner.id,
+                    session,
+                    &job.id.to_string(),
+                    artifacts.iter().map(|artifact| artifact.id.clone()),
+                )?;
+            }
+            Ok(())
+        },
     );
-    let artifacts = mirror
-        .as_ref()
-        .map(|evidence| crate::evidence::controller_artifact_metadata(&evidence.runs))
-        .transpose()?
-        .unwrap_or_default();
-    if let Some(session) = accepted_session.as_ref() {
-        super::super::generation_store::record_job_artifacts(
-            &runner.id,
-            session,
-            &job_id,
-            artifacts.iter().map(|artifact| artifact.id.clone()),
-        )?;
-    }
-    let mutation_artifacts = mutation_artifacts_from_job(&job, &result);
-    if print_handoff_output {
-        print_lab_offload_handoff(
-            &runner.id,
-            Some(&cwd),
-            &job.id.to_string(),
-            mirror_run_id.as_deref(),
-            DaemonJobHandoffState::Terminal(job.status),
-        );
-    }
-
-    let runner_job = RunnerJob::from_job(&runner.id, "daemon", &command, Some(cwd.clone()), &job);
-    let mut runner_result = runner_result(
-        Some(&job),
-        exit_code,
-        &stdout,
-        &stderr,
-        mirror_run_id.as_deref(),
-        mutation_artifacts.clone(),
-    );
-    runner_result.artifact_refs = artifacts
-        .iter()
-        .map(crate::session::runner_artifact_ref_from_metadata)
-        .collect();
-    let provenance_extensions = required_extensions_for_command(
-        &command,
-        &super::super::workload::merge_lab_runner_workload_required_extensions(
-            Vec::new(),
-            lab_runner_workload.as_ref(),
-        ),
-    );
-    let handoff = lab_runner_handoff(
-        runner,
-        "daemon",
-        Some(runner_job.clone()),
-        Some(runner_result.clone()),
-    );
-    let execution_record = runner_execution_record_for_output(
-        runner,
-        "daemon",
-        exit_code,
-        Some(job.id.to_string()),
-        mirror_run_id.clone(),
-        Some(&source_snapshot),
-        path_materialization_plan,
-        &require_paths,
-        &provenance_extensions,
-        &artifacts,
-        Some(&runner_result),
-    );
-    persist_runner_execution_transition(&execution_record, &cwd, &command)?;
-    let mut output = RunnerExecOutput {
-        variant: "exec",
-        command: "runner.exec",
-        runner_id: runner.id.clone(),
-        dry_run: false,
-        mode: RunnerExecMode::Daemon,
-        argv: redact_argv(&command),
-        remote_cwd: cwd,
-        exit_code,
-        stdout,
-        stderr,
-        source_snapshot: Some(source_snapshot.clone()),
-        job_id: Some(job.id.to_string()),
-        job: Some(job),
-        runner_job: Some(runner_job),
-        job_events: Some(events),
-        mirror_run_id: mirror_run_id.clone(),
-        patch,
-        mutation_artifacts,
-        artifacts,
-        promoted_outputs: Vec::new(),
-        structured_summaries: Vec::new(),
-        metrics,
-        capture,
-        execution_record: Some(execution_record),
-        runner_result: Some(runner_result),
-        handoff: Some(handoff),
-        diagnostics: runner_exec_diagnostics(runner, Some(&source_snapshot), &require_paths),
-    };
-    for hint in result
-        .get("diagnostic_hints")
-        .and_then(serde_json::Value::as_array)
-        .into_iter()
-        .flatten()
-        .filter_map(serde_json::Value::as_str)
-    {
-        append_runner_exec_diagnostic_hint(&mut output, Some(hint.to_string()));
-    }
-    Ok((output, exit_code))
 }
 
 pub(super) fn record_and_report_promotion_progress_frames(
@@ -2449,7 +2213,7 @@ pub(crate) fn result_event_data(events: &[JobEvent]) -> Option<Value> {
         .and_then(|event| event.data.clone())
 }
 
-fn append_agent_task_lifecycle_workload_event(
+pub(super) fn append_agent_task_lifecycle_workload_event(
     events: &mut Vec<JobEvent>,
     lab_runner_workload: Option<&LabRunnerWorkload>,
     runner_id: &str,
@@ -2498,7 +2262,7 @@ fn append_agent_task_lifecycle_workload_event(
 /// failure, it just means the controller's retained output fallback runs. This
 /// is the opposite of the run-plan path, where a malformed aggregate is a hard
 /// error because the controller has no other source for it.
-fn append_agent_task_dispatch_handoff_workload_event(
+pub(super) fn append_agent_task_dispatch_handoff_workload_event(
     events: &mut Vec<JobEvent>,
     lab_runner_workload: Option<&LabRunnerWorkload>,
     runner_id: &str,

--- a/crates/homeboy-lab-runner/src/execution/job_flow.rs
+++ b/crates/homeboy-lab-runner/src/execution/job_flow.rs
@@ -1,0 +1,374 @@
+//! Transport-neutral lifecycle for an accepted runner job.
+//!
+//! Direct-daemon and reverse-broker transports differ at their HTTP boundaries,
+//! but an accepted job has one controller lifecycle: bind, persist or detach,
+//! poll, mirror, and assemble the caller-visible result.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use homeboy_core::api_jobs::{Job, JobEvent, RunnerJobLogSnapshot};
+use homeboy_core::error::Result;
+use homeboy_core::lab_contract::{JobArtifactMetadata, LabRunnerWorkload};
+use homeboy_core::redaction::redact_argv;
+use homeboy_core::runner_execution_envelope::PathMaterializationPlan;
+use homeboy_core::source_snapshot::SourceSnapshot;
+
+use super::*;
+
+pub(super) struct MirroredJobEvidence {
+    pub(super) run_id: String,
+    pub(super) patch: Option<serde_json::Value>,
+    pub(super) artifacts: Vec<JobArtifactMetadata>,
+}
+
+pub(super) struct SubmittedRunnerJobFlow<'a> {
+    pub(super) runner: &'a Runner,
+    pub(super) mode: RunnerExecMode,
+    pub(super) transport: &'static str,
+    pub(super) runner_job_transport: &'static str,
+    pub(super) timeout_label: &'static str,
+    pub(super) cwd: String,
+    pub(super) command: Vec<String>,
+    pub(super) redaction_env: &'a HashMap<String, String>,
+    pub(super) secret_env_names: &'a [String],
+    pub(super) source_snapshot: SourceSnapshot,
+    pub(super) path_materialization_plan: Option<PathMaterializationPlan>,
+    pub(super) require_paths: Vec<String>,
+    pub(super) lab_runner_workload: Option<LabRunnerWorkload>,
+    pub(super) run_id: Option<String>,
+    pub(super) run_id_owns_generic_exec: bool,
+    pub(super) detach_after_handoff: bool,
+    pub(super) mirror_evidence: bool,
+    pub(super) print_handoff_output: bool,
+    pub(super) handoff_endpoint: Option<&'a str>,
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Transport hooks keep HTTP and lease semantics outside the shared lifecycle."
+)]
+pub(super) fn complete_submitted_runner_job<Accepted, Poll, Events, Mirror, AfterEvents, Finalize>(
+    flow: SubmittedRunnerJobFlow<'_>,
+    mut job: Job,
+    mut accepted: Accepted,
+    mut poll: Poll,
+    mut events: Events,
+    mirror: Mirror,
+    mut after_events: AfterEvents,
+    mut finalize: Finalize,
+) -> Result<(RunnerExecOutput, i32)>
+where
+    Accepted: FnMut(&Job) -> Result<()>,
+    Poll: FnMut(&Job) -> Result<Job>,
+    Events: FnMut(&str) -> Result<Vec<JobEvent>>,
+    Mirror: FnOnce(&Job, &[JobEvent], &serde_json::Value) -> Result<Option<MirroredJobEvidence>>,
+    AfterEvents: FnMut() -> Result<()>,
+    Finalize: FnMut(&Job, &[JobArtifactMetadata]) -> Result<()>,
+{
+    if let Some(run_id) = flow.run_id.as_deref() {
+        let binding = if flow.run_id_owns_generic_exec {
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_job_identity(
+                run_id,
+                &flow.runner.id,
+                &job.id.to_string(),
+                &flow.cwd,
+                &flow.command,
+            )
+            .map(|_| ())
+        } else {
+            homeboy_agents::agent_task_lifecycle::bind_accepted_lab_runner_job(
+                &homeboy_core::lab_contract::RunnerJobIdentity::new(
+                    run_id,
+                    &flow.runner.id,
+                    job.id.to_string(),
+                ),
+                &flow.cwd,
+                &flow.command,
+            )
+            .map(|_| ())
+        };
+        binding.map_err(|error| {
+            super::accepted_handoff_persistence_error(error, &flow.runner.id, &job.id.to_string())
+        })?;
+    }
+    accepted(&job)?;
+    persist_runner_execution_transition(
+        &RunnerExecutionRecord::in_flight(
+            job.id.to_string(),
+            flow.runner.id.clone(),
+            flow.transport,
+        )
+        .with_job_id(job.id.to_string())
+        .with_path_materialization_plan(flow.path_materialization_plan.clone())
+        .with_orchestration_provenance(orchestration_target_provenance(
+            flow.runner,
+            None,
+            Some(&flow.source_snapshot),
+            &[],
+        ))
+        .with_next_actions(runner_execution_next_actions(
+            &flow.runner.id,
+            &job.id.to_string(),
+        )),
+        &flow.cwd,
+        &flow.command,
+    )?;
+    let persisted_run_id = flow
+        .mirror_evidence
+        .then(|| {
+            persist_lab_offload_handoff_run(
+                flow.runner,
+                &flow.cwd,
+                &flow.command,
+                &job,
+                flow.run_id.as_deref(),
+                flow.handoff_endpoint,
+            )
+        })
+        .flatten();
+    validate_generic_exec_mirror_run_id(
+        flow.run_id_owns_generic_exec,
+        flow.run_id.as_deref(),
+        persisted_run_id.as_deref(),
+    )?;
+    if flow.detach_after_handoff {
+        return Ok(detached_handoff_output(
+            flow.runner,
+            flow.mode,
+            flow.cwd,
+            flow.command,
+            flow.source_snapshot,
+            job,
+            flow.path_materialization_plan,
+            flow.require_paths,
+            flow.run_id,
+            persisted_run_id,
+        ));
+    }
+
+    let deadline = Instant::now() + runner_exec_wait_timeout();
+    let mut reported_progress_sequence = 0;
+    while !job.status.is_terminal() {
+        let job_id = job.id.to_string();
+        if Instant::now() >= deadline {
+            let events = events(&job_id)
+                .map(|events| {
+                    redact_runner_job_events(&events, flow.redaction_env, flow.secret_env_names)
+                })
+                .unwrap_or_default();
+            record_and_report_promotion_progress_frames(
+                flow.run_id.as_deref(),
+                &job_id,
+                &events,
+                &mut reported_progress_sequence,
+            );
+            return Err(daemon_job_wait_timeout(
+                flow.runner,
+                &flow.cwd,
+                &flow.command,
+                &job,
+                &events,
+                flow.timeout_label,
+                true,
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(200));
+        job = poll(&job)?;
+        if let Ok(events) = events(&job_id) {
+            let events =
+                redact_runner_job_events(&events, flow.redaction_env, flow.secret_env_names);
+            record_and_report_promotion_progress_frames(
+                flow.run_id.as_deref(),
+                &job_id,
+                &events,
+                &mut reported_progress_sequence,
+            );
+        }
+    }
+    let job_id = job.id.to_string();
+    let mut job_events = events(&job_id).map(|events| {
+        redact_runner_job_events(&events, flow.redaction_env, flow.secret_env_names)
+    })?;
+    record_and_report_promotion_progress_frames(
+        flow.run_id.as_deref(),
+        &job_id,
+        &job_events,
+        &mut reported_progress_sequence,
+    );
+    append_agent_task_lifecycle_workload_event(
+        &mut job_events,
+        flow.lab_runner_workload.as_ref(),
+        &flow.runner.id,
+        &job_id,
+    )?;
+    append_agent_task_dispatch_handoff_workload_event(
+        &mut job_events,
+        flow.lab_runner_workload.as_ref(),
+        &flow.runner.id,
+        &job_id,
+    );
+    let RunnerJobResultFields {
+        result,
+        stdout,
+        stderr,
+        metrics,
+        capture,
+        exit_code,
+    } = runner_job_result_fields(
+        &job_events,
+        job.status,
+        flow.redaction_env,
+        flow.secret_env_names,
+    );
+    let terminal_snapshot = RunnerJobLogSnapshot {
+        job: job.clone(),
+        events: job_events.clone(),
+    };
+    if flow.run_id_owns_generic_exec {
+        if let Some(run_id) = flow.run_id.as_deref() {
+            homeboy_agents::agent_task_lifecycle::record_runner_exec_terminal_checkpoint(
+                run_id,
+                &terminal_snapshot,
+            )?;
+        }
+    }
+    after_events()?;
+    let mirrored = if flow.mirror_evidence {
+        mirror(&job, &job_events, &result).map_err(|error| {
+            if flow.run_id_owns_generic_exec {
+                if let Some(run_id) = flow.run_id.as_deref() {
+                    let _ =
+                        homeboy_agents::agent_task_lifecycle::record_runner_exec_projection_failure(
+                            run_id,
+                            &terminal_snapshot,
+                            &error,
+                        );
+                }
+            }
+            error
+        })?
+    } else {
+        None
+    };
+    let patch = mirrored
+        .as_ref()
+        .and_then(|evidence| evidence.patch.clone());
+    let mirror_run_id = mirrored.as_ref().map(|evidence| evidence.run_id.clone());
+    validate_generic_exec_mirror_run_id(
+        flow.run_id_owns_generic_exec,
+        flow.run_id.as_deref(),
+        mirror_run_id.as_deref(),
+    )?;
+    fire_runner_direct_notification(
+        flow.run_id.as_deref(),
+        &job,
+        flow.lab_runner_workload
+            .as_ref()
+            .and_then(|workload| workload.notification_route.as_ref()),
+    );
+    let artifacts = mirrored
+        .map(|evidence| evidence.artifacts)
+        .unwrap_or_default();
+    finalize(&job, &artifacts)?;
+    let mutation_artifacts = mutation_artifacts_from_job(&job, &result);
+    if flow.print_handoff_output {
+        print_lab_offload_handoff(
+            &flow.runner.id,
+            Some(&flow.cwd),
+            &job_id,
+            mirror_run_id.as_deref(),
+            DaemonJobHandoffState::Terminal(job.status),
+        );
+    }
+    let runner_job = RunnerJob::from_job(
+        &flow.runner.id,
+        flow.runner_job_transport,
+        &flow.command,
+        Some(flow.cwd.clone()),
+        &job,
+    );
+    let mut runner_result = runner_result(
+        Some(&job),
+        exit_code,
+        &stdout,
+        &stderr,
+        mirror_run_id.as_deref(),
+        mutation_artifacts.clone(),
+    );
+    runner_result.artifact_refs = artifacts
+        .iter()
+        .map(crate::session::runner_artifact_ref_from_metadata)
+        .collect();
+    let provenance_extensions = required_extensions_for_command(
+        &flow.command,
+        &super::super::workload::merge_lab_runner_workload_required_extensions(
+            Vec::new(),
+            flow.lab_runner_workload.as_ref(),
+        ),
+    );
+    let handoff = lab_runner_handoff(
+        flow.runner,
+        flow.transport,
+        Some(runner_job.clone()),
+        Some(runner_result.clone()),
+    );
+    let execution_record = runner_execution_record_for_output(
+        flow.runner,
+        flow.transport,
+        exit_code,
+        Some(job_id.clone()),
+        mirror_run_id.clone(),
+        Some(&flow.source_snapshot),
+        flow.path_materialization_plan,
+        &flow.require_paths,
+        &provenance_extensions,
+        &artifacts,
+        Some(&runner_result),
+    );
+    persist_runner_execution_transition(&execution_record, &flow.cwd, &flow.command)?;
+    let diagnostics = runner_exec_diagnostics(
+        flow.runner,
+        Some(&flow.source_snapshot),
+        &flow.require_paths,
+    );
+    let mut output = RunnerExecOutput {
+        variant: "exec",
+        command: "runner.exec",
+        runner_id: flow.runner.id.clone(),
+        dry_run: false,
+        mode: flow.mode,
+        argv: redact_argv(&flow.command),
+        remote_cwd: flow.cwd,
+        exit_code,
+        stdout,
+        stderr,
+        source_snapshot: Some(flow.source_snapshot),
+        job_id: Some(job_id),
+        job: Some(job),
+        runner_job: Some(runner_job),
+        job_events: Some(job_events),
+        mirror_run_id,
+        patch,
+        mutation_artifacts,
+        artifacts,
+        promoted_outputs: Vec::new(),
+        structured_summaries: Vec::new(),
+        metrics,
+        capture,
+        execution_record: Some(execution_record),
+        runner_result: Some(runner_result),
+        handoff: Some(handoff),
+        diagnostics,
+    };
+    for hint in result
+        .get("diagnostic_hints")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(serde_json::Value::as_str)
+    {
+        append_runner_exec_diagnostic_hint(&mut output, Some(hint.to_string()));
+    }
+    Ok((output, exit_code))
+}

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -59,6 +59,7 @@ mod daemon_api;
 mod extension_parity;
 mod failure;
 mod handoff;
+mod job_flow;
 mod paths;
 mod policy;
 mod process;
@@ -88,6 +89,7 @@ pub(crate) use daemon_api::{
 };
 use failure::*;
 use handoff::*;
+use job_flow::*;
 use paths::*;
 use process::*;
 use redaction::*;


### PR DESCRIPTION
Closes #7514

## Summary
- centralize accepted runner-job binding, handoff/detach, polling, evidence mirroring, and terminal result assembly
- retain direct-daemon endpoint recovery, foreground lease renewal, and generation artifact tracking as transport adapters
- retain reverse-broker submission and broker evidence retrieval as transport adapters

## Verification
- `cargo fmt --check`
- `cargo check -p homeboy-lab-runner`
- `cargo test -p homeboy-lab-runner execution::tests::handoff --lib` (34 passed)

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode was used to inspect the extracted crate layout, implement the shared transport-neutral job flow, and run focused verification. Chris Huber reviewed and remains responsible for the change.