### PR TITLE
fix(lint): preserve legacy full-scope baselines

### DIFF
--- a/crates/homeboy-extension/src/lint/baseline.rs
+++ b/crates/homeboy-extension/src/lint/baseline.rs
@@ -87,6 +87,15 @@ impl LintBaselineProvenance {
             exclude_sniffs,
         }
     }
+
+    fn permits_legacy_full_baseline(&self) -> bool {
+        self.scope == "full"
+            && self.files.is_empty()
+            && self.category.is_none()
+            && !self.errors_only
+            && self.sniffs.is_none()
+            && self.exclude_sniffs.is_none()
+    }
 }
 
 struct LintFingerprint<'a>(&'a HomeboyFinding);
@@ -205,6 +214,26 @@ pub fn load_baseline_for_scope(
 ) -> Option<LintBaseline> {
     let config = config(source_path, provenance);
     generic::load::<LintBaselineMetadata>(&config).unwrap_or_default()
+}
+
+/// Load the scope-specific baseline, falling back to the pre-scope full-tree
+/// baseline only when this run measures that same unfiltered population.
+pub fn load_baseline_for_scope_or_legacy_full(
+    source_path: &Path,
+    provenance: &mut LintBaselineProvenance,
+) -> Option<LintBaseline> {
+    if let Some(baseline) = load_baseline_for_scope(source_path, Some(provenance)) {
+        return Some(baseline);
+    }
+
+    if provenance.permits_legacy_full_baseline() {
+        if let Some(baseline) = load_baseline(source_path) {
+            provenance.baseline_key = BASELINE_KEY.to_string();
+            return Some(baseline);
+        }
+    }
+
+    None
 }
 
 pub fn compare(findings: &[HomeboyFinding], baseline: &LintBaseline) -> BaselineComparison {
@@ -357,6 +386,143 @@ mod tests {
 
         assert_eq!(comparison.new_items.len(), 1);
         assert_eq!(comparison.new_items[0].fingerprint, "id-2");
+    }
+
+    #[test]
+    fn scoped_full_baseline_is_preferred_over_legacy_baseline() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut provenance = LintBaselineProvenance::new(
+            Vec::new(),
+            vec!["eslint".to_string()],
+            "full",
+            None,
+            false,
+            None,
+            None,
+        );
+        save_baseline(
+            dir.path(),
+            "legacy",
+            &[lint_finding("legacy", "lint", "legacy")],
+        )
+        .expect("save legacy baseline");
+        save_baseline_for_scope(
+            dir.path(),
+            "scoped",
+            &[lint_finding("scoped", "lint", "scoped")],
+            Some(&provenance),
+        )
+        .expect("save scoped baseline");
+
+        let baseline = load_baseline_for_scope_or_legacy_full(dir.path(), &mut provenance)
+            .expect("load scoped baseline");
+
+        assert_eq!(baseline.context_id, "scoped");
+        assert_ne!(provenance.baseline_key, BASELINE_KEY);
+    }
+
+    #[test]
+    fn equivalent_full_scope_falls_back_to_legacy_baseline() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut provenance = LintBaselineProvenance::new(
+            Vec::new(),
+            vec!["eslint".to_string()],
+            "full",
+            None,
+            false,
+            None,
+            None,
+        );
+        save_baseline(
+            dir.path(),
+            "legacy",
+            &[lint_finding("legacy", "lint", "legacy")],
+        )
+        .expect("save legacy baseline");
+
+        let baseline = load_baseline_for_scope_or_legacy_full(dir.path(), &mut provenance)
+            .expect("load legacy baseline");
+
+        assert_eq!(baseline.context_id, "legacy");
+        assert_eq!(provenance.baseline_key, BASELINE_KEY);
+    }
+
+    #[test]
+    fn scoped_or_filtered_runs_do_not_fall_back_to_legacy_baseline() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        save_baseline(
+            dir.path(),
+            "legacy",
+            &[lint_finding("legacy", "lint", "legacy")],
+        )
+        .expect("save legacy baseline");
+        let cases = [
+            (
+                vec!["changed.rs".to_string()],
+                "changed",
+                None,
+                false,
+                None,
+                None,
+            ),
+            (
+                vec!["src/lib.rs".to_string()],
+                "file",
+                None,
+                false,
+                None,
+                None,
+            ),
+            (
+                vec!["src/**/*.rs".to_string()],
+                "glob",
+                None,
+                false,
+                None,
+                None,
+            ),
+            (
+                Vec::new(),
+                "full",
+                Some("style".to_string()),
+                false,
+                None,
+                None,
+            ),
+            (Vec::new(), "full", None, true, None, None),
+            (
+                Vec::new(),
+                "full",
+                None,
+                false,
+                Some("Rule.One".to_string()),
+                None,
+            ),
+            (
+                Vec::new(),
+                "full",
+                None,
+                false,
+                None,
+                Some("Rule.Two".to_string()),
+            ),
+        ];
+
+        for (files, scope, category, errors_only, sniffs, exclude_sniffs) in cases {
+            let mut provenance = LintBaselineProvenance::new(
+                files,
+                vec!["eslint".to_string()],
+                scope,
+                category,
+                errors_only,
+                sniffs,
+                exclude_sniffs,
+            );
+            let scoped_key = provenance.baseline_key.clone();
+
+            assert!(load_baseline_for_scope_or_legacy_full(dir.path(), &mut provenance).is_none());
+            assert_eq!(provenance.baseline_key, scoped_key);
+        }
     }
 
     #[test]

