### PR TITLE
Fix repeated Lab pre-provider failure dispatches

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -4,6 +4,9 @@ use homeboy_engine_primitives::content_hash;
 use sha2::Digest;
 use std::path::{Path, PathBuf};
 
+const LAB_PRE_EXECUTION_CIRCUIT_SCHEMA: &str = "homeboy/lab-pre-execution-circuit/v1";
+const LAB_PRE_EXECUTION_REPAIR_ACTION: &str = "repair_lab_pre_execution_and_retry";
+
 pub fn record_pre_execution_failure(
     run_id: &str,
     plan: &AgentTaskPlan,
@@ -178,6 +181,7 @@ fn record_pre_execution_failure_locked(
     apply_aggregate_to_record(&mut record, plan, &aggregate, aggregate_path);
     let mut failed_record = record;
     let runner_id = failed_record.runner_id().map(str::to_string);
+    let circuit = lab_pre_execution_circuit(&failed_record, plan, phase, error);
     let metadata = failed_record.ensure_metadata_object();
     if retryable {
         metadata.insert("retryable".to_string(), json!(true));
@@ -204,12 +208,168 @@ fn record_pre_execution_failure_locked(
             })).collect::<Vec<_>>(),
         }),
     );
+    if let Some(circuit) = circuit {
+        metadata.insert("lab_pre_execution_circuit".to_string(), circuit);
+    }
     let failed_record = lifecycle_store
         .write_aggregate_and_record_locked_without_terminal_projection(
             &failed_record,
             &aggregate,
         )?;
     Ok((failed_record, Some(aggregate)))
