### PR TITLE
fix(agents): preflight provider model identity

### DIFF
--- a/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
@@ -168,7 +168,10 @@ pub fn build_dispatch_plan_with_provider_requirements(
     let policy_model = initial_route
         .as_ref()
         .and_then(|route| route.model.clone())
-        .or_else(|| request.model.clone());
+        .or_else(|| request.model.clone())
+        // Provider configuration is part of Cook's declared selection surface.
+        // Persist it so readiness, execution, and finalization share one model.
+        .or_else(|| config_string(&provider_config, "model"));
     let resolved_rotation = initial_route
         .as_ref()
         .and_then(|route| route.rotation.clone());

--- a/crates/homeboy-agents/src/agent_task_dispatch_service.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_service.rs
@@ -210,7 +210,7 @@ fn dispatch_with_provider_catalog(
             catalog.provider_requires_cwd_git_checkout(backend, selector)
         })?;
     catalog.apply_provider_runner_secret_env_contracts(&mut plan);
-    catalog.validate_explicit_models(&plan)?;
+    catalog.validate_selected_models(&plan)?;
     catalog.enforce_runtime_preflight_checks_for_plan(&plan)?;
     preflight_dispatch_provider_secrets(&plan)?;
     preflight_plan_provider_config_with_providers(&plan, catalog.providers())?;
@@ -244,7 +244,7 @@ pub fn dispatch_with_provider_requirements(
         provider_requires_cwd_git_checkout,
     )?;
     apply_provider_runner_secret_env_contracts(&mut plan);
