### PR TITLE
refactor(agents): light up agent_task_promotion for the dead-code lint

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/apply.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/apply.rs
@@ -454,6 +454,8 @@ impl ExternalPromotionWorkspaceProvider {
         self.provenance.as_ref()
     }
 
+    #[cfg(test)]
+    // Read only by the promotion test shards' provider assertions.
     pub(super) fn invocation(&self) -> Option<&CommandInvocation> {
         self.invocation.as_ref()
     }

--- a/crates/homeboy-agents/src/agent_task_promotion/committed_changes.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/committed_changes.rs
@@ -269,15 +269,6 @@ fn validate_adoption_parent_lineage(
     Ok(())
 }
 
-fn git_commit_parents(cwd: &Path, revision: &str) -> Result<Vec<String>> {
-    let output = git_stdout(cwd, &["rev-list", "--parents", "-n", "1", revision])?;
-    Ok(output
-        .split_whitespace()
-        .skip(1)
-        .map(str::to_string)
-        .collect())
-}
-
 fn is_ancestor(cwd: &Path, ancestor: &str, descendant: &str) -> Result<bool> {
     Command::new("git")
         .args(["merge-base", "--is-ancestor", ancestor, descendant])

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -618,6 +618,8 @@ fn verify_patch_is_present(
     Ok(report)
 }
 
+#[cfg(test)]
+// Provider-injection seam: production promotes through `promote`.
 pub(crate) fn promote_with_provider(
     options: AgentTaskPromotionOptions,
     provider: &mut impl AgentTaskPromotionWorkspaceProvider,
@@ -625,6 +627,8 @@ pub(crate) fn promote_with_provider(
     promote_with_provider_and_checkpoint(options, provider, &mut |_| Ok(()))
 }
 
+#[cfg(test)]
+// Checkpoint seam reached only by the promotion test shards.
 pub(super) fn promote_with_provider_and_checkpoint(
     options: AgentTaskPromotionOptions,
     provider: &mut impl AgentTaskPromotionWorkspaceProvider,
@@ -1200,6 +1204,8 @@ fn gate_feedback_baseline_for_artifact(
 /// Replace a runner-local baseline path with the controller artifact-store
 /// identity before a follow-up can reuse a dirty destination. Older baselines
 /// without source identity retain their existing strict path/hash contract.
+#[cfg(test)]
+// Superseded by `bind_gate_feedback_baseline_internal` in cb7c0317e; retained as the tests' entry point.
 pub(crate) fn bind_gate_feedback_baseline(baseline: Option<Value>) -> Result<Option<Value>> {
     // One call is one unit of work, so the store resolves once here rather
     // than at each projection lookup inside (#7505).

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/mod.rs
@@ -3,41 +3,22 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 use super::apply::{
-    preflight_configured_workspace_provider_with_config, run_provider_command,
     AgentTaskPromotionApplyRequest, AgentTaskPromotionWorkspace,
-    AgentTaskPromotionWorkspaceProvider, ExternalPromotionWorkspaceProvider,
-    AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA, AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA,
+    AgentTaskPromotionWorkspaceProvider,
 };
 
-use super::promote::{
-    normalize_promotion_patch, promote, promote_with_provider,
-    promote_with_provider_and_checkpoint, resume_promoted_patch, select_patch_artifact,
-    validate_artifact_content,
-};
+use super::promote::promote_with_provider;
 use super::types::{
-    AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandCapture,
-    AgentTaskPromotionCommandReport, AgentTaskPromotionNotification, AgentTaskPromotionOptions,
-    AgentTaskPromotionReport, AgentTaskPromotionSource, AgentTaskPromotionStatus,
-    AgentTaskPromotionTarget, AGENT_TASK_PROMOTION_REPORT_SCHEMA,
+    AgentTaskPromotionCommandCapture, AgentTaskPromotionCommandReport, AgentTaskPromotionOptions,
+    AgentTaskPromotionReport,
 };
-use crate::agent_task::{
-    AgentTaskArtifact, AgentTaskOutcome, AgentTaskOutcomeStatus, AGENT_TASK_ARTIFACT_SCHEMA,
-    AGENT_TASK_OUTCOME_SCHEMA,
-};
+use crate::agent_task::{AGENT_TASK_ARTIFACT_SCHEMA, AGENT_TASK_OUTCOME_SCHEMA};
 use crate::agent_task_gate::{
     AgentTaskGateReport, AgentTaskGateRevealPolicy, AgentTaskGateVisibility, VerifyGateOptions,
 };
-use crate::agent_task_scheduler::{AgentTaskAggregate, AgentTaskPlan};
-use homeboy_core::command_invocation::CommandInvocation;
-use homeboy_core::defaults::{
-    HomeboyConfig, WorktreeProviderCommands, WorktreeProviderConfig, WorktreeProviderKind,
-    WorktreeProviderListResultMapping,
-};
-use homeboy_core::lab_contract::AgentTaskDispatchIdentity;
 use homeboy_core::{Error, Result};
 
 pub(super) const VALID_PATCH: &str = "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n";

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
@@ -3,42 +3,29 @@
 
 use super::super::apply::{
     preflight_configured_workspace_provider_with_config, run_provider_command,
-    AgentTaskPromotionApplyRequest, AgentTaskPromotionWorkspace,
-    AgentTaskPromotionWorkspaceProvider, ExternalPromotionWorkspaceProvider,
-    AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA, AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA,
+    AgentTaskPromotionApplyRequest, AgentTaskPromotionWorkspaceProvider,
+    ExternalPromotionWorkspaceProvider, AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA,
+    AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA,
 };
 use super::super::promote::{
     normalize_promotion_patch, promote, promote_with_provider,
     promote_with_provider_and_checkpoint,
     promote_with_provider_and_checkpoint_in_observation_store, resume_promoted_patch,
-    retain_committed_changes_artifact, select_patch_artifact, validate_artifact_content,
+    retain_committed_changes_artifact,
 };
-use super::super::types::{
-    AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandCapture,
-    AgentTaskPromotionCommandReport, AgentTaskPromotionNotification, AgentTaskPromotionOptions,
-    AgentTaskPromotionReport, AgentTaskPromotionSource, AgentTaskPromotionStatus,
-    AgentTaskPromotionTarget, AGENT_TASK_PROMOTION_REPORT_SCHEMA,
-};
+use super::super::types::{AgentTaskPromotionOptions, AgentTaskPromotionStatus};
 use super::*;
-use crate::agent_task::{
-    AgentTaskArtifact, AgentTaskOutcome, AgentTaskOutcomeStatus, AGENT_TASK_ARTIFACT_SCHEMA,
-    AGENT_TASK_OUTCOME_SCHEMA,
-};
-use crate::agent_task_gate::{
-    AgentTaskGateReport, AgentTaskGateRevealPolicy, AgentTaskGateVisibility, VerifyGateOptions,
-};
-use crate::agent_task_scheduler::{AgentTaskAggregate, AgentTaskPlan};
+use crate::agent_task::AGENT_TASK_OUTCOME_SCHEMA;
+use crate::agent_task_gate::{AgentTaskGateRevealPolicy, VerifyGateOptions};
+use crate::agent_task_scheduler::AgentTaskAggregate;
 use homeboy_core::command_invocation::CommandInvocation;
 use homeboy_core::defaults::{
     HomeboyConfig, WorktreeProviderCommands, WorktreeProviderConfig, WorktreeProviderKind,
     WorktreeProviderListResultMapping,
 };
-use homeboy_core::lab_contract::AgentTaskDispatchIdentity;
 use homeboy_core::worktree::{self, WorktreeAdoptOptions};
-use homeboy_core::{Error, Result};
 use serde_json::Value;
-use sha2::{Digest, Sha256};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Command;
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -2,43 +2,28 @@
 #![cfg(test)]
 
 use super::super::apply::{
-    preflight_configured_workspace_provider_with_config, run_provider_command,
-    run_provider_command_with_timeout, AgentTaskPromotionApplyRequest, AgentTaskPromotionWorkspace,
-    AgentTaskPromotionWorkspaceProvider, ExternalPromotionWorkspaceProvider,
+    run_provider_command, run_provider_command_with_timeout, AgentTaskPromotionApplyRequest,
     AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA, AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA,
 };
 use super::super::promote::{
-    normalize_promotion_patch, promote, promote_with_provider,
-    promote_with_provider_and_checkpoint, resume_promoted_patch, select_patch_artifact,
-    validate_artifact_content,
+    normalize_promotion_patch, promote_with_provider, promote_with_provider_and_checkpoint,
+    resume_promoted_patch, select_patch_artifact, validate_artifact_content,
 };
-use super::super::types::{
-    AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandCapture,
-    AgentTaskPromotionCommandReport, AgentTaskPromotionNotification, AgentTaskPromotionOptions,
-    AgentTaskPromotionReport, AgentTaskPromotionSource, AgentTaskPromotionStatus,
-    AgentTaskPromotionTarget, AGENT_TASK_PROMOTION_REPORT_SCHEMA,
-};
+use super::super::types::{AgentTaskPromotionOptions, AgentTaskPromotionStatus};
 use super::*;
 use crate::agent_task::{
-    AgentTaskArtifact, AgentTaskOutcome, AgentTaskOutcomeStatus, AGENT_TASK_ARTIFACT_SCHEMA,
-    AGENT_TASK_OUTCOME_SCHEMA,
+    AgentTaskArtifact, AgentTaskOutcome, AGENT_TASK_ARTIFACT_SCHEMA, AGENT_TASK_OUTCOME_SCHEMA,
 };
 use crate::agent_task_gate::{
-    AgentTaskGateEnvironmentPolicy, AgentTaskGateExecutionPolicy, AgentTaskGateReport,
-    AgentTaskGateRevealPolicy, AgentTaskGateStatus, AgentTaskGateVisibility, VerifyGateOptions,
+    AgentTaskGateEnvironmentPolicy, AgentTaskGateExecutionPolicy, AgentTaskGateRevealPolicy,
+    AgentTaskGateStatus, AgentTaskGateVisibility, VerifyGateOptions,
 };
 use crate::agent_task_scheduler::{AgentTaskAggregate, AgentTaskPlan};
 use homeboy_core::command_invocation::CommandInvocation;
-use homeboy_core::defaults::{
-    HomeboyConfig, WorktreeProviderCommands, WorktreeProviderConfig, WorktreeProviderKind,
-    WorktreeProviderListResultMapping,
-};
-use homeboy_core::lab_contract::AgentTaskDispatchIdentity;
-use homeboy_core::{Error, Result};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
@@ -3,29 +3,21 @@
 
 use super::super::apply::{
     preflight_configured_workspace_provider_with_config, run_provider_command,
-    AgentTaskPromotionApplyRequest, AgentTaskPromotionWorkspace,
-    AgentTaskPromotionWorkspaceProvider, ExternalPromotionWorkspaceProvider,
-    TrustedUnpushedCandidateDestination, AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA,
-    AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA,
+    AgentTaskPromotionApplyRequest, AgentTaskPromotionWorkspaceProvider,
+    ExternalPromotionWorkspaceProvider, TrustedUnpushedCandidateDestination,
+    AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA,
 };
 use super::super::promote::{
-    normalize_promotion_patch, promote, promote_with_provider,
-    promote_with_provider_and_checkpoint, resume_promoted_patch, select_patch_artifact,
-    validate_artifact_content,
+    normalize_promotion_patch, promote, promote_with_provider, select_patch_artifact,
 };
-use super::super::types::{
-    AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandCapture,
-    AgentTaskPromotionCommandReport, AgentTaskPromotionNotification, AgentTaskPromotionOptions,
-    AgentTaskPromotionReport, AgentTaskPromotionSource, AgentTaskPromotionStatus,
-    AgentTaskPromotionTarget, AGENT_TASK_PROMOTION_REPORT_SCHEMA,
-};
+use super::super::types::{AgentTaskPromotionOptions, AgentTaskPromotionStatus};
 use super::*;
 use crate::agent_task::{
     AgentTaskArtifact, AgentTaskOutcome, AgentTaskOutcomeStatus, AGENT_TASK_ARTIFACT_SCHEMA,
     AGENT_TASK_OUTCOME_SCHEMA,
 };
 use crate::agent_task_gate::{
-    AgentTaskGateReport, AgentTaskGateRevealPolicy, AgentTaskGateVisibility, VerifyGateOptions,
+    AgentTaskGateRevealPolicy, AgentTaskGateVisibility, VerifyGateOptions,
 };
 use crate::agent_task_scheduler::{AgentTaskAggregate, AgentTaskPlan};
 use homeboy_core::command_invocation::CommandInvocation;
@@ -34,11 +26,8 @@ use homeboy_core::defaults::{
     WorktreeProviderListResultMapping,
 };
 use homeboy_core::lab_contract::AgentTaskDispatchIdentity;
-use homeboy_core::{Error, Result};
 use serde_json::Value;
-use sha2::{Digest, Sha256};
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::path::PathBuf;
 
 #[test]
 fn bridge_reconciliation_marks_missing_or_mismatched_finalized_bytes_pending() {

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
@@ -2,42 +2,26 @@
 #![cfg(test)]
 
 use super::super::apply::{
-    preflight_configured_workspace_provider_with_config, run_provider_command,
-    AgentTaskPromotionApplyRequest, AgentTaskPromotionWorkspace,
-    AgentTaskPromotionWorkspaceProvider, ExternalPromotionWorkspaceProvider,
-    AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA, AGENT_TASK_PROMOTION_APPLY_RESPONSE_SCHEMA,
+    AgentTaskPromotionApplyRequest, AgentTaskPromotionWorkspaceProvider,
+    ExternalPromotionWorkspaceProvider, AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA,
 };
-use super::super::promote::{
-    normalize_promotion_patch, promote, promote_with_provider,
-    promote_with_provider_and_checkpoint, resume_promoted_patch, select_patch_artifact,
-    validate_artifact_content,
-};
+use super::super::promote::{normalize_promotion_patch, promote_with_provider};
 use super::super::types::{
-    AgentTaskPromotionArtifactRef, AgentTaskPromotionCommandCapture,
-    AgentTaskPromotionCommandReport, AgentTaskPromotionNotification, AgentTaskPromotionOptions,
+    AgentTaskPromotionArtifactRef, AgentTaskPromotionNotification, AgentTaskPromotionOptions,
     AgentTaskPromotionReport, AgentTaskPromotionSource, AgentTaskPromotionStatus,
     AgentTaskPromotionTarget, AGENT_TASK_PROMOTION_REPORT_SCHEMA,
 };
 use super::*;
-use crate::agent_task::{
-    AgentTaskArtifact, AgentTaskOutcome, AgentTaskOutcomeStatus, AGENT_TASK_ARTIFACT_SCHEMA,
-    AGENT_TASK_OUTCOME_SCHEMA,
-};
+use crate::agent_task::{AGENT_TASK_ARTIFACT_SCHEMA, AGENT_TASK_OUTCOME_SCHEMA};
 use crate::agent_task_gate::{
-    AgentTaskGateReport, AgentTaskGateRevealPolicy, AgentTaskGateVisibility, VerifyGateOptions,
+    AgentTaskGateRevealPolicy, AgentTaskGateVisibility, VerifyGateOptions,
 };
-use crate::agent_task_scheduler::{AgentTaskAggregate, AgentTaskPlan};
-use homeboy_core::command_invocation::CommandInvocation;
 use homeboy_core::defaults::{
     HomeboyConfig, WorktreeProviderCommands, WorktreeProviderConfig, WorktreeProviderKind,
     WorktreeProviderListResultMapping,
 };
-use homeboy_core::lab_contract::AgentTaskDispatchIdentity;
-use homeboy_core::{Error, Result};
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 #[test]
 fn promotion_uses_verified_controller_projection_for_recovered_runner_aggregate_sources() {

--- a/crates/homeboy-agents/src/lib.rs
+++ b/crates/homeboy-agents/src/lib.rs
@@ -39,11 +39,6 @@ pub mod agent_task_model;
 // and controller lifecycle notifications. Cook's own emitters stay internal.
 pub mod agent_task_notify;
 mod agent_task_process_containment;
-#[allow(
-    dead_code,
-    unused_imports,
-    reason = "Promotion test shards share fixtures and provider helpers."
-)]
 pub mod agent_task_promotion;
 pub mod agent_task_prompts;
 #[allow(

--- a/tests/dead_code_suppression_ratchet_test.rs
+++ b/tests/dead_code_suppression_ratchet_test.rs
@@ -42,7 +42,7 @@ use std::path::{Path, PathBuf};
 /// homeboy-agents modules, plus two `#[path]`-shared test support modules that
 /// each test binary includes whole and uses in part. It is a ceiling, not a
 /// target: lower it whenever a crate is cleared, and never raise it.
-const MODULE_SUPPRESSION_CEILING: usize = 7;
+const MODULE_SUPPRESSION_CEILING: usize = 6;
 
 /// One module-level suppression, located precisely enough to act on.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
Slice 3. **Stacks on #13312** (which stacks on #13311). Retarget as each lands.

## What the attribute was hiding

It suppressed `unused_imports` as well as `dead_code`. Removing it surfaced **85 unused imports** across the five test shards, plus six dead items.

## The dead items share one shape

A refactor introduces a variant with a wider signature, repoints production at it, and leaves the original name alive because tests still call it:

| orphaned | production moved to |
|---|---|
| `promote_with_provider` | `promote_with_provider_and_checkpoint` |
| `bind_gate_feedback_baseline` | `bind_gate_feedback_baseline_internal` (cb7c0317e) |

**This is the third slice in a row to find it** — #13312 found the same shape in `agent_task_finalization`. The module attribute is what let them accumulate without anyone noticing the old name had become test-only scaffolding.

Both now carry `#[cfg(test)]` naming what they actually are.

## One near-miss worth recording

`ExternalPromotionWorkspaceProvider::invocation` is reported dead by the **lib** build and is required by the **test** build. Deleting it produced eight `E0599`s. It is gated rather than removed.

That is the argument for compiling between every step instead of trusting a single warning list — a `--all-targets` warning set mixes findings from configurations with different reachability.

`git_commit_parents` had no callers in any configuration and is deleted outright.

## Verification

```
cargo check --workspace --all-targets    0 warnings, 0 errors
cargo fmt --all --check                  clean
ratchet test                             3 passed
agent_task_promotion tests               102 pass / 2 fail
origin/main, same box, same filter       102 pass / 2 fail  (identical names)
```

No regressions.

## Ceiling

7 → 6. Remaining: `provider` (17.2k), `scheduler` (17.3k), `lifecycle` (44.5k), `service` (55.8k).