### PR TITLE
refactor(agents): light up agent_task_batch for the dead-code lint

### DIFF
--- a/crates/homeboy-agents/src/lib.rs
+++ b/crates/homeboy-agents/src/lib.rs
@@ -9,10 +9,6 @@
 pub mod agent_task;
 pub mod agent_task_aggregate;
 pub mod agent_task_artifacts;
-#[allow(
-    dead_code,
-    reason = "Batch test fixtures cover alternative artifact execution paths."
-)]
 pub mod agent_task_batch;
 pub mod agent_task_candidate_baseline;
 pub mod agent_task_config_materialization;

--- a/tests/dead_code_suppression_ratchet_test.rs
+++ b/tests/dead_code_suppression_ratchet_test.rs
@@ -42,7 +42,7 @@ use std::path::{Path, PathBuf};
 /// homeboy-agents modules, plus two `#[path]`-shared test support modules that
 /// each test binary includes whole and uses in part. It is a ceiling, not a
 /// target: lower it whenever a crate is cleared, and never raise it.
-const MODULE_SUPPRESSION_CEILING: usize = 9;
+const MODULE_SUPPRESSION_CEILING: usize = 8;
 
 /// One module-level suppression, located precisely enough to act on.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
Slice 1 of the homeboy-agents dead-code sweep. One module per PR, smallest first, so each rebase window stays shorter than main's churn rate.

## What this does

Removes the module-level `#[allow(dead_code)]` on `agent_task_batch` and lowers the ratchet ceiling 9 → 8.

## The attribute suppressed nothing

Its stated reason was that batch test fixtures cover alternative artifact execution paths. Removing it produces **zero warnings**:

```
cargo check -p homeboy-agents --all-targets   0 warnings, 0 errors
cargo check --workspace --all-targets         0 warnings, 0 errors
cargo fmt --all --check                       clean
cargo test --test dead_code_suppression_ratchet_test   3 passed
```

No deletions. The module is entirely reachable.

## Why it still mattered

3,649 lines sat outside the dead-code lint. Nothing had died there yet — but anything that died from here on would have died silently, which is the exact failure mode the sweep exists to close. Four of the five crates cleared so far caught real dead items within hours of landing.

Six agents modules remain: `finalization` (6.4k), `promotion` (11.8k), `provider` (17.2k), `scheduler` (17.3k), `lifecycle` (44.5k), `service` (55.8k). Each gets its own PR.