### PR TITLE
fix(cook): capture missing persisted base

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -76,19 +76,15 @@ use super::AgentTaskRunResult;
 /// controller's lease elapses so a resumed pass can reconcile and continue.
 const PROMOTION_CLAIM_LEASE: std::time::Duration = std::time::Duration::from_secs(30 * 60);
 
-/// The base capture reaches `origin`, so retain the durable operation lease
-/// until the recipe and controller plan have both recorded its result.
-const WORKSPACE_BASE_CAPTURE_OPERATION: &str = "workspace_base_capture";
-const WORKSPACE_BASE_CAPTURE_CLAIM_LEASE: Duration = Duration::from_secs(30 * 60);
-
 #[cfg(test)]
-static WORKSPACE_BASE_CAPTURE_COUNTER: LazyLock<Mutex<Option<Arc<WorkspaceBaseCaptureCounter>>>> =
+static WORKSPACE_BASE_CAPTURE_HOOK: LazyLock<Mutex<Option<Arc<WorkspaceBaseCaptureHook>>>> =
     LazyLock::new(|| Mutex::new(None));
 
 #[cfg(test)]
-struct WorkspaceBaseCaptureCounter {
+struct WorkspaceBaseCaptureHook {
     workspace: PathBuf,
     count: AtomicUsize,
+    fail_after_recipe_persistence: std::sync::atomic::AtomicBool,
 }
 
 /// Render the public CLI continuation route.
@@ -4513,15 +4509,13 @@ fn run_cook_spine(
     )?;
     // Base resolution reaches origin. Keep its transport failure behind the
     // recipe/run saga so retry and replay have durable zero-provider evidence.
-    if options.task_base_sha.is_none() {
-        pin_and_persist_initial_cook_workspace_base(store, lifecycle_store, &mut options).map_err(
-            |error| {
-                let mut error = with_pre_execution_phase(error, "workspace_base_capture");
-                error.details["cook_materialized_by_invocation"] = Value::Bool(true);
-                error
-            },
-        )?;
-    }
+    pin_and_persist_initial_cook_workspace_base(store, lifecycle_store, &mut options).map_err(
+        |error| {
+            let mut error = with_pre_execution_phase(error, "workspace_base_capture");
+            error.details["cook_materialized_by_invocation"] = Value::Bool(true);
+            error
+        },
+    )?;
     // A persisted recipe can replace the just-validated inputs. Re-check its
     // workspace and candidate topology before it reaches transport preparation
     // or a resumed attempt.
@@ -6690,50 +6684,59 @@ fn pin_and_persist_initial_cook_workspace_base(
     lifecycle_store: &AgentTaskLifecycleStore,
     options: &mut AgentTaskCookServiceOptions,
 ) -> Result<()> {
-    let recipe = store.load_recipe(&options.cook_id)?;
-    if recipe.finalization["task_base_sha"].is_string() {
-        return apply_persisted_task_base(options, &recipe);
-    }
-    match lifecycle_store.claim_cook_operation(
-        &options.initial_run_id,
-        WORKSPACE_BASE_CAPTURE_OPERATION,
-        WORKSPACE_BASE_CAPTURE_CLAIM_LEASE,
-    )? {
-        agent_task_lifecycle::ClaimOutcome::AlreadyCompleted(_) => {
-            return apply_persisted_task_base(options, &store.load_recipe(&options.cook_id)?);
+    let cook_id = options.cook_id.clone();
+    store.with_workspace_base_capture_lock(&cook_id, || {
+        let mut recipe = store.load_recipe(&options.cook_id)?;
+        if recipe.finalization["task_base_sha"].is_string() {
+            apply_persisted_task_base(options, &recipe)?;
+            return reconcile_persisted_task_base_plan(lifecycle_store, options, &recipe);
         }
-        agent_task_lifecycle::ClaimOutcome::LeaseHeld => {
-            let recipe = store.load_recipe(&options.cook_id)?;
-            if recipe.finalization["task_base_sha"].is_string() {
-                return apply_persisted_task_base(options, &recipe);
-            }
-            return Err(workspace_base_capture_in_progress(options));
-        }
-        agent_task_lifecycle::ClaimOutcome::Acquired => {}
-    }
 
-    if let Err(error) = pin_initial_cook_workspace_base(options) {
-        let _ = lifecycle_store.fail_cook_operation(
-            &options.initial_run_id,
-            WORKSPACE_BASE_CAPTURE_OPERATION,
-            serde_json::json!({ "error": error.message }),
-        );
-        return Err(error);
-    }
-    let Some(task_base_sha) = options.task_base_sha.as_ref() else {
-        // No workspace was available to capture. Leave the operation retryable
-        // rather than completing a claim with no persisted result.
-        lifecycle_store.fail_cook_operation(
-            &options.initial_run_id,
-            WORKSPACE_BASE_CAPTURE_OPERATION,
-            serde_json::json!({ "reason": "workspace_unavailable" }),
-        )?;
-        return Ok(());
-    };
-    let mut recipe = store.load_recipe(&options.cook_id)?;
+        pin_initial_cook_workspace_base(options)?;
+        let Some(task_base_sha) = options.task_base_sha.as_ref() else {
+            return Ok(());
+        };
+        let attempt = recipe
+            .attempts
+            .iter_mut()
+            .find(|attempt| attempt.run_id == options.initial_run_id)
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "cook_recipe.attempts",
+                    "initial Cook recipe is missing its materialized attempt",
+                    Some(options.initial_run_id.clone()),
+                    None,
+                )
+            })?;
+        attempt.plan = options.initial_plan.clone();
+        recipe.finalization["task_base_sha"] = Value::String(task_base_sha.clone());
+        store.persist_recipe(&recipe)?;
+        #[cfg(test)]
+        if WORKSPACE_BASE_CAPTURE_HOOK
+            .lock()
+            .expect("workspace base capture hook")
+            .as_ref()
+            .is_some_and(|hook| {
+                hook.fail_after_recipe_persistence
+                    .swap(false, Ordering::SeqCst)
+            })
+        {
+            return Err(Error::internal_unexpected(
+                "test interruption after Cook recipe base persistence",
+            ));
+        }
+        reconcile_persisted_task_base_plan(lifecycle_store, options, &recipe)
+    })
+}
+
+fn reconcile_persisted_task_base_plan(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    options: &AgentTaskCookServiceOptions,
+    recipe: &super::cook_recipe::AgentTaskCookRecipe,
+) -> Result<()> {
     let attempt = recipe
         .attempts
-        .iter_mut()
+        .iter()
         .find(|attempt| attempt.run_id == options.initial_run_id)
         .ok_or_else(|| {
             Error::validation_invalid_argument(
@@ -6743,33 +6746,22 @@ fn pin_and_persist_initial_cook_workspace_base(
                 None,
             )
         })?;
-    attempt.plan = options.initial_plan.clone();
-    recipe.finalization["task_base_sha"] = Value::String(task_base_sha.clone());
-    store.persist_recipe(&recipe)?;
-    agent_task_lifecycle::persist_controller_plan_in_store(
-        lifecycle_store,
-        &options.initial_run_id,
-        &options.initial_plan,
-    )?;
-    lifecycle_store.complete_cook_operation(
-        &options.initial_run_id,
-        WORKSPACE_BASE_CAPTURE_OPERATION,
-        serde_json::json!({ "task_base_sha": task_base_sha }),
-    )
-}
-
-fn workspace_base_capture_in_progress(options: &AgentTaskCookServiceOptions) -> Error {
-    Error::validation_invalid_argument(
-        "task_base_sha",
-        "workspace_base_capture_in_progress",
-        Some(options.cook_id.clone()),
-        Some(vec![cook_continue_command(
-            None,
+    // The recipe write precedes the controller plan write. After an interruption,
+    // its immutable attempt plan is the only authority needed to repair that
+    // second projection without touching origin.
+    if lifecycle_store
+        .read_controller_plan(&options.initial_run_id)
+        .ok()
+        .as_ref()
+        != Some(&attempt.plan)
+    {
+        agent_task_lifecycle::persist_controller_plan_in_store(
+            lifecycle_store,
             &options.initial_run_id,
-            false,
-            None,
-        )]),
-    )
+            &attempt.plan,
+        )?;
+    }
+    Ok(())
 }
 
 fn apply_persisted_task_base(
@@ -6804,7 +6796,7 @@ fn pin_cook_workspace_base_at(
         return Ok(());
     }
     #[cfg(test)]
-    if let Some(counter) = WORKSPACE_BASE_CAPTURE_COUNTER
+    if let Some(counter) = WORKSPACE_BASE_CAPTURE_HOOK
         .lock()
         .expect("workspace base capture counter")
         .clone()

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -64,7 +64,7 @@ use super::cook_promotion::{
     refreshed_moving_base_recovery, retryable_provider_discovery_failure,
     retryable_provider_discovery_failure_with_store, CookReportInput, MovingBaseCookRecovery,
 };
-use super::cook_recipe::{CookRecipeStore, InitialRecipeMaterialization, TaskBaseCaptureClaim};
+use super::cook_recipe::{CookRecipeStore, InitialRecipeMaterialization};
 use super::cook_supervision::{resolve_supervision_policy, CookSupervisor};
 #[cfg(test)]
 use super::execution::run_loaded_plan_with_derived_cook_baseline;
@@ -75,6 +75,11 @@ use super::AgentTaskRunResult;
 /// controller finishes promoting and records the result within it; a crashed
 /// controller's lease elapses so a resumed pass can reconcile and continue.
 const PROMOTION_CLAIM_LEASE: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
+/// The base capture reaches `origin`, so retain the durable operation lease
+/// until the recipe and controller plan have both recorded its result.
+const WORKSPACE_BASE_CAPTURE_OPERATION: &str = "workspace_base_capture";
+const WORKSPACE_BASE_CAPTURE_CLAIM_LEASE: Duration = Duration::from_secs(30 * 60);
 
 #[cfg(test)]
 static WORKSPACE_BASE_CAPTURE_COUNTER: LazyLock<Mutex<Option<Arc<WorkspaceBaseCaptureCounter>>>> =
@@ -6685,41 +6690,47 @@ fn pin_and_persist_initial_cook_workspace_base(
     lifecycle_store: &AgentTaskLifecycleStore,
     options: &mut AgentTaskCookServiceOptions,
 ) -> Result<()> {
-    let claim = store.claim_missing_task_base(&options.cook_id)?;
-    let mut recipe = match claim {
-        TaskBaseCaptureClaim::Observed(recipe) => {
-            apply_persisted_task_base(options, &recipe)?;
-            return Ok(());
+    let recipe = store.load_recipe(&options.cook_id)?;
+    if recipe.finalization["task_base_sha"].is_string() {
+        return apply_persisted_task_base(options, &recipe);
+    }
+    match lifecycle_store.claim_cook_operation(
+        &options.initial_run_id,
+        WORKSPACE_BASE_CAPTURE_OPERATION,
+        WORKSPACE_BASE_CAPTURE_CLAIM_LEASE,
+    )? {
+        agent_task_lifecycle::ClaimOutcome::AlreadyCompleted(_) => {
+            return apply_persisted_task_base(options, &store.load_recipe(&options.cook_id)?);
         }
-        TaskBaseCaptureClaim::InProgress => {
-            return Err(Error::validation_invalid_argument(
-                "task_base_sha",
-                "workspace_base_capture_in_progress",
-                Some(options.cook_id.clone()),
-                Some(vec![cook_continue_command(
-                    None,
-                    &options.initial_run_id,
-                    false,
-                    None,
-                )]),
-            ));
-        }
-        // The lease stays live across the origin lookup, but it is scoped to
-        // this one recipe field rather than a broad recipe mutation lock.
-        TaskBaseCaptureClaim::Acquired(_lease) => {
-            pin_initial_cook_workspace_base(options)?;
-            let Some(_) = options.task_base_sha.as_ref() else {
-                return Ok(());
-            };
+        agent_task_lifecycle::ClaimOutcome::LeaseHeld => {
             let recipe = store.load_recipe(&options.cook_id)?;
             if recipe.finalization["task_base_sha"].is_string() {
-                apply_persisted_task_base(options, &recipe)?;
-                return Ok(());
+                return apply_persisted_task_base(options, &recipe);
             }
-            recipe
+            return Err(workspace_base_capture_in_progress(options));
         }
+        agent_task_lifecycle::ClaimOutcome::Acquired => {}
+    }
+
+    if let Err(error) = pin_initial_cook_workspace_base(options) {
+        let _ = lifecycle_store.fail_cook_operation(
+            &options.initial_run_id,
+            WORKSPACE_BASE_CAPTURE_OPERATION,
+            serde_json::json!({ "error": error.message }),
+        );
+        return Err(error);
+    }
+    let Some(task_base_sha) = options.task_base_sha.as_ref() else {
+        // No workspace was available to capture. Leave the operation retryable
+        // rather than completing a claim with no persisted result.
+        lifecycle_store.fail_cook_operation(
+            &options.initial_run_id,
+            WORKSPACE_BASE_CAPTURE_OPERATION,
+            serde_json::json!({ "reason": "workspace_unavailable" }),
+        )?;
+        return Ok(());
     };
-    let task_base_sha = options.task_base_sha.as_ref().expect("captured task base");
+    let mut recipe = store.load_recipe(&options.cook_id)?;
     let attempt = recipe
         .attempts
         .iter_mut()
@@ -6739,6 +6750,25 @@ fn pin_and_persist_initial_cook_workspace_base(
         lifecycle_store,
         &options.initial_run_id,
         &options.initial_plan,
+    )?;
+    lifecycle_store.complete_cook_operation(
+        &options.initial_run_id,
+        WORKSPACE_BASE_CAPTURE_OPERATION,
+        serde_json::json!({ "task_base_sha": task_base_sha }),
+    )
+}
+
+fn workspace_base_capture_in_progress(options: &AgentTaskCookServiceOptions) -> Error {
+    Error::validation_invalid_argument(
+        "task_base_sha",
+        "workspace_base_capture_in_progress",
+        Some(options.cook_id.clone()),
+        Some(vec![cook_continue_command(
+            None,
+            &options.initial_run_id,
+            false,
+            None,
+        )]),
     )
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4494,7 +4494,7 @@ fn run_cook_spine(
     )?;
     // Base resolution reaches origin. Keep its transport failure behind the
     // recipe/run saga so retry and replay have durable zero-provider evidence.
-    if recipe_materialization.created && options.task_base_sha.is_none() {
+    if options.task_base_sha.is_none() {
         pin_and_persist_initial_cook_workspace_base(store, lifecycle_store, &mut options).map_err(
             |error| {
                 let mut error = with_pre_execution_phase(error, "workspace_base_capture");

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4507,6 +4507,18 @@ fn run_cook_spine(
         &options,
         recipe_materialization.created,
     )?;
+    // Reject a known-invalid managed workspace before base capture reaches its
+    // remote. Detached first handoffs have no local source path and remain
+    // eligible for runner-owned materialization below.
+    if cook_attempt_needs_execution_with_store(lifecycle_store, &options.initial_run_id)
+        && !cook_workspace_lookup_pending(&options.initial_plan)
+        && (options.attempt_dispatcher.is_none() || options.source_worktree_path.is_some())
+    {
+        validate_cook_workspace(&options).map_err(|mut error| {
+            error.details["cook_materialized_by_invocation"] = materialized_by_invocation.into();
+            error
+        })?;
+    }
     // Base resolution reaches origin. Keep its transport failure behind the
     // recipe/run saga so retry and replay have durable zero-provider evidence.
     pin_and_persist_initial_cook_workspace_base(store, lifecycle_store, &mut options).map_err(

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4,6 +4,10 @@
 
 use serde_json::Value;
 use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+#[cfg(test)]
+use std::sync::LazyLock;
 use std::sync::{mpsc, Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -60,7 +64,7 @@ use super::cook_promotion::{
     refreshed_moving_base_recovery, retryable_provider_discovery_failure,
     retryable_provider_discovery_failure_with_store, CookReportInput, MovingBaseCookRecovery,
 };
-use super::cook_recipe::{CookRecipeStore, InitialRecipeMaterialization};
+use super::cook_recipe::{CookRecipeStore, InitialRecipeMaterialization, TaskBaseCaptureClaim};
 use super::cook_supervision::{resolve_supervision_policy, CookSupervisor};
 #[cfg(test)]
 use super::execution::run_loaded_plan_with_derived_cook_baseline;
@@ -71,6 +75,16 @@ use super::AgentTaskRunResult;
 /// controller finishes promoting and records the result within it; a crashed
 /// controller's lease elapses so a resumed pass can reconcile and continue.
 const PROMOTION_CLAIM_LEASE: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
+#[cfg(test)]
+static WORKSPACE_BASE_CAPTURE_COUNTER: LazyLock<Mutex<Option<Arc<WorkspaceBaseCaptureCounter>>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+#[cfg(test)]
+struct WorkspaceBaseCaptureCounter {
+    workspace: PathBuf,
+    count: AtomicUsize,
+}
 
 /// Render the public CLI continuation route.
 ///
@@ -6671,11 +6685,41 @@ fn pin_and_persist_initial_cook_workspace_base(
     lifecycle_store: &AgentTaskLifecycleStore,
     options: &mut AgentTaskCookServiceOptions,
 ) -> Result<()> {
-    pin_initial_cook_workspace_base(options)?;
-    let Some(task_base_sha) = options.task_base_sha.as_ref() else {
-        return Ok(());
+    let claim = store.claim_missing_task_base(&options.cook_id)?;
+    let mut recipe = match claim {
+        TaskBaseCaptureClaim::Observed(recipe) => {
+            apply_persisted_task_base(options, &recipe)?;
+            return Ok(());
+        }
+        TaskBaseCaptureClaim::InProgress => {
+            return Err(Error::validation_invalid_argument(
+                "task_base_sha",
+                "workspace_base_capture_in_progress",
+                Some(options.cook_id.clone()),
+                Some(vec![cook_continue_command(
+                    None,
+                    &options.initial_run_id,
+                    false,
+                    None,
+                )]),
+            ));
+        }
+        // The lease stays live across the origin lookup, but it is scoped to
+        // this one recipe field rather than a broad recipe mutation lock.
+        TaskBaseCaptureClaim::Acquired(_lease) => {
+            pin_initial_cook_workspace_base(options)?;
+            let Some(_) = options.task_base_sha.as_ref() else {
+                return Ok(());
+            };
+            let recipe = store.load_recipe(&options.cook_id)?;
+            if recipe.finalization["task_base_sha"].is_string() {
+                apply_persisted_task_base(options, &recipe)?;
+                return Ok(());
+            }
+            recipe
+        }
     };
-    let mut recipe = store.load_recipe(&options.cook_id)?;
+    let task_base_sha = options.task_base_sha.as_ref().expect("captured task base");
     let attempt = recipe
         .attempts
         .iter_mut()
@@ -6698,12 +6742,45 @@ fn pin_and_persist_initial_cook_workspace_base(
     )
 }
 
+fn apply_persisted_task_base(
+    options: &mut AgentTaskCookServiceOptions,
+    recipe: &super::cook_recipe::AgentTaskCookRecipe,
+) -> Result<()> {
+    let task_base_sha = recipe.finalization["task_base_sha"]
+        .as_str()
+        .ok_or_else(|| Error::internal_json("persisted Cook task base is not a string", None))?;
+    let attempt = recipe
+        .attempts
+        .iter()
+        .find(|attempt| attempt.run_id == options.initial_run_id)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "cook_recipe.attempts",
+                "initial Cook recipe is missing its materialized attempt",
+                Some(options.initial_run_id.clone()),
+                None,
+            )
+        })?;
+    options.task_base_sha = Some(task_base_sha.to_string());
+    options.initial_plan = attempt.plan.clone();
+    Ok(())
+}
+
 fn pin_cook_workspace_base_at(
     options: &mut AgentTaskCookServiceOptions,
     workspace: &Path,
 ) -> Result<()> {
     if options.task_base_sha.is_some() {
         return Ok(());
+    }
+    #[cfg(test)]
+    if let Some(counter) = WORKSPACE_BASE_CAPTURE_COUNTER
+        .lock()
+        .expect("workspace base capture counter")
+        .clone()
+        .filter(|counter| counter.workspace == workspace)
+    {
+        counter.count.fetch_add(1, Ordering::SeqCst);
     }
     let Some(base) =
         crate::agent_task_promotion::capture_declared_base(workspace, Some(&options.base))?

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -7,7 +7,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 #[cfg(test)]
 use std::sync::{Barrier, LazyLock, Mutex};
-use std::time::{Duration, SystemTime};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -23,32 +22,6 @@ use homeboy_core::{paths, Error, Result};
 
 pub const COOK_RECIPE_SCHEMA: &str = "homeboy/agent-task-cook-recipe/v1";
 const CONTINUATION_SCHEMA: &str = "homeboy/agent-task-cook-continuation/v1";
-const TASK_BASE_CAPTURE_CLAIM_LEASE: Duration = Duration::from_secs(30 * 60);
-
-/// Exclusive authority for the one external base capture that may fill an
-/// otherwise incomplete recipe. The claim is a lease, not a lock: its owner
-/// may perform the slow origin lookup without serializing other recipe work.
-pub(crate) enum TaskBaseCaptureClaim {
-    Acquired(TaskBaseCaptureLease),
-    Observed(AgentTaskCookRecipe),
-    InProgress,
-}
-
-pub(crate) struct TaskBaseCaptureLease {
-    path: PathBuf,
-    token: String,
-}
-
-impl Drop for TaskBaseCaptureLease {
-    fn drop(&mut self) {
-        // A stale owner can outlive its lease. Never let its cleanup remove a
-        // successor's claim after the successor atomically took the path over.
-        if fs::read_to_string(&self.path).ok().as_deref() == Some(&self.token) {
-            let _ = fs::remove_file(&self.path);
-        }
-    }
-}
-
 #[cfg(test)]
 static INITIAL_RECIPE_CREATION_BARRIER: LazyLock<Mutex<(Option<Arc<Barrier>>, usize)>> =
     LazyLock::new(|| Mutex::new((None, 0)));
@@ -122,82 +95,6 @@ impl CookRecipeStore {
     fn supersession_path(&self, cook_id: &str) -> PathBuf {
         self.recipe_path(cook_id)
             .with_file_name("supersession.json")
-    }
-
-    fn task_base_capture_claim_path(&self, cook_id: &str) -> PathBuf {
-        self.recipe_path(cook_id)
-            .with_file_name("task-base-capture.claim")
-    }
-
-    /// Elect one capture owner before it reaches `origin`. A completed owner
-    /// is observed from the recipe; a live owner is reported deterministically
-    /// so continuations can retry rather than repeat the external lookup.
-    pub(crate) fn claim_missing_task_base(&self, cook_id: &str) -> Result<TaskBaseCaptureClaim> {
-        loop {
-            let recipe = self.load_recipe(cook_id)?;
-            if recipe.finalization["task_base_sha"].is_string() {
-                return Ok(TaskBaseCaptureClaim::Observed(recipe));
-            }
-            let path = self.task_base_capture_claim_path(cook_id);
-            let directory = path.parent().expect("claim path has parent");
-            fs::create_dir_all(directory).map_err(|error| {
-                Error::internal_io(error.to_string(), Some(path.display().to_string()))
-            })?;
-            let mut options = OpenOptions::new();
-            options.write(true).create_new(true);
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::OpenOptionsExt;
-                options.mode(0o600);
-            }
-            match options.open(&path) {
-                Ok(mut file) => {
-                    let token = Uuid::new_v4().to_string();
-                    if let Err(error) = file
-                        .write_all(token.as_bytes())
-                        .and_then(|_| file.sync_all())
-                    {
-                        let _ = fs::remove_file(&path);
-                        return Err(Error::internal_io(
-                            error.to_string(),
-                            Some(path.display().to_string()),
-                        ));
-                    }
-                    return Ok(TaskBaseCaptureClaim::Acquired(TaskBaseCaptureLease {
-                        path,
-                        token,
-                    }));
-                }
-                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-                    // Reload before declaring the lease live: its owner may have
-                    // persisted the SHA immediately before releasing the claim.
-                    let recipe = self.load_recipe(cook_id)?;
-                    if recipe.finalization["task_base_sha"].is_string() {
-                        return Ok(TaskBaseCaptureClaim::Observed(recipe));
-                    }
-                    let stale = fs::metadata(&path)
-                        .and_then(|metadata| metadata.modified())
-                        .ok()
-                        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
-                        .is_some_and(|age| age >= TASK_BASE_CAPTURE_CLAIM_LEASE);
-                    if stale {
-                        let retired =
-                            path.with_extension(format!("claim.stale.{}", Uuid::new_v4()));
-                        if fs::rename(&path, &retired).is_ok() {
-                            let _ = fs::remove_file(retired);
-                        }
-                        continue;
-                    }
-                    return Ok(TaskBaseCaptureClaim::InProgress);
-                }
-                Err(error) => {
-                    return Err(Error::internal_io(
-                        error.to_string(),
-                        Some(path.display().to_string()),
-                    ));
-                }
-            }
-        }
     }
 
     fn queue_root(&self) -> PathBuf {

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 #[cfg(test)]
 use std::sync::{Barrier, LazyLock, Mutex};
+use std::time::{Duration, SystemTime};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -22,6 +23,31 @@ use homeboy_core::{paths, Error, Result};
 
 pub const COOK_RECIPE_SCHEMA: &str = "homeboy/agent-task-cook-recipe/v1";
 const CONTINUATION_SCHEMA: &str = "homeboy/agent-task-cook-continuation/v1";
+const TASK_BASE_CAPTURE_CLAIM_LEASE: Duration = Duration::from_secs(30 * 60);
+
+/// Exclusive authority for the one external base capture that may fill an
+/// otherwise incomplete recipe. The claim is a lease, not a lock: its owner
+/// may perform the slow origin lookup without serializing other recipe work.
+pub(crate) enum TaskBaseCaptureClaim {
+    Acquired(TaskBaseCaptureLease),
+    Observed(AgentTaskCookRecipe),
+    InProgress,
+}
+
+pub(crate) struct TaskBaseCaptureLease {
+    path: PathBuf,
+    token: String,
+}
+
+impl Drop for TaskBaseCaptureLease {
+    fn drop(&mut self) {
+        // A stale owner can outlive its lease. Never let its cleanup remove a
+        // successor's claim after the successor atomically took the path over.
+        if fs::read_to_string(&self.path).ok().as_deref() == Some(&self.token) {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+}
 
 #[cfg(test)]
 static INITIAL_RECIPE_CREATION_BARRIER: LazyLock<Mutex<(Option<Arc<Barrier>>, usize)>> =
@@ -96,6 +122,82 @@ impl CookRecipeStore {
     fn supersession_path(&self, cook_id: &str) -> PathBuf {
         self.recipe_path(cook_id)
             .with_file_name("supersession.json")
+    }
+
+    fn task_base_capture_claim_path(&self, cook_id: &str) -> PathBuf {
+        self.recipe_path(cook_id)
+            .with_file_name("task-base-capture.claim")
+    }
+
+    /// Elect one capture owner before it reaches `origin`. A completed owner
+    /// is observed from the recipe; a live owner is reported deterministically
+    /// so continuations can retry rather than repeat the external lookup.
+    pub(crate) fn claim_missing_task_base(&self, cook_id: &str) -> Result<TaskBaseCaptureClaim> {
+        loop {
+            let recipe = self.load_recipe(cook_id)?;
+            if recipe.finalization["task_base_sha"].is_string() {
+                return Ok(TaskBaseCaptureClaim::Observed(recipe));
+            }
+            let path = self.task_base_capture_claim_path(cook_id);
+            let directory = path.parent().expect("claim path has parent");
+            fs::create_dir_all(directory).map_err(|error| {
+                Error::internal_io(error.to_string(), Some(path.display().to_string()))
+            })?;
+            let mut options = OpenOptions::new();
+            options.write(true).create_new(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                options.mode(0o600);
+            }
+            match options.open(&path) {
+                Ok(mut file) => {
+                    let token = Uuid::new_v4().to_string();
+                    if let Err(error) = file
+                        .write_all(token.as_bytes())
+                        .and_then(|_| file.sync_all())
+                    {
+                        let _ = fs::remove_file(&path);
+                        return Err(Error::internal_io(
+                            error.to_string(),
+                            Some(path.display().to_string()),
+                        ));
+                    }
+                    return Ok(TaskBaseCaptureClaim::Acquired(TaskBaseCaptureLease {
+                        path,
+                        token,
+                    }));
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    // Reload before declaring the lease live: its owner may have
+                    // persisted the SHA immediately before releasing the claim.
+                    let recipe = self.load_recipe(cook_id)?;
+                    if recipe.finalization["task_base_sha"].is_string() {
+                        return Ok(TaskBaseCaptureClaim::Observed(recipe));
+                    }
+                    let stale = fs::metadata(&path)
+                        .and_then(|metadata| metadata.modified())
+                        .ok()
+                        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
+                        .is_some_and(|age| age >= TASK_BASE_CAPTURE_CLAIM_LEASE);
+                    if stale {
+                        let retired =
+                            path.with_extension(format!("claim.stale.{}", Uuid::new_v4()));
+                        if fs::rename(&path, &retired).is_ok() {
+                            let _ = fs::remove_file(retired);
+                        }
+                        continue;
+                    }
+                    return Ok(TaskBaseCaptureClaim::InProgress);
+                }
+                Err(error) => {
+                    return Err(Error::internal_io(
+                        error.to_string(),
+                        Some(path.display().to_string()),
+                    ));
+                }
+            }
+        }
     }
 
     fn queue_root(&self) -> PathBuf {

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 #[cfg(test)]
 use std::sync::{Barrier, LazyLock, Mutex};
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -22,6 +23,10 @@ use homeboy_core::{paths, Error, Result};
 
 pub const COOK_RECIPE_SCHEMA: &str = "homeboy/agent-task-cook-recipe/v1";
 const CONTINUATION_SCHEMA: &str = "homeboy/agent-task-cook-continuation/v1";
+// Base capture reaches the network while holding this lock. It must always
+// surface a wedged peer rather than inherit an operator-configured unbounded
+// config-lock wait.
+const WORKSPACE_BASE_CAPTURE_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
 #[cfg(test)]
 static INITIAL_RECIPE_CREATION_BARRIER: LazyLock<Mutex<(Option<Arc<Barrier>>, usize)>> =
     LazyLock::new(|| Mutex::new((None, 0)));
@@ -93,12 +98,35 @@ impl CookRecipeStore {
     }
 
     /// Serialize the bounded base capture transaction for one durable recipe.
-    /// `flock` ownership is tied to this open file description, so the kernel
-    /// releases it if the controller process exits before completing either
-    /// persistence step.
+    /// Advisory lock ownership is tied to this open file, so the operating
+    /// system releases it if the controller process exits before completing
+    /// either persistence step.
     pub(crate) fn with_workspace_base_capture_lock<T>(
         &self,
         cook_id: &str,
+        operation: impl FnOnce() -> Result<T>,
+    ) -> Result<T> {
+        self.with_workspace_base_capture_lock_for(
+            cook_id,
+            WORKSPACE_BASE_CAPTURE_LOCK_TIMEOUT,
+            operation,
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_workspace_base_capture_lock_for_test<T>(
+        &self,
+        cook_id: &str,
+        timeout: Duration,
+        operation: impl FnOnce() -> Result<T>,
+    ) -> Result<T> {
+        self.with_workspace_base_capture_lock_for(cook_id, timeout, operation)
+    }
+
+    fn with_workspace_base_capture_lock_for<T>(
+        &self,
+        cook_id: &str,
+        timeout: Duration,
         operation: impl FnOnce() -> Result<T>,
     ) -> Result<T> {
         let lock_path = self
@@ -120,12 +148,7 @@ impl CookRecipeStore {
                     Some("open Cook workspace base capture lock".to_string()),
                 )
             })?;
-        #[cfg(unix)]
-        homeboy_core::config::lock_exclusive_bounded(
-            &lock,
-            &lock_path,
-            "lock Cook workspace base capture",
-        )?;
+        lock_workspace_base_capture(&lock, &lock_path, timeout)?;
         let _lock = lock;
         operation()
     }
@@ -275,6 +298,49 @@ impl CookRecipeStore {
             ));
         }
         consume_claimed_with_dispatcher_policy(self, claim, dispatcher, execute, false)
+    }
+}
+
+fn lock_workspace_base_capture(lock: &File, lock_path: &Path, timeout: Duration) -> Result<()> {
+    use fs4::fs_std::FileExt;
+
+    let started = Instant::now();
+    let mut backoff = Duration::from_millis(1);
+    loop {
+        match lock.try_lock_exclusive() {
+            Ok(true) => return Ok(()),
+            Ok(false) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
+            Err(error) => {
+                return Err(Error::internal_io(
+                    error.to_string(),
+                    Some("lock Cook workspace base capture".to_string()),
+                ));
+            }
+        }
+
+        let waited = started.elapsed();
+        if waited >= timeout {
+            let mut error = Error::internal_io(
+                format!(
+                    "timed out after {}ms waiting for Cook workspace base capture lock at {}",
+                    waited.as_millis(),
+                    lock_path.display()
+                ),
+                Some("lock Cook workspace base capture".to_string()),
+            );
+            error.details = serde_json::json!({
+                "kind": "workspace_base_capture_lock_timeout",
+                "path": lock_path,
+                "timeout_ms": timeout.as_millis(),
+                "waited_ms": waited.as_millis(),
+            });
+            error.retryable = Some(true);
+            return Err(error);
+        }
+
+        std::thread::sleep(backoff.min(timeout - waited));
+        backoff = (backoff * 2).min(Duration::from_millis(50));
     }
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -92,6 +92,44 @@ impl CookRecipeStore {
             .join("recipe.json")
     }
 
+    /// Serialize the bounded base capture transaction for one durable recipe.
+    /// `flock` ownership is tied to this open file description, so the kernel
+    /// releases it if the controller process exits before completing either
+    /// persistence step.
+    pub(crate) fn with_workspace_base_capture_lock<T>(
+        &self,
+        cook_id: &str,
+        operation: impl FnOnce() -> Result<T>,
+    ) -> Result<T> {
+        let lock_path = self
+            .recipe_path(cook_id)
+            .with_file_name("workspace-base-capture.lock");
+        let parent = lock_path.parent().expect("recipe lock has parent");
+        fs::create_dir_all(parent).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(parent.display().to_string()))
+        })?;
+        let lock = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&lock_path)
+            .map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some("open Cook workspace base capture lock".to_string()),
+                )
+            })?;
+        #[cfg(unix)]
+        homeboy_core::config::lock_exclusive_bounded(
+            &lock,
+            &lock_path,
+            "lock Cook workspace base capture",
+        )?;
+        let _lock = lock;
+        operation()
+    }
+
     fn supersession_path(&self, cook_id: &str) -> PathBuf {
         self.recipe_path(cook_id)
             .with_file_name("supersession.json")

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -8633,6 +8633,26 @@ fn cook_continue_adopts_recipe_bound_retry_missing_run_and_index() {
                 "base",
             ],
         );
+        let base = String::from_utf8(
+            Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .current_dir(&repository)
+                .output()
+                .expect("resolve declared base")
+                .stdout,
+        )
+        .expect("base is UTF-8")
+        .trim()
+        .to_string();
+        git(
+            &repository,
+            &[
+                "remote",
+                "add",
+                "origin",
+                repository.to_str().expect("repository path"),
+            ],
+        );
         git(
             &repository,
             &[
@@ -8672,6 +8692,8 @@ fn cook_continue_adopts_recipe_bound_retry_missing_run_and_index() {
             provenance: None,
         })
         .expect("register destination workspace");
+        // Model an interruption after recipe persistence and before the
+        // declared base capture can complete.
         super::super::persist_initial_recipe(&options).expect("persist durable recipe");
         assert!(super::super::load_recipe(cook_id)
             .expect("load durable recipe")
@@ -8720,6 +8742,13 @@ fn cook_continue_adopts_recipe_bound_retry_missing_run_and_index() {
             false,
         )
         .expect("continuation repairs and dispatches recipe-bound retry");
+        assert_eq!(
+            super::super::load_recipe(cook_id)
+                .expect("resumed recipe captures declared base")
+                .finalization["task_base_sha"],
+            serde_json::json!(base)
+        );
+        git(&destination, &["remote", "remove", "origin"]);
         let repeated = run_cook_spine(
             &ambient_recipe_store,
             &ambient_lifecycle_store,
@@ -8729,7 +8758,7 @@ fn cook_continue_adopts_recipe_bound_retry_missing_run_and_index() {
             None,
             false,
         )
-        .expect("repeated continuation remains idempotent");
+        .expect("captured continuation does not require origin");
 
         assert_eq!(result.value.status, "in_flight", "{result:#?}");
         assert_eq!(result.value.latest_run_id.as_deref(), Some(stranded_run_id));

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -8945,6 +8945,53 @@ fn concurrent_missing_task_base_capture_serializes_and_reuses_its_sha() {
 }
 
 #[test]
+fn workspace_base_capture_lock_times_out_while_another_controller_holds_it() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let store = CookRecipeStore::from_current_data_root().expect("recipe store");
+        let cook_id = "cook-base-capture-lock-contention";
+        let (holder_ready, wait_for_holder) = std::sync::mpsc::sync_channel(0);
+        let (release_holder, holder_release) = std::sync::mpsc::sync_channel(0);
+
+        std::thread::scope(|scope| {
+            let holder_store = &store;
+            let holder = scope.spawn(move || {
+                holder_store.with_workspace_base_capture_lock_for_test(
+                    cook_id,
+                    std::time::Duration::from_secs(1),
+                    || {
+                        holder_ready.send(()).expect("report lock holder");
+                        holder_release.recv().expect("release lock holder");
+                        Ok(())
+                    },
+                )
+            });
+            wait_for_holder.recv().expect("holder acquired lock");
+
+            let started = Instant::now();
+            let error = store
+                .with_workspace_base_capture_lock_for_test(
+                    cook_id,
+                    std::time::Duration::from_millis(50),
+                    || Ok(()),
+                )
+                .expect_err("contending base capture must time out");
+            release_holder.send(()).expect("release lock holder");
+            holder
+                .join()
+                .expect("holder joins")
+                .expect("holder releases cleanly");
+
+            assert_eq!(error.details["kind"], "workspace_base_capture_lock_timeout");
+            assert_eq!(error.details["timeout_ms"], 50);
+            assert!(error.details["waited_ms"]
+                .as_u64()
+                .is_some_and(|waited| waited >= 50));
+            assert!(started.elapsed() < std::time::Duration::from_secs(1));
+        });
+    });
+}
+
+#[test]
 fn workspace_base_capture_repairs_controller_plan_after_recipe_write_interruption() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let temp = tempfile::tempdir().expect("temporary repository");
@@ -14702,6 +14749,7 @@ fn baseline_comparison_is_persisted_before_feedback_finalization() {
         std::fs::write(root.join("candidate"), "base\n").unwrap();
         git_output(root, &["add", "."]).unwrap();
         git_output(root, &["commit", "-m", "base"]).unwrap();
+        git_output(root, &["remote", "add", "origin", "."]).unwrap();
         let base = git_output(root, &["rev-parse", "HEAD"]).unwrap();
         std::fs::write(root.join("candidate"), "provider-produced\n").unwrap();
         git_output(root, &["add", "candidate"]).unwrap();
@@ -18058,6 +18106,7 @@ fn fanout_resume_prefers_immutable_verification_checkpoint_over_later_failed_att
         let patch = format!("{}\n", git_output(&target, &["diff", "--binary"]).unwrap());
         let patch_path = temp.path().join("candidate.patch");
         std::fs::write(&patch_path, &patch).unwrap();
+        let base_sha = git_output(&target, &["rev-parse", "HEAD"]).unwrap();
 
         let dispatches = Arc::new(AtomicUsize::new(0));
         let cook_id = "cook-9703";
@@ -18070,6 +18119,7 @@ fn fanout_resume_prefers_immutable_verification_checkpoint_over_later_failed_att
         options.initial_run_id = agent_task_lifecycle::cook_attempt_run_id(cook_id, 1);
         options.initial_plan.tasks[0].workspace.root = Some(target.display().to_string());
         options.source_worktree_path = None;
+        options.task_base_sha = Some(base_sha.trim().to_string());
         options.gates.verify = vec!["true".to_string()];
         options.no_finalize = false;
         options.head = Some("fix/8058".to_string());
@@ -18104,7 +18154,6 @@ fn fanout_resume_prefers_immutable_verification_checkpoint_over_later_failed_att
             target.to_str().expect("target path"),
         )
         .unwrap();
-        let base_sha = git_output(&target, &["rev-parse", "HEAD"]).unwrap();
         let mut checkpoint = serde_json::to_value(promotion(&run_id)).unwrap();
         checkpoint["status"] = serde_json::json!("verification_pending");
         checkpoint["source"]["task_id"] = serde_json::json!(options.initial_plan.tasks[0].task_id);
@@ -18116,7 +18165,7 @@ fn fanout_resume_prefers_immutable_verification_checkpoint_over_later_failed_att
         checkpoint["provenance"] = serde_json::json!({
             "worktree_path": target,
             "candidate": candidate,
-            "resume_inputs": {"base_ref": "main", "task_base_sha": null, "candidate_ref": null}
+            "resume_inputs": {"base_ref": "main", "task_base_sha": base_sha.trim(), "candidate_ref": null}
         });
         checkpoint["verified_base"]["sha"] = serde_json::json!(base_sha.trim());
         agent_task_lifecycle::record_promotion(&run_id, checkpoint.clone()).unwrap();

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -8789,6 +8789,144 @@ fn cook_continue_adopts_recipe_bound_retry_missing_run_and_index() {
 }
 
 #[test]
+fn concurrent_missing_task_base_capture_has_one_origin_owner_and_reuses_its_sha() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("temporary repository");
+        let repository = temp.path().join("repository");
+        std::fs::create_dir(&repository).expect("create repository");
+        let git = |args: &[&str]| {
+            assert!(Command::new("git")
+                .args(args)
+                .current_dir(&repository)
+                .status()
+                .expect("run git")
+                .success());
+        };
+        git(&["init", "-b", "main"]);
+        std::fs::write(repository.join("fixture.txt"), "base\n").expect("write base");
+        git(&["add", "fixture.txt"]);
+        git(&[
+            "-c",
+            "user.name=Homeboy Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-m",
+            "base",
+        ]);
+        let expected_sha = String::from_utf8(
+            Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .current_dir(&repository)
+                .output()
+                .expect("resolve base")
+                .stdout,
+        )
+        .expect("base is UTF-8")
+        .trim()
+        .to_string();
+        git(&[
+            "remote",
+            "add",
+            "origin",
+            repository.to_str().expect("repository path"),
+        ]);
+
+        let roots = homeboy_core::paths::PathRoots::from_environment().expect("isolated roots");
+        let store = CookRecipeStore::new(roots.clone());
+        let lifecycle_store = AgentTaskLifecycleStore::new(roots);
+        let cook_id = "cook-concurrent-task-base-capture";
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.source_worktree_path = Some(repository.clone());
+        options.initial_plan.tasks[0].workspace.root = Some(repository.display().to_string());
+        store
+            .persist_initial_recipe(&options)
+            .expect("persist incomplete recipe");
+        materialize_initial_cook_attempt_with_stores(&store, &lifecycle_store, &options)
+            .expect("materialize initial attempt");
+
+        let capture_counter = Arc::new(WorkspaceBaseCaptureCounter {
+            workspace: repository.clone(),
+            count: AtomicUsize::new(0),
+        });
+        *WORKSPACE_BASE_CAPTURE_COUNTER
+            .lock()
+            .expect("install workspace base capture counter") = Some(Arc::clone(&capture_counter));
+        let mut winner_options = options.clone();
+        let mut loser_options = options.clone();
+        let barrier = Arc::new(Barrier::new(2));
+        let (winner, loser) = std::thread::scope(|scope| {
+            let winner = scope.spawn(|| {
+                barrier.wait();
+                pin_and_persist_initial_cook_workspace_base(
+                    &store,
+                    &lifecycle_store,
+                    &mut winner_options,
+                )
+            });
+            let loser = scope.spawn(|| {
+                barrier.wait();
+                pin_and_persist_initial_cook_workspace_base(
+                    &store,
+                    &lifecycle_store,
+                    &mut loser_options,
+                )
+            });
+            (
+                winner.join().expect("capture owner joins"),
+                loser.join().expect("capture peer joins"),
+            )
+        });
+        assert!(
+            winner.is_ok() || loser.is_ok(),
+            "one concurrent continuation owns the capture: winner={winner:?}, loser={loser:?}"
+        );
+        if let Err(error) = winner {
+            assert_eq!(
+                error.details["problem"],
+                "workspace_base_capture_in_progress"
+            );
+            pin_and_persist_initial_cook_workspace_base(
+                &store,
+                &lifecycle_store,
+                &mut winner_options,
+            )
+            .expect("later owner continuation reloads captured base");
+        }
+        if let Err(error) = loser {
+            assert_eq!(
+                error.details["problem"],
+                "workspace_base_capture_in_progress"
+            );
+            pin_and_persist_initial_cook_workspace_base(
+                &store,
+                &lifecycle_store,
+                &mut loser_options,
+            )
+            .expect("later continuation reloads captured base");
+        }
+        *WORKSPACE_BASE_CAPTURE_COUNTER
+            .lock()
+            .expect("remove workspace base capture counter") = None;
+        assert_eq!(
+            capture_counter.count.load(Ordering::SeqCst),
+            1,
+            "only the claim owner reaches origin"
+        );
+        let recipe = store.load_recipe(cook_id).expect("captured recipe");
+        assert_eq!(
+            recipe.finalization["task_base_sha"],
+            serde_json::json!(expected_sha)
+        );
+        assert_eq!(winner_options.task_base_sha, loser_options.task_base_sha);
+        assert_eq!(
+            winner_options.task_base_sha.as_deref(),
+            Some(expected_sha.as_str())
+        );
+    });
+}
+
+#[test]
 fn recipe_only_initial_attempt_recovers_once_without_provider_dispatch() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let cook_id = "cook-recipe-only-initial";

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -8789,7 +8789,7 @@ fn cook_continue_adopts_recipe_bound_retry_missing_run_and_index() {
 }
 
 #[test]
-fn concurrent_missing_task_base_capture_has_one_origin_owner_and_reuses_its_sha() {
+fn concurrent_missing_task_base_capture_recovers_a_crashed_owner_and_reuses_its_sha() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let temp = tempfile::tempdir().expect("temporary repository");
         let repository = temp.path().join("repository");
@@ -8831,6 +8831,15 @@ fn concurrent_missing_task_base_capture_has_one_origin_owner_and_reuses_its_sha(
             "origin",
             repository.to_str().expect("repository path"),
         ]);
+        let destination = temp.path().join("destination");
+        git(&[
+            "worktree",
+            "add",
+            "-b",
+            "fixture-candidate",
+            destination.to_str().expect("destination path"),
+            "HEAD",
+        ]);
 
         let roots = homeboy_core::paths::PathRoots::from_environment().expect("isolated roots");
         let store = CookRecipeStore::new(roots.clone());
@@ -8838,12 +8847,52 @@ fn concurrent_missing_task_base_capture_has_one_origin_owner_and_reuses_its_sha(
         let cook_id = "cook-concurrent-task-base-capture";
         let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
         options.source_worktree_path = Some(repository.clone());
-        options.initial_plan.tasks[0].workspace.root = Some(repository.display().to_string());
+        options.initial_plan.tasks[0].workspace.root = Some(destination.display().to_string());
+        options.initial_plan.tasks[0].workspace.kind = Some("homeboy-worktree".to_string());
+        options.initial_plan.tasks[0].workspace.materialization = serde_json::json!({
+            "kind": "homeboy-worktree",
+            "id": options.to_worktree.clone(),
+            "root": destination,
+            "branch": "fixture-candidate",
+        });
+        homeboy_core::worktree::adopt(homeboy_core::worktree::WorktreeAdoptOptions {
+            handle: options.to_worktree.clone(),
+            path: destination.display().to_string(),
+            kind: Some("test-fixture".to_string()),
+            provenance: None,
+        })
+        .expect("register destination workspace");
         store
             .persist_initial_recipe(&options)
             .expect("persist incomplete recipe");
         materialize_initial_cook_attempt_with_stores(&store, &lifecycle_store, &options)
             .expect("materialize initial attempt");
+        lifecycle_store
+            .mutate_record(&options.initial_run_id, |record| {
+                record.state = AgentTaskRunState::Succeeded;
+                true
+            })
+            .expect("make the continuation a terminal service replay");
+
+        // Simulate a controller crash after it reserved the durable operation
+        // but before it reached origin. The lifecycle claim, not a recipe-side
+        // pathname timestamp, must make the continuation recoverable.
+        assert!(matches!(
+            lifecycle_store
+                .claim_cook_operation(
+                    &options.initial_run_id,
+                    WORKSPACE_BASE_CAPTURE_OPERATION,
+                    WORKSPACE_BASE_CAPTURE_CLAIM_LEASE,
+                )
+                .expect("reserve interrupted capture"),
+            agent_task_lifecycle::ClaimOutcome::Acquired
+        ));
+        lifecycle_store
+            .mutate_record(&options.initial_run_id, |record| {
+                record.metadata["cook_operation_claims"][0]["owner_pid"] = serde_json::json!(0);
+                true
+            })
+            .expect("mark interrupted owner dead");
 
         let capture_counter = Arc::new(WorkspaceBaseCaptureCounter {
             workspace: repository.clone(),
@@ -8852,24 +8901,36 @@ fn concurrent_missing_task_base_capture_has_one_origin_owner_and_reuses_its_sha(
         *WORKSPACE_BASE_CAPTURE_COUNTER
             .lock()
             .expect("install workspace base capture counter") = Some(Arc::clone(&capture_counter));
-        let mut winner_options = options.clone();
-        let mut loser_options = options.clone();
+        let winner_options = options.clone();
+        let loser_options = options.clone();
         let barrier = Arc::new(Barrier::new(2));
         let (winner, loser) = std::thread::scope(|scope| {
             let winner = scope.spawn(|| {
                 barrier.wait();
-                pin_and_persist_initial_cook_workspace_base(
+                let mut side_effects =
+                    DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({})));
+                run_cook_spine(
                     &store,
                     &lifecycle_store,
-                    &mut winner_options,
+                    winner_options.clone(),
+                    Arc::new(UnusedExecutor),
+                    &mut side_effects,
+                    None,
+                    false,
                 )
             });
             let loser = scope.spawn(|| {
                 barrier.wait();
-                pin_and_persist_initial_cook_workspace_base(
+                let mut side_effects =
+                    DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({})));
+                run_cook_spine(
                     &store,
                     &lifecycle_store,
-                    &mut loser_options,
+                    loser_options.clone(),
+                    Arc::new(UnusedExecutor),
+                    &mut side_effects,
+                    None,
+                    false,
                 )
             });
             (
@@ -8886,10 +8947,16 @@ fn concurrent_missing_task_base_capture_has_one_origin_owner_and_reuses_its_sha(
                 error.details["problem"],
                 "workspace_base_capture_in_progress"
             );
-            pin_and_persist_initial_cook_workspace_base(
+            let mut side_effects =
+                DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({})));
+            run_cook_spine(
                 &store,
                 &lifecycle_store,
-                &mut winner_options,
+                winner_options.clone(),
+                Arc::new(UnusedExecutor),
+                &mut side_effects,
+                None,
+                false,
             )
             .expect("later owner continuation reloads captured base");
         }
@@ -8898,10 +8965,16 @@ fn concurrent_missing_task_base_capture_has_one_origin_owner_and_reuses_its_sha(
                 error.details["problem"],
                 "workspace_base_capture_in_progress"
             );
-            pin_and_persist_initial_cook_workspace_base(
+            let mut side_effects =
+                DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({})));
+            run_cook_spine(
                 &store,
                 &lifecycle_store,
-                &mut loser_options,
+                loser_options.clone(),
+                Arc::new(UnusedExecutor),
+                &mut side_effects,
+                None,
+                false,
             )
             .expect("later continuation reloads captured base");
         }
@@ -8911,17 +8984,19 @@ fn concurrent_missing_task_base_capture_has_one_origin_owner_and_reuses_its_sha(
         assert_eq!(
             capture_counter.count.load(Ordering::SeqCst),
             1,
-            "only the claim owner reaches origin"
+            "only the recovered claim owner reaches origin"
         );
         let recipe = store.load_recipe(cook_id).expect("captured recipe");
         assert_eq!(
             recipe.finalization["task_base_sha"],
             serde_json::json!(expected_sha)
         );
-        assert_eq!(winner_options.task_base_sha, loser_options.task_base_sha);
         assert_eq!(
-            winner_options.task_base_sha.as_deref(),
-            Some(expected_sha.as_str())
+            store
+                .load_recipe(cook_id)
+                .expect("reloaded recipe")
+                .finalization["task_base_sha"],
+            serde_json::json!(expected_sha)
         );
     });
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -8789,7 +8789,7 @@ fn cook_continue_adopts_recipe_bound_retry_missing_run_and_index() {
 }
 
 #[test]
-fn concurrent_missing_task_base_capture_recovers_a_crashed_owner_and_reuses_its_sha() {
+fn concurrent_missing_task_base_capture_serializes_and_reuses_its_sha() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let temp = tempfile::tempdir().expect("temporary repository");
         let repository = temp.path().join("repository");
@@ -8874,31 +8874,12 @@ fn concurrent_missing_task_base_capture_recovers_a_crashed_owner_and_reuses_its_
             })
             .expect("make the continuation a terminal service replay");
 
-        // Simulate a controller crash after it reserved the durable operation
-        // but before it reached origin. The lifecycle claim, not a recipe-side
-        // pathname timestamp, must make the continuation recoverable.
-        assert!(matches!(
-            lifecycle_store
-                .claim_cook_operation(
-                    &options.initial_run_id,
-                    WORKSPACE_BASE_CAPTURE_OPERATION,
-                    WORKSPACE_BASE_CAPTURE_CLAIM_LEASE,
-                )
-                .expect("reserve interrupted capture"),
-            agent_task_lifecycle::ClaimOutcome::Acquired
-        ));
-        lifecycle_store
-            .mutate_record(&options.initial_run_id, |record| {
-                record.metadata["cook_operation_claims"][0]["owner_pid"] = serde_json::json!(0);
-                true
-            })
-            .expect("mark interrupted owner dead");
-
-        let capture_counter = Arc::new(WorkspaceBaseCaptureCounter {
+        let capture_counter = Arc::new(WorkspaceBaseCaptureHook {
             workspace: repository.clone(),
             count: AtomicUsize::new(0),
+            fail_after_recipe_persistence: AtomicBool::new(false),
         });
-        *WORKSPACE_BASE_CAPTURE_COUNTER
+        *WORKSPACE_BASE_CAPTURE_HOOK
             .lock()
             .expect("install workspace base capture counter") = Some(Arc::clone(&capture_counter));
         let winner_options = options.clone();
@@ -8938,47 +8919,9 @@ fn concurrent_missing_task_base_capture_recovers_a_crashed_owner_and_reuses_its_
                 loser.join().expect("capture peer joins"),
             )
         });
