### PR TITLE
fix: contain untimed SSH descendants

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -2138,9 +2138,7 @@ mod tests {
             .find(|command| command.scope == "daemon_refresh")
             .expect("daemon refresh command");
         assert!(refresh.command.starts_with(&job_binary_refresh));
-        assert!(refresh
-            .description
-            .contains("configured job command binary"));
+        assert!(refresh.description.contains("configured Homeboy binary"));
     }
 
     #[test]

--- a/crates/homeboy-core/src/server/client/ssh_client.rs
+++ b/crates/homeboy-core/src/server/client/ssh_client.rs
@@ -529,7 +529,8 @@ impl SshClient {
             Err(error) => return ssh_process_error(error),
         };
 
-        let args = self.build_ssh_args(Some(&effective), false);
+        let remote_command = wrap_owned_remote_command(&effective);
+        let args = self.build_ssh_args(Some(&remote_command), false);
         let mut cmd = Command::new("ssh");
         cmd.args(&args)
             .stdin(Stdio::piped())
@@ -695,61 +696,10 @@ pub(super) fn run_command_with_stdin_source(
     let stdout = child.stdout.take().map(read_stream);
     let stderr = child.stderr.take().map(read_stream);
     let status = child.wait();
-    let cleanup_deadline = status.as_ref().err().map(|_| {
-        let deadline = Instant::now() + PROCESS_CLEANUP_ALLOWANCE;
-        let _ = terminate_process_group_with_deadline(&mut child, pid, deadline);
-        deadline
-    });
     let stdin_failed = writer
         .and_then(|writer| writer.finish_after_child())
         .is_some_and(|result: std::io::Result<()>| result.is_err());
-    let (stdout, mut stderr, streams_stalled) = match cleanup_deadline {
-        Some(deadline) => collect_streams_before(stdout, stderr, deadline),
-        None => (collect_stream(stdout), collect_stream(stderr), false),
-    };
-    if streams_stalled {
-        if !stderr.is_empty() && !stderr.ends_with('\n') {
-            stderr.push('\n');
-        }
-        stderr.push_str("Homeboy SSH stream drain exceeded its cleanup deadline after a transport observation failure.");
-    }
-    if stdin_failed {
-        if !stderr.is_empty() && !stderr.ends_with('\n') {
-            stderr.push('\n');
-        }
-        stderr.push_str("Homeboy SSH stdin delivery failed before command completion.");
-    }
-    match status {
-        Ok(status) => {
-            let exit_code = status.code().unwrap_or(-1);
-            CommandOutput {
-                stdout,
-                stderr,
-                success: status.success() && !stdin_failed,
-                exit_code: if stdin_failed && exit_code == 0 {
-                    1
-                } else {
-                    exit_code
-                },
-                timed_out: false,
-                observation: if stdin_failed {
-                    super::CommandObservation::StdinDeliveryFailed
-                } else {
-                    super::CommandObservation::Complete
-                },
-                child_resource: None,
-            }
-        }
-        Err(error) => CommandOutput {
-            stdout,
-            stderr: format!("{stderr}\nSSH error: {error}"),
-            success: false,
-            exit_code: -1,
-            timed_out: false,
-            observation: super::CommandObservation::TransportObservationFailed,
-            child_resource: None,
-        },
-    }
+    collect_ssh_child_output(&mut child, pid, Some(status), stdin_failed, stdout, stderr)
 }
 
 fn read_stream(mut pipe: impl Read + Send + 'static) -> Receiver<String> {
@@ -760,12 +710,6 @@ fn read_stream(mut pipe: impl Read + Send + 'static) -> Receiver<String> {
         let _ = sender.send(String::from_utf8_lossy(&bytes).to_string());
     });
     receiver
