### PR TITLE
fix(cook): preserve component cwd during adoption

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -5666,6 +5666,7 @@ fn run_cook_spine(
             compare_gate_failures_to_verified_base(
                 &mut promotion,
                 std::path::Path::new(&repository_root),
+                std::path::Path::new(&repository_root),
                 &base_sha,
                 options.gates.gate_timeout(),
                 |_compared, _total| Ok(()),

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -332,6 +332,8 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
             None,
         )
     })?;
+    let gate_workspace = super::cook_promotion::component_workspace_path(&options)?
+        .unwrap_or_else(|| source_worktree.clone());
     // Resolve the caller input to the commit object before durable ownership is
     // claimed, then use that immutable SHA for every subsequent operation.
     let candidate_sha = resolve_candidate_revision(&source_worktree, candidate_ref)?;
@@ -561,7 +563,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
                             source,
                             source_run_id: Some(record.run_id.clone()),
                             source_path,
-                            source_worktree_path: options.source_worktree_path.clone(),
+                            source_worktree_path: Some(gate_workspace.clone()),
                             base_ref: Some(options.base.clone()),
                             task_base_sha: options.task_base_sha.clone(),
                             candidate_ref: Some(candidate_sha.clone()),
@@ -624,6 +626,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
     super::cook_baseline::compare_gate_failures_to_verified_base(
         &mut promotion,
         &source_worktree,
+        &gate_workspace,
         &candidate_base_sha,
         options.gates.gate_timeout(),
         |compared, total| {

--- a/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
@@ -301,6 +301,7 @@ pub(crate) fn materialize_follow_up_baseline_in_root(
 pub(crate) fn compare_gate_failures_to_verified_base(
     promotion: &mut AgentTaskPromotionReport,
     repository_root: &std::path::Path,
+    gate_workspace: &std::path::Path,
     base_sha: &str,
     timeout: std::time::Duration,
     mut checkpoint: impl FnMut(usize, usize) -> Result<()>,
@@ -318,6 +319,18 @@ pub(crate) fn compare_gate_failures_to_verified_base(
     if unresolved == 0 {
         return Ok(());
     }
+    let repository_root = repository_root.canonicalize().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("canonicalize Cook gate repository root".to_string()),
+        )
+    })?;
+    let gate_workspace = gate_workspace.canonicalize().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("canonicalize Cook gate workspace".to_string()),
+        )
+    })?;
     let baseline_root = tempfile::tempdir().map_err(|error| {
         Error::internal_io(
             error.to_string(),
@@ -325,11 +338,19 @@ pub(crate) fn compare_gate_failures_to_verified_base(
         )
     })?;
     let baseline_path = baseline_root.path().join("base");
+    let gate_workspace_relative = gate_workspace.strip_prefix(&repository_root).map_err(|_| {
+        Error::validation_invalid_argument(
+            "gate_workspace",
+            "Cook gate workspace is outside its repository root",
+            Some(gate_workspace.display().to_string()),
+            None,
+        )
+    })?;
     let output = std::process::Command::new("git")
         .args(["worktree", "add", "--detach"])
         .arg(&baseline_path)
         .arg(base_sha)
-        .current_dir(repository_root)
+        .current_dir(&repository_root)
         .output()
         .map_err(|error| {
             Error::internal_io(
@@ -344,7 +365,36 @@ pub(crate) fn compare_gate_failures_to_verified_base(
         ));
     }
     let comparison = (|| -> Result<()> {
-        homeboy_core::hygiene::materialize_worktree_dependencies(&baseline_path)?;
+        let canonical_baseline_path = baseline_path.canonicalize().map_err(|error| {
+            Error::validation_invalid_argument(
+                "gate_workspace",
+                format!("canonicalize Cook gate baseline root: {error}"),
+                Some(baseline_path.display().to_string()),
+                None,
+            )
+        })?;
+        let baseline_gate_workspace = homeboy_core::resolve_contained_local_path(
+            &canonical_baseline_path,
+            gate_workspace_relative,
+            "gate_workspace",
+        )?;
+        let baseline_gate_workspace = baseline_gate_workspace.canonicalize().map_err(|error| {
+            Error::validation_invalid_argument(
+                "gate_workspace",
+                format!("canonicalize Cook baseline component workspace: {error}"),
+                Some(baseline_gate_workspace.display().to_string()),
+                None,
+            )
+        })?;
+        if !baseline_gate_workspace.starts_with(&canonical_baseline_path) {
+            return Err(Error::validation_invalid_argument(
+                "gate_workspace",
+                "canonical Cook baseline component workspace escapes its baseline root",
+                Some(baseline_gate_workspace.display().to_string()),
+                None,
+            ));
+        }
+        homeboy_core::hygiene::materialize_worktree_dependencies(&baseline_gate_workspace)?;
         let mut compared = 0;
         for (index, gate) in promotion.deterministic_gates.iter_mut().enumerate() {
             if gate.status != AgentTaskGateStatus::Failed || gate.baseline_comparison.is_some() {
@@ -371,7 +421,7 @@ pub(crate) fn compare_gate_failures_to_verified_base(
                     &homeboy_core::engine::invocation::InvocationRequirements::default(),
                 )?;
                 run_gate_command_with_timeout(
-                    &baseline_path,
+                    &baseline_gate_workspace,
                     index + 1,
                     &command,
                     gate.visibility,
@@ -503,7 +553,7 @@ pub(crate) fn compare_gate_failures_to_verified_base(
     let cleanup = std::process::Command::new("git")
         .args(["worktree", "remove", "--force"])
         .arg(&baseline_path)
-        .current_dir(repository_root)
+        .current_dir(&repository_root)
         .status()
         .map_err(|error| {
             Error::internal_io(
@@ -896,6 +946,7 @@ mod tests {
 
             let result = compare_gate_failures_to_verified_base(
                 &mut promotion,
+                temp.path(),
                 temp.path(),
                 &base,
                 timeout,

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -55,14 +55,47 @@ pub fn source_worktree_path(cwd: Option<String>, workspace: Option<String>) -> O
     .map(PathBuf::from)
 }
 
-fn component_workspace_path(options: &AgentTaskCookServiceOptions) -> Option<PathBuf> {
-    let source = options.source_worktree_path.as_ref()?;
-    let component_cwd = options
+pub(crate) fn component_workspace_path(
+    options: &AgentTaskCookServiceOptions,
+) -> Result<Option<PathBuf>> {
+    let Some(source) = options.source_worktree_path.as_ref() else {
+        return Ok(None);
+    };
+    let Some(component_cwd) = options
         .initial_plan
         .metadata
         .pointer("/gate_workspace/component_cwd")
-        .and_then(Value::as_str)?;
-    homeboy_core::resolve_contained_local_path(source, component_cwd, "component_cwd").ok()
+        .and_then(Value::as_str)
+    else {
+        return Ok(None);
+    };
+    let source = source.canonicalize().map_err(|error| {
+        Error::validation_invalid_argument(
+            "component_cwd",
+            format!("canonicalize Cook source workspace: {error}"),
+            Some(source.display().to_string()),
+            None,
+        )
+    })?;
+    let component =
+        homeboy_core::resolve_contained_local_path(&source, component_cwd, "component_cwd")?;
+    let component = component.canonicalize().map_err(|error| {
+        Error::validation_invalid_argument(
+            "component_cwd",
+            format!("canonicalize Cook component workspace: {error}"),
+            Some(component.display().to_string()),
+            None,
+        )
+    })?;
+    if !component.starts_with(&source) {
+        return Err(Error::validation_invalid_argument(
+            "component_cwd",
+            "canonical Cook component workspace escapes its source workspace",
+            Some(component.display().to_string()),
+            None,
+        ));
+    }
+    Ok(Some(component))
 }
 
 fn replacement_component_workspace(
@@ -156,7 +189,7 @@ pub(crate) fn promote_attempt_in_store(
             source,
             source_run_id: Some(run_id.to_string()),
             source_path,
-            source_worktree_path: component_workspace_path(options)
+            source_worktree_path: component_workspace_path(options)?
                 .or_else(|| options.source_worktree_path.clone()),
             base_ref: Some(options.base.clone()),
             task_base_sha: options.task_base_sha.clone(),
@@ -204,7 +237,7 @@ pub(crate) fn canonical_cook_patch_artifact_id_in_store(
         source,
         source_run_id: Some(run_id.to_string()),
         source_path,
-        source_worktree_path: component_workspace_path(options)
+        source_worktree_path: component_workspace_path(options)?
             .or_else(|| options.source_worktree_path.clone()),
         base_ref: Some(options.base.clone()),
         task_base_sha: options.task_base_sha.clone(),
@@ -727,7 +760,7 @@ pub(crate) fn promote_or_load_attempt_in_store(
                     source,
                     source_run_id: Some(run_id.to_string()),
                     source_path,
-                    source_worktree_path: component_workspace_path(options)
+                    source_worktree_path: component_workspace_path(options)?
                         .or_else(|| options.source_worktree_path.clone()),
                     base_ref: Some(options.base.clone()),
                     task_base_sha: options.task_base_sha.clone(),
@@ -1857,7 +1890,7 @@ pub(crate) fn recover_moving_base_cook_candidate_in_store(
             source,
             source_run_id: Some(recovery.run_id.clone()),
             source_path,
-            source_worktree_path: component_workspace_path(options)
+            source_worktree_path: component_workspace_path(options)?
                 .or_else(|| options.source_worktree_path.clone()),
             base_ref: Some(options.base.clone()),
             task_base_sha: options.task_base_sha.clone(),

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -5171,6 +5171,288 @@ fn adoption_blocks_a_changed_failure_despite_inherited_failure_authorization() {
 }
 
 #[test]
+fn adoption_replays_candidate_and_baseline_gates_from_the_persisted_component_workspace() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let mut fixture =
+            CandidateAdoptionFixture::new("cook-13091-component-cwd", 1, 0, true, None);
+        let component = fixture.source.join("component");
+        std::fs::create_dir(&component).expect("create component workspace");
+        std::fs::write(component.join("marker"), "unchanged\n").expect("write component baseline");
+        git_output(&fixture.source, &["add", "component/marker"])
+            .expect("stage component baseline");
+        git_output(&fixture.source, &["commit", "-m", "component baseline"])
+            .expect("commit component baseline");
+        std::fs::write(fixture.source.join("candidate.txt"), "candidate\n")
+            .expect("write unrelated candidate change");
+        git_output(&fixture.source, &["add", "candidate.txt"])
+            .expect("stage unrelated candidate change");
+        git_output(&fixture.source, &["commit", "-m", "component candidate"])
+            .expect("commit component candidate");
+        fixture.candidate = git_output(&fixture.source, &["rev-parse", "HEAD"])
+            .expect("read component candidate revision");
+        std::fs::write(
+            &fixture.provider,
+            format!(
+                "#!/bin/sh\ncat >/dev/null\ngit -C {target} fetch origin {candidate}\ngit -C {target} reset --hard --quiet FETCH_HEAD\nprintf '{{\"schema\":\"homeboy/agent-task-promotion-apply-response/v1\",\"workspace_path\":\"{target}\",\"command_evidence\":[]}}'\n",
+                target = fixture.target.display(),
+                candidate = fixture.candidate,
+            ),
+        )
+        .expect("update promotion provider");
+        fixture.options.initial_plan.metadata["gate_workspace"] = serde_json::json!({
+            "component_cwd": "component"
+        });
+        fixture.options.source_worktree_path = Some(fixture.source.join("component").join(".."));
+        fixture.options.gates.verify = vec!["cat marker >&2; exit 1".to_string()];
+        let mut recipe = super::super::load_recipe(&fixture.cook_id).expect("load fixture recipe");
+        let attempt = recipe
+            .attempts
+            .iter_mut()
+            .find(|attempt| attempt.run_id == fixture.run_id)
+            .expect("fixture recipe attempt");
+        attempt.plan = fixture.options.initial_plan.clone();
+        recipe.gate_policy =
+            serde_json::to_value(&fixture.options.gates).expect("serialize component gate policy");
+        recipe.finalization["source_worktree_path"] =
+            serde_json::to_value(&fixture.options.source_worktree_path)
+                .expect("serialize non-normalized source workspace");
+        let recipe_path = homeboy_core::paths::homeboy_data()
+            .expect("Homeboy data path")
+            .join("agent-task-cooks")
+            .join(&fixture.cook_id)
+            .join("recipe.json");
+        std::fs::write(
+            &recipe_path,
+            serde_json::to_vec(&recipe).expect("serialize fixture recipe"),
+        )
+        .expect("persist component workspace recipe");
+
+        let mut backend = CaptureBackend::default();
+        let result = fixture
+            .adopt_run_with_inherited_failure_acceptance(
+                &fixture.run_id,
+                true,
+                |_| Ok(None),
+                Arc::new(UnusedExecutor),
+                &mut backend,
+            )
+            .expect("component gate comparison completes");
+
+        let gate = &result.value.attempts[0]
+            .promotion
+            .as_ref()
+            .expect("adoption promotion")
+            .deterministic_gates[0];
+        assert_eq!(gate.stderr.trim(), "unchanged");
+        assert_eq!(
+            gate.baseline_comparison
+                .as_ref()
+                .expect("baseline comparison")
+                .result,
+            crate::agent_task_gate::AgentTaskGateDifferentialResult::BaselineRed,
+            "candidate and baseline both execute in the component workspace"
+        );
+    });
+}
+
+#[test]
+fn component_workspace_path_rejects_escaping_persisted_paths() {
+    let source = tempfile::tempdir().expect("source workspace");
+    for component_cwd in ["../outside", "/outside"] {
+        let mut options = batch_cook_options(
+            "cook-13091-invalid-component",
+            Arc::new(AcceptedDetachedAttemptDispatcher),
+        );
+        options.source_worktree_path = Some(source.path().to_path_buf());
+        options.initial_plan.metadata["gate_workspace"] = serde_json::json!({
+            "component_cwd": component_cwd
+        });
+
+        let error = super::super::cook_promotion::component_workspace_path(&options)
+            .expect_err("escaping component cwd must fail closed");
+        assert_eq!(error.details["field"], "component_cwd");
+    }
+}
+
+#[test]
+fn adoption_rejects_an_escaping_component_path_before_provider_or_gate_execution() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let mut fixture =
+            CandidateAdoptionFixture::new("cook-13091-escaping-component", 1, 0, true, None);
+        let provider_started = fixture.source.parent().unwrap().join("provider-started");
+        let gate_started = fixture.source.parent().unwrap().join("gate-started");
+        std::fs::write(
+            &fixture.provider,
+            format!(
+                "#!/bin/sh\ntouch {provider_started}\n",
+                provider_started = provider_started.display(),
+            ),
+        )
+        .expect("write provider sentinel");
+        fixture.options.initial_plan.metadata["gate_workspace"] = serde_json::json!({
+            "component_cwd": fixture.source.parent().unwrap().join("outside")
+        });
+        fixture.options.gates.verify = vec![format!("touch {}", gate_started.display())];
+        let mut recipe = super::super::load_recipe(&fixture.cook_id).expect("load fixture recipe");
+        let attempt = recipe
+            .attempts
+            .iter_mut()
+            .find(|attempt| attempt.run_id == fixture.run_id)
+            .expect("fixture recipe attempt");
+        attempt.plan = fixture.options.initial_plan.clone();
+        recipe.gate_policy =
+            serde_json::to_value(&fixture.options.gates).expect("serialize escaping gate policy");
+        let recipe_path = homeboy_core::paths::homeboy_data()
+            .expect("Homeboy data path")
+            .join("agent-task-cooks")
+            .join(&fixture.cook_id)
+            .join("recipe.json");
+        std::fs::write(
+            &recipe_path,
+            serde_json::to_vec(&recipe).expect("serialize fixture recipe"),
+        )
+        .expect("persist escaping component recipe");
+
+        let mut backend = CaptureBackend::default();
+        let error = fixture
+            .adopt(|_| Ok(None), Arc::new(UnusedExecutor), &mut backend)
+            .expect_err("escaping component path must reject adoption");
+        assert_eq!(error.details["field"], "component_cwd");
+        assert!(!provider_started.exists(), "provider must not execute");
+        assert!(!gate_started.exists(), "gate must not execute");
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn adoption_rejects_component_symlink_escape_before_provider_or_gate_execution() {
+    use std::os::unix::fs::symlink;
+
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let mut fixture =
+            CandidateAdoptionFixture::new("cook-13091-component-symlink", 1, 0, true, None);
+        let external = tempfile::tempdir().expect("external workspace");
+        symlink(external.path(), fixture.source.join("component"))
+            .expect("create component symlink");
+        let provider_started = fixture.source.parent().unwrap().join("provider-started");
+        let gate_started = fixture.source.parent().unwrap().join("gate-started");
+        std::fs::write(
+            &fixture.provider,
+            format!(
+                "#!/bin/sh\ntouch {provider_started}\n",
+                provider_started = provider_started.display(),
+            ),
+        )
+        .expect("write provider sentinel");
+        fixture.options.initial_plan.metadata["gate_workspace"] = serde_json::json!({
+            "component_cwd": "component"
+        });
+        fixture.options.gates.verify = vec![format!("touch {}", gate_started.display())];
+        let mut recipe = super::super::load_recipe(&fixture.cook_id).expect("load fixture recipe");
+        let attempt = recipe
+            .attempts
+            .iter_mut()
+            .find(|attempt| attempt.run_id == fixture.run_id)
+            .expect("fixture recipe attempt");
+        attempt.plan = fixture.options.initial_plan.clone();
+        recipe.gate_policy =
+            serde_json::to_value(&fixture.options.gates).expect("serialize symlink gate policy");
+        let recipe_path = homeboy_core::paths::homeboy_data()
+            .expect("Homeboy data path")
+            .join("agent-task-cooks")
+            .join(&fixture.cook_id)
+            .join("recipe.json");
+        std::fs::write(
+            &recipe_path,
+            serde_json::to_vec(&recipe).expect("serialize fixture recipe"),
+        )
+        .expect("persist symlink component recipe");
+
+        let mut backend = CaptureBackend::default();
+        let error = fixture
+            .adopt(|_| Ok(None), Arc::new(UnusedExecutor), &mut backend)
+            .expect_err("symlink component path must reject adoption");
+        assert_eq!(error.details["field"], "component_cwd");
+        assert!(!provider_started.exists(), "provider must not execute");
+        assert!(!gate_started.exists(), "gate must not execute");
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn adoption_rejects_a_baseline_component_symlink_escape_before_external_gate_execution() {
+    use std::os::unix::fs::symlink;
+
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let mut fixture =
+            CandidateAdoptionFixture::new("cook-13091-baseline-symlink", 1, 0, true, None);
+        let external = fixture.source.parent().unwrap().join("external");
+        std::fs::create_dir(&external).expect("create external workspace");
+        let component = fixture.source.join("component");
+        symlink(&external, &component).expect("create baseline component symlink");
+        git_output(&fixture.source, &["add", "component"]).expect("stage baseline symlink");
+        git_output(
+            &fixture.source,
+            &["commit", "-m", "baseline component symlink"],
+        )
+        .expect("commit baseline symlink");
+        let baseline = git_output(&fixture.source, &["rev-parse", "HEAD"]).expect("baseline SHA");
+        std::fs::remove_file(&component).expect("remove baseline symlink");
+        std::fs::create_dir(&component).expect("create candidate component");
+        std::fs::write(component.join("marker"), "candidate\n").expect("write candidate component");
+        git_output(&fixture.source, &["add", "-A"]).expect("stage candidate component");
+        git_output(&fixture.source, &["commit", "-m", "candidate component"])
+            .expect("commit candidate component");
+        fixture.candidate =
+            git_output(&fixture.source, &["rev-parse", "HEAD"]).expect("candidate SHA");
+        fixture.options.task_base_sha = Some(baseline.clone());
+        std::fs::write(
+            &fixture.provider,
+            format!(
+                "#!/bin/sh\ncat >/dev/null\ngit -C {target} fetch origin {candidate}\ngit -C {target} reset --hard --quiet FETCH_HEAD\nprintf '{{\"schema\":\"homeboy/agent-task-promotion-apply-response/v1\",\"workspace_path\":\"{target}\",\"command_evidence\":[]}}'\n",
+                target = fixture.target.display(),
+                candidate = fixture.candidate,
+            ),
+        )
+        .expect("update promotion provider");
+        fixture.options.initial_plan.metadata["gate_workspace"] = serde_json::json!({
+            "component_cwd": "component"
+        });
+        fixture.options.gates.verify = vec!["touch \"$PWD/gate-ran\"; exit 1".to_string()];
+        let mut recipe = super::super::load_recipe(&fixture.cook_id).expect("load fixture recipe");
+        let attempt = recipe
+            .attempts
+            .iter_mut()
+            .find(|attempt| attempt.run_id == fixture.run_id)
+            .expect("fixture recipe attempt");
+        attempt.plan = fixture.options.initial_plan.clone();
+        recipe.gate_policy =
+            serde_json::to_value(&fixture.options.gates).expect("serialize baseline gate policy");
+        recipe.finalization["task_base_sha"] = serde_json::json!(baseline);
+        let recipe_path = homeboy_core::paths::homeboy_data()
+            .expect("Homeboy data path")
+            .join("agent-task-cooks")
+            .join(&fixture.cook_id)
+            .join("recipe.json");
+        std::fs::write(
+            &recipe_path,
+            serde_json::to_vec(&recipe).expect("serialize fixture recipe"),
+        )
+        .expect("persist baseline symlink recipe");
+
+        let mut backend = CaptureBackend::default();
+        let error = fixture
+            .adopt(|_| Ok(None), Arc::new(UnusedExecutor), &mut backend)
+            .expect_err("baseline symlink escape must reject adoption");
+        assert_eq!(error.details["field"], "gate_workspace");
+        assert!(
+            !external.join("gate-ran").exists(),
+            "external gate must not execute"
+        );
+    });
+}
+
+#[test]
 fn adoption_blocks_inherited_failure_when_candidate_package_artifact_differs_from_base() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let mut fixture = CandidateAdoptionFixture::new("cook-11978-artifact", 1, 0, true, None);


### PR DESCRIPTION
## Summary

- replay candidate and immutable-baseline gates from the persisted monorepo component workspace
- fail closed for lexical and physical component path escapes
- canonicalize candidate and baseline workspace identities before dependency or gate execution
- preserve repository-root behavior when no component cwd is recorded

## Verification

- focused candidate/baseline component-cwd adoption test
- candidate symlink escape test
- baseline symlink escape test
- escaping persisted-path tests
- `cargo fmt --all --check`
- `git diff --check`

Closes #13091

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode general coding and independent review agents implemented, security-hardened, tested, and reviewed component-workspace adoption. Chris Huber remains responsible for every line.