### PR TITLE
Compose Lab routing below the static CLI enum

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -2051,10 +2051,25 @@ fn preflight_composed_lab_route(
     let Ok((resources, _)) = crate::commands::resources::run_preflight() else {
         return None;
     };
-    let readiness = hot_command
+    let mut readiness = hot_command
         .lab_offload_supported
         .then(|| crate::runner::lab_runner_readiness().ok())
         .flatten();
+    let observed_at_ms = unix_timestamp_ms();
+    if hot_command.lab_offload_supported
+        && options.runner.is_none()
+        && !matches!(options.placement, crate::cli_surface::Placement::Local)
+        && resource_policy::evaluate_with_runner_hint(hot_command, &resources, readiness.as_ref())
+            .is_some()
+    {
+        if let Some(observed) = readiness.take() {
+            let (resolved, _) = resolve_terminal_lab_inventory(observed, observed_at_ms, || {
+                let refreshed = crate::runner::refresh_lab_runner_readiness_for_admission()?;
+                Ok((refreshed, unix_timestamp_ms()))
+            });
+            readiness = Some(resolved);
+        }
+    }
     let warning =
         resource_policy::evaluate_with_runner_hint(hot_command, &resources, readiness.as_ref());
     let runner_hosted = resource_policy::is_runner_hosted_exec();

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -591,6 +591,27 @@ impl CliRuntime {
                     return std::process::ExitCode::from(2);
                 }
             };
+            let placement = *matches
+                .get_one::<crate::cli_surface::Placement>("placement")
+                .unwrap_or(&crate::cli_surface::Placement::Auto);
+            let runner = matches.get_one::<String>("runner").map(String::as_str);
+            if route.is_none()
+                && (placement == crate::cli_surface::Placement::Lab || runner.is_some())
+            {
+                let error = crate::core::Error::validation_invalid_argument(
+                    "placement",
+                    "this composed command has no Lab route contract",
+                    None,
+                    None,
+                );
+                output_runtime::emit_json_result_for_identity(
+                    Err(error),
+                    output_file.as_deref(),
+                    2,
+                    &command_identity,
+                );
+                return std::process::ExitCode::from(2);
+            }
             if let Some(route) = route {
                 let runner_env = matches
                     .get_many::<String>("runner_env")
@@ -601,10 +622,8 @@ impl CliRuntime {
                     .map(|values| values.cloned().collect::<Vec<_>>())
                     .unwrap_or_default();
                 let options = crate::commands::route::ComposedLabRouteOptions {
-                    placement: *matches
-                        .get_one::<crate::cli_surface::Placement>("placement")
-                        .unwrap_or(&crate::cli_surface::Placement::Auto),
-                    runner: matches.get_one::<String>("runner").map(String::as_str),
+                    placement,
+                    runner,
                     allow_dirty_lab_workspace: matches.get_flag("allow_dirty_lab_workspace"),
                     skip_deps_hydration: matches.get_flag("skip_deps_hydration"),
                     preserve_workspace_on_failure: matches

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -619,6 +619,24 @@ impl CliRuntime {
                         .get_one::<String>("runner_workspace_root")
                         .map(String::as_str),
                 };
+                if let Some(exit_code) = preflight_composed_lab_route(
+                    &route,
+                    &options,
+                    output_file.as_deref(),
+                    &command_identity,
+                ) {
+                    return std::process::ExitCode::from(exit_code_to_u8(exit_code));
+                }
+                crate::commands::utils::execution_provenance::capture_composed(
+                    options.placement,
+                    options.runner,
+                    options.detach_after_handoff,
+                    options.allow_dirty_lab_workspace,
+                    options.skip_deps_hydration,
+                    options.runner_env,
+                    options.lab_env_json,
+                    &normalized,
+                );
                 match crate::commands::route::route_composed_lab_command(
                     &route,
                     options,
@@ -976,7 +994,7 @@ impl CliRuntime {
             .iter()
             .filter_map(|capability| capability.lab_command_route_support())
             .collect::<Vec<_>>();
-        crate::command_contract::scope_lab_cli_arguments_with(command, &support)
+        crate::command_contract::scope_composed_lab_cli_arguments(command, &support)
     }
 
     fn capability_matches<'a>(
@@ -2021,6 +2039,69 @@ fn preflight_hot_command(
     preflight_hot_command_with(cli, output_file, command_identity, || {
         crate::commands::resources::run_preflight()
     })
+}
+
+fn preflight_composed_lab_route(
+    route: &LabCommandRoute,
+    options: &crate::commands::route::ComposedLabRouteOptions<'_>,
+    output_file: Option<&str>,
+    command_identity: &output::CommandIdentity,
+) -> Option<i32> {
+    let hot_command = resource_policy::hot_command_for_lab_route(route)?;
+    let Ok((resources, _)) = crate::commands::resources::run_preflight() else {
+        return None;
+    };
+    let readiness = hot_command
+        .lab_offload_supported
+        .then(|| crate::runner::lab_runner_readiness().ok())
+        .flatten();
+    let warning =
+        resource_policy::evaluate_with_runner_hint(hot_command, &resources, readiness.as_ref());
+    let runner_hosted = resource_policy::is_runner_hosted_exec();
+    let runner_admits_offload = options.runner.is_some()
+        || readiness.as_ref().is_some_and(|readiness| {
+            readiness.state == crate::runner::runners::LabRunnerReadinessState::ConnectedReady
+                && readiness.selected_runner_id.is_some()
+        });
+    let auto_local_capacity_fallback = resource_policy::admits_auto_local_capacity_fallback(
+        hot_command,
+        &resources,
+        readiness.as_ref(),
+        options.placement,
+    );
+    let mut context = resource_policy::resource_policy_context_from_evaluation(
+        hot_command,
+        &resources,
+        if runner_hosted {
+            None
+        } else {
+            warning.as_ref()
+        },
+        options.placement.is_explicit_local_override(),
+        auto_local_capacity_fallback,
+        readiness.as_ref(),
+        runner_hosted,
+    );
+    if let Some(runner) = options.runner {
+        context.runner_selection.reason = "explicit_lab_runner".to_string();
+        context.runner_selection.runner_id = Some(runner.to_string());
+    }
+    resource_policy::capture_context(context);
+    let warning = warning?;
+    if let Some(error) = resource_policy::non_interactive_preflight_error(
+        &warning,
+        options.placement.is_explicit_local_override() || runner_hosted,
+        is_interactive_shell(),
+        resource_policy::admission_recovery(
+            &std::env::args().collect::<Vec<_>>(),
+            readiness.as_ref(),
+        ),
+        runner_admits_offload || auto_local_capacity_fallback,
+    ) {
+        output_runtime::emit_json_result_for_identity(Err(error), output_file, 2, command_identity);
+        return Some(2);
+    }
+    None
 }
 
 fn preflight_hot_command_with(

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -579,14 +579,66 @@ impl CliRuntime {
         crate::core::set_artifact_root_override(artifact_root_override.clone());
 
         if let Some((capability, capability_matches)) = self.capability_matches(&matches) {
-            if let Err(error) = capability.lab_command_route(capability_matches) {
-                output_runtime::emit_json_result_for_identity(
-                    Err(error),
+            let route = match capability.lab_command_route(capability_matches) {
+                Ok(route) => route,
+                Err(error) => {
+                    output_runtime::emit_json_result_for_identity(
+                        Err(error),
+                        output_file.as_deref(),
+                        2,
+                        &command_identity,
+                    );
+                    return std::process::ExitCode::from(2);
+                }
+            };
+            if let Some(route) = route {
+                let runner_env = matches
+                    .get_many::<String>("runner_env")
+                    .map(|values| values.cloned().collect::<Vec<_>>())
+                    .unwrap_or_default();
+                let runner_secret_env = matches
+                    .get_many::<String>("runner_secret_env")
+                    .map(|values| values.cloned().collect::<Vec<_>>())
+                    .unwrap_or_default();
+                let options = crate::commands::route::ComposedLabRouteOptions {
+                    placement: *matches
+                        .get_one::<crate::cli_surface::Placement>("placement")
+                        .unwrap_or(&crate::cli_surface::Placement::Auto),
+                    runner: matches.get_one::<String>("runner").map(String::as_str),
+                    allow_dirty_lab_workspace: matches.get_flag("allow_dirty_lab_workspace"),
+                    skip_deps_hydration: matches.get_flag("skip_deps_hydration"),
+                    preserve_workspace_on_failure: matches
+                        .get_flag("preserve_workspace_on_failure"),
+                    detach_after_handoff: matches.get_flag("detach_after_handoff"),
+                    runner_env: &runner_env,
+                    runner_secret_env: &runner_secret_env,
+                    lab_env_json: matches
+                        .get_one::<String>("lab_env_json")
+                        .map(String::as_str),
+                    runner_workspace_root: matches
+                        .get_one::<String>("runner_workspace_root")
+                        .map(String::as_str),
+                };
+                match crate::commands::route::route_composed_lab_command(
+                    &route,
+                    options,
+                    &normalized,
                     output_file.as_deref(),
-                    2,
-                    &command_identity,
-                );
-                return std::process::ExitCode::from(2);
+                ) {
+                    Ok(Some(exit_code)) => {
+                        return std::process::ExitCode::from(exit_code_to_u8(exit_code));
+                    }
+                    Ok(None) => {}
+                    Err(error) => {
+                        output_runtime::emit_json_result_for_identity(
+                            Err(error),
+                            output_file.as_deref(),
+                            2,
+                            &command_identity,
+                        );
+                        return std::process::ExitCode::from(2);
+                    }
+                }
             }
             if let Some(path) = output_file.as_deref() {
                 if let Some(exit) = output_file_path_exit_code(path, &command_identity) {

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -13,6 +13,7 @@ use crate::command_capability::{
     classify as classify_command_capability, homeboy_owned_args, requires_startup_reconciliation,
     CommandCapability,
 };
+use crate::command_contract::{LabCommandRoute, LabCommandRouteSupport};
 use crate::commands;
 use crate::commands::cli;
 use crate::commands::output_runtime;
@@ -34,6 +35,20 @@ pub trait CliCapability: Sync {
     fn name(&self) -> &'static str;
     fn command(&self) -> Command;
     fn run(&self, matches: &ArgMatches) -> crate::core::Result<(serde_json::Value, i32)>;
+
+    /// Resolve a descriptor-composed command through the same typed Lab route
+    /// contract as a built-in command. Absent remains fail-closed.
+    fn lab_command_route(
+        &self,
+        _matches: &ArgMatches,
+    ) -> crate::core::Result<Option<LabCommandRoute>> {
+        Ok(None)
+    }
+
+    /// Declares scoped help and runner-guidance metadata for the route.
+    fn lab_command_route_support(&self) -> Option<LabCommandRouteSupport> {
+        None
+    }
 }
 
 const COOK_PINNED_RUNTIME_ENV: &str = "HOMEBOY_COOK_PINNED_CONTROLLER_RUNTIME";
@@ -247,6 +262,7 @@ pub(crate) fn register_startup_providers_before_reconcile() {
 /// directory.
 fn register_startup_providers_after_reconcile(
     agent_task: &crate::core::defaults::AgentTaskConfig,
+    capabilities: &[&dyn CliCapability],
 ) -> Result<(), crate::core::error::Error> {
     // Register the runner daemon-exec driver so the daemon's /exec endpoint
     // can prepare and run a runner job as a local child without core
@@ -365,8 +381,12 @@ fn register_startup_providers_after_reconcile(
     // Register the Lab-runner hint provider so core::runner can compose
     // `--runner`/`--placement` unsupported errors from the command-spec table
     // without depending on `command_contract`.
-    crate::runner::set_lab_runner_hint_provider(|| {
-        let summary = crate::command_contract::lab_runner_support_summary();
+    let lab_support = capabilities
+        .iter()
+        .filter_map(|capability| capability.lab_command_route_support())
+        .collect::<Vec<_>>();
+    crate::runner::set_lab_runner_hint_provider(move || {
+        let summary = crate::command_contract::lab_runner_support_summary(&lab_support);
         crate::runner::LabRunnerHint {
             hint: summary.hint,
             unsupported_message: summary.unsupported_message,
@@ -388,7 +408,7 @@ pub fn register_all_providers(
     agent_task: &crate::core::defaults::AgentTaskConfig,
 ) -> Result<(), crate::core::error::Error> {
     register_startup_providers_before_reconcile();
-    register_startup_providers_after_reconcile(agent_task)
+    register_startup_providers_after_reconcile(agent_task, &[])
 }
 
 impl CliRuntime {
@@ -414,7 +434,9 @@ impl CliRuntime {
         register_startup_providers_before_reconcile();
         if std::env::var_os(CONTROLLER_FALLBACK_RECONCILIATION_ENV).is_some() {
             let config = crate::core::defaults::load_config();
-            if register_startup_providers_after_reconcile(&config.agent_task).is_err() {
+            if register_startup_providers_after_reconcile(&config.agent_task, self.capabilities)
+                .is_err()
+            {
                 return std::process::ExitCode::from(2);
             }
             let _ =
@@ -468,7 +490,9 @@ impl CliRuntime {
             return std::process::ExitCode::SUCCESS;
         }
         let config = crate::core::defaults::load_config();
-        if let Err(error) = register_startup_providers_after_reconcile(&config.agent_task) {
+        if let Err(error) =
+            register_startup_providers_after_reconcile(&config.agent_task, self.capabilities)
+        {
             eprintln!("error: {error}");
             return std::process::ExitCode::from(2);
         }
@@ -555,6 +579,15 @@ impl CliRuntime {
         crate::core::set_artifact_root_override(artifact_root_override.clone());
 
         if let Some((capability, capability_matches)) = self.capability_matches(&matches) {
+            if let Err(error) = capability.lab_command_route(capability_matches) {
+                output_runtime::emit_json_result_for_identity(
+                    Err(error),
+                    output_file.as_deref(),
+                    2,
+                    &command_identity,
+                );
+                return std::process::ExitCode::from(2);
+            }
             if let Some(path) = output_file.as_deref() {
                 if let Some(exit) = output_file_path_exit_code(path, &command_identity) {
                     return exit;
@@ -886,7 +919,12 @@ impl CliRuntime {
         for capability in self.capabilities {
             command = command.subcommand(capability.command());
         }
-        command
+        let support = self
+            .capabilities
+            .iter()
+            .filter_map(|capability| capability.lab_command_route_support())
+            .collect::<Vec<_>>();
+        crate::command_contract::scope_lab_cli_arguments_with(command, &support)
     }
 
     fn capability_matches<'a>(

--- a/crates/homeboy-cli/src/command_contract.rs
+++ b/crates/homeboy-cli/src/command_contract.rs
@@ -38,7 +38,7 @@ pub use lab::LabCommandRouteSupport;
 #[cfg(test)]
 pub(crate) use lab::LabSourcePathMode;
 pub(crate) use lab::{
-    lab_runner_support_summary, scope_lab_cli_arguments, scope_lab_cli_arguments_with,
+    lab_runner_support_summary, scope_composed_lab_cli_arguments, scope_lab_cli_arguments,
     LabRigWorkloadKind, LabWorkspaceModePolicy, LAB_RUNNER_HANDOFF_ENVELOPE_SCHEMA,
     LAB_RUNNER_WORKLOAD_SCHEMA, LAB_TRACE_EXTRA_CAPABILITIES, RUNNER_ARTIFACT_MANIFEST_FILE,
     RUNNER_ARTIFACT_MANIFEST_REF_NAME, RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,

--- a/crates/homeboy-cli/src/command_contract.rs
+++ b/crates/homeboy-cli/src/command_contract.rs
@@ -26,22 +26,27 @@ mod public_variants;
 mod registry;
 mod spec;
 
+pub use crate::commands::contract_lab_routing::LabCommandRoute;
 pub use crate::core::artifact_ref::{
     validate_reviewer_facing_artifact_ref, ArtifactReference, ReviewerFacingArtifactRefError,
 };
 pub(crate) use constants::{contract_constants, ContractConstantsOutput};
+pub use lab::LabCommandRouteSupport;
 /// Only `commands::contract_lab_routing_tests` reads this; the shipped binary
 /// matches on the contract rather than the mode, so it is compiled out of the
 /// lib build instead of carrying an unused re-export.
 #[cfg(test)]
 pub(crate) use lab::LabSourcePathMode;
 pub(crate) use lab::{
-    lab_runner_support_summary, scope_lab_cli_arguments, CommandPortabilityContract,
-    LabCommandContract, LabCommandPortability, LabCommandRouteContract, LabRigWorkloadArguments,
+    lab_runner_support_summary, scope_lab_cli_arguments, scope_lab_cli_arguments_with,
     LabRigWorkloadKind, LabWorkspaceModePolicy, LAB_RUNNER_HANDOFF_ENVELOPE_SCHEMA,
     LAB_RUNNER_WORKLOAD_SCHEMA, LAB_TRACE_EXTRA_CAPABILITIES, RUNNER_ARTIFACT_MANIFEST_FILE,
     RUNNER_ARTIFACT_MANIFEST_REF_NAME, RUNNER_ARTIFACT_MANIFEST_REF_SCHEMA,
     RUNNER_ARTIFACT_MANIFEST_SCHEMA, RUNNER_ARTIFACT_ROOT_DIR_SUFFIX, RUN_LOCATION_INDEX_SCHEMA,
+};
+pub use lab::{
+    CommandPortabilityContract, LabCommandContract, LabCommandPortability, LabCommandRouteContract,
+    LabRigWorkloadArguments,
 };
 pub(crate) use lab::{
     LAB_AGENT_TASK_SECRET_ENV_SOURCES, LAB_NO_EXTRA_CAPABILITIES, LAB_TRACE_SECRET_ENV_SOURCES,

--- a/crates/homeboy-cli/src/command_contract/lab.rs
+++ b/crates/homeboy-cli/src/command_contract/lab.rs
@@ -2,6 +2,15 @@
 
 use clap::Command;
 
+/// Declarative help and runner-hint surface for one Lab-capable command family.
+/// Capability packages provide this alongside their parsed-match route resolver.
+#[derive(Debug, Clone, Copy)]
+pub struct LabCommandRouteSupport {
+    pub visible_paths: &'static [&'static [&'static str]],
+    pub message_label: &'static str,
+    pub hint_label: &'static str,
+}
+
 const LAB_CLI_ARGUMENT_IDS: &[&str] = &[
     "placement",
     "detach_after_handoff",
@@ -17,6 +26,13 @@ const LAB_CLI_ARGUMENT_IDS: &[&str] = &[
 ];
 
 pub(crate) fn scope_lab_cli_arguments(command: Command) -> Command {
+    scope_lab_cli_arguments_with(command, &[])
+}
+
+pub(crate) fn scope_lab_cli_arguments_with(
+    command: Command,
+    composed_support: &[LabCommandRouteSupport],
+) -> Command {
     let lab_args = command
         .get_arguments()
         .filter(|arg| LAB_CLI_ARGUMENT_IDS.contains(&arg.get_id().as_str()))
@@ -32,7 +48,12 @@ pub(crate) fn scope_lab_cli_arguments(command: Command) -> Command {
             }
         })
     });
-    scope_cook_help(scope_lab_cli_arguments_at_path(command, &[], &lab_args))
+    scope_cook_help(scope_lab_cli_arguments_at_path(
+        command,
+        &[],
+        &lab_args,
+        composed_support,
+    ))
 }
 
 /// Cook has a large control-plane surface, but the routine tracked-task path
@@ -91,12 +112,13 @@ fn scope_lab_cli_arguments_at_path(
     command: Command,
     path: &[String],
     lab_args: &[clap::Arg],
+    composed_support: &[LabCommandRouteSupport],
 ) -> Command {
     // Only re-expose the Lab placement/runner flags on commands that actually
     // support Lab offload. A previous refactor collapsed this to
     // `!path.is_empty()`, which advertised the flags on every subcommand
     // (including non-portable ones like `contract manifest`).
-    let visible = lab_cli_arguments_are_visible_for_path(path);
+    let visible = lab_cli_arguments_are_visible_for_path(path, composed_support);
     let command = if visible {
         lab_args.iter().fold(command, |command, arg| {
             let already_declared = command
@@ -157,7 +179,7 @@ fn scope_lab_cli_arguments_at_path(
     command.mut_subcommands(|subcommand| {
         let mut subcommand_path = path.to_vec();
         subcommand_path.push(subcommand.get_name().to_string());
-        scope_lab_cli_arguments_at_path(subcommand, &subcommand_path, lab_args)
+        scope_lab_cli_arguments_at_path(subcommand, &subcommand_path, lab_args, composed_support)
     })
 }
 
@@ -233,7 +255,10 @@ const LAB_VISIBLE_COMMAND_PATHS: &[&[&str]] = &[
     &["tunnel", "service", "start"],
 ];
 
-fn lab_cli_arguments_are_visible_for_path(path: &[String]) -> bool {
+fn lab_cli_arguments_are_visible_for_path(
+    path: &[String],
+    composed_support: &[LabCommandRouteSupport],
+) -> bool {
     let path = path.iter().map(String::as_str).collect::<Vec<_>>();
 
     // `CommandSpec.lab_supported` already answers "does this command family
@@ -242,6 +267,14 @@ fn lab_cli_arguments_are_visible_for_path(path: &[String]) -> bool {
     // a command the registry does not declare Lab-supported now shows nothing
     // and fails the agreement test below, instead of quietly advertising
     // placement flags on a command that cannot honour them.
+    if composed_support.iter().any(|support| {
+        support
+            .visible_paths
+            .iter()
+            .any(|candidate| candidate == &path.as_slice())
+    }) {
+        return true;
+    }
     if !path
         .first()
         .copied()

--- a/crates/homeboy-cli/src/command_contract/lab.rs
+++ b/crates/homeboy-cli/src/command_contract/lab.rs
@@ -53,7 +53,22 @@ pub(crate) fn scope_lab_cli_arguments_with(
         &[],
         &lab_args,
         composed_support,
+        true,
     ))
+}
+
+/// Add scoped Lab arguments only for capability-composed paths. The base CLI
+/// has already scoped its static command tree before capabilities are attached.
+pub(crate) fn scope_composed_lab_cli_arguments(
+    command: Command,
+    composed_support: &[LabCommandRouteSupport],
+) -> Command {
+    let lab_args = command
+        .get_arguments()
+        .filter(|arg| LAB_CLI_ARGUMENT_IDS.contains(&arg.get_id().as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    scope_lab_cli_arguments_at_path(command, &[], &lab_args, composed_support, false)
 }
 
 /// Cook has a large control-plane surface, but the routine tracked-task path
@@ -113,12 +128,13 @@ fn scope_lab_cli_arguments_at_path(
     path: &[String],
     lab_args: &[clap::Arg],
     composed_support: &[LabCommandRouteSupport],
+    include_builtin: bool,
 ) -> Command {
     // Only re-expose the Lab placement/runner flags on commands that actually
     // support Lab offload. A previous refactor collapsed this to
     // `!path.is_empty()`, which advertised the flags on every subcommand
     // (including non-portable ones like `contract manifest`).
-    let visible = lab_cli_arguments_are_visible_for_path(path, composed_support);
+    let visible = lab_cli_arguments_are_visible_for_path(path, composed_support, include_builtin);
     let command = if visible {
         lab_args.iter().fold(command, |command, arg| {
             let already_declared = command
@@ -179,7 +195,13 @@ fn scope_lab_cli_arguments_at_path(
     command.mut_subcommands(|subcommand| {
         let mut subcommand_path = path.to_vec();
         subcommand_path.push(subcommand.get_name().to_string());
-        scope_lab_cli_arguments_at_path(subcommand, &subcommand_path, lab_args, composed_support)
+        scope_lab_cli_arguments_at_path(
+            subcommand,
+            &subcommand_path,
+            lab_args,
+            composed_support,
+            include_builtin,
+        )
     })
 }
 
@@ -258,6 +280,7 @@ const LAB_VISIBLE_COMMAND_PATHS: &[&[&str]] = &[
 fn lab_cli_arguments_are_visible_for_path(
     path: &[String],
     composed_support: &[LabCommandRouteSupport],
+    include_builtin: bool,
 ) -> bool {
     let path = path.iter().map(String::as_str).collect::<Vec<_>>();
 
@@ -275,10 +298,11 @@ fn lab_cli_arguments_are_visible_for_path(
     }) {
         return true;
     }
-    if !path
-        .first()
-        .copied()
-        .is_some_and(top_level_command_is_lab_supported)
+    if !include_builtin
+        || !path
+            .first()
+            .copied()
+            .is_some_and(top_level_command_is_lab_supported)
     {
         return false;
     }

--- a/crates/homeboy-cli/src/command_contract/lab/support.rs
+++ b/crates/homeboy-cli/src/command_contract/lab/support.rs
@@ -1,6 +1,7 @@
 //! User-facing summaries of commands that support Lab runners.
 
-use crate::command_contract::spec::{CommandLabSupportSummary, COMMAND_SPECS};
+use super::LabCommandRouteSupport;
+use crate::command_contract::spec::COMMAND_SPECS;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LabRunnerSupportSummary {
@@ -9,15 +10,23 @@ pub struct LabRunnerSupportSummary {
     pub hint: String,
 }
 
-pub(crate) fn lab_runner_supported_labels() -> Vec<&'static str> {
-    lab_support_summaries()
+pub(crate) fn lab_runner_supported_labels(
+    composed_support: &[LabCommandRouteSupport],
+) -> Vec<&'static str> {
+    let mut labels = COMMAND_SPECS
+        .iter()
+        .flat_map(|spec| spec.lab_support_summary.iter())
         .map(|summary| summary.message_label)
-        .collect()
+        .collect::<Vec<_>>();
+    labels.extend(composed_support.iter().map(|support| support.message_label));
+    labels
 }
 
-pub(crate) fn lab_runner_support_summary() -> LabRunnerSupportSummary {
-    let supported_labels = lab_runner_supported_labels();
-    let hint_labels = lab_runner_supported_hint_labels();
+pub(crate) fn lab_runner_support_summary(
+    composed_support: &[LabCommandRouteSupport],
+) -> LabRunnerSupportSummary {
+    let supported_labels = lab_runner_supported_labels(composed_support);
+    let hint_labels = lab_runner_supported_hint_labels(composed_support);
 
     LabRunnerSupportSummary {
         unsupported_message: format!(
@@ -29,16 +38,16 @@ pub(crate) fn lab_runner_support_summary() -> LabRunnerSupportSummary {
     }
 }
 
-fn lab_runner_supported_hint_labels() -> Vec<&'static str> {
-    lab_support_summaries()
-        .map(|summary| summary.hint_label)
-        .collect()
-}
-
-fn lab_support_summaries() -> impl Iterator<Item = &'static CommandLabSupportSummary> {
-    COMMAND_SPECS
+fn lab_runner_supported_hint_labels(
+    composed_support: &[LabCommandRouteSupport],
+) -> Vec<&'static str> {
+    let mut labels = COMMAND_SPECS
         .iter()
         .flat_map(|spec| spec.lab_support_summary.iter())
+        .map(|summary| summary.hint_label)
+        .collect::<Vec<_>>();
+    labels.extend(composed_support.iter().map(|support| support.hint_label));
+    labels
 }
 
 fn human_join(labels: &[&str]) -> String {

--- a/crates/homeboy-cli/src/command_contract/lab/tests.rs
+++ b/crates/homeboy-cli/src/command_contract/lab/tests.rs
@@ -13,8 +13,13 @@
 //! registry (#10313) was a declared path spelling clap does not expose, which
 //! is likewise unobservable here without a test.
 
-use super::{lab_cli_arguments_are_visible_for_path, LAB_VISIBLE_COMMAND_PATHS};
+use super::{
+    lab_cli_arguments_are_visible_for_path, scope_lab_cli_arguments_with, LabCommandRouteSupport,
+    LAB_VISIBLE_COMMAND_PATHS,
+};
+use crate::cli_runtime::CliCapability;
 use crate::cli_surface::{current_command_surface, Cli, CommandSurfaceEntry};
+use crate::command_contract::{CommandPortabilityContract, LabCommandContract, LabCommandRoute};
 use clap::{CommandFactory, FromArgMatches};
 
 fn cook_command(command: clap::Command) -> clap::Command {
@@ -218,7 +223,7 @@ fn owned(path: &[&str]) -> Vec<String> {
 fn every_declared_path_is_visible_and_undeclared_paths_are_not() {
     for path in LAB_VISIBLE_COMMAND_PATHS {
         assert!(
-            lab_cli_arguments_are_visible_for_path(&owned(path)),
+            lab_cli_arguments_are_visible_for_path(&owned(path), &[]),
             "declared Lab-visible path `{}` is not visible",
             path.join(" ")
         );
@@ -228,7 +233,7 @@ fn every_declared_path_is_visible_and_undeclared_paths_are_not() {
     // subcommand a previous refactor wrongly advertised these flags on.
     for path in [vec![], vec!["contract"], vec!["contract", "manifest"]] {
         assert!(
-            !lab_cli_arguments_are_visible_for_path(&owned(&path)),
+            !lab_cli_arguments_are_visible_for_path(&owned(&path), &[]),
             "`{}` must not advertise Lab placement flags",
             path.join(" ")
         );
@@ -324,11 +329,97 @@ fn every_lab_visible_path_has_an_invocation_with_a_lab_contract() {
             .expect("validated arguments should parse")
             .command;
 
+        let route = command.lab_route().expect("built-in route resolves");
         assert!(
-            command.portability_contract().lab_command().is_some(),
+            route.lab_contract().is_some(),
             "`{}` advertises the Lab placement flags in --help but `{}` resolves no Lab contract",
             path.join(" "),
             argv.join(" ")
         );
     }
+}
+
+struct ComposedLabCapability;
+
+impl CliCapability for ComposedLabCapability {
+    fn name(&self) -> &'static str {
+        "composed-lab"
+    }
+
+    fn command(&self) -> clap::Command {
+        clap::Command::new(self.name()).arg(
+            clap::Arg::new("destructive")
+                .long("destructive")
+                .action(clap::ArgAction::SetTrue),
+        )
+    }
+
+    fn run(&self, _: &clap::ArgMatches) -> crate::core::Result<(serde_json::Value, i32)> {
+        Ok((serde_json::Value::Null, 0))
+    }
+
+    fn lab_command_route(
+        &self,
+        matches: &clap::ArgMatches,
+    ) -> crate::core::Result<Option<LabCommandRoute>> {
+        let contract = if matches.get_flag("destructive") {
+            LabCommandContract::local_only(
+                "composed lab",
+                "destructive composed commands stay local",
+            )
+        } else {
+            LabCommandContract::portable("composed lab", None, false, &[])
+        };
+        Ok(Some(LabCommandRoute::new(
+            CommandPortabilityContract::lab(contract),
+            Vec::new(),
+            None,
+        )))
+    }
+
+    fn lab_command_route_support(&self) -> Option<LabCommandRouteSupport> {
+        Some(LabCommandRouteSupport {
+            visible_paths: &[&["composed-lab"]],
+            message_label: "composed-lab",
+            hint_label: "composed lab",
+        })
+    }
+}
+
+#[test]
+fn composed_command_uses_the_typed_route_and_scoped_lab_surface() {
+    let capability = ComposedLabCapability;
+    let support = capability
+        .lab_command_route_support()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let summary = super::lab_runner_support_summary(&support);
+    assert!(summary.supported_labels.contains(&"composed-lab"));
+    assert!(summary.hint.contains("composed lab"));
+    let command =
+        scope_lab_cli_arguments_with(Cli::command().subcommand(capability.command()), &support);
+    let matches = command
+        .clone()
+        .try_get_matches_from(["homeboy", "composed-lab", "--placement", "lab"])
+        .expect("composed Lab flags parse only through its declared support");
+    let (_, subcommand_matches) = matches.subcommand().expect("composed command match");
+    let route = capability
+        .lab_command_route(subcommand_matches)
+        .expect("route resolution")
+        .expect("Lab route");
+    assert!(route
+        .lab_contract()
+        .is_some_and(|contract| contract.is_portable()));
+
+    let destructive = command
+        .try_get_matches_from(["homeboy", "composed-lab", "--destructive"])
+        .expect("composed destructive command parses");
+    let (_, destructive_matches) = destructive.subcommand().expect("composed command match");
+    assert!(!capability
+        .lab_command_route(destructive_matches)
+        .expect("route resolution")
+        .expect("Lab route")
+        .lab_contract()
+        .expect("contract")
+        .is_portable());
 }

--- a/crates/homeboy-cli/src/command_contract/lab/tests.rs
+++ b/crates/homeboy-cli/src/command_contract/lab/tests.rs
@@ -224,7 +224,7 @@ fn owned(path: &[&str]) -> Vec<String> {
 fn every_declared_path_is_visible_and_undeclared_paths_are_not() {
     for path in LAB_VISIBLE_COMMAND_PATHS {
         assert!(
-            lab_cli_arguments_are_visible_for_path(&owned(path), &[]),
+            lab_cli_arguments_are_visible_for_path(&owned(path), &[], true),
             "declared Lab-visible path `{}` is not visible",
             path.join(" ")
         );
@@ -234,7 +234,7 @@ fn every_declared_path_is_visible_and_undeclared_paths_are_not() {
     // subcommand a previous refactor wrongly advertised these flags on.
     for path in [vec![], vec!["contract"], vec!["contract", "manifest"]] {
         assert!(
-            !lab_cli_arguments_are_visible_for_path(&owned(&path), &[]),
+            !lab_cli_arguments_are_visible_for_path(&owned(&path), &[], true),
             "`{}` must not advertise Lab placement flags",
             path.join(" ")
         );

--- a/crates/homeboy-cli/src/command_contract/lab/tests.rs
+++ b/crates/homeboy-cli/src/command_contract/lab/tests.rs
@@ -20,6 +20,7 @@ use super::{
 use crate::cli_runtime::CliCapability;
 use crate::cli_surface::{current_command_surface, Cli, CommandSurfaceEntry};
 use crate::command_contract::{CommandPortabilityContract, LabCommandContract, LabCommandRoute};
+use crate::commands::route::{route_composed_lab_command, ComposedLabRouteOptions};
 use clap::{CommandFactory, FromArgMatches};
 
 fn cook_command(command: clap::Command) -> clap::Command {
@@ -422,4 +423,69 @@ fn composed_command_uses_the_typed_route_and_scoped_lab_surface() {
         .lab_contract()
         .expect("contract")
         .is_portable());
+}
+
+fn composed_options(placement: crate::cli_surface::Placement) -> ComposedLabRouteOptions<'static> {
+    ComposedLabRouteOptions {
+        placement,
+        runner: None,
+        allow_dirty_lab_workspace: false,
+        skip_deps_hydration: false,
+        preserve_workspace_on_failure: false,
+        detach_after_handoff: false,
+        runner_env: &[],
+        runner_secret_env: &[],
+        lab_env_json: None,
+        runner_workspace_root: None,
+    }
+}
+
+#[test]
+fn composed_routes_enter_generic_lab_dispatch_and_reject_local_only_lab_placement() {
+    let portable = LabCommandRoute::new(
+        CommandPortabilityContract::lab(LabCommandContract::portable(
+            "composed portable",
+            Some("--write"),
+            true,
+            &["fixture-capability"],
+        )),
+        vec!["fixture-extension".to_string()],
+        None,
+    );
+    let error = route_composed_lab_command(
+        &portable,
+        composed_options(crate::cli_surface::Placement::Lab),
+        &["homeboy".to_string(), "composed-lab".to_string()],
+        None,
+    )
+    .expect_err("required Lab placement enters the generic dispatcher and requires a runner");
+    assert!(error
+        .message
+        .contains("required Lab placement has no selected ready runner"));
+    let contract = portable
+        .lab_route_contract()
+        .expect("portable route contract");
+    assert_eq!(contract.required_extensions, ["fixture-extension"]);
+    assert_eq!(contract.required_capabilities[0].name, "fixture-capability");
+    assert_eq!(portable.lab_offload_mutation_flag(), Some("--write"));
+    assert!(portable.lab_offload_captures_mutation_patch());
+
+    let local_only = LabCommandRoute::new(
+        CommandPortabilityContract::lab(LabCommandContract::local_only(
+            "composed destructive",
+            "destructive composed commands stay local",
+        )),
+        Vec::new(),
+        None,
+    );
+    let error = route_composed_lab_command(
+        &local_only,
+        composed_options(crate::cli_surface::Placement::Lab),
+        &["homeboy".to_string(), "composed-lab".to_string()],
+        None,
+    )
+    .expect_err("local-only composed routes fail closed for explicit Lab placement");
+    assert!(error
+        .message
+        .contains("destructive composed commands stay local"));
 }

--- a/crates/homeboy-cli/src/commands/contract_lab_routing.rs
+++ b/crates/homeboy-cli/src/commands/contract_lab_routing.rs
@@ -22,6 +22,65 @@ use crate::command_contract::{
     LAB_AGENT_TASK_SECRET_ENV_SOURCES, LAB_NO_EXTRA_CAPABILITIES,
 };
 
+/// Fully resolved Lab policy for one parsed command invocation.
+///
+/// This sits below the static `Commands` transport enum: built-ins construct it
+/// from their typed arguments, while descriptor-composed commands construct the
+/// same value from their parsed Clap matches. Routing consumers therefore never
+/// need a second capability-specific policy path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LabCommandRoute {
+    portability: CommandPortabilityContract,
+    command: Option<LabCommandContract>,
+    required_extensions: Vec<String>,
+    workload: Option<crate::command_contract::LabRigWorkloadArguments>,
+    capture_mutation_patch: bool,
+}
+
+impl LabCommandRoute {
+    pub fn new(
+        portability: CommandPortabilityContract,
+        required_extensions: Vec<String>,
+        workload: Option<crate::command_contract::LabRigWorkloadArguments>,
+    ) -> Self {
+        let capture_mutation_patch = portability
+            .lab_command()
+            .is_some_and(|contract| contract.capture_mutation_patch);
+        Self {
+            command: portability.lab_command(),
+            portability,
+            required_extensions,
+            workload,
+            capture_mutation_patch,
+        }
+    }
+
+    pub fn portability_contract(&self) -> &CommandPortabilityContract {
+        &self.portability
+    }
+
+    pub fn lab_contract(&self) -> Option<LabCommandContract> {
+        self.command.clone()
+    }
+
+    pub fn lab_route_contract(&self) -> Option<crate::command_contract::LabCommandRouteContract> {
+        self.lab_contract().map(|contract| {
+            let mut route = contract.into_route_contract(self.required_extensions.clone());
+            route.workload = self.workload.clone();
+            route
+        })
+    }
+
+    pub fn lab_offload_mutation_flag(&self) -> Option<&'static str> {
+        self.lab_contract()
+            .and_then(|contract| contract.mutation_flag)
+    }
+
+    pub fn lab_offload_captures_mutation_patch(&self) -> bool {
+        self.capture_mutation_patch
+    }
+}
+
 const AGENT_TASK_COOK_MISSING_VERIFY_GATE_REASON: &str =
     "agent-task cook requires at least one deterministic --verify or --private-verify gate";
 pub(crate) const AGENT_TASK_COOK_COORDINATOR_CONTROLLER_REASON: &str =
@@ -34,19 +93,39 @@ pub(crate) const AGENT_TASK_FANOUT_COORDINATOR_CONTROLLER_REASON: &str =
     "agent-task fanout coordination is controller-owned so durable batch state, worktree ownership, and recovery remain available; `--placement lab` (or `--runner <runner-id>`) selects the Lab runner each child provider attempt is dispatched to, and never offloads the coordinator itself";
 
 impl Commands {
-    pub fn lab_contract(&self) -> Option<LabCommandContract> {
-        let mut contract = self.portability_contract().lab_command()?;
-
-        if let Commands::AgentTask(args) = self {
-            if matches!(args.command, agent_task::AgentTaskCommand::Promote(_))
-                || agent_task_controller_materializes_worktree(&args.command)
-                || agent_task_provider_requires_cwd_git_checkout(&args.command)
-            {
-                contract.workspace_mode_policy = LabWorkspaceModePolicy::GitCheckoutRequired;
+    /// Resolve this built-in command through the generic Lab route contract.
+    pub(crate) fn lab_route(&self) -> crate::core::Result<LabCommandRoute> {
+        let portability = self.portability_contract();
+        let workload = match self {
+            Commands::Bench(args) => args.lab_rig_workload_arguments(),
+            Commands::Fuzz(args) => args.lab_rig_workload_arguments(),
+            _ => None,
+        };
+        let mut route = LabCommandRoute::new(portability, Vec::new(), workload);
+        if let Some(mut contract) = route.lab_contract() {
+            if let Commands::AgentTask(args) = self {
+                if matches!(args.command, agent_task::AgentTaskCommand::Promote(_))
+                    || agent_task_controller_materializes_worktree(&args.command)
+                    || agent_task_provider_requires_cwd_git_checkout(&args.command)
+                {
+                    contract.workspace_mode_policy = LabWorkspaceModePolicy::GitCheckoutRequired;
+                }
             }
+            route.command = Some(contract);
         }
+        if matches!(
+            self,
+            Commands::AgentTask(agent_task::AgentTaskArgs {
+                command: agent_task::AgentTaskCommand::Promote(args),
+            }) if args.dry_run
+        ) {
+            route.capture_mutation_patch = false;
+        }
+        Ok(route)
+    }
 
-        Some(contract)
+    pub fn lab_contract(&self) -> Option<LabCommandContract> {
+        self.lab_route().ok()?.lab_contract()
     }
 
     pub(crate) fn portability_contract(&self) -> CommandPortabilityContract {
@@ -252,39 +331,26 @@ impl Commands {
     pub(crate) fn lab_route_contract(
         &self,
     ) -> crate::core::Result<Option<crate::command_contract::LabCommandRouteContract>> {
-        let Some(contract) = self.lab_contract() else {
-            return Ok(None);
-        };
-        let required_extensions = self.lab_required_extensions()?;
-        let mut route = contract.into_route_contract(required_extensions);
-        route.workload = match self {
-            Commands::Bench(args) => args.lab_rig_workload_arguments(),
-            Commands::Fuzz(args) => args.lab_rig_workload_arguments(),
-            _ => None,
-        };
-        Ok(Some(route))
+        let mut route = self.lab_route()?;
+        route.required_extensions =
+            self.lab_required_extensions_for(route.portability_contract())?;
+        Ok(route.lab_route_contract())
     }
 
     pub(crate) fn lab_offload_mutation_flag(&self) -> Option<&'static str> {
-        self.lab_contract()
-            .and_then(|contract| contract.mutation_flag)
+        self.lab_route().ok()?.lab_offload_mutation_flag()
     }
 
     pub(crate) fn lab_offload_captures_mutation_patch(&self) -> bool {
-        if matches!(
-            self,
-            Commands::AgentTask(agent_task::AgentTaskArgs {
-                command: agent_task::AgentTaskCommand::Promote(args),
-            }) if args.dry_run
-        ) {
-            return false;
-        }
-        self.lab_contract()
-            .is_some_and(|contract| contract.capture_mutation_patch)
+        self.lab_route()
+            .is_ok_and(|route| route.lab_offload_captures_mutation_patch())
     }
 
-    pub(crate) fn lab_required_extensions(&self) -> crate::core::Result<Vec<String>> {
-        let Some(contract) = self.lab_contract() else {
+    fn lab_required_extensions_for(
+        &self,
+        portability: &CommandPortabilityContract,
+    ) -> crate::core::Result<Vec<String>> {
+        let Some(contract) = portability.lab_command() else {
             return Ok(Vec::new());
         };
         if !contract.routing_policy.requires_extension_parity {

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -658,10 +658,8 @@ pub(crate) fn route_composed_lab_command(
     let command = lab_routing::lab_offload_command_from_route_contract(route_contract);
     let task = command.command.hot_label;
     let inferred_runner = options.runner.map(ToOwned::to_owned).or_else(|| {
-        command
-            .command
-            .routing_policy
-            .default_lab_offload
+        (command.command.routing_policy.default_lab_offload
+            || options.placement == homeboy::cli_surface::Placement::Lab)
             .then(|| runners::lab_runner_readiness().ok())
             .flatten()
             .and_then(|readiness| readiness.selected_runner_id)

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::agents::agent_task_service::DerivedCookBaselineCapability;
+use crate::command_contract::{LabCommandPortability, LabCommandRoute};
 use crate::commands::utils::resource_policy;
 use crate::core::io::output_file::write_output_file;
 
@@ -592,6 +593,269 @@ pub(crate) fn route_after_parse_with_provenance(
             Ok(Some(output.exit_code))
         }
     }
+}
+
+/// Global route inputs available to descriptor-composed commands. Keeping this
+/// separate from `Cli` lets a capability use the shared Lab dispatcher without
+/// pretending its parsed arguments are a static `Commands` variant.
+pub(crate) struct ComposedLabRouteOptions<'a> {
+    pub placement: homeboy::cli_surface::Placement,
+    pub runner: Option<&'a str>,
+    pub allow_dirty_lab_workspace: bool,
+    pub skip_deps_hydration: bool,
+    pub preserve_workspace_on_failure: bool,
+    pub detach_after_handoff: bool,
+    pub runner_env: &'a [String],
+    pub runner_secret_env: &'a [String],
+    pub lab_env_json: Option<&'a str>,
+    pub runner_workspace_root: Option<&'a str>,
+}
+
+/// Route a descriptor-composed command through the same core Lab contract and
+/// placement dispatcher used by built-ins. Static-command controller adapters
+/// (Cook/Fanout materialization and trace observers) intentionally remain on
+/// their typed path; composed commands use the generic no-op observer.
+pub(crate) fn route_composed_lab_command(
+    route: &LabCommandRoute,
+    options: ComposedLabRouteOptions<'_>,
+    normalized_args: &[String],
+    output_file: Option<&str>,
+) -> homeboy::core::Result<Option<i32>> {
+    let Some(route_contract) = route.lab_route_contract() else {
+        if options.placement == homeboy::cli_surface::Placement::Lab || options.runner.is_some() {
+            return Err(Error::validation_invalid_argument(
+                "placement",
+                "this composed command has no Lab route contract",
+                None,
+                None,
+            ));
+        }
+        return Ok(None);
+    };
+    if matches!(
+        route_contract.command.portability,
+        LabCommandPortability::LocalOnly(_)
+    ) {
+        if options.placement == homeboy::cli_surface::Placement::Lab || options.runner.is_some() {
+            let LabCommandPortability::LocalOnly(reason) = route_contract.command.portability
+            else {
+                unreachable!("local-only route was matched above");
+            };
+            return Err(Error::validation_invalid_argument(
+                "placement",
+                format!("Lab placement is unavailable for this composed command: {reason}"),
+                None,
+                None,
+            ));
+        }
+        return Ok(None);
+    }
+    if options.placement == homeboy::cli_surface::Placement::Local {
+        return Ok(None);
+    }
+
+    let read_only_polling = route_contract.command.routing_policy.read_only_polling;
+    let command = lab_routing::lab_offload_command_from_route_contract(route_contract);
+    let task = command.command.hot_label;
+    let inferred_runner = options.runner.map(ToOwned::to_owned).or_else(|| {
+        command
+            .command
+            .routing_policy
+            .default_lab_offload
+            .then(|| runners::lab_runner_readiness().ok())
+            .flatten()
+            .and_then(|readiness| readiness.selected_runner_id)
+    });
+    let runner_id = inferred_runner.as_deref().filter(|_| {
+        options.runner.is_some()
+            || lab_routing::authorizes_policy_lab_runner(
+                &command.command,
+                options.placement,
+                lab_routing::captured_pressure_severity().as_deref(),
+            )
+    });
+    if runner_id.is_none() && options.placement != homeboy::cli_surface::Placement::Lab {
+        return Ok(None);
+    }
+
+    let source_path = std::env::current_dir().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("resolve composed Lab source path".to_string()),
+        )
+    })?;
+    let decision = composed_placement_decision(
+        options.placement,
+        options.runner.is_some(),
+        runner_id,
+        task,
+        &source_path,
+    )?;
+    let outcome = lab_routing::dispatch_lab_offload(
+        LabRoutingRequest {
+            placement_decision: decision,
+            command: Some(command),
+            normalized_args,
+            explicit_runner: options.runner,
+            placement: options.placement,
+            allow_local_fallback: options.placement.allows_local_fallback(),
+            allow_dirty_lab_workspace: options.allow_dirty_lab_workspace,
+            skip_deps_hydration: options.skip_deps_hydration,
+            preserve_workspace_on_failure: options.preserve_workspace_on_failure,
+            capture_patch: route.lab_offload_captures_mutation_patch(),
+            mutation_flag: route.lab_offload_mutation_flag(),
+            timeout: None,
+            placement_outcome_target: None,
+            detach_after_handoff: options.detach_after_handoff,
+            output_file_requested: output_file.is_some(),
+            read_only_polling,
+            local_output_file: output_file,
+            durable_agent_task_plan: None,
+            durable_run_id: None,
+            source_path: Some(&source_path),
+            verified_cook_baseline: None,
+            require_controller_git_bundle: false,
+            reuse_compatible_snapshot: false,
+            job_overrides: composed_lab_job_overrides(&options)?,
+        },
+        runner_id,
+        Box::new(NoopLabDispatchObserver),
+    )?;
+    match outcome {
+        LabRouteOutcome::RunLocal => Ok(None),
+        LabRouteOutcome::InFlight(output) | LabRouteOutcome::Offloaded(output) => {
+            if !output.stderr.is_empty() {
+                eprint!("{}", output.stderr);
+            }
+            if let Some(path) = output_file {
+                write_offloaded_stdout(path, &output.stdout)?;
+            }
+            print!("{}", output.stdout);
+            Ok(Some(output.exit_code))
+        }
+    }
+}
+
+fn composed_placement_decision(
+    placement: homeboy::cli_surface::Placement,
+    explicit_runner: bool,
+    runner_id: Option<&str>,
+    task: &str,
+    source_path: &Path,
+) -> homeboy::core::Result<homeboy_lab_runner_contract::ExecutionPlacementDecision> {
+    use homeboy_lab_runner_contract::{
+        EffectiveExecutionPlacement, ExecutionPlacementFallback, ExecutionPlacementIdentity,
+        ExecutionPlacementOverrideAuthorization, ExecutionPlacementRequirement,
+        ExecutionPlacementRunnerSelection, RunnerSelectionSource,
+    };
+    if placement == homeboy::cli_surface::Placement::Lab && runner_id.is_none() {
+        return Err(Error::validation_invalid_argument(
+            "placement",
+            "required Lab placement has no selected ready runner",
+            Some("lab".to_string()),
+            None,
+        ));
+    }
+    let required = (placement == homeboy::cli_surface::Placement::Lab || explicit_runner)
+        .then_some(ExecutionPlacementRequirement::Lab)
+        .unwrap_or(ExecutionPlacementRequirement::Either);
+    Ok(
+        homeboy_lab_runner_contract::ExecutionPlacementDecision::new(
+            "lab-route-contract",
+            "v1",
+            ExecutionPlacementIdentity {
+                repository: source_path
+                    .file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| "controller-cwd".to_string()),
+                workspace: source_path.display().to_string(),
+                task: task.to_string(),
+                candidate: homeboy::core::git::head_sha(source_path),
+                base: homeboy::core::git::rev_parse(source_path, "origin/HEAD"),
+            },
+            placement,
+            required,
+            runner_id
+                .map(|_| EffectiveExecutionPlacement::Lab)
+                .unwrap_or(EffectiveExecutionPlacement::Local),
+            runner_id.map(|runner_id| ExecutionPlacementRunnerSelection {
+                runner_id: runner_id.to_string(),
+                source: if explicit_runner {
+                    RunnerSelectionSource::Explicit
+                } else {
+                    RunnerSelectionSource::Policy
+                },
+            }),
+            ExecutionPlacementFallback {
+                local_allowed: required != ExecutionPlacementRequirement::Lab
+                    && placement.allows_local_fallback(),
+                reason: None,
+            },
+            ExecutionPlacementOverrideAuthorization {
+                authorized: placement == homeboy::cli_surface::Placement::Local,
+                authority: (placement == homeboy::cli_surface::Placement::Local)
+                    .then(|| "operator --placement local".to_string()),
+            },
+        ),
+    )
+}
+
+fn composed_lab_job_overrides(
+    options: &ComposedLabRouteOptions<'_>,
+) -> homeboy::core::Result<runners::LabJobOverrides> {
+    let mut overrides = runners::LabJobOverrides::default();
+    let policy = RedactionPolicy::default();
+    for raw in options.runner_env {
+        let (name, value) = parse_lab_env_pair("runner-env", raw)?;
+        validate_explicit_runner_env(&policy, &name, &value)?;
+        insert_lab_env_override(&mut overrides, &policy, name, value)?;
+    }
+    for name in options.runner_secret_env {
+        overrides
+            .secret_env_names
+            .push(validate_lab_env_name("runner-secret-env", name)?);
+    }
+    if let Some(raw_json) = options.lab_env_json {
+        let value: serde_json::Value = serde_json::from_str(raw_json).map_err(|error| {
+            Error::validation_invalid_argument("lab-env-json", error.to_string(), None, None)
+        })?;
+        let object = value.as_object().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "lab-env-json",
+                "--lab-env-json must be a JSON object of string or null values",
+                Some(raw_json.to_string()),
+                None,
+            )
+        })?;
+        for (name, value) in object {
+            let value = match value {
+                serde_json::Value::String(value) => value.clone(),
+                serde_json::Value::Null => String::new(),
+                _ => {
+                    return Err(Error::validation_invalid_argument(
+                        "lab-env-json",
+                        "values must be strings or null",
+                        None,
+                        None,
+                    ))
+                }
+            };
+            insert_lab_env_override(
+                &mut overrides,
+                &policy,
+                validate_lab_env_name("lab-env-json", name)?,
+                value,
+            )?;
+        }
+    }
+    overrides.secret_env_names.sort();
+    overrides.secret_env_names.dedup();
+    overrides.workspace_root = options
+        .runner_workspace_root
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    Ok(overrides)
 }
 
 fn needs_provider_resolved_cook_interception(cli: &Cli, inferred_runner_id: Option<&str>) -> bool {

--- a/crates/homeboy-cli/src/commands/utils/execution_provenance.rs
+++ b/crates/homeboy-cli/src/commands/utils/execution_provenance.rs
@@ -25,6 +25,50 @@ pub fn capture(cli: &Cli, normalized_args: &[String]) {
     }
 }
 
+/// Capture descriptor-composed command intent without requiring a synthetic
+/// static `Commands` value.
+pub fn capture_composed(
+    placement: Placement,
+    runner: Option<&str>,
+    detach_after_handoff: bool,
+    allow_dirty_lab_workspace: bool,
+    skip_deps_hydration: bool,
+    runner_env: &[String],
+    lab_env_json: Option<&str>,
+    normalized_args: &[String],
+) {
+    let mut slot = captured_storage()
+        .write()
+        .unwrap_or_else(|error| error.into_inner());
+    if slot.is_none() {
+        let execution = homeboy::core::resource_policy_context::lab_execution_runner_id()
+            .map(|runner_id| ("lab", Some(runner_id)))
+            .unwrap_or(("controller", None));
+        let argv = redact_execution_argv(normalized_args);
+        *slot = Some(json!({
+            "schema": SCHEMA,
+            "operator_intent": {
+                "argv": argv,
+                "rerun_command": homeboy::core::redaction::redact_argv_shell_display(&redact_execution_argv(normalized_args)),
+                "placement": placement_name(placement),
+                "runner_id": runner,
+                "global_flags": {
+                    "detach_after_handoff": detach_after_handoff,
+                    "allow_dirty_lab_workspace": allow_dirty_lab_workspace,
+                    "skip_deps_hydration": skip_deps_hydration,
+                    "runner_env": runner_env.iter().map(|value| redact_env_assignment(value, &homeboy::core::redaction::RedactionPolicy::default())).collect::<Vec<_>>(),
+                    "lab_env_json": lab_env_json.map(|value| redact_json_env(value, &homeboy::core::redaction::RedactionPolicy::default())),
+                },
+            },
+            "resolved_execution": { "location": execution.0, "runner_id": execution.1 },
+            "resource_policy": {
+                "decision_origin": if runner.is_some() || matches!(placement, Placement::Local | Placement::Lab) { "explicit" } else { "automatic" },
+                "preflight": crate::commands::utils::resource_policy::captured_context().as_ref().map(crate::commands::utils::resource_policy::resource_policy_context_to_json),
+            },
+        }));
+    }
+}
+
 /// Return the command provenance captured for this process, if any. Older
 /// callers and imported observations remain valid without this optional field.
 pub fn captured() -> Option<Value> {

--- a/crates/homeboy-cli/src/commands/utils/execution_provenance.rs
+++ b/crates/homeboy-cli/src/commands/utils/execution_provenance.rs
@@ -62,7 +62,7 @@ pub fn capture_composed(
             },
             "resolved_execution": { "location": execution.0, "runner_id": execution.1 },
             "resource_policy": {
-                "decision_origin": if runner.is_some() || matches!(placement, Placement::Local | Placement::Lab) { "explicit" } else { "automatic" },
+                "decision_origin": decision_origin(placement, runner.is_some(), execution.0),
                 "preflight": crate::commands::utils::resource_policy::captured_context().as_ref().map(crate::commands::utils::resource_policy::resource_policy_context_to_json),
             },
         }));
@@ -91,11 +91,7 @@ fn build_with_execution(
     let argv = redact_execution_argv(normalized_args);
     let rerun_command = homeboy::core::redaction::redact_argv_shell_display(&argv);
     let placement = placement_name(cli.placement);
-    let decision_origin = match (cli.runner.is_some(), cli.placement, location) {
-        (true, _, _) | (_, Placement::Local | Placement::Lab, _) => "explicit",
-        (_, Placement::LabOrLocal, "controller") => "fallback",
-        _ => "automatic",
-    };
+    let decision_origin = decision_origin(cli.placement, cli.runner.is_some(), location);
 
     json!({
         "schema": SCHEMA,
@@ -209,6 +205,14 @@ fn placement_name(placement: Placement) -> &'static str {
     }
 }
 
+fn decision_origin(placement: Placement, has_runner: bool, location: &str) -> &'static str {
+    match (has_runner, placement, location) {
+        (true, _, _) | (_, Placement::Local | Placement::Lab, _) => "explicit",
+        (_, Placement::LabOrLocal, "controller") => "fallback",
+        _ => "automatic",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -267,6 +271,26 @@ mod tests {
             .as_str()
             .expect("rerun command")
             .contains("--placement=lab-or-local"));
+    }
+
+    #[test]
+    fn composed_decision_origin_matches_builtin_semantics() {
+        assert_eq!(
+            decision_origin(Placement::LabOrLocal, false, "controller"),
+            "fallback"
+        );
+        assert_eq!(
+            decision_origin(Placement::Lab, false, "controller"),
+            "explicit"
+        );
+        assert_eq!(
+            decision_origin(Placement::Auto, true, "controller"),
+            "explicit"
+        );
+        assert_eq!(
+            decision_origin(Placement::Auto, false, "controller"),
+            "automatic"
+        );
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
@@ -274,7 +274,7 @@ pub(crate) fn hot_command(command: &Commands) -> Option<HotCommand> {
     }) = command
     {
         if !cook.gates.has_deterministic_gate() {
-            let contract = command.lab_contract()?;
+            let contract = command.lab_route().ok()?.lab_contract()?;
             let LabCommandPortability::LocalOnly(reason) = contract.portability else {
                 unreachable!("an unverified cook must retain its local-only portability contract");
             };
@@ -308,11 +308,12 @@ pub(crate) fn hot_command(command: &Commands) -> Option<HotCommand> {
         });
     }
 
-    if !command.portability_contract().is_resource_intensive() {
+    let route = command.lab_route().ok()?;
+    if !route.portability_contract().is_resource_intensive() {
         return None;
     }
 
-    let contract = command.lab_contract()?;
+    let contract = route.lab_contract()?;
 
     match contract.portability {
         LabCommandPortability::Portable => {

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
@@ -3,6 +3,7 @@ mod messages;
 
 use crate::cli_surface::Commands;
 use crate::command_contract::LabCommandPortability;
+use crate::command_contract::LabCommandRoute;
 use crate::commands::agent_task;
 use crate::runner::runners::LabRunnerReadiness;
 
@@ -325,6 +326,24 @@ pub(crate) fn hot_command(command: &Commands) -> Option<HotCommand> {
             hot.offload_only_when_hot = contract.routing_policy.offload_only_when_hot;
             Some(hot)
         }
+        LabCommandPortability::LocalOnly(reason) => {
+            Some(HotCommand::local_only(contract.hot_label, Some(reason)))
+        }
+    }
+}
+
+/// Classify a descriptor-composed route with the exact portable/local-only and
+/// pressure-threshold rules used after built-in command classification.
+pub(crate) fn hot_command_for_lab_route(route: &LabCommandRoute) -> Option<HotCommand> {
+    if !route.portability_contract().is_resource_intensive() {
+        return None;
+    }
+    let contract = route.lab_contract()?;
+    match contract.portability {
+        LabCommandPortability::Portable => Some(HotCommand {
+            offload_only_when_hot: contract.routing_policy.offload_only_when_hot,
+            ..HotCommand::lab_supported(contract.hot_label)
+        }),
         LabCommandPortability::LocalOnly(reason) => {
             Some(HotCommand::local_only(contract.hot_label, Some(reason)))
         }

--- a/crates/homeboy-lab-runner/src/cli_resolver.rs
+++ b/crates/homeboy-lab-runner/src/cli_resolver.rs
@@ -7,6 +7,7 @@
 //! these resolvers at startup and core invokes them through the hook.
 
 use homeboy_agents::agent_task_dispatch_service::AgentTaskDispatchCommand;
+use std::sync::Arc;
 use std::sync::{OnceLock, RwLock};
 
 /// Resolve a dispatched command's argv to its hot-command label (e.g. `bench`,
@@ -97,7 +98,7 @@ pub struct LabRunnerHint {
     pub unsupported_message: String,
 }
 
-type LabRunnerHintProvider = fn() -> LabRunnerHint;
+type LabRunnerHintProvider = Arc<dyn Fn() -> LabRunnerHint + Send + Sync>;
 
 fn lab_runner_hint_provider() -> &'static RwLock<Option<LabRunnerHintProvider>> {
     static PROVIDER: OnceLock<RwLock<Option<LabRunnerHintProvider>>> = OnceLock::new();
@@ -106,11 +107,11 @@ fn lab_runner_hint_provider() -> &'static RwLock<Option<LabRunnerHintProvider>> 
 
 /// Register the provider that supplies Lab-runner support hint strings. Called
 /// once during startup by the CLI layer.
-pub fn set_lab_runner_hint_provider(provider: LabRunnerHintProvider) {
+pub fn set_lab_runner_hint_provider(provider: impl Fn() -> LabRunnerHint + Send + Sync + 'static) {
     let mut guard = lab_runner_hint_provider()
         .write()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    *guard = Some(provider);
+    *guard = Some(Arc::new(provider));
 }
 
 /// Resolve the Lab-runner support hints via the registered provider, falling
@@ -121,7 +122,7 @@ pub fn resolve_lab_runner_hint() -> LabRunnerHint {
         let guard = lab_runner_hint_provider()
             .read()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        *guard
+        guard.clone()
     };
     match provider {
         Some(f) => f(),


### PR DESCRIPTION
## Summary

- introduce a generic typed `LabCommandRoute` shared by built-in and descriptor-composed commands
- preserve built-in placement, runner, extension, mutation, resource, JSON, and observability contracts
- route composed commands through bounded runner refresh, resource admission, provenance, and generic Lab dispatch
- scope Lab flags exactly once and reject unsupported, local-only, destructive, or controller-only Lab intent fail-closed
- cover the built-in route matrix plus runtime composed dispatch and help parity

## Verification

- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-cli command_contract::lab::tests --lib` (8 passed)
- `cargo test -p homeboy-cli cli_runtime::tests::explicit_subcommand_help_uses_the_startup_fast_path --lib`
- provenance and composed runtime tests
- `cargo fmt --check`
- `git diff --check`

Closes #13241.

## AI Assistance

OpenAI `gpt-5.6-sol` via OpenCode general coding and repeated independent review subagents implemented, adversarially reviewed, and verified the generic Lab route abstraction under Chris Huber direction. Chris remains responsible for every line.