### PR TITLE
chore: delete 14 orphaned ambient wrappers (#7505)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -4332,25 +4332,11 @@ pub struct AgentTaskQueuedRunClaim {
 /// quarantined records rather than letting stale history monopolize a worker.
 pub const MAX_QUEUE_ADMISSION_RECORDS: usize = 64;
 
-/// Claim the oldest executable queued record. Invalid provenance is retained on
-/// a nonterminal quarantine record before any running transition can occur.
-pub fn claim_next_eligible_queued_run() -> Result<AgentTaskQueuedRunClaim> {
-    claim_next_eligible_queued_run_with_preflight(|_, _| Ok(()))
-}
-
 /// Claim the oldest executable queued record from an explicitly rooted store.
 pub fn claim_next_eligible_queued_run_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
 ) -> Result<AgentTaskQueuedRunClaim> {
     claim_next_eligible_queued_run_with_preflight_in_store(lifecycle_store, |_, _| Ok(()))
-}
-
-/// Claim the oldest executable queued record after caller-supplied admission
-/// checks have validated its durable plan, but before the atomic Running claim.
-pub fn claim_next_eligible_queued_run_with_preflight(
-    preflight: impl Fn(&AgentTaskRunRecord, &AgentTaskPlan) -> Result<()>,
-) -> Result<AgentTaskQueuedRunClaim> {
-    claim_next_eligible_queued_run_with_preflight_and_filter(|_| true, preflight)
 }
 
 /// Preflighted admission against an explicitly rooted store. The preflight
@@ -4499,10 +4485,6 @@ pub fn claim_next_eligible_queued_run_with_preflight_and_filter_and_limit_in_sto
         inspected,
         admission_limit_reached: false,
     })
-}
-
-pub fn claim_next_queued_run() -> Result<Option<AgentTaskRunRecord>> {
-    Ok(claim_next_eligible_queued_run()?.record)
 }
 
 /// Claim the oldest executable queued record from an explicitly rooted store,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
@@ -1334,10 +1334,6 @@ pub(crate) fn renew_record_workspace_owner_in_store(
     Ok(())
 }
 
-pub(crate) fn ensure_record_workspace_owner(record: &mut AgentTaskRunRecord) -> Result<()> {
-    ensure_record_workspace_owner_in_store(&store()?, record)
-}
-
 /// The store-rooted counterpart of [`ensure_record_workspace_owner`].
 ///
 /// Validating an existing lease and registering its replacement are one

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -688,13 +688,6 @@ fn mismatch_freeze_boundary(field: &str) -> RecipeFreezeBoundary {
     }
 }
 
-fn reached_freeze_boundary(recipe: &AgentTaskCookRecipe) -> Result<Option<RecipeFreezeBoundary>> {
-    reached_freeze_boundary_in_store(
-        &crate::agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?,
-        recipe,
-    )
-}
-
 /// [`reached_freeze_boundary`] against an explicitly injected lifecycle root.
 ///
 /// The freeze boundary is decided entirely by what the attempts' own records

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -304,7 +304,7 @@ pub mod lifecycle {
         aggregate_source, artifacts, cancel, cancel_run, claim_cook_operation,
         claim_local_cook_retry_launch_in_store,
         claim_next_eligible_queued_run_with_preflight_and_filter,
-        claim_next_eligible_queued_run_with_preflight_and_filter_and_limit, claim_next_queued_run,
+        claim_next_eligible_queued_run_with_preflight_and_filter_and_limit,
         complete_cook_operation, consume_unmaterialized_cook_replay_claim, cook_attempt_run_id,
         cook_index, cook_index_exists, cook_index_exists_in_store, cook_index_in_store,
         cook_terminal_notification_outcome, durable_local_read, durable_local_read_in_store,

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -1145,15 +1145,6 @@ pub fn migrate_legacy_pin_in_root(root: &Path, runtime: &Value) -> Result<Value>
     migrate_legacy_pin_unlocked(runtime)
 }
 
