### PR TITLE
fix(lab): exclude late snapshot context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: dtolnay/rust-toolchain@1.95.0
       - name: Run portable external resolver fixture subprocess tests
-        run: cargo test --locked -p homeboy-cli --lib commands::ci::external_check_detail_resolver::tests::discovery_invokes_cross_platform_fixture_for_success_unavailable_and_malformed
+        run: cargo test --locked -p homeboy-cli --features test-support --test external_check_detail_resolver_fixture
 
   # Keep `main` rustfmt-clean so a feature branch's `cargo fmt` only ever touches
   # the files it changed. Without this gate, unformatted files drift onto main

--- a/crates/homeboy-cli/src/commands/ci.rs
+++ b/crates/homeboy-cli/src/commands/ci.rs
@@ -4,6 +4,12 @@ mod gate;
 mod plan;
 mod scope;
 
+#[cfg(feature = "test-support")]
+#[doc(hidden)]
+pub fn test_external_check_detail_resolver_fixture() {
+    external_check_detail_resolver::test_cross_platform_fixture();
+}
+
 use clap::{Args, Subcommand};
 use serde::Serialize;
 use std::path::PathBuf;

--- a/crates/homeboy-cli/src/commands/ci/external_check_detail_resolver.rs
+++ b/crates/homeboy-cli/src/commands/ci/external_check_detail_resolver.rs
@@ -450,6 +450,142 @@ fn bound(value: &str, limit: usize) -> String {
     value.chars().take(limit).collect()
 }
 
