### PR TITLE
refactor(cli): collapse ContractDetail, and close out the twin-type backlog

### DIFF
--- a/crates/homeboy-cli/src/commands/contract/mod.rs
+++ b/crates/homeboy-cli/src/commands/contract/mod.rs
@@ -196,15 +196,14 @@ pub struct ContractListEntry {
     pub title: &'static str,
 }
 
-#[derive(Debug, Serialize, PartialEq, Eq)]
-pub struct ContractDetail {
-    pub schema_id: &'static str,
-    pub name: &'static str,
-    pub title: &'static str,
-    pub owner: &'static str,
-    pub summary: &'static str,
-    pub rust_type: &'static str,
-}
+/// The detail view of one registered contract.
+///
+/// This was a second declaration of [`ContractRegistryEntry`] -- the same six
+/// `&'static str` fields in the same order -- and the conversion between them
+/// copied all six across one at a time. A registry row and the detail rendered
+/// from that row were never different data; `ContractRegistrySummary` and
+/// `ContractListEntry` are the pair that genuinely narrows, and they still do.
+pub type ContractDetail = ContractRegistryEntry;
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
 pub struct ContractValidateOutput {
@@ -254,19 +253,6 @@ impl From<&'static ContractRegistryEntry> for ContractListEntry {
             schema_id: entry.schema_id,
             name: entry.name,
             title: entry.title,
-        }
-    }
-}
-
-impl From<&'static ContractRegistryEntry> for ContractDetail {
-    fn from(entry: &'static ContractRegistryEntry) -> Self {
-        Self {
-            schema_id: entry.schema_id,
-            name: entry.name,
-            title: entry.title,
-            owner: entry.owner,
-            summary: entry.summary,
-            rust_type: entry.rust_type,
         }
     }
 }
@@ -421,7 +407,7 @@ pub fn run(args: ContractArgs) -> CmdResult<ContractOutput> {
             Ok((
                 ContractOutput::Show(ContractShowOutput {
                     kind: "show",
-                    contract: contract.into(),
+                    contract: *contract,
                 }),
                 0,
             ))

--- a/homeboy.json
+++ b/homeboy.json
@@ -635,7 +635,7 @@
     "audit": {
       "context_id": "homeboy",
       "created_at": "2026-07-27T04:11:26Z",
-      "item_count": 1128,
+      "item_count": 1130,
       "known_fingerprints": [
         "Commands::crates/homeboy-cli/src/commands/agent_task_dispatch.rs::MissingMethod",
         "Src::crates/contracts/homeboy-audit-contract/src/finding.rs::MissingMethod",
@@ -1764,7 +1764,9 @@
         "thin_command_adapter::crates/homeboy-cli/src/commands/agent_task/fanout.rs::ThinCommandAdapterViolation",
         "thin_command_adapter::crates/homeboy-cli/src/commands/agent_task/run.rs::ThinCommandAdapterViolation",
         "thin_command_adapter::crates/homeboy-cli/src/commands/infra/output_runtime.rs::ThinCommandAdapterViolation",
-        "thin_command_adapter::crates/homeboy-cli/src/commands/ssh.rs::ThinCommandAdapterViolation"
+        "thin_command_adapter::crates/homeboy-cli/src/commands/ssh.rs::ThinCommandAdapterViolation",
+        "twin_type_declaration::crates/homeboy-core/src/engine/hooks.rs::TwinTypeDeclaration",
+        "twin_type_declaration::crates/homeboy-deploy/src/types.rs::TwinTypeDeclaration"
       ],
       "metadata": {
         "alignment_score": 0.8165137767791748,

--- a/tests/audit_baseline_ratchet_test.rs
+++ b/tests/audit_baseline_ratchet_test.rs
@@ -47,7 +47,7 @@ use serde_json::Value;
 /// a ceiling, not a target: lower it whenever suppressions are retired, and
 /// never raise it. Raising this number is the one edit this test exists to make
 /// someone argue for in review.
-const AUDIT_BASELINE_CEILING: usize = 1128;
+const AUDIT_BASELINE_CEILING: usize = 1130;
 
 fn baseline_fingerprints() -> Vec<String> {
     let config: Value =


### PR DESCRIPTION
Finishes the triage promised in #13362. The twin-type detector (#13358) reported **four clusters** on `main`; this fixes the last genuine one and baselines the two that should stay — each with a written reason.

**-23 / +9** in `contract/mod.rs`, plus two baseline rows and the ceiling.

## The fix

`ContractDetail` was a second declaration of `ContractRegistryEntry` — the same six `&'static str` fields in the same order — and `From<&'static ContractRegistryEntry> for ContractDetail` copied all six across one at a time. **A registry row and the detail rendered from that row were never different data.**

`ContractDetail` is now an alias. Because `ContractRegistryEntry` is `Copy`, the single call site drops `.into()` for `*contract`, which **deletes** the conversion rather than reducing it to a one-liner.

Worth noting what stayed: `ContractRegistrySummary` / `ContractListEntry` are the pair here that *genuinely narrows* — three fields out of six — and they're untouched. That narrowing is the distinction the twin had lost.

## The two that stay, and why

**`MultiDeploySummary` / `ReleaseDeploymentSummary`** — 5 `u32` counters, but different serialized shapes in different crates:

```rust
// homeboy-deploy                  // homeboy-release
#[derive(Serialize)]               #[derive(Serialize, Deserialize, Default)]
pub total_projects: u32,           #[serde(default)]
                                   pub(crate) total_projects: u32,
                                   #[serde(skip_serializing_if = "is_zero_u32")]
```

One round-trips and omits zero counters; the other always emits and never deserializes. The release-side fields are `pub(crate)`, so neither crate can use the other's type today. Collapsing needs a shared contract crate and would change one of two wire shapes — a design change, not a collapse.

**`PrRefreshCheck` / `HookCommandResult`** — `{command, success, exit_code, stdout, stderr}` is the universal shape of "I ran a subprocess". Two places modelling that independently is **convergence, not copying**: no conversion between them, different field order, different `skip_serializing_if`, and nothing breaks if they diverge. A shared `CommandOutcome` would be nicer; that's an improvement, not a hazard.

## Ratchet

`AUDIT_BASELINE_CEILING` **1128 → 1130**, with exactly these rows:

```
twin_type_declaration::crates/homeboy-deploy/src/types.rs::TwinTypeDeclaration
twin_type_declaration::crates/homeboy-core/src/engine/hooks.rs::TwinTypeDeclaration
```

`docs/audit/baseline-ratchet.md` puts fixing above suppressing and asks that a raise be justified. **Two of the four were fixed** (#13362 and this PR); these two are suppressed because they *should not be fixed*, not because the detector is new.

Anchor files were not derived by hand — the rust extension's `fingerprint.sh` was re-run over the tree after both fixes, confirming exactly these two clusters remain and which `type_id` each anchors on.

## Verification

- `cargo check --workspace --all-targets -j2` → **exit 0**. One warning, `retry_with_force_and_metadata_in_store` in `homeboy-agents` — a crate this diff doesn't touch.
- `cargo test --test audit_baseline_ratchet_test` → **4 passed, 0 failed**: `may_only_shrink`, `ceiling_leaves_no_slack`, `rows_are_unique`, `rows_reference_live_paths`.

That last one matters: it validates every fingerprint path against the production full-tree validator, so the two new rows are confirmed to point at live files.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode
