### PR TITLE
fix: retain controller runtime provenance in status

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -1291,6 +1291,15 @@ fn normalized_full_status(
     let output = json!({
         "schema": "homeboy/agent-task-status-full/v2",
         "presentation": "normalized_evidence_graph",
+        "metadata": {
+            "controller_runtime": value.pointer("/metadata/controller_runtime/originating").map(|originating| json!({
+                "originating": {
+                    "build_identity": bounded_value(originating.get("build_identity").unwrap_or(&Value::Null)),
+                    "sha256": bounded_value(originating.get("sha256").unwrap_or(&Value::Null)),
+                    "source": bounded_value(originating.get("source").unwrap_or(&Value::Null)),
+                }
+            })).unwrap_or(Value::Null),
+        },
         "action_eligibility": value.get("action_eligibility").cloned().unwrap_or(Value::Null),
         "outcome": {
             "run_id": bounded_value(value.get("run_id").unwrap_or(&Value::Null)),


### PR DESCRIPTION
## Summary
- retain bounded controller runtime identity, digest, and compiled source provenance in full agent-task status
- fixes #13313 without reading repository state from the caller worktree

## Verification
- cargo fmt --check
- cargo build --bin homeboy && cargo test -p homeboy --test controller_runtime_provenance

## AI assistance
OpenAI openai/gpt-5.6-terra via OpenCode investigated the regression, implemented the bounded status projection, and ran the focused verification. Chris Huber remains responsible for the change.