### PR TITLE
fix(cook): defer gate remediation classification

### DIFF
--- a/crates/homeboy-agents/src/agent_task_cook_loop.rs
+++ b/crates/homeboy-agents/src/agent_task_cook_loop.rs
@@ -83,6 +83,9 @@ pub enum AgentTaskCookLoopStatus {
     /// The candidate and immutable baseline failed identically. The candidate
     /// is not a regression, but required verification is still red.
     BaselineRed,
+    /// Immutable-base replay could not establish whether the candidate failed
+    /// differently, so provider remediation is intentionally withheld.
+    BaselineInconclusive,
     IntentionalNoChange,
     NoChanges,
     NoOpGateFailed,
@@ -240,6 +243,17 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
                         && comparison.matches_candidate_failure
                 })
         });
+    let baseline_inconclusive = options
+        .promotion_report
+        .deterministic_gates
+        .iter()
+        .any(|gate| {
+            gate.status == AgentTaskGateStatus::Failed
+                && gate.baseline_comparison.as_ref().is_some_and(|comparison| {
+                    comparison.result
+                        == crate::agent_task_gate::AgentTaskGateDifferentialResult::Inconclusive
+                })
+        });
     let intentional_no_change = (options.promotion_report.status
         == AgentTaskPromotionStatus::VerifiedNoChanges)
         .then(|| {
@@ -256,9 +270,31 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
     apply_failure_progression_to_quality(&mut quality, &failure_progression);
     let should_retry = options.promotion_report.status == AgentTaskPromotionStatus::GateFailed
         && !failed_gates.is_empty()
-        && failed_gates
+        // A candidate-code label describes the candidate-side observation; it is
+        // not remediation authority until immutable-base replay proves a delta.
+        // This prevents a shared path or environment failure from consuming a
+        // provider attempt before it can be classified as inherited.
+        && options
+            .promotion_report
+            .deterministic_gates
             .iter()
-            .all(|gate| gate.classification == AgentTaskGateFailureClassification::CandidateCode)
+            .filter(|gate| {
+                matches!(
+                    gate.status,
+                    AgentTaskGateStatus::Failed | AgentTaskGateStatus::AcceptedInheritedFailure
+                )
+            })
+            .all(|gate| {
+                gate.failure_evidence
+                    .as_ref()
+                    .is_some_and(|evidence| {
+                        evidence.classification == AgentTaskGateFailureClassification::CandidateCode
+                    })
+                    && gate.baseline_comparison.as_ref().is_some_and(|comparison| {
+                        comparison.result
+                            == crate::agent_task_gate::AgentTaskGateDifferentialResult::CandidateRegression
+                    })
+            })
         && !baseline_red
         && retry_budget_remaining > 0;
     // Deterministic gates take precedence: a red gate must be fixed before the
@@ -297,6 +333,8 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
         AgentTaskCookLoopStatus::NoChanges
     } else if baseline_red {
         AgentTaskCookLoopStatus::BaselineRed
+    } else if baseline_inconclusive {
+        AgentTaskCookLoopStatus::BaselineInconclusive
     } else if !failed_gates.is_empty() {
         AgentTaskCookLoopStatus::RetriesExhausted
     } else if matches!(&review_form_gap, Some(Some(_))) {
@@ -321,7 +359,12 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
         failed_gate_results,
         follow_up_request,
         intentional_no_change,
-        metadata: report_metadata(options.metadata, &failure_progression, baseline_red),
+        metadata: report_metadata(
+            options.metadata,
+            &failure_progression,
+            baseline_red,
+            baseline_inconclusive,
+        ),
     }
 }
 
