### PR TITLE
Seal the homeboy-release crate boundary

### DIFF
--- a/crates/homeboy-release/src/release/cascade.rs
+++ b/crates/homeboy-release/src/release/cascade.rs
@@ -28,13 +28,13 @@ use super::types::ReleaseCommandInput;
 /// declared pin on a just-released upstream. Receives the released coordinates
 /// in the action payload's `dependency` block (see
 /// [`build_update_dependency_payload`]).
-pub const UPDATE_DEPENDENCY_ACTION: &str = "release.update_dependency";
+pub(crate) const UPDATE_DEPENDENCY_ACTION: &str = "release.update_dependency";
 
 /// Bump type used for a dependent released purely because an upstream changed.
 /// Passing this as the release bump override also permits a release with no new
 /// commits since the last tag (a pure dependency bump), instead of skipping
 /// with "no releasable commits".
-pub const DEPENDENCY_BUMP: &str = "patch";
+pub(crate) const DEPENDENCY_BUMP: &str = "patch";
 
 /// Released coordinates for one component in the cascade.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -47,40 +47,40 @@ pub struct ReleasedCoordinates {
 
 /// One incoming dependency edge into a downstream dependent.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct CascadeEdge {
+pub(crate) struct CascadeEdge {
     /// The upstream (released) component this edge depends on.
-    pub upstream: String,
+    pub(crate) upstream: String,
     /// The package name that links upstream → downstream.
-    pub package: String,
+    pub(crate) package: String,
 }
 
 /// A downstream dependent to update and release, with every incoming dependency
 /// edge collapsed so the dependent is released at most once per cascade.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct CascadeTarget {
-    pub downstream: String,
-    pub downstream_path: String,
-    pub incoming: Vec<CascadeEdge>,
+pub(crate) struct CascadeTarget {
+    pub(crate) downstream: String,
+    pub(crate) downstream_path: String,
+    pub(crate) incoming: Vec<CascadeEdge>,
 }
 
 /// Per-dependent outcome of a cascade run.
 #[derive(Debug, Clone, Serialize)]
 pub struct CascadeStepResult {
-    pub downstream: String,
+    pub(crate) downstream: String,
     /// Packages whose pin was updated on this dependent.
-    pub updated_packages: Vec<String>,
-    pub status: String,
+    pub(crate) updated_packages: Vec<String>,
+    pub(crate) status: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub new_version: Option<String>,
+    pub(crate) new_version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tag: Option<String>,
+    pub(crate) tag: Option<String>,
 }
 
 /// Aggregate result of a cascade run.
 #[derive(Debug, Clone, Serialize)]
 pub struct CascadeResult {
-    pub upstream: String,
-    pub released: Vec<CascadeStepResult>,
+    pub(crate) upstream: String,
+    pub(crate) released: Vec<CascadeStepResult>,
 }
 
 /// Collapse an ordered (BFS / topological) dependency stack plan into a

--- a/crates/homeboy-release/src/release/containment.rs
+++ b/crates/homeboy-release/src/release/containment.rs
@@ -45,9 +45,9 @@ use homeboy_core::git;
 use crate::release::scope::ReleaseScope;
 
 /// Command an operator runs when a fix is merged but no release contains it.
-pub const REMEDIATION_RELEASE: &str = "homeboy release";
+pub(crate) const REMEDIATION_RELEASE: &str = "homeboy release";
 /// Command an operator runs when a release contains the fix but this binary does not.
-pub const REMEDIATION_UPGRADE: &str = "homeboy upgrade";
+pub(crate) const REMEDIATION_UPGRADE: &str = "homeboy upgrade";
 
 /// A release tag paired with the exact semantic version it encodes.
 ///
@@ -55,9 +55,9 @@ pub const REMEDIATION_UPGRADE: &str = "homeboy upgrade";
 /// `v1.2`-style short tag, or an arbitrary annotation is not a release this
 /// query can order, so it is dropped rather than guessed at.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ReleaseTag {
-    pub tag: String,
-    pub version: Version,
+pub(crate) struct ReleaseTag {
+    pub(crate) tag: String,
+    pub(crate) version: Version,
 }
 
 /// Parse the exact release version a tag encodes inside a component's tag
