### PR TITLE
fix: normalize task provider resolution

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -3071,7 +3071,7 @@ pub(crate) fn resolve_cook_destination(
             "--task-url <url> is required when --to-worktree is omitted".to_string(),
         ])
     })?;
-    let task_url = canonical_cook_task_url(task_url);
+    let task_url = homeboy::core::worktree_providers::normalize_task_url(task_url);
     args.dispatch.task_url = Some(task_url.clone());
     let config = defaults::load_config();
     // Resolve the requested branch before task discovery. An explicit --head is
@@ -3853,7 +3853,7 @@ fn repository_identity_error(
 }
 
 fn derived_cook_branch(task_url: &str) -> homeboy::core::Result<String> {
-    let issue = canonical_cook_task_url(task_url);
+    let issue = homeboy::core::worktree_providers::normalize_task_url(task_url);
     let issue = issue.as_str();
     let Some((repository, number)) = issue.rsplit_once("/issues/") else {
         return Err(homeboy::core::Error::validation_invalid_argument(
@@ -3884,16 +3884,6 @@ fn derived_cook_branch(task_url: &str) -> homeboy::core::Result<String> {
         ));
     }
     Ok(format!("fix/issue-{number}-{}", slugify_cook_branch(repo)))
-}
-
-fn canonical_cook_task_url(task_url: &str) -> String {
-    task_url
-        .trim()
-        .split(['?', '#'])
-        .next()
-        .unwrap_or_default()
-        .trim_end_matches('/')
-        .to_string()
 }
 
 fn slugify_cook_branch(value: &str) -> String {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -173,7 +173,7 @@ fn cook_reuses_a_task_candidate_without_overriding_explicit_head() {
         std::fs::write(
             &provider,
             format!(
-                "#!/bin/sh\nprintf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"project@task-216\",\"path\":\"{}\",\"branch\":\"fix/216-persist-task\",\"task_url\":\"https://example.test/owner/project/issues/216\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'\n",
+                "#!/bin/sh\nprintf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"project@task-216\",\"path\":\"{}\",\"branch\":\"fix/216-persist-task\",\"task_url\":\"HTTPS://EXAMPLE.TEST/owner/Project/issues/216/?provider=1#result\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'\n",
                 workspace.path().display()
             ),
         )
@@ -226,7 +226,7 @@ fn cook_reuses_a_task_candidate_without_overriding_explicit_head() {
             "--repo".to_string(),
             "project".to_string(),
             "--task-url".to_string(),
-            "https://example.test/owner/project/issues/216".to_string(),
+            " HTTPS://example.test/owner/Project/issues/216/?source=cook#details ".to_string(),
             "--head".to_string(),
             "fix/216-persist-task".to_string(),
             "--no-finalize".to_string(),

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -1231,6 +1231,21 @@ mod tests {
     }
 
     #[test]
+    fn legacy_worktree_provider_commands_config_defaults_task_not_found_exit_codes() {
+        let config: HomeboyConfig = serde_json::from_value(serde_json::json!({
+            "worktree_providers": {"fixture": {"commands": {
+                "resolve_task": ["provider", "resolve-task", "{task_url}"],
+                "resolve_not_found_exit_codes": [41]
+            }}}
+        }))
+        .expect("legacy config deserializes");
+        let commands = &config.worktree_providers["fixture"].commands;
+
+        assert_eq!(commands.resolve_not_found_exit_codes, vec![41]);
+        assert!(commands.resolve_task_not_found_exit_codes.is_empty());
+    }
+
+    #[test]
     fn homeboy_config_parses_lab_preferred_runner() {
         let config: HomeboyConfig = serde_json::from_str(
             r#"{

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -679,6 +679,10 @@ pub struct WorktreeProviderCommands {
     /// absent destination.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolve_task: Option<Vec<String>>,
+    /// Targeted tracker lookup exit statuses that mean the requested task is
+    /// absent. This is independent from exact handle/path resolution.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub resolve_task_not_found_exit_codes: Vec<i32>,
     /// Targeted canonical-path lookup. Each `{path}` argument is replaced with
     /// the requested canonical path. The result uses `list_result_mapping` and
     /// may contain one item.
@@ -738,6 +742,7 @@ impl Default for WorktreeProviderCommands {
             attest_safety: None,
             resolve: None,
             resolve_task: None,
+            resolve_task_not_found_exit_codes: Vec::new(),
             resolve_path: None,
             resolve_not_found_exit_codes: Vec::new(),
             list: None,
@@ -1207,6 +1212,7 @@ mod tests {
             attest_safety: None,
             resolve: None,
             resolve_task: None,
+            resolve_task_not_found_exit_codes: Vec::new(),
             resolve_path: None,
             resolve_not_found_exit_codes: Vec::new(),
             list: Some(vec!["provider".to_string(), "list".to_string()]),

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -956,6 +956,7 @@ pub fn find_apply_enabled_worktree_provider_by_task_url_and_head_from_config(
     head: Option<&str>,
     config: &HomeboyConfig,
 ) -> Result<Option<WorktreeProviderResolution>> {
+    let task_url = normalize_task_url(task_url);
     let mut matches = Vec::new();
     for (provider_id, provider) in &config.worktree_providers {
         if !provider.enabled
@@ -969,14 +970,17 @@ pub fn find_apply_enabled_worktree_provider_by_task_url_and_head_from_config(
             continue;
         }
         let worktrees = if let Some(command) = provider.commands.resolve_task.as_ref() {
-            run_provider_resolve_task_command(provider_id, provider, command, task_url)?
+            run_provider_resolve_task_command(provider_id, provider, command, &task_url)?
         } else if let Some(command) = provider.commands.list.as_ref() {
             run_provider_list_command(provider_id, provider, command)?
         } else {
             continue;
         };
         for worktree in worktrees {
-            if worktree.task_url.as_deref() == Some(task_url)
+            if worktree
+                .task_url
+                .as_deref()
+                .is_some_and(|candidate| normalize_task_url(candidate) == task_url)
                 && head.is_none_or(|head| worktree.branch == head)
             {
                 validate_provider_handle(provider_id, &worktree, None, None)?;
@@ -1001,7 +1005,7 @@ pub fn find_apply_enabled_worktree_provider_by_task_url_and_head_from_config(
                     .collect::<Vec<_>>()
                     .join(", ")
             ),
-            Some(task_url.to_string()),
+            Some(task_url),
             None,
         )),
     }
@@ -1898,7 +1902,51 @@ fn run_provider_resolve_task_command(
         provider,
         &command,
         "resolve_task",
-        &provider.commands.resolve_not_found_exit_codes,
+        &provider.commands.resolve_task_not_found_exit_codes,
+    )
+}
+
+/// Normalize tracker URLs without changing their path identity.
+pub fn normalize_task_url(task_url: &str) -> String {
+    let url = task_url
+        .trim()
+        .split(['?', '#'])
+        .next()
+        .unwrap_or_default()
+        .trim_end_matches('/');
+    let Some((scheme, remainder)) = url.split_once("://") else {
+        return url.to_string();
+    };
+    let authority_end = remainder.find('/').unwrap_or(remainder.len());
+    let (authority, path) = remainder.split_at(authority_end);
+    let (userinfo, host_port) = authority
+        .rsplit_once('@')
+        .map_or(("", authority), |(userinfo, host_port)| {
+            (userinfo, host_port)
+        });
+    let (host, port) = if host_port.starts_with('[') {
+        host_port
+            .find(']')
+            .map_or((host_port, ""), |end| host_port.split_at(end + 1))
+    } else {
+        host_port
+            .rsplit_once(':')
+            .map_or((host_port, ""), |(host, _)| {
+                (host, &host_port[host.len()..])
+            })
+    };
+    let userinfo = if userinfo.is_empty() {
+        String::new()
+    } else {
+        format!("{userinfo}@")
+    };
+    format!(
+        "{}://{}{}{}{}",
+        scheme.to_ascii_lowercase(),
+        userinfo,
+        host.to_ascii_lowercase(),
+        port,
+        path
     )
 }
 
@@ -3784,6 +3832,8 @@ mod tests {
                     "kind": "command",
                     "apply_enabled": true,
                     "commands": {
+                        "resolve_task": ["fixture-bin", "resolve-task", "{task_url}"],
+                        "resolve_task_not_found_exit_codes": [42],
                         "cleanup_preview": ["fixture-bin", "preview"],
                         "cleanup_apply": ["fixture-bin", "apply"],
                         "artifacts_preview": ["fixture-bin", "artifacts-preview"]
@@ -3806,6 +3856,10 @@ mod tests {
         assert!(provider.enabled);
         assert_eq!(provider.kind, WorktreeProviderKind::Command);
         assert!(provider.apply_enabled);
+        assert_eq!(
+            provider.commands.resolve_task_not_found_exit_codes,
+            vec![42]
+        );
         assert_eq!(
             provider.commands.cleanup_preview.as_ref().expect("command"),
             &vec!["fixture-bin".to_string(), "preview".to_string()]
@@ -6311,6 +6365,111 @@ mod tests {
         )
         .expect_err("duplicate ownership must be explicit");
         assert!(error.message.contains("project@first, project@second"));
+    }
+
+    #[test]
+    fn normalizes_task_urls_without_changing_path_case() {
+        assert_eq!(
+            normalize_task_url(
+                " HTTPS://Example.TEST:8443/Owner/Project/issues/42/?source=cook#details "
+            ),
+            "https://example.test:8443/Owner/Project/issues/42"
+        );
+    }
+
+    #[test]
+    fn task_lookup_normalizes_provider_urls_but_requires_exact_path_case() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        git_init(workspace.path(), "issue-42");
+        let requested = " HTTPS://example.test/Owner/Project/issues/42/?source=cook#details ";
+        let mapping = WorktreeProviderListResultMapping {
+            items: "$.worktrees".to_string(),
+            handle: "$.handle".to_string(),
+            path: "$.path".to_string(),
+            branch: "$.branch".to_string(),
+            dirty: "$.safety.dirty".to_string(),
+            unpushed: "$.safety.unpushed".to_string(),
+            primary: "$.safety.primary".to_string(),
+            task_url: Some("$.task_url".to_string()),
+        };
+        let script = fake_list_provider_script(json!({ "worktrees": [
+            {
+                "handle": "project@exact-path", "path": workspace.path(), "branch": "issue-42",
+                "task_url": "HTTPS://EXAMPLE.TEST/Owner/Project/issues/42/?provider=1#result",
+                "safety": { "dirty": false, "unpushed": false, "primary": false }
+            },
+            {
+                "handle": "project@different-path-case", "path": workspace.path(), "branch": "issue-42",
+                "task_url": "https://example.test/owner/project/issues/42",
+                "safety": { "dirty": false, "unpushed": false, "primary": false }
+            }
+        ] }));
+        let mut provider = list_provider(script.clone(), mapping);
+        provider.apply_enabled = true;
+        provider.commands.list = None;
+        provider.commands.resolve_task = Some(vec![script, "{task_url}".to_string()]);
+
+        let found = find_apply_enabled_worktree_provider_by_task_url_from_config(
+            requested,
+            &config_with_provider(provider),
+        )
+        .expect("task lookup")
+        .expect("exact path-case candidate");
+        assert_eq!(found.worktree.handle, "project@exact-path");
+    }
+
+    #[test]
+    fn resolve_task_uses_its_own_not_found_exit_codes() {
+        let mut provider = list_provider(
+            fake_list_provider_script(json!({ "worktrees": [] })),
+            worktrees_mapping(),
+        );
+        provider.apply_enabled = true;
+        provider.commands.list = None;
+        provider.commands.resolve_task = Some(vec![
+            fake_provider_script_body("exit 42\n"),
+            "{task_url}".to_string(),
+        ]);
+        provider.commands.resolve_not_found_exit_codes = vec![41];
+        provider.commands.resolve_task_not_found_exit_codes = vec![42];
+
+        assert!(
+            find_apply_enabled_worktree_provider_by_task_url_from_config(
+                "https://example.test/issues/42",
+                &config_with_provider(provider),
+            )
+            .expect("task-specific not-found exit is accepted")
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn exact_handle_resolution_keeps_shared_not_found_exit_codes() {
+        let provider = WorktreeProviderConfig {
+            enabled: true,
+            kind: WorktreeProviderKind::Command,
+            apply_enabled: false,
+            lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
+            lookup_output_limit_bytes: 64 * 1024,
+            commands: WorktreeProviderCommands {
+                resolve: Some(vec![
+                    fake_provider_script_body("exit 41\n"),
+                    "{handle}".to_string(),
+                ]),
+                resolve_not_found_exit_codes: vec![41],
+                resolve_task_not_found_exit_codes: vec![42],
+                ..Default::default()
+            },
+            list_result_mapping: Some(worktrees_mapping()),
+        };
+
+        let error = resolve_worktree_provider_handle_from_config(
+            "project@issue-42",
+            &config_with_provider(provider),
+        )
+        .expect_err("exact resolution remains not found after its accepted exit");
+        assert_eq!(error.details["worktree_provider_lookup"], "not_found");
     }
 
     #[test]

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -1897,12 +1897,21 @@ fn run_provider_resolve_task_command(
         .iter()
         .map(|argument| argument.replace("{task_url}", task_url))
         .collect::<Vec<_>>();
+    let not_found_exit_codes = if provider
+        .commands
+        .resolve_task_not_found_exit_codes
+        .is_empty()
+    {
+        &provider.commands.resolve_not_found_exit_codes
+    } else {
+        &provider.commands.resolve_task_not_found_exit_codes
+    };
     run_provider_lookup_command(
         provider_id,
         provider,
         &command,
         "resolve_task",
-        &provider.commands.resolve_task_not_found_exit_codes,
+        not_found_exit_codes,
     )
 }
 
@@ -1940,9 +1949,14 @@ pub fn normalize_task_url(task_url: &str) -> String {
     } else {
         format!("{userinfo}@")
     };
+    let scheme = scheme.to_ascii_lowercase();
+    let port = match (scheme.as_str(), port) {
+        ("http", ":80") | ("https", ":443") => "",
+        _ => port,
+    };
     format!(
         "{}://{}{}{}{}",
-        scheme.to_ascii_lowercase(),
+        scheme,
         userinfo,
         host.to_ascii_lowercase(),
         port,
@@ -6368,20 +6382,31 @@ mod tests {
     }
 
     #[test]
-    fn normalizes_task_urls_without_changing_path_case() {
-        assert_eq!(
-            normalize_task_url(
-                " HTTPS://Example.TEST:8443/Owner/Project/issues/42/?source=cook#details "
+    fn normalizes_task_urls_without_changing_path_or_userinfo() {
+        for (input, expected) in [
+            (
+                " HTTPS://User:Token@Example.TEST:443/Owner/Project/issues/42/?source=cook#details ",
+                "https://User:Token@example.test/Owner/Project/issues/42",
             ),
-            "https://example.test:8443/Owner/Project/issues/42"
-        );
+            (
+                "http://user@example.test:80/Owner/Project/issues/42",
+                "http://user@example.test/Owner/Project/issues/42",
+            ),
+            (
+                "https://User:Token@Example.TEST:8443/Owner/Project/issues/42",
+                "https://User:Token@example.test:8443/Owner/Project/issues/42",
+            ),
+        ] {
+            assert_eq!(normalize_task_url(input), expected);
+        }
     }
 
     #[test]
     fn task_lookup_normalizes_provider_urls_but_requires_exact_path_case() {
         let workspace = tempfile::tempdir().expect("workspace");
         git_init(workspace.path(), "issue-42");
-        let requested = " HTTPS://example.test/Owner/Project/issues/42/?source=cook#details ";
+        let requested =
+            " HTTPS://User:Token@example.test:443/Owner/Project/issues/42/?source=cook#details ";
         let mapping = WorktreeProviderListResultMapping {
             items: "$.worktrees".to_string(),
             handle: "$.handle".to_string(),
@@ -6395,7 +6420,7 @@ mod tests {
         let script = fake_list_provider_script(json!({ "worktrees": [
             {
                 "handle": "project@exact-path", "path": workspace.path(), "branch": "issue-42",
-                "task_url": "HTTPS://EXAMPLE.TEST/Owner/Project/issues/42/?provider=1#result",
+                "task_url": "https://User:Token@EXAMPLE.TEST/Owner/Project/issues/42/?provider=1#result",
                 "safety": { "dirty": false, "unpushed": false, "primary": false }
             },
             {
@@ -6439,6 +6464,30 @@ mod tests {
                 &config_with_provider(provider),
             )
             .expect("task-specific not-found exit is accepted")
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn resolve_task_uses_shared_not_found_exit_codes_when_task_codes_are_absent() {
+        let mut provider = list_provider(
+            fake_list_provider_script(json!({ "worktrees": [] })),
+            worktrees_mapping(),
+        );
+        provider.apply_enabled = true;
+        provider.commands.list = None;
+        provider.commands.resolve_task = Some(vec![
+            fake_provider_script_body("exit 41\n"),
+            "{task_url}".to_string(),
+        ]);
+        provider.commands.resolve_not_found_exit_codes = vec![41];
+
+        assert!(
+            find_apply_enabled_worktree_provider_by_task_url_from_config(
+                "https://example.test/issues/42",
+                &config_with_provider(provider),
+            )
+            .expect("legacy shared not-found exit is accepted")
             .is_none()
         );
     }

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -1950,8 +1950,12 @@ pub fn normalize_task_url(task_url: &str) -> String {
         format!("{userinfo}@")
     };
     let scheme = scheme.to_ascii_lowercase();
-    let port = match (scheme.as_str(), port) {
-        ("http", ":80") | ("https", ":443") => "",
+    let port = match (
+        scheme.as_str(),
+        port.strip_prefix(':')
+            .and_then(|value| value.parse::<u16>().ok()),
+    ) {
+        ("http", Some(80)) | ("https", Some(443)) => "",
         _ => port,
     };
     format!(
@@ -6385,16 +6389,16 @@ mod tests {
     fn normalizes_task_urls_without_changing_path_or_userinfo() {
         for (input, expected) in [
             (
-                " HTTPS://User:Token@Example.TEST:443/Owner/Project/issues/42/?source=cook#details ",
+                " HTTPS://User:Token@Example.TEST:0443/Owner/Project/issues/42/?source=cook#details ",
                 "https://User:Token@example.test/Owner/Project/issues/42",
             ),
             (
-                "http://user@example.test:80/Owner/Project/issues/42",
+                "http://user@example.test:080/Owner/Project/issues/42",
                 "http://user@example.test/Owner/Project/issues/42",
             ),
             (
-                "https://User:Token@Example.TEST:8443/Owner/Project/issues/42",
-                "https://User:Token@example.test:8443/Owner/Project/issues/42",
+                "https://User:Token@Example.TEST:08443/Owner/Project/issues/42",
+                "https://User:Token@example.test:08443/Owner/Project/issues/42",
             ),
         ] {
             assert_eq!(normalize_task_url(input), expected);
@@ -6406,7 +6410,7 @@ mod tests {
         let workspace = tempfile::tempdir().expect("workspace");
         git_init(workspace.path(), "issue-42");
         let requested =
-            " HTTPS://User:Token@example.test:443/Owner/Project/issues/42/?source=cook#details ";
+            " HTTPS://User:Token@example.test:0443/Owner/Project/issues/42/?source=cook#details ";
         let mapping = WorktreeProviderListResultMapping {
             items: "$.worktrees".to_string(),
             handle: "$.handle".to_string(),
@@ -6420,7 +6424,7 @@ mod tests {
         let script = fake_list_provider_script(json!({ "worktrees": [
             {
                 "handle": "project@exact-path", "path": workspace.path(), "branch": "issue-42",
-                "task_url": "https://User:Token@EXAMPLE.TEST/Owner/Project/issues/42/?provider=1#result",
+                "task_url": "https://User:Token@EXAMPLE.TEST:443/Owner/Project/issues/42/?provider=1#result",
                 "safety": { "dirty": false, "unpushed": false, "primary": false }
             },
             {


### PR DESCRIPTION
## Summary
- add task-only provider not-found exit codes while preserving exact-resolution behavior
- preserve legacy `resolve_task` behavior by using shared `resolve_not_found_exit_codes` when task-specific values are omitted or empty
- normalize task URLs generically before provider lookup and candidate matching, dropping HTTP(S) default ports while preserving non-default ports, path case, and userinfo
- cover legacy configuration, exit-code fallback and override behavior, URL equivalence, ambiguity, and exact resolution

Follow-up for #13255 and merged PR #13275.

## Verification
- `cargo fmt --all --check`
- `cargo test -p homeboy-core legacy_worktree_provider_commands_config_defaults_task_not_found_exit_codes --locked`
- `cargo test -p homeboy-core resolve_task_uses_shared_not_found_exit_codes_when_task_codes_are_absent --locked`
- `cargo test -p homeboy-core resolve_task_uses_its_own_not_found_exit_codes --locked`
- `cargo test -p homeboy-core normalizes_task_urls_without_changing_path_or_userinfo --locked`
- `cargo test -p homeboy-core task_lookup_normalizes_provider_urls_but_requires_exact_path_case --locked`
- `cargo test -p homeboy-cli --features test-support cook_reuses_a_task_candidate_without_overriding_explicit_head --locked`
- `cargo check --workspace --tests --locked`

## AI assistance disclosure
OpenAI GPT-5.6-terra via OpenCode was used to inspect the review findings, implement backward-compatible provider resolution and URL normalization, and add and run focused tests.