### PR TITLE
fix: restore the homeboy-agents test build (#13164 regression)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
@@ -1033,6 +1033,7 @@ mod tests {
         compare_gate_failures_to_verified_base(
             &mut promotion,
             temp.path(),
+            temp.path(),
             &base,
             std::time::Duration::from_secs(1),
             |_compared, _total| Ok(()),


### PR DESCRIPTION
`homeboy-agents` has **not compiled with test targets since #13164**, which added a `gate_workspace` parameter to `compare_gate_failures_to_verified_base` and updated one of its two unit-test call sites.

```text
error[E0061]: this function takes 6 arguments but 5 arguments were supplied
  --> crates/homeboy-agents/src/agent_task_service/cook_baseline.rs:1033:9
     argument #3 of type `&std::path::Path` is missing
```

The sibling test ~500 lines up passes `temp.path()` for **both** the repository root and the gate workspace. This one now does the same — the test builds a single throwaway repository and gates run in it directly.

## Why it slipped through

A plain `cargo check --workspace` builds only the ordinary library configuration and passes. It takes `--all-targets` to compile unit tests.

That's the mirror image of #13168, where `--tests` alone missed a `#[cfg(test)]` mistake in the library configuration. Between them the lesson is the same one: **`--all-targets` is the only form that checks both configurations**, and either of the narrower commands will report green on a red tree.

Found while working in an adjacent file — not by a gate. Worth noting there is currently no post-merge full-scope check on main to catch this class.

## Verification

- `cargo check --workspace --all-targets -j2` — green