### PR TITLE
fix(agent-task): isolate terminal batch status stores

### DIFF
--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -563,15 +563,17 @@ fn stalled_admission_recovery_command_with(
         })
 }
 
-fn status_in_store<S, P>(
+fn status_in_store<S, P, E>(
     store: &AgentTaskBatchStore,
     batch_id: &str,
     mut child_status: S,
     mut projection_readiness: P,
+    mut lifecycle_record_exists: E,
 ) -> Result<AgentTaskBatchStatusReport>
 where
     S: FnMut(&str) -> Result<agent_task_lifecycle::AgentTaskRunRecord>,
     P: FnMut(&str) -> Result<Option<String>>,
+    E: FnMut(&str) -> Result<bool>,
 {
     let mut batch = store.read_batch(batch_id)?;
     if batch.metadata["terminal_failure"].is_object() {
@@ -582,9 +584,7 @@ where
         let admitted = batch
             .child_runs
             .iter()
-            .filter(|child| {
-                agent_task_lifecycle::run_record_exists_readonly(&child.run_id).unwrap_or(false)
-            })
+            .filter(|child| lifecycle_record_exists(&child.run_id).unwrap_or(false))
             .count();
         let mut next_actions = vec![commands.status.clone(), commands.artifacts.clone()];
         if let Some(command) = admission_blocker
@@ -1017,6 +1017,7 @@ fn artifacts_in_store(
                 run_id,
             )
         },
+        |run_id| agent_task_lifecycle::run_record_exists_readonly_in_store(lifecycle_store, run_id),
     )?;
     let mut unavailable_child_runs = report.unavailable_child_runs.clone();
     let child_runs = report
@@ -1347,6 +1348,7 @@ impl AgentTaskBatchStore {
             batch_id,
             agent_task_lifecycle::persisted_status,
             agent_task_lifecycle::terminal_artifact_projection_readiness_bounded,
+            agent_task_lifecycle::run_record_exists_readonly,
         )
     }
 
@@ -1359,17 +1361,25 @@ impl AgentTaskBatchStore {
         expire_stalled_fanout_admission_in_store(self, &lifecycle_store, batch_id)
     }
 
-    pub fn status_with<S, P>(
+    pub fn status_with<S, P, E>(
         &self,
         batch_id: &str,
         child_status: S,
         projection_readiness: P,
+        lifecycle_record_exists: E,
     ) -> Result<AgentTaskBatchStatusReport>
     where
         S: FnMut(&str) -> Result<agent_task_lifecycle::AgentTaskRunRecord>,
         P: FnMut(&str) -> Result<Option<String>>,
+        E: FnMut(&str) -> Result<bool>,
     {
-        status_in_store(self, batch_id, child_status, projection_readiness)
+        status_in_store(
+            self,
+            batch_id,
+            child_status,
+            projection_readiness,
+            lifecycle_record_exists,
+        )
     }
 
     pub fn record_child_finalization(
@@ -1756,6 +1766,7 @@ mod tests {
                 batch_id,
                 |run_id| lifecycle_store.read_record(run_id),
                 |_| Ok(None),
+                |run_id| lifecycle_store.record_exists_readonly(run_id),
             )
             .expect("batch status")
     }
@@ -1970,6 +1981,7 @@ mod tests {
                     ))
                 },
                 |_| Ok(None),
+                |run_id| lifecycle_store.record_exists_readonly(run_id),
             )
             .expect("fanout status falls back to terminal durable state");
 
@@ -2243,6 +2255,7 @@ mod tests {
                 "batch/projection",
                 |run_id| lifecycle_store.read_record(run_id),
                 |_| Ok(Some("controller projection is pending".to_string())),
+                |run_id| lifecycle_store.record_exists_readonly(run_id),
             )
             .expect("batch status");
 
@@ -2377,6 +2390,7 @@ mod tests {
                     "batch/contended-status",
                     |run_id| lifecycle_store.read_record_bounded(run_id),
                     |_| Ok(None),
+                    |run_id| lifecycle_store.record_exists_readonly(run_id),
                 )
                 .expect("fanout status remains available during writes");
             assert_eq!(report.batch.state, AgentTaskBatchState::Queued);