-/// Publish a migrated pin and persist its durable reference while the admission
-/// lock remains held, so cleanup cannot reclaim the new identity in between.
-pub fn migrate_legacy_pin_and_persist(
-    runtime: &Value,
-    persist: impl FnOnce(&Value) -> Result<()>,
-) -> Result<Value> {
-    migrate_legacy_pin_and_persist_in_root(&runtime_root()?, runtime, persist)
-}
-
 /// [`migrate_legacy_pin_and_persist`] under an already-resolved runtime root.
 pub fn migrate_legacy_pin_and_persist_in_root(
     runtime_root: &Path,

--- a/crates/homeboy-core/src/notify_outbox.rs
+++ b/crates/homeboy-core/src/notify_outbox.rs
@@ -266,6 +266,9 @@ fn pending_dir() -> Option<PathBuf> {
     Some(pending_dir_in_root(&ambient_config_root()?))
 }
 
+/// Only the tests below still resolve this ambiently. Production reaches the
+/// inflight directory through an injected root (#7505).
+#[cfg(test)]
 fn inflight_dir() -> Option<PathBuf> {
     Some(inflight_dir_in_root(&ambient_config_root()?))
 }
@@ -771,11 +774,6 @@ pub fn dead_letter_entries() -> Vec<NotifyOutboxEntry> {
 /// [`dead_letter_entries`] against an already-resolved config root.
 pub fn dead_letter_entries_in_root(config_root: &Path) -> Vec<NotifyOutboxEntry> {
     read_dir_entries(&dead_letter_dir_in_root(config_root))
-}
-
-/// Entries currently claimed by a drain pass.
-pub fn inflight_entries() -> Vec<NotifyOutboxEntry> {
-    read_dir_entries_opt(inflight_dir())
 }
 
 /// [`inflight_entries`] against an already-resolved config root.

--- a/crates/homeboy-paths/src/lib.rs
+++ b/crates/homeboy-paths/src/lib.rs
@@ -566,11 +566,6 @@ pub fn agent_runtime_manifest_in_root(config_root: &Path, id: &str) -> PathBuf {
         .join(format!("{}.json", id))
 }
 
-/// Agent runtime manifest file path
-pub fn agent_runtime_manifest(id: &str) -> Result<PathBuf> {
-    Ok(agent_runtime_manifest_in_root(&homeboy()?, id))
-}
-
 /// Key file path below an already-resolved config root.
 pub fn key_in_root(config_root: &Path, server_id: &str) -> PathBuf {
     keys_in_root(config_root).join(format!("{}_id_rsa", server_id))

--- a/crates/homeboy-paths/src/locations.rs
+++ b/crates/homeboy-paths/src/locations.rs
@@ -104,8 +104,3 @@ pub fn keys() -> Result<PathBuf> {
 pub fn backups_in_root(config_root: &Path) -> PathBuf {
     config_root.join("backups")
 }
-
-/// Backups directory
-pub fn backups() -> Result<PathBuf> {
-    Ok(backups_in_root(&homeboy()?))
-}

--- a/crates/homeboy-paths/src/rigs.rs
+++ b/crates/homeboy-paths/src/rigs.rs
@@ -15,15 +15,6 @@ pub fn rig_registry_root_in_root(config_root: &Path) -> PathBuf {
     rig_registry_root_from_env(env::var(RIG_REGISTRY_ROOT_ENV).ok(), config_root)
 }
 
-/// Root for rig-specific mutable state.
-///
-/// An unset or blank override retains the historical `homeboy()` root. This
-/// intentionally scopes only rig registries; general Homeboy configuration is
-/// unaffected.
-pub fn rig_registry_root() -> Result<PathBuf> {
-    Ok(rig_registry_root_in_root(&homeboy()?))
-}
-
 /// Resolve a rig registry root from an explicit environment value.
 ///
 /// Kept pure so callers can verify the environment contract without mutating
@@ -65,11 +56,6 @@ pub fn rig_package_in_root(config_root: &Path, id: &str) -> PathBuf {
     rig_packages_in_root(config_root).join(id)
 }
 
-/// Cloned rig package path (~/.config/homeboy/rig-packages/{id}/)
-pub fn rig_package(id: &str) -> Result<PathBuf> {
-    Ok(rig_package_in_root(&homeboy()?, id))
-}
-
 /// Rig source metadata directory below an already-resolved config root.
 pub fn rig_sources_in_root(config_root: &Path) -> PathBuf {
     rig_registry_root_in_root(config_root).join("rig-sources")
@@ -85,11 +71,6 @@ pub fn rig_source_metadata_in_root(config_root: &Path, id: &str) -> PathBuf {
     rig_sources_in_root(config_root).join(format!("{}.json", id))
 }
 
-/// Rig source metadata file (~/.config/homeboy/rig-sources/{id}.json)
-pub fn rig_source_metadata(id: &str) -> Result<PathBuf> {
-    Ok(rig_source_metadata_in_root(&homeboy()?, id))
-}
-
 /// Stack source metadata directory below an already-resolved config root.
 pub fn stack_sources_in_root(config_root: &Path) -> PathBuf {
     rig_registry_root_in_root(config_root).join("stack-sources")
@@ -103,11 +84,6 @@ pub fn stack_sources() -> Result<PathBuf> {
 /// Stack source metadata file below an already-resolved config root.
 pub fn stack_source_metadata_in_root(config_root: &Path, id: &str) -> PathBuf {
     stack_sources_in_root(config_root).join(format!("{}.json", id))
-}
-
-/// Stack source metadata file (~/.config/homeboy/stack-sources/{id}.json)
-pub fn stack_source_metadata(id: &str) -> Result<PathBuf> {
-    Ok(stack_source_metadata_in_root(&homeboy()?, id))
 }
 
 /// Rig state directory below an already-resolved config root.
@@ -178,11 +154,6 @@ pub fn stacks() -> Result<PathBuf> {
 /// Stack config file path below an already-resolved config root.
 pub fn stack_config_in_root(config_root: &Path, id: &str) -> PathBuf {
     stacks_in_root(config_root).join(format!("{}.json", id))
-}
-
-/// Stack config file path (~/.config/homeboy/stacks/{id}.json)
-pub fn stack_config(id: &str) -> Result<PathBuf> {
-    Ok(stack_config_in_root(&homeboy()?, id))
 }
 
 #[cfg(test)]

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -403,7 +403,8 @@ mod install_flows {
         assert_eq!(result.installed.len(), 1);
         assert_eq!(result.installed_stacks.len(), 1);
         assert_eq!(result.installed_stacks[0].id, "studio-combined");
-        let installed = homeboy_core::paths::stack_config("studio-combined").expect("stack path");
+        let installed =
+            homeboy_core::paths::stack_config_in_root(&test_config_root(), "studio-combined");
         assert!(installed.exists());
         #[cfg(unix)]
         assert_eq!(fs::read_link(&installed).expect("symlink"), stack_path);
@@ -468,7 +469,7 @@ mod install_flows {
 
             assert_eq!(result.installed_stacks.len(), 1);
             let installed =
-                homeboy_core::paths::stack_config("studio-combined").expect("stack path");
+                homeboy_core::paths::stack_config_in_root(&test_config_root(), "studio-combined");
             assert!(installed.exists());
             #[cfg(unix)]
             assert_eq!(fs::read_link(&installed).expect("symlink"), stack_path);
@@ -1389,8 +1390,11 @@ mod multi_rig {
         assert!(homeboy_core::paths::rig_config("alpha").unwrap().exists());
         assert!(!homeboy_core::paths::rig_config("beta").unwrap().exists());
         assert_eq!(
-            fs::read_link(homeboy_core::paths::stack_config("stale-stack").unwrap())
-                .expect("stale stack symlink remains reported by sources list"),
+            fs::read_link(homeboy_core::paths::stack_config_in_root(
+                &test_config_root(),
+                "stale-stack"
+            ))
+            .expect("stale stack symlink remains reported by sources list"),
             stale_stack
         );
     }
@@ -1595,7 +1599,7 @@ mod refresh_and_identity {
 
         fs::create_dir_all(homeboy_core::paths::stacks().expect("stacks dir")).expect("stacks dir");
         fs::write(
-            homeboy_core::paths::stack_config("studio-combined").expect("stack path"),
+            homeboy_core::paths::stack_config_in_root(&test_config_root(), "studio-combined"),
             fs::read_to_string(&stack_path).expect("package stack"),
         )
         .expect("existing stack");
@@ -1625,7 +1629,7 @@ mod refresh_and_identity {
 
         fs::create_dir_all(homeboy_core::paths::stacks().expect("stacks dir")).expect("stacks dir");
         let stack_config =
-            homeboy_core::paths::stack_config("studio-combined").expect("stack path");
+            homeboy_core::paths::stack_config_in_root(&test_config_root(), "studio-combined");
         fs::write(&stack_config, &manual_stack).expect("conflicting stack");
 
         let err = install(
@@ -1741,12 +1745,14 @@ mod git_url {
         assert!(!homeboy_core::paths::rig_config("other").unwrap().exists());
         assert_eq!(result.installed_stacks.len(), 1);
         assert_eq!(result.installed_stacks[0].id, "studio-combined");
-        assert!(homeboy_core::paths::stack_config("studio-combined")
-            .unwrap()
-            .exists());
-        assert!(!homeboy_core::paths::stack_config("root-combined")
-            .unwrap()
-            .exists());
+        assert!(
+            homeboy_core::paths::stack_config_in_root(&test_config_root(), "studio-combined")
+                .exists()
+        );
+        assert!(
+            !homeboy_core::paths::stack_config_in_root(&test_config_root(), "root-combined")
+                .exists()
+        );
 
         let metadata =
             read_source_metadata_in_root(&test_config_root(), "studio").expect("metadata");

--- a/tests/core/rig/runner_observation_test.rs
+++ b/tests/core/rig/runner_observation_test.rs
@@ -519,7 +519,11 @@ fn git_output(repo: &std::path::Path, args: &[&str]) -> String {
 }
 
 fn write_rig_source_metadata(rig_id: &str) {
-    let path = paths::rig_source_metadata(rig_id).expect("metadata path");
+    let config_root = paths::PathRoots::from_environment()
+        .expect("path roots")
+        .config()
+        .to_path_buf();
+    let path = paths::rig_source_metadata_in_root(&config_root, rig_id);
     std::fs::create_dir_all(path.parent().expect("metadata parent")).expect("metadata dir");
     std::fs::write(
         path,

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -158,7 +158,7 @@ fn list_sources_reports_stack_specs_from_package() {
 #[test]
 fn sources_list_reports_legacy_stack_without_inferring_or_mutating_provenance() {
     let _home = HomeGuard::new();
-    let config = homeboy_core::paths::stack_config("legacy").expect("stack config");
+    let config = homeboy_core::paths::stack_config_in_root(&test_config_root(), "legacy");
     fs::create_dir_all(config.parent().expect("stacks dir")).expect("stacks dir");
     let content = minimal_stack("legacy", "legacy")
         .replace("${env.DEV_ROOT}/legacy", "/definitely/missing/legacy");
@@ -197,9 +197,9 @@ fn sources_list_reports_legacy_stack_without_inferring_or_mutating_provenance() 
         fs::read_to_string(&config).expect("legacy stack unchanged"),
         content
     );
-    assert!(!homeboy_core::paths::stack_source_metadata("legacy")
-        .expect("metadata path")
-        .exists());
+    assert!(
+        !homeboy_core::paths::stack_source_metadata_in_root(&test_config_root(), "legacy").exists()
+    );
 }
 
 #[test]
@@ -226,12 +226,12 @@ fn test_remove_source() {
     assert!(result.removed_package_path.is_none());
     assert!(!homeboy_core::paths::rig_config("alpha").unwrap().exists());
     assert!(!homeboy_core::paths::rig_config("beta").unwrap().exists());
-    assert!(!homeboy_core::paths::rig_source_metadata("alpha")
-        .unwrap()
-        .exists());
-    assert!(!homeboy_core::paths::rig_source_metadata("beta")
-        .unwrap()
-        .exists());
+    assert!(
+        !homeboy_core::paths::rig_source_metadata_in_root(&test_config_root(), "alpha").exists()
+    );
+    assert!(
+        !homeboy_core::paths::rig_source_metadata_in_root(&test_config_root(), "beta").exists()
+    );
     assert!(manual.exists());
     assert!(package.path().exists());
 }
@@ -258,9 +258,9 @@ fn remove_source_preserves_replaced_config_but_drops_metadata() {
     assert!(result.removed.is_empty());
     assert_eq!(result.skipped.len(), 1);
     assert!(config.exists());
-    assert!(!homeboy_core::paths::rig_source_metadata("alpha")
-        .unwrap()
-        .exists());
+    assert!(
+        !homeboy_core::paths::rig_source_metadata_in_root(&test_config_root(), "alpha").exists()
+    );
 }
 
 #[test]
@@ -277,7 +277,7 @@ fn remove_source_preserves_replaced_stack_config_but_drops_metadata() {
         false,
     )
     .expect("install");
-    let config = homeboy_core::paths::stack_config("alpha-combined").expect("stack config");
+    let config = homeboy_core::paths::stack_config_in_root(&test_config_root(), "alpha-combined");
     fs::remove_file(&config).expect("remove symlink");
     fs::write(&config, minimal_stack("alpha-combined", "manual")).expect("replacement stack");
 
@@ -287,11 +287,11 @@ fn remove_source_preserves_replaced_stack_config_but_drops_metadata() {
     assert!(result.removed_stacks.is_empty());
     assert_eq!(result.skipped_stacks.len(), 1);
     assert!(config.exists());
-    assert!(
-        !homeboy_core::paths::stack_source_metadata("alpha-combined")
-            .unwrap()
-            .exists()
-    );
+    assert!(!homeboy_core::paths::stack_source_metadata_in_root(
+        &test_config_root(),
+        "alpha-combined"
+    )
+    .exists());
 }
 
 #[test]
@@ -319,9 +319,9 @@ fn remove_source_treats_copied_config_as_owned_when_contents_match() {
     assert_eq!(result.removed.len(), 1);
     assert!(result.skipped.is_empty());
     assert!(!config.exists());
-    assert!(!homeboy_core::paths::rig_source_metadata("alpha")
-        .unwrap()
-        .exists());
+    assert!(
+        !homeboy_core::paths::rig_source_metadata_in_root(&test_config_root(), "alpha").exists()
+    );
 }
 
 #[test]
@@ -330,12 +330,12 @@ fn sources_list_reports_corrupt_metadata_and_missing_configs() {
     fs::create_dir_all(homeboy_core::paths::rig_sources().expect("sources dir"))
         .expect("sources dir");
     fs::write(
-        homeboy_core::paths::rig_source_metadata("broken").expect("broken metadata"),
+        homeboy_core::paths::rig_source_metadata_in_root(&test_config_root(), "broken"),
         "not json",
     )
     .expect("broken metadata");
     fs::write(
-        homeboy_core::paths::rig_source_metadata("missing").expect("missing metadata"),
+        homeboy_core::paths::rig_source_metadata_in_root(&test_config_root(), "missing"),
         r#"{
             "source": "/tmp/package",
             "package_path": "/tmp/package",
@@ -437,13 +437,13 @@ fn sources_list_skips_non_json_and_collects_invalid_stack_metadata() {
     )
     .expect("non-json metadata");
     fs::write(
-        homeboy_core::paths::stack_source_metadata("broken-stack").expect("stack metadata"),
+        homeboy_core::paths::stack_source_metadata_in_root(&test_config_root(), "broken-stack"),
         "not json",
     )
     .expect("broken stack metadata");
     fs::create_dir_all(homeboy_core::paths::stacks().expect("stacks dir")).expect("stacks dir");
     fs::write(
-        homeboy_core::paths::stack_config("broken-stack").expect("stack config"),
+        homeboy_core::paths::stack_config_in_root(&test_config_root(), "broken-stack"),
         minimal_stack("broken-stack", "broken"),
     )
     .expect("installed stack");
@@ -532,9 +532,11 @@ fn update_git_source_refreshes_owned_stack_specs() {
     assert_eq!(result.updated_stacks.len(), 1);
     assert_eq!(result.updated_stacks[0].id, "alpha-combined");
     assert_ne!(result.updated_stacks[0].source_revision, before);
-    let installed =
-        fs::read_to_string(homeboy_core::paths::stack_config("alpha-combined").unwrap())
-            .expect("installed stack");
+    let installed = fs::read_to_string(homeboy_core::paths::stack_config_in_root(
+        &test_config_root(),
+        "alpha-combined",
+    ))
+    .expect("installed stack");
     assert!(installed.contains("updated stack"));
     let metadata = crate::read_stack_source_metadata_in_root(&test_config_root(), "alpha-combined")
         .expect("refreshed stack metadata");
@@ -557,7 +559,7 @@ fn legacy_source_without_a_valid_discovery_path_fails_before_refresh_mutation() 
     metadata.discovery_path = None;
     metadata.package_path = "relative-package-with-unknown-provenance".to_string();
     fs::write(
-        homeboy_core::paths::rig_source_metadata("alpha").expect("metadata path"),
+        homeboy_core::paths::rig_source_metadata_in_root(&test_config_root(), "alpha"),
         serde_json::to_vec_pretty(&metadata).expect("serialize metadata"),
     )
     .expect("write legacy metadata");
@@ -702,7 +704,7 @@ fn update_git_source_skips_user_replaced_stack_specs() {
     let source = bare_source_path(&bare).to_string_lossy().to_string();
 
     install(&test_config_root(), &source, None, false).expect("install");
-    let config = homeboy_core::paths::stack_config("alpha-combined").expect("stack config");
+    let config = homeboy_core::paths::stack_config_in_root(&test_config_root(), "alpha-combined");
     fs::remove_file(&config).expect("remove symlink");
     fs::write(&config, minimal_stack("alpha-combined", "manual")).expect("manual stack");
     fs::write(


### PR DESCRIPTION
First substantial subtraction of this migration. **406 pairs → 392**, net **−67 lines**.

## What went

| crate | wrappers deleted |
|---|---|
| `paths` | `stack_config`, `rig_source_metadata`, `stack_source_metadata`, `rig_package`, `rig_registry_root`, `agent_runtime_manifest`, `backups` |
| `agents` | `claim_next_queued_run`, `claim_next_eligible_queued_run`, `claim_next_eligible_queued_run_with_preflight`, `ensure_record_workspace_owner`, `reached_freeze_boundary` |
| `core` | `migrate_legacy_pin_and_persist`, `inflight_entries` |

The three `paths` rig wrappers had 22 test callers. Those tests **already had a `test_config_root()` helper and used it 63 times elsewhere in the same files** — so this was finishing a pattern, not introducing one. Ambient resolution now sits in one helper per file instead of spread across 22 call sites.

## The guard from #13123 earned its place immediately

Removing `claim_next_queued_run` from a re-export list orphaned `claim_next_eligible_queued_run`. Deleting *that* orphaned `claim_next_eligible_queued_run_with_preflight`.

**A three-deep chain of dead delegation**, and nothing else reported it — `pub` items don't warn when they become unreachable across crates. Without the guard those two would still be sitting there looking load-bearing.

## One near-miss worth recording

I nearly deleted `terminal_artifact_projection_readiness_bounded`. It has zero *call sites* — because it's passed as a **function pointer** to `status_with`:

```rust
self.status_with(
    batch_id,
    agent_task_lifecycle::persisted_status,
    agent_task_lifecycle::terminal_artifact_projection_readiness_bounded,
)
```

No call-site scan can see that. `cargo check` caught it, and the guard test would have too — it counts *mentions*, not calls, which is exactly why it's deliberately blunt. Kept, and the comment beneath it already documented the pair as intentional.

`inflight_dir` survives as `#[cfg(test)]` — only tests still resolve it ambiently.

## Runway

Remaining wrappers by production callers left:

| callers left | wrappers |
|--:|--:|
| **0** | **27** ⬅ next |
| 1 | ~85 |
| 2 | ~56 |
| 3 | ~35 |
| 6+ | ~162 |

Front-loaded. The first three buckets are most of the deletions and they're the easy ones.

## Verification

- `cargo check --workspace --tests -j2` — green, no warnings
- `no_orphaned_ambient_wrappers_test` — passes, and drove the cascade discovery

Refs #7505.