@@ -773,6 +816,7 @@ fn report_metadata(
     metadata: Value,
     progression: &AgentTaskCookLoopFailureProgression,
     baseline_red: bool,
+    baseline_inconclusive: bool,
 ) -> Value {
     let mut metadata = metadata.as_object().cloned().unwrap_or_default();
     metadata.insert("failure_progression".to_string(), json!(progression));
@@ -781,6 +825,19 @@ fn report_metadata(
         metadata.insert(
             "failure_origin".to_string(),
             Value::String("inherited_infrastructure".to_string()),
+        );
+    }
+    if baseline_inconclusive {
+        metadata.insert("baseline_inconclusive".to_string(), Value::Bool(true));
+        metadata.insert(
+            "failure_origin".to_string(),
+            Value::String("baseline_replay_inconclusive".to_string()),
+        );
+        metadata.insert(
+            "next_action".to_string(),
+            Value::String(
+                "repair the gate baseline setup or replay environment, then rerun Cook".to_string(),
+            ),
         );
     }
     Value::Object(metadata)
@@ -1048,6 +1105,143 @@ mod tests {
             report.failed_gates[0].classification,
             AgentTaskGateFailureClassification::GateDeclaration
         );
+    }
+
+    #[test]
+    fn unclassified_candidate_gate_failure_does_not_spend_remediation_budget() {
+        let report = evaluate_cook_loop(AgentTaskCookLoopOptions {
+            source_request: source_request(),
+            promotion_report: promotion_report(
+                AgentTaskPromotionStatus::GateFailed,
+                vec![AgentTaskGateReport::new(
+                    "gate-1",
+                    vec![
+                        "sh".to_string(),
+                        "-lc".to_string(),
+                        "opaque-gate".to_string(),
+                    ],
+                    1,
+                    "",
+                    "candidate gate failure",
+                    Some(AgentTaskGateFailureEvidence {
+                        classification: AgentTaskGateFailureClassification::CandidateCode,
+                        summary: "candidate gate failed".to_string(),
+                        command: "opaque-gate".to_string(),
+                        exit_code: 1,
+                        stdout_tail: String::new(),
+                        stderr_tail: "candidate gate failure".to_string(),
+                        agent_feedback: "Fix the candidate gate failure.".to_string(),
+                        diagnostics: Vec::new(),
+                    }),
+                    AgentTaskGateVisibility::Visible,
+                    AgentTaskGateRevealPolicy::FullEvidence,
+                    AgentTaskGateEnvironment::default(),
+                )],
+            ),
+            attempt: 1,
+            max_attempts: 3,
+            source_run_id: Some("run-provisional".to_string()),
+            current_diff: String::new(),
+            require_review_form: false,
+            review_form: None,
+            metadata: Value::Null,
+        });
+
+        assert_eq!(report.status, AgentTaskCookLoopStatus::RetriesExhausted);
+        assert!(report.follow_up_request.is_none());
+    }
+
+    #[test]
+    fn intrinsic_failures_cannot_be_accepted_or_finalized_from_a_red_baseline() {
+        for classification in [
+            AgentTaskGateFailureClassification::GateDeclaration,
+            AgentTaskGateFailureClassification::ZeroTestsSelected,
+        ] {
+            let mut gate = failed_gate();
+            gate.failure_evidence
+                .as_mut()
+                .expect("failure evidence")
+                .classification = classification;
+            gate.baseline_comparison
+                .as_mut()
+                .expect("comparison")
+                .result = crate::agent_task_gate::AgentTaskGateDifferentialResult::BaselineRed;
+            gate.baseline_comparison
+                .as_mut()
+                .expect("comparison")
+                .matches_candidate_failure = true;
+            gate.accept_inherited_failure();
+            assert_eq!(gate.status, AgentTaskGateStatus::Failed);
+
+            // Defend persisted reports too: a malformed historical status cannot
+            // make an intrinsic failure eligible for explicit acceptance.
+            gate.status = AgentTaskGateStatus::AcceptedInheritedFailure;
+            let promotion = promotion_report(AgentTaskPromotionStatus::GateFailed, vec![gate]);
+            assert!(!promotion.finalization_eligible(true));
+        }
+    }
+
+    #[test]
+    fn inconclusive_baseline_replay_is_terminal_with_recovery_action() {
+        let mut gate = failed_gate();
+        gate.baseline_comparison
+            .as_mut()
+            .expect("comparison")
+            .result = crate::agent_task_gate::AgentTaskGateDifferentialResult::Inconclusive;
+        let report = evaluate_cook_loop(AgentTaskCookLoopOptions {
+            source_request: source_request(),
+            promotion_report: promotion_report(AgentTaskPromotionStatus::GateFailed, vec![gate]),
+            attempt: 1,
+            max_attempts: 3,
+            source_run_id: Some("run-inconclusive".to_string()),
+            current_diff: String::new(),
+            require_review_form: false,
+            review_form: None,
+            metadata: Value::Null,
+        });
+
+        assert_eq!(report.status, AgentTaskCookLoopStatus::BaselineInconclusive);
+        assert!(report.follow_up_request.is_none());
+        assert_eq!(
+            report.metadata["failure_origin"],
+            "baseline_replay_inconclusive"
+        );
+        assert!(report.metadata["next_action"]
+            .as_str()
+            .is_some_and(|action| action.contains("replay environment")));
+    }
+
+    #[test]
+    fn ordered_fail_fast_skip_does_not_block_a_proven_candidate_regression() {
+        let skipped = AgentTaskGateReport::skipped(
+            "gate-2",
+            vec![
+                "sh".to_string(),
+                "-lc".to_string(),
+                "later-gate".to_string(),
+            ],
+            AgentTaskGateVisibility::Visible,
+            AgentTaskGateRevealPolicy::FullEvidence,
+            "gate-1",
+        );
+        let report = evaluate_cook_loop(AgentTaskCookLoopOptions {
+            source_request: source_request(),
+            promotion_report: promotion_report(
+                AgentTaskPromotionStatus::GateFailed,
+                vec![failed_gate(), skipped],
+            ),
+            attempt: 1,
+            max_attempts: 3,
+            source_run_id: Some("run-ordered-fail-fast".to_string()),
+            current_diff: String::new(),
+            require_review_form: false,
+            review_form: None,
+            metadata: Value::Null,
+        });
+
+        assert_eq!(report.status, AgentTaskCookLoopStatus::RetryRequested);
+        assert_eq!(report.failed_gates.len(), 1);
+        assert_eq!(report.failed_gates[0].gate_id, "gate-1");
     }
 
     #[test]
