### PR TITLE
refactor(lifecycle): give external_runtime_ids one derivation

### DIFF
--- a/crates/contracts/homeboy-lifecycle-contract/src/run_lifecycle_record.rs
+++ b/crates/contracts/homeboy-lifecycle-contract/src/run_lifecycle_record.rs
@@ -51,6 +51,35 @@ impl RunLifecycleRecord {
         }
     }
 
+    /// Recompute `external_runtime_ids` from `provider_runtime`.
+    ///
+    /// The field is a flattened index of the ids already carried by each entry
+    /// in `provider_runtime`; it exists so a consumer can ask "what external
+    /// runtimes did this run touch" without walking the per-task structure. It
+    /// is therefore never independent data, and any writer that sets
+    /// `provider_runtime` owes a call here.
+    ///
+    /// It stays a serialized field rather than becoming a method because it is
+    /// published in `homeboy/run-lifecycle-record/v1` and this crate cannot see
+    /// its out-of-tree consumers.
+    ///
+    /// Readers that test both this field *and* every entry's own ids are not
+    /// being redundant, and collapsing them onto `provider_runtime` alone
+    /// regresses four lifecycle tests plus a cook adoption test. The field is
+    /// `#[serde(default)]`, so a record written before it existed deserializes
+    /// with an empty vector while `provider_runtime` is populated: for those
+    /// records "the flattened index is empty" and "no entry has ids" are
+    /// genuinely different questions, and the conjunction is what keeps a
+    /// migrated legacy run classified as having had no real provider
+    /// execution. Leave those call sites alone.
+    pub fn refresh_external_runtime_ids(&mut self) {
+        self.external_runtime_ids = self
+            .provider_runtime
+            .iter()
+            .flat_map(|runtime| runtime.external_runtime_ids.clone())
+            .collect();
+    }
+
     pub fn provider_runtime_state(&self) -> ProviderRuntimeState {
         let mut states = self.provider_runtime.iter().map(|runtime| runtime.state);
         let Some(first) = states.next() else {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_record_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_record_ops.rs
@@ -111,12 +111,7 @@ pub(crate) fn update_lifecycle_from_record(record: &mut AgentTaskRunRecord, plan
         });
     }
     record.lifecycle.provider_runtime = provider_runtime;
-    record.lifecycle.external_runtime_ids = record
-        .lifecycle
-        .provider_runtime
-        .iter()
-        .flat_map(|runtime| runtime.external_runtime_ids.clone())
-        .collect();
+    record.lifecycle.refresh_external_runtime_ids();
     record.lifecycle.artifact_retention = ArtifactRetentionLifecycle {
         status: if record.artifact_refs.is_empty() {
             ArtifactRetentionStatus::NotApplicable

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
@@ -610,12 +610,7 @@ fn merge_live_provider_handles(
             .iter()
             .map(provider_runtime_for_handle)
             .collect();
-        record.lifecycle.external_runtime_ids = record
-            .lifecycle
-            .provider_runtime
-            .iter()
-            .flat_map(|runtime| runtime.external_runtime_ids.clone())
-            .collect();
+        record.lifecycle.refresh_external_runtime_ids();
     }
 }
 


### PR DESCRIPTION
## What

`RunLifecycleRecord::external_runtime_ids` is a flattened index of ids already carried by each `provider_runtime` entry. It was recomputed by **two byte-identical six-line expressions** in different files:

```rust
// lifecycle_record_ops.rs:114  AND  lifecycle_runner_projection.rs:613
record.lifecycle.external_runtime_ids = record
    .lifecycle
    .provider_runtime
    .iter()
    .flat_map(|runtime| runtime.external_runtime_ids.clone())
    .collect();
```

Both now call `RunLifecycleRecord::refresh_external_runtime_ids`, so "which writers owe a refresh" is a property of the type instead of something you have to know.

It stays a serialized field rather than becoming a method — it's published in `homeboy/run-lifecycle-record/v1` and this crate cannot see its out-of-tree consumers.

## What I tried, and why it's not here

Two readers test both the field *and* every entry's own ids:

```rust
lifecycle.external_runtime_ids.is_empty()
    && lifecycle.provider_runtime.iter().all(|r| r.external_runtime_ids.is_empty() && ..)
```

I read that as the same question asked twice — the flattened field is empty exactly when every entry's is — and collapsed it. **It regressed five tests**, including `record_health_recovers_after_interrupted_migration_without_changing_terminal_status`.

The field is `#[serde(default)]`. A record written *before the field existed* deserializes with an empty vector while `provider_runtime` is populated. For a migrated legacy run, "the flattened index is empty" and "no entry has ids" are genuinely different questions, and the conjunction is what keeps that run classified as having had no real provider execution.

That is now documented on the method, so the next person doesn't spend the same afternoon on it.

## Scope correction

An investigation suggested the whole `record.lifecycle` field could be computed on demand for 600–1,200 lines. Reading it, that isn't right:

| field | derivable? |
| --- | --- |
| `external_runtime_ids` | yes — flat_map of `provider_runtime` |
| `artifact_retention` | yes — function of `artifact_refs` |
| `provider_runtime` | yes — from handles + tasks + metadata |
| `execution.started_at` / `finished_at` | **no** — stamped at transition time |
| `heartbeat` | **no** — genuine state (`last_seen_at`, `owner_pid`) |
| `cleanup` | **no** — derived from the plan, which the record does not carry |

`set_run_state` carries a `debug_assert!(record.run_state_projections_agree())`, which is what made it look fully derived. It only covers `execution.state`.

## Verification

`cargo check --workspace --all-targets` — 0 errors, **0 warnings**.

`homeboy-agents --lib` (finalization/lifecycle/candidate): **11 failures vs 13 on `origin/main`** — fewer than baseline. Two names not in the baseline list both pass in isolation under `--test-threads=1`, so they are parallel-execution flakes.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode
