### PR TITLE
refactor(agents): light up agent_task_provider for the dead-code lint

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_provider.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 #[cfg(not(test))]
 use std::sync::{OnceLock, RwLock};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -137,9 +137,6 @@ use outcome_normalization::{
     surface_provider_run_result_diagnostics,
 };
 #[cfg(test)]
-use resolution::{
-    discover_agent_task_executor_providers, provider_requires_cwd_git_checkout_with_providers,
-    select_provider_by_backend,
-};
+use resolution::{provider_requires_cwd_git_checkout_with_providers, select_provider_by_backend};
 #[cfg(test)]
 use secrets::{apply_provider_runner_secret_env_contracts_with_providers, provider_secret_sources};

--- a/crates/homeboy-agents/src/agent_task_provider/artifact_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/artifact_finalization.rs
@@ -29,6 +29,9 @@ pub(crate) struct ExecutorArtifactRootIdentity {
 }
 
 impl ExecutorArtifactRootIdentity {
+    #[cfg(test)]
+    // Convenience entry point used only by the provider test fixtures; production
+    // resolves the finalized root explicitly through capture_with_finalized_root.
     pub(crate) fn capture(path: &Path) -> Result<Self> {
         let finalized_root = homeboy_core::paths::artifact_root()?.join("executor-finalized");
         Self::capture_with_finalized_root(path, finalized_root)

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -18,7 +18,7 @@ use crate::agent_task_process_containment::{
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::Instant;
 
 const EXECUTOR_OUTPUT_CAPTURE_LIMIT_BYTES: usize = 16 * 1024;
 const REDACTED_VALUE: &str = "[redacted]";
@@ -1536,15 +1536,6 @@ fn test_executor_request(request: &AgentTaskRequest) -> AgentTaskExecutorRequest
         },
         resolved_runtime_tools: Vec::new(),
     }
-}
-
-fn now_unix_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis()
-        .try_into()
-        .unwrap_or(u64::MAX)
 }
 
 fn spawn_output_reader<R>(

--- a/crates/homeboy-agents/src/agent_task_provider/config_preflight.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/config_preflight.rs
@@ -367,7 +367,7 @@ mod tests {
 
     use crate::agent_task::{
         AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace,
-        AgentTaskWorkspaceMode, AGENT_TASK_REQUEST_SCHEMA,
+        AGENT_TASK_REQUEST_SCHEMA,
     };
 
     use super::*;

--- a/crates/homeboy-agents/src/agent_task_provider/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/discovery.rs
@@ -7,7 +7,6 @@
 //! opaquely) into the agents crate.
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use std::collections::BTreeMap;
 
 use homeboy_extension_contract::agent_task_executor_declaration::parse_agent_task_executor_declaration;
@@ -260,37 +259,6 @@ fn expected_agent_runtime_provider_refs(
         }
     }
     Ok(expected)
-}
-
-struct ParsedAgentTaskExecutorProviderCatalog {
-    providers: Vec<AgentTaskExecutorProvider>,
-    diagnostics: Vec<AgentRuntimeDiscoveryDiagnostic>,
-}
-
-fn parse_agent_task_executor_provider_catalog(
-    values: &[Value],
-    runtime_id: &str,
-    extension_id: Option<&str>,
-    path: Option<&str>,
-) -> ParsedAgentTaskExecutorProviderCatalog {
-    let mut providers = Vec::new();
-    let mut diagnostics = Vec::new();
-    for value in values {
-        match serde_json::from_value(value.clone()) {
-            Ok(provider) => providers.push(provider),
-            Err(error) => diagnostics.push(AgentRuntimeDiscoveryDiagnostic {
-                class: "agent_task_executor_provider.parse_failed".to_string(),
-                message: error.to_string(),
-                runtime_id: Some(runtime_id.to_string()),
-                extension_id: extension_id.map(str::to_string),
-                path: path.map(str::to_string),
-            }),
-        }
-    }
-    ParsedAgentTaskExecutorProviderCatalog {
-        providers,
-        diagnostics,
-    }
 }
 
 /// Agent-task implementation of core's extension provider-discovery validator.

--- a/crates/homeboy-agents/src/agent_task_provider/resolution.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/resolution.rs
@@ -48,11 +48,6 @@ pub(super) fn provider_requires_cwd_git_checkout_with_providers(
         })
         .unwrap_or(false)
 }
-#[cfg(test)]
-pub(super) fn discover_agent_task_executor_providers() -> Vec<AgentTaskExecutorProvider> {
-    super::discovery::discover_agent_task_executor_providers()
-}
-
 pub(super) fn select_provider<'a>(
     providers: &'a [AgentTaskExecutorProvider],
     request: &AgentTaskRequest,

--- a/crates/homeboy-agents/src/lib.rs
+++ b/crates/homeboy-agents/src/lib.rs
@@ -41,11 +41,6 @@ pub mod agent_task_notify;
 mod agent_task_process_containment;
 pub mod agent_task_promotion;
 pub mod agent_task_prompts;
-#[allow(
-    dead_code,
-    unused_imports,
-    reason = "Provider discovery and test fixtures support configured optional executors."
-)]
 pub mod agent_task_provider;
 pub mod agent_task_repo_loop_compile;
 pub mod agent_task_review_dossier;

--- a/tests/dead_code_suppression_ratchet_test.rs
+++ b/tests/dead_code_suppression_ratchet_test.rs
@@ -42,7 +42,7 @@ use std::path::{Path, PathBuf};
 /// homeboy-agents modules, plus two `#[path]`-shared test support modules that
 /// each test binary includes whole and uses in part. It is a ceiling, not a
 /// target: lower it whenever a crate is cleared, and never raise it.
-const MODULE_SUPPRESSION_CEILING: usize = 6;
+const MODULE_SUPPRESSION_CEILING: usize = 5;
 
 /// One module-level suppression, located precisely enough to act on.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
Slice 4. Based directly on `main` — the first three slices are merged (#13311, #13312, #13316).

## 17.2k lines, twelve warnings

Four of the dead items were **duplicates**, not abandoned features:

| dead | the live one |
|---|---|
| `ExecutorArtifactRootIdentity::capture` | `capture_with_finalized_root` |
| `resolution::discover_agent_task_executor_providers` | `discovery::` of the same name |
| `command_runner::now_unix_ms` | `agent_task_timeout::now_unix_ms` |
| `parse_agent_task_executor_provider_catalog` + its result struct | no callers at all |

**This is the fourth consecutive slice to find the same shape.** A wider variant gets introduced, production moves to it, the original survives on test callers or on nothing, and the module attribute keeps anyone from noticing.

## Two things worth flagging

`resolution::discover_agent_task_executor_providers` already carried `#[cfg(test)]` **and was still reported dead** — not even the tests it was gated for called it. A `cfg(test)` gate is not a parking spot; the lint still reaches it.

`capture` is reported dead by the **lib** build and required by the **test** build. Deleting it produced three `E0599`s, so it is gated rather than removed — the second slice running where a lib-only dead report named an item the test build needs. Worth treating as the default suspicion for any `pub(crate)` accessor in this crate.

## Verification

```
cargo check --workspace --all-targets    0 warnings, 0 errors
cargo fmt --all --check                  clean
ratchet test                             3 passed
agent_task_provider tests                188 pass / 1 fail
origin/main, same box, same filter       188 pass / 1 fail  (identical name)
```

## Ceiling

6 → 5. Remaining: `scheduler` (17.3k), `lifecycle` (44.5k), `service` (55.8k).