-    AgentTaskProviderCatalog::discover().validate_explicit_models(&plan)?;
+    AgentTaskProviderCatalog::discover().validate_selected_models(&plan)?;
     enforce_runtime_preflight_checks_for_plan(&plan)?;
     preflight_dispatch_provider_secrets(&plan)?;
     preflight_plan_provider_config_with_providers(
@@ -403,13 +403,23 @@ pub fn resolve_cook_initial_provider_route_with_catalog(
     catalog: &AgentTaskProviderCatalog,
 ) -> Result<AgentTaskInitialProviderRoute> {
     let request = resolve_dispatch_request(command)?;
-    Ok(initial_provider_route_from_policy(
-        controller_resolved_execution_policy_with_sources(
+    let mut route =
+        initial_provider_route_from_policy(controller_resolved_execution_policy_with_sources(
             &request,
             catalog,
             configured_rotation_policy(),
-        ),
-    ))
+        ));
+    // Provider configuration is the configured-model source used by Cook when
+    // policy and CLI do not select one. Keep discovery on the same default.
+    if route.model.is_none() {
+        route.model = homeboy_core::defaults::load_config()
+            .settings
+            .get("model")
+            .and_then(Value::as_str)
+            .filter(|model| !model.trim().is_empty())
+            .map(str::to_string);
+    }
+    Ok(route)
 }
 
 fn configured_rotation_policy() -> Option<AgentTaskProviderRotationPolicy> {

--- a/crates/homeboy-agents/src/agent_task_provider/catalog.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/catalog.rs
@@ -147,14 +147,15 @@ impl AgentTaskProviderCatalog {
         apply_provider_runner_secret_env_contracts_with_providers(plan, &self.providers);
     }
 
-    /// Validate explicit model requests before provider dispatch when a provider
-    /// declares its supported models. Providers with no declarations retain a
-    /// provider-generic model namespace.
-    pub fn validate_explicit_models(&self, plan: &AgentTaskPlan) -> homeboy_core::Result<()> {
+    /// Validate the concrete model selection before provider dispatch. A Cook
+    /// candidate needs durable model provenance, so a provider that cannot name
+    /// its selected model is not dispatchable for Cook.
+    pub fn validate_selected_models(&self, plan: &AgentTaskPlan) -> homeboy_core::Result<()> {
         for task in &plan.tasks {
-            let Some(requested) = task.metadata["model_selection"]["requested"].as_str() else {
-                continue;
-            };
+            let selected = task
+                .executor
+                .model()
+                .or_else(|| task.metadata["model_selection"]["selected"].as_str());
             let ProviderResolution::Resolved(provider) = resolve_provider_for_backend(
                 &self.providers,
                 &task.executor.backend,
@@ -170,14 +171,31 @@ impl AgentTaskProviderCatalog {
                 .collect::<Vec<_>>();
             supported.sort();
             supported.dedup();
-            if !supported.is_empty() && !supported.iter().any(|model| model == requested) {
+            let Some(selected) = selected.filter(|model| !model.trim().is_empty()) else {
+                // Providers without a declared model catalog can only attest an
+                // actual model at runtime. Preserve that generic adapter path;
+                // terminal provenance remains mandatory before promotion.
+                if supported.is_empty() {
+                    continue;
+                }
                 return Err(Error::validation_invalid_argument(
                     "model",
                     format!(
-                        "provider `{}` does not support requested model `{requested}`",
+                        "provider `{}` has no concrete selected model; pass --model or configure provider model selection",
                         provider.id
                     ),
-                    Some(requested.to_string()),
+                    None,
+                    Some(vec!["Run `homeboy agent-task providers --backend <backend> --validate-readiness` to inspect configured model selection.".to_string()]),
+                ));
+            };
+            if !supported.is_empty() && !supported.iter().any(|model| model == selected) {
+                return Err(Error::validation_invalid_argument(
+                    "model",
+                    format!(
+                        "provider `{}` does not support selected model `{selected}`",
+                        provider.id
+                    ),
+                    Some(selected.to_string()),
                     Some(vec![format!("supported models: {}", supported.join(", "))]),
                 ));
             }
@@ -870,12 +888,34 @@ mod tests {
         );
 
         let error = catalog
-            .validate_explicit_models(&plan)
+            .validate_selected_models(&plan)
             .expect_err("unsupported model");
-        assert!(error.message.contains("does not support requested model"));
+        assert!(error.message.contains("does not support selected model"));
         assert_eq!(
             error.details["tried"][0].as_str(),
             Some("supported models: openai/gpt-5.6-sol, openai/gpt-5.6-terra")
         );
+    }
+
+    #[test]
+    fn selected_model_is_required_before_provider_dispatch() {
+        let catalog = disclosure_catalog();
+        let mut plan = AgentTaskPlan::new("missing-model", Vec::new());
+        plan.tasks.push(
+            serde_json::from_value(serde_json::json!({
+                "schema": crate::agent_task::AGENT_TASK_REQUEST_SCHEMA,
+                "task_id": "task",
+                "executor": { "backend": "opencode" },
+                "instructions": "Cook",
+                "workspace": { "mode": "existing" }
+            }))
+            .expect("task"),
+        );
+
+        let error = catalog
+            .validate_selected_models(&plan)
+            .expect_err("missing model must fail before execution");
+        assert_eq!(error.details["field"], "model");
+        assert!(error.message.contains("no concrete selected model"));
     }
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -2590,7 +2590,7 @@ pub fn compile_cook_attempt_with_catalog_and_readiness_cache(
             &request,
             |backend, selector| catalog.provider_requires_cwd_git_checkout(backend, selector),
         )?;
-    catalog.validate_explicit_models(&options.initial_plan)?;
+    catalog.validate_selected_models(&options.initial_plan)?;
     crate::agent_task_provider::preflight_plan_provider_config_with_providers(
         &options.initial_plan,
         catalog.providers(),
@@ -3828,6 +3828,10 @@ pub fn terminal_review_form_continuation_is_eligible(
 /// This deliberately stops before recipe/lifecycle materialization, transport
 /// preparation, provider dispatch, and finalization.
 pub fn preflight_cook_continuation_admission(options: &AgentTaskCookServiceOptions) -> Result<()> {
+    // Continuation can lead directly to promotion/finalization. Apply the same
+    // durable model-provenance boundary here so it cannot admit a legacy null
+    // model candidate that publication will deterministically reject.
+    super::cook_promotion::validate_cook_attempt_model_provenance(&options.initial_run_id)?;
     let moving_base_continuation = agent_task_lifecycle::status(&options.initial_run_id)
         .ok()
         .and_then(|record| record.metadata.get("cook_moving_base_recovery").cloned())

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -4358,6 +4358,18 @@ fn required_execution_model(execution: &CookAttemptExecution, run_id: &str) -> R
     })
 }
 
+/// Shared continuation/finalization admission. Legacy attempts without durable
+/// model evidence are rejected before a continuation can claim or promote them.
+pub(crate) fn validate_cook_attempt_model_provenance(run_id: &str) -> Result<()> {
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    required_execution_model(
+        &cook_attempt_execution_in_store(&lifecycle_store, run_id)?,
+        run_id,
+    )
+    .map(|_| ())
+}
+
 fn cook_ai_lineage_with_stores(
     store: &super::cook_recipe::CookRecipeStore,
     lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -4360,7 +4360,7 @@ fn required_execution_model(execution: &CookAttemptExecution, run_id: &str) -> R
 
 /// Shared continuation/finalization admission. Legacy attempts without durable
 /// model evidence are rejected before a continuation can claim or promote them.
-pub(crate) fn validate_cook_attempt_model_provenance(run_id: &str) -> Result<()> {
+pub fn validate_cook_attempt_model_provenance(run_id: &str) -> Result<()> {
     let lifecycle_store =
         agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
     required_execution_model(

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -129,7 +129,7 @@ pub fn validate_plan_spec(spec: &str) -> AgentTaskPlanValidationReport {
     for (kind, result) in [
         (
             AgentTaskPlanValidationKind::UnavailableCapability,
-            catalog.validate_explicit_models(&plan),
+            catalog.validate_selected_models(&plan),
         ),
         (
             AgentTaskPlanValidationKind::MissingReadiness,
@@ -1991,7 +1991,7 @@ fn preflight_queued_plan_provider_eligibility(plan: &AgentTaskPlan) -> Result<()
     let mut plan = plan.clone();
     let catalog = crate::agent_task_provider::AgentTaskProviderCatalog::discover();
     catalog.apply_provider_runner_secret_env_contracts(&mut plan);
-    catalog.validate_explicit_models(&plan)?;
+    catalog.validate_selected_models(&plan)?;
     catalog.enforce_runtime_preflight_checks_for_plan(&plan)?;
     preflight_plan_secret_env(&plan)?;
     crate::agent_task_provider::preflight_plan_provider_config_with_providers(

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
@@ -409,6 +409,9 @@ pub struct ProvidersArgs {
         value_name = "PROVIDER_ID"
     )]
     pub selector: Option<String>,
+    /// Validate or report this exact model selection using Cook's provider route.
+    #[arg(long = "model", value_name = "MODEL")]
+    pub model: Option<String>,
     /// Restrict results to the runtime that owns the provider.
     #[arg(long = "runtime", value_name = "RUNTIME")]
     pub runtime: Option<String>,

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -1841,6 +1841,21 @@ fn compile_batch_cooks(
                 invocation.dispatch,
                 &mut readiness_cache,
             )?;
+            if let Some(executor) = options
+                .initial_plan
+                .tasks
+                .first()
+                .map(|task| &task.executor)
+            {
+                let model = executor.model().map(str::to_string);
+                options.ai_tool = resolve_ai_tool_disclosure(
+                    &options.ai_tool,
+                    Some(&executor.backend),
+                    executor.selector.as_deref(),
+                    model.as_deref(),
+                );
+                options.ai_model = model;
+            }
             options.harvest_context = harvest_context.clone();
             configure(&mut options);
             Ok(options)

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -1900,11 +1900,16 @@ impl ProviderRoute {
             Self::Resolved {
                 backend,
                 provider_id,
+                model,
                 ..
             } => format!(
-                "homeboy agent-task providers --backend {} --selector {} --validate-readiness",
+                "homeboy agent-task providers --backend {} --selector {}{} --validate-readiness",
                 shell_arg(backend),
                 shell_arg(provider_id),
+                model
+                    .as_deref()
+                    .map(|model| format!(" --model {}", shell_arg(model)))
+                    .unwrap_or_default(),
             ),
             Self::Blocked { next_command, .. } => next_command.clone(),
             Self::SelectionRequired { choices } => choices
@@ -3051,6 +3056,21 @@ mod tests {
         assert_eq!(
             command,
             "homeboy agent-task providers --full --backend 'backend; touch /tmp/unwanted' --selector 'provider id'"
+        );
+    }
+
+    #[test]
+    fn provider_route_replay_preserves_the_selected_model() {
+        let route = ProviderRoute::Resolved {
+            backend: "opencode".to_string(),
+            provider_id: "opencode.executor".to_string(),
+            model: Some("openai/gpt-5.6-sol".to_string()),
+            dispatchable: true,
+        };
+
+        assert_eq!(
+            route.next_command(),
+            "homeboy agent-task providers --backend opencode --selector opencode.executor --model openai/gpt-5.6-sol --validate-readiness"
         );
     }
 

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -1935,6 +1935,7 @@ fn resolve_provider_route(
     resolve_provider_route_for(
         args.backend.clone(),
         args.selector.clone(),
+        args.model.clone(),
         catalog,
         args.validate_readiness,
     )
@@ -1946,6 +1947,7 @@ fn resolve_provider_route(
 fn resolve_provider_route_for(
     backend: Option<String>,
     selector: Option<String>,
+    model: Option<String>,
     catalog: &AgentTaskProviderCatalog,
     probe_runtime: bool,
 ) -> Option<ProviderRoute> {
@@ -1953,6 +1955,7 @@ fn resolve_provider_route_for(
     let command = agent_task_dispatch_service::AgentTaskDispatchCommand {
         backend,
         selector,
+        model,
         ..Default::default()
     };
     let route = match agent_task_dispatch_service::resolve_cook_initial_provider_route_with_catalog(
@@ -1978,12 +1981,33 @@ fn resolve_provider_route_for(
         &route.backend,
         route.selector.as_deref(),
     ) {
-        ProviderResolution::Resolved(provider) => Some(ProviderRoute::Resolved {
-            backend: route.backend,
-            provider_id: provider.id.clone(),
-            model: route.model,
-            dispatchable: provider_credential_readiness(provider).dispatchable,
-        }),
+        ProviderResolution::Resolved(provider) => {
+            if probe_runtime
+                && route.model.as_deref().is_none_or(str::is_empty)
+                && provider
+                    .cli
+                    .profiles
+                    .iter()
+                    .any(|profile| profile.model.is_some())
+            {
+                return Some(ProviderRoute::Blocked {
+                    reason: format!(
+                        "Cook resolved backend `{}` but no concrete model; pass --model or configure provider model selection",
+                        route.backend
+                    ),
+                    next_command: format!(
+                        "homeboy agent-task providers --backend {} --model <model> --validate-readiness",
+                        shell_arg(&route.backend)
+                    ),
+                });
+            }
+            Some(ProviderRoute::Resolved {
+                backend: route.backend,
+                provider_id: provider.id.clone(),
+                model: route.model,
+                dispatchable: provider_credential_readiness(provider).dispatchable,
+            })
+        }
         ProviderResolution::AmbiguousExtensionAlias { mut candidate_ids } => {
             candidate_ids.sort();
             Some(ProviderRoute::Ambiguous {
@@ -2105,6 +2129,43 @@ fn validate_effective_provider_route(
             Some(vec![route.next_command()]),
         ));
     };
+    let provider = catalog
+        .providers()
+        .iter()
+        .find(|provider| provider.id == *provider_id)
+        .expect("resolved provider route is catalog-backed");
+    let mut supported_models = provider
+        .cli
+        .profiles
+        .iter()
+        .filter_map(|profile| profile.model.as_deref())
+        .collect::<Vec<_>>();
+    supported_models.sort_unstable();
+    supported_models.dedup();
+    if !supported_models.is_empty()
+        && !model
+            .as_deref()
+            .is_some_and(|model| supported_models.iter().any(|available| *available == model))
+    {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "model",
+            match model {
+                Some(model) => format!(
+                    "provider `{}` does not support selected model `{model}`",
+                    provider.id
+                ),
+                None => format!(
+                    "provider `{}` has no concrete selected model; pass --model or configure provider model selection",
+                    provider.id
+                ),
+            },
+            model.clone(),
+            Some(vec![format!(
+                "supported models: {}",
+                supported_models.join(", ")
+            )]),
+        ));
+    }
     preflight_provider_dispatchability(catalog, backend, Some(provider_id), model.as_deref())?;
     Ok(Some((backend.clone(), provider_id.clone())))
 }
@@ -2140,7 +2201,13 @@ fn declared_backend_readiness(
                         .any(|provider| provider.backend == backend && provider.id == *selector)
                 })
                 .map(str::to_string);
-            let route = resolve_provider_route_for(Some(backend.clone()), selector, catalog, true);
+            let route = resolve_provider_route_for(
+                Some(backend.clone()),
+                selector,
+                args.model.clone(),
+                catalog,
+                true,
+            );
             let (identity, failure) =
                 match validate_effective_provider_route(route.as_ref(), catalog) {
                     Ok(identity) => (identity, None),
@@ -2284,6 +2351,7 @@ fn provider_full_command(args: &ProvidersArgs) -> String {
     for (flag, value) in [
         ("backend", args.backend.as_deref()),
         ("selector", args.selector.as_deref()),
+        ("model", args.model.as_deref()),
         ("runtime", args.runtime.as_deref()),
         ("status", args.status.as_deref()),
     ] {
@@ -2969,6 +3037,7 @@ mod tests {
         let command = provider_full_command(&ProvidersArgs {
             backend: Some("backend; touch /tmp/unwanted".to_string()),
             selector: Some("provider id".to_string()),
+            model: None,
             runtime: None,
             status: None,
             secret_env: Vec::new(),
@@ -3006,6 +3075,7 @@ mod tests {
         ProvidersArgs {
             backend: None,
             selector: None,
+            model: None,
             runtime: None,
             status: None,
             secret_env: Vec::new(),

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -4898,7 +4898,7 @@ pub(crate) fn compile_cook_plan(
         }
     }
     homeboy::agents::agent_task_provider::AgentTaskProviderCatalog::discover()
-        .validate_explicit_models(&plan)?;
+        .validate_selected_models(&plan)?;
     record_cook_goal(&mut plan, args.goal.as_deref());
     if !args.provider_evidence_inputs.is_empty() {
         for task in &mut plan.tasks {

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -2395,6 +2395,29 @@ pub(crate) fn preflight_continue_cook(args: CookContinueArgs) -> CmdResult<Value
                 ))
             }
         };
+    // A terminal legacy candidate with no model can never finalize. Reject it
+    // before reconciliation can enqueue a continuation or reserve promotion.
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    if lifecycle_store
+        .read_record(&run_id)
+        .is_ok_and(|record| record.state.is_terminal())
+    {
+        if let Err(error) =
+            agent_task_service_direct::validate_cook_attempt_model_provenance(&run_id)
+        {
+            return Ok((
+                cook_continuation_preflight_report(
+                    selected_run_id,
+                    candidate_fingerprint,
+                    phases,
+                    "model_provenance",
+                    &error,
+                ),
+                1,
+            ));
+        }
+    }
     let record = match agent_task_service::reconcile_recipe_attempt_for_continuation(
         &recipe, &run_id,
     ) {
@@ -4262,11 +4285,16 @@ pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress(
         .commit_message
         .clone()
         .unwrap_or_else(|| default_loop_commit_message(&args));
-    let selected_model = initial_plan
-        .tasks
-        .first()
-        .and_then(|task| task.executor.model())
-        .map(str::to_string);
+    let selected_identity = initial_plan.tasks.first().map(|task| {
+        (
+            task.executor.backend.clone(),
+            task.executor.selector.clone(),
+            task.executor.model().map(str::to_string),
+        )
+    });
+    let selected_model = selected_identity
+        .as_ref()
+        .and_then(|(_, _, model)| model.clone());
     let durable_observer = |event: &agent_task_service::CookProgressEvent<'_>| {
         if no_progress && event.phase != "durable_identity" {
             return Ok(());
@@ -4318,9 +4346,11 @@ pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress(
             protected_branches: args.protected_branches,
             ai_tool: super::fanout::resolve_ai_tool_disclosure(
                 &args.ai_tool,
-                args.dispatch.backend.as_deref(),
-                args.dispatch.selector.as_deref(),
-                args.dispatch.model.as_deref(),
+                selected_identity.as_ref().map(|(backend, _, _)| backend.as_str()),
+                selected_identity
+                    .as_ref()
+                    .and_then(|(_, selector, _)| selector.as_deref()),
+                selected_model.as_deref(),
             ),
             // Model identity comes only from explicit/config/rotation selection
             // (`--model`, provider profile). Disclosure text like

--- a/crates/homeboy-cli/src/commands/agent_task/tests/contract.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/contract.rs
@@ -8,6 +8,7 @@ fn providers_output_includes_core_capability_contract() {
         let (value, status) = review::providers(ProvidersArgs {
             backend: None,
             selector: None,
+            model: None,
             runtime: None,
             status: None,
             secret_env: Vec::new(),
@@ -56,6 +57,7 @@ fn providers_output_declares_the_scope_it_observed() {
         let result = review::providers(ProvidersArgs {
             backend: None,
             selector: None,
+            model: None,
             runtime: None,
             status: None,
             secret_env: Vec::new(),

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -1059,6 +1059,123 @@ fn status_and_cook_continue_materialize_recipe_only_attempt_without_provider_wor
 }
 
 #[test]
+fn cook_continue_preflight_rejects_legacy_terminal_candidate_without_model_provenance() {
+    with_temp_home(|| {
+        let cook_id = "cook-legacy-null-model";
+        let run_id = "cook-legacy-null-model-attempt-1";
+        let plan = AgentTaskPlan::new(
+            "cook-legacy-null-model-plan",
+            vec![serde_json::from_value(json!({
+                "task_id": "provider",
+                "executor": { "backend": "fixture" },
+                "instructions": "legacy candidate"
+            }))
+            .expect("provider task")],
+        );
+        let options = homeboy::agents::agent_task_service::AgentTaskCookServiceOptions {
+            cook_id: cook_id.to_string(),
+            initial_run_id: run_id.to_string(),
+            initial_plan: plan.clone(),
+            to_worktree: "fixture@legacy-null-model".to_string(),
+            source_worktree_path: None,
+            provider_command: None,
+            provider_invocation: None,
+            gates: Default::default(),
+            max_attempts: 1,
+            no_finalize: true,
+            draft_pr: false,
+            base: "main".to_string(),
+            task_base_sha: None,
+            head: None,
+            title: "Legacy candidate".to_string(),
+            commit_message: "Legacy candidate".to_string(),
+            source_refs: Vec::new(),
+            protected_branches: Vec::new(),
+            ai_tool: "fixture".to_string(),
+            ai_model: None,
+            ai_used_for: "test".to_string(),
+            attempt_dispatcher: None,
+            harvest_context: homeboy::agents::agent_task_scheduler::HarvestExecutionContext::from_current_process()
+                .expect("harvest context"),
+        };
+        homeboy::agents::agent_task_service::persist_initial_recipe(&options)
+            .expect("persist legacy recipe");
+        agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("submit legacy attempt");
+        agent_task_lifecycle::record_cook_attempt_in_store(
+            &test_lifecycle_store(),
+            cook_id,
+            1,
+            run_id,
+        )
+        .expect("bind attempt to recipe");
+        agent_task_lifecycle::record_run_aggregate(
+            run_id,
+            &plan,
+            &AgentTaskAggregate {
+                schema: "homeboy/agent-task-aggregate/v1".to_string(),
+                plan_id: plan.plan_id.clone(),
+                status: homeboy::agents::agent_tasks::scheduler::AgentTaskAggregateStatus::CandidateRecoverable,
+                totals: Default::default(),
+                outcomes: vec![AgentTaskOutcome {
+                    schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+                    task_id: "provider".to_string(),
+                    status: AgentTaskOutcomeStatus::CandidateRecoverable,
+                    summary: Some("legacy candidate".to_string()),
+                    failure_classification: None,
+                    artifacts: Vec::new(),
+                    typed_artifacts: Vec::new(),
+                    evidence_refs: Vec::new(),
+                    diagnostics: Vec::new(),
+                    outputs: Value::Null,
+                    workflow: None,
+                    follow_up: None,
+                    metadata: Value::Null,
+                }],
+                events: Vec::new(),
+                artifact_lineage: Vec::new(),
+                child_runs: Vec::new(),
+                artifact_bindings: Vec::new(),
+                queue: Default::default(),
+            },
+        )
+        .expect("persist terminal legacy candidate");
+        let before = filesystem_snapshot(&homeboy::core::paths::homeboy_data().expect("data root"));
+
+        let (report, exit_code) = super::super::run::preflight_continue_cook(CookContinueArgs {
+            cook_or_attempt_id: cook_id.to_string(),
+            preflight: true,
+            rearm: false,
+            artifact_id: None,
+            full: false,
+        })
+        .expect("preflight reports provenance rejection");
+
+        assert_eq!(exit_code, 1);
+        assert_eq!(report["admitted"], false);
+        assert_eq!(
+            report["phases"]
+                .as_array()
+                .expect("phases")
+                .last()
+                .expect("blocked")["phase"],
+            "model_provenance"
+        );
+        assert!(report["phases"]
+            .as_array()
+            .expect("phases")
+            .last()
+            .expect("blocked")["message"]
+            .as_str()
+            .expect("message")
+            .contains("no concrete executed model"));
+        assert_eq!(
+            filesystem_snapshot(&homeboy::core::paths::homeboy_data().expect("data root")),
+            before
+        );
+    });
+}
+
+#[test]
 fn cook_continue_reconciles_a_delayed_runner_attempt_then_advances_its_terminal_recipe_once() {
     with_temp_home(|| {
         let workspace = tempfile::tempdir().expect("workspace");


### PR DESCRIPTION
## Summary
- resolve model identity from Cook policy, explicit selection, or configured provider defaults before dispatch
- validate catalog-backed model selections consistently in Cook and `agent-task providers --model`
- derive Cook and fanout disclosure from the compiled model identity while preserving provider-reported actual model authority at finalization
- reject legacy null-model continuations read-only before reconciliation can enqueue retry or promotion work

Closes #13045
Closes #13310

## Tests
- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test -p homeboy-agents agent_task_provider::catalog::tests --lib`
- `cargo test -p homeboy-agents agent_task_scheduler::tests::outcome_tests --lib`
- `cargo test -p homeboy-agents agent_task_service::cook::tests::compile_cook_with_injected_catalog_proceeds_only_when_every_check_is_ready --lib -- --test-threads=1`
- `cargo test -p homeboy-agents agent_task_service::cook::tests::compile_cook_with_injected_catalog_rejects_each_unavailable_dimension_before_workspace_materialization --lib -- --test-threads=1`
- `cargo test -p homeboy-cli commands::agent_task::tests::contract --lib`
- `cargo test -p homeboy-cli commands::agent_task::review::tests::providers_end_to_end_uses_rotation_for_unavailable_default_and_live_validation --lib`
- `cargo test -p homeboy-cli commands::agent_task::review::tests::provider_route_replay_preserves_the_selected_model --lib`
- `cargo test -p homeboy-cli commands::agent_task::tests::lifecycle::cook_continue_preflight_rejects_legacy_terminal_candidate_without_model_provenance --lib -- --test-threads=1`
- `cargo test -p homeboy-cli commands::agent_task::run::tests::cook_continue_preflight_reports_a_read_only_rejection_without_creating_a_run --lib -- --test-threads=1`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode was used to trace live Cook evidence, implement the typed model contract, and verify it; Chris Huber owns decisions.