### PR TITLE
refactor: light up five stable crates for the dead-code lint

### DIFF
--- a/crates/homeboy-deploy/src/binding.rs
+++ b/crates/homeboy-deploy/src/binding.rs
@@ -22,6 +22,10 @@ pub(crate) struct ProjectPayloadBinding {
     pub install_dir: String,
 }
 
+#[allow(
+    dead_code,
+    reason = "Constructed only by the test-only `evidence()` projection above."
+)]
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub(crate) struct ProjectPayloadBindingEvidence {
     pub project_id: String,
@@ -32,6 +36,10 @@ pub(crate) struct ProjectPayloadBindingEvidence {
     pub artifact: PayloadIdentityEvidence,
 }
 
+#[allow(
+    dead_code,
+    reason = "Constructed only by the test-only `evidence()` projection above."
+)]
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub(crate) struct InstallInstructions {
     pub extract_command: Option<String>,
@@ -40,6 +48,10 @@ pub(crate) struct InstallInstructions {
     pub hooks: std::collections::HashMap<String, Vec<String>>,
 }
 
+#[allow(
+    dead_code,
+    reason = "Constructed only by the test-only `evidence()` projection above."
+)]
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub(crate) struct PayloadIdentityEvidence {
     pub component_id: String,
@@ -51,6 +63,10 @@ pub(crate) struct PayloadIdentityEvidence {
 }
 
 impl ProjectPayloadBinding {
+    #[allow(
+        dead_code,
+        reason = "No production caller: binding evidence is asserted by this module's tests; nothing emits it on a deploy."
+    )]
     pub fn evidence(&self, project_id: &str) -> ProjectPayloadBindingEvidence {
         ProjectPayloadBindingEvidence {
             project_id: project_id.to_string(),

--- a/crates/homeboy-deploy/src/lib.rs
+++ b/crates/homeboy-deploy/src/lib.rs
@@ -1,7 +1,3 @@
-#[allow(
-    dead_code,
-    reason = "Deployment binding evidence supports optional planning paths."
-)]
 pub(crate) mod binding;
 mod content_manifest;
 mod effect;
@@ -13,16 +9,8 @@ mod orchestration_ref_checkout;
 mod orchestration_tag_checkout;
 mod path_roots;
 pub(crate) mod permissions;
-#[allow(
-    dead_code,
-    reason = "Component loading supports optional deployment planning."
-)]
 mod planning;
 mod policy;
-#[allow(
-    dead_code,
-    reason = "Payload preparation evidence supports optional deployment execution."
-)]
 pub(crate) mod preparation;
 pub(crate) mod provenance;
 mod provider;

--- a/crates/homeboy-deploy/src/planning.rs
+++ b/crates/homeboy-deploy/src/planning.rs
@@ -730,6 +730,10 @@ pub(super) struct LoadedComponents {
 ///
 /// Returns both the deployable components and the IDs of skipped (non-deployable) ones,
 /// so callers can produce accurate error messages.
+#[allow(
+    dead_code,
+    reason = "No production caller: exercised by orchestration tests that assert component loading in isolation."
+)]
 pub(super) fn load_project_components(
     project: &Project,
     requested_ids: &[String],

--- a/crates/homeboy-deploy/src/preparation.rs
+++ b/crates/homeboy-deploy/src/preparation.rs
@@ -76,6 +76,10 @@ impl ComponentPayloadPreparationRequest {
         ))
     }
 