-        assert!(
-            winner.is_ok() || loser.is_ok(),
-            "one concurrent continuation owns the capture: winner={winner:?}, loser={loser:?}"
-        );
-        if let Err(error) = winner {
-            assert_eq!(
-                error.details["problem"],
-                "workspace_base_capture_in_progress"
-            );
-            let mut side_effects =
-                DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({})));
-            run_cook_spine(
-                &store,
-                &lifecycle_store,
-                winner_options.clone(),
-                Arc::new(UnusedExecutor),
-                &mut side_effects,
-                None,
-                false,
-            )
-            .expect("later owner continuation reloads captured base");
-        }
-        if let Err(error) = loser {
-            assert_eq!(
-                error.details["problem"],
-                "workspace_base_capture_in_progress"
-            );
-            let mut side_effects =
-                DefaultCookSideEffects::new(|_, _, _, _| Ok(serde_json::json!({})));
-            run_cook_spine(
-                &store,
-                &lifecycle_store,
-                loser_options.clone(),
-                Arc::new(UnusedExecutor),
-                &mut side_effects,
-                None,
-                false,
-            )
-            .expect("later continuation reloads captured base");
-        }
-        *WORKSPACE_BASE_CAPTURE_COUNTER
+        winner.expect("first concurrent continuation reloads captured base");
+        loser.expect("second concurrent continuation reloads captured base");
+        *WORKSPACE_BASE_CAPTURE_HOOK
             .lock()
             .expect("remove workspace base capture counter") = None;
         assert_eq!(
@@ -8997,6 +8940,109 @@ fn concurrent_missing_task_base_capture_recovers_a_crashed_owner_and_reuses_its_
                 .expect("reloaded recipe")
                 .finalization["task_base_sha"],
             serde_json::json!(expected_sha)
+        );
+    });
+}
+
+#[test]
+fn workspace_base_capture_repairs_controller_plan_after_recipe_write_interruption() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let temp = tempfile::tempdir().expect("temporary repository");
+        let repository = temp.path().join("repository");
+        std::fs::create_dir(&repository).expect("create repository");
+        let git = |args: &[&str]| {
+            assert!(Command::new("git")
+                .args(args)
+                .current_dir(&repository)
+                .status()
+                .expect("run git")
+                .success());
+        };
+        git(&["init", "-b", "main"]);
+        std::fs::write(repository.join("fixture.txt"), "base\n").expect("write base");
+        git(&["add", "fixture.txt"]);
+        git(&[
+            "-c",
+            "user.name=Homeboy Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-m",
+            "base",
+        ]);
+        git(&[
+            "remote",
+            "add",
+            "origin",
+            repository.to_str().expect("repository path"),
+        ]);
+
+        let roots = homeboy_core::paths::PathRoots::from_environment().expect("isolated roots");
+        let store = CookRecipeStore::new(roots.clone());
+        let lifecycle_store = AgentTaskLifecycleStore::new(roots);
+        let mut options = batch_cook_options(
+            "cook-base-write-interruption",
+            Arc::new(AcceptedDetachedAttemptDispatcher),
+        );
+        options.source_worktree_path = Some(repository.clone());
+        store
+            .persist_initial_recipe(&options)
+            .expect("persist incomplete recipe");
+        materialize_initial_cook_attempt_with_stores(&store, &lifecycle_store, &options)
+            .expect("materialize initial attempt");
+
+        let hook = Arc::new(WorkspaceBaseCaptureHook {
+            workspace: repository.clone(),
+            count: AtomicUsize::new(0),
+            fail_after_recipe_persistence: AtomicBool::new(true),
+        });
+        *WORKSPACE_BASE_CAPTURE_HOOK
+            .lock()
+            .expect("install workspace base capture hook") = Some(Arc::clone(&hook));
+        let error =
+            pin_and_persist_initial_cook_workspace_base(&store, &lifecycle_store, &mut options)
+                .expect_err("injected interruption follows recipe persistence");
+        assert!(error.message.contains("after Cook recipe base persistence"));
+
+        let recipe = store
+            .load_recipe(&options.cook_id)
+            .expect("recipe survives interruption");
+        assert!(recipe.finalization["task_base_sha"].is_string());
+        assert_ne!(
+            lifecycle_store
+                .read_controller_plan(&options.initial_run_id)
+                .expect("old controller plan"),
+            recipe.attempts[0].plan
+        );
+        git(&["remote", "remove", "origin"]);
+
+        let mut recovery_options = batch_cook_options(
+            "cook-base-write-interruption",
+            Arc::new(AcceptedDetachedAttemptDispatcher),
+        );
+        recovery_options.source_worktree_path = Some(repository);
+        pin_and_persist_initial_cook_workspace_base(
+            &store,
+            &lifecycle_store,
+            &mut recovery_options,
+        )
+        .expect("recovery repairs the controller plan from the recipe SHA");
+        *WORKSPACE_BASE_CAPTURE_HOOK
+            .lock()
+            .expect("remove workspace base capture hook") = None;
+
+        assert_eq!(hook.count.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            recovery_options.task_base_sha,
+            recipe.finalization["task_base_sha"]
+                .as_str()
+                .map(str::to_string)
+        );
+        assert_eq!(
+            lifecycle_store
+                .read_controller_plan(&recovery_options.initial_run_id)
+                .expect("repaired controller plan"),
+            recipe.attempts[0].plan
         );
     });
 }


### PR DESCRIPTION
## Summary

Fixes #13288. Replaces the base-capture operation claim with a per-recipe cross-platform advisory file lock. All continuations for one recipe acquire the same lock, which the operating system releases if the controller process exits. The recipe-base capture path has its own fixed 30-second contention bound and never inherits the global config-lock setting.

While holding the lock, Cook reloads the recipe and controller plan. A persisted recipe SHA is authoritative: Cook repairs a missing or stale controller plan from that immutable recipe without contacting `origin`. Without a SHA, Cook captures the base once, persists the recipe SHA and matching attempt plan, then persists the controller plan before releasing the lock.

## Verification

- `cargo test -p homeboy-agents agent_task_service::cook::tests::concurrent_missing_task_base_capture_serializes_and_reuses_its_sha -- --exact` (run twice)
- `cargo test -p homeboy-agents workspace_base_capture -- --nocapture`
- `cargo test -p homeboy-agents cook_continue_adopts_recipe_bound_retry_missing_run_and_index -- --nocapture`
- `cargo test -p homeboy-agents agent_task_service::cook::tests::baseline_comparison_is_persisted_before_feedback_finalization -- --exact`
- `cargo test -p homeboy-agents agent_task_service::cook::tests::fanout_resume_prefers_immutable_verification_checkpoint_over_later_failed_attempt -- --exact`
- `cargo test -p homeboy-agents agent_task_service::cook::tests::reconstructed_cook_rejects_a_removed_managed_workspace_before_provider_execution -- --exact`
- `cargo fmt --check`
- `cargo check -p homeboy-agents`
- `git diff --check`

The prior Test differential (`current=122`, `base=119`) used valid base/candidate checkout manifests but a malformed test-failures sidecar, so it emitted only aggregate count findings. The three reproducible branch-caused Cook fixture failures are repaired; the high-signal tests remain.

## AI assistance

OpenAI gpt-5.6-terra via OpenCode inspected Cook lifecycle and CI artifacts, replaced the Unix-only base-capture lock with the existing cross-platform `fs4` advisory-lock primitive, added contention coverage, repaired affected provenance fixtures, and ran the listed verification. Chris Huber remains responsible for this change.