### PR TITLE
fix: give the scheduler one lifecycle store per run (#7505)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -3323,18 +3323,6 @@ pub enum ProviderExecutionReservation {
     AlreadyReserved,
 }
 
-/// Durably reserve one provider execution before the scheduler blocks on the
-/// backend. A resumed controller must reconcile an existing reservation rather
-/// than dispatching the same `(task_id, attempt)` a second time.
-pub fn reserve_provider_execution(
-    run_id: &str,
-    task: &AgentTaskRequest,
-    attempt: u32,
-) -> Result<ProviderExecutionReservation> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    reserve_provider_execution_in_store(&lifecycle_store, run_id, task, attempt)
-}
-
 pub fn reserve_provider_execution_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
@@ -3775,25 +3763,6 @@ pub fn record_provider_execution_terminal(
     )
 }
 
-/// Record a terminal provider result with its normalized concrete model.
-pub fn record_provider_execution_terminal_with_model(
-    run_id: &str,
-    task_id: &str,
-    attempt: u32,
-    state: &str,
-    model: Option<&str>,
-) -> Result<AgentTaskRunRecord> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    record_provider_execution_terminal_with_model_in_store(
-        &lifecycle_store,
-        run_id,
-        task_id,
-        attempt,
-        state,
-        model,
-    )
-}
-
 pub fn record_provider_execution_terminal_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
@@ -3954,24 +3923,6 @@ pub fn has_active_provider_execution_in_store(
                 .iter()
                 .any(|execution| execution["state"] == json!("running"))
         }))
