### PR TITLE
fix(ci): dereference Homeboy Action pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
     # (sharded Test result retrieval works across reruns), #424 (extension-owned
     # Cargo build and quality caches), and #425 (cache ownership assertions).
     # Refs #10997 and #11751 W1-2, W1-5, W1-6, W1-7, W1-10.
-    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@5d7f0525567d085725ec0b66bfee3100abf1923e
+    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@1db8e159b381accb965125108266d4031d7f6feb
     with:
       commands: review test
       # `review test` defaults to running the extension's pre-test lint, which


### PR DESCRIPTION
## Summary
- replace the annotated `v2` tag object SHA with the dereferenced v2.15.1 commit SHA
- restore reusable-workflow startup after #13240

## Root cause
GitHub `uses:` cannot resolve annotated tag objects. The v2 ref object `5d7f052` dereferences to commit `1db8e159`, which contains `.github/workflows/ci.yml`.

## Verification
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- GitHub Contents API resolves `.github/workflows/ci.yml` at `1db8e159b381accb965125108266d4031d7f6feb`

Repairs the zero-job workflow startup failure in #13240.

## AI assistance
Implemented and verified with OpenAI gpt-5.6-sol using OpenCode; AI was used to inspect the failed Actions annotation, identify the annotated-tag object, dereference it, and verify the reusable workflow exists at the commit.