### PR TITLE
chore: delete the whole ambient path layer in rigs.rs (#7505)

### DIFF
--- a/crates/homeboy-cli/src/commands/runs/resources.rs
+++ b/crates/homeboy-cli/src/commands/runs/resources.rs
@@ -911,7 +911,7 @@ mod tests {
     }
 
     fn write_rig_lease(lease: RigRunLease) {
-        let dir = homeboy::core::paths::rig_leases_dir().expect("rig leases dir");
+        let dir = homeboy::core::paths::rig_leases_dir_in_root(&test_config_root());
         std::fs::create_dir_all(&dir).expect("create lease dir");
         std::fs::write(
             dir.join(format!("{}.json", lease.rig_id)),

--- a/crates/homeboy-cli/src/commands/trace/compare_targets.rs
+++ b/crates/homeboy-cli/src/commands/trace/compare_targets.rs
@@ -958,10 +958,15 @@ mod tests {
     use homeboy::core::component::ScopedExtensionConfig;
     use homeboy::core::observation::ObservationStore;
 
+    /// A test is the entry point for its own unit of work, so resolving once
+    /// here is a boundary resolution (#7505).
+    fn test_config_root() -> std::path::PathBuf {
+        homeboy_core::paths::homeboy().expect("config root")
+    }
+
     fn set_trace_rig_resources(rig_id: &str, resources: serde_json::Value) {
-        let rig_path = homeboy::core::paths::rigs()
-            .expect("rig dir")
-            .join(format!("{rig_id}.json"));
+        let rig_path =
+            homeboy::core::paths::rigs_in_root(&test_config_root()).join(format!("{rig_id}.json"));
         let mut rig_json: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&rig_path).expect("read rig"))
                 .expect("parse rig");
@@ -1030,7 +1035,7 @@ mod tests {
     fn compare_target_component_uses_rig_declared_component() {
         crate::test_support::with_isolated_home(|_| {
             let component_dir = tempfile::TempDir::new().expect("component dir");
-            let rig_dir = homeboy::core::paths::rigs().expect("rig dir");
+            let rig_dir = homeboy::core::paths::rigs_in_root(&test_config_root());
             std::fs::create_dir_all(&rig_dir).expect("create rig dir");
             std::fs::write(
                 rig_dir.join("trace-lab.json"),
@@ -1077,7 +1082,7 @@ mod tests {
     fn compare_target_component_uses_single_rig_component_by_default() {
         crate::test_support::with_isolated_home(|_| {
             let component_dir = tempfile::TempDir::new().expect("component dir");
-            let rig_dir = homeboy::core::paths::rigs().expect("rig dir");
+            let rig_dir = homeboy::core::paths::rigs_in_root(&test_config_root());
             std::fs::create_dir_all(&rig_dir).expect("create rig dir");
             std::fs::write(
                 rig_dir.join("single-trace-lab.json"),

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -1238,6 +1238,12 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
     use std::process::Command;
 
+    /// A test is the entry point for its own unit of work, so resolving once
+    /// here is a boundary resolution (#7505).
+    fn test_config_root() -> std::path::PathBuf {
+        homeboy_core::paths::homeboy().expect("config root")
+    }
+
     #[test]
     fn old_daemon_evidence_refusal_precedes_workspace_sync() {
         let synced = Cell::new(false);
@@ -1507,7 +1513,7 @@ mod tests {
             git(component_checkout.path(), &["add", "."]);
             git(component_checkout.path(), &["commit", "-m", "component"]);
             let component_ref = git_output(component_checkout.path(), &["rev-parse", "HEAD"]);
-            let rig_dir = homeboy_core::paths::rigs().expect("rig dir");
+            let rig_dir = homeboy_core::paths::rigs_in_root(&test_config_root());
             std::fs::create_dir_all(&rig_dir).expect("create rig dir");
             std::fs::write(
                 rig_dir.join("jetpack-api-route-inventory.json"),

--- a/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
@@ -1274,6 +1274,12 @@ mod tests {
 
     use super::*;
 
+    /// A test is the entry point for its own unit of work, so resolving once
+    /// here is a boundary resolution (#7505).
+    fn test_config_root() -> std::path::PathBuf {
+        homeboy_core::paths::homeboy().expect("config root")
+    }
+
     fn initialize_git_checkout(checkout_root: &Path) {
         let status = Command::new("git")
             .args(["init", "--quiet"])
@@ -1449,7 +1455,7 @@ mod tests {
     }
 
     fn write_checkout_root_rig(rig_id: &str, component_path: &Path, checkout_root: &str) {
-        let rig_dir = homeboy_core::paths::rigs().expect("rig dir");
+        let rig_dir = homeboy_core::paths::rigs_in_root(&test_config_root());
         std::fs::create_dir_all(&rig_dir).expect("create rig dir");
         std::fs::write(
             rig_dir.join(format!("{rig_id}.json")),
@@ -1580,7 +1586,7 @@ mod tests {
             std::fs::create_dir_all(rig_package.join("rigs/jetpack-api-route-inventory"))
                 .expect("rig package");
             std::fs::create_dir_all(&component).expect("component checkout");
-            let rig_dir = homeboy_core::paths::rigs().expect("rig dir");
+            let rig_dir = homeboy_core::paths::rigs_in_root(&test_config_root());
             std::fs::create_dir_all(&rig_dir).expect("create rig dir");
             std::fs::write(
                 rig_dir.join("jetpack-api-route-inventory.json"),
@@ -1732,7 +1738,7 @@ mod tests {
     #[test]
     fn default_component_selects_its_materialized_checkout() {
         homeboy_core::test_support::with_isolated_home(|_| {
-            let rig_dir = homeboy_core::paths::rigs().expect("rig dir");
+            let rig_dir = homeboy_core::paths::rigs_in_root(&test_config_root());
             std::fs::create_dir_all(&rig_dir).expect("create rig dir");
             std::fs::write(
                 rig_dir.join("default-component.json"),
@@ -1796,7 +1802,7 @@ mod tests {
         homeboy_core::test_support::with_isolated_home(|home| {
             let checkout = home.path().join("Developer/woocommerce");
             std::fs::create_dir_all(checkout.join("plugins/woocommerce")).expect("checkout");
-            let rig_dir = homeboy_core::paths::rigs().expect("rig dir");
+            let rig_dir = homeboy_core::paths::rigs_in_root(&test_config_root());
             std::fs::create_dir_all(&rig_dir).expect("create rig dir");
             std::fs::write(
                 rig_dir.join("woocommerce-performance.json"),
@@ -1853,7 +1859,7 @@ mod tests {
         // entry. Planning is network-free; the immutable fetch occurs only on
         // the selected Lab runner during the later sync phase.
         homeboy_core::test_support::with_isolated_home(|_| {
-            let rig_dir = homeboy_core::paths::rigs().expect("rig dir");
+            let rig_dir = homeboy_core::paths::rigs_in_root(&test_config_root());
             std::fs::create_dir_all(&rig_dir).expect("create rig dir");
             let base_sha = "0123456789abcdef0123456789abcdef01234567";
             let pr_sha = "89abcdef0123456789abcdef0123456789abcdef";
@@ -1925,7 +1931,7 @@ mod tests {
             let override_component = override_checkout.join("packages/example-component");
             std::fs::create_dir_all(checkout.join("packages/example-component")).expect("checkout");
             std::fs::create_dir_all(&override_component).expect("override checkout");
-            let rig_dir = homeboy_core::paths::rigs().expect("rig dir");
+            let rig_dir = homeboy_core::paths::rigs_in_root(&test_config_root());
             std::fs::create_dir_all(&rig_dir).expect("create rig dir");
             std::fs::write(
                 rig_dir.join("example-monorepo.json"),
@@ -2015,7 +2021,7 @@ mod tests {
         homeboy_core::test_support::with_isolated_home(|home| {
             let checkout = home.path().join("Developer/example-component");
             std::fs::create_dir_all(&checkout).expect("checkout");
-            let rig_dir = homeboy_core::paths::rigs().expect("rig dir");
+            let rig_dir = homeboy_core::paths::rigs_in_root(&test_config_root());
             std::fs::create_dir_all(&rig_dir).expect("create rig dir");
             std::fs::write(
                 rig_dir.join("example-fuzz.json"),
@@ -2069,7 +2075,7 @@ mod tests {
             let checkout_root = home.path().join("Developer/example");
             let component_path = checkout_root.join("projects/plugins/example-component");
             std::fs::create_dir_all(&component_path).expect("component path");
-            let rig_dir = homeboy_core::paths::rigs().expect("rig dir");
+            let rig_dir = homeboy_core::paths::rigs_in_root(&test_config_root());
             std::fs::create_dir_all(&rig_dir).expect("create rig dir");
             std::fs::write(
                 rig_dir.join("example-fuzz.json"),
@@ -2130,7 +2136,7 @@ mod tests {
             let override_component = override_checkout.join("packages/example-component");
             std::fs::create_dir_all(checkout.join("packages/example-component")).expect("checkout");
             std::fs::create_dir_all(&override_component).expect("override checkout");
-            let rig_dir = homeboy_core::paths::rigs().expect("rig dir");
+            let rig_dir = homeboy_core::paths::rigs_in_root(&test_config_root());
             std::fs::create_dir_all(&rig_dir).expect("create rig dir");
             std::fs::write(
                 rig_dir.join("example-monorepo.json"),
@@ -2268,7 +2274,7 @@ mod tests {
             let checkout = home.path().join("Developer/studio-web");
             std::fs::create_dir_all(checkout.join("rigs/studio-web-product-matrix"))
                 .expect("rig package");
-            let rig_dir = homeboy_core::paths::rigs().expect("rig dir");
+            let rig_dir = homeboy_core::paths::rigs_in_root(&test_config_root());
             std::fs::create_dir_all(&rig_dir).expect("create rig dir");
             std::fs::write(
                 rig_dir.join("studio-web-product-matrix.json"),
@@ -2284,7 +2290,7 @@ mod tests {
                 .to_string(),
             )
             .expect("save rig");
-            std::fs::create_dir_all(homeboy_core::paths::rig_sources().expect("rig sources"))
+            std::fs::create_dir_all(homeboy_core::paths::rig_sources_in_root(&test_config_root()))
                 .expect("create rig sources");
             homeboy_rig::install::write_source_metadata(
                 &homeboy_core::paths::homeboy().expect("config root"),

--- a/crates/homeboy-paths/src/rigs.rs
+++ b/crates/homeboy-paths/src/rigs.rs
@@ -1,4 +1,4 @@
-use super::{expand_tilde_path, homeboy, Result};
+use super::expand_tilde_path;
 use std::env;
 use std::path::{Path, PathBuf};
 
@@ -31,19 +31,9 @@ pub fn rigs_in_root(config_root: &Path) -> PathBuf {
     rig_registry_root_in_root(config_root).join("rigs")
 }
 
-/// Rigs directory (~/.config/homeboy/rigs/)
-pub fn rigs() -> Result<PathBuf> {
-    Ok(rigs_in_root(&homeboy()?))
-}
-
 /// Rig config file path below an already-resolved config root.
 pub fn rig_config_in_root(config_root: &Path, id: &str) -> PathBuf {
     rigs_in_root(config_root).join(format!("{}.json", id))
-}
-
-/// Rig config file path (~/.config/homeboy/rigs/{id}.json)
-pub fn rig_config(id: &str) -> Result<PathBuf> {
-    Ok(rig_config_in_root(&homeboy()?, id))
 }
 
 /// Installed rig package directory below an already-resolved config root.
@@ -59,11 +49,6 @@ pub fn rig_package_in_root(config_root: &Path, id: &str) -> PathBuf {
 /// Rig source metadata directory below an already-resolved config root.
 pub fn rig_sources_in_root(config_root: &Path) -> PathBuf {
     rig_registry_root_in_root(config_root).join("rig-sources")
-}
-
-/// Rig source metadata directory (~/.config/homeboy/rig-sources/)
-pub fn rig_sources() -> Result<PathBuf> {
-    Ok(rig_sources_in_root(&homeboy()?))
 }
 
 /// Rig source metadata file below an already-resolved config root.
@@ -86,20 +71,9 @@ pub fn rig_state_dir_in_root(config_root: &Path, id: &str) -> PathBuf {
     rigs_in_root(config_root).join(format!("{}.state", id))
 }
 
-/// Rig state directory (~/.config/homeboy/rigs/{id}.state/)
-/// Holds service PIDs, logs, and last check results.
-pub fn rig_state_dir(id: &str) -> Result<PathBuf> {
-    Ok(rig_state_dir_in_root(&homeboy()?, id))
-}
-
 /// Rig state file below an already-resolved config root.
 pub fn rig_state_file_in_root(config_root: &Path, id: &str) -> PathBuf {
     rig_state_dir_in_root(config_root, id).join("state.json")
-}
-
-/// Rig state file (~/.config/homeboy/rigs/{id}.state/state.json)
-pub fn rig_state_file(id: &str) -> Result<PathBuf> {
-    Ok(rig_state_file_in_root(&homeboy()?, id))
 }
 
 /// Rig service logs directory below an already-resolved config root.
@@ -107,23 +81,9 @@ pub fn rig_logs_dir_in_root(config_root: &Path, id: &str) -> PathBuf {
     rig_state_dir_in_root(config_root, id).join("logs")
 }
 
-/// Rig service logs directory (~/.config/homeboy/rigs/{id}.state/logs/)
-pub fn rig_logs_dir(id: &str) -> Result<PathBuf> {
-    Ok(rig_logs_dir_in_root(&homeboy()?, id))
-}
-
 /// Rig-owned baseline root below an already-resolved config root.
 pub fn rig_baseline_root_in_root(config_root: &Path, id: &str) -> PathBuf {
     rig_state_dir_in_root(config_root, id).join("baselines")
-}
-
-/// Rig-owned baseline root (~/.config/homeboy/rigs/{id}.state/baselines/).
-///
-/// Baselines for rig-owned workloads (e.g. trace --rig) live here instead of
-/// in the target component checkout. The component repo may be unrelated to
-/// Homeboy and must stay clean.
-pub fn rig_baseline_root(id: &str) -> Result<PathBuf> {
-    Ok(rig_baseline_root_in_root(&homeboy()?, id))
 }
 
 /// Active rig run leases below an already-resolved config root.
@@ -131,19 +91,9 @@ pub fn rig_leases_dir_in_root(config_root: &Path) -> PathBuf {
     rig_registry_root_in_root(config_root).join("rig-leases")
 }
 
-/// Active rig run leases (~/.config/homeboy/rig-leases/).
-pub fn rig_leases_dir() -> Result<PathBuf> {
-    Ok(rig_leases_dir_in_root(&homeboy()?))
-}
-
 /// Stacks directory below an already-resolved config root.
 pub fn stacks_in_root(config_root: &Path) -> PathBuf {
     rig_registry_root_in_root(config_root).join("stacks")
-}
-
-/// Stacks directory (~/.config/homeboy/stacks/)
-pub fn stacks() -> Result<PathBuf> {
-    Ok(stacks_in_root(&homeboy()?))
 }
 
 /// Stack config file path below an already-resolved config root.
@@ -155,9 +105,15 @@ pub fn stack_config_in_root(config_root: &Path, id: &str) -> PathBuf {
 mod tests {
     use super::*;
 
+    /// A test is the entry point for its own unit of work, so resolving once
+    /// here is a boundary resolution (#7505).
+    fn test_config_root() -> std::path::PathBuf {
+        crate::homeboy().expect("config root")
+    }
+
     #[test]
     fn test_rigs_path_under_homeboy_dir() {
-        let path = rigs().expect("rigs path resolves");
+        let path = rigs_in_root(&test_config_root());
         assert!(path.ends_with("rigs"), "got {}", path.display());
         assert!(path.parent().expect("parent").ends_with("homeboy"));
     }
@@ -206,7 +162,7 @@ mod tests {
 
     #[test]
     fn test_rig_config_uses_id_filename() {
-        let path = rig_config("studio-dev").expect("rig_config resolves");
+        let path = rig_config_in_root(&test_config_root(), "studio-dev");
         assert_eq!(
             path.file_name().and_then(|s| s.to_str()),
             Some("studio-dev.json")
@@ -215,7 +171,7 @@ mod tests {
 
     #[test]
     fn test_rig_state_dir_uses_state_suffix() {
-        let path = rig_state_dir("studio-dev").expect("rig_state_dir resolves");
+        let path = rig_state_dir_in_root(&test_config_root(), "studio-dev");
         assert_eq!(
             path.file_name().and_then(|s| s.to_str()),
             Some("studio-dev.state")
@@ -224,7 +180,7 @@ mod tests {
 
     #[test]
     fn test_rig_state_file_nested_under_state_dir() {
-        let path = rig_state_file("studio-dev").expect("rig_state_file resolves");
+        let path = rig_state_file_in_root(&test_config_root(), "studio-dev");
         assert_eq!(
             path.file_name().and_then(|s| s.to_str()),
             Some("state.json")
@@ -239,7 +195,7 @@ mod tests {
 
     #[test]
     fn test_rig_logs_dir_nested_under_state_dir() {
-        let path = rig_logs_dir("studio-dev").expect("rig_logs_dir resolves");
+        let path = rig_logs_dir_in_root(&test_config_root(), "studio-dev");
         assert_eq!(path.file_name().and_then(|s| s.to_str()), Some("logs"));
         assert_eq!(
             path.parent()
@@ -251,7 +207,7 @@ mod tests {
 
     #[test]
     fn test_rig_baseline_root_nested_under_state_dir() {
-        let path = rig_baseline_root("studio-dev").expect("rig_baseline_root resolves");
+        let path = rig_baseline_root_in_root(&test_config_root(), "studio-dev");
         assert_eq!(path.file_name().and_then(|s| s.to_str()), Some("baselines"));
         assert_eq!(
             path.parent()

--- a/tests/core/rig/bench_resource_lease_test.rs
+++ b/tests/core/rig/bench_resource_lease_test.rs
@@ -2,6 +2,12 @@ use super::*;
 use crate::core::error::ErrorCode;
 use std::fs;
 
+/// A test is the entry point for its own unit of work, so resolving once
+/// here is a boundary resolution (#7505).
+fn test_config_root() -> std::path::PathBuf {
+    homeboy_core::paths::homeboy().expect("config root")
+}
+
 fn set_rig_resources(home: &tempfile::TempDir, rig_id: &str, resources: serde_json::Value) {
     let rig_path = home
         .path()
@@ -69,8 +75,6 @@ fn run_single_rig_bench_without_resources_does_not_create_lease() {
         assert!(crate::rig::lease::active_run_leases(home.path())
             .expect("list active leases")
             .is_empty());
-        assert!(!crate::core::paths::rig_leases_dir()
-            .expect("lease dir path")
-            .exists());
+        assert!(!crate::core::paths::rig_leases_dir_in_root(&test_config_root()).exists());
     });
 }

--- a/tests/core/rig/expand_test.rs
+++ b/tests/core/rig/expand_test.rs
@@ -12,6 +12,12 @@ use homeboy_core::test_support::with_isolated_home;
 use std::collections::HashMap;
 use std::fs;
 
+/// A test is the entry point for its own unit of work, so resolving once
+/// here is a boundary resolution (#7505).
+fn test_config_root() -> std::path::PathBuf {
+    homeboy_core::paths::homeboy().expect("config root")
+}
+
 fn rig_with(id: &str, components: HashMap<String, ComponentSpec>) -> RigSpec {
     RigSpec {
         id: id.to_string(),
@@ -82,7 +88,7 @@ fn test_expand_vars_component_path() {
 fn test_expand_vars_package_root_from_installed_source_metadata() {
     with_isolated_home(|home| {
         let package_root = home.path().join("rig-packages/studio-web");
-        let metadata_dir = paths::rig_sources().expect("rig sources dir");
+        let metadata_dir = paths::rig_sources_in_root(&test_config_root());
         fs::create_dir_all(&metadata_dir).expect("mkdir rig sources");
         fs::write(
             metadata_dir.join("studio-web-product-matrix.json"),

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -83,7 +83,7 @@ mod discovery {
         assert_eq!(result.installed.len(), 1);
         assert_eq!(result.installed[0].id, "alpha");
 
-        let installed = homeboy_core::paths::rig_config("alpha").expect("rig path");
+        let installed = homeboy_core::paths::rig_config_in_root(&test_config_root(), "alpha");
         assert!(installed.exists());
         #[cfg(unix)]
         assert_eq!(fs::read_link(&installed).expect("symlink"), source);
@@ -817,7 +817,7 @@ mod install_flows {
         .expect("install");
 
         assert_eq!(result.installed.len(), 1);
-        let installed_path = homeboy_core::paths::rig_config("alpha").expect("rig config");
+        let installed_path = homeboy_core::paths::rig_config_in_root(&test_config_root(), "alpha");
         #[cfg(unix)]
         assert!(fs::read_link(&installed_path).is_err());
         let installed = fs::read_to_string(&installed_path).expect("installed rig");
@@ -1166,7 +1166,7 @@ mod install_flows {
             )
             .expect("install");
 
-            let installed_path = homeboy_core::paths::rig_config(id).expect("rig config");
+            let installed_path = homeboy_core::paths::rig_config_in_root(&test_config_root(), id);
             let installed = fs::read_to_string(&installed_path).expect("installed rig");
             assert!(!installed.contains("$append"));
             assert!(!installed.contains("$merge_by"));
@@ -1230,7 +1230,8 @@ mod install_flows {
             false,
         )
         .expect("install");
-        let installed_path = homeboy_core::paths::rig_config("replacer").expect("rig config");
+        let installed_path =
+            homeboy_core::paths::rig_config_in_root(&test_config_root(), "replacer");
         let installed = fs::read_to_string(&installed_path).expect("installed rig");
         let value: serde_json::Value = serde_json::from_str(&installed).expect("materialized json");
         let labels: Vec<&str> = value["pipeline"]["check"]
@@ -1351,8 +1352,8 @@ mod multi_rig {
         .expect("install");
         assert_eq!(result.installed.len(), 1);
         assert_eq!(result.installed[0].id, "beta");
-        assert!(homeboy_core::paths::rig_config("beta").unwrap().exists());
-        assert!(!homeboy_core::paths::rig_config("alpha").unwrap().exists());
+        assert!(homeboy_core::paths::rig_config_in_root(&test_config_root(), "beta").exists());
+        assert!(!homeboy_core::paths::rig_config_in_root(&test_config_root(), "alpha").exists());
     }
 
     #[test]
@@ -1387,8 +1388,8 @@ mod multi_rig {
         assert_eq!(result.installed.len(), 1);
         assert_eq!(result.installed[0].id, "alpha");
         assert!(result.installed_stacks.is_empty());
-        assert!(homeboy_core::paths::rig_config("alpha").unwrap().exists());
-        assert!(!homeboy_core::paths::rig_config("beta").unwrap().exists());
+        assert!(homeboy_core::paths::rig_config_in_root(&test_config_root(), "alpha").exists());
+        assert!(!homeboy_core::paths::rig_config_in_root(&test_config_root(), "beta").exists());
         assert_eq!(
             fs::read_link(homeboy_core::paths::stack_config_in_root(
                 &test_config_root(),
@@ -1422,8 +1423,8 @@ mod multi_rig {
 
         assert_eq!(result.installed.len(), 1);
         assert_eq!(result.installed[0].id, "alpha");
-        assert!(homeboy_core::paths::rig_config("alpha").unwrap().exists());
-        assert!(!homeboy_core::paths::rig_config("broken").unwrap().exists());
+        assert!(homeboy_core::paths::rig_config_in_root(&test_config_root(), "alpha").exists());
+        assert!(!homeboy_core::paths::rig_config_in_root(&test_config_root(), "broken").exists());
     }
 
     #[test]
@@ -1460,8 +1461,8 @@ mod multi_rig {
         )
         .expect("install");
         assert_eq!(result.installed.len(), 2);
-        assert!(homeboy_core::paths::rig_config("alpha").unwrap().exists());
-        assert!(homeboy_core::paths::rig_config("beta").unwrap().exists());
+        assert!(homeboy_core::paths::rig_config_in_root(&test_config_root(), "alpha").exists());
+        assert!(homeboy_core::paths::rig_config_in_root(&test_config_root(), "beta").exists());
     }
 
     #[test]
@@ -1498,8 +1499,8 @@ mod multi_rig {
                     && outcome["active_homeboy_version"]
                         == homeboy_product_identity::product_version()
             }));
-        assert!(!homeboy_core::paths::rig_config("alpha").unwrap().exists());
-        assert!(!homeboy_core::paths::rig_config("beta").unwrap().exists());
+        assert!(!homeboy_core::paths::rig_config_in_root(&test_config_root(), "alpha").exists());
+        assert!(!homeboy_core::paths::rig_config_in_root(&test_config_root(), "beta").exists());
     }
 }
 
@@ -1513,9 +1514,10 @@ mod refresh_and_identity {
         let refreshed = minimal_rig("alpha").replace("alpha rig", "alpha rig refreshed");
         write_rig(package.path(), "alpha", &refreshed);
 
-        fs::create_dir_all(homeboy_core::paths::rigs().expect("rigs dir")).expect("rigs dir");
+        fs::create_dir_all(homeboy_core::paths::rigs_in_root(&test_config_root()))
+            .expect("rigs dir");
         fs::write(
-            homeboy_core::paths::rig_config("alpha").expect("alpha rig path"),
+            homeboy_core::paths::rig_config_in_root(&test_config_root(), "alpha"),
             minimal_rig("alpha"),
         )
         .expect("stale installed rig");
@@ -1529,8 +1531,11 @@ mod refresh_and_identity {
         .expect("refresh");
 
         assert_eq!(result.installed.len(), 1);
-        let installed = fs::read_to_string(homeboy_core::paths::rig_config("alpha").unwrap())
-            .expect("installed rig");
+        let installed = fs::read_to_string(homeboy_core::paths::rig_config_in_root(
+            &test_config_root(),
+            "alpha",
+        ))
+        .expect("installed rig");
         assert!(installed.contains("alpha rig refreshed"));
         assert_eq!(
             read_source_metadata_in_root(&test_config_root(), "alpha")
@@ -1548,8 +1553,9 @@ mod refresh_and_identity {
         let refreshed = minimal_rig("alpha").replace("alpha rig", "alpha rig refreshed");
         let source = write_rig(package.path(), "alpha", &refreshed);
 
-        fs::create_dir_all(homeboy_core::paths::rigs().expect("rigs dir")).expect("rigs dir");
-        let installed = homeboy_core::paths::rig_config("alpha").expect("alpha rig path");
+        fs::create_dir_all(homeboy_core::paths::rigs_in_root(&test_config_root()))
+            .expect("rigs dir");
+        let installed = homeboy_core::paths::rig_config_in_root(&test_config_root(), "alpha");
         std::os::unix::fs::symlink(package.path().join("missing-rig.json"), &installed)
             .expect("broken rig symlink");
 
@@ -1573,9 +1579,10 @@ mod refresh_and_identity {
         let package = tempfile::tempdir().expect("package");
         write_rig(package.path(), "alpha", &minimal_rig("alpha"));
 
-        fs::create_dir_all(homeboy_core::paths::rigs().expect("rigs dir")).expect("rigs dir");
+        fs::create_dir_all(homeboy_core::paths::rigs_in_root(&test_config_root()))
+            .expect("rigs dir");
         fs::write(
-            homeboy_core::paths::rig_config("alpha").expect("alpha rig path"),
+            homeboy_core::paths::rig_config_in_root(&test_config_root(), "alpha"),
             minimal_rig("beta"),
         )
         .expect("conflicting installed rig");
@@ -1597,7 +1604,8 @@ mod refresh_and_identity {
         write_rig(package.path(), "studio", &minimal_rig("studio"));
         let stack_path = write_stack(package.path(), "studio-combined", "studio");
 
-        fs::create_dir_all(homeboy_core::paths::stacks().expect("stacks dir")).expect("stacks dir");
+        fs::create_dir_all(homeboy_core::paths::stacks_in_root(&test_config_root()))
+            .expect("stacks dir");
         fs::write(
             homeboy_core::paths::stack_config_in_root(&test_config_root(), "studio-combined"),
             fs::read_to_string(&stack_path).expect("package stack"),
@@ -1627,7 +1635,8 @@ mod refresh_and_identity {
         write_stack(package.path(), "studio-combined", "studio");
         let manual_stack = minimal_stack("studio-combined", "other");
 
-        fs::create_dir_all(homeboy_core::paths::stacks().expect("stacks dir")).expect("stacks dir");
+        fs::create_dir_all(homeboy_core::paths::stacks_in_root(&test_config_root()))
+            .expect("stacks dir");
         let stack_config =
             homeboy_core::paths::stack_config_in_root(&test_config_root(), "studio-combined");
         fs::write(&stack_config, &manual_stack).expect("conflicting stack");
@@ -1649,9 +1658,10 @@ mod refresh_and_identity {
     #[test]
     fn installed_filename_is_runtime_identity_when_declared_id_differs() {
         let _home = HomeGuard::new();
-        fs::create_dir_all(homeboy_core::paths::rigs().expect("rigs dir")).expect("rigs dir");
+        fs::create_dir_all(homeboy_core::paths::rigs_in_root(&test_config_root()))
+            .expect("rigs dir");
         fs::write(
-            homeboy_core::paths::rig_config("replacement").expect("replacement rig path"),
+            homeboy_core::paths::rig_config_in_root(&test_config_root(), "replacement"),
             minimal_rig("alpha"),
         )
         .expect("replacement rig");
@@ -1690,16 +1700,15 @@ mod refresh_and_identity {
     #[test]
     fn rig_list_ids_skip_non_json_files() {
         let _home = HomeGuard::new();
-        fs::create_dir_all(homeboy_core::paths::rigs().expect("rigs dir")).expect("rigs dir");
+        fs::create_dir_all(homeboy_core::paths::rigs_in_root(&test_config_root()))
+            .expect("rigs dir");
         fs::write(
-            homeboy_core::paths::rig_config("alpha").expect("alpha rig path"),
+            homeboy_core::paths::rig_config_in_root(&test_config_root(), "alpha"),
             minimal_rig("alpha"),
         )
         .expect("alpha rig");
         fs::write(
-            homeboy_core::paths::rigs()
-                .expect("rigs dir")
-                .join("ignore.txt"),
+            homeboy_core::paths::rigs_in_root(&test_config_root()).join("ignore.txt"),
             "not json",
         )
         .expect("non-json rig sidecar");
@@ -1741,8 +1750,8 @@ mod git_url {
         assert!(result.installed[0]
             .spec_path
             .ends_with("packages/studio/rig.json"));
-        assert!(homeboy_core::paths::rig_config("studio").unwrap().exists());
-        assert!(!homeboy_core::paths::rig_config("other").unwrap().exists());
+        assert!(homeboy_core::paths::rig_config_in_root(&test_config_root(), "studio").exists());
+        assert!(!homeboy_core::paths::rig_config_in_root(&test_config_root(), "other").exists());
         assert_eq!(result.installed_stacks.len(), 1);
         assert_eq!(result.installed_stacks[0].id, "studio-combined");
         assert!(

--- a/tests/core/rig/lease_test.rs
+++ b/tests/core/rig/lease_test.rs
@@ -297,7 +297,7 @@ fn test_acquire_active_run_lease_prunes_stale_pid() {
             runner_id: None,
             resources: resources(),
         };
-        let lease_dir = homeboy_core::paths::rig_leases_dir().expect("lease dir");
+        let lease_dir = homeboy_core::paths::rig_leases_dir_in_root(&test_config_root());
         std::fs::create_dir_all(&lease_dir).expect("create lease dir");
         std::fs::write(
             lease_dir.join("studio.json"),
@@ -315,7 +315,7 @@ fn test_acquire_active_run_lease_prunes_stale_pid() {
 }
 
 fn write_lease(lease: &RigRunLease) {
-    let lease_dir = homeboy_core::paths::rig_leases_dir().expect("lease dir");
+    let lease_dir = homeboy_core::paths::rig_leases_dir_in_root(&test_config_root());
     std::fs::create_dir_all(&lease_dir).expect("create lease dir");
     std::fs::write(
         lease_dir.join(format!("{}.json", lease.rig_id)),

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -216,7 +216,7 @@ fn test_remove_source() {
         true,
     )
     .expect("install all");
-    let manual = homeboy_core::paths::rig_config("manual").expect("manual rig path");
+    let manual = homeboy_core::paths::rig_config_in_root(&test_config_root(), "manual");
     fs::write(&manual, minimal_rig("manual")).expect("manual rig");
 
     let result = remove_source(&test_config_root(), &package.path().to_string_lossy())
@@ -224,8 +224,8 @@ fn test_remove_source() {
     assert_eq!(result.removed.len(), 2);
     assert!(result.skipped.is_empty());
     assert!(result.removed_package_path.is_none());
-    assert!(!homeboy_core::paths::rig_config("alpha").unwrap().exists());
-    assert!(!homeboy_core::paths::rig_config("beta").unwrap().exists());
+    assert!(!homeboy_core::paths::rig_config_in_root(&test_config_root(), "alpha").exists());
+    assert!(!homeboy_core::paths::rig_config_in_root(&test_config_root(), "beta").exists());
     assert!(
         !homeboy_core::paths::rig_source_metadata_in_root(&test_config_root(), "alpha").exists()
     );
@@ -249,7 +249,7 @@ fn remove_source_preserves_replaced_config_but_drops_metadata() {
         false,
     )
     .expect("install");
-    let config = homeboy_core::paths::rig_config("alpha").expect("rig config");
+    let config = homeboy_core::paths::rig_config_in_root(&test_config_root(), "alpha");
     fs::remove_file(&config).expect("remove symlink");
     fs::write(&config, minimal_rig("replacement")).expect("replacement rig");
 
@@ -307,7 +307,7 @@ fn remove_source_treats_copied_config_as_owned_when_contents_match() {
         false,
     )
     .expect("install");
-    let config = homeboy_core::paths::rig_config("alpha").expect("rig config");
+    let config = homeboy_core::paths::rig_config_in_root(&test_config_root(), "alpha");
     fs::remove_file(&config).expect("remove symlink");
     fs::copy(&source, &config).expect("copy rig config");
 
@@ -327,7 +327,7 @@ fn remove_source_treats_copied_config_as_owned_when_contents_match() {
 #[test]
 fn sources_list_reports_corrupt_metadata_and_missing_configs() {
     let _home = HomeGuard::new();
-    fs::create_dir_all(homeboy_core::paths::rig_sources().expect("sources dir"))
+    fs::create_dir_all(homeboy_core::paths::rig_sources_in_root(&test_config_root()))
         .expect("sources dir");
     fs::write(
         homeboy_core::paths::rig_source_metadata_in_root(&test_config_root(), "broken"),
@@ -425,16 +425,14 @@ fn missing_linked_source_gets_rig_source_diagnostic_not_not_found_hint() {
 #[test]
 fn sources_list_skips_non_json_and_collects_invalid_stack_metadata() {
     let _home = HomeGuard::new();
-    fs::create_dir_all(homeboy_core::paths::rig_sources().expect("rig sources dir"))
+    fs::create_dir_all(homeboy_core::paths::rig_sources_in_root(&test_config_root()))
         .expect("rig sources dir");
     fs::create_dir_all(homeboy_core::paths::stack_sources_in_root(
         &test_config_root(),
     ))
     .expect("stack sources dir");
     fs::write(
-        homeboy_core::paths::rig_sources()
-            .expect("rig sources dir")
-            .join("ignored.txt"),
+        homeboy_core::paths::rig_sources_in_root(&test_config_root()).join("ignored.txt"),
         "not json",
     )
     .expect("non-json metadata");
@@ -443,7 +441,8 @@ fn sources_list_skips_non_json_and_collects_invalid_stack_metadata() {
         "not json",
     )
     .expect("broken stack metadata");
-    fs::create_dir_all(homeboy_core::paths::stacks().expect("stacks dir")).expect("stacks dir");
+    fs::create_dir_all(homeboy_core::paths::stacks_in_root(&test_config_root()))
+        .expect("stacks dir");
     fs::write(
         homeboy_core::paths::stack_config_in_root(&test_config_root(), "broken-stack"),
         minimal_stack("broken-stack", "broken"),
@@ -490,8 +489,11 @@ fn update_git_source_fast_forwards_package_and_refreshes_metadata() {
     assert_eq!(result.updated[0].id, "alpha");
     assert_eq!(result.updated[0].previous_revision, before);
     assert_ne!(result.updated[0].source_revision, before);
-    let installed = fs::read_to_string(homeboy_core::paths::rig_config("alpha").unwrap())
-        .expect("installed rig");
+    let installed = fs::read_to_string(homeboy_core::paths::rig_config_in_root(
+        &test_config_root(),
+        "alpha",
+    ))
+    .expect("installed rig");
     assert!(installed.contains("alpha rig updated"));
     assert_eq!(
         crate::read_source_metadata("alpha")
@@ -582,11 +584,12 @@ fn legacy_source_without_a_valid_discovery_path_fails_before_refresh_mutation() 
         homeboy_core::git::short_head_revision_at(Path::new(&installed_root)),
         installed_revision
     );
-    assert!(
-        !fs::read_to_string(homeboy_core::paths::rig_config("alpha").unwrap())
-            .expect("installed rig")
-            .contains("remote update")
-    );
+    assert!(!fs::read_to_string(homeboy_core::paths::rig_config_in_root(
+        &test_config_root(),
+        "alpha"
+    ))
+    .expect("installed rig")
+    .contains("remote update"));
 }
 
 #[test]
@@ -622,8 +625,11 @@ fn update_all_reports_broken_sources_and_continues() {
     assert!(result.failed[0].reason.contains("missing"));
     assert_eq!(result.updated.len(), 1);
     assert_eq!(result.updated[0].id, "good");
-    let installed = fs::read_to_string(homeboy_core::paths::rig_config("good").unwrap())
-        .expect("installed good rig");
+    let installed = fs::read_to_string(homeboy_core::paths::rig_config_in_root(
+        &test_config_root(),
+        "good",
+    ))
+    .expect("installed good rig");
     assert!(installed.contains("good rig updated"));
 }
 
@@ -658,17 +664,16 @@ fn refresh_source_selector_updates_recorded_package() {
     assert_eq!(result.updated[0].source, source);
     assert_eq!(
         result.updated[0].path,
-        homeboy_core::paths::rig_config("alpha")
-            .unwrap()
-            .to_string_lossy()
+        homeboy_core::paths::rig_config_in_root(&test_config_root(), "alpha").to_string_lossy()
     );
     assert_eq!(result.updated[0].previous_revision, before);
     assert_ne!(result.updated[0].source_revision, before);
-    assert!(
-        fs::read_to_string(homeboy_core::paths::rig_config("alpha").unwrap())
-            .expect("installed rig")
-            .contains("alpha rig refreshed")
-    );
+    assert!(fs::read_to_string(homeboy_core::paths::rig_config_in_root(
+        &test_config_root(),
+        "alpha"
+    ))
+    .expect("installed rig")
+    .contains("alpha rig refreshed"));
 }
 
 #[test]


### PR DESCRIPTION
**365 pairs → 356.** An entire module's ambient layer, gone in one pass.

## All nine had zero production callers

`rigs`, `stacks`, `rig_config`, `rig_sources`, `rig_state_dir`, `rig_state_file`, `rig_logs_dir`, `rig_baseline_root`, `rig_leases_dir`.

The production code of `homeboy-paths/src/rigs.rs` was **already fully rooted**. The ambient layer survived purely because tests called it.

## Why the orphan guard never fired

The guard from #13123 reports a wrapper with **no mentions at all** — and a test mention is a mention. That is the right call for safety (it's what stops the function-pointer false deletions), but it means *test-only ambient layers are invisible to it*. This class needs the caller scan, filtered to production files.

Worth knowing: there are likely more modules in this state.

## What changed

70 test call sites moved to the `_in_root` forms behind a local `test_config_root()`. The rooted siblings are **infallible**, so the `.expect()` and `?` the fallible ambient forms required are gone with them:

```rust
- let path = rig_config("studio-dev").expect("rig_config resolves");
+ let path = rig_config_in_root(&test_config_root(), "studio-dev");
```

## The compiler confirmed the result

After deletion, `homeboy` and `Result` were **unused imports** in the module. Outside one doc comment and the test helper, `rigs.rs` no longer resolves a path root at all.

## Verification

- `cargo check --workspace --all-targets -j2` — green, no new warnings (using the corrected gate from #13168)
- `no_orphaned_ambient_wrappers_test` — green

Refs #7505.