+}
+
+/// Refuse a Cook replacement only when its own prior Lab failure has the same
+/// bounded failure and execution identity. This is deliberately per-run
+/// lineage: unrelated workloads never share a circuit state.
+pub fn admit_lab_pre_execution_replay(
+    record: &AgentTaskRunRecord,
+    plan: &AgentTaskPlan,
+) -> Result<()> {
+    let Some(previous) = record.metadata.get("lab_pre_execution_circuit") else {
+        return Ok(());
+    };
+    let Some(current) = lab_pre_execution_circuit_from_failure(record, plan) else {
+        return Ok(());
+    };
+    if previous["fingerprint"] != current["fingerprint"]
+        || previous["identity"] != current["identity"]
+    {
+        return Ok(());
+    }
+    let mut error = Error::validation_invalid_argument(
+        "lab_pre_execution_circuit_breaker",
+        "identical Lab pre-provider failure is still open; repair the Lab snapshot or SSH cleanup before retrying",
+        Some(record.run_id.clone()),
+        Some(vec![format!(
+            "Repair the owning Lab failure, then retry: homeboy agent-task retry {} --run",
+            record.run_id
+        )]),
+    );
+    error.details = json!({
+        "field": "lab_pre_execution_circuit_breaker",
+        "schema": LAB_PRE_EXECUTION_CIRCUIT_SCHEMA,
+        "action": LAB_PRE_EXECUTION_REPAIR_ACTION,
+        "fingerprint": previous["fingerprint"],
+        "provider_executions_consumed": 0,
+    });
+    Err(error)
+}
+
+fn lab_pre_execution_circuit(
+    record: &AgentTaskRunRecord,
+    plan: &AgentTaskPlan,
+    phase: &str,
+    error: &Error,
+) -> Option<Value> {
+    if !is_circuit_breaking_lab_failure(phase, &error.message, &error.details)
+        || error.retryable != Some(true)
+        || record.metadata["provider_executions_consumed"]
+            .as_u64()
+            .unwrap_or_default()
+            != 0
+    {
+        return None;
+    }
+    let identity = lab_pre_execution_identity(record, plan);
+    let failure = json!({
+        "phase": bounded(phase, 128),
+        "error_code": error.code.as_str(),
+        "failure_code": error.details["field"]
+            .as_str()
+            .map(|value| bounded(value, 128))
+            .unwrap_or_else(|| error.code.as_str().to_string()),
+        "message": bounded(failure_message(&error.message, &error.details), 512),
+    });
+    let fingerprint = content_hash::sha256_hex(
+        serde_json::to_vec(&json!({ "identity": identity, "failure": failure }))
+            .expect("circuit fingerprint is serializable")
+            .as_slice(),
+    );
+    Some(json!({
+        "schema": LAB_PRE_EXECUTION_CIRCUIT_SCHEMA,
+        "state": "open",
+        "action": LAB_PRE_EXECUTION_REPAIR_ACTION,
+        "fingerprint": fingerprint,
+        "identity": identity,
+        "provider_executions_consumed": 0,
+    }))
+}
+
+fn lab_pre_execution_circuit_from_failure(
+    record: &AgentTaskRunRecord,
+    plan: &AgentTaskPlan,
+) -> Option<Value> {
+    let failure = record.metadata.get("pre_execution_failure")?;
+    let phase = failure.get("phase")?.as_str()?;
+    if !is_circuit_breaking_lab_failure(
+        phase,
+        failure["message"].as_str().unwrap_or_default(),
+        &failure["details"],
+    ) || failure["retryable"] != Value::Bool(true)
+    {
+        return None;
+    }
+    let identity = lab_pre_execution_identity(record, plan);
+    let signature = json!({
+        "phase": bounded(phase, 128),
+        "error_code": failure["error_code"].as_str().unwrap_or_default(),
+        "failure_code": failure["failure_code"].as_str().map(|value| bounded(value, 128)),
+        "message": bounded(
+            failure_message(failure["message"].as_str().unwrap_or_default(), &failure["details"]),
+            512,
+        ),
+    });
+    let fingerprint = content_hash::sha256_hex(
+        serde_json::to_vec(&json!({ "identity": identity, "failure": signature }))
+            .expect("circuit fingerprint is serializable")
+            .as_slice(),
+    );
+    Some(json!({ "fingerprint": fingerprint, "identity": identity }))
+}
+
+fn lab_pre_execution_identity(record: &AgentTaskRunRecord, plan: &AgentTaskPlan) -> Value {
+    let source = json!({
+        "source_checkout": record.metadata["source_checkout"],
+        "tasks": plan.tasks.iter().map(|task| json!({
+            "workspace": task.workspace,
+            "source_refs": task.source_refs,
+        })).collect::<Vec<_>>(),
+    });
+    let current_generation = homeboy_core::build_identity::current().display;
+    let runner_generation = record.metadata["runner_generation"]
+        .as_str()
+        .or_else(|| {
+            record
+                .metadata
+                .pointer("/runner_execution_record/generation")
+                .and_then(Value::as_str)
+        })
+        .unwrap_or(&current_generation);
+    json!({
+        "runner_id": record.runner_id().map(|value| bounded(value, 256)),
+        "runner_generation": bounded(runner_generation, 256),
+        "source_identity": content_hash::sha256_hex(
+            serde_json::to_vec(&source).expect("source identity is serializable").as_slice(),
+        ),
+    })
+}
+
+fn bounded(value: &str, limit: usize) -> String {
+    value.chars().take(limit).collect()
+}
+
+fn failure_message<'a>(message: &'a str, details: &'a Value) -> &'a str {
+    details["error"].as_str().unwrap_or(message)
+}
+
+fn is_circuit_breaking_lab_failure(phase: &str, message: &str, details: &Value) -> bool {
+    if phase != "lab_workspace_stage" {
+        return false;
+    }
+    let message = failure_message(message, details);
+    message.contains("snapshot manifests differ")
+        || message.contains("SSH stream drain exceeded its cleanup deadline")
 }
 
 fn record_transport_follow_up_failure_in_store(

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -29,7 +29,8 @@ use super::super::cook_recipe::{
 };
 use super::*;
 use crate::agent_task::{
-    AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace,
+    AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskRequest, AgentTaskSourceRef,
+    AgentTaskWorkspace,
 };
 use crate::agent_task_finalization::{
     AgentTaskPrDurableGateProof, AgentTaskPrFinalizationBackend, AgentTaskPrFinalizationReport,
@@ -7936,6 +7937,94 @@ fn retryable_pre_provider_cook(cook_id: &str, max_attempts: u32) -> AgentTaskCoo
     )
     .expect("record retryable environment failure");
     options
+}
+
+fn retryable_lab_pre_provider_cook(cook_id: &str, message: &str) -> AgentTaskCookServiceOptions {
+    let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+    options.initial_run_id = format!("{cook_id}-attempt-1");
+    options.max_attempts = 2;
+    options.initial_plan.tasks[0].executor.backend = "homeboy-lab".to_string();
+    options.initial_plan.tasks[0].source_refs = vec![AgentTaskSourceRef {
+        kind: "git".to_string(),
+        uri: "https://example.test/workload.git".to_string(),
+        revision: Some("source-a".to_string()),
+    }];
+    super::super::persist_initial_recipe(&options).expect("persist Cook recipe");
+    super::super::materialize_initial_cook_attempt(&options).expect("materialize first attempt");
+    agent_task_lifecycle::rewrite_record_for_test(&options.initial_run_id, |record| {
+        record.metadata["runner_id"] = serde_json::json!("fixture-lab");
+        record.metadata["runner_generation"] = serde_json::json!("generation-a");
+        record.metadata["source_checkout"] = serde_json::json!({ "commit": "source-a" });
+    })
+    .expect("seed Lab identity");
+    agent_task_lifecycle::record_pre_execution_failure(
+        &options.initial_run_id,
+        &options.initial_plan,
+        "lab_workspace_stage",
+        &Error::internal_io(message, None).with_retryable(true),
+    )
+    .expect("record Lab pre-provider failure");
+    options
+}
+
+#[test]
+fn snapshot_divergence_opens_a_per_cook_circuit_until_source_identity_changes() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let options = retryable_lab_pre_provider_cook(
+            "snapshot-circuit",
+            "source and staged snapshot manifests differ; refusing a mixed snapshot",
+        );
+        let source =
+            agent_task_lifecycle::exact_record(&options.initial_run_id).expect("source record");
+        assert!(source.metadata["lab_pre_execution_circuit"].is_object());
+        agent_task_lifecycle::admit_lab_pre_execution_replay(&source, &options.initial_plan)
+            .expect_err("direct admission rejects identical identity");
+        let error = crate::agent_task_service::retry(&options.initial_run_id, None, false, false)
+            .expect_err("identical snapshot replay is refused before reservation");
+        assert_eq!(error.details["field"], "lab_pre_execution_circuit_breaker");
+        assert_eq!(
+            error.details["action"],
+            "repair_lab_pre_execution_and_retry"
+        );
+        assert_eq!(
+            agent_task_lifecycle::list_records().expect("records").len(),
+            1
+        );
+        assert_eq!(
+            agent_task_lifecycle::exact_record(&options.initial_run_id)
+                .expect("source record")
+                .metadata["provider_executions_consumed"],
+            0
+        );
+
+        agent_task_lifecycle::rewrite_record_for_test(&options.initial_run_id, |record| {
+            record.metadata["source_checkout"] = serde_json::json!({ "commit": "source-b" });
+        })
+        .expect("record refreshed source identity");
+        let replay = crate::agent_task_service::retry(&options.initial_run_id, None, false, false)
+            .expect("changed source identity reopens only this Cook");
+        assert_eq!(replay.record.metadata["cook_id"], options.cook_id);
+    });
+}
+
+#[test]
+fn ssh_cleanup_circuit_reopens_when_the_runner_generation_changes() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let options = retryable_lab_pre_provider_cook(
+            "ssh-cleanup-circuit",
+            "Homeboy SSH stream drain exceeded its cleanup deadline.",
+        );
+        assert!(
+            crate::agent_task_service::retry(&options.initial_run_id, None, false, false).is_err()
+        );
+        agent_task_lifecycle::rewrite_record_for_test(&options.initial_run_id, |record| {
+            record.metadata["runner_generation"] = serde_json::json!("generation-b");
+        })
+        .expect("record reconnected runner generation");
+        let replay = crate::agent_task_service::retry(&options.initial_run_id, None, false, false)
+            .expect("new runner generation reopens the SSH cleanup circuit");
+        assert_eq!(replay.record.metadata["retry_of"], options.initial_run_id);
+    });
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -1459,6 +1459,7 @@ fn retryable_cook_attempt(
             )]),
         ));
     };
