### PR TITLE
fix(upgrade): revalidate compatibility before promotion

### DIFF
--- a/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
@@ -12,9 +12,9 @@ use homeboy_upgrade::upgrade::RunnerUpgradeEntry;
 use std::path::Path;
 
 pub fn preflight_configured_runners_for_upgrade(
-    method_override: Option<InstallMethod>,
-    source_path: Option<&Path>,
-    explicit_source_path: bool,
+    _method_override: Option<InstallMethod>,
+    _source_path: Option<&Path>,
+    _explicit_source_path: bool,
     runner_targets: &[String],
     candidate_version: &str,
     extension_ids: &[String],
@@ -31,44 +31,6 @@ pub fn preflight_configured_runners_for_upgrade(
             .homeboy_path
             .clone()
             .unwrap_or_else(|| "homeboy".to_string());
-        if method_override == Some(InstallMethod::Source) && source_path.is_some() {
-            let materialized = if explicit_source_path {
-                materialize_explicit_runner_source_path(
-                    runner,
-                    source_path.expect("source path checked"),
-                )
-            } else {
-                materialize_runner_source_path(runner, source_path.expect("source path checked"))
-            };
-            let source_path = match materialized {
-                Ok(path) => path,
-                Err(error) => {
-                    failures.push(runner_upgrade_failure_entry(
-                        &runner.id,
-                        homeboy_path.clone(),
-                        None,
-                        1,
-                        format!("runner preflight materialization failed: {}", error.message),
-                    ));
-                    continue;
-                }
-            };
-            if let Some(detail) = prepare_runner_source_checkout_for_upgrade(
-                runner,
-                method_override,
-                Some(&source_path),
-                &mut runner::exec,
-            ) {
-                failures.push(runner_upgrade_failure_entry(
-                    &runner.id,
-                    homeboy_path.clone(),
-                    None,
-                    1,
-                    format!("runner preflight source checkout failed: {detail}"),
-                ));
-                continue;
-            }
-        }
         if let Some(detail) =
             runner_manifest_preflight(runner, &homeboy_path, candidate_version, extension_ids)
         {
@@ -93,6 +55,22 @@ fn runner_manifest_preflight(
     candidate_version: &str,
     extension_ids: &[String],
 ) -> Option<String> {
+    runner_manifest_preflight_with_executor(
+        runner,
+        homeboy_path,
+        candidate_version,
+        extension_ids,
+        &mut runner::exec,
+    )
+}
+
+fn runner_manifest_preflight_with_executor(
+    runner: &Runner,
+    homeboy_path: &str,
+    candidate_version: &str,
+    extension_ids: &[String],
+    exec: &mut impl FnMut(&str, RunnerExecOptions) -> Result<(runner::RunnerExecOutput, i32)>,
+) -> Option<String> {
     for extension_id in extension_ids {
         if !runner_supports_extension_sync(runner, extension_id) {
             continue;
@@ -109,7 +87,7 @@ fn runner_manifest_preflight(
         options.print_handoff = false;
         options.mirror_evidence = false;
         options.read_only_artifact_access = true;
-        let Ok((output, exit_code)) = runner::exec(&runner.id, options) else {
+        let Ok((output, exit_code)) = exec(&runner.id, options) else {
             return Some(format!(
                 "runner manifest preflight could not query extension `{extension_id}`"
             ));
@@ -143,7 +121,10 @@ fn runner_extension_requires_homeboy(stdout: &str) -> Option<String> {
 
 #[cfg(test)]
 mod manifest_preflight_tests {
-    use super::runner_extension_requires_homeboy;
+    use super::*;
+    use crate::{RunnerExecMode, RunnerExecOutput};
+    use homeboy_core::server::RunnerSettings;
+    use std::collections::HashMap;
 
     #[test]
     fn reads_runner_manifest_compatibility_from_extension_show_json() {
@@ -158,6 +139,85 @@ mod manifest_preflight_tests {
     fn ignores_extension_show_without_a_compatibility_declaration() {
         let stdout = r#"{"success":true,"data":{"extension":{"id":"example"}}}"#;
         assert!(runner_extension_requires_homeboy(stdout).is_none());
+    }
+
+    #[test]
+    fn changed_runner_manifest_is_rejected_by_revalidation_without_source_sync() {
+        let runner = Runner {
+            id: "lab-a".to_string(),
+            kind: RunnerKind::Ssh,
+            server_id: Some("lab-a-server".to_string()),
+            workspace_root: Some("/home/user/workspace".to_string()),
+            settings: RunnerSettings::default(),
+            env: HashMap::new(),
+            secret_env: HashMap::new(),
+            resources: HashMap::new(),
+            policy: Default::default(),
+        };
+        let extension_ids = vec!["rust".to_string()];
+        let manifests = [
+            r#"{"success":true,"data":{"extension":{"core_compatibility":{"requires_homeboy":">=2.0.0"}}}}"#,
+            r#"{"success":true,"data":{"extension":{"core_compatibility":{"requires_homeboy":">=3.0.0"}}}}"#,
+        ];
+        let mut call_count = 0;
+        let mut exec = |runner_id: &str, options: RunnerExecOptions| {
+            assert_eq!(runner_id, "lab-a");
+            assert_eq!(options.command, ["homeboy", "extension", "show", "rust"]);
+            assert!(options.read_only_artifact_access);
+            let stdout = manifests[call_count].to_string();
+            call_count += 1;
+            Ok((
+                RunnerExecOutput {
+                    variant: "exec",
+                    command: "runner.exec",
+                    runner_id: runner_id.to_string(),
+                    dry_run: false,
+                    mode: RunnerExecMode::DiagnosticSsh,
+                    argv: options.command,
+                    remote_cwd: "/home/user/workspace".to_string(),
+                    exit_code: 0,
+                    stdout,
+                    stderr: String::new(),
+                    source_snapshot: None,
+                    job: None,
+                    runner_job: None,
+                    job_id: None,
+                    job_events: None,
+                    mirror_run_id: None,
+                    patch: None,
+                    mutation_artifacts: None,
+                    artifacts: Vec::new(),
+                    promoted_outputs: Vec::new(),
+                    structured_summaries: Vec::new(),
+                    metrics: None,
+                    capture: None,
+                    execution_record: None,
+                    runner_result: None,
+                    handoff: None,
+                    diagnostics: None,
+                },
+                0,
+            ))
+        };
+
+        assert!(runner_manifest_preflight_with_executor(
+            &runner,
+            "homeboy",
+            "2.1.0",
+            &extension_ids,
+            &mut exec,
+        )
+        .is_none());
+        let rejection = runner_manifest_preflight_with_executor(
+            &runner,
+            "homeboy",
+            "2.1.0",
+            &extension_ids,
+            &mut exec,
+        )
+        .expect("changed manifest is rejected during revalidation");
+        assert!(rejection.contains("incompatible with selected controller 2.1.0"));
+        assert_eq!(call_count, 2);
     }
 }
 

--- a/crates/homeboy-upgrade/src/upgrade/execution.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution.rs
@@ -122,6 +122,7 @@ pub(crate) fn execute_upgrade(
     force: bool,
     previous_build_identity: Option<&str>,
     selected_release: Option<&SelectedRelease>,
+    promotion_lease: Option<&homeboy_core::runtime_promotion::RuntimePromotionLease>,
 ) -> UpgradeExecutionResult {
     let selected_binary_version = selected_release.map(|release| release.version.as_str());
     let defaults = defaults::load_defaults();
@@ -196,6 +197,7 @@ pub(crate) fn execute_upgrade(
                 force,
                 previous_build_identity,
                 source_revision,
+                promotion_lease,
             );
         }
         InstallMethod::Binary => {
@@ -482,16 +484,24 @@ fn complete_source_upgrade(
     force: bool,
     previous_build_identity: Option<&str>,
     source_revision: Option<String>,
+    promotion_lease: Option<&homeboy_core::runtime_promotion::RuntimePromotionLease>,
 ) -> UpgradeExecutionResult {
     let replacement_target = replacement_target.ok_or_else(|| {
         Error::internal_unexpected("active binary path unavailable for source upgrade install")
     })?;
     // Builds may finish in any order. Only promotion is serialized, and the
     // installed target is re-read while holding that lease before the rename.
-    let promotion_lease = homeboy_core::runtime_promotion::acquire(
-        "controller source promotion",
-        replacement_target.display().to_string(),
-    )?;
+    let owned_promotion_lease;
+    let promotion_lease = match promotion_lease {
+        Some(lease) => lease,
+        None => {
+            owned_promotion_lease = homeboy_core::runtime_promotion::acquire(
+                "controller source promotion",
+                replacement_target.display().to_string(),
+            )?;
+            &owned_promotion_lease
+        }
+    };
     let active_identity = installed_target_build_identity()?;
     if source_promotion_is_superseded(force, active_identity.as_ref(), &workspace_root) {
         let active = active_identity.expect("identity checked above");

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -482,19 +482,44 @@ pub fn run_upgrade_with_method(
         }
     }
 
-    // Packaged installers still own their download-and-swap command. Keep their
-    // established full-operation lease until that contract is moved in-process;
-    // source builds use the narrower lease at the final rename instead.
-    let controller_mutation_lease = (install_method != InstallMethod::Source)
-        .then(|| {
-            homeboy_core::runtime_promotion::acquire("controller upgrade", "active controller")
-        })
-        .transpose()?;
-    let controller_upgrade =
-        run_controller_mutation_after_runner_preflight(runner_preflight, || {
-            if let Some(lease) = &controller_mutation_lease {
-                lease.assert_generation()?;
+    // Keep the same promotion authority from compatibility revalidation through
+    // the controller swap. Source builds retain their isolated build target, but
+    // their final install shares this lease rather than opening a TOCTOU window.
+    let controller_mutation_lease =
+        homeboy_core::runtime_promotion::acquire("controller upgrade", "active controller")?;
+    controller_mutation_lease.assert_generation()?;
+    let extension_revalidation = (!skip_extensions)
+        .then(|| preflight_extensions_for_upgrade(&candidate_version))
+        .unwrap_or_default();
+    if !extension_revalidation.is_empty() {
+        return Ok(extension_preflight_failure_result(
+            install_method,
+            previous_version,
+            previous_build_identity,
+            &candidate_version,
+            extension_revalidation,
+        ));
+    }
+    let controller_upgrade = run_controller_mutation_after_runner_preflight(
+        runner_preflight,
+        || {
+            controller_mutation_lease.assert_generation()?;
+            if skip_runners {
+                Ok(Vec::new())
+            } else {
+                super::with_runner_upgrade(|provider| {
+                    provider.preflight_configured_runners_for_upgrade(
+                        runner_method_override,
+                        source_upgrade_path.as_deref(),
+                        source_upgrade_path.is_some(),
+                        runner_targets,
+                        &candidate_version,
+                        &extension::available_extension_ids(),
+                    )
+                })
             }
+        },
+        || {
             execute_upgrade(
                 install_method,
                 source_upgrade_path.as_deref(),
@@ -502,8 +527,10 @@ pub fn run_upgrade_with_method(
                 force,
                 previous_build_identity.as_deref(),
                 selected_release.as_ref(),
+                Some(&controller_mutation_lease),
             )
-        })?;
+        },
+    )?;
     let (success, new_version, new_build_identity, source_revision, superseded) =
         match controller_upgrade {
             Ok(result) => result,
@@ -690,13 +717,17 @@ fn source_upgrade_noop_result(
 
 fn run_controller_mutation_after_runner_preflight<T>(
     runner_preflight: Vec<RunnerUpgradeEntry>,
+    revalidate_runners: impl FnOnce() -> Result<Vec<RunnerUpgradeEntry>>,
     mutate_controller: impl FnOnce() -> Result<T>,
 ) -> Result<std::result::Result<T, Vec<RunnerUpgradeEntry>>> {
-    if runner_preflight.is_empty() {
-        return mutate_controller().map(Ok);
+    if !runner_preflight.is_empty() {
+        return Ok(Err(runner_preflight));
     }
-
-    Ok(Err(runner_preflight))
+    let revalidation = revalidate_runners()?;
+    if !revalidation.is_empty() {
+        return Ok(Err(revalidation));
+    }
+    mutate_controller().map(Ok)
 }
 
 fn runner_preflight_failure_result(
@@ -2135,41 +2166,58 @@ fn is_lowercase_hex(value: &str, length: usize) -> bool {
 #[cfg(test)]
 mod runner_source_upgrade_tests {
     use super::*;
+    use std::cell::RefCell;
     use std::process::Command;
     use tempfile::tempdir;
 
     #[test]
-    fn runner_preflight_failure_does_not_invoke_controller_mutation() {
-        let mut controller_mutated = false;
+    fn changed_runner_compatibility_revalidation_precedes_controller_mutation() {
+        let events = RefCell::new(Vec::new());
+        let changed_manifest_requires_homeboy = ">=3.0.0";
         let result = run_controller_mutation_after_runner_preflight(
-            vec![RunnerUpgradeEntry {
-                runner_id: "lab-a".to_string(),
-                homeboy_path: "homeboy".to_string(),
-                success: false,
-                upgraded: false,
-                previous_version: None,
-                new_version: None,
-                bare_homeboy_version: None,
-                path_drift: None,
-                recovery_commands: Vec::new(),
-                extensions_synced: Vec::new(),
-                extensions_skipped: Vec::new(),
-                extensions_failed: Vec::new(),
-                stale_daemon: None,
-                daemon_previous_version: None,
-                daemon_new_version: None,
-                exit_code: 1,
-                detail: "runner preflight materialization failed".to_string(),
-            }],
+            Vec::new(),
             || {
-                controller_mutated = true;
+                events.borrow_mut().push("runner manifest revalidation");
+                let compatible = homeboy_extension::evaluate_core_compatibility_for_version(
+                    Some(changed_manifest_requires_homeboy),
+                    None,
+                    "2.1.0",
+                )?
+                .status
+                    != "incompatible";
+                Ok((!compatible)
+                    .then(|| RunnerUpgradeEntry {
+                        runner_id: "lab-a".to_string(),
+                        homeboy_path: "homeboy".to_string(),
+                        success: false,
+                        upgraded: false,
+                        previous_version: None,
+                        new_version: None,
+                        bare_homeboy_version: None,
+                        path_drift: None,
+                        recovery_commands: Vec::new(),
+                        extensions_synced: Vec::new(),
+                        extensions_skipped: Vec::new(),
+                        extensions_failed: Vec::new(),
+                        stale_daemon: None,
+                        daemon_previous_version: None,
+                        daemon_new_version: None,
+                        exit_code: 1,
+                        detail: "runner manifest changed to an incompatible requirement"
+                            .to_string(),
+                    })
+                    .into_iter()
+                    .collect())
+            },
+            || {
+                events.borrow_mut().push("controller mutation");
                 Ok(())
             },
         )
         .expect("preflight evaluation");
 
-        assert!(!controller_mutated, "controller build/install must not run");
         let runners_skipped = result.unwrap_err();
+        assert_eq!(*events.borrow(), ["runner manifest revalidation"]);
         assert_eq!(runners_skipped[0].runner_id, "lab-a");
         let upgrade = runner_preflight_failure_result(
             InstallMethod::Source,


### PR DESCRIPTION
## Summary

Successor to merged #13259 for the follow-up that landed on its branch after merge.

- keeps runner manifest preflight read-only by removing source materialization from admission
- revalidates extension and runner compatibility while holding the controller promotion lease
- carries the controller promotion lease through source installation to close the under-lease revalidation window

Fixes #13244. Follow-up to #13259.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-upgrade runner_source_upgrade_tests`
- `cargo test -p homeboy-lab-runner manifest_preflight_tests`
- `cargo check -p homeboy-upgrade -p homeboy-lab-runner`
- `git diff --check origin/main...HEAD`

## AI assistance

OpenAI gpt-5.6-terra via OpenCode verified commit ancestry and patch scope, created the successor branch, ran focused validation, and drafted this PR. Chris Huber remains responsible for the change.