### PR TITLE
Fix accepted Lab work without durable runner identity

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
@@ -80,7 +80,7 @@ pub fn bind_accepted_lab_runner_job_in_store(
             None,
         ));
     }
-    record_detached_lab_run_in_store(
+    let record = record_detached_lab_run_in_store(
         lifecycle_store,
         DetachedLabRunRecord {
             run_id: &identity.run_id,
@@ -89,7 +89,17 @@ pub fn bind_accepted_lab_runner_job_in_store(
             remote_workspace,
             remote_command,
         },
-    )
+    )?;
+    if accepted_lab_runner_job_identity_from_record(&record)
+        .as_ref()
+        .is_some_and(|persisted| persisted.matches(identity))
+    {
+        return Ok(record);
+    }
+    Err(Error::internal_unexpected(format!(
+        "accepted Lab runner job identity was not durably persisted: {}",
+        identity.describe()
+    )))
 }
 
 #[derive(Debug, Clone)]

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -203,6 +203,58 @@ fn accepted_runner_identity_binds_before_snapshot_validation_and_survives_caller
     assert_eq!(recovered.state, AgentTaskRunState::Running);
 }
 
+#[test]
+fn accepted_runner_binding_fails_if_terminalization_wins_before_identity_persistence() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
+    let run_id = "cook-12926-accepted-before-binding";
+    let plan = test_plan();
+    record_lab_offload_phase_with_submission_in_store(
+        &lifecycle_store,
+        LabOffloadPhaseRecord {
+            requested_run_id: run_id,
+            runner_id: "homeboy-lab",
+            phase: "provider_dispatch",
+            remote_workspace: Some("/runner/workspace/homeboy"),
+            source_checkout: None,
+            provider_rotation: None,
+            durable_plan: Some(&plan),
+        },
+        &stub_lab_offload_submission,
+    )
+    .expect("persist planned handoff before daemon acceptance");
+    let mut terminal = lifecycle_store
+        .read_record(run_id)
+        .expect("planned handoff");
+    set_run_state(&mut terminal, AgentTaskRunState::Cancelled);
+    terminal.metadata["cancel_reason"] = json!("missing_runner_pid");
+    lifecycle_store
+        .write_record(&terminal)
+        .expect("terminalization wins before accepted identity is bound");
+    let identity = homeboy_core::lab_contract::RunnerJobIdentity::new(
+        run_id,
+        "homeboy-lab",
+        "00000000-0000-0000-0000-000000012926",
+    );
+
+    let error = bind_accepted_lab_runner_job_in_store(
+        &lifecycle_store,
+        &identity,
+        "/runner/workspace/homeboy",
+        &[],
+    )
+    .expect_err("accepted work cannot proceed without a durable runner identity");
+
+    assert_eq!(error.code, ErrorCode::InternalUnexpected);
+    let persisted = lifecycle_store
+        .read_record(run_id)
+        .expect("terminal record remains readable");
+    assert_eq!(persisted.state, AgentTaskRunState::Cancelled);
+    assert!(accepted_lab_runner_job_identity_from_record(&persisted).is_none());
+    assert!(persisted.runner_job_id().is_none());
+}
+
 /// Rooted in an explicit store rather than a mutated process environment
 /// (#7505). The mutable metadata is written into, and the typed-handoff read is
 /// taken out of, one store — which is the whole claim: "metadata is not


### PR DESCRIPTION
## Summary

- require the canonical typed Lab acceptance path to prove the exact run/runner/job identity was durably persisted before returning success
- fail closed when stale reconciliation terminalizes the controller record between daemon acceptance and identity binding
- add deterministic coverage for both orderings: binding wins and terminalization wins

## Root Cause

A runner daemon can create a job before the controller persists the accepted identity. If missing-PID reconciliation terminalized the parent in that interval, the lower-level detached-run recorder returned the matching terminal runner record as `Ok` without attaching the job identity. The canonical acceptance wrapper forwarded that result, so accepted work could proceed with no durable runner job identity.

The fix keeps transport and provider policy unchanged. It adds a postcondition to the provider-neutral typed acceptance wrapper: success requires the exact accepted `RunnerJobIdentity` to be readable from the returned durable record.

Fixes #12926

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-agents accepted_runner_identity_binds_before_snapshot_validation_and_survives_caller_loss`
- `cargo test -p homeboy-agents accepted_runner_binding_fails_if_terminalization_wins_before_identity_persistence`
- `cargo test -p homeboy-lab-runner accepted_handoff_persistence_error_carries_an_explicit_remote_boundary`
- `cargo check --workspace`
- `RUSTFLAGS="-D warnings" cargo check --workspace --bins`
- `git diff --check`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode read the issue and discussion, traced the Lab runner submission and lifecycle persistence paths, reproduced the race, implemented the fix and focused coverage, ran verification, and drafted this pull request. Chris Huber remains responsible for the change.