### PR TITLE
fix: restore the lab-runner non-test build (#13140 regression)

### DIFF
--- a/crates/homeboy-lab-runner/src/evidence/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mod.rs
@@ -30,5 +30,4 @@ pub(crate) use mirror::{
     ReverseBrokerEvidenceContext,
 };
 pub use mirror::{runner_job_log_snapshot_for_session, runner_job_log_snapshot_for_session_until};
-#[cfg(test)]
 pub(crate) use util::{local_job_run_id, runner_exec_run_label};

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -18,7 +18,6 @@ use super::super::capabilities::{
     runner_capability_snapshot_for_preflight, validate_runner_capability_preflight,
 };
 use super::super::daemon_http_get::daemon_get;
-#[cfg(test)]
 use super::super::evidence::{local_job_run_id, runner_exec_run_label};
 use super::super::evidence::{
     mirror_daemon_evidence, mirror_daemon_job_progress, terminalize_mirrored_daemon_job,
@@ -2065,10 +2064,14 @@ pub(super) fn daemon_identity_transition(
     })
 }
 
-/// Only the handoff tests construct this error shape. It was already reachable
-/// from nothing but tests; deleting the ambient lifecycle wrappers this file
-/// sat beside is what made the compiler say so (#7505).
-#[cfg(test)]
+/// The terminal transport error shape, used by the daemon's own result
+/// delivery and by the handoff tests.
+///
+/// This carried `#[cfg(test)]` between #13140 and this commit, which broke
+/// the non-test build. `cargo check --workspace --tests` cannot see that
+/// class of mistake: with only test targets requested, the library is
+/// compiled once under `cfg(test)` and the ordinary configuration is never
+/// checked at all.
 pub(super) fn lab_terminal_result_transport_error(
     runner: &Runner,
     cwd: &str,


### PR DESCRIPTION
`homeboy-lab-runner` **has not compiled in its ordinary configuration** since #13140. My regression, reported as soon as I hit it.

## What broke

#13140 put `#[cfg(test)]` in three places — the function, its import in `daemon.rs`, and its re-export in `evidence/mod.rs` — on this claim:

> Only the handoff tests construct this error shape.

That was wrong. There is a production call site **1780 lines above it in the same file**:

```rust
// daemon.rs:292
|error| lab_terminal_result_transport_error(runner, &cwd, &command, job, error),
```

All three gates removed.

## Why it shipped — the gate cannot see this

`cargo check --workspace --tests` is **structurally blind** to this class of mistake.

With only test targets requested, cargo compiles the library **once, under `cfg(test)`**. The ordinary configuration is never checked at all. Every line the gate compiled had `cfg(test)` true — so a `#[cfg(test)]` that hides a production dependency is invisible to it *by construction*, not by bad luck.

This is a different failure mode from the one already recorded ("check proves it compiles, it does not run tests"). Here check didn't even prove it compiles.

## The fix to the gate

| command | time | catches this |
|---|--:|:--:|
| `cargo check --workspace --tests -j2` | 1m30s | ❌ |
| `cargo check --workspace --all-targets -j2` | **1m43s** | ✅ |

Thirteen seconds. **Use `--all-targets`.**

## Verification

- `cargo check --workspace -j2` (non-test lib) — green
- `cargo check --workspace --all-targets -j2` — green, one pre-existing `FIXTURE_MODE_ENV` warning