### PR TITLE
fix(ci): isolate portable resolver fixture target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,9 +163,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: dtolnay/rust-toolchain@1.95.0
       - name: Run portable external resolver fixture subprocess tests
-        # Keep this filter compatible with PR heads created before the fixture
-        # was extracted: the library fixture is the portable contract.
-        run: cargo test --locked -p homeboy-cli --lib cross_platform_fixture
+        run: cargo test --locked -p homeboy-cli --features test-support --test external_check_detail_resolver_fixture
 
   # Keep `main` rustfmt-clean so a feature branch's `cargo fmt` only ever touches
   # the files it changed. Without this gate, unformatted files drift onto main

--- a/crates/homeboy-cli/src/commands/ci.rs
+++ b/crates/homeboy-cli/src/commands/ci.rs
@@ -4,6 +4,12 @@ mod gate;
 mod plan;
 mod scope;
 
+#[cfg(feature = "test-support")]
+#[doc(hidden)]
+pub fn test_external_check_detail_resolver_fixture() {
+    external_check_detail_resolver::test_cross_platform_fixture();
+}
+
 use clap::{Args, Subcommand};
 use serde::Serialize;
 use std::path::PathBuf;

--- a/crates/homeboy-cli/src/commands/ci/external_check_detail_resolver.rs
+++ b/crates/homeboy-cli/src/commands/ci/external_check_detail_resolver.rs
@@ -453,9 +453,8 @@ fn bound(value: &str, limit: usize) -> String {
     value.chars().take(limit).collect()
 }
 
-#[cfg(test)]
-#[test]
-fn cross_platform_fixture() {
+#[cfg(any(test, feature = "test-support"))]
+pub(super) fn test_cross_platform_fixture() {
     const FIXTURE_MODE_ENV: &str = "HOMEBOY_EXTERNAL_CHECK_FIXTURE_MODE";
 
     for (mode, expected_detail, expected_diagnostic, budget, expected_message) in [
@@ -566,7 +565,7 @@ fn cross_platform_fixture() {
     });
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 fn install_fixture_extension(mode: &str, fixture_mode_env: &str) {
     let root = homeboy::core::paths::homeboy().unwrap();
     let extension = root.join("extensions").join("fixture-external-check");
@@ -595,7 +594,7 @@ fn install_fixture_extension(mode: &str, fixture_mode_env: &str) {
     std::env::set_var(fixture_mode_env, mode);
 }
 
-#[cfg(all(test, unix))]
+#[cfg(all(any(test, feature = "test-support"), unix))]
 fn fixture_program(extension: &Path, fixture_mode_env: &str) -> String {
     use std::os::unix::fs::PermissionsExt;
 
@@ -612,7 +611,7 @@ fn fixture_program(extension: &Path, fixture_mode_env: &str) -> String {
     name.into()
 }
 
-#[cfg(all(test, windows))]
+#[cfg(all(any(test, feature = "test-support"), windows))]
 fn fixture_program(extension: &Path, fixture_mode_env: &str) -> String {
     let name = "fixture-resolver.cmd";
     let path = extension.join(name);

--- a/crates/homeboy-cli/tests/external_check_detail_resolver_fixture.rs
+++ b/crates/homeboy-cli/tests/external_check_detail_resolver_fixture.rs
@@ -1,0 +1,4 @@
+#[test]
+fn resolver_fixture_is_bounded_and_cross_platform() {
+    homeboy_cli::commands::ci::test_external_check_detail_resolver_fixture();
+}

--- a/tests/pr_ci_lifecycle_test.rs
+++ b/tests/pr_ci_lifecycle_test.rs
@@ -118,9 +118,9 @@ fn closed_prs_stop_candidate_admission_at_every_fanout_boundary() {
 
     let resolver_fixture = job_section(workflow, "external-resolver-fixtures");
     assert!(resolver_fixture.contains("os: [ubuntu-latest, macos-14, windows-latest]"));
-    assert!(resolver_fixture
-        .contains("cargo test --locked -p homeboy-cli --lib cross_platform_fixture"));
-    assert!(!resolver_fixture.contains("--test external_check_detail_resolver_fixture"));
+    assert!(resolver_fixture.contains(
+        "cargo test --locked -p homeboy-cli --features test-support --test external_check_detail_resolver_fixture"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- restore the external resolver fixture as a dedicated integration test target
- run only that target on Ubuntu, macOS, and Windows instead of compiling every library test
- preserve the bounded timeout and process-tree cleanup contract from #13178

Fixes #13160

## Evidence
- failing exact-branch run: https://github.com/Extra-Chill/homeboy/actions/runs/32662381545
- `cargo test --locked -p homeboy-cli --features test-support --test external_check_detail_resolver_fixture`
- `cargo test --locked --test pr_ci_lifecycle_test`
- `RUSTFLAGS=-Dwarnings cargo check --locked -p homeboy-cli --features test-support`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode inspected the cross-platform failure logs, identified the Cargo test-target boundary as the Windows root cause, correlated the Ubuntu failure with #13202, implemented the isolated integration target, and ran focused verification. Chris Huber reviewed and remains responsible for every line.