### PR TITLE
refactor: collapse two more twin types made visible by better type resolution

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -9,8 +9,8 @@ use homeboy::core::agent_runtime_manifest::{
 use homeboy::core::daemon::{DaemonRecoveryEvidence, DaemonStaleReasonCode};
 use homeboy::runner::readonly_probe;
 use homeboy::runner::runners::{
-    self as runner, Runner, RunnerActiveJobState, RunnerBinarySource, RunnerKind, RunnerSession,
-    RunnerStatusReport, RunnerTunnelMode, RuntimeMaterializationStatus,
+    self as runner, Runner, RunnerActiveJobState, RunnerKind, RunnerSession, RunnerStatusReport,
+    RunnerTunnelMode, RuntimeMaterializationStatus,
 };
 
 use super::super::CmdResult;
@@ -19,11 +19,11 @@ use super::types::{
     LabFollowup, LabRunnerConnectionCapability, LabRunnerHomeboyOutput, LabSelectedRunnerOutput,
     RunnerArtifactFeatureDiagnostics, RunnerConnectionOutput,
     RunnerExecutableRequirementDiagnostics, RunnerExecutionCapabilities, RunnerExecutionCapability,
-    RunnerExtra, RunnerHomeboyBinaryRole, RunnerOperatorCommand, RunnerOperatorSummary,
-    RunnerOutput, RunnerReconciliationOutcome, RunnerReconciliationStatus,
-    RunnerRuntimeDiagnostics, RunnerRuntimePackageDiagnostics, RunnerStatusInspection,
-    RunnerStatusUnavailable, RunnerToolDiagnostics, RunnerTruncation, RunnerWorkflowBinaryGuidance,
-    RuntimeDiagnostic, RuntimePackageOutput, RuntimeProbeValue, SelectedRuntimeOutput,
+    RunnerExtra, RunnerOperatorCommand, RunnerOperatorSummary, RunnerOutput,
+    RunnerReconciliationOutcome, RunnerReconciliationStatus, RunnerRuntimeDiagnostics,
+    RunnerRuntimePackageDiagnostics, RunnerStatusInspection, RunnerStatusUnavailable,
+    RunnerToolDiagnostics, RunnerTruncation, RunnerWorkflowBinaryGuidance, RuntimeDiagnostic,
+    RuntimePackageOutput, RuntimeProbeValue, SelectedRuntimeOutput,
 };
 
 const DEFAULT_STATUS_SESSION_LIMIT: usize = 20;
@@ -812,11 +812,7 @@ fn lab_runner_homeboy_output_with_recovery_guidance(
         .stale_daemon
         .as_ref()
         .and_then(|warning| stale_daemon_output(warning, refresh_command));
-    let binary_roles: Vec<_> = materialization
-        .binary_sources
-        .iter()
-        .map(runner_homeboy_binary_role)
-        .collect();
+    let binary_roles: Vec<_> = materialization.binary_sources.iter().cloned().collect();
     let controller_cli = binary_roles[0].clone();
     let active_daemon = binary_roles[1].clone();
     let configured_job_binary = binary_roles[2].clone();
@@ -1312,17 +1308,6 @@ fn lab_command_availability_checks(homeboy_path: &str) -> Vec<String> {
         format!("{binary} runs evidence --help"),
         format!("{binary} extension list"),
     ]
-}
-
-fn runner_homeboy_binary_role(source: &RunnerBinarySource) -> RunnerHomeboyBinaryRole {
-    RunnerHomeboyBinaryRole {
-        role: source.role,
-        owner: source.owner,
-        path: source.path.clone(),
-        version: source.version.clone(),
-        build_identity: source.build_identity.clone(),
-        purpose: source.purpose,
-    }
 }
 
 fn runner_workflow_binary_guidance() -> RunnerWorkflowBinaryGuidance {

--- a/crates/homeboy-cli/src/commands/runner/types.rs
+++ b/crates/homeboy-cli/src/commands/runner/types.rs
@@ -268,18 +268,16 @@ pub struct LabRunnerHomeboyOutput {
     pub dev_sync: Option<Value>,
 }
 
-#[derive(Debug, Clone, Serialize)]
-pub struct RunnerHomeboyBinaryRole {
-    pub role: &'static str,
-    pub owner: &'static str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub path: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub build_identity: Option<String>,
-    pub purpose: &'static str,
-}
+/// One homeboy binary a runner resolves, as the operator status output renders it.
+///
+/// This was a second declaration of [`homeboy::runner::runners::RunnerBinarySource`]
+/// -- the same six fields with the same serde attributes -- and
+/// `runner_homeboy_binary_role` in `status.rs` copied them across one at a time
+/// in a file that already imported both. `homeboy-cli` depends on
+/// `homeboy-lab-runner` directly, so there was no boundary for the copy to
+/// bridge; the CLI name is kept as an alias because the status output is where
+/// operators read it.
+pub type RunnerHomeboyBinaryRole = homeboy::runner::runners::RunnerBinarySource;
 
 #[derive(Debug, Serialize)]
 pub struct RunnerWorkflowBinaryGuidance {

--- a/crates/homeboy-rig/src/source/types.rs
+++ b/crates/homeboy-rig/src/source/types.rs
@@ -146,17 +146,14 @@ pub struct RigSourceUpdatedRig {
     pub source_revision: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
-pub struct RigSourceUpdatedStack {
-    pub id: String,
-    pub source: String,
-    pub path: String,
-    pub spec_path: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub previous_revision: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub source_revision: Option<String>,
-}
+/// A stack updated by a rig source sync.
+///
+/// Identical in shape to [`RigSourceUpdatedRig`] -- same six fields, same order,
+/// same serde -- because a rig and a stack record the same thing about an
+/// update. The rig-versus-stack distinction is already carried by which field of
+/// `RigSourceUpdateResult` the value lands in (`updated` versus
+/// `updated_stacks`), so it was never in the shape.
+pub type RigSourceUpdatedStack = RigSourceUpdatedRig;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct SkippedRigSourceUpdate {


### PR DESCRIPTION
Extra-Chill/homeboy-extensions#2697 resolves generic field types structurally, taking unresolved declared fields from **48% to 13%**. The twin-type detector (#13358) skips any definition with an unresolved field — that's what bounded its recall. Fixing resolution raises it from **4 clusters to 15**.

This fixes two of the newly visible ones. **-46 / +26.**

## `RunnerHomeboyBinaryRole` → `RunnerBinarySource`

Same six fields, same serde attributes — and `runner_homeboy_binary_role` in `status.rs` copied them across one at a time **in a file that already imported both**. `homeboy-cli` depends on `homeboy-lab-runner` directly, so there was no boundary for the copy to bridge.

The CLI name stays as an alias because the operator status output is where it's read. The converter is **deleted** rather than shortened — the call site was `.map(runner_homeboy_binary_role)` over borrowed sources and is now `.cloned()`.

## `RigSourceUpdatedStack` → `RigSourceUpdatedRig`

Same six fields, same order, same serde, adjacent in one file. A rig and a stack record the same thing about an update, and the distinction is **already carried by which field of `RigSourceUpdateResult` the value lands in** — `updated` vs `updated_stacks`. It was never in the shape.

## Verification

`cargo check --workspace --all-targets -j2` → **exit 0**, no errors and no unused imports once both aliases removed their converters' last references.

`cargo test -p homeboy-rig -p homeboy-lab-runner --lib -- --test-threads=1` → **1,911 passed, 14 failed.**

Worth noting how that was checked. My first instinct was that the failures were unreachable from this diff because they're all in `homeboy-lab-runner`, which I didn't touch — **that reasoning was wrong**: `homeboy-lab-runner` depends on `homeboy-rig`, which this diff modifies. So I baselined properly instead: stashing `crates/` and re-running the identical command produced an identical 14-name failure set, with `comm` reporting nothing unique to either side.

<callout accent="#f59e0b">
## Nine clusters still untriaged — the extensions release is still blocked

These are **pre-existing debt that better resolution made visible**, not new duplication. The audit ratchet doesn't know that: releasing homeboy-extensions#2697 before they're handled turns all nine into new findings and fails the gate.

| cluster | fields |
|---|---|
| `RunsRefsArgs` / `RunsRefsFilters` | 8 |
| `GitSnapshot` / `RepoBaselineSnapshot` | 7 |
| `PathMaterializationEntry` / `PathMaterializationProjection` | 6 |
| `RawLinkedPr` / `TriageLinkedPr` | 5 |
| `RunnerWorkspaceSnapshotFilters` / `...AppliedFilters` | 5 |
| `RunnerJobLifecycleMetadata` / `RunnerExecutionLifecycle` | 5 |
| `CiTriageArgs` / `CiFailureTriageRequest` | 5 |
| `RigInstalledSummary` / `RigInstalledStackSummary` | 5 |
| `PublicOutputVariantContract` / `PublicOutputVariantExport` | 5 |

Each needs fixing or baselining **with a written reason**. I deliberately did not mass-baseline them here — nine unjustified rows is exactly the ratchet spend `docs/audit/baseline-ratchet.md` exists to prevent, and I'd have been inventing reasons for clusters I hadn't read closely enough.

At a glance several look real (`RunsRefsArgs`/`Filters` is a clap struct and its serialized echo; `PathMaterializationEntry`/`Projection` differ only by `deny_unknown_fields`), and at least two look like legitimate wire-in/domain-out boundaries. That's a judgement per cluster, not a bulk call.
</callout>

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode
