### PR TITLE
refactor(agents): light up agent_task_lifecycle for the dead-code lint

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2420,6 +2420,7 @@ impl RuntimeAdmissionEvidence for Value {
 
 /// Persist the run identity before controller admission so an admission failure
 /// remains inspectable and retryable through the normal lifecycle commands.
+#[cfg(test)]
 pub(crate) fn submit_plan_with_runtime_admission<F, A>(
     plan: &AgentTaskPlan,
     requested_run_id: Option<&str>,
@@ -5738,6 +5739,7 @@ fn retry_with_force_inner_in_store(
 /// `paths::controller_runtimes_store()` and takes a cross-process lock — but the
 /// cancellation check inside it reads *lifecycle* state, and that read is rooted
 /// by the caller that owns the store.
+#[cfg(test)]
 pub(crate) fn retry_with_runtime_admission_in_store<F, A>(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -3,20 +3,19 @@
 
 use super::*;
 use crate::agent_task::{
-    AgentTaskArtifact, AgentTaskArtifactDeclaration, AgentTaskExecutionHandle, AgentTaskExecutor,
-    AgentTaskLimits, AgentTaskOutcomeStatus, AgentTaskPolicy, AgentTaskRequest, AgentTaskSourceRef,
+    AgentTaskArtifact, AgentTaskArtifactDeclaration, AgentTaskExecutionHandle,
     AgentTaskWorkflowEvidence, AgentTaskWorkflowStepEvidence, AgentTaskWorkflowStepStatus,
-    AgentTaskWorkspace, AGENT_TASK_REQUEST_SCHEMA, AGENT_TASK_WORKFLOW_SCHEMA,
+    AGENT_TASK_WORKFLOW_SCHEMA,
 };
 use crate::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
     AGENT_TASK_AGGREGATE_SCHEMA,
 };
-use homeboy_core::api_jobs::{Job, JobEvent, JobEventKind, JobStore, RemoteRunnerJobRequest};
+use homeboy_core::api_jobs::{Job, RemoteRunnerJobRequest};
 use homeboy_core::test_support::with_isolated_home;
 use sha2::{Digest, Sha256};
 use std::process::Command;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 /// The tests below drive the store-rooted entry points. Resolving the store
 /// once here keeps the ambient lookup in one place and lets the ambient

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/lifecycle_store.rs
@@ -8,13 +8,6 @@ use crate::agent_task_lifecycle::{
 use homeboy_core::run_lifecycle_record::{RunExecutionState, RunLifecycleRecord};
 use serde_json::json;
 
-/// The tests below drive the store-rooted entry points. Resolving the store
-/// once here keeps the ambient lookup in one place and lets the ambient
-/// wrappers be deleted (#7505).
-fn test_lifecycle_store() -> AgentTaskLifecycleStore {
-    AgentTaskLifecycleStore::from_current_environment().expect("lifecycle store")
-}
-
 fn record(store: &AgentTaskLifecycleStore, run_id: &str, marker: &str) -> AgentTaskRunRecord {
     let plan = test_plan();
     AgentTaskRunRecord {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/mod.rs
@@ -3,17 +3,15 @@
 
 use super::*;
 use crate::agent_task::{
-    AgentTaskArtifact, AgentTaskArtifactDeclaration, AgentTaskExecutionHandle, AgentTaskExecutor,
-    AgentTaskLimits, AgentTaskOutcomeStatus, AgentTaskPolicy, AgentTaskRequest, AgentTaskSourceRef,
-    AgentTaskWorkflowEvidence, AgentTaskWorkflowStepEvidence, AgentTaskWorkflowStepStatus,
-    AgentTaskWorkspace, AGENT_TASK_REQUEST_SCHEMA, AGENT_TASK_WORKFLOW_SCHEMA,
+    AgentTaskArtifact, AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskRequest,
+    AgentTaskWorkspace, AGENT_TASK_REQUEST_SCHEMA,
 };
 use crate::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
     AGENT_TASK_AGGREGATE_SCHEMA,
 };
 use homeboy_core::api_jobs::{
-    Job, JobEvent, JobEventKind, JobStore, RemoteRunnerJobRequest, RemoteRunnerSubmissionLookup,
+    Job, JobEventKind, JobStore, RemoteRunnerJobRequest, RemoteRunnerSubmissionLookup,
 };
 use homeboy_core::test_support::with_isolated_home;
 use sha2::{Digest, Sha256};

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -2,12 +2,7 @@
 #![cfg(test)]
 
 use super::*;
-use crate::agent_task::{
-    AgentTaskArtifact, AgentTaskArtifactDeclaration, AgentTaskExecutionHandle, AgentTaskExecutor,
-    AgentTaskLimits, AgentTaskOutcomeStatus, AgentTaskPolicy, AgentTaskRequest, AgentTaskSourceRef,
-    AgentTaskWorkflowEvidence, AgentTaskWorkflowStepEvidence, AgentTaskWorkflowStepStatus,
-    AgentTaskWorkspace, AGENT_TASK_REQUEST_SCHEMA, AGENT_TASK_WORKFLOW_SCHEMA,
-};
+use crate::agent_task::{AgentTaskArtifact, AgentTaskOutcomeStatus};
 use crate::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
     AGENT_TASK_AGGREGATE_SCHEMA,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -3,18 +3,15 @@
 
 use super::*;
 use crate::agent_task::{
-    AgentTaskArtifact, AgentTaskArtifactDeclaration, AgentTaskExecutionHandle, AgentTaskExecutor,
-    AgentTaskLimits, AgentTaskOutcomeStatus, AgentTaskPolicy, AgentTaskRequest, AgentTaskSourceRef,
-    AgentTaskWorkflowEvidence, AgentTaskWorkflowStepEvidence, AgentTaskWorkflowStepStatus,
-    AgentTaskWorkspace, AGENT_TASK_REQUEST_SCHEMA, AGENT_TASK_WORKFLOW_SCHEMA,
+    AgentTaskArtifact, AgentTaskExecutionHandle, AgentTaskOutcomeStatus, AgentTaskSourceRef,
 };
 use crate::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
     AGENT_TASK_AGGREGATE_SCHEMA,
 };
-use homeboy_core::api_jobs::{Job, JobEvent, JobEventKind, JobStore, RemoteRunnerJobRequest};
+use homeboy_core::api_jobs::JobStore;
 use homeboy_core::test_support::with_isolated_home;
-use sha2::{Digest, Sha256};
+use sha2::Digest;
 use std::process::Command;
 use std::sync::{Arc, Mutex};
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -2,21 +2,15 @@
 #![cfg(test)]
 
 use super::*;
-use crate::agent_task::{
-    AgentTaskArtifact, AgentTaskArtifactDeclaration, AgentTaskEvidenceRef,
-    AgentTaskExecutionHandle, AgentTaskExecutor, AgentTaskLimits, AgentTaskOutcomeStatus,
-    AgentTaskPolicy, AgentTaskRequest, AgentTaskSourceRef, AgentTaskWorkflowEvidence,
-    AgentTaskWorkflowStepEvidence, AgentTaskWorkflowStepStatus, AgentTaskWorkspace,
-    AGENT_TASK_REQUEST_SCHEMA, AGENT_TASK_WORKFLOW_SCHEMA,
-};
+use crate::agent_task::{AgentTaskArtifact, AgentTaskEvidenceRef, AgentTaskOutcomeStatus};
 use crate::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
     AGENT_TASK_AGGREGATE_SCHEMA,
 };
 use crate::agent_task_service::{reconcile_run, reconcile_stale_active_runs};
-use homeboy_core::api_jobs::{Job, JobEvent, JobEventKind, JobStore, RemoteRunnerJobRequest};
+use homeboy_core::api_jobs::{Job, JobEventKind, RemoteRunnerJobRequest};
 use homeboy_core::test_support::with_isolated_home;
-use sha2::{Digest, Sha256};
+use sha2::Digest;
 use std::process::Command;
 use std::sync::{Arc, LazyLock, Mutex};
 use tempfile::TempDir;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_authority.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_authority.rs
@@ -344,10 +344,6 @@ fn authority_digest(run_id: &str, runner_id: &str, remote_workspace: &str) -> St
     ])
 }
 
-pub(crate) fn persist_terminal_from_record(record: &AgentTaskRunRecord) -> Result<()> {
-    WorkspaceTerminalAuthorityStore::from_environment()?.persist_terminal_from_record(record)
-}
-
 fn persist_workspace_terminal_authority(receipt: WorkspaceTerminalAuthorityReceipt) -> Result<()> {
     WorkspaceTerminalAuthorityStore::from_environment()?.persist(receipt)
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
@@ -1298,12 +1298,6 @@ pub(crate) fn register_local_workspace_owner_in_store(
     )
 }
 
-pub(crate) fn renew_local_workspace_owner(
-    lease: &WorkspaceOwnerLease,
-) -> Result<WorkspaceOwnerLease> {
-    store()?.renew_owner(lease, LOCAL_WORKSPACE_OWNER_LEASE_TTL_MS, now_ms())
-}
-
 pub(crate) fn validate_local_workspace_owner_in_store(
     store: &WorkspaceClaimStore,
     lease: &WorkspaceOwnerLease,
@@ -1331,43 +1325,6 @@ pub(crate) fn renew_record_workspace_owner_in_store(
     let renewed = store.renew_owner(lease, LOCAL_WORKSPACE_OWNER_LEASE_TTL_MS, now_ms())?;
     record.workspace_lifecycle_revision = renewed.lifecycle_revision;
     record.workspace_owner_lease = Some(renewed);
-    Ok(())
-}
-
-/// The store-rooted counterpart of [`ensure_record_workspace_owner`].
-///
-/// Validating an existing lease and registering its replacement are one
-/// decision: "is this record still the owner, and if not, make it one." The
-/// ambient form resolved a claim store for each half, so a repoint between them
-/// could reject a live lease in one home and register its successor in another,
-/// leaving two installations each believing they own the workspace (#7505).
-pub(crate) fn ensure_record_workspace_owner_in_store(
-    store: &WorkspaceClaimStore,
-    record: &mut AgentTaskRunRecord,
-) -> Result<()> {
-    let Some(identity) = record.workspace_identity.clone() else {
-        return Ok(());
-    };
-    identity.verify()?;
-    if let Some(lease) = record.workspace_owner_lease.as_ref() {
-        if lease.workspace == identity
-            && lease.owner_id == record.run_id
-            && lease.lifecycle_revision == record.workspace_lifecycle_revision
-            && validate_local_workspace_owner_in_store(store, lease)?
-        {
-            return Ok(());
-        }
-    }
-    record.workspace_owner_lease = Some(register_local_workspace_owner_in_store(
-        store,
-        identity,
-        &record.run_id,
-    )?);
-    record.workspace_lifecycle_revision = record
-        .workspace_owner_lease
-        .as_ref()
-        .expect("registered owner lease")
-        .lifecycle_revision;
     Ok(())
 }
 

--- a/crates/homeboy-agents/src/lib.rs
+++ b/crates/homeboy-agents/src/lib.rs
@@ -25,11 +25,6 @@ pub mod agent_task_fanout_supervisor;
 pub mod agent_task_finalization;
 pub mod agent_task_gate;
 pub mod agent_task_gate_executor;
-#[allow(
-    dead_code,
-    unused_imports,
-    reason = "Lifecycle test shards share fixtures and recovery helpers."
-)]
 pub mod agent_task_lifecycle;
 pub mod agent_task_loop_controller;
 pub mod agent_task_loop_definition;

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -331,19 +331,6 @@ impl AgentTaskLifecycleStore {
         )
     }
 
-    pub(crate) fn record_provider_execution_runtime_evidence(
-        &self,
-        run_id: &str,
-        task_id: &str,
-        attempt: u32,
-        stdout_uri: Option<String>,
-        stderr_uri: Option<String>,
-    ) -> Result<AgentTaskRunRecord> {
-        super::lifecycle_ops::record_provider_execution_runtime_evidence_in_store(
-            self, run_id, task_id, attempt, stdout_uri, stderr_uri,
-        )
-    }
-
     pub(crate) fn record_provider_execution_cleanup_elapsed(
         &self,
         run_id: &str,
@@ -1054,6 +1041,7 @@ fn migrate_execution_budget(plan: &mut AgentTaskPlan) -> Result<bool> {
         })
 }
 
+#[cfg(test)]
 pub(super) fn write_aggregate(run_id: &str, aggregate: &AgentTaskAggregate) -> Result<PathBuf> {
     write_aggregate_in_store(&default_store()?, run_id, aggregate)
 }
@@ -1458,12 +1446,6 @@ pub(super) fn confirm_cook_notification_in_store(
     write_private_json(&delivered_path, marker)
 }
 
-/// Release a provisional claim after a non-delivery so a later terminal
-/// observer can retry it.
-pub(super) fn release_cook_notification_claim(cook_id: &str) -> Result<()> {
-    release_cook_notification_claim_in_store(&default_store()?, cook_id)
-}
-
 /// Release a provisional claim beside the injected store's own Cook index.
 ///
 /// This removes the marker `claim_cook_notification_in_store` created, so it
@@ -1583,6 +1565,7 @@ const RETRY_SUCCESSOR_SCAN_LIMIT: usize = 256;
 /// and then create one, so a truncated lineage would silently double-book a
 /// retry. The page is therefore read with an explicit truncation signal and a
 /// truncated lineage fails loudly rather than answering wrongly (#11177).
+#[cfg(test)]
 pub(super) fn read_retry_successors(source_run_id: &str) -> Result<Vec<AgentTaskRunRecord>> {
     read_retry_successors_in_store(&default_store()?, source_run_id)
 }
@@ -1608,17 +1591,6 @@ pub(super) fn read_retry_successors_in_store(
         )));
     }
     page.runs.iter().map(record_from_run).collect()
-}
-
-pub(super) fn read_records_with_health_bounded(
-    limit: usize,
-) -> Result<(Vec<AgentTaskRunRecord>, super::AgentTaskRecordHealthSummary)> {
-    default_store()?.read_records_with_health_bounded(limit)
-}
-
-pub(super) fn read_all_records_with_health(
-) -> Result<(Vec<AgentTaskRunRecord>, super::AgentTaskRecordHealthSummary)> {
-    default_store()?.read_all_records_with_health()
 }
 
 fn records_with_health(

--- a/tests/dead_code_suppression_ratchet_test.rs
+++ b/tests/dead_code_suppression_ratchet_test.rs
@@ -42,7 +42,7 @@ use std::path::{Path, PathBuf};
 /// homeboy-agents modules, plus two `#[path]`-shared test support modules that
 /// each test binary includes whole and uses in part. It is a ceiling, not a
 /// target: lower it whenever a crate is cleared, and never raise it.
-const MODULE_SUPPRESSION_CEILING: usize = 4;
+const MODULE_SUPPRESSION_CEILING: usize = 3;
 
 /// One module-level suppression, located precisely enough to act on.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
Slice 6. Based on `main`; #13311, #13312, #13316, #13335 and #13337 are merged.

## 44.5k lines: 66 unused imports (all in test shards) and twelve dead items

**Four are test-reachable and gated:** `write_aggregate`, `read_retry_successors`, `submit_plan_with_runtime_admission`, `retry_with_runtime_admission_in_store`.

**Eight are dead in both configurations and deleted.** Six are the same duplication this sweep keeps finding — a free function in `lifecycle_store` forwarding to the identically named **method** on `AgentTaskLifecycleStore`:

```rust
// dead: nothing calls the free function
pub(super) fn read_all_records_with_health() -> Result<...> {
    default_store()?.read_all_records_with_health()   // live: production calls the method
}
```

## The duplication is also what made the first deletion attempt wrong

I matched the function name with a regex. It hit the **live method** before the dead forwarder and removed the wrong one — seven `E0599`s.

In a file that defines the same name twice, deleting strictly at **compiler-reported line numbers** is the only safe method. Name matching is not a shortcut here; it is the failure mode.

## Verification

```
cargo check --workspace --all-targets    0 warnings, 0 errors
cargo fmt --all --check                  clean
ratchet test                             3 passed
agent_task_lifecycle tests               338 pass / 3 fail
origin/main, same box, same filter       340 pass / 1 fail
```

### On those three failures

The lifecycle suite is **not stable under parallel execution**. Three consecutive runs of the same branch commit produced **3, 5 and 2** failures with different names each time. Both names that exceeded main's baseline pass in isolation, twice each.

Only `cancel_run_signals_live_running_record` fails consistently — and it fails on `origin/main` too.

Worth a separate issue; it makes this crate's suite hard to use as a regression signal.

## Ceiling

4 → 3. Remaining: `agent_task_service` (55.8k), plus the two shared test-support modules.