### PR TITLE
fix: close the timeout leg of the provider-execution sequence (#7505)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -3743,26 +3743,6 @@ pub fn record_cook_terminal_result_in_store(
     record.ok_or_else(|| Error::internal_unexpected("Cook terminal result was unchanged"))
 }
 
-/// Record the provider's terminal result before controller-owned patch
-/// harvesting. Harvesting can fail or be interrupted independently of the
-/// provider execution, so it must not leave this reservation running.
-pub fn record_provider_execution_terminal(
-    run_id: &str,
-    task_id: &str,
-    attempt: u32,
-    state: &str,
-) -> Result<AgentTaskRunRecord> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    record_provider_execution_terminal_with_model_in_store(
-        &lifecycle_store,
-        run_id,
-        task_id,
-        attempt,
-        state,
-        None,
-    )
-}
-
 pub fn record_provider_execution_terminal_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -3293,8 +3293,14 @@ fn status_does_not_terminalize_a_live_owner_after_provider_success() {
             1,
         )
         .expect("reserved");
-        record_provider_execution_terminal("owner-live-late-import", "task-a", 1, "succeeded")
-            .expect("provider success recorded");
+        record_provider_execution_terminal_in_store(
+            &test_lifecycle_store(),
+            "owner-live-late-import",
+            "task-a",
+            1,
+            "succeeded",
+        )
+        .expect("provider success recorded");
 
         let record = status("owner-live-late-import").expect("status before aggregate import");
         assert_eq!(record.state, AgentTaskRunState::Running);
@@ -3445,8 +3451,14 @@ fn dead_owner_preserves_late_provider_success_as_recoverable_candidate() {
             1,
         )
         .expect("reserved");
-        record_provider_execution_terminal("owner-late-success", "task-a", 1, "succeeded")
-            .expect("provider success recorded");
+        record_provider_execution_terminal_in_store(
+            &test_lifecycle_store(),
+            "owner-late-success",
+            "task-a",
+            1,
+            "succeeded",
+        )
+        .expect("provider success recorded");
         let mut owner = Command::new("sleep")
             .arg("60")
             .spawn()
@@ -3485,8 +3497,14 @@ fn terminal_provider_failure_without_owner_or_aggregate_converges_to_failed() {
             1,
         )
         .expect("reserved");
