### PR TITLE
Add lifecycle-owned external storage retention providers

### DIFF
--- a/crates/contracts/homeboy-command-contract/src/cleanup.rs
+++ b/crates/contracts/homeboy-command-contract/src/cleanup.rs
@@ -84,6 +84,9 @@ pub enum CleanupCategoryArg {
     /// filename marker plus the liveness of the PID stamped into it, so it can
     /// plan and apply with the observation store shut (#11073).
     LeakedTestHomes,
+    /// Installed runtime providers own discovery and native reclaim for roots
+    /// outside Homeboy worktrees.
+    ExternalStorage,
 }
 
 #[derive(Subcommand, Debug, PartialEq, Eq)]
@@ -279,6 +282,17 @@ mod tests {
             ]
         );
         assert_eq!(parsed.cleanup.exclude, vec![CleanupCategoryArg::RuntimeTmp]);
+    }
+
+    #[test]
+    fn parser_accepts_external_storage_cleanup_category() {
+        let parsed =
+            CleanupParserTest::parse_from(["cleanup", "--include", "external-storage", "--apply"]);
+        assert_eq!(
+            parsed.cleanup.include,
+            vec![CleanupCategoryArg::ExternalStorage]
+        );
+        assert!(parsed.cleanup.apply);
     }
 
     #[test]

--- a/crates/contracts/homeboy-extension-contract/src/external_storage_retention.rs
+++ b/crates/contracts/homeboy-extension-contract/src/external_storage_retention.rs
@@ -51,6 +51,7 @@ pub enum ExternalStorageResourceClass {
 #[serde(deny_unknown_fields)]
 pub struct ExternalStorageItem {
     pub id: String,
+    pub root_id: String,
     pub class: ExternalStorageResourceClass,
     pub bytes: u64,
     /// A provider-local, non-secret locator for bounded operator evidence.
@@ -67,6 +68,17 @@ pub struct ExternalStorageItem {
     pub ownership_known: bool,
     /// Whole days since the provider's terminal lifecycle transition.
     pub age_days: u64,
+    /// Provider-issued conditional capability valid only for this inventory
+    /// generation. A provider rejects it after liveness or references change.
+    pub reclaim_token: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalStorageRoot {
+    pub id: String,
+    /// Core reads capacity from this path but never deletes it directly.
+    pub path: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -75,6 +87,11 @@ pub struct ExternalStorageInventory {
     #[serde(default = "default_external_storage_schema")]
     pub schema: String,
     pub provider_id: String,
+    /// Opaque snapshot/lease identity that binds a reclaim request to this
+    /// inventory. Providers must reject stale generations.
+    pub generation: String,
+    #[serde(default)]
+    pub roots: Vec<ExternalStorageRoot>,
     #[serde(default)]
     pub items: Vec<ExternalStorageItem>,
     /// Bytes the provider can account for but cannot safely classify. They are
@@ -92,8 +109,17 @@ fn default_external_storage_schema() -> String {
 pub struct ExternalStorageRequest {
     pub schema: String,
     pub operation: ExternalStorageOperation,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generation: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub item_ids: Vec<String>,
+    pub reclaim_targets: Vec<ExternalStorageReclaimTarget>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalStorageReclaimTarget {
+    pub id: String,
+    pub reclaim_token: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -111,6 +137,7 @@ pub enum ExternalStorageOperation {
 pub struct ExternalStorageReclaimResult {
     pub schema: String,
     pub provider_id: String,
+    pub generation: String,
     #[serde(default)]
     pub reclaimed_item_ids: Vec<String>,
     #[serde(default)]
@@ -125,11 +152,13 @@ mod tests {
     fn inventory_contract_round_trips_liveness_and_unknown_bytes() {
         let inventory: ExternalStorageInventory = serde_json::from_value(serde_json::json!({
             "provider_id": "fixture-runtime",
+            "generation": "generation-1",
             "unknown_bytes": 9,
             "items": [{
-                "id": "scratch-1", "class": "scratch", "bytes": 4,
+                "id": "scratch-1", "root_id": "temp", "class": "scratch", "bytes": 4,
                 "locator": "tmp/scratch-1", "reconstructable": true,
-                "active": false, "referenced": false, "ownership_known": true, "age_days": 7
+                "active": false, "referenced": false, "ownership_known": true, "age_days": 7,
+                "reclaim_token": "opaque"
             }]
         }))
         .expect("inventory parses");

--- a/crates/contracts/homeboy-extension-contract/src/external_storage_retention.rs
+++ b/crates/contracts/homeboy-extension-contract/src/external_storage_retention.rs
@@ -6,6 +6,10 @@ use serde::{Deserialize, Serialize};
 
 pub const EXTERNAL_STORAGE_RETENTION_SCHEMA: &str = "homeboy/external-storage-retention/v1";
 pub const DEFAULT_EXTERNAL_STORAGE_PROVIDER_TIMEOUT_SECONDS: u64 = 30;
+/// Hard protocol ceilings protect stdin delivery before provider-specific policy
+/// is available. The aggregate may choose stricter limits.
+pub const MAX_EXTERNAL_STORAGE_RECLAIM_TARGETS: usize = 1_000;
+pub const MAX_EXTERNAL_STORAGE_REQUEST_BYTES: usize = 256 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/contracts/homeboy-extension-contract/src/external_storage_retention.rs
+++ b/crates/contracts/homeboy-extension-contract/src/external_storage_retention.rs
@@ -1,0 +1,139 @@
+//! Versioned provider contract for storage an installed runtime owns outside a
+//! Homeboy checkout. Providers inventory and reclaim their own resources; core
+//! supplies policy and never removes an external path itself.
+
+use serde::{Deserialize, Serialize};
+
+pub const EXTERNAL_STORAGE_RETENTION_SCHEMA: &str = "homeboy/external-storage-retention/v1";
+pub const DEFAULT_EXTERNAL_STORAGE_PROVIDER_TIMEOUT_SECONDS: u64 = 30;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalStorageRetentionProviderConfig {
+    pub id: String,
+    /// Executable plus fixed arguments. The provider receives one JSON request
+    /// on stdin and returns one JSON response on stdout.
+    pub command: Vec<String>,
+    /// Per-invocation ceiling. A hung runtime helper must not block the bounded
+    /// aggregate retention pass indefinitely.
+    #[serde(default = "default_external_storage_provider_timeout_seconds")]
+    pub timeout_seconds: u64,
+}
+
+fn default_external_storage_provider_timeout_seconds() -> u64 {
+    DEFAULT_EXTERNAL_STORAGE_PROVIDER_TIMEOUT_SECONDS
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalStorageRetentionConfig {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub providers: Vec<ExternalStorageRetentionProviderConfig>,
+}
+
+impl ExternalStorageRetentionConfig {
+    pub fn is_empty(&self) -> bool {
+        self.providers.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExternalStorageResourceClass {
+    Scratch,
+    DurableArtifact,
+    SessionStore,
+    Credential,
+    PinnedExport,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalStorageItem {
+    pub id: String,
+    pub class: ExternalStorageResourceClass,
+    pub bytes: u64,
+    /// A provider-local, non-secret locator for bounded operator evidence.
+    pub locator: String,
+    /// Reclaimable items must be reproducible by the provider or be reclaimed
+    /// through a provider-native compaction action.
+    pub reconstructable: bool,
+    /// An active lease/session/owner is an unconditional veto.
+    pub active: bool,
+    /// A retained session, snapshot, or export still points at this item.
+    pub referenced: bool,
+    /// Unknown ownership fails closed. This lets mixed-version installs report
+    /// bytes without promoting old unlabelled paths to deletion candidates.
+    pub ownership_known: bool,
+    /// Whole days since the provider's terminal lifecycle transition.
+    pub age_days: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalStorageInventory {
+    #[serde(default = "default_external_storage_schema")]
+    pub schema: String,
+    pub provider_id: String,
+    #[serde(default)]
+    pub items: Vec<ExternalStorageItem>,
+    /// Bytes the provider can account for but cannot safely classify. They are
+    /// visible separately and never candidates.
+    #[serde(default)]
+    pub unknown_bytes: u64,
+}
+
+fn default_external_storage_schema() -> String {
+    EXTERNAL_STORAGE_RETENTION_SCHEMA.to_string()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalStorageRequest {
+    pub schema: String,
+    pub operation: ExternalStorageOperation,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub item_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExternalStorageOperation {
+    Inventory,
+    Reclaim,
+}
+
+/// Provider-native reclaim receipt. A session-store provider can remove expired
+/// reference rows and compact a database here without exposing database paths
+/// to Homeboy.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalStorageReclaimResult {
+    pub schema: String,
+    pub provider_id: String,
+    #[serde(default)]
+    pub reclaimed_item_ids: Vec<String>,
+    #[serde(default)]
+    pub reclaimed_bytes: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inventory_contract_round_trips_liveness_and_unknown_bytes() {
+        let inventory: ExternalStorageInventory = serde_json::from_value(serde_json::json!({
+            "provider_id": "fixture-runtime",
+            "unknown_bytes": 9,
+            "items": [{
+                "id": "scratch-1", "class": "scratch", "bytes": 4,
+                "locator": "tmp/scratch-1", "reconstructable": true,
+                "active": false, "referenced": false, "ownership_known": true, "age_days": 7
+            }]
+        }))
+        .expect("inventory parses");
+        assert_eq!(inventory.schema, EXTERNAL_STORAGE_RETENTION_SCHEMA);
+        assert_eq!(inventory.unknown_bytes, 9);
+    }
+}

--- a/crates/contracts/homeboy-extension-contract/src/lib.rs
+++ b/crates/contracts/homeboy-extension-contract/src/lib.rs
@@ -125,8 +125,9 @@ pub use external_check_detail_resolver::{
 };
 pub use external_storage_retention::{
     ExternalStorageInventory, ExternalStorageItem, ExternalStorageOperation,
-    ExternalStorageReclaimResult, ExternalStorageRequest, ExternalStorageResourceClass,
-    ExternalStorageRetentionConfig, ExternalStorageRetentionProviderConfig,
+    ExternalStorageReclaimResult, ExternalStorageReclaimTarget, ExternalStorageRequest,
+    ExternalStorageResourceClass, ExternalStorageRetentionConfig,
+    ExternalStorageRetentionProviderConfig, ExternalStorageRoot,
     DEFAULT_EXTERNAL_STORAGE_PROVIDER_TIMEOUT_SECONDS, EXTERNAL_STORAGE_RETENTION_SCHEMA,
 };
 pub use manifest::ExtensionManifest;

--- a/crates/contracts/homeboy-extension-contract/src/lib.rs
+++ b/crates/contracts/homeboy-extension-contract/src/lib.rs
@@ -129,6 +129,7 @@ pub use external_storage_retention::{
     ExternalStorageResourceClass, ExternalStorageRetentionConfig,
     ExternalStorageRetentionProviderConfig, ExternalStorageRoot,
     DEFAULT_EXTERNAL_STORAGE_PROVIDER_TIMEOUT_SECONDS, EXTERNAL_STORAGE_RETENTION_SCHEMA,
+    MAX_EXTERNAL_STORAGE_RECLAIM_TARGETS, MAX_EXTERNAL_STORAGE_REQUEST_BYTES,
 };
 pub use manifest::ExtensionManifest;
 pub use manifest_artifact_cleanup::{

--- a/crates/contracts/homeboy-extension-contract/src/lib.rs
+++ b/crates/contracts/homeboy-extension-contract/src/lib.rs
@@ -97,6 +97,7 @@ pub mod core_compat;
 pub mod exec_context;
 pub mod extension_contract_producer;
 pub mod external_check_detail_resolver;
+pub mod external_storage_retention;
 pub mod fuzz_config;
 pub mod manifest;
 pub mod manifest_action_config;
@@ -121,6 +122,12 @@ pub use external_check_detail_resolver::{
     ExternalCheckDetailRequest, ExternalCheckDetailResolverConfig, ExternalCheckDetailResponse,
     EXTERNAL_CHECK_DETAIL_REQUEST_SCHEMA, EXTERNAL_CHECK_DETAIL_RESOLVER_SCHEMA,
     EXTERNAL_CHECK_DETAIL_RESPONSE_SCHEMA,
+};
+pub use external_storage_retention::{
+    ExternalStorageInventory, ExternalStorageItem, ExternalStorageOperation,
+    ExternalStorageReclaimResult, ExternalStorageRequest, ExternalStorageResourceClass,
+    ExternalStorageRetentionConfig, ExternalStorageRetentionProviderConfig,
+    DEFAULT_EXTERNAL_STORAGE_PROVIDER_TIMEOUT_SECONDS, EXTERNAL_STORAGE_RETENTION_SCHEMA,
 };
 pub use manifest::ExtensionManifest;
 pub use manifest_artifact_cleanup::{

--- a/crates/contracts/homeboy-extension-contract/src/manifest.rs
+++ b/crates/contracts/homeboy-extension-contract/src/manifest.rs
@@ -12,6 +12,7 @@ use crate::autofix_config::*;
 use crate::ci_config::*;
 use crate::extension_contract_producer::*;
 use crate::external_check_detail_resolver::*;
+use crate::external_storage_retention::*;
 use crate::fuzz_config::*;
 use crate::manifest_action_config::*;
 use crate::manifest_artifact_cleanup::*;
@@ -108,6 +109,13 @@ pub struct ExtensionManifest {
     /// extension only declares what is reconstructable.
     #[serde(default, skip_serializing_if = "ArtifactCleanupConfig::is_empty")]
     pub artifact_cleanup: ArtifactCleanupConfig,
+    /// Provider-owned external runtime storage. Unlike `artifact_cleanup`,
+    /// providers discover paths outside checkouts and perform native reclaim.
+    #[serde(
+        default,
+        skip_serializing_if = "ExternalStorageRetentionConfig::is_empty"
+    )]
+    pub external_storage_retention: ExternalStorageRetentionConfig,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deps: Option<DepsConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -2201,13 +2201,16 @@ fn cleanup_inventory_with_deadline(
                 let output = cleanup::cleanup_external_storage_from_extensions(
                     cleanup::ExternalStorageCleanupOptions {
                         apply,
-                        min_age_days: policy.terminal_run_days.max(0) as u64,
+                        min_age_days: config.retention.external_storage_days,
+                        max_bytes: config.retention.external_storage_max_bytes,
+                        reserve_bytes: config.retention.external_storage_reserve_bytes,
                         limit: policy.scan_limit(),
                         evidence_limit: if args.full {
                             policy.scan_limit()
                         } else {
                             OutputBudget::COLLECTION.max_items
                         },
+                        deadline,
                     },
                 )?;
                 category_from_output(

--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -78,7 +78,7 @@ struct AutomaticRetentionControllerOutput {
 /// bytes by hand, and they arrive at hundreds of megabytes each (#11073). It is
 /// bounded by an age floor, a byte ceiling, and the scan limit, and it can only
 /// ever reach a directory whose owning process is gone.
-const AUTOMATIC_RETENTION_CATEGORIES: [CleanupCategoryArg; 10] = [
+const AUTOMATIC_RETENTION_CATEGORIES: [CleanupCategoryArg; 11] = [
     CleanupCategoryArg::WorktreeProviders,
     CleanupCategoryArg::TerminalRuns,
     CleanupCategoryArg::PersistedRunArtifacts,
@@ -89,6 +89,7 @@ const AUTOMATIC_RETENTION_CATEGORIES: [CleanupCategoryArg; 10] = [
     CleanupCategoryArg::ControllerRuntimes,
     CleanupCategoryArg::RemoteLabWorkspaces,
     CleanupCategoryArg::RunnerBinaryCaches,
+    CleanupCategoryArg::ExternalStorage,
 ];
 
 /// Categories held out of the unattended pass on purpose, with the reason.
@@ -1406,6 +1407,14 @@ const WORKTREE_PROVIDERS_METADATA: CleanupInventoryCategoryMetadata =
         apply_command: "homeboy cleanup worktrees --all-providers --apply",
     };
 
+const EXTERNAL_STORAGE_METADATA: CleanupInventoryCategoryMetadata =
+    CleanupInventoryCategoryMetadata {
+        category: "external_storage",
+        include_arg: "external-storage",
+        dry_run_command: "homeboy cleanup --include external-storage",
+        apply_command: "homeboy cleanup --include external-storage --apply",
+    };
+
 const PERSISTED_RUN_ARTIFACTS_METADATA: CleanupInventoryCategoryMetadata =
     CleanupInventoryCategoryMetadata {
         category: "persisted_run_artifacts",
@@ -2181,6 +2190,43 @@ fn cleanup_inventory_with_deadline(
         );
     }
 
+    if selected.includes(CleanupCategoryArg::ExternalStorage) {
+        isolate_cleanup_category(
+            &mut categories,
+            EXTERNAL_STORAGE_METADATA,
+            apply,
+            None,
+            None,
+            || {
+                let output = cleanup::cleanup_external_storage_from_extensions(
+                    cleanup::ExternalStorageCleanupOptions {
+                        apply,
+                        min_age_days: policy.terminal_run_days.max(0) as u64,
+                        limit: policy.scan_limit(),
+                        evidence_limit: if args.full {
+                            policy.scan_limit()
+                        } else {
+                            OutputBudget::COLLECTION.max_items
+                        },
+                    },
+                )?;
+                category_from_output(
+                    EXTERNAL_STORAGE_METADATA,
+                    apply,
+                    CleanupCategoryMetrics {
+                        candidate_count: output.candidate_count,
+                        applied_count: output.applied_count,
+                        skipped_count: output.skipped_count,
+                        estimated_bytes: output.estimated_bytes,
+                        reclaimed_bytes: output.reclaimed_bytes,
+                    },
+                    output,
+                )
+                .map(|category| vec![category])
+            },
+        );
+    }
+
     let candidate_count = categories
         .iter()
         .map(|category| category.candidate_count)
@@ -2305,6 +2351,7 @@ fn cleanup_category_arg_name(category: &CleanupCategoryArg) -> &'static str {
         CleanupCategoryArg::SharedCargoTargets => "shared-cargo-targets",
         CleanupCategoryArg::ControllerRuntimes => "controller-runtimes",
         CleanupCategoryArg::LeakedTestHomes => "leaked-test-homes",
+        CleanupCategoryArg::ExternalStorage => "external-storage",
     }
 }
 

--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -2210,7 +2210,11 @@ fn cleanup_inventory_with_deadline(
                         } else {
                             OutputBudget::COLLECTION.max_items
                         },
-                        deadline,
+                        deadline: deadline.or_else(|| {
+                            SystemTime::now().checked_add(Duration::from_secs(
+                                config.retention.automatic_retention_max_run_seconds,
+                            ))
+                        }),
                     },
                 )?;
                 category_from_output(

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -40,6 +40,11 @@ pub use degraded::{
     STORE_INDEPENDENT_CLEANUP_CATEGORIES,
 };
 mod extension_declarations;
+mod external_storage;
+pub use external_storage::{
+    cleanup_external_storage_from_extensions, cleanup_external_storage_with_providers,
+    ExternalStorageCleanupOptions, ExternalStorageCleanupOutput,
+};
 pub mod leaked_test_homes;
 pub use leaked_test_homes::{
     cleanup_leaked_test_homes, effective_temp_roots, owned_test_tempdir_prefix,

--- a/crates/homeboy-core/src/cleanup/external_storage.rs
+++ b/crates/homeboy-core/src/cleanup/external_storage.rs
@@ -418,6 +418,7 @@ fn invoke_raw(
     reclaim_targets: Vec<ExternalStorageReclaimTarget>,
     deadline: Option<SystemTime>,
 ) -> Result<Vec<u8>> {
+    let inventory_request = matches!(&operation, ExternalStorageOperation::Inventory);
     let Some((program, args)) = provider.command.split_first() else {
         return Err(Error::validation_invalid_argument(
             "external_storage_retention.providers.command",
@@ -519,12 +520,6 @@ fn invoke_raw(
             provider.id
         ))
     })?;
-    write_result.map_err(|error| {
-        Error::internal_unexpected(format!(
-            "write external storage provider '{}': {error}",
-            provider.id
-        ))
-    })?;
     if result.termination != SupervisedCommandTermination::Completed
         || !result.output.status.success()
     {
@@ -532,6 +527,19 @@ fn invoke_raw(
             "external storage provider '{}' failed or exceeded its output budget",
             provider.id
         )));
+    }
+    if let Err(error) = write_result {
+        // Inventory is a read-only probe. A helper may emit its complete
+        // terminal response and close stdin without reading the request; once
+        // the supervised terminal status is successful, let the JSON response
+        // below decide its validity. Reclaim targets are mutations and always
+        // require complete stdin delivery.
+        if !inventory_request || error.kind() != std::io::ErrorKind::BrokenPipe {
+            return Err(Error::internal_unexpected(format!(
+                "write external storage provider '{}': {error}",
+                provider.id
+            )));
+        }
     }
     Ok(result.output.stdout)
 }
@@ -822,6 +830,46 @@ mod tests {
         assert_eq!(output.provider_count, 1);
         assert_eq!(output.providers.len(), 1);
         assert_eq!(output.providers[0].candidate_count, 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn successful_inventory_early_close_uses_terminal_output() {
+        // This fixture closes stdin before emitting JSON. A successful terminal
+        // response remains authoritative for this read-only operation.
+        let inventory = serde_json::json!({
+            "schema": EXTERNAL_STORAGE_RETENTION_SCHEMA, "provider_id": "early-close",
+            "generation": "g1", "items": [{
+                "id": "scratch", "root_id": "root", "class": "scratch", "bytes": 10,
+                "locator": "scratch", "reconstructable": true, "active": false,
+                "referenced": false, "ownership_known": true, "age_days": 7,
+                "reclaim_token": "token"
+            }]
+        });
+        let provider = ExternalStorageRetentionProviderConfig {
+            id: "early-close".to_string(),
+            command: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                format!("exec 0<&-; sleep 0.1; printf '%s' '{}'", inventory),
+                "fixture".to_string(),
+            ],
+            timeout_seconds: 1,
+        };
+        let output = cleanup_external_storage_with_providers(
+            &[provider],
+            ExternalStorageCleanupOptions {
+                apply: false,
+                min_age_days: 0,
+                max_bytes: 10,
+                reserve_bytes: 0,
+                limit: 1,
+                evidence_limit: 1,
+                deadline: None,
+            },
+        )
+        .expect("successful inventory output");
+        assert_eq!(output.candidate_count, 1);
     }
 
     #[cfg(unix)]

--- a/crates/homeboy-core/src/cleanup/external_storage.rs
+++ b/crates/homeboy-core/src/cleanup/external_storage.rs
@@ -90,7 +90,7 @@ pub fn cleanup_external_storage_with_providers(
 ) -> Result<ExternalStorageCleanupOutput> {
     let mut seen = HashSet::new();
     let mut output = ExternalStorageCleanupOutput {
-        provider_count: providers.len(),
+        provider_count: providers.len().min(options.limit),
         candidate_count: 0,
         applied_count: 0,
         skipped_count: 0,
@@ -101,7 +101,8 @@ pub fn cleanup_external_storage_with_providers(
     };
     let mut remaining_count = options.limit;
     let mut remaining_bytes = options.max_bytes;
-    for provider in providers {
+    let mut remaining_evidence = options.evidence_limit;
+    for provider in providers.iter().take(options.limit) {
         if !seen.insert(&provider.id) {
             return Err(Error::validation_invalid_argument(
                 "external_storage_retention.providers",
@@ -134,9 +135,18 @@ pub fn cleanup_external_storage_with_providers(
             remaining_count,
             &inventory.generation,
         );
-        let estimated_bytes = candidates.iter().map(|item| item.bytes).sum();
+        let estimated_bytes = checked_sum(
+            candidates.iter().map(|item| item.bytes),
+            "planned external storage bytes",
+        )?;
         remaining_count = remaining_count.saturating_sub(candidates.len());
-        remaining_bytes = remaining_bytes.saturating_sub(estimated_bytes);
+        remaining_bytes = remaining_bytes
+            .checked_sub(estimated_bytes)
+            .ok_or_else(|| {
+                Error::internal_unexpected(
+                    "external storage plan exceeded its aggregate byte ceiling",
+                )
+            })?;
         let targets = candidates
             .iter()
             .map(|item| ExternalStorageReclaimTarget {
@@ -163,9 +173,16 @@ pub fn cleanup_external_storage_with_providers(
         };
         let candidate_evidence = candidates
             .iter()
-            .take(options.evidence_limit)
+            .take(remaining_evidence)
             .map(|item| evidence(item))
-            .collect();
+            .collect::<Vec<_>>();
+        remaining_evidence = remaining_evidence.saturating_sub(candidate_evidence.len());
+        let applied_evidence = applied
+            .iter()
+            .take(remaining_evidence)
+            .map(|item| evidence(item))
+            .collect::<Vec<_>>();
+        remaining_evidence = remaining_evidence.saturating_sub(applied_evidence.len());
         let provider_output = ExternalStorageProviderOutput {
             provider_id: provider.id.clone(),
             candidate_count: candidates.len(),
@@ -175,18 +192,26 @@ pub fn cleanup_external_storage_with_providers(
             reclaimed_bytes,
             unknown_bytes: inventory.unknown_bytes,
             candidates: candidate_evidence,
-            applied: applied
-                .iter()
-                .take(options.evidence_limit)
-                .map(|item| evidence(item))
-                .collect(),
+            applied: applied_evidence,
         };
         output.candidate_count += provider_output.candidate_count;
         output.applied_count += provider_output.applied_count;
         output.skipped_count += provider_output.skipped_count;
-        output.estimated_bytes += provider_output.estimated_bytes;
-        output.reclaimed_bytes += provider_output.reclaimed_bytes;
-        output.unknown_bytes += provider_output.unknown_bytes;
+        output.estimated_bytes = checked_add(
+            output.estimated_bytes,
+            provider_output.estimated_bytes,
+            "external storage estimated bytes",
+        )?;
+        output.reclaimed_bytes = checked_add(
+            output.reclaimed_bytes,
+            provider_output.reclaimed_bytes,
+            "external storage reclaimed bytes",
+        )?;
+        output.unknown_bytes = checked_add(
+            output.unknown_bytes,
+            provider_output.unknown_bytes,
+            "external storage unknown bytes",
+        )?;
         output.providers.push(provider_output);
     }
     Ok(output)
@@ -216,10 +241,14 @@ fn plan<'a>(
         {
             continue;
         }
-        if selected.len() >= limit.min(MAX_EXTERNAL_STORAGE_RECLAIM_TARGETS)
-            || selected_bytes.saturating_add(item.bytes) > max_bytes
-        {
+        if selected.len() >= limit.min(MAX_EXTERNAL_STORAGE_RECLAIM_TARGETS) {
             break;
+        }
+        let Some(next_bytes) = selected_bytes.checked_add(item.bytes) else {
+            continue;
+        };
+        if next_bytes > max_bytes {
+            continue;
         }
         if !reclaim_request_fits(
             generation,
@@ -232,12 +261,21 @@ fn plan<'a>(
                     reclaim_token: item.reclaim_token.clone(),
                 }),
         ) {
-            break;
+            continue;
         }
-        selected_bytes = selected_bytes.saturating_add(item.bytes);
+        selected_bytes = next_bytes;
         selected.push(item);
     }
     selected
+}
+
+fn checked_add(left: u64, right: u64, subject: &str) -> Result<u64> {
+    left.checked_add(right)
+        .ok_or_else(|| Error::internal_unexpected(format!("{subject} overflow")))
+}
+
+fn checked_sum(mut values: impl Iterator<Item = u64>, subject: &str) -> Result<u64> {
+    values.try_fold(0_u64, |total, value| checked_add(total, value, subject))
 }
 
 fn reclaim_request_fits(
@@ -309,7 +347,12 @@ fn validate_reclaim_receipt<'a>(
         };
         applied.push(*item);
     }
-    if receipt.reclaimed_bytes > applied.iter().map(|item| item.bytes).sum() {
+    if receipt.reclaimed_bytes
+        > checked_sum(
+            applied.iter().map(|item| item.bytes),
+            "confirmed external storage bytes",
+        )?
+    {
         return Err(Error::validation_invalid_argument(
             "external_storage_retention provider reclaim response",
             "receipt bytes exceed confirmed item bytes",
@@ -621,6 +664,45 @@ mod tests {
     }
 
     #[test]
+    fn plan_skips_oversized_candidates_and_keeps_later_fitting_order() {
+        let mut oversized = item("oversized", ExternalStorageResourceClass::Scratch);
+        oversized.bytes = 100;
+        let mut first = item("first-fitting", ExternalStorageResourceClass::Scratch);
+        first.bytes = 4;
+        let mut second = item("second-fitting", ExternalStorageResourceClass::Scratch);
+        second.bytes = 5;
+        let inventory = [oversized, first, second];
+        let planned = plan(&inventory, &HashSet::new(), 0, 9, 10, "generation");
+        assert_eq!(
+            planned
+                .iter()
+                .map(|item| item.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["first-fitting", "second-fitting"],
+        );
+    }
+
+    #[test]
+    fn checked_accounting_rejects_u64_overflow() {
+        assert!(checked_sum([u64::MAX, 1].into_iter(), "fixture").is_err());
+        let first = item("first", ExternalStorageResourceClass::Scratch);
+        let mut second = item("second", ExternalStorageResourceClass::Scratch);
+        second.bytes = u64::MAX;
+        assert_eq!(
+            plan(
+                &[first, second],
+                &HashSet::new(),
+                0,
+                u64::MAX,
+                10,
+                "generation"
+            )
+            .len(),
+            1,
+        );
+    }
+
+    #[test]
     fn policy_applies_age_byte_ceiling_and_pressure_without_widening_liveness() {
         let old = item("old", ExternalStorageResourceClass::Scratch);
         let mut young = item("young", ExternalStorageResourceClass::Scratch);
@@ -714,8 +796,43 @@ mod tests {
         .expect("plan");
         assert_eq!(output.candidate_count, 1);
         assert_eq!(output.estimated_bytes, 10);
+        assert_eq!(output.provider_count, 1);
+        assert_eq!(output.providers.len(), 1);
         assert_eq!(output.providers[0].candidate_count, 1);
-        assert_eq!(output.providers[1].candidate_count, 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn aggregate_unknown_byte_overflow_fails_closed() {
+        let provider = |id: &str| {
+            let inventory = serde_json::json!({
+                "schema": EXTERNAL_STORAGE_RETENTION_SCHEMA, "provider_id": id,
+                "generation": "g1", "unknown_bytes": u64::MAX,
+            });
+            ExternalStorageRetentionProviderConfig {
+                id: id.to_string(),
+                command: vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    format!("printf '%s' '{}'", inventory),
+                    "fixture".to_string(),
+                ],
+                timeout_seconds: 1,
+            }
+        };
+        let result = cleanup_external_storage_with_providers(
+            &[provider("one"), provider("two")],
+            ExternalStorageCleanupOptions {
+                apply: false,
+                min_age_days: 0,
+                max_bytes: u64::MAX,
+                reserve_bytes: 0,
+                limit: 10,
+                evidence_limit: 1,
+                deadline: None,
+            },
+        );
+        assert!(result.is_err());
     }
 
     #[cfg(unix)]
@@ -768,6 +885,31 @@ mod tests {
         .expect_err("expired deadline");
         assert!(error.message.contains("deadline elapsed"));
         assert!(!marker.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn aggregate_deadline_bounds_manual_provider_inventory() {
+        let provider = ExternalStorageRetentionProviderConfig {
+            id: "manual-deadline".to_string(),
+            command: vec!["sh".to_string(), "-c".to_string(), "sleep 5".to_string()],
+            timeout_seconds: 30,
+        };
+        let started = std::time::Instant::now();
+        assert!(cleanup_external_storage_with_providers(
+            &[provider],
+            ExternalStorageCleanupOptions {
+                apply: false,
+                min_age_days: 0,
+                max_bytes: 0,
+                reserve_bytes: 0,
+                limit: 1,
+                evidence_limit: 1,
+                deadline: Some(SystemTime::now() + Duration::from_millis(1)),
+            },
+        )
+        .is_err());
+        assert!(started.elapsed() < Duration::from_secs(3));
     }
 
     #[cfg(unix)]

--- a/crates/homeboy-core/src/cleanup/external_storage.rs
+++ b/crates/homeboy-core/src/cleanup/external_storage.rs
@@ -5,29 +5,35 @@
 //! selected identities back for native reclaim. It intentionally never calls
 //! `remove_dir_all` on a provider locator.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
+use std::time::{Duration, SystemTime};
 
+use homeboy_engine_primitives::command::{
+    wait_with_bounded_output_supervised, ControllerChildGuard, SupervisedCommandTermination,
+};
 use homeboy_extension_contract::{
     ExternalStorageInventory, ExternalStorageItem, ExternalStorageOperation,
-    ExternalStorageReclaimResult, ExternalStorageRequest, ExternalStorageResourceClass,
-    ExternalStorageRetentionProviderConfig, EXTERNAL_STORAGE_RETENTION_SCHEMA,
+    ExternalStorageReclaimResult, ExternalStorageReclaimTarget, ExternalStorageRequest,
+    ExternalStorageResourceClass, ExternalStorageRetentionProviderConfig,
+    EXTERNAL_STORAGE_RETENTION_SCHEMA,
 };
 use serde::Serialize;
 
 use crate::{Error, Result};
 
 const PROVIDER_OUTPUT_LIMIT: usize = 1024 * 1024;
-const PROVIDER_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 #[derive(Debug, Clone)]
 pub struct ExternalStorageCleanupOptions {
     pub apply: bool,
     pub min_age_days: u64,
+    pub max_bytes: u64,
+    pub reserve_bytes: u64,
     pub limit: usize,
     pub evidence_limit: usize,
+    pub deadline: Option<SystemTime>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -52,6 +58,7 @@ pub struct ExternalStorageProviderOutput {
     pub reclaimed_bytes: u64,
     pub unknown_bytes: u64,
     pub candidates: Vec<ExternalStorageEvidence>,
+    pub applied: Vec<ExternalStorageEvidence>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -99,7 +106,11 @@ pub fn cleanup_external_storage_with_providers(
                 None,
             ));
         }
-        let inventory = invoke(provider, ExternalStorageOperation::Inventory, Vec::new())?;
+        let inventory = invoke(
+            provider,
+            ExternalStorageOperation::Inventory,
+            options.deadline,
+        )?;
         if inventory.schema != EXTERNAL_STORAGE_RETENTION_SCHEMA
             || inventory.provider_id != provider.id
         {
@@ -110,13 +121,27 @@ pub fn cleanup_external_storage_with_providers(
                 None,
             ));
         }
-        let candidates = plan(&inventory.items, options.min_age_days, options.limit);
+        let pressured_roots = pressured_roots(&inventory, options.reserve_bytes);
+        let candidates = plan(
+            &inventory.items,
+            &pressured_roots,
+            options.min_age_days,
+            options.max_bytes,
+            options.limit,
+        );
         let estimated_bytes = candidates.iter().map(|item| item.bytes).sum();
-        let item_ids = candidates.iter().map(|item| item.id.clone()).collect();
-        let reclaimed_bytes = if options.apply && !candidates.is_empty() {
+        let targets = candidates
+            .iter()
+            .map(|item| ExternalStorageReclaimTarget {
+                id: item.id.clone(),
+                reclaim_token: item.reclaim_token.clone(),
+            })
+            .collect::<Vec<_>>();
+        let (reclaimed_bytes, applied) = if options.apply && !candidates.is_empty() {
             // A provider performs deletion/compaction atomically in its own
             // model. Core's candidate bytes are accounting, not path authority.
-            let reclaim = invoke_reclaim(provider, item_ids)?;
+            let reclaim =
+                invoke_reclaim(provider, &inventory.generation, targets, options.deadline)?;
             if reclaim.schema != EXTERNAL_STORAGE_RETENTION_SCHEMA
                 || reclaim.provider_id != provider.id
             {
@@ -124,11 +149,12 @@ pub fn cleanup_external_storage_with_providers(
                     "external storage provider returned an invalid reclaim response",
                 ));
             }
-            reclaim.reclaimed_bytes
+            let applied = validate_reclaim_receipt(&reclaim, &inventory.generation, &candidates)?;
+            (reclaim.reclaimed_bytes, applied)
         } else {
-            0
+            (0, Vec::new())
         };
-        let evidence = candidates
+        let candidate_evidence = candidates
             .iter()
             .take(options.evidence_limit)
             .map(|item| evidence(item))
@@ -136,12 +162,17 @@ pub fn cleanup_external_storage_with_providers(
         let provider_output = ExternalStorageProviderOutput {
             provider_id: provider.id.clone(),
             candidate_count: candidates.len(),
-            applied_count: if options.apply { candidates.len() } else { 0 },
+            applied_count: applied.len(),
             skipped_count: inventory.items.len().saturating_sub(candidates.len()),
             estimated_bytes,
             reclaimed_bytes,
             unknown_bytes: inventory.unknown_bytes,
-            candidates: evidence,
+            candidates: candidate_evidence,
+            applied: applied
+                .iter()
+                .take(options.evidence_limit)
+                .map(|item| evidence(item))
+                .collect(),
         };
         output.candidate_count += provider_output.candidate_count;
         output.applied_count += provider_output.applied_count;
@@ -154,26 +185,103 @@ pub fn cleanup_external_storage_with_providers(
     Ok(output)
 }
 
-fn plan(
-    items: &[ExternalStorageItem],
+fn plan<'a>(
+    items: &'a [ExternalStorageItem],
+    pressured_roots: &HashSet<String>,
     min_age_days: u64,
+    max_bytes: u64,
     limit: usize,
-) -> Vec<&ExternalStorageItem> {
-    items
-        .iter()
-        .filter(|item| item.ownership_known)
-        .filter(|item| item.reconstructable)
-        .filter(|item| !item.active && !item.referenced)
-        .filter(|item| {
-            !matches!(
+) -> Vec<&'a ExternalStorageItem> {
+    let mut selected = Vec::new();
+    let mut selected_bytes = 0_u64;
+    for item in items {
+        if selected.len() >= limit || selected_bytes.saturating_add(item.bytes) > max_bytes {
+            continue;
+        }
+        if !item.ownership_known
+            || !item.reconstructable
+            || item.active
+            || item.referenced
+            || matches!(
                 item.class,
                 ExternalStorageResourceClass::Credential
                     | ExternalStorageResourceClass::PinnedExport
             )
+            || (!pressured_roots.contains(&item.root_id) && item.age_days < min_age_days)
+        {
+            continue;
+        }
+        selected_bytes = selected_bytes.saturating_add(item.bytes);
+        selected.push(item);
+    }
+    selected
+}
+
+fn pressured_roots(inventory: &ExternalStorageInventory, reserve_bytes: u64) -> HashSet<String> {
+    inventory
+        .roots
+        .iter()
+        .filter_map(|root| {
+            (reserve_bytes > 0
+                && crate::observation::disk_budget::disk_budget(
+                    std::path::Path::new(&root.path),
+                    "external storage",
+                    "provider root capacity is not measurable",
+                )
+                .available_bytes
+                .is_some_and(|available| available < reserve_bytes))
+            .then(|| root.id.clone())
         })
-        .filter(|item| item.age_days >= min_age_days)
-        .take(limit)
         .collect()
+}
+
+fn validate_reclaim_receipt<'a>(
+    receipt: &ExternalStorageReclaimResult,
+    generation: &str,
+    candidates: &[&'a ExternalStorageItem],
+) -> Result<Vec<&'a ExternalStorageItem>> {
+    if receipt.generation != generation {
+        return Err(Error::validation_invalid_argument(
+            "external_storage_retention provider reclaim response",
+            "provider rejected or did not echo the inventory generation",
+            None,
+            None,
+        ));
+    }
+    let requested: HashMap<_, _> = candidates
+        .iter()
+        .map(|item| (item.id.as_str(), *item))
+        .collect();
+    let mut seen = HashSet::new();
+    let mut applied = Vec::new();
+    for id in &receipt.reclaimed_item_ids {
+        if !seen.insert(id) {
+            return Err(Error::validation_invalid_argument(
+                "external_storage_retention provider reclaim response",
+                "receipt contains duplicate item ids",
+                None,
+                None,
+            ));
+        }
+        let Some(item) = requested.get(id.as_str()) else {
+            return Err(Error::validation_invalid_argument(
+                "external_storage_retention provider reclaim response",
+                "receipt contains an item that was not requested",
+                None,
+                None,
+            ));
+        };
+        applied.push(*item);
+    }
+    if receipt.reclaimed_bytes > applied.iter().map(|item| item.bytes).sum() {
+        return Err(Error::validation_invalid_argument(
+            "external_storage_retention provider reclaim response",
+            "receipt bytes exceed confirmed item bytes",
+            None,
+            None,
+        ));
+    }
+    Ok(applied)
 }
 
 fn evidence(item: &ExternalStorageItem) -> ExternalStorageEvidence {
@@ -188,9 +296,9 @@ fn evidence(item: &ExternalStorageItem) -> ExternalStorageEvidence {
 fn invoke(
     provider: &ExternalStorageRetentionProviderConfig,
     operation: ExternalStorageOperation,
-    item_ids: Vec<String>,
+    deadline: Option<SystemTime>,
 ) -> Result<ExternalStorageInventory> {
-    let value = invoke_raw(provider, operation, item_ids)?;
+    let value = invoke_raw(provider, operation, None, Vec::new(), deadline)?;
     serde_json::from_slice(&value).map_err(|error| {
         Error::validation_invalid_argument(
             "external_storage_retention provider response",
@@ -204,7 +312,9 @@ fn invoke(
 fn invoke_raw(
     provider: &ExternalStorageRetentionProviderConfig,
     operation: ExternalStorageOperation,
-    item_ids: Vec<String>,
+    generation: Option<String>,
+    reclaim_targets: Vec<ExternalStorageReclaimTarget>,
+    deadline: Option<SystemTime>,
 ) -> Result<Vec<u8>> {
     let Some((program, args)) = provider.command.split_first() else {
         return Err(Error::validation_invalid_argument(
@@ -217,7 +327,8 @@ fn invoke_raw(
     let request = serde_json::to_vec(&ExternalStorageRequest {
         schema: EXTERNAL_STORAGE_RETENTION_SCHEMA.to_string(),
         operation,
-        item_ids,
+        generation,
+        reclaim_targets,
     })
     .map_err(|error| {
         Error::internal_json(
@@ -225,18 +336,33 @@ fn invoke_raw(
             Some("serialize external storage request".to_string()),
         )
     })?;
-    let mut child = Command::new(program)
+    let timeout = deadline
+        .and_then(|deadline| deadline.duration_since(SystemTime::now()).ok())
+        .map(|remaining| remaining.min(Duration::from_secs(provider.timeout_seconds)))
+        .unwrap_or_else(|| Duration::from_secs(provider.timeout_seconds));
+    if timeout.is_zero() {
+        return Err(Error::internal_unexpected(
+            "external storage retention deadline elapsed",
+        ));
+    }
+    let mut command = Command::new(program);
+    command
         .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|error| {
-            Error::internal_unexpected(format!(
-                "start external storage provider '{}': {error}",
-                provider.id
-            ))
-        })?;
+        .stderr(Stdio::piped());
+    let guard = ControllerChildGuard::prepare(&mut command).map_err(|error| {
+        Error::internal_unexpected(format!(
+            "guard external storage provider '{}': {error}",
+            provider.id
+        ))
+    })?;
+    let mut child = command.spawn().map_err(|error| {
+        Error::internal_unexpected(format!(
+            "start external storage provider '{}': {error}",
+            provider.id
+        ))
+    })?;
     let mut stdin = child.stdin.take().expect("piped stdin");
     stdin.write_all(&request).map_err(|error| {
         Error::internal_unexpected(format!(
@@ -245,52 +371,50 @@ fn invoke_raw(
         ))
     })?;
     drop(stdin);
-    let deadline = Instant::now()
-        .checked_add(Duration::from_secs(provider.timeout_seconds))
-        .unwrap_or_else(Instant::now);
-    loop {
-        if child
-            .try_wait()
-            .map_err(|error| {
-                Error::internal_unexpected(format!(
-                    "poll external storage provider '{}': {error}",
-                    provider.id
-                ))
-            })?
-            .is_some()
-        {
-            break;
-        }
-        if Instant::now() >= deadline {
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err(Error::internal_unexpected(format!(
-                "external storage provider '{}' exceeded its timeout",
-                provider.id
-            )));
-        }
-        std::thread::sleep(PROVIDER_POLL_INTERVAL);
-    }
-    let result = child.wait_with_output().map_err(|error| {
+    guard.attach(&child).map_err(|error| {
+        Error::internal_unexpected(format!(
+            "attach external storage provider guard '{}': {error}",
+            provider.id
+        ))
+    })?;
+    let result = wait_with_bounded_output_supervised(
+        &mut child,
+        PROVIDER_OUTPUT_LIMIT,
+        timeout,
+        Duration::from_millis(100),
+        || false,
+        |_, _| Ok(()),
+    )
+    .map_err(|error| {
         Error::internal_unexpected(format!(
             "wait for external storage provider '{}': {error}",
             provider.id
         ))
     })?;
-    if !result.status.success() || result.stdout.len() > PROVIDER_OUTPUT_LIMIT {
+    if result.termination != SupervisedCommandTermination::Completed
+        || !result.output.status.success()
+    {
         return Err(Error::internal_unexpected(format!(
             "external storage provider '{}' failed or exceeded its output budget",
             provider.id
         )));
     }
-    Ok(result.stdout)
+    Ok(result.output.stdout)
 }
 
 fn invoke_reclaim(
     provider: &ExternalStorageRetentionProviderConfig,
-    item_ids: Vec<String>,
+    generation: &str,
+    reclaim_targets: Vec<ExternalStorageReclaimTarget>,
+    deadline: Option<SystemTime>,
 ) -> Result<ExternalStorageReclaimResult> {
-    let value = invoke_raw(provider, ExternalStorageOperation::Reclaim, item_ids)?;
+    let value = invoke_raw(
+        provider,
+        ExternalStorageOperation::Reclaim,
+        Some(generation.to_string()),
+        reclaim_targets,
+        deadline,
+    )?;
     serde_json::from_slice(&value).map_err(|error| {
         Error::validation_invalid_argument(
             "external_storage_retention provider reclaim response",
@@ -308,6 +432,7 @@ mod tests {
     fn item(id: &str, class: ExternalStorageResourceClass) -> ExternalStorageItem {
         ExternalStorageItem {
             id: id.to_string(),
+            root_id: "root".to_string(),
             class,
             bytes: 10,
             locator: id.to_string(),
@@ -316,6 +441,7 @@ mod tests {
             referenced: false,
             ownership_known: true,
             age_days: 7,
+            reclaim_token: format!("token-{id}"),
         }
     }
 
@@ -334,7 +460,7 @@ mod tests {
             unknown,
             item("credentials", ExternalStorageResourceClass::Credential),
         ];
-        let planned = plan(&inventory, 0, 10);
+        let planned = plan(&inventory, &HashSet::new(), 0, 100, 10);
         assert_eq!(
             planned
                 .iter()
@@ -350,14 +476,64 @@ mod tests {
             item("one", ExternalStorageResourceClass::Scratch),
             item("two", ExternalStorageResourceClass::Scratch),
         ];
-        assert_eq!(plan(&inventory, 0, 1).len(), 1);
+        assert_eq!(plan(&inventory, &HashSet::new(), 0, 100, 1).len(), 1);
+    }
+
+    #[test]
+    fn policy_applies_age_byte_ceiling_and_pressure_without_widening_liveness() {
+        let old = item("old", ExternalStorageResourceClass::Scratch);
+        let mut young = item("young", ExternalStorageResourceClass::Scratch);
+        young.age_days = 0;
+        let mut live = item("live", ExternalStorageResourceClass::Scratch);
+        live.age_days = 0;
+        live.active = true;
+        let mut credential = item("credential", ExternalStorageResourceClass::Credential);
+        credential.age_days = 99;
+        let mut pinned = item("pinned", ExternalStorageResourceClass::PinnedExport);
+        pinned.age_days = 99;
+        let mut referenced = item("referenced", ExternalStorageResourceClass::DurableArtifact);
+        referenced.referenced = true;
+        let inventory = vec![old, young, live, credential, pinned, referenced];
+        assert_eq!(
+            plan(&inventory, &HashSet::new(), 7, 10, 10)
+                .iter()
+                .map(|item| item.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["old"],
+        );
+        let pressured = HashSet::from(["root".to_string()]);
+        assert_eq!(
+            plan(&inventory, &pressured, 7, 20, 10)
+                .iter().map(|item| item.id.as_str()).collect::<Vec<_>>(),
+            vec!["old", "young"],
+            "reserve pressure bypasses age only; live, referenced, credential, and pinned resources remain protected",
+        );
+    }
+
+    #[test]
+    fn stale_generation_and_unconfirmed_receipts_are_rejected() {
+        let candidate = item("scratch", ExternalStorageResourceClass::Scratch);
+        let stale = ExternalStorageReclaimResult {
+            schema: EXTERNAL_STORAGE_RETENTION_SCHEMA.to_string(),
+            provider_id: "fixture".to_string(),
+            generation: "old-generation".to_string(),
+            reclaimed_item_ids: vec!["scratch".to_string()],
+            reclaimed_bytes: 10,
+        };
+        assert!(validate_reclaim_receipt(&stale, "current-generation", &[&candidate]).is_err());
+        let overclaim = ExternalStorageReclaimResult {
+            generation: "current-generation".to_string(),
+            reclaimed_item_ids: vec!["scratch".to_string(), "scratch".to_string()],
+            ..stale
+        };
+        assert!(validate_reclaim_receipt(&overclaim, "current-generation", &[&candidate]).is_err());
     }
 
     #[cfg(unix)]
     #[test]
     fn provider_inventory_is_planned_and_reclaimed_without_path_deletion() {
         let receipt = tempfile::NamedTempFile::new().expect("receipt");
-        let script = r#"input=$(cat); printf '%s' "$input" > "$1"; case "$input" in *'reclaim'*) printf '%s' '{"schema":"homeboy/external-storage-retention/v1","provider_id":"fixture","reclaimed_item_ids":["scratch"],"reclaimed_bytes":12}' ;; *) printf '%s' '{"schema":"homeboy/external-storage-retention/v1","provider_id":"fixture","unknown_bytes":99,"items":[{"id":"scratch","class":"scratch","bytes":12,"locator":"external/tmp/scratch","reconstructable":true,"active":false,"referenced":false,"ownership_known":true,"age_days":7},{"id":"live-db","class":"session_store","bytes":58,"locator":"external/data/live.db","reconstructable":false,"active":true,"referenced":true,"ownership_known":true,"age_days":7}]}' ;; esac"#;
+        let script = r#"input=$(cat); printf '%s' "$input" > "$1"; case "$input" in *'reclaim'*) printf '%s' '{"schema":"homeboy/external-storage-retention/v1","provider_id":"fixture","generation":"g1","reclaimed_item_ids":["scratch"],"reclaimed_bytes":12}' ;; *) printf '%s' '{"schema":"homeboy/external-storage-retention/v1","provider_id":"fixture","generation":"g1","unknown_bytes":99,"items":[{"id":"scratch","root_id":"tmp","class":"scratch","bytes":12,"locator":"external/tmp/scratch","reconstructable":true,"active":false,"referenced":false,"ownership_known":true,"age_days":7,"reclaim_token":"t1"},{"id":"live-db","root_id":"data","class":"session_store","bytes":58,"locator":"external/data/live.db","reconstructable":false,"active":true,"referenced":true,"ownership_known":true,"age_days":7,"reclaim_token":"t2"},{"id":"referenced-output","root_id":"data","class":"durable_artifact","bytes":11,"locator":"external/tool-output","reconstructable":true,"active":false,"referenced":true,"ownership_known":true,"age_days":7,"reclaim_token":"t3"},{"id":"credential","root_id":"data","class":"credential","bytes":2,"locator":"external/auth","reconstructable":true,"active":false,"referenced":false,"ownership_known":true,"age_days":7,"reclaim_token":"t4"},{"id":"pinned","root_id":"data","class":"pinned_export","bytes":3,"locator":"external/export","reconstructable":true,"active":false,"referenced":false,"ownership_known":true,"age_days":7,"reclaim_token":"t5"},{"id":"old-unmanaged","root_id":"tmp","class":"scratch","bytes":4,"locator":"external/old","reconstructable":true,"active":false,"referenced":false,"ownership_known":false,"age_days":7,"reclaim_token":"t6"}]}' ;; esac"#;
         let provider = ExternalStorageRetentionProviderConfig {
             id: "fixture".to_string(),
             command: vec![
@@ -374,8 +550,11 @@ mod tests {
             ExternalStorageCleanupOptions {
                 apply: true,
                 min_age_days: 0,
+                max_bytes: 100,
+                reserve_bytes: 0,
                 limit: 10,
                 evidence_limit: 1,
+                deadline: None,
             },
         )
         .expect("cleanup");

--- a/crates/homeboy-core/src/cleanup/external_storage.rs
+++ b/crates/homeboy-core/src/cleanup/external_storage.rs
@@ -5,7 +5,7 @@
 //! selected identities back for native reclaim. It intentionally never calls
 //! `remove_dir_all` on a provider locator.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::io::Write;
 use std::process::{Command, Stdio};
 use std::time::{Duration, SystemTime};
@@ -126,6 +126,7 @@ pub fn cleanup_external_storage_with_providers(
                 None,
             ));
         }
+        validate_inventory_item_ids(&inventory)?;
         let pressured_roots = pressured_roots(&inventory, options.reserve_bytes);
         let candidates = plan(
             &inventory.items,
@@ -215,6 +216,28 @@ pub fn cleanup_external_storage_with_providers(
         output.providers.push(provider_output);
     }
     Ok(output)
+}
+
+fn validate_inventory_item_ids(inventory: &ExternalStorageInventory) -> Result<()> {
+    let mut seen = HashSet::new();
+    let mut duplicates = BTreeSet::new();
+    for item in &inventory.items {
+        if !seen.insert(item.id.as_str()) {
+            duplicates.insert(item.id.as_str());
+        }
+    }
+    if let Some(id) = duplicates.into_iter().next() {
+        return Err(Error::validation_invalid_argument(
+            "external_storage_retention provider inventory",
+            format!(
+                "provider '{}' returned duplicate item id '{id}'",
+                inventory.provider_id
+            ),
+            Some(inventory.provider_id.clone()),
+            None,
+        ));
+    }
+    Ok(())
 }
 
 fn plan<'a>(
@@ -833,6 +856,41 @@ mod tests {
             },
         );
         assert!(result.is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn duplicate_inventory_ids_fail_before_reclaim() {
+        let receipt = tempfile::NamedTempFile::new().expect("receipt");
+        let script = r#"input=$(cat); printf '%s\n' "$input" >> "$1"; printf '%s' '{"schema":"homeboy/external-storage-retention/v1","provider_id":"duplicate","generation":"g1","items":[{"id":"duplicate","root_id":"root","class":"scratch","bytes":1,"locator":"one","reconstructable":true,"active":false,"referenced":false,"ownership_known":true,"age_days":7,"reclaim_token":"one"},{"id":"duplicate","root_id":"root","class":"scratch","bytes":1,"locator":"two","reconstructable":true,"active":false,"referenced":false,"ownership_known":true,"age_days":7,"reclaim_token":"two"}]}'"#;
+        let provider = ExternalStorageRetentionProviderConfig {
+            id: "duplicate".to_string(),
+            command: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                script.to_string(),
+                "fixture".to_string(),
+                receipt.path().display().to_string(),
+            ],
+            timeout_seconds: 1,
+        };
+        let error = cleanup_external_storage_with_providers(
+            &[provider],
+            ExternalStorageCleanupOptions {
+                apply: true,
+                min_age_days: 0,
+                max_bytes: 10,
+                reserve_bytes: 0,
+                limit: 10,
+                evidence_limit: 1,
+                deadline: None,
+            },
+        )
+        .expect_err("duplicate inventory id");
+        assert!(error.message.contains("duplicate item id 'duplicate'"));
+        let requests = std::fs::read_to_string(receipt.path()).expect("receipt");
+        assert!(requests.contains("inventory"));
+        assert!(!requests.contains("reclaim"));
     }
 
     #[cfg(unix)]

--- a/crates/homeboy-core/src/cleanup/external_storage.rs
+++ b/crates/homeboy-core/src/cleanup/external_storage.rs
@@ -11,13 +11,15 @@ use std::process::{Command, Stdio};
 use std::time::{Duration, SystemTime};
 
 use homeboy_engine_primitives::command::{
-    wait_with_bounded_output_supervised, ControllerChildGuard, SupervisedCommandTermination,
+    terminate_process_tree_and_reap, wait_with_bounded_output_supervised, ControllerChildGuard,
+    SupervisedCommandTermination,
 };
 use homeboy_extension_contract::{
     ExternalStorageInventory, ExternalStorageItem, ExternalStorageOperation,
     ExternalStorageReclaimResult, ExternalStorageReclaimTarget, ExternalStorageRequest,
     ExternalStorageResourceClass, ExternalStorageRetentionProviderConfig,
-    EXTERNAL_STORAGE_RETENTION_SCHEMA,
+    EXTERNAL_STORAGE_RETENTION_SCHEMA, MAX_EXTERNAL_STORAGE_RECLAIM_TARGETS,
+    MAX_EXTERNAL_STORAGE_REQUEST_BYTES,
 };
 use serde::Serialize;
 
@@ -97,6 +99,8 @@ pub fn cleanup_external_storage_with_providers(
         unknown_bytes: 0,
         providers: Vec::new(),
     };
+    let mut remaining_count = options.limit;
+    let mut remaining_bytes = options.max_bytes;
     for provider in providers {
         if !seen.insert(&provider.id) {
             return Err(Error::validation_invalid_argument(
@@ -126,10 +130,12 @@ pub fn cleanup_external_storage_with_providers(
             &inventory.items,
             &pressured_roots,
             options.min_age_days,
-            options.max_bytes,
-            options.limit,
+            remaining_bytes,
+            remaining_count,
         );
         let estimated_bytes = candidates.iter().map(|item| item.bytes).sum();
+        remaining_count = remaining_count.saturating_sub(candidates.len());
+        remaining_bytes = remaining_bytes.saturating_sub(estimated_bytes);
         let targets = candidates
             .iter()
             .map(|item| ExternalStorageReclaimTarget {
@@ -324,6 +330,14 @@ fn invoke_raw(
             None,
         ));
     };
+    if reclaim_targets.len() > MAX_EXTERNAL_STORAGE_RECLAIM_TARGETS {
+        return Err(Error::validation_invalid_argument(
+            "external_storage_retention provider request",
+            "reclaim request exceeds the protocol target ceiling",
+            Some(provider.id.clone()),
+            None,
+        ));
+    }
     let request = serde_json::to_vec(&ExternalStorageRequest {
         schema: EXTERNAL_STORAGE_RETENTION_SCHEMA.to_string(),
         operation,
@@ -336,6 +350,14 @@ fn invoke_raw(
             Some("serialize external storage request".to_string()),
         )
     })?;
+    if request.len() > MAX_EXTERNAL_STORAGE_REQUEST_BYTES {
+        return Err(Error::validation_invalid_argument(
+            "external_storage_retention provider request",
+            "reclaim request exceeds the protocol target or byte ceiling",
+            Some(provider.id.clone()),
+            None,
+        ));
+    }
     let timeout = deadline
         .and_then(|deadline| deadline.duration_since(SystemTime::now()).ok())
         .map(|remaining| remaining.min(Duration::from_secs(provider.timeout_seconds)))
@@ -363,31 +385,39 @@ fn invoke_raw(
             provider.id
         ))
     })?;
-    let mut stdin = child.stdin.take().expect("piped stdin");
-    stdin.write_all(&request).map_err(|error| {
-        Error::internal_unexpected(format!(
-            "write external storage provider '{}': {error}",
-            provider.id
-        ))
-    })?;
-    drop(stdin);
-    guard.attach(&child).map_err(|error| {
+    attach_guard_or_reap(&mut child, |child| guard.attach(child)).map_err(|error| {
         Error::internal_unexpected(format!(
             "attach external storage provider guard '{}': {error}",
             provider.id
         ))
     })?;
-    let result = wait_with_bounded_output_supervised(
+    // Start stdin delivery only after process-tree ownership is established.
+    // The writer can block on a provider that never reads, while the supervisor
+    // concurrently drains output and kills the tree at the shared deadline.
+    let mut stdin = child.stdin.take().expect("piped stdin");
+    let writer = std::thread::spawn(move || stdin.write_all(&request));
+    let supervised = wait_with_bounded_output_supervised(
         &mut child,
         PROVIDER_OUTPUT_LIMIT,
         timeout,
         Duration::from_millis(100),
         || false,
         |_, _| Ok(()),
-    )
-    .map_err(|error| {
+    );
+    // Always join delivery, including a supervision I/O failure, so no writer
+    // remains detached after the process tree has been reaped.
+    let write_result = writer.join().map_err(|_| {
+        Error::internal_unexpected("external storage provider stdin writer panicked")
+    })?;
+    let result = supervised.map_err(|error| {
         Error::internal_unexpected(format!(
             "wait for external storage provider '{}': {error}",
+            provider.id
+        ))
+    })?;
+    write_result.map_err(|error| {
+        Error::internal_unexpected(format!(
+            "write external storage provider '{}': {error}",
             provider.id
         ))
     })?;
@@ -400,6 +430,17 @@ fn invoke_raw(
         )));
     }
     Ok(result.output.stdout)
+}
+
+fn attach_guard_or_reap(
+    child: &mut std::process::Child,
+    attach: impl FnOnce(&std::process::Child) -> std::io::Result<()>,
+) -> std::io::Result<()> {
+    if let Err(error) = attach(child) {
+        let _ = terminate_process_tree_and_reap(child);
+        return Err(error);
+    }
+    Ok(())
 }
 
 fn invoke_reclaim(
@@ -527,6 +568,95 @@ mod tests {
             ..stale
         };
         assert!(validate_reclaim_receipt(&overclaim, "current-generation", &[&candidate]).is_err());
+    }
+
+    #[cfg(unix)]
+    fn inventory_provider(id: &str, item_id: &str) -> ExternalStorageRetentionProviderConfig {
+        let inventory = serde_json::json!({
+            "schema": EXTERNAL_STORAGE_RETENTION_SCHEMA, "provider_id": id, "generation": "g1",
+            "items": [{
+                "id": item_id, "root_id": "root", "class": "scratch", "bytes": 10,
+                "locator": item_id, "reconstructable": true, "active": false,
+                "referenced": false, "ownership_known": true, "age_days": 7,
+                "reclaim_token": format!("token-{item_id}")
+            }]
+        });
+        ExternalStorageRetentionProviderConfig {
+            id: id.to_string(),
+            command: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                format!("printf '%s' '{}'", inventory),
+                "fixture".to_string(),
+            ],
+            timeout_seconds: 1,
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn aggregate_limit_is_not_reset_for_each_provider() {
+        let output = cleanup_external_storage_with_providers(
+            &[
+                inventory_provider("one", "one"),
+                inventory_provider("two", "two"),
+            ],
+            ExternalStorageCleanupOptions {
+                apply: false,
+                min_age_days: 0,
+                max_bytes: 10,
+                reserve_bytes: 0,
+                limit: 1,
+                evidence_limit: 10,
+                deadline: None,
+            },
+        )
+        .expect("plan");
+        assert_eq!(output.candidate_count, 1);
+        assert_eq!(output.estimated_bytes, 10);
+        assert_eq!(output.providers[0].candidate_count, 1);
+        assert_eq!(output.providers[1].candidate_count, 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn blocked_provider_stdin_is_cancelled_by_supervision() {
+        let provider = ExternalStorageRetentionProviderConfig {
+            id: "blocked".to_string(),
+            command: vec!["sh".to_string(), "-c".to_string(), "sleep 5".to_string()],
+            timeout_seconds: 1,
+        };
+        let targets = (0..MAX_EXTERNAL_STORAGE_RECLAIM_TARGETS)
+            .map(|index| ExternalStorageReclaimTarget {
+                id: index.to_string(),
+                reclaim_token: "x".repeat(200),
+            })
+            .collect();
+        let started = std::time::Instant::now();
+        assert!(invoke_raw(
+            &provider,
+            ExternalStorageOperation::Reclaim,
+            Some("g1".to_string()),
+            targets,
+            None
+        )
+        .is_err());
+        assert!(started.elapsed() < Duration::from_secs(3));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn guard_attach_failure_reaps_spawned_process() {
+        let mut command = Command::new("sh");
+        command.arg("-c").arg("sleep 5");
+        let guard = ControllerChildGuard::prepare(&mut command).expect("guard");
+        let mut child = command.spawn().expect("spawn");
+        let result = attach_guard_or_reap(&mut child, |_| {
+            Err(std::io::Error::other("fixture attach failure"))
+        });
+        assert!(result.is_err());
+        assert!(child.try_wait().expect("poll").is_some());
+        drop(guard);
     }
 
     #[cfg(unix)]

--- a/crates/homeboy-core/src/cleanup/external_storage.rs
+++ b/crates/homeboy-core/src/cleanup/external_storage.rs
@@ -132,6 +132,7 @@ pub fn cleanup_external_storage_with_providers(
             options.min_age_days,
             remaining_bytes,
             remaining_count,
+            &inventory.generation,
         );
         let estimated_bytes = candidates.iter().map(|item| item.bytes).sum();
         remaining_count = remaining_count.saturating_sub(candidates.len());
@@ -197,13 +198,11 @@ fn plan<'a>(
     min_age_days: u64,
     max_bytes: u64,
     limit: usize,
+    generation: &str,
 ) -> Vec<&'a ExternalStorageItem> {
     let mut selected = Vec::new();
     let mut selected_bytes = 0_u64;
     for item in items {
-        if selected.len() >= limit || selected_bytes.saturating_add(item.bytes) > max_bytes {
-            continue;
-        }
         if !item.ownership_known
             || !item.reconstructable
             || item.active
@@ -217,10 +216,41 @@ fn plan<'a>(
         {
             continue;
         }
+        if selected.len() >= limit.min(MAX_EXTERNAL_STORAGE_RECLAIM_TARGETS)
+            || selected_bytes.saturating_add(item.bytes) > max_bytes
+        {
+            break;
+        }
+        if !reclaim_request_fits(
+            generation,
+            selected
+                .iter()
+                .copied()
+                .chain(std::iter::once(item))
+                .map(|item| ExternalStorageReclaimTarget {
+                    id: item.id.clone(),
+                    reclaim_token: item.reclaim_token.clone(),
+                }),
+        ) {
+            break;
+        }
         selected_bytes = selected_bytes.saturating_add(item.bytes);
         selected.push(item);
     }
     selected
+}
+
+fn reclaim_request_fits(
+    generation: &str,
+    reclaim_targets: impl Iterator<Item = ExternalStorageReclaimTarget>,
+) -> bool {
+    serde_json::to_vec(&ExternalStorageRequest {
+        schema: EXTERNAL_STORAGE_RETENTION_SCHEMA.to_string(),
+        operation: ExternalStorageOperation::Reclaim,
+        generation: Some(generation.to_string()),
+        reclaim_targets: reclaim_targets.collect(),
+    })
+    .is_ok_and(|request| request.len() <= MAX_EXTERNAL_STORAGE_REQUEST_BYTES)
 }
 
 fn pressured_roots(inventory: &ExternalStorageInventory, reserve_bytes: u64) -> HashSet<String> {
@@ -358,10 +388,13 @@ fn invoke_raw(
             None,
         ));
     }
-    let timeout = deadline
-        .and_then(|deadline| deadline.duration_since(SystemTime::now()).ok())
-        .map(|remaining| remaining.min(Duration::from_secs(provider.timeout_seconds)))
-        .unwrap_or_else(|| Duration::from_secs(provider.timeout_seconds));
+    let remaining = match deadline {
+        Some(deadline) => deadline.duration_since(SystemTime::now()).map_err(|_| {
+            Error::internal_unexpected("external storage retention deadline elapsed")
+        })?,
+        None => Duration::from_secs(provider.timeout_seconds),
+    };
+    let timeout = remaining.min(Duration::from_secs(provider.timeout_seconds));
     if timeout.is_zero() {
         return Err(Error::internal_unexpected(
             "external storage retention deadline elapsed",
@@ -385,7 +418,12 @@ fn invoke_raw(
             provider.id
         ))
     })?;
-    attach_guard_or_reap(&mut child, |child| guard.attach(child)).map_err(|error| {
+    attach_guard_or_reap(
+        &mut child,
+        |child| guard.attach(child),
+        terminate_process_tree_and_reap,
+    )
+    .map_err(|error| {
         Error::internal_unexpected(format!(
             "attach external storage provider guard '{}': {error}",
             provider.id
@@ -435,12 +473,40 @@ fn invoke_raw(
 fn attach_guard_or_reap(
     child: &mut std::process::Child,
     attach: impl FnOnce(&std::process::Child) -> std::io::Result<()>,
+    reap: impl FnOnce(&mut std::process::Child) -> std::io::Result<std::process::ExitStatus>,
 ) -> std::io::Result<()> {
     if let Err(error) = attach(child) {
-        let _ = terminate_process_tree_and_reap(child);
-        return Err(error);
+        match reap(child) {
+            Ok(_) if child.try_wait()?.is_some() => return Err(error),
+            Ok(_) => {}
+            Err(cleanup_error) => {
+                return force_reap_after_attach_failure(child, error, cleanup_error);
+            }
+        }
+        return force_reap_after_attach_failure(
+            child,
+            error,
+            std::io::Error::other("guard cleanup returned without reaping the child"),
+        );
     }
     Ok(())
+}
+
+fn force_reap_after_attach_failure(
+    child: &mut std::process::Child,
+    attach_error: std::io::Error,
+    cleanup_error: std::io::Error,
+) -> std::io::Result<()> {
+    let kill_error = child.kill().err();
+    let wait_error = child.wait().err();
+    let fallback = match (kill_error, wait_error) {
+        (_, Some(error)) => format!("fallback reap failed: {error}"),
+        (Some(error), None) => format!("fallback kill failed: {error}"),
+        (None, None) => "fallback child kill and reap succeeded".to_string(),
+    };
+    Err(std::io::Error::other(format!(
+        "guard attach failed: {attach_error}; process-tree cleanup failed: {cleanup_error}; {fallback}"
+    )))
 }
 
 fn invoke_reclaim(
@@ -501,7 +567,7 @@ mod tests {
             unknown,
             item("credentials", ExternalStorageResourceClass::Credential),
         ];
-        let planned = plan(&inventory, &HashSet::new(), 0, 100, 10);
+        let planned = plan(&inventory, &HashSet::new(), 0, 100, 10, "generation");
         assert_eq!(
             planned
                 .iter()
@@ -517,7 +583,41 @@ mod tests {
             item("one", ExternalStorageResourceClass::Scratch),
             item("two", ExternalStorageResourceClass::Scratch),
         ];
-        assert_eq!(plan(&inventory, &HashSet::new(), 0, 100, 1).len(), 1);
+        assert_eq!(
+            plan(&inventory, &HashSet::new(), 0, 100, 1, "generation").len(),
+            1
+        );
+    }
+
+    #[test]
+    fn plan_uses_the_serialized_reclaim_prefix_including_opaque_tokens() {
+        let mut inventory = (0..MAX_EXTERNAL_STORAGE_RECLAIM_TARGETS + 1)
+            .map(|index| {
+                item(
+                    &format!("item-{index}"),
+                    ExternalStorageResourceClass::Scratch,
+                )
+            })
+            .collect::<Vec<_>>();
+        for item in &mut inventory {
+            item.reclaim_token = "x".repeat(300);
+        }
+        let planned = plan(
+            &inventory,
+            &HashSet::new(),
+            0,
+            u64::MAX,
+            usize::MAX,
+            "generation",
+        );
+        assert!(planned.len() < MAX_EXTERNAL_STORAGE_RECLAIM_TARGETS);
+        assert!(reclaim_request_fits(
+            "generation",
+            planned.iter().map(|item| ExternalStorageReclaimTarget {
+                id: item.id.clone(),
+                reclaim_token: item.reclaim_token.clone(),
+            }),
+        ));
     }
 
     #[test]
@@ -536,7 +636,7 @@ mod tests {
         referenced.referenced = true;
         let inventory = vec![old, young, live, credential, pinned, referenced];
         assert_eq!(
-            plan(&inventory, &HashSet::new(), 7, 10, 10)
+            plan(&inventory, &HashSet::new(), 7, 10, 10, "generation")
                 .iter()
                 .map(|item| item.id.as_str())
                 .collect::<Vec<_>>(),
@@ -544,7 +644,7 @@ mod tests {
         );
         let pressured = HashSet::from(["root".to_string()]);
         assert_eq!(
-            plan(&inventory, &pressured, 7, 20, 10)
+            plan(&inventory, &pressured, 7, 20, 10, "generation")
                 .iter().map(|item| item.id.as_str()).collect::<Vec<_>>(),
             vec!["old", "young"],
             "reserve pressure bypasses age only; live, referenced, credential, and pinned resources remain protected",
@@ -646,15 +746,47 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn expired_aggregate_deadline_does_not_spawn_a_provider() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let marker = directory.path().join("spawned");
+        let provider = ExternalStorageRetentionProviderConfig {
+            id: "expired".to_string(),
+            command: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                format!("touch '{}'", marker.display()),
+            ],
+            timeout_seconds: 30,
+        };
+        let error = invoke_raw(
+            &provider,
+            ExternalStorageOperation::Inventory,
+            None,
+            Vec::new(),
+            Some(SystemTime::now() - Duration::from_secs(1)),
+        )
+        .expect_err("expired deadline");
+        assert!(error.message.contains("deadline elapsed"));
+        assert!(!marker.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn guard_attach_failure_reaps_spawned_process() {
         let mut command = Command::new("sh");
         command.arg("-c").arg("sleep 5");
         let guard = ControllerChildGuard::prepare(&mut command).expect("guard");
         let mut child = command.spawn().expect("spawn");
-        let result = attach_guard_or_reap(&mut child, |_| {
-            Err(std::io::Error::other("fixture attach failure"))
-        });
+        let result = attach_guard_or_reap(
+            &mut child,
+            |_| Err(std::io::Error::other("fixture attach failure")),
+            |_| Err(std::io::Error::other("fixture cleanup failure")),
+        );
         assert!(result.is_err());
+        assert!(result
+            .expect_err("failure")
+            .to_string()
+            .contains("fixture cleanup failure"));
         assert!(child.try_wait().expect("poll").is_some());
         drop(guard);
     }

--- a/crates/homeboy-core/src/cleanup/external_storage.rs
+++ b/crates/homeboy-core/src/cleanup/external_storage.rs
@@ -1,0 +1,393 @@
+//! Generic execution and policy for extension-owned external storage.
+//!
+//! The extension provider is the only code that understands its roots and its
+//! durable store. Core validates inventory, applies lifecycle policy, and sends
+//! selected identities back for native reclaim. It intentionally never calls
+//! `remove_dir_all` on a provider locator.
+
+use std::collections::HashSet;
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use homeboy_extension_contract::{
+    ExternalStorageInventory, ExternalStorageItem, ExternalStorageOperation,
+    ExternalStorageReclaimResult, ExternalStorageRequest, ExternalStorageResourceClass,
+    ExternalStorageRetentionProviderConfig, EXTERNAL_STORAGE_RETENTION_SCHEMA,
+};
+use serde::Serialize;
+
+use crate::{Error, Result};
+
+const PROVIDER_OUTPUT_LIMIT: usize = 1024 * 1024;
+const PROVIDER_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+#[derive(Debug, Clone)]
+pub struct ExternalStorageCleanupOptions {
+    pub apply: bool,
+    pub min_age_days: u64,
+    pub limit: usize,
+    pub evidence_limit: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ExternalStorageCleanupOutput {
+    pub provider_count: usize,
+    pub candidate_count: usize,
+    pub applied_count: usize,
+    pub skipped_count: usize,
+    pub estimated_bytes: u64,
+    pub reclaimed_bytes: u64,
+    pub unknown_bytes: u64,
+    pub providers: Vec<ExternalStorageProviderOutput>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ExternalStorageProviderOutput {
+    pub provider_id: String,
+    pub candidate_count: usize,
+    pub applied_count: usize,
+    pub skipped_count: usize,
+    pub estimated_bytes: u64,
+    pub reclaimed_bytes: u64,
+    pub unknown_bytes: u64,
+    pub candidates: Vec<ExternalStorageEvidence>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ExternalStorageEvidence {
+    pub id: String,
+    pub class: ExternalStorageResourceClass,
+    pub bytes: u64,
+    pub locator: String,
+}
+
+/// Discover every installed provider and execute one bounded policy pass.
+pub fn cleanup_external_storage_from_extensions(
+    options: ExternalStorageCleanupOptions,
+) -> Result<ExternalStorageCleanupOutput> {
+    let providers = crate::extension_store::load_all_extensions()?
+        .into_iter()
+        .flat_map(|extension| extension.external_storage_retention.providers)
+        .collect::<Vec<_>>();
+    cleanup_external_storage_with_providers(&providers, options)
+}
+
+/// Execute explicit provider declarations. Kept public for deterministic
+/// embeddings and tests; normal callers discover declarations from extensions.
+pub fn cleanup_external_storage_with_providers(
+    providers: &[ExternalStorageRetentionProviderConfig],
+    options: ExternalStorageCleanupOptions,
+) -> Result<ExternalStorageCleanupOutput> {
+    let mut seen = HashSet::new();
+    let mut output = ExternalStorageCleanupOutput {
+        provider_count: providers.len(),
+        candidate_count: 0,
+        applied_count: 0,
+        skipped_count: 0,
+        estimated_bytes: 0,
+        reclaimed_bytes: 0,
+        unknown_bytes: 0,
+        providers: Vec::new(),
+    };
+    for provider in providers {
+        if !seen.insert(&provider.id) {
+            return Err(Error::validation_invalid_argument(
+                "external_storage_retention.providers",
+                format!("duplicate external storage provider id '{}'", provider.id),
+                None,
+                None,
+            ));
+        }
+        let inventory = invoke(provider, ExternalStorageOperation::Inventory, Vec::new())?;
+        if inventory.schema != EXTERNAL_STORAGE_RETENTION_SCHEMA
+            || inventory.provider_id != provider.id
+        {
+            return Err(Error::validation_invalid_argument(
+                "external_storage_retention provider response",
+                "provider returned an unexpected schema or provider id",
+                Some(provider.id.clone()),
+                None,
+            ));
+        }
+        let candidates = plan(&inventory.items, options.min_age_days, options.limit);
+        let estimated_bytes = candidates.iter().map(|item| item.bytes).sum();
+        let item_ids = candidates.iter().map(|item| item.id.clone()).collect();
+        let reclaimed_bytes = if options.apply && !candidates.is_empty() {
+            // A provider performs deletion/compaction atomically in its own
+            // model. Core's candidate bytes are accounting, not path authority.
+            let reclaim = invoke_reclaim(provider, item_ids)?;
+            if reclaim.schema != EXTERNAL_STORAGE_RETENTION_SCHEMA
+                || reclaim.provider_id != provider.id
+            {
+                return Err(Error::internal_unexpected(
+                    "external storage provider returned an invalid reclaim response",
+                ));
+            }
+            reclaim.reclaimed_bytes
+        } else {
+            0
+        };
+        let evidence = candidates
+            .iter()
+            .take(options.evidence_limit)
+            .map(|item| evidence(item))
+            .collect();
+        let provider_output = ExternalStorageProviderOutput {
+            provider_id: provider.id.clone(),
+            candidate_count: candidates.len(),
+            applied_count: if options.apply { candidates.len() } else { 0 },
+            skipped_count: inventory.items.len().saturating_sub(candidates.len()),
+            estimated_bytes,
+            reclaimed_bytes,
+            unknown_bytes: inventory.unknown_bytes,
+            candidates: evidence,
+        };
+        output.candidate_count += provider_output.candidate_count;
+        output.applied_count += provider_output.applied_count;
+        output.skipped_count += provider_output.skipped_count;
+        output.estimated_bytes += provider_output.estimated_bytes;
+        output.reclaimed_bytes += provider_output.reclaimed_bytes;
+        output.unknown_bytes += provider_output.unknown_bytes;
+        output.providers.push(provider_output);
+    }
+    Ok(output)
+}
+
+fn plan(
+    items: &[ExternalStorageItem],
+    min_age_days: u64,
+    limit: usize,
+) -> Vec<&ExternalStorageItem> {
+    items
+        .iter()
+        .filter(|item| item.ownership_known)
+        .filter(|item| item.reconstructable)
+        .filter(|item| !item.active && !item.referenced)
+        .filter(|item| {
+            !matches!(
+                item.class,
+                ExternalStorageResourceClass::Credential
+                    | ExternalStorageResourceClass::PinnedExport
+            )
+        })
+        .filter(|item| item.age_days >= min_age_days)
+        .take(limit)
+        .collect()
+}
+
+fn evidence(item: &ExternalStorageItem) -> ExternalStorageEvidence {
+    ExternalStorageEvidence {
+        id: item.id.clone(),
+        class: item.class.clone(),
+        bytes: item.bytes,
+        locator: item.locator.clone(),
+    }
+}
+
+fn invoke(
+    provider: &ExternalStorageRetentionProviderConfig,
+    operation: ExternalStorageOperation,
+    item_ids: Vec<String>,
+) -> Result<ExternalStorageInventory> {
+    let value = invoke_raw(provider, operation, item_ids)?;
+    serde_json::from_slice(&value).map_err(|error| {
+        Error::validation_invalid_argument(
+            "external_storage_retention provider response",
+            format!("invalid JSON: {error}"),
+            Some(provider.id.clone()),
+            None,
+        )
+    })
+}
+
+fn invoke_raw(
+    provider: &ExternalStorageRetentionProviderConfig,
+    operation: ExternalStorageOperation,
+    item_ids: Vec<String>,
+) -> Result<Vec<u8>> {
+    let Some((program, args)) = provider.command.split_first() else {
+        return Err(Error::validation_invalid_argument(
+            "external_storage_retention.providers.command",
+            "provider command must not be empty",
+            Some(provider.id.clone()),
+            None,
+        ));
+    };
+    let request = serde_json::to_vec(&ExternalStorageRequest {
+        schema: EXTERNAL_STORAGE_RETENTION_SCHEMA.to_string(),
+        operation,
+        item_ids,
+    })
+    .map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize external storage request".to_string()),
+        )
+    })?;
+    let mut child = Command::new(program)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| {
+            Error::internal_unexpected(format!(
+                "start external storage provider '{}': {error}",
+                provider.id
+            ))
+        })?;
+    let mut stdin = child.stdin.take().expect("piped stdin");
+    stdin.write_all(&request).map_err(|error| {
+        Error::internal_unexpected(format!(
+            "write external storage provider '{}': {error}",
+            provider.id
+        ))
+    })?;
+    drop(stdin);
+    let deadline = Instant::now()
+        .checked_add(Duration::from_secs(provider.timeout_seconds))
+        .unwrap_or_else(Instant::now);
+    loop {
+        if child
+            .try_wait()
+            .map_err(|error| {
+                Error::internal_unexpected(format!(
+                    "poll external storage provider '{}': {error}",
+                    provider.id
+                ))
+            })?
+            .is_some()
+        {
+            break;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(Error::internal_unexpected(format!(
+                "external storage provider '{}' exceeded its timeout",
+                provider.id
+            )));
+        }
+        std::thread::sleep(PROVIDER_POLL_INTERVAL);
+    }
+    let result = child.wait_with_output().map_err(|error| {
+        Error::internal_unexpected(format!(
+            "wait for external storage provider '{}': {error}",
+            provider.id
+        ))
+    })?;
+    if !result.status.success() || result.stdout.len() > PROVIDER_OUTPUT_LIMIT {
+        return Err(Error::internal_unexpected(format!(
+            "external storage provider '{}' failed or exceeded its output budget",
+            provider.id
+        )));
+    }
+    Ok(result.stdout)
+}
+
+fn invoke_reclaim(
+    provider: &ExternalStorageRetentionProviderConfig,
+    item_ids: Vec<String>,
+) -> Result<ExternalStorageReclaimResult> {
+    let value = invoke_raw(provider, ExternalStorageOperation::Reclaim, item_ids)?;
+    serde_json::from_slice(&value).map_err(|error| {
+        Error::validation_invalid_argument(
+            "external_storage_retention provider reclaim response",
+            format!("invalid JSON: {error}"),
+            Some(provider.id.clone()),
+            None,
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(id: &str, class: ExternalStorageResourceClass) -> ExternalStorageItem {
+        ExternalStorageItem {
+            id: id.to_string(),
+            class,
+            bytes: 10,
+            locator: id.to_string(),
+            reconstructable: true,
+            active: false,
+            referenced: false,
+            ownership_known: true,
+            age_days: 7,
+        }
+    }
+
+    #[test]
+    fn plan_reclaims_only_terminal_unreferenced_reconstructable_resources() {
+        let mut active = item("active", ExternalStorageResourceClass::Scratch);
+        active.active = true;
+        let mut referenced = item("referenced", ExternalStorageResourceClass::DurableArtifact);
+        referenced.referenced = true;
+        let mut unknown = item("old-unmanaged", ExternalStorageResourceClass::Scratch);
+        unknown.ownership_known = false;
+        let inventory = vec![
+            item("terminal-scratch", ExternalStorageResourceClass::Scratch),
+            active,
+            referenced,
+            unknown,
+            item("credentials", ExternalStorageResourceClass::Credential),
+        ];
+        let planned = plan(&inventory, 0, 10);
+        assert_eq!(
+            planned
+                .iter()
+                .map(|item| item.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["terminal-scratch"]
+        );
+    }
+
+    #[test]
+    fn plan_is_bounded_before_evidence_is_rendered() {
+        let inventory = vec![
+            item("one", ExternalStorageResourceClass::Scratch),
+            item("two", ExternalStorageResourceClass::Scratch),
+        ];
+        assert_eq!(plan(&inventory, 0, 1).len(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn provider_inventory_is_planned_and_reclaimed_without_path_deletion() {
+        let receipt = tempfile::NamedTempFile::new().expect("receipt");
+        let script = r#"input=$(cat); printf '%s' "$input" > "$1"; case "$input" in *'reclaim'*) printf '%s' '{"schema":"homeboy/external-storage-retention/v1","provider_id":"fixture","reclaimed_item_ids":["scratch"],"reclaimed_bytes":12}' ;; *) printf '%s' '{"schema":"homeboy/external-storage-retention/v1","provider_id":"fixture","unknown_bytes":99,"items":[{"id":"scratch","class":"scratch","bytes":12,"locator":"external/tmp/scratch","reconstructable":true,"active":false,"referenced":false,"ownership_known":true,"age_days":7},{"id":"live-db","class":"session_store","bytes":58,"locator":"external/data/live.db","reconstructable":false,"active":true,"referenced":true,"ownership_known":true,"age_days":7}]}' ;; esac"#;
+        let provider = ExternalStorageRetentionProviderConfig {
+            id: "fixture".to_string(),
+            command: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                script.to_string(),
+                "fixture".to_string(),
+                receipt.path().display().to_string(),
+            ],
+            timeout_seconds: 1,
+        };
+        let output = cleanup_external_storage_with_providers(
+            &[provider],
+            ExternalStorageCleanupOptions {
+                apply: true,
+                min_age_days: 0,
+                limit: 10,
+                evidence_limit: 1,
+            },
+        )
+        .expect("cleanup");
+        assert_eq!(output.candidate_count, 1);
+        assert_eq!(output.reclaimed_bytes, 12);
+        assert_eq!(output.unknown_bytes, 99);
+        assert_eq!(
+            output.providers[0].candidates[0].locator,
+            "external/tmp/scratch"
+        );
+        assert!(std::fs::read_to_string(receipt.path())
+            .expect("receipt")
+            .contains("reclaim"));
+    }
+}

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -244,6 +244,12 @@ pub struct RetentionConfig {
     /// artifact retention may bypass its age floor before managed work starts.
     #[serde(default = "default_reconstructable_artifact_reserve_bytes")]
     pub reconstructable_artifact_reserve_bytes: u64,
+    #[serde(default = "default_external_storage_retention_days")]
+    pub external_storage_days: u64,
+    #[serde(default = "default_external_storage_max_bytes")]
+    pub external_storage_max_bytes: u64,
+    #[serde(default = "default_external_storage_reserve_bytes")]
+    pub external_storage_reserve_bytes: u64,
     /// Cooperative wall-clock budget for one automatic pass. Category owners
     /// finish an in-progress safe mutation before the executor yields.
     #[serde(default = "default_automatic_retention_max_run_seconds")]
@@ -268,6 +274,9 @@ impl Default for RetentionConfig {
             reconstructable_artifact_days: default_reconstructable_artifact_retention_days(),
             reconstructable_artifact_reserve_bytes: default_reconstructable_artifact_reserve_bytes(
             ),
+            external_storage_days: default_external_storage_retention_days(),
+            external_storage_max_bytes: default_external_storage_max_bytes(),
+            external_storage_reserve_bytes: default_external_storage_reserve_bytes(),
             automatic_retention_max_run_seconds: default_automatic_retention_max_run_seconds(),
         }
     }
@@ -326,6 +335,16 @@ fn default_reconstructable_artifact_retention_days() -> u64 {
 }
 
 fn default_reconstructable_artifact_reserve_bytes() -> u64 {
+    20 * 1024 * 1024 * 1024
+}
+
+fn default_external_storage_retention_days() -> u64 {
+    7
+}
+fn default_external_storage_max_bytes() -> u64 {
+    20 * 1024 * 1024 * 1024
+}
+fn default_external_storage_reserve_bytes() -> u64 {
     20 * 1024 * 1024 * 1024
 }
 


### PR DESCRIPTION
## Summary

- add a versioned extension contract for provider-owned external storage inventory and reclaim
- keep Homeboy runtime-agnostic: providers own opaque identities, references, liveness, generation tokens, and native compaction
- enforce active/reference/credential/pinned/unknown vetoes, aggregate age/byte/reserve/deadline limits, bounded process-tree execution, request/output ceilings, and validated receipts
- integrate `external-storage` into manual and automatic cleanup with deterministic evidence

## Verification

- `cargo test -p homeboy-extension-contract external_storage_retention --lib`
- `cargo test -p homeboy-core cleanup::external_storage --lib` (16 passed)
- `cargo test -p homeboy-cli commands::cleanup --lib`
- `cargo check -p homeboy`
- `cargo fmt --check`

Implements the core contract for #13174. The concrete OpenCode provider is tracked by Extra-Chill/homeboy-extensions#2678.

## AI Assistance

OpenAI `gpt-5.6-sol` via OpenCode general coding and independent review subagents designed, implemented, adversarially reviewed, and verified the generic retention protocol under Chris Huber direction. Chris remains responsible for every line.