### PR TITLE
fix(audit): validate and prune stale baseline rows

### DIFF
--- a/crates/homeboy-cli/src/commands/audit_baseline.rs
+++ b/crates/homeboy-cli/src/commands/audit_baseline.rs
@@ -21,12 +21,23 @@ pub struct AuditBaselineArgs {
 
 #[derive(Subcommand)]
 enum AuditBaselineCommand {
+    /// Verify every persisted fingerprint still references a live source path
+    Validate(AuditBaselineValidateArgs),
     /// Refresh only persisted audit baseline data for changed files
     Refresh(AuditBaselineRefreshArgs),
     /// Auto-merge a baseline-only `homeboy.json` merge/rebase conflict
     Merge(AuditBaselineMergeArgs),
     /// Safely remove specific fingerprints from the baseline (no hand-editing)
     Prune(AuditBaselinePruneArgs),
+}
+
+#[derive(Args)]
+pub struct AuditBaselineValidateArgs {
+    #[command(flatten)]
+    pub comp: PositionalComponentArgs,
+
+    #[command(flatten)]
+    pub extension_override: ExtensionOverrideArgs,
 }
 
 #[derive(Args)]
@@ -82,10 +93,53 @@ pub struct AuditBaselineRefreshOutput {
 
 pub fn run(args: AuditBaselineArgs) -> CmdResult<AuditBaselineRefreshOutput> {
     match args.command {
+        AuditBaselineCommand::Validate(args) => validate(args),
         AuditBaselineCommand::Refresh(args) => refresh(args),
         AuditBaselineCommand::Merge(args) => merge(args),
         AuditBaselineCommand::Prune(args) => prune(args),
     }
+}
+
+fn validate(args: AuditBaselineValidateArgs) -> CmdResult<AuditBaselineRefreshOutput> {
+    let source_ctx = resolve_source_context(
+        &args.comp,
+        &SettingArgs::default(),
+        &args.extension_override,
+        None,
+    )?;
+    let source_path = source_ctx.source_path.to_string_lossy().to_string();
+    let source = Path::new(&source_path);
+    let baseline_path = source.join("homeboy.json").to_string_lossy().to_string();
+    let baseline = baseline::load_baseline(source).ok_or_else(|| {
+        homeboy::core::Error::validation_invalid_argument(
+            "baselines.audit.known_fingerprints",
+            format!("{baseline_path} has no audit baseline to validate."),
+            None,
+            None,
+        )
+    })?;
+
+    baseline::validate_fingerprint_paths(source, &baseline)?;
+    let count = baseline.known_fingerprints.len();
+    eprintln!("[audit-baseline] validated {baseline_path}: {count} live fingerprint(s)");
+
+    Ok((
+        AuditBaselineRefreshOutput {
+            command: "audit-baseline.validate".to_string(),
+            component_id: source_ctx.component_id,
+            source_path,
+            baseline_path,
+            changed_since: "validate".to_string(),
+            previous_source: "current baseline".to_string(),
+            previous_count: count,
+            current_count: count,
+            added_count: 0,
+            resolved_count: 0,
+            added_fingerprints: Vec::new(),
+            resolved_fingerprints: Vec::new(),
+        },
+        0,
+    ))
 }
 
 fn prune(args: AuditBaselinePruneArgs) -> CmdResult<AuditBaselineRefreshOutput> {
@@ -437,6 +491,8 @@ fn fail_if_homeboy_json_has_conflict_markers(source: &Path) -> homeboy::core::Re
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli_surface::Cli;
+    use clap::Parser;
 
     fn set(values: &[&str]) -> BTreeSet<String> {
         values.iter().map(|value| value.to_string()).collect()
@@ -463,5 +519,20 @@ mod tests {
             .expect_err("conflict markers should fail preflight");
 
         assert!(error.to_string().contains("merge conflict markers"));
+    }
+
+    #[test]
+    fn validate_command_uses_the_public_baseline_contract() {
+        let args = crate::commands::utils::args::normalize(vec![
+            "homeboy".to_string(),
+            "review".to_string(),
+            "audit".to_string(),
+            "baseline".to_string(),
+            "validate".to_string(),
+            "--path".to_string(),
+            ".".to_string(),
+        ]);
+
+        assert!(Cli::try_parse_from(args).is_ok());
     }
 }

--- a/crates/homeboy-cli/src/commands/utils/args.rs
+++ b/crates/homeboy-cli/src/commands/utils/args.rs
@@ -271,11 +271,12 @@ fn normalize_legacy_allow_local_fallback(args: Vec<String>) -> Vec<String> {
 }
 
 fn normalize_review_audit_baseline(mut args: Vec<String>) -> Vec<String> {
-    if matches!(args.get(1).map(String::as_str), Some("review"))
-        && matches!(args.get(2).map(String::as_str), Some("audit"))
-        && matches!(args.get(3).map(String::as_str), Some("baseline"))
-    {
-        args.splice(2..4, ["audit-baseline".to_string()]);
+    if let Some(position) = args.windows(3).position(|window| {
+        matches!(window[0].as_str(), "review")
+            && matches!(window[1].as_str(), "audit")
+            && matches!(window[2].as_str(), "baseline")
+    }) {
+        args.splice(position + 1..position + 3, ["audit-baseline".to_string()]);
     }
     args
 }
@@ -459,6 +460,36 @@ mod normalize_tests {
                 "review",
                 "audit-baseline",
                 "refresh",
+                "--path",
+                ".",
+            ])
+        );
+        assert!(Cli::try_parse_from(args).is_ok());
+    }
+
+    #[test]
+    fn review_audit_baseline_normalizes_after_global_options() {
+        let args = normalize(argv(&[
+            "homeboy",
+            "--placement",
+            "local",
+            "review",
+            "audit",
+            "baseline",
+            "validate",
+            "--path",
+            ".",
+        ]));
+
+        assert_eq!(
+            args,
+            argv(&[
+                "homeboy",
+                "--placement",
+                "local",
+                "review",
+                "audit-baseline",
+                "validate",
                 "--path",
                 ".",
             ])

--- a/docs/audit/baseline-ratchet.md
+++ b/docs/audit/baseline-ratchet.md
@@ -49,8 +49,8 @@ convention::file::description::Kind
 
 so it is per file + kind + message. Still not per instance.
 
-Of the current rows, 821 are the three-segment per-file+kind form (covering 821
-distinct file+kind pairs across 582 files) and 312 are the four-segment
+Of the current rows, 820 are the three-segment per-file+kind form (covering 820
+distinct file+kind pairs across 581 files) and 312 are the four-segment
 `CoreBoundaryLeak` form.
 
 ## Two ways the list grows on its own
@@ -79,7 +79,24 @@ In order of preference:
 1. Fix the finding. This is the default and usually the cheaper option.
 2. Retire an existing suppression in the same PR, so the total does not rise.
 3. Raise `AUDIT_BASELINE_CEILING` in the same PR, and justify it in the PR body.
-   Expect to be asked why the finding cannot be fixed.
+    Expect to be asked why the finding cannot be fixed.
+
+## Updating and validating rows
+
+Treat the baseline as generated configuration, not an audit result to accept
+wholesale. For a moved or deleted path, use the explicit, reproducible sequence:
+
+```sh
+homeboy review audit baseline validate --path .
+homeboy review audit baseline prune --path . --fingerprint '<exact fingerprint from validate>'
+homeboy review audit baseline validate --path .
+```
+
+`validate` uses the production full-tree path validator and fails with every
+stale fingerprint. `prune` changes only the exact named rows semantically,
+fails when none match, writes a deterministic canonical baseline, and updates
+`item_count`; review its generated diff before committing. Repoint a row rather
+than pruning it when the finding still applies at its new path.
 
 ### Lowering the ceiling
 
@@ -95,7 +112,7 @@ you forget.
 
 ## Current debt, by finding kind
 
-1,133 rows as of the commit that introduced this ratchet. This table exists so
+1,128 rows as of the current ratchet update. This table exists so
 the debt is visible rather than hidden inside a 158 KB JSON blob — that array is
 93% of `homeboy.json` by byte count.
 
@@ -104,7 +121,7 @@ the debt is visible rather than hidden inside a 158 KB JSON blob — that array 
 | `CoreBoundaryLeak` | 312 |
 | `SkeletonDuplicate` | 147 |
 | `HighItemCount` | 133 |
-| `ConstantBypassLiteral` | 128 |
+| `ConstantBypassLiteral` | 127 |
 | `IntraMethodDuplicate` | 114 |
 | `GodFile` | 94 |
 | `UnreferencedExport` | 47 |
@@ -129,7 +146,7 @@ the debt is visible rather than hidden inside a 158 KB JSON blob — that array 
 | `MissingInterface` | 1 |
 | `NamingMismatch` | 1 |
 | `ParallelRunnerSetup` | 1 |
-| **Total** | **1133** |
+| **Total** | **1128** |
 
 Roughly: 307 duplication findings, 227 size findings, 47 dead public exports.
 
@@ -145,16 +162,9 @@ it from getting worse.
 
 ## Known wrinkles
 
-- **`metadata.item_count` is stale.** It reads 1137 while the array holds 1133.
-  `normalize_loaded_baseline` only recomputes `item_count` when a policy section
-  enumerates fingerprints, and the sections now use the `fingerprint_prefix`
-  form with empty enumerations, so that branch never runs. `compare` uses
-  `item_count` for its reported `delta`, so that number is off by four. It does
-  not affect `drift_increased`, which is computed from the fingerprint set, so
-  suppression behavior is correct. The ratchet measures the array length, not
-  `item_count`.
-- **Rows are not sorted.** `save` sorts, but 363 of the 1,133 rows are out of
-  sorted position, so order is not an invariant and no test pins it.
+- **Rows are canonicalized by baseline tooling.** `prune` and `save` sort
+  fingerprints and serialize the baseline deterministically, so generated
+  changes are reproducible and reviewable.
 - **The baseline is not in a separate file.** Splitting it out would make config
   diffs readable, but `BaselineConfig::json_path()` hardcodes `homeboy.json`,
   and so do the git-ref reader (`git show <ref>:homeboy.json`) and the whole

--- a/homeboy.json
+++ b/homeboy.json
@@ -318,8 +318,8 @@
             "value": "python3"
           },
           {
-            "value": "node",
-            "context": "string_literal"
+            "context": "string_literal",
+            "value": "node"
           },
           {
             "value": "opencode"
@@ -565,7 +565,6 @@
   "audit_rules": {
     "layer_rules": [
       {
-        "name": "contracts-own-no-process-execution",
         "forbid": {
           "glob": "crates/contracts/**",
           "patterns": [
@@ -574,10 +573,10 @@
             "reqwest::",
             "tokio::spawn"
           ]
-        }
+        },
+        "name": "contracts-own-no-process-execution"
       },
       {
-        "name": "engine-primitives-own-no-domain-crates",
         "forbid": {
           "glob": "crates/homeboy-engine-primitives/src/**",
           "patterns": [
@@ -586,30 +585,30 @@
             "homeboy_agents::",
             "homeboy_rig::"
           ]
-        }
+        },
+        "name": "engine-primitives-own-no-domain-crates"
       },
       {
-        "name": "cli-surface-owns-no-process-execution",
         "forbid": {
           "glob": "crates/homeboy-cli/src/cli_surface/**",
           "patterns": [
             "std::process::Command",
             "std::process::exit"
           ]
-        }
+        },
+        "name": "cli-surface-owns-no-process-execution"
       },
       {
-        "name": "command-contract-owns-no-process-execution",
         "forbid": {
           "glob": "crates/homeboy-cli/src/command_contract/**",
           "patterns": [
             "std::process::Command",
             "std::process::exit"
           ]
-        }
+        },
+        "name": "command-contract-owns-no-process-execution"
       },
       {
-        "name": "rig-owns-no-service-implementation",
         "forbid": {
           "glob": "crates/homeboy-rig/src/**",
           "patterns": [
@@ -618,7 +617,8 @@
             "hyper::Server",
             "axum::serve"
           ]
-        }
+        },
+        "name": "rig-owns-no-service-implementation"
       }
     ]
   },
@@ -635,7 +635,7 @@
     "audit": {
       "context_id": "homeboy",
       "created_at": "2026-07-27T04:11:26Z",
-      "item_count": 1137,
+      "item_count": 1128,
       "known_fingerprints": [
         "Commands::crates/homeboy-cli/src/commands/agent_task_dispatch.rs::MissingMethod",
         "Src::crates/contracts/homeboy-audit-contract/src/finding.rs::MissingMethod",
@@ -662,6 +662,12 @@
         "command_wrapper_bypass::crates/homeboy-core/src/git/pr_refresh.rs::CommandWrapperBypass",
         "command_wrapper_bypass::crates/homeboy-core/src/hygiene.rs::CommandWrapperBypass",
         "command_wrapper_bypass::crates/homeboy-core/src/worktree_providers.rs::CommandWrapperBypass",
+        "command_wrapper_bypass::crates/homeboy-deploy/src/orchestration/preflight.rs::CommandWrapperBypass",
+        "command_wrapper_bypass::crates/homeboy-deploy/src/orchestration_tag_checkout.rs::CommandWrapperBypass",
+        "command_wrapper_bypass::crates/homeboy-deploy/src/planning.rs::CommandWrapperBypass",
+        "command_wrapper_bypass::crates/homeboy-deploy/src/preparation.rs::CommandWrapperBypass",
+        "command_wrapper_bypass::crates/homeboy-deploy/src/provenance.rs::CommandWrapperBypass",
+        "command_wrapper_bypass::crates/homeboy-deploy/src/types.rs::CommandWrapperBypass",
         "command_wrapper_bypass::crates/homeboy-extension/src/trace/canonicality.rs::CommandWrapperBypass",
         "command_wrapper_bypass::crates/homeboy-extension/src/trace/run/provenance.rs::CommandWrapperBypass",
         "command_wrapper_bypass::crates/homeboy-lab-runner/src/git_dependency_materialization.rs::CommandWrapperBypass",
@@ -673,12 +679,6 @@
         "command_wrapper_bypass::crates/homeboy-lab-runner/src/workspace/git.rs::CommandWrapperBypass",
         "command_wrapper_bypass::crates/homeboy-lab-runner/src/workspace/provenance.rs::CommandWrapperBypass",
         "command_wrapper_bypass::crates/homeboy-lab-runner/src/workspace/snapshot.rs::CommandWrapperBypass",
-        "command_wrapper_bypass::crates/homeboy-deploy/src/orchestration/preflight.rs::CommandWrapperBypass",
-        "command_wrapper_bypass::crates/homeboy-deploy/src/orchestration_tag_checkout.rs::CommandWrapperBypass",
-        "command_wrapper_bypass::crates/homeboy-deploy/src/planning.rs::CommandWrapperBypass",
-        "command_wrapper_bypass::crates/homeboy-deploy/src/preparation.rs::CommandWrapperBypass",
-        "command_wrapper_bypass::crates/homeboy-deploy/src/provenance.rs::CommandWrapperBypass",
-        "command_wrapper_bypass::crates/homeboy-deploy/src/types.rs::CommandWrapperBypass",
         "command_wrapper_bypass::crates/homeboy-release/src/release/checkout_guard.rs::CommandWrapperBypass",
         "command_wrapper_bypass::crates/homeboy-release/src/release/executor/version_targets.rs::CommandWrapperBypass",
         "command_wrapper_bypass::crates/homeboy-release/src/release/planning_git.rs::CommandWrapperBypass",
@@ -737,18 +737,17 @@
         "constant_bypass_literal::crates/homeboy-cli/src/commands/fuzz/execution.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/fuzz/replay.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/issues.rs::ConstantBypassLiteral",
-        "constant_bypass_literal::crates/homeboy-cli/src/commands/runs/report/failure_digest/bench.rs::ConstantBypassLiteral",
-        "constant_bypass_literal::crates/homeboy-cli/src/commands/runs/report/failure_digest/trace.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/runner/types.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/runs/fuzz_compare.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/runs/remote_artifact.rs::ConstantBypassLiteral",
+        "constant_bypass_literal::crates/homeboy-cli/src/commands/runs/report/failure_digest/bench.rs::ConstantBypassLiteral",
+        "constant_bypass_literal::crates/homeboy-cli/src/commands/runs/report/failure_digest/trace.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/runs/types.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/runs/watch.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/runs_summary.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/schedule.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/trace/bundle.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/trace/compare_bundle.rs::ConstantBypassLiteral",
-        "constant_bypass_literal::crates/homeboy-cli/src/commands/triage.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/utils/response.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-code-audit/src/report.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-core/src/agent_runtime_manifest.rs::ConstantBypassLiteral",
@@ -768,6 +767,7 @@
         "constant_bypass_literal::crates/homeboy-core/src/proof/validation.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-core/src/runner_execution_envelope.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-core/src/test_support.rs::ConstantBypassLiteral",
+        "constant_bypass_literal::crates/homeboy-deploy/src/planning.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-engine-primitives/src/identifier.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-extension/src/bench/report.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-extension/src/bench/run/list.rs::ConstantBypassLiteral",
@@ -797,7 +797,6 @@
         "constant_bypass_literal::crates/homeboy-lab-runner/src/worker/result.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-lab-runner/src/workspace/provenance.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-refactor/src/plan/sources/extension_source.rs::ConstantBypassLiteral",
-        "constant_bypass_literal::crates/homeboy-deploy/src/planning.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-release/src/release/cascade.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-release/src/release/executor/artifacts.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-release/src/release/executor/github_release/gh_cli.rs::ConstantBypassLiteral",
@@ -853,9 +852,6 @@
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/fuzz/inspect.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `fuzz_failure_diagnostic`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/project.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `wp-content` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/refactor.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runs/report/failure_digest.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `cargo` appears at line <line> in behavioral context `render_formatting_findings`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runs/report/failure_digest.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `phpcs` appears at line <line> in behavioral context `render_lint_section`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runs/report/failure_digest.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `phpstan` appears at line <line> in behavioral context `render_lint_section`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runner/cli.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `cargo` appears at line <line> in behavioral context `compact_exec_stdout`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runner/doctor/probes.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `.cargo` appears at line <line> in behavioral context `remote_preferred_homeboy_candidate`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runner/doctor/probes.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `cargo` appears at line <line> in behavioral context `remote_preferred_homeboy_candidate`::CoreBoundaryLeak",
@@ -868,6 +864,9 @@
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runs/gh_actions.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `actions/` appears at line <line> in behavioral context `list_run_artifacts`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runs/gh_actions.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `actions/` appears at line <line> in behavioral context `list_workflow_runs`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runs/gh_actions.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `actions/` appears at line <line> in behavioral context `split_headers_and_body`::CoreBoundaryLeak",
+        "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runs/report/failure_digest.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `cargo` appears at line <line> in behavioral context `render_formatting_findings`::CoreBoundaryLeak",
+        "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runs/report/failure_digest.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `phpcs` appears at line <line> in behavioral context `render_lint_section`::CoreBoundaryLeak",
+        "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runs/report/failure_digest.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `phpstan` appears at line <line> in behavioral context `render_lint_section`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/tunnel.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `node` appears at line <line> in behavioral context `portability_contract`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/upgrade.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `cargo` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/upgrade.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `homebrew` appears at line <line> in behavioral context `run`::CoreBoundaryLeak",
@@ -922,6 +921,12 @@
         "core_boundary_leak:core-agnostic-source::crates/homeboy-core/src/setup.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `pnpm` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-core/src/setup.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `yarn` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-core/src/test_support.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `cargo` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
+        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/permissions.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `wp-content` appears at line <line> in behavioral context `fix_deployed_ownership`::CoreBoundaryLeak",
+        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/policy.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `node_modules` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
+        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/safety_and_artifact.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `node_modules` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
+        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/transfer.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `upload_directory`::CoreBoundaryLeak",
+        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/version_overrides.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `node_modules` appears at line <line> in behavioral context `archive_install_override`::CoreBoundaryLeak",
+        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/version_overrides.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `node` appears at line <line> in behavioral context `archive_install_override`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-engine-primitives/src/codebase_scan.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `node_modules` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-engine-primitives/src/codebase_scan.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-engine-primitives/src/edit_op_apply.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `apply_edit_ops_to_content`::CoreBoundaryLeak",
@@ -1041,12 +1046,6 @@
         "core_boundary_leak:core-agnostic-source::crates/homeboy-refactor/src/plan/generate/signatures.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `rust` appears at line <line> in behavioral context `primary_type_name_from_declaration`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-refactor/src/propagate.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `rust` appears at line <line> in behavioral context `propagate`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-refactor/src/propagate.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `rust` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/permissions.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `wp-content` appears at line <line> in behavioral context `fix_deployed_ownership`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/policy.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `node_modules` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/safety_and_artifact.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `node_modules` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/transfer.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `upload_directory`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/version_overrides.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `node_modules` appears at line <line> in behavioral context `archive_install_override`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/version_overrides.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `node` appears at line <line> in behavioral context `archive_install_override`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-release/src/release/cascade.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `composer` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-release/src/release/execution_dispatch.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `composer` appears at line <line> in behavioral context `dependency_preflight_result`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-release/src/release/execution_dispatch.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `composer` appears at line <line> in behavioral context `remove_ignored_untracked_composer_lock`::CoreBoundaryLeak",
@@ -1072,8 +1071,6 @@
         "core_boundary_leak:core-agnostic-source::crates/homeboy-release/src/release/planning_worktree.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `package.json` appears at line <line> in behavioral context `derived_release_lockfiles`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-release/src/release/planning_worktree.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `pnpm` appears at line <line> in behavioral context `derived_release_lockfiles`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-release/src/release/planning_worktree.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `yarn` appears at line <line> in behavioral context `derived_release_lockfiles`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::crates/homeboy-version/src/version/default_pattern_for_file.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `build_init_warnings`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::crates/homeboy-version/src/version/default_pattern_for_file.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `detect_unconfigured_patterns`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-release/src/release/version_guard.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-rig/src/lint.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `claude` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-rig/src/lint.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `claude` appears at line <line> in behavioral context `unknown_top_level_field_failures`::CoreBoundaryLeak",
@@ -1108,6 +1105,8 @@
         "core_boundary_leak:core-agnostic-source::crates/homeboy-upgrade/src/upgrade/helpers.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `homebrew` appears at line <line> in behavioral context `detect_install_method_from_exe_path`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-upgrade/src/upgrade/types.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `homebrew` appears at line <line> in behavioral context `deserialize`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-upgrade/src/upgrade/types.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `homebrew` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
+        "core_boundary_leak:core-agnostic-source::crates/homeboy-version/src/version/default_pattern_for_file.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `build_init_warnings`::CoreBoundaryLeak",
+        "core_boundary_leak:core-agnostic-source::crates/homeboy-version/src/version/default_pattern_for_file.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `detect_unconfigured_patterns`::CoreBoundaryLeak",
         "core_boundary_leak:detector-agnostic-source::crates/homeboy-code-audit/src/detectors/command_wrapper_bypass.rs::Core boundary leak (detector-agnostic-source) configured ecosystem term `Rust` appears at line <line> in behavioral context `f`::CoreBoundaryLeak",
         "core_boundary_leak:detector-agnostic-source::crates/homeboy-code-audit/src/detectors/command_wrapper_bypass.rs::Core boundary leak (detector-agnostic-source) configured ecosystem term `Rust` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:detector-agnostic-source::crates/homeboy-code-audit/src/detectors/command_wrapper_bypass.rs::Core boundary leak (detector-agnostic-source) configured ecosystem term `rust` appears at line <line> in behavioral context `f`::CoreBoundaryLeak",
@@ -1136,9 +1135,9 @@
         "dead_code::crates/homeboy-cli/src/command_contract/constants.rs::UnreferencedExport",
         "dead_code::crates/homeboy-cli/src/commands/ci/failure_log_triage.rs::UnreferencedExport",
         "dead_code::crates/homeboy-cli/src/commands/infra/output_runtime.rs::UnreferencedExport",
-        "dead_code::crates/homeboy-cli/src/commands/runs/report/browser_evidence_compare/implementation/reader.rs::UnreferencedExport",
         "dead_code::crates/homeboy-cli/src/commands/runs/gh_actions.rs::UnreferencedExport",
         "dead_code::crates/homeboy-cli/src/commands/runs/gh_actions_cache.rs::UnreferencedExport",
+        "dead_code::crates/homeboy-cli/src/commands/runs/report/browser_evidence_compare/implementation/reader.rs::UnreferencedExport",
         "dead_code::crates/homeboy-cli/src/commands/utils/execution_provenance.rs::UnreferencedExport",
         "dead_code::crates/homeboy-cli/src/commands/utils/response.rs::UnreferencedExport",
         "dead_code::crates/homeboy-code-audit/src/baseline.rs::UnreferencedExport",
@@ -1156,6 +1155,7 @@
         "dead_code::crates/homeboy-core/src/runtime_promotion.rs::UnreferencedExport",
         "dead_code::crates/homeboy-core/src/schedule/execution.rs::UnreferencedExport",
         "dead_code::crates/homeboy-core/src/schedule/ticker.rs::UnreferencedExport",
+        "dead_code::crates/homeboy-deploy/src/preparation.rs::DeadCodeMarker",
         "dead_code::crates/homeboy-extension/src/bench/responsiveness.rs::UnreferencedExport",
         "dead_code::crates/homeboy-lab-runner/src/dev_run.rs::UnreferencedExport",
         "dead_code::crates/homeboy-lab-runner/src/lab_staging_controller.rs::UnreferencedExport",
@@ -1168,7 +1168,6 @@
         "dead_code::crates/homeboy-lab-runner/src/workspace/types.rs::UnreferencedExport",
         "dead_code::crates/homeboy-paths/src/rigs.rs::UnreferencedExport",
         "dead_code::crates/homeboy-refactor/src/edit_op_tagged.rs::UnreferencedExport",
-        "dead_code::crates/homeboy-deploy/src/preparation.rs::DeadCodeMarker",
         "dead_code::crates/homeboy-release/src/release/cascade.rs::UnreferencedExport",
         "dead_code::crates/homeboy-release/src/release/version_guard.rs::UnreferencedExport",
         "dead_code::crates/homeboy-rig/src/lint.rs::UnreferencedExport",
@@ -1185,10 +1184,10 @@
         "direct_aggregate_construction::crates/homeboy-core/src/component/resolution.rs::DirectAggregateConstruction",
         "direct_aggregate_construction::crates/homeboy-core/src/defaults.rs::DirectAggregateConstruction",
         "direct_aggregate_construction::crates/homeboy-core/src/runner_execution_envelope.rs::DirectAggregateConstruction",
-        "direct_aggregate_construction::crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs::DirectAggregateConstruction",
         "direct_aggregate_construction::crates/homeboy-deploy/src/content_manifest.rs::DirectAggregateConstruction",
         "direct_aggregate_construction::crates/homeboy-deploy/src/orchestration/modes.rs::DirectAggregateConstruction",
         "direct_aggregate_construction::crates/homeboy-deploy/src/orchestration/smoke_check.rs::DirectAggregateConstruction",
+        "direct_aggregate_construction::crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs::DirectAggregateConstruction",
         "direct_aggregate_construction::crates/homeboy-release/src/release/execution_dispatch.rs::DirectAggregateConstruction",
         "docs::docs/architecture/core-runner-output-parse.md::StaleDocReference",
         "docs::docs/architecture/runner-contract.md::StaleDocReference",
@@ -1270,6 +1269,9 @@
         "intra-method-duplication::crates/homeboy-core/src/observation/store/artifacts.rs::IntraMethodDuplicate",
         "intra-method-duplication::crates/homeboy-core/src/server/client/local_exec.rs::IntraMethodDuplicate",
         "intra-method-duplication::crates/homeboy-core/src/worktree_providers.rs::IntraMethodDuplicate",
+        "intra-method-duplication::crates/homeboy-deploy/src/execution/preflight.rs::IntraMethodDuplicate",
+        "intra-method-duplication::crates/homeboy-deploy/src/orchestration_ref_checkout.rs::IntraMethodDuplicate",
+        "intra-method-duplication::crates/homeboy-deploy/src/planning.rs::IntraMethodDuplicate",
         "intra-method-duplication::crates/homeboy-extension/src/bench/artifact_persistence.rs::IntraMethodDuplicate",
         "intra-method-duplication::crates/homeboy-extension/src/bench/run/results.rs::IntraMethodDuplicate",
         "intra-method-duplication::crates/homeboy-extension/src/bench/run/workflow.rs::IntraMethodDuplicate",
@@ -1307,9 +1309,6 @@
         "intra-method-duplication::crates/homeboy-lab-runner/src/workspace/materializer.rs::IntraMethodDuplicate",
         "intra-method-duplication::crates/homeboy-lab-runner/src/workspace/snapshot.rs::IntraMethodDuplicate",
         "intra-method-duplication::crates/homeboy-refactor/src/rename/engine.rs::IntraMethodDuplicate",
-        "intra-method-duplication::crates/homeboy-deploy/src/execution/preflight.rs::IntraMethodDuplicate",
-        "intra-method-duplication::crates/homeboy-deploy/src/orchestration_ref_checkout.rs::IntraMethodDuplicate",
-        "intra-method-duplication::crates/homeboy-deploy/src/planning.rs::IntraMethodDuplicate",
         "intra-method-duplication::crates/homeboy-release/src/release/execution_projection.rs::IntraMethodDuplicate",
         "intra-method-duplication::crates/homeboy-release/src/release/executor/github_release/gh_cli.rs::IntraMethodDuplicate",
         "intra-method-duplication::crates/homeboy-release/src/release/executor/github_release/run.rs::IntraMethodDuplicate",
@@ -1354,18 +1353,18 @@
         "output_capture::tests/readonly_cli_lock_test.rs::UnboundedOutputCapture",
         "parallel-implementation::crates/homeboy-agents/src/agent_task_prompts.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-cli/src/commands/agent_task/fanout.rs::ParallelImplementation",
-        "parallel-implementation::crates/homeboy-cli/src/commands/runs/report/browser_evidence_compare/implementation/visual.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-cli/src/commands/runs/reconcile.rs::ParallelImplementation",
+        "parallel-implementation::crates/homeboy-cli/src/commands/runs/report/browser_evidence_compare/implementation/visual.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-cli/src/commands/runs/types.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-cli/src/commands/utils/response.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-core/src/http_api.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-core/src/runtime_promotion.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-core/src/source_snapshot.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-core/src/test_support.rs::ParallelImplementation",
+        "parallel-implementation::crates/homeboy-deploy/src/content_manifest.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-lab-runner/src/workspace/util.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-refactor/src/collapse.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-refactor/src/propagate.rs::ParallelImplementation",
-        "parallel-implementation::crates/homeboy-deploy/src/content_manifest.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-rig/src/dependency_materialization_cache.rs::ParallelImplementation",
         "parallel_runner_setup::crates/homeboy-core/src/api_jobs/runner_job_preparation.rs::ParallelRunnerSetup",
         "remote_execution_preflight::crates/homeboy-cli/src/commands/infra/route.rs::RemoteExecutionPreflight",
@@ -1463,6 +1462,10 @@
         "skeleton-duplication::crates/homeboy-core/src/resource_lifecycle_index.rs::SkeletonDuplicate",
         "skeleton-duplication::crates/homeboy-core/src/runtime_package.rs::SkeletonDuplicate",
         "skeleton-duplication::crates/homeboy-core/src/test_support.rs::SkeletonDuplicate",
+        "skeleton-duplication::crates/homeboy-deploy/src/orchestration/preflight.rs::SkeletonDuplicate",
+        "skeleton-duplication::crates/homeboy-deploy/src/preparation.rs::SkeletonDuplicate",
+        "skeleton-duplication::crates/homeboy-deploy/src/types.rs::SkeletonDuplicate",
+        "skeleton-duplication::crates/homeboy-deploy/src/version_overrides.rs::SkeletonDuplicate",
         "skeleton-duplication::crates/homeboy-extension/src/bench/run/memory_timeline.rs::SkeletonDuplicate",
         "skeleton-duplication::crates/homeboy-extension/src/bench/run_metadata.rs::SkeletonDuplicate",
         "skeleton-duplication::crates/homeboy-extension/src/lifecycle/install_sources.rs::SkeletonDuplicate",
@@ -1497,10 +1500,6 @@
         "skeleton-duplication::crates/homeboy-lab-runner/src/workspace/util.rs::SkeletonDuplicate",
         "skeleton-duplication::crates/homeboy-refactor/src/plan/sources/lint_scope.rs::SkeletonDuplicate",
         "skeleton-duplication::crates/homeboy-refactor/src/rename/casing.rs::SkeletonDuplicate",
-        "skeleton-duplication::crates/homeboy-deploy/src/orchestration/preflight.rs::SkeletonDuplicate",
-        "skeleton-duplication::crates/homeboy-deploy/src/preparation.rs::SkeletonDuplicate",
-        "skeleton-duplication::crates/homeboy-deploy/src/types.rs::SkeletonDuplicate",
-        "skeleton-duplication::crates/homeboy-deploy/src/version_overrides.rs::SkeletonDuplicate",
         "skeleton-duplication::crates/homeboy-release/src/release/executor/github_release/gh_cli.rs::SkeletonDuplicate",
         "skeleton-duplication::crates/homeboy-release/src/release/executor/lockfile_guard.rs::SkeletonDuplicate",
         "skeleton-duplication::crates/homeboy-release/src/release/executor/prepare.rs::SkeletonDuplicate",
@@ -1673,6 +1672,9 @@
         "structural::crates/homeboy-core/src/test_support.rs::HighItemCount",
         "structural::crates/homeboy-core/src/worktree_providers.rs::GodFile",
         "structural::crates/homeboy-core/src::DirectorySprawl",
+        "structural::crates/homeboy-deploy/src/orchestration/mod.rs::GodFile",
+        "structural::crates/homeboy-deploy/src/planning.rs::GodFile",
+        "structural::crates/homeboy-deploy/src/preparation.rs::GodFile",
         "structural::crates/homeboy-engine-primitives/src/command.rs::HighItemCount",
         "structural::crates/homeboy-error/src/lib.rs::HighItemCount",
         "structural::crates/homeboy-extension/src/bench/parsing/mod.rs::GodFile",
@@ -1726,9 +1728,6 @@
         "structural::crates/homeboy-paths/src/lib.rs::HighItemCount",
         "structural::crates/homeboy-refactor/src/rename/tests.rs::GodFile",
         "structural::crates/homeboy-refactor/src/rename/tests.rs::HighItemCount",
-        "structural::crates/homeboy-deploy/src/orchestration/mod.rs::GodFile",
-        "structural::crates/homeboy-deploy/src/planning.rs::GodFile",
-        "structural::crates/homeboy-deploy/src/preparation.rs::GodFile",
         "structural::crates/homeboy-release/src/release/execution_dispatch.rs::GodFile",
         "structural::crates/homeboy-release/src/release/executor.rs::GodFile",
         "structural::crates/homeboy-release/src/release/executor/github_release/gh_cli.rs::GodFile",
@@ -1795,9 +1794,9 @@
         "policy_sections": [
           {
             "audit_policy": "core_boundary_leak:core-agnostic-source",
+            "fingerprint_prefix": "core_boundary_leak:core-agnostic-source",
             "issue": "#3498",
             "key": "core_boundary_leak:core-agnostic-source/core-boundary",
-            "fingerprint_prefix": "core_boundary_leak:core-agnostic-source",
             "known_fingerprints": [],
             "rationale": "Scoped source-policy/core-boundary debt baseline for reviewable ratchets.",
             "scope": "core-boundary"
@@ -1818,9 +1817,9 @@
   "extensions": {
     "rust": {
       "settings": {
-        "rust_test_runner": "nextest",
         "rust_cargo_test_threads": 1,
-        "rust_nextest_shard_threads": 0
+        "rust_nextest_shard_threads": 0,
+        "rust_test_runner": "nextest"
       }
     }
   },

--- a/tests/audit_baseline_ratchet_test.rs
+++ b/tests/audit_baseline_ratchet_test.rs
@@ -47,7 +47,7 @@ use serde_json::Value;
 /// a ceiling, not a target: lower it whenever suppressions are retired, and
 /// never raise it. Raising this number is the one edit this test exists to make
 /// someone argue for in review.
-const AUDIT_BASELINE_CEILING: usize = 1129;
+const AUDIT_BASELINE_CEILING: usize = 1128;
 
 fn baseline_fingerprints() -> Vec<String> {
     let config: Value =
@@ -232,9 +232,14 @@ A full-tree `homeboy review audit` FAILS on this — it does not merely warn.
 `--changed-since` runs skip the check, so PR CI and rolling releases stay green
 while the weekly Audit Debt sweep is dead.
 
-Fix: repoint the row at the file's new path if the finding still applies, or
-prune it with `homeboy audit --prune-baseline <fingerprint>` if it does not.
-Do it in the same PR as the move.
+Fix: repoint the row at the file's new path if the finding still applies. If it
+does not, remove that exact row with:
+
+  homeboy review audit baseline prune --path . --fingerprint <fingerprint>
+
+Then run `homeboy review audit baseline validate --path .`. Prune refuses an
+unmatched fingerprint; inspect its deterministic diff rather than regenerating
+or hand-editing the baseline. Do this in the same PR as the move.
 
 See docs/audit/baseline-ratchet.md
 "#


### PR DESCRIPTION
Fixes #13284

## Summary

- Prune the deleted `triage.rs` audit fingerprint with the repository baseline command and ratchet the baseline to 1,128 rows.
- Add `homeboy review audit baseline validate --path .` so full-tree fingerprint-path validation is an explicit, reproducible contract.
- Support the public `review audit baseline` form after global options such as `--placement local`, and document the validate-prune-validate workflow.

## Verification

- `cargo fmt --check`
- `cargo test --test audit_baseline_ratchet_test`
- `cargo test -p homeboy-cli audit_baseline --lib`
- `cargo run -- --placement local review audit baseline validate --path .`
- `cargo test --workspace` compiled and ran through the ambient-store suite, then failed in the unrelated open #13280 work: `agent_task_store_injection_test` has 3 known failures on `main`; #13286 owns that repair. The audit ratchet target passes.

## AI assistance

- Model: OpenAI `openai/gpt-5.6-terra`
- Tool: OpenCode
- Used for: inspected issue/worktree/PR state, reproduced and isolated the stale baseline failure, implemented the validation and command-normalization contract, executed the explicit baseline prune, and ran the listed verification. Chris Huber remains responsible for review and decisions.