### PR TITLE
Fix Lab child daemon state resolution

### DIFF
--- a/crates/homeboy-core/src/runner_job_execution_context.rs
+++ b/crates/homeboy-core/src/runner_job_execution_context.rs
@@ -683,6 +683,9 @@ mod tests {
             let _job = EnvVarGuard::set(RUNNER_JOB_ID_ENV, job.id.to_string());
             let _reservation = EnvVarGuard::set(RUNNER_CHILD_RESERVATION_ENV, &reservation_id);
             let _context = EnvVarGuard::set(RUNNER_JOB_EXECUTION_CONTEXT_ID_ENV, context.id());
+            // Lab execution bundles redirect HOME for extension isolation. The
+            // daemon state selector must keep this child attached to its parent.
+            let _execution_home = EnvVarGuard::set("HOME", "/runner/job/home");
             let resolved =
                 RunnerJobExecutionContext::from_direct_daemon_child_environment(runner_id)
                     .expect("resolve accepted authority")

--- a/crates/homeboy-lab-runner/src/execution/process.rs
+++ b/crates/homeboy-lab-runner/src/execution/process.rs
@@ -1407,7 +1407,16 @@ fn validated_runner_inherited_env(
 }
 
 pub(super) fn inherited_runner_process_env_keys() -> &'static [&'static str] {
-    &["HOME", "USER", "LOGNAME", "SHELL", "TMPDIR", "TEMP", "TMP"]
+    &[
+        "HOME",
+        "USER",
+        "LOGNAME",
+        "SHELL",
+        "TMPDIR",
+        "TEMP",
+        "TMP",
+        homeboy_core::paths::DAEMON_STATE_DIR_ENV,
+    ]
 }
 
 pub(super) fn command_output(

--- a/crates/homeboy-lab-runner/src/execution/tests/exec.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/exec.rs
@@ -10,6 +10,7 @@ use homeboy_core::runner_execution_envelope::{
 use serde_json::json;
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::process::Command;
 
 #[test]
 fn extension_runtime_home_keeps_homeboy_data_on_the_runner() {
@@ -23,9 +24,51 @@ fn extension_runtime_home_keeps_homeboy_data_on_the_runner() {
 }
 
 #[test]
-fn runner_child_inherits_the_daemon_state_selector() {
-    assert!(
-        inherited_runner_process_env_keys().contains(&homeboy_core::paths::DAEMON_STATE_DIR_ENV)
+fn runner_child_environment_keeps_daemon_state_with_redirected_home() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let daemon_state_dir = workspace.path().join("daemon-state");
+    let _env_lock = homeboy_core::test_support::env_lock();
+    let _daemon_state = homeboy_core::test_support::EnvVarGuard::set(
+        homeboy_core::paths::DAEMON_STATE_DIR_ENV,
+        daemon_state_dir.as_os_str(),
+    );
+    let plan = prepare_daemon_local_process(RunnerProcessRequest {
+        runner_id: "lab".to_string(),
+        runner: Some(local_runner(workspace.path().display().to_string())),
+        cwd: Some(workspace.path().display().to_string()),
+        project_id: None,
+        command: vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            format!(
+                "printf '%s' \"${}\"",
+                homeboy_core::paths::DAEMON_STATE_DIR_ENV
+            ),
+        ],
+        env: HashMap::from([("HOME".to_string(), "/runner/job/home".to_string())]),
+        secret_env_names: Vec::new(),
+        secret_env_plan: None,
+        capture_patch: false,
+        raw_exec: false,
+        source_snapshot: None,
+        require_paths: Vec::new(),
+        validate_require_paths_on_host: false,
+    })
+    .expect("prepare daemon child");
+    let temp_owner = homeboy_core::engine::temp::RuntimeTempOwner::allocate(
+        "homeboy-runner-tmp",
+        "runner_execution",
+    )
+    .expect("allocate child temp owner");
+    let mut child = Command::new(&plan.command[0]);
+    child.args(&plan.command[1..]).current_dir(&plan.cwd);
+    apply_runner_process_env(&mut child, &plan, &temp_owner).expect("prepare child environment");
+
+    let output = child.output().expect("run child");
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("daemon state output"),
+        daemon_state_dir.display().to_string()
     );
 }
 

--- a/crates/homeboy-lab-runner/src/execution/tests/exec.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/exec.rs
@@ -23,6 +23,13 @@ fn extension_runtime_home_keeps_homeboy_data_on_the_runner() {
 }
 
 #[test]
+fn runner_child_inherits_the_daemon_state_selector() {
+    assert!(
+        inherited_runner_process_env_keys().contains(&homeboy_core::paths::DAEMON_STATE_DIR_ENV)
+    );
+}
+
+#[test]
 fn explicit_job_data_directory_remains_authoritative() {
     let job_env = HashMap::from([
         ("HOME".to_string(), "/job/extension-home".to_string()),


### PR DESCRIPTION
## Summary

- preserve `HOMEBOY_DAEMON_STATE_DIR` after the Lab runner clears and reconstructs child process environment
- keep runner-job lookup independent from redirected `HOME` and distinct durable/attempt IDs
- cover the actual child environment boundary and accepted-job resolution

## Verification

- `cargo test -p homeboy-lab-runner runner_child_environment_keeps_daemon_state_with_redirected_home`
- `cargo test -p homeboy-core daemon_child_environment_resolves_runner_job_with_distinct_durable_and_attempt_ids`
- `cargo check -p homeboy-core -p homeboy-lab-runner`
- `cargo fmt --all -- --check`

Closes #12974.

## AI Assistance

OpenAI `gpt-5.6-sol` via OpenCode general coding subagents investigated the current-release regression, implemented and reviewed the repair, and ran focused verification under Chris Huber direction. Chris remains responsible for every line.