### PR TITLE
test(audit): repair stale baseline fingerprint

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -748,7 +748,6 @@
         "constant_bypass_literal::crates/homeboy-cli/src/commands/schedule.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/trace/bundle.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/trace/compare_bundle.rs::ConstantBypassLiteral",
-        "constant_bypass_literal::crates/homeboy-cli/src/commands/triage.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-cli/src/commands/utils/response.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-code-audit/src/report.rs::ConstantBypassLiteral",
         "constant_bypass_literal::crates/homeboy-core/src/agent_runtime_manifest.rs::ConstantBypassLiteral",

--- a/tests/audit_baseline_ratchet_test.rs
+++ b/tests/audit_baseline_ratchet_test.rs
@@ -47,7 +47,7 @@ use serde_json::Value;
 /// a ceiling, not a target: lower it whenever suppressions are retired, and
 /// never raise it. Raising this number is the one edit this test exists to make
 /// someone argue for in review.
-const AUDIT_BASELINE_CEILING: usize = 1129;
+const AUDIT_BASELINE_CEILING: usize = 1128;
 
 fn baseline_fingerprints() -> Vec<String> {
     let config: Value =


### PR DESCRIPTION
## Summary\n\nFixes #13304.\n\n- Removes the stale triage fingerprint after its source path was removed.\n- Lowers the audit-baseline ratchet ceiling to the resulting exact count.\n\n## Verification\n\n- `cargo test --test audit_baseline_ratchet_test`\n\n## AI assistance\n\nOpenAI `openai/gpt-5.6-terra` via OpenCode reproduced the clean-main workspace failure, repaired the stale audit baseline, and ran the focused gate. Chris Huber remains responsible for the change.