### PR TITLE
fix(runner): preserve terminal daemon report errors

### DIFF
--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -293,6 +293,7 @@ pub(super) fn exec_via_reverse_broker(
         },
         job,
         |_| Ok(()),
+        |_| Ok(()),
         |current| {
             fetch_daemon_job_resilient(&client, broker_url, &current.id.to_string()).map_err(
                 |err| {
@@ -312,7 +313,7 @@ pub(super) fn exec_via_reverse_broker(
                 },
             )
         },
-        |job_id| fetch_daemon_events(&client, broker_url, job_id),
+        |job| fetch_daemon_events(&client, broker_url, &job.id.to_string()),
         |job, events, result| {
             let request = crate::evidence::MirrorEvidenceRequest::new(
                 runner,

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -224,6 +224,9 @@ pub(super) fn exec_via_daemon(
                     )?;
                 }
             }
+            Ok(())
+        },
+        |job| {
             if let Some(run_id) = run_id.as_deref() {
                 let token = uuid::Uuid::new_v4().to_string();
                 let store = lease_store
@@ -283,7 +286,11 @@ pub(super) fn exec_via_daemon(
             *daemon_endpoint.borrow_mut() = endpoint;
             Ok(refreshed)
         },
-        |job_id| fetch_daemon_events(&client, &daemon_endpoint.borrow(), job_id),
+        |job| {
+            fetch_daemon_events(&client, &daemon_endpoint.borrow(), &job.id.to_string()).map_err(
+                |error| lab_terminal_result_transport_error(runner, &cwd, &command, job, error),
+            )
+        },
         |job, events, result| {
             let request = crate::evidence::MirrorEvidenceRequest::new(
                 runner,

--- a/crates/homeboy-lab-runner/src/execution/job_flow.rs
+++ b/crates/homeboy-lab-runner/src/execution/job_flow.rs
@@ -48,10 +48,19 @@ pub(super) struct SubmittedRunnerJobFlow<'a> {
     clippy::too_many_arguments,
     reason = "Transport hooks keep HTTP and lease semantics outside the shared lifecycle."
 )]
-pub(super) fn complete_submitted_runner_job<Accepted, Poll, Events, Mirror, AfterEvents, Finalize>(
+pub(super) fn complete_submitted_runner_job<
+    Accepted,
+    AfterHandoff,
+    Poll,
+    Events,
+    Mirror,
+    AfterEvents,
+    Finalize,
+>(
     flow: SubmittedRunnerJobFlow<'_>,
     mut job: Job,
     mut accepted: Accepted,
+    mut after_handoff: AfterHandoff,
     mut poll: Poll,
     mut events: Events,
     mirror: Mirror,
@@ -60,8 +69,9 @@ pub(super) fn complete_submitted_runner_job<Accepted, Poll, Events, Mirror, Afte
 ) -> Result<(RunnerExecOutput, i32)>
 where
     Accepted: FnMut(&Job) -> Result<()>,
+    AfterHandoff: FnMut(&Job) -> Result<()>,
     Poll: FnMut(&Job) -> Result<Job>,
-    Events: FnMut(&str) -> Result<Vec<JobEvent>>,
+    Events: FnMut(&Job) -> Result<Vec<JobEvent>>,
     Mirror: FnOnce(&Job, &[JobEvent], &serde_json::Value) -> Result<Option<MirroredJobEvidence>>,
     AfterEvents: FnMut() -> Result<()>,
     Finalize: FnMut(&Job, &[JobArtifactMetadata]) -> Result<()>,
@@ -132,6 +142,7 @@ where
         flow.run_id.as_deref(),
         persisted_run_id.as_deref(),
     )?;
+    after_handoff(&job)?;
     if flow.detach_after_handoff {
         return Ok(detached_handoff_output(
             flow.runner,
@@ -152,7 +163,7 @@ where
     while !job.status.is_terminal() {
         let job_id = job.id.to_string();
         if Instant::now() >= deadline {
-            let events = events(&job_id)
+            let events = events(&job)
                 .map(|events| {
                     redact_runner_job_events(&events, flow.redaction_env, flow.secret_env_names)
                 })
@@ -175,7 +186,7 @@ where
         }
         std::thread::sleep(Duration::from_millis(200));
         job = poll(&job)?;
-        if let Ok(events) = events(&job_id) {
+        if let Ok(events) = events(&job) {
             let events =
                 redact_runner_job_events(&events, flow.redaction_env, flow.secret_env_names);
             record_and_report_promotion_progress_frames(
@@ -187,7 +198,7 @@ where
         }
     }
     let job_id = job.id.to_string();
-    let mut job_events = events(&job_id).map(|events| {
+    let mut job_events = events(&job).map(|events| {
         redact_runner_job_events(&events, flow.redaction_env, flow.secret_env_names)
     })?;
     record_and_report_promotion_progress_frames(


### PR DESCRIPTION
## Context
Follow-up to #7514 and #13133. The original PR merged before this warning/timing correction; this PR intentionally does not close the already-closed issue.

## Change
- reuse the direct-daemon terminal-report transport error wrapper through the shared job-flow event hook
- preserve foreground lease acquisition after durable handoff persistence, including detached execution timing

## Verification
- `cargo fmt --check`
- `RUSTFLAGS=-Dwarnings cargo check -p homeboy-lab-runner`
- `cargo test -p homeboy-lab-runner execution::tests::handoff --lib -- --test-threads=1` (34 passed)

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode was used to trace the warning to the extracted shared job flow, preserve the terminal daemon error contract and handoff timing, and run focused verification. Chris Huber reviewed and remains responsible for the change.