-}
-
-fn collect_stream(receiver: Option<Receiver<String>>) -> String {
-    receiver
-        .and_then(|receiver| receiver.recv().ok())
-        .unwrap_or_default()
 }
 
 fn collect_stream_before(receiver: Option<Receiver<String>>, deadline: Instant) -> (String, bool) {
@@ -1481,8 +1425,10 @@ const PROCESS_TERMINATION_GRACE: Duration = Duration::from_millis(100);
 /// restoring the original stdin stream.
 pub(super) fn wrap_owned_remote_command(command: &str) -> String {
     format!(
-        "command -v setsid >/dev/null 2>&1 || {{ printf '%s\\n' 'Homeboy SSH execution requires remote setsid process authority.' >&2; exit 127; }}; exec 3<&0 || {{ printf '%s\\n' 'Homeboy SSH execution could not preserve remote stdin.' >&2; exit 1; }}; setsid sh -c {} <&3 & __homeboy_remote_pid=$!; exec 3<&-; __homeboy_remote_cleanup() {{ kill -TERM -\"$__homeboy_remote_pid\" 2>/dev/null || true; __homeboy_remote_attempt=0; while kill -0 -\"$__homeboy_remote_pid\" 2>/dev/null && [ \"$__homeboy_remote_attempt\" -lt 10 ]; do sleep 0.01; __homeboy_remote_attempt=$((__homeboy_remote_attempt + 1)); done; kill -KILL -\"$__homeboy_remote_pid\" 2>/dev/null || true; }}; trap '__homeboy_remote_cleanup; exit 143' HUP INT TERM; wait \"$__homeboy_remote_pid\"; __homeboy_remote_status=$?; __homeboy_remote_cleanup; exit \"$__homeboy_remote_status\"",
-        shell::quote_arg(command)
+        "exec 3<&0 || {{ printf '%s\\n' 'Homeboy SSH execution could not preserve remote stdin.' >&2; exit 1; }}; if command -v setsid >/dev/null 2>&1; then setsid sh -c {} <&3 & elif command -v perl >/dev/null 2>&1; then perl -MPOSIX -e {} sh -c {} <&3 & else printf '%s\\n' 'Homeboy SSH execution requires remote session authority (setsid or Perl POSIX).' >&2; exec 3<&-; exit 127; fi; __homeboy_remote_pid=$!; exec 3<&-; __homeboy_remote_cleanup() {{ kill -TERM -\"$__homeboy_remote_pid\" 2>/dev/null || true; __homeboy_remote_attempt=0; while kill -0 -\"$__homeboy_remote_pid\" 2>/dev/null && [ \"$__homeboy_remote_attempt\" -lt 10 ]; do sleep 0.01; __homeboy_remote_attempt=$((__homeboy_remote_attempt + 1)); done; kill -KILL -\"$__homeboy_remote_pid\" 2>/dev/null || true; }}; trap '__homeboy_remote_cleanup; exit 143' HUP INT TERM; wait \"$__homeboy_remote_pid\"; __homeboy_remote_status=$?; __homeboy_remote_cleanup; exit \"$__homeboy_remote_status\"",
+        shell::quote_arg(command),
+        shell::quote_arg("POSIX::setsid() >= 0 or die \"setsid: $!\\n\"; exec @ARGV or die \"exec: $!\\n\";"),
+        shell::quote_arg(command),
     )
 }
 

--- a/crates/homeboy-core/src/server/client/tests.rs
+++ b/crates/homeboy-core/src/server/client/tests.rs
@@ -151,6 +151,8 @@ fn ssh_envelope_owns_remote_descendant_cleanup() {
     let envelope = wrap_owned_remote_command("sleep 30 & printf terminal-result");
 
     assert!(envelope.contains("setsid sh -c"));
+    assert!(envelope.contains("command -v perl"));
+    assert!(envelope.contains("POSIX::setsid"));
     assert!(envelope.contains("exec 3<&0"));
     assert!(envelope.contains("<&3"));
     assert!(envelope.contains("kill -TERM -\"$__homeboy_remote_pid\""));
@@ -870,38 +872,39 @@ fn managed_session_connect_builds_master_command() {
 }
 
 #[cfg(unix)]
-#[test]
-fn successful_owned_remote_shell_with_delayed_eof_reaps_descendant_before_drain() {
-    let marker =
-        std::env::temp_dir().join(format!("homeboy-ssh-stream-drain-{}", std::process::id()));
-    let _ = std::fs::remove_file(&marker);
-    let fixture = tempfile::tempdir().expect("setsid fixture");
-    let setsid = fixture.path().join("setsid");
+fn ssh_equivalent_command(fixture: &tempfile::TempDir, remote_command: &str) -> Command {
+    let transport = fixture.path().join("ssh");
     std::fs::write(
-        &setsid,
-        "#!/usr/bin/env python3\nimport os, signal, sys\npid = os.fork()\nif pid:\n    _, status = os.waitpid(pid, 0)\n    os.killpg(pid, signal.SIGTERM)\n    sys.exit(os.waitstatus_to_exitcode(status))\nos.setsid()\nos.execvp(sys.argv[1], sys.argv[1:])\n",
+        &transport,
+        "#!/bin/sh\nfor argument do remote_command=$argument; done\nexec /bin/sh -c \"$remote_command\"\n",
     )
-    .expect("write setsid fixture");
+    .expect("write SSH-equivalent transport");
     use std::os::unix::fs::PermissionsExt;
-    std::fs::set_permissions(&setsid, std::fs::Permissions::from_mode(0o755))
-        .expect("make setsid fixture executable");
-    let mut paths = vec![fixture.path().to_path_buf()];
-    paths.extend(std::env::split_paths(
-        &std::env::var_os("PATH").expect("PATH"),
-    ));
-    let mut command = Command::new("sh");
+    std::fs::set_permissions(&transport, std::fs::Permissions::from_mode(0o755))
+        .expect("make SSH-equivalent transport executable");
+    let mut command = Command::new(transport);
     command
-        .args([
-            "-c",
-            &wrap_owned_remote_command(&format!(
-                "sleep 5 & printf '%s' \"$!\" > {}; printf snapshot-output",
-                crate::engine::shell::quote_path(&marker.to_string_lossy())
-            )),
-        ])
-        .env("PATH", std::env::join_paths(paths).expect("fixture PATH"))
+        .args(["fixture@remote", remote_command])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     crate::server::process_cleanup::configure_process_group_cleanup(&mut command);
+    command
+}
+
+#[cfg(unix)]
+#[test]
+fn ssh_equivalent_untimed_execution_reaps_remote_pipe_holder() {
+    let marker =
+        std::env::temp_dir().join(format!("homeboy-ssh-stream-drain-{}", std::process::id()));
+    let _ = std::fs::remove_file(&marker);
+    let fixture = tempfile::tempdir().expect("SSH-equivalent fixture");
+    let command = ssh_equivalent_command(
+        &fixture,
+        &wrap_owned_remote_command(&format!(
+            "sleep 5 & printf '%s' \"$!\" > {}; printf snapshot-output",
+            crate::engine::shell::quote_path(&marker.to_string_lossy())
+        )),
+    );
     let started = Instant::now();
 
     let output = run_ssh_with_child(command);
@@ -920,6 +923,46 @@ fn successful_owned_remote_shell_with_delayed_eof_reaps_descendant_before_drain(
     assert!(
         !crate::process::pid_is_running(pid),
         "successful SSH child leaked its descendant"
+    );
+    let _ = std::fs::remove_file(marker);
+}
+
+#[cfg(unix)]
+#[test]
+fn ssh_equivalent_untimed_piped_execution_reaps_remote_pipe_holder() {
+    let marker = std::env::temp_dir().join(format!(
+        "homeboy-ssh-piped-stream-drain-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&marker);
+    let fixture = tempfile::tempdir().expect("SSH-equivalent fixture");
+    let command = ssh_equivalent_command(
+        &fixture,
+        &wrap_owned_remote_command(&format!(
+            "cat >/dev/null; sleep 5 & printf '%s' \"$!\" > {}; printf piped-output",
+            crate::engine::shell::quote_path(&marker.to_string_lossy())
+        )),
+    );
+    let started = Instant::now();
+
+    let output = run_command_with_stdin_source(
+        command,
+        StdinSource::Reader(Box::new(Cursor::new(b"piped input".to_vec()))),
+    );
+
+    assert!(output.success, "{}", output.stderr);
+    assert_eq!(output.stdout, "piped-output");
+    assert!(
+        started.elapsed() < Duration::from_millis(750),
+        "piped SSH output collection must not wait for a pipe-holding descendant"
+    );
+    let pid = std::fs::read_to_string(&marker)
+        .expect("pipe-holding descendant pid")
+        .parse()
+        .expect("numeric descendant pid");
+    assert!(
+        !crate::process::pid_is_running(pid),
+        "piped SSH child leaked its descendant"
     );
     let _ = std::fs::remove_file(marker);
 }


### PR DESCRIPTION
Closes #13277

## Summary
- apply the owned remote-command wrapper to untimed piped SSH execution
- bound untimed piped stream collection through the shared SSH collector
- use `setsid` when available and Perl POSIX `setsid` as the deterministic portable fallback
- replace the self-cleaning shim with SSH-equivalent transport tests proving Homeboy reaps pipe-holding descendants for piped and non-piped commands

## Verification
- `cargo fmt --all --check`
- `cargo check --workspace --tests --locked`
- `RUSTFLAGS=-Dwarnings cargo build --locked -p homeboy --bin homeboy`
- `cargo test -p homeboy-core server::client::tests::ssh_equivalent_untimed_execution_reaps_remote_pipe_holder -- --exact --nocapture`
- `cargo test -p homeboy-core server::client::tests::ssh_equivalent_untimed_piped_execution_reaps_remote_pipe_holder -- --exact --nocapture`

## AI assistance disclosure
OpenAI gpt-5.6-terra via OpenCode was used to inspect the SSH lifecycle, implement the portable containment change, and run verification.