### PR TITLE
refactor(agents): light up agent_task_scheduler for the dead-code lint

### DIFF
--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -1706,13 +1706,12 @@ pub fn record_dependency_action_receipt_in_store(
 mod tests {
     use super::*;
     use crate::agent_task::{
-        AgentTaskArtifact, AgentTaskEvidenceRef, AgentTaskExecutor, AgentTaskOutcome,
-        AgentTaskOutcomeStatus, AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace,
-        AGENT_TASK_ARTIFACT_SCHEMA, AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
+        AgentTaskArtifact, AgentTaskExecutor, AgentTaskOutcome, AgentTaskOutcomeStatus,
+        AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace, AGENT_TASK_ARTIFACT_SCHEMA,
+        AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
     };
     use crate::agent_task_scheduler::{
         AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
-        AgentTaskExecutionContext, AgentTaskExecutorAdapter,
     };
     use std::collections::HashMap;
     use std::sync::{Arc, Barrier};
@@ -3434,50 +3433,6 @@ mod tests {
             output_declarations: Vec::new(),
             runtime_tools: Vec::new(),
             metadata: Value::Null,
-        }
-    }
-
-    struct ArtifactExecutor;
-
-    impl AgentTaskExecutorAdapter for ArtifactExecutor {
-        fn execute(
-            &self,
-            request: AgentTaskRequest,
-            _context: AgentTaskExecutionContext,
-        ) -> AgentTaskOutcome {
-            AgentTaskOutcome {
-                schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
-                task_id: request.task_id.clone(),
-                status: AgentTaskOutcomeStatus::Succeeded,
-                summary: Some("ok".to_string()),
-                failure_classification: None,
-                artifacts: vec![AgentTaskArtifact {
-                    schema: AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
-                    id: format!("artifact-{}", request.task_id),
-                    kind: "report".to_string(),
-                    name: Some("report.json".to_string()),
-                    label: Some("Report".to_string()),
-                    role: Some("report".to_string()),
-                    semantic_key: Some("agent_task.report".to_string()),
-                    path: Some(format!("artifacts/{}/report.json", request.task_id)),
-                    url: None,
-                    mime: Some("application/json".to_string()),
-                    size_bytes: Some(12),
-                    sha256: None,
-                    metadata: Value::Null,
-                }],
-                typed_artifacts: Vec::new(),
-                evidence_refs: vec![AgentTaskEvidenceRef {
-                    kind: "executor-log".to_string(),
-                    uri: format!("homeboy://agent-task/evidence/{}", request.task_id),
-                    label: Some("Executor log".to_string()),
-                }],
-                diagnostics: Vec::new(),
-                outputs: Value::Null,
-                workflow: None,
-                follow_up: None,
-                metadata: Value::Null,
-            }
         }
     }
 }

--- a/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
@@ -63,6 +63,7 @@ impl HarvestExecutionContext {
         )
     }
 
+    #[cfg(test)]
     fn from_transport_values(
         source: Option<&str>,
         lab: Option<&str>,

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -135,6 +135,8 @@ impl AgentTaskScheduler {
         )
     }
 
+    #[cfg(test)]
+    // Cancellation harness entry point; production drives run() directly.
     pub(crate) fn run_with_cancellation(
         &self,
         plan: AgentTaskPlan,

--- a/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
@@ -644,7 +644,7 @@ mod committed_harvest_tests {
         AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskWorkspace,
         AGENT_TASK_REQUEST_SCHEMA,
     };
-    use homeboy_core::source_snapshot::SourceSnapshot;
+
     use sha2::{Digest, Sha256};
     use std::sync::{Mutex, OnceLock};
     use std::time::Instant;

--- a/crates/homeboy-agents/src/agent_task_scheduler/managed_services.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/managed_services.rs
@@ -12,6 +12,7 @@ use std::process::{Child, Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+#[cfg(test)]
 use homeboy_core::agent_task_config::AgentTaskManagedServiceReadiness;
 use homeboy_core::process::{
     process_identity_state_with_start_identity, process_start_identity,
@@ -20,10 +21,9 @@ use homeboy_core::process::{
 };
 use serde_json::{json, Value};
 
-use super::{
-    AgentTaskEvidenceRef, AgentTaskManagedService, AgentTaskManagedServiceLifecycle,
-    AgentTaskManagedServiceReadinessKind,
-};
+#[cfg(test)]
+use super::AgentTaskManagedServiceLifecycle;
+use super::{AgentTaskEvidenceRef, AgentTaskManagedService, AgentTaskManagedServiceReadinessKind};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct AgentTaskManagedServiceRecord {
@@ -126,7 +126,15 @@ struct RunningService {
     child: Child,
     containment: homeboy_core::process::ProcessContainment,
     record: AgentTaskManagedServiceRecord,
+    #[allow(
+        dead_code,
+        reason = "Held to keep the port lease and listener alive until RunningService drops."
+    )]
     port_lease: Option<PortLease>,
+    #[allow(
+        dead_code,
+        reason = "Held to keep the port lease and listener alive until RunningService drops."
+    )]
     listener: Option<TcpListener>,
 }
 
@@ -320,6 +328,10 @@ impl AgentTaskServiceSupervisor {
         Ok(())
     }
 