@@ -3327,6 +3341,70 @@ mod tests {
         assert!(right_store
             .claim_fanout_run_batch("exclusive-left")
             .is_err());
+    }
+
+    #[test]
+    fn terminal_status_uses_the_injected_lifecycle_store_in_parallel() {
+        let left_context = homeboy_core::test_support::HermeticTestContext::new();
+        let right_context = homeboy_core::test_support::HermeticTestContext::new();
+        let left_batch_store = AgentTaskBatchStore::new(left_context.path_roots());
+        let right_batch_store = AgentTaskBatchStore::new(right_context.path_roots());
+        let left_lifecycle_store =
+            agent_task_lifecycle::AgentTaskLifecycleStore::new(left_context.path_roots());
+        let right_lifecycle_store =
+            agent_task_lifecycle::AgentTaskLifecycleStore::new(right_context.path_roots());
+        let plan = AgentTaskPlan::new("fanout/terminal-isolation", vec![request("child")]);
+
+        for (batch_store, lifecycle_store) in [
+            (&left_batch_store, &left_lifecycle_store),
+            (&right_batch_store, &right_lifecycle_store),
+        ] {
+            submit_batch(
+                batch_store,
+                lifecycle_store,
+                &plan,
+                "shared-terminal-isolation",
+            );
+            let mut batch = batch_store
+                .read_batch("shared-terminal-isolation")
+                .expect("terminal batch");
+            batch.metadata["terminal_failure"] = json!({ "failure": "admission failed" });
+            batch_store
+                .write_batch(&batch)
+                .expect("persist terminal batch");
+        }
+
+        let left = std::thread::spawn(move || {
+            left_batch_store.status_with(
+                "shared-terminal-isolation",
+                |run_id| left_lifecycle_store.read_record(run_id),
+                |_| Ok(None),
+                |run_id| left_lifecycle_store.record_exists_readonly(run_id),
+            )
+        });
+        let right = std::thread::spawn(move || {
+            right_batch_store.status_with(
+                "shared-terminal-isolation",
+                |run_id| right_lifecycle_store.read_record(run_id),
+                |_| Ok(None),
+                |run_id| right_lifecycle_store.record_exists_readonly(run_id),
+            )
+        });
+
+        for report in [
+            left.join()
+                .expect("left status thread")
+                .expect("left status"),
+            right
+                .join()
+                .expect("right status thread")
+                .expect("right status"),
+        ] {
+            assert_eq!(report.status, "failed");
+            assert_eq!(report.admission.expected, 1);
+            assert_eq!(report.admission.admitted, 1);
+            assert_eq!(report.admission.rejected, 0);
+        }
     }
 
     fn request(task_id: &str) -> AgentTaskRequest {

--- a/tests/agent_task_store_injection_test.rs
+++ b/tests/agent_task_store_injection_test.rs
@@ -714,7 +714,7 @@ fn function_regions(lines: &[&str], start: usize, indent: usize) -> Option<(Stri
 /// away is that `update_cook_candidate_after_completion` has an `_in_store`
 /// sibling and resolves a root of its own.
 const PRE_FIX_RECORD_AGGREGATE: &str = r#"
-pub(crate) fn update_cook_candidate_after_completion_in_store(&test_lifecycle_store(),
+pub(crate) fn update_cook_candidate_after_completion(
     record: &AgentTaskRunRecord,
     aggregate: &AgentTaskAggregate,
     promotion: Option<Value>,
@@ -745,7 +745,7 @@ pub(crate) fn record_aggregate_in_store(
     crate::controller_scratch::finalize_run_at(&lifecycle_store.data_root(), &record.run_id)?;
     lifecycle_store.write_aggregate_and_record(record, aggregate)?;
     record_terminal_artifact_projection_in_store(lifecycle_store, record, aggregate)?;
-    update_cook_candidate_after_completion_in_store(&test_lifecycle_store(), record, aggregate, None)?;
+    update_cook_candidate_after_completion(record, aggregate, None)?;
     Ok(record.clone())
 }
 "#;
@@ -753,7 +753,7 @@ pub(crate) fn record_aggregate_in_store(
 /// The same region as #12618 merged it: one call rerouted to the rooted sibling,
 /// with a comment that names the ambient function it stopped calling.
 const FIXED_RECORD_AGGREGATE: &str = r#"
-pub(crate) fn update_cook_candidate_after_completion_in_store(&test_lifecycle_store(),
+pub(crate) fn update_cook_candidate_after_completion(
     record: &AgentTaskRunRecord,
     aggregate: &AgentTaskAggregate,
     promotion: Option<Value>,
@@ -820,7 +820,7 @@ fn the_ambient_reach_check_catches_the_pre_fix_record_aggregate_in_store() {
     );
     assert!(
         findings[0].reaches[0].starts_with(
-            "`update_cook_candidate_after_completion_in_store(&test_lifecycle_store(), `"
+            "`update_cook_candidate_after_completion(`"
         ),
         "the reach must name the ambient call, not something incidental: {}",
         findings[0].reaches[0]

--- a/tests/agent_task_store_injection_test.rs
+++ b/tests/agent_task_store_injection_test.rs
@@ -819,9 +819,7 @@ fn the_ambient_reach_check_catches_the_pre_fix_record_aggregate_in_store() {
         findings[0].reaches
     );
     assert!(
-        findings[0].reaches[0].starts_with(
-            "`update_cook_candidate_after_completion(`"
-        ),
+        findings[0].reaches[0].starts_with("`update_cook_candidate_after_completion(`"),
         "the reach must name the ambient call, not something incidental: {}",
         findings[0].reaches[0]
     );


### PR DESCRIPTION
## Summary\n\nFixes #13299.\n\n- Threads the lifecycle readonly-existence probe through terminal fanout status.\n- Preserves the production ambient wrapper while rooted callers provide their own lifecycle store probe.\n- Adds parallel identical-ID two-root coverage for terminal admission status.\n- Repairs the store-isolation scanner fixtures so their ambient-wrapper preconditions are executable.\n\n## Verification\n\n- `cargo test --test agent_task_store_injection_test`\n- `cargo test -p homeboy-agents agent_task_batch::tests::terminal_status_uses_the_injected_lifecycle_store_in_parallel`\n- `cargo test --workspace` (reached a separate stale audit-baseline failure, tracked and repaired in #13304 / #13305)\n\n## AI assistance\n\nOpenAI `openai/gpt-5.6-terra` via OpenCode reproduced the current-main failure, implemented the explicit store propagation and parallel regression coverage, repaired the scanner fixtures, and ran the listed gates. Chris Huber remains responsible for the change.