### PR TITLE
fix(lint): compare changed scope to git base

### DIFF
--- a/crates/homeboy-extension/src/lint/baseline.rs
+++ b/crates/homeboy-extension/src/lint/baseline.rs
@@ -32,6 +32,8 @@ pub struct LintBaselineMetadata {
 pub struct LintBaselineProvenance {
     pub baseline_key: String,
     pub compared: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_ref: Option<String>,
     pub files: Vec<String>,
     pub tools: Vec<String>,
     pub scope: String,
@@ -75,6 +77,7 @@ impl LintBaselineProvenance {
         Self {
             baseline_key: format!("{BASELINE_KEY}:{digest}"),
             compared: false,
+            base_ref: None,
             files,
             tools,
             scope,
@@ -207,6 +210,26 @@ pub fn load_baseline_for_scope(
 pub fn compare(findings: &[HomeboyFinding], baseline: &LintBaseline) -> BaselineComparison {
     let items: Vec<LintFingerprint> = findings.iter().map(LintFingerprint).collect();
     generic::compare(&items, baseline)
+}
+
+/// Compare candidate findings with findings measured from an immutable source revision.
+pub fn compare_against_findings(
+    findings: &[HomeboyFinding],
+    baseline_findings: &[HomeboyFinding],
+) -> BaselineComparison {
+    let baseline = LintBaseline {
+        created_at: String::new(),
+        context_id: "git-base".to_string(),
+        item_count: baseline_findings.len(),
+        known_fingerprints: baseline_findings
+            .iter()
+            .map(|finding| LintFingerprint(finding).fingerprint())
+            .collect(),
+        metadata: LintBaselineMetadata {
+            findings_count: baseline_findings.len(),
+        },
+    };
+    compare(findings, &baseline)
 }
 
 fn normalize_sidecar_finding(mut finding: HomeboyFinding, path: &Path) -> HomeboyFinding {

--- a/crates/homeboy-extension/src/lint/run/tests/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/tests/workflow.rs
@@ -260,6 +260,62 @@ exit 1
 }
 
 #[test]
+fn unavailable_changed_since_baseline_does_not_suppress_matching_stored_findings() {
+    homeboy_core::test_support::with_isolated_home(|home| {
+        let source = tempfile::tempdir().expect("source dir");
+        let component = routed_lint_component(
+            home.path(),
+            source.path(),
+            r#"#!/bin/sh
+printf '[{"tool":"phpcs","message":"known","fingerprint":"known","file":"legacy.php"}]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+exit 1
+"#,
+        );
+        let mut seed_args = lint_args();
+        seed_args.changed_since = Some("unreachable-base".to_string());
+        seed_args.precomputed_changed_files = Some(vec!["legacy.php".to_string()]);
+        seed_args.baseline_flags.ignore_baseline = true;
+        let seed = run_main_lint_workflow(
+            &component,
+            source.path(),
+            seed_args,
+            &RunDir::create().expect("seed run dir"),
+        )
+        .expect("seed workflow result");
+        let provenance = seed
+            .baseline_provenance
+            .as_ref()
+            .expect("stored baseline provenance");
+        crate::lint::baseline::save_baseline_for_scope(
+            source.path(),
+            "fixture",
+            seed.findings.as_deref().expect("seed findings"),
+            Some(provenance),
+        )
+        .expect("save matching baseline");
+
+        let mut args = lint_args();
+        args.changed_since = Some("unreachable-base".to_string());
+        args.precomputed_changed_files = Some(vec!["legacy.php".to_string()]);
+        let result = run_main_lint_workflow(
+            &component,
+            source.path(),
+            args,
+            &RunDir::create().expect("candidate run dir"),
+        )
+        .expect("candidate workflow result");
+
+        assert_eq!(result.status, "failed");
+        assert_eq!(result.exit_code, 1);
+        assert!(result.baseline_comparison.is_none());
+        assert!(result
+            .baseline_provenance
+            .is_some_and(|provenance| !provenance.compared));
+        assert_eq!(result.findings.as_ref().map(Vec::len), Some(1));
+    });
+}
+
+#[test]
 fn runner_failure_without_findings_is_an_infrastructure_error_without_autofix() {
     homeboy_core::test_support::with_isolated_home(|home| {
         let source = tempfile::tempdir().expect("source dir");

--- a/crates/homeboy-extension/src/lint/run/tests/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/tests/workflow.rs
@@ -196,21 +196,19 @@ fn scoped_zero_findings_do_not_compare_unrelated_legacy_baseline() {
             home.path(),
             source.path(),
             r#"#!/bin/sh
-if [ -n "$HOMEBOY_LINT_GLOB" ]; then
+if grep -q candidate "$HOMEBOY_LINT_GLOB"; then
+  if grep -q 'candidate new' "$HOMEBOY_LINT_GLOB"; then
+    printf '[{"tool":"phpcs","message":"introduced","fingerprint":"introduced","file":"legacy.php"}]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+    exit 1
+  fi
   printf '[]' > "$HOMEBOY_LINT_FINDINGS_FILE"
   printf '[{"tool":"phpcs","status":"passed","finding_count":0},{"tool":"phpstan","status":"passed","finding_count":0}]' > "$HOMEBOY_LINT_PRODUCERS_FILE"
   exit 0
-else
-  printf '[{"tool":"phpcs","message":"known","fingerprint":"known","file":"untouched.php"},{"tool":"phpstan","message":"relocated","fingerprint":"relocated","file":"legacy.php"}]' > "$HOMEBOY_LINT_FINDINGS_FILE"
-  exit 1
 fi
+printf '[{"tool":"phpcs","message":"known","fingerprint":"known","file":"legacy.php"}]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+exit 1
 "#,
         );
-        let known = homeboy_core::finding::HomeboyFinding::builder("phpcs", "known")
-            .fingerprint("known")
-            .build();
-        crate::lint::baseline::save_baseline(source.path(), "fixture", &[known])
-            .expect("save baseline");
 
         let mut pr_args = lint_args();
         pr_args.changed_since = Some("baseline".to_string());
@@ -226,47 +224,38 @@ fi
         assert_eq!(pr_result.status, "passed");
         assert_eq!(pr_result.exit_code, 0);
         assert!(pr_result.findings.as_ref().is_some_and(Vec::is_empty));
-        assert!(pr_result.baseline_comparison.is_none());
+        assert!(pr_result
+            .baseline_comparison
+            .is_some_and(|comparison| comparison.new_items.is_empty()));
         let provenance = pr_result
             .baseline_provenance
             .as_ref()
             .expect("scoped baseline provenance");
-        assert!(!provenance.compared);
+        assert!(provenance.compared);
+        assert!(provenance.base_ref.is_some());
         assert_eq!(provenance.files, vec!["legacy.php"]);
         assert_eq!(provenance.tools, vec!["phpcs", "phpstan"]);
         assert_eq!(provenance.scope, "changed");
         assert!(provenance.baseline_key.starts_with("lint:"));
         assert_ne!(provenance.baseline_key, "lint");
 
-        let mut save_args = lint_args();
-        save_args.changed_since = Some("baseline".to_string());
-        save_args.precomputed_changed_files = Some(vec!["legacy.php".to_string()]);
-        save_args.baseline_flags.baseline = true;
-        run_main_lint_workflow(
+        std::fs::write(source.path().join("legacy.php"), "<?php // candidate new\n")
+            .expect("introduced candidate source");
+        let mut introduced_args = lint_args();
+        introduced_args.changed_since = Some("baseline".to_string());
+        introduced_args.precomputed_changed_files = Some(vec!["legacy.php".to_string()]);
+        let introduced = run_main_lint_workflow(
             &component,
             source.path(),
-            save_args,
-            &RunDir::create().expect("scoped baseline run dir"),
+            introduced_args,
+            &RunDir::create().expect("introduced finding run dir"),
         )
-        .expect("save scoped baseline");
-
-        let mut compare_args = lint_args();
-        compare_args.changed_since = Some("baseline".to_string());
-        compare_args.precomputed_changed_files = Some(vec!["legacy.php".to_string()]);
-        let scoped_baseline_result = run_main_lint_workflow(
-            &component,
-            source.path(),
-            compare_args,
-            &RunDir::create().expect("scoped comparison run dir"),
-        )
-        .expect("compare scoped baseline");
-        assert!(scoped_baseline_result
-            .baseline_provenance
-            .as_ref()
-            .is_some_and(|provenance| provenance.compared));
-        assert!(scoped_baseline_result
+        .expect("introduced finding workflow result");
+        assert_eq!(introduced.status, "failed");
+        assert_eq!(introduced.exit_code, 1);
+        assert!(introduced
             .baseline_comparison
-            .is_some_and(|comparison| comparison.new_items.is_empty()));
+            .is_some_and(|comparison| comparison.new_items.len() == 1));
     });
 }
 

--- a/crates/homeboy-extension/src/lint/run/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/workflow.rs
@@ -228,30 +228,31 @@ pub fn run_main_lint_workflow(
 
     // Baseline lifecycle
     let baseline_context = baseline_provenance(&args, scoped_plan.as_ref(), &producer_summaries);
-    let (baseline_comparison, baseline_exit_override, baseline_provenance) =
-        if args.changed_since.is_some()
-            && !args.baseline_flags.baseline
-            && !args.baseline_flags.ignore_baseline
-        {
-            match process_changed_since_baseline(
-                component,
-                source_path,
-                &args,
-                &baseline_context,
-                &lint_findings,
-            ) {
-                Ok(result) => result,
-                Err(error) => {
-                    eprintln!(
+    let (baseline_comparison, baseline_exit_override, baseline_provenance) = if args
+        .changed_since
+        .is_some()
+        && !args.baseline_flags.baseline
+        && !args.baseline_flags.ignore_baseline
+    {
+        match process_changed_since_baseline(
+            component,
+            source_path,
+            &args,
+            &baseline_context,
+            &lint_findings,
+        ) {
+            Ok(result) => result,
+            Err(error) => {
+                eprintln!(
                     "[lint] Changed-since baseline unavailable; preserving full finding set: {}",
                     error.message
                 );
-                    process_baseline(source_path, &args, &lint_findings, baseline_context)?
-                }
+                (None, None, baseline_context)
             }
-        } else {
-            process_baseline(source_path, &args, &lint_findings, baseline_context)?
-        };
+        }
+    } else {
+        process_baseline(source_path, &args, &lint_findings, baseline_context)?
+    };
 
     let harness_error = lint_exit_code != 0
         && self_check_output_is_harness_failure(output.exit_code, &output.stdout, &output.stderr);

--- a/crates/homeboy-extension/src/lint/run/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/workflow.rs
@@ -228,31 +228,30 @@ pub fn run_main_lint_workflow(
 
     // Baseline lifecycle
     let baseline_context = baseline_provenance(&args, scoped_plan.as_ref(), &producer_summaries);
-    let (baseline_comparison, baseline_exit_override, baseline_provenance) = if args
-        .changed_since
-        .is_some()
-        && !args.baseline_flags.baseline
-        && !args.baseline_flags.ignore_baseline
-    {
-        match process_changed_since_baseline(
-            component,
-            source_path,
-            &args,
-            &baseline_context,
-            &lint_findings,
-        ) {
-            Ok(result) => result,
-            Err(error) => {
-                eprintln!(
+    let (baseline_comparison, baseline_exit_override, baseline_provenance) =
+        if args.changed_since.is_some()
+            && !args.baseline_flags.baseline
+            && !args.baseline_flags.ignore_baseline
+        {
+            match process_changed_since_baseline(
+                component,
+                source_path,
+                &args,
+                &baseline_context,
+                &lint_findings,
+            ) {
+                Ok(result) => result,
+                Err(error) => {
+                    eprintln!(
                     "[lint] Changed-since baseline unavailable; preserving full finding set: {}",
                     error.message
                 );
-                (None, None, baseline_context)
+                    (None, None, baseline_context)
+                }
             }
-        }
-    } else {
-        process_baseline(source_path, &args, &lint_findings, baseline_context)?
-    };
+        } else {
+            process_baseline(source_path, &args, &lint_findings, baseline_context)?
+        };
 
     let harness_error = lint_exit_code != 0
         && self_check_output_is_harness_failure(output.exit_code, &output.stdout, &output.stderr);

--- a/crates/homeboy-extension/src/lint/run/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/workflow.rs
@@ -21,6 +21,7 @@ use homeboy_core::engine::run_dir::{self, RunDir};
 use homeboy_core::finding::HomeboyFinding;
 use homeboy_core::validation_progress::{write_command_artifact, ValidationProgressRecorder};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 struct LintRunEvidence {
     findings: Vec<HomeboyFinding>,
@@ -228,7 +229,29 @@ pub fn run_main_lint_workflow(
     // Baseline lifecycle
     let baseline_context = baseline_provenance(&args, scoped_plan.as_ref(), &producer_summaries);
     let (baseline_comparison, baseline_exit_override, baseline_provenance) =
-        process_baseline(source_path, &args, &lint_findings, baseline_context)?;
+        if args.changed_since.is_some()
+            && !args.baseline_flags.baseline
+            && !args.baseline_flags.ignore_baseline
+        {
+            match process_changed_since_baseline(
+                component,
+                source_path,
+                &args,
+                &baseline_context,
+                &lint_findings,
+            ) {
+                Ok(result) => result,
+                Err(error) => {
+                    eprintln!(
+                    "[lint] Changed-since baseline unavailable; preserving full finding set: {}",
+                    error.message
+                );
+                    process_baseline(source_path, &args, &lint_findings, baseline_context)?
+                }
+            }
+        } else {
+            process_baseline(source_path, &args, &lint_findings, baseline_context)?
+        };
 
     let harness_error = lint_exit_code != 0
         && self_check_output_is_harness_failure(output.exit_code, &output.stdout, &output.stderr);
@@ -675,4 +698,93 @@ fn process_baseline(
     }
 
     Ok((baseline_comparison, baseline_exit_override, provenance))
+}
+
+/// Run the same changed-file scope from the resolved merge base in an isolated
+/// checkout. A persisted baseline cannot represent arbitrary PR ancestry.
+fn process_changed_since_baseline(
+    component: &Component,
+    source_path: &Path,
+    args: &LintRunWorkflowArgs,
+    provenance: &lint_baseline::LintBaselineProvenance,
+    lint_findings: &[HomeboyFinding],
+) -> homeboy_core::Result<(
+    Option<lint_baseline::BaselineComparison>,
+    Option<i32>,
+    lint_baseline::LintBaselineProvenance,
+)> {
+    let changed_since = args
+        .changed_since
+        .as_deref()
+        .expect("changed-since baseline only runs with a git ref");
+    let source = source_path.to_string_lossy();
+    let base_ref = homeboy_core::git::resolve_merge_base(&source, changed_since)?;
+    let repo_root = PathBuf::from(homeboy_core::git::get_git_root(&source)?);
+    let component_suffix = source_path.strip_prefix(&repo_root).map_err(|_| {
+        homeboy_core::Error::git_command_failed(format!(
+            "component path {} is outside repository {}",
+            source_path.display(),
+            repo_root.display()
+        ))
+    })?;
+    let changed_files = provenance.files.clone();
+    let checkout_root = tempfile::tempdir().map_err(|error| {
+        homeboy_core::Error::internal_io(
+            format!("create changed-since baseline checkout: {error}"),
+            Some("lint.changed_since_baseline".to_string()),
+        )
+    })?;
+    let checkout = checkout_root.path().join("base");
+    let add = Command::new("git")
+        .current_dir(&repo_root)
+        .args(["worktree", "add", "--detach", "--quiet"])
+        .arg(&checkout)
+        .arg(&base_ref)
+        .output()
+        .map_err(|error| homeboy_core::Error::git_command_failed(error.to_string()))?;
+    if !add.status.success() {
+        return Err(homeboy_core::Error::git_command_failed(format!(
+            "git worktree add baseline {}: {}",
+            base_ref,
+            String::from_utf8_lossy(&add.stderr).trim()
+        )));
+    }
+
+    let baseline_component_path = checkout.join(component_suffix);
+    let mut baseline_component = component.clone();
+    baseline_component.local_path = baseline_component_path.to_string_lossy().to_string();
+    let mut baseline_args = args.clone();
+    baseline_args.path_override = Some(baseline_component.local_path.clone());
+    baseline_args.changed_only = true;
+    baseline_args.changed_since = None;
+    baseline_args.precomputed_changed_files = Some(changed_files);
+    baseline_args.baseline_flags.ignore_baseline = true;
+    let baseline_run_dir = RunDir::create()?;
+    let baseline_result = run_main_lint_workflow(
+        &baseline_component,
+        &baseline_component_path,
+        baseline_args,
+        &baseline_run_dir,
+    );
+    let remove = Command::new("git")
+        .current_dir(&repo_root)
+        .args(["worktree", "remove", "--force"])
+        .arg(&checkout)
+        .output();
+    if let Ok(remove) = remove {
+        if !remove.status.success() {
+            eprintln!(
+                "[lint] Failed to remove changed-since baseline checkout: {}",
+                String::from_utf8_lossy(&remove.stderr).trim()
+            );
+        }
+    }
+    let baseline_findings = baseline_result?.findings.unwrap_or_default();
+
+    let mut provenance = provenance.clone();
+    provenance.compared = true;
+    provenance.base_ref = Some(base_ref);
+    let comparison = lint_baseline::compare_against_findings(lint_findings, &baseline_findings);
+    let exit_override = Some(if comparison.drift_increased { 1 } else { 0 });
+    Ok((Some(comparison), exit_override, provenance))
 }


### PR DESCRIPTION
## Summary

- Run the identical changed-file lint scope in an isolated checkout at the resolved merge base.
- Compare candidate findings with base findings so inherited whole-file findings do not block a small change.
- Record the resolved base SHA in baseline provenance and preserve the full finding set if base measurement is unavailable.

The reported `homeboy report` recovery command is already absent from current Homeboy source and GitHub code search; current documentation and command registration use `homeboy runs report`, so no duplicate command-path change is included.

Closes #13237

## Verification

```sh
cargo fmt --check
cargo test -p homeboy-extension lint::run::tests::workflow -- --nocapture
cargo test -p homeboy-extension
```

The package suite passed: 794 tests.

## AI Assistance

OpenCode (openai/gpt-5.6-terra) used GitHub CLI and raw Git worktrees to audit trackers, reproduce the unavailable command, implement the isolated Git-base comparison, and run the listed tests. Chris Huber directs and reviews the work.