### PR TITLE
fix(agents): gate persist_workspace_terminal_authority to its caller's cfg

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_authority.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_authority.rs
@@ -344,6 +344,7 @@ fn authority_digest(run_id: &str, runner_id: &str, remote_workspace: &str) -> St
     ])
 }
 
+#[cfg(any(test, feature = "test-support"))]
 fn persist_workspace_terminal_authority(receipt: WorkspaceTerminalAuthorityReceipt) -> Result<()> {
     WorkspaceTerminalAuthorityStore::from_environment()?.persist(receipt)
 }


### PR DESCRIPTION
**main is currently red on the Warning Clean gate.**

```
warning: function `persist_workspace_terminal_authority` is never used
error: could not compile `homeboy-agents` (lib) due to 1 previous error
```

## Cause

#13343 deleted `persist_terminal_from_record`, which was the last **production** caller. The only remaining caller is `persist_workspace_terminal_authority_for_test`, which is `#[cfg(any(test, feature = "test-support"))]`. With that feature off, the function has no callers at all.

This landed because #13343 auto-merged roughly two minutes after it was opened, on a partial check rollup, while the full workflow was still running. I had the fix ready and pushed it to the branch, but the PR was already closed so no run was ever triggered for it.

## Why local verification missed it

```
cargo check --workspace --all-targets     clean      <- what I ran
cargo check -p homeboy-agents             WARNS      <- what CI runs
```

`--workspace` **unifies features across members**. Something in the workspace enables `homeboy-agents/test-support`, which keeps the caller compiled in and the callee alive. Building the crate with its own feature set reproduces CI exactly, in about 90 seconds.

That is a third configuration axis in this crate, on top of lib-vs-test and `cfg(windows)`. Worth adding `cargo check -p <crate>` to the local gate for any dead-code work.

## Verification

```
cargo check -p homeboy-agents             clean  (warns without this patch)
cargo check --workspace --all-targets     0 warnings, 0 errors
cargo fmt --all --check                   clean
```