### PR TITLE
fix(cook): expand preview lifecycle placeholders

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -24,9 +24,9 @@ use homeboy::core::command_invocation::CommandInvocation;
 use homeboy::core::defaults;
 use homeboy::core::engine::shell::quote_args;
 use homeboy::core::worktree_providers::{
-    plan_apply_enabled_worktree_provider_from_config,
-    provision_apply_enabled_worktree_provider_from_config, WorktreeProviderCreateIntent,
-    WorktreeProviderCreatePlan,
+    plan_apply_enabled_worktree_provider_with_lifecycle_from_config,
+    provision_apply_enabled_worktree_provider_from_config, WorktreeProviderCleanupPolicy,
+    WorktreeProviderCreateIntent, WorktreeProviderCreatePlan, WorktreeProviderLifecycleIntent,
 };
 
 use super::super::agent_task_dispatch::DispatchArgs;
@@ -301,6 +301,7 @@ pub(crate) fn preview_cook(
     // Source policy is a static validation and must apply to preview exactly as
     // it applies before an execution route can inspect the destination.
     validate_cook_request_with_provenance(&args, provenance)?;
+    bind_cook_preview_lifecycle(&mut args);
     record_preview_phase(&mut progress, "destination_resolution");
     let (args, mut provision) = resolve_cook_preview_destination(args)?;
     project_preview_dirty_admission(&mut provision);
@@ -560,14 +561,16 @@ fn cook_preview_replay_argv(args: &AgentTaskCookArgs) -> PreviewReplayArgv {
         .any(|parts| parts == ["agent-task", "cook"])
         && process_argv.iter().any(|part| part == "--preview")
     {
-        return redact_preview_replay_argv(
-            std::iter::once("homeboy".to_string()).chain(
+        let mut replay = std::iter::once("homeboy".to_string())
+            .chain(
                 process_argv
                     .into_iter()
                     .skip(1)
                     .filter(|part| part != "--preview"),
-            ),
-        );
+            )
+            .collect::<Vec<_>>();
+        append_preview_lifecycle_replay_argv(&mut replay, args);
+        return redact_preview_replay_argv(replay);
     }
 
     redact_preview_replay_argv(cook_replay_argv(args))
@@ -603,6 +606,12 @@ fn cook_replay_argv(args: &AgentTaskCookArgs) -> Vec<String> {
     if let Some(model) = &args.dispatch.model {
         argv.extend(["--model".to_string(), model.clone()]);
     }
+    if let Some(run_id) = &args.dispatch.run_id {
+        argv.extend(["--run-id".to_string(), run_id.clone()]);
+    }
+    if let Some(run_id) = &args.attempt_run_id {
+        argv.extend(["--attempt-run-id".to_string(), run_id.clone()]);
+    }
     if let Some(worktree) = &args.to_worktree {
         argv.extend(["--to-worktree".to_string(), worktree.clone()]);
     }
@@ -622,6 +631,35 @@ fn cook_replay_argv(args: &AgentTaskCookArgs) -> Vec<String> {
         argv.push("--draft-pr".to_string());
     }
     argv
+}
+
+fn bind_cook_preview_lifecycle(args: &mut AgentTaskCookArgs) {
+    let requested_cook_id = args.dispatch.run_id.clone();
+    let owner_run_ref = args.attempt_run_id.clone().unwrap_or_else(|| {
+        requested_cook_id.as_deref().map_or_else(
+            || format!("agent-task-{}", uuid::Uuid::new_v4()),
+            |cook_id| agent_task_lifecycle::cook_attempt_run_id(cook_id, 1),
+        )
+    });
+    args.dispatch.run_id = Some(requested_cook_id.unwrap_or_else(|| owner_run_ref.clone()));
+    args.attempt_run_id = Some(owner_run_ref);
+}
+
+fn append_preview_lifecycle_replay_argv(argv: &mut Vec<String>, args: &AgentTaskCookArgs) {
+    for (flag, value) in [
+        ("--run-id", args.dispatch.run_id.as_ref()),
+        ("--attempt-run-id", args.attempt_run_id.as_ref()),
+    ] {
+        if !argv
+            .iter()
+            .any(|argument| argument == flag || argument.starts_with(&format!("{flag}=")))
+        {
+            argv.extend([
+                flag.to_string(),
+                value.expect("preview lifecycle is bound").clone(),
+            ]);
+        }
+    }
 }
 
 fn redact_preview_replay_argv(argv: impl IntoIterator<Item = String>) -> PreviewReplayArgv {
@@ -979,11 +1017,15 @@ mod preview_tests {
         crate::test_support::with_isolated_home(|home| {
             let temp = tempfile::tempdir().expect("tempdir");
             let marker = temp.path().join("ensure-called");
+            let plan_argv = temp.path().join("plan-argv");
+            let planned_workspace = temp.path().join("planned-workspace");
             let provider = temp.path().join("provider.sh");
             std::fs::write(
                 &provider,
                 format!(
-                    "#!/bin/sh\ncase \"$1\" in\nresolve) printf '%s\\n' '{{\"worktrees\":[]}}' ;;\nplan) printf '%s\\n' \"{{\\\"worktrees\\\":[{{\\\"handle\\\":\\\"$2\\\",\\\"path\\\":\\\"/provider/planned/$2\\\",\\\"branch\\\":\\\"$5\\\",\\\"safety\\\":{{\\\"dirty\\\":false,\\\"unpushed\\\":false,\\\"primary\\\":false}}}}]}}\" ;;\nensure) touch '{}' ;;\nesac\n",
+                    "#!/bin/sh\ncase \"$1\" in\nresolve) printf '%s\\n' '{{\"worktrees\":[]}}' ;;\nplan) printf '%s\\n' \"$0\" \"$@\" > '{}'; printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"fixture@fix-issue-12890-repo\",\"path\":\"{}\",\"branch\":\"fix/issue-12890-repo\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}' ;;\nensure) touch '{}' ;;\nesac\n",
+                    plan_argv.display(),
+                    planned_workspace.display(),
                     marker.display(),
                 ),
             )
@@ -1018,6 +1060,10 @@ mod preview_tests {
                             "{base}".to_string(),
                             "{head}".to_string(),
                             "{task_url}".to_string(),
+                            "{idempotency_key}".to_string(),
+                            "{purpose}".to_string(),
+                            "{owner_run_ref}".to_string(),
+                            "{cleanup_policy}".to_string(),
                         ]),
                         ensure: Some(vec![provider.display().to_string(), "ensure".to_string()]),
                         ..Default::default()
@@ -1047,6 +1093,10 @@ mod preview_tests {
                     "--preview",
                     "--backend",
                     "fixture",
+                    "--run-id",
+                    "preview-cook",
+                    "--attempt-run-id",
+                    "preview-owner",
                     "--prompt",
                     "implement the issue",
                     "--repo",
@@ -1068,14 +1118,30 @@ mod preview_tests {
             );
             assert_eq!(
                 preview["resolved"]["workspace"]["path"],
-                "/provider/planned/fixture@fix-issue-12890-repo"
+                planned_workspace.display().to_string()
             );
             assert_eq!(preview["resolved"]["workspace"]["intent"]["base"], "main");
             assert_eq!(
                 preview["resolved"]["workspace"]["intent"]["head"],
                 "fix/issue-12890-repo"
             );
+            assert_eq!(
+                std::fs::read_to_string(&plan_argv).expect("captured plan argv"),
+                format!(
+                    "{}\nplan\nfixture@fix-issue-12890-repo\nfixture\nmain\nfix/issue-12890-repo\nhttps://example.test/owner/repo/issues/12890\nfixture@fix-issue-12890-repo:fixture:main:fix/issue-12890-repo\nagent_task_cook\npreview-owner\nremove_on_success\n",
+                    provider.display(),
+                )
+            );
+            assert!(preview["replay_argv"]
+                .as_array()
+                .expect("replay argv")
+                .windows(2)
+                .any(|pair| pair == ["--attempt-run-id", "preview-owner"]));
             assert!(!marker.exists(), "preview must not invoke ensure");
+            assert!(
+                !planned_workspace.exists(),
+                "preview must not create the planned workspace"
+            );
             assert_eq!(
                 std::fs::read_dir(home).expect("read isolated home").count(),
                 before
@@ -3338,7 +3404,19 @@ fn resolve_cook_preview_destination(
                 if issue_derived && error.details["worktree_provider_lookup"] == "not_found" =>
             {
                 let intent = cook_workspace_create_intent(&args)?;
-                let plan = match plan_apply_enabled_worktree_provider_from_config(&intent, &config) {
+                let lifecycle = WorktreeProviderLifecycleIntent {
+                    purpose: "agent_task_cook".to_string(),
+                    owner_run_ref: args
+                        .attempt_run_id
+                        .clone()
+                        .expect("preview lifecycle is bound before destination resolution"),
+                    cleanup_policy: WorktreeProviderCleanupPolicy::RemoveOnSuccess,
+                };
+                let plan = match plan_apply_enabled_worktree_provider_with_lifecycle_from_config(
+                    &intent,
+                    &lifecycle,
+                    &config,
+                ) {
                     Ok(plan) => plan,
                     Err(error) => {
                         return Ok((args, unresolved_provider_preview(&handle, error)));

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -1088,21 +1088,28 @@ pub fn plan_apply_enabled_worktree_provider_from_config(
     intent: &WorktreeProviderCreateIntent,
     config: &HomeboyConfig,
 ) -> Result<WorktreeProviderCreatePlan> {
-    plan_apply_enabled_worktree_provider_from_config_with_id(intent, None, config)
+    plan_apply_enabled_worktree_provider_from_config_with_id(intent, None, None, config)
 }
 
 /// Plan a purpose-owned workspace with the same creation-capable provider
 /// selection that execution uses, without running its ensure command.
 pub fn plan_apply_enabled_worktree_provider_with_lifecycle_from_config(
     intent: &WorktreeProviderCreateIntent,
+    lifecycle: &WorktreeProviderLifecycleIntent,
     config: &HomeboyConfig,
 ) -> Result<WorktreeProviderCreatePlan> {
     let provider_id = select_apply_enabled_worktree_provider_from_config(intent, config)?;
-    plan_apply_enabled_worktree_provider_from_config_with_id(intent, Some(provider_id), config)
+    plan_apply_enabled_worktree_provider_from_config_with_id(
+        intent,
+        Some(lifecycle),
+        Some(provider_id),
+        config,
+    )
 }
 
 fn plan_apply_enabled_worktree_provider_from_config_with_id(
     intent: &WorktreeProviderCreateIntent,
+    lifecycle: Option<&WorktreeProviderLifecycleIntent>,
     selected_provider_id: Option<String>,
     config: &HomeboyConfig,
 ) -> Result<WorktreeProviderCreatePlan> {
@@ -1180,7 +1187,13 @@ fn plan_apply_enabled_worktree_provider_from_config_with_id(
         error.details["handle"] = Value::String(intent.handle.clone());
         return Err(error);
     };
-    let command = expand_ensure_command(command, intent, &provision_idempotency_key(intent));
+    let idempotency_key = provision_idempotency_key(intent);
+    let command = match lifecycle {
+        Some(lifecycle) => {
+            expand_lifecycle_ensure_command(command, intent, lifecycle, &idempotency_key)
+        }
+        None => expand_ensure_command(command, intent, &idempotency_key),
+    };
     let worktrees = run_provider_lookup_command(
         &provider_id,
         provider,
@@ -1676,26 +1689,6 @@ fn run_provider_mutation_command(
     command: &[String],
     operation: &str,
 ) -> Result<Vec<u8>> {
-    if let Some(argument) = command.iter().find(|argument| {
-        argument.split('{').skip(1).any(|tail| {
-            tail.chars()
-                .next()
-                .is_some_and(|character| character.is_ascii_alphabetic() || character == '_')
-                && tail.contains('}')
-        })
-    }) {
-        return Err(provider_lookup_error(
-            provider_id,
-            command,
-            operation,
-            "command",
-            "worktree_providers.commands",
-            format!(
-                "worktree provider `{provider_id}` command contains an unresolved placeholder: {argument}"
-            ),
-            false,
-        ));
-    }
     let timeout = provider_mutation_timeout(provider)?;
     let output_limit = provider_lookup_output_limit(provider)?;
     let supervised = run_bounded_provider_lookup_command(
@@ -2564,6 +2557,7 @@ fn run_bounded_provider_lookup_command(
     timeout: Duration,
     output_limit: usize,
 ) -> Result<BoundedProviderLookupCommand> {
+    validate_provider_command_argv(provider_id, command, operation)?;
     let (program, args) = command
         .split_first()
         .filter(|(program, _)| !program.trim().is_empty())
@@ -2628,6 +2622,41 @@ fn run_bounded_provider_lookup_command(
         output,
         elapsed_ms: started.elapsed().as_millis(),
     })
+}
+
+fn validate_provider_command_argv(
+    provider_id: &str,
+    command: &[String],
+    operation: &str,
+) -> Result<()> {
+    let Some(argument) = command.iter().find(|argument| {
+        argument.split('{').skip(1).any(|tail| {
+            tail.chars()
+                .next()
+                .is_some_and(|character| character.is_ascii_alphabetic() || character == '_')
+                && tail.contains('}')
+        })
+    }) else {
+        return Ok(());
+    };
+    let field = format!("worktree_providers.commands.{operation}");
+    let mut error = Error::validation_invalid_argument(
+        &field,
+        format!(
+            "worktree provider `{provider_id}` {operation} command contains an unresolved placeholder: {argument}"
+        ),
+        Some(provider_id.to_string()),
+        Some(vec![format!(
+            "Replace or remove the unresolved placeholder in {field}, then retry."
+        )]),
+    );
+    error.details["worktree_provider_id"] = Value::String(provider_id.to_string());
+    error.details["worktree_provider_operation"] = Value::String(operation.to_string());
+    error.details["worktree_provider_call_classification"] =
+        Value::String("configuration".to_string());
+    error.details["worktree_provider_phase"] =
+        Value::String(format!("worktree_provider_{operation}"));
+    Err(error)
 }
 
 fn provider_lookup_error(
@@ -4055,6 +4084,67 @@ mod tests {
             !marker.exists(),
             "unsupported planning must not invoke ensure"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn provider_plan_rejects_unresolved_placeholders_before_process_spawn() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let marker = temp.path().join("plan-called");
+        let script = temp.path().join("provider");
+        fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\ncase \"$1\" in\nresolve) printf '%s\\n' '{{\"worktrees\":[]}}' ;;\nplan) touch '{}'; printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"fixture@fix-placeholder\",\"path\":\"/provider/planned/fixture@fix-placeholder\",\"branch\":\"fix/placeholder\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}' ;;\nesac\n",
+                marker.display(),
+            ),
+        )
+        .expect("write provider");
+        let mut permissions = fs::metadata(&script).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script, permissions).expect("executable");
+        let config = config_with_provider(WorktreeProviderConfig {
+            enabled: true,
+            kind: WorktreeProviderKind::Command,
+            apply_enabled: true,
+            lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
+            lookup_output_limit_bytes: 64 * 1024,
+            commands: WorktreeProviderCommands {
+                resolve: Some(vec![script.display().to_string(), "resolve".to_string()]),
+                plan: Some(vec![
+                    script.display().to_string(),
+                    "plan".to_string(),
+                    "{unknown_lifecycle_field}".to_string(),
+                ]),
+                ensure: Some(vec![script.display().to_string(), "ensure".to_string()]),
+                ..Default::default()
+            },
+            list_result_mapping: Some(worktrees_mapping()),
+        });
+        let intent = WorktreeProviderCreateIntent {
+            handle: "fixture@fix-placeholder".to_string(),
+            repo: "fixture".to_string(),
+            base: "main".to_string(),
+            head: "fix/placeholder".to_string(),
+            task_url: "https://example.test/issues/13349".to_string(),
+        };
+
+        let error = plan_apply_enabled_worktree_provider_from_config(&intent, &config)
+            .expect_err("unresolved template placeholder must fail configuration validation");
+
+        assert_eq!(error.details["field"], "worktree_providers.commands.plan");
+        assert_eq!(
+            error.details["worktree_provider_call_classification"],
+            "configuration"
+        );
+        assert!(error
+            .details
+            .get("worktree_provider_replay_command")
+            .is_none());
+        assert!(!marker.exists(), "invalid argv must not reach the provider");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- pass typed Cook lifecycle intent through non-mutating worktree provider plan template expansion
- bind preview and replay to one exact, non-persisted attempt owner identity
- reject unresolved provider command placeholders at the shared process boundary before argv can spawn
- assert exact lifecycle plan argv and that preview creates no workspace, ensure effect, or durable Homeboy state

Closes #13349.

## Verification
- `cargo test -p homeboy-core --lib provider_plan_rejects_unresolved_placeholders_before_process_spawn`
- `cargo test -p homeboy-cli --lib preview_plans_an_absent_issue_workspace_without_ensuring_it`
- `cargo test -p homeboy-cli --lib preview_tests` (25 passed)
- `cargo test -p homeboy-core --lib provider_create_plan_projects_absent_existing_and_unsupported_destinations_without_ensure`
- `cargo test -p homeboy-core --lib lifecycle_commands_resolve_all_owner_and_terminal_placeholders`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

The named core regression was rerun successfully after the final relevant main rebase. The named CLI regression passed before the conflict-free rebases; a post-rebase rerun was interrupted during compilation, and no behavioral conflict affected the scoped diff.

## AI Assistance
OpenCode using OpenAI `openai/gpt-5.6-sol` inspected the issue and generic provider lifecycle contracts, implemented the typed preview planning fix and process-boundary validation, added deterministic regression coverage, ran verification, self-reviewed the scoped diff, and prepared this PR. Chris Huber remains responsible for the change.