### PR TITLE
refactor(core): collapse the two projection twins onto their source types

### DIFF
--- a/crates/homeboy-core/src/run_outcome_envelope.rs
+++ b/crates/homeboy-core/src/run_outcome_envelope.rs
@@ -30,23 +30,16 @@ pub struct RunOutcomeEnvelope {
     pub result: Value,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RunOutcomeProjection {
-    pub schema: String,
-    pub status: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub run_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub runner_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub exit_code: Option<i32>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub artifact_refs: Vec<ArtifactRef>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub evidence_refs: Vec<EvidenceRef>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub handoffs: Vec<RunOutcomeHandoffRef>,
-}
+/// The inspection view of a run outcome: the same envelope with the opaque
+/// `result` payload cleared.
+///
+/// This used to be a second struct repeating all eight of the envelope's other
+/// fields verbatim, rebuilt field-by-field by `projection()`. `result` is
+/// `#[serde(skip_serializing_if = "Value::is_null")]`, so "the envelope without
+/// `result`" is a *value* of `RunOutcomeEnvelope`, not a second type -- the
+/// distinction was never in the serialized shape. Same collapse as #10310 and
+/// #11137 applied to the artifact-ref twins in `runner_execution_envelope`.
+pub type RunOutcomeProjection = RunOutcomeEnvelope;
 
 impl RunOutcomeEnvelope {
     pub fn new(status: impl Into<String>) -> Self {
@@ -140,16 +133,12 @@ impl RunOutcomeEnvelope {
         });
     }
 
+    /// Inspection view: everything except the opaque `result` payload, which is
+    /// cleared to `Value::Null` so `skip_serializing_if` drops the key.
     pub fn projection(&self) -> RunOutcomeProjection {
-        RunOutcomeProjection {
-            schema: self.schema.clone(),
-            status: self.status.clone(),
-            run_id: self.run_id.clone(),
-            runner_id: self.runner_id.clone(),
-            exit_code: self.exit_code,
-            artifact_refs: self.artifact_refs.clone(),
-            evidence_refs: self.evidence_refs.clone(),
-            handoffs: self.handoffs.clone(),
+        Self {
+            result: Value::Null,
+            ..self.clone()
         }
     }
 

--- a/crates/homeboy-core/src/runner_execution_envelope.rs
+++ b/crates/homeboy-core/src/runner_execution_envelope.rs
@@ -137,6 +137,12 @@ pub struct RunnerExecutionRecord {
     pub agent_task_run_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mirror_run_id: Option<String>,
+    /// Flattened runtime view of `path_materialization_plan`, populated only by
+    /// [`RunnerExecutionRecord::projection`]. Always empty on a stored record,
+    /// so `homeboy/runner-execution-record/v1` emits exactly the fields it
+    /// emitted before this field existed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub materialized_paths: Vec<PathMaterializationProjection>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path_materialization_plan: Option<PathMaterializationPlan>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -147,30 +153,16 @@ pub struct RunnerExecutionRecord {
     pub next_actions: Vec<RunnerExecutionNextAction>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RunnerExecutionProjection {
-    pub schema: String,
-    pub execution_id: String,
-    pub runner_id: String,
-    pub transport: String,
-    pub status: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub job_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub local_run_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub remote_run_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub agent_task_run_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub mirror_run_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub materialized_paths: Vec<PathMaterializationProjection>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub artifact_refs: Vec<JobArtifactMetadata>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub next_actions: Vec<RunnerExecutionNextAction>,
-}
+/// The inspection view of a runner execution record: the stored
+/// `path_materialization_plan` swapped for its flattened runtime projection,
+/// and `orchestration_provenance` dropped.
+///
+/// This used to be a second struct repeating ten of the record's fields
+/// verbatim, rebuilt field-by-field by `projection()`. Every field the two
+/// states disagree on is `skip_serializing_if`, so "record" and "projection"
+/// are two *values* of one type, not two types -- the same collapse #10310 and
+/// #11137 applied to the artifact-ref twins above.
+pub type RunnerExecutionProjection = RunnerExecutionRecord;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OrchestrationTargetProvenance {
@@ -267,27 +259,39 @@ pub struct RunnerExecutionNextAction {
 }
 
 impl RunnerExecutionRecord {
-    pub fn planned(
+    /// The one empty-record constructor. `planned`, `terminal` and `in_flight`
+    /// differed only in the `status` string they wrote.
+    fn at_status(
         execution_id: impl Into<String>,
         runner_id: impl Into<String>,
         transport: impl Into<String>,
+        status: impl Into<String>,
     ) -> Self {
         Self {
             schema: RUNNER_EXECUTION_RECORD_SCHEMA.to_string(),
             execution_id: execution_id.into(),
             runner_id: runner_id.into(),
             transport: transport.into(),
-            status: "planned".to_string(),
+            status: status.into(),
             job_id: None,
             local_run_id: None,
             remote_run_id: None,
             agent_task_run_id: None,
             mirror_run_id: None,
+            materialized_paths: Vec::new(),
             path_materialization_plan: None,
             orchestration_provenance: None,
             artifact_refs: Vec::new(),
             next_actions: Vec::new(),
         }
+    }
+
+    pub fn planned(
+        execution_id: impl Into<String>,
+        runner_id: impl Into<String>,
+        transport: impl Into<String>,
+    ) -> Self {
+        Self::at_status(execution_id, runner_id, transport, "planned")
     }
 
     pub fn terminal(
@@ -296,27 +300,16 @@ impl RunnerExecutionRecord {
         transport: impl Into<String>,
         exit_code: i32,
     ) -> Self {
-        Self {
-            schema: RUNNER_EXECUTION_RECORD_SCHEMA.to_string(),
-            execution_id: execution_id.into(),
-            runner_id: runner_id.into(),
-            transport: transport.into(),
-            status: if exit_code == 0 {
+        Self::at_status(
+            execution_id,
+            runner_id,
+            transport,
+            if exit_code == 0 {
                 "succeeded"
             } else {
                 "failed"
-            }
-            .to_string(),
-            job_id: None,
-            local_run_id: None,
-            remote_run_id: None,
-            agent_task_run_id: None,
-            mirror_run_id: None,
-            path_materialization_plan: None,
-            orchestration_provenance: None,
-            artifact_refs: Vec::new(),
-            next_actions: Vec::new(),
-        }
+            },
+        )
     }
 
     pub fn in_flight(
@@ -324,22 +317,7 @@ impl RunnerExecutionRecord {
         runner_id: impl Into<String>,
         transport: impl Into<String>,
     ) -> Self {
-        Self {
-            schema: RUNNER_EXECUTION_RECORD_SCHEMA.to_string(),
-            execution_id: execution_id.into(),
-            runner_id: runner_id.into(),
-            transport: transport.into(),
-            status: "running".to_string(),
-            job_id: None,
-            local_run_id: None,
-            remote_run_id: None,
-            agent_task_run_id: None,
-            mirror_run_id: None,
-            path_materialization_plan: None,
-            orchestration_provenance: None,
-            artifact_refs: Vec::new(),
-            next_actions: Vec::new(),
-        }
+        Self::at_status(execution_id, runner_id, transport, "running")
     }
 
     pub fn with_job_id(mut self, job_id: impl Into<String>) -> Self {
@@ -390,25 +368,19 @@ impl RunnerExecutionRecord {
         self
     }
 
+    /// Inspection view: the stored plan is replaced by its flattened runtime
+    /// entries and the orchestration provenance is dropped, so both
+    /// `skip_serializing_if` themselves out of the emitted shape.
     pub fn projection(&self) -> RunnerExecutionProjection {
-        RunnerExecutionProjection {
-            schema: self.schema.clone(),
-            execution_id: self.execution_id.clone(),
-            runner_id: self.runner_id.clone(),
-            transport: self.transport.clone(),
-            status: self.status.clone(),
-            job_id: self.job_id.clone(),
-            local_run_id: self.local_run_id.clone(),
-            remote_run_id: self.remote_run_id.clone(),
-            agent_task_run_id: self.agent_task_run_id.clone(),
-            mirror_run_id: self.mirror_run_id.clone(),
+        Self {
             materialized_paths: self
                 .path_materialization_plan
                 .as_ref()
                 .map(PathMaterializationPlan::projection_entries)
                 .unwrap_or_default(),
-            artifact_refs: self.artifact_refs.clone(),
-            next_actions: self.next_actions.clone(),
+            path_materialization_plan: None,
+            orchestration_provenance: None,
+            ..self.clone()
         }
     }
 }


### PR DESCRIPTION
Continues the duplication burn-down (#13271, #13295, #13314, #13327).

`RunOutcomeProjection` and `RunnerExecutionProjection` were each a second struct repeating their source type's fields verbatim, rebuilt field-by-field by a `projection()` that was pure `.clone()`. Both are now documented type aliases, and `projection()` returns a *value* of the one type.

**The precedent is in the same file.** #10310 folded `RunnerExecutionArtifactRef` and #11137 folded `LabRunnerWorkloadArtifactRef`, both onto `JobArtifactMetadata`, on the reasoning that "the distinction was never in the serialized shape" (`runner_execution_envelope.rs:10-23`). Same reasoning, same shape.

**-99 / +60** across two pure-DTO files (no file I/O, no SQL).

## What collapsed

**`run_outcome_envelope.rs:33`** — `RunOutcomeProjection` repeated all eight non-`result` fields of `RunOutcomeEnvelope`. `result` is `#[serde(skip_serializing_if = "Value::is_null")]` (`run_outcome_envelope.rs:29`), so "the envelope without `result`" is `Self { result: Value::Null, ..self.clone() }`. The key is dropped by serde, not by a second type.

**`runner_execution_envelope.rs:151`** — `RunnerExecutionProjection` repeated ten of `RunnerExecutionRecord`'s fields. `materialized_paths` moves onto the record directly above `path_materialization_plan` (`runner_execution_envelope.rs:141-146`), where `projection()` populates it from `PathMaterializationPlan::projection_entries` and clears `path_materialization_plan` / `orchestration_provenance`.

**`RunnerExecutionRecord::{planned,terminal,in_flight}`** were three sixteen-line constructors differing only in the `status` string; they now delegate to one private `at_status`.

## Wire compatibility

`materialized_paths` is `#[serde(default, skip_serializing_if = "Vec::is_empty")]` and is only ever populated by `projection()`, so a stored `homeboy/runner-execution-record/v1` emits exactly the fields it emitted before. Field order places it where the old projection had it, so the projection's emitted key order is byte-identical too, and still matches `runner_execution_record_constants().projection_fields` (`command_contract/constants.rs:369-385`) exactly.

Neither projection type was ever in `CONTRACT_SCHEMAS` (`commands/contract/mod.rs:1277-1301`) — only the envelopes and the record are, and those are unchanged. `LAB_RUNNER_WORKLOAD_SCHEMA` is untouched.

The aliases keep `RunOutcomeProjection` / `RunnerExecutionProjection` readable as names at the ~8 call sites in homeboy-cli and homeboy-lab-runner (`dev_run.rs:86`, `commands/contract/mod.rs:222`, `command_contract.rs:97,102`).

Both pinned tests pass **unchanged**:
- `run_outcome_projection_exposes_inspection_fields_without_result_payload` — `value.get("result").is_none()` ✅
- `runner_execution_projection_flattens_materialized_paths` ✅

## Gate

`cargo check --workspace --all-targets -j2` → **exit 0 in 3m25s, zero warnings.** (`--all-targets`, not `--tests`, per RULES.md.)

## Baseline diff

`cargo test -p homeboy-core --lib -j2` on this branch: **all 15 tests in the two touched modules pass**, including both pinned assertions and `runner_execution_record_artifact_refs_keep_the_pre_collapse_wire_shape`.

22 other tests failed, and **none are assertion failures** — every one carries the `/var/tmp/.homeboy-test-tmp/... unable to open database file` / `SQLite ... disk I/O error` signature, in `cleanup::`, `test_support::sweep`, `worktree::`, `daemon::runner_files::` (quota), `process::scope_cleanup`, `http_api::`. That is exactly the undeclared free-space precondition documented in **#13273** ("at 83% used / 13G free an 11th test also failed; at 80% / 15G free it passed").

The run confirms it: free space fell 26G → 8.8G during the suite, with a concurrent 19G `target/` build in another worktree on the same volume. The clean-main re-run was **not** completed — restarting a suite that consumes ~17G with 12G free is the exact mechanism behind the 2026-07-29 root-volume outage, so I stopped at the RULES.md threshold rather than push through it. Full-suite confirmation is left to CI, which is where RULES.md routes `cargo test` anyway.

## What I deliberately did NOT collapse

- **`RunnerExecutionEnvelope` / `RunnerExecutionRecord`** are not twins — disjoint field sets, two distinct published schemas, both in the contract catalog.
- **`materialized_paths` stays a field**, not a derived method or a serialization-time computation. `runner_execution_projection_flattens_materialized_paths` and `runner_execution_record_normalizer_projects_materialized_paths` (`commands/contract/mod.rs:1937`) both read it as a field, and the brief forbids editing those assertions.
- **The projection type names stay**, rather than being deleted in favour of the source names — matching the `pub use ... as` shape of #10310/#11137, and keeping the diff to two files.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode
