### PR TITLE
Resolve repository-local Lab rig sources

### DIFF
--- a/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
@@ -287,17 +287,21 @@ pub(super) fn sync_lab_offload_rigs(
                         ]),
                     )
                 })?;
-                let (source_root, package_path) = resolve_installed_rig_source(
+                let resolved_source = resolve_installed_rig_source(
                     rig_id,
                     metadata.source_root.as_deref(),
                     &metadata.package_path,
                     primary.local_path,
                 )?;
-                validate_installed_rig_source(rig_id, &source_root, &package_path)?;
+                validate_installed_rig_source(
+                    rig_id,
+                    &resolved_source.source_root,
+                    &resolved_source.package_path,
+                )?;
                 let synced = sync_workspace(
                     runner_id,
                     RunnerWorkspaceSyncOptions {
-                        path: source_root.clone(),
+                        path: resolved_source.snapshot_root.clone(),
                         mode: RunnerWorkspaceSyncMode::Snapshot,
                         controller_routed_git: false,
                         changed_since_base: None,
@@ -308,8 +312,11 @@ pub(super) fn sync_lab_offload_rigs(
                     },
                 )?
                 .0;
-                let install_source =
-                    remote_package_path(&source_root, &package_path, &synced.remote_path);
+                let install_source = remote_package_path(
+                    &resolved_source.snapshot_root,
+                    &resolved_source.package_path,
+                    &synced.remote_path,
+                );
                 let source_snapshot = homeboy_core::source_snapshot::collect_local(
                     runner_id,
                     Path::new(&synced.local_path),
@@ -318,8 +325,8 @@ pub(super) fn sync_lab_offload_rigs(
                 );
                 let package_source = LabOffloadRigPackageSource {
                     source: metadata.source,
-                    source_root,
-                    package_path,
+                    source_root: resolved_source.source_root,
+                    package_path: resolved_source.package_path,
                     install_source: install_source.clone(),
                     rig_path: Some(metadata.rig_path),
                     discovery_path: metadata.discovery_path,
@@ -1323,23 +1330,27 @@ mod tests {
     }
 
     #[test]
-    fn sync_lab_offload_rigs_materializes_relative_file_source_from_declared_worktree() {
+    fn sync_lab_offload_rigs_snapshots_worktree_and_remaps_nested_relative_directory_package() {
         homeboy_core::test_support::with_isolated_home(|home| {
             let worktree = home.path().join("declared-worktree");
-            let rig_file = worktree.join("rigs/fixture-matrix/rig.json");
+            let rig_file = worktree.join("rigs/fixture-matrix/nested/rig.json");
             std::fs::create_dir_all(rig_file.parent().expect("rig parent")).expect("rig parent");
             // Keep this package out of the primary-source branch so the test
             // exercises installed relative metadata.
             std::fs::write(&rig_file, r#"{"id":"unrelated-rig"}"#).expect("rig file");
+            let primary_rig = worktree.join("rigs/primary/rig.json");
+            std::fs::create_dir_all(primary_rig.parent().expect("primary rig parent"))
+                .expect("primary rig parent");
+            std::fs::write(&primary_rig, r#"{"id":"primary"}"#).expect("primary rig file");
             std::fs::write(worktree.join("shared-template.txt"), "snapshot me")
                 .expect("worktree dependency");
 
             let installed_source = homeboy_rig::install::RigSourceMetadata {
-                source: "rigs/fixture-matrix/rig.json".to_string(),
-                source_root: Some("rigs/fixture-matrix/rig.json".to_string()),
-                package_path: "rigs/fixture-matrix/rig.json".to_string(),
-                rig_path: "rigs/fixture-matrix/rig.json".to_string(),
-                discovery_path: Some("rigs/fixture-matrix".to_string()),
+                source: "rigs/fixture-matrix".to_string(),
+                source_root: Some("rigs/fixture-matrix".to_string()),
+                package_path: "rigs/fixture-matrix/nested".to_string(),
+                rig_path: "rigs/fixture-matrix/nested/rig.json".to_string(),
+                discovery_path: Some("rigs/fixture-matrix/nested".to_string()),
                 source_revision: None,
                 source_ref: None,
                 source_dirty: false,
@@ -1412,12 +1423,17 @@ mod tests {
             assert_eq!(sync.source_kind, LabOffloadRigSyncSource::InstalledMetadata);
             assert_eq!(
                 sync.package_source.source_root,
-                worktree.canonicalize().unwrap().display().to_string()
+                worktree
+                    .join("rigs/fixture-matrix")
+                    .canonicalize()
+                    .unwrap()
+                    .display()
+                    .to_string()
             );
             assert!(sync
                 .package_source
                 .install_source
-                .ends_with("/rigs/fixture-matrix"));
+                .ends_with("/rigs/fixture-matrix/nested"));
             assert_eq!(
                 std::fs::read_to_string(&install_record).expect("recorded install source"),
                 sync.package_source.install_source
@@ -1431,7 +1447,7 @@ mod tests {
                 .join("shared-template.txt")
                 .is_file());
             assert!(Path::new(snapshot_root)
-                .join("rigs/fixture-matrix/rig.json")
+                .join("rigs/fixture-matrix/nested/rig.json")
                 .is_file());
             assert!(!sync.workload_hashes.workspace_snapshot_identity.is_empty());
             let evidence = serde_json::to_value(sync).expect("sync evidence");
@@ -1441,6 +1457,69 @@ mod tests {
                 Some(sync.package_source.install_source.as_str())
             );
             assert!(evidence["source_snapshot"]["snapshot_hash"].is_string());
+        });
+    }
+
+    #[test]
+    fn sync_lab_offload_rigs_rejects_relative_directory_sibling_package() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let worktree = home.path().join("declared-worktree");
+            for path in [
+                worktree.join("rigs/a/rig.json"),
+                worktree.join("rigs/b/rig.json"),
+            ] {
+                std::fs::create_dir_all(path.parent().expect("rig parent")).expect("rig parent");
+                std::fs::write(path, r#"{"id":"unrelated-rig"}"#).expect("rig file");
+            }
+            let installed_source = homeboy_rig::install::RigSourceMetadata {
+                source: "rigs/a".to_string(),
+                source_root: Some("rigs/a".to_string()),
+                package_path: "rigs/b".to_string(),
+                rig_path: "rigs/b/rig.json".to_string(),
+                discovery_path: Some("rigs/b".to_string()),
+                source_revision: None,
+                source_ref: None,
+                source_dirty: false,
+                source_content_hash: None,
+                linked: true,
+                materialized: false,
+            };
+            std::fs::create_dir_all(homeboy_core::paths::rig_sources().expect("rig sources"))
+                .expect("rig sources");
+            homeboy_rig::install::write_source_metadata(
+                &homeboy_core::paths::homeboy().expect("config root"),
+                "fixture-matrix",
+                &installed_source,
+            )
+            .expect("source metadata");
+            let primary_snapshot = homeboy_core::source_snapshot::collect_local(
+                "local-stack-test",
+                &worktree,
+                None,
+                "primary",
+            );
+
+            let error = sync_lab_offload_rigs(
+                "local-stack-test",
+                "homeboy",
+                "/runner",
+                "/runner/.homeboy/rig-registry",
+                &[
+                    "homeboy".to_string(),
+                    "bench".to_string(),
+                    "--rig".to_string(),
+                    "fixture-matrix".to_string(),
+                ],
+                LabOffloadPrimaryRigSource {
+                    local_path: &worktree.display().to_string(),
+                    remote_path: "/runner",
+                    source_snapshot: &primary_snapshot,
+                    workspace_snapshot_identity: "primary-snapshot",
+                },
+            )
+            .expect_err("sibling package is outside its declared source directory");
+
+            assert!(error.message.contains("outside the declared source root"));
         });
     }
 

--- a/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
@@ -313,10 +313,11 @@ pub(super) fn sync_lab_offload_rigs(
                 )?
                 .0;
                 let install_source = remote_package_path(
+                    rig_id,
                     &resolved_source.snapshot_root,
                     &resolved_source.package_path,
                     &synced.remote_path,
-                );
+                )?;
                 let source_snapshot = homeboy_core::source_snapshot::collect_local(
                     runner_id,
                     Path::new(&synced.local_path),

--- a/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
@@ -1349,8 +1349,12 @@ mod tests {
             };
             std::fs::create_dir_all(homeboy_core::paths::rig_sources().expect("rig sources"))
                 .expect("rig sources");
-            homeboy_rig::install::write_source_metadata("fixture-matrix", &installed_source)
-                .expect("source metadata");
+            homeboy_rig::install::write_source_metadata(
+                &homeboy_core::paths::homeboy().expect("config root"),
+                "fixture-matrix",
+                &installed_source,
+            )
+            .expect("source metadata");
 
             let install_record = home.path().join("installed-source.txt");
             let command = home.path().join("fake-homeboy");

--- a/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
@@ -130,8 +130,9 @@ fn remove_partial_lab_stack(runner: &super::Runner, destination: &str) {
 
 mod rig_source_install;
 use rig_source_install::{
-    remote_package_path, remove_runner_installed_rig_source, rig_install_capability_preflight,
-    rig_registry_env, runner_rig_install_command, validate_installed_rig_source,
+    remote_package_path, remove_runner_installed_rig_source, resolve_installed_rig_source,
+    rig_install_capability_preflight, rig_registry_env, runner_rig_install_command,
+    validate_installed_rig_source,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -286,11 +287,13 @@ pub(super) fn sync_lab_offload_rigs(
                         ]),
                     )
                 })?;
-                let source_root = metadata
-                    .source_root
-                    .clone()
-                    .unwrap_or_else(|| metadata.package_path.clone());
-                validate_installed_rig_source(rig_id, &source_root, &metadata.package_path)?;
+                let (source_root, package_path) = resolve_installed_rig_source(
+                    rig_id,
+                    metadata.source_root.as_deref(),
+                    &metadata.package_path,
+                    primary.local_path,
+                )?;
+                validate_installed_rig_source(rig_id, &source_root, &package_path)?;
                 let synced = sync_workspace(
                     runner_id,
                     RunnerWorkspaceSyncOptions {
@@ -306,7 +309,7 @@ pub(super) fn sync_lab_offload_rigs(
                 )?
                 .0;
                 let install_source =
-                    remote_package_path(&source_root, &metadata.package_path, &synced.remote_path);
+                    remote_package_path(&source_root, &package_path, &synced.remote_path);
                 let source_snapshot = homeboy_core::source_snapshot::collect_local(
                     runner_id,
                     Path::new(&synced.local_path),
@@ -316,7 +319,7 @@ pub(super) fn sync_lab_offload_rigs(
                 let package_source = LabOffloadRigPackageSource {
                     source: metadata.source,
                     source_root,
-                    package_path: metadata.package_path,
+                    package_path,
                     install_source: install_source.clone(),
                     rig_path: Some(metadata.rig_path),
                     discovery_path: metadata.discovery_path,

--- a/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
@@ -1272,6 +1272,7 @@ fn push_unique<T: PartialEq>(items: &mut Vec<T>, item: T) {
 
 #[cfg(test)]
 mod tests {
+    use std::os::unix::fs::PermissionsExt;
     use std::process::Command;
     use std::sync::Arc;
 
@@ -1319,6 +1320,124 @@ mod tests {
             resources: Default::default(),
             policy: homeboy_core::server::RunnerPolicy::default(),
         }
+    }
+
+    #[test]
+    fn sync_lab_offload_rigs_materializes_relative_file_source_from_declared_worktree() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let worktree = home.path().join("declared-worktree");
+            let rig_file = worktree.join("rigs/fixture-matrix/rig.json");
+            std::fs::create_dir_all(rig_file.parent().expect("rig parent")).expect("rig parent");
+            // Keep this package out of the primary-source branch so the test
+            // exercises installed relative metadata.
+            std::fs::write(&rig_file, r#"{"id":"unrelated-rig"}"#).expect("rig file");
+            std::fs::write(worktree.join("shared-template.txt"), "snapshot me")
+                .expect("worktree dependency");
+
+            let installed_source = homeboy_rig::install::RigSourceMetadata {
+                source: "rigs/fixture-matrix/rig.json".to_string(),
+                source_root: Some("rigs/fixture-matrix/rig.json".to_string()),
+                package_path: "rigs/fixture-matrix/rig.json".to_string(),
+                rig_path: "rigs/fixture-matrix/rig.json".to_string(),
+                discovery_path: Some("rigs/fixture-matrix".to_string()),
+                source_revision: None,
+                source_ref: None,
+                source_dirty: false,
+                source_content_hash: None,
+                linked: true,
+                materialized: false,
+            };
+            std::fs::create_dir_all(homeboy_core::paths::rig_sources().expect("rig sources"))
+                .expect("rig sources");
+            homeboy_rig::install::write_source_metadata("fixture-matrix", &installed_source)
+                .expect("source metadata");
+
+            let install_record = home.path().join("installed-source.txt");
+            let command = home.path().join("fake-homeboy");
+            std::fs::write(
+                &command,
+                "#!/bin/sh\ncase \"$1 $2\" in\n  'rig sources') printf '%s' '{\"data\":{\"report\":{\"sources\":[]}}}' ;;\n  'rig install') printf '%s' \"$3\" > \"$HOMEBOY_TEST_INSTALL_SOURCE\"; printf '%s' '{\"data\":{\"installed\":[{\"id\":\"fixture-matrix\",\"path\":\"/runner/rigs/fixture-matrix\"}]}}' ;;\nesac\n",
+            )
+            .expect("fake homeboy");
+            std::fs::set_permissions(&command, std::fs::Permissions::from_mode(0o755))
+                .expect("make fake homeboy executable");
+
+            let mut runner = local_runner();
+            runner.id = "relative-rig-source".to_string();
+            runner.workspace_root =
+                Some(home.path().join("runner-workspaces").display().to_string());
+            runner.settings.homeboy_path = Some(command.display().to_string());
+            runner.env.insert(
+                "HOMEBOY_TEST_INSTALL_SOURCE".to_string(),
+                install_record.display().to_string(),
+            );
+            homeboy_core::config::save(&runner).expect("save runner");
+            let remote_cwd = home.path().join("runner-cwd");
+            std::fs::create_dir_all(&remote_cwd).expect("runner cwd");
+            let remote_cwd = remote_cwd.display().to_string();
+
+            let primary_snapshot = homeboy_core::source_snapshot::collect_local(
+                &runner.id,
+                &worktree,
+                Some(&remote_cwd),
+                "primary",
+            );
+            let synced = sync_lab_offload_rigs(
+                &runner.id,
+                &command.display().to_string(),
+                &remote_cwd,
+                &format!("{remote_cwd}/.homeboy/rig-registry"),
+                &[
+                    "homeboy".to_string(),
+                    "bench".to_string(),
+                    "--rig".to_string(),
+                    "fixture-matrix".to_string(),
+                ],
+                LabOffloadPrimaryRigSource {
+                    local_path: &worktree.display().to_string(),
+                    remote_path: &remote_cwd,
+                    source_snapshot: &primary_snapshot,
+                    workspace_snapshot_identity: "primary-snapshot",
+                },
+            )
+            .expect("sync installed relative rig source");
+
+            let [sync] = synced.as_slice() else {
+                panic!("one installed rig source should sync");
+            };
+            assert_eq!(sync.source_kind, LabOffloadRigSyncSource::InstalledMetadata);
+            assert_eq!(
+                sync.package_source.source_root,
+                worktree.canonicalize().unwrap().display().to_string()
+            );
+            assert!(sync
+                .package_source
+                .install_source
+                .ends_with("/rigs/fixture-matrix"));
+            assert_eq!(
+                std::fs::read_to_string(&install_record).expect("recorded install source"),
+                sync.package_source.install_source
+            );
+            let snapshot_root = sync
+                .source_snapshot
+                .remote_path
+                .as_deref()
+                .expect("snapshot path");
+            assert!(Path::new(snapshot_root)
+                .join("shared-template.txt")
+                .is_file());
+            assert!(Path::new(snapshot_root)
+                .join("rigs/fixture-matrix/rig.json")
+                .is_file());
+            assert!(!sync.workload_hashes.workspace_snapshot_identity.is_empty());
+            let evidence = serde_json::to_value(sync).expect("sync evidence");
+            assert_eq!(evidence["source_kind"], "installed_metadata");
+            assert_eq!(
+                evidence["package_source"]["install_source"].as_str(),
+                Some(sync.package_source.install_source.as_str())
+            );
+            assert!(evidence["source_snapshot"]["snapshot_hash"].is_string());
+        });
     }
 
     fn local_bare_stack_fixture() -> (tempfile::TempDir, homeboy_rig::LabStackSpec, String) {

--- a/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
@@ -1280,6 +1280,7 @@ fn push_unique<T: PartialEq>(items: &mut Vec<T>, item: T) {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
     use std::process::Command;
     use std::sync::Arc;
@@ -1330,6 +1331,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     #[test]
     fn sync_lab_offload_rigs_snapshots_worktree_and_remaps_nested_relative_directory_package() {
         homeboy_core::test_support::with_isolated_home(|home| {
@@ -1359,7 +1361,7 @@ mod tests {
                 linked: true,
                 materialized: false,
             };
-            std::fs::create_dir_all(homeboy_core::paths::rig_sources().expect("rig sources"))
+            std::fs::create_dir_all(homeboy_core::paths::rig_sources_in_root(&test_config_root()))
                 .expect("rig sources");
             homeboy_rig::install::write_source_metadata(
                 &homeboy_core::paths::homeboy().expect("config root"),
@@ -1485,7 +1487,7 @@ mod tests {
                 linked: true,
                 materialized: false,
             };
-            std::fs::create_dir_all(homeboy_core::paths::rig_sources().expect("rig sources"))
+            std::fs::create_dir_all(homeboy_core::paths::rig_sources_in_root(&test_config_root()))
                 .expect("rig sources");
             homeboy_rig::install::write_source_metadata(
                 &homeboy_core::paths::homeboy().expect("config root"),

--- a/crates/homeboy-lab-runner/src/rig_materialization/rig_source_install.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/rig_source_install.rs
@@ -36,19 +36,31 @@ pub(super) fn rig_install_capability_preflight() -> RunnerCapabilityPreflight {
 }
 
 pub(super) fn remote_package_path(
+    rig_id: &str,
     source_root: &str,
     package_path: &str,
     remote_source_root: &str,
-) -> String {
+) -> Result<String> {
     let source_root = Path::new(source_root);
     let package_path = Path::new(package_path);
-    match package_path.strip_prefix(source_root) {
-        Ok(relative) if !relative.as_os_str().is_empty() => Path::new(remote_source_root)
-            .join(relative)
-            .to_string_lossy()
-            .to_string(),
-        _ => remote_source_root.to_string(),
-    }
+    let relative = package_path.strip_prefix(source_root).map_err(|_| {
+        Error::validation_invalid_argument(
+            "rig",
+            format!(
+                "runner dispatch cannot materialize rig `{rig_id}` because its package path cannot be remapped from the synced worktree"
+            ),
+            Some(package_path.display().to_string()),
+            Some(vec![
+                format!("synced worktree: {}", source_root.display()),
+                "Reinstall the rig from a package inside the declared worktree before using --runner."
+                    .to_string(),
+            ]),
+        )
+    })?;
+    Ok(Path::new(remote_source_root)
+        .join(relative)
+        .to_string_lossy()
+        .to_string())
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -90,6 +102,21 @@ pub(super) fn resolve_installed_rig_source(
         package_path,
         declared_root.as_deref(),
     )?;
+
+    if let Some(declared_root) = declared_root.as_deref() {
+        validate_relative_metadata_within_worktree(
+            rig_id,
+            "source root",
+            &declared_source,
+            declared_root,
+        )?;
+        validate_relative_metadata_within_worktree(
+            rig_id,
+            "package path",
+            &package_path,
+            declared_root,
+        )?;
+    }
 
     if declared_source.is_file() && package_path != declared_source {
         return Err(Error::validation_invalid_argument(
@@ -143,6 +170,30 @@ fn source_directory(path: PathBuf) -> PathBuf {
     } else {
         path
     }
+}
+
+fn validate_relative_metadata_within_worktree(
+    rig_id: &str,
+    label: &str,
+    path: &Path,
+    declared_worktree: &Path,
+) -> Result<()> {
+    if path.starts_with(declared_worktree) {
+        return Ok(());
+    }
+
+    Err(Error::validation_invalid_argument(
+        "rig",
+        format!(
+            "runner dispatch cannot materialize rig `{rig_id}` because its relative {label} resolves outside the declared worktree"
+        ),
+        Some(path.display().to_string()),
+        Some(vec![
+            format!("declared worktree: {}", declared_worktree.display()),
+            "Replace the escaping symlink or reinstall the rig from a package inside the declared worktree."
+                .to_string(),
+        ]),
+    ))
 }
 
 fn package_directory(rig_id: &str, path: PathBuf) -> Result<PathBuf> {
@@ -542,10 +593,12 @@ mod tests {
         );
         assert_eq!(
             remote_package_path(
+                "fixture-matrix",
                 &resolved.snapshot_root,
                 &resolved.package_path,
                 "/runner/worktree"
-            ),
+            )
+            .unwrap(),
             "/runner/worktree/rigs/fixture-matrix"
         );
     }
@@ -670,6 +723,102 @@ mod tests {
         )
         .expect_err("symlink to sibling is outside declared source directory");
         assert!(error.message.contains("outside the declared source root"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relative_source_root_symlink_escaping_worktree_rejects() {
+        use std::os::unix::fs::symlink;
+
+        let worktree = tempfile::tempdir().expect("worktree");
+        let external = tempfile::tempdir().expect("external package");
+        symlink(external.path(), worktree.path().join("external-source"))
+            .expect("external source symlink");
+
+        let error = resolve_installed_rig_source(
+            "fixture-matrix",
+            Some("external-source"),
+            "external-source",
+            &worktree.path().display().to_string(),
+        )
+        .expect_err("source symlink outside worktree rejects");
+
+        assert!(error
+            .message
+            .contains("source root resolves outside the declared worktree"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relative_package_symlink_escaping_worktree_rejects() {
+        use std::os::unix::fs::symlink;
+
+        let worktree = tempfile::tempdir().expect("worktree");
+        let external = tempfile::tempdir().expect("external package");
+        std::fs::create_dir_all(worktree.path().join("rigs")).expect("source root");
+        symlink(
+            external.path(),
+            worktree.path().join("rigs/external-package"),
+        )
+        .expect("external package symlink");
+
+        let error = resolve_installed_rig_source(
+            "fixture-matrix",
+            Some("rigs"),
+            "rigs/external-package",
+            &worktree.path().display().to_string(),
+        )
+        .expect_err("package symlink outside worktree rejects");
+
+        assert!(error
+            .message
+            .contains("package path resolves outside the declared worktree"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relative_internal_symlink_source_and_package_are_authorized() {
+        use std::os::unix::fs::symlink;
+
+        let worktree = tempfile::tempdir().expect("worktree");
+        let package = worktree.path().join("rigs/authorized");
+        std::fs::create_dir_all(&package).expect("authorized package");
+        symlink(&package, worktree.path().join("rigs/authorized-link"))
+            .expect("internal package symlink");
+
+        let resolved = resolve_installed_rig_source(
+            "fixture-matrix",
+            Some("rigs/authorized-link"),
+            "rigs/authorized-link",
+            &worktree.path().display().to_string(),
+        )
+        .expect("internal symlink remains inside the declared worktree");
+
+        assert_eq!(
+            resolved.package_path,
+            package.canonicalize().unwrap().display().to_string()
+        );
+    }
+
+    #[test]
+    fn remote_package_path_rejects_paths_outside_snapshot() {
+        let error = remote_package_path(
+            "fixture-matrix",
+            "/snapshot/worktree",
+            "/outside/package",
+            "/runner/worktree",
+        )
+        .expect_err("outside package cannot remap to snapshot root");
+
+        assert!(error
+            .message
+            .contains("cannot be remapped from the synced worktree"));
+        assert!(error.details["tried"]
+            .as_array()
+            .expect("actionable hints")
+            .iter()
+            .filter_map(|hint| hint.as_str())
+            .any(|hint| hint.contains("Reinstall the rig")));
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/rig_materialization/rig_source_install.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/rig_source_install.rs
@@ -6,7 +6,7 @@
 //! the root stays under the structural item-count threshold (#5241).
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 use crate::shell_quote::shell_arg;
 use homeboy_core::{Error, Result};
@@ -49,6 +49,142 @@ pub(super) fn remote_package_path(
             .to_string(),
         _ => remote_source_root.to_string(),
     }
+}
+
+/// Resolve installed local-source metadata before staging it for Lab.
+///
+/// Relative paths are meaningful only below the repository or worktree chosen
+/// for this dispatch. Absolute paths preserve the installed package behavior.
+pub(super) fn resolve_installed_rig_source(
+    rig_id: &str,
+    source_root: Option<&str>,
+    package_path: &str,
+    declared_source_root: &str,
+) -> Result<(String, String)> {
+    let source_root = source_root.unwrap_or(package_path);
+    let source_is_relative = Path::new(source_root).is_relative();
+    let package_is_relative = Path::new(package_path).is_relative();
+    let declared_root = if source_is_relative || package_is_relative {
+        Some(resolve_declared_source_root(rig_id, declared_source_root)?)
+    } else {
+        None
+    };
+
+    let source_root = if source_is_relative {
+        // Materialize the declared worktree so package dependencies and
+        // templates outside a nested rig directory remain available.
+        declared_root
+            .as_ref()
+            .expect("relative source requires declared root")
+            .clone()
+    } else {
+        canonical_source_path(rig_id, "source root", source_root, None)?
+    };
+    let source_root = source_directory(source_root);
+    let package_path = canonical_source_path(
+        rig_id,
+        "package path",
+        package_path,
+        declared_root.as_deref(),
+    )?;
+    let package_path = package_directory(rig_id, package_path)?;
+
+    if !package_path.starts_with(&source_root) {
+        return Err(Error::validation_invalid_argument(
+            "rig",
+            format!(
+                "runner dispatch cannot materialize rig `{rig_id}` because its installed package path is outside the declared source root"
+            ),
+            Some(package_path.display().to_string()),
+            Some(vec![format!("declared source root: {}", source_root.display())]),
+        ));
+    }
+
+    Ok((
+        source_root.display().to_string(),
+        package_path.display().to_string(),
+    ))
+}
+
+fn source_directory(path: PathBuf) -> PathBuf {
+    if path.is_file() {
+        path.parent().expect("source file has parent").to_path_buf()
+    } else {
+        path
+    }
+}
+
+fn package_directory(rig_id: &str, path: PathBuf) -> Result<PathBuf> {
+    if !path.is_file() {
+        return Ok(path);
+    }
+    if path.file_name().is_none_or(|name| name != "rig.json") {
+        return Err(Error::validation_invalid_argument(
+            "rig",
+            format!(
+                "runner dispatch cannot materialize rig `{rig_id}` because its installed package path is a file other than rig.json"
+            ),
+            Some(path.display().to_string()),
+            None,
+        ));
+    }
+    Ok(path.parent().expect("rig file has parent").to_path_buf())
+}
+
+fn resolve_declared_source_root(rig_id: &str, declared_source_root: &str) -> Result<PathBuf> {
+    if declared_source_root.trim().is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "rig",
+            format!(
+                "runner dispatch cannot materialize relative rig source metadata for `{rig_id}` without a declared repository or worktree context"
+            ),
+            None,
+            Some(vec![
+                "Run the command from the source checkout or pass --path <source-worktree>.".to_string(),
+            ]),
+        ));
+    }
+    canonical_source_path(rig_id, "declared source root", declared_source_root, None)
+}
+
+fn canonical_source_path(
+    rig_id: &str,
+    label: &str,
+    path: &str,
+    relative_root: Option<&Path>,
+) -> Result<PathBuf> {
+    let path = Path::new(path);
+    if path.is_relative()
+        && path.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+    {
+        return Err(Error::validation_invalid_argument(
+            "rig",
+            format!(
+                "runner dispatch cannot materialize rig `{rig_id}` because its relative {label} escapes the declared source root"
+            ),
+            Some(path.display().to_string()),
+            None,
+        ));
+    }
+    let candidate = match relative_root {
+        Some(root) if path.is_relative() => root.join(path),
+        _ => path.to_path_buf(),
+    };
+    candidate.canonicalize().map_err(|error| {
+        Error::validation_invalid_argument(
+            "rig",
+            format!(
+                "runner dispatch cannot materialize rig `{rig_id}` because its installed {label} does not exist"
+            ),
+            Some(candidate.display().to_string()),
+            Some(vec![error.to_string()]),
+        )
+    })
 }
 
 /// Run a runner-side `rig sources <args...>` command, returning its captured
@@ -337,5 +473,109 @@ mod tests {
         assert!(hints.contains("homeboy rig install"));
         assert!(hints.contains("--id woocommerce-performance --reinstall"));
         assert!(hints.contains("homeboy rig sources list"));
+    }
+
+    #[test]
+    fn relative_rig_source_resolves_from_declared_worktree_for_lab_materialization() {
+        let worktree = tempfile::tempdir().expect("worktree");
+        let rig_file = worktree.path().join("rigs/fixture-matrix/rig.json");
+        std::fs::create_dir_all(rig_file.parent().expect("rig parent")).expect("rig parent");
+        std::fs::write(&rig_file, "{}").expect("rig file");
+
+        let (source_root, package_path) = resolve_installed_rig_source(
+            "fixture-matrix",
+            Some("rigs/fixture-matrix/rig.json"),
+            "rigs/fixture-matrix/rig.json",
+            &worktree.path().display().to_string(),
+        )
+        .expect("relative source resolves from declared worktree");
+
+        assert_eq!(
+            source_root,
+            worktree
+                .path()
+                .canonicalize()
+                .unwrap()
+                .display()
+                .to_string()
+        );
+        assert_eq!(
+            package_path,
+            rig_file
+                .parent()
+                .unwrap()
+                .canonicalize()
+                .unwrap()
+                .display()
+                .to_string()
+        );
+        assert_eq!(
+            remote_package_path(&source_root, &package_path, "/runner/worktree"),
+            "/runner/worktree/rigs/fixture-matrix"
+        );
+    }
+
+    #[test]
+    fn relative_rig_source_requires_declared_worktree_context() {
+        let error = resolve_installed_rig_source(
+            "fixture-matrix",
+            Some("rigs/fixture-matrix"),
+            "rigs/fixture-matrix",
+            "",
+        )
+        .expect_err("relative source without context rejects");
+
+        assert!(error
+            .message
+            .contains("declared repository or worktree context"));
+    }
+
+    #[test]
+    fn relative_rig_source_rejects_missing_package_file() {
+        let worktree = tempfile::tempdir().expect("worktree");
+        let error = resolve_installed_rig_source(
+            "fixture-matrix",
+            Some("rigs/fixture-matrix"),
+            "rigs/fixture-matrix/rig.json",
+            &worktree.path().display().to_string(),
+        )
+        .expect_err("missing package file rejects");
+
+        assert!(error.message.contains("package path does not exist"));
+    }
+
+    #[test]
+    fn relative_rig_source_rejects_worktree_traversal() {
+        let worktree = tempfile::tempdir().expect("worktree");
+        let error = resolve_installed_rig_source(
+            "fixture-matrix",
+            Some("../outside"),
+            "../outside",
+            &worktree.path().display().to_string(),
+        )
+        .expect_err("traversal rejects");
+
+        assert!(error.message.contains("escapes the declared source root"));
+    }
+
+    #[test]
+    fn absolute_local_rig_source_keeps_existing_package_boundary() {
+        let package = tempfile::tempdir().expect("package");
+        let rig_file = package.path().join("rig.json");
+        std::fs::write(&rig_file, "{}").expect("rig file");
+
+        let (source_root, package_path) = resolve_installed_rig_source(
+            "fixture-matrix",
+            Some(&package.path().display().to_string()),
+            &rig_file.display().to_string(),
+            "",
+        )
+        .expect("absolute source preserves existing behavior");
+
+        assert_eq!(
+            source_root,
+            package.path().canonicalize().unwrap().display().to_string()
+        );
+        assert_eq!(package_path, source_root);
     }
 }

--- a/crates/homeboy-lab-runner/src/rig_materialization/rig_source_install.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/rig_source_install.rs
@@ -51,6 +51,15 @@ pub(super) fn remote_package_path(
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct ResolvedInstalledRigSource {
+    /// The complete worktree copied to the runner.
+    pub snapshot_root: String,
+    /// The declared local package authority boundary.
+    pub source_root: String,
+    pub package_path: String,
+}
+
 /// Resolve installed local-source metadata before staging it for Lab.
 ///
 /// Relative paths are meaningful only below the repository or worktree chosen
@@ -60,7 +69,7 @@ pub(super) fn resolve_installed_rig_source(
     source_root: Option<&str>,
     package_path: &str,
     declared_source_root: &str,
-) -> Result<(String, String)> {
+) -> Result<ResolvedInstalledRigSource> {
     let source_root = source_root.unwrap_or(package_path);
     let source_is_relative = Path::new(source_root).is_relative();
     let package_is_relative = Path::new(package_path).is_relative();
@@ -96,7 +105,7 @@ pub(super) fn resolve_installed_rig_source(
         ));
     }
 
-    let source_root = if source_is_relative {
+    let snapshot_root = if source_is_relative {
         // Materialize the declared worktree so package dependencies and
         // templates outside a nested rig directory remain available.
         declared_root
@@ -104,9 +113,10 @@ pub(super) fn resolve_installed_rig_source(
             .expect("relative source requires declared root")
             .clone()
     } else {
-        declared_source
+        declared_source.clone()
     };
-    let source_root = source_directory(source_root);
+    let snapshot_root = source_directory(snapshot_root);
+    let source_root = source_directory(declared_source);
     let package_path = package_directory(rig_id, package_path)?;
 
     if !package_path.starts_with(&source_root) {
@@ -120,10 +130,11 @@ pub(super) fn resolve_installed_rig_source(
         ));
     }
 
-    Ok((
-        source_root.display().to_string(),
-        package_path.display().to_string(),
-    ))
+    Ok(ResolvedInstalledRigSource {
+        snapshot_root: snapshot_root.display().to_string(),
+        source_root: source_root.display().to_string(),
+        package_path: package_path.display().to_string(),
+    })
 }
 
 fn source_directory(path: PathBuf) -> PathBuf {
@@ -502,7 +513,7 @@ mod tests {
         std::fs::create_dir_all(rig_file.parent().expect("rig parent")).expect("rig parent");
         std::fs::write(&rig_file, "{}").expect("rig file");
 
-        let (source_root, package_path) = resolve_installed_rig_source(
+        let resolved = resolve_installed_rig_source(
             "fixture-matrix",
             Some("rigs/fixture-matrix/rig.json"),
             "rigs/fixture-matrix/rig.json",
@@ -511,7 +522,7 @@ mod tests {
         .expect("relative source resolves from declared worktree");
 
         assert_eq!(
-            source_root,
+            resolved.snapshot_root,
             worktree
                 .path()
                 .canonicalize()
@@ -520,7 +531,7 @@ mod tests {
                 .to_string()
         );
         assert_eq!(
-            package_path,
+            resolved.package_path,
             rig_file
                 .parent()
                 .unwrap()
@@ -530,7 +541,11 @@ mod tests {
                 .to_string()
         );
         assert_eq!(
-            remote_package_path(&source_root, &package_path, "/runner/worktree"),
+            remote_package_path(
+                &resolved.snapshot_root,
+                &resolved.package_path,
+                "/runner/worktree"
+            ),
             "/runner/worktree/rigs/fixture-matrix"
         );
     }
@@ -589,6 +604,75 @@ mod tests {
     }
 
     #[test]
+    fn directory_source_root_authorizes_nested_package_but_not_sibling() {
+        let worktree = tempfile::tempdir().expect("worktree");
+        let source_root = worktree.path().join("rigs/a");
+        let nested_package = source_root.join("nested");
+        let sibling_package = worktree.path().join("rigs/b");
+        std::fs::create_dir_all(&nested_package).expect("nested package");
+        std::fs::create_dir_all(&sibling_package).expect("sibling package");
+
+        let resolved = resolve_installed_rig_source(
+            "fixture-matrix",
+            Some("rigs/a"),
+            "rigs/a/nested",
+            &worktree.path().display().to_string(),
+        )
+        .expect("nested package is authorized by declared source directory");
+        assert_eq!(
+            resolved.snapshot_root,
+            worktree
+                .path()
+                .canonicalize()
+                .unwrap()
+                .display()
+                .to_string()
+        );
+        assert_eq!(
+            resolved.source_root,
+            source_root.canonicalize().unwrap().display().to_string()
+        );
+
+        let error = resolve_installed_rig_source(
+            "fixture-matrix",
+            Some("rigs/a"),
+            "rigs/b",
+            &worktree.path().display().to_string(),
+        )
+        .expect_err("sibling package is outside declared source directory");
+        assert!(error.message.contains("outside the declared source root"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn directory_source_root_rejects_symlinked_sibling_package() {
+        use std::os::unix::fs::symlink;
+
+        let worktree = tempfile::tempdir().expect("worktree");
+        std::fs::create_dir_all(worktree.path().join("rigs/a")).expect("source package");
+        std::fs::create_dir_all(worktree.path().join("rigs/b")).expect("sibling package");
+        symlink(
+            worktree.path().join("rigs/a"),
+            worktree.path().join("rigs/a-link"),
+        )
+        .expect("symlink source package");
+        symlink(
+            worktree.path().join("rigs/b"),
+            worktree.path().join("rigs/b-link"),
+        )
+        .expect("symlink sibling package");
+
+        let error = resolve_installed_rig_source(
+            "fixture-matrix",
+            Some("rigs/a-link"),
+            "rigs/b-link",
+            &worktree.path().display().to_string(),
+        )
+        .expect_err("symlink to sibling is outside declared source directory");
+        assert!(error.message.contains("outside the declared source root"));
+    }
+
+    #[test]
     fn relative_rig_source_rejects_worktree_traversal() {
         let worktree = tempfile::tempdir().expect("worktree");
         let error = resolve_installed_rig_source(
@@ -608,7 +692,7 @@ mod tests {
         let rig_file = package.path().join("rig.json");
         std::fs::write(&rig_file, "{}").expect("rig file");
 
-        let (source_root, package_path) = resolve_installed_rig_source(
+        let resolved = resolve_installed_rig_source(
             "fixture-matrix",
             Some(&package.path().display().to_string()),
             &rig_file.display().to_string(),
@@ -617,9 +701,9 @@ mod tests {
         .expect("absolute source preserves existing behavior");
 
         assert_eq!(
-            source_root,
+            resolved.snapshot_root,
             package.path().canonicalize().unwrap().display().to_string()
         );
-        assert_eq!(package_path, source_root);
+        assert_eq!(resolved.package_path, resolved.source_root);
     }
 }

--- a/crates/homeboy-lab-runner/src/rig_materialization/rig_source_install.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/rig_source_install.rs
@@ -70,6 +70,32 @@ pub(super) fn resolve_installed_rig_source(
         None
     };
 
+    let declared_source = if source_is_relative {
+        canonical_source_path(rig_id, "source root", source_root, declared_root.as_deref())?
+    } else {
+        canonical_source_path(rig_id, "source root", source_root, None)?
+    };
+    let package_path = canonical_source_path(
+        rig_id,
+        "package path",
+        package_path,
+        declared_root.as_deref(),
+    )?;
+
+    if declared_source.is_file() && package_path != declared_source {
+        return Err(Error::validation_invalid_argument(
+            "rig",
+            format!(
+                "runner dispatch cannot materialize rig `{rig_id}` because its installed package path differs from the declared rig.json source root"
+            ),
+            Some(package_path.display().to_string()),
+            Some(vec![format!(
+                "declared rig.json source root: {}",
+                declared_source.display()
+            )]),
+        ));
+    }
+
     let source_root = if source_is_relative {
         // Materialize the declared worktree so package dependencies and
         // templates outside a nested rig directory remain available.
@@ -78,15 +104,9 @@ pub(super) fn resolve_installed_rig_source(
             .expect("relative source requires declared root")
             .clone()
     } else {
-        canonical_source_path(rig_id, "source root", source_root, None)?
+        declared_source
     };
     let source_root = source_directory(source_root);
-    let package_path = canonical_source_path(
-        rig_id,
-        "package path",
-        package_path,
-        declared_root.as_deref(),
-    )?;
     let package_path = package_directory(rig_id, package_path)?;
 
     if !package_path.starts_with(&source_root) {
@@ -533,6 +553,7 @@ mod tests {
     #[test]
     fn relative_rig_source_rejects_missing_package_file() {
         let worktree = tempfile::tempdir().expect("worktree");
+        std::fs::create_dir_all(worktree.path().join("rigs/fixture-matrix")).expect("source root");
         let error = resolve_installed_rig_source(
             "fixture-matrix",
             Some("rigs/fixture-matrix"),
@@ -542,6 +563,29 @@ mod tests {
         .expect_err("missing package file rejects");
 
         assert!(error.message.contains("package path does not exist"));
+    }
+
+    #[test]
+    fn file_valued_source_root_rejects_sibling_package() {
+        let worktree = tempfile::tempdir().expect("worktree");
+        let declared_rig = worktree.path().join("rigs/fixture-matrix/rig.json");
+        let sibling_rig = worktree.path().join("rigs/other/rig.json");
+        std::fs::create_dir_all(declared_rig.parent().expect("declared parent"))
+            .expect("declared parent");
+        std::fs::create_dir_all(sibling_rig.parent().expect("sibling parent"))
+            .expect("sibling parent");
+        std::fs::write(&declared_rig, "{}").expect("declared rig");
+        std::fs::write(&sibling_rig, "{}").expect("sibling rig");
+
+        let error = resolve_installed_rig_source(
+            "fixture-matrix",
+            Some("rigs/fixture-matrix/rig.json"),
+            "rigs/other/rig.json",
+            &worktree.path().display().to_string(),
+        )
+        .expect_err("file-valued source root must not authorize sibling packages");
+
+        assert!(error.message.contains("differs from the declared rig.json"));
     }
 
     #[test]

--- a/tests/stale_linked_rig_recovery.rs
+++ b/tests/stale_linked_rig_recovery.rs
@@ -147,6 +147,7 @@ fn install_then_remove_source_a(context: &HermeticTestContext, source_a: &Path) 
     fs::remove_dir_all(source_a).expect("remove source A");
 }
 
+#[cfg(unix)]
 #[test]
 fn bench_repairs_missing_linked_rig_source_from_path_override() {
     let context = HermeticTestContext::new();


### PR DESCRIPTION
## Summary
- resolve relative installed-rig metadata against the declared worktree instead of Homeboy process cwd
- keep package authority separate from the worktree snapshot root
- reject traversal, sibling-package substitution, and symlink escapes before remote remapping
- materialize authorized nested rig packages with deterministic Lab sync evidence

## Tracker
Regression follow-up for #6310.

## Verification
- `cargo check --workspace --all-targets`
- `cargo test -p homeboy-lab-runner rig_materialization --lib` (62 tests)
- focused `sync_lab_offload_rigs` and stale linked-rig recovery integration tests
- independent authority/security review with no findings

## AI assistance
OpenCode using `openai/gpt-5.6-sol` was used to reproduce relative rig resolution, implement worktree-scoped materialization, add containment tests, and perform independent review. Chris Huber reviewed and remains responsible for the change.