### PR TITLE
chore: enforce the runs dispatch boundary for three handlers (#7505)

### DIFF
--- a/crates/homeboy-cli/src/commands/runs/artifact_index_tests.rs
+++ b/crates/homeboy-cli/src/commands/runs/artifact_index_tests.rs
@@ -267,24 +267,27 @@ fn runs_artifacts_pages_large_inventory_and_filters_before_rendering() {
                 .expect("record artifact");
         }
 
-        let (output, _) = handlers::artifacts_from_args(RunsArtifactsArgs {
-            run_id: run.id.clone(),
-            runner: None,
-            pull: false,
-            pull_dir: None,
-            token: None,
-            kind: None,
-            mime: None,
-            original_path: None,
-            path_suffix: None,
-            fixture: None,
-            surface: None,
-            scenario: None,
-            name_glob: None,
-            limit: 50,
-            offset: 0,
-            full: false,
-        })
+        let (output, _) = handlers::artifacts_from_args(
+            &test_store(),
+            RunsArtifactsArgs {
+                run_id: run.id.clone(),
+                runner: None,
+                pull: false,
+                pull_dir: None,
+                token: None,
+                kind: None,
+                mime: None,
+                original_path: None,
+                path_suffix: None,
+                fixture: None,
+                surface: None,
+                scenario: None,
+                name_glob: None,
+                limit: 50,
+                offset: 0,
+                full: false,
+            },
+        )
         .expect("bounded listing");
         let RunsOutput::Artifacts(output) = output else {
             panic!("artifacts output")
@@ -294,24 +297,27 @@ fn runs_artifacts_pages_large_inventory_and_filters_before_rendering() {
         assert_eq!(page.total, 240);
         assert_eq!(page.next_offset, Some(50));
 
-        let (output, _) = handlers::artifacts_from_args(RunsArtifactsArgs {
-            run_id: run.id,
-            runner: None,
-            pull: false,
-            pull_dir: None,
-            token: None,
-            kind: Some("visual_diff".to_string()),
-            mime: Some("image/png".to_string()),
-            original_path: None,
-            path_suffix: Some("visual.png".to_string()),
-            fixture: Some("fixture-89".to_string()),
-            surface: Some("desktop".to_string()),
-            scenario: Some("visual-regression".to_string()),
-            name_glob: Some("visual_*".to_string()),
-            limit: 100,
-            offset: 0,
-            full: false,
-        })
+        let (output, _) = handlers::artifacts_from_args(
+            &test_store(),
+            RunsArtifactsArgs {
+                run_id: run.id,
+                runner: None,
+                pull: false,
+                pull_dir: None,
+                token: None,
+                kind: Some("visual_diff".to_string()),
+                mime: Some("image/png".to_string()),
+                original_path: None,
+                path_suffix: Some("visual.png".to_string()),
+                fixture: Some("fixture-89".to_string()),
+                surface: Some("desktop".to_string()),
+                scenario: Some("visual-regression".to_string()),
+                name_glob: Some("visual_*".to_string()),
+                limit: 100,
+                offset: 0,
+                full: false,
+            },
+        )
         .expect("filtered listing");
         let RunsOutput::Artifacts(output) = output else {
             panic!("artifacts output")

--- a/crates/homeboy-cli/src/commands/runs/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/runs/dispatch.rs
@@ -220,7 +220,7 @@ pub fn run(args: RunsArgs) -> CmdResult<RunsOutput> {
             json: _,
             presentation: _,
         } => dossier::runs_dossier(&run_id),
-        RunsCommand::ResumePlan { run_id } => handlers::resume_plan(&run_id),
+        RunsCommand::ResumePlan { run_id } => handlers::resume_plan(&store, &run_id),
         RunsCommand::Evidence {
             run_id,
             full,
@@ -233,8 +233,8 @@ pub fn run(args: RunsArgs) -> CmdResult<RunsOutput> {
                 handlers::apply_field_selection(output, &field)
             }
         }
-        RunsCommand::Env { run_id } => handlers::env(&run_id),
-        RunsCommand::Artifacts(args) => handlers::artifacts_from_args(args),
+        RunsCommand::Env { run_id } => handlers::env(&store, &run_id),
+        RunsCommand::Artifacts(args) => handlers::artifacts_from_args(&store, args),
         RunsCommand::Artifact(args) => handlers::artifact_command(args),
         RunsCommand::Findings(args) => findings::findings(&store, args),
         RunsCommand::Finding { finding_id } => findings::finding(&store, &finding_id),

--- a/crates/homeboy-cli/src/commands/runs/handlers.rs
+++ b/crates/homeboy-cli/src/commands/runs/handlers.rs
@@ -728,10 +728,9 @@ pub fn show_run(run_id: &str) -> CmdResult<RunsOutput> {
     ))
 }
 
-pub(crate) fn resume_plan(run_id: &str) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
-    reconcile::reconcile_owned_stale_running_runs(&store, 1000)?;
-    let run = runs_service::require_run(&store, run_id)?;
+pub(crate) fn resume_plan(store: &ObservationStore, run_id: &str) -> CmdResult<RunsOutput> {
+    reconcile::reconcile_owned_stale_running_runs(store, 1000)?;
+    let run = runs_service::require_run(store, run_id)?;
     let Some(ledger) = validation_progress_ledger_for_run(&run) else {
         return Err(Error::validation_invalid_argument(
             "run_id",
@@ -775,29 +774,35 @@ fn validation_progress_ledger_for_run(run: &RunRecord) -> Option<ValidationProgr
 
 #[cfg(test)]
 pub fn artifacts(run_id: &str) -> CmdResult<RunsOutput> {
-    artifacts_from_args(RunsArtifactsArgs {
-        run_id: run_id.to_string(),
-        runner: None,
-        pull: false,
-        pull_dir: None,
-        token: None,
-        kind: None,
-        mime: None,
-        original_path: None,
-        path_suffix: None,
-        fixture: None,
-        surface: None,
-        scenario: None,
-        name_glob: None,
-        limit: 50,
-        offset: 0,
-        // Preserve the direct test helper's historical exhaustive projection;
-        // the public CLI defaults to the bounded discovery page.
-        full: true,
-    })
+    artifacts_from_args(
+        &test_store(),
+        RunsArtifactsArgs {
+            run_id: run_id.to_string(),
+            runner: None,
+            pull: false,
+            pull_dir: None,
+            token: None,
+            kind: None,
+            mime: None,
+            original_path: None,
+            path_suffix: None,
+            fixture: None,
+            surface: None,
+            scenario: None,
+            name_glob: None,
+            limit: 50,
+            offset: 0,
+            // Preserve the direct test helper's historical exhaustive projection;
+            // the public CLI defaults to the bounded discovery page.
+            full: true,
+        },
+    )
 }
 
-pub(crate) fn artifacts_from_args(args: RunsArtifactsArgs) -> CmdResult<RunsOutput> {
+pub(crate) fn artifacts_from_args(
+    store: &ObservationStore,
+    args: RunsArtifactsArgs,
+) -> CmdResult<RunsOutput> {
     if let Some(runner_id) = args.runner.as_deref() {
         if args.pull {
             return Err(Error::validation_invalid_argument(
@@ -812,8 +817,7 @@ pub(crate) fn artifacts_from_args(args: RunsArtifactsArgs) -> CmdResult<RunsOutp
         return remote::runner_artifacts(runner_id, &args);
     }
 
-    let store = ObservationStore::open_initialized()?;
-    let run = runs_service::require_run(&store, &args.run_id)?;
+    let run = runs_service::require_run(store, &args.run_id)?;
     let run_id = run.id;
     let filter = ArtifactListFilter {
         token: args.token.clone(),
@@ -835,7 +839,7 @@ pub(crate) fn artifacts_from_args(args: RunsArtifactsArgs) -> CmdResult<RunsOutp
     };
     let artifacts = match page.as_ref() {
         Some(page) => page.artifacts.clone(),
-        None => runs_service::list_artifacts_for_run(&store, &run_id)?,
+        None => runs_service::list_artifacts_for_run(store, &run_id)?,
     };
     if !args.full {
         let page = page.expect("bounded artifact page is present");
@@ -1165,9 +1169,8 @@ fn sanitize_artifact_filename(artifact_id: &str) -> String {
     homeboy::core::runner_download_cache::sanitize_artifact_file_name(artifact_id)
 }
 
-pub fn env(run_id: &str) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
-    let run = runs_service::require_run(&store, run_id)?;
+pub fn env(store: &ObservationStore, run_id: &str) -> CmdResult<RunsOutput> {
+    let run = runs_service::require_run(store, run_id)?;
     let Some(envelope) = run.metadata_json.get("env_resolution").cloned() else {
         return Err(Error::validation_invalid_argument(
             "run_id",
@@ -1717,24 +1720,27 @@ mod pull_tests {
 
     #[test]
     fn artifacts_from_args_pull_with_runner_is_rejected() {
-        let result = artifacts_from_args(RunsArtifactsArgs {
-            run_id: "run-1".to_string(),
-            runner: Some("lab".to_string()),
-            pull: true,
-            pull_dir: None,
-            token: None,
-            kind: None,
-            mime: None,
-            original_path: None,
-            path_suffix: None,
-            fixture: None,
-            surface: None,
-            scenario: None,
-            name_glob: None,
-            limit: 50,
-            offset: 0,
-            full: false,
-        });
+        let result = artifacts_from_args(
+            &test_store(),
+            RunsArtifactsArgs {
+                run_id: "run-1".to_string(),
+                runner: Some("lab".to_string()),
+                pull: true,
+                pull_dir: None,
+                token: None,
+                kind: None,
+                mime: None,
+                original_path: None,
+                path_suffix: None,
+                fixture: None,
+                surface: None,
+                scenario: None,
+                name_glob: None,
+                limit: 50,
+                offset: 0,
+                full: false,
+            },
+        );
         let Err(err) = result else {
             panic!("--pull with --runner should fail");
         };

--- a/crates/homeboy-cli/src/commands/runs/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/runs/tests/mod.rs
@@ -1023,7 +1023,7 @@ fn runs_env_explains_redacted_lab_env_resolution() {
             ))
             .expect("run");
 
-        let (output, _) = env(&run.id).expect("runs env");
+        let (output, _) = env(&test_store(), &run.id).expect("runs env");
         let RunsOutput::Env(output) = output else {
             panic!("expected env output");
         };
@@ -1074,7 +1074,7 @@ fn runs_env_refuses_unredacted_env_resolution() {
             ))
             .expect("run");
 
-        let error = match env(&run.id) {
+        let error = match env(&test_store(), &run.id) {
             Ok(_) => panic!("unredacted env must fail"),
             Err(error) => error,
         };

--- a/tests/runs_dispatch_boundary_rooting_test.rs
+++ b/tests/runs_dispatch_boundary_rooting_test.rs
@@ -1,0 +1,79 @@
+//! Pins `homeboy runs` onto one observation store per invocation.
+//!
+//! ## What went wrong, concretely
+//!
+//! `dispatch::run` already declared the boundary and opened one store:
+//!
+//! ```text
+//! pub fn run(args: RunsArgs) -> CmdResult<RunsOutput> {
+//!     let store = ObservationStore::open_initialized()?;
+//!     match args.command { .. }
+//! }
+//! ```
+//!
+//! But several variants were dispatched without it and opened their own, so a
+//! single `homeboy runs env` opened two stores: the boundary's, unused, and the
+//! handler's. That is not a wrong answer today -- both resolve the same
+//! environment inside one short process -- but it means the boundary was
+//! declared and not enforced, and every handler that keeps its own open is one
+//! more place that has to be revisited before the ambient entry point can go.
+//!
+//! `resume_plan`, `env`, and `artifacts_from_args` now take the store the
+//! dispatcher already holds.
+//!
+//! ## What this test pins
+//!
+//! That those three keep taking an injected store. It deliberately does not
+//! assert a total count for the module: `show_run` uses `open_readonly`, which
+//! is a different mode chosen so a read cannot create or migrate a database,
+//! and several sibling commands are still their own boundaries.
+
+use std::path::PathBuf;
+
+fn source(relative: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("crates/homeboy-cli/src/commands/runs")
+        .join(relative);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
+}
+
+#[test]
+fn dispatched_handlers_do_not_reopen_the_store_they_were_given() {
+    let handlers = source("handlers.rs");
+    for name in ["resume_plan", "artifacts_from_args", "env"] {
+        let start = handlers
+            .find(&format!("fn {name}("))
+            .unwrap_or_else(|| panic!("`{name}` still exists in handlers.rs"));
+        let rest = &handlers[start..];
+        let end = rest.find("\n}\n").expect("terminated body");
+        let body = &rest[..end];
+        assert!(
+            body.contains("store: &ObservationStore"),
+            "`{name}` stopped taking the dispatcher's store (#7505)."
+        );
+        assert!(
+            !body.contains("ObservationStore::open_initialized()"),
+            "`{name}` takes an injected store and then opens another one. That \
+             is the shape the compiler cannot catch: the signature looks rooted \
+             while the body still resolves the environment for itself (#7505)."
+        );
+    }
+}
+
+#[test]
+fn the_dispatcher_hands_its_store_to_those_handlers() {
+    let dispatch = source("dispatch.rs");
+    for call in [
+        "handlers::resume_plan(&store, &run_id)",
+        "handlers::env(&store, &run_id)",
+        "handlers::artifacts_from_args(&store, args)",
+    ] {
+        assert!(
+            dispatch.contains(call),
+            "`dispatch::run` no longer passes its store to a handler that takes \
+             one. The boundary is only real if the dispatcher actually hands the \
+             store down (#7505). Expected:\n{call}"
+        );
+    }
+}


### PR DESCRIPTION
First slice of **item 4**. `dispatch::run` already declared the boundary:

```rust
pub fn run(args: RunsArgs) -> CmdResult<RunsOutput> {
    // Boundary: one `homeboy runs` invocation is one unit of work [...] (#7505)
    let store = ObservationStore::open_initialized()?;
    match args.command { .. }
}
```

…but several variants were dispatched **without** it and opened their own. `resume_plan`, `env`, and `artifacts_from_args` now take the store the dispatcher already holds.

## This is boundary discipline, not a defect fix

Worth stating plainly: both opens resolve the same environment inside one short CLI process, so `homeboy runs env` was **not producing a wrong answer** — it was opening two stores and using one.

What it cost was the ability to *finish*. Every handler that keeps its own open is another site to revisit before the ambient entry point can be deleted.

## `show_run` deliberately untouched

It uses **`open_readonly`** — a different mode, chosen so inspecting a run cannot create or migrate a database. Handing it the initialized store would quietly change that.

## The guard asserts bodies, not signatures

I first wrote it against the signatures. Both attempts to inject that regression **failed to compile** — a signature change is already an error at the call site, so the assertion added nothing.

What the compiler *cannot* see is a handler that accepts an injected store and then opens another one anyway. That is what the test asserts now, and injecting exactly that does fail it.

## Correcting the item 4 estimate

The issue's scoping comment puts `runs/**` at "132 sites across 23 files." Measured with test modules excluded:

```text
90 ambient opens across 14 files
  ~71 are in test files (tests/mod.rs alone has 39)
  ~15 are production, under the dispatch boundary
```

The genuine production cluster is **~15 sites, not 132** — the same fixture-count inflation the comment warns about two paragraphs earlier.

## Verification

- `cargo check --workspace --all-targets -j2` — green, no new warnings
- `no_orphaned_ambient_wrappers_test` — green
- guard verified non-vacuous against a regression that compiles

Refs #7505.