### PR TITLE
chore(ci): pin Homeboy Action v2.15.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,10 +263,11 @@ jobs:
     # candidate no longer reruns its baseline), #380 (the differential audit is
     # changed-scoped instead of scanning the whole repository), #381 (shard
     # partitioning coverage), #402 (immutable extension revisions), #405
-    # (downloaded Test archives stay out of consumer Git state), and #416
-    # (sharded Test result retrieval works across reruns). Refs
-    # #10997 and #11751 W1-2, W1-7, W1-10.
-    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@66765097113913bc66c7a05fa0a827723715763c
+    # (downloaded Test archives stay out of consumer Git state), #416
+    # (sharded Test result retrieval works across reruns), #424 (extension-owned
+    # Cargo build and quality caches), and #425 (cache ownership assertions).
+    # Refs #10997 and #11751 W1-2, W1-5, W1-6, W1-7, W1-10.
+    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@5d7f0525567d085725ec0b66bfee3100abf1923e
     with:
       commands: review test
       # `review test` defaults to running the extension's pre-test lint, which


### PR DESCRIPTION
## Summary
- advance the immutable reusable-workflow pin from Homeboy Action v2.14.6 to v2.15.1
- activate extension-owned `cargo-build` and `cargo-quality` caches in Homeboy PR CI
- document the W1-5/W1-6 cache contract and its repaired assertions

## Verification
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- focused Rust integration tests made no compile errors but exceeded two bounded 300s local attempts before test execution

Completes activation of Extra-Chill/homeboy#11751 W1-5/W1-6 in Homeboy PR CI.

## AI assistance
Implemented and verified with OpenAI gpt-5.6-sol using OpenCode; AI was used to verify the released v2 tag target, update the immutable workflow pin, and run focused workflow validation.