### PR TITLE
fix: preserve clean producers with proc diagnostics

### DIFF
--- a/crates/homeboy-core/src/process.rs
+++ b/crates/homeboy-core/src/process.rs
@@ -163,6 +163,10 @@ pub struct ProcessContainment {
 pub struct ProcessContainmentCleanup {
     pub forced: bool,
     pub complete: bool,
+    /// Non-fatal evidence collected while confirming cleanup. This is separate
+    /// from `detail` so unrelated host-process metadata cannot turn a verified
+    /// run-owned scope cleanup into a producer failure.
+    pub diagnostic: Option<String>,
     pub detail: Option<String>,
 }
 
@@ -269,6 +273,7 @@ impl ProcessContainment {
                 Ok(ProcessContainmentCleanup {
                     forced: true,
                     complete: true,
+                    diagnostic: None,
                     detail: None,
                 })
             } else {
@@ -311,6 +316,7 @@ impl ProcessContainment {
                     ProcessContainmentCleanup {
                         forced: termination.signal == "SIGKILL",
                         complete: true,
+                        diagnostic: None,
                         detail: None,
                     }
                 });
@@ -322,6 +328,7 @@ impl ProcessContainment {
                 ProcessContainmentCleanup {
                     forced,
                     complete: true,
+                    diagnostic: None,
                     detail: None,
                 }
             })
@@ -1265,11 +1272,12 @@ fn scope_cleanup_report(
     let unreadable = targets
         .unreadable_environments
         .max(survivors.unreadable_environments);
-    let complete = !targets.pids.is_empty() && unreadable == 0;
+    let complete = !targets.pids.is_empty() && survivors.pids.is_empty();
     let detail = (!complete).then(|| {
-        if unreadable > 0 {
+        if !survivors.pids.is_empty() {
             format!(
-                "process-scope discovery was incomplete: {unreadable} /proc environment entries could not be read"
+                "process-scope cleanup confirmed run-owned survivors: {}",
+                join_pids(&survivors.pids)
             )
         } else {
             "process-scope discovery found no marker-owned process; an escaped descendant may have removed HOMEBOY_PROCESS_SCOPE".to_string()
@@ -1278,6 +1286,11 @@ fn scope_cleanup_report(
     ProcessContainmentCleanup {
         forced,
         complete,
+        diagnostic: (unreadable > 0).then(|| {
+            format!(
+                "process-scope discovery could not read {unreadable} unrelated /proc environment entries"
+            )
+        }),
         detail,
     }
 }
@@ -1772,7 +1785,7 @@ mod tests {
     }
 
     #[test]
-    fn scope_cleanup_reports_omitted_or_unreadable_marker_discovery() {
+    fn scope_cleanup_keeps_unreadable_unrelated_environments_as_diagnostics() {
         let omitted = scope_cleanup_report(
             LinuxScopeDiscovery {
                 pids: Vec::new(),
@@ -1801,12 +1814,36 @@ mod tests {
             },
             true,
         );
-        assert!(!unreadable.complete);
+        assert!(unreadable.complete);
         assert!(unreadable.forced);
+        assert_eq!(unreadable.detail, None);
         assert!(unreadable
+            .diagnostic
+            .as_deref()
+            .is_some_and(|detail| detail.contains("unrelated /proc environment entries")));
+    }
+
+    #[test]
+    fn scope_cleanup_fails_closed_for_confirmed_run_owned_survivors() {
+        let cleanup = scope_cleanup_report(
+            LinuxScopeDiscovery {
+                pids: vec![42],
+                unreadable_environments: 1,
+            },
+            LinuxScopeDiscovery {
+                pids: vec![43],
+                unreadable_environments: 1,
+            },
+            true,
+        );
+
+        assert!(!cleanup.complete);
+        assert!(cleanup.forced);
+        assert!(cleanup
             .detail
             .as_deref()
-            .is_some_and(|detail| detail.contains("could not be read")));
+            .is_some_and(|detail| detail.contains("run-owned survivors: 43")));
+        assert!(cleanup.diagnostic.is_some());
     }
 
     #[test]

--- a/crates/homeboy-core/src/process.rs
+++ b/crates/homeboy-core/src/process.rs
@@ -303,6 +303,7 @@ impl ProcessContainment {
             return Ok(ProcessContainmentCleanup {
                 forced: cleanup.forced || forced_group,
                 complete: cleanup.complete,
+                diagnostic: cleanup.diagnostic,
                 detail: cleanup.detail,
             });
         }

--- a/crates/homeboy-core/src/server/client/local_exec.rs
+++ b/crates/homeboy-core/src/server/client/local_exec.rs
@@ -301,7 +301,7 @@ fn run_local_command(
         }
         if let Some(detail) = cleanup_detail {
             stderr.push_str(&format!(
-                "Homeboy containment cleanup was incomplete: {detail}.\n"
+                "Homeboy containment cleanup diagnostic: {detail}.\n"
             ));
         }
         if streams_stalled {

--- a/crates/homeboy-core/src/server/process_cleanup.rs
+++ b/crates/homeboy-core/src/server/process_cleanup.rs
@@ -166,7 +166,7 @@ fn cleanup_process_group(
     #[cfg(target_os = "linux")]
     if let Some(containment) = containment {
         match containment.cleanup_with_grace(Duration::from_millis(200), false) {
-            Ok(cleanup) if cleanup.complete => return None,
+            Ok(cleanup) if cleanup.complete => return cleanup.diagnostic,
             Ok(cleanup) => return cleanup.detail,
             Err(error) => {
                 cleanup_process_group_fallback(pgid);

--- a/crates/homeboy-extension/src/execution.rs
+++ b/crates/homeboy-extension/src/execution.rs
@@ -1637,7 +1637,7 @@ mod tests {
         assert_eq!(output.stdout, "{\"status\":\"passed\"}\n");
         assert!(!output.success);
         assert!(output.timed_out);
-        assert!(output.stderr.contains("containment cleanup was incomplete"));
+        assert!(output.stderr.contains("containment cleanup diagnostic"));
         assert!(output.stderr.contains("output pipes remained open"));
         assert!(
             homeboy_core::process::pid_is_running(pid as u32),


### PR DESCRIPTION
## Summary
- preserve successful producer results when unrelated `/proc/*/environ` entries cannot be read
- retain unreadable process metadata as a containment diagnostic
- continue failing closed for missing scope ownership, confirmed run-owned survivors, and teardown errors

Fixes #13128

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p homeboy-extension --lib`
- Linux-target focused tests could not run locally: the macOS host lacks `x86_64-linux-gnu-gcc` required by bundled native dependencies.
- `cargo clippy -p homeboy-core --all-targets -- -D warnings` remains blocked by 21 existing warnings outside this change.

## AI Assistance
GPT-5.6 Sol via OpenCode was used to inspect the issue evidence, implement the scoped containment contract change, and run verification. Chris Huber reviewed and remains responsible for every line.