+    agent_task_lifecycle::admit_lab_pre_execution_replay(source, &source_recipe_attempt.plan)?;
     let retryable_pre_execution_failure =
         source.metadata["pre_execution_failure"]["retryable"] == serde_json::Value::Bool(true);
     if source.metadata["pre_execution_failure"].is_object() && !retryable_pre_execution_failure {


### PR DESCRIPTION
## Summary
- persist a bounded per-Cook circuit fingerprint for deterministic Lab workspace-stage snapshot divergence and SSH stream-drain cleanup failures
- refuse identical Cook retry admission with a typed owning repair action before successor reservation
- reopen only when the source identity or runner generation changes; provider execution budget remains zero

Closes #13303

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-agents snapshot_divergence_opens_a_per_cook_circuit_until_source_identity_changes --lib`
- `cargo test -p homeboy-agents ssh_cleanup_circuit_reopens_when_the_runner_generation_changes --lib`

`cargo test -p homeboy-agents --lib` was also run: 1946 passed, 57 failed. Failures are existing shared fixture/environment failures (missing temporary workspaces, git remote availability, and unrelated retry-lineage expectations); the focused new contracts pass.

## AI assistance
OpenCode using OpenAI GPT-5.6 Sol inspected the durable run, failure-recording, and retry-admission architecture; implemented the circuit breaker and contract tests; and ran the listed verification. Chris Huber remains responsible for review and merge.