### PR TITLE
refactor(extension): ParsedItem is GrammarItem, and always said so

### DIFF
--- a/crates/homeboy-extension/src/refactor_protocol.rs
+++ b/crates/homeboy-extension/src/refactor_protocol.rs
@@ -162,37 +162,17 @@ impl RefactorScriptFailure {
     }
 }
 
-/// Output from a `parse_items` refactor command.
-/// Each item has boundaries, kind, name, visibility, and source text.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct ParsedItem {
-    /// Name of the item (function, struct, etc.).
-    pub name: String,
-    /// What kind of item (function, struct, enum, const, etc.).
-    pub kind: String,
-    /// Start line (1-indexed, includes doc comments and attributes).
-    pub start_line: usize,
-    /// End line (1-indexed, inclusive).
-    pub end_line: usize,
-    /// The extracted source code (including doc comments and attributes).
-    pub source: String,
-    /// Visibility: "pub", "pub(crate)", "pub(super)", or "" for private.
-    #[serde(default)]
-    pub visibility: String,
-}
-
-impl From<crate::grammar_items::GrammarItem> for ParsedItem {
-    fn from(gi: crate::grammar_items::GrammarItem) -> Self {
-        Self {
-            name: gi.name,
-            kind: gi.kind,
-            start_line: gi.start_line,
-            end_line: gi.end_line,
-            source: gi.source,
-            visibility: gi.visibility,
-        }
-    }
-}
+/// Output from a `parse_items` refactor command: the protocol name for a parsed
+/// top-level item.
+///
+/// This was a second declaration of [`crate::grammar_items::GrammarItem`] --
+/// same six fields, same order, same serde, and the same doc comment on every
+/// field -- plus a `From` impl that moved them across one at a time.
+/// `GrammarItem`'s own doc already described it as "the core equivalent of
+/// `extension::ParsedItem`", and this crate re-exports the core module as
+/// `grammar_items`, so the two names always resolved through the same crate with
+/// no dependency boundary between them to justify a copy.
+pub type ParsedItem = crate::grammar_items::GrammarItem;
 
 /// Output from a `resolve_imports` refactor command.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
First fix found by the twin-type detector from #13358 rather than by hand, and the triage of all four clusters that detector reports on `main`.

## The fix

`ParsedItem` was a second declaration of `GrammarItem` — same six fields, same order, same serde, **and the same doc comment on every field** — joined by a `From` impl that moved them across one at a time. **-31 / +11.**

The types already said this. `GrammarItem`'s own doc (`grammar/items.rs:28`):

> This is the core equivalent of `extension::ParsedItem`, produced entirely from grammar patterns without calling extension scripts.

And `homeboy-extension/src/lib.rs:22`:

```rust
pub use homeboy_engine_primitives::grammar::items as grammar_items;
```

So `GrammarItem` was already reachable as `homeboy_extension::grammar_items::GrammarItem`, **in the same crate that declared the copy**, with a direct dependency in `Cargo.toml:21`. There was no boundary for the copy to bridge.

`ParsedItem` is now a type alias — the protocol name stays where callers use it, with one declaration behind it.

Call sites are unchanged. `homeboy-refactor::decompose` builds `ParsedItem` literals, deserializes `Vec<ParsedItem>`, and maps `ParsedItem::from` over `Vec<GrammarItem>`; that last one now resolves to the reflexive `impl<T> From<T> for T` instead of the deleted hand-written impl.

## Triage of all four detector clusters

You asked for these to be worked rather than baselined. Here is every one, with the call:

### FIX — `GrammarItem` / `ParsedItem` (6 fields) — this PR
Identical fields, identical per-field doc comments, no dependency boundary, and a doc comment that names the duplication outright.

### FIX (follow-up) — `ContractDetail` / `ContractRegistryEntry` (6 fields)
Same six `&'static str` fields, same crate (`homeboy-cli`), `commands/contract/mod.rs:200` vs `command_contract/registry.rs:6`. `ContractRegistryEntry` additionally derives `Clone, Copy`. Looks like the registry row and the command output for that row, declared separately. Worth its own PR rather than bundling — the output type is part of a command contract and deserves its own wire check.

### LEAVE — `MultiDeploySummary` / `ReleaseDeploymentSummary` (5 fields)
Same five `u32` counters, but **different serialized shapes and different crates**:

```rust
// homeboy-deploy                    // homeboy-release
#[derive(Serialize)]                 #[derive(Serialize, Deserialize, Default)]
pub struct MultiDeploySummary {      #[serde(default)]
    pub total_projects: u32,         pub struct ReleaseDeploymentSummary {
    ...                                  pub(crate) total_projects: u32,
                                         #[serde(skip_serializing_if = "is_zero_u32")]
                                         pub(crate) skipped: u32,
```

One round-trips and omits zero counters; the other always emits and never deserializes. The release-side fields are `pub(crate)`, so neither crate can currently use the other's type. Collapsing needs a shared contract crate — that is a design change, not a collapse, and it would change one of two wire shapes.

### LEAVE — `PrRefreshCheck` / `HookCommandResult` (5 fields)
`{command, success, exit_code, stdout, stderr}` is the universal shape of "I ran a subprocess". Two independent places modelling that independently is convergence, not copying: there is no conversion between them, different field order, different `skip_serializing_if`, and **nothing breaks if they diverge**. No bug class to remove.

A shared `CommandOutcome` type would arguably be nicer. That is an improvement, not a hazard, and it fails the bar I have been holding the other slices to.

## Ratchet position after this

4 clusters → 3 with this merged, → 2 after the `ContractDetail` follow-up. The remaining two are the `LEAVE` pair above, which is what the baseline is actually for: **2 rows, each with a written reason**, rather than 4 rows for "the detector is new."

## Verification

- `cargo check --workspace --all-targets -j2` → **exit 0**. Two warnings, both `retry_with_force_and_metadata_in_store` in `homeboy-agents` — a crate this one-file diff does not touch.
- `cargo test -p homeboy-refactor -p homeboy-extension --lib` → **1,153 passed, 0 failed**.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode
