### PR TITLE
refactor(fuzz): declare the replay/minimize argument set once instead of three times

### DIFF
--- a/crates/homeboy-cli/src/commands/fuzz/replay.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/replay.rs
@@ -14,26 +14,25 @@ use homeboy_extension::{self, ExtensionCapability, ExtensionRunner};
 
 use super::super::utils::args::PositionalComponentArgs;
 use super::types::{
-    FuzzMinimizeArgs, FuzzReplayArgs, FuzzReplayArtifactAccess, FuzzReplayEnv, FuzzReplayExecution,
+    FuzzReplayArtifactAccess, FuzzReplayEnv, FuzzReplayExecution, FuzzReplayLikeArgs,
     FuzzReplayOutput,
 };
 use super::workloads::{load_rig, resolve_component_id, resolve_fuzz_context};
 
-pub(super) fn run_replay(args: FuzzReplayArgs) -> homeboy::core::Result<(FuzzReplayOutput, i32)> {
-    run_replay_like(ReplayLikeArgs::from_replay(args), ReplayLikeMode::Replay)
+pub(super) fn run_replay(
+    args: FuzzReplayLikeArgs,
+) -> homeboy::core::Result<(FuzzReplayOutput, i32)> {
+    run_replay_like(args, ReplayLikeMode::Replay)
 }
 
 pub(super) fn run_minimize(
-    args: FuzzMinimizeArgs,
+    args: FuzzReplayLikeArgs,
 ) -> homeboy::core::Result<(FuzzReplayOutput, i32)> {
-    run_replay_like(
-        ReplayLikeArgs::from_minimize(args),
-        ReplayLikeMode::Minimize,
-    )
+    run_replay_like(args, ReplayLikeMode::Minimize)
 }
 
 fn run_replay_like(
-    args: ReplayLikeArgs,
+    args: FuzzReplayLikeArgs,
     mode: ReplayLikeMode,
 ) -> homeboy::core::Result<(FuzzReplayOutput, i32)> {
     let mut artifact_ref = replay_artifact_ref(&args);
@@ -270,55 +269,6 @@ fn run_replay_like(
     Ok(result)
 }
 
-#[derive(Clone)]
-struct ReplayLikeArgs {
-    component: Option<String>,
-    path: Option<String>,
-    rig: Option<String>,
-    extension_override: super::super::utils::args::ExtensionOverrideArgs,
-    setting_args: super::super::utils::args::SettingArgs,
-    artifact_or_case: Option<String>,
-    artifact: Option<PathBuf>,
-    case_id: Option<String>,
-    run_id: Option<String>,
-    dry_run: bool,
-    args: Vec<String>,
-}
-
-impl ReplayLikeArgs {
-    fn from_replay(args: FuzzReplayArgs) -> Self {
-        Self {
-            component: args.component,
-            path: args.path,
-            rig: args.rig,
-            extension_override: args.extension_override,
-            setting_args: args.setting_args,
-            artifact_or_case: args.artifact_or_case,
-            artifact: args.artifact,
-            case_id: args.case_id,
-            run_id: args.run_id,
-            dry_run: args.dry_run,
-            args: args.args,
-        }
-    }
-
-    fn from_minimize(args: FuzzMinimizeArgs) -> Self {
-        Self {
-            component: args.component,
-            path: args.path,
-            rig: args.rig,
-            extension_override: args.extension_override,
-            setting_args: args.setting_args,
-            artifact_or_case: args.artifact_or_case,
-            artifact: args.artifact,
-            case_id: args.case_id,
-            run_id: args.run_id,
-            dry_run: args.dry_run,
-            args: args.args,
-        }
-    }
-}
-
 #[derive(Clone, Copy)]
 enum ReplayLikeMode {
     Replay,
@@ -363,7 +313,7 @@ struct ResolvedReplayContext {
 }
 
 fn resolve_replay_context(
-    args: &ReplayLikeArgs,
+    args: &FuzzReplayLikeArgs,
     mode: ReplayLikeMode,
 ) -> homeboy::core::Result<Option<ResolvedReplayContext>> {
     let comp = replay_component_args(args);
@@ -399,7 +349,7 @@ fn resolve_replay_context(
     }))
 }
 
-fn replay_component_args(args: &ReplayLikeArgs) -> PositionalComponentArgs {
+fn replay_component_args(args: &FuzzReplayLikeArgs) -> PositionalComponentArgs {
     PositionalComponentArgs {
         component: args.component.clone(),
         path: args.path.clone(),
@@ -554,7 +504,7 @@ struct ResolvedReplayArtifact {
     replay: Option<FuzzReplayMetadata>,
 }
 
-fn replay_artifact_path(args: &ReplayLikeArgs) -> Option<PathBuf> {
+fn replay_artifact_path(args: &FuzzReplayLikeArgs) -> Option<PathBuf> {
     args.artifact.clone().or_else(|| {
         args.artifact_or_case.as_ref().and_then(|value| {
             if is_replay_artifact_ref(value) {
@@ -567,7 +517,7 @@ fn replay_artifact_path(args: &ReplayLikeArgs) -> Option<PathBuf> {
     })
 }
 
-fn replay_artifact_ref(args: &ReplayLikeArgs) -> Option<String> {
+fn replay_artifact_ref(args: &FuzzReplayLikeArgs) -> Option<String> {
     args.artifact_or_case
         .as_deref()
         .filter(|value| is_replay_artifact_ref(value))

--- a/crates/homeboy-cli/src/commands/fuzz/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/mod.rs
@@ -20,9 +20,9 @@ use super::report::{
 };
 use super::types::{
     FuzzCommand, FuzzDiscoverArgs, FuzzExecutionOutput, FuzzGateProfileArg, FuzzIsolationArg,
-    FuzzListArgs, FuzzListComponentMapping, FuzzListDiagnostics, FuzzListOutput, FuzzMinimizeArgs,
-    FuzzOutput, FuzzPlanArgs, FuzzPlanStrategy, FuzzReplayArgs, FuzzReportArgs, FuzzRunArgs,
-    FuzzRunOutput, FuzzRunnerContract, FuzzValidateArgs, FuzzWorkloadOutput,
+    FuzzListArgs, FuzzListComponentMapping, FuzzListDiagnostics, FuzzListOutput, FuzzOutput,
+    FuzzPlanArgs, FuzzPlanStrategy, FuzzReplayLikeArgs, FuzzReportArgs, FuzzRunArgs, FuzzRunOutput,
+    FuzzRunnerContract, FuzzValidateArgs, FuzzWorkloadOutput,
 };
 use super::workloads::{
     fuzz_workloads, resolve_component_id, resolve_fuzz_context, resolve_profile_workload_id,

--- a/crates/homeboy-cli/src/commands/fuzz/tests/replay_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/replay_tests.rs
@@ -87,7 +87,7 @@ fn fuzz_replay_resolves_campaign_metadata_without_executing() {
     });
     std::fs::write(&path, serde_json::to_string(&campaign).unwrap()).expect("write campaign");
 
-    let output = run_replay(FuzzReplayArgs {
+    let output = run_replay(FuzzReplayLikeArgs {
         component: None,
         path: None,
         rig: None,
@@ -143,7 +143,7 @@ fn fuzz_replay_resolves_persisted_run_artifact_without_path() {
             .record_artifact(&run.id, "fuzz_results", &path)
             .expect("artifact");
 
-        let (output, exit) = run_replay(FuzzReplayArgs {
+        let (output, exit) = run_replay(FuzzReplayLikeArgs {
             component: None,
             path: None,
             rig: None,
@@ -221,7 +221,7 @@ fn fuzz_replay_resolves_case_from_nested_lab_normalized_result_payload() {
             .record_artifact(&run.id, "fuzz_result_envelope", &path)
             .expect("artifact");
 
-        let (output, exit) = run_replay(FuzzReplayArgs {
+        let (output, exit) = run_replay(FuzzReplayLikeArgs {
             component: None,
             path: None,
             rig: None,
@@ -299,7 +299,7 @@ fn fuzz_minimize_resolves_case_from_nested_lab_fuzz_result_artifact_payload() {
     )
     .expect("write lab wrapper");
 
-    let (output, exit) = run_minimize(FuzzMinimizeArgs {
+    let (output, exit) = run_minimize(FuzzReplayLikeArgs {
         component: None,
         path: None,
         rig: None,
@@ -359,7 +359,7 @@ fn fuzz_replay_preserves_clear_error_when_nested_case_is_absent() {
     )
     .expect("write lab envelope");
 
-    let result = run_replay(FuzzReplayArgs {
+    let result = run_replay(FuzzReplayLikeArgs {
         component: None,
         path: None,
         rig: None,
@@ -445,7 +445,7 @@ fn fuzz_replay_dry_run_resolves_persisted_homeboy_artifact_ref_without_local_byt
             std::env::remove_var("HOMEBOY_EMPTY_COMPONENT_PATH");
         }
 
-        let (output, exit) = run_replay(FuzzReplayArgs {
+        let (output, exit) = run_replay(FuzzReplayLikeArgs {
             component: Some("component-a".to_string()),
             path: None,
             rig: Some("fixture-rig".to_string()),
@@ -474,7 +474,7 @@ fn fuzz_replay_dry_run_resolves_persisted_homeboy_artifact_ref_without_local_byt
 fn fuzz_replay_dry_run_accepts_runner_artifact_ref_without_local_bytes() {
     let reference = "runner-artifact://lab-runner/proof-run/fuzz-result-envelope";
 
-    let (output, exit) = run_replay(FuzzReplayArgs {
+    let (output, exit) = run_replay(FuzzReplayLikeArgs {
         component: None,
         path: None,
         rig: None,
@@ -513,7 +513,7 @@ fn fuzz_replay_dry_run_explains_missing_extension_replay_command() {
         );
         let path = write_replay_campaign(component_dir.path());
 
-        let (output, exit) = run_replay(FuzzReplayArgs {
+        let (output, exit) = run_replay(FuzzReplayLikeArgs {
             component: Some("component-a".to_string()),
             path: None,
             rig: Some("fixture-rig".to_string()),
@@ -583,7 +583,7 @@ fn fuzz_replay_dry_run_surfaces_persisted_artifact_public_access() {
             })
             .expect("import artifact ref");
 
-        let (output, exit) = run_replay(FuzzReplayArgs {
+        let (output, exit) = run_replay(FuzzReplayLikeArgs {
             component: None,
             path: None,
             rig: None,
@@ -616,7 +616,7 @@ fn fuzz_replay_dry_run_surfaces_persisted_artifact_public_access() {
 
 #[test]
 fn fuzz_replay_runner_artifact_ref_without_dry_run_is_actionable() {
-    let result = run_replay(FuzzReplayArgs {
+    let result = run_replay(FuzzReplayLikeArgs {
         component: None,
         path: None,
         rig: None,
@@ -668,7 +668,7 @@ fn fuzz_replay_executes_manifest_replay_command_with_env() {
         );
         let path = write_replay_campaign(component_dir.path());
 
-        let (output, exit) = run_replay(FuzzReplayArgs {
+        let (output, exit) = run_replay(FuzzReplayLikeArgs {
             component: Some("component-a".to_string()),
             path: None,
             rig: Some("fixture-rig".to_string()),
@@ -709,7 +709,7 @@ fn fuzz_replay_reports_unsupported_when_manifest_has_no_replay_command() {
         );
         let path = write_replay_campaign(component_dir.path());
 
-        let (output, exit) = run_replay(FuzzReplayArgs {
+        let (output, exit) = run_replay(FuzzReplayLikeArgs {
             component: Some("component-a".to_string()),
             path: None,
             rig: Some("fixture-rig".to_string()),
@@ -754,7 +754,7 @@ fn fuzz_minimize_executes_manifest_minimize_command_with_replay_env() {
         );
         let path = write_replay_campaign(component_dir.path());
 
-        let (output, exit) = run_minimize(FuzzMinimizeArgs {
+        let (output, exit) = run_minimize(FuzzReplayLikeArgs {
             component: Some("component-a".to_string()),
             path: None,
             rig: Some("fixture-rig".to_string()),
@@ -793,7 +793,7 @@ fn fuzz_minimize_reports_unsupported_without_minimize_command() {
         );
         let path = write_replay_campaign(component_dir.path());
 
-        let (output, exit) = run_minimize(FuzzMinimizeArgs {
+        let (output, exit) = run_minimize(FuzzReplayLikeArgs {
             component: Some("component-a".to_string()),
             path: None,
             rig: Some("fixture-rig".to_string()),

--- a/crates/homeboy-cli/src/commands/fuzz/types.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/types.rs
@@ -189,9 +189,9 @@ pub(crate) enum FuzzCommand {
     /// Compare two persisted fuzz result envelopes
     Compare(FuzzCompareArgs),
     /// Resolve replay metadata for persisted fuzz cases
-    Replay(FuzzReplayArgs),
+    Replay(FuzzReplayLikeArgs),
     /// Resolve minimization metadata for persisted fuzz cases
-    Minimize(FuzzMinimizeArgs),
+    Minimize(FuzzReplayLikeArgs),
     /// Print a compact fuzz failure diagnosis or the complete runner result
     Inspect(FuzzInspectArgs),
 }
@@ -686,17 +686,28 @@ impl FuzzCompareHotspotPolicy {
     }
 }
 
+/// Arguments shared by `fuzz replay` and `fuzz minimize`.
+///
+/// The two subcommands take an identical argument set and differ only in which
+/// extension manifest command they resolve (`replay_command` vs
+/// `minimize_command`) -- a distinction the private `ReplayLikeMode` enum in
+/// `replay.rs` already carries.
+///
+/// They used to be two field-for-field clap structs, plus a third private
+/// `ReplayLikeArgs` copy in `replay.rs` that both were rebuilt into
+/// field-by-field before use. The same eleven arguments were declared three
+/// times, and the only thing that ever differed between them was help text.
 #[derive(Args, Clone)]
-pub(crate) struct FuzzReplayArgs {
-    /// Component ID used to resolve the extension replay_command.
+pub(crate) struct FuzzReplayLikeArgs {
+    /// Component ID used to resolve the extension replay/minimize command.
     #[arg(long = "component", value_name = "ID")]
     pub(crate) component: Option<String>,
 
-    /// Override the component checkout path for replay command execution.
+    /// Override the component checkout path for command execution.
     #[arg(long)]
     pub(crate) path: Option<String>,
 
-    /// Resolve replay through a rig's component path and extension config.
+    /// Resolve the command through a rig's component path and extension config.
     #[arg(long, value_name = "RIG_ID")]
     pub(crate) rig: Option<String>,
 
@@ -710,11 +721,11 @@ pub(crate) struct FuzzReplayArgs {
     #[arg(value_name = "ARTIFACT_OR_CASE")]
     pub(crate) artifact_or_case: Option<String>,
 
-    /// Fuzz campaign or result envelope artifact to inspect for replay metadata.
+    /// Fuzz campaign or result envelope artifact to inspect for replay/minimize metadata.
     #[arg(long = "artifact", value_name = "PATH")]
     pub(crate) artifact: Option<PathBuf>,
 
-    /// Case id to replay from the campaign/envelope artifact.
+    /// Case id to replay or minimize from the campaign/envelope artifact.
     #[arg(long = "case-id", value_name = "ID")]
     pub(crate) case_id: Option<String>,
 
@@ -722,56 +733,11 @@ pub(crate) struct FuzzReplayArgs {
     #[arg(long = "run-id", value_name = "ID")]
     pub(crate) run_id: Option<String>,
 
-    /// Resolve replay metadata and command environment without executing replay_command.
+    /// Resolve metadata and command environment without executing the extension command.
     #[arg(long = "dry-run")]
     pub(crate) dry_run: bool,
 
-    /// Additional arguments passed to the extension replay command.
-    #[arg(last = true)]
-    pub(crate) args: Vec<String>,
-}
-
-#[derive(Args, Clone)]
-pub(crate) struct FuzzMinimizeArgs {
-    /// Component ID used to resolve the extension minimize_command.
-    #[arg(long = "component", value_name = "ID")]
-    pub(crate) component: Option<String>,
-
-    /// Override the component checkout path for minimize command execution.
-    #[arg(long)]
-    pub(crate) path: Option<String>,
-
-    /// Resolve minimization through a rig's component path and extension config.
-    #[arg(long, value_name = "RIG_ID")]
-    pub(crate) rig: Option<String>,
-
-    #[command(flatten)]
-    pub(crate) extension_override: ExtensionOverrideArgs,
-
-    #[command(flatten)]
-    pub(crate) setting_args: SettingArgs,
-
-    /// Fuzz campaign/result envelope path, or a case id when --artifact is used.
-    #[arg(value_name = "ARTIFACT_OR_CASE")]
-    pub(crate) artifact_or_case: Option<String>,
-
-    /// Fuzz campaign or result envelope artifact to inspect for minimization metadata.
-    #[arg(long = "artifact", value_name = "PATH")]
-    pub(crate) artifact: Option<PathBuf>,
-
-    /// Case id to minimize from the campaign/envelope artifact.
-    #[arg(long = "case-id", value_name = "ID")]
-    pub(crate) case_id: Option<String>,
-
-    /// Stable Homeboy run id associated with the persisted fuzz evidence.
-    #[arg(long = "run-id", value_name = "ID")]
-    pub(crate) run_id: Option<String>,
-
-    /// Resolve minimization metadata and command environment without executing minimize_command.
-    #[arg(long = "dry-run")]
-    pub(crate) dry_run: bool,
-
-    /// Additional arguments passed to the extension minimize command.
+    /// Additional arguments passed to the extension replay/minimize command.
     #[arg(last = true)]
     pub(crate) args: Vec<String>,
 }


### PR DESCRIPTION
Continues the duplication burn-down (#13271, #13295, #13314, #13327, #13338, #13339).

`fuzz replay` and `fuzz minimize` take an identical eleven-argument set. It was declared **three times**:

```
types.rs:689   FuzzReplayArgs    (clap Args, 11 fields)  ─┐
types.rs:734   FuzzMinimizeArgs  (clap Args, 11 fields)  ─┤ identical but for help text
replay.rs:274  ReplayLikeArgs    (private, 11 fields)    ─┘
               ├─ from_replay(FuzzReplayArgs)     -> 13 lines of `x: args.x`
               └─ from_minimize(FuzzMinimizeArgs) -> 13 lines of `x: args.x`
```

Someone already noticed the duplication and built `ReplayLikeArgs` to unify the two — and thereby created a third copy plus two hand-maintained conversions. **-134 / +50** across four files.

## What collapsed

The two clap structs become one `FuzzReplayLikeArgs`. `ReplayLikeArgs` and both constructors are deleted; `run_replay` and `run_minimize` now hand their args straight to `run_replay_like`.

The replay-vs-minimize distinction was **never in the argument set**. It lives in `ReplayLikeMode`, which already existed in the same file and already resolves the manifest key (`replay_command` vs `minimize_command`) and the command name.

## CLI surface — verified mechanically

The real risk in merging clap structs is a silently changed flag. Every argument's identifier, clap attribute, type and declaration order in the merged struct is byte-identical to **both** originals:

```
FuzzReplayArgs(before):    11 args
FuzzMinimizeArgs(before):  11 args
FuzzReplayLikeArgs(after): 11 args

replay   -> merged: IDENTICAL clap surface (name, attrs, type, order)
minimize -> merged: IDENTICAL clap surface (name, attrs, type, order)
```

Flag names, value names, the positional, and the `last = true` passthrough are unchanged, so parsing is unchanged.

## The one real trade: help text

Help strings are now mode-neutral — *"resolve the extension replay/minimize command"* rather than a per-command *"replay_command"* / *"minimize_command"*.

I want to be straight that this is a (small) loss, and equally straight that it is **the codebase's existing convention, not a new concession**: `ExtensionOverrideArgs` and `SettingArgs` are flattened into these same two commands and into 10+ others, each with a single shared help string. Nothing pins fuzz help text in a contract, spec, or test.

Two structs to carry two adjectives was not paying for itself. Three was indefensible.

## Verification

`cargo check --workspace --all-targets -j2` → **exit 0, zero warnings**. That includes the 16 test call sites in `fuzz/tests/replay_tests.rs`, which were renamed to the merged type with no field changes.

<details>
<summary>Why <code>cargo test -p homeboy-cli --lib</code> was not run</summary>

12G free on the build volume with two cargo processes already live in another worktree — the disk condition RULES.md says to stop at, and the mechanism behind the 2026-07-29 root-volume outage. Routed to CI, which is where RULES.md sends `cargo test` anyway.
</details>

## What I deliberately did NOT do

- **Did not fold `component`/`path` into the existing `PositionalComponentArgs`**, even though `replay_component_args()` builds one from exactly those two fields. That is a different refactor with its own clap-surface implications, and mixing it in would have muddied the "surface is provably identical" claim above.
- **Did not widen `ReplayLikeMode`'s visibility.** I bumped it to `pub(super)` mid-change for a doc link, then reverted it and de-linked the reference — an unused visibility widening is a cost, not a neutral.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode
