### PR TITLE
fix(cook): report terminal outcome in progress

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -500,6 +500,11 @@ pub struct CookProgressEvent<'a> {
     pub attempt: u32,
     /// Controller-owned description of the phase.
     pub detail: Option<&'a str>,
+    /// The terminal Cook result, when this is the terminal progress event.
+    ///
+    /// This remains separate from `detail`, which is persisted as the Cook's
+    /// status string for durable readers.
+    pub terminal_success: Option<bool>,
     /// What the provider is doing right now, when it is observable.
     pub activity: Option<&'a CookProviderActivity>,
 }
@@ -531,6 +536,7 @@ fn report_cook_progress(
         attempt,
         detail,
         None,
+        None,
     )
 }
 
@@ -543,6 +549,7 @@ fn report_cook_progress_with_activity(
     attempt: u32,
     detail: Option<&str>,
     activity: Option<&CookProviderActivity>,
+    terminal_success: Option<bool>,
 ) -> Result<()> {
     lifecycle_store.record_cook_progress_with_activity(
         run_id,
@@ -557,6 +564,7 @@ fn report_cook_progress_with_activity(
         run_id,
         attempt,
         detail,
+        terminal_success,
         activity,
     };
     if let Some(observer) = observer {
@@ -4088,7 +4096,7 @@ fn run_cook_reported(
             .map(|attempt| attempt.attempt)
             .unwrap_or(1);
         let phase = result.value.disposition.phase();
-        if let Err(error) = report_cook_progress(
+        if let Err(error) = report_cook_progress_with_activity(
             lifecycle_store,
             durable_observer,
             &result.value.cook_id,
@@ -4096,6 +4104,8 @@ fn run_cook_reported(
             phase,
             attempt,
             Some(&result.value.status),
+            None,
+            (phase == "terminal").then_some(result.exit_code == 0),
         ) {
             return durable_cook_error_report_with_store(
                 store,
@@ -5096,6 +5106,7 @@ fn run_cook_spine(
                                             .unwrap_or("provider execution is still running"),
                                     ),
                                     (!activity.is_empty()).then_some(&activity),
+                                    None,
                                 );
                                 // Supervision evidence is written even when the
                                 // policy is undeclared: the resource timeline is

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -14672,6 +14672,7 @@ fn cook_observer_failures_write_only_to_the_explicit_lifecycle_store() {
         1,
         None,
         None,
+        None,
     )
     .expect("observer failure remains non-authoritative");
 
@@ -17801,6 +17802,7 @@ fn a_progress_event_carries_provider_activity_to_the_observer() {
         run_id: "cook-1-attempt-1",
         attempt: 1,
         detail: Some("provider execution is still running"),
+        terminal_success: None,
         activity: Some(&activity),
     };
 
@@ -17821,6 +17823,7 @@ fn a_progress_event_without_a_sample_renders_no_activity() {
         run_id: "cook-1-attempt-1",
         attempt: 1,
         detail: None,
+        terminal_success: None,
         activity: None,
     };
 

--- a/crates/homeboy-cli/src/commands/agent_task.rs
+++ b/crates/homeboy-cli/src/commands/agent_task.rs
@@ -104,6 +104,19 @@ fn cook_progress_message(phase: &str, cook_id: Option<&str>, run_id: Option<&str
     }
 }
 
+fn cook_terminal_progress_message(run_id: &str, outcome: Option<&str>) -> String {
+    let mut message = format!(
+        "Cook terminal: durable run `{run_id}`. Phase: terminal. Outcome: {}. Next: `homeboy agent-task status {run_id}`.",
+        outcome.unwrap_or("terminal")
+    );
+    if outcome == Some("failed") {
+        message.push_str(&format!(
+            " Diagnose: `homeboy agent-task diagnose {run_id} --full`. Retry: `homeboy agent-task retry {run_id} --run`."
+        ));
+    }
+    message
+}
+
 const MAX_MACHINE_PROGRESS_LINES: usize = 12;
 
 #[derive(Debug, Default)]
@@ -146,6 +159,14 @@ impl CookProgressReporter {
             return;
         }
         if crate::commands::utils::tty::is_stdout_tty() {
+            if phase == "terminal" {
+                if let Some(run_id) = run_id {
+                    crate::commands::utils::tty::status(&cook_terminal_progress_message(
+                        run_id, activity,
+                    ));
+                    return;
+                }
+            }
             crate::commands::utils::tty::status(&format!(
                 "cook: {phase}{}{}",
                 run_id
@@ -214,7 +235,9 @@ fn next_machine_progress_message(
         ));
     }
     state.heartbeat_count = 0;
-    let message = if !state.pointer_emitted && run_id.is_some() {
+    let message = if terminal {
+        run_id.map(|run_id| cook_terminal_progress_message(run_id, activity))?
+    } else if !state.pointer_emitted && run_id.is_some() {
         state.pointer_emitted = true;
         cook_progress_message(phase, cook_id, run_id)
     } else if state.last_phase.as_deref() != Some(phase) {
@@ -506,8 +529,10 @@ mod progress_tests {
         )
         .expect("terminal outcome remains visible");
 
-        assert!(terminal.contains("Cook terminal: durable run `run-123`"));
-        assert!(terminal.contains("homeboy agent-task status run-123"));
+        assert_eq!(
+            terminal,
+            "Cook terminal: durable run `run-123`. Phase: terminal. Outcome: failed. Next: `homeboy agent-task status run-123`. Diagnose: `homeboy agent-task diagnose run-123 --full`. Retry: `homeboy agent-task retry run-123 --run`."
+        );
         assert_eq!(state.emitted_lines, MAX_MACHINE_PROGRESS_LINES + 1);
         assert!(next_machine_progress_message(
             &mut state,
@@ -541,6 +566,24 @@ mod progress_tests {
         )
         .is_none());
         assert_eq!(state.emitted_lines, 1);
+    }
+
+    #[test]
+    fn terminal_machine_progress_names_a_successful_outcome() {
+        let mut state = CookProgressState::default();
+        let terminal = next_machine_progress_message(
+            &mut state,
+            "terminal",
+            None,
+            Some("run-123"),
+            Some("succeeded"),
+        )
+        .expect("terminal outcome remains visible");
+
+        assert_eq!(
+            terminal,
+            "Cook terminal: durable run `run-123`. Phase: terminal. Outcome: succeeded. Next: `homeboy agent-task status run-123`."
+        );
     }
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -4220,13 +4220,17 @@ pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress(
         // struct on, so foreground clients (TTY, machine log, `--output` file)
         // all describe a running provider with the same bounded sentence.
         let activity = event.activity_summary();
+        let terminal_outcome =
+            event
+                .terminal_success
+                .map(|succeeded| if succeeded { "succeeded" } else { "failed" });
         progress
             .map(|progress| {
                 progress(
                     event.phase,
                     Some(event.cook_id),
                     Some(event.run_id),
-                    activity.as_deref(),
+                    terminal_outcome.or(activity.as_deref()),
                 )
             })
             .unwrap_or(Ok(()))


### PR DESCRIPTION
## Summary
- report explicit terminal success/failure from the Cook result exit code on TTY and non-TTY progress surfaces
- include terminal phase plus status, diagnose, and retry pointers for failed Cooks
- preserve the persisted Cook progress detail and structured JSON final-report contracts

Closes #13172

## Verification
- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-cli --features test-support progress_tests -- --test-threads=1`
- `cargo test -p homeboy-agents a_progress_event_carries_provider_activity_to_the_observer -- --test-threads=1`
- `git diff --check`
- `cargo fmt --all -- --check` is blocked by pre-existing trailing whitespace in `crates/homeboy-agents/src/agent_task_service/cook_tests.rs:17365` and `crates/homeboy-agents/src/agent_task_lifecycle/tests/operation_claims.rs:285`; neither file was changed to address that existing formatter failure.

## AI assistance
OpenAI gpt-5.6-sol via OpenCode took over interrupted partial work, audited the issue and current source, corrected the terminal-event data flow, added deterministic CLI coverage, and ran the listed verification. Chris Huber remains responsible for every line.