### PR TITLE
Fix explicit rig package boundaries

### DIFF
--- a/crates/homeboy-rig/src/lib.rs
+++ b/crates/homeboy-rig/src/lib.rs
@@ -418,22 +418,9 @@ pub(crate) fn validate_rig_spec(spec: &RigSpec) -> Result<()> {
 }
 
 fn local_package_root_for_rig_json(path: &Path) -> PathBuf {
-    let Some(rig_dir) = path.parent() else {
-        return PathBuf::from(".");
-    };
-    if rig_dir
-        .parent()
-        .and_then(Path::file_name)
-        .and_then(|name| name.to_str())
-        == Some("rigs")
-    {
-        return rig_dir
-            .parent()
-            .and_then(Path::parent)
-            .unwrap_or(rig_dir)
-            .to_path_buf();
-    }
-    rig_dir.to_path_buf()
+    path.parent()
+        .unwrap_or_else(|| Path::new("."))
+        .to_path_buf()
 }
 
 fn absolute_path(path: &str) -> Result<PathBuf> {
@@ -854,5 +841,36 @@ mod schema_error_tests {
             .is_some_and(|details| details.iter().any(|detail| detail
                 .as_str()
                 .is_some_and(|value| value.contains("env instead")))));
+    }
+
+    #[test]
+    fn local_rig_file_materializes_with_its_own_package_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let rig_dir = tmp.path().join("rigs/isolated");
+        fs::create_dir_all(&rig_dir).expect("rig dir");
+        fs::write(
+            rig_dir.join("base.json"),
+            r#"{ "description": "materialized from this package" }"#,
+        )
+        .expect("base spec");
+        let rig_path = rig_dir.join("rig.json");
+        fs::write(
+            &rig_path,
+            r#"{
+                "extends": "./base.json",
+                "id": "isolated",
+                "components": { "app": { "path": "${package.root}/app" } }
+            }"#,
+        )
+        .expect("rig spec");
+
+        let spec = load_local_source(rig_path.to_str().expect("UTF-8 path"), None)
+            .expect("materialize local rig");
+
+        assert_eq!(spec.description, "materialized from this package");
+        assert_eq!(
+            local_package_root("isolated").as_deref(),
+            Some(rig_dir.as_path())
+        );
     }
 }

--- a/crates/homeboy-rig/src/lint.rs
+++ b/crates/homeboy-rig/src/lint.rs
@@ -2654,6 +2654,35 @@ mod tests {
     }
 
     #[test]
+    fn package_lint_scopes_explicit_rig_file_to_its_package() {
+        let temp = tempfile::TempDir::new().expect("temp package");
+        git(temp.path(), &["init", "--quiet"]);
+        let rig_dir = temp.path().join("rigs").join("isolated");
+        fs::create_dir_all(&rig_dir).expect("rig dir");
+        let rig_path = rig_dir.join("rig.json");
+        fs::write(
+            &rig_path,
+            r#"{
+                "id": "isolated",
+                "components": { "app": { "path": "${package.root}/app" } }
+            }"#,
+        )
+        .expect("rig spec");
+        fs::write(
+            temp.path().join("unrelated.mjs"),
+            "const checkout = '/Users/example/project';\n",
+        )
+        .expect("unrelated source");
+        git(temp.path(), &["add", "."]);
+
+        let rig = super::super::load_local_source(rig_path.to_str().expect("UTF-8 path"), None)
+            .expect("load local rig");
+        let outcome = run_package_lint(&rig).expect("lint explicit rig package");
+
+        assert_eq!(portability_step(&outcome).status, "pass", "{outcome:?}");
+    }
+
+    #[test]
     fn package_lint_reports_profile_reference_failures() {
         let temp = tempfile::TempDir::new().expect("temp package");
         let rig_dir = temp.path().join("rigs").join("profiles");

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -746,10 +746,9 @@ mod install_flows {
     }
 
     #[test]
-    fn local_direct_rig_json_check_resolves_package_root() {
+    fn local_direct_rig_json_check_resolves_rig_package_root() {
         let _home = HomeGuard::new();
         let package = tempfile::tempdir().expect("package");
-        fs::write(package.path().join("marker.txt"), "ok\n").expect("marker");
         let rig_path = write_rig(
             package.path(),
             "direct-alpha",
@@ -762,6 +761,11 @@ mod install_flows {
             }
         }"#,
         );
+        fs::write(
+            rig_path.parent().expect("rig directory").join("marker.txt"),
+            "ok\n",
+        )
+        .expect("marker");
 
         let rig =
             load_local_source(rig_path.to_str().unwrap(), None).expect("load direct rig json");
@@ -770,7 +774,11 @@ mod install_flows {
         assert!(report.success, "direct rig.json check should pass");
         assert_eq!(
             crate::expand::expand_vars(&rig, "${package.root}/marker.txt"),
-            package.path().join("marker.txt").to_string_lossy()
+            rig_path
+                .parent()
+                .expect("rig directory")
+                .join("marker.txt")
+                .to_string_lossy()
         );
         assert!(read_source_metadata_in_root(&test_config_root(), "direct-alpha").is_none());
     }


### PR DESCRIPTION
## Summary\n- scope an explicitly selected rig.json to its own package directory\n- keep portability lint enforced within that package\n- cover direct-rig materialization and git-backed lint scoping\n\n## Tests\n- cargo test -p homeboy-rig\n- cargo run --quiet -- rig lint /path/to/rigs/wp-build-preview-e2e/rig.json\n\nCloses #11550\n\n## AI assistance\nOpenAI gpt-5.6-terra via OpenCode identified the package-boundary defect, implemented the generic Homeboy contract and deterministic tests, and verified the affected rig lint. Chris Huber directed and remains responsible for the change.