### PR TITLE
Make dirty Cook recovery actionable

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -6764,6 +6764,10 @@ fn preflight_cook_workspace_base_ancestry(target: &Path, base: &str) -> Result<O
             "candidate_only_commits": ahead,
             "next_action": "clean_destination_before_provider",
         });
+        error.details["dirty_candidate_adoption"] = serde_json::json!({
+            "workspace": target,
+            "reason": "first_provider_admission",
+        });
         return Err(error);
     }
     if behind == 0 {
@@ -7014,12 +7018,17 @@ fn admit_explicit_cook_workspace_before_provider(
         .filter(|path| !ignored_evidence.iter().any(|evidence| evidence == path))
         .collect::<Vec<_>>();
     if !dirty_paths.is_empty() {
-        return Err(Error::validation_invalid_argument(
+        let mut error = Error::validation_invalid_argument(
             "to_worktree",
             "explicit Cook checkout must be clean before its first provider execution",
             Some(options.to_worktree.clone()),
             None,
-        ));
+        );
+        error.details["dirty_candidate_adoption"] = serde_json::json!({
+            "workspace": source,
+            "reason": "first_provider_admission",
+        });
+        return Err(error);
     }
     if agent_task_lifecycle::run_record_exists(run_id)? {
         agent_task_lifecycle::record_metadata_value(

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -16,7 +16,7 @@ use std::path::PathBuf;
 use homeboy_core::cook_status::{CookDisposition, CookStatus};
 use homeboy_core::engine::canonical_json::canonical_json_bytes;
 use homeboy_engine_primitives::content_hash;
-use homeboy_engine_primitives::shell::quote_args;
+use homeboy_engine_primitives::shell::{quote_arg, quote_args};
 
 use crate::agent_task_finalization::{
     finalize_pr_with_backend, finalize_pr_with_backend_in_store, preflight_pr_with_backend,
@@ -4869,18 +4869,26 @@ pub fn cook_failure_context(
             None,
         )
     };
-    let recovery_actions = cook_recovery_actions(
-        status,
+    let recovery_actions = dirty_candidate_adoption_recovery_actions(
+        &recipe,
+        record.as_ref(),
+        cook_id,
         &chronological_latest_run_id,
-        recovery_legal,
-        blocking_claim.is_some(),
-        record
-            .as_ref()
-            .is_some_and(|record| super::retry_admission(&record.run_id).is_ok()),
-        exact_checkpoint_candidate_mismatch(&diagnostic),
-        ambiguous_promotion_artifact_ids(record_run_id, promotion_diagnostic.as_ref(), &recipe),
-        record.as_ref().and_then(lab_handoff_runtime_recovery),
-    );
+    )
+    .unwrap_or_else(|| {
+        cook_recovery_actions(
+            status,
+            &chronological_latest_run_id,
+            recovery_legal,
+            blocking_claim.is_some(),
+            record
+                .as_ref()
+                .is_some_and(|record| super::retry_admission(&record.run_id).is_ok()),
+            exact_checkpoint_candidate_mismatch(&diagnostic),
+            ambiguous_promotion_artifact_ids(record_run_id, promotion_diagnostic.as_ref(), &recipe),
+            record.as_ref().and_then(lab_handoff_runtime_recovery),
+        )
+    });
     let promotion_provenance = promotion.cloned();
     Some(super::AgentTaskCookFailureContext {
         cook_id: cook_id.to_string(),
@@ -4906,6 +4914,62 @@ pub fn cook_failure_context(
         recovery_reason: recovery_actions.reason,
         next_actions: recovery_actions.next_actions,
         legal_actions: recovery_actions.legal_actions,
+    })
+}
+
+/// A dirty initial checkout is never provider input. Its durable failed attempt
+/// can instead adopt a human-committed immutable candidate without replaying a
+/// provider patch. This is available only for the recorded first-provider
+/// admission failure and a recipe that already names the candidate's model.
+fn dirty_candidate_adoption_recovery_actions(
+    recipe: &super::AgentTaskCookRecipe,
+    record: Option<&agent_task_lifecycle::AgentTaskRunRecord>,
+    cook_id: &str,
+    run_id: &str,
+) -> Option<CookRecoveryActions> {
+    let record = record?;
+    if record.metadata["provider_executions_consumed"]
+        .as_u64()
+        .unwrap_or_default()
+        != 0
+        || record.metadata["pre_execution_failure"]["details"]["dirty_candidate_adoption"]["reason"]
+            != "first_provider_admission"
+    {
+        return None;
+    }
+    let workspace = record.metadata["pre_execution_failure"]["details"]["dirty_candidate_adoption"]
+        ["workspace"]
+        .as_str()?;
+    let options = super::cook_recipe::reconstruct_adoption_options(recipe).ok()?;
+    let model = options.ai_model?;
+    let prefix = super::cook_recovery_command_prefix(run_id);
+    let actions = vec![
+        super::AgentTaskCookRecoveryAction {
+            action: "commit_candidate".to_string(),
+            command: format!(
+                "git -C {} add -A && git -C {} commit -m {}",
+                quote_arg(workspace),
+                quote_arg(workspace),
+                quote_arg(&options.commit_message),
+            ),
+        },
+        super::AgentTaskCookRecoveryAction {
+            action: "review_candidate".to_string(),
+            command: format!("{prefix} agent-task review {}", quote_arg(run_id)),
+        },
+        super::AgentTaskCookRecoveryAction {
+            action: "adopt_candidate".to_string(),
+            command: format!(
+                "{prefix} agent-task adopt {} --candidate-ref HEAD --model {}",
+                quote_arg(cook_id),
+                quote_arg(&model),
+            ),
+        },
+    ];
+    Some(CookRecoveryActions {
+        reason: "The first provider admission refused a dirty checkout. Commit the immutable candidate, record its tracked review, then adopt HEAD through the durable Cook gates without provider patch replay.".to_string(),
+        legal_actions: actions.clone(),
+        next_actions: actions,
     })
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -4600,6 +4600,15 @@ fn dirty_explicit_cwd_blocks_detached_provider_dispatch() {
                 "HEAD",
             ],
         );
+        git(
+            primary.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                primary.path().to_str().expect("UTF-8 primary path"),
+            ],
+        );
 
         let dispatches = Arc::new(AtomicUsize::new(0));
         let mut options = batch_cook_options(
@@ -4614,11 +4623,43 @@ fn dirty_explicit_cwd_blocks_detached_provider_dispatch() {
         options.initial_plan.tasks[0].metadata["worktree_provision"] =
             serde_json::json!({ "kind": "explicit_cwd" });
         std::fs::write(target.join("untracked.txt"), "user drift\n").expect("write drift");
+        options.ai_model = Some("openai/gpt-5.6-terra".to_string());
 
         let result = run_cook(CookContext::new(options, Arc::new(UnusedExecutor)))
             .expect("Cook reports admission failure");
         assert_eq!(result.value.status, "pre_execution_failure");
         assert_eq!(dispatches.load(Ordering::SeqCst), 0);
+        let context = result
+            .value
+            .failure_context
+            .expect("durable recovery context");
+        assert_eq!(context.cook_id, "cwd-detached-dirty");
+        assert_eq!(context.latest_run_id, "cwd-detached-dirty-run");
+        assert_eq!(
+            context
+                .next_actions
+                .iter()
+                .map(|action| action.action.as_str())
+                .collect::<Vec<_>>(),
+            vec!["commit_candidate", "review_candidate", "adopt_candidate"]
+        );
+        assert_eq!(
+            context.next_actions[0].command,
+            format!(
+                "git -C {} add -A && git -C {} commit -m {}",
+                quote_arg(target.to_str().expect("UTF-8 target path")),
+                quote_arg(target.to_str().expect("UTF-8 target path")),
+                quote_arg("test")
+            )
+        );
+        assert_eq!(
+            context.next_actions[1].command,
+            "homeboy agent-task review cwd-detached-dirty-run"
+        );
+        assert_eq!(
+            context.next_actions[2].command,
+            "homeboy agent-task adopt cwd-detached-dirty --candidate-ref HEAD --model openai/gpt-5.6-terra"
+        );
     });
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -302,7 +302,8 @@ pub(crate) fn preview_cook(
     // it applies before an execution route can inspect the destination.
     validate_cook_request_with_provenance(&args, provenance)?;
     record_preview_phase(&mut progress, "destination_resolution");
-    let (args, provision) = resolve_cook_preview_destination(args)?;
+    let (args, mut provision) = resolve_cook_preview_destination(args)?;
+    project_preview_dirty_admission(&mut provision);
     let replay = cook_preview_replay_argv(&args);
     record_preview_phase(&mut progress, "placement_projection");
     let placement = preview_placement_policy_with_admission(&replay.argv);
@@ -3356,6 +3357,45 @@ fn resolve_cook_preview_destination(
             "path": path,
         }),
     ))
+}
+
+/// Preview must report the same fail-closed first-provider admission when the
+/// resolved local checkout can be inspected without mutating it.
+fn project_preview_dirty_admission(provision: &mut Value) {
+    let Some(path) = provision.get("path").and_then(Value::as_str) else {
+        return;
+    };
+    let output = Command::new("git")
+        .args(["status", "--porcelain=v1", "-z", "--untracked-files=all"])
+        .current_dir(path)
+        .output();
+    let Ok(output) = output else {
+        return;
+    };
+    if !output.status.success() {
+        return;
+    }
+    let mut tracked = 0;
+    let mut staged = 0;
+    let mut untracked = 0;
+    for entry in output.stdout.split(|byte| *byte == b'\0') {
+        if entry.len() < 2 {
+            continue;
+        }
+        if entry.starts_with(b"??") {
+            untracked += 1;
+        } else {
+            staged += usize::from(entry[0] != b' ');
+            tracked += usize::from(entry[1] != b' ');
+        }
+    }
+    if tracked + staged + untracked > 0 {
+        provision["admission"] = serde_json::json!({
+            "status": "would_refuse_dirty_candidate",
+            "reason": "Cook requires a clean destination before its first provider execution",
+            "changes": { "tracked": tracked, "staged": staged, "untracked": untracked },
+        });
+    }
 }
 
 fn unresolved_provider_preview(handle: &str, error: homeboy::core::Error) -> Value {
@@ -6942,9 +6982,46 @@ mod tests {
         cook_attached_local_placement_disclosure, cook_continuation_status,
         cook_provider_timeout_disclosure, cook_report_with_continuation,
         cook_resolved_policy_disclosure, detached_cook_route_less_warning,
-        durable_cook_identity_lines, preflight_continue_cook,
+        durable_cook_identity_lines, preflight_continue_cook, project_preview_dirty_admission,
     };
     use crate::commands::agent_task::args::CookContinueArgs;
+
+    #[test]
+    fn preview_projects_each_dirty_admission_state() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let git = |args: &[&str]| {
+            assert!(std::process::Command::new("git")
+                .args(args)
+                .current_dir(workspace.path())
+                .status()
+                .expect("run git")
+                .success());
+        };
+        git(&["init", "--initial-branch=main"]);
+        git(&["config", "user.email", "agent@example.test"]);
+        git(&["config", "user.name", "Agent"]);
+        std::fs::write(workspace.path().join("tracked.txt"), "base\n").expect("write base");
+        git(&["add", "tracked.txt"]);
+        git(&["commit", "-m", "base"]);
+
+        std::fs::write(workspace.path().join("tracked.txt"), "modified\n")
+            .expect("modify tracked file");
+        std::fs::write(workspace.path().join("staged.txt"), "staged\n").expect("write staged file");
+        git(&["add", "staged.txt"]);
+        std::fs::write(workspace.path().join("untracked.txt"), "untracked\n")
+            .expect("write untracked file");
+
+        let mut provision = serde_json::json!({ "path": workspace.path() });
+        project_preview_dirty_admission(&mut provision);
+
+        assert_eq!(
+            provision["admission"]["status"],
+            "would_refuse_dirty_candidate"
+        );
+        assert_eq!(provision["admission"]["changes"]["tracked"], 1);
+        assert_eq!(provision["admission"]["changes"]["staged"], 1);
+        assert_eq!(provision["admission"]["changes"]["untracked"], 1);
+    }
 
     #[test]
     fn durable_cook_identity_block_leads_with_the_run_id_and_follow_up_commands() {

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -354,6 +354,14 @@ explains a stop. `agent-task status` projects both under
 Use `promote` for patch-artifact candidates; it remains the controller-owned
 patch-artifact ingestion and gate path.
 
+If a first Cook admission finds an already-implemented dirty candidate, it
+fails before provider execution and returns the durable Cook/run plus this
+recovery sequence: commit the candidate in the named worktree, run `agent-task
+review <run-id>`, then run the emitted `agent-task adopt <cook-id>
+--candidate-ref HEAD --model <model>` command. Adoption verifies the immutable
+commit through the recorded gates and finalization policy; it does not create or
+apply provider patch content.
+
 `finalize-pr` is the core-owned publication boundary for external runtimes. Its
 `homeboy/agent-task-pr-finalization/v1` report keeps the legacy top-level
 `status`, `pr_action`, `pr_number`, and `pr_url` fields, and also emits explicit

--- a/docs/workflows/run-agent-task-loops.md
+++ b/docs/workflows/run-agent-task-loops.md
@@ -51,6 +51,12 @@ locally or through Homeboy's active managed workspace registry to that same
 worktree; Cook does not query a provider merely to rediscover the supplied path.
 The explicit checkout must be clean when the first provider attempt is admitted;
 later retries retain the candidate changes produced by earlier attempts.
+When a preview or initial admission identifies an already-implemented dirty
+candidate, Cook keeps provider execution fail-closed and returns its durable
+Cook/run plus an executable sequence: commit the named checkout, run
+`agent-task review <run-id>`, then adopt `HEAD` with the emitted command.
+Adoption verifies that immutable commit through the recorded gates and
+finalization policy without creating or applying provider patch content.
 
 ## 3. Define A Durable Loop
 


### PR DESCRIPTION
## Summary

- preserve fail-closed dirty checkout admission while recording immutable adoption recovery
- project tracked, staged, and untracked dirty state during Cook preview
- render executable commit, review, and `agent-task adopt --candidate-ref HEAD` actions
- document the supported recovery in compact command and workflow guidance

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-agents dirty_explicit_cwd_blocks_detached_provider_dispatch --lib`
- `cargo test -p homeboy-cli preview_projects_each_dirty_admission_state --lib`
- `git diff --check`

Closes #12546.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode general coding agents was used to inspect the Cook/adoption contracts, implement the recovery path, add deterministic tests, and review the final diff. Chris Huber orchestrated and verified the work.