+#[cfg(any(test, feature = "test-support"))]
+pub(super) fn test_cross_platform_fixture() {
+    const FIXTURE_MODE_ENV: &str = "HOMEBOY_EXTERNAL_CHECK_FIXTURE_MODE";
+
+    for (mode, expected_detail, expected_diagnostic) in [
+        ("success", true, None),
+        ("unavailable", false, Some("unavailable")),
+        ("malformed", false, Some("malformed")),
+        ("missing-executable", false, Some("unavailable")),
+    ] {
+        homeboy::core::test_support::with_isolated_home(|_| {
+            install_fixture_extension(mode, FIXTURE_MODE_ENV);
+            let (details, diagnostics) = hydrate(
+                "fixture-ci",
+                "failure",
+                Some("https://example.test/build/42"),
+                Instant::now() + Duration::from_secs(10),
+            );
+            assert_eq!(
+                details.len() == 1,
+                expected_detail,
+                "{mode}: {diagnostics:?}"
+            );
+            assert_eq!(
+                diagnostics
+                    .first()
+                    .map(|diagnostic| diagnostic.kind.as_str()),
+                expected_diagnostic,
+                "{mode}"
+            );
+            if mode == "success" {
+                assert_eq!(details[0].actions, ["fixture-ci replay 42"]);
+                let mut resolver_slots = MAX_RESOLVERS;
+                let check = super::failure_log_triage::hydrate_external(
+                    "fixture-ci".into(),
+                    "failure".into(),
+                    Some("legacy failure description".into()),
+                    Some("https://example.test/build/42".into()),
+                    &mut resolver_slots,
+                    Instant::now() + Duration::from_secs(10),
+                );
+                assert_eq!(check.status, "failure");
+                assert_eq!(
+                    check.description.as_deref(),
+                    Some("legacy failure description")
+                );
+                let summary = super::failure_log_triage::render_human_summary(
+                    "owner/repo",
+                    &super::failure_log_triage::GhPullRequest {
+                        number: 42,
+                        title: "Fixture".into(),
+                        url: "https://example.test/pull/42".into(),
+                        head_sha: "abc".into(),
+                    },
+                    0,
+                    &[],
+                    &[check],
+                    &[],
+                    &[],
+                );
+                assert!(summary.contains("fixture-ci replay 42"));
+            }
+        });
+    }
+    homeboy::core::test_support::with_isolated_home(|_| {
+        let (details, diagnostics) = hydrate(
+            "no-installed-provider",
+            "error",
+            None,
+            Instant::now() + Duration::from_secs(10),
+        );
+        assert!(details.is_empty());
+        assert_eq!(diagnostics[0].kind, "unknown");
+    });
+}
+
+#[cfg(any(test, feature = "test-support"))]
+fn install_fixture_extension(mode: &str, fixture_mode_env: &str) {
+    let root = homeboy::core::paths::homeboy().unwrap();
+    let extension = root.join("extensions").join("fixture-external-check");
+    std::fs::create_dir_all(&extension).unwrap();
+    let executable = fixture_program(&extension, fixture_mode_env);
+    let command = if mode == "missing-executable" {
+        "not-installed-resolver".to_string()
+    } else {
+        executable
+    };
+    std::fs::write(
+        extension.join("fixture-external-check.json"),
+        serde_json::json!({
+            "name": "Fixture external check",
+            "version": "1.0.0",
+            "external_check_detail_resolvers": [{
+                "schema": "homeboy/external-check-detail-resolver/v1",
+                "provider": "fixture-ci",
+                "command": [command],
+                "public_env": [fixture_mode_env]
+            }]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    std::env::set_var(fixture_mode_env, mode);
+}
+
+#[cfg(all(any(test, feature = "test-support"), unix))]
+fn fixture_program(extension: &Path, fixture_mode_env: &str) -> String {
+    use std::os::unix::fs::PermissionsExt;
+
+    let name = "fixture-resolver";
+    let path = extension.join(name);
+    std::fs::write(
+        &path,
+        format!(
+            "#!/bin/sh\ncase \"${fixture_mode_env}\" in\nsuccess) printf '%s\\n' '{{\"schema\":\"homeboy/external-check-detail-response/v1\",\"provider\":\"fixture-ci\",\"summary\":\"fixture hydrated failure\",\"actions\":[\"fixture-ci replay 42\"]}}' ;;\nmalformed) printf '%s' 'not json' ;;\nunavailable) exit 23 ;;\n*) exit 24 ;;\nesac\n"
+        ),
+    )
+    .unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    name.into()
+}
+
+#[cfg(all(any(test, feature = "test-support"), windows))]
+fn fixture_program(extension: &Path, fixture_mode_env: &str) -> String {
+    let name = "fixture-resolver.cmd";
+    let path = extension.join(name);
+    std::fs::write(
+        &path,
+        format!(
+            "@echo off\r\nif \"%{fixture_mode_env}%\"==\"success\" (echo {{\"schema\":\"homeboy/external-check-detail-response/v1\",\"provider\":\"fixture-ci\",\"summary\":\"fixture hydrated failure\",\"actions\":[\"fixture-ci replay 42\"]}}& exit /b 0)\r\nif \"%{fixture_mode_env}%\"==\"malformed\" (set /p =not json<nul& exit /b 0)\r\nif \"%{fixture_mode_env}%\"==\"unavailable\" exit /b 23\r\nexit /b 24\r\n"
+        ),
+    )
+    .unwrap();
+    name.into()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -469,140 +605,6 @@ mod tests {
         let response: ExternalCheckDetailResponse = serde_json::from_str(r#"{"schema":"homeboy/external-check-detail-response/v1","provider":"example","summary":"failed"}"#).unwrap();
         assert_eq!(response.provider, "example");
         assert!(response.actions.is_empty());
-    }
-
-    #[test]
-    fn discovery_invokes_cross_platform_fixture_for_success_unavailable_and_malformed() {
-        homeboy::core::test_support::with_isolated_home(|_| {
-            for (mode, expected_detail, expected_diagnostic) in [
-                ("success", true, None),
-                ("unavailable", false, Some("unavailable")),
-                ("malformed", false, Some("malformed")),
-                ("missing-executable", false, Some("unavailable")),
-            ] {
-                install_fixture_extension(mode);
-                let (details, diagnostics) = hydrate(
-                    "fixture-ci",
-                    "failure",
-                    Some("https://example.test/build/42"),
-                    Instant::now() + Duration::from_secs(10),
-                );
-                assert_eq!(
-                    details.len() == 1,
-                    expected_detail,
-                    "{mode}: {diagnostics:?}"
-                );
-                assert_eq!(
-                    diagnostics
-                        .first()
-                        .map(|diagnostic| diagnostic.kind.as_str()),
-                    expected_diagnostic,
-                    "{mode}"
-                );
-                if mode == "success" {
-                    assert_eq!(details[0].actions, ["fixture-ci replay 42"]);
-                    let mut resolver_slots = MAX_RESOLVERS;
-                    let check = super::super::failure_log_triage::hydrate_external(
-                        "fixture-ci".into(),
-                        "failure".into(),
-                        Some("legacy failure description".into()),
-                        Some("https://example.test/build/42".into()),
-                        &mut resolver_slots,
-                        Instant::now() + Duration::from_secs(10),
-                    );
-                    assert_eq!(check.status, "failure");
-                    assert_eq!(
-                        check.description.as_deref(),
-                        Some("legacy failure description")
-                    );
-                    let summary = super::super::failure_log_triage::render_human_summary(
-                        "owner/repo",
-                        &super::super::failure_log_triage::GhPullRequest {
-                            number: 42,
-                            title: "Fixture".into(),
-                            url: "https://example.test/pull/42".into(),
-                            head_sha: "abc".into(),
-                        },
-                        0,
-                        &[],
-                        &[check],
-                        &[],
-                        &[],
-                    );
-                    assert!(summary.contains("fixture-ci replay 42"));
-                }
-            }
-            let (details, diagnostics) = hydrate(
-                "no-installed-provider",
-                "error",
-                None,
-                Instant::now() + Duration::from_secs(10),
-            );
-            assert!(details.is_empty());
-            assert_eq!(diagnostics[0].kind, "unknown");
-        });
-    }
-
-    fn install_fixture_extension(mode: &str) {
-        let root = homeboy::core::paths::homeboy().unwrap();
-        let extension = root.join("extensions").join("fixture-external-check");
-        std::fs::create_dir_all(&extension).unwrap();
-        let executable = fixture_program(&extension);
-        let command = if mode == "missing-executable" {
-            "not-installed-resolver".to_string()
-        } else {
-            executable
-        };
-        std::fs::write(
-            extension.join("fixture-external-check.json"),
-            serde_json::json!({
-                "name": "Fixture external check",
-                "version": "1.0.0",
-                "external_check_detail_resolvers": [{
-                    "schema": "homeboy/external-check-detail-resolver/v1",
-                    "provider": "fixture-ci",
-                    "command": [command],
-                    "public_env": [FIXTURE_MODE_ENV]
-                }]
-            })
-            .to_string(),
-        )
-        .unwrap();
-        std::env::set_var(FIXTURE_MODE_ENV, mode);
-    }
-
-    #[cfg(unix)]
-    fn fixture_program(extension: &Path) -> String {
-        use std::os::unix::fs::PermissionsExt;
-
-        let name = "fixture-resolver";
-        let path = extension.join(name);
-        std::fs::write(
-            &path,
-            format!(
-                "#!/bin/sh\ncase \"${FIXTURE_MODE_ENV}\" in\nsuccess) printf '%s\\n' '{{\"schema\":\"homeboy/external-check-detail-response/v1\",\"provider\":\"fixture-ci\",\"summary\":\"fixture hydrated failure\",\"actions\":[\"fixture-ci replay 42\"]}}' ;;\nmalformed) printf '%s' 'not json' ;;\nunavailable) exit 23 ;;\n*) exit 24 ;;\nesac\n"
-            ),
-        )
-        .unwrap();
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
-        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
-        assert_ne!(mode & 0o111, 0, "fixture must be executable");
-        name.into()
-    }
-
-    #[cfg(windows)]
-    fn fixture_program(extension: &Path) -> String {
-        let name = "fixture-resolver.cmd";
-        let path = extension.join(name);
-        std::fs::write(
-            &path,
-            format!(
-                "@echo off\r\nif \"%{FIXTURE_MODE_ENV}%\"==\"success\" (echo {{\"schema\":\"homeboy/external-check-detail-response/v1\",\"provider\":\"fixture-ci\",\"summary\":\"fixture hydrated failure\",\"actions\":[\"fixture-ci replay 42\"]}}& exit /b 0)\r\nif \"%{FIXTURE_MODE_ENV}%\"==\"malformed\" (set /p =not json<nul& exit /b 0)\r\nif \"%{FIXTURE_MODE_ENV}%\"==\"unavailable\" exit /b 23\r\nexit /b 24\r\n"
-            ),
-        )
-        .unwrap();
-        assert!(path.is_file(), "fixture must be ready before discovery");
-        name.into()
     }
 
     #[test]

--- a/crates/homeboy-cli/src/lib.rs
+++ b/crates/homeboy-cli/src/lib.rs
@@ -46,6 +46,6 @@ pub mod help_topics;
 // layer's `crate::test_support::*` call sites are unchanged. Available only in
 // test builds (core exposes it via its `test-support` feature, which this crate
 // enables as a dev-dependency).
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 #[doc(hidden)]
 pub use homeboy_core::test_support;

--- a/crates/homeboy-cli/tests/external_check_detail_resolver_fixture.rs
+++ b/crates/homeboy-cli/tests/external_check_detail_resolver_fixture.rs
@@ -1,0 +1,4 @@
+#[test]
+fn discovery_invokes_cross_platform_fixture_for_success_unavailable_and_malformed() {
+    homeboy_cli::commands::ci::test_external_check_detail_resolver_fixture();
+}

--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -821,7 +821,10 @@ pub(super) fn is_excluded(
     excludes.iter().any(|pattern| {
         let root_anchored = pattern.starts_with("./");
         let pattern = pattern.trim_start_matches("./");
-        let directory_pattern = pattern.trim_end_matches('/');
+        // `path/**` denotes the complete directory subtree. Match its root too
+        // so traversal and tar do not retain an empty directory after a late
+        // context artifact appears beneath it.
+        let directory_pattern = pattern.trim_end_matches("/**").trim_end_matches('/');
         pattern == rel
             || directory_pattern == rel
             || glob_match(pattern, rel)
@@ -2101,7 +2104,7 @@ pub(super) fn materialize_snapshot_stage(
     let archive_excludes = excludes
         .iter()
         .filter(|pattern| !is_root_input_exclude(pattern))
-        .cloned()
+        .flat_map(|pattern| snapshot_archive_excludes(pattern))
         .collect::<Vec<_>>();
     let source_archive = format!(
         "COPYFILE_DISABLE=1 tar --no-xattrs -C {src} {exclude} -cf - --null -T -",
@@ -2150,6 +2153,16 @@ fn is_root_input_exclude(pattern: &str) -> bool {
     };
     let root = pattern.trim_end_matches("/**").trim_end_matches('/');
     !root.is_empty() && !root.contains('/')
+}
+
+fn snapshot_archive_excludes(pattern: &str) -> Vec<String> {
+    let mut excludes = vec![pattern.to_string()];
+    if let Some(directory) = pattern.strip_suffix("/**") {
+        if !directory.is_empty() {
+            excludes.push(directory.to_string());
+        }
+    }
+    excludes
 }
 
 fn snapshot_manifest_tar_input(manifest: &SnapshotInputManifest) -> String {

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -125,7 +125,7 @@ pub fn sync_workspace_in_roots(
             excludes.push(pattern.clone());
         }
     }
-    for pattern in homeboy_core::source_snapshot::declared_sync_excludes_for_path(&local_path) {
+    for pattern in homeboy_core::source_snapshot::policy_for_path(&local_path).sync_excludes {
         if !excludes.contains(&pattern) {
             excludes.push(pattern);
         }
@@ -854,7 +854,7 @@ pub fn update_workspace(
             excludes.push(pattern.clone());
         }
     }
-    for pattern in homeboy_core::source_snapshot::declared_sync_excludes_for_path(&local_path) {
+    for pattern in homeboy_core::source_snapshot::policy_for_path(&local_path).sync_excludes {
         if !excludes.contains(&pattern) {
             excludes.push(pattern);
         }
@@ -1055,7 +1055,7 @@ pub fn reuse_compatible_snapshot_workspace(
             excludes.push(pattern.clone());
         }
     }
-    for pattern in homeboy_core::source_snapshot::declared_sync_excludes_for_path(&local_path) {
+    for pattern in homeboy_core::source_snapshot::policy_for_path(&local_path).sync_excludes {
         if !excludes.contains(&pattern) {
             excludes.push(pattern);
         }

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -148,6 +148,7 @@ use crate::workspace::types::{
 use crate::workspace::util::git_output;
 
 static PATH_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+static SOURCE_SYNC_EXCLUDES_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 #[test]
 fn snapshot_git_reports_checkout_provenance_for_committed_harvest() {
@@ -969,6 +970,90 @@ fn snapshot_sync_uses_gitignore_excludes_as_generic_fallback() {
             .join("build.tsbuildinfo")
             .exists());
     });
+}
+
+#[test]
+fn snapshot_sync_excludes_late_injected_dmc_context_from_every_manifest() {
+    let _source_sync_excludes_guard = SOURCE_SYNC_EXCLUDES_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("source sync excludes lock");
+    let previous = std::env::var_os("HOMEBOY_SOURCE_SYNC_EXCLUDES");
+    std::env::set_var(
+        "HOMEBOY_SOURCE_SYNC_EXCLUDES",
+        "./docs/superpowers/plans/**",
+    );
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let source = tempfile::tempdir().expect("clean DMC-managed worktree");
+        let runner_root = tempfile::tempdir().expect("runner root");
+        fs::create_dir_all(source.path().join("docs")).expect("docs directory");
+        fs::write(source.path().join("docs/README.md"), "tracked docs\n").expect("tracked docs");
+        fs::write(source.path().join("Cargo.toml"), "[workspace]\n").expect("worktree marker");
+        git(source.path(), &["init", "-b", "main"]);
+        git(source.path(), &["config", "user.email", "test@example.com"]);
+        git(source.path(), &["config", "user.name", "Test User"]);
+        git(source.path(), &["add", "."]);
+        git(source.path(), &["commit", "-m", "clean source"]);
+
+        crate::create(
+            &format!(
+                r#"{{"id":"lab-late-dmc-context","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+
+        let injected_context = source
+            .path()
+            .join("docs/superpowers/plans/2026-06-25-ftp2-page-reconstruct-lift-map.md");
+        let injected_context_for_hook = injected_context.clone();
+        let _hook = register_after_snapshot_directory_discovery_hook(
+            source.path().join("docs"),
+            move || {
+                fs::create_dir_all(
+                    injected_context_for_hook
+                        .parent()
+                        .expect("context parent directory"),
+                )
+                .expect("inject DMC context directory");
+                fs::write(&injected_context_for_hook, "late DMC context\n")
+                    .expect("inject DMC context file");
+            },
+        );
+
+        let (output, exit_code) = sync_workspace(
+            "lab-late-dmc-context",
+            RunnerWorkspaceSyncOptions {
+                path: source.path().display().to_string(),
+                mode: RunnerWorkspaceSyncMode::Snapshot,
+                ..Default::default()
+            },
+        )
+        .expect("late configured context must remain outside the snapshot");
+
+        assert_eq!(exit_code, 0);
+        assert!(output
+            .excludes
+            .contains(&"./docs/superpowers/plans/**".to_string()));
+        assert!(
+            injected_context.is_file(),
+            "fixture injected context after discovery"
+        );
+        assert!(Path::new(&output.remote_path)
+            .join("docs/README.md")
+            .is_file());
+        assert!(
+            !Path::new(&output.remote_path)
+                .join("docs/superpowers/plans/2026-06-25-ftp2-page-reconstruct-lift-map.md")
+                .exists(),
+            "the injected context must be absent from the staged and materialized manifests"
+        );
+    });
+    match previous {
+        Some(value) => std::env::set_var("HOMEBOY_SOURCE_SYNC_EXCLUDES", value),
+        None => std::env::remove_var("HOMEBOY_SOURCE_SYNC_EXCLUDES"),
+    }
 }
 
 #[test]


### PR DESCRIPTION
Fixes #12963.

Workspace sync now consumes the complete source-snapshot policy, including environment/context exclusions, across initial sync, updates, and reusable snapshot checks. Snapshot traversal and archive staging consistently treat `path/**` as excluding the directory root, so late DMC context injection cannot leave empty directories across manifests.

Tests:
- `cargo test -p homeboy-lab-runner snapshot_sync_excludes_late_injected_dmc_context -- --nocapture`
- `cargo test -p homeboy-lab-runner snapshot_stability_rejects_a_mixed_staged_tree_even_if_source_is_restored -- --nocapture`
- `cargo fmt --all`

AI assistance: OpenAI GPT-5.6 Sol via OpenCode implemented and verified the Lab snapshot exclusion repair. Chris Huber remains responsible for every line.