-        record_provider_execution_terminal("provider-failed-no-owner", "task-a", 1, "failed")
-            .expect("provider failure recorded");
+        record_provider_execution_terminal_in_store(
+            &test_lifecycle_store(),
+            "provider-failed-no-owner",
+            "task-a",
+            1,
+            "failed",
+        )
+        .expect("provider failure recorded");
         rewrite_record_for_test("provider-failed-no-owner", |record| {
             let execution = record.metadata["provider_executions"][0]
                 .as_object_mut()
@@ -3527,8 +3545,14 @@ fn interrupted_foreground_owner_converges_terminal_provider_failure() {
             1,
         )
         .expect("reserved");
-        record_provider_execution_terminal("provider-failed-owner-dead", "task-a", 1, "failed")
-            .expect("provider failure recorded");
+        record_provider_execution_terminal_in_store(
+            &test_lifecycle_store(),
+            "provider-failed-owner-dead",
+            "task-a",
+            1,
+            "failed",
+        )
+        .expect("provider failure recorded");
         let mut owner = Command::new("sleep")
             .arg("60")
             .spawn()
@@ -3571,8 +3595,14 @@ fn cancellation_race_defers_to_a_durable_provider_success() {
             1,
         )
         .expect("reserved");
-        record_provider_execution_terminal("cancel-race", "task-a", 1, "succeeded")
-            .expect("provider success recorded");
+        record_provider_execution_terminal_in_store(
+            &test_lifecycle_store(),
+            "cancel-race",
+            "task-a",
+            1,
+            "succeeded",
+        )
+        .expect("provider success recorded");
 
         let deferred = cancel_run("cancel-race", Some("operator cancel"))
             .expect("cancellation defers to terminal provider");
@@ -3604,7 +3634,8 @@ fn provider_terminalization_observes_cancellation_that_won_the_race() {
         cancel_run("provider-terminal-cancel-race", Some("stale owner"))
             .expect("cancellation recorded");
 
-        let terminal = record_provider_execution_terminal(
+        let terminal = record_provider_execution_terminal_in_store(
+            &test_lifecycle_store(),
             "provider-terminal-cancel-race",
             "task-a",
             1,
@@ -3634,7 +3665,8 @@ fn provider_terminalization_rejects_an_invalid_terminal_state() {
         )
         .expect("reserved");
 
-        let error = record_provider_execution_terminal(
+        let error = record_provider_execution_terminal_in_store(
+            &test_lifecycle_store(),
             "invalid-provider-terminal-state",
             "task-a",
             1,
@@ -3658,7 +3690,8 @@ fn provider_terminalization_rejects_a_missing_execution_attempt() {
         let plan = test_plan();
         submit_plan(&plan, Some("missing-provider-terminal-attempt")).expect("submitted");
 
-        let error = record_provider_execution_terminal(
+        let error = record_provider_execution_terminal_in_store(
+            &test_lifecycle_store(),
             "missing-provider-terminal-attempt",
             "task-a",
             1,

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -788,8 +788,8 @@ impl AgentTaskScheduler {
                     _attempt_workspace: attempt_workspace.clone(),
                     run_id: self.run_id.clone(),
                     artifact_root: self
-                        .lifecycle_store
-                        .as_ref()
+                        .durable_lifecycle_store()
+                        .ok()
                         .map(|store| store.artifact_root()),
                     artifact_nonce: uuid::Uuid::new_v4().to_string(),
                     task_base_sha,
@@ -831,7 +831,7 @@ impl AgentTaskScheduler {
                 &mut outcomes,
                 &mut events,
                 self.executor.as_ref(),
-                self.lifecycle_store.as_ref(),
+                self.durable_lifecycle_store().ok(),
             );
 
             if running.is_empty() {
@@ -1329,7 +1329,7 @@ impl AgentTaskScheduler {
                             &mut outcomes,
                             &mut events,
                             self.executor.as_ref(),
-                            self.lifecycle_store.as_ref(),
+                            self.durable_lifecycle_store().ok(),
                         );
                         break;
                     }

--- a/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
@@ -688,20 +688,20 @@ impl AgentTaskScheduleSupport {
 
             let mut task = running.remove(index);
             if let Some(run_id) = task.run_id.as_deref() {
-                let _ = match lifecycle_store {
-                    Some(store) => store.record_provider_execution_terminal(
+                // The timeout terminal record belongs to the same exactly-once
+                // sequence as the reservation this task holds, so it is written
+                // only through the store the caller resolved. Falling back to the
+                // environment here could record the timeout in a different
+                // installation than the one holding the reservation, which is the
+                // divergence this record exists to close (#7505).
+                if let Some(store) = lifecycle_store {
+                    let _ = store.record_provider_execution_terminal(
                         run_id,
                         &task.task_id,
                         task.attempt,
                         "timed_out",
-                    ),
-                    None => crate::agent_task_lifecycle::record_provider_execution_terminal(
-                        run_id,
-                        &task.task_id,
-                        task.attempt,
-                        "timed_out",
-                    ),
-                };
+                    );
+                }
             }
             let mut outcome =
                 deferred_timeout_outcome(&task.task_id, timeout_ms, "scheduler_timeout");

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -416,7 +416,8 @@ fn provider_execution_reservation_is_exactly_once_and_terminal() {
             0,
             "an existing reservation must be reconciled, never redispatched"
         );
-        agent_task_lifecycle::record_provider_execution_terminal(
+        agent_task_lifecycle::record_provider_execution_terminal_in_store(
+            &test_lifecycle_store(),
             "provider-reservation",
             &task.task_id,
             1,

--- a/tests/scheduler_provider_execution_rooting_test.rs
+++ b/tests/scheduler_provider_execution_rooting_test.rs
@@ -11,7 +11,14 @@
 //!   ... the provider actually runs, for minutes ...
 //! record_provider_execution_terminal_with_model   records the outcome
 //! record_provider_execution_cleanup_elapsed       records teardown cost
+//! record_provider_execution_terminal              records a timeout instead
 //! ```
+//!
+//! The timeout leg lives in `scheduling.rs::expire_timed_out_tasks`, which
+//! received the store as an `Option` and had the same ambient `None` arm. It is
+//! the terminal record for a task holding a reservation taken through the
+//! accessor, so recording it against the environment could put the timeout in a
+//! different installation than the reservation it closes.
 //!
 //! Each wrote `match self.lifecycle_store.as_ref() { Some(store) => .., None =>
 //! <ambient> }`. The `None` arm was not defensive: `agent_task_dispatch_service`
@@ -89,4 +96,28 @@ fn the_durable_writes_do_not_reintroduce_a_fallback() {
              durable_lifecycle_store() (#7505)."
         );
     }
+}
+
+fn scheduling_source() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs");
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
+}
+
+#[test]
+fn the_timeout_terminal_record_has_no_ambient_fallback() {
+    let source = scheduling_source();
+    assert!(
+        !source.contains("agent_task_lifecycle::record_provider_execution_terminal("),
+        "expire_timed_out_tasks falls back to the free-function form, which \
+         resolves its own root. The timeout terminal closes a reservation taken \
+         through the scheduler's store, so it must use the store it was given \
+         and write nothing when there is none (#7505)."
+    );
+    assert!(
+        !source.contains("from_current_environment("),
+        "scheduling.rs resolves the environment directly; the scheduler owns \
+         that resolution and passes the store down (#7505)."
+    );
 }


### PR DESCRIPTION
**#13203 fixed three of four legs.** This is the one it missed — found by finishing the sweep of `Option<store>` uses rather than stopping at the three that were obviously wrong.

## The gap

A task that times out records its terminal state from `scheduling.rs::expire_timed_out_tasks`, which took the store as an `Option` and carried the same ambient arm:

```rust
let _ = match lifecycle_store {
    Some(store) => store.record_provider_execution_terminal(..),
    None        => agent_task_lifecycle::record_provider_execution_terminal(..),  // ambient
};
```

And the engine passed **`self.lifecycle_store.as_ref()`** into it — the raw field, not the resolved accessor.

So after #13203 the state was *worse than uniform*:

```text
reserve_provider_execution   -> durable_lifecycle_store()   <- resolved once
    ... task times out ...
record_provider_execution_terminal -> ambient               <- resolves again
```

Two halves of **one exactly-once pair** resolving differently. Precisely the divergence #13203 set out to remove, left intact on the timeout path.

## Fix

- `expire_timed_out_tasks` writes **only** through the store it was given, and writes nothing when there is none. Recording a timeout into the wrong installation is worse than not recording a best-effort line that was already `let _ =`.
- Both engine call sites now pass `durable_lifecycle_store().ok()`.
- The same accessor supplies the running task's **artifact root**, so artifacts and durable records name one installation.
- Ambient wrapper deleted, 9 test callers moved to `_in_store`.

## Guard

Fourth assertion added, covering `scheduling.rs`. Verified by reintroducing the pattern and watching it fail — not assumed.

## Verification

- `cargo check --workspace --all-targets -j2` — green
- `no_orphaned_ambient_wrappers_test` — green
- 280 → 279 pairs
- The `homeboy-triage` `CommandFactory` warning is **pre-existing** — confirmed against a stashed tree rather than assumed

Refs #7505.