### PR TITLE
fix: keep triage independent from CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,7 +1269,6 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
- "homeboy-cli",
  "homeboy-core",
  "homeboy-rig",
  "serde",

--- a/crates/homeboy-triage/Cargo.toml
+++ b/crates/homeboy-triage/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/lib.rs"
 
 [dependencies]
 homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
-homeboy-cli = { version = "0.1.0", path = "../homeboy-cli" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4"

--- a/crates/homeboy-triage/src/cli_capability.rs
+++ b/crates/homeboy-triage/src/cli_capability.rs
@@ -1,5 +1,4 @@
 use clap::{ArgMatches, Args, FromArgMatches, Subcommand};
-use homeboy_cli::cli_runtime::CliCapability;
 use homeboy_core::Error;
 use std::path::PathBuf;
 
@@ -8,40 +7,32 @@ use crate::{
     TriageLandingOptions, TriageOptions, TriageTarget, TriageWatchOptions,
 };
 
-pub static TRIAGE_CAPABILITY: TriageCapability = TriageCapability;
+pub const COMMAND_NAME: &str = "triage";
 
-pub fn capability() -> &'static dyn CliCapability {
-    &TRIAGE_CAPABILITY
+/// The typed Triage command shape, independent of CLI composition.
+pub fn command() -> clap::Command {
+    TriageArgs::augment_args(
+        clap::Command::new(COMMAND_NAME).about(
+            "Attention reports and watch utilities for components, projects, fleets, and rigs",
+        ),
+    )
 }
 
-pub struct TriageCapability;
-
-impl CliCapability for TriageCapability {
-    fn name(&self) -> &'static str {
-        "triage"
-    }
-
-    fn command(&self) -> clap::Command {
-        TriageArgs::augment_args(clap::Command::new(self.name()).about(
-            "Attention reports and watch utilities for components, projects, fleets, and rigs",
-        ))
-    }
-
-    fn run(&self, matches: &ArgMatches) -> homeboy_core::Result<(serde_json::Value, i32)> {
-        let args = TriageArgs::from_arg_matches(matches).map_err(|error| {
-            Error::validation_invalid_argument("triage", error.to_string(), None, None)
-        })?;
-        let (output, exit_code) = run_triage(args)?;
-        Ok((
-            serde_json::to_value(output).map_err(|error| {
-                Error::internal_json(
-                    error.to_string(),
-                    Some("serialize triage output".to_string()),
-                )
-            })?,
-            exit_code,
-        ))
-    }
+/// Parse and execute Triage from its subcommand matches.
+pub fn run_command(matches: &ArgMatches) -> homeboy_core::Result<(serde_json::Value, i32)> {
+    let args = TriageArgs::from_arg_matches(matches).map_err(|error| {
+        Error::validation_invalid_argument(COMMAND_NAME, error.to_string(), None, None)
+    })?;
+    let (output, exit_code) = run_triage(args)?;
+    Ok((
+        serde_json::to_value(output).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize triage output".to_string()),
+            )
+        })?,
+        exit_code,
+    ))
 }
 
 #[derive(Args)]
@@ -294,11 +285,10 @@ fn parse_duration(name: &str, raw: &str) -> homeboy_core::Result<std::time::Dura
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clap::CommandFactory;
 
     #[test]
     fn published_triage_spellings_stay_in_the_product_descriptor() {
-        let command = TRIAGE_CAPABILITY.command();
+        let command = command();
         for argv in [
             vec!["triage", "landing", "--workspace", "--branch", "e2e/*"],
             vec![

--- a/crates/homeboy-triage/src/lib.rs
+++ b/crates/homeboy-triage/src/lib.rs
@@ -30,7 +30,7 @@ pub use types::{
     TriagePrItem, TriageRepo, TriageRepoRef, TriageSummary, TriageUnresolved,
 };
 
-pub use cli_capability::{capability, TRIAGE_CAPABILITY};
+pub use cli_capability::{command, run_command, COMMAND_NAME};
 pub use watch::{
     run as watch, TriageWatchEvent, TriageWatchItemState, TriageWatchOptions, TriageWatchOutput,
     TriageWatchTargetOutput,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,26 @@
-use homeboy::cli_runtime::CliRuntime;
+use clap::{ArgMatches, Command};
+use homeboy::cli_runtime::{CliCapability, CliRuntime};
 
 static PRODUCT_CAPABILITIES: [&'static dyn homeboy::cli_runtime::CliCapability; 1] =
-    [&homeboy_triage::TRIAGE_CAPABILITY];
+    [&TRIAGE_CAPABILITY];
+
+struct TriageCapability;
+
+static TRIAGE_CAPABILITY: TriageCapability = TriageCapability;
+
+impl CliCapability for TriageCapability {
+    fn name(&self) -> &'static str {
+        homeboy_triage::COMMAND_NAME
+    }
+
+    fn command(&self) -> Command {
+        homeboy_triage::command()
+    }
+
+    fn run(&self, matches: &ArgMatches) -> homeboy::core::Result<(serde_json::Value, i32)> {
+        homeboy_triage::run_command(matches)
+    }
+}
 
 fn main() -> std::process::ExitCode {
     let args: Vec<String> = std::env::args().collect();

--- a/tests/cli_binary/output_dispatch.rs
+++ b/tests/cli_binary/output_dispatch.rs
@@ -52,6 +52,38 @@ fn self_identity_preserves_canonical_envelopes_on_stdout_and_output_file() {
     assert_canonical_self_identity_envelope(&output.stdout);
 }
 
+#[test]
+fn composed_triage_keeps_help_and_standard_json_error_envelope() {
+    let help = Command::new(homeboy_bin())
+        .args(["triage", "--help"])
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .output()
+        .expect("run composed triage help");
+    assert_eq!(help.status.code(), Some(0));
+    let help = String::from_utf8(help.stdout).expect("triage help is UTF-8");
+    assert!(help.contains("Attention reports and watch utilities"));
+    assert!(help.contains("--poll-interval"));
+
+    // This reaches the composed capability runner but stops before filesystem
+    // or GitHub access, proving its typed error is emitted by the shared CLI
+    // JSON-envelope path.
+    let output = Command::new(homeboy_bin())
+        .args(["triage", "component"])
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .output()
+        .expect("run composed triage validation failure");
+    assert_eq!(output.status.code(), Some(2));
+    let envelope: Value = serde_json::from_slice(&output.stdout).expect("triage JSON envelope");
+    assert_eq!(envelope["command"], "triage");
+    assert_eq!(envelope["operation"], "component");
+    assert_eq!(envelope["success"], false);
+    assert_eq!(envelope["status"], "failed");
+    assert_eq!(
+        envelope["diagnostics"]["code"],
+        "validation.missing_argument"
+    );
+}
+
 fn assert_canonical_self_identity_envelope(bytes: &[u8]) {
     let envelope: Value = serde_json::from_slice(bytes).expect("self identity JSON envelope");
     assert_eq!(envelope["command"], "self");


### PR DESCRIPTION
Follow-up to #13177. Refs #13141.

## Correction
PR #13177 merged before its dependency-direction correction. This branch contains only that correction: `homeboy-triage` now exports neutral typed `command()` and `run_command(&ArgMatches)` functions; the root product composition owns the `CliCapability` adapter. The forbidden `homeboy-triage -> homeboy-cli` edge is removed.

## Exact graph and LOC
- Triage direct normal dependencies: 6 -> 5. Removed fan-in: `homeboy-cli`.
- Triage transitive package closure: 339 -> 323, measured from the resolved graph with and without the former direct CLI edge.
- This correction changes no `homeboy-cli` source files.
- `homeboy-triage` Rust LOC: 5,699 -> 5,689 (-10).
- Root adapter and binary contract test add 51 Rust LOC, so correction-only tracked Rust LOC is +41.

## Checks on current origin/main
- `cargo check -p homeboy-triage`: passed, 39.20s.
- `cargo test -p homeboy-triage --lib`: 61 passed, 105.14s total; execution 3.01s.
- `cargo check -p homeboy`: passed, 93.51s.
- `cargo test --test cli_binary output_dispatch::composed_triage_keeps_help_and_standard_json_error_envelope -- --exact`: passed, 248.04s total; binary test execution 106.30s. It verifies composed `homeboy triage --help` and the canonical JSON error envelope for `homeboy triage component`.
- `git diff --check origin/main...HEAD`: passed.

No persisted schemas, readers/writers, provider registrations, or command spellings changed. The generated command reference remains from #13177; this correction does not alter it.

AI assistance: OpenAI GPT-5.6 Sol via OpenCode inspected the merged PR state, created this isolated correction branch, implemented and verified the neutral Triage API/root adapter split, and drafted this PR. Chris Huber remains responsible for every line.