### PR TITLE
fix: resolve task worktrees before deriving handles

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -3071,14 +3071,16 @@ pub(crate) fn resolve_cook_destination(
             "--task-url <url> is required when --to-worktree is omitted".to_string(),
         ])
     })?;
+    let task_url = canonical_cook_task_url(task_url);
+    args.dispatch.task_url = Some(task_url.clone());
     let config = defaults::load_config();
     // Resolve the requested branch before task discovery. An explicit --head is
     // authoritative through candidate reuse, provisioning, and finalization.
     let head = match args.head.clone() {
         Some(head) => head,
-        None => derived_cook_branch(task_url)?,
+        None => derived_cook_branch(&task_url)?,
     };
-    args.to_worktree = Some(match homeboy::core::worktree_providers::find_apply_enabled_worktree_provider_by_task_url_and_head_from_config(task_url, args.head.as_deref(), &config) {
+    args.to_worktree = Some(match homeboy::core::worktree_providers::find_apply_enabled_worktree_provider_by_task_url_and_head_from_config(&task_url, args.head.as_deref(), &config) {
         Ok(Some(resolution)) => {
             if args.head.is_none() {
                 args.head = Some(resolution.worktree.branch.clone());
@@ -3851,12 +3853,8 @@ fn repository_identity_error(
 }
 
 fn derived_cook_branch(task_url: &str) -> homeboy::core::Result<String> {
-    let issue = task_url
-        .trim()
-        .split(['?', '#'])
-        .next()
-        .unwrap_or_default()
-        .trim_end_matches('/');
+    let issue = canonical_cook_task_url(task_url);
+    let issue = issue.as_str();
     let Some((repository, number)) = issue.rsplit_once("/issues/") else {
         return Err(homeboy::core::Error::validation_invalid_argument(
             "task_url",
@@ -3886,6 +3884,16 @@ fn derived_cook_branch(task_url: &str) -> homeboy::core::Result<String> {
         ));
     }
     Ok(format!("fix/issue-{number}-{}", slugify_cook_branch(repo)))
+}
+
+fn canonical_cook_task_url(task_url: &str) -> String {
+    task_url
+        .trim()
+        .split(['?', '#'])
+        .next()
+        .unwrap_or_default()
+        .trim_end_matches('/')
+        .to_string()
 }
 
 fn slugify_cook_branch(value: &str) -> String {

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -3072,12 +3072,20 @@ pub(crate) fn resolve_cook_destination(
         ])
     })?;
     let config = defaults::load_config();
-    // DMC's provider mapping currently exposes safety and handle metadata but
-    // not task ownership. In that mode the canonical handle is still resolved
-    // first; its ensure operation must reject a different task-owned worktree.
-    args.to_worktree = Some(match homeboy::core::worktree_providers::find_apply_enabled_worktree_provider_by_task_url_from_config(task_url, &config) {
-        Ok(Some(resolution)) => resolution.worktree.handle,
-        Ok(None) => format!("{repo}@{}", slugify_cook_branch(&derived_cook_branch(task_url)?)),
+    // Resolve the requested branch before task discovery. An explicit --head is
+    // authoritative through candidate reuse, provisioning, and finalization.
+    let head = match args.head.clone() {
+        Some(head) => head,
+        None => derived_cook_branch(task_url)?,
+    };
+    args.to_worktree = Some(match homeboy::core::worktree_providers::find_apply_enabled_worktree_provider_by_task_url_and_head_from_config(task_url, args.head.as_deref(), &config) {
+        Ok(Some(resolution)) => {
+            if args.head.is_none() {
+                args.head = Some(resolution.worktree.branch.clone());
+            }
+            resolution.worktree.handle
+        }
+        Ok(None) => format!("{repo}@{}", slugify_cook_branch(&head)),
         Err(mut error) => {
             if let Some(handles) = error.message.strip_prefix(&format!("multiple active apply-enabled worktrees are owned by `{task_url}`: ")) {
                 error.details["recovery"] = serde_json::json!(handles.split(", ").map(|handle| format!("homeboy agent-task cook --to-worktree {handle}")).collect::<Vec<_>>());
@@ -3086,7 +3094,7 @@ pub(crate) fn resolve_cook_destination(
         }
     });
     if args.head.is_none() {
-        args.head = Some(derived_cook_branch(task_url)?);
+        args.head = Some(head);
     }
     resolve_cook_base(&mut args)?;
     Ok(args)

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -155,6 +155,90 @@ fn cook_derives_issue_destination_and_preserves_explicit_override() {
 
 #[cfg(unix)]
 #[test]
+fn cook_reuses_a_task_candidate_without_overriding_explicit_head() {
+    use std::os::unix::fs::PermissionsExt;
+
+    with_isolated_home(|_| {
+        let workspace = tempfile::tempdir().expect("workspace");
+        init_runtime_component_checkout(workspace.path());
+        assert!(Command::new("git")
+            .args(["checkout", "-b", "fix/216-persist-task"])
+            .current_dir(workspace.path())
+            .status()
+            .expect("create fixture branch")
+            .success());
+        let provider = tempfile::NamedTempFile::new()
+            .expect("provider file")
+            .into_temp_path();
+        std::fs::write(
+            &provider,
+            format!(
+                "#!/bin/sh\nprintf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"project@task-216\",\"path\":\"{}\",\"branch\":\"fix/216-persist-task\",\"task_url\":\"https://example.test/owner/project/issues/216\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'\n",
+                workspace.path().display()
+            ),
+        )
+        .expect("write provider");
+        let mut permissions = std::fs::metadata(&provider)
+            .expect("provider metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&provider, permissions).expect("make provider executable");
+
+        let mut config = homeboy::core::defaults::HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            homeboy::core::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: homeboy::core::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: homeboy::core::defaults::WorktreeProviderCommands {
+                    resolve_task: Some(vec![
+                        provider.display().to_string(),
+                        "{task_url}".to_string(),
+                    ]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(
+                    homeboy::core::defaults::WorktreeProviderListResultMapping {
+                        items: "$.worktrees".to_string(),
+                        handle: "$.handle".to_string(),
+                        path: "$.path".to_string(),
+                        branch: "$.branch".to_string(),
+                        dirty: "$.safety.dirty".to_string(),
+                        unpushed: "$.safety.unpushed".to_string(),
+                        primary: "$.safety.primary".to_string(),
+                        task_url: Some("$.task_url".to_string()),
+                    },
+                ),
+            },
+        );
+        homeboy::core::defaults::save_config(&config).expect("save provider config");
+
+        let resolved = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "reuse task workspace".to_string(),
+            "--repo".to_string(),
+            "project".to_string(),
+            "--task-url".to_string(),
+            "https://example.test/owner/project/issues/216".to_string(),
+            "--head".to_string(),
+            "fix/216-persist-task".to_string(),
+            "--no-finalize".to_string(),
+        ]))
+        .expect("reuse the matching task workspace");
+        assert_eq!(resolved.to_worktree.as_deref(), Some("project@task-216"));
+        assert_eq!(resolved.head.as_deref(), Some("fix/216-persist-task"));
+    });
+}
+
+#[cfg(unix)]
+#[test]
 fn cook_explicit_repo_skips_unrelated_portable_git_enrichment() {
     use std::os::unix::fs::PermissionsExt;
 

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -673,6 +673,12 @@ pub struct WorktreeProviderCommands {
     /// requested handle. The result uses `list_result_mapping` and may contain one item.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolve: Option<Vec<String>>,
+    /// Targeted tracker lookup. Each `{task_url}` argument is replaced with the
+    /// canonical task URL and returns every candidate owned by that task. The
+    /// provider owns pagination so Homeboy never mistakes a partial page for an
+    /// absent destination.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolve_task: Option<Vec<String>>,
     /// Targeted canonical-path lookup. Each `{path}` argument is replaced with
     /// the requested canonical path. The result uses `list_result_mapping` and
     /// may contain one item.
@@ -731,6 +737,7 @@ impl Default for WorktreeProviderCommands {
             resolve_identity: None,
             attest_safety: None,
             resolve: None,
+            resolve_task: None,
             resolve_path: None,
             resolve_not_found_exit_codes: Vec::new(),
             list: None,
@@ -1199,6 +1206,7 @@ mod tests {
             resolve_identity: None,
             attest_safety: None,
             resolve: None,
+            resolve_task: None,
             resolve_path: None,
             resolve_not_found_exit_codes: Vec::new(),
             list: Some(vec!["provider".to_string(), "list".to_string()]),

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -945,6 +945,17 @@ pub fn find_apply_enabled_worktree_provider_by_task_url_from_config(
     task_url: &str,
     config: &HomeboyConfig,
 ) -> Result<Option<WorktreeProviderResolution>> {
+    find_apply_enabled_worktree_provider_by_task_url_and_head_from_config(task_url, None, config)
+}
+
+/// Find the sole clean apply-enabled provider worktree owned by a tracker URL
+/// that is compatible with an explicitly requested branch. Providers with a
+/// targeted task lookup own pagination; older providers retain list discovery.
+pub fn find_apply_enabled_worktree_provider_by_task_url_and_head_from_config(
+    task_url: &str,
+    head: Option<&str>,
+    config: &HomeboyConfig,
+) -> Result<Option<WorktreeProviderResolution>> {
     let mut matches = Vec::new();
     for (provider_id, provider) in &config.worktree_providers {
         if !provider.enabled
@@ -957,11 +968,17 @@ pub fn find_apply_enabled_worktree_provider_by_task_url_from_config(
         {
             continue;
         }
-        let Some(command) = provider.commands.list.as_ref() else {
+        let worktrees = if let Some(command) = provider.commands.resolve_task.as_ref() {
+            run_provider_resolve_task_command(provider_id, provider, command, task_url)?
+        } else if let Some(command) = provider.commands.list.as_ref() {
+            run_provider_list_command(provider_id, provider, command)?
+        } else {
             continue;
         };
-        for worktree in run_provider_list_command(provider_id, provider, command)? {
-            if worktree.task_url.as_deref() == Some(task_url) {
+        for worktree in worktrees {
+            if worktree.task_url.as_deref() == Some(task_url)
+                && head.is_none_or(|head| worktree.branch == head)
+            {
                 validate_provider_handle(provider_id, &worktree, None, None)?;
                 matches.push(WorktreeProviderResolution {
                     provider_id: provider_id.clone(),
@@ -1862,6 +1879,25 @@ fn run_provider_resolve_command(
         provider,
         &command,
         "resolve",
+        &provider.commands.resolve_not_found_exit_codes,
+    )
+}
+
+fn run_provider_resolve_task_command(
+    provider_id: &str,
+    provider: &WorktreeProviderConfig,
+    command: &[String],
+    task_url: &str,
+) -> Result<Vec<WorktreeProviderHandle>> {
+    let command = command
+        .iter()
+        .map(|argument| argument.replace("{task_url}", task_url))
+        .collect::<Vec<_>>();
+    run_provider_lookup_command(
+        provider_id,
+        provider,
+        &command,
+        "resolve_task",
         &provider.commands.resolve_not_found_exit_codes,
     )
 }
@@ -6275,6 +6311,46 @@ mod tests {
         )
         .expect_err("duplicate ownership must be explicit");
         assert!(error.message.contains("project@first, project@second"));
+    }
+
+    #[test]
+    fn targeted_task_lookup_reuses_a_later_compatible_candidate() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        git_init(workspace.path(), "task-216");
+        let task_url = "https://example.test/owner/project/issues/216";
+        let mapping = WorktreeProviderListResultMapping {
+            items: "$.worktrees".to_string(),
+            handle: "$.handle".to_string(),
+            path: "$.path".to_string(),
+            branch: "$.branch".to_string(),
+            dirty: "$.safety.dirty".to_string(),
+            unpushed: "$.safety.unpushed".to_string(),
+            primary: "$.safety.primary".to_string(),
+            task_url: Some("$.task_url".to_string()),
+        };
+        let script = fake_list_provider_script(json!({ "worktrees": [
+            {
+                "handle": "project@first-page", "path": workspace.path(), "branch": "fix/other",
+                "task_url": task_url, "safety": { "dirty": false, "unpushed": false, "primary": false }
+            },
+            {
+                "handle": "project@task-216", "path": workspace.path(), "branch": "task-216",
+                "task_url": task_url, "safety": { "dirty": false, "unpushed": false, "primary": false }
+            }
+        ] }));
+        let mut provider = list_provider(script.clone(), mapping);
+        provider.apply_enabled = true;
+        provider.commands.list = None;
+        provider.commands.resolve_task = Some(vec![script, "{task_url}".to_string()]);
+
+        let found = find_apply_enabled_worktree_provider_by_task_url_and_head_from_config(
+            task_url,
+            Some("task-216"),
+            &config_with_provider(provider),
+        )
+        .expect("targeted task lookup")
+        .expect("later compatible task candidate");
+        assert_eq!(found.worktree.handle, "project@task-216");
     }
 
     #[test]

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -189,6 +189,7 @@ persisted default that would silently apply to every future sweep.
 ### `WorktreeProviderCommands`
 
 - `resolve` — Targeted handle lookup. Configure `resolve_not_found_exit_codes` when the provider signals an absent handle with a non-zero status; all statuses not listed remain hard lookup failures.
+- `resolve_task` — Targeted task URL lookup. Homeboy expands `{task_url}` and the provider returns the complete candidate set for that task, including any pagination required by its own backend.
 - `resolve_not_found_exit_codes` — Provider-native statuses that mean `resolve` found no matching handle.
 - `list`
 - `ensure` — Atomic create-or-return-existing argv template. Homeboy invokes it only after an explicit typed provider no-match, expands `{handle}`, `{repo}`, `{base}`, `{head}`, `{task_url}`, and `{idempotency_key}`, and requires `apply_enabled: true`.


### PR DESCRIPTION
## Summary
- resolve provider-owned task candidates before deriving a fallback Cook handle
- persist the selected provider into Cook's deferred exact-resolution lifecycle
- canonicalize requested and provider-returned task URLs
- add provider-native `resolve_task` lookup with independent not-found exit codes and provider-owned complete pagination

Fixes #13255

## Verification
- `cargo fmt --all --check`
- `cargo test -p homeboy-core targeted_task_lookup_reuses_a_later_compatible_candidate`
- `cargo test -p homeboy-core targeted_task_lookup_uses_its_own_not_found_exit_codes`
- `cargo test -p homeboy-cli --features test-support cook_reuses_a_task_candidate_without_overriding_explicit_head`
- `cargo check --workspace --tests --locked`

## AI assistance disclosure
OpenAI GPT-5.6-sol via OpenCode general coding subagent was used to address review findings, implement the generic provider contract, and add focused lifecycle coverage.