### PR TITLE
fix(lab): preserve controller agent task identity

### DIFF
--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -257,7 +257,7 @@ pub(crate) fn mirror_daemon_evidence(
             request.runner,
             request.job,
             request.result,
-            controller_owned_generic_run_id(request),
+            controller_owned_run_id(request),
             request.notification_route,
         )?;
         if request.job.status.is_terminal()
@@ -335,7 +335,7 @@ pub(crate) fn mirror_reverse_broker_evidence(
         };
         let declared_run_ids = explicit_observation_run_ids(request.result, request.job)
             .into_iter()
-            .filter(|run_id| Some(run_id.as_str()) != controller_owned_generic_run_id(request))
+            .filter(|run_id| Some(run_id.as_str()) != controller_owned_run_id(request))
             .collect::<Vec<_>>();
         let runs;
         let local_artifacts = if request.job.status == JobStatus::Failed {
@@ -751,7 +751,7 @@ where
             request.runner,
             request.job,
             request.result,
-            controller_owned_generic_run_id(request),
+            controller_owned_run_id(request),
             request.notification_route,
         )?;
         let terminal = matches!(
@@ -1387,11 +1387,10 @@ fn mirror_remote_observation_runs(
     Ok(Vec::new())
 }
 
-fn controller_owned_generic_run_id(request: MirrorEvidenceRequest<'_>) -> Option<&str> {
-    let run_id = request.run_id?;
-    // This flag is set only by the explicit generic runner-exec admission path,
-    // which creates and ownership-checks the run before the daemon is called.
-    request.generic_runner_exec_run.then_some(run_id)
+fn controller_owned_run_id(request: MirrorEvidenceRequest<'_>) -> Option<&str> {
+    // An explicit request run ID is created and ownership-checked by the
+    // controller before dispatch. It is never a runner observation to mirror.
+    request.run_id
 }
 
 /// Legacy terminal producers may advertise artifacts without a durable

--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -649,6 +649,69 @@ fn explicit_generic_runner_exec_run_skips_missing_remote_run_projection() {
 }
 
 #[test]
+fn explicit_agent_task_run_skips_missing_remote_run_projection() {
+    // #13263: agent-task results echo their controller lifecycle ID as the
+    // durable run ID. That identity is not a runner `/runs/<id>` observation.
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let job = terminal_runner_job();
+        let run_id = "agent-task-controller-owned-13263";
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+        ];
+        homeboy_agents::agent_task_lifecycle::record_lab_offload_planned(
+            homeboy_agents::agent_task_lifecycle::LabOffloadProxyPlan {
+                run_id,
+                runner_id: "lab",
+                remote_workspace: "/runner/project",
+                remote_command: &command,
+                durable_plan: None,
+            },
+        )
+        .expect("controller agent-task run is persisted before dispatch");
+
+        let result = json!({ "exit_code": 0, "durable_run_id": run_id });
+        let evidence = mirror_daemon_evidence(
+            MirrorEvidenceRequest::new(
+                &ssh_runner(),
+                "/runner/project",
+                &command,
+                &job,
+                &[],
+                &result,
+                Some(run_id),
+                None,
+            ),
+            &test_roots(),
+        )
+        .expect("controller agent-task run does not require a remote run lookup")
+        .expect("terminal evidence");
+
+        assert_eq!(evidence.run.id, run_id);
+        assert!(evidence.run.metadata_json.get("agent_task_run").is_some());
+
+        let reverse = mirror_reverse_broker_evidence(ReverseBrokerEvidenceContext {
+            request: MirrorEvidenceRequest::new(
+                &ssh_runner(),
+                "/runner/project",
+                &command,
+                &job,
+                &[],
+                &result,
+                Some(run_id),
+                None,
+            ),
+            broker_url: "http://127.0.0.1:1",
+        })
+        .expect("reverse broker also skips the controller agent-task run")
+        .expect("reverse terminal evidence");
+
+        assert_eq!(reverse.run.id, run_id);
+    });
+}
+
+#[test]
 fn failed_job_without_terminal_exit_code_projects_root_failure_fallback() {
     let context = homeboy_core::test_support::HermeticTestContext::new();
     let roots = context.path_roots();


### PR DESCRIPTION
## Summary

Fix Lab evidence reconciliation treating a controller-owned agent-task lifecycle ID as a runner observation ID.

Closes #13263.

## What changed

- Exclude every explicit controller request run ID from remote observation lookup, not only generic runner-exec IDs.
- Preserve fail-closed mirroring for independently declared runner observations.
- Cover direct-daemon and reverse-broker agent-task handoffs that echo the controller lifecycle ID.

## Verification

- `cargo test -p homeboy-lab-runner explicit_agent_task_run_skips_missing_remote_run_projection`
- `cargo test -p homeboy-lab-runner explicit_generic_runner_exec_run_skips_missing_remote_run_projection`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -p homeboy-lab-runner --all-targets -- -D warnings` remains blocked by 22 pre-existing Rust 1.95 warnings in `homeboy-core`; no reported warning is in the changed files.

## AI assistance

OpenAI gpt-5.6-sol via OpenCode traced the production Lab handoff failure, identified the lifecycle/observation ID namespace confusion, implemented the bounded fix and direct/reverse regression coverage, and ran the focused verification.