### PR TITLE
fix(runner): export socket-safe temp aliases

### DIFF
--- a/crates/homeboy-core/src/engine/invocation.rs
+++ b/crates/homeboy-core/src/engine/invocation.rs
@@ -404,7 +404,7 @@ impl Drop for InvocationGuard {
 }
 
 #[cfg(unix)]
-fn exported_runtime_tmp_dir(
+pub(crate) fn exported_runtime_tmp_dir(
     runtime_root: &Path,
     short: &str,
     runtime_tmp_dir: &Path,
@@ -425,7 +425,7 @@ fn exported_runtime_tmp_dir(
 }
 
 #[cfg(not(unix))]
-fn exported_runtime_tmp_dir(
+pub(crate) fn exported_runtime_tmp_dir(
     _runtime_root: &Path,
     _short: &str,
     runtime_tmp_dir: &Path,

--- a/crates/homeboy-core/src/engine/temp/implementation.rs
+++ b/crates/homeboy-core/src/engine/temp/implementation.rs
@@ -57,6 +57,8 @@ pub(crate) struct RuntimeTempPin {
 #[derive(Debug)]
 pub struct RuntimeTempOwner {
     path: PathBuf,
+    exported_path: PathBuf,
+    runtime_tmp_alias: Option<PathBuf>,
     pin: Option<RuntimeTempPin>,
 }
 
@@ -64,8 +66,35 @@ impl RuntimeTempOwner {
     /// Allocate a metadata-backed child temp root before launching a workload.
     pub fn allocate(prefix: &str, producer: &str) -> Result<Self> {
         let (path, pin) = managed_run_temp_dir_for_producer(prefix, Some(producer))?;
+        let exported = (|| {
+            let runtime_root = crate::engine::invocation::invocation_runtime_root()?;
+            fs::create_dir_all(&runtime_root).map_err(|error| {
+                Error::internal_io(
+                    format!(
+                        "Failed to create socket-safe runtime directory {}: {error}",
+                        runtime_root.display()
+                    ),
+                    Some("runtime.tmp.alias.root".to_string()),
+                )
+            })?;
+            crate::engine::invocation::exported_runtime_tmp_dir(
+                &runtime_root,
+                &crate::engine::invocation::short_invocation_id(),
+                &path,
+            )
+        })();
+        let (exported_path, runtime_tmp_alias) = match exported {
+            Ok(exported) => exported,
+            Err(error) => {
+                drop(pin);
+                let _ = fs::remove_dir_all(&path);
+                return Err(error);
+            }
+        };
         Ok(Self {
             path,
+            exported_path,
+            runtime_tmp_alias,
             pin: Some(pin),
         })
     }
@@ -87,7 +116,7 @@ impl RuntimeTempOwner {
 
     /// Environment variables understood by common child toolchains.
     pub fn child_env_vars(&self) -> Vec<(String, String)> {
-        let path = self.path.display().to_string();
+        let path = self.exported_path.display().to_string();
         vec![
             ("TMPDIR".to_string(), path.clone()),
             ("TMP".to_string(), path.clone()),
@@ -109,6 +138,7 @@ impl RuntimeTempOwner {
         let runtime_tmpdir_env = runtime_tmpdir_env();
         let data_dir_env = crate::product_identity::PRODUCT_IDENTITY.env_var("DATA_DIR");
         let product_id = crate::product_identity::PRODUCT_IDENTITY.data_dirname;
+        let alias_name = format!("{}.t", crate::engine::invocation::short_invocation_id());
 
         format!(
             r#"set -eu
@@ -123,6 +153,16 @@ else
 fi
 mkdir -p "$runtime_tmp_root"
 runtime_tmp_dir="$(mktemp -d "$runtime_tmp_root/homeboy-runner-tmp.XXXXXX")"
+if [ -d /tmp ] && [ -w /tmp ]; then
+  runtime_tmp_alias_root="/tmp/hb-$(id -u)"
+elif [ -n "${{XDG_RUNTIME_DIR:-}}" ]; then
+  runtime_tmp_alias_root="$XDG_RUNTIME_DIR/hb"
+else
+  runtime_tmp_alias_root="${{TMPDIR:-$HOME/.cache}}/hb"
+fi
+mkdir -p "$runtime_tmp_alias_root"
+runtime_tmp_alias="$runtime_tmp_alias_root/{alias_name}"
+ln -s "$runtime_tmp_dir" "$runtime_tmp_alias"
 runtime_tmp_owner="$runtime_tmp_dir/{RUN_OWNER_FILE}"
 runtime_tmp_pin="$runtime_tmp_dir/{RUNTIME_TEMP_PIN_FILE}"
 runtime_tmp_created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -142,13 +182,14 @@ runtime_tmp_finish() {{
   else
     runtime_tmp_write_owner failed "remote workload exited with status $runtime_tmp_status" "$runtime_tmp_completed"
   fi
+  rm -f "$runtime_tmp_alias"
   rm -f "$runtime_tmp_pin"
   exit "$runtime_tmp_status"
 }}
 trap 'runtime_tmp_finish 143' HUP INT TERM
 set +e
 (
-  export TMPDIR="$runtime_tmp_dir" TMP="$runtime_tmp_dir" TEMP="$runtime_tmp_dir"
+  export TMPDIR="$runtime_tmp_alias" TMP="$runtime_tmp_alias" TEMP="$runtime_tmp_alias"
   {command}
 )
 runtime_tmp_status="$?"
@@ -160,6 +201,9 @@ runtime_tmp_finish "$runtime_tmp_status""#
 
 impl Drop for RuntimeTempOwner {
     fn drop(&mut self) {
+        if let Some(alias) = &self.runtime_tmp_alias {
+            let _ = fs::remove_file(alias);
+        }
         mark_run_dir_succeeded(&self.path);
         self.pin.take();
     }
@@ -2354,8 +2398,10 @@ mod tests {
             }
             std::thread::sleep(Duration::from_millis(10));
         }
-        let path = PathBuf::from(fs::read_to_string(&ready).expect("remote workload temp path"));
-        assert!(path.exists());
+        let exported_path =
+            PathBuf::from(fs::read_to_string(&ready).expect("remote workload temp path"));
+        let path = fs::canonicalize(&exported_path).expect("durable remote workload temp path");
+        assert_ne!(exported_path, path);
 
         let mut options = bounded_options(true, Some("homeboy-runner-tmp"));
         options.managed_older_than_days = Some(0);
@@ -2372,6 +2418,7 @@ mod tests {
 
         fs::write(&release, []).expect("release remote workload");
         assert!(child.wait().expect("wait remote workload").success());
+        assert!(!exported_path.exists());
 
         let terminal = cleanup_runtime_tmp_bounded(options).expect("terminal cleanup");
         assert_eq!(terminal.removed_count, 1);

--- a/crates/homeboy-lab-runner/src/execution/process.rs
+++ b/crates/homeboy-lab-runner/src/execution/process.rs
@@ -1044,6 +1044,42 @@ mod tests {
         assert!(unknown.exists());
         std::env::remove_var("HOMEBOY_RUNTIME_TMPDIR");
     }
+
+    #[cfg(unix)]
+    #[test]
+    fn runner_temp_owner_exports_a_socket_safe_alias_for_long_run_identity() {
+        use std::os::unix::net::UnixListener;
+
+        let _guard = homeboy_core::test_support::home_env_guard();
+        let runtime_root = tempfile::tempdir_in("/tmp").expect("short runtime root");
+        let durable_root = tempfile::tempdir().expect("durable runtime temp root");
+        std::env::set_var(
+            homeboy_core::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV,
+            runtime_root.path(),
+        );
+        std::env::set_var("HOMEBOY_RUNTIME_TMPDIR", durable_root.path());
+        let run_id = format!("runner-workload-{}", "long-identity-segment-".repeat(12));
+        let owner = runner_temp_owner(&HashMap::from([("HOMEBOY_RUN_ID".to_string(), run_id)]))
+            .expect("runner temp owner");
+        let env = owner
+            .child_env_vars()
+            .into_iter()
+            .collect::<HashMap<_, _>>();
+        let exported = PathBuf::from(env.get("TMPDIR").expect("exported TMPDIR"));
+        let socket_dir = exported.join("tsx-1000");
+        fs::create_dir(&socket_dir).expect("socket parent");
+        let socket = socket_dir.join("123456.pipe");
+
+        let listener = UnixListener::bind(&socket).expect("bind socket below exported TMPDIR");
+        assert_ne!(exported, owner.path());
+        assert!(socket.as_os_str().len() < 108);
+        drop(listener);
+        drop(owner);
+        assert!(!exported.exists());
+
+        std::env::remove_var(homeboy_core::engine::invocation::HOMEBOY_INVOCATION_RUNTIME_DIR_ENV);
+        std::env::remove_var("HOMEBOY_RUNTIME_TMPDIR");
+    }
 }
 
 pub(super) fn apply_runner_process_env(


### PR DESCRIPTION
## Summary

- export a short per-owner temp alias for direct runner child processes
- preserve durable `RuntimeTempOwner` lifecycle metadata and cleanup identity
- apply the same alias contract to diagnostic SSH workloads
- bind a real Unix socket beneath the exported path in regression coverage

Closes #13230.

## Verification

- `cargo fmt --all --check`
- `cargo test -p homeboy-core engine::temp` (38 passed)
- `cargo test -p homeboy-lab-runner runner_temp_owner` (2 passed)
- live lab WordPress extension setup rebuilt WP Codebox 0.23.4 without the prior `tsx` `EINVAL`

The full `homeboy-lab-runner` test suite exceeded the 20-minute local command budget without reporting a failure. Strict Clippy is currently blocked by unrelated pre-existing Rust 1.95 warnings outside this diff.

## AI assistance

OpenCode with `openai/gpt-5.6-sol` was used to trace the temp ownership path, implement the generic alias lifecycle, add deterministic socket coverage, and run verification. Chris Huber directed and reviewed the work.