### PR TITLE
fix(runner): bind candidate reconnect continuation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
     # (sharded Test result retrieval works across reruns), #424 (extension-owned
     # Cargo build and quality caches), and #425 (cache ownership assertions).
     # Refs #10997, #11751 W1-2, W1-5, W1-6, W1-7, W1-10, and #13267.
-    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@721d468ba9bf6668a053f10313ef6b67c676a966
+    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@bf6b7072e6cb11a21d14c0f78ccd33beade24f48
     with:
       commands: review test
       # `review test` defaults to running the extension's pre-test lint, which

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,7 @@ jobs:
       args: --skip-lint
       expected-commands: review audit,review lint,review test
       component: homeboy
+      action-ref: bf6b7072e6cb11a21d14c0f78ccd33beade24f48
       extension-ref: 691d0527d7a4b3917649043a7f91a81913a139ab
       source: .
       scope: auto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,8 +266,8 @@ jobs:
     # (downloaded Test archives stay out of consumer Git state), #416
     # (sharded Test result retrieval works across reruns), #424 (extension-owned
     # Cargo build and quality caches), and #425 (cache ownership assertions).
-    # Refs #10997 and #11751 W1-2, W1-5, W1-6, W1-7, W1-10.
-    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@1db8e159b381accb965125108266d4031d7f6feb
+    # Refs #10997, #11751 W1-2, W1-5, W1-6, W1-7, W1-10, and #13267.
+    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@721d468ba9bf6668a053f10313ef6b67c676a966
     with:
       commands: review test
       # `review test` defaults to running the extension's pre-test lint, which

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -833,7 +833,7 @@ pub fn refresh_homeboy_binary(
                 if converged { 0 } else { 1 },
             ));
             let followup_commands = readiness.continuation.clone().into_iter().collect();
