### PR TITLE
refactor(controller-runtime): key both digest caches on one file identity

### DIFF
--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -149,9 +149,8 @@ static TEST_ADMISSION_HEAD_BARRIER: OnceLock<Mutex<Option<std::sync::Arc<std::sy
 #[cfg(test)]
 static TEST_ADMISSION_OWNER_CAS_REPLACEMENT: OnceLock<Mutex<Option<Value>>> = OnceLock::new();
 #[cfg(all(unix, any(test, feature = "test-support")))]
-static TEST_CONTROLLER_FIXTURE_DIGESTS: OnceLock<
-    Mutex<BTreeMap<TestExecutableFileIdentity, String>>,
-> = OnceLock::new();
+static TEST_CONTROLLER_FIXTURE_DIGESTS: OnceLock<Mutex<BTreeMap<ExecutableFileIdentity, String>>> =
+    OnceLock::new();
 /// Digests this process has already computed, keyed by observed file identity.
 ///
 /// Sealing a cook into an immutable runtime hashes the same bytes repeatedly:
@@ -181,24 +180,16 @@ static TEST_CONTROLLER_FIXTURE_DIGEST_CALLS: std::sync::atomic::AtomicUsize =
 /// One executable file as this process observed it. Inode and change time are
 /// part of the identity so replacing or modifying a path cannot reuse its prior
 /// digest.
+///
+/// This is the single definition of "same file" for both the process-local
+/// digest memo and the test fixture digest cache. It used to be duplicated as a
+/// verbatim `TestExecutableFileIdentity` clone -- same eight fields, same order,
+/// same derives -- which meant strengthening the production identity left the
+/// fixture cache keyed on the older, weaker one and the tests silently stopped
+/// exercising what production does.
 #[cfg(unix)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct ExecutableFileIdentity {
