### PR TITLE
Delete DeployTarget::parse and the test that outlived it

### DIFF
--- a/crates/homeboy-deploy/src/route.rs
+++ b/crates/homeboy-deploy/src/route.rs
@@ -14,7 +14,6 @@
 //! never silent.
 
 use homeboy_core::component::Component;
-use homeboy_core::error::{Error, Result};
 use homeboy_core::project::Project;
 use serde::{Deserialize, Serialize};
 
@@ -35,29 +34,6 @@ impl DeployTarget {
         match self {
             Self::Server => "server",
             Self::Provider => "provider",
-        }
-    }
-
-    /// Parse the operator-facing `--target` value.
-    #[allow(
-        dead_code,
-        reason = "No production caller: clap owns `--target` parsing through `DeployTargetArg` and converts with `From`, so only this module's tests reach the string form."
-    )]
-    pub(crate) fn parse(value: &str) -> Result<Self> {
-        match value.trim().to_ascii_lowercase().as_str() {
-            "server" => Ok(Self::Server),
-            "provider" => Ok(Self::Provider),
-            other => Err(Error::validation_invalid_argument(
-                "target",
-                format!("Unknown deployment target '{other}'"),
-                None,
-                Some(vec![
-                    "--target server deploys the build artifact to the project's remote path"
-                        .to_string(),
-                    "--target provider deploys through the component's declared deployment provider"
-                        .to_string(),
-                ]),
-            )),
         }
     }
 }
@@ -248,23 +224,5 @@ mod tests {
         );
 
         assert!(server_route_disclosure(&component, &project(None), &config(None)).is_none());
-    }
-
-    #[test]
-    fn an_unknown_target_value_is_rejected_with_the_supported_ones() {
-        let error = DeployTarget::parse("worker").expect_err("unknown target");
-
-        assert_eq!(error.details["field"], "target");
-        assert_eq!(
-            error.details["tried"],
-            serde_json::json!([
-                "--target server deploys the build artifact to the project's remote path",
-                "--target provider deploys through the component's declared deployment provider"
-            ])
-        );
-        assert_eq!(
-            DeployTarget::parse("Server").expect("case"),
-            DeployTarget::Server
-        );
     }
 }


### PR DESCRIPTION
## Context

#13344 sealed `homeboy-deploy` and `dead_code` immediately reported `DeployTarget::parse` as unused. It landed with a per-item allow rather than a deletion, because the triage rule keeps test-only items and because removing a function whose body builds operator-facing error text deserves a human. This is that follow-up.

## Three things had to be true. All three are.

### 1. Nothing outside tests calls it

Only callers were `route.rs:255` and `route.rs:266`, both inside `#[cfg(test)] mod tests`. Every production `DeployTarget` is produced by `From<DeployTargetArg>` (`crates/homeboy-cli/src/commands/deploy.rs:620`) or by a literal `DeployTarget::Server` / `DeployTarget::Provider`.

### 2. The behaviour it guarded is already tested where it actually runs

clap owns `--target` through `#[arg(long, value_enum)]` on `DeployTargetArg`. `tests/commands/deploy_test.rs:542` asserts the same rejection, with the same value:

```rust
assert!(
    Cli::try_parse_from([.., "--target", "worker"]).is_err(),
    "an unselectable target must be rejected at parse time"
);
```

This deletion removes a **duplicate assertion at the wrong layer**, not coverage.

### 3. Its other assertion was never true in production

<callout accent="#8b5cf6">
The deleted test also asserted `DeployTarget::parse("Server")` succeeds — case-**in**sensitive.

Production is case-**sensitive**. `#[arg(long, value_enum, value_name = "TARGET")]` (`commands/deploy.rs:146`) sets no `ignore_case`, so `--target Server` is rejected today and always has been.

The function encoded a lenience the CLI never had. That is drift — and it is the strongest argument for deleting it rather than annotating it. An allow would have frozen a false claim in place.
</callout>

## Scope

42 lines deleted, all unreachable from any production path:

- `DeployTarget::parse` and its `#[allow(dead_code, reason = ...)]`
- `an_unknown_target_value_is_rejected_with_the_supported_ones`
- `use homeboy_core::error::{Error, Result}`, unused in `route.rs` once the function went

`DeployTarget` still derives `Deserialize` with `rename_all = "snake_case"`, so any config-borne target keeps its own serde-generated parsing and error. This touches only the hand-rolled string path.

Fixpoint reached in one pass — no second-order dead code.

## If you actually want case-insensitive `--target`

The fix is `ignore_case` on the clap arg, not this function. Restoring `parse` would not deliver it, because nothing calls `parse`. Say so and I will open it separately.

## Gate

```
$ cargo check --workspace --all-targets -j2      # exit 0, 0 warnings, 0 errors
$ cargo fmt --all -- --check                     # clean
```

`fmt` is now run immediately before `git add` rather than mid-loop — that ordering is what produced the rustfmt failure on #13344.

## AI assistance

Tool(s): OpenCode