### PR TITLE
fix(ssh): own remote descendants for untimed commands

### DIFF
--- a/crates/homeboy-core/src/server/client/ssh_client.rs
+++ b/crates/homeboy-core/src/server/client/ssh_client.rs
@@ -552,7 +552,7 @@ impl SshClient {
             Ok(stdin) => stdin,
             Err(error) => return ssh_process_error(error),
         };
-        let remote_command = wrap_timed_remote_command(&effective);
+        let remote_command = wrap_owned_remote_command(&effective);
         let args = self.build_ssh_args(Some(&remote_command), false);
         let mut cmd = Command::new("ssh");
         cmd.args(&args)
@@ -650,7 +650,7 @@ impl SshClient {
         stdin: Option<&[u8]>,
         timeout: Duration,
     ) -> CommandOutput {
-        let remote_command = wrap_timed_remote_command(command);
+        let remote_command = wrap_owned_remote_command(command);
         self.execute_ssh_with_timeout_and_multiplexing(&remote_command, stdin, timeout, false)
     }
 
@@ -862,7 +862,7 @@ impl ProbeLimits {
             let remaining = timeout.saturating_sub(started.elapsed());
             if !remaining.is_zero() {
                 output = client.execute_ssh_with_timeout_and_multiplexing(
-                    &wrap_timed_remote_command(&client.prepend_env(command)),
+                    &wrap_owned_remote_command(&client.prepend_env(command)),
                     None,
                     remaining,
                     true,
@@ -1468,7 +1468,7 @@ mod bounded_probe_output_tests {
 const PROCESS_CLEANUP_ALLOWANCE: Duration = Duration::from_millis(250);
 const PROCESS_TERMINATION_GRACE: Duration = Duration::from_millis(100);
 
-/// Run a timed SSH command in a remote session that Homeboy explicitly owns.
+/// Run an SSH command in a remote session that Homeboy explicitly owns.
 /// The remote shell, rather than the controller's local `ssh` process group,
 /// owns cleanup of descendants that inherit the SSH output pipes.
 ///
@@ -1479,9 +1479,9 @@ const PROCESS_TERMINATION_GRACE: Duration = Duration::from_millis(100);
 /// the local `ssh` process. We copy the remote shell's fd 0 to fd 3 before
 /// backgrounding and then explicitly redirect the child's fd 0 from fd 3,
 /// restoring the original stdin stream.
-pub(super) fn wrap_timed_remote_command(command: &str) -> String {
+pub(super) fn wrap_owned_remote_command(command: &str) -> String {
     format!(
-        "command -v setsid >/dev/null 2>&1 || {{ printf '%s\\n' 'Homeboy timed SSH execution requires remote setsid process authority.' >&2; exit 127; }}; exec 3<&0 || {{ printf '%s\\n' 'Homeboy timed SSH execution could not preserve remote stdin.' >&2; exit 1; }}; setsid sh -c {} <&3 & __homeboy_remote_pid=$!; exec 3<&-; __homeboy_remote_cleanup() {{ kill -TERM -\"$__homeboy_remote_pid\" 2>/dev/null || true; __homeboy_remote_attempt=0; while kill -0 -\"$__homeboy_remote_pid\" 2>/dev/null && [ \"$__homeboy_remote_attempt\" -lt 10 ]; do sleep 0.01; __homeboy_remote_attempt=$((__homeboy_remote_attempt + 1)); done; kill -KILL -\"$__homeboy_remote_pid\" 2>/dev/null || true; }}; trap '__homeboy_remote_cleanup; exit 143' HUP INT TERM; wait \"$__homeboy_remote_pid\"; __homeboy_remote_status=$?; __homeboy_remote_cleanup; exit \"$__homeboy_remote_status\"",
+        "command -v setsid >/dev/null 2>&1 || {{ printf '%s\\n' 'Homeboy SSH execution requires remote setsid process authority.' >&2; exit 127; }}; exec 3<&0 || {{ printf '%s\\n' 'Homeboy SSH execution could not preserve remote stdin.' >&2; exit 1; }}; setsid sh -c {} <&3 & __homeboy_remote_pid=$!; exec 3<&-; __homeboy_remote_cleanup() {{ kill -TERM -\"$__homeboy_remote_pid\" 2>/dev/null || true; __homeboy_remote_attempt=0; while kill -0 -\"$__homeboy_remote_pid\" 2>/dev/null && [ \"$__homeboy_remote_attempt\" -lt 10 ]; do sleep 0.01; __homeboy_remote_attempt=$((__homeboy_remote_attempt + 1)); done; kill -KILL -\"$__homeboy_remote_pid\" 2>/dev/null || true; }}; trap '__homeboy_remote_cleanup; exit 143' HUP INT TERM; wait \"$__homeboy_remote_pid\"; __homeboy_remote_status=$?; __homeboy_remote_cleanup; exit \"$__homeboy_remote_status\"",
         shell::quote_arg(command)
     )
 }
@@ -1693,7 +1693,11 @@ impl SshClient {
             };
         }
 
-        let args = self.build_ssh_args(Some(command), false);
+        // The remote process group is distinct from the local `ssh` process
+        // group. Give it an owned session so a successful shell can reap a
+        // descendant that retains the SSH output pipes before EOF is awaited.
+        let remote_command = wrap_owned_remote_command(command);
+        let args = self.build_ssh_args(Some(&remote_command), false);
 
         let mut cmd = Command::new("ssh");
         cmd.args(&args);

--- a/crates/homeboy-core/src/server/client/tests.rs
+++ b/crates/homeboy-core/src/server/client/tests.rs
@@ -17,7 +17,7 @@ use super::ssh_client::{
     build_secret_env_stdin_block, execute_command_with_stdin_source_timeout,
     execute_command_with_stdin_timeout, execute_command_with_writer_factory,
     run_command_with_stdin_source, run_ssh_with_child, wrap_command_with_secret_env_read_loop,
-    wrap_timed_remote_command, SECRET_ENV_STDIN_SENTINEL,
+    wrap_owned_remote_command, SECRET_ENV_STDIN_SENTINEL,
 };
 use super::{CommandObservation, CommandOutput, SshClient};
 
@@ -147,8 +147,8 @@ fn small_secret_stdin_payload_completes_successfully() {
 }
 
 #[test]
-fn timed_ssh_envelope_owns_remote_descendant_cleanup() {
-    let envelope = wrap_timed_remote_command("sleep 30 & printf terminal-result");
+fn ssh_envelope_owns_remote_descendant_cleanup() {
+    let envelope = wrap_owned_remote_command("sleep 30 & printf terminal-result");
 
     assert!(envelope.contains("setsid sh -c"));
     assert!(envelope.contains("exec 3<&0"));
@@ -170,7 +170,7 @@ fn timed_piped_ssh_envelope_preserves_stdin_and_output_while_reaping_descendants
     command
         .args([
             "-c",
-            &wrap_timed_remote_command(&format!(
+            &wrap_owned_remote_command(&format!(
                 "input=$(cat); sleep 30 & descendant=$!; printf '%s' \"$descendant\" > {}; printf '{{\"success\":true,\"data\":{{\"input\":\"%s\",\"action\":\"stop\",\"stopped\":true}}}}\\n' \"$input\"",
                 crate::engine::shell::quote_path(&descendant_pid_path.to_string_lossy())
             )),
@@ -214,7 +214,7 @@ fn timed_piped_ssh_envelope_preserves_stdin_and_output_while_reaping_descendants
 fn timed_remote_wrapper_preserves_piped_stdin() {
     let mut command = Command::new("sh");
     command
-        .args(["-c", &wrap_timed_remote_command("cat")])
+        .args(["-c", &wrap_owned_remote_command("cat")])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     crate::server::process_cleanup::configure_process_group_cleanup(&mut command);
@@ -251,7 +251,7 @@ fn timed_and_untimed_paths_preserve_identical_stdin_bytes() {
     timed
         .args([
             "-c",
-            &wrap_timed_remote_command(&format!(
+            &wrap_owned_remote_command(&format!(
                 "cat > {}",
                 crate::engine::shell::quote_path(&timed_target.path().to_string_lossy())
             )),
@@ -283,7 +283,7 @@ fn timed_remote_wrapper_with_idle_pipe_and_fast_exit_is_bounded() {
     let (reader, _producer) = idle_pipe();
     let mut command = Command::new("sh");
     command
-        .args(["-c", &wrap_timed_remote_command("exit 0")])
+        .args(["-c", &wrap_owned_remote_command("exit 0")])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     crate::server::process_cleanup::configure_process_group_cleanup(&mut command);
@@ -871,19 +871,34 @@ fn managed_session_connect_builds_master_command() {
 
 #[cfg(unix)]
 #[test]
-fn successful_ssh_child_with_delayed_eof_reaps_descendant_before_drain() {
+fn successful_owned_remote_shell_with_delayed_eof_reaps_descendant_before_drain() {
     let marker =
         std::env::temp_dir().join(format!("homeboy-ssh-stream-drain-{}", std::process::id()));
     let _ = std::fs::remove_file(&marker);
+    let fixture = tempfile::tempdir().expect("setsid fixture");
+    let setsid = fixture.path().join("setsid");
+    std::fs::write(
+        &setsid,
+        "#!/usr/bin/env python3\nimport os, signal, sys\npid = os.fork()\nif pid:\n    _, status = os.waitpid(pid, 0)\n    os.killpg(pid, signal.SIGTERM)\n    sys.exit(os.waitstatus_to_exitcode(status))\nos.setsid()\nos.execvp(sys.argv[1], sys.argv[1:])\n",
+    )
+    .expect("write setsid fixture");
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(&setsid, std::fs::Permissions::from_mode(0o755))
+        .expect("make setsid fixture executable");
+    let mut paths = vec![fixture.path().to_path_buf()];
+    paths.extend(std::env::split_paths(
+        &std::env::var_os("PATH").expect("PATH"),
+    ));
     let mut command = Command::new("sh");
     command
         .args([
             "-c",
-            &format!(
+            &wrap_owned_remote_command(&format!(
                 "sleep 5 & printf '%s' \"$!\" > {}; printf snapshot-output",
                 crate::engine::shell::quote_path(&marker.to_string_lossy())
-            ),
+            )),
         ])
+        .env("PATH", std::env::join_paths(paths).expect("fixture PATH"))
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     crate::server::process_cleanup::configure_process_group_cleanup(&mut command);


### PR DESCRIPTION
## Summary
- run untimed SSH commands in the owned remote session already used by bounded operations
- reap a remote descendant that retains stdout or stderr before the local SSH client waits for EOF
- preserve the existing bounded cleanup deadline and stream-drain diagnostics

## Root cause
The prior cleanup change only reaped the controller-local `ssh` process group. Lab workspace snapshot scanning uses the untimed SSH path, where a remote shell descendant is outside that group and can retain the SSH channel after the shell succeeds.

## Verification
- `cargo test -p homeboy-core successful_owned_remote_shell_with_delayed_eof_reaps_descendant_before_drain`
- `cargo test -p homeboy-core ssh_envelope_owns_remote_descendant_cleanup`
- `cargo test -p homeboy-core timed_ssh_child_with_stuck_streams_fails_within_its_cleanup_bound`
- `cargo test -p homeboy-lab-runner ssh_snapshot_listing_preserves_entries_and_isolates_invalid_metadata`
- `cargo fmt --all --check`
- `git diff --check`

`cargo test -p homeboy-core` had 2,564 passing tests and 19 unrelated failures in shared test environment isolation, including `TMPDIR`, daemon state, and SQLite-lock cases. `cargo clippy -p homeboy-core --all-targets -- -D warnings` is blocked by 22 existing warnings outside this change.

Fixes #13254

## AI assistance
- **Model:** OpenAI GPT-5.6-sol
- **Tool:** OpenCode general coding subagent
- **Used for:** SSH lifecycle tracing, remote descendant reproduction, implementation, deterministic process tests, and verification.

Chris Huber remains responsible for the change.