### PR TITLE
chore: collapse 4 more ambient wrapper pairs (#7505)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -595,19 +595,6 @@ fn finalization_operation_key(run_id: &str, promotion: &AgentTaskPromotionReport
 /// with the finalization result after it is durable. A resumed pass revalidates
 /// the existing PR idempotently, including its live Git and GitHub identities
 /// (#8357).
-fn finalize_with_operation_claim(
-    options: &AgentTaskCookServiceOptions,
-    run_id: &str,
-    promotion: &AgentTaskPromotionReport,
-    finalize: &mut dyn FnMut(
-        &AgentTaskCookServiceOptions,
-        &str,
-        &AgentTaskPromotionReport,
-    ) -> Result<Value>,
-) -> Result<Value> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    finalize_with_operation_claim_in_store(&lifecycle_store, options, run_id, promotion, finalize)
-}
 
 fn finalize_with_operation_claim_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
@@ -654,22 +641,6 @@ fn finalize_with_operation_claim_in_store(
             Ok(finalization)
         }
     }
-}
-
-/// Promote a cook attempt under a durable exactly-once operation claim.
-///
-/// `promote_or_load_attempt_in_store` already loads an already-persisted promotion, but
-/// the fresh-promote path performs its external effect (`promote_attempt`) and
-/// only then records the result. A controller crash in that window re-runs the
-/// effect on restart. The claim closes it: reserve `promote:<run_id>` before the
-/// effect, complete it after the result is durable, and on a resumed pass return
-/// the persisted promotion instead of repeating the effect (#8357).
-fn promote_with_operation_claim(
-    options: &AgentTaskCookServiceOptions,
-    run_id: &str,
-) -> Result<AgentTaskPromotionReport> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    promote_with_operation_claim_in_store(&lifecycle_store, options, run_id)
 }
 
 fn promote_with_operation_claim_in_store(
@@ -6219,24 +6190,6 @@ fn run_cook_spine(
         exit_code: 1,
         invocation_latest_run_id: Some(&run_id),
     }))
-}
-
-fn resumable_cook_run_id(
-    recipe: &super::AgentTaskCookRecipe,
-    cook_id: &str,
-    initial_run_id: &str,
-    requested_attempt: u32,
-    verification_pending_continuation: bool,
-) -> Option<String> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment().ok()?;
-    resumable_cook_run_id_in_store(
-        &lifecycle_store,
-        recipe,
-        cook_id,
-        initial_run_id,
-        requested_attempt,
-        verification_pending_continuation,
-    )
 }
 
 fn resumable_cook_run_id_in_store(

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -11155,7 +11155,14 @@ fn adoption_by_cook_id_selects_the_latest_substantive_candidate_not_a_newer_empt
         );
         let recipe = super::super::load_recipe(cook_id).expect("load recipe");
         assert_eq!(
-            resumable_cook_run_id(&recipe, cook_id, first_run_id, 1, false),
+            resumable_cook_run_id_in_store(
+                &test_lifecycle_store(),
+                &recipe,
+                cook_id,
+                first_run_id,
+                1,
+                false
+            ),
             Some(second_run_id.to_string()),
             "continuation must keep the selected substantive attempt, not the latest alias"
         );
@@ -11236,7 +11243,14 @@ fn cook_alias_continuation_starts_from_failed_gate_feedback_attempt() {
         );
         let recipe = super::super::load_recipe(cook_id).expect("load recipe");
         assert_eq!(
-            resumable_cook_run_id(&recipe, cook_id, &continuation_run_id, 2, false),
+            resumable_cook_run_id_in_store(
+                &test_lifecycle_store(),
+                &recipe,
+                cook_id,
+                &continuation_run_id,
+                2,
+                false
+            ),
             None,
             "continuation resumes attempt 2 so the remaining budget reaches attempt 3"
         );
@@ -13592,7 +13606,9 @@ fn promotion_operation_claim_completes_once_and_replays_persisted_result() {
                 .is_none()
         );
 
-        let first = promote_with_operation_claim(&options, run_id).unwrap();
+        let first =
+            promote_with_operation_claim_in_store(&test_lifecycle_store(), &options, run_id)
+                .unwrap();
         assert_eq!(first.source.run_id.as_deref(), Some(run_id));
 
         // The claim is now completed with the promotion result.