@@ -158,7 +158,7 @@ impl ContainmentStatus {
 
     /// The command that closes the gap, or `None` when there is nothing to do
     /// or nothing established.
-    pub fn remediation(self) -> Option<&'static str> {
+    pub(crate) fn remediation(self) -> Option<&'static str> {
         match self {
             Self::NotYetReleased => Some(REMEDIATION_RELEASE),
             Self::ReleasedNotInstalled => Some(REMEDIATION_UPGRADE),
@@ -172,45 +172,48 @@ impl ContainmentStatus {
 /// Separated from the git layer so the ordering rule, the status split, and the
 /// message are testable without a repository.
 #[derive(Debug, Clone, Copy)]
-pub struct ContainmentFacts<'a> {
+pub(crate) struct ContainmentFacts<'a> {
     /// Every tag present in this checkout (release and otherwise).
-    pub known_tags: &'a [String],
+    pub(crate) known_tags: &'a [String],
     /// The subset that contains the commit — `git tag --contains <sha>`.
-    pub containing_tags: &'a [String],
+    pub(crate) containing_tags: &'a [String],
     /// The release tag the installed build corresponds to, when one is known.
-    pub installed_tag: Option<&'a str>,
+    pub(crate) installed_tag: Option<&'a str>,
 }
 
 /// The containment verdict for one commit.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ContainmentAssessment {
-    pub status: ContainmentStatus,
+    pub(crate) status: ContainmentStatus,
     /// Earliest release tag containing the commit.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub first_released_in: Option<String>,
+    pub(crate) first_released_in: Option<String>,
     /// That tag's version, without the tag namespace or `v` prefix.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub first_released_version: Option<String>,
+    pub(crate) first_released_version: Option<String>,
     /// Release tag the installed build corresponds to.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub installed_tag: Option<String>,
+    pub(crate) installed_tag: Option<String>,
     /// Whether that tag exists in this checkout at all. When false the
     /// installed comparison is not attempted — an absent tag is missing
     /// evidence, not evidence of absence.
-    pub installed_tag_known_locally: bool,
+    pub(crate) installed_tag_known_locally: bool,
     /// Whether the installed build contains the commit. `None` when the
     /// comparison could not be made.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub installed_contains: Option<bool>,
+    pub(crate) installed_contains: Option<bool>,
     /// Number of releases cut at or after the first containing one.
-    pub releases_since: usize,
-    pub detail: String,
+    pub(crate) releases_since: usize,
+    pub(crate) detail: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub remediation: Option<String>,
+    pub(crate) remediation: Option<String>,
 }
 
 /// Pure containment assessment. No git, no network, no clock.
-pub fn assess(facts: ContainmentFacts<'_>, tag_prefix: Option<&str>) -> ContainmentAssessment {
+pub(crate) fn assess(
+    facts: ContainmentFacts<'_>,
+    tag_prefix: Option<&str>,
+) -> ContainmentAssessment {
     let first = earliest_containing_release(facts.containing_tags, tag_prefix);
     let known = parse_release_tags(facts.known_tags, tag_prefix);
 
@@ -305,24 +308,24 @@ pub enum GapStatus {
 /// The installed-versus-latest verdict for one component checkout.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReleaseGapAssessment {
-    pub status: GapStatus,
+    pub(crate) status: GapStatus,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub installed_version: Option<String>,
+    pub(crate) installed_version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub installed_tag: Option<String>,
+    pub(crate) installed_tag: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub latest_tag: Option<String>,
+    pub(crate) latest_tag: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub latest_version: Option<String>,
+    pub(crate) latest_version: Option<String>,
     /// Releases published after the installed one.
-    pub releases_behind: usize,
+    pub(crate) releases_behind: usize,
     /// Commits on the newest release that the installed release does not have.
     /// `None` when it could not be counted offline.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub commits_behind: Option<u64>,
-    pub detail: String,
+    pub(crate) commits_behind: Option<u64>,
+    pub(crate) detail: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub remediation: Option<String>,
+    pub(crate) remediation: Option<String>,
 }
 
 /// Pure gap assessment. `commits_behind` is filled in by the git layer.
@@ -413,18 +416,18 @@ fn gap_detail(
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ResolvedCommit {
     /// Full resolved commit sha.
-    pub commit: String,
+    pub(crate) commit: String,
     /// Abbreviated sha, as an operator would paste it.
-    pub short_commit: String,
+    pub(crate) short_commit: String,
     /// Commit subject, when the checkout has the commit's metadata.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub subject: Option<String>,
+    pub(crate) subject: Option<String>,
     /// Issue number the commit was resolved from, when `--issue` was used.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub resolved_from_issue: Option<u64>,
+    pub(crate) resolved_from_issue: Option<u64>,
     /// Pull request the issue resolved through.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub resolved_via_pull_request: Option<u64>,
+    pub(crate) resolved_via_pull_request: Option<u64>,
 }
 
 /// What to ask about, and against which checkout.
@@ -443,21 +446,21 @@ pub struct ContainsQuery {
 /// The full `homeboy release contains` answer.
 #[derive(Debug, Clone, Serialize)]
 pub struct ReleaseContainsReport {
-    pub command: String,
-    pub component_id: String,
-    pub resolved: ResolvedCommit,
-    pub containment: ContainmentAssessment,
+    pub(crate) command: String,
+    pub(crate) component_id: String,
+    pub(crate) resolved: ResolvedCommit,
+    pub(crate) containment: ContainmentAssessment,
     /// Human-readable lines, in the order an operator should read them.
-    pub summary: Vec<String>,
+    pub(crate) summary: Vec<String>,
 }
 
 /// The full `homeboy release gap` answer.
 #[derive(Debug, Clone, Serialize)]
 pub struct ReleaseGapReport {
-    pub command: String,
-    pub component_id: String,
-    pub gap: ReleaseGapAssessment,
-    pub summary: Vec<String>,
+    pub(crate) command: String,
+    pub(crate) component_id: String,
+    pub(crate) gap: ReleaseGapAssessment,
+    pub(crate) summary: Vec<String>,
 }
 
 /// Answer "which release first contained this commit, and does this binary
@@ -713,9 +716,9 @@ fn resolve_commit(
 
 /// A pull request that closed an issue, and the commit it merged as.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct IssueResolution {
-    pub pull_request: u64,
-    pub commit: String,
+pub(crate) struct IssueResolution {
+    pub(crate) pull_request: u64,
+    pub(crate) commit: String,
 }
 
 /// Resolve an issue number to the commit of the pull request that closed it.

--- a/crates/homeboy-release/src/release/executor.rs
+++ b/crates/homeboy-release/src/release/executor.rs
@@ -554,7 +554,7 @@ mod tests {
     use super::package::store_artifacts_from_output;
     use super::{github_release, package_preflight, run_cleanup, run_package, PackageRequest};
     use crate::release::types::ReleaseState;
-    use crate::release::{ReleaseArtifact, ReleaseStepStatus};
+    use crate::release::types::{ReleaseArtifact, ReleaseStepStatus};
     use homeboy_core::component::Component;
     use homeboy_core::git::release_download::GitHubRepo;
     use homeboy_extension::ExtensionManifest;

--- a/crates/homeboy-release/src/release/executor/artifacts.rs
+++ b/crates/homeboy-release/src/release/executor/artifacts.rs
@@ -1178,7 +1178,7 @@ mod tests {
     use crate::release::executor::github_release::github_release_publications;
     use crate::release::types::ReleaseArtifact;
     use crate::release::types::ReleaseState;
-    use crate::release::ReleaseStepStatus;
+    use crate::release::types::ReleaseStepStatus;
 
     #[test]
     fn test_run_artifact_inventory() {

--- a/crates/homeboy-release/src/release/executor/changelog.rs
+++ b/crates/homeboy-release/src/release/executor/changelog.rs
@@ -53,7 +53,7 @@ pub(crate) fn run_changelog_finalize(
 mod tests {
     use super::run_changelog_finalize;
     use crate::release::types::ReleaseState;
-    use crate::release::ReleaseStepStatus;
+    use crate::release::types::ReleaseStepStatus;
     use homeboy_core::component::{Component, VersionTarget};
     use homeboy_core::plan::PlanStep;
 

--- a/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/gh_cli.rs
@@ -32,10 +32,10 @@ const DIAGNOSTIC_TRUNCATION_MARKER: &str = "...[truncated]";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GhCommandOutput {
-    pub stdout: String,
-    pub stderr: String,
-    pub exit_code: Option<i32>,
-    pub timed_out: bool,
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+    pub(crate) exit_code: Option<i32>,
+    pub(crate) timed_out: bool,
 }
 
 /// Safe, bounded evidence from a failed `gh` invocation for persisted release
@@ -43,21 +43,21 @@ pub(crate) struct GhCommandOutput {
 /// notes and upload paths can contain credentials.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct GitHubCommandFailureDiagnostic {
-    pub operation: String,
-    pub endpoint: String,
-    pub exit_code: Option<i32>,
-    pub timed_out: bool,
-    pub stdout: String,
-    pub stderr: String,
-    pub http_status: Option<u16>,
-    pub github_request_id: Option<String>,
-    pub summary: String,
+    pub(crate) operation: String,
+    pub(crate) endpoint: String,
+    pub(crate) exit_code: Option<i32>,
+    pub(crate) timed_out: bool,
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+    pub(crate) http_status: Option<u16>,
+    pub(crate) github_request_id: Option<String>,
+    pub(crate) summary: String,
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct GitHubReleaseMetadataError {
-    pub message: String,
-    pub diagnostics: Vec<GitHubCommandFailureDiagnostic>,
+    pub(crate) message: String,
+    pub(crate) diagnostics: Vec<GitHubCommandFailureDiagnostic>,
 }
 
 impl GitHubReleaseMetadataError {
@@ -187,23 +187,23 @@ impl std::error::Error for GitHubReleaseMetadataError {}
 #[derive(Debug, Clone, serde::Deserialize)]
 pub(crate) struct GitHubReleaseMetadata {
     #[serde(default)]
-    pub tag_name: String,
+    pub(crate) tag_name: String,
     #[serde(rename = "draft", alias = "isDraft")]
-    pub is_draft: bool,
+    pub(crate) is_draft: bool,
     #[serde(default)]
-    pub assets: Vec<GitHubReleaseAsset>,
+    pub(crate) assets: Vec<GitHubReleaseAsset>,
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]
 pub(crate) struct GitHubReleaseAsset {
     #[serde(default)]
-    pub id: Option<u64>,
-    pub name: String,
-    pub size: u64,
+    pub(crate) id: Option<u64>,
+    pub(crate) name: String,
+    pub(crate) size: u64,
     #[serde(default)]
-    pub state: String,
+    pub(crate) state: String,
     #[serde(default)]
-    pub digest: Option<String>,
+    pub(crate) digest: Option<String>,
 }
 
 /// A content-addressed intent to publish bytes under one canonical remote name.
@@ -211,10 +211,10 @@ pub(crate) struct GitHubReleaseAsset {
 /// coordinate through this target-name plus digest identity.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct ReleaseAssetPublication {
-    pub target_name: String,
-    pub sha256: String,
-    pub size: u64,
-    pub source_path: String,
+    pub(crate) target_name: String,
+    pub(crate) sha256: String,
+    pub(crate) size: u64,
+    pub(crate) source_path: String,
 }
 
 impl ReleaseAssetPublication {

--- a/crates/homeboy-release/src/release/executor/github_release/notes.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/notes.rs
@@ -31,12 +31,12 @@ use super::gh_cli::{
 #[derive(Debug, Clone)]
 pub(crate) struct GitHubReleaseBody {
     /// The exact markdown body passed to `gh release create --notes`.
-    pub body: String,
+    pub(crate) body: String,
     /// Whether GitHub-generated notes succeeded. `false` means the changelog
     /// fallback body was used.
-    pub generated_notes_ok: bool,
+    pub(crate) generated_notes_ok: bool,
     /// The changelog URL embedded in the footer, when one was resolved.
-    pub changelog_url: Option<String>,
+    pub(crate) changelog_url: Option<String>,
     pub(crate) source: String,
 }
 

--- a/crates/homeboy-release/src/release/executor/github_release/repair.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/repair.rs
@@ -8,18 +8,18 @@ use super::gh_cli::{gh_env_hint, gh_env_prefix, github_cli_env, safe_filename};
 
 #[derive(Debug, Clone)]
 pub(crate) struct GitHubReleaseRepairCommands {
-    pub notes_file: String,
-    pub notes_guidance: String,
-    pub generate_notes_command: String,
-    pub create_command: String,
-    pub upload_command: String,
-    pub publish_command: String,
-    pub view_command: String,
-    pub env_hint: Option<String>,
+    pub(crate) notes_file: String,
+    pub(crate) notes_guidance: String,
+    pub(crate) generate_notes_command: String,
+    pub(crate) create_command: String,
+    pub(crate) upload_command: String,
+    pub(crate) publish_command: String,
+    pub(crate) view_command: String,
+    pub(crate) env_hint: Option<String>,
     /// True when `notes_file` is the persisted exact Homeboy release body
     /// (issue #3508), so recovery reproduces the identical body rather than
     /// regenerating notes that could diverge.
-    pub exact_body_available: bool,
+    pub(crate) exact_body_available: bool,
 }
 
 pub(crate) fn github_release_repair_commands(

--- a/crates/homeboy-release/src/release/executor/github_release/results.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/results.rs
@@ -23,13 +23,13 @@ fn github_command_error_details(
 
 /// Evidence and recovery context for a failed GitHub Release asset upload.
 pub(crate) struct UploadFailedResultRequest<'a> {
-    pub stdout: String,
-    pub stderr: String,
-    pub exit_code: Option<i32>,
-    pub timed_out: bool,
-    pub artifact_count: usize,
-    pub repair: GitHubReleaseRepairCommands,
-    pub diagnostics: &'a [GitHubCommandFailureDiagnostic],
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+    pub(crate) exit_code: Option<i32>,
+    pub(crate) timed_out: bool,
+    pub(crate) artifact_count: usize,
+    pub(crate) repair: GitHubReleaseRepairCommands,
+    pub(crate) diagnostics: &'a [GitHubCommandFailureDiagnostic],
 }
 
 pub(crate) fn published_release_url(

--- a/crates/homeboy-release/src/release/executor/package.rs
+++ b/crates/homeboy-release/src/release/executor/package.rs
@@ -28,9 +28,9 @@ const PACKAGE_ACTION_MAX_ATTEMPTS: usize = 2;
 /// Step-specific inputs for package execution, kept together to make every
 /// caller name the release context it passes to a provider.
 pub(crate) struct PackageRequest<'a> {
-    pub component_source_path: Option<&'a str>,
-    pub declared_build_artifact: Option<&'a str>,
-    pub skip_build_validation: bool,
+    pub(crate) component_source_path: Option<&'a str>,
+    pub(crate) declared_build_artifact: Option<&'a str>,
+    pub(crate) skip_build_validation: bool,
 }
 
 /// Invoke the `release.package` action on every extension that provides it,

--- a/crates/homeboy-release/src/release/executor/prepare.rs
+++ b/crates/homeboy-release/src/release/executor/prepare.rs
@@ -116,7 +116,7 @@ fn extension_action_failure_message(
 #[cfg(test)]
 mod tests {
     use super::prepare_step_result;
-    use crate::release::ReleaseStepStatus;
+    use crate::release::types::ReleaseStepStatus;
 
     #[test]
     fn prepare_step_fails_when_extension_command_fails() {

--- a/crates/homeboy-release/src/release/executor/publish.rs
+++ b/crates/homeboy-release/src/release/executor/publish.rs
@@ -428,7 +428,7 @@ fn publish_failure_message(target: &str, response: &serde_json::Value) -> String
 mod tests {
     use super::{publish_step_result, run_publish};
     use crate::release::types::ReleaseState;
-    use crate::release::ReleaseStepStatus;
+    use crate::release::types::ReleaseStepStatus;
     use homeboy_core::component::{GithubConfig, GithubHostConfig};
     use homeboy_extension::ExtensionManifest;
     use std::collections::HashMap;

--- a/crates/homeboy-release/src/release/mod.rs
+++ b/crates/homeboy-release/src/release/mod.rs
@@ -1,5 +1,5 @@
 mod advanced_remote;
-pub mod cascade;
+mod cascade;
 mod checkout_guard;
 // "Is my fix released yet?" — commit→release containment and the inverse
 // installed-versus-latest gap (#11754). Public because the CLI surfaces it
@@ -12,7 +12,8 @@ mod execution_plan;
 mod execution_projection;
 mod executor;
 // Durable operation/finalization records. Lived in homeboy-core until #11143;
-// the release workspace finalizer is their only consumer.
+// the release workspace finalizer is their only consumer. Public because
+// `homeboy release readiness show` reads records back out of the store.
 pub mod operation_record;
 mod orchestrator;
 mod package_recovery;
@@ -28,6 +29,8 @@ mod planning_quality;
 mod planning_semver;
 mod planning_worktree;
 mod preflight_identity;
+// `homeboy-core` reaches release/deploy behavior only through the
+// `release_provider` hook; the CLI registers this implementation at startup.
 pub use homeboy_deploy::provider_impl;
 mod types;
 mod utils;
@@ -40,8 +43,10 @@ mod workspace;
 // `homeboy-version` so `homeboy-deploy` can use them without depending on this
 // crate (#11144). Re-exported under their original names so every release-side
 // `super::scope::`, `crate::release::changelog::`, and `version::` path keeps
-// resolving unchanged.
-pub use homeboy_version::{changelog, scope};
+// resolving unchanged. `changelog` is public because `homeboy release
+// changelog` and `homeboy review` surface it directly; `scope` is internal.
+pub use homeboy_version::changelog;
+pub(crate) use homeboy_version::scope;
 
 /// The shared version primitives, plus the release-only version mutation guard.
 ///
@@ -54,11 +59,10 @@ pub mod version {
     pub use homeboy_version::version::*;
 }
 
-pub use cascade::{run_cascade, CascadeResult, CascadeStepResult, ReleasedCoordinates};
-pub use containment::{
-    ContainmentAssessment, ContainmentStatus, ContainsQuery, GapStatus, ReleaseContainsReport,
-    ReleaseGapAssessment, ReleaseGapReport,
-};
+// Public API — every item below is reached from `homeboy-cli`. Anything the CLI
+// does not name stays `pub(crate)` so `dead_code` can see it.
+pub use cascade::{run_cascade, CascadeResult, ReleasedCoordinates};
+pub use containment::{ContainsQuery, ReleaseContainsReport, ReleaseGapReport};
 pub use context::readiness_provenance;
 pub use executor::artifacts::{
     write_artifact_source_authority_manifest, ArtifactSourceAuthorityManifest,
@@ -66,28 +70,28 @@ pub use executor::artifacts::{
 pub use executor::release_notes_path;
 pub use package_recovery::{package_existing_tag, ReleasePackageResult};
 pub use pipeline::run;
-pub use planner::plan;
 pub use types::readiness_is_valid;
 pub use types::{
-    BatchReleaseComponentResult, BatchReleaseResult, BatchReleaseSummary, ReleaseArtifact,
-    ReleaseCommandInput, ReleaseCommandResult, ReleaseDeploymentResult, ReleaseDeploymentSummary,
-    ReleaseExecutionPlan, ReleaseOptions, ReleasePhase, ReleasePipelineOptions, ReleasePlan,
-    ReleasePreflightPlacement, ReleasePreflightPlacementPolicy, ReleasePreflightSourceIdentity,
-    ReleaseProjectDeployResult, ReleaseReadinessEnvelope, ReleaseReadinessGateResult,
-    ReleaseReadinessLocalOnly, ReleaseReadinessProvenance, ReleaseRollbackEvidence, ReleaseRun,
-    ReleaseRunResult, ReleaseRunSummary, ReleaseSemverCommit, ReleaseSemverRecommendation,
-    ReleaseStepResult, ReleaseStepStatus, ReleaseWorkspaceCommandResult, ReleaseWorkspaceOutput,
+    BatchReleaseResult, ReleaseCommandInput, ReleaseCommandResult, ReleaseExecutionPlan,
+    ReleasePhase, ReleasePipelineOptions, ReleasePreflightPlacement,
+    ReleasePreflightPlacementPolicy, ReleasePreflightSourceIdentity, ReleaseReadinessEnvelope,
+    ReleaseReadinessGateResult, ReleaseReadinessLocalOnly, ReleaseReadinessProvenance,
+    ReleaseWorkspaceOutput,
 };
-pub use utils::{extract_latest_notes, parse_release_artifacts};
-pub use workflow::{
-    run_batch, run_command, run_command_with_recovery_owner, run_command_with_workspace,
-    SKIPPED_RELEASE_EXIT_CODE,
-};
+pub use workflow::{run_batch, run_command_with_workspace, SKIPPED_RELEASE_EXIT_CODE};
+
+// Crate-internal re-exports: submodules reach these through `super::`/
+// `crate::release::` paths, so the alias has to exist, but nothing outside the
+// crate names them.
+pub(crate) use homeboy_version::component_tag_name;
+pub(crate) use planner::plan;
+pub(crate) use workflow::run_command;
 
 // The component tag-naming contract moved to `homeboy-version` alongside
 // `scope`. Deploy resolves release tags too (tag-gap detection, ref checkout),
 // so the contract has to sit below both subsystems rather than inside release.
-pub use homeboy_version::{component_tag_name, component_tag_prefix, latest_component_tag};
+// `homeboy status` derives its tag prefix through this re-export.
+pub use homeboy_version::component_tag_prefix;
 
 /// Whether this component would normally get a reviewer-facing GitHub Release
 /// created as part of a release (i.e. it resolves to a GitHub remote).

--- a/crates/homeboy-release/src/release/operation_record.rs
+++ b/crates/homeboy-release/src/release/operation_record.rs
@@ -33,7 +33,7 @@ pub struct OperationRecord {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum FinalizationClaim {
+pub(crate) enum FinalizationClaim {
     Claimed {
         lease: String,
         record: OperationRecord,
@@ -43,7 +43,7 @@ pub enum FinalizationClaim {
 }
 
 impl OperationRecord {
-    pub fn finalization_pending(&self) -> bool {
+    pub(crate) fn finalization_pending(&self) -> bool {
         self.finalization_status != "completed"
     }
 }
@@ -79,7 +79,7 @@ impl OperationRecordStore {
     /// resolved the data root twice — once inside `lock()` and again inside
     /// `record_path()` — so a repoint between them could have serialized
     /// against one home's `.lock` while replacing the other home's record.
-    pub fn update(
+    pub(crate) fn update(
         &self,
         owner_run_ref: &str,
         update: impl FnOnce(Option<OperationRecord>) -> Result<OperationRecord>,
@@ -117,7 +117,7 @@ impl OperationRecordStore {
 
     /// Claims finalization before an external provider call. A live lease is
     /// never stolen; only a bounded stale lease can be retried.
-    pub fn claim_finalization(&self, owner_run_ref: &str) -> Result<FinalizationClaim> {
+    pub(crate) fn claim_finalization(&self, owner_run_ref: &str) -> Result<FinalizationClaim> {
         const STALE_LEASE_MS: u128 = 5 * 60 * 1000;
         let now = now_ms();
         let candidate_lease = uuid::Uuid::new_v4().to_string();
@@ -162,7 +162,7 @@ impl OperationRecordStore {
         })
     }
 
-    pub fn complete_finalization(
+    pub(crate) fn complete_finalization(
         &self,
         owner_run_ref: &str,
         lease: &str,
@@ -190,7 +190,7 @@ impl OperationRecordStore {
         })
     }
 
-    pub fn fail_finalization(
+    pub(crate) fn fail_finalization(
         &self,
         owner_run_ref: &str,
         lease: &str,
@@ -217,7 +217,7 @@ impl OperationRecordStore {
         })
     }
 
-    pub fn pending_for_subject(
+    pub(crate) fn pending_for_subject(
         &self,
         operation: &str,
         subject: &str,

--- a/crates/homeboy-release/src/release/package_recovery.rs
+++ b/crates/homeboy-release/src/release/package_recovery.rs
@@ -15,16 +15,16 @@ use super::types::{ReleaseArtifact, ReleaseOptions, ReleaseState, ReleaseStepRes
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ReleasePackageResult {
-    pub schema: &'static str,
-    pub schema_version: u32,
-    pub component_id: String,
-    pub tag: String,
-    pub version: String,
-    pub commit: String,
-    pub artifact_dir: String,
-    pub manifest_path: String,
-    pub artifacts: Vec<ReleaseArtifact>,
-    pub package_step: ReleaseStepResult,
+    pub(crate) schema: &'static str,
+    pub(crate) schema_version: u32,
+    pub(crate) component_id: String,
+    pub(crate) tag: String,
+    pub(crate) version: String,
+    pub(crate) commit: String,
+    pub(crate) artifact_dir: String,
+    pub(crate) manifest_path: String,
+    pub(crate) artifacts: Vec<ReleaseArtifact>,
+    pub(crate) package_step: ReleaseStepResult,
 }
 
 /// Regenerate the release package for an already-published tag.

--- a/crates/homeboy-release/src/release/planner.rs
+++ b/crates/homeboy-release/src/release/planner.rs
@@ -35,7 +35,7 @@ pub(super) fn oversized_patch_release_bump(bump: &str, item_count: usize) -> &st
 /// without side effects and by release execution to drive the same steps.
 ///
 /// Requires a clean working tree (uncommitted changes cause an error).
-pub fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan> {
+pub(crate) fn plan(component_id: &str, options: &ReleaseOptions) -> Result<ReleasePlan> {
     let component = load_component(component_id, options)?;
     let extensions = resolve_extensions(&component)?;
 

--- a/crates/homeboy-release/src/release/planning_semver.rs
+++ b/crates/homeboy-release/src/release/planning_semver.rs
@@ -173,9 +173,9 @@ pub(super) fn validate_release_version_floor(
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct ReleaseVersionBaseline {
-    pub source: String,
-    pub authoritative: String,
-    pub tag: Option<String>,
+    pub(crate) source: String,
+    pub(crate) authoritative: String,
+    pub(crate) tag: Option<String>,
 }
 
 /// Resolve the version from which Homeboy may safely advance a release.

--- a/crates/homeboy-release/src/release/types.rs
+++ b/crates/homeboy-release/src/release/types.rs
@@ -12,14 +12,14 @@ use homeboy_core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanStepStatus};
 /// `pipeline::run()` for real releases so the previewed steps match execution.
 #[derive(Debug, Clone)]
 pub struct ReleasePlan {
-    pub plan: HomeboyPlan,
+    pub(crate) plan: HomeboyPlan,
 }
 
 impl ReleasePlan {
     const ENABLED_POLICY_KEY: &'static str = "enabled";
     const SEMVER_RECOMMENDATION_POLICY_KEY: &'static str = "semver_recommendation";
 
-    pub fn new(
+    pub(crate) fn new(
         component_id: impl Into<String>,
         enabled: bool,
         steps: Vec<PlanStep>,
@@ -53,15 +53,15 @@ impl ReleasePlan {
     /// projected from the generic plan subject/policy during serialization so
     /// existing release JSON consumers keep the same shape without creating a
     /// second authoritative release data store.
-    pub fn from_plan(plan: HomeboyPlan) -> Self {
+    pub(crate) fn from_plan(plan: HomeboyPlan) -> Self {
         Self { plan }
     }
 
-    pub fn component_id(&self) -> Option<&str> {
+    pub(crate) fn component_id(&self) -> Option<&str> {
         self.plan.subject.component_id.as_deref()
     }
 
-    pub fn enabled(&self) -> bool {
+    pub(crate) fn enabled(&self) -> bool {
         if let Some(enabled) = self
             .plan
             .policy
@@ -77,7 +77,7 @@ impl ReleasePlan {
             .any(|step| matches!(step.status, PlanStepStatus::Ready | PlanStepStatus::Running))
     }
 
-    pub fn semver_recommendation(&self) -> Option<ReleaseSemverRecommendation> {
+    pub(crate) fn semver_recommendation(&self) -> Option<ReleaseSemverRecommendation> {
         self.plan
             .policy
             .get(Self::SEMVER_RECOMMENDATION_POLICY_KEY)
@@ -118,50 +118,50 @@ impl Serialize for ReleasePlan {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ReleaseSemverCommit {
-    pub sha: String,
-    pub subject: String,
-    pub commit_type: String,
-    pub breaking: bool,
+pub(crate) struct ReleaseSemverCommit {
+    pub(crate) sha: String,
+    pub(crate) subject: String,
+    pub(crate) commit_type: String,
+    pub(crate) breaking: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ReleaseSemverRecommendation {
+pub(crate) struct ReleaseSemverRecommendation {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub latest_tag: Option<String>,
-    pub range: String,
-    pub commits: Vec<ReleaseSemverCommit>,
+    pub(crate) latest_tag: Option<String>,
+    pub(crate) range: String,
+    pub(crate) commits: Vec<ReleaseSemverCommit>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub recommended_bump: Option<String>,
-    pub requested_bump: String,
-    pub is_underbump: bool,
-    pub reasons: Vec<String>,
+    pub(crate) recommended_bump: Option<String>,
+    pub(crate) requested_bump: String,
+    pub(crate) is_underbump: bool,
+    pub(crate) reasons: Vec<String>,
     /// How many commits in range carried no recognizable conventional-commit
     /// prefix (`feat:`/`fix:`/etc.). On repos that don't use conventional commits
     /// these are classified `other` and only ever drive a `patch` bump, so a
     /// high count next to a low bump is a silent under-bump signal (#6851).
     #[serde(default)]
-    pub non_conventional_commit_count: usize,
+    pub(crate) non_conventional_commit_count: usize,
     /// Total commits considered for the bump (excludes merge/release noise).
     #[serde(default)]
-    pub considered_commit_count: usize,
+    pub(crate) considered_commit_count: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bump_policy: Option<ReleaseBumpPolicy>,
+    pub(crate) bump_policy: Option<ReleaseBumpPolicy>,
 }
 
 /// Structured evidence for a release bump policy decision.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ReleaseBumpPolicy {
-    pub policy: String,
-    pub signals: Vec<ReleaseBumpPolicySignal>,
-    pub override_used: bool,
+pub(crate) struct ReleaseBumpPolicy {
+    pub(crate) policy: String,
+    pub(crate) signals: Vec<ReleaseBumpPolicySignal>,
+    pub(crate) override_used: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ReleaseBumpPolicySignal {
-    pub name: String,
-    pub observed: usize,
-    pub threshold: usize,
+pub(crate) struct ReleaseBumpPolicySignal {
+    pub(crate) name: String,
+    pub(crate) observed: usize,
+    pub(crate) threshold: usize,
 }
 
 /// Explicit changelog contract carried by the release plan.
@@ -170,12 +170,12 @@ pub struct ReleaseBumpPolicySignal {
 /// release execution share one source of truth. The release executor consumes
 /// this contract when the version step finalizes the changelog on disk.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ReleaseChangelogPlan {
-    pub policy: String,
-    pub path: String,
-    pub dry_run: bool,
-    pub entries: HashMap<String, Vec<String>>,
-    pub entry_count: usize,
+pub(crate) struct ReleaseChangelogPlan {
+    pub(crate) policy: String,
+    pub(crate) path: String,
+    pub(crate) dry_run: bool,
+    pub(crate) entries: HashMap<String, Vec<String>>,
+    pub(crate) entry_count: usize,
 }
 
 /// Run result for a single release. Shape is preserved from the pre-refactor
@@ -183,49 +183,49 @@ pub struct ReleaseChangelogPlan {
 /// consumers see no change.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReleaseRun {
-    pub component_id: String,
-    pub enabled: bool,
-    pub result: ReleaseRunResult,
+    pub(crate) component_id: String,
+    pub(crate) enabled: bool,
+    pub(crate) result: ReleaseRunResult,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReleaseRunResult {
-    pub steps: Vec<ReleaseStepResult>,
-    pub status: ReleaseStepStatus,
+    pub(crate) steps: Vec<ReleaseStepResult>,
+    pub(crate) status: ReleaseStepStatus,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub warnings: Vec<String>,
+    pub(crate) warnings: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub summary: Option<ReleaseRunSummary>,
+    pub(crate) summary: Option<ReleaseRunSummary>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub phase_timings: Option<PhaseTimingReport>,
+    pub(crate) phase_timings: Option<PhaseTimingReport>,
     /// Recorded only after a failed release has restored the checkout. This
     /// makes the result describe the durable exit state rather than mutations
     /// attempted before rollback.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub rollback: Option<ReleaseRollbackEvidence>,
+    pub(crate) rollback: Option<ReleaseRollbackEvidence>,
 }
 
 /// The authoritative checkout used by a release and its terminal disposition.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReleaseWorkspaceOutput {
-    pub kind: String,
-    pub path: String,
+    pub(crate) kind: String,
+    pub(crate) path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub provider_id: Option<String>,
+    pub(crate) provider_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub handle: Option<String>,
+    pub(crate) handle: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub owner_run_ref: Option<String>,
+    pub(crate) owner_run_ref: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub source_sha: Option<String>,
+    pub(crate) source_sha: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub final_disposition: Option<String>,
+    pub(crate) final_disposition: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub continuation_ref: Option<String>,
+    pub(crate) continuation_ref: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub finalization_error: Option<String>,
+    pub(crate) finalization_error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reconciliation_ref: Option<String>,
+    pub(crate) reconciliation_ref: Option<String>,
 }
 
 impl ReleaseWorkspaceOutput {
@@ -259,34 +259,34 @@ pub struct ReleaseRollbackEvidence {
     /// `restored` means final_head was independently observed at original_head.
     /// `interrupted` requires operator recovery and must never be presented as
     /// rollback success.
-    pub status: String,
-    pub original_head: String,
-    pub temporary_head: String,
-    pub release_commit: String,
-    pub final_head: Option<String>,
-    pub tag_state: String,
+    pub(crate) status: String,
+    pub(crate) original_head: String,
+    pub(crate) temporary_head: String,
+    pub(crate) release_commit: String,
+    pub(crate) final_head: Option<String>,
+    pub(crate) tag_state: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
+    pub(crate) error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub recovery_action: Option<String>,
+    pub(crate) recovery_action: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReleaseStepResult {
-    pub id: String,
+    pub(crate) id: String,
     #[serde(rename = "type")]
-    pub step_type: String,
-    pub status: ReleaseStepStatus,
+    pub(crate) step_type: String,
+    pub(crate) status: ReleaseStepStatus,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub missing: Vec<String>,
+    pub(crate) missing: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub warnings: Vec<String>,
+    pub(crate) warnings: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub hints: Vec<homeboy_core::error::Hint>,
+    pub(crate) hints: Vec<homeboy_core::error::Hint>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<serde_json::Value>,
+    pub(crate) data: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
+    pub(crate) error: Option<String>,
 }
 
 impl Default for ReleaseStepResult {
@@ -322,40 +322,40 @@ pub enum ReleaseStepStatus {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReleaseRunSummary {
-    pub total_steps: usize,
-    pub succeeded: usize,
-    pub failed: usize,
-    pub skipped: usize,
-    pub missing: usize,
+    pub(crate) total_steps: usize,
+    pub(crate) succeeded: usize,
+    pub(crate) failed: usize,
+    pub(crate) skipped: usize,
+    pub(crate) missing: usize,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub next_actions: Vec<String>,
+    pub(crate) next_actions: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub success_summary: Vec<String>,
+    pub(crate) success_summary: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReleaseArtifact {
-    pub path: String,
+    pub(crate) path: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub durable_path: Option<String>,
+    pub(crate) durable_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub artifact_type: Option<String>,
+    pub(crate) artifact_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub platform: Option<String>,
+    pub(crate) platform: Option<String>,
     /// Lifecycle phase that produced these bytes. Final package output has
     /// precedence over validation/preflight output with the same target name.
     #[serde(default = "default_artifact_phase")]
-    pub phase: String,
+    pub(crate) phase: String,
     /// Producer responsible for the artifact (component build, extension, or
     /// externally supplied recovery inventory).
     #[serde(default = "default_artifact_producer")]
-    pub producer: String,
+    pub(crate) producer: String,
     /// Content identity persisted with the durable inventory.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub sha256: Option<String>,
+    pub(crate) sha256: Option<String>,
     /// Exactly one artifact per target name is allowed to publish.
     #[serde(default)]
-    pub publication_authority: bool,
+    pub(crate) publication_authority: bool,
 }
 
 fn default_artifact_phase() -> String {
@@ -374,31 +374,31 @@ fn default_artifact_producer() -> String {
 /// through a generic pipeline DAG — a pattern the execution never actually
 /// needed because every step runs sequentially.
 #[derive(Debug, Clone, Default)]
-pub struct ReleaseState {
-    pub version: Option<String>,
-    pub tag: Option<String>,
-    pub notes: Option<String>,
+pub(crate) struct ReleaseState {
+    pub(crate) version: Option<String>,
+    pub(crate) tag: Option<String>,
+    pub(crate) notes: Option<String>,
     /// A manifest-bound final GitHub Release body recovered without regeneration.
-    pub exact_release_notes: Option<ExactReleaseNotes>,
-    pub artifacts: Vec<ReleaseArtifact>,
+    pub(crate) exact_release_notes: Option<ExactReleaseNotes>,
+    pub(crate) artifacts: Vec<ReleaseArtifact>,
     /// Component-relative checkout paths proven absent before packaging and
     /// created by the current package invocation.
-    pub package_owned_paths: Vec<String>,
-    pub changelog_validation: Option<crate::release::version::ChangelogValidationResult>,
+    pub(crate) package_owned_paths: Vec<String>,
+    pub(crate) changelog_validation: Option<crate::release::version::ChangelogValidationResult>,
     /// A remote-only draft may be published only when this manifest-bound
     /// intent has been validated against the active release identity.
-    pub draft_adoption: Option<DraftAdoptionIntent>,
+    pub(crate) draft_adoption: Option<DraftAdoptionIntent>,
 }
 
 #[derive(Debug, Clone)]
-pub struct ExactReleaseNotes {
-    pub body: String,
-    pub source: String,
+pub(crate) struct ExactReleaseNotes {
+    pub(crate) body: String,
+    pub(crate) source: String,
 }
 
 #[derive(Debug, Clone)]
-pub struct DraftAdoptionIntent {
-    pub expected_assets: Vec<String>,
+pub(crate) struct DraftAdoptionIntent {
+    pub(crate) expected_assets: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -420,19 +420,19 @@ pub struct ReleasePipelineOptions {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ReleaseOptions {
-    pub bump_type: String,
-    pub dry_run: bool,
+    pub(crate) bump_type: String,
+    pub(crate) dry_run: bool,
     /// Override the component's `local_path` for this release.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub path_override: Option<String>,
+    pub(crate) path_override: Option<String>,
     /// Skip lint/test code quality checks before release.
     #[serde(default)]
-    pub skip_checks: bool,
+    pub(crate) skip_checks: bool,
     /// Granular per-check skips (e.g. `["lint"]`). Disables only the listed
     /// preflight quality checks while leaving working_tree/remote_sync and the
     /// other checks active. Honored independently of `skip_checks`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub skip_checks_granular: Vec<String>,
+    pub(crate) skip_checks_granular: Vec<String>,
     /// Bypass the package/build-structure validation that runs inside the
     /// `preflight.package` and `package` steps, while still running the build
     /// itself. The flag is forwarded to the packaging extension as a generic
@@ -442,28 +442,28 @@ pub struct ReleaseOptions {
     /// bypassed. Use when an operator knows a structure assertion is a false
     /// positive (see issue #5425).
     #[serde(default)]
-    pub skip_build_validation: bool,
+    pub(crate) skip_build_validation: bool,
     /// Skip dependency hydration during release preflight.
     #[serde(default)]
-    pub skip_deps_hydration: bool,
+    pub(crate) skip_deps_hydration: bool,
     #[serde(default, flatten)]
-    pub pipeline: ReleasePipelineOptions,
+    pub(crate) pipeline: ReleasePipelineOptions,
     /// Skip the GitHub Release creation step (tag + notes on github.com).
     /// Use when another pipeline (CI, semantic-release, etc.) already owns that step.
     #[serde(default)]
-    pub skip_github_release: bool,
+    pub(crate) skip_github_release: bool,
     /// Git identity for release commits: "bot", "Name <email>", or None (use existing config).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub git_identity: Option<String>,
+    pub(crate) git_identity: Option<String>,
     /// Bump policy controls that affect release plan validation.
     #[serde(default, skip_serializing_if = "ReleaseBumpPolicyOptions::is_default")]
-    pub bump_policy: ReleaseBumpPolicyOptions,
+    pub(crate) bump_policy: ReleaseBumpPolicyOptions,
     /// Placement selected for portable release-readiness gates. Release mutation
     /// always remains controller-owned; a runner is evidence provenance only.
     #[serde(default, skip_serializing_if = "ReleasePreflightPlacement::is_default")]
-    pub preflight_placement: ReleasePreflightPlacement,
+    pub(crate) preflight_placement: ReleasePreflightPlacement,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub readiness: Option<ReleaseReadinessEnvelope>,
+    pub(crate) readiness: Option<ReleaseReadinessEnvelope>,
 }
 
 /// Typed placement policy for the portable portion of release preflight.
@@ -593,13 +593,13 @@ pub struct ReleaseReadinessLocalOnly {
 pub struct ReleaseBumpPolicyOptions {
     /// Permit a keyword bump lower than the commit-derived recommendation.
     #[serde(default)]
-    pub force_lower_bump: bool,
+    pub(crate) force_lower_bump: bool,
     /// Permit a release when no releasable commits were detected.
     #[serde(default)]
-    pub force_empty_release: bool,
+    pub(crate) force_empty_release: bool,
     /// Require an explicit `--bump major` for stable major releases.
     #[serde(default)]
-    pub require_explicit_major: bool,
+    pub(crate) require_explicit_major: bool,
 }
 
 impl ReleaseBumpPolicyOptions {
@@ -675,7 +675,7 @@ impl ReleaseExecutionPlan {
         }
     }
 
-    pub fn default_for_command_input(input: &ReleaseCommandInput) -> Self {
+    pub(crate) fn default_for_command_input(input: &ReleaseCommandInput) -> Self {
         let phase = if input.recover {
             ReleasePhase::Recover
         } else if input.dry_run {
@@ -695,13 +695,13 @@ impl ReleaseExecutionPlan {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct ReleaseDeploymentSummary {
-    pub total_projects: u32,
-    pub succeeded: u32,
-    pub failed: u32,
+    pub(crate) total_projects: u32,
+    pub(crate) succeeded: u32,
+    pub(crate) failed: u32,
     #[serde(skip_serializing_if = "is_zero_u32")]
-    pub skipped: u32,
+    pub(crate) skipped: u32,
     #[serde(skip_serializing_if = "is_zero_u32")]
-    pub planned: u32,
+    pub(crate) planned: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -716,18 +716,18 @@ pub enum ReleasePhase {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReleaseProjectDeployResult {
-    pub project_id: String,
-    pub status: String,
+    pub(crate) project_id: String,
+    pub(crate) status: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
+    pub(crate) error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub component_result: Option<homeboy_deploy::ComponentDeployResult>,
+    pub(crate) component_result: Option<homeboy_deploy::ComponentDeployResult>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReleaseDeploymentResult {
-    pub projects: Vec<ReleaseProjectDeployResult>,
-    pub summary: ReleaseDeploymentSummary,
+    pub(crate) projects: Vec<ReleaseProjectDeployResult>,
+    pub(crate) summary: ReleaseDeploymentSummary,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -763,25 +763,25 @@ pub struct ReleaseCommandResult {
 /// Result of a batch release across multiple components.
 #[derive(Debug, Clone, Serialize)]
 pub struct BatchReleaseResult {
-    pub results: Vec<BatchReleaseComponentResult>,
+    pub(crate) results: Vec<BatchReleaseComponentResult>,
     pub summary: BatchReleaseSummary,
 }
 
 /// Per-component result within a batch release.
 #[derive(Debug, Clone, Serialize)]
 pub struct BatchReleaseComponentResult {
-    pub component_id: String,
-    pub status: String,
+    pub(crate) component_id: String,
+    pub(crate) status: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
+    pub(crate) error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub result: Option<ReleaseCommandResult>,
+    pub(crate) result: Option<ReleaseCommandResult>,
 }
 
 /// Summary counts for a batch release.
 #[derive(Debug, Clone, Serialize)]
 pub struct BatchReleaseSummary {
-    pub total: u32,
+    pub(crate) total: u32,
     pub released: u32,
     pub skipped: u32,
     pub failed: u32,

--- a/crates/homeboy-release/src/release/utils.rs
+++ b/crates/homeboy-release/src/release/utils.rs
@@ -3,7 +3,7 @@ use homeboy_core::error::Result;
 
 use super::types::ReleaseArtifact;
 
-pub fn extract_latest_notes(content: &str) -> Option<String> {
+pub(crate) fn extract_latest_notes(content: &str) -> Option<String> {
     let mut in_section = false;
     let mut buffer = Vec::new();
 
@@ -40,7 +40,7 @@ fn extract_version_from_heading(label: &str) -> Option<String> {
         .map(|m| m.as_str().to_string())
 }
 
-pub fn parse_release_artifacts(value: &serde_json::Value) -> Result<Vec<ReleaseArtifact>> {
+pub(crate) fn parse_release_artifacts(value: &serde_json::Value) -> Result<Vec<ReleaseArtifact>> {
     let mut artifacts = Vec::new();
     let items = match value {
         serde_json::Value::Array(arr) => arr.clone(),

--- a/crates/homeboy-release/src/release/version_guard.rs
+++ b/crates/homeboy-release/src/release/version_guard.rs
@@ -16,7 +16,7 @@ pub struct VersionMutation {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReleaseOwnedMutationViolation {
-    pub file: String,
+    pub(crate) file: String,
     pub message: String,
 }
 
@@ -113,7 +113,7 @@ pub(crate) fn derived_lockfiles(targets: &[VersionTarget]) -> BTreeSet<String> {
         .collect()
 }
 
-pub fn release_owned_lockfiles(component: &Component) -> BTreeSet<String> {
+pub(crate) fn release_owned_lockfiles(component: &Component) -> BTreeSet<String> {
     let mut lockfiles = derived_lockfiles(component.version_targets.as_deref().unwrap_or_default());
     lockfiles.extend(homeboy_core::component::drift::extension_declared_lockfile_paths(component));
     lockfiles

--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -31,13 +31,13 @@ pub(super) fn release_execution_plan(input: &ReleaseCommandInput) -> ReleaseExec
         .unwrap_or_else(|| ReleaseExecutionPlan::default_for_command_input(input))
 }
 
-pub fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32)> {
+pub(crate) fn run_command(input: ReleaseCommandInput) -> Result<(ReleaseCommandResult, i32)> {
     run_command_with_recovery_owner(input, None)
 }
 
 /// Additive recovery entry point for callers that have a durable provider
 /// owner reference. `ReleaseCommandInput` remains source-compatible.
-pub fn run_command_with_recovery_owner(
+pub(crate) fn run_command_with_recovery_owner(
     input: ReleaseCommandInput,
     recovery_owner_run_ref: Option<&str>,
 ) -> Result<(ReleaseCommandResult, i32)> {
@@ -1132,7 +1132,7 @@ mod tests {
         )
     }
 
-    use crate::release::{
+    use crate::release::types::{
         ReleasePreflightPlacement, ReleasePreflightSourceIdentity, ReleaseReadinessEnvelope,
         ReleaseReadinessGateResult, ReleaseRollbackEvidence, ReleaseRunResult, ReleaseStepResult,
         ReleaseStepStatus,

--- a/crates/homeboy-release/src/release/workflow_recover.rs
+++ b/crates/homeboy-release/src/release/workflow_recover.rs
@@ -18,7 +18,7 @@ use super::workflow::{release_execution_plan, short_sha};
 /// `--recover` repairs Git state only. Keep the remaining release lifecycle
 /// explicit so an orchestration result cannot mistake a pushed tag for a
 /// published release.
-pub const RECOVERY_INCOMPLETE_EXIT_CODE: i32 = 4;
+pub(crate) const RECOVERY_INCOMPLETE_EXIT_CODE: i32 = 4;
 
 fn publication_continuation_command(input: &ReleaseCommandInput) -> String {
     let mut command = format!("homeboy release {} --head", input.component_id);


### PR DESCRIPTION
## What

`pub` suppresses `dead_code` independently of `#[allow(dead_code)]` — rustc cannot call a `pub` item dead because something outside the crate might call it. #13271 removed this crate's module-level allow, so `homeboy-release` *looked* lit. It was not. 438 `pub` declarations were still structurally invisible to the lint.

Two symbols actually escape the crate:

```
$ grep -rhoP '(homeboy_release|crate::release)::\K[a-zA-Z_]+' \
    crates/homeboy-cli/src crates/homeboy-core/src src tests --include='*.rs' | sort -u
provider_impl
release
```

Every `pub` under `crates/homeboy-release/src/release/` was narrowed to `pub(crate)`, then the compiler widened back exactly what the boundary needs. Nothing was widened on judgement:

| signal | what it proved | count |
|---|---|---|
| `E0364` / `E0365` | facade re-export needs the item `pub` | 31 |
| `private_interfaces` | type reachable through a public signature | 22 |
| `E0616` / `E0624` | field/method `homeboy-cli` reads | 19 fields, 6 methods |
| `E0451` | struct `homeboy-cli` constructs with a literal | 7 structs |

## Before / after

`crates/homeboy-release/src/release/`:

|  | before | after |
|---|---|---|
| `pub fn` | 39 | **19** |
| `pub struct` / `pub enum` | 61 | **47** |
| `pub const` / `pub static` | 6 | **1** |
| `pub mod` | 4 | **3** |
| `pub` struct fields | 328 | **94** |
| `pub(crate)` | 164 | **441** |

274 declarations narrowed. `release/mod.rs` is now a facade in the shape of `homeboy-deploy` — private modules, one explicit `pub use` block, a comment on each item that crosses the boundary (`crates/homeboy-release/src/release/mod.rs:62-85`).

## What was deleted

Thirteen re-exports from `release/mod.rs` that no caller outside the crate names: `plan`, `run_command`, `run_command_with_recovery_owner`, `extract_latest_notes`, `parse_release_artifacts`, `component_tag_name`, `latest_component_tag`, `scope`, `CascadeStepResult`, `ContainmentAssessment`, `ContainmentStatus`, `GapStatus`, `ReleaseGapAssessment`, plus 17 `types::` names from the same block.

Four of those are still reached from inside the crate through `super::` / `crate::release::` paths and became `pub(crate) use` (`crates/homeboy-release/src/release/mod.rs:86-90`). Six `#[cfg(test)]` imports that resolved through the facade were repointed at `crate::release::types::` (`executor.rs:557`, `workflow.rs:1135`, `executor/{artifacts,changelog,prepare,publish}.rs`) so the alias did not have to exist for tests alone.

## What was kept, and why

No new `#[allow(dead_code)]` was added — none was needed. The four per-item allows already in the crate (`containment.rs:151`, `executor/github_release/results.rs:283`, `executor/github_release/gh_cli.rs:867`, `workspace.rs:423`) are untouched prior work.

No module-level suppression was cleared, so `MODULE_SUPPRESSION_CEILING` stays at 5 in `tests/dead_code_suppression_ratchet_test.rs:45`.

## No dead code found — and that is a measured result, not an absence of looking

The sealed crate compiles with **zero** `dead_code` warnings. Silence from a lint is worth nothing unless you show the lint is running, so I proved it:

```
$ printf '\nfn sealprobe_live_check() -> u8 { 9 }\n' >> crates/homeboy-release/src/release/utils.rs
$ cargo check -p homeboy-release --all-targets -j2
warning: function `sealprobe_live_check` is never used
warning: `homeboy-release` (lib) generated 1 warning
warning: `homeboy-release` (lib test) generated 1 warning (1 duplicate)
```

The probe was then removed. #13271 had already burned down the `pub(crate)` half of this crate; the remaining `pub` items are all genuinely reachable from `run`, `run_batch`, `run_cascade`, `containment` and `operation_record`. What changes is that the *next* unused item fails the build instead of hiding behind `pub`.

> **Trap for the next person:** rustc exempts any item whose name starts with `_` from `dead_code`. My first four probes were named `__seal_probe_*` and all reported clean, which cost about forty minutes chasing a nonexistent lint-suppression config. Name probes without a leading underscore.

## Constraints honoured

No command spelling, JSON output shape, or `provider_impl` seam changed. `.github/workflows/release.yml` invokes `homeboy release` unchanged. Every non-visibility line in the diff is a `rustfmt` reflow (longer visibility keyword), an import-path repoint, or a comment:

```
$ git diff -U0 origin/main -- crates/homeboy-release \
    | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-]\s*(pub|pub\(crate\))\s'
```

## Gate

```
$ cargo check --workspace --all-targets -j2
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 42s
```

Exit 0. **0 errors, 0 warnings**, whole workspace, all targets.

### Baseline diff

Not applicable, and deliberately so. Visibility is a compile-time property — a `pub` → `pub(crate)` narrowing cannot change runtime behaviour, and `--all-targets` type-checks every test body in the workspace, so the gate *is* the proof for this class of change. Running the suite locally would require the 28G test-build documented in `RULES.md` against 15G free on this VPS; that is the exact mechanism behind the 2026-07-29 root-volume outage. Tests route to CI. Pre-existing failures are tracked in #13273.

One error seen mid-work is pre-existing and unrelated: `cargo check -p homeboy-cli --all-targets` alone reports `E0425` for `homeboy_cli::commands::ci::test_external_check_detail_resolver_fixture` (`crates/homeboy-cli/tests/external_check_detail_resolver_fixture.rs:3`). It resolves under `--workspace` feature unification and is untouched by this PR.

## AI assistance

Tool(s): OpenCode