### PR TITLE
perf(ci): unify release Cargo cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,15 +328,26 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.95.0
 
+      - name: Resolve Cargo build cache
+        id: cargo-cache
+        run: |
+          lock_digest="$(sha256sum Cargo.lock | cut -d' ' -f1)"
+          fingerprint="$(printf 'Cargo.lock:%s\n' "${lock_digest}" | sha256sum | cut -d' ' -f1)"
+          {
+            echo "key=${RUNNER_OS}-cargo-build-${fingerprint}"
+            echo "paths<<HOMEBOY_CACHE_PATHS"
+            echo "${HOME}/.cargo/registry"
+            echo "${HOME}/.cargo/git"
+            echo "target"
+            echo "HOMEBOY_CACHE_PATHS"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Cache cargo
         uses: actions/cache@v5
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-release-gate-${{ hashFiles('Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-release-gate-
+          path: ${{ steps.cargo-cache.outputs.paths }}
+          key: ${{ steps.cargo-cache.outputs.key }}
+          restore-keys: ${{ runner.os }}-cargo-build-
 
       - name: Build homeboy
         run: cargo build --release


### PR DESCRIPTION
## Summary
- replace the final `cargo-release-gate` namespace with the shared `cargo-build` namespace
- use the same absolute Cargo registry/git/target path list and lock fingerprint as Homeboy Action
- eliminate cache-version divergence caused by different path expressions

## Verification
- `actionlint -ignore 'SC2129|SC2086' .github/workflows/release.yml`
- `git diff --check`
- `cargo test --locked --test release_workflow_test` compiled without errors but exceeded two bounded local attempts (300s and 240s) before test execution

Completes the owning-repository portion of Extra-Chill/homeboy#11751 W1-6 after Extra-Chill/homeboy-action#424.

## AI assistance
Implemented and verified with OpenAI gpt-5.6-sol using OpenCode; AI was used to compare live cache inventory, align the final release cache namespace/path contract, and run workflow validation.