### PR TITLE
refactor(agents): light up agent_task_finalization for the dead-code lint

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -38,10 +38,6 @@ pub fn preflight_pr(
     preflight_pr_with_backend(options, &mut RealAgentTaskPrFinalizationBackend)
 }
 
-fn validate_real_candidate_fingerprint(options: &AgentTaskPrFinalizationOptions) -> Result<()> {
-    backend::validate_real_candidate_fingerprint(options)
-}
-
 pub fn finalize_pr_with_backend<B: AgentTaskPrFinalizationBackend>(
     options: AgentTaskPrFinalizationOptions,
     backend: &mut B,

--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
 
+use super::backend::validate_real_candidate_fingerprint;
 use super::*;
 use crate::{
     agent_task::{

--- a/crates/homeboy-agents/src/lib.rs
+++ b/crates/homeboy-agents/src/lib.rs
@@ -22,10 +22,6 @@ pub mod agent_task_dispatch_service;
 pub mod agent_task_executor_evidence;
 pub mod agent_task_fanout;
 pub mod agent_task_fanout_supervisor;
-#[allow(
-    dead_code,
-    reason = "Finalization validation supports recovery-driven finalization."
-)]
 pub mod agent_task_finalization;
 pub mod agent_task_gate;
 pub mod agent_task_gate_executor;

--- a/tests/dead_code_suppression_ratchet_test.rs
+++ b/tests/dead_code_suppression_ratchet_test.rs
@@ -42,7 +42,7 @@ use std::path::{Path, PathBuf};
 /// homeboy-agents modules, plus two `#[path]`-shared test support modules that
 /// each test binary includes whole and uses in part. It is a ceiling, not a
 /// target: lower it whenever a crate is cleared, and never raise it.
-const MODULE_SUPPRESSION_CEILING: usize = 8;
+const MODULE_SUPPRESSION_CEILING: usize = 7;
 
 /// One module-level suppression, located precisely enough to act on.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
Slice 2 of the homeboy-agents sweep. **Stacks on #13311** — base is `deadcode-agents-batch`, retarget to `main` once that merges.

## The one item it surfaced

`agent_task_finalization::validate_real_candidate_fingerprint` — a private three-line forwarder:

```rust
fn validate_real_candidate_fingerprint(options: &AgentTaskPrFinalizationOptions) -> Result<()> {
    backend::validate_real_candidate_fingerprint(options)
}
```

Production never called it. `backend.rs` calls its own `pub(super)` function directly. The forwarder existed only so tests could reach it via `use super::*`.

**This is the item that broke finalization in the earlier full-crate attempt.** Two functions share the name; deleting the wrong one takes out the live path. Deleted the forwarder, imported the real function into tests — one name now means one thing.

## Verification

```
cargo check --workspace --all-targets    0 warnings, 0 errors
cargo fmt --all --check                  clean
ratchet test                             3 passed
agent_task_finalization tests            71 of 72 pass
```

The one failure, `production_validator_finalizes_only_the_adopted_merge_candidate_and_resolution_tree`, **fails identically on `origin/main`** on the same machine — `Text file busy (os error 26)` starting the promotion provider. Pre-existing and environmental, verified by checking out main and running the same case.

## Ceiling

8 → 7. The `leaves_no_slack` assertion requires the ceiling to be exact, so these slices stack rather than race.

Remaining: `promotion` (11.8k), `provider` (17.2k), `scheduler` (17.3k), `lifecycle` (44.5k), `service` (55.8k).