-    path: PathBuf,
-    device: u64,
-    inode: u64,
-    size: u64,
-    modified_seconds: i64,
-    modified_nanoseconds: i64,
-    changed_seconds: i64,
-    changed_nanoseconds: i64,
-}
-
-/// A source fixture is immutable for a hermetic test context. Include inode and
-/// change time so replacing or modifying a path cannot reuse its prior digest.
-#[cfg(all(unix, any(test, feature = "test-support")))]
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-struct TestExecutableFileIdentity {
     path: PathBuf,
     device: u64,
     inode: u64,
@@ -2582,7 +2573,7 @@ fn test_controller_identity(path: &Path, verified_digest: Option<&str>) -> Optio
 
 #[cfg(all(unix, any(test, feature = "test-support")))]
 fn test_controller_fixture_digest(path: &Path) -> Result<String> {
-    let file_identity = test_executable_file_identity(path)?;
+    let file_identity = executable_file_identity(path)?;
     let cache = TEST_CONTROLLER_FIXTURE_DIGESTS.get_or_init(|| Mutex::new(BTreeMap::new()));
     if let Some(digest) = cache
         .lock()
@@ -2610,35 +2601,13 @@ fn test_controller_fixture_digest(path: &Path) -> Result<String> {
 
 #[cfg(all(unix, any(test, feature = "test-support")))]
 fn test_registered_fixture_digest(path: &Path) -> Option<String> {
-    let file_identity = test_executable_file_identity(path).ok()?;
+    let file_identity = executable_file_identity(path).ok()?;
     TEST_CONTROLLER_FIXTURE_DIGESTS
         .get_or_init(|| Mutex::new(BTreeMap::new()))
         .lock()
         .expect("test controller fixture digest cache is not poisoned")
         .get(&file_identity)
         .cloned()
-}
-
-#[cfg(all(unix, any(test, feature = "test-support")))]
-fn test_executable_file_identity(path: &Path) -> Result<TestExecutableFileIdentity> {
-    use std::os::unix::fs::MetadataExt;
-
-    let metadata = fs::metadata(path).map_err(|error| {
-        Error::internal_io(
-            error.to_string(),
-            Some("inspect test controller executable".to_string()),
-        )
-    })?;
-    Ok(TestExecutableFileIdentity {
-        path: path.to_path_buf(),
-        device: metadata.dev(),
-        inode: metadata.ino(),
-        size: metadata.size(),
-        modified_seconds: metadata.mtime(),
-        modified_nanoseconds: metadata.mtime_nsec(),
-        changed_seconds: metadata.ctime(),
-        changed_nanoseconds: metadata.ctime_nsec(),
-    })
 }
 
 #[cfg(all(unix, any(test, feature = "test-support")))]
@@ -2703,12 +2672,19 @@ fn executable_digest(path: &Path) -> Result<String> {
     Ok(digest)
 }
 
+/// Stat `path` into its observed identity. The one place the eight identity
+/// fields are read, for both the digest memo and the fixture cache.
 #[cfg(unix)]
-fn observed_executable_identity(path: &Path) -> Option<ExecutableFileIdentity> {
+fn executable_file_identity(path: &Path) -> Result<ExecutableFileIdentity> {
     use std::os::unix::fs::MetadataExt;
 
-    let metadata = fs::metadata(path).ok()?;
-    Some(ExecutableFileIdentity {
+    let metadata = fs::metadata(path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some("inspect controller executable".to_string()),
+        )
+    })?;
+    Ok(ExecutableFileIdentity {
         path: path.to_path_buf(),
         device: metadata.dev(),
         inode: metadata.ino(),
@@ -2718,6 +2694,12 @@ fn observed_executable_identity(path: &Path) -> Option<ExecutableFileIdentity> {
         changed_seconds: metadata.ctime(),
         changed_nanoseconds: metadata.ctime_nsec(),
     })
+}
+
+/// The memo's view: an unreadable path is simply not memoizable, never an error.
+#[cfg(unix)]
+fn observed_executable_identity(path: &Path) -> Option<ExecutableFileIdentity> {
+    executable_file_identity(path).ok()
 }
 
 #[cfg(not(unix))]
@@ -2920,7 +2902,7 @@ fn register_test_fixture_candidate(source: &Path, candidate: &Path, expected_dig
     {
         return;
     }
-    let Ok(candidate_identity) = test_executable_file_identity(candidate) else {
+    let Ok(candidate_identity) = executable_file_identity(candidate) else {
         return;
     };
     TEST_CONTROLLER_FIXTURE_DIGESTS


### PR DESCRIPTION
Continues the duplication burn-down (#13271, #13295, #13314, #13327, #13338, #13339, #13342).

`TestExecutableFileIdentity` was a **verbatim clone** of `ExecutableFileIdentity` — same eight fields, same order, same derives, both private to `controller_runtime.rs`, neither serialized — differing only in its `#[cfg]`. Their two constructors were identical stat-and-build bodies differing only in `Result` vs `Option`.

**-46 / +28.**

## Why this one, on the bug-class bar

I said last round I'd score slices on *"does this remove a place where a correct-looking change is wrong"* rather than on lines. This one qualifies, and it's a nastier variant than usual:

> Strengthening the production identity — adding, say, a birth time so a same-inode rewrite can't reuse a digest — would update `ExecutableFileIdentity` and leave `TEST_CONTROLLER_FIXTURE_DIGESTS` keyed on the older, weaker clone. **Nothing would fail to compile.** The fixture cache would keep answering "same file" for a file production now considers different, and the tests covering that cache would quietly stop exercising what production does.

A duplicated type that makes *tests* lie is worth more than its eighteen net lines.

## What collapsed

`TestExecutableFileIdentity` is deleted; `TEST_CONTROLLER_FIXTURE_DIGESTS` now keys on `ExecutableFileIdentity`. The two caches remain **separate statics** — only the key type is shared.

The two constructors fold into one `executable_file_identity(path) -> Result<ExecutableFileIdentity>`. `observed_executable_identity` becomes:

```rust
/// The memo's view: an unreadable path is simply not memoizable, never an error.
fn observed_executable_identity(path: &Path) -> Option<ExecutableFileIdentity> {
    executable_file_identity(path).ok()
}
```

which states the memo's actual policy instead of restating eight `MetadataExt` calls to reach it.

## Verification

`cargo check --workspace --all-targets -j2` → **exit 0, zero warnings**.

`cargo test -p homeboy-core --lib controller_runtime:: -- --test-threads=1` → **60 passed, 2 failed**, baselined per protocol (stashed `crates/`, re-ran the identical command on clean main):

```
baseline failures:  publication_is_no_clobber_and_idempotent
                    test_fixture_identity_cache_reuses_sealed_candidates...
branch failures:    (identical)
unique to branch:   none
```

Both are pre-existing with **byte-identical messages and values** (`left: 1, right: 2`). `executable_digests_are_memoized_per_observed_file_identity` — the test for the production memo whose key type both caches now share — passes.

<callout accent="#f59e0b">
The pre-existing `chmod` failure is **not** the disk class from #13273 — it is a real call-count assertion failing on clean `main`. Reported separately; not fixed here.
</callout>

## Two candidates I looked at and rejected

Recording these so the next pass doesn't re-derive them. Both are field-for-field twins that my scan flagged, and both should be **left alone**:

**`DispatchCoreArgs` (homeboy-cli) / `DispatchCoreInputs` (homeboy-agents)** — 12 identical fields. This is a legitimate clap/domain boundary: collapsing it would make `homeboy-agents` depend on clap. More importantly `impl From<DispatchCoreArgs> for DispatchCoreInputs` is an **exhaustive struct literal with no `..Default::default()`**, so adding a field is a hard `E0063`. The compiler already enforces what a collapse would enforce. Not a bug factory.

**`AgentTaskPromotionOptions` / `AgentTaskPromotionRequest`** — 14 identical fields, same crate, and `Request::options()` is exhaustive in one direction. But the two types **deliberately serialize differently**:

```rust
// AgentTaskPromotionOptions        // AgentTaskPromotionRequest
#[serde(flatten)]                   #[serde(default)]
pub gates: VerifyGateOptions,       pub gates: VerifyGateOptions,
```

`Options` flattens `gates` to preserve *"the historical flat `verify` / `private_verify` / `private_gate_reveal` keys"*; `Request` nests it and is embedded in the durable `homeboy/agent-task-promotion-job/v1` schema, where *"a recovered job never reparses operator argv."* Collapsing would change one persisted shape or the other and break in-flight job recovery across an upgrade. Filed separately rather than fixed silently.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode
