### PR TITLE
refactor: collapse two parallel-implementation clusters (#13199)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_authority.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_authority.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
 use super::*;
 
@@ -76,11 +75,10 @@ impl WorkspaceTerminalAuthorityStore {
     }
 
     fn run_index_path(&self, run_id: &str) -> PathBuf {
-        let mut digest = Sha256::new();
-        digest.update(run_id.as_bytes());
-        self.root
-            .join("by-run")
-            .join(format!("{:x}.json", digest.finalize()))
+        // One field, so this is a plain content digest rather than a composite
+        // identity: the bytes are identical to the hand-rolled hasher it replaces.
+        let digest = homeboy_engine_primitives::content_hash::sha256_hex(run_id.as_bytes());
+        self.root.join("by-run").join(format!("{digest}.json"))
     }
 
     fn receipt_path(&self, run_id: &str, runner_id: &str, remote_workspace: &str) -> PathBuf {
@@ -339,13 +337,11 @@ impl WorkspaceTerminalAuthorityStore {
 }
 
 fn authority_digest(run_id: &str, runner_id: &str, remote_workspace: &str) -> String {
-    let mut digest = Sha256::new();
-    digest.update(run_id.as_bytes());
-    digest.update([0]);
-    digest.update(runner_id.as_bytes());
-    digest.update([0]);
-    digest.update(remote_workspace.as_bytes());
-    format!("{:x}", digest.finalize())
+    homeboy_engine_primitives::content_hash::nul_separated_digest([
+        run_id,
+        runner_id,
+        remote_workspace,
+    ])
 }
 
 pub(crate) fn persist_terminal_from_record(record: &AgentTaskRunRecord) -> Result<()> {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
@@ -13,7 +13,6 @@ use homeboy_core::worktree::{
     TERMINAL_WORKSPACE_AUTHORITY_SCHEMA,
 };
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use std::fs;
 #[cfg(test)]
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -934,13 +933,14 @@ fn composite_acquisition_intent_dir() -> Result<std::path::PathBuf> {
 }
 
 fn composite_acquisition_intent_path(workspace: &WorkspaceIdentity) -> Result<std::path::PathBuf> {
-    let mut digest = Sha256::new();
-    digest.update(workspace.schema.as_bytes());
-    digest.update([0]);
-    digest.update(workspace.kind.as_bytes());
-    digest.update([0]);
-    digest.update(workspace.locator.as_bytes());
-    Ok(composite_acquisition_intent_dir()?.join(format!("{:x}.json", digest.finalize())))
+    // This digest is the on-disk filename, so its bytes are a compatibility
+    // surface -- see the pinned assertions in `content_hash`.
+    let digest = homeboy_engine_primitives::content_hash::nul_separated_digest([
+        workspace.schema.as_str(),
+        workspace.kind.as_str(),
+        workspace.locator.as_str(),
+    ]);
+    Ok(composite_acquisition_intent_dir()?.join(format!("{digest}.json")))
 }
 
 fn write_composite_acquisition_intent(intent: &CompositeAcquisitionIntent) -> Result<()> {

--- a/crates/homeboy-core/src/worktree/types.rs
+++ b/crates/homeboy-core/src/worktree/types.rs
@@ -205,13 +205,9 @@ impl TerminalWorkspaceAuthorityProof {
 }
 
 pub fn authority_set_fingerprint(authorities: &[String]) -> String {
-    use sha2::{Digest, Sha256};
-    let mut hasher = Sha256::new();
-    for authority in authorities {
-        hasher.update(authority.as_bytes());
-        hasher.update([0]);
-    }
-    format!("{:x}", hasher.finalize())
+    // Terminated, not separated: the authority set is variable-length, so a
+    // trailing separator after every element is what keeps it unambiguous.
+    homeboy_engine_primitives::content_hash::nul_terminated_digest(authorities)
 }
 
 impl TaskWorktreeRecord {

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -7,7 +7,6 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 
 use crate::defaults::{
     self, HomeboyConfig, WorktreeProviderConfig, WorktreeProviderKind,
@@ -928,15 +927,13 @@ pub fn attest_apply_enabled_worktree_provider_safety_from_config(
 }
 
 fn compatibility_identity_token(resolution: &WorktreeProviderResolution) -> String {
-    let mut digest = Sha256::new();
-    digest.update(resolution.provider_id.as_bytes());
-    digest.update([0]);
-    digest.update(resolution.worktree.handle.as_bytes());
-    digest.update([0]);
-    digest.update(resolution.worktree.path.as_bytes());
-    digest.update([0]);
-    digest.update(resolution.worktree.branch.as_bytes());
-    format!("compat-v1:{:x}", digest.finalize())
+    let digest = homeboy_engine_primitives::content_hash::nul_separated_digest([
+        resolution.provider_id.as_str(),
+        resolution.worktree.handle.as_str(),
+        resolution.worktree.path.as_str(),
+        resolution.worktree.branch.as_str(),
+    ]);
+    format!("compat-v1:{digest}")
 }
 /// Find the sole apply-enabled provider worktree owned by a tracker URL.
 /// Providers must map `task_url` to participate, preserving existing provider

--- a/crates/homeboy-engine-primitives/src/content_hash.rs
+++ b/crates/homeboy-engine-primitives/src/content_hash.rs
@@ -73,6 +73,57 @@ pub fn is_sha256_hex(value: &str) -> bool {
     value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
+/// SHA-256 over `fields` joined by a NUL byte, rendered as lowercase hex.
+///
+/// This is a *composite identity* scheme, distinct from [`sha256_hex`]: it
+/// identifies an ordered tuple of strings rather than a blob of bytes. NUL is
+/// the separator because it cannot occur in any of the identifiers these
+/// callers hash (run ids, provider ids, worktree handles, filesystem paths), so
+/// `("a", "bc")` and `("ab", "c")` cannot collide the way a naive
+/// concatenation lets them.
+///
+/// Bytes hashed: `a\0b\0c` — separators go *between* fields, with none after
+/// the last. Use [`nul_terminated_digest`] when every field is followed by a
+/// separator. The two are not interchangeable and produce different digests for
+/// the same input.
+///
+/// Callers persist these digests as compatibility tokens and as filenames, so
+/// the byte sequence is a compatibility surface: changing it orphans data.
+pub fn nul_separated_digest<I, S>(fields: I) -> String
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<[u8]>,
+{
+    let mut hasher = Sha256::new();
+    for (index, field) in fields.into_iter().enumerate() {
+        if index > 0 {
+            hasher.update([0]);
+        }
+        hasher.update(field.as_ref());
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+/// SHA-256 over `fields` with a NUL byte after **every** field, as lowercase hex.
+///
+/// Bytes hashed: `a\0b\0c\0`. See [`nul_separated_digest`] for why NUL and why
+/// the trailing separator is a distinct scheme rather than a variant flag: a
+/// terminated digest is unambiguous for a set of arbitrary length, whereas a
+/// separated one is only unambiguous for a fixed-arity tuple. Callers hashing a
+/// variable-length collection want this one.
+pub fn nul_terminated_digest<I, S>(fields: I) -> String
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<[u8]>,
+{
+    let mut hasher = Sha256::new();
+    for field in fields {
+        hasher.update(field.as_ref());
+        hasher.update([0]);
+    }
+    format!("{:x}", hasher.finalize())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -167,5 +218,62 @@ mod tests {
         assert!(!is_sha256_hex(&value));
         // Correct length, but a prefixed algorithm label is not bare hex.
         assert!(!is_sha256_hex(&format!("sha256:{}", &ABC_SHA256[7..])));
+    }
+
+    /// The exact digests the four hand-rolled implementations produced before
+    /// they were migrated onto these primitives (homeboy#13199). Two of those
+    /// callers persist their output -- one as a `compat-v1:` token, one as a
+    /// filename -- so these are compatibility assertions, not example values.
+    /// A change here orphans data on disk.
+    #[test]
+    fn field_digests_match_the_hand_rolled_implementations_they_replaced() {
+        // was: worktree::types::authority_set_fingerprint(["alpha", "beta"])
+        assert_eq!(
+            nul_terminated_digest(["alpha", "beta"]),
+            "63ed4f61f097667f9297e42c5f0e173bb382b51758b2c7772ca37ceea99f4ae0"
+        );
+        // was: agent_task_lifecycle::workspace_authority::authority_digest
+        assert_eq!(
+            nul_separated_digest(["run", "runner", "/ws"]),
+            "edb57fdec3c0765ebda93bceac4f73c7c423fe4ac4f76507f6be859199adf6b7"
+        );
+        // was: worktree_providers::compatibility_identity_token (sans prefix)
+        assert_eq!(
+            nul_separated_digest(["p", "h", "pa", "br"]),
+            "f54325cdac18afbc3abefc904101cee3e5e639868a2b805fdb4e246cf80482d4"
+        );
+        // was: agent_task_lifecycle::workspace_claims::composite_acquisition_intent_path
+        assert_eq!(
+            nul_separated_digest(["s", "k", "l"]),
+            "6f01cb2795aa0bc529fd52bf971f316ca4e36f95e62d946d2c6bbcbb4d1dfba3"
+        );
+    }
+
+    /// The separated and terminated schemes are not a flag on one function.
+    #[test]
+    fn separated_and_terminated_are_different_identity_schemes() {
+        assert_ne!(
+            nul_separated_digest(["alpha", "beta"]),
+            nul_terminated_digest(["alpha", "beta"])
+        );
+    }
+
+    /// The property that makes NUL the right separator: no field can contain
+    /// one, so a tuple boundary cannot be forged by moving characters across it.
+    #[test]
+    fn nul_separator_prevents_the_collision_a_bare_concatenation_allows() {
+        assert_ne!(
+            nul_separated_digest(["a", "bc"]),
+            nul_separated_digest(["ab", "c"])
+        );
+        assert_eq!(nul_separated_digest(["ab"]), sha256_hex(b"ab"));
+    }
+
+    /// A single field has no separator to write, so the two schemes only agree
+    /// with the blob primitive in the separated case.
+    #[test]
+    fn empty_and_single_field_inputs_are_well_defined() {
+        assert_eq!(nul_separated_digest(Vec::<&str>::new()), sha256_hex(b""));
+        assert_eq!(nul_terminated_digest(["a"]), sha256_hex(b"a\0"));
     }
 }

--- a/crates/homeboy-lab-runner/src/cancellable_sleep.rs
+++ b/crates/homeboy-lab-runner/src/cancellable_sleep.rs
@@ -1,0 +1,88 @@
+//! Interruptible waiting.
+//!
+//! A runner that must wait -- for a daemon to reach a terminal state, for a
+//! staging poll interval to elapse -- cannot simply `thread::sleep` the whole
+//! interval: a cancellation arriving one millisecond in would not be observed
+//! until the interval ended. Both call sites solved this the same way, by
+//! slicing the interval and re-checking cancellation between slices, and both
+//! chose the same 200ms slice. This is that loop, written once.
+//!
+//! Cancellation is passed as a closure rather than a token type because the two
+//! callers carry different ones (`&dyn Fn() -> bool` and a
+//! `LabStagingCancellationToken`). Adapting at the call site keeps this module
+//! free of either.
+
+use std::time::Duration;
+
+/// How long to sleep before re-checking cancellation.
+///
+/// Short enough that a cancelled wait unwinds promptly, long enough that a
+/// multi-second wait is not thousands of wakeups. Both callers independently
+/// picked this value before it was shared.
+const CANCELLATION_POLL_SLICE: Duration = Duration::from_millis(200);
+
+/// Sleep up to `interval`, re-checking `cancelled` every
+/// [`CANCELLATION_POLL_SLICE`]. Returns `true` if the wait was cancelled.
+///
+/// Cancellation is checked *before* the first sleep, so an already-cancelled
+/// wait returns immediately without sleeping at all, and again after the last
+/// slice, so a cancellation that lands during the final slice is still
+/// reported. A zero `interval` is therefore a pure cancellation check.
+pub(crate) fn sleep_unless_cancelled(interval: Duration, cancelled: impl Fn() -> bool) -> bool {
+    let mut remaining = interval;
+    while !remaining.is_zero() {
+        if cancelled() {
+            return true;
+        }
+        let slice = remaining.min(CANCELLATION_POLL_SLICE);
+        std::thread::sleep(slice);
+        remaining = remaining.saturating_sub(slice);
+    }
+    cancelled()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Instant;
+
+    #[test]
+    fn an_already_cancelled_wait_returns_without_sleeping() {
+        let started = Instant::now();
+        assert!(sleep_unless_cancelled(Duration::from_secs(30), || true));
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "a cancelled wait must not sleep the interval"
+        );
+    }
+
+    #[test]
+    fn an_uncancelled_wait_sleeps_the_whole_interval_and_reports_not_cancelled() {
+        let started = Instant::now();
+        assert!(!sleep_unless_cancelled(Duration::from_millis(300), || {
+            false
+        }));
+        assert!(started.elapsed() >= Duration::from_millis(300));
+    }
+
+    #[test]
+    fn a_zero_interval_is_a_pure_cancellation_check() {
+        assert!(!sleep_unless_cancelled(Duration::ZERO, || false));
+        assert!(sleep_unless_cancelled(Duration::ZERO, || true));
+    }
+
+    #[test]
+    fn cancellation_is_rechecked_between_slices_not_only_at_the_end() {
+        let checks = AtomicUsize::new(0);
+        // Long enough to require several slices; cancels on the third check.
+        let cancelled = sleep_unless_cancelled(Duration::from_secs(30), || {
+            checks.fetch_add(1, Ordering::SeqCst) >= 2
+        });
+        assert!(cancelled);
+        assert!(
+            checks.load(Ordering::SeqCst) < 10,
+            "cancellation must be observed within a few slices, not after the interval"
+        );
+    }
+}

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -1636,22 +1636,10 @@ const DAEMON_TERMINAL_WAIT_INITIAL_BACKOFF: Duration = Duration::from_millis(200
 /// Ceiling for terminal-wait backoff, so a long-running job is polled at a
 /// steady low rate instead of 5 times a second for its whole duration.
 const DAEMON_TERMINAL_WAIT_MAX_BACKOFF: Duration = Duration::from_secs(5);
-/// Longest uninterrupted sleep while waiting, bounding cancellation latency
-/// independently of how far backoff has grown.
-const DAEMON_TERMINAL_WAIT_CANCELLATION_SLICE: Duration = Duration::from_millis(200);
 
 /// Sleep up to `interval`, returning `true` if cancellation was observed.
 fn sleep_daemon_wait_unless_cancelled(interval: Duration, cancelled: &dyn Fn() -> bool) -> bool {
-    let mut remaining = interval;
-    while !remaining.is_zero() {
-        if cancelled() {
-            return true;
-        }
-        let slice = remaining.min(DAEMON_TERMINAL_WAIT_CANCELLATION_SLICE);
-        std::thread::sleep(slice);
-        remaining = remaining.saturating_sub(slice);
-    }
-    cancelled()
+    crate::cancellable_sleep::sleep_unless_cancelled(interval, || cancelled())
 }
 
 fn daemon_terminal_wait_cancelled_error(job_id: &str) -> Error {

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -2377,11 +2377,6 @@ const LAB_STAGING_POLL_INITIAL_BACKOFF: Duration = Duration::from_millis(200);
 /// produced.
 const LAB_STAGING_POLL_MAX_BACKOFF: Duration = Duration::from_secs(5);
 
-/// Longest uninterrupted sleep slice. Backoff grows the *total* wait between
-/// polls, but cancellation is still observed at this granularity, so growing
-/// backoff cannot regress cancellation responsiveness.
-const LAB_STAGING_POLL_CANCELLATION_SLICE: Duration = Duration::from_millis(200);
-
 fn now_unix_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -2425,23 +2420,17 @@ fn staging_poll_budget(request: &LabStagingExecutionRequest) -> Duration {
 
 /// Sleep up to `interval`, waking early if cancellation is observed.
 ///
-/// Returns `true` when cancellation was seen. Sleeping in
-/// `LAB_STAGING_POLL_CANCELLATION_SLICE` slices keeps worst-case cancellation
-/// latency fixed regardless of how far backoff has grown.
+/// Returns `true` when cancellation was seen. The slicing lives in
+/// [`crate::cancellable_sleep`]; backoff grows the *total* wait between polls,
+/// but cancellation is still observed at a fixed slice granularity, so growing
+/// backoff cannot regress cancellation responsiveness.
 fn sleep_unless_cancelled(
     interval: Duration,
     cancellation: Option<&LabStagingCancellationToken>,
 ) -> bool {
-    let mut remaining = interval;
-    while !remaining.is_zero() {
-        if cancellation.is_some_and(LabStagingCancellationToken::is_cancelled) {
-            return true;
-        }
-        let slice = remaining.min(LAB_STAGING_POLL_CANCELLATION_SLICE);
-        std::thread::sleep(slice);
-        remaining = remaining.saturating_sub(slice);
-    }
-    cancellation.is_some_and(LabStagingCancellationToken::is_cancelled)
+    crate::cancellable_sleep::sleep_unless_cancelled(interval, || {
+        cancellation.is_some_and(LabStagingCancellationToken::is_cancelled)
+    })
 }
 
 fn next_staging_poll_backoff(current: Duration) -> Duration {

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -23,6 +23,7 @@ mod apply;
 pub mod artifact_attach;
 mod availability_provider;
 mod broker_http;
+mod cancellable_sleep;
 pub mod dev_run;
 pub use homeboy_core::broker_auth::{
     broker_submit_token_for_runner, broker_token_from_env, extract_bearer_token,

--- a/homeboy.json
+++ b/homeboy.json
@@ -318,8 +318,8 @@
             "value": "python3"
           },
           {
-            "value": "node",
-            "context": "string_literal"
+            "context": "string_literal",
+            "value": "node"
           },
           {
             "value": "opencode"
@@ -565,7 +565,6 @@
   "audit_rules": {
     "layer_rules": [
       {
-        "name": "contracts-own-no-process-execution",
         "forbid": {
           "glob": "crates/contracts/**",
           "patterns": [
@@ -574,10 +573,10 @@
             "reqwest::",
             "tokio::spawn"
           ]
-        }
+        },
+        "name": "contracts-own-no-process-execution"
       },
       {
-        "name": "engine-primitives-own-no-domain-crates",
         "forbid": {
           "glob": "crates/homeboy-engine-primitives/src/**",
           "patterns": [
@@ -586,30 +585,30 @@
             "homeboy_agents::",
             "homeboy_rig::"
           ]
-        }
+        },
+        "name": "engine-primitives-own-no-domain-crates"
       },
       {
-        "name": "cli-surface-owns-no-process-execution",
         "forbid": {
           "glob": "crates/homeboy-cli/src/cli_surface/**",
           "patterns": [
             "std::process::Command",
             "std::process::exit"
           ]
-        }
+        },
+        "name": "cli-surface-owns-no-process-execution"
       },
       {
-        "name": "command-contract-owns-no-process-execution",
         "forbid": {
           "glob": "crates/homeboy-cli/src/command_contract/**",
           "patterns": [
             "std::process::Command",
             "std::process::exit"
           ]
-        }
+        },
+        "name": "command-contract-owns-no-process-execution"
       },
       {
-        "name": "rig-owns-no-service-implementation",
         "forbid": {
           "glob": "crates/homeboy-rig/src/**",
           "patterns": [
@@ -618,7 +617,8 @@
             "hyper::Server",
             "axum::serve"
           ]
-        }
+        },
+        "name": "rig-owns-no-service-implementation"
       }
     ]
   },
@@ -635,7 +635,7 @@
     "audit": {
       "context_id": "homeboy",
       "created_at": "2026-07-27T04:11:26Z",
-      "item_count": 1137,
+      "item_count": 1128,
       "known_fingerprints": [
         "Commands::crates/homeboy-cli/src/commands/agent_task_dispatch.rs::MissingMethod",
         "Src::crates/contracts/homeboy-audit-contract/src/finding.rs::MissingMethod",
@@ -662,6 +662,12 @@
         "command_wrapper_bypass::crates/homeboy-core/src/git/pr_refresh.rs::CommandWrapperBypass",
         "command_wrapper_bypass::crates/homeboy-core/src/hygiene.rs::CommandWrapperBypass",
         "command_wrapper_bypass::crates/homeboy-core/src/worktree_providers.rs::CommandWrapperBypass",
+        "command_wrapper_bypass::crates/homeboy-deploy/src/orchestration/preflight.rs::CommandWrapperBypass",
+        "command_wrapper_bypass::crates/homeboy-deploy/src/orchestration_tag_checkout.rs::CommandWrapperBypass",
+        "command_wrapper_bypass::crates/homeboy-deploy/src/planning.rs::CommandWrapperBypass",
+        "command_wrapper_bypass::crates/homeboy-deploy/src/preparation.rs::CommandWrapperBypass",
+        "command_wrapper_bypass::crates/homeboy-deploy/src/provenance.rs::CommandWrapperBypass",
+        "command_wrapper_bypass::crates/homeboy-deploy/src/types.rs::CommandWrapperBypass",
         "command_wrapper_bypass::crates/homeboy-extension/src/trace/canonicality.rs::CommandWrapperBypass",
         "command_wrapper_bypass::crates/homeboy-extension/src/trace/run/provenance.rs::CommandWrapperBypass",
         "command_wrapper_bypass::crates/homeboy-lab-runner/src/git_dependency_materialization.rs::CommandWrapperBypass",
@@ -673,12 +679,6 @@
         "command_wrapper_bypass::crates/homeboy-lab-runner/src/workspace/git.rs::CommandWrapperBypass",
         "command_wrapper_bypass::crates/homeboy-lab-runner/src/workspace/provenance.rs::CommandWrapperBypass",
         "command_wrapper_bypass::crates/homeboy-lab-runner/src/workspace/snapshot.rs::CommandWrapperBypass",
-        "command_wrapper_bypass::crates/homeboy-deploy/src/orchestration/preflight.rs::CommandWrapperBypass",
-        "command_wrapper_bypass::crates/homeboy-deploy/src/orchestration_tag_checkout.rs::CommandWrapperBypass",
-        "command_wrapper_bypass::crates/homeboy-deploy/src/planning.rs::CommandWrapperBypass",
-        "command_wrapper_bypass::crates/homeboy-deploy/src/preparation.rs::CommandWrapperBypass",
-        "command_wrapper_bypass::crates/homeboy-deploy/src/provenance.rs::CommandWrapperBypass",
-        "command_wrapper_bypass::crates/homeboy-deploy/src/types.rs::CommandWrapperBypass",
         "command_wrapper_bypass::crates/homeboy-release/src/release/checkout_guard.rs::CommandWrapperBypass",
         "command_wrapper_bypass::crates/homeboy-release/src/release/executor/version_targets.rs::CommandWrapperBypass",
         "command_wrapper_bypass::crates/homeboy-release/src/release/planning_git.rs::CommandWrapperBypass",
@@ -737,18 +737,17 @@
         "constant_bypass_literal::crates/homeboy-cli/src/commands/fuzz/execution.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/fuzz/replay.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/issues.rs::ConstantBypassLiteral",
-        "constant_bypass_literal::crates/homeboy-cli/src/commands/runs/report/failure_digest/bench.rs::ConstantBypassLiteral",
-        "constant_bypass_literal::crates/homeboy-cli/src/commands/runs/report/failure_digest/trace.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/runner/types.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/runs/fuzz_compare.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/runs/remote_artifact.rs::ConstantBypassLiteral",
+        "constant_bypass_literal::crates/homeboy-cli/src/commands/runs/report/failure_digest/bench.rs::ConstantBypassLiteral",
+        "constant_bypass_literal::crates/homeboy-cli/src/commands/runs/report/failure_digest/trace.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/runs/types.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/runs/watch.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/runs_summary.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/schedule.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/trace/bundle.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/trace/compare_bundle.rs::ConstantBypassLiteral",
-        "constant_bypass_literal::crates/homeboy-cli/src/commands/triage.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/utils/response.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-code-audit/src/report.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-core/src/agent_runtime_manifest.rs::ConstantBypassLiteral",
@@ -768,6 +767,7 @@
         "constant_bypass_literal::crates/homeboy-core/src/proof/validation.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-core/src/runner_execution_envelope.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-core/src/test_support.rs::ConstantBypassLiteral",
+        "constant_bypass_literal::crates/homeboy-deploy/src/planning.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-engine-primitives/src/identifier.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-extension/src/bench/report.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-extension/src/bench/run/list.rs::ConstantBypassLiteral",
@@ -797,7 +797,6 @@
         "constant_bypass_literal::crates/homeboy-lab-runner/src/worker/result.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-lab-runner/src/workspace/provenance.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-refactor/src/plan/sources/extension_source.rs::ConstantBypassLiteral",
-        "constant_bypass_literal::crates/homeboy-deploy/src/planning.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-release/src/release/cascade.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-release/src/release/executor/artifacts.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-release/src/release/executor/github_release/gh_cli.rs::ConstantBypassLiteral",
@@ -853,9 +852,6 @@
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/fuzz/inspect.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `fuzz_failure_diagnostic`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/project.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `wp-content` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/refactor.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runs/report/failure_digest.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `cargo` appears at line <line> in behavioral context `render_formatting_findings`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runs/report/failure_digest.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `phpcs` appears at line <line> in behavioral context `render_lint_section`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runs/report/failure_digest.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `phpstan` appears at line <line> in behavioral context `render_lint_section`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runner/cli.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `cargo` appears at line <line> in behavioral context `compact_exec_stdout`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runner/doctor/probes.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `.cargo` appears at line <line> in behavioral context `remote_preferred_homeboy_candidate`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runner/doctor/probes.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `cargo` appears at line <line> in behavioral context `remote_preferred_homeboy_candidate`::CoreBoundaryLeak",
@@ -868,6 +864,9 @@
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runs/gh_actions.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `actions/` appears at line <line> in behavioral context `list_run_artifacts`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runs/gh_actions.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `actions/` appears at line <line> in behavioral context `list_workflow_runs`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runs/gh_actions.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `actions/` appears at line <line> in behavioral context `split_headers_and_body`::CoreBoundaryLeak",
+        "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runs/report/failure_digest.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `cargo` appears at line <line> in behavioral context `render_formatting_findings`::CoreBoundaryLeak",
+        "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runs/report/failure_digest.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `phpcs` appears at line <line> in behavioral context `render_lint_section`::CoreBoundaryLeak",
+        "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/runs/report/failure_digest.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `phpstan` appears at line <line> in behavioral context `render_lint_section`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/tunnel.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `node` appears at line <line> in behavioral context `portability_contract`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/upgrade.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `cargo` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-cli/src/commands/upgrade.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `homebrew` appears at line <line> in behavioral context `run`::CoreBoundaryLeak",
@@ -922,6 +921,12 @@
         "core_boundary_leak:core-agnostic-source::crates/homeboy-core/src/setup.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `pnpm` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-core/src/setup.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `yarn` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-core/src/test_support.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `cargo` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
+        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/permissions.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `wp-content` appears at line <line> in behavioral context `fix_deployed_ownership`::CoreBoundaryLeak",
+        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/policy.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `node_modules` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
+        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/safety_and_artifact.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `node_modules` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
+        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/transfer.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `upload_directory`::CoreBoundaryLeak",
+        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/version_overrides.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `node_modules` appears at line <line> in behavioral context `archive_install_override`::CoreBoundaryLeak",
+        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/version_overrides.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `node` appears at line <line> in behavioral context `archive_install_override`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-engine-primitives/src/codebase_scan.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `node_modules` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-engine-primitives/src/codebase_scan.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-engine-primitives/src/edit_op_apply.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `apply_edit_ops_to_content`::CoreBoundaryLeak",
@@ -1041,12 +1046,6 @@
         "core_boundary_leak:core-agnostic-source::crates/homeboy-refactor/src/plan/generate/signatures.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `rust` appears at line <line> in behavioral context `primary_type_name_from_declaration`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-refactor/src/propagate.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `rust` appears at line <line> in behavioral context `propagate`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-refactor/src/propagate.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `rust` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/permissions.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `wp-content` appears at line <line> in behavioral context `fix_deployed_ownership`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/policy.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `node_modules` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/safety_and_artifact.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `node_modules` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/transfer.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `upload_directory`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/version_overrides.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `node_modules` appears at line <line> in behavioral context `archive_install_override`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::crates/homeboy-deploy/src/version_overrides.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `node` appears at line <line> in behavioral context `archive_install_override`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-release/src/release/cascade.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `composer` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-release/src/release/execution_dispatch.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `composer` appears at line <line> in behavioral context `dependency_preflight_result`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-release/src/release/execution_dispatch.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `composer` appears at line <line> in behavioral context `remove_ignored_untracked_composer_lock`::CoreBoundaryLeak",
@@ -1072,8 +1071,6 @@
         "core_boundary_leak:core-agnostic-source::crates/homeboy-release/src/release/planning_worktree.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `package.json` appears at line <line> in behavioral context `derived_release_lockfiles`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-release/src/release/planning_worktree.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `pnpm` appears at line <line> in behavioral context `derived_release_lockfiles`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-release/src/release/planning_worktree.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `yarn` appears at line <line> in behavioral context `derived_release_lockfiles`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::crates/homeboy-version/src/version/default_pattern_for_file.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `build_init_warnings`::CoreBoundaryLeak",
-        "core_boundary_leak:core-agnostic-source::crates/homeboy-version/src/version/default_pattern_for_file.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `detect_unconfigured_patterns`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-release/src/release/version_guard.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-rig/src/lint.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `claude` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-rig/src/lint.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `claude` appears at line <line> in behavioral context `unknown_top_level_field_failures`::CoreBoundaryLeak",
@@ -1108,6 +1105,8 @@
         "core_boundary_leak:core-agnostic-source::crates/homeboy-upgrade/src/upgrade/helpers.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `homebrew` appears at line <line> in behavioral context `detect_install_method_from_exe_path`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-upgrade/src/upgrade/types.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `homebrew` appears at line <line> in behavioral context `deserialize`::CoreBoundaryLeak",
         "core_boundary_leak:core-agnostic-source::crates/homeboy-upgrade/src/upgrade/types.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `homebrew` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
+        "core_boundary_leak:core-agnostic-source::crates/homeboy-version/src/version/default_pattern_for_file.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `build_init_warnings`::CoreBoundaryLeak",
+        "core_boundary_leak:core-agnostic-source::crates/homeboy-version/src/version/default_pattern_for_file.rs::Core boundary leak (core-agnostic-source) configured ecosystem term `php` appears at line <line> in behavioral context `detect_unconfigured_patterns`::CoreBoundaryLeak",
         "core_boundary_leak:detector-agnostic-source::crates/homeboy-code-audit/src/detectors/command_wrapper_bypass.rs::Core boundary leak (detector-agnostic-source) configured ecosystem term `Rust` appears at line <line> in behavioral context `f`::CoreBoundaryLeak",
         "core_boundary_leak:detector-agnostic-source::crates/homeboy-code-audit/src/detectors/command_wrapper_bypass.rs::Core boundary leak (detector-agnostic-source) configured ecosystem term `Rust` appears at line <line> in behavioral context `top-level`::CoreBoundaryLeak",
         "core_boundary_leak:detector-agnostic-source::crates/homeboy-code-audit/src/detectors/command_wrapper_bypass.rs::Core boundary leak (detector-agnostic-source) configured ecosystem term `rust` appears at line <line> in behavioral context `f`::CoreBoundaryLeak",
@@ -1136,9 +1135,9 @@
         "dead_code::crates/homeboy-cli/src/command_contract/constants.rs::UnreferencedExport",
         "dead_code::crates/homeboy-cli/src/commands/ci/failure_log_triage.rs::UnreferencedExport",
         "dead_code::crates/homeboy-cli/src/commands/infra/output_runtime.rs::UnreferencedExport",
-        "dead_code::crates/homeboy-cli/src/commands/runs/report/browser_evidence_compare/implementation/reader.rs::UnreferencedExport",
         "dead_code::crates/homeboy-cli/src/commands/runs/gh_actions.rs::UnreferencedExport",
         "dead_code::crates/homeboy-cli/src/commands/runs/gh_actions_cache.rs::UnreferencedExport",
+        "dead_code::crates/homeboy-cli/src/commands/runs/report/browser_evidence_compare/implementation/reader.rs::UnreferencedExport",
         "dead_code::crates/homeboy-cli/src/commands/utils/execution_provenance.rs::UnreferencedExport",
         "dead_code::crates/homeboy-cli/src/commands/utils/response.rs::UnreferencedExport",
         "dead_code::crates/homeboy-code-audit/src/baseline.rs::UnreferencedExport",
@@ -1156,6 +1155,7 @@
         "dead_code::crates/homeboy-core/src/runtime_promotion.rs::UnreferencedExport",
         "dead_code::crates/homeboy-core/src/schedule/execution.rs::UnreferencedExport",
         "dead_code::crates/homeboy-core/src/schedule/ticker.rs::UnreferencedExport",
+        "dead_code::crates/homeboy-deploy/src/preparation.rs::DeadCodeMarker",
         "dead_code::crates/homeboy-extension/src/bench/responsiveness.rs::UnreferencedExport",
         "dead_code::crates/homeboy-lab-runner/src/dev_run.rs::UnreferencedExport",
         "dead_code::crates/homeboy-lab-runner/src/lab_staging_controller.rs::UnreferencedExport",
@@ -1168,7 +1168,6 @@
         "dead_code::crates/homeboy-lab-runner/src/workspace/types.rs::UnreferencedExport",
         "dead_code::crates/homeboy-paths/src/rigs.rs::UnreferencedExport",
         "dead_code::crates/homeboy-refactor/src/edit_op_tagged.rs::UnreferencedExport",
-        "dead_code::crates/homeboy-deploy/src/preparation.rs::DeadCodeMarker",
         "dead_code::crates/homeboy-release/src/release/cascade.rs::UnreferencedExport",
         "dead_code::crates/homeboy-release/src/release/version_guard.rs::UnreferencedExport",
         "dead_code::crates/homeboy-rig/src/lint.rs::UnreferencedExport",
@@ -1185,10 +1184,10 @@
         "direct_aggregate_construction::crates/homeboy-core/src/component/resolution.rs::DirectAggregateConstruction",
         "direct_aggregate_construction::crates/homeboy-core/src/defaults.rs::DirectAggregateConstruction",
         "direct_aggregate_construction::crates/homeboy-core/src/runner_execution_envelope.rs::DirectAggregateConstruction",
-        "direct_aggregate_construction::crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs::DirectAggregateConstruction",
         "direct_aggregate_construction::crates/homeboy-deploy/src/content_manifest.rs::DirectAggregateConstruction",
         "direct_aggregate_construction::crates/homeboy-deploy/src/orchestration/modes.rs::DirectAggregateConstruction",
         "direct_aggregate_construction::crates/homeboy-deploy/src/orchestration/smoke_check.rs::DirectAggregateConstruction",
+        "direct_aggregate_construction::crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs::DirectAggregateConstruction",
         "direct_aggregate_construction::crates/homeboy-release/src/release/execution_dispatch.rs::DirectAggregateConstruction",
         "docs::docs/architecture/core-runner-output-parse.md::StaleDocReference",
         "docs::docs/architecture/runner-contract.md::StaleDocReference",
@@ -1270,6 +1269,9 @@
         "intra-method-duplication::crates/homeboy-core/src/observation/store/artifacts.rs::IntraMethodDuplicate",
         "intra-method-duplication::crates/homeboy-core/src/server/client/local_exec.rs::IntraMethodDuplicate",
         "intra-method-duplication::crates/homeboy-core/src/worktree_providers.rs::IntraMethodDuplicate",
+        "intra-method-duplication::crates/homeboy-deploy/src/execution/preflight.rs::IntraMethodDuplicate",
+        "intra-method-duplication::crates/homeboy-deploy/src/orchestration_ref_checkout.rs::IntraMethodDuplicate",
+        "intra-method-duplication::crates/homeboy-deploy/src/planning.rs::IntraMethodDuplicate",
         "intra-method-duplication::crates/homeboy-extension/src/bench/artifact_persistence.rs::IntraMethodDuplicate",
         "intra-method-duplication::crates/homeboy-extension/src/bench/run/results.rs::IntraMethodDuplicate",
         "intra-method-duplication::crates/homeboy-extension/src/bench/run/workflow.rs::IntraMethodDuplicate",
@@ -1307,9 +1309,6 @@
         "intra-method-duplication::crates/homeboy-lab-runner/src/workspace/materializer.rs::IntraMethodDuplicate",
         "intra-method-duplication::crates/homeboy-lab-runner/src/workspace/snapshot.rs::IntraMethodDuplicate",
         "intra-method-duplication::crates/homeboy-refactor/src/rename/engine.rs::IntraMethodDuplicate",
-        "intra-method-duplication::crates/homeboy-deploy/src/execution/preflight.rs::IntraMethodDuplicate",
-        "intra-method-duplication::crates/homeboy-deploy/src/orchestration_ref_checkout.rs::IntraMethodDuplicate",
-        "intra-method-duplication::crates/homeboy-deploy/src/planning.rs::IntraMethodDuplicate",
         "intra-method-duplication::crates/homeboy-release/src/release/execution_projection.rs::IntraMethodDuplicate",
         "intra-method-duplication::crates/homeboy-release/src/release/executor/github_release/gh_cli.rs::IntraMethodDuplicate",
         "intra-method-duplication::crates/homeboy-release/src/release/executor/github_release/run.rs::IntraMethodDuplicate",
@@ -1354,18 +1353,18 @@
         "output_capture::tests/readonly_cli_lock_test.rs::UnboundedOutputCapture",
         "parallel-implementation::crates/homeboy-agents/src/agent_task_prompts.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-cli/src/commands/agent_task/fanout.rs::ParallelImplementation",
-        "parallel-implementation::crates/homeboy-cli/src/commands/runs/report/browser_evidence_compare/implementation/visual.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-cli/src/commands/runs/reconcile.rs::ParallelImplementation",
+        "parallel-implementation::crates/homeboy-cli/src/commands/runs/report/browser_evidence_compare/implementation/visual.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-cli/src/commands/runs/types.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-cli/src/commands/utils/response.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-core/src/http_api.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-core/src/runtime_promotion.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-core/src/source_snapshot.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-core/src/test_support.rs::ParallelImplementation",
+        "parallel-implementation::crates/homeboy-deploy/src/content_manifest.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-lab-runner/src/workspace/util.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-refactor/src/collapse.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-refactor/src/propagate.rs::ParallelImplementation",
-        "parallel-implementation::crates/homeboy-deploy/src/content_manifest.rs::ParallelImplementation",
         "parallel-implementation::crates/homeboy-rig/src/dependency_materialization_cache.rs::ParallelImplementation",
         "parallel_runner_setup::crates/homeboy-core/src/api_jobs/runner_job_preparation.rs::ParallelRunnerSetup",
         "remote_execution_preflight::crates/homeboy-cli/src/commands/infra/route.rs::RemoteExecutionPreflight",
@@ -1463,6 +1462,10 @@
         "skeleton-duplication::crates/homeboy-core/src/resource_lifecycle_index.rs::SkeletonDuplicate",
         "skeleton-duplication::crates/homeboy-core/src/runtime_package.rs::SkeletonDuplicate",
         "skeleton-duplication::crates/homeboy-core/src/test_support.rs::SkeletonDuplicate",
+        "skeleton-duplication::crates/homeboy-deploy/src/orchestration/preflight.rs::SkeletonDuplicate",
+        "skeleton-duplication::crates/homeboy-deploy/src/preparation.rs::SkeletonDuplicate",
+        "skeleton-duplication::crates/homeboy-deploy/src/types.rs::SkeletonDuplicate",
+        "skeleton-duplication::crates/homeboy-deploy/src/version_overrides.rs::SkeletonDuplicate",
         "skeleton-duplication::crates/homeboy-extension/src/bench/run/memory_timeline.rs::SkeletonDuplicate",
         "skeleton-duplication::crates/homeboy-extension/src/bench/run_metadata.rs::SkeletonDuplicate",
         "skeleton-duplication::crates/homeboy-extension/src/lifecycle/install_sources.rs::SkeletonDuplicate",
@@ -1497,10 +1500,6 @@
         "skeleton-duplication::crates/homeboy-lab-runner/src/workspace/util.rs::SkeletonDuplicate",
         "skeleton-duplication::crates/homeboy-refactor/src/plan/sources/lint_scope.rs::SkeletonDuplicate",
         "skeleton-duplication::crates/homeboy-refactor/src/rename/casing.rs::SkeletonDuplicate",
-        "skeleton-duplication::crates/homeboy-deploy/src/orchestration/preflight.rs::SkeletonDuplicate",
-        "skeleton-duplication::crates/homeboy-deploy/src/preparation.rs::SkeletonDuplicate",
-        "skeleton-duplication::crates/homeboy-deploy/src/types.rs::SkeletonDuplicate",
-        "skeleton-duplication::crates/homeboy-deploy/src/version_overrides.rs::SkeletonDuplicate",
         "skeleton-duplication::crates/homeboy-release/src/release/executor/github_release/gh_cli.rs::SkeletonDuplicate",
         "skeleton-duplication::crates/homeboy-release/src/release/executor/lockfile_guard.rs::SkeletonDuplicate",
         "skeleton-duplication::crates/homeboy-release/src/release/executor/prepare.rs::SkeletonDuplicate",
@@ -1673,6 +1672,9 @@
         "structural::crates/homeboy-core/src/test_support.rs::HighItemCount",
         "structural::crates/homeboy-core/src/worktree_providers.rs::GodFile",
         "structural::crates/homeboy-core/src::DirectorySprawl",
+        "structural::crates/homeboy-deploy/src/orchestration/mod.rs::GodFile",
+        "structural::crates/homeboy-deploy/src/planning.rs::GodFile",
+        "structural::crates/homeboy-deploy/src/preparation.rs::GodFile",
         "structural::crates/homeboy-engine-primitives/src/command.rs::HighItemCount",
         "structural::crates/homeboy-error/src/lib.rs::HighItemCount",
         "structural::crates/homeboy-extension/src/bench/parsing/mod.rs::GodFile",
@@ -1726,9 +1728,6 @@
         "structural::crates/homeboy-paths/src/lib.rs::HighItemCount",
         "structural::crates/homeboy-refactor/src/rename/tests.rs::GodFile",
         "structural::crates/homeboy-refactor/src/rename/tests.rs::HighItemCount",
-        "structural::crates/homeboy-deploy/src/orchestration/mod.rs::GodFile",
-        "structural::crates/homeboy-deploy/src/planning.rs::GodFile",
-        "structural::crates/homeboy-deploy/src/preparation.rs::GodFile",
         "structural::crates/homeboy-release/src/release/execution_dispatch.rs::GodFile",
         "structural::crates/homeboy-release/src/release/executor.rs::GodFile",
         "structural::crates/homeboy-release/src/release/executor/github_release/gh_cli.rs::GodFile",
@@ -1795,9 +1794,9 @@
         "policy_sections": [
           {
             "audit_policy": "core_boundary_leak:core-agnostic-source",
+            "fingerprint_prefix": "core_boundary_leak:core-agnostic-source",
             "issue": "#3498",
             "key": "core_boundary_leak:core-agnostic-source/core-boundary",
-            "fingerprint_prefix": "core_boundary_leak:core-agnostic-source",
             "known_fingerprints": [],
             "rationale": "Scoped source-policy/core-boundary debt baseline for reviewable ratchets.",
             "scope": "core-boundary"
@@ -1818,9 +1817,9 @@
   "extensions": {
     "rust": {
       "settings": {
-        "rust_test_runner": "nextest",
         "rust_cargo_test_threads": 1,
-        "rust_nextest_shard_threads": 0
+        "rust_nextest_shard_threads": 0,
+        "rust_test_runner": "nextest"
       }
     }
   },


### PR DESCRIPTION
Closes part of #13199.

## Measurement

`homeboy review audit --only parallel_implementation`, run on this worktree before and after, with the stale baseline row pruned in both directions so the comparison is honest:

```
clean main   9 unbaselined findings
             agent_task_gate.rs
             agent_task_lifecycle/workspace_authority.rs
             agent_task_lifecycle/workspace_claims.rs
             core/worktree/types.rs
             core/worktree_providers.rs
             lab-runner/execution/daemon.rs
             lab-runner/lab_staging_controller.rs
             core/controller_runtime.rs
             core/repository_integrity.rs

this PR     2 unbaselined findings
             core/controller_runtime.rs
             core/repository_integrity.rs
```

**9 → 2.** No new findings introduced — the two new functions do not pair with each other or anything else.

## Cluster 1 — composite field digest

Four functions in three crates hand-rolled the same identity scheme: SHA-256 over an ordered tuple of strings joined by a NUL byte.

| function | crate |
| --- | --- |
| `authority_set_fingerprint` | homeboy-core |
| `compatibility_identity_token` | homeboy-core |
| `authority_digest` | homeboy-agents |
| `composite_acquisition_intent_path` | homeboy-agents |

They are **not interchangeable**, which is why this adds two primitives rather than one with a flag:

```
nul_terminated_digest(["a","b"])  ->  sha256(b"a\0b\0")   trailing after every field
nul_separated_digest(["a","b"])   ->  sha256(b"a\0b")     between fields only
```

`authority_set_fingerprint` uses the first; the other three use the second. A terminated digest is unambiguous for a set of arbitrary length; a separated one is only unambiguous for a fixed-arity tuple. Collapsing them into one function would have changed three digests.

### These digests are persisted

One becomes a `compat-v1:` compatibility token. One becomes an **on-disk filename**. Changing their bytes orphans data.

So the exact output of each hand-rolled implementation was computed and pinned as an assertion in `content_hash` **before** the migration:

```rust
#[test]
fn field_digests_match_the_hand_rolled_implementations_they_replaced() {
    // was: worktree::types::authority_set_fingerprint(["alpha", "beta"])
    assert_eq!(
        nul_terminated_digest(["alpha", "beta"]),
        "63ed4f61f097667f9297e42c5f0e173bb382b51758b2c7772ca37ceea99f4ae0"
    );
    ...
}
```

The migration is byte-identical against all four.

### Why not fold into `sha256_hex`

`content_hash`'s module docs already drew this line:

> Deliberately *not* covered here: digests that hash something other than the raw bytes (canonicalized overlays, ordered directory trees, salted inputs)... collapsing them into this primitive would silently change what they identify.

A composite-tuple digest is exactly such a scheme. It gets its own named primitive in the same module.

### Not migrated, deliberately

`rust_cache_identity` length-prefixes file contents and folds in OS/ARCH. `deterministic_remote_path` concatenates without separators and truncates to 12 chars. Both identify something different. Neither is flagged any more, because the functions they paired with stopped hashing.

`run_index_path` hashed a single field with its own hasher and is now `sha256_hex` — same bytes. Between that and the migrations, `sha2` leaves two files entirely.

## Cluster 2 — cancellable sleep

`sleep_daemon_wait_unless_cancelled` and `sleep_unless_cancelled` are the same loop, and both independently chose a 200ms slice, so the constant was duplicated too:

```rust
const DAEMON_TERMINAL_WAIT_CANCELLATION_SLICE: Duration = Duration::from_millis(200);
const LAB_STAGING_POLL_CANCELLATION_SLICE:     Duration = Duration::from_millis(200);
```

The loop moves to `homeboy-lab-runner::cancellable_sleep` with four behavioral tests. Both call sites keep their wrapper, so nothing above them changes; each adapts its own cancellation type (`&dyn Fn() -> bool`, `LabStagingCancellationToken`) into a closure.

It stays inside lab-runner because both consumers are there. Pushing it into `homeboy-engine-primitives` without a third caller would be speculative.

## Baseline row for a deleted file

`baselines.audit` carried a fingerprint for `crates/homeboy-cli/src/commands/triage.rs`, deleted in #13177 when triage became a composed CLI capability. A baseline row pointing at a path that no longer exists makes `homeboy review audit` **exit 2 before reporting anything** — the audit could not be run locally at all.

Pruned with `homeboy review audit-baseline prune`. 1129 → 1128.

Worth noting on its own: the baseline `item_count` had been frozen at 1137/1129 since 2026-08-01. A gate that cannot execute is a plausible contributor.

## Remaining from #13199

`controller_runtime::protected_executables` and `repository_integrity::exceptions` still pair on `from_str` / `pointer` / `validation_invalid_json`. Both pull a JSON pointer out of config and raise the same error shape. That is a config-read seam rather than a shared algorithm, and wants its own change.

## Verification

`cargo check --workspace --all-targets` — **0 errors, 0 warnings.**

New tests: 4 in `content_hash` (including the byte-identity pin), 4 in `cancellable_sleep`. All pass.

Regression tests compared against a stashed baseline on clean `main` in the same worktree:

| suite | this PR | clean main |
| --- | --- | --- |
| `homeboy-lab-runner --lib staging daemon` | 6 failures | **same 6** |
| `homeboy-core --lib worktree` | 3 failures | **same 3** |

A 4th `homeboy-core` failure (`cleanup::tests::unreadable_task_worktree_registry_retains_cargo_targets`) appeared once under `--test-threads=2` and passes in isolation.

Pre-existing failures are tracked in #13273.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode
