### PR TITLE
fix(runner): converge pinned source recovery

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -847,7 +847,17 @@ fn lab_runner_homeboy_output_with_recovery_guidance(
         refresh_commands: (!recovery_blocked)
             .then(|| lab_runner_homeboy_refresh_commands(runner_id, status))
             .unwrap_or_default(),
-        upgrade_command: (!recovery_blocked).then(|| {
+        // An exact refresh owns stale-daemon recovery end-to-end: it selects the
+        // controller commit, rotates the daemon, verifies both identities, and
+        // proves admission. Do not present the known-weaker fleet upgrade beside it.
+        upgrade_command: (!recovery_blocked
+            && !(status.stale_daemon.is_some()
+                && recovery_refresh_command(
+                    &shell_arg(runner_id),
+                    recovery_refresh_guidance(status),
+                )
+                .is_some()))
+        .then(|| {
             format!(
                 "homeboy upgrade --force --upgrade-runner {}",
                 shell_arg(runner_id)
@@ -1372,16 +1382,14 @@ fn lab_runner_homeboy_refresh_commands(
     status: &RunnerStatusReport,
 ) -> Vec<String> {
     let runner_arg = shell_arg(runner_id);
-    let mut commands = Vec::new();
     if let Some(command) = recovery_refresh_command(&runner_arg, recovery_refresh_guidance(status))
     {
-        commands.push(command);
+        return vec![command];
     }
-    commands.extend([
+    vec![
         format!("homeboy runner disconnect {runner_arg}"),
         format!("homeboy runner connect {runner_arg}"),
-    ]);
-    commands
+    ]
 }
 
 pub(super) fn runner_followups(
@@ -1408,6 +1416,10 @@ pub(super) fn runner_followups(
             purpose: "Materialize a clean runner-side Homeboy binary, select it for Lab jobs, and refresh the daemon session.".to_string(),
         });
     }
+    let has_exact_stale_daemon_refresh = status.is_some_and(|status| {
+        status.stale_daemon.is_some()
+            && recovery_refresh_command(&runner_arg, recovery_refresh_guidance(status)).is_some()
+    });
     followups.extend([
         LabFollowup {
             label: "doctor".to_string(),
@@ -1447,6 +1459,16 @@ pub(super) fn runner_followups(
             purpose: "Reclaim safe orphaned Lab workspaces in bounded passes when the runner workspace filesystem is under disk pressure.".to_string(),
         },
     ]);
+    if has_exact_stale_daemon_refresh {
+        // The refresh action includes reconnection, identity verification, and
+        // admission readiness. Suppress weaker local/upgrade alternatives.
+        followups.retain(|followup| {
+            !matches!(
+                followup.label.as_str(),
+                "exec" | "homeboy_binary_refresh" | "homeboy_binary_upgrade"
+            )
+        });
+    }
     followups.extend(declared_followups(None, Some(runner_id)));
     if let Ok(path) = std::env::current_dir() {
         followups.push(LabFollowup {
@@ -1536,7 +1558,7 @@ fn build_identity_commit(identity: &str) -> Option<&str> {
         .then_some(commit)
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum RecoveryRefreshGuidance {
     Refresh(String),
     IdentityDrift {
@@ -1864,6 +1886,20 @@ fn runner_status_operator_commands_with_recovery_guidance(
         return Vec::new();
     };
 
+    if report.active_job_count == 0 && report.stale_daemon.is_some() {
+        if let Some(command) =
+            recovery_refresh_command(&shell_arg(&report.runner_id), guidance.clone())
+        {
+            return vec![RunnerOperatorCommand {
+                scope: "daemon_refresh",
+                runner_id: report.runner_id.clone(),
+                job_id: None,
+                command,
+                description: "Refresh the configured Homeboy binary, rotate the idle daemon, and verify identity plus admission convergence.".to_string(),
+            }];
+        }
+    }
+
     let mut commands = Vec::new();
     if report.active_job_count > 0 {
         commands.push(RunnerOperatorCommand {
@@ -2128,6 +2164,22 @@ mod tests {
                 .command,
             commands[0]
         );
+        assert_eq!(commands.len(), 1);
+        assert!(followups.iter().all(|followup| {
+            !matches!(
+                followup.label.as_str(),
+                "exec" | "homeboy_binary_refresh" | "homeboy_binary_upgrade"
+            )
+        }));
+
+        let output = lab_runner_homeboy_output("homeboy-lab", "/opt/homeboy", &report);
+        assert_eq!(output.refresh_commands, commands);
+        assert_eq!(output.upgrade_command, None);
+
+        let operator_commands = runner_status_operator_commands(&report);
+        assert_eq!(operator_commands.len(), 1);
+        assert_eq!(operator_commands[0].scope, "daemon_refresh");
+        assert_eq!(operator_commands[0].command, commands[0]);
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/commands.rs
@@ -68,15 +68,11 @@ pub fn is_managed_immutable_homeboy_path(runner: &Runner, homeboy_path: &str) ->
 }
 
 pub fn managed_immutable_runner_recovery_commands(runner_id: &str) -> Vec<String> {
-    let refresh = format!(
+    vec![format!(
         "homeboy runner refresh-homeboy {} --ref {} --reconnect",
         shell_arg(runner_id),
         shell_arg(&crate::homeboy_refresh::controller_refresh_ref())
-    );
-    vec![
-        refresh,
-        format!("homeboy runner reconcile {}", shell_arg(runner_id)),
-    ]
+    )]
 }
 
 pub fn reconnect_runner_daemon(runner_id: &str) -> Result<(String, Option<String>)> {

--- a/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/tests/part_b.rs
@@ -13,7 +13,7 @@ thread_local! {
 }
 
 #[test]
-fn managed_immutable_runner_slots_route_to_refresh_and_reconciliation() {
+fn managed_immutable_runner_slots_route_to_one_exact_refresh_action() {
     let runner = ssh_runner(
         "homeboy-lab",
         Some("/home/user/workspace/_homeboy_binaries/homeboy-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/homeboy"),
@@ -37,10 +37,9 @@ fn managed_immutable_runner_slots_route_to_refresh_and_reconciliation() {
     ));
 
     let commands = managed_immutable_runner_recovery_commands("homeboy-lab");
-    assert_eq!(commands.len(), 2);
+    assert_eq!(commands.len(), 1);
     assert!(commands[0].starts_with("homeboy runner refresh-homeboy homeboy-lab --ref "));
     assert!(commands[0].ends_with(" --reconnect"));
-    assert_eq!(commands[1], "homeboy runner reconcile homeboy-lab");
 }
 
 #[test]


### PR DESCRIPTION
Closes #10518.

## Summary
- emit one controller-supported `runner refresh-homeboy --ref <resolved> --reconnect` action for immutable pinned runner slots
- make stale, idle daemon drift status expose that exact action instead of upgrade/restart/exec alternatives
- preserve refresh postconditions: configured job binary identity, active daemon identity, and admission readiness

## Tests
- `cargo fmt --check`
- `cargo test -p homeboy-cli --features test-support --lib commands::runner::status::tests::active_refresh_guidance_uses_an_immutable_controller_commit_when_known`
- `cargo test -p homeboy-lab-runner homeboy_refresh::tests::part_a::refreshed_daemon_verification_retries_until_the_configured_job_binary_converges`
- `cargo test -p homeboy-lab-runner upgrade_runners::tests::part_b::managed_immutable_runner_slots_route_to_one_exact_refresh_action`

## AI assistance
- Model: OpenAI GPT-5.6 Terra
- Tool: OpenCode
- Used for: investigated the existing runner recovery and status paths, implemented the focused change, and ran the listed tests. Chris Huber owns review and decisions.