### PR TITLE
chore: finish the controller-runtime admission rooting (#7505)

### DIFF
--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -701,11 +701,7 @@ impl Drop for AdmissionLock {
     }
 }
 
-pub fn pin_current() -> Result<Value> {
-    pin_current_in_root(&runtime_root()?)
-}
-
-/// [`pin_current`] under an already-resolved runtime root.
+/// `pin_current` under an already-resolved runtime root.
 pub fn pin_current_in_root(root: &Path) -> Result<Value> {
     let _lock = acquire_admission_lock(&root.join(ADMISSION_LOCK_DIR))?;
     pin_current_unlocked()
@@ -1133,13 +1129,7 @@ pub fn validate_for_mutation(metadata: &Value, current_identity: &str) -> Result
     ))
 }
 
-/// Upgrade a legacy pin into the immutable content-addressed v2 format.
-/// The caller persists the returned metadata only after this has completed.
-pub fn migrate_legacy_pin(runtime: &Value) -> Result<Value> {
-    migrate_legacy_pin_in_root(&runtime_root()?, runtime)
-}
-
-/// [`migrate_legacy_pin`] under an already-resolved runtime root.
+/// `migrate_legacy_pin` under an already-resolved runtime root.
 pub fn migrate_legacy_pin_in_root(root: &Path, runtime: &Value) -> Result<Value> {
     let _lock = acquire_admission_lock(&root.join(ADMISSION_LOCK_DIR))?;
     migrate_legacy_pin_unlocked(runtime)
@@ -1212,18 +1202,7 @@ pub fn validate(runtime: &Value) -> Result<()> {
     validate_pin(runtime)
 }
 
-/// Restore a missing or corrupted pin from one explicitly supplied trusted
-/// artifact or source checkout without changing the durable identity or digest
-/// contract.
-pub fn recover_pin(
-    runtime: &Value,
-    artifact: Option<&Path>,
-    source: Option<&Path>,
-) -> Result<Value> {
-    recover_pin_in_root(&runtime_root()?, runtime, artifact, source)
-}
-
-/// [`recover_pin`] under an already-resolved runtime root.
+/// `recover_pin` under an already-resolved runtime root.
 pub fn recover_pin_in_root(
     root: &Path,
     runtime: &Value,
@@ -3124,6 +3103,18 @@ mod identity_probe_tests {
 
 #[cfg(test)]
 mod tests {
+
+    /// A test is the entry point for its own unit of work, so the runtime root
+    /// resolves once here and the rooted entry points take it (#7505).
+    fn test_runtime_root() -> std::path::PathBuf {
+        runtime_root_in(
+            &crate::paths::PathRoots::from_environment()
+                .expect("path roots")
+                .data()
+                .to_path_buf(),
+        )
+        .expect("runtime root")
+    }
     use super::*;
 
     #[cfg(unix)]
@@ -4166,7 +4157,7 @@ mod tests {
     #[test]
     fn admission_replaces_a_stale_active_generation_with_the_submitting_runtime() {
         crate::test_support::with_isolated_home(|_| {
-            let mut runtime_a = pin_current().expect("pin runtime A");
+            let mut runtime_a = pin_current_in_root(&test_runtime_root()).expect("pin runtime A");
             runtime_a["originating"]["build_identity"] = json!("homeboy runtime-a");
             runtime_a["requested"] = json!("homeboy runtime-a");
             runtime_a["current"] = json!("homeboy runtime-a");
@@ -4203,7 +4194,8 @@ mod tests {
     #[test]
     fn pin_current_uses_the_explicit_test_controller_fixture() {
         crate::test_support::with_isolated_home(|_| {
-            let runtime = pin_current().expect("pin explicit controller fixture");
+            let runtime =
+                pin_current_in_root(&test_runtime_root()).expect("pin explicit controller fixture");
             let source = runtime
                 .pointer("/originating/executable")
                 .and_then(Value::as_str)
@@ -4264,7 +4256,8 @@ mod tests {
                 .clear();
             TEST_CONTROLLER_FIXTURE_DIGEST_CALLS.store(0, std::sync::atomic::Ordering::Relaxed);
 
-            let runtime = pin_current().expect("pin test controller fixture");
+            let runtime =
+                pin_current_in_root(&test_runtime_root()).expect("pin test controller fixture");
             let candidate = runtime
                 .pointer("/originating/pinned_executable")
                 .and_then(Value::as_str)
@@ -4554,7 +4547,8 @@ mod tests {
                 "pinned_executable": legacy,
             }});
 
-            let migrated = migrate_legacy_pin(&runtime).expect("migrate legacy pin");
+            let migrated = migrate_legacy_pin_in_root(&test_runtime_root(), &runtime)
+                .expect("migrate legacy pin");
             let destination = PathBuf::from(
                 migrated["originating"]["pinned_executable"]
                     .as_str()
@@ -4689,8 +4683,9 @@ mod tests {
             assert!(error.message.contains("hash mismatch"));
             assert!(error.message.contains(&digest_a));
 
-            let recovered = recover_pin(&runtime_a, Some(&artifact_a), None)
-                .expect("recover runtime A from trusted artifact");
+            let recovered =
+                recover_pin_in_root(&test_runtime_root(), &runtime_a, Some(&artifact_a), None)
+                    .expect("recover runtime A from trusted artifact");
             let recovered_pin = PathBuf::from(
                 recovered["originating"]["pinned_executable"]
                     .as_str()

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -2936,7 +2936,16 @@ mod tests {
     fn isolated_homes_share_the_read_only_controller_fixture_and_not_pins() {
         let first = with_isolated_home(|_| {
             let fixture = controller_runtime_test_executable();
-            let runtime = crate::controller_runtime::pin_current().expect("pin first fixture");
+            let runtime = crate::controller_runtime::pin_current_in_root(
+                &crate::controller_runtime::runtime_root_in(
+                    &crate::paths::PathRoots::from_environment()
+                        .expect("path roots")
+                        .data()
+                        .to_path_buf(),
+                )
+                .expect("runtime root"),
+            )
+            .expect("pin first fixture");
             let pin = runtime["originating"]["pinned_executable"]
                 .as_str()
                 .map(PathBuf::from)
@@ -2945,7 +2954,16 @@ mod tests {
         });
         let second = with_isolated_home(|_| {
             let fixture = controller_runtime_test_executable();
-            let runtime = crate::controller_runtime::pin_current().expect("pin second fixture");
+            let runtime = crate::controller_runtime::pin_current_in_root(
+                &crate::controller_runtime::runtime_root_in(
+                    &crate::paths::PathRoots::from_environment()
+                        .expect("path roots")
+                        .data()
+                        .to_path_buf(),
+                )
+                .expect("runtime root"),
+            )
+            .expect("pin second fixture");
             let pin = runtime["originating"]["pinned_executable"]
                 .as_str()
                 .map(PathBuf::from)


### PR DESCRIPTION
Closes out **item 2** of the plan in [#7505's scoping comment](https://github.com/Extra-Chill/homeboy/issues/7505) — "root the controller-runtime admission store", estimated there at ~13 ambient callers.

## Re-measured: most of it was already done

The admission entry points are **`#[cfg(test)]`** — production cannot reach them at all:

```text
admit_current_for_with_cancellation_check   cfg(test)
admission_status                            cfg(test)
cancel_admission                            cfg(test)
pin_current_queued                          cfg(test)
```

`tests/controller_admission_rooting_test.rs` has held that since #13035.

## What was actually left

Three production-reachable ambient functions with **zero production callers**: `migrate_legacy_pin`, `pin_current`, `recover_pin`. Deleted; their 7 test callers moved to `_in_root` behind a local `test_runtime_root()`.

**Deleted rather than gated.** #13140 gated a function on the claim that only tests used it and broke the non-test build for three days (#13168). An unreachable ambient entry point should stop existing rather than acquire an attribute that has to be right.

## What remains, and why

| function | callers | reason to keep |
|---|--:|---|
| `activate_installed_generation` | 1 | the upgrade command — a boundary, resolves once |
| `cleanup` | 1 | the cleanup CLI command — likewise |
| `recover_pin_and_persist` | 1 | **documented deliberate exception** — the immutable runtime store is a content-addressed executable cache shared across homes, so it is not one of the lifecycle store's roots |

## Status of the #7505 plan

| item | state |
|---|---|
| 1. root the rig registry | ✅ 0 production ambient sites |
| 2. root controller-runtime admission | ✅ **this PR** |
| 3. flip `rust_nextest_shard_threads` to 0 | ✅ already 0 — landed in #13049, lab-runner **410.3s → 98.5s (4.2×)** |
| 4. `ObservationStore` by boundary | ⬜ 499 sites, the long tail |
| 5. `HomeGuard` deletion | ⬜ explicitly de-prioritised in the issue |

Items 1–3 were described in the issue as "a bounded, self-contained project with a measurable CI outcome." That project is now **complete**, and the measurable outcome is banked.

## Verification

- `cargo check --workspace --all-targets -j2` — green
- `controller_admission_rooting_test` — green
- `no_orphaned_ambient_wrappers_test` — green

Refs #7505.