### PR TITLE
refactor(observation): one trace run record, because trace_runs assigns no column

### DIFF
--- a/crates/homeboy-core/src/observation/records.rs
+++ b/crates/homeboy-core/src/observation/records.rs
@@ -171,28 +171,14 @@ pub struct ArtifactCleanupCandidateRecord {
     pub run_status: String,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct NewTraceRunRecord {
-    pub run_id: String,
-    pub component_id: String,
-    pub rig_id: Option<String>,
-    pub scenario_id: String,
-    pub status: String,
-    pub baseline_status: Option<String>,
-    pub metadata_json: serde_json::Value,
-}
-
-impl NewTraceRunRecord {
-    pub fn builder(
-        run_id: impl Into<String>,
-        component_id: impl Into<String>,
-        scenario_id: impl Into<String>,
-        status: impl Into<String>,
-    ) -> NewTraceRunRecordBuilder {
-        NewTraceRunRecordBuilder::new(run_id, component_id, scenario_id, status)
-    }
-}
-
+/// One trace run, on both sides of the observation store.
+///
+/// The `New*Record` / `*Record` split here exists so a stored record can carry
+/// the columns its table assigns: [`RunRecord`] adds `id`/`started_at`/
+/// `finished_at`/`status`, [`TraceSpanRecord`] adds `trace_spans.id`.
+///
+/// `trace_runs` assigns nothing -- `run_id TEXT PRIMARY KEY` comes from the
+/// caller -- so the split had nothing to express here and was a verbatim copy.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct TraceRunRecord {
     pub run_id: String,
@@ -202,6 +188,21 @@ pub struct TraceRunRecord {
     pub status: String,
     pub baseline_status: Option<String>,
     pub metadata_json: serde_json::Value,
+}
+
+/// The insert-side name for [`TraceRunRecord`], kept so `record_trace_run` and
+/// `NewTraceRunRecord::builder()` still read as the insert path.
+pub type NewTraceRunRecord = TraceRunRecord;
+
+impl TraceRunRecord {
+    pub fn builder(
+        run_id: impl Into<String>,
+        component_id: impl Into<String>,
+        scenario_id: impl Into<String>,
+        status: impl Into<String>,
+    ) -> NewTraceRunRecordBuilder {
+        NewTraceRunRecordBuilder::new(run_id, component_id, scenario_id, status)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]


### PR DESCRIPTION
Continues the duplication burn-down (#13338, #13339, #13342, #13345).

`NewTraceRunRecord` and `TraceRunRecord` were **byte-identical** — same seven fields, same order, same derives, adjacent in the same file. They are now one type, with the insert-side name kept as an alias.

**-13 / +14.** The duplicate type is gone; what replaces it is the explanation of why it can't come back. I'm not going to pretend that's a line-count win.

## Why this is an accident, not a design

`observation/records.rs` uses a `New*Record` / `*Record` split so a stored record can carry the columns its table assigns. Both sibling pairs in the same file do exactly that — and differ by exactly those columns:

```
NewRunRecord       vs RunRecord        differs: id, started_at, finished_at, status
NewTraceSpanRecord vs TraceSpanRecord  differs: trace_spans.id
NewTraceRunRecord  vs TraceRunRecord   IDENTICAL
```

The schema says why:

```sql
CREATE TABLE trace_runs (        CREATE TABLE trace_spans (
    run_id TEXT PRIMARY KEY,         id TEXT PRIMARY KEY,      <- store assigns
    ...                              run_id TEXT NOT NULL,
```

**`trace_runs` assigns nothing.** `run_id` is supplied by the caller and is itself the primary key. There is no column a stored trace run can carry that the inserted one did not — so the split had nothing to express here, and the second type was a verbatim copy of the first.

That's provable from the schema rather than inferred from field equality, and it's the two *correct* sibling pairs that make it provable. This is the convention applied where the convention is empty.

## What changed

`TraceRunRecord` is the surviving definition. `pub type NewTraceRunRecord = TraceRunRecord` keeps `record_trace_run(NewTraceRunRecord)` and `NewTraceRunRecord::builder()` reading as the insert path. **Every call site is unchanged.** `NewTraceRunRecordBuilder` keeps its name.

## What I deliberately did NOT do

**Did not remove the read-back in `record_trace_run`.** It inserts, then re-reads the row through `get_trace_run` to build its return value. With one type that looks like an obviously redundant `SELECT` returning the caller's own input — but `metadata_json` is written via `serialize_metadata` and read via `parse_metadata`, so the round trip through `TEXT` can normalize it. Not provably a no-op, so left alone.

**Did not add `Deserialize` to `TraceRunRecord`**, even though both sibling *stored* records derive it and its absence looks like part of the same oversight. Additive and probably correct, but out of scope for a collapse.

## Verification

`cargo check --workspace --all-targets -j2` → **exit 0, zero warnings**.

`cargo test -p homeboy-core --lib observation:: -- --test-threads=1` → **290 passed, 1 failed**: `lifecycle_open_does_not_wait_for_rollback_writer_maintenance_lock`.

Baselined per protocol — stashed `crates/`, re-ran on clean main, fails identically at `artifacts.rs:2614`. Pre-existing, not a regression. The baseline was scoped to that single test rather than the whole module because free space was at the 15G floor RULES.md sets.

## Three candidates I rejected this round

Recording these so the next pass doesn't re-derive them:

| pair | why it stays |
|---|---|
| `PreparedDaemonExec` / `PreparedDaemonExecRequest` (11 fields, same file) | `Request` exists so `plan_token` can be private on the built type. `new()` **destructures exhaustively**, so adding a field is `E0027` on one side and `E0063` on the other — protected in both directions. |
| `DomBoxElement` / `BrowserElement` (11 fields, same file) | Real parse boundary. `BrowserElement` takes `Option<Value>` from the browser report; `DomBoxElement` narrows to `Option<Map<String, Value>>` via `evidence_object`, and the conversion also runs `truncate_text_sample`. Not a pure move. |
| `RunsRefsArgs` / `RunsRefsFilters`, `FileFindOutput` / `FileGrepOutput`, and friends | Independent output/arg types with no conversion between them. Identical today, but nothing forces them to stay identical and nothing breaks if they diverge — no bug class to remove. |

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode
