### PR TITLE
fix(ci): report zero required gates

### DIFF
--- a/.github/ci-required-gates-executed.sh
+++ b/.github/ci-required-gates-executed.sh
@@ -125,9 +125,13 @@ declared_count="$(jq 'length' <<< "${declared_contexts}")"
 execution_contexts="$(jq -c '[.[] | select(. != "homeboy / Required Gates Executed")]' <<< "${declared_contexts}")"
 
 if [ "${declared_count}" -eq 0 ]; then
-  echo "::error::required-gates policy declares no required checks, so execution cannot be verified"
-  echo "required-gates policy declares no required checks" >&2
-  exit 1
+  # No declared contexts is the versioned reporting-only policy. There is no
+  # execution claim to verify, so avoid treating its deliberate absence as a
+  # failed required-gates policy.
+  echo "::notice::required-gates-executed basis=reporting-only-policy run=${GITHUB_RUN_ID:-unknown} attempt=${GITHUB_RUN_ATTEMPT:-unknown} pr_state_active=${active} declared=0 executed=0 dependencies=${dependency_count} dependencies_skipped=${dependency_skipped} outcome=not-required"
+  echo "::notice::required-gates-executed: The policy declares no required gates; execution reporting is not required."
+  echo "required-gates-executed-status=not-required"
+  exit 0
 fi
 
 run_jobs=''

--- a/tests/required_gates_policy_test.rs
+++ b/tests/required_gates_policy_test.rs
@@ -98,6 +98,16 @@ fn no_required_checks() -> String {
     .expect("live rules fixture")
 }
 
+fn reporting_only_policy() -> String {
+    serde_json::to_string_pretty(&serde_json::json!({
+        "rules": [
+            { "type": "deletion" },
+            { "type": "non_fast_forward" }
+        ]
+    }))
+    .expect("reporting-only policy fixture")
+}
+
 fn ruleset_detail(bypass_actors: serde_json::Value, current_user_can_bypass: &str) -> String {
     serde_json::to_string_pretty(&serde_json::json!({
         "id": 13680120,
@@ -637,6 +647,45 @@ fn terminal_execution_verdict_rejects_pending_skipped_cancelled_failed_and_absen
             && stdout_of(&output).contains("required-gates-executed-status=skipped"),
         "an absent terminal context must leave the PR unmergeable: {}",
         stdout_of(&output)
+    );
+}
+
+#[test]
+fn terminal_execution_verdict_reports_reporting_only_policy_without_probing_jobs() {
+    let scratch = Scratch::new("reporting-only-execution");
+    let policy = scratch.write("ruleset.json", &reporting_only_policy());
+    let output = run_execution_gate(&[
+        ("REQUIRED_GATES_CONFIG", policy.as_str()),
+        // A reporting-only policy has no execution evidence to verify.
+        (
+            "REQUIRED_GATES_EXECUTED_JOBS",
+            scratch.missing("jobs.json").as_str(),
+        ),
+    ]);
+
+    assert!(
+        output.status.success(),
+        "a zero-context policy is reporting-only: {}\n{}",
+        stdout_of(&output),
+        stderr_of(&output)
+    );
+    assert!(
+        stdout_of(&output).contains("required-gates-executed-status=not-required")
+            && stdout_of(&output).contains("basis=reporting-only-policy"),
+        "{}",
+        stdout_of(&output)
+    );
+}
+
+#[test]
+fn terminal_execution_verdict_rejects_a_malformed_ruleset() {
+    let scratch = Scratch::new("malformed-execution-policy");
+    let policy = scratch.write("ruleset.json", "not JSON");
+    let output = run_execution_gate(&[("REQUIRED_GATES_CONFIG", policy.as_str())]);
+
+    assert!(
+        !output.status.success(),
+        "a malformed policy must not be reported as a successful execution"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #13251.

- Treat a zero-context required-gates policy as explicit reporting-only execution rather than a failure.
- Emit `not-required` provenance without probing jobs when there are no declared contexts.
- Keep nonzero required-context execution verification fail-closed, with hermetic coverage for success, missing, failed, and malformed policy inputs.

## Verification

- `cargo test --test required_gates_policy_test` (29 passed)
- `bash .github/test-manage-required-gates-ruleset.sh`
- `bash .github/validate-required-gates.sh --local`
- `bash -n .github/ci-required-gates-executed.sh`
- `cargo fmt --all -- --check`
- `actionlint .github/workflows/ci.yml`
- `git diff --check`

## AI Assistance

OpenCode using `openai/gpt-5.6-terra` investigated the issue and policy history, reproduced the reporting-only failure, implemented and tested the terminal-gate fix, and prepared this PR. Chris Huber remains responsible for the change.