### PR TITLE
ci: use dev profile for release planning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,6 +184,10 @@ jobs:
         uses: Extra-Chill/homeboy-action@v2
         with:
           source: '.'
+          # Planning is read-only and executes for seconds after compilation.
+          # Keep candidate-binary manifest compatibility without paying for
+          # release-profile optimization before the real build job.
+          source-build-profile: dev
           commands: release
           expected-commands: review audit,review lint,review test
           args: --skip-checks=audit,lint,test

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -2055,14 +2055,20 @@ fn release_dry_run_establishes_its_branch_instead_of_claiming_release_head() {
 /// The release check parses the current extension manifests before the
 /// downstream build job exists. It must therefore run the candidate Homeboy
 /// contract, not the latest published binary, which may predate those manifests.
+/// Planning is read-only, so optimizing that short-lived binary only extends the
+/// serial release path without strengthening this compatibility proof.
 #[test]
-fn release_dry_run_bootstraps_with_the_candidate_binary() {
+fn release_dry_run_bootstraps_a_dev_profile_candidate_binary() {
     let check = job_section(release_workflow(), "check");
     let dry_run = release_step_block(check, "name: Dry-run release check");
 
     assert!(
         dry_run.contains("source: '.'"),
         "the self-release check must build the candidate before installing current extensions"
+    );
+    assert!(
+        dry_run.contains("source-build-profile: dev"),
+        "read-only release planning must not pay for release-profile optimization"
     );
     assert!(
         !dry_run.contains("version:"),


### PR DESCRIPTION
## Summary

- compile the candidate Homeboy planner with Cargo's `dev` profile
- retain `source: .` so current extension manifests are parsed by the candidate binary
- pin the workflow contract with a focused release test

Tracks #11751 W1-13. Depends on Extra-Chill/homeboy-action#423; merge and release that owning-layer input first.

The measured failing Release run spent 7m51s optimizing the source-built planner before executing the actual release plan in 7.5s. This removes release-profile optimization from that serial planning stage without substituting a stale published binary.

## Verification

- `cargo test --locked --test release_workflow_test release_dry_run_bootstraps_a_dev_profile_candidate_binary` (1 passed)
- `cargo fmt --all --check`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced the release-planning compatibility contract, implemented the dependent workflow opt-in and regression test, and ran verification. Chris Huber reviewed and remains responsible for every line.