### PR TITLE
fix: stop reporting an empty process scope as an escaped descendant (#13128)

### DIFF
--- a/crates/homeboy-core/src/process.rs
+++ b/crates/homeboy-core/src/process.rs
@@ -158,10 +158,14 @@ pub struct ProcessContainment {
 
 /// The result of best-effort containment cleanup. Linux process scopes use an
 /// inherited environment marker rather than a kernel-enforced boundary, so an
-/// escaped descendant can remove the marker before it is discovered.
+/// escaped descendant can remove the marker before it is discovered. That blind
+/// spot is real, but it is invisible to marker discovery by construction —
+/// callers detect it through the pipes such a descendant keeps open, not here.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProcessContainmentCleanup {
     pub forced: bool,
+    /// True when no run-owned process is known to remain. An empty scope is the
+    /// goal state of cleanup, so it reads as complete rather than as a failure.
     pub complete: bool,
     /// Non-fatal evidence collected while confirming cleanup. This is separate
     /// from `detail` so unrelated host-process metadata cannot turn a verified
@@ -1273,16 +1277,24 @@ fn scope_cleanup_report(
     let unreadable = targets
         .unreadable_environments
         .max(survivors.unreadable_environments);
-    let complete = !targets.pids.is_empty() && survivors.pids.is_empty();
+    // An empty scope is the state cleanup exists to produce, so it cannot also
+    // be cleanup's failure signal. Every command whose processes exited leaves
+    // discovery with nothing to find, and that is indistinguishable from a
+    // descendant that escaped by unsetting HOMEBOY_PROCESS_SCOPE. Treating the
+    // two alike reported "an escaped descendant may have removed
+    // HOMEBOY_PROCESS_SCOPE" on every clean short-lived command (#13128).
+    //
+    // A marker-dropping escapee is caught where it leaves real evidence
+    // instead: it inherits this command's stdout/stderr, so `run_local_command`
+    // sees the pipes stay open after teardown and fails the command there.
+    // Marker discovery cannot see it at all, and claiming otherwise only
+    // produced noise.
+    let complete = survivors.pids.is_empty();
     let detail = (!complete).then(|| {
-        if !survivors.pids.is_empty() {
-            format!(
-                "process-scope cleanup confirmed run-owned survivors: {}",
-                join_pids(&survivors.pids)
-            )
-        } else {
-            "process-scope discovery found no marker-owned process; an escaped descendant may have removed HOMEBOY_PROCESS_SCOPE".to_string()
-        }
+        format!(
+            "process-scope cleanup confirmed run-owned survivors: {}",
+            join_pids(&survivors.pids)
+        )
     });
     ProcessContainmentCleanup {
         forced,
@@ -1808,7 +1820,10 @@ mod tests {
 
     #[test]
     fn scope_cleanup_keeps_unreadable_same_owner_environments_as_diagnostics() {
-        let omitted = scope_cleanup_report(
+        // A scope that is already empty when teardown starts is the ordinary
+        // end state of every command whose processes exited. It must report
+        // clean and say nothing (#13128).
+        let drained = scope_cleanup_report(
             LinuxScopeDiscovery {
                 pids: Vec::new(),
                 unreadable_environments: 0,
@@ -1819,11 +1834,9 @@ mod tests {
             },
             false,
         );
-        assert!(!omitted.complete);
-        assert!(omitted
-            .detail
-            .as_deref()
-            .is_some_and(|detail| detail.contains("no marker-owned process")));
+        assert!(drained.complete);
+        assert_eq!(drained.detail, None);
+        assert_eq!(drained.diagnostic, None);
 
         let unreadable = scope_cleanup_report(
             LinuxScopeDiscovery {

--- a/crates/homeboy-extension/src/execution.rs
+++ b/crates/homeboy-extension/src/execution.rs
@@ -1637,7 +1637,12 @@ mod tests {
         assert_eq!(output.stdout, "{\"status\":\"passed\"}\n");
         assert!(!output.success);
         assert!(output.timed_out);
-        assert!(output.stderr.contains("containment cleanup diagnostic"));
+        // The escapee unset HOMEBOY_PROCESS_SCOPE, so marker discovery is blind
+        // to it by construction. What it cannot hide is the stdout/stderr it
+        // inherited: the pipes stay open past teardown, and that is what fails
+        // this command. Asserting on a marker-discovery message instead would
+        // pass for the wrong reason, because a clean run produced the identical
+        // message (#13128).
         assert!(output.stderr.contains("output pipes remained open"));
         assert!(
             homeboy_core::process::pid_is_running(pid as u32),
@@ -1645,6 +1650,35 @@ mod tests {
         );
 
         unsafe { libc::kill(pid, libc::SIGKILL) };
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn capability_script_teardown_stays_silent_for_a_clean_command() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output = execute_capability_script(
+            dir.path(),
+            "unused.sh",
+            &[],
+            &[],
+            None,
+            Some("printf '{\"status\":\"passed\"}\\n'"),
+            CapabilityScriptOptions {
+                passthrough: false,
+                stderr_passthrough: false,
+                timeout: Some(Duration::from_secs(5)),
+            },
+        )
+        .expect("script should run");
+
+        assert!(output.success);
+        assert!(!output.timed_out);
+        assert_eq!(output.stdout, "{\"status\":\"passed\"}\n");
+        // Every process this command owned has exited, which is precisely what
+        // containment teardown exists to achieve. An empty scope is success, so
+        // teardown has nothing to say. Before #13128 this path accused a clean
+        // run of leaking an escaped descendant on every invocation.
+        assert_eq!(output.stderr, "");
     }
 
     fn lint_execution_context() -> crate::ExtensionExecutionContext {


### PR DESCRIPTION
The loose end noted when closing #13128. Same defect class as #13161/#13173 — a containment signal that fires on clean runs — but a different mechanism, and it required revisiting the escapee contract from #12777 rather than being folded into either.

## The signal was information-free

`scope_cleanup_report` treated *marker discovery found nothing* as a cleanup failure:

```rust
let complete = !targets.pids.is_empty() && survivors.pids.is_empty();
//              ^^^^^^^^^^^^^^^^^^^^^^^
```

An empty scope is **the state cleanup exists to produce.** Every command whose processes exited leaves discovery with nothing to find. That is indistinguishable from a descendant that escaped by unsetting `HOMEBOY_PROCESS_SCOPE`, so the condition fired on every clean short-lived command and carried no information at all.

The concrete cost, stamped into stderr on ordinary runs:

```
Homeboy containment cleanup diagnostic: process-scope discovery found no
marker-owned process; an escaped descendant may have removed HOMEBOY_PROCESS_SCOPE.
```

`homeboy-extension::execution::tests::test_execute_capability_script_supports_stderr_only_passthrough` has been **red on Linux since #12777** because of it. It passes on macOS, where `cleanup_process_group` has no containment branch — which is how it survived review and CI.

Baseline on `main` at `d1ef34624`, then with this branch:

```
before   test result: FAILED.  22 passed; 1 failed
after    test result: ok.      24 passed; 0 failed
```

## Fix

`complete` now keys only on positively identified run-owned survivors — the one observation that actually proves containment leaked.

**The escapee is still caught**, by the evidence it cannot suppress. It inherits the command's stdout/stderr, so `run_local_command` sees the pipes stay open past teardown and fails the command there. That is already what makes the escapee test's `success` false and `timed_out` true.

Its third assertion, on the marker-discovery message, was redundant with `output.stderr.contains("output pipes remained open")` **and passed for the wrong reason** — a completely clean run emitted the identical string, so the assertion could not distinguish the escape it was written to detect. It now asserts on the pipe-stall evidence, and the comment records why marker discovery is structurally blind here.

## Also fixed

The managed-service ledger. A service whose scope had already drained before teardown recorded

```
cleanup:         cleanup_incomplete:<reason>:...no marker-owned process
cleanup_reaped:  false
```

on a perfectly graceful shutdown. It now records a graceful cleanup. No test asserted on those fields, so this was silently wrong in the durable record.

## Tests

- `capability_script_teardown_stays_silent_for_a_clean_command` (new) — pins the contract by name: a clean command's teardown has nothing to say, so `stderr` stays empty.
- `scope_cleanup_keeps_unreadable_same_owner_environments_as_diagnostics` — its `omitted` case encoded the old contract and is replaced by a `drained` case asserting an already-empty scope reports complete and silent.
- `capability_script_returns_partial_output_when_an_escapee_removes_its_scope_marker` (#12777) — retargeted onto the pipe-stall evidence; `!success`, `timed_out`, stdout preservation, and the surviving-escapee check are untouched.
- `scope_cleanup_fails_closed_for_confirmed_run_owned_survivors` (#13161) — unchanged, still green.

Verified locally:

- `cargo check --workspace --all-targets -j2` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test -p homeboy-extension --lib execution::tests` — 24 passed
- `cargo test -p homeboy-core --lib process::` — 22 passed

AI assistance: Claude Sonnet 4.6 via chubes-bot investigated, measured, and implemented this change. Chris Huber reviewed and remains responsible.