@@ -2090,7 +2284,7 @@ mod tests {
     }
 
     fn failed_gate() -> AgentTaskGateReport {
-        AgentTaskGateReport::new(
+        let mut gate = AgentTaskGateReport::new(
             "gate-1",
             vec![
                 "sh".to_string(),
@@ -2113,7 +2307,15 @@ mod tests {
             AgentTaskGateVisibility::Visible,
             AgentTaskGateRevealPolicy::FullEvidence,
             AgentTaskGateEnvironment::default(),
-        )
+        );
+        gate.baseline_comparison = Some(crate::agent_task_gate::AgentTaskGateBaselineComparison {
+            base_ref: "base".to_string(),
+            exit_code: 0,
+            failure_fingerprint: String::new(),
+            matches_candidate_failure: false,
+            result: crate::agent_task_gate::AgentTaskGateDifferentialResult::CandidateRegression,
+        });
+        gate
     }
 
     fn green_gate() -> AgentTaskGateReport {
@@ -2135,7 +2337,7 @@ mod tests {
     }
 
     fn private_failed_gate(reveal_policy: AgentTaskGateRevealPolicy) -> AgentTaskGateReport {
-        AgentTaskGateReport::new(
+        let mut gate = AgentTaskGateReport::new(
             "gate-1",
             vec![
                 "sh".to_string(),
@@ -2158,6 +2360,14 @@ mod tests {
             AgentTaskGateVisibility::Private,
             reveal_policy,
             AgentTaskGateEnvironment::default(),
-        )
+        );
+        gate.baseline_comparison = Some(crate::agent_task_gate::AgentTaskGateBaselineComparison {
+            base_ref: "base".to_string(),
+            exit_code: 0,
+            failure_fingerprint: String::new(),
+            matches_candidate_failure: false,
+            result: crate::agent_task_gate::AgentTaskGateDifferentialResult::CandidateRegression,
+        });
+        gate
     }
 }

--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -1257,6 +1257,14 @@ impl AgentTaskGateReport {
     }
 
     pub(crate) fn accept_inherited_failure(&mut self) {
+        // Only a candidate-code failure can be explained by an identical base
+        // replay. Gate declarations and invalid focused selections are intrinsic
+        // policy failures, even when the base has the same bad configuration.
+        if !self.failure_evidence.as_ref().is_some_and(|evidence| {
+            evidence.classification == AgentTaskGateFailureClassification::CandidateCode
+        }) {
+            return;
+        }
         self.status = AgentTaskGateStatus::AcceptedInheritedFailure;
         let gate_result = HomeboyGateResult::new(
             self.id.clone(),

--- a/crates/homeboy-agents/src/agent_task_promotion/types.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/types.rs
@@ -93,6 +93,10 @@ impl AgentTaskPromotionReport {
                 AgentTaskGateStatus::Succeeded => gate.exit_code == 0,
                 AgentTaskGateStatus::AcceptedInheritedFailure => {
                     accept_inherited_failures
+                        && gate.failure_evidence.as_ref().is_some_and(|evidence| {
+                            evidence.classification
+                                == crate::agent_task_gate::AgentTaskGateFailureClassification::CandidateCode
+                        })
                         && gate.baseline_comparison.as_ref().is_some_and(|comparison| {
                             comparison.matches_candidate_failure
                                 && comparison.result

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -6072,6 +6072,21 @@ fn run_cook_spine(
                     invocation_latest_run_id: Some(&run_id),
                 }));
             }
+            AgentTaskCookLoopStatus::BaselineInconclusive => {
+                return Ok(cook_report(CookReportInput {
+                    cook_id,
+                    status: "baseline_inconclusive",
+                    disposition: CookDisposition::Terminal,
+                    attempts,
+                    finalization: None,
+                    stop_reason: Some(
+                        "immutable baseline replay was inconclusive; repair the gate baseline setup or replay environment before rerunning Cook"
+                            .to_string(),
+                    ),
+                    exit_code: 1,
+                    invocation_latest_run_id: Some(&run_id),
+                }));
+            }
             AgentTaskCookLoopStatus::NoChanges => {
                 return Ok(cook_report(CookReportInput {
                     cook_id,

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -854,6 +854,20 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
             }));
         }
     }
+    if feedback.status == AgentTaskCookLoopStatus::BaselineInconclusive {
+        let reason = "immutable baseline replay was inconclusive; repair the gate baseline setup or replay environment before retrying adoption";
+        lifecycle_store.finish_candidate_adoption(&record.run_id, Some(reason.to_string()))?;
+        return Ok(cook_report(CookReportInput {
+            cook_id: cook_id.to_string(),
+            status: "baseline_inconclusive",
+            disposition: CookDisposition::Terminal,
+            attempts: vec![attempt],
+            finalization: None,
+            stop_reason: Some(reason.to_string()),
+            exit_code: 1,
+            invocation_latest_run_id: Some(record.run_id.as_str()),
+        }));
+    }
     if feedback.status != AgentTaskCookLoopStatus::GreenCompleted
         && !(feedback.status == AgentTaskCookLoopStatus::BaselineRed
             && options.gates.accept_inherited_failures

--- a/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
@@ -806,7 +806,8 @@ pub(crate) fn git_output_with_env(
 mod tests {
     use super::*;
     use crate::agent_task_gate::{
-        AgentTaskGateEnvironment, AgentTaskGateRevealPolicy, AgentTaskGateStatus,
+        AgentTaskGateEnvironment, AgentTaskGateFailureClassification, AgentTaskGateFailureEvidence,
+        AgentTaskGateRevealPolicy, AgentTaskGateStatus,
     };
     use homeboy_core::gate::HomeboyGateVisibility;
     use sha2::{Digest, Sha256};
@@ -921,5 +922,80 @@ mod tests {
                 crate::agent_task_promotion::AgentTaskPromotionStatus::GateFailed
             );
         }
+    }
+
+    #[test]
+    fn differential_gate_comparison_accepts_an_identical_missing_monorepo_path() {
+        let temp = tempfile::tempdir().expect("repository");
+        git_output(temp.path(), &["init", "-b", "main"]).expect("init");
+        git_output(temp.path(), &["config", "user.name", "Homeboy Test"]).expect("name");
+        git_output(temp.path(), &["config", "user.email", "test@example.test"]).expect("email");
+        std::fs::write(temp.path().join("README"), "base\n").expect("base file");
+        git_output(temp.path(), &["add", "README"]).expect("add");
+        git_output(temp.path(), &["commit", "-m", "base"]).expect("commit");
+        let base = git_output(temp.path(), &["rev-parse", "HEAD"]).expect("base sha");
+
+        let command = "cd packages/missing-component && cargo test";
+        let candidate = std::process::Command::new("sh")
+            .args(["-lc", command])
+            .current_dir(temp.path())
+            .output()
+            .expect("run candidate gate");
+        assert!(!candidate.status.success());
+        let mut promotion: AgentTaskPromotionReport = serde_json::from_value(serde_json::json!({
+            "schema": "homeboy/agent-task-promotion-report/v1",
+            "status": "gate_failed",
+            "source": {"kind": "aggregate", "task_id": "task"},
+            "to_worktree": "fixture",
+            "target": {"worktree": "fixture", "path": temp.path()},
+            "patch_artifact": {"id": "patch", "kind": "patch", "path": "patch"},
+            "deterministic_gates": [],
+            "operator_notification": {"status": "blocked", "message": "red"}
+        }))
+        .expect("promotion");
+        let stdout = String::from_utf8_lossy(&candidate.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&candidate.stderr).to_string();
+        let exit_code = candidate.status.code().unwrap_or(1);
+        let mut gate = crate::agent_task_gate::AgentTaskGateReport::new(
+            "monorepo-gate",
+            vec!["sh".to_string(), "-lc".to_string(), command.to_string()],
+            exit_code,
+            &stdout,
+            &stderr,
+            None,
+            HomeboyGateVisibility::Visible,
+            AgentTaskGateRevealPolicy::FullEvidence,
+            AgentTaskGateEnvironment::default(),
+        );
+        gate.failure_evidence = Some(AgentTaskGateFailureEvidence {
+            classification: AgentTaskGateFailureClassification::CandidateCode,
+            summary: "monorepo gate failed from its requested path".to_string(),
+            command: command.to_string(),
+            exit_code,
+            stdout_tail: stdout,
+            stderr_tail: stderr,
+            agent_feedback: "Repair the candidate gate failure.".to_string(),
+            diagnostics: Vec::new(),
+        });
+        promotion.deterministic_gates.push(gate);
+
+        compare_gate_failures_to_verified_base(
+            &mut promotion,
+            temp.path(),
+            &base,
+            std::time::Duration::from_secs(1),
+            |_compared, _total| Ok(()),
+        )
+        .expect("baseline comparison");
+
+        let gate = &promotion.deterministic_gates[0];
+        assert_eq!(gate.status, AgentTaskGateStatus::AcceptedInheritedFailure);
+        assert_eq!(
+            gate.baseline_comparison
+                .as_ref()
+                .expect("comparison")
+                .result,
+            AgentTaskGateDifferentialResult::BaselineRed
+        );
     }
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -13312,7 +13312,7 @@ fn adopted_baseline_gate_outcome_is_candidate_bound_and_recovery_safe() {
 }
 
 #[test]
-fn closed_observer_pipe_does_not_stop_explicitly_accepted_inherited_gate_finalization() {
+fn baseline_comparison_is_persisted_before_feedback_finalization() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let temp = tempfile::tempdir().expect("repository");
         let root = temp.path();
@@ -13340,6 +13340,8 @@ fn closed_observer_pipe_does_not_stop_explicitly_accepted_inherited_gate_finaliz
         options.to_worktree = root.display().to_string();
         options.source_worktree_path = Some(root.to_path_buf());
         options.max_attempts = 1;
+        options.initial_plan.tasks[0].executor.model = Some("test/model".to_string());
+        options.ai_model = Some("test/model".to_string());
         options.gates.accept_inherited_failures = true;
         options.gates.verify = vec!["cat failure >&2; exit 1".to_string()];
         options.initial_plan.options.execution_budget =
@@ -13352,7 +13354,7 @@ fn closed_observer_pipe_does_not_stop_explicitly_accepted_inherited_gate_finaliz
             record.metadata["provider_executions_consumed"] = serde_json::json!(1);
         })
         .unwrap();
-        let gate = crate::agent_task_gate::AgentTaskGateReport::new(
+        let mut gate = crate::agent_task_gate::AgentTaskGateReport::new(
             "verify-1",
             vec![
                 "sh".to_string(),
@@ -13367,6 +13369,17 @@ fn closed_observer_pipe_does_not_stop_explicitly_accepted_inherited_gate_finaliz
             crate::agent_task_gate::AgentTaskGateRevealPolicy::FullEvidence,
             crate::agent_task_gate::AgentTaskGateEnvironment::default(),
         );
+        gate.failure_evidence = Some(crate::agent_task_gate::AgentTaskGateFailureEvidence {
+            classification:
+                crate::agent_task_gate::AgentTaskGateFailureClassification::CandidateCode,
+            summary: "inherited gate failure".to_string(),
+            command: options.gates.verify[0].clone(),
+            exit_code: 1,
+            stdout_tail: String::new(),
+            stderr_tail: "inherited".to_string(),
+            agent_feedback: "Repair the candidate gate failure.".to_string(),
+            diagnostics: Vec::new(),
+        });
         let promotion: AgentTaskPromotionReport = serde_json::from_value(serde_json::json!({
             "schema": "homeboy/agent-task-promotion-report/v1",
             "status": "gate_failed",
@@ -13404,6 +13417,12 @@ fn closed_observer_pipe_does_not_stop_explicitly_accepted_inherited_gate_finaliz
                 move |_, _, received_run, promotion| {
                     finalization_count.fetch_add(1, Ordering::SeqCst);
                     assert_eq!(received_run, expected_run_id);
+                    let persisted = agent_task_lifecycle::status(received_run).unwrap();
+                    assert_eq!(
+                        persisted.metadata["latest_promotion"]["deterministic_gates"][0]
+                            ["baseline_comparison"]["result"],
+                        "baseline_red"
+                    );
                     assert_eq!(promotion.verified_base.as_ref().unwrap().sha, expected_base);
                     assert_eq!(
                         promotion.deterministic_gates[0]


### PR DESCRIPTION
## Summary

- require immutable-baseline candidate-regression evidence before provider remediation
- keep intrinsic gate declaration and zero-selection failures ineligible for inherited acceptance
- report inconclusive baseline replay as an explicit terminal recovery state
- preserve ordered fail-fast behavior and persist comparison evidence before feedback/finalization

## Verification

- `cargo test -p homeboy-agents differential_gate_comparison_accepts_an_identical_missing_monorepo_path`
- `cargo test -p homeboy-agents agent_task_cook_loop::tests::`
- `cargo test -p homeboy-agents baseline_comparison_is_persisted_before_feedback_finalization`
- `cargo fmt --check`
- `git diff --check`

Closes #13121

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode general coding and independent review agents implemented, corrected, tested, and reviewed the gate-classification lifecycle. Chris Huber remains responsible for every line.