+    #[allow(
+        dead_code,
+        reason = "Binds the out-of-process supervisor's services; #[cfg(test)] start() returns Local, so no test reaches this path."
+    )]
     pub(super) fn bind_into(&self, inputs: &mut Value, metadata: &mut Value) {
         let values = self.records().into_iter().map(|record| (record.id.clone(), json!({
             "local_url": record.local_url, "public_url": record.public_url,

--- a/crates/homeboy-agents/src/agent_task_scheduler/postprocess.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/postprocess.rs
@@ -1,6 +1,7 @@
 //! Plan-native execution of generic artifact postprocess actions.
 
 use std::path::{Component, Path, PathBuf};
+#[cfg(not(test))]
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -252,6 +253,7 @@ fn start_or_reconcile_worker_with_retry(
     Err("artifact postprocess worker did not complete before scheduler wait limit".to_string())
 }
 
+#[cfg(not(test))]
 fn postprocess_worker_executable() -> PathBuf {
     let configured = std::env::var_os("HOMEBOY_POSTPROCESS_WORKER").map(PathBuf::from);
     // Archive-replayed integration tests execute from a rooted helper copy while
@@ -974,7 +976,6 @@ const CLAIM_SCHEMA: &str = "homeboy/agent-task-postprocess-claim/v2";
 const COMPLETION_SCHEMA: &str = "homeboy/agent-task-postprocess-completion/v1";
 const WORKER_REQUEST_SCHEMA: &str = "homeboy/agent-task-postprocess-worker-request/v1";
 const WORKER_SPAWN_SCHEMA: &str = "homeboy/agent-task-postprocess-worker-spawn/v1";
-const CLAIM_STALE_AFTER_SECS: u64 = 300;
 const CLAIM_HEARTBEAT_INTERVAL_SECS: u64 = 1;
 
 struct PostprocessClaimGuard {

--- a/crates/homeboy-agents/src/lib.rs
+++ b/crates/homeboy-agents/src/lib.rs
@@ -46,11 +46,6 @@ pub mod agent_task_repo_loop_compile;
 pub mod agent_task_review_dossier;
 pub mod agent_task_runtime_dependency_graph;
 pub mod agent_task_schedule;
-#[allow(
-    dead_code,
-    unused_imports,
-    reason = "Scheduler adapters and test fixtures support cancellation and recovery execution paths."
-)]
 pub mod agent_task_scheduler;
 pub mod agent_task_secrets;
 #[allow(

--- a/tests/dead_code_suppression_ratchet_test.rs
+++ b/tests/dead_code_suppression_ratchet_test.rs
@@ -42,7 +42,7 @@ use std::path::{Path, PathBuf};
 /// homeboy-agents modules, plus two `#[path]`-shared test support modules that
 /// each test binary includes whole and uses in part. It is a ceiling, not a
 /// target: lower it whenever a crate is cleared, and never raise it.
-const MODULE_SUPPRESSION_CEILING: usize = 5;
+const MODULE_SUPPRESSION_CEILING: usize = 4;
 
 /// One module-level suppression, located precisely enough to act on.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
Slice 5. Based on `main`; #13311, #13312, #13316 and #13335 are merged.

## This is the slice where auto-applying compiler suggestions breaks the build — both ways

`std::process::Command` is used only under `#[cfg(not(test))]`. The **test** build reports it unused; removing it fails the **lib** build with `E0433`.

`AgentTaskManagedServiceLifecycle` and `AgentTaskManagedServiceReadiness` run the **opposite** way: reported unused by the **lib** build, required by the **test** build (`E0433`/`E0422`).

A `--all-targets` warning list is a **union across configurations with different reachability**. Nothing in the list says which configuration produced it, so no import removal in this crate is safe without compiling after it. All three are gated to match their real use sites.

## Items resolved

| item | disposition |
|---|---|
| `CLAIM_STALE_AFTER_SECS` | deleted — no callers |
| `ArtifactExecutor` + adapter impl | deleted — never constructed |
| `postprocess_worker_executable` | `#[cfg(not(test))]` |
| `run_with_cancellation` | `#[cfg(test)]` — cancellation harness only |
| `from_transport_values` | `#[cfg(test)]` — sole caller is in `mod tests` |
| `RunningService::port_lease` / `listener` | per-item allow — RAII, held for `Drop` |
| `AgentTaskServiceSupervisor::bind_into` | per-item allow — out-of-process path that `#[cfg(test)] start()` never takes |

The last two are the false-positive class: items that are *never read* yet load-bearing. Deleting a guard field that exists to be dropped silently changes runtime behavior and no test fails.

## Verification

```
cargo check --workspace --all-targets    0 warnings, 0 errors
cargo fmt --all --check                  clean
ratchet test                             3 passed
agent_task_scheduler tests               153 pass / 2 fail
origin/main, same box, same filter       154 pass / 1 fail
```

The extra name is `timeout_quarantines_only_its_workspace_without_starving_unrelated_work`, which is **non-deterministic on identical code** — 1 of 3 passing on this branch, 1 of 4 on `origin/main`. Pre-existing flake, not a regression.

## Ceiling

5 → 4. Remaining: `lifecycle` (44.5k), `service` (55.8k).