### PR TITLE
fix(cook): skip base capture for reconstructed recipes

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4494,7 +4494,7 @@ fn run_cook_spine(
     )?;
     // Base resolution reaches origin. Keep its transport failure behind the
     // recipe/run saga so retry and replay have durable zero-provider evidence.
-    if options.task_base_sha.is_none() {
+    if recipe_materialization.created && options.task_base_sha.is_none() {
         pin_and_persist_initial_cook_workspace_base(store, lifecycle_store, &mut options).map_err(
             |error| {
                 let mut error = with_pre_execution_phase(error, "workspace_base_capture");

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -8514,6 +8514,10 @@ fn cook_continue_adopts_recipe_bound_retry_missing_run_and_index() {
         })
         .expect("register destination workspace");
         super::super::persist_initial_recipe(&options).expect("persist durable recipe");
+        assert!(super::super::load_recipe(cook_id)
+            .expect("load durable recipe")
+            .finalization["task_base_sha"]
+            .is_null());
         super::super::materialize_initial_cook_attempt(&options)
             .expect("materialize initial attempt");
         agent_task_lifecycle::record_pre_execution_failure(


### PR DESCRIPTION
Carries forward commit 1969264d8 after #13229 merged before this successor commit reached its PR head.

The change skips base capture for reconstructed cook recipes and adds focused coverage.

AI assistance: OpenCode using gpt-5.6-terra inspected the remote/PR divergence, created the successor branch and PR, and verified CI state.