### PR TITLE
Fix Lab broker target materialization

### DIFF
--- a/crates/homeboy-cli/src/commands/ssh.rs
+++ b/crates/homeboy-cli/src/commands/ssh.rs
@@ -173,7 +173,30 @@ pub fn run(args: SshArgs) -> CmdResult<SshOutput> {
                     server: None,
                 }
             };
-            let result = resolve_context(&resolve_args)?;
+            let result = resolve_context(&resolve_args).map_err(|error| {
+                let declared = std::env::var("HOMEBOY_DECLARED_SSH_TARGETS").ok();
+                let requested = args.target.as_deref().unwrap_or_default();
+                match declared.as_deref().filter(|value| !value.is_empty()) {
+                    Some(declared) if declared.split(',').any(|target| target == requested) => {
+                        homeboy::core::Error::validation_invalid_argument(
+                            "target",
+                            format!("declared SSH target `{requested}` is unavailable in this Lab job"),
+                            Some(requested.to_string()),
+                            Some(vec!["Verify the controller target configuration and rerun the Lab workload.".to_string()]),
+                        )
+                    }
+                    Some(declared) => homeboy::core::Error::validation_invalid_argument(
+                        "target",
+                        format!("SSH target `{requested}` is not declared by this Lab workload"),
+                        Some(requested.to_string()),
+                        Some(vec![
+                            format!("Declare `{requested}` in the rig requirements.broker_targets before offloading."),
+                            format!("Declared targets: {declared}"),
+                        ]),
+                    ),
+                    None => error,
+                }
+            })?;
             ssh_phase("target-resolved");
 
             let command_string: Option<String> = if args.command.is_empty() {

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -2002,6 +2002,8 @@ pub(crate) fn run_lab_offload_inner(
         mut remote_command,
         remote_output_file,
         rig_component_path_overrides,
+        broker_target_home,
+        broker_target_ids,
         dependency_cache_saves,
         runtime_overlay_env,
         runtime_overlay_metadata,
@@ -2212,6 +2214,13 @@ pub(crate) fn run_lab_offload_inner(
     let declared_dependency_paths_env =
         forward_declared_dependency_paths_env(&mut env_delta, &workspace_mapping);
     apply_rig_component_path_overrides(&mut env_delta, &rig_component_path_overrides);
+    if let Some(home) = broker_target_home.as_deref() {
+        env_delta.insert("HOME".to_string(), home.to_string());
+        env_delta.insert(
+            "HOMEBOY_DECLARED_SSH_TARGETS".to_string(),
+            broker_target_ids.join(","),
+        );
+    }
     // Surface synced runtime-overlay remote paths into the command env so a hot
     // command (e.g. a CLI-runner env entry) points at the real remote runtime
     // directory rather than a controller-local path (#3831).
@@ -2274,6 +2283,10 @@ pub(crate) fn run_lab_offload_inner(
     lab_metadata["declared_dependency_paths_env"] = declared_dependency_paths_env;
     lab_metadata["rig_component_path_overrides"] =
         rig_component_path_overrides_metadata(&rig_component_path_overrides);
+    lab_metadata["rig_broker_targets"] = serde_json::json!({
+        "configured": broker_target_home.is_some(),
+        "credential_scope": "runner_owned_only",
+    });
     lab_metadata["settings_env"] =
         settings_env_diagnostics(&remapped_args, &secret_env_handoff.env_delta);
     lab_metadata["runner_homeboy"] = runner_homeboy.clone();

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -72,6 +72,10 @@ pub(crate) struct LabOffloadWorkspaceStage {
     pub(crate) remote_command: Vec<String>,
     pub(crate) remote_output_file: Option<String>,
     pub(crate) rig_component_path_overrides: Vec<(String, String)>,
+    /// Job-scoped HOME containing declared rig broker-target resolution config.
+    pub(crate) broker_target_home: Option<String>,
+    /// Named targets explicitly admitted to the job-scoped SSH broker config.
+    pub(crate) broker_target_ids: Vec<String>,
     pub(crate) dependency_cache_saves: Vec<RunnerDependencyCacheSaveRequest>,
     /// Env-var overrides surfacing synced runtime-overlay remote paths to the
     /// hot command. Empty when no overlay declared `expose_remote_path_env`.
@@ -119,6 +123,8 @@ pub(crate) fn durable_workspace_stage_projection(
         "remote_command": stage.remote_command,
         "remote_output_file": stage.remote_output_file,
         "rig_component_path_overrides": stage.rig_component_path_overrides,
+        "broker_target_home": stage.broker_target_home.as_ref().map(|_| "[job-scoped]"),
+        "broker_targets": stage.broker_target_ids,
         "dependency_cache_saves": stage.dependency_cache_saves,
         "runtime_overlay_env": stage.runtime_overlay_env,
         "runtime_overlay_metadata": stage.runtime_overlay_metadata,
@@ -498,6 +504,25 @@ fn prepare_lab_offload_workspace_stage_inner(
     let dependency_cache_saves = rig_component_sync.dependency_cache_saves;
     let rig_component_path_overrides = rig_component_sync.component_path_env;
     let selected_rig_component_path = rig_component_sync.selected_component_path;
+    let broker_target_sync = rig_materialization::sync_lab_offload_broker_targets(
+        runner_id,
+        &changed_since_preflight.args,
+        &remote_cwd,
+    )?;
+    let broker_target_home = broker_target_sync.home;
+    let broker_target_ids = broker_target_sync
+        .targets
+        .iter()
+        .map(|target| target.id.clone())
+        .collect::<Vec<_>>();
+    if !broker_target_sync.targets.is_empty() {
+        plan = with_step(
+            plan,
+            PlanStep::ready("lab.sync_rig_broker_targets", "lab.sync_rig_broker_targets")
+                .inputs(PlanValues::new().json("targets", &broker_target_sync.targets))
+                .build(),
+        );
+    }
     if !synced_rig_dependencies.is_empty() {
         for dependency in &synced_rig_dependencies {
             workspace_mapping.extend(workspace_mapping_entries_for_git_dependency(
@@ -691,6 +716,8 @@ fn prepare_lab_offload_workspace_stage_inner(
         remote_command,
         remote_output_file,
         rig_component_path_overrides,
+        broker_target_home,
+        broker_target_ids,
         dependency_cache_saves,
         runtime_overlay_env,
         runtime_overlay_metadata,

--- a/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 
 use homeboy_core::materialization_currency::{self, Currency};
@@ -703,6 +703,187 @@ pub(super) struct LabOffloadRigComponentSync {
     pub selected_component_path: Option<String>,
 }
 
+/// Safe, job-scoped projection of a rig-declared SSH target. Configuration
+/// values are intentionally absent from this evidence: runner credentials stay
+/// in the runner's SSH agent/keychain transport.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub(super) struct LabBrokerTargetProjection {
+    pub id: String,
+    pub resolved_as: &'static str,
+    pub server_id: String,
+}
+
+pub(super) struct LabBrokerTargetSync {
+    pub home: Option<String>,
+    pub targets: Vec<LabBrokerTargetProjection>,
+}
+
+/// Materialize only the fields `homeboy ssh <target>` needs into a private
+/// child of the Lab workspace. The child is deleted with the workspace; neither
+/// controller credentials nor arbitrary project/server configuration cross the
+/// boundary.
+pub(super) fn sync_lab_offload_broker_targets(
+    runner_id: &str,
+    args: &[String],
+    remote_cwd: &str,
+) -> Result<LabBrokerTargetSync> {
+    let config_root = rig_registry_config_root()?;
+    let target_ids = lab_offload_rig_ids(args)
+        .into_iter()
+        .map(|rig_id| homeboy_rig::load(&config_root, &rig_id))
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .flat_map(|rig| rig.requirements.broker_targets)
+        .collect::<BTreeSet<_>>();
+    if target_ids.is_empty() {
+        return Ok(LabBrokerTargetSync {
+            home: None,
+            targets: Vec::new(),
+        });
+    }
+
+    let home = format!(
+        "{}/rig-broker-targets/home",
+        crate::lab::offload::remote_lab_artifact_dir(remote_cwd)
+    );
+    let mut targets = Vec::new();
+    for target_id in target_ids {
+        if target_id.trim().is_empty()
+            || !target_id
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+        {
+            return Err(Error::validation_invalid_argument(
+                "requirements.broker_targets",
+                "broker target IDs must contain only ASCII letters, digits, hyphens, and underscores",
+                Some(target_id),
+                None,
+            ));
+        }
+
+        let (project, server, projection) = match homeboy_core::project::load_in_root(
+            &config_root,
+            &target_id,
+        ) {
+            Ok(project) => {
+                let server_id = project.server_id.clone().ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        "requirements.broker_targets",
+                        format!("declared broker target `{target_id}` is a project without server_id"),
+                        Some(target_id.clone()),
+                        Some(vec!["Declare a project target with server_id, or declare its server ID directly.".to_string()]),
+                    )
+                })?;
+                let server = homeboy_core::server::load_in_root(&config_root, &server_id)?;
+                let projection = LabBrokerTargetProjection {
+                    id: target_id.clone(),
+                    resolved_as: "project",
+                    server_id,
+                };
+                (Some(project), server, projection)
+            }
+            Err(_) => match homeboy_core::server::load_in_root(&config_root, &target_id) {
+                Ok(server) => {
+                    let projection = LabBrokerTargetProjection {
+                        id: target_id.clone(),
+                        resolved_as: "server",
+                        server_id: server.id.clone(),
+                    };
+                    (None, server, projection)
+                }
+                Err(_) => {
+                    return Err(Error::validation_invalid_argument(
+                        "requirements.broker_targets",
+                        format!("declared broker target `{target_id}` is not configured on the controller"),
+                        Some(target_id.clone()),
+                        Some(vec![
+                            format!("Configure project or server `{target_id}` on the controller before Lab offload."),
+                            "Remove the target from requirements.broker_targets when the workload does not use it.".to_string(),
+                        ]),
+                    ));
+                }
+            },
+        };
+        write_broker_target_projection(runner_id, &home, project.as_ref(), &server)?;
+        targets.push(projection);
+    }
+    Ok(LabBrokerTargetSync {
+        home: Some(home),
+        targets,
+    })
+}
+
+fn write_broker_target_projection(
+    runner_id: &str,
+    home: &str,
+    project: Option<&homeboy_core::project::Project>,
+    server: &homeboy_core::server::Server,
+) -> Result<()> {
+    for (path, value) in broker_target_projection_files(home, project, server) {
+        write_runner_json(runner_id, &path, &value)?;
+    }
+    Ok(())
+}
+
+fn broker_target_projection_files(
+    home: &str,
+    project: Option<&homeboy_core::project::Project>,
+    server: &homeboy_core::server::Server,
+) -> Vec<(String, serde_json::Value)> {
+    let config_root = format!("{home}/.config/homeboy");
+    let mut files = vec![(
+        format!("{config_root}/servers/{}.json", server.id),
+        serde_json::json!({
+            "aliases": server.aliases,
+            "host": server.host,
+            "user": server.user,
+            "port": server.port,
+        }),
+    )];
+    if let Some(project) = project {
+        files.push((
+            format!("{config_root}/projects/{0}/{0}.json", project.id),
+            serde_json::json!({
+                "aliases": project.aliases,
+                "server_id": project.server_id,
+                "base_path": project.base_path,
+            }),
+        ));
+    }
+    files
+}
+
+fn write_runner_json(runner_id: &str, path: &str, value: &serde_json::Value) -> Result<()> {
+    use base64::Engine;
+
+    let encoded = base64::engine::general_purpose::STANDARD
+        .encode(serde_json::to_vec(value).expect("broker target projection serializes"));
+    let quoted_path = homeboy_core::engine::shell::quote_arg(path);
+    let quoted_parent = homeboy_core::engine::shell::quote_arg(
+        Path::new(path)
+            .parent()
+            .expect("broker target projection path has parent")
+            .to_string_lossy()
+            .as_ref(),
+    );
+    let command = format!(
+        "mkdir -p {quoted_parent} && printf %s {encoded} | base64 --decode > {quoted_path}"
+    );
+    let (output, exit_code) = exec(
+        runner_id,
+        RunnerExecOptions::command(vec!["sh".to_string(), "-c".to_string(), command]),
+    )?;
+    if exit_code != 0 {
+        return Err(Error::validation_invalid_argument(
+            "requirements.broker_targets",
+            "Lab runner could not materialize declared broker target configuration",
+            None,
+            Some(vec![output.stderr.trim().to_string()]),
+        ));
+    }
+    Ok(())
+}
+
 pub(super) fn sync_lab_offload_rig_component_dependencies(
     runner_id: &str,
     args: &[String],
@@ -1291,6 +1472,39 @@ mod tests {
     /// here is a boundary resolution (#7505).
     fn test_config_root() -> std::path::PathBuf {
         homeboy_core::paths::homeboy().expect("config root")
+    }
+
+    #[test]
+    fn broker_target_projection_keeps_credentials_out_of_runner_config() {
+        let server = homeboy_core::server::Server {
+            id: "fixture-server".to_string(),
+            host: "fixture.example.test".to_string(),
+            user: "fixture-user".to_string(),
+            identity_file: Some("/controller/private-key".to_string()),
+            env: std::collections::HashMap::from([(
+                "FIXTURE_TOKEN".to_string(),
+                "must-not-cross-the-lab-boundary".to_string(),
+            )]),
+            aliases: Vec::new(),
+            port: 22,
+            kind: None,
+            auth: None,
+            runner: None,
+        };
+        let project = homeboy_core::project::Project {
+            id: "fixture-project".to_string(),
+            server_id: Some(server.id.clone()),
+            base_path: Some("/srv/fixture".to_string()),
+            ..Default::default()
+        };
+
+        let files = broker_target_projection_files("/runner/job", Some(&project), &server);
+        let serialized = serde_json::to_string(&files).expect("serialize projection");
+        assert!(serialized.contains("fixture.example.test"));
+        assert!(serialized.contains("fixture-project"));
+        assert!(!serialized.contains("must-not-cross-the-lab-boundary"));
+        assert!(!serialized.contains("private-key"));
+        assert!(!serialized.contains("database"));
     }
 
     fn initialize_git_checkout(checkout_root: &Path) {

--- a/crates/homeboy-rig/src/spec.rs
+++ b/crates/homeboy-rig/src/spec.rs
@@ -428,6 +428,11 @@ pub struct RigRequirementsSpec {
     /// semantics belong to the referenced runner or extension.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dependency_materialization: Vec<DependencyMaterializationStepSpec>,
+
+    /// Named SSH broker targets required by this rig's workloads. Lab projects
+    /// their connection-safe configuration into the job-scoped runner home.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub broker_targets: Vec<String>,
 }
 
 impl RigRequirementsSpec {
@@ -437,6 +442,7 @@ impl RigRequirementsSpec {
             && self.runner_tools.is_empty()
             && self.extensions.is_empty()
             && self.dependency_materialization.is_empty()
+            && self.broker_targets.is_empty()
     }
 }
 


### PR DESCRIPTION
## Summary
- add generic rig broker target declarations
- project only SSH-resolution-safe project/server fields into a job-scoped Lab home
- make undeclared and unavailable targets actionable from homeboy ssh

## Verification
- cargo check -p homeboy-cli -p homeboy-lab-runner
- cargo test -p homeboy-lab-runner broker_target_projection_keeps_credentials_out_of_runner_config --lib
- cargo test -p homeboy-cli ssh --lib

Closes #6310.

## AI assistance
OpenAI openai/gpt-5.6-terra via OpenCode investigated the linked-rig Lab regression, implemented the generic broker-target projection, ran focused Rust checks/tests, and prepared this PR. Chris Huber remains responsible for review and merge.