--- a/crates/homeboy-extension/src/lint/run/tests/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/tests/workflow.rs
@@ -162,6 +162,43 @@ exit 1
 }
 
 #[test]
+fn full_scope_legacy_baseline_is_compared_with_legacy_provenance() {
+    homeboy_core::test_support::with_isolated_home(|home| {
+        let source = tempfile::tempdir().expect("source dir");
+        let finding = homeboy_core::finding::HomeboyFinding::builder("eslint", "known finding")
+            .fingerprint("known")
+            .build();
+        crate::lint::baseline::save_baseline(source.path(), "legacy", &[finding])
+            .expect("save legacy baseline");
+        let component = routed_lint_component(
+            home.path(),
+            source.path(),
+            r#"#!/bin/sh
+printf '[{"tool":"eslint","message":"known finding","fingerprint":"known","file":"src/lib.rs"}]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+exit 1
+"#,
+        );
+
+        let workflow = run_main_lint_workflow(
+            &component,
+            source.path(),
+            lint_args(),
+            &RunDir::create().expect("run dir"),
+        )
+        .expect("workflow result");
+
+        assert_eq!(workflow.status, "passed");
+        assert_eq!(workflow.exit_code, 0);
+        let provenance = workflow
+            .baseline_provenance
+            .as_ref()
+            .expect("baseline provenance");
+        assert!(provenance.compared);
+        assert_eq!(provenance.baseline_key, "lint");
+    });
+}
+
+#[test]
 fn scoped_zero_findings_do_not_compare_unrelated_legacy_baseline() {
     homeboy_core::test_support::with_isolated_home(|home| {
         let source = tempfile::tempdir().expect("source dir");

--- a/crates/homeboy-extension/src/lint/run/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/workflow.rs
@@ -671,7 +671,7 @@ fn process_baseline(
 
     if !args.baseline_flags.baseline && !args.baseline_flags.ignore_baseline {
         if let Some(existing) =
-            lint_baseline::load_baseline_for_scope(source_path, Some(&provenance))
+            lint_baseline::load_baseline_for_scope_or_legacy_full(source_path, &mut provenance)
         {
             provenance.compared = true;
             let comparison = lint_baseline::compare(lint_findings, &existing);


### PR DESCRIPTION
## Summary

- prefer provenance-scoped lint baselines when they exist
- fall back to the persisted pre-scope `lint` baseline only for an equivalent unfiltered full-workspace run
- report the actual legacy key in structured provenance and keep changed/file/glob/filter scopes isolated

Fixes #13328

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-extension lint::baseline --lib --no-fail-fast`
- `cargo test -p homeboy-extension lint::run::tests::workflow::full_scope_legacy_baseline_is_compared_with_legacy_provenance --lib --no-fail-fast`
- `cargo check --workspace`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed the persisted baseline migration regression, orchestrated an isolated implementation agent, reviewed and extended the scope-boundary coverage, and verified the patch. Chris Huber remains responsible for every line.
