### PR TITLE
fix: bind locked registry mutations to the lock's root (#7505)

### DIFF
--- a/crates/homeboy-lab-runner/src/generation_store.rs
+++ b/crates/homeboy-lab-runner/src/generation_store.rs
@@ -1,6 +1,6 @@
 use std::fs::{File, OpenOptions};
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
@@ -33,10 +33,20 @@ struct GenerationRegistry<E> {
     generations: RollingGenerations<E>,
 }
 
-fn path(runner_id: &str) -> Result<PathBuf> {
-    Ok(paths::runner_sessions_dir()?
+/// The registry file below an already-resolved config root.
+///
+/// Every path in this module hangs off one runner-sessions directory. The
+/// fallible ambient forms below each read the environment again, so a lock
+/// taken through one and a write performed through another are not guaranteed
+/// to name the same installation (#7505).
+fn path_in_root(config_root: &Path, runner_id: &str) -> PathBuf {
+    paths::runner_sessions_dir_in_root(config_root)
         .join(runner_id)
-        .join("generations.json"))
+        .join("generations.json")
+}
+
+fn path(runner_id: &str) -> Result<PathBuf> {
+    Ok(path_in_root(&paths::homeboy()?, runner_id))
 }
 
 fn recovery_lock_path(runner_id: &str, generation: &str) -> Result<PathBuf> {
@@ -55,36 +65,57 @@ fn recovery_lock_path(runner_id: &str, generation: &str) -> Result<PathBuf> {
         .join(format!("recovery-{generation}.lock")))
 }
 
-fn pending_replacement_path(runner_id: &str) -> Result<PathBuf> {
-    Ok(paths::runner_sessions_dir()?
+fn pending_replacement_path_in_root(config_root: &Path, runner_id: &str) -> PathBuf {
+    paths::runner_sessions_dir_in_root(config_root)
         .join(runner_id)
-        .join("pending-replacement.json"))
+        .join("pending-replacement.json")
+}
+
+fn pending_replacement_path(runner_id: &str) -> Result<PathBuf> {
+    Ok(pending_replacement_path_in_root(
+        &paths::homeboy()?,
+        runner_id,
+    ))
+}
+
+fn replacement_operation_path_in_root(config_root: &Path, runner_id: &str) -> PathBuf {
+    paths::runner_sessions_dir_in_root(config_root)
+        .join(runner_id)
+        .join("replacement-operation.json")
 }
 
 fn replacement_operation_path(runner_id: &str) -> Result<PathBuf> {
-    Ok(paths::runner_sessions_dir()?
-        .join(runner_id)
-        .join("replacement-operation.json"))
+    Ok(replacement_operation_path_in_root(
+        &paths::homeboy()?,
+        runner_id,
+    ))
 }
 
-fn rejected_replacement_path(runner_id: &str) -> Result<PathBuf> {
-    Ok(paths::runner_sessions_dir()?
+fn rejected_replacement_path_in_root(config_root: &Path, runner_id: &str) -> PathBuf {
+    paths::runner_sessions_dir_in_root(config_root)
         .join(runner_id)
         .join("rejected-replacements")
-        .join(format!("{}.json", uuid::Uuid::new_v4())))
+        .join(format!("{}.json", uuid::Uuid::new_v4()))
 }
 
-fn superseded_replacement_path(runner_id: &str) -> Result<PathBuf> {
-    Ok(paths::runner_sessions_dir()?
+fn superseded_replacement_path_in_root(config_root: &Path, runner_id: &str) -> PathBuf {
+    paths::runner_sessions_dir_in_root(config_root)
         .join(runner_id)
         .join("superseded-replacements")
-        .join(format!("{}.json", uuid::Uuid::new_v4())))
+        .join(format!("{}.json", uuid::Uuid::new_v4()))
+}
+
+fn admission_reservation_path_in_root(config_root: &Path, runner_id: &str) -> PathBuf {
+    paths::runner_sessions_dir_in_root(config_root)
+        .join(runner_id)
+        .join("admission-mutation-reservation.json")
 }
 
 fn admission_reservation_path(runner_id: &str) -> Result<PathBuf> {
-    Ok(paths::runner_sessions_dir()?
-        .join(runner_id)
-        .join("admission-mutation-reservation.json"))
+    Ok(admission_reservation_path_in_root(
+        &paths::homeboy()?,
+        runner_id,
+    ))
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -264,6 +295,27 @@ fn with_registry_lock<T>(runner_id: &str, operation: impl FnOnce() -> Result<T>)
         path(runner_id)?.with_extension("lock"),
         runner_id,
         operation,
+    )
+}
+
+/// Serialize one runner's registry mutations under a lock, and hand the
+/// operation the config root that lock was taken against.
+///
+/// The lock exists to make a read-modify-write sequence atomic. That guarantee
+/// only holds if the lock file and the files it guards name the same
+/// installation. The ambient path helpers each read the environment
+/// independently, so a repoint between taking the lock and performing the write
+/// leaves the lock guarding one home while the mutation lands in another
+/// (#7505).
+fn with_rooted_registry_lock<T>(
+    runner_id: &str,
+    operation: impl FnOnce(&Path) -> Result<T>,
+) -> Result<T> {
+    let config_root = paths::homeboy()?;
+    with_lock(
+        path_in_root(&config_root, runner_id).with_extension("lock"),
+        runner_id,
+        || operation(&config_root),
     )
 }
 
@@ -798,8 +850,8 @@ pub(crate) fn record_unleased_candidate_reconciliation_replay(
     runner_id: &str,
     command: &str,
 ) -> Result<()> {
-    with_registry_lock(runner_id, || {
-        let path = replacement_operation_path(runner_id)?;
+    with_rooted_registry_lock(runner_id, |config_root| {
+        let path = replacement_operation_path_in_root(config_root, runner_id);
         let mut operation: ReplacementOperation =
             serde_json::from_slice(&std::fs::read(&path).map_err(|error| {
                 Error::internal_io(error.to_string(), Some(format!("read {}", path.display())))
@@ -812,7 +864,7 @@ pub(crate) fn record_unleased_candidate_reconciliation_replay(
             (Some("unleased-candidates"), Some(existing)) if existing == command => return Ok(()),
             (Some("ensure-running"), Some(previous_command)) => {
                 write_durable_json(
-                    &superseded_replacement_path(runner_id)?,
+                    &superseded_replacement_path_in_root(config_root, runner_id),
                     &SupersededReplacementEvidence {
                         schema: "homeboy/runner-replacement-operation-supersession/v1",
                         runner_id,
@@ -901,12 +953,12 @@ pub(crate) fn retire_pending_replacement(runner_id: &str) -> Result<String> {
 }
 
 fn retire_replacement(runner_id: &str) -> Result<String> {
-    with_registry_lock(runner_id, || {
+    with_rooted_registry_lock(runner_id, |config_root| {
         let operation_id = uuid::Uuid::new_v4().to_string();
         // Publish the successor receipt before releasing the old coordinates.
         // A crash can therefore leave both records, but never neither record.
         write_durable_json(
-            &replacement_operation_path(runner_id)?,
+            &replacement_operation_path_in_root(config_root, runner_id),
             &ReplacementOperation {
                 runner_id: runner_id.to_string(),
                 operation_id: operation_id.clone(),
@@ -914,7 +966,7 @@ fn retire_replacement(runner_id: &str) -> Result<String> {
                 kind: None,
             },
         )?;
-        let pending_path = pending_replacement_path(runner_id)?;
+        let pending_path = pending_replacement_path_in_root(config_root, runner_id);
         if pending_path.exists() {
             std::fs::remove_file(&pending_path).map_err(|error| {
                 Error::internal_io(
@@ -934,8 +986,8 @@ pub(crate) fn retire_rejected_state_loss_replacement(
     runner_id: &str,
     output: &homeboy_core::server::CommandOutput,
 ) -> Result<()> {
-    with_registry_lock(runner_id, || {
-        let operation_path = replacement_operation_path(runner_id)?;
+    with_rooted_registry_lock(runner_id, |config_root| {
+        let operation_path = replacement_operation_path_in_root(config_root, runner_id);
         let operation: ReplacementOperation =
             serde_json::from_slice(&std::fs::read(&operation_path).map_err(|error| {
                 Error::internal_io(
@@ -951,7 +1003,7 @@ pub(crate) fn retire_rejected_state_loss_replacement(
                 "refusing to retire a replacement operation that is not the rejected state-loss recovery",
             ));
         }
-        let evidence_path = rejected_replacement_path(runner_id)?;
+        let evidence_path = rejected_replacement_path_in_root(config_root, runner_id);
         write_durable_json(
             &evidence_path,
             &RejectedReplacementEvidence {
@@ -976,7 +1028,7 @@ pub(crate) fn retire_rejected_state_loss_replacement(
                 kind: None,
             },
         )?;
-        let pending_path = pending_replacement_path(runner_id)?;
+        let pending_path = pending_replacement_path_in_root(config_root, runner_id);
         if pending_path.exists() {
             std::fs::remove_file(&pending_path).map_err(|error| {
                 Error::internal_io(

--- a/tests/generation_store_lock_rooting_test.rs
+++ b/tests/generation_store_lock_rooting_test.rs
@@ -1,0 +1,83 @@
+//! Pins a locked registry mutation onto the root its lock was taken against.
+//!
+//! ## What went wrong, concretely
+//!
+//! `generation_store` addresses every file through one runner-sessions
+//! directory, but reached it through seven separate fallible helpers, each of
+//! which read the environment for itself. A locked mutation therefore looked
+//! like this:
+//!
+//! ```text
+//! with_registry_lock(runner_id, || {          <- resolves, locks
+//!     let operation = replacement_operation_path(runner_id)?;   <- resolves again
+//!     let evidence  = rejected_replacement_path(runner_id)?;    <- and again
+//!     write_durable_json(&evidence, ..)?;
+//!     write_durable_json(&operation, ..)?;
+//! })
+//! ```
+//!
+//! The lock exists to make that read-modify-write atomic, and that guarantee
+//! holds only if the lock file and the files it guards are in the same
+//! installation. Four independent reads do not promise that. A repoint between
+//! the lock and the write leaves the lock guarding one home while the mutation
+//! lands in another -- which is the one thing a lock is supposed to prevent.
+//!
+//! `with_rooted_registry_lock` resolves the config root once, takes the lock
+//! against it, and hands it to the operation, so the fence and the mutation
+//! address one installation by construction.
+
+use std::path::PathBuf;
+
+fn generation_store_source() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("crates/homeboy-lab-runner/src/generation_store.rs");
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
+}
+
+#[test]
+fn the_rooted_lock_hands_its_root_to_the_operation() {
+    let source = generation_store_source();
+    let accessor = source
+        .split_once("fn with_rooted_registry_lock")
+        .map(|(_, rest)| rest)
+        .expect("generation_store still defines with_rooted_registry_lock");
+    let body_end = accessor
+        .find("\n}\n")
+        .expect("with_rooted_registry_lock has a terminated body");
+    let body = &accessor[..body_end];
+    assert!(
+        body.contains("path_in_root(&config_root, runner_id)"),
+        "with_rooted_registry_lock no longer takes its lock against the root it \
+         passes down. The lock file and the files it guards have to be resolved \
+         from one root or the lock guarantees nothing (#7505)."
+    );
+}
+
+#[test]
+fn rooted_operations_do_not_reresolve_inside_the_lock() {
+    let source = generation_store_source();
+    for (operation, ambient) in [
+        (
+            "retire_rejected_state_loss_replacement",
+            "rejected_replacement_path(runner_id)",
+        ),
+        (
+            "record_unleased_candidate_reconciliation_replay",
+            "superseded_replacement_path(runner_id)",
+        ),
+        ("retire_replacement", "pending_replacement_path(runner_id)"),
+    ] {
+        let start = source
+            .find(&format!("fn {operation}"))
+            .unwrap_or_else(|| panic!("{operation} still exists"));
+        let body = &source[start..];
+        let end = body.find("\n}\n").expect("terminated body");
+        assert!(
+            !body[..end].contains(ambient),
+            "{operation} resolves `{ambient}` inside a lock it already holds a \
+             root for. Use the `_in_root` form with the lock's config_root \
+             (#7505)."
+        );
+    }
+}


### PR DESCRIPTION
**A lock that guards a different installation than the one being written guarantees nothing.**

## The shape

`generation_store` addresses every file through one runner-sessions directory — but reached it through **seven separate fallible helpers**, each reading the environment for itself:

```rust
with_registry_lock(runner_id, || {                        // resolves, locks
    let operation = replacement_operation_path(runner_id)?;   // resolves AGAIN
    let evidence  = rejected_replacement_path(runner_id)?;    // and AGAIN
    write_durable_json(&evidence, ..)?;
    write_durable_json(&operation, ..)?;
})
```

The lock exists to make that read-modify-write **atomic**. That guarantee holds only if the lock file and the files it guards are in the same installation — and four independent environment reads do not promise it.

A repoint between the lock and the write leaves the lock guarding one home while the mutation lands in another. Which is precisely the thing a lock is there to prevent.

## The fix

`with_rooted_registry_lock` resolves the config root **once**, takes the lock against it, and hands it to the operation. Six `_in_root` path helpers added beside the ambient forms.

## Scope: three of twenty-six

Migrated only the operations that resolved **more than once inside a single lock** — `retire_rejected_state_loss_replacement`, `record_unleased_candidate_reconciliation_replay`, `retire_replacement`. Those are the only places the fence and the mutation could actually disagree.

The other 23 `with_registry_lock` callers resolve exactly once. Converting them is a rename with no correctness claim attached, and doing it here would bury the three that matter in a 26-file diff.

Deleting the now-orphaned ambient helpers took `paths::homeboy()` in this module from **7 → 5**.

## Guard

Two assertions, each verified against a regression that compiles:

| assertion | injected | result |
|---|---|---|
| rooted lock uses the root it passes down | lock taken via ambient `path()` | ✅ FAILED |
| operations don't re-resolve inside the lock | ambient helper restored in body | ✅ FAILED |

## Verification

- `cargo check --workspace --all-targets -j2` — green, no new warnings
- `no_orphaned_ambient_wrappers_test` — green

Refs #7505.