@@ -13604,7 +13620,9 @@ fn promotion_operation_claim_completes_once_and_replays_persisted_result() {
 
         // A resumed pass replays the same promotion via AlreadyCompleted without
         // re-running the effect.
-        let replayed = promote_with_operation_claim(&options, run_id).unwrap();
+        let replayed =
+            promote_with_operation_claim_in_store(&test_lifecycle_store(), &options, run_id)
+                .unwrap();
         assert_eq!(replayed.source.run_id, first.source.run_id);
         assert_eq!(replayed.patch_artifact.id, first.patch_artifact.id);
     });
@@ -13743,15 +13761,27 @@ fn finalization_operation_claim_revalidates_completed_publication() {
                 Ok(serde_json::json!({"status": "review_ready", "run_id": rid}))
             };
 
-        let first =
-            finalize_with_operation_claim(&options, run_id, &promotion, &mut finalize).unwrap();
+        let first = finalize_with_operation_claim_in_store(
+            &test_lifecycle_store(),
+            &options,
+            run_id,
+            &promotion,
+            &mut finalize,
+        )
+        .unwrap();
         assert_eq!(first["status"], "review_ready");
         assert_eq!(finalize_calls.load(Ordering::SeqCst), 1);
 
         // A resumed pass must re-read publication identities rather than trust a
         // prior durable report.
-        let replayed =
-            finalize_with_operation_claim(&options, run_id, &promotion, &mut finalize).unwrap();
+        let replayed = finalize_with_operation_claim_in_store(
+            &test_lifecycle_store(),
+            &options,
+            run_id,
+            &promotion,
+            &mut finalize,
+        )
+        .unwrap();
         assert_eq!(replayed["status"], "review_ready");
         assert_eq!(
             finalize_calls.load(Ordering::SeqCst),

--- a/crates/homeboy-paths/src/rigs.rs
+++ b/crates/homeboy-paths/src/rigs.rs
@@ -76,11 +76,6 @@ pub fn stack_sources_in_root(config_root: &Path) -> PathBuf {
     rig_registry_root_in_root(config_root).join("stack-sources")
 }
 
-/// Stack source metadata directory (~/.config/homeboy/stack-sources/)
-pub fn stack_sources() -> Result<PathBuf> {
-    Ok(stack_sources_in_root(&homeboy()?))
-}
-
 /// Stack source metadata file below an already-resolved config root.
 pub fn stack_source_metadata_in_root(config_root: &Path, id: &str) -> PathBuf {
     stack_sources_in_root(config_root).join(format!("{}.json", id))

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -427,8 +427,10 @@ fn sources_list_skips_non_json_and_collects_invalid_stack_metadata() {
     let _home = HomeGuard::new();
     fs::create_dir_all(homeboy_core::paths::rig_sources().expect("rig sources dir"))
         .expect("rig sources dir");
-    fs::create_dir_all(homeboy_core::paths::stack_sources().expect("stack sources dir"))
-        .expect("stack sources dir");
+    fs::create_dir_all(homeboy_core::paths::stack_sources_in_root(
+        &test_config_root(),
+    ))
+    .expect("stack sources dir");
     fs::write(
         homeboy_core::paths::rig_sources()
             .expect("rig sources dir")


### PR DESCRIPTION
**376 pairs → 372.**

| where | wrappers |
|---|---|
| `cook.rs` | `finalize_with_operation_claim`, `promote_with_operation_claim`, `resumable_cook_run_id` |
| `paths/rigs` | `stack_sources` |

## Function-pointer position keeps trying to eat a live function

Kept `terminal_artifact_projection_is_verified`. Zero call sites — because it's passed as a **function pointer**:

```rust
terminal_artifact_projection_readiness_for_record_with(
    record,
    aggregate,
    terminal_artifact_projection_is_verified,
)
```

That's the **third time tonight** a call-site scan proposed deleting a live function for this reason, and the **second time in this same file**.

Any scan looking for `name(` is blind to it. The orphan guard from #13123 counts *mentions* rather than calls specifically so it doesn't make this mistake — it's the authority, and the faster scan is only a candidate generator. Worth internalising before the next batch.

## Deliberately left alone

Neither of these is an ambient-root wrapper, so neither belongs in this migration:

- `materialize_follow_up_baseline` — supplies default arguments to an `_at` form
- `recover_completed_cook_operation` — carries a real body over `store::mutate_record`

## Verification

- `cargo check --workspace --tests -j2` — green, no warnings
- `no_orphaned_ambient_wrappers_test` — green, and it caught `finalize_with_operation_claim` after the first pass missed it on a line-count heuristic

Refs #7505.