### PR TITLE
Delete dead retry_with_force_and_metadata_in_store

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -5682,24 +5682,6 @@ pub(crate) fn retry_with_force_in_store(
     )
 }
 
-pub(crate) fn retry_with_force_and_metadata_in_store(
-    lifecycle_store: &AgentTaskLifecycleStore,
-    run_id: &str,
-    requested_run_id: Option<&str>,
-    force: bool,
-    metadata: serde_json::Map<String, Value>,
-) -> Result<AgentTaskRunRecord> {
-    retry_with_force_inner_in_store(
-        lifecycle_store,
-        run_id,
-        requested_run_id,
-        force,
-        true,
-        Some(metadata),
-        None,
-    )
-}
-
 /// Reserve a retry after revalidating the action while the lineage lock is held.
 pub(crate) fn retry_with_force_and_metadata_and_preflight_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,


### PR DESCRIPTION
## What

`retry_with_force_and_metadata_in_store` (`crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs:5685`) is dead on `main` right now. rustc already reports it:

```
warning: function `retry_with_force_and_metadata_in_store` is never used
    --> crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs:5685:15
```

Zero callers anywhere — no production path, no test, not even a `#[cfg(test)]` helper:

```
$ grep -rn 'retry_with_force_and_metadata_in_store' --include='*.rs' .
crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs:5685:   (the definition)
```

It is one of **five** thin wrappers over `retry_with_force_inner_in_store`. The other four are live. This one passes `Some(metadata)` with no preflight, and nothing ever wanted that combination — `retry_with_force_and_metadata_and_preflight_in_store` covers metadata, and `retry_with_force_in_store` covers the plain case.

18 lines. Fixpoint in one pass — nothing went dead behind it.

## Gate

```
$ cargo check --workspace --all-targets -j2      # exit 0, 0 warnings, 0 errors
$ cargo fmt --all -- --check                     # clean
```

## AI assistance

Tool(s): OpenCode