### PR TITLE
Fix stale runtime Cook admission

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -655,6 +655,16 @@ impl CliRuntime {
             }
         }
 
+        if let Err(err) = guard_cook_runtime_compatibility(&cli, &normalized) {
+            output_runtime::emit_json_result_for_identity(
+                Err(err),
+                output_file.as_deref(),
+                2,
+                &command_identity,
+            );
+            return std::process::ExitCode::from(2);
+        }
+
         match delegate_agent_task_cook_to_pinned_runtime(&cli, &normalized) {
             Ok(Some(exit_code)) => return std::process::ExitCode::from(exit_code_to_u8(exit_code)),
             Ok(None) => {}
@@ -863,6 +873,50 @@ impl CliRuntime {
         self.extension_discovery
             .get_or_init(collect_extension_cli_info_metadata_only)
     }
+}
+
+/// Durable Cook must not create a recipe under a runtime that the existing
+/// update policy has already proven incompatible with the allowed stable.
+/// Preview stays read-only and deliberately does not acquire this admission.
+fn guard_cook_runtime_compatibility(
+    cli: &Cli,
+    normalized_args: &[String],
+) -> homeboy::core::Result<()> {
+    let is_durable_cook = matches!(
+        &cli.command,
+        Commands::AgentTask(agent_task)
+            if matches!(
+                &agent_task.command,
+                crate::commands::agent_task::AgentTaskCommand::Cook(cook) if !cook.preview
+            )
+    );
+    if !is_durable_cook {
+        return Ok(());
+    }
+    let controller = homeboy_product_identity::build_identity();
+    let Some(stable) =
+        homeboy_upgrade::upgrade::update_check::incompatible_allowed_stable(&controller.display)
+    else {
+        return Ok(());
+    };
+    let replay = homeboy_core::engine::shell::quote_args(normalized_args);
+    let recovery = format!("homeboy upgrade && {replay}");
+    let mut error = homeboy::core::Error::validation_invalid_argument(
+        "runtime_set",
+        format!(
+            "Durable Cook refused before preview or materialization because installed controller `{}` cannot satisfy the declared runtime contracts for latest allowed stable `{}`",
+            controller.display, stable.version
+        ),
+        Some(controller.display),
+        Some(vec![recovery.clone()]),
+    );
+    error.details["runtime_set"] = serde_json::json!({
+        "latest_allowed_stable": stable.version,
+        "required_contracts": stable.compatibility.map(|compatibility| compatibility.required_contracts),
+        "recovery_command": recovery,
+        "preserved_invocation": replay,
+    });
+    Err(error)
 }
 
 fn schedule_runner_exec_recovery() {

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -424,7 +424,7 @@ fn runtime_major_minor(identity: &str) -> Option<(u64, u64)> {
 
 fn runtime_set_admission(
     controller: &str,
-    latest_allowed_stable: Option<&str>,
+    latest_allowed_stable: Option<&homeboy_upgrade::update_check::AllowedStableRuntime>,
     requested: &str,
     configured: Option<&str>,
     daemon: Option<&str>,
@@ -434,7 +434,14 @@ fn runtime_set_admission(
     // revision, not a registry's latest stable release.
     if policy.enforce_latest_stable
         && !policy.controller_is_source_build
-        && latest_allowed_stable.is_some_and(|latest| runtime_version_is_newer(latest, controller))
+        && latest_allowed_stable.is_some_and(|latest| {
+            runtime_version_is_newer(&latest.version, controller)
+                && latest.compatibility.as_ref().is_some_and(|required| {
+                    !required.compatible_with(
+                        &homeboy_upgrade::update_check::current_runtime_compatibility(),
+                    )
+                })
+        })
     {
         return RuntimeSetAdmission::RefuseControllerUpgrade;
     }
@@ -746,7 +753,7 @@ pub(crate) fn converge_lab_handoff_runtime(
     });
     match runtime_set_admission(
         &controller.display,
-        latest_allowed_stable.as_deref(),
+        latest_allowed_stable.as_ref(),
         requested,
         None,
         None,
@@ -760,7 +767,10 @@ pub(crate) fn converge_lab_handoff_runtime(
             return Err(controller_runtime_set_error(
                 runner_id,
                 &controller.display,
-                latest_allowed_stable.as_deref().expect("checked stable"),
+                &latest_allowed_stable
+                    .as_ref()
+                    .expect("checked stable")
+                    .version,
             ))
         }
         RuntimeSetAdmission::RefuseControllerRuntime => {
@@ -2622,7 +2632,8 @@ impl ProductionLabStagingOperations {
         let compatibility = runtime_set_compatibility(requested, daemon.as_deref());
         Ok(Some(LabHandoffHomeboyIdentity {
             controller_build_identity: Some(homeboy_product_identity::build_identity().display),
-            latest_allowed_stable: homeboy_upgrade::update_check::latest_allowed_stable(),
+            latest_allowed_stable: homeboy_upgrade::update_check::latest_allowed_stable()
+                .map(|stable| stable.version),
             requested_build_identity: requested.to_string(),
             configured_command_build_identity: configured
                 .clone()
@@ -5513,7 +5524,7 @@ mod tests {
     fn two_stable_releases_behind_refuses_before_dispatch() {
         let admission = runtime_set_admission(
             "homeboy 1.2.0",
-            Some("1.2.2"),
+            Some(&stable_runtime("1.2.2", [("wire", 2)])),
             "homeboy 1.2.0",
             Some("homeboy 1.2.1+daemon"),
             Some("homeboy 1.2.1+daemon"),
@@ -5527,6 +5538,67 @@ mod tests {
             admission,
             RuntimeSetAdmission::RefuseControllerUpgrade
         ));
+    }
+
+    #[test]
+    fn one_minor_behind_with_compatible_release_contracts_is_admitted() {
+        let admission = runtime_set_admission(
+            "homeboy 1.1.9",
+            Some(&stable_runtime("1.2.0", [("provider", 1), ("snapshot", 1)])),
+            "homeboy 1.1.9",
+            Some("homeboy 1.1.9"),
+            Some("homeboy 1.1.9"),
+            RuntimeSetPolicy {
+                enforce_latest_stable: true,
+                controller_is_source_build: false,
+                allow_convergence: true,
+            },
+        );
+
+        assert!(matches!(
+            admission,
+            RuntimeSetAdmission::Ready(RuntimeSetCompatibility::Exact)
+        ));
+    }
+
+    #[test]
+    fn incompatible_stable_admission_preserves_the_immutable_cook_recipe() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let run_id = "stale-runtime-recipe";
+            submit_recipe_run(run_id);
+            let recipe = persist_lab_staging_recipe(
+                run_id,
+                "lab-1",
+                &recipe_request(
+                    Some(recipe_command()),
+                    &["agent-task".to_string(), "cook".to_string()],
+                    HashMap::new(),
+                ),
+            )
+            .expect("persist immutable recipe");
+
+            let admission = runtime_set_admission(
+                "homeboy 1.1.9",
+                Some(&stable_runtime("1.2.0", [("snapshot", 2)])),
+                "homeboy 1.1.9",
+                Some("homeboy 1.1.9"),
+                Some("homeboy 1.1.9"),
+                RuntimeSetPolicy {
+                    enforce_latest_stable: true,
+                    controller_is_source_build: false,
+                    allow_convergence: true,
+                },
+            );
+
+            assert!(matches!(
+                admission,
+                RuntimeSetAdmission::RefuseControllerUpgrade
+            ));
+            assert_eq!(
+                load_lab_staging_recipe(run_id).expect("load recipe").recipe,
+                recipe
+            );
+        });
     }
 
     #[test]
@@ -5594,7 +5666,7 @@ mod tests {
     fn compatible_patch_daemon_is_admitted_without_dispatch_mutation() {
         let admission = runtime_set_admission(
             "homeboy 1.2.2",
-            Some("1.2.2"),
+            Some(&stable_runtime("1.2.2", [])),
             "homeboy 1.2.2",
             Some("homeboy 1.2.1"),
             Some("homeboy 1.2.1"),
@@ -5620,7 +5692,7 @@ mod tests {
         assert!(matches!(
             runtime_set_admission(
                 "homeboy 1.2.2+requested",
-                Some("1.2.2"),
+                Some(&stable_runtime("1.2.2", [])),
                 "homeboy 1.2.2+requested",
                 Some("homeboy 1.1.9+runner"),
                 Some("homeboy 1.1.9+daemon"),
@@ -5631,7 +5703,7 @@ mod tests {
         assert!(matches!(
             runtime_set_admission(
                 "homeboy 1.2.2+requested",
-                Some("1.2.2"),
+                Some(&stable_runtime("1.2.2", [])),
                 "homeboy 1.2.2+requested",
                 Some("homeboy 1.1.9+runner"),
                 Some("homeboy 1.1.9+daemon"),
@@ -5650,6 +5722,22 @@ mod tests {
             "policy": { "allow_homeboy_convergence": allowed },
         }))
         .expect("runner")
+    }
+
+    fn stable_runtime(
+        version: &str,
+        contracts: impl IntoIterator<Item = (&'static str, u32)>,
+    ) -> homeboy_upgrade::update_check::AllowedStableRuntime {
+        homeboy_upgrade::update_check::AllowedStableRuntime {
+            version: version.to_string(),
+            compatibility: Some(homeboy_upgrade::update_check::RuntimeCompatibility {
+                schema: "homeboy/runtime-compatibility/v1".to_string(),
+                required_contracts: contracts
+                    .into_iter()
+                    .map(|(id, version)| (id.to_string(), version))
+                    .collect(),
+            }),
+        }
     }
 
     fn convergence_status(daemon_identity: &str) -> crate::RunnerStatusReport {

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -14,6 +14,7 @@ use super::execution::{
 use super::release_catalog::{self, InstallableSelection, ReleaseEntry, SelectedRelease};
 use super::services;
 use super::types::*;
+use super::update_check::RuntimeCompatibility;
 use super::validation::check_for_updates;
 
 pub fn current_version() -> &'static str {
@@ -55,6 +56,52 @@ pub fn fetch_latest_version(method: InstallMethod) -> Result<String> {
     fetch_latest_github_version_at(latest_version_endpoint(method))
 }
 
+/// Read release-declared durable compatibility from the same daily update
+/// source. This is deliberately not called by Cook admission: the cache is the
+/// only runtime input there, so a durable command never adds a network edge.
+pub fn fetch_latest_runtime_compatibility(
+    expected_version: &str,
+) -> Result<Option<RuntimeCompatibility>> {
+    let client = reqwest::blocking::Client::builder()
+        .user_agent(format!("homeboy/{}", VERSION))
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| Error::internal_io(e.to_string(), Some("create HTTP client".to_string())))?;
+    let release: GitHubRelease = client
+        .get(GITHUB_RELEASES_API)
+        .send()
+        .map_err(|e| Error::internal_io(e.to_string(), Some("query GitHub releases".to_string())))?
+        .json()
+        .map_err(|e| {
+            Error::internal_json(
+                e.to_string(),
+                Some("parse GitHub release response".to_string()),
+            )
+        })?;
+    if release.tag_name.trim_start_matches('v') != expected_version.trim_start_matches('v') {
+        return Ok(None);
+    }
+    runtime_compatibility_from_release_notes(&release.body)
+}
+
+const RUNTIME_COMPATIBILITY_MARKER: &str = "<!-- homeboy-runtime-compatibility: ";
+
+fn runtime_compatibility_from_release_notes(body: &str) -> Result<Option<RuntimeCompatibility>> {
+    let Some(start) = body.find(RUNTIME_COMPATIBILITY_MARKER) else {
+        return Ok(None);
+    };
+    let value = &body[start + RUNTIME_COMPATIBILITY_MARKER.len()..];
+    let Some(json) = value.split_once(" -->").map(|(json, _)| json) else {
+        return Ok(None);
+    };
+    serde_json::from_str(json).map(Some).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("parse release runtime compatibility".to_string()),
+        )
+    })
+}
+
 fn latest_version_endpoint(_method: InstallMethod) -> &'static str {
     GITHUB_RELEASES_API
 }
@@ -89,6 +136,7 @@ where
             return InstallMethod::Homebrew;
         }
     }
+
     for pattern in &defaults.install_methods.secondary.path_patterns {
         if exe_path.contains(pattern) {
             return InstallMethod::Secondary;
@@ -116,6 +164,20 @@ where
     }
 
     InstallMethod::Unknown
+}
+
+#[cfg(test)]
+#[test]
+fn release_notes_runtime_compatibility_is_explicit_and_versioned() {
+    let compatibility = runtime_compatibility_from_release_notes(
+        "release\n<!-- homeboy-runtime-compatibility: {\"schema\":\"homeboy/runtime-compatibility/v1\",\"required_contracts\":{\"snapshot\":2}} -->",
+    )
+    .expect("parse declaration")
+    .expect("declaration");
+    assert_eq!(compatibility.required_contracts["snapshot"], 2);
+    assert!(runtime_compatibility_from_release_notes("release")
+        .unwrap()
+        .is_none());
 }
 
 pub fn version_is_newer(latest: &str, current: &str) -> bool {

--- a/crates/homeboy-upgrade/src/upgrade/types.rs
+++ b/crates/homeboy-upgrade/src/upgrade/types.rs
@@ -408,4 +408,6 @@ mod tests {
 #[derive(Deserialize)]
 pub(super) struct GitHubRelease {
     pub(super) tag_name: String,
+    #[serde(default)]
+    pub(super) body: String,
 }

--- a/crates/homeboy-upgrade/src/upgrade/update_check.rs
+++ b/crates/homeboy-upgrade/src/upgrade/update_check.rs
@@ -14,10 +14,11 @@
 //! schema live here and are unchanged.
 
 use crate::upgrade;
+use crate::upgrade::helpers::fetch_latest_runtime_compatibility;
 use homeboy_core::update_check_cache;
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, Instant};
@@ -39,6 +40,47 @@ pub struct UpdateCheckCache {
     pub current_version: String,
     pub update_available: bool,
     pub checked_at: u64,
+    /// Release-declared protocol floors. Absence means the update checker did
+    /// not establish a compatibility verdict, so durable admission stays local.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_compatibility: Option<RuntimeCompatibility>,
+}
+
+/// Versioned protocol evidence carried with an allowed stable release.
+///
+/// Contract identifiers are intentionally product-neutral. A release only
+/// blocks durable work when it declares a floor that the running runtime does
+/// not meet; semver distance alone is never compatibility evidence.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeCompatibility {
+    pub schema: String,
+    #[serde(default)]
+    pub required_contracts: BTreeMap<String, u32>,
+}
+
+impl RuntimeCompatibility {
+    pub fn compatible_with(&self, installed: &Self) -> bool {
+        self.schema == installed.schema
+            && self.required_contracts.iter().all(|(contract, required)| {
+                installed
+                    .required_contracts
+                    .get(contract)
+                    .is_some_and(|provided| provided >= required)
+            })
+    }
+}
+
+/// The runtime contracts this binary provides to durable Cook admission.
+pub fn current_runtime_compatibility() -> RuntimeCompatibility {
+    RuntimeCompatibility {
+        schema: "homeboy/runtime-compatibility/v1".to_string(),
+        required_contracts: BTreeMap::from([
+            ("lifecycle".to_string(), 1),
+            ("wire".to_string(), 1),
+            ("provider".to_string(), 1),
+            ("snapshot".to_string(), 1),
+        ]),
+    }
 }
 
 fn read_cache() -> Option<UpdateCheckCache> {
@@ -48,13 +90,35 @@ fn read_cache() -> Option<UpdateCheckCache> {
 /// Return the latest stable version already admitted by the normal update
 /// check. Durable admission deliberately never performs network I/O: an
 /// unavailable cache is explicit offline evidence, not a reason to guess.
-pub fn latest_allowed_stable() -> Option<String> {
+pub fn latest_allowed_stable() -> Option<AllowedStableRuntime> {
     if is_disabled() {
         return None;
     }
     read_cache().and_then(|cache| {
-        (is_cache_fresh(&cache) && cache.update_available && !cache.latest_version.is_empty())
-            .then_some(cache.latest_version)
+        (is_cache_fresh(&cache) && cache.update_available && !cache.latest_version.is_empty()).then(
+            || AllowedStableRuntime {
+                version: cache.latest_version,
+                compatibility: cache.runtime_compatibility,
+            },
+        )
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AllowedStableRuntime {
+    pub version: String,
+    pub compatibility: Option<RuntimeCompatibility>,
+}
+
+/// Return the cached stable only when its declared contracts require a newer
+/// controller. This is a pure local-cache decision for Cook pre-dispatch.
+pub fn incompatible_allowed_stable(controller_version: &str) -> Option<AllowedStableRuntime> {
+    latest_allowed_stable().filter(|stable| {
+        crate::upgrade::version_is_newer(&stable.version, controller_version)
+            && stable
+                .compatibility
+                .as_ref()
+                .is_some_and(|required| !required.compatible_with(&current_runtime_compatibility()))
     })
 }
 
@@ -300,11 +364,17 @@ pub fn run_startup_check() {
     };
 
     let checked_at = update_check_cache::now_unix();
+    let runtime_compatibility = check
+        .latest_version
+        .as_deref()
+        .and_then(|version| fetch_latest_runtime_compatibility(version).ok())
+        .flatten();
     write_cache(&UpdateCheckCache {
         latest_version: check.latest_version.clone().unwrap_or_default(),
         current_version: check.current_version.clone(),
         update_available: check.update_available,
         checked_at,
+        runtime_compatibility,
     });
 
     if !already_printed && check.update_available {
@@ -337,6 +407,7 @@ mod tests {
             current_version: upgrade::current_version().to_string(),
             update_available,
             checked_at,
+            runtime_compatibility: None,
         });
 
         assert!(path.is_file(), "cache fixture was written to {path:?}");
@@ -411,6 +482,22 @@ mod tests {
                 Some("0.329.1".to_string())
             );
         });
+    }
+
+    #[test]
+    fn declared_runtime_compatibility_requires_each_declared_contract_floor() {
+        let installed = current_runtime_compatibility();
+        let compatible = RuntimeCompatibility {
+            schema: installed.schema.clone(),
+            required_contracts: BTreeMap::from([("provider".to_string(), 1)]),
+        };
+        let incompatible = RuntimeCompatibility {
+            schema: installed.schema.clone(),
+            required_contracts: BTreeMap::from([("snapshot".to_string(), 2)]),
+        };
+
+        assert!(compatible.compatible_with(&installed));
+        assert!(!incompatible.compatible_with(&installed));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- gate durable Cook before runtime sealing, routing, and materialization when cached allowed-stable compatibility evidence requires newer lifecycle, wire, provider, or snapshot contracts
- persist release-declared compatibility in the existing daily update cache; Cook admission performs no network I/O
- return one replayable upgrade-and-retry action and retain the immutable Lab recipe

Fixes #10115

## Verification
- `cargo fmt --check`
- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-upgrade runtime_compatibility --no-fail-fast`
- `cargo test -p homeboy-lab-runner one_minor_behind_with_compatible_release_contracts_is_admitted --no-fail-fast`
- `cargo test -p homeboy-lab-runner incompatible_stable_admission_preserves_the_immutable_cook_recipe --no-fail-fast`

AI assistance: OpenAI GPT-5.6 Sol via OpenCode implemented and verified the stale-runtime admission repair. Chris Huber remains responsible for every line.