+    #[allow(
+        dead_code,
+        reason = "No production caller: redacted preparation evidence is asserted by this module's tests; nothing emits it on a deploy."
+    )]
     pub fn evidence(&self) -> serde_json::Value {
         let mut evidence = serde_json::to_value(self).expect("preparation request serializes");
         let component = evidence["component"]
@@ -232,12 +236,11 @@ impl From<&DeployConfig> for PreparationConfig {
 /// any target mutation such as transfer, install, hooks, or smoke checks.
 pub(crate) struct PreparedComponentPayload {
     pub artifact: PreparedDeployArtifact,
-    pub source_commit: String,
     /// Whether preparing this payload ran a fresh build in this lifecycle.
     pub build_ran: bool,
     _release_artifact: Option<ReleaseArtifactLease>,
     _exact_ref_checkout: Option<ExactRefCheckout>,
-    payload_artifact: PreparedArtifactCleanup,
+    _payload_artifact: PreparedArtifactCleanup,
 }
 
 /// Owns only the temporary copy made by preparation. The configured component
@@ -418,12 +421,11 @@ fn prepare_payload(
             request.config.expected_version.as_deref(),
         )?;
         return Ok(PreparedComponentPayload {
-            source_commit: artifact.source_commit.clone(),
             artifact,
             build_ran: false,
             _release_artifact: None,
             _exact_ref_checkout: None,
-            payload_artifact: PreparedArtifactCleanup(None),
+            _payload_artifact: PreparedArtifactCleanup(None),
         });
     }
 
@@ -570,7 +572,7 @@ fn prepare_payload(
             .as_ref()
             .map(|identity| identity.requested_ref.clone())
             .unwrap_or_else(|| format!("v{version}")),
-        source_commit: source_commit.clone(),
+        source_commit,
     };
     artifact.validate(&component.id, request.config.expected_version.as_deref())?;
     if let Some(cleanup) = generated_source_artifact.as_mut() {
@@ -578,11 +580,10 @@ fn prepare_payload(
     }
     Ok(PreparedComponentPayload {
         artifact,
-        source_commit,
         build_ran: release_artifact.is_none() && !request.config.skip_build,
         _release_artifact: release_artifact,
         _exact_ref_checkout: checkout,
-        payload_artifact,
+        _payload_artifact: payload_artifact,
     })
 }
 
@@ -1409,6 +1410,7 @@ mod tests {
                 .payload
                 .as_ref()
                 .unwrap()
+                .artifact
                 .source_commit,
             accepted_sha
         );
@@ -1507,7 +1509,6 @@ mod tests {
                 std::fs::read_to_string(payload.artifact.effective_path()).expect("payload bytes"),
                 "requested source\n"
             );
-            assert_eq!(payload.source_commit, requested_sha);
             assert_eq!(payload.artifact.source_commit, requested_sha);
         });
     }

--- a/crates/homeboy-engine-primitives/src/fs_index_lock.rs
+++ b/crates/homeboy-engine-primitives/src/fs_index_lock.rs
@@ -64,7 +64,6 @@ impl FsIndexLockConfig {
 #[derive(Debug)]
 pub struct FsIndexLock {
     path: PathBuf,
-    config: FsIndexLockConfig,
 }
 
 impl FsIndexLock {
@@ -79,11 +78,11 @@ impl FsIndexLock {
         })?;
         let path = dir.join(config.name);
         match fs::create_dir(&path) {
-            Ok(()) => Ok(Some(Self { path, config })),
+            Ok(()) => Ok(Some(Self { path })),
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                 remove_if_stale(&path, config)?;
                 match fs::create_dir(&path) {
-                    Ok(()) => Ok(Some(Self { path, config })),
+                    Ok(()) => Ok(Some(Self { path })),
                     Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(None),
                     Err(e) => Err(Error::internal_unexpected(format!(
                         "Failed to acquire {} lock {}: {}",
@@ -114,7 +113,7 @@ impl FsIndexLock {
         let path = dir.join(config.name);
         for _ in 0..config.attempts {
             match fs::create_dir(&path) {
-                Ok(()) => return Ok(Self { path, config }),
+                Ok(()) => return Ok(Self { path }),
                 Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                     remove_if_stale(&path, config)?;
                     thread::sleep(config.sleep);

--- a/crates/homeboy-engine-primitives/src/lib.rs
+++ b/crates/homeboy-engine-primitives/src/lib.rs
@@ -17,10 +17,6 @@ pub mod content_hash;
 pub mod detail_output;
 pub mod edit_op;
 pub mod edit_op_apply;
-#[allow(
-    dead_code,
-    reason = "Lock configuration is retained for diagnostic and platform-specific behavior."
-)]
 pub mod fs_index_lock;
 pub mod git_changes;
 pub mod grammar;

--- a/crates/homeboy-extension/src/bench/budget_findings.rs
+++ b/crates/homeboy-extension/src/bench/budget_findings.rs
@@ -1,17 +1,6 @@
-use serde::{Deserialize, Deserializer};
 use serde_json::Value;
 
 use homeboy_core::finding::{FindingSource, HomeboyFinding};
-
-pub(crate) fn deserialize_budget_findings<'de, D>(
-    deserializer: D,
-) -> std::result::Result<Vec<HomeboyFinding>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let values = Vec::<HomeboyFinding>::deserialize(deserializer)?;
-    Ok(values)
-}
 
 pub(crate) fn failure(
     code: impl Into<String>,

--- a/crates/homeboy-extension/src/bench/metric_policy_preset.rs
+++ b/crates/homeboy-extension/src/bench/metric_policy_preset.rs
@@ -6,10 +6,6 @@ pub use homeboy_extension_contract::bench_metric_preset::{
 use super::gate::{BenchGate, BenchGateOp};
 use super::parsing::{BenchMetricDirection, BenchResults};
 
-fn is_false(value: &bool) -> bool {
-    !*value
-}
-
 pub(crate) fn expand_metric_policy_presets(results: &mut BenchResults) -> Result<()> {
     for (metric, preset) in results.metric_policy_presets.clone() {
         match preset.preset {

--- a/crates/homeboy-extension/src/bench/phase_events.rs
+++ b/crates/homeboy-extension/src/bench/phase_events.rs
@@ -117,10 +117,6 @@ fn is_failure_status(status: &str) -> bool {
     )
 }
 
-fn is_zero_usize(value: &usize) -> bool {
-    *value == 0
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/homeboy-extension/src/lib.rs
+++ b/crates/homeboy-extension/src/lib.rs
@@ -5,10 +5,6 @@ pub mod audit_compiler_warning_provider;
 pub mod audit_fingerprint_script_provider;
 pub mod audit_grammar_source_provider;
 pub mod audit_manifest_provider;
-#[allow(
-    dead_code,
-    reason = "Benchmark serde compatibility helpers support optional result formats."
-)]
 pub mod bench;
 pub mod build;
 mod capability;

--- a/crates/homeboy-paths/src/lib.rs
+++ b/crates/homeboy-paths/src/lib.rs
@@ -57,10 +57,6 @@ impl PathRoots {
 
 mod locations;
 mod rigs;
-#[allow(
-    dead_code,
-    reason = "Runtime path helpers support platform-specific and integration-test flows."
-)]
 mod runtime;
 
 pub use locations::*;

--- a/crates/homeboy-paths/src/runtime.rs
+++ b/crates/homeboy-paths/src/runtime.rs
@@ -156,18 +156,6 @@ pub fn runner_controller_session_file(id: &str, controller_id: &str) -> Result<P
     ))
 }
 
-/// Controller-owned lease evidence below an already-resolved config root.
-pub(crate) fn runner_lease_evidence_file_in_root(
-    config_root: &Path,
-    runner_id: &str,
-    lease_id: &str,
-) -> PathBuf {
-    config_root
-        .join("runner-lease-evidence")
-        .join(sanitize_path_segment(runner_id))
-        .join(format!("{}.json", sanitize_path_segment(lease_id)))
-}
-
 /// Runner-owned durable reverse-execution evidence below an already-resolved
 /// config root.
 pub fn runner_job_execution_context_evidence_file_in_root(

--- a/crates/homeboy-release/src/lib.rs
+++ b/crates/homeboy-release/src/lib.rs
@@ -15,10 +15,6 @@
 //! Core still reaches release/deploy behavior only through the
 //! `homeboy_core::release_provider` hook, implemented here in `provider_impl`.
 
-#[allow(
-    dead_code,
-    reason = "Release upload verification supports recovery and optional publication paths."
-)]
 pub mod release;
 
 pub use release::provider_impl;

--- a/crates/homeboy-release/src/release/containment.rs
+++ b/crates/homeboy-release/src/release/containment.rs
@@ -148,6 +148,10 @@ pub enum ContainmentStatus {
 
 impl ContainmentStatus {
     /// True when some release provably contains the commit.
+    #[allow(
+        dead_code,
+        reason = "No production caller: the released/not-released partition is asserted by this module's tests."
+    )]
     pub(crate) fn is_released(self) -> bool {
         !matches!(self, Self::NotYetReleased)
     }

--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -864,6 +864,10 @@ pub(crate) fn parse_listed_release_metadata(stdout: &str) -> Option<GitHubReleas
         .and_then(|line| serde_json::from_str(line).ok())
 }
 
+#[allow(
+    dead_code,
+    reason = "No production caller: release upload verification is asserted by this module's tests but is not wired into the publish path."
+)]
 pub(crate) fn verify_release_assets(
     artifact_paths: &[String],
     assets: &[GitHubReleaseAsset],

--- a/crates/homeboy-release/src/release/executor/github_release/results.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/results.rs
@@ -280,6 +280,10 @@ pub(crate) fn upload_failed_result(
     )
 }
 
+#[allow(
+    dead_code,
+    reason = "No production caller: retained as a test result builder for the upload success shape."
+)]
 pub(crate) fn upload_success_result(
     tag: &str,
     github: &GitHubRepo,

--- a/crates/homeboy-release/src/release/plan_steps/release.rs
+++ b/crates/homeboy-release/src/release/plan_steps/release.rs
@@ -11,34 +11,6 @@ use homeboy_core::plan::PlanStep;
 use homeboy_core::Result;
 use homeboy_extension::{ExtensionCapability, ExtensionManifest};
 
-/// Build all release steps: core steps (non-configurable) + publish steps (extension-derived).
-#[allow(clippy::too_many_arguments)]
-pub(in crate::release) fn build_release_steps(
-    component: &Component,
-    extensions: &[ExtensionManifest],
-    current_version: &str,
-    new_version: &str,
-    changelog_plan: &ReleaseChangelogPlan,
-    options: &ReleaseOptions,
-    release_scope: &ReleaseScope,
-    warnings: &mut Vec<String>,
-    hints: &mut Vec<String>,
-) -> Result<Vec<PlanStep>> {
-    build_release_steps_with_reconciliation(
-        component,
-        extensions,
-        current_version,
-        new_version,
-        changelog_plan,
-        options,
-        release_scope,
-        warnings,
-        hints,
-        None,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
 pub(in crate::release) fn build_release_steps_with_reconciliation(
     component: &Component,
     extensions: &[ExtensionManifest],

--- a/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
+++ b/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
@@ -1,15 +1,45 @@
 use super::hints::{github_release_applies, push_publish_vs_github_release_hints};
 use super::preflight::build_preflight_steps;
-use super::release::build_release_steps;
+use super::release::build_release_steps_with_reconciliation;
 use crate::release::scope::ReleaseScope;
 use crate::release::types::{
     ReleaseBumpPolicyOptions, ReleaseChangelogPlan, ReleaseOptions, ReleasePipelineOptions,
     ReleaseSemverRecommendation,
 };
 use homeboy_core::component::{Component, ComponentScriptsConfig, ScopedExtensionConfig};
-use homeboy_core::plan::PlanStepStatus;
+use homeboy_core::plan::{PlanStep, PlanStepStatus};
+use homeboy_core::Result;
 use homeboy_extension::ExtensionManifest;
 
+/// Test-local shim: production callers pass their own reconciliation input,
+/// so the no-reconciliation default only ever existed for these assertions.
+#[allow(clippy::too_many_arguments)]
+fn build_release_steps(
+    component: &Component,
+    extensions: &[ExtensionManifest],
+    current_version: &str,
+    new_version: &str,
+    changelog_plan: &ReleaseChangelogPlan,
+    options: &ReleaseOptions,
+    release_scope: &ReleaseScope,
+    warnings: &mut Vec<String>,
+    hints: &mut Vec<String>,
+) -> Result<Vec<PlanStep>> {
+    build_release_steps_with_reconciliation(
+        component,
+        extensions,
+        current_version,
+        new_version,
+        changelog_plan,
+        options,
+        release_scope,
+        warnings,
+        hints,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
 #[test]
 fn test_build_preflight_steps() {
     let options = ReleaseOptions {

--- a/tests/dead_code_suppression_ratchet_test.rs
+++ b/tests/dead_code_suppression_ratchet_test.rs
@@ -36,10 +36,13 @@ use std::path::{Path, PathBuf};
 
 /// Maximum permitted number of module-level `dead_code` suppressions.
 ///
-/// This is the exact count as of the commit that introduced this ratchet, down
-/// from 40 before the sweep. It is a ceiling, not a target: lower it whenever
-/// a crate is cleared, and never raise it.
-const MODULE_SUPPRESSION_CEILING: usize = 16;
+/// Down from 40 before the 2026-08 sweep and 16 when this ratchet landed.
+/// Clearing homeboy-release, homeboy-extension, homeboy-deploy,
+/// homeboy-engine-primitives and homeboy-paths took it to 9: the seven
+/// homeboy-agents modules, plus two `#[path]`-shared test support modules that
+/// each test binary includes whole and uses in part. It is a ceiling, not a
+/// target: lower it whenever a crate is cleared, and never raise it.
+const MODULE_SUPPRESSION_CEILING: usize = 9;
 
 /// One module-level suppression, located precisely enough to act on.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
## Problem

`#[allow(dead_code)]` on a `mod` switches the lint off for that entire subtree. It is one line, it reads like housekeeping, and `tests/dead_code_suppression_ratchet_test.rs` exists because of it.

The 2026-08 sweep took the count 40 → 16 and deleted ~8,900 lines. It stopped one short of the ceiling. The 15 that remained still covered **210,890 lines — 18% of the tree**.

Seven of those were in crates with essentially no churn:

| loc | module | crate | files touched / last 300 commits |
| ---: | --- | --- | ---: |
| 39,624 | `release` | homeboy-release | 3 |
| 10,783 | `bench` | homeboy-extension | 3 |
| 1,620 | `planning` | homeboy-deploy | 1 |
| 1,555 | `preparation` | homeboy-deploy | 1 |
| 346 | `fs_index_lock` | homeboy-engine-primitives | 0 |
| 292 | `binding` | homeboy-deploy | 1 |
| 243 | `runtime` | homeboy-paths | 0 |

**54,463 lines**, zero of it touched by an open PR. These crates reported clean builds while a fifth of their code was exempt from the check.

## What the lint found

Removing all seven surfaced 20 items. They were not one thing, which is why this is a triage rather than a bulk delete.

### Deleted — orphans with no caller anywhere

- `homeboy-paths`: `runner_lease_evidence_file_in_root`
- `homeboy-extension/bench`: `is_false`, `is_zero_usize`, and `deserialize_budget_findings` — an identity passthrough that calls `Vec::<HomeboyFinding>::deserialize` and returns it, never wired to any `#[serde(deserialize_with = ...)]`
- `homeboy-engine-primitives`: `FsIndexLock::config`, stored at three construction sites and never read. The reason it carried — "retained for diagnostic and platform-specific behavior" — described a diagnostic that could not happen.

### Collapsed — a duplicated source of truth

`PreparedComponentPayload::source_commit` was set from the same local as `artifact.source_commit` at both construction sites (`source_commit: artifact.source_commit.clone()` in one, the same moved variable in the other). Production only ever read the artifact's copy. One test asserted both equalled the same value:

```rust
assert_eq!(payload.source_commit, requested_sha);
assert_eq!(payload.artifact.source_commit, requested_sha);
```

The field is gone; the two test reads go to the artifact.

### Moved — a test-only shim

`build_release_steps` is a nine-argument wrapper whose entire body passes `None` for reconciliation. Production calls `build_release_steps_with_reconciliation` directly; all 15 call sites were tests. It now lives in the test module.

### Kept with a per-item reason — production code held alive by its tests

- `homeboy-release`: `verify_release_assets`, `upload_success_result`, `is_released`
- `homeboy-deploy`: `load_project_components`, both `evidence()` projections, and the three structs they build

Per the ratchet's own doc: a module attribute is an opt-out; a per-item `allow` naming one item is a claim that survives review, and the next unused member of the same impl still fails the build.

### Renamed — an RAII guard the lint mislabels

`payload_artifact` is reported unread but is a `PreparedArtifactCleanup` with a `Drop` impl. Deleting it would have silently dropped temp-copy cleanup on every deploy. Renamed `_payload_artifact` to match `_release_artifact` and `_exact_ref_checkout` beside it.

## `--all-targets` reports dead code per target

A warning on the `(lib)` target means **no production caller**, not unused. I deleted the two deploy `evidence()` methods on that reading and the next check returned six `E0599`s from their tests. Restored with per-item reasons. Worth knowing before the next crate.

## Fixpoint

Each pass exposed the next layer:

```
pass 1  remove 7 attributes      -> 20 items
pass 2  delete evidence()        -> E0599 x6 + redaction helpers now dead
pass 3  rename payload_artifact  -> source_commit surfaced behind it
pass 4  collapse source_commit   -> 0 warnings, 0 errors
```

The `source_commit` duplication was only reachable by renaming the field in front of it.

## Ratchet

`MODULE_SUPPRESSION_CEILING` 16 → 9. Remaining: the seven `homeboy-agents` modules (156,427 lines, active branches) plus two `#[path]`-shared test support modules each binary includes whole and uses in part. `module_suppression_ceiling_leaves_no_slack` passes, so 9 is exact.

Every stable crate in the repo is now lit.

## Verification

`cargo check --workspace --all-targets` — **0 errors, 0 dead-code warnings.**

Affected-crate tests were compared against a stashed baseline on clean `main` in the same worktree, not read raw:

| crate | result |
| --- | --- |
| `homeboy-deploy --lib` | 10 failures, **identical set to origin/main** |
| `homeboy-engine-primitives --lib` | 1 failure, `every_gate_layer_decision_declares_how_it_established_measurement` |
| `homeboy-release`, `homeboy-paths`, `homeboy-extension` | clean |

**No new failures.** Both pre-existing groups are unrelated to this diff:

- The deploy failures are disk-sensitive (`Filesystem capacity exhausted`, `unable to open database file`, `mkdir: cannot create directory`). An 11th appeared at 83% disk and vanished after freeing space; the other 10 reproduce on clean `main` at 15G free.
- The gate-layer failure is about unregistered `.github/*.sh` sites. This diff touches neither `.github/` nor that test.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode
