### PR TITLE
fix(cook): pin and converge provider base

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -6525,9 +6525,19 @@ fn pin_initial_cook_workspace_base(options: &mut AgentTaskCookServiceOptions) ->
                 .and_then(|task| task.workspace.root.as_deref())
                 .map(std::path::Path::new)
         });
-    let Some(workspace) = workspace else {
+    let Some(workspace) = workspace.map(Path::to_path_buf) else {
         return Ok(());
     };
+    pin_cook_workspace_base_at(options, &workspace)
+}
+
+fn pin_cook_workspace_base_at(
+    options: &mut AgentTaskCookServiceOptions,
+    workspace: &Path,
+) -> Result<()> {
+    if options.task_base_sha.is_some() {
+        return Ok(());
+    }
     let Some(base) =
         crate::agent_task_promotion::capture_declared_base(workspace, Some(&options.base))?
     else {
@@ -6586,6 +6596,7 @@ fn preflight_cook_workspace_base_ancestry_with_provider(
                 "provider_id": convergence.provider_id,
                 "handle": convergence.handle,
                 "path": convergence.path,
+                "provider_evidence": convergence.evidence,
             })))
         }
         Err(error) => Err(error),
@@ -6971,6 +6982,14 @@ fn materialize_pending_cook_workspace(
     effective_lookup_timeout_ms: Option<u64>,
 ) -> Result<()> {
     restore_legacy_cook_provision(&mut options.initial_plan)?;
+    if options.task_base_sha.is_none() {
+        options.task_base_sha = options
+            .initial_plan
+            .metadata
+            .pointer("/cook_workspace_base/sha")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+    }
     let provider_id = |options: &AgentTaskCookServiceOptions| {
         options
             .initial_plan
@@ -7089,6 +7108,10 @@ fn materialize_pending_cook_workspace(
     let target = std::fs::canonicalize(&target).map_err(|error| {
         Error::internal_io(error.to_string(), Some(target.display().to_string()))
     })?;
+    // Deferred provider materialization has no checkout at initial recipe
+    // persistence. Capture and persist this immutable boundary before Cook can
+    // admit or dispatch the materialized destination.
+    pin_cook_workspace_base_at(options, &target)?;
     validate_pending_cook_repository_identity(&options.initial_plan, &target)?;
     for task in &mut options.initial_plan.tasks {
         task.workspace.root = Some(target.display().to_string());

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4330,6 +4330,9 @@ fn run_cook_spine(
     }
     project_controller_owned_gate_contract(&mut options);
     project_initial_finalizing_review_form_contract(&mut options);
+    if !store.recipe_exists(&options.cook_id) {
+        pin_initial_cook_workspace_base(&mut options)?;
+    }
     // A configured provider is controller authority. Resolve it before an
     // external runner can spend a provider attempt; explicit transports are
     // caller-owned overrides and retain their existing behavior. A typed
@@ -4467,10 +4470,16 @@ fn run_cook_spine(
         && !cook_workspace_lookup_pending(&options.initial_plan)
         && (options.attempt_dispatcher.is_none() || options.source_worktree_path.is_some())
     {
-        validate_cook_workspace(&options).map_err(|mut error| {
+        if let Some(evidence) = validate_cook_workspace(&options).map_err(|mut error| {
             error.details["cook_materialized_by_invocation"] = materialized_by_invocation.into();
             error
-        })?;
+        })? {
+            record_cook_workspace_base_convergence(
+                lifecycle_store,
+                &options.initial_run_id,
+                evidence,
+            )?;
+        }
     }
     validate_cook_candidate_group(&options.initial_plan)?;
     // Reserve the source tree's projected copy before the scheduler creates its
@@ -4895,7 +4904,9 @@ fn run_cook_spine(
             let mut failed_dispatch_plan = None;
             let execution = (|| {
                 if options.attempt_dispatcher.is_none() || options.source_worktree_path.is_some() {
-                    validate_cook_workspace(&options)?;
+                    if let Some(evidence) = validate_cook_workspace(&options)? {
+                        record_cook_workspace_base_convergence(lifecycle_store, &run_id, evidence)?;
+                    }
                 }
                 if options.attempt_dispatcher.is_none() {
                     homeboy_core::cleanup::admit_reconstructable_artifact_work(
@@ -6353,7 +6364,7 @@ fn cook_run_record_needs_execution(record: &agent_task_lifecycle::AgentTaskRunRe
 /// Validate the Cook target before a provider can run. An explicit source path
 /// is already the authoritative workspace; otherwise resolve the declared
 /// handle through the existing local/provider path.
-fn validate_cook_workspace(options: &AgentTaskCookServiceOptions) -> Result<()> {
+fn validate_cook_workspace(options: &AgentTaskCookServiceOptions) -> Result<Option<Value>> {
     let continuation = tracked_promotion_continuation(options)?;
     let source = options.source_worktree_path.as_deref();
     let target = if let Some(source) = source {
@@ -6476,9 +6487,109 @@ fn validate_cook_workspace(options: &AgentTaskCookServiceOptions) -> Result<()> 
             ));
         }
     }
-    preflight_cook_workspace_base_ancestry(&target, &options.base)
-        .map_err(|error| with_pre_execution_phase(error, "workspace_base_ancestry_preflight"))?;
+    preflight_cook_workspace_base_ancestry_with_provider(&target, options)
+        .map_err(|error| with_pre_execution_phase(error, "workspace_base_ancestry_preflight"))
+}
+
+fn record_cook_workspace_base_convergence(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    evidence: Value,
+) -> Result<()> {
+    lifecycle_store.mutate_record(run_id, |record| {
+        record.metadata["cook_workspace_base_convergence"] = evidence;
+        true
+    })?;
     Ok(())
+}
+
+/// Capture the base once before a new Cook recipe freezes its execution
+/// lineage. Existing recipes retain their recorded boundary on every retry.
+fn pin_initial_cook_workspace_base(options: &mut AgentTaskCookServiceOptions) -> Result<()> {
+    if options.task_base_sha.is_some() {
+        return Ok(());
+    }
+    let workspace = options
+        .source_worktree_path
+        .as_deref()
+        .or_else(|| {
+            std::path::Path::new(&options.to_worktree)
+                .is_dir()
+                .then_some(std::path::Path::new(&options.to_worktree))
+        })
+        .or_else(|| {
+            options
+                .initial_plan
+                .tasks
+                .first()
+                .and_then(|task| task.workspace.root.as_deref())
+                .map(std::path::Path::new)
+        });
+    let Some(workspace) = workspace else {
+        return Ok(());
+    };
+    let Some(base) =
+        crate::agent_task_promotion::capture_declared_base(workspace, Some(&options.base))?
+    else {
+        return Ok(());
+    };
+    options.task_base_sha = Some(base.sha.clone());
+    options.initial_plan.metadata["cook_workspace_base"] = serde_json::json!({
+        "schema": "homeboy/cook-workspace-base/v1",
+        "base": base.base,
+        "sha": base.sha,
+    });
+    Ok(())
+}
+
+fn preflight_cook_workspace_base_ancestry_with_provider(
+    target: &Path,
+    options: &AgentTaskCookServiceOptions,
+) -> Result<Option<Value>> {
+    let base = options.task_base_sha.as_deref().unwrap_or(&options.base);
+    match preflight_cook_workspace_base_ancestry(target, base) {
+        Ok(()) => Ok(None),
+        Err(error)
+            if error.details["workspace_base_ancestry"]["direction"] == "behind"
+                && options.task_base_sha.is_some() =>
+        {
+            let config = homeboy_core::defaults::load_config();
+            let handle = if std::path::Path::new(&options.to_worktree).is_dir() {
+                let Some(resolution) =
+                    homeboy_core::worktree_providers::resolve_worktree_provider_path_from_config(
+                        target, &config,
+                    )?
+                else {
+                    return Err(error);
+                };
+                resolution.worktree.handle
+            } else {
+                options.to_worktree.clone()
+            };
+            let convergence = homeboy_core::worktree_providers::converge_apply_enabled_worktree_provider_to_base_from_config(
+                &handle,
+                base,
+                &config,
+            )?;
+            preflight_cook_workspace_base_ancestry(target, base).map_err(|mut error| {
+                error.details["workspace_base_ancestry"]["convergence"] = serde_json::json!({
+                    "provider_id": convergence.provider_id,
+                    "handle": convergence.handle,
+                    "path": convergence.path,
+                    "base_sha": convergence.base_sha,
+                });
+                error
+            })?;
+            Ok(Some(serde_json::json!({
+                "schema": "homeboy/cook-workspace-base-convergence/v1",
+                "planned_base_sha": base,
+                "provider_id": convergence.provider_id,
+                "handle": convergence.handle,
+                "path": convergence.path,
+            })))
+        }
+        Err(error) => Err(error),
+    }
 }
 
 /// A candidate diff is meaningful only when its destination contains the
@@ -6500,10 +6611,20 @@ fn preflight_cook_workspace_base_ancestry(target: &Path, base: &str) -> Result<(
     if !origin.status.success() {
         return Ok(());
     }
-    let Some(resolved_base) =
-        crate::agent_task_promotion::capture_declared_base(target, Some(base))?
-    else {
-        return Ok(());
+    let resolved_base = if base.len() == 40 && base.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        homeboy_core::git::run_git(
+            target,
+            &["rev-parse", "--verify", &format!("{base}^{{commit}}")],
+            "resolve pinned Cook base",
+        )?
+        .trim()
+        .to_string()
+    } else {
+        let Some(base) = crate::agent_task_promotion::capture_declared_base(target, Some(base))?
+        else {
+            return Ok(());
+        };
+        base.sha
     };
     let counts = homeboy_core::git::run_git(
         target,
@@ -6511,7 +6632,7 @@ fn preflight_cook_workspace_base_ancestry(target: &Path, base: &str) -> Result<(
             "rev-list",
             "--left-right",
             "--count",
-            &format!("{}...HEAD", resolved_base.sha),
+            &format!("{resolved_base}...HEAD"),
         ],
         "compare Cook destination to resolved base",
     )?;
@@ -6533,18 +6654,18 @@ fn preflight_cook_workspace_base_ancestry(target: &Path, base: &str) -> Result<(
         "base",
         format!(
             "Cook destination is {direction} from resolved base `{}` at {}; converge the destination before provider execution",
-            resolved_base.base, resolved_base.sha
+            base, resolved_base
         ),
         Some(target.display().to_string()),
         Some(vec![format!(
             "Update the destination with `{}` and rerun Cook; provider execution has not started.",
-            format!("git merge --ff-only {}", resolved_base.sha)
+            format!("git merge --ff-only {resolved_base}")
         )]),
     );
     error.details["workspace_base_ancestry"] = serde_json::json!({
         "schema": "homeboy/cook-workspace-base-ancestry/v1",
-        "base": resolved_base.base,
-        "resolved_base": resolved_base.sha,
+        "base": base,
+        "resolved_base": resolved_base,
         "destination_head": fingerprint.head,
         "direction": direction,
         "base_only_commits": behind,

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -674,6 +674,10 @@ pub struct WorktreeProviderCommands {
     /// `{cleanup_policy}`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ensure: Option<Vec<String>>,
+    /// Fast-forward one already-owned clean worktree to the immutable `{base}`
+    /// supplied by the caller. It also receives `{handle}`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub converge: Option<Vec<String>>,
     /// Read-only projection of an `ensure` request. It receives the same
     /// placeholders as `ensure` and returns the prospective workspace through
     /// `list_result_mapping`, without creating a branch or checkout.
@@ -711,6 +715,7 @@ impl Default for WorktreeProviderCommands {
             resolve_not_found_exit_codes: Vec::new(),
             list: None,
             ensure: None,
+            converge: None,
             plan: None,
             cleanup_preview: None,
             cleanup_preview_timeout_ms: DEFAULT_WORKTREE_PROVIDER_CLEANUP_TIMEOUT_MS,
@@ -1178,6 +1183,7 @@ mod tests {
             resolve_not_found_exit_codes: Vec::new(),
             list: Some(vec!["provider".to_string(), "list".to_string()]),
             ensure: Some(vec!["provider".to_string(), "ensure".to_string()]),
+            converge: None,
             plan: None,
             cleanup_preview: None,
             cleanup_preview_timeout_ms: DEFAULT_WORKTREE_PROVIDER_CLEANUP_TIMEOUT_MS,

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -674,8 +674,9 @@ pub struct WorktreeProviderCommands {
     /// `{cleanup_policy}`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ensure: Option<Vec<String>>,
-    /// Fast-forward one already-owned clean worktree to the immutable `{base}`
-    /// supplied by the caller. It also receives `{handle}`.
+    /// Atomically converge one already-owned clean worktree to immutable
+    /// `{base}`. It receives `{handle}` and the attested opaque `{identity}`, and
+    /// returns a `homeboy/worktree-provider-convergence/v1` evidence envelope.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub converge: Option<Vec<String>>,
     /// Read-only projection of an `ensure` request. It receives the same

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -345,6 +345,14 @@ pub struct WorktreeProviderConvergence {
     pub handle: String,
     pub path: String,
     pub base_sha: String,
+    pub evidence: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorktreeProviderConvergenceEvidence {
+    schema: String,
+    identity_token: String,
+    base_sha: String,
 }
 
 /// Converge a provider-owned worktree only through its declared mutation
@@ -361,51 +369,84 @@ pub fn converge_apply_enabled_worktree_provider_to_base_from_config(
         .worktree_providers
         .get(&resolution.identity.provider_id)
         .expect("split resolution selects a configured provider");
-    if let Some(command) = provider.commands.converge.as_ref() {
-        let command = command
-            .iter()
-            .map(|argument| {
-                argument
-                    .replace("{handle}", handle)
-                    .replace("{base}", base_sha)
-            })
-            .collect::<Vec<_>>();
-        run_provider_mutation_command(
-            &resolution.identity.provider_id,
-            provider,
-            &command,
-            "converge",
-        )?;
-    } else {
-        // The split provider attestation above makes this canonical path a
-        // provider-owned mutation capability, not an ambient caller path.
-        crate::git::run_git(
-            std::path::Path::new(&resolution.identity.path),
-            &["merge", "--ff-only", base_sha],
-            "fast-forward provider-owned worktree to pinned Cook base",
-        )?;
-    }
-    let converged = resolve_apply_enabled_worktree_provider_split_from_config(handle, config)?;
-    if converged.identity.schema != resolution.identity.schema
-        || converged.identity.provider_id != resolution.identity.provider_id
-        || converged.identity.token != resolution.identity.token
-        || converged.identity.handle != resolution.identity.handle
-        || converged.identity.path != resolution.identity.path
-        || converged.identity.branch != resolution.identity.branch
-        || converged.identity.primary != resolution.identity.primary
+    let command = provider.commands.converge.as_ref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "to_worktree",
+            format!(
+                "provider `{}` owns `{handle}` but does not configure token-bound commands.converge",
+                resolution.identity.provider_id
+            ),
+            Some(handle.to_string()),
+            None,
+        )
+    })?;
+    let command = command
+        .iter()
+        .map(|argument| {
+            argument
+                .replace("{handle}", handle)
+                .replace("{identity}", &resolution.identity.token)
+                .replace("{base}", base_sha)
+        })
+        .collect::<Vec<_>>();
+    let output = run_provider_mutation_command(
+        &resolution.identity.provider_id,
+        provider,
+        &command,
+        "converge",
+    )?;
+    let evidence_value: Value = serde_json::from_slice(&output).map_err(|error| {
+        Error::validation_invalid_argument(
+            "to_worktree",
+            format!(
+                "provider `{}` returned invalid convergence evidence: {error}",
+                resolution.identity.provider_id
+            ),
+            Some(handle.to_string()),
+            None,
+        )
+    })?;
+    let evidence: WorktreeProviderConvergenceEvidence =
+        serde_json::from_value(evidence_value.clone()).map_err(|error| {
+            Error::validation_invalid_argument(
+                "to_worktree",
+                format!(
+                    "provider `{}` returned incomplete convergence evidence: {error}",
+                    resolution.identity.provider_id
+                ),
+                Some(handle.to_string()),
+                None,
+            )
+        })?;
+    if evidence.schema != "homeboy/worktree-provider-convergence/v1"
+        || evidence.identity_token != resolution.identity.token
+        || evidence.base_sha != base_sha
     {
         return Err(Error::validation_invalid_argument(
             "to_worktree",
-            "provider changed the exact worktree identity while converging Cook's pinned base",
+            "provider convergence evidence does not bind the attested identity token and pinned base",
+            Some(handle.to_string()),
+            None,
+        ));
+    }
+    // The mutation command is bound to the pre-mutation opaque token. Re-attest
+    // afterward only to detect a changed safety state, never as authorization.
+    let safety =
+        attest_apply_enabled_worktree_provider_safety_from_config(&resolution.identity, config)?;
+    if !safety.fresh || safety.dirty || safety.unpushed || resolution.identity.primary {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            "provider safety attestation is not safe after pinned Cook convergence",
             Some(handle.to_string()),
             None,
         ));
     }
     Ok(WorktreeProviderConvergence {
-        provider_id: converged.identity.provider_id,
-        handle: converged.identity.handle,
-        path: converged.identity.path,
+        provider_id: resolution.identity.provider_id,
+        handle: resolution.identity.handle,
+        path: resolution.identity.path,
         base_sha: base_sha.to_string(),
+        evidence: evidence_value,
     })
 }
 
@@ -1608,7 +1649,7 @@ fn run_provider_ensure_command(
     provider: &WorktreeProviderConfig,
     command: &[String],
 ) -> Result<()> {
-    run_provider_mutation_command(provider_id, provider, command, "ensure")
+    run_provider_mutation_command(provider_id, provider, command, "ensure").map(|_| ())
 }
 
 fn run_provider_mutation_command(
@@ -1616,8 +1657,15 @@ fn run_provider_mutation_command(
     provider: &WorktreeProviderConfig,
     command: &[String],
     operation: &str,
-) -> Result<()> {
-    if let Some(argument) = command.iter().find(|argument| argument.contains('{')) {
+) -> Result<Vec<u8>> {
+    if let Some(argument) = command.iter().find(|argument| {
+        argument.split('{').skip(1).any(|tail| {
+            tail.chars()
+                .next()
+                .is_some_and(|character| character.is_ascii_alphabetic() || character == '_')
+                && tail.contains('}')
+        })
+    }) {
         return Err(provider_lookup_error(
             provider_id,
             command,
@@ -1675,7 +1723,7 @@ fn run_provider_mutation_command(
     }
     let output = output.into_output();
     if output.status.success() {
-        return Ok(());
+        return Ok(output.stdout);
     }
     let mut error = Error::validation_invalid_argument_with_evidence(
         "to_worktree",
@@ -6572,11 +6620,12 @@ mod tests {
             "sh".to_string(),
             "-c".to_string(),
             format!(
-                "git -C '{}' merge --ff-only \"$2\" && printf '%s' \"$2\" > '{evidence_path}'",
+                "git -C '{}' merge --ff-only \"$3\" >/dev/null && printf '%s' \"$3\" > '{evidence_path}' && printf '{{\"schema\":\"homeboy/worktree-provider-convergence/v1\",\"identity_token\":\"%s\",\"base_sha\":\"%s\"}}' \"$2\" \"$3\"",
                 workspace.display()
             ),
             "_".to_string(),
             "{handle}".to_string(),
+            "{identity}".to_string(),
             "{base}".to_string(),
         ]);
 

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -339,6 +339,76 @@ pub struct WorktreeProviderHandleSafety {
     pub primary: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeProviderConvergence {
+    pub provider_id: String,
+    pub handle: String,
+    pub path: String,
+    pub base_sha: String,
+}
+
+/// Converge a provider-owned worktree only through its declared mutation
+/// capability. The split resolver proves the handle is currently clean,
+/// pushed, non-primary, and owned by an apply-enabled provider before the
+/// provider receives the immutable base SHA.
+pub fn converge_apply_enabled_worktree_provider_to_base_from_config(
+    handle: &str,
+    base_sha: &str,
+    config: &HomeboyConfig,
+) -> Result<WorktreeProviderConvergence> {
+    let resolution = resolve_apply_enabled_worktree_provider_split_from_config(handle, config)?;
+    let provider = config
+        .worktree_providers
+        .get(&resolution.identity.provider_id)
+        .expect("split resolution selects a configured provider");
+    if let Some(command) = provider.commands.converge.as_ref() {
+        let command = command
+            .iter()
+            .map(|argument| {
+                argument
+                    .replace("{handle}", handle)
+                    .replace("{base}", base_sha)
+            })
+            .collect::<Vec<_>>();
+        run_provider_mutation_command(
+            &resolution.identity.provider_id,
+            provider,
+            &command,
+            "converge",
+        )?;
+    } else {
+        // The split provider attestation above makes this canonical path a
+        // provider-owned mutation capability, not an ambient caller path.
+        crate::git::run_git(
+            std::path::Path::new(&resolution.identity.path),
+            &["merge", "--ff-only", base_sha],
+            "fast-forward provider-owned worktree to pinned Cook base",
+        )?;
+    }
+    let converged = resolve_apply_enabled_worktree_provider_split_from_config(handle, config)?;
+    if converged.identity.schema != resolution.identity.schema
+        || converged.identity.provider_id != resolution.identity.provider_id
+        || converged.identity.token != resolution.identity.token
+        || converged.identity.handle != resolution.identity.handle
+        || converged.identity.path != resolution.identity.path
+        || converged.identity.branch != resolution.identity.branch
+        || converged.identity.primary != resolution.identity.primary
+    {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            "provider changed the exact worktree identity while converging Cook's pinned base",
+            Some(handle.to_string()),
+            None,
+        ));
+    }
+    Ok(WorktreeProviderConvergence {
+        provider_id: converged.identity.provider_id,
+        handle: converged.identity.handle,
+        path: converged.identity.path,
+        base_sha: base_sha.to_string(),
+    })
+}
+
 /// Resolve an externally managed worktree handle without creating or adopting
 /// a Homeboy record. This is intentionally a lookup-only boundary.
 pub fn resolve_worktree_provider_handle(handle: &str) -> Result<WorktreeProviderHandle> {
@@ -6464,6 +6534,110 @@ mod tests {
         )
         .expect_err("mismatched evidence is fail-closed");
         assert!(error.message.contains("different exact identity"));
+    }
+
+    #[test]
+    fn provider_convergence_uses_the_pinned_base_after_safe_attestation() {
+        let (root, workspace) = linked_workspace("branch");
+        let source = root.path().join("source");
+        let git = |args: &[&str]| {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(&source)
+                .output()
+                .expect("run source git command");
+            assert!(output.status.success(), "git {args:?} failed");
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        };
+        // Materialization starts at the initial commit. Pin the first advance,
+        // then advance the moving branch again before destination admission.
+        git(&["commit", "--allow-empty", "-m", "pinned base"]);
+        let pinned_base = git(&["rev-parse", "HEAD"]);
+        git(&["commit", "--allow-empty", "-m", "later base"]);
+        let later_base = git(&["rev-parse", "HEAD"]);
+        let evidence = tempfile::NamedTempFile::new().expect("convergence evidence file");
+        let evidence_path = evidence.path().display().to_string();
+        let mut provider = default_command_provider();
+        provider.commands.resolve_identity = Some(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            format!("printf '%s' '{{\"schema\":\"homeboy/worktree-provider-identity/v1\",\"provider_id\":\"fixture\",\"token\":\"opaque-identity\",\"handle\":\"fixture@branch\",\"path\":\"{}\",\"branch\":\"branch\",\"primary\":false,\"latency_ms\":0,\"budget_ms\":0}}'", workspace.display()),
+        ]);
+        provider.commands.attest_safety = Some(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "printf '%s' '{\"schema\":\"homeboy/worktree-provider-safety/v1\",\"identity_token\":\"opaque-identity\",\"observed_at\":\"2026-01-01T00:00:00Z\",\"dirty\":false,\"unpushed\":false,\"fresh\":true,\"latency_ms\":0,\"budget_ms\":0}'".to_string(),
+        ]);
+        provider.commands.converge = Some(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            format!(
+                "git -C '{}' merge --ff-only \"$2\" && printf '%s' \"$2\" > '{evidence_path}'",
+                workspace.display()
+            ),
+            "_".to_string(),
+            "{handle}".to_string(),
+            "{base}".to_string(),
+        ]);
+
+        let convergence = converge_apply_enabled_worktree_provider_to_base_from_config(
+            "fixture@branch",
+            &pinned_base,
+            &config_with_provider(provider),
+        )
+        .expect("clean managed worktree converges through its provider");
+
+        assert_eq!(convergence.provider_id, "fixture");
+        assert_eq!(
+            std::fs::read_to_string(evidence.path()).expect("read convergence evidence"),
+            pinned_base
+        );
+        let workspace_head = std::process::Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(&workspace)
+            .output()
+            .expect("read converged workspace HEAD");
+        assert!(workspace_head.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&workspace_head.stdout).trim(),
+            pinned_base,
+            "the later moving base was not used"
+        );
+        assert_ne!(pinned_base, later_base);
+    }
+
+    #[test]
+    fn provider_convergence_refuses_dirty_worktree_without_mutation() {
+        let (_root, workspace) = linked_workspace("branch");
+        let evidence = tempfile::NamedTempFile::new().expect("convergence evidence file");
+        std::fs::remove_file(evidence.path()).expect("remove untouched evidence file");
+        let evidence_path = evidence.path().display().to_string();
+        let mut provider = default_command_provider();
+        provider.commands.resolve_identity = Some(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            format!("printf '%s' '{{\"schema\":\"homeboy/worktree-provider-identity/v1\",\"provider_id\":\"fixture\",\"token\":\"opaque-identity\",\"handle\":\"fixture@branch\",\"path\":\"{}\",\"branch\":\"branch\",\"primary\":false,\"latency_ms\":0,\"budget_ms\":0}}'", workspace.display()),
+        ]);
+        provider.commands.attest_safety = Some(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "printf '%s' '{\"schema\":\"homeboy/worktree-provider-safety/v1\",\"identity_token\":\"opaque-identity\",\"observed_at\":\"2026-01-01T00:00:00Z\",\"dirty\":true,\"unpushed\":false,\"fresh\":true,\"latency_ms\":0,\"budget_ms\":0}'".to_string(),
+        ]);
+        provider.commands.converge = Some(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            format!("touch '{evidence_path}'"),
+        ]);
+
+        let error = converge_apply_enabled_worktree_provider_to_base_from_config(
+            "fixture@branch",
+            "0123456789012345678901234567890123456789",
+            &config_with_provider(provider),
+        )
+        .expect_err("dirty managed worktree is never converged");
+
+        assert!(error.message.contains("not safe for mutation"));
+        assert!(!evidence.path().exists());
     }
 
     #[test]


### PR DESCRIPTION
Closes #13120

Pins the Cook base SHA before recipe/admission, preserves it across retries, and safely fast-forwards only provider-owned, clean, pushed, non-primary destinations that are strictly behind with no candidate commits. Records pinned-base and convergence evidence in the durable lifecycle metadata.

Tests:
- provider convergence pins the first advance even when the source advances again
- dirty provider workspace refuses before mutation
- existing behind/diverged preflight behavior remains rejected

AI assistance: OpenAI GPT-5.6 Sol via OpenCode was used to diagnose, implement, and verify this change. Chris Huber remains responsible.