### PR TITLE
fix(ci): restore bounded resolver fixture gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: dtolnay/rust-toolchain@1.95.0
       - name: Run portable external resolver fixture subprocess tests
-        run: cargo test --locked -p homeboy-cli --features test-support --test external_check_detail_resolver_fixture
+        # Keep this filter compatible with PR heads created before the fixture
+        # was extracted: the library fixture is the portable contract.
+        run: cargo test --locked -p homeboy-cli --lib cross_platform_fixture
 
   # Keep `main` rustfmt-clean so a feature branch's `cargo fmt` only ever touches
   # the files it changed. Without this gate, unformatted files drift onto main

--- a/crates/homeboy-cli/src/commands/ci.rs
+++ b/crates/homeboy-cli/src/commands/ci.rs
@@ -4,12 +4,6 @@ mod gate;
 mod plan;
 mod scope;
 
-#[cfg(feature = "test-support")]
-#[doc(hidden)]
-pub fn test_external_check_detail_resolver_fixture() {
-    external_check_detail_resolver::test_cross_platform_fixture();
-}
-
 use clap::{Args, Subcommand};
 use serde::Serialize;
 use std::path::PathBuf;

--- a/crates/homeboy-cli/src/commands/ci/external_check_detail_resolver.rs
+++ b/crates/homeboy-cli/src/commands/ci/external_check_detail_resolver.rs
@@ -369,7 +369,10 @@ fn invoke(
             Ok(None) => {
                 cleanup(&containment, &mut child, false);
                 join_readers(stdout_reader, stderr_reader);
-                return Err(InvocationFailure::Unavailable("Resolver timed out.".into()));
+                return Err(InvocationFailure::Unavailable(
+                    "Resolver timed out at its deadline; its process tree was terminated. Inspect the extension resolver command and its child-process cleanup."
+                        .into(),
+                ));
             }
             Err(error) => {
                 cleanup(&containment, &mut child, false);
@@ -450,23 +453,54 @@ fn bound(value: &str, limit: usize) -> String {
     value.chars().take(limit).collect()
 }
 
-#[cfg(any(test, feature = "test-support"))]
-pub(super) fn test_cross_platform_fixture() {
+#[cfg(test)]
+#[test]
+fn cross_platform_fixture() {
     const FIXTURE_MODE_ENV: &str = "HOMEBOY_EXTERNAL_CHECK_FIXTURE_MODE";
 
-    for (mode, expected_detail, expected_diagnostic) in [
-        ("success", true, None),
-        ("unavailable", false, Some("unavailable")),
-        ("malformed", false, Some("malformed")),
-        ("missing-executable", false, Some("unavailable")),
+    for (mode, expected_detail, expected_diagnostic, budget, expected_message) in [
+        ("success", true, None, Duration::from_secs(10), None),
+        (
+            "unavailable",
+            false,
+            Some("unavailable"),
+            Duration::from_secs(10),
+            None,
+        ),
+        (
+            "malformed",
+            false,
+            Some("malformed"),
+            Duration::from_secs(10),
+            None,
+        ),
+        (
+            "missing-executable",
+            false,
+            Some("unavailable"),
+            Duration::from_secs(10),
+            None,
+        ),
+        (
+            "timeout",
+            false,
+            Some("unavailable"),
+            Duration::from_millis(200),
+            Some("process tree was terminated"),
+        ),
     ] {
         homeboy::core::test_support::with_isolated_home(|_| {
             install_fixture_extension(mode, FIXTURE_MODE_ENV);
+            let started = Instant::now();
             let (details, diagnostics) = hydrate(
                 "fixture-ci",
                 "failure",
                 Some("https://example.test/build/42"),
-                Instant::now() + Duration::from_secs(10),
+                started + budget,
+            );
+            assert!(
+                started.elapsed() < Duration::from_secs(3),
+                "{mode}: resolver timeout did not return after process cleanup"
             );
             assert_eq!(
                 details.len() == 1,
@@ -480,6 +514,12 @@ pub(super) fn test_cross_platform_fixture() {
                 expected_diagnostic,
                 "{mode}"
             );
+            if let Some(expected_message) = expected_message {
+                assert!(
+                    diagnostics[0].message.contains(expected_message),
+                    "{mode}: {diagnostics:?}"
+                );
+            }
             if mode == "success" {
                 assert_eq!(details[0].actions, ["fixture-ci replay 42"]);
                 let mut resolver_slots = MAX_RESOLVERS;
@@ -526,7 +566,7 @@ pub(super) fn test_cross_platform_fixture() {
     });
 }
 
-#[cfg(any(test, feature = "test-support"))]
+#[cfg(test)]
 fn install_fixture_extension(mode: &str, fixture_mode_env: &str) {
     let root = homeboy::core::paths::homeboy().unwrap();
     let extension = root.join("extensions").join("fixture-external-check");
@@ -555,7 +595,7 @@ fn install_fixture_extension(mode: &str, fixture_mode_env: &str) {
     std::env::set_var(fixture_mode_env, mode);
 }
 
-#[cfg(all(any(test, feature = "test-support"), unix))]
+#[cfg(all(test, unix))]
 fn fixture_program(extension: &Path, fixture_mode_env: &str) -> String {
     use std::os::unix::fs::PermissionsExt;
 
@@ -564,7 +604,7 @@ fn fixture_program(extension: &Path, fixture_mode_env: &str) -> String {
     std::fs::write(
         &path,
         format!(
-            "#!/bin/sh\ncase \"${fixture_mode_env}\" in\nsuccess) printf '%s\\n' '{{\"schema\":\"homeboy/external-check-detail-response/v1\",\"provider\":\"fixture-ci\",\"summary\":\"fixture hydrated failure\",\"actions\":[\"fixture-ci replay 42\"]}}' ;;\nmalformed) printf '%s' 'not json' ;;\nunavailable) exit 23 ;;\n*) exit 24 ;;\nesac\n"
+            "#!/bin/sh\ncase \"${fixture_mode_env}\" in\nsuccess) printf '%s\\n' '{{\"schema\":\"homeboy/external-check-detail-response/v1\",\"provider\":\"fixture-ci\",\"summary\":\"fixture hydrated failure\",\"actions\":[\"fixture-ci replay 42\"]}}' ;;\nmalformed) printf '%s' 'not json' ;;\nunavailable) exit 23 ;;\ntimeout) sleep 30 ;;\n*) exit 24 ;;\nesac\n"
         ),
     )
     .unwrap();
@@ -572,14 +612,14 @@ fn fixture_program(extension: &Path, fixture_mode_env: &str) -> String {
     name.into()
 }
 
-#[cfg(all(any(test, feature = "test-support"), windows))]
+#[cfg(all(test, windows))]
 fn fixture_program(extension: &Path, fixture_mode_env: &str) -> String {
     let name = "fixture-resolver.cmd";
     let path = extension.join(name);
     std::fs::write(
         &path,
         format!(
-            "@echo off\r\nif \"%{fixture_mode_env}%\"==\"success\" (echo {{\"schema\":\"homeboy/external-check-detail-response/v1\",\"provider\":\"fixture-ci\",\"summary\":\"fixture hydrated failure\",\"actions\":[\"fixture-ci replay 42\"]}}& exit /b 0)\r\nif \"%{fixture_mode_env}%\"==\"malformed\" (set /p =not json<nul& exit /b 0)\r\nif \"%{fixture_mode_env}%\"==\"unavailable\" exit /b 23\r\nexit /b 24\r\n"
+            "@echo off\r\nif \"%{fixture_mode_env}%\"==\"success\" (echo {{\"schema\":\"homeboy/external-check-detail-response/v1\",\"provider\":\"fixture-ci\",\"summary\":\"fixture hydrated failure\",\"actions\":[\"fixture-ci replay 42\"]}}& exit /b 0)\r\nif \"%{fixture_mode_env}%\"==\"malformed\" (set /p =not json<nul& exit /b 0)\r\nif \"%{fixture_mode_env}%\"==\"unavailable\" exit /b 23\r\nif \"%{fixture_mode_env}%\"==\"timeout\" timeout /t 30 /nobreak >nul\r\nexit /b 24\r\n"
         ),
     )
     .unwrap();
@@ -589,8 +629,6 @@ fn fixture_program(extension: &Path, fixture_mode_env: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    const FIXTURE_MODE_ENV: &str = "HOMEBOY_EXTERNAL_CHECK_FIXTURE_MODE";
 
     #[test]
     fn target_url_strips_fragments_and_credentials() {
@@ -679,7 +717,7 @@ mod tests {
         .expect_err("resolver must time out");
         assert!(matches!(
             error,
-            InvocationFailure::Unavailable(ref message) if message == "Resolver timed out."
+            InvocationFailure::Unavailable(ref message) if message.contains("process tree was terminated")
         ));
         let descendant_pid = std::fs::read_to_string(&pid_file)
             .unwrap()

--- a/crates/homeboy-cli/tests/external_check_detail_resolver_fixture.rs
+++ b/crates/homeboy-cli/tests/external_check_detail_resolver_fixture.rs
@@ -1,4 +1,0 @@
-#[test]
-fn discovery_invokes_cross_platform_fixture_for_success_unavailable_and_malformed() {
-    homeboy_cli::commands::ci::test_external_check_detail_resolver_fixture();
-}

--- a/tests/pr_ci_lifecycle_test.rs
+++ b/tests/pr_ci_lifecycle_test.rs
@@ -94,6 +94,7 @@ fn closed_prs_stop_candidate_admission_at_every_fanout_boundary() {
         "workspace-tests-compile",
         "warning-clean",
         "windows-compile",
+        "external-resolver-fixtures",
         "rustfmt",
         "homeboy-fast",
         "homeboy",
@@ -114,6 +115,12 @@ fn closed_prs_stop_candidate_admission_at_every_fanout_boundary() {
     assert!(test.contains("uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@"));
     assert!(test.contains("needs: [pr-state, ci-capacity-admission]"));
     assert!(test.contains("test-shards: ${{ needs.ci-capacity-admission.outputs.test-shards }}"));
+
+    let resolver_fixture = job_section(workflow, "external-resolver-fixtures");
+    assert!(resolver_fixture.contains("os: [ubuntu-latest, macos-14, windows-latest]"));
+    assert!(resolver_fixture
+        .contains("cargo test --locked -p homeboy-cli --lib cross_platform_fixture"));
+    assert!(!resolver_fixture.contains("--test external_check_detail_resolver_fixture"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- run the stable in-library external resolver fixture on every hosted OS instead of a branch-sensitive integration target
- exercise a 200 ms hanging resolver on Unix and Windows, verify prompt cleanup, and retain a diagnostic identifying terminated process-tree cleanup
- assert the workflow keeps the portable matrix and stable test contract

Fixes #13160

## Verification
- `cargo test --locked -p homeboy-cli --lib cross_platform_fixture`
- `cargo test --locked --test pr_ci_lifecycle_test`
- `RUSTFLAGS=-Dwarnings cargo check --locked -p homeboy-cli`
- `rustfmt --check --edition 2021 crates/homeboy-cli/src/commands/ci/external_check_detail_resolver.rs tests/pr_ci_lifecycle_test.rs`
- `git diff --check`

`cargo fmt --all --check` remains blocked by existing trailing whitespace in two unrelated agent-task test files; touched Rust files pass direct rustfmt checking.

## AI Assistance
GPT-5.6 Sol via OpenCode AI was used to inspect the run evidence, identify the branch-sensitive fixture-target regression, implement the bounded cross-platform fixture, and run focused verification. Chris Huber reviewed and remains responsible for every line.