### PR TITLE
fix: bound operational inventory output

### DIFF
--- a/crates/homeboy-cli/src/commands/json_output/mod.rs
+++ b/crates/homeboy-cli/src/commands/json_output/mod.rs
@@ -110,6 +110,23 @@ pub(crate) fn run_command_output(
         Commands::Runner(args) if refresh_homeboy_uses_bounded_output(&args) => {
             refresh_homeboy_command_run(args, output_file)
         }
+        Commands::Ssh(args)
+            if matches!(
+                args.subcommand,
+                Some(super::ssh::SshSubcommand::List { full: false })
+            ) =>
+        {
+            command_run_with_summary(
+                dispatch(Commands::Ssh(args), spec, placement),
+                |payload, _| super::ssh::render_list_summary(payload),
+            )
+        }
+        Commands::Runner(args) if runner::is_compact_doctor_stdout(&args) => {
+            command_run_with_summary(
+                dispatch(Commands::Runner(args), spec, placement),
+                |payload, _| super::runner::doctor::render_summary(payload),
+            )
+        }
         Commands::Runner(args) => runner::run_command_output(args),
         Commands::Activity(args) => command_run_with_summary(
             dispatch(Commands::Activity(args), spec, placement),

--- a/crates/homeboy-cli/src/commands/runner/cli.rs
+++ b/crates/homeboy-cli/src/commands/runner/cli.rs
@@ -26,6 +26,10 @@ impl RunnerArgs {
             }
         )
     }
+
+    pub(crate) fn compact_doctor_stdout(&self) -> bool {
+        matches!(&self.command, RunnerCommand::Doctor { full: false, .. })
+    }
 }
 
 #[derive(Subcommand)]
@@ -214,6 +218,10 @@ pub(super) enum RunnerCommand {
         /// Safely repair issues in the selected scope, such as reconnecting a stale Lab daemon. Without --scope, repairs use lab-offload.
         #[arg(long)]
         repair: bool,
+
+        /// Return complete, redacted probe evidence and resource maps.
+        #[arg(long)]
+        full: bool,
     },
     /// Evaluate workload placement without creating a run, rig lease, runner job, or connection
     Preflight {

--- a/crates/homeboy-cli/src/commands/runner/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/runner/dispatch.rs
@@ -119,18 +119,22 @@ pub fn run(args: RunnerArgs) -> CmdResult<RunnerCommandOutput> {
             required_tools,
             scope,
             repair,
-        } => map_doctor(doctor::run_with_options(
-            &runner_id,
-            doctor::RunnerDoctorOptions {
-                path,
-                extensions: required_extensions,
-                required_tools,
-                agent_backend: None,
-                agent_selector: None,
-                scope: scope.into(),
-                repair,
-            },
-        )),
+            full,
+        } => map_doctor(
+            doctor::run_with_options(
+                &runner_id,
+                doctor::RunnerDoctorOptions {
+                    path,
+                    extensions: required_extensions,
+                    required_tools,
+                    agent_backend: None,
+                    agent_selector: None,
+                    scope: scope.into(),
+                    repair,
+                },
+            ),
+            full,
+        ),
         RunnerCommand::Preflight { request } => Ok((
             RunnerCommandOutput::Preflight(Box::new(runner::placement_readiness(
                 &serde_json::from_str(&request).map_err(|error| {
@@ -891,8 +895,16 @@ fn runner_variant_from_command(command: &str) -> &'static str {
     }
 }
 
-fn map_doctor(result: CmdResult<doctor::RunnerDoctorOutput>) -> CmdResult<RunnerCommandOutput> {
-    result.map(|(output, exit_code)| (RunnerCommandOutput::Doctor(Box::new(output)), exit_code))
+fn map_doctor(
+    result: CmdResult<doctor::RunnerDoctorOutput>,
+    full: bool,
+) -> CmdResult<RunnerCommandOutput> {
+    result.map(|(output, exit_code)| {
+        (
+            RunnerCommandOutput::Doctor(Box::new(doctor::output_projection(output, full))),
+            exit_code,
+        )
+    })
 }
 
 fn map_execution(result: CmdResult<RunnerExecOutput>) -> CmdResult<RunnerCommandOutput> {

--- a/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
@@ -104,6 +104,108 @@ pub(crate) fn run_with_options(
     Ok((report, exit_code))
 }
 
+const COMPACT_CHECK_LIMIT: usize = 12;
+const COMPACT_PROVIDER_LIMIT: usize = 10;
+const COMPACT_TEXT_LIMIT: usize = 256;
+
+/// Keep default doctor output to the facts needed to decide whether the runner
+/// is usable. `--full` remains a lossless, redacted evidence surface.
+pub(crate) fn output_projection(report: RunnerDoctorOutput, full: bool) -> serde_json::Value {
+    let value = serde_json::to_value(&report).unwrap_or(serde_json::Value::Null);
+    if full {
+        return homeboy::core::redaction::redact_json(&value);
+    }
+
+    let failed_checks = report
+        .checks
+        .iter()
+        .filter(|check| check.status != RunnerDoctorStatus::Ok)
+        .count();
+    let checks = report
+        .checks
+        .iter()
+        .take(COMPACT_CHECK_LIMIT)
+        .map(|check| {
+            serde_json::json!({
+                "id": bounded_text(&check.id),
+                "status": check.status,
+                "message": bounded_text(&check.message),
+                "remediation": check.remediation.as_deref().map(bounded_text),
+            })
+        })
+        .collect::<Vec<_>>();
+    let (ready_for, blocked_for) = report.provider_readiness.as_ref().map_or_else(
+        || (Vec::new(), Vec::new()),
+        |readiness| {
+            (
+                readiness
+                    .ready_for
+                    .iter()
+                    .take(COMPACT_PROVIDER_LIMIT)
+                    .map(|value| bounded_text(value))
+                    .collect::<Vec<_>>(),
+                readiness
+                    .blocked_for
+                    .iter()
+                    .take(COMPACT_PROVIDER_LIMIT)
+                    .map(|value| bounded_text(value))
+                    .collect::<Vec<_>>(),
+            )
+        },
+    );
+    let provider_total = report.provider_readiness.as_ref().map_or(0, |readiness| {
+        readiness.ready_for.len() + readiness.blocked_for.len()
+    });
+    let runner_id = bounded_text(&report.runner_id);
+    serde_json::json!({
+        "schema": "homeboy/runner-doctor/v1",
+        "command": report.command,
+        "runner_id": runner_id,
+        "runner": report.runner,
+        "status": report.status,
+        "operator_summary": {
+            "identity": "runner doctor",
+            "state": match report.status { RunnerDoctorStatus::Ok => "ready", RunnerDoctorStatus::Warning => "degraded", RunnerDoctorStatus::Error => "blocked" },
+            "risk": if failed_checks == 0 { Vec::new() } else { vec![format!("{failed_checks} check(s) need attention")] },
+            "next_action": format!("homeboy runner doctor {} --full", report.runner_id),
+        },
+        "capabilities": report.capabilities,
+        "resources": {
+            "homeboy": { "version": bounded_text(&report.resources.homeboy.version) },
+            "system": { "os": bounded_text(&report.resources.system.os), "arch": bounded_text(&report.resources.system.arch) },
+            "cpu": { "count": report.resources.cpu.count },
+        },
+        "checks": checks,
+        "provider_readiness": if provider_total == 0 { serde_json::Value::Null } else { serde_json::json!({ "ready_for": ready_for, "blocked_for": blocked_for }) },
+        "truncation": {
+            "checks": { "shown": checks.len(), "omitted": report.checks.len().saturating_sub(checks.len()), "evidence_ref": "runner:doctor:checks", "full_command": format!("homeboy runner doctor {} --full", report.runner_id) },
+            "provider_readiness": { "shown": ready_for.len() + blocked_for.len(), "omitted": provider_total.saturating_sub(ready_for.len() + blocked_for.len()), "evidence_ref": "runner:doctor:provider-readiness", "full_command": format!("homeboy runner doctor {} --full", report.runner_id) },
+            "omitted_sections": ["resource_maps", "probe_details", "diagnostics", "repairs", "secret_env_migration", "daemon_recovery", "admission_summary"],
+        }
+    })
+}
+
+fn bounded_text(value: &str) -> String {
+    if value.len() <= COMPACT_TEXT_LIMIT {
+        return value.to_string();
+    }
+    let end = value
+        .char_indices()
+        .find_map(|(index, _)| (index >= COMPACT_TEXT_LIMIT).then_some(index))
+        .unwrap_or(value.len());
+    format!("{}...", &value[..end])
+}
+
+pub(crate) fn render_summary(payload: &serde_json::Value) -> Option<String> {
+    let summary = payload.get("operator_summary")?;
+    let checks = payload.get("checks")?.as_array()?.len();
+    Some(format!(
+        "Runner doctor\nStatus: {}\nChecks shown: {checks}\nNext: {}",
+        summary.get("state")?.as_str()?,
+        summary.get("next_action")?.as_str()?,
+    ))
+}
+
 /// A bare `--repair` is the Lab daemon recovery request emitted by runner
 /// recovery guidance. Resolve it before probing so that command both diagnoses
 /// and applies the repair it advertises.

--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/shape.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/shape.rs
@@ -51,6 +51,33 @@ fn doctor_output_omits_empty_repairs() {
 }
 
 #[test]
+fn compact_doctor_projection_bounds_evidence_and_renders_action() {
+    let (mut report, _) = run("local").expect("local doctor report");
+    report.checks = (0..(COMPACT_CHECK_LIMIT + 5))
+        .map(|index| types::RunnerCheck {
+            id: format!("check-{index}"),
+            status: RunnerDoctorStatus::Warning,
+            message: "m".repeat(4_000),
+            remediation: Some("homeboy runner doctor local --repair".to_string()),
+            details: BTreeMap::from([("large".to_string(), "d".repeat(4_000))]),
+        })
+        .collect();
+
+    let compact = output_projection(report, false);
+    let rendered = serde_json::to_string(&compact).expect("compact JSON");
+    assert_eq!(
+        compact["checks"].as_array().expect("checks").len(),
+        COMPACT_CHECK_LIMIT
+    );
+    assert_eq!(compact["truncation"]["checks"]["omitted"], 5);
+    assert!(rendered.len() < 16 * 1024, "{rendered}");
+    assert_eq!(
+        render_summary(&compact).as_deref(),
+        Some("Runner doctor\nStatus: degraded\nChecks shown: 12\nNext: homeboy runner doctor local --full")
+    );
+}
+
+#[test]
 fn capabilities_are_runner_substrate_only() {
     let (report, _) = run("local").expect("local doctor report");
     let value = serde_json::to_value(report).expect("serialize report");

--- a/crates/homeboy-cli/src/commands/runner/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/mod.rs
@@ -35,6 +35,10 @@ pub(crate) fn is_compact_exec_stdout(args: &RunnerArgs) -> bool {
     args.compact_exec_stdout()
 }
 
+pub(crate) fn is_compact_doctor_stdout(args: &RunnerArgs) -> bool {
+    args.compact_doctor_stdout()
+}
+
 pub(crate) fn refresh_homeboy_uses_bounded_output(args: &RunnerArgs) -> bool {
     matches!(
         &args.command,

--- a/crates/homeboy-cli/src/commands/runner/types.rs
+++ b/crates/homeboy-cli/src/commands/runner/types.rs
@@ -12,7 +12,6 @@ use homeboy::runner::runners::{
 
 use std::collections::BTreeMap;
 
-use super::doctor;
 use super::lifecycle;
 use super::refresh_plan;
 use super::workspace;
@@ -440,7 +439,7 @@ pub(super) const REDACTED_ENV_VALUE: &str = "[redacted]";
 #[serde(untagged)]
 pub enum RunnerCommandOutput {
     Registry(Box<RunnerOutput>),
-    Doctor(Box<doctor::RunnerDoctorOutput>),
+    Doctor(Box<serde_json::Value>),
     Preflight(Box<homeboy::runner::runners::PlacementReadiness>),
     Execution(Box<RunnerExecutionCommandOutput>),
     Env(Box<RunnerEnvOutput>),

--- a/crates/homeboy-cli/src/commands/ssh.rs
+++ b/crates/homeboy-cli/src/commands/ssh.rs
@@ -3,6 +3,7 @@ use homeboy::core::engine::shell;
 use homeboy::core::server::{self, Server};
 use homeboy::core::server::{resolve_context, CommandObservation, SshClient, SshResolveArgs};
 use serde::Serialize;
+use serde_json::Value;
 use std::io::IsTerminal;
 use std::time::Duration;
 
@@ -66,14 +67,18 @@ pub(super) fn is_raw_command(args: &SshArgs) -> bool {
 #[derive(Subcommand)]
 pub enum SshSubcommand {
     /// List configured SSH server targets
-    List,
+    List {
+        /// Return complete, redacted server configuration records.
+        #[arg(long)]
+        full: bool,
+    },
 }
 
 #[derive(Debug, Serialize)]
 #[serde(tag = "action")]
 pub enum SshOutput {
     Connect(SshConnectOutput),
-    List(SshListOutput),
+    List(Value),
 }
 
 #[derive(Debug, Serialize)]
@@ -146,17 +151,11 @@ fn bounded_tail(value: &str) -> String {
     value[start..].to_string()
 }
 
-#[derive(Debug, Serialize)]
-
-pub struct SshListOutput {
-    pub servers: Vec<Server>,
-}
-
 pub fn run(args: SshArgs) -> CmdResult<SshOutput> {
     match args.subcommand {
-        Some(SshSubcommand::List) => {
+        Some(SshSubcommand::List { full }) => {
             let servers = server::list()?;
-            Ok((SshOutput::List(SshListOutput { servers }), 0))
+            Ok((SshOutput::List(list_output(servers, full)), 0))
         }
         None => {
             ssh_phase("target-resolution-start");
@@ -255,6 +254,71 @@ pub fn run(args: SshArgs) -> CmdResult<SshOutput> {
             }
         }
     }
+}
+
+const SSH_LIST_LIMIT: usize = 20;
+
+fn list_output(servers: Vec<Server>, full: bool) -> Value {
+    if full {
+        return homeboy::core::redaction::redact_json(
+            &serde_json::to_value(servers).unwrap_or(Value::Null),
+        );
+    }
+
+    let total = servers.len();
+    let shown = servers
+        .iter()
+        .take(SSH_LIST_LIMIT)
+        .map(|server| {
+            serde_json::json!({
+                "id": server.id,
+                "host": bounded_text(&server.host, 160),
+                "user": bounded_text(&server.user, 160),
+                "port": server.port,
+                "kind": server.kind,
+                "runner_configured": server.runner.is_some(),
+            })
+        })
+        .collect::<Vec<_>>();
+    serde_json::json!({
+        "schema": "homeboy/ssh-list/v1",
+        "operator_summary": {
+            "identity": "ssh list",
+            "state": if total == 0 { "empty" } else { "configured" },
+            "risk": Vec::<String>::new(),
+            "next_action": "homeboy ssh <server-id> -- <command>",
+        },
+        "servers": shown,
+        "truncation": {
+            "servers": {
+                "shown": shown.len(),
+                "omitted": total.saturating_sub(shown.len()),
+                "evidence_ref": "ssh:server-config",
+                "full_command": "homeboy ssh list --full",
+            }
+        }
+    })
+}
+
+fn bounded_text(value: &str, limit: usize) -> String {
+    if value.len() <= limit {
+        return value.to_string();
+    }
+    let end = value
+        .char_indices()
+        .find_map(|(index, _)| (index >= limit).then_some(index))
+        .unwrap_or(value.len());
+    format!("{}...", &value[..end])
+}
+
+pub(crate) fn render_list_summary(payload: &Value) -> Option<String> {
+    let summary = payload.get("operator_summary")?;
+    let count = payload.get("servers")?.as_array()?.len();
+    Some(format!(
+        "SSH targets\nStatus: {}\nTargets shown: {count}\nNext: {}",
+        summary.get("state")?.as_str()?,
+        summary.get("next_action")?.as_str()?,
+    ))
 }
 
 fn connect_output_from_execution(
@@ -538,6 +602,41 @@ mod tests {
     use super::*;
     use crate::cli_surface::{Cli, Commands};
     use clap::Parser;
+    use std::collections::HashMap;
+
+    #[test]
+    fn list_projection_bounds_items_bytes_and_redacts_full_records() {
+        let servers = (0..(SSH_LIST_LIMIT + 5))
+            .map(|index| Server {
+                id: format!("server-{index}"),
+                aliases: Vec::new(),
+                host: "h".repeat(4_000),
+                user: "user".to_string(),
+                port: 22,
+                identity_file: None,
+                kind: None,
+                auth: None,
+                env: HashMap::from([("API_TOKEN".to_string(), "secret-value".to_string())]),
+                runner: None,
+            })
+            .collect::<Vec<_>>();
+        let compact = list_output(servers.clone(), false);
+        let rendered = serde_json::to_string(&compact).expect("compact JSON");
+
+        assert_eq!(
+            compact["servers"].as_array().expect("servers").len(),
+            SSH_LIST_LIMIT
+        );
+        assert_eq!(compact["truncation"]["servers"]["omitted"], 5);
+        assert!(rendered.len() < 8 * 1024, "{rendered}");
+        assert_eq!(
+            render_list_summary(&compact).as_deref(),
+            Some("SSH targets\nStatus: configured\nTargets shown: 20\nNext: homeboy ssh <server-id> -- <command>")
+        );
+
+        let full = list_output(servers, true).to_string();
+        assert!(!full.contains("secret-value"), "{full}");
+    }
 
     /// A cwd-rooted interactive session must hand back a shell, not run `cd` and quit.
     #[test]


### PR DESCRIPTION
## Summary
- Bound default `ssh list` and `runner doctor` output to operational identity, readiness, compact evidence, truncation metadata, and a lossless `--full` follow-up.
- Add redacted `--full` records for both commands and compact human summaries.
- Cover default item/byte budgets, redaction, and presentation rendering.

Closes #13256

## Verification
- `cargo fmt --check`
- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-cli --features test-support list_projection_bounds_items_bytes_and_redacts_full_records --no-fail-fast`
- `cargo test -p homeboy-cli --features test-support compact_doctor_projection_bounds_evidence_and_renders_action --no-fail-fast`
- `cargo test -p homeboy-cli --lib --features test-support commands::agent_task::tests::contract --no-fail-fast`
- Full `cargo test -p homeboy-cli --lib --features test-support --no-fail-fast` exceeded 10 minutes and has pre-existing unrelated fanout/provider failures.

## AI assistance
OpenAI GPT-5.6-sol via OpenCode general coding subagent implemented the bounded projections, tests, and verification under Chris Huber's direction.