-}
-
-/// Record the controller time spent after a provider returned and before its
-/// terminal outcome was fully harvested and finalized.
-pub fn record_provider_execution_cleanup_elapsed(
-    run_id: &str,
-    task_id: &str,
-    attempt: u32,
-    elapsed_ms: u64,
-) -> Result<AgentTaskRunRecord> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    record_provider_execution_cleanup_elapsed_in_store(
-        &lifecycle_store,
-        run_id,
-        task_id,
-        attempt,
-        elapsed_ms,
-    )
 }
 
 pub fn record_provider_execution_cleanup_elapsed_in_store(

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -1,7 +1,7 @@
 use homeboy_engine_primitives::content_hash;
 use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
-use std::sync::{mpsc, Arc};
+use std::sync::{mpsc, Arc, OnceLock};
 use std::thread;
 use std::time::Instant;
 
@@ -45,6 +45,11 @@ pub struct AgentTaskScheduler {
     run_id: Option<String>,
     harvest_context: HarvestExecutionContext,
     lifecycle_store: Option<crate::agent_task_lifecycle::AgentTaskLifecycleStore>,
+    /// The store the durable provider-execution records resolve against when
+    /// no caller injected one. It is resolved at most once per scheduler so
+    /// that the reservation, the terminal record, and the cleanup record are
+    /// guaranteed to name the same installation (#7505).
+    resolved_lifecycle_store: OnceLock<crate::agent_task_lifecycle::AgentTaskLifecycleStore>,
     #[cfg(test)]
     scratch_root: Option<std::path::PathBuf>,
 }
@@ -62,6 +67,7 @@ impl AgentTaskScheduler {
             run_id: None,
             harvest_context: HarvestExecutionContext::default(),
             lifecycle_store: None,
+            resolved_lifecycle_store: OnceLock::new(),
             #[cfg(test)]
             scratch_root: None,
         }
@@ -83,6 +89,28 @@ impl AgentTaskScheduler {
     ) -> Self {
         self.lifecycle_store = Some(lifecycle_store);
         self
+    }
+
+    /// The store the durable provider-execution records are written through.
+    ///
+    /// A reservation, its terminal record, and its cleanup record are one
+    /// exactly-once sequence spanning a provider execution that can run for
+    /// minutes. They used to resolve the environment independently, so a
+    /// repoint mid-execution could reserve in one installation and record the
+    /// terminal state in another, leaving the reservation held. Resolving at
+    /// most once here makes that impossible (#7505).
+    fn durable_lifecycle_store(
+        &self,
+    ) -> homeboy_core::Result<&crate::agent_task_lifecycle::AgentTaskLifecycleStore> {
+        if let Some(store) = self.lifecycle_store.as_ref() {
+            return Ok(store);
+        }
+        if let Some(store) = self.resolved_lifecycle_store.get() {
+            return Ok(store);
+        }
+        let store =
+            crate::agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+        Ok(self.resolved_lifecycle_store.get_or_init(|| store))
     }
 
     #[cfg(test)]
@@ -683,12 +711,9 @@ impl AgentTaskScheduler {
                 };
 
                 if let Some(run_id) = self.run_id.as_deref() {
-                    let reservation = match self.lifecycle_store.as_ref() {
-                        Some(store) => store.reserve_provider_execution(run_id, &request, attempt),
-                        None => crate::agent_task_lifecycle::reserve_provider_execution(
-                            run_id, &request, attempt,
-                        ),
-                    };
+                    let reservation = self.durable_lifecycle_store().and_then(|store| {
+                        store.reserve_provider_execution(run_id, &request, attempt)
+                    });
                     match reservation {
                         Ok(crate::agent_task_lifecycle::ProviderExecutionReservation::Acquired) => {}
                         Ok(crate::agent_task_lifecycle::ProviderExecutionReservation::AlreadyReserved) => {
@@ -868,24 +893,15 @@ impl AgentTaskScheduler {
                             AgentTaskOutcomeStatus::CandidateRecoverable => "candidate_recoverable",
                             _ => "failed",
                         };
-                        let terminal = match self.lifecycle_store.as_ref() {
-                            Some(store) => store.record_provider_execution_terminal_with_model(
+                        let terminal = self.durable_lifecycle_store().and_then(|store| {
+                            store.record_provider_execution_terminal_with_model(
                                 run_id,
                                 &outcome.task_id,
                                 result.attempt,
                                 terminal_state,
                                 outcome.selected_model(),
-                            ),
-                            None => {
-                                crate::agent_task_lifecycle::record_provider_execution_terminal_with_model(
-                                    run_id,
-                                    &outcome.task_id,
-                                    result.attempt,
-                                    terminal_state,
-                                    outcome.selected_model(),
-                                )
-                            }
-                        };
+                            )
+                        });
                         if let Err(error) = terminal {
                             outcome.status = AgentTaskOutcomeStatus::Failed;
                             outcome.failure_classification =
@@ -1263,20 +1279,14 @@ impl AgentTaskScheduler {
                         &outcome,
                     );
                     if let Some(run_id) = running_task.run_id.as_deref() {
-                        let _ = match self.lifecycle_store.as_ref() {
-                            Some(store) => store.record_provider_execution_cleanup_elapsed(
+                        let _ = self.durable_lifecycle_store().and_then(|store| {
+                            store.record_provider_execution_cleanup_elapsed(
                                 run_id,
                                 &outcome.task_id,
                                 result.attempt,
                                 provider_completed_at.elapsed().as_millis() as u64,
-                            ),
-                            None => crate::agent_task_lifecycle::record_provider_execution_cleanup_elapsed(
-                                run_id,
-                                &outcome.task_id,
-                                result.attempt,
-                                provider_completed_at.elapsed().as_millis() as u64,
-                            ),
-                        };
+                            )
+                        });
                     }
                     record_completed_outcome(&mut completed_by_task, &mut outcomes, outcome);
                     if candidate_completion == AgentTaskCandidateCompletionPolicy::FirstGreen

--- a/tests/agent_task_store_injection_test.rs
+++ b/tests/agent_task_store_injection_test.rs
@@ -54,14 +54,6 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-/// The tests below drive the store-rooted entry points. Resolving the store
-/// once here keeps the ambient lookup in one place and lets the ambient
-/// wrappers be deleted (#7505).
-fn test_lifecycle_store() -> homeboy::agents::agent_task_lifecycle::AgentTaskLifecycleStore {
-    homeboy::agents::agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()
-        .expect("lifecycle store")
-}
-
 /// A durable store that `homeboy-agents` roots explicitly.
 struct Store {
     /// The type name as it reads in a parameter position, with or without a

--- a/tests/scheduler_provider_execution_rooting_test.rs
+++ b/tests/scheduler_provider_execution_rooting_test.rs
@@ -1,0 +1,92 @@
+//! Pins the scheduler's durable provider-execution records onto one store.
+//!
+//! ## What went wrong, concretely
+//!
+//! `AgentTaskScheduler` carries `lifecycle_store: Option<..>`, defaulting to
+//! `None` and populated only by the `with_lifecycle_store` builder. Three
+//! durable writes consulted it:
+//!
+//! ```text
+//! reserve_provider_execution                claims the execution slot
+//!   ... the provider actually runs, for minutes ...
+//! record_provider_execution_terminal_with_model   records the outcome
+//! record_provider_execution_cleanup_elapsed       records teardown cost
+//! ```
+//!
+//! Each wrote `match self.lifecycle_store.as_ref() { Some(store) => .., None =>
+//! <ambient> }`. The `None` arm was not defensive: `agent_task_dispatch_service`
+//! sets `with_run_id` and never sets a store, so every `agent-task dispatch`
+//! took it -- three independent reads of the environment around one provider
+//! execution.
+//!
+//! A reservation and its terminal record are an exactly-once pair. Resolving
+//! separately means a repoint between them reserves in one installation and
+//! records the terminal state in another, leaving the reservation held forever
+//! and the next dispatch seeing an execution already reserved.
+//!
+//! The fix is `durable_lifecycle_store()`, which prefers an injected store and
+//! otherwise resolves at most once into a `OnceLock`.
+//!
+//! ## What this test pins
+//!
+//! That engine.rs performs at most one ambient lifecycle resolution, and that
+//! it is the one inside the accessor. This reads source rather than running the
+//! scheduler because the property is structural: it is about how many times the
+//! environment may be consulted, not about what any single run returns.
+
+use std::path::PathBuf;
+
+fn engine_source() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("crates/homeboy-agents/src/agent_task_scheduler/engine.rs");
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
+}
+
+#[test]
+fn scheduler_resolves_at_most_one_lifecycle_store() {
+    let source = engine_source();
+    let resolutions = source.matches("from_current_environment(").count();
+    assert!(
+        resolutions <= 1,
+        "engine.rs performs {resolutions} ambient lifecycle resolutions; the \
+         reservation, terminal record, and cleanup record are one exactly-once \
+         sequence and must share one store. Route the new call through \
+         durable_lifecycle_store() instead (#7505)."
+    );
+}
+
+#[test]
+fn the_one_resolution_lives_in_the_shared_accessor() {
+    let source = engine_source();
+    let accessor = source
+        .split_once("fn durable_lifecycle_store(")
+        .map(|(_, rest)| rest)
+        .expect("engine.rs still defines durable_lifecycle_store");
+    let body_end = accessor
+        .find("\n    }\n")
+        .expect("durable_lifecycle_store has a terminated body");
+    assert!(
+        accessor[..body_end].contains("from_current_environment("),
+        "the single ambient resolution moved out of durable_lifecycle_store; \
+         that accessor is what makes the three durable provider-execution \
+         writes name one installation (#7505)."
+    );
+}
+
+#[test]
+fn the_durable_writes_do_not_reintroduce_a_fallback() {
+    let source = engine_source();
+    for wrapper in [
+        "agent_task_lifecycle::reserve_provider_execution(",
+        "agent_task_lifecycle::record_provider_execution_terminal_with_model(",
+        "agent_task_lifecycle::record_provider_execution_cleanup_elapsed(",
+    ] {
+        assert!(
+            !source.contains(wrapper),
+            "engine.rs calls the free-function form `{wrapper}`, which resolves \
+             its own root. That is the fallback arm this change removed; use \
+             durable_lifecycle_store() (#7505)."
+        );
+    }
+}


### PR DESCRIPTION
**The fallback arm was the live production path.** Not defensive code.

## What was wrong

`AgentTaskScheduler` carried `lifecycle_store: Option<..>`, defaulting to `None` and set only by a builder. Three durable writes consulted it:

```rust
match self.lifecycle_store.as_ref() {
    Some(store) => store.reserve_provider_execution(...),
    None        => agent_task_lifecycle::reserve_provider_execution(...),  // ambient
}
```

`agent_task_dispatch_service` sets `.with_run_id(...)` and **never** sets a store. So every `agent-task dispatch` took the `None` arm — at all three sites:

```text
reserve_provider_execution                    <- reads environment
    ... the provider runs, for minutes ...
record_provider_execution_terminal_with_model <- reads environment AGAIN
record_provider_execution_cleanup_elapsed     <- and AGAIN
```

A reservation and its terminal record are an **exactly-once pair**. Resolve them separately and a repoint between them reserves in one installation and records the terminal state in another — the reservation stays held, and the next dispatch sees an execution already reserved.

## The fix

`durable_lifecycle_store()` prefers an injected store, otherwise resolves **at most once** into a `OnceLock`. All three writes name one installation whether or not a caller injected anything. The three ambient wrappers are deleted.

I did *not* change `with_run_id`'s signature to require a store — 34 call sites, and the resulting churn would dwarf the defect. The `OnceLock` gets the correctness property at a fraction of the blast radius.

## Guard test, verified non-vacuous

`tests/scheduler_provider_execution_rooting_test.rs`. Each assertion was checked against a regression **that compiles**:

| assertion | injected regression | result |
|---|---|---|
| at most one resolution | second `from_current_environment` | ✅ FAILED |
| resolution lives in the accessor | hoisted into a helper fn | ✅ FAILED |
| no fallback re-added | pattern reintroduced | ✅ FAILED |

Worth noting: reintroducing the *actual* call is now a **compile error**, since the wrapper is deleted. The string assertion is belt-and-braces behind that.

## Verification

- `cargo check --workspace --all-targets -j2` — green, no new warnings
- `no_orphaned_ambient_wrappers_test` — green
- 283 → 280 pairs

Refs #7505.