### PR TITLE
fix(cook): unify durable retry guidance

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -9530,7 +9530,7 @@ fn cook_persists_controller_runtime_mismatch_before_provider_execution() {
 }
 
 #[test]
-fn cook_does_not_retry_deterministic_pre_provider_input_failures() {
+fn cook_lab_workspace_stage_failure_advertises_diagnostics_not_retry() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let run_id = "cook-invalid-input-attempt-1";
         let mut options = batch_cook_options(
@@ -9574,6 +9574,14 @@ fn cook_does_not_retry_deterministic_pre_provider_input_failures() {
             "homeboy runner refresh-homeboy homeboy-lab --ref required --reconnect"
         );
         assert!(context
+            .legal_actions
+            .iter()
+            .all(|action| action.action != "retry"));
+        assert!(context
+            .next_actions
+            .iter()
+            .all(|action| action.action != "retry"));
+        assert!(context
             .next_actions
             .iter()
             .all(|action| action.action != "refresh_lab_runtime"));
@@ -9588,6 +9596,47 @@ fn cook_does_not_retry_deterministic_pre_provider_input_failures() {
         let record = agent_task_lifecycle::status(run_id).expect("attempt exists");
         assert!(record.provider_handles.is_empty());
         assert_eq!(record.metadata["provider_executions_consumed"], 0);
+    });
+}
+
+#[test]
+fn cook_pre_provider_worktree_lookup_failure_advertises_diagnostics_not_retry() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let run_id = "cook-worktree-lookup-attempt-1";
+        let mut options = batch_cook_options(
+            "cook-worktree-lookup",
+            Arc::new(AdmissionFailingAttemptDispatcher {
+                message: "configured worktree could not be resolved before provider dispatch",
+                runtime_recovery: None,
+                phase: "pre_provider_worktree_lookup",
+            }),
+        );
+        options.provider_command = Some("fixture-provider".to_string());
+        options.initial_run_id = run_id.to_string();
+
+        let result = run_cook(CookContext::new(options, Arc::new(UnusedExecutor)))
+            .expect("Cook persists the worktree lookup failure");
+        let context = result
+            .value
+            .failure_context
+            .expect("durable failure context");
+
+        assert_eq!(
+            result.value.terminal_phase.as_deref(),
+            Some("pre_provider_worktree_lookup")
+        );
+        assert_eq!(
+            context
+                .legal_actions
+                .iter()
+                .map(|action| action.action.as_str())
+                .collect::<Vec<_>>(),
+            vec!["status", "diagnose"]
+        );
+        assert!(context
+            .next_actions
+            .iter()
+            .all(|action| action.action != "retry"));
     });
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -1761,7 +1761,21 @@ pub fn retry_admission(run_id: &str) -> Result<()> {
         &lifecycle_store,
         run_id,
     )?;
-    let _ = retry_admission_in_store(&lifecycle_store, &source, true)?;
+    let retry = retry_admission_in_store(&lifecycle_store, &source, true)?;
+    if retry.as_ref().is_some_and(|attempt| {
+        attempt
+            .plan
+            .metadata
+            .get("generic_lab_command_replay")
+            .is_some()
+    }) {
+        return Err(Error::validation_invalid_argument(
+            "generic_lab_command_replay",
+            "generic Lab replay requires controller workspace preflight",
+            Some(source.run_id.clone()),
+            None,
+        ));
+    }
     Ok(())
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -7457,54 +7457,6 @@ fn retry_replay_action(record: &AgentTaskRunRecord) -> RetryReplayAction {
             "persisted replay plan has no materialization identity",
         );
     }
-    if let Some(replay) = plan.metadata.get("generic_lab_command_replay") {
-        let root = replay
-            .pointer("/materialization/canonical_root")
-            .and_then(Value::as_str);
-        let expected_identity = replay
-            .pointer("/materialization/content_identity")
-            .and_then(Value::as_str);
-        let (Some(root), Some(expected_identity)) = (root, expected_identity) else {
-            return RetryReplayAction::unavailable(
-                owner,
-                "generic Lab replay is missing its materialization identity",
-            );
-        };
-        match homeboy::runner::controller_workspace_materialization_identity(std::path::Path::new(
-            root,
-        )) {
-            Ok(actual_identity) if actual_identity == expected_identity => {}
-            Ok(actual_identity) => {
-                let reason = "source workspace no longer matches the persisted Lab replay identity";
-                return RetryReplayAction {
-                    owner,
-                    readiness: "unavailable",
-                    reason: Some(reason.to_string()),
-                    admission: json!({
-                        "admitted": false,
-                        "reason": reason,
-                        "compared_values": {
-                            "canonical_root": root,
-                            "expected_content_identity": expected_identity,
-                            "actual_content_identity": actual_identity,
-                        },
-                    }),
-                    action: None,
-                    continuation: None,
-                };
-            }
-            Err(error) => {
-                return RetryReplayAction::unavailable(
-                    owner,
-                    format!(
-                        "cannot validate persisted Lab replay identity: {}",
-                        error.message
-                    ),
-                );
-            }
-        }
-    }
-
     RetryReplayAction {
         owner: owner.clone(),
         readiness: "ready",


### PR DESCRIPTION
## Summary
- make durable Cook retry admission reject Lab replay that still needs controller workspace preflight
- remove the status-only replay check so Cook, status, diagnose, and notifications consume the same legal retry action
- cover pre-provider worktree lookup and Lab workspace-stage failures with diagnostics-only recovery

Closes #13253

## Verification
- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-agents --features test-support cook_lab_workspace_stage_failure_advertises_diagnostics_not_retry -- --test-threads=1`
- `cargo test -p homeboy-agents --features test-support cook_pre_provider_worktree_lookup_failure_advertises_diagnostics_not_retry -- --test-threads=1`
- `cargo test -p homeboy-cli --features test-support unavailable_retry_has_a_reason_and_no_executable_action -- --test-threads=1`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

## AI assistance
OpenAI GPT-5.6-sol via OpenCode general coding subagent investigated the durable retry-action projections, implemented the shared admission gate, and ran focused verification. Chris Huber remains responsible for every line.