### PR TITLE
fix(lab): unify snapshot ignore manifests

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -827,7 +827,13 @@ pub(super) fn is_excluded(
         let directory_pattern = pattern.trim_end_matches("/**").trim_end_matches('/');
         pattern == rel
             || directory_pattern == rel
+            // A Git-style `**/directory/` rule also includes that directory at
+            // the workspace root. Tar already applies this interpretation.
+            || directory_pattern
+                .strip_prefix("**/")
+                .is_some_and(|unrooted| unrooted == rel)
             || glob_match(pattern, rel)
+            || glob_match(directory_pattern, rel)
             || (!root_anchored && (pattern == name || glob_match(pattern, name)))
     })
 }
@@ -1866,7 +1872,7 @@ pub(super) fn materialize_snapshot_piped(
     manifest
         .entries
         .retain(|entry| stage.path().join(&entry.staging_output).exists());
-    let staged_manifest = snapshot_stable_manifest(&stage.path().join("source"), &[])?;
+    let staged_manifest = snapshot_stable_manifest(&stage.path().join("source"), excludes)?;
     let current_manifest = snapshot_stable_manifest(local_path, excludes)?;
     validate_snapshot_stability(
         &source_manifest,
@@ -2157,11 +2163,25 @@ fn is_root_input_exclude(pattern: &str) -> bool {
 
 fn snapshot_archive_excludes(pattern: &str) -> Vec<String> {
     let mut excludes = vec![pattern.to_string()];
-    if let Some(directory) = pattern.strip_suffix("/**") {
+    let directory = if pattern.ends_with('/') {
+        Some(pattern.trim_end_matches('/'))
+    } else {
+        pattern.strip_suffix("/**")
+    };
+    if let Some(directory) = directory {
         if !directory.is_empty() {
             excludes.push(directory.to_string());
+            excludes.push(format!("{directory}/**"));
+            // Tar does not let a leading `**/` match the archive root. Add the
+            // root form so its policy agrees with the manifest traversal.
+            if let Some(root_directory) = directory.strip_prefix("**/") {
+                excludes.push(root_directory.to_string());
+                excludes.push(format!("{root_directory}/**"));
+            }
         }
     }
+    excludes.sort();
+    excludes.dedup();
     excludes
 }
 

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -1703,6 +1703,51 @@ fn snapshot_staging_keeps_nested_root_ignored_outputs_out_of_repeated_snapshots(
 }
 
 #[test]
+fn snapshot_staging_uses_one_manifest_policy_for_nested_ignored_directories() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let source = workspace.path().join("source");
+    let ignored = source.join("docs/superpowers/plans/ignored.md");
+    fs::create_dir_all(ignored.parent().expect("ignored parent")).expect("ignored directory");
+    fs::write(source.join("README.md"), "tracked\n").expect("tracked source");
+    fs::write(&ignored, "ignored\n").expect("ignored source");
+    let excludes = vec!["**/docs/superpowers/".to_string()];
+
+    let before = snapshot_stable_manifest(&source, &excludes).expect("source manifest");
+    let manifest = snapshot_input_manifest(&source, &excludes).expect("input manifest");
+    let stage = materialize_snapshot_stage(&source, &excludes, &manifest, None).expect("stage");
+    let staged =
+        snapshot_stable_manifest(&stage.path().join("source"), &excludes).expect("staged manifest");
+    let after = snapshot_stable_manifest(&source, &excludes).expect("current manifest");
+
+    validate_snapshot_stability(
+        &before,
+        &staged,
+        &after,
+        &source,
+        &stage.path().join("source"),
+    )
+    .expect("ignored paths use one manifest policy");
+
+    let provider_workspace = workspace.path().join("provider-workspace");
+    fs::create_dir_all(&provider_workspace).expect("provider workspace");
+    materialize_snapshot_piped(
+        &source,
+        &format!(
+            "tar -C {} -xf -",
+            homeboy_core::engine::shell::quote_arg(&provider_workspace.display().to_string())
+        ),
+        &excludes,
+        "test snapshot transport",
+        None,
+    )
+    .expect("snapshot reaches provider transport");
+    assert!(provider_workspace.join("README.md").is_file());
+    assert!(!provider_workspace
+        .join("docs/superpowers/plans/ignored.md")
+        .exists());
+}
+
+#[test]
 fn lab_snapshot_preacceptance_preserves_tracked_build_sources_before_provider_execution() {
     let workspace = tempfile::tempdir().expect("workspace");
     let source = workspace.path().join("source");


### PR DESCRIPTION
## Summary
- apply one ignore policy to source, staged, and post-stage snapshot manifests
- make trailing-slash `**/directory/` exclusions match the workspace root in both manifest traversal and tar staging
- add regression coverage for nested ignored directories and provider transport

Closes #13238

## Verification
- `cargo nextest run --profile quick -p homeboy-lab-runner workspace::tests::snapshot::`

## AI assistance disclosure
OpenAI GPT-5.6 Sol via OpenCode was used to inspect the issue and snapshot implementation, implement the fix, and run tests. Chris Huber reviewed the work and remains responsible for this change.