### PR TITLE
Preflight upgrade extension compatibility

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/core_compat.rs
+++ b/crates/contracts/homeboy-extension-contract/src/core_compat.rs
@@ -21,9 +21,13 @@ pub struct CoreCompatibilityReport {
 
 impl CoreCompatibilityReport {
     pub fn undeclared(source_revision: Option<String>) -> Self {
+        Self::undeclared_for_version(source_revision, installed_homeboy_version())
+    }
+
+    fn undeclared_for_version(source_revision: Option<String>, homeboy_version: String) -> Self {
         Self {
             status: "undeclared".to_string(),
-            installed_homeboy: installed_homeboy_version(),
+            installed_homeboy: homeboy_version,
             requires_homeboy: None,
             source_revision,
             remediation_command: None,
@@ -39,9 +43,27 @@ pub fn evaluate_core_compatibility(
     requires_homeboy: Option<&str>,
     source_revision: Option<String>,
 ) -> Result<CoreCompatibilityReport> {
-    let installed = installed_homeboy_version();
+    evaluate_core_compatibility_for_version(
+        requires_homeboy,
+        source_revision,
+        &installed_homeboy_version(),
+    )
+}
+
+/// Evaluate an extension declaration against an explicit controller version.
+/// Upgrade admission uses this before the selected controller replaces the
+/// running binary, while runtime callers continue using the installed version.
+pub fn evaluate_core_compatibility_for_version(
+    requires_homeboy: Option<&str>,
+    source_revision: Option<String>,
+    homeboy_version: &str,
+) -> Result<CoreCompatibilityReport> {
+    let installed = homeboy_version.to_string();
     let Some(constraint) = requires_homeboy.filter(|value| !value.trim().is_empty()) else {
-        return Ok(CoreCompatibilityReport::undeclared(source_revision));
+        return Ok(CoreCompatibilityReport::undeclared_for_version(
+            source_revision,
+            installed,
+        ));
     };
 
     let parsed_constraint = VersionConstraint::parse(constraint)?;
@@ -144,6 +166,22 @@ mod tests {
             report.requires_homeboy.as_deref(),
             Some(format!(">={current}").as_str())
         );
+    }
+
+    #[test]
+    fn explicit_candidate_version_is_evaluated_without_using_the_running_binary() {
+        let report = evaluate_core_compatibility_for_version(Some(">=2.0.0"), None, "2.1.0")
+            .expect("compat report");
+        assert_eq!(report.status, "compatible");
+        assert_eq!(report.installed_homeboy, "2.1.0");
+    }
+
+    #[test]
+    fn undeclared_candidate_version_is_reported_as_the_selected_controller() {
+        let report =
+            evaluate_core_compatibility_for_version(None, None, "2.1.0").expect("compat report");
+        assert_eq!(report.status, "undeclared");
+        assert_eq!(report.installed_homeboy, "2.1.0");
     }
 
     #[test]

--- a/crates/contracts/homeboy-extension-contract/src/lib.rs
+++ b/crates/contracts/homeboy-extension-contract/src/lib.rs
@@ -152,9 +152,9 @@ pub use trace_spec::{
 };
 
 pub use core_compat::{
-    core_incompatible_error, evaluate_core_compatibility, installed_homeboy_version,
-    validate_core_compatibility, CoreCompatibilityReport, CORE_COMPAT_REMEDIATION_COMMAND,
-    CORE_INCOMPATIBLE_DIAGNOSTIC,
+    core_incompatible_error, evaluate_core_compatibility, evaluate_core_compatibility_for_version,
+    installed_homeboy_version, validate_core_compatibility, CoreCompatibilityReport,
+    CORE_COMPAT_REMEDIATION_COMMAND, CORE_INCOMPATIBLE_DIAGNOSTIC,
 };
 pub use manifest_deploy_config::{DeployArchiveInstallPolicy, DeployRequiredHeader};
 pub use manifest_test_config::{TestPassthroughFilter, TestPassthroughFilterStrategy};

--- a/crates/contracts/homeboy-extension-contract/src/version.rs
+++ b/crates/contracts/homeboy-extension-contract/src/version.rs
@@ -38,6 +38,8 @@ pub enum VersionConstraint {
     LessEqual(Version),
     /// `<version`
     Less(Version),
+    /// Every comma-separated constraint must match.
+    All(Vec<VersionConstraint>),
 }
 
 impl VersionConstraint {
@@ -49,6 +51,15 @@ impl VersionConstraint {
 
         if input == "*" {
             return Ok(VersionConstraint::Any);
+        }
+
+        if input.contains(',') {
+            return input
+                .split(',')
+                .map(str::trim)
+                .map(VersionConstraint::parse)
+                .collect::<Result<Vec<_>>>()
+                .map(VersionConstraint::All);
         }
 
         if let Some(rest) = input.strip_prefix(">=") {
@@ -97,6 +108,9 @@ impl VersionConstraint {
             VersionConstraint::Less(v) => version < v,
             VersionConstraint::Caret(v) => caret_matches(v, version),
             VersionConstraint::Tilde(v) => tilde_matches(v, version),
+            VersionConstraint::All(constraints) => constraints
+                .iter()
+                .all(|constraint| constraint.matches(version)),
         }
     }
 }
@@ -112,6 +126,16 @@ impl std::fmt::Display for VersionConstraint {
             VersionConstraint::Less(v) => write!(f, "<{}", v),
             VersionConstraint::Caret(v) => write!(f, "^{}", v),
             VersionConstraint::Tilde(v) => write!(f, "~{}", v),
+            VersionConstraint::All(constraints) => {
+                let mut constraints = constraints.iter();
+                if let Some(first) = constraints.next() {
+                    write!(f, "{first}")?;
+                }
+                for constraint in constraints {
+                    write!(f, ", {constraint}")?;
+                }
+                Ok(())
+            }
         }
     }
 }
@@ -260,6 +284,14 @@ mod tests {
     fn parse_with_spaces() {
         let c = VersionConstraint::parse(">= 1.0.0 ").unwrap();
         assert_eq!(c, VersionConstraint::GreaterEqual(v("1.0.0")));
+    }
+
+    #[test]
+    fn comma_separated_constraints_require_every_bound() {
+        let c = VersionConstraint::parse(">=2.0.0, <3.0.0").unwrap();
+        assert!(c.matches(&v("2.1.0")));
+        assert!(!c.matches(&v("3.0.0")));
+        assert_eq!(c.to_string(), ">=2.0.0, <3.0.0");
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/upgrade.rs
+++ b/crates/homeboy-cli/src/commands/upgrade.rs
@@ -366,6 +366,7 @@ mod tests {
             source_revision: None,
             upgraded: true,
             outcome: None,
+            preflight: None,
             controller: None,
             extensions: None,
             runners: None,

--- a/crates/homeboy-extension/src/lib.rs
+++ b/crates/homeboy-extension/src/lib.rs
@@ -57,9 +57,9 @@ pub use homeboy_core::extension_execution::{
     resolve_extension_for_capability, ExtensionExecutionContext,
 };
 pub use homeboy_extension_contract::core_compat::{
-    core_incompatible_error, evaluate_core_compatibility, installed_homeboy_version,
-    validate_core_compatibility, CoreCompatibilityReport, CORE_COMPAT_REMEDIATION_COMMAND,
-    CORE_INCOMPATIBLE_DIAGNOSTIC,
+    core_incompatible_error, evaluate_core_compatibility, evaluate_core_compatibility_for_version,
+    installed_homeboy_version, validate_core_compatibility, CoreCompatibilityReport,
+    CORE_COMPAT_REMEDIATION_COMMAND, CORE_INCOMPATIBLE_DIAGNOSTIC,
 };
 pub use homeboy_extension_contract::ExtensionCapability;
 

--- a/crates/homeboy-lab-runner/src/upgrade_runners/mod.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/mod.rs
@@ -45,12 +45,16 @@ impl RunnerUpgradeProvider for RunnerUpgrade {
         source_path: Option<&Path>,
         explicit_source_path: bool,
         runner_targets: &[String],
+        candidate_version: &str,
+        extension_ids: &[String],
     ) -> Result<Vec<RunnerUpgradeEntry>> {
         preflight_configured_runners_for_upgrade(
             method_override,
             source_path,
             explicit_source_path,
             runner_targets,
+            candidate_version,
+            extension_ids,
         )
     }
 

--- a/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
@@ -16,11 +16,9 @@ pub fn preflight_configured_runners_for_upgrade(
     source_path: Option<&Path>,
     explicit_source_path: bool,
     runner_targets: &[String],
+    candidate_version: &str,
+    extension_ids: &[String],
 ) -> Result<Vec<RunnerUpgradeEntry>> {
-    if method_override != Some(InstallMethod::Source) || source_path.is_none() {
-        return Ok(Vec::new());
-    }
-
     let runners = runner_upgrade_targets(runner_targets)?;
     let mut failures = Vec::new();
     for runner in &runners {
@@ -33,44 +31,134 @@ pub fn preflight_configured_runners_for_upgrade(
             .homeboy_path
             .clone()
             .unwrap_or_else(|| "homeboy".to_string());
-        let materialized = if explicit_source_path {
-            materialize_explicit_runner_source_path(
+        if method_override == Some(InstallMethod::Source) && source_path.is_some() {
+            let materialized = if explicit_source_path {
+                materialize_explicit_runner_source_path(
+                    runner,
+                    source_path.expect("source path checked"),
+                )
+            } else {
+                materialize_runner_source_path(runner, source_path.expect("source path checked"))
+            };
+            let source_path = match materialized {
+                Ok(path) => path,
+                Err(error) => {
+                    failures.push(runner_upgrade_failure_entry(
+                        &runner.id,
+                        homeboy_path.clone(),
+                        None,
+                        1,
+                        format!("runner preflight materialization failed: {}", error.message),
+                    ));
+                    continue;
+                }
+            };
+            if let Some(detail) = prepare_runner_source_checkout_for_upgrade(
                 runner,
-                source_path.expect("source path checked"),
-            )
-        } else {
-            materialize_runner_source_path(runner, source_path.expect("source path checked"))
-        };
-        let source_path = match materialized {
-            Ok(path) => path,
-            Err(error) => {
+                method_override,
+                Some(&source_path),
+                &mut runner::exec,
+            ) {
                 failures.push(runner_upgrade_failure_entry(
                     &runner.id,
-                    homeboy_path,
+                    homeboy_path.clone(),
                     None,
                     1,
-                    format!("runner preflight materialization failed: {}", error.message),
+                    format!("runner preflight source checkout failed: {detail}"),
                 ));
                 continue;
             }
-        };
-        if let Some(detail) = prepare_runner_source_checkout_for_upgrade(
-            runner,
-            method_override,
-            Some(&source_path),
-            &mut runner::exec,
-        ) {
+        }
+        if let Some(detail) =
+            runner_manifest_preflight(runner, &homeboy_path, candidate_version, extension_ids)
+        {
             failures.push(runner_upgrade_failure_entry(
                 &runner.id,
                 homeboy_path,
                 None,
                 1,
-                format!("runner preflight source checkout failed: {detail}"),
+                detail,
             ));
         }
     }
 
     Ok(failures)
+}
+
+/// Query only the runner's manifest summary. This admission does not install,
+/// refresh, or materialize extensions; those operations remain after promotion.
+fn runner_manifest_preflight(
+    runner: &Runner,
+    homeboy_path: &str,
+    candidate_version: &str,
+    extension_ids: &[String],
+) -> Option<String> {
+    for extension_id in extension_ids {
+        if !runner_supports_extension_sync(runner, extension_id) {
+            continue;
+        }
+        let mut options = runner_exec_options(
+            runner,
+            vec![
+                homeboy_path.to_string(),
+                "extension".to_string(),
+                "show".to_string(),
+                extension_id.clone(),
+            ],
+        );
+        options.print_handoff = false;
+        options.mirror_evidence = false;
+        options.read_only_artifact_access = true;
+        let Ok((output, exit_code)) = runner::exec(&runner.id, options) else {
+            return Some(format!(
+                "runner manifest preflight could not query extension `{extension_id}`"
+            ));
+        };
+        if exit_code != 0 {
+            return Some(format!("runner manifest preflight failed for extension `{extension_id}`; recover with: {homeboy_path} extension show {extension_id}"));
+        }
+        let Some(requires_homeboy) = runner_extension_requires_homeboy(&output.stdout) else {
+            continue;
+        };
+        match homeboy_extension::evaluate_core_compatibility_for_version(
+            Some(&requires_homeboy),
+            None,
+            candidate_version,
+        ) {
+            Ok(report) if report.status != "incompatible" => {}
+            Ok(_) => return Some(format!("runner extension `{extension_id}` requires homeboy {requires_homeboy}, incompatible with selected controller {candidate_version}; recover with: {homeboy_path} extension update {extension_id}")),
+            Err(error) => return Some(format!("runner extension `{extension_id}` has invalid homeboy compatibility declaration: {}; recover with: {homeboy_path} extension show {extension_id}", error.message)),
+        }
+    }
+    None
+}
+
+fn runner_extension_requires_homeboy(stdout: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(stdout.trim()).ok()?;
+    value
+        .pointer("/data/extension/core_compatibility/requires_homeboy")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod manifest_preflight_tests {
+    use super::runner_extension_requires_homeboy;
+
+    #[test]
+    fn reads_runner_manifest_compatibility_from_extension_show_json() {
+        let stdout = r#"{"success":true,"data":{"extension":{"core_compatibility":{"requires_homeboy":">=2.0.0, <3.0.0"}}}}"#;
+        assert_eq!(
+            runner_extension_requires_homeboy(stdout).as_deref(),
+            Some(">=2.0.0, <3.0.0")
+        );
+    }
+
+    #[test]
+    fn ignores_extension_show_without_a_compatibility_declaration() {
+        let stdout = r#"{"success":true,"data":{"extension":{"id":"example"}}}"#;
+        assert!(runner_extension_requires_homeboy(stdout).is_none());
+    }
 }
 
 pub(crate) fn upgrade_configured_runners(

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -358,6 +358,8 @@ pub fn run_upgrade_with_method(
                 // input, even when it was inferred from the source install.
                 source_upgrade_path.is_some(),
                 runner_targets,
+                &candidate_version,
+                &extension::available_extension_ids(),
             )
         })?
     };

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -307,6 +307,69 @@ pub fn run_upgrade_with_method(
     let replacement_approved =
         controller_replacement_proceeds(deliberate, source_upgrade_decision, false);
 
+    // Resolve the binary candidate and validate installed extension sources
+    // before the no-op branch can refresh extensions without swapping the
+    // controller. This keeps every extension mutation behind the same gate.
+    let selected_release = if install_method == InstallMethod::Binary {
+        Some(resolve_binary_release(pinned_version)?)
+    } else {
+        None
+    };
+    let candidate_version = if let Some(release) = selected_release.as_ref() {
+        release.version.clone()
+    } else if install_method == InstallMethod::Source {
+        source_upgrade_path
+            .as_deref()
+            .and_then(source_build_identity)
+            .map(|identity| identity.version)
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "source_path",
+                    "Selected source checkout has no readable package version for extension compatibility preflight",
+                    source_upgrade_path
+                        .as_ref()
+                        .map(|path| path.display().to_string()),
+                    None,
+                )
+            })?
+    } else {
+        current_version().to_string()
+    };
+    let extension_preflight = (!skip_extensions)
+        .then(|| preflight_extensions_for_upgrade(&candidate_version))
+        .unwrap_or_default();
+    if !extension_preflight.is_empty() {
+        return Ok(extension_preflight_failure_result(
+            install_method,
+            previous_version,
+            previous_build_identity,
+            &candidate_version,
+            extension_preflight,
+        ));
+    }
+    let runner_preflight = if skip_runners {
+        Vec::new()
+    } else {
+        super::with_runner_upgrade(|provider| {
+            provider.preflight_configured_runners_for_upgrade(
+                runner_method_override,
+                source_upgrade_path.as_deref(),
+                // A resolved source workspace is the controller-selected build
+                // input, even when it was inferred from the source install.
+                source_upgrade_path.is_some(),
+                runner_targets,
+            )
+        })?
+    };
+    if !runner_preflight.is_empty() {
+        return Ok(runner_preflight_failure_result(
+            install_method,
+            previous_version,
+            previous_build_identity,
+            runner_preflight,
+        ));
+    }
+
     // Check if a release update is available unless an explicit source target
     // has already been approved for controller replacement.
     if !replacement_approved {
@@ -369,6 +432,7 @@ pub fn run_upgrade_with_method(
                 source_revision: None,
                 upgraded: false,
                 outcome: Some("controller_unchanged".to_string()),
+                preflight: None,
                 controller: Some(component_status("unchanged", "controller already current")),
                 extensions: Some(extensions_status.clone()),
                 runners: Some(runner_component_status(
@@ -416,31 +480,6 @@ pub fn run_upgrade_with_method(
         }
     }
 
-    // Binary upgrades install a published release asset. Resolve *which*
-    // release before mutation: the newest release is not necessarily
-    // installable on this target, so this selects the newest release that is,
-    // or the operator's explicit pin. Resolving it here also lets post-swap
-    // verification prove the PATH destination runs the exact release selected.
-    let selected_release = if install_method == InstallMethod::Binary {
-        Some(resolve_binary_release(pinned_version)?)
-    } else {
-        None
-    };
-
-    let runner_preflight = if skip_runners {
-        Vec::new()
-    } else {
-        super::with_runner_upgrade(|provider| {
-            provider.preflight_configured_runners_for_upgrade(
-                runner_method_override,
-                source_upgrade_path.as_deref(),
-                // A resolved source workspace is the controller-selected build
-                // input, even when it was inferred from the source install.
-                source_upgrade_path.is_some(),
-                runner_targets,
-            )
-        })?
-    };
     // Packaged installers still own their download-and-swap command. Keep their
     // established full-operation lease until that contract is moved in-process;
     // source builds use the narrower lease at the final rename instead.
@@ -551,6 +590,7 @@ pub fn run_upgrade_with_method(
         } else {
             upgrade_outcome(success, runner_disposition).to_string()
         }),
+        preflight: None,
         controller: Some(component_status(
             if superseded {
                 "superseded"
@@ -623,6 +663,7 @@ fn source_upgrade_noop_result(
         source_revision: None,
         upgraded: false,
         outcome: Some("controller_unchanged".to_string()),
+        preflight: None,
         controller: Some(component_status("unchanged", "controller was not promoted")),
         extensions: Some(component_status("skipped", "extensions were not refreshed")),
         runners: Some(component_status(
@@ -672,6 +713,7 @@ fn runner_preflight_failure_result(
         source_revision: None,
         upgraded: false,
         outcome: Some("runner_preflight_failed".to_string()),
+        preflight: None,
         controller: Some(component_status(
             "runner_preflight_failed",
             "controller was not updated because selected runner preflight failed",
@@ -697,6 +739,117 @@ fn runner_preflight_failure_result(
         services_restarted: Vec::new(),
         services_pending_restart: Vec::new(),
     }
+}
+
+fn extension_preflight_failure_result(
+    install_method: InstallMethod,
+    previous_version: String,
+    previous_build_identity: Option<String>,
+    candidate_version: &str,
+    extension_blockers: Vec<ExtensionPreflightBlocker>,
+) -> UpgradeResult {
+    UpgradeResult {
+        command: "upgrade".to_string(),
+        install_method,
+        new_version: Some(previous_version.clone()),
+        previous_version,
+        previous_build_identity,
+        new_build_identity: None,
+        source_revision: None,
+        upgraded: false,
+        outcome: Some("extension_preflight_failed".to_string()),
+        preflight: Some(UpgradePreflight {
+            candidate_version: candidate_version.to_string(),
+            extension_blockers,
+        }),
+        controller: Some(component_status(
+            "extension_preflight_failed",
+            "controller was not updated because extension preflight failed",
+        )),
+        extensions: Some(component_status(
+            "extension_preflight_failed",
+            "one or more installed extensions cannot be safely refreshed",
+        )),
+        runners: Some(component_status(
+            "not_run",
+            "runner convergence was not attempted because extension preflight failed",
+        )),
+        partial: true,
+        runner_convergence: None,
+        message: "extension_preflight_failed: controller was not updated".to_string(),
+        restart_required: false,
+        extensions_updated: Vec::new(),
+        extensions_skipped: Vec::new(),
+        extension_skips: Vec::new(),
+        runners_updated: Vec::new(),
+        runners_skipped: Vec::new(),
+        extensions_unrefreshed: Vec::new(),
+        services_restarted: Vec::new(),
+        services_pending_restart: Vec::new(),
+    }
+}
+
+/// Check deterministic local extension conditions before the controller swap.
+/// Network refresh, setup, and runner convergence remain in their established
+/// phases; this gate only rejects failures that cannot be repaired by a retry.
+fn preflight_extensions_for_upgrade(candidate_version: &str) -> Vec<ExtensionPreflightBlocker> {
+    extension::discover_extensions()
+        .into_iter()
+        .filter_map(|discovered| match discovered {
+            extension::DiscoveredExtension::Invalid(failure) => {
+                let extension_id = failure.id;
+                Some(ExtensionPreflightBlocker {
+                    extension_id: extension_id.clone(),
+                    classification: failure.category.to_string(),
+                    detail: failure.diagnostic.to_string(),
+                    recovery_command: format!("homeboy extension show {extension_id}"),
+                })
+            }
+            extension::DiscoveredExtension::Valid(manifest) => {
+                let extension_id = manifest.id.clone();
+                let source_path = manifest.extension_path.as_deref().map(Path::new)?;
+                if extension::is_extension_linked(&extension_id)
+                    && git::get_git_root(&source_path.to_string_lossy()).is_err()
+                {
+                    return Some(ExtensionPreflightBlocker {
+                        extension_id: extension_id.clone(),
+                        classification: "linked_source_root_unrecognized".to_string(),
+                        detail: "linked extension path is not inside a Git checkout".to_string(),
+                        recovery_command: format!("homeboy extension relink {extension_id} <path>"),
+                    });
+                }
+                let requires = manifest
+                    .requires
+                    .as_ref()
+                    .and_then(|requirements| requirements.homeboy.as_deref());
+                match homeboy_extension::evaluate_core_compatibility_for_version(
+                    requires,
+                    homeboy_core::extension_update_check::read_source_revision(&extension_id),
+                    candidate_version,
+                ) {
+                    Ok(report) if report.status != "incompatible" => None,
+                    Ok(report) => Some(ExtensionPreflightBlocker {
+                        extension_id,
+                        classification: "controller_version_incompatible".to_string(),
+                        detail: format!(
+                            "requires homeboy {} but selected controller is {}",
+                            report
+                                .requires_homeboy
+                                .unwrap_or_else(|| "<undeclared>".to_string()),
+                            candidate_version
+                        ),
+                        recovery_command: "homeboy upgrade --skip-extensions".to_string(),
+                    }),
+                    Err(error) => Some(ExtensionPreflightBlocker {
+                        extension_id,
+                        classification: "manifest_compatibility_invalid".to_string(),
+                        detail: error.message,
+                        recovery_command: "homeboy extension show <extension-id>".to_string(),
+                    }),
+                }
+            }
+        })
+        .collect()
 }
 
 fn upgrade_outcome(
@@ -944,6 +1097,7 @@ fn run_targeted_runner_upgrade(
         source_revision: None,
         upgraded: false,
         outcome: Some("runner_only".to_string()),
+        preflight: None,
         controller: Some(component_status(
             "unchanged",
             "targeted runner operation did not promote controller",
@@ -2040,6 +2194,129 @@ mod runner_source_upgrade_tests {
     fn write_extension(dir: &Path, id: &str, manifest: &str) {
         std::fs::create_dir_all(dir).unwrap();
         std::fs::write(dir.join(format!("{id}.json")), manifest).unwrap();
+    }
+
+    #[test]
+    fn extension_preflight_returns_bounded_manifest_blocker() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let extensions = home.path().join(".config/homeboy/extensions");
+            write_extension(&extensions.join("broken"), "broken", "{ malformed");
+
+            let blockers = preflight_extensions_for_upgrade("1.0.0");
+            assert_eq!(blockers.len(), 1);
+            assert_eq!(blockers[0].extension_id, "broken");
+            assert_eq!(blockers[0].classification, "manifest_json_malformed");
+            assert_eq!(
+                blockers[0].recovery_command,
+                "homeboy extension show broken"
+            );
+        });
+    }
+
+    #[test]
+    fn extension_preflight_blocks_a_manifest_incompatible_with_the_candidate() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let extensions = home.path().join(".config/homeboy/extensions");
+            write_extension(
+                &extensions.join("future"),
+                "future",
+                r#"{"name":"future","version":"1.0.0","requires":{"homeboy":">=999.0.0"}}"#,
+            );
+
+            let blockers = preflight_extensions_for_upgrade("2.0.0");
+            assert_eq!(blockers.len(), 1);
+            assert_eq!(
+                blockers[0].classification,
+                "controller_version_incompatible"
+            );
+            assert!(blockers[0].detail.contains("selected controller is 2.0.0"));
+            assert_eq!(
+                blockers[0].recovery_command,
+                "homeboy upgrade --skip-extensions"
+            );
+        });
+    }
+
+    #[test]
+    fn extension_preflight_allows_a_compatible_copied_manifest() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let extensions = home.path().join(".config/homeboy/extensions");
+            write_extension(
+                &extensions.join("compatible"),
+                "compatible",
+                r#"{"name":"compatible","version":"1.0.0","requires":{"homeboy":">=1.0.0"}}"#,
+            );
+
+            assert!(preflight_extensions_for_upgrade("1.0.0").is_empty());
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extension_preflight_resolves_a_nested_linked_source_through_its_git_root() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let source_root = home.path().join("extension-source");
+            let source = source_root.join("packages/nested");
+            std::fs::create_dir_all(&source).expect("nested source");
+            write_source_manifest(&source_root, "1.0.0");
+            write_extension(&source, "nested", r#"{"name":"nested","version":"1.0.0"}"#);
+            git(&source_root, &["init"]);
+            git(&source_root, &["add", "."]);
+            git(
+                &source_root,
+                &[
+                    "-c",
+                    "user.name=Test",
+                    "-c",
+                    "user.email=test@example.test",
+                    "commit",
+                    "-m",
+                    "source",
+                ],
+            );
+
+            let extensions = home.path().join(".config/homeboy/extensions");
+            std::fs::create_dir_all(&extensions).expect("extensions directory");
+            std::os::unix::fs::symlink(&source, extensions.join("nested"))
+                .expect("linked extension");
+
+            assert!(preflight_extensions_for_upgrade("1.0.0").is_empty());
+        });
+    }
+
+    #[test]
+    fn extension_preflight_failure_does_not_invoke_controller_mutation() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let extensions = home.path().join(".config/homeboy/extensions");
+            write_extension(
+                &extensions.join("incompatible"),
+                "incompatible",
+                r#"{"name":"incompatible","version":"1.0.0","requires":{"homeboy":">=3.0.0"}}"#,
+            );
+
+            let mut controller_mutated = false;
+            let blockers = preflight_extensions_for_upgrade("2.1.0");
+            let result = if blockers.is_empty() {
+                controller_mutated = true;
+                Ok(())
+            } else {
+                Err(extension_preflight_failure_result(
+                    InstallMethod::Binary,
+                    "2.0.0".to_string(),
+                    None,
+                    "2.1.0",
+                    blockers,
+                ))
+            };
+
+            assert!(!controller_mutated, "controller installation must not run");
+            let result = result.expect_err("incompatible extension blocks upgrade");
+            assert_eq!(
+                result.outcome.as_deref(),
+                Some("extension_preflight_failed")
+            );
+            assert_eq!(result.preflight.unwrap().extension_blockers.len(), 1);
+        });
     }
 
     #[test]

--- a/crates/homeboy-upgrade/src/upgrade/mod.rs
+++ b/crates/homeboy-upgrade/src/upgrade/mod.rs
@@ -28,9 +28,9 @@ pub(crate) use runner_upgrade_provider::with_runner_upgrade;
 pub use runner_upgrade_provider::{register_runner_upgrade_provider, RunnerUpgradeProvider};
 pub use services::restart_extension_services;
 pub use types::{
-    ExtensionUpgradeEntry, ExtensionUpgradeSkip, InstallMethod, RunnerDaemonDriftEntry,
-    RunnerExtensionSyncEntry, RunnerUpgradeEntry, ServiceRestartEntry, UpgradeComponentStatus,
-    UpgradeResult, VersionCheck,
+    ExtensionPreflightBlocker, ExtensionUpgradeEntry, ExtensionUpgradeSkip, InstallMethod,
+    RunnerDaemonDriftEntry, RunnerExtensionSyncEntry, RunnerUpgradeEntry, ServiceRestartEntry,
+    UpgradeComponentStatus, UpgradePreflight, UpgradeResult, VersionCheck,
 };
 pub use validation::check_for_updates;
 

--- a/crates/homeboy-upgrade/src/upgrade/runner_upgrade_provider.rs
+++ b/crates/homeboy-upgrade/src/upgrade/runner_upgrade_provider.rs
@@ -16,8 +16,10 @@ use homeboy_core::error::Result;
 /// The runner-upgrade contract the core upgrade flow depends on. Implemented by
 /// the runner layer and registered at startup.
 pub trait RunnerUpgradeProvider: Send + Sync {
-    /// Validate that selected runners can receive a source upgrade before the
-    /// controller build/install begins. Returns one entry per failed runner.
+    /// Read-only admission for selected runners before any controller,
+    /// extension, or runner mutation. Implementations validate source inputs
+    /// when relevant and runner extension manifests against `candidate_version`.
+    /// Returns one bounded failure entry per runner.
     #[allow(clippy::too_many_arguments)]
     fn preflight_configured_runners_for_upgrade(
         &self,
@@ -25,6 +27,8 @@ pub trait RunnerUpgradeProvider: Send + Sync {
         source_path: Option<&Path>,
         explicit_source_path: bool,
         runner_targets: &[String],
+        candidate_version: &str,
+        extension_ids: &[String],
     ) -> Result<Vec<RunnerUpgradeEntry>>;
 
     /// Upgrade the configured runners from an explicit source checkout,
@@ -58,6 +62,8 @@ impl RunnerUpgradeProvider for NoopRunnerUpgradeProvider {
         _source_path: Option<&Path>,
         _explicit_source_path: bool,
         _runner_targets: &[String],
+        _candidate_version: &str,
+        _extension_ids: &[String],
     ) -> Result<Vec<RunnerUpgradeEntry>> {
         Ok(Vec::new())
     }

--- a/crates/homeboy-upgrade/src/upgrade/types.rs
+++ b/crates/homeboy-upgrade/src/upgrade/types.rs
@@ -111,6 +111,10 @@ pub struct UpgradeResult {
     /// Machine-readable outcome for controller and runner ordering semantics.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub outcome: Option<String>,
+    /// Read-only admission findings that prevented controller mutation. Kept
+    /// bounded to one entry and recovery command per extension blocker.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preflight: Option<UpgradePreflight>,
     /// Independent controller mutation outcome. Additive so persisted and
     /// older callers can continue using `upgraded` and `partial` unchanged.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -171,6 +175,21 @@ pub struct UpgradeResult {
 pub struct UpgradeComponentStatus {
     pub status: String,
     pub summary: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UpgradePreflight {
+    pub candidate_version: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extension_blockers: Vec<ExtensionPreflightBlocker>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionPreflightBlocker {
+    pub extension_id: String,
+    pub classification: String,
+    pub detail: String,
+    pub recovery_command: String,
 }
 
 /// Outcome of attempting to restart one declared binary-resident service after
@@ -332,6 +351,7 @@ mod tests {
             source_revision: None,
             upgraded: true,
             outcome: Some("controller_updated".to_string()),
+            preflight: None,
             controller: Some(UpgradeComponentStatus {
                 status: "updated".to_string(),
                 summary: "controller installation completed".to_string(),


### PR DESCRIPTION
## Summary

- preflight local extension source/manifest compatibility before controller mutation
- probe selected Lab runner extension manifests against the candidate controller version
- return bounded typed blockers and recovery commands without noisy probe handoffs

Relates to #13244.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-extension-contract`
- `cargo test -p homeboy-upgrade`
- `cargo test -p homeboy-lab-runner manifest_preflight_tests -- --nocapture`
- `cargo check --workspace`
- local `cargo test --workspace` encountered an unrelated existing `agent_task_store_injection_test` failure; the broad `homeboy-lab-runner` run exceeded the 20-minute command budget without reporting a failure.

## Follow-up

Bounded concurrent runner probes and durable detailed-evidence references require a reusable runner execution primitive; #13244 remains open for that independent scope.

## AI assistance

OpenAI `openai/gpt-5.6-terra` via OpenCode inspected the interrupted worktree, completed and verified local and runner compatibility preflight ordering, and prepared this PR. Chris Huber remains responsible.