-            let next_actions = controller_continuation_actions(&plan, &identity)?;
+            let next_actions = controller_continuation_actions(&plan, &identity, Vec::new())?;
             return Ok((
                 HomeboyBinaryRefreshOutput {
                     variant: "refresh_homeboy",
@@ -1028,10 +1028,11 @@ pub fn refresh_homeboy_binary(
                     reconnect_deferred: None,
                     failure: Some(refresh_reconnect_failure(
                         &plan,
+                        &identity,
                         &exec_output,
                         &report,
                         daemon_identity_verification.err().as_deref(),
-                    )),
+                    )?),
                     bootstrap_provenance: Some(refresh_bootstrap_provenance(
                         diagnostic_ssh_bootstrap,
                         &plan,
@@ -1101,10 +1102,11 @@ pub fn refresh_homeboy_binary(
                         reconnect_deferred: None,
                         failure: Some(refresh_reconnect_failure(
                             &plan,
+                            &identity,
                             &exec_output,
                             &report,
                             Some(readiness_error.message.as_str()),
-                        )),
+                        )?),
                         bootstrap_provenance: Some(refresh_bootstrap_provenance(
                             diagnostic_ssh_bootstrap,
                             &plan,
@@ -1142,7 +1144,7 @@ pub fn refresh_homeboy_binary(
         .and_then(|readiness| readiness.continuation.clone())
         .map(|continuation| vec![continuation])
         .unwrap_or_else(|| plan.followup_commands.clone());
-    let next_actions = controller_continuation_actions(&plan, &identity)?;
+    let next_actions = controller_continuation_actions(&plan, &identity, Vec::new())?;
     Ok((
         HomeboyBinaryRefreshOutput {
             variant: "refresh_homeboy",
@@ -2846,12 +2848,14 @@ fn error_context(error: &Error) -> String {
 
 fn refresh_reconnect_failure(
     plan: &HomeboyBinaryRefreshPlan,
+    identity: &Value,
     execution: &RunnerExecOutput,
     report: &super::RunnerConnectReport,
     daemon_identity_verification: Option<&str>,
-) -> HomeboyBinaryRefreshFailure {
+) -> Result<HomeboyBinaryRefreshFailure> {
     refresh_reconnect_failure_with_message(
         plan,
+        identity,
         execution,
         report
             .failure_message
@@ -2866,25 +2870,40 @@ fn refresh_reconnect_failure(
 /// retry that can rematerialize or select a different executable.
 fn refresh_reconnect_failure_with_message(
     plan: &HomeboyBinaryRefreshPlan,
+    identity: &Value,
     execution: &RunnerExecOutput,
     reconnect_error: &str,
-) -> HomeboyBinaryRefreshFailure {
+) -> Result<HomeboyBinaryRefreshFailure> {
     let mut failure = refresh_failure(plan, execution.clone(), 1);
+    let invocation = vec![
+        "runner".to_string(),
+        "connect".to_string(),
+        plan.runner_id.clone(),
+    ];
+    let recovery_command = if plan.mode == "materialize" {
+        controller_continuation_actions(plan, identity, invocation)?
+            .into_iter()
+            .next()
+            .expect("materialized candidate continuation is present")
+            .command
+    } else {
+        vec![
+            "homeboy".to_string(),
+            "runner".to_string(),
+            "connect".to_string(),
+            plan.runner_id.clone(),
+        ]
+    };
     failure.recovery_actions = vec![
         homeboy_core::runner_execution_envelope::RunnerExecutionNextAction {
             label: "reconnect_after_promotion".to_string(),
-            command: vec![
-                "homeboy".to_string(),
-                "runner".to_string(),
-                "connect".to_string(),
-                plan.runner_id.clone(),
-            ],
+            command: recovery_command,
         },
     ];
     failure.verification = Some(format!(
         "reconnect failed after selection; the promoted configured binary remains selected: {reconnect_error}"
     ));
-    failure
+    Ok(failure)
 }
 
 fn build_local_homeboy_binary(
@@ -2934,6 +2953,7 @@ fn build_local_homeboy_binary(
 fn controller_continuation_actions(
     plan: &HomeboyBinaryRefreshPlan,
     identity: &Value,
+    invocation: Vec<String>,
 ) -> Result<Vec<HomeboyControllerContinuationAction>> {
     if plan.mode != "materialize" {
         return Ok(Vec::new());
@@ -2972,7 +2992,7 @@ fn controller_continuation_actions(
                 None,
             )
         })?;
-    let command = vec![
+    let mut command = vec![
         "homeboy".to_string(),
         "runtime".to_string(),
         "materialize-controller".to_string(),
@@ -2983,13 +3003,17 @@ fn controller_continuation_actions(
         "--identity".to_string(),
         expected.to_string(),
     ];
+    if !invocation.is_empty() {
+        command.push("--".to_string());
+        command.extend(invocation.iter().cloned());
+    }
     Ok(vec![HomeboyControllerContinuationAction {
         label: "materialize_controller_candidate".to_string(),
         command,
         source: source.to_string(),
         commit: exact_commit.to_string(),
         identity: expected.to_string(),
-        invocation: Vec::new(),
+        invocation,
     }])
 }
 

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use super::*;
-use crate::{RunnerSession, RunnerSessionRole, RunnerTunnelMode};
+use crate::{RunnerExecMode, RunnerSession, RunnerSessionRole, RunnerTunnelMode};
 use homeboy_core::test_support;
 use std::time::{Duration, Instant};
 
@@ -830,7 +830,8 @@ fn verified_materialized_refresh_defers_controller_materialization_to_exact_cont
         followup_commands: Vec::new(),
     };
 
-    let actions = controller_continuation_actions(&plan, &identity).expect("continuation");
+    let actions =
+        controller_continuation_actions(&plan, &identity, Vec::new()).expect("continuation");
     assert_eq!(actions.len(), 1);
     let action = &actions[0];
     assert_eq!(action.commit, "exact-remote-sha");
@@ -855,9 +856,81 @@ fn verified_materialized_refresh_defers_controller_materialization_to_exact_cont
         source: None,
         ..plan
     };
-    assert!(controller_continuation_actions(&select, &identity)
-        .expect("select continuation")
-        .is_empty());
+    assert!(
+        controller_continuation_actions(&select, &identity, Vec::new())
+            .expect("select continuation")
+            .is_empty()
+    );
+}
+
+#[test]
+fn candidate_reconnect_retry_executes_the_materialized_controller_not_ambient_homeboy() {
+    let identity = serde_json::json!({
+        "data": {
+            "display": "homeboy 1.2.3+candidate-commit",
+            "git_commit": "candidate-commit"
+        }
+    });
+    let plan = HomeboyBinaryRefreshPlan {
+        runner_id: "generic-lab".to_string(),
+        mode: "materialize".to_string(),
+        source: Some("https://example.test/homeboy.git".to_string()),
+        git_ref: Some("candidate".to_string()),
+        target_dir: Some("/runner/homeboy".to_string()),
+        binary_path: "/runner/homeboy/target/release/homeboy".to_string(),
+        script: "fixture".to_string(),
+        reconnect: true,
+        followup_commands: Vec::new(),
+    };
+    let execution = RunnerExecOutput {
+        variant: "exec",
+        command: "runner.exec",
+        runner_id: "generic-lab".to_string(),
+        dry_run: false,
+        mode: RunnerExecMode::Daemon,
+        argv: Vec::new(),
+        remote_cwd: "/runner".to_string(),
+        exit_code: 1,
+        stdout: String::new(),
+        stderr: String::new(),
+        source_snapshot: None,
+        job: None,
+        runner_job: None,
+        job_id: None,
+        job_events: None,
+        mirror_run_id: None,
+        patch: None,
+        mutation_artifacts: None,
+        artifacts: Vec::new(),
+        promoted_outputs: Vec::new(),
+        structured_summaries: Vec::new(),
+        metrics: None,
+        capture: None,
+        execution_record: None,
+        runner_result: None,
+        handoff: None,
+        diagnostics: None,
+    };
+
+    let failure = refresh_reconnect_failure_with_message(
+        &plan,
+        &identity,
+        &execution,
+        "transient reconnect failure",
+    )
+    .expect("candidate reconnect continuation");
+    let command = &failure.recovery_actions[0].command;
+
+    assert_eq!(
+        command[0..3],
+        ["homeboy", "runtime", "materialize-controller"]
+    );
+    assert_eq!(
+        command[command.len() - 4..],
+        ["--", "runner", "connect", "generic-lab"]
+    );
+    assert!(command.iter().any(|arg| arg == "candidate-commit"));
+    assert_ne!(command, &["homeboy", "runner", "connect", "generic-lab"]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #13289.

A materialized runner candidate previously emitted two separate actions: an unbound controller materialization and a bare `homeboy runner connect <runner>` retry. A newer ambient CLI could own that retry and recreate controller/configured version skew.

The reconnect recovery now invokes `runtime materialize-controller ... -- runner connect <runner>`. The materializer seals the exact verified candidate and execs that continuation, so the selected candidate identity survives retry and reconnect. Candidate identity failures are fail-closed; they cannot fall back to an ambient reconnect.

## Verification

- `cargo test -p homeboy-lab-runner "homeboy_refresh::tests::part_b::" --lib` (39 passed)
- `cargo test -p homeboy-core prune_pins_honors_the_configured_window_until_a_purge_is_requested --lib`
- `cargo check -p homeboy-lab-runner`
- `homeboy review lint homeboy --placement local --changed-since origin/main`
- `cargo fmt --check`
- `git diff --check`

`homeboy review audit` and the umbrella test gate were externally terminated at the 10-minute execution limit. The latter completed Clippy successfully but was terminated before Nextest started; the focused tests above passed.

## AI assistance

OpenCode using `openai/gpt-5.6-terra` investigated the continuation boundary, implemented the generic runtime-identity binding, and ran focused verification under Chris Huber's direction.