### PR TITLE
fix: allocate attempt scratch under the durable root (#7505)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -607,12 +607,20 @@ impl AgentTaskScheduler {
                     }
                     #[cfg(not(test))]
                     {
-                        crate::controller_scratch::allocate_attempt(
-                            &scratch_run_id,
-                            &plan.plan_id,
-                            &request.task_id,
-                            scheduled.attempt,
-                        )
+                        // The scratch directory holds the working files of the
+                        // very attempt whose reservation was taken through the
+                        // accessor. Allocating it from the environment instead
+                        // would let an attempt's scratch and its durable records
+                        // live in different installations (#7505).
+                        self.durable_lifecycle_store().and_then(|lifecycle_store| {
+                            crate::controller_scratch::allocate_attempt_at(
+                                &lifecycle_store.data_root(),
+                                &scratch_run_id,
+                                &plan.plan_id,
+                                &request.task_id,
+                                scheduled.attempt,
+                            )
+                        })
                     }
                 };
                 let scratch = match scratch {

--- a/tests/scheduler_provider_execution_rooting_test.rs
+++ b/tests/scheduler_provider_execution_rooting_test.rs
@@ -121,3 +121,16 @@ fn the_timeout_terminal_record_has_no_ambient_fallback() {
          that resolution and passes the store down (#7505)."
     );
 }
+
+#[test]
+fn the_attempt_scratch_shares_the_durable_root() {
+    let source = engine_source();
+    assert!(
+        !source.contains("controller_scratch::allocate_attempt("),
+        "engine.rs allocates attempt scratch through the ambient \
+         `allocate_attempt`, which resolves its own data root. The scratch \
+         directory holds the working files of the attempt whose reservation was \
+         taken through durable_lifecycle_store(), so the two must share a root: \
+         use `allocate_attempt_at(&store.data_root(), ..)` (#7505)."
+    );
+}


### PR DESCRIPTION
Completes `engine.rs`. The scratch directory holds the working files of the very attempt whose reservation, terminal record, and cleanup record now go through `durable_lifecycle_store()` — but its production allocation still called the ambient `controller_scratch::allocate_attempt`, which resolves its own data root.

So an attempt's **scratch and its durable records could live in different installations.**

## Ordering matters here

The `#[cfg(test)]` arm is deliberately untouched. Tests place scratch via `with_scratch_root`, and that choice has to keep winning over an ambient resolution:

```text
injected store  ->  scratch_root (test)  ->  accessor
```

Routing the test arm through the accessor would have silently relocated every test's scratch to the ambient data root. Only the `#[cfg(not(test))]` arm changed.

## What this closes out

This was the **last use of the raw `lifecycle_store` field** on a path that also writes durable records. `engine.rs` no longer has a way to disagree with itself about which installation an attempt belongs to.

Across #13203, #13204 and this PR, all five legs now share one root:

| leg | before | after |
|---|---|---|
| reservation | ambient | accessor |
| terminal record | ambient | accessor |
| cleanup record | ambient | accessor |
| timeout terminal | ambient | accessor |
| attempt scratch | ambient | accessor |

## Kept deliberately

`controller_scratch::allocate_attempt` stays — `promote.rs` still calls it from `gate_setup_failure` and `run_promotion_gate`. I verified those are real production sites (not `#[cfg(test)]` code) rather than deleting on a scan result. They're their own rooting job.

## Guard

Fifth assertion added, verified by reintroducing the ambient call and watching it fail.

## Verification

- `cargo check --workspace --all-targets -j2` — green
- `no_orphaned_ambient_wrappers_test` — green
- guard test: 5 assertions, each verified non-vacuous

Refs #7505.