### PR TITLE
fix(agent-task): persist Cook output bootstrap

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -4184,7 +4184,13 @@ pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress(
     let cook_id = requested_cook_id.clone().unwrap_or_else(|| run_id.clone());
     if !no_progress {
         if let Some(progress) = progress {
-            progress("preparing", None, None, None, None)?;
+            progress(
+                "preparing",
+                Some(&cook_id),
+                Some(&run_id),
+                Some("preparing durable Cook inputs"),
+                None,
+            )?;
         }
     }
     let (run_id, mut initial_plan) = if let Some(attempt_plan) = args.attempt_plan.as_deref() {

--- a/crates/homeboy-cli/src/commands/infra/output_runtime.rs
+++ b/crates/homeboy-cli/src/commands/infra/output_runtime.rs
@@ -39,7 +39,6 @@ impl CookOutputLease {
             token,
             lock,
         };
-        lease.write_in_flight("preparing", None, None, None)?;
         Ok(lease)
     }
 
@@ -88,6 +87,13 @@ impl CookOutputLease {
             "success": false,
             "exit_code": null,
             "status": if run_id.is_some() { "in_flight" } else { "preparing" },
+            "submission_state": if matches!(phase, "submission_bootstrap" | "preparing") {
+                "preparing"
+            } else if run_id.is_some() {
+                "submitted"
+            } else {
+                "preparing"
+            },
             "invocation_id": self.token,
             "updated_at": chrono::Utc::now().to_rfc3339(),
             "phase": phase,
@@ -1008,18 +1014,30 @@ mod tests {
     }
 
     #[test]
-    fn preparing_output_has_no_durable_recovery_identity_before_recipe_persists() {
+    fn claimed_output_is_not_published_until_its_durable_submission_exists() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("cook.json");
         let lease = CookOutputLease::claim(path.to_str().unwrap()).expect("claim output");
 
-        let preparing: Value =
+        assert!(!path.exists());
+
+        lease
+            .progress(
+                "submission_bootstrap",
+                Some("cook-durable"),
+                Some("cook-durable"),
+                Some("durable Cook submission is preparing"),
+            )
+            .unwrap();
+        let bootstrap: Value =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
-        assert_eq!(preparing["phase"], "preparing");
-        assert_eq!(preparing["status"], "preparing");
-        assert!(preparing.get("run").is_none());
-        assert!(preparing.get("cook_id").is_none());
-        assert!(preparing.get("recovery").is_none());
+        assert_eq!(bootstrap["submission_state"], "preparing");
+        assert_eq!(bootstrap["cook_id"], "cook-durable");
+        assert_eq!(bootstrap["run"]["id"], "cook-durable");
+        assert!(bootstrap["recovery"]["status"]
+            .as_str()
+            .unwrap()
+            .contains("cook-durable"));
 
         lease
             .progress("in_flight", Some("cook-durable"), Some("run-durable"), None)
@@ -1027,6 +1045,7 @@ mod tests {
         let durable: Value =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(durable["status"], "in_flight");
+        assert_eq!(durable["submission_state"], "submitted");
         assert_eq!(durable["run"]["id"], "run-durable");
     }
 
@@ -1043,6 +1062,65 @@ mod tests {
 
         CookOutputLease::claim(path.to_str().expect("utf8 path"))
             .expect("released output can be claimed by a later invocation");
+    }
+
+    #[test]
+    fn interrupted_bootstrap_keeps_its_recovery_identity_after_the_lease_owner_exits() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cook.json");
+        let lease = CookOutputLease::claim(path.to_str().unwrap()).expect("claim output");
+        lease
+            .progress(
+                "submission_bootstrap",
+                Some("cook-interrupted"),
+                Some("cook-interrupted"),
+                None,
+            )
+            .expect("publish durable bootstrap");
+        drop(lease);
+
+        let output: Value = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(output["submission_state"], "preparing");
+        assert_eq!(output["cook_id"], "cook-interrupted");
+        assert_eq!(output["run"]["id"], "cook-interrupted");
+    }
+
+    #[test]
+    fn startup_failure_atomically_replaces_bootstrap_output() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cook.json");
+        let lease = CookOutputLease::claim(path.to_str().unwrap()).expect("claim output");
+        lease
+            .progress(
+                "submission_bootstrap",
+                Some("cook-startup-failure"),
+                Some("cook-startup-failure"),
+                None,
+            )
+            .expect("publish bootstrap");
+        let failure = Err(homeboy::core::Error::validation_invalid_argument(
+            "verify",
+            "startup validation failed",
+            None,
+            None,
+        ));
+        lease
+            .finish(
+                &failure,
+                2,
+                &CommandIdentity::with_operation("agent-task", "cook"),
+                None,
+            )
+            .expect("replace bootstrap atomically");
+
+        let output: Value = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(output["schema"], "homeboy/command-result/v3");
+        assert_eq!(output["success"], false);
+        assert!(output["diagnostics"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("startup validation failed"));
+        assert!(output.get("submission_state").is_none());
     }
 
     #[test]
@@ -1128,8 +1206,7 @@ mod tests {
 
         let lease = CookOutputLease::claim(path.to_str().expect("utf8 path"))
             .expect("reclaim dead owner lock");
-        let output: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
-        assert_eq!(output["status"], "preparing");
+        assert!(!path.exists());
         drop(lease);
         assert!(!lock.exists());
     }

--- a/crates/homeboy-cli/src/commands/json_output/mod.rs
+++ b/crates/homeboy-cli/src/commands/json_output/mod.rs
@@ -46,7 +46,7 @@ pub(crate) fn run_command_output(
     crate::commands::utils::tty::status("homeboy is working...");
     let summarize_changed_since_audit = changed_since_audit_uses_bounded_output(&command);
     let run = match command {
-        Commands::AgentTask(args) => {
+        Commands::AgentTask(mut args) => {
             let run_from_spec_output_ref =
                 agent_task_controller_run_from_spec_output_ref_eligible(&args, output_file);
             let summary_kind = agent_task_summary_kind_for_output(&args);
@@ -66,6 +66,49 @@ pub(crate) fn run_command_output(
                                 .with_output_file_already_written();
                         }
                     };
+                    // The output lease is deliberately silent until this parent
+                    // exists. A killed client can therefore always resolve or
+                    // cancel the identity in its first published envelope.
+                    let cook_args = match &mut args.command {
+                        crate::commands::agent_task::AgentTaskCommand::Cook(cook_args) => cook_args,
+                        _ => unreachable!("Cook output branch has a Cook command"),
+                    };
+                    let cook_id = cook_args
+                        .dispatch
+                        .run_id
+                        .clone()
+                        .unwrap_or_else(|| format!("agent-task-{}", uuid::Uuid::new_v4()));
+                    cook_args.dispatch.run_id = Some(cook_id.clone());
+                    let bootstrap = (|| {
+                        let store = homeboy::agents::agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+                        homeboy::agents::agent_task_lifecycle::record_detached_cook_handoff_parent_in_store(
+                            &store, &cook_id,
+                        )
+                    })();
+                    if let Err(error) = bootstrap {
+                        let result = Err(error);
+                        let _ = lease.finish(
+                            &result,
+                            2,
+                            &crate::commands::utils::response::CommandIdentity::with_operation(
+                                "agent-task",
+                                "cook",
+                            ),
+                            None,
+                        );
+                        return CommandRun::from_stdout_result(result, 2)
+                            .with_command(spec.name)
+                            .with_output_file_already_written();
+                    }
+                    if let Err(error) = lease.progress(
+                        "submission_bootstrap",
+                        Some(&cook_id),
+                        Some(&cook_id),
+                        Some("durable Cook submission is preparing"),
+                    ) {
+                        return CommandRun::from_stdout_result(Err(error), 2)
+                            .with_command(spec.name);
+                    }
                     let progress =
                         |phase: &str,
                          cook_id: Option<&str>,
@@ -81,6 +124,42 @@ pub(crate) fn run_command_output(
                             Some(provenance),
                         ),
                     );
+                    if let Err(error) = &result {
+                        // A bootstrap parent is a real lifecycle record, not an
+                        // output-only marker. If normal preparation never
+                        // materialized its first attempt, terminalize that parent
+                        // before replacing the in-flight envelope.
+                        let terminalize = (|| {
+                            let store = homeboy::agents::agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+                            if store.cook_index_exists(&cook_id) {
+                                return Ok(());
+                            }
+                            let plan = store.read_controller_plan(&cook_id)?;
+                            homeboy::agents::agent_task_lifecycle::record_pre_execution_failure_in_store(
+                                &store,
+                                &cook_id,
+                                &plan,
+                                "output_bootstrap",
+                                error,
+                            )?;
+                            Ok(())
+                        })();
+                        if let Err(terminal_error) = terminalize {
+                            let result = Err(terminal_error);
+                            let _ = lease.finish(
+                                &result,
+                                2,
+                                &crate::commands::utils::response::CommandIdentity::with_operation(
+                                    "agent-task",
+                                    "cook",
+                                ),
+                                None,
+                            );
+                            return CommandRun::from_stdout_result(result, 2)
+                                .with_command(spec.name)
+                                .with_output_file_already_written();
+                        }
+                    }
                     if let Err(error) = lease.finish(
                         &result,
                         exit_code,


### PR DESCRIPTION
## Summary

- persist a durable Cook submission identity before publishing the first `--output` envelope
- expose explicit preparing/submitted state and recovery commands
- atomically terminalize startup failures before replacing bootstrap output
- preserve fail-closed output lease contention and duplicate-safe recovery

Closes #13321.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-cli cook_output --lib`
- `cargo test -p homeboy-cli interrupted_bootstrap --lib`
- `cargo test -p homeboy-cli startup_failure_atomically --lib`
- `cargo check -p homeboy-cli`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode and general coding subagents implemented and verified this change. Chris Huber reviewed and owns it.
