### PR TITLE
refactor(rig): seal the crate boundary so rustc can see inside it

### DIFF
--- a/crates/homeboy-rig/src/artifact_index.rs
+++ b/crates/homeboy-rig/src/artifact_index.rs
@@ -58,7 +58,7 @@ pub struct RigRunFailedStepRef {
 /// `ObservationStore::artifact_root` is the authority: injected roots answer
 /// directly, and an ambiently-opened store answers with the ambient root it
 /// was already using. Asking the store cannot disagree with the store (#7505).
-pub fn for_completed_rig_run(
+pub(crate) fn for_completed_rig_run(
     store: &ObservationStore,
     rig: &RigSpec,
     run_id: &str,
@@ -88,6 +88,10 @@ pub fn for_completed_rig_run(
     Some(index)
 }
 
+#[allow(
+    dead_code,
+    reason = "no production caller; driven by tests/core/rig/runner_observation_test.rs"
+)]
 pub fn for_run(store: &ObservationStore, run: &RunRecord) -> Option<RigRunArtifactIndex> {
     if run.rig_id.is_none() || run.kind != "rig" {
         return None;

--- a/crates/homeboy-rig/src/capabilities.rs
+++ b/crates/homeboy-rig/src/capabilities.rs
@@ -11,13 +11,21 @@ use homeboy_lab_runner_contract::RunnerCapabilityPreflight;
 use homeboy_lab_runner_contract::RunnerToolCapabilityRequirement;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct RigRequirementCheckPlan {
+#[allow(
+    dead_code,
+    reason = "no production caller; exercised by the rig test suite"
+)]
+pub(crate) struct RigRequirementCheckPlan {
     pub kind: String,
     pub label: String,
     pub target: String,
 }
 
-pub fn plan_requirement_checks(rig: &RigSpec) -> Vec<RigRequirementCheckPlan> {
+#[allow(
+    dead_code,
+    reason = "no production caller; exercised by the rig test suite"
+)]
+pub(crate) fn plan_requirement_checks(rig: &RigSpec) -> Vec<RigRequirementCheckPlan> {
     rig.requirements
         .executables
         .iter()
@@ -39,7 +47,7 @@ pub fn plan_requirement_checks(rig: &RigSpec) -> Vec<RigRequirementCheckPlan> {
         .collect()
 }
 
-pub fn evaluate_requirements(rig: &RigSpec) -> PipelineOutcome {
+pub(crate) fn evaluate_requirements(rig: &RigSpec) -> PipelineOutcome {
     let mut steps = Vec::new();
 
     for requirement in &rig.requirements.executables {
@@ -66,7 +74,11 @@ pub fn evaluate_requirements(rig: &RigSpec) -> PipelineOutcome {
     }
 }
 
-pub fn runner_capability_preflight(
+#[allow(
+    dead_code,
+    reason = "no production caller; exercised by the rig test suite"
+)]
+pub(crate) fn runner_capability_preflight(
     rig: &RigSpec,
     command: &str,
 ) -> Option<RunnerCapabilityPreflight> {
@@ -107,6 +119,10 @@ pub fn runner_capability_preflight(
     })
 }
 
+#[allow(
+    dead_code,
+    reason = "no production caller; exercised by the rig test suite"
+)]
 fn effective_tool_command(tool: &super::spec::RunnerToolRequirementSpec) -> String {
     if !tool.command.trim().is_empty() {
         return tool.command.trim().to_string();

--- a/crates/homeboy-rig/src/dependency_materialization_cache.rs
+++ b/crates/homeboy-rig/src/dependency_materialization_cache.rs
@@ -66,13 +66,13 @@ struct Output {
     bytes: u64,
 }
 
-pub enum CacheResult {
+pub(crate) enum CacheResult {
     Hit { bytes: u64 },
     Miss { reason: String },
     Saved { bytes: u64 },
 }
 
-pub struct DependencyMaterializationCache {
+pub(crate) struct DependencyMaterializationCache {
     root: PathBuf,
     entry: PathBuf,
     key: String,
@@ -82,7 +82,7 @@ pub struct DependencyMaterializationCache {
 }
 
 impl DependencyMaterializationCache {
-    pub fn new(
+    pub(crate) fn new(
         rig: &RigSpec,
         step: &DependencyMaterializationStepSpec,
         settings: &[(String, String)],
@@ -114,7 +114,7 @@ impl DependencyMaterializationCache {
     /// triple, the resolved toolchain executables, and the step's own declared
     /// environment describe the machine the materialization ran on, which is
     /// what makes the entry safe to reuse. That is identity, not location.
-    pub fn new_in_roots(
+    pub(crate) fn new_in_roots(
         data_root: &Path,
         rig: &RigSpec,
         step: &DependencyMaterializationStepSpec,
@@ -237,7 +237,7 @@ impl DependencyMaterializationCache {
         }))
     }
 
-    pub fn restore(&self) -> Result<CacheResult> {
+    pub(crate) fn restore(&self) -> Result<CacheResult> {
         let _lock = self.lock()?;
         let manifest_path = self.entry.join("manifest.json");
         let manifest: Manifest = match read_json::<Manifest>(&manifest_path) {
@@ -307,11 +307,15 @@ impl DependencyMaterializationCache {
         self.evidence(CacheResult::Hit { bytes })
     }
 
-    pub fn key(&self) -> &str {
+    #[allow(
+        dead_code,
+        reason = "no production caller; exercised by the rig test suite"
+    )]
+    pub(crate) fn key(&self) -> &str {
         &self.key
     }
 
-    pub fn save(&self) -> Result<()> {
+    pub(crate) fn save(&self) -> Result<()> {
         let _lock = self.lock()?;
         let staging = self
             .root
@@ -421,7 +425,7 @@ impl DependencyMaterializationCache {
 // the observation store the index is recorded into (#7505).
 
 /// [`cache_root`] below an explicitly injected data root.
-pub fn cache_root_in_roots(data_root: &Path) -> PathBuf {
+pub(crate) fn cache_root_in_roots(data_root: &Path) -> PathBuf {
     data_root
         .join("cache")
         .join("dependency-materialization")
@@ -593,7 +597,7 @@ static RESTORE_PUBLISH_FAILURE_AFTER: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(usize::MAX);
 
 #[cfg(test)]
-pub fn inject_restore_publish_failure_after(publishes: usize) {
+pub(crate) fn inject_restore_publish_failure_after(publishes: usize) {
     RESTORE_PUBLISH_FAILURE_AFTER.store(publishes, std::sync::atomic::Ordering::SeqCst);
 }
 

--- a/crates/homeboy-rig/src/expand.rs
+++ b/crates/homeboy-rig/src/expand.rs
@@ -21,7 +21,7 @@ pub fn expand_vars(rig: &RigSpec, input: &str) -> String {
 
 /// Expand variables + tilde in a string, with rig settings materialized as
 /// `HOMEBOY_SETTINGS_<KEY>` values for `${env.*}` lookups.
-pub fn expand_vars_with_settings(
+pub(crate) fn expand_vars_with_settings(
     rig: &RigSpec,
     input: &str,
     settings: &[(String, String)],
@@ -36,7 +36,7 @@ pub fn expand_resources(rig: &RigSpec) -> RigResourcesSpec {
 }
 
 /// Return a copy of the rig resource declarations with expandable string entries expanded.
-pub fn expand_resources_with_settings(
+pub(crate) fn expand_resources_with_settings(
     rig: &RigSpec,
     settings: &[(String, String)],
 ) -> RigResourcesSpec {
@@ -185,7 +185,7 @@ pub(crate) fn unsupported_component_interpolations(input: &str) -> Vec<String> {
 /// Settings override inherited process env for their own `HOMEBOY_SETTINGS_*`
 /// names. That matches bench setting semantics: an explicit CLI setting is the
 /// effective value for this invocation.
-pub fn settings_env(settings: &[(String, String)]) -> BTreeMap<String, String> {
+pub(crate) fn settings_env(settings: &[(String, String)]) -> BTreeMap<String, String> {
     let mut env = BTreeMap::new();
     for (key, value) in settings {
         env.insert(

--- a/crates/homeboy-rig/src/lease.rs
+++ b/crates/homeboy-rig/src/lease.rs
@@ -18,7 +18,7 @@ mod lock;
 /// becomes reclaimable on the next acquire. Unset (the default) means leases are
 /// only reclaimed when their holder process is provably gone — a live, recent
 /// holder is never reclaimed automatically.
-pub const RIG_LEASE_TTL_ENV: &str = "HOMEBOY_RIG_LEASE_TTL_SECS";
+pub(crate) const RIG_LEASE_TTL_ENV: &str = "HOMEBOY_RIG_LEASE_TTL_SECS";
 
 use super::expand::expand_resources_with_settings;
 use super::spec::{RigResourcesSpec, RigSpec};

--- a/crates/homeboy-rig/src/lib.rs
+++ b/crates/homeboy-rig/src/lib.rs
@@ -18,110 +18,125 @@
 //! lifecycle automation, extension-registered service kinds, spec sharing.
 
 pub mod app;
-pub mod artifact_index;
-pub mod capabilities;
+mod artifact_index;
+mod capabilities;
 pub mod check;
-pub mod component_resolution;
-pub mod dependency_materialization_cache;
+mod component_resolution;
+mod dependency_materialization_cache;
 mod discovery;
 pub mod expand;
 pub mod install;
 mod json_config;
 pub mod lease;
 pub mod lint;
-pub mod local_artifact;
-pub mod pipeline;
+mod local_artifact;
+mod pipeline;
 pub mod provider;
-pub mod resource_lifecycle;
-pub mod runner;
-pub mod service;
-pub mod source;
+mod resource_lifecycle;
+mod runner;
+mod service;
+mod source;
 pub mod spec;
-pub mod stack;
-pub mod state;
-pub mod toolchain;
+mod stack;
+mod state;
+mod toolchain;
 pub mod trace_experiment;
-pub mod workloads;
+mod workloads;
 
 #[cfg(test)]
 #[path = "../../../tests/core/rig/support.rs"]
 mod rig_test_support;
 
-pub use app::{AppLauncherAction, AppLauncherOptions, AppLauncherReport};
+pub use app::AppLauncherAction;
+pub use app::{AppLauncherOptions, AppLauncherReport};
+// Reachable through `RigRunArtifactIndex`'s public fields.
 pub use artifact_index::{
-    for_run as artifact_index_for_run,
     for_run_with_artifacts as artifact_index_for_run_with_artifacts, RigRunArtifactIndex,
-    RigRunArtifactRef, RigRunFailedStepRef,
 };
-pub use capabilities::{
-    evaluate_requirements, plan_requirement_checks, runner_capability_preflight,
-    RigRequirementCheckPlan,
-};
+pub use artifact_index::{RigRunArtifactRef, RigRunFailedStepRef};
+// `tests/core/rig/runner_observation_test.rs` drives this through the alias;
+// production builds the index via `artifact_index_for_run_with_artifacts`.
+#[allow(unused_imports)]
+pub(crate) use artifact_index::for_run as artifact_index_for_run;
+
 pub use component_resolution::{component_ref, resolve_component, resolve_component_path};
 pub use install::{
-    default_materialize_source_root, discover_rigs, discover_stacks, install, materialize_rig_spec,
-    materialize_rig_spec_with_default_source_root, package_content_hash, read_source_metadata,
-    read_source_metadata_in_root, read_stack_source_metadata_in_root, DiscoveredRig,
+    default_materialize_source_root, discover_rigs, install, materialize_rig_spec,
+    materialize_rig_spec_with_default_source_root, read_source_metadata,
+    read_source_metadata_in_root,
+};
+pub use install::{
+    discover_stacks, package_content_hash, read_stack_source_metadata_in_root, DiscoveredRig,
     DiscoveredStack, InstalledStack, RigInstallResult, RigSourceMetadata, StackSourceMetadata,
 };
-pub use lease::{
-    acquire_active_run_lease, acquire_active_run_lease_with_settings, active_run_leases,
-    release_active_run_lease, ActiveRigRunLease, ReleaseLeaseOutcome, RigRunLease,
+#[allow(unused_imports)] // consumed by `tests/core/rig/*` via the crate root
+pub(crate) use lease::{
+    acquire_active_run_lease, acquire_active_run_lease_with_settings, RigRunLease,
     RIG_LEASE_TTL_ENV,
 };
-pub use local_artifact::{
-    register_current_run_artifact, LocalArtifactRegistration, RIG_ARTIFACT_MANIFEST_ENV,
-};
-pub use pipeline::{PipelineOutcome, PipelineStepOutcome};
-pub use resource_lifecycle::{
-    lifecycle_snapshot_lifecycle_records, rig_resource_lifecycle_index,
-    rig_resource_lifecycle_records, RigResourceLifecycleOptions, LIFECYCLE_SNAPSHOT_RESOURCE_KIND,
-};
+pub use lease::{active_run_leases, release_active_run_lease, ReleaseLeaseOutcome};
+
+pub use local_artifact::{register_current_run_artifact, LocalArtifactRegistration};
+pub use pipeline::PipelineOutcome;
+pub use pipeline::PipelineStepOutcome;
+
 pub use runner::{
     head_sha_and_branch, preflight_effective_component_checkouts, record_effective_component_path,
     run_bench_prepare, run_check, run_check_groups, run_check_groups_with_settings,
-    run_check_with_settings, run_down, run_down_with_settings, run_fuzz_prepare, run_lint,
-    run_repair, run_status, run_up, snapshot_state, BenchPrepareReport, CheckReport, DownReport,
-    FuzzPrepareReport, RepairReport, RepairResourceReport, RigComponentStatusReport,
-    RigStatusReport, SymlinkStatusReport, SymlinkStatusState, UpReport,
+    run_check_with_settings, run_down_with_settings, run_fuzz_prepare, run_lint, run_repair,
+    run_status, run_up, snapshot_state, BenchPrepareReport, CheckReport, DownReport,
+    FuzzPrepareReport, RepairReport, RigStatusReport, UpReport,
 };
-pub use service::{DiscoveredProcess, ServiceStatus};
+// Reachable through `RepairReport`/`RigStatusReport` public fields.
+#[allow(unused_imports)] // consumed by `tests/core/rig/*` via the crate root
+pub(crate) use runner::run_down;
+#[allow(unused_imports)] // consumed by `tests/core/rig/*` via the crate root
+pub use runner::SymlinkStatusState;
+pub use runner::{RepairResourceReport, RigComponentStatusReport, SymlinkStatusReport};
+#[allow(unused_imports)] // consumed by `tests/core/rig/*` via the crate root
+pub(crate) use service::ServiceStatus;
 pub use source::{
     list_sources, remove_source, update_all_sources, update_source, update_source_for_rig,
+    RigSourceListResult, RigSourceRemoveResult, RigSourceUpdateResult,
+};
+pub use source::{
     InvalidRigSourceMetadata, OrphanedRigSourceStack, RemovedRigSourceRig, RemovedRigSourceStack,
-    RigSourceGroup, RigSourceListResult, RigSourceRecoveryAction, RigSourceRemoveResult,
-    RigSourceRig, RigSourceStack, RigSourceUpdateResult, RigSourceUpdatedRig,
+    RigSourceGroup, RigSourceRecoveryAction, RigSourceRig, RigSourceStack, RigSourceUpdatedRig,
     RigSourceUpdatedStack, SkippedRigSourceRig, SkippedRigSourceStack, SkippedRigSourceUpdate,
 };
 pub use spec::{
     normalize_dependency_materialization_steps, validate_dependency_materialization_steps,
-    AppLauncherPlatform, AppLauncherPreflight, AppLauncherSpec, ArtifactPostprocessSpec, BenchSpec,
-    CheckSpec, ComponentSpec, DependencyMaterializationArtifactSpec,
-    DependencyMaterializationLogSpec, DependencyMaterializationOutputKind,
-    DependencyMaterializationOutputSpec, DependencyMaterializationSafety,
-    DependencyMaterializationStepSpec, DiscoverSpec, ExecutableRequirementSpec,
-    FilesystemAssertionKind, FilesystemAssertionSpec, LabStackPrSpec, LabStackRef, LabStackSpec,
-    LifecycleContract, LifecyclePhaseContract, LifecyclePhaseKind, LifecyclePhaseResult,
-    LifecyclePhaseStatus, LifecycleResultMetadata, LifecycleSnapshotRef, LifecycleWorkloadKind,
-    LifecycleWorkloadRef, NewerThanSpec, NormalizedDependencyMaterializationStep, PatchOp,
-    PipelineStep, RigRequirementsSpec, RigResourceRetentionSpec, RigResourcesSpec, RigSpec,
-    RunnerToolRequirementSpec, ServiceKind, ServiceSpec, SharedPathOp, SharedPathSpec, StackOp,
-    SymlinkSpec, TimeSource, TraceConfig, TraceDependencySpec, TraceExperimentArtifactSpec,
-    TraceExperimentCommandSpec, TraceExperimentSpec, TraceGuardrailSpec,
-    TraceNativePublicPreviewSpec, TracePhaseTemplateSpec, TracePreviewAssetFanoutSpec,
-    TraceProfileSpec, TracePublicPreviewMode, TracePublicPreviewSpec, TraceVariantSpec,
-    WorkloadSpec, RIG_RESOURCE_CLASSES, RIG_RESOURCE_CLASS_EXCLUSIVE,
-    RIG_RESOURCE_CLASS_LIFECYCLE_SNAPSHOTS, RIG_RESOURCE_CLASS_PATHS, RIG_RESOURCE_CLASS_PORTS,
-    RIG_RESOURCE_CLASS_PROCESS_PATTERNS,
+    AppLauncherPlatform, AppLauncherPreflight, AppLauncherSpec, CheckSpec,
+    DependencyMaterializationArtifactSpec, DependencyMaterializationLogSpec,
+    DependencyMaterializationOutputKind, DependencyMaterializationOutputSpec,
+    DependencyMaterializationSafety, DependencyMaterializationStepSpec, DiscoverSpec,
+    ExecutableRequirementSpec, FilesystemAssertionKind, FilesystemAssertionSpec, LifecycleContract,
+    LifecyclePhaseContract, LifecyclePhaseKind, LifecyclePhaseResult, LifecyclePhaseStatus,
+    LifecycleResultMetadata, LifecycleSnapshotRef, LifecycleWorkloadKind, LifecycleWorkloadRef,
+    NewerThanSpec, NormalizedDependencyMaterializationStep, PatchOp, RigRequirementsSpec,
+    RigResourceRetentionSpec, RunnerToolRequirementSpec, ServiceKind, ServiceSpec, SharedPathOp,
+    SharedPathSpec, StackOp, SymlinkSpec, TimeSource, TraceConfig, TraceExperimentArtifactSpec,
+    TraceExperimentCommandSpec, TracePhaseTemplateSpec, TracePublicPreviewMode, WorkloadSpec,
+    RIG_RESOURCE_CLASSES, RIG_RESOURCE_CLASS_EXCLUSIVE, RIG_RESOURCE_CLASS_LIFECYCLE_SNAPSHOTS,
+    RIG_RESOURCE_CLASS_PATHS, RIG_RESOURCE_CLASS_PORTS, RIG_RESOURCE_CLASS_PROCESS_PATTERNS,
 };
-pub use stack::{
-    plan_stack_sync, run_component_sync, run_sync, RigStackPlanEntry, RigStackSyncEntry,
-    RigStackSyncReport,
+pub use spec::{
+    ArtifactPostprocessSpec, BenchSpec, ComponentSpec, LabStackPrSpec, LabStackRef, LabStackSpec,
+    PipelineStep, RigResourcesSpec, RigSpec, TraceDependencySpec, TraceExperimentSpec,
+    TraceGuardrailSpec, TraceNativePublicPreviewSpec, TracePreviewAssetFanoutSpec,
+    TraceProfileSpec, TracePublicPreviewSpec, TraceVariantSpec,
 };
-pub use state::{
-    ComponentSnapshot, LifecycleSnapshotState, MaterializedRigState, RigState, RigStateSnapshot,
-    RigStateStore, ServiceState,
-};
+pub use stack::RigStackSyncEntry;
+#[allow(unused_imports)] // consumed by `tests/core/rig/*` via the crate root
+pub(crate) use stack::{plan_stack_sync, run_component_sync};
+pub use stack::{run_sync, RigStackSyncReport};
+pub use state::MaterializedRigState;
+pub use state::{ComponentSnapshot, RigStateSnapshot};
+#[allow(unused_imports)] // consumed by `tests/core/rig/*` via the crate root
+pub(crate) use state::{LifecycleSnapshotState, RigState, ServiceState};
+#[allow(unused_imports)] // consumed by `tests/core/rig/*` via the crate root
+pub(crate) use workloads::workload_lifecycle_contract;
+pub use workloads::RigWorkloadPathExpansion;
 pub use workloads::{
     check_groups_for_bench_scenarios, check_groups_for_extension_workloads,
     component_extension_ids_for_workload, component_ids_for_workload,
@@ -129,8 +144,8 @@ pub use workloads::{
     extension_workload_inputs, invocation_requirements_for_extension_workloads,
     required_component_id_for_workload, required_extension_ids_for_workload,
     runner_capabilities_for_extension, trace_dependencies_for_extension,
-    workload_lifecycle_contract, workload_path_expansions_for_extension, workloads_for_extension,
-    RigExtensionWorkloadInputs, RigWorkloadKind, RigWorkloadPathExpansion,
+    workload_path_expansions_for_extension, workloads_for_extension, RigExtensionWorkloadInputs,
+    RigWorkloadKind,
 };
 
 use discovery::discover_rigs_for_install;

--- a/crates/homeboy-rig/src/lint.rs
+++ b/crates/homeboy-rig/src/lint.rs
@@ -33,7 +33,7 @@ const STRUCTURAL_IGNORED_DIRECTORIES: &[&str] = &[
     "venv",
 ];
 
-pub fn run_package_lint(rig: &RigSpec) -> Result<PipelineOutcome> {
+pub(crate) fn run_package_lint(rig: &RigSpec) -> Result<PipelineOutcome> {
     let Some(root) = package_lint_root(rig) else {
         return Ok(empty_outcome());
     };

--- a/crates/homeboy-rig/src/local_artifact.rs
+++ b/crates/homeboy-rig/src/local_artifact.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 use homeboy_core::error::{Error, Result};
 use serde::{Deserialize, Serialize};
 
-pub const RIG_ARTIFACT_MANIFEST_ENV: &str = "HOMEBOY_RIG_ARTIFACT_MANIFEST";
+pub(crate) const RIG_ARTIFACT_MANIFEST_ENV: &str = "HOMEBOY_RIG_ARTIFACT_MANIFEST";
 const MANIFEST_SCHEMA: &str = "homeboy/rig-command-artifacts/v1";
 const MAX_REGISTRATIONS: usize = 128;
 const MAX_KIND_LEN: usize = 64;

--- a/crates/homeboy-rig/src/pipeline/mod.rs
+++ b/crates/homeboy-rig/src/pipeline/mod.rs
@@ -34,7 +34,7 @@ pub(super) use command_step::run_command_step;
 /// writes, instead of a second copy that can drift.
 pub(super) use lifecycle_step::step_key as lifecycle_step_key;
 
-pub fn run_pipeline(
+pub(crate) fn run_pipeline(
     state_store: &RigStateStore,
     rig: &RigSpec,
     name: &str,
@@ -43,7 +43,7 @@ pub fn run_pipeline(
     run_pipeline_with_settings(state_store, rig, name, fail_fast, &[])
 }
 
-pub fn run_pipeline_with_settings(
+pub(crate) fn run_pipeline_with_settings(
     state_store: &RigStateStore,
     rig: &RigSpec,
     name: &str,
@@ -63,7 +63,7 @@ pub fn run_pipeline_with_settings(
     )
 }
 
-pub fn run_pipeline_check_groups(
+pub(crate) fn run_pipeline_check_groups(
     state_store: &RigStateStore,
     rig: &RigSpec,
     groups: &[String],
@@ -91,7 +91,7 @@ pub fn run_pipeline_check_groups(
     )
 }
 
-pub fn run_prepare_requirement_steps(
+pub(crate) fn run_prepare_requirement_steps(
     rig: &RigSpec,
     phase: &str,
     settings: &[(String, String)],
@@ -165,7 +165,7 @@ fn is_prepare_requirement_step(step: &PipelineStep, phase: &str) -> bool {
     )
 }
 
-pub fn cleanup_shared_paths(state_store: &RigStateStore, rig: &RigSpec) -> Result<()> {
+pub(crate) fn cleanup_shared_paths(state_store: &RigStateStore, rig: &RigSpec) -> Result<()> {
     fs_step::cleanup_shared_paths(state_store, rig)
 }
 

--- a/crates/homeboy-rig/src/pipeline/outcome.rs
+++ b/crates/homeboy-rig/src/pipeline/outcome.rs
@@ -25,7 +25,7 @@ pub struct PipelineOutcome {
 }
 
 impl PipelineOutcome {
-    pub fn is_success(&self) -> bool {
+    pub(crate) fn is_success(&self) -> bool {
         self.failed == 0
     }
 }

--- a/crates/homeboy-rig/src/resource_lifecycle.rs
+++ b/crates/homeboy-rig/src/resource_lifecycle.rs
@@ -12,7 +12,7 @@ use super::spec::{
 use super::state::LifecycleSnapshotState;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RigResourceLifecycleOptions {
+pub(crate) struct RigResourceLifecycleOptions {
     pub owner: String,
     pub run_id: String,
     pub runner_id: Option<String>,
@@ -21,7 +21,7 @@ pub struct RigResourceLifecycleOptions {
 }
 
 impl RigResourceLifecycleOptions {
-    pub fn new(run_id: impl Into<String>, status: ResourceLifecycleResourceStatus) -> Self {
+    pub(crate) fn new(run_id: impl Into<String>, status: ResourceLifecycleResourceStatus) -> Self {
         Self {
             owner: "homeboy.rig".to_string(),
             run_id: run_id.into(),
@@ -32,7 +32,7 @@ impl RigResourceLifecycleOptions {
     }
 }
 
-pub fn rig_resource_lifecycle_index(
+pub(crate) fn rig_resource_lifecycle_index(
     rig_id: &str,
     resources: &RigResourcesSpec,
     options: RigResourceLifecycleOptions,
@@ -43,7 +43,7 @@ pub fn rig_resource_lifecycle_index(
     }
 }
 
-pub fn rig_resource_lifecycle_records(
+pub(crate) fn rig_resource_lifecycle_records(
     rig_id: &str,
     resources: &RigResourcesSpec,
     options: RigResourceLifecycleOptions,
@@ -90,7 +90,7 @@ pub fn rig_resource_lifecycle_records(
 /// Add durable dependency-cache storage to the same lifecycle index as rig
 /// resources. Entries are content addressed and independent of a run workspace,
 /// so retention is TTL based rather than terminal-run cleanup.
-pub fn dependency_materialization_cache_lifecycle_record(
+pub(crate) fn dependency_materialization_cache_lifecycle_record(
     options: &RigResourceLifecycleOptions,
     root: &std::path::Path,
 ) -> ResourceLifecycleRecord {
@@ -127,7 +127,7 @@ pub fn dependency_materialization_cache_lifecycle_record(
 const LIFECYCLE_SNAPSHOT_DEFAULT_TTL: &str = "P1D";
 
 /// Resource kind recorded for a live lifecycle snapshot handle.
-pub const LIFECYCLE_SNAPSHOT_RESOURCE_KIND: &str = "lifecycle_snapshot";
+pub(crate) const LIFECYCLE_SNAPSHOT_RESOURCE_KIND: &str = "lifecycle_snapshot";
 
 /// Lifecycle records for the snapshot handles a rig currently holds.
 ///
@@ -136,7 +136,7 @@ pub const LIFECYCLE_SNAPSHOT_RESOURCE_KIND: &str = "lifecycle_snapshot";
 /// handle's own `locator` is the resource path when the runtime supplied one,
 /// otherwise a rig-scoped URI, so the record is always addressable without
 /// Homeboy inventing knowledge about the environment.
-pub fn lifecycle_snapshot_lifecycle_records<'a>(
+pub(crate) fn lifecycle_snapshot_lifecycle_records<'a>(
     rig_id: &str,
     resources: &RigResourcesSpec,
     options: &RigResourceLifecycleOptions,

--- a/crates/homeboy-rig/src/runner.rs
+++ b/crates/homeboy-rig/src/runner.rs
@@ -130,13 +130,13 @@ pub struct RepairResourceReport {
 }
 
 /// `repaired` — drift this rig owned and corrected.
-pub const REPAIR_STATUS_REPAIRED: &str = "repaired";
+pub(crate) const REPAIR_STATUS_REPAIRED: &str = "repaired";
 /// `unchanged` — the resource is already healthy.
-pub const REPAIR_STATUS_UNCHANGED: &str = "unchanged";
+pub(crate) const REPAIR_STATUS_UNCHANGED: &str = "unchanged";
 /// `blocked` — drift repair refuses to touch; needs manual attention.
-pub const REPAIR_STATUS_BLOCKED: &str = "blocked";
+pub(crate) const REPAIR_STATUS_BLOCKED: &str = "blocked";
 /// `skipped` — declared, but outside what `repair` manages.
-pub const REPAIR_STATUS_SKIPPED: &str = "skipped";
+pub(crate) const REPAIR_STATUS_SKIPPED: &str = "skipped";
 
 /// Report from `rig status`.
 #[derive(Debug, Clone, Serialize)]
@@ -694,7 +694,11 @@ fn merge_prepare_outcomes(
 /// Tear down a rig. Runs the `down` pipeline if defined, then stops every
 /// service the rig knows about (belt + suspenders — spec authors sometimes
 /// forget to add `service stop` steps to `down`).
-pub fn run_down(rig: &RigSpec) -> Result<DownReport> {
+#[allow(
+    dead_code,
+    reason = "no production caller; exercised by the rig test suite"
+)]
+pub(crate) fn run_down(rig: &RigSpec) -> Result<DownReport> {
     run_down_with_settings(rig, &[])
 }
 

--- a/crates/homeboy-rig/src/service.rs
+++ b/crates/homeboy-rig/src/service.rs
@@ -28,14 +28,14 @@ use homeboy_core::error::Result;
 /// chatty service filled the disk and nothing reclaimed it (#11128). The other
 /// runtime byte producers carry a size and a count bound
 /// (`runtime_run_max_bytes` / `runtime_run_max_count`); this is the same shape.
-pub const RIG_LOG_MAX_BYTES: u64 = 64 * 1024 * 1024;
+pub(crate) const RIG_LOG_MAX_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Rotated generations retained beside the live log.
 ///
 /// The bound that matters is the product: at most
 /// `RIG_LOG_MAX_BYTES * (RIG_LOG_MAX_GENERATIONS + 1)` per service, plus
 /// whatever the live process appends before its next start.
-pub const RIG_LOG_MAX_GENERATIONS: usize = 3;
+pub(crate) const RIG_LOG_MAX_GENERATIONS: usize = 3;
 
 /// Size-bounded rotation for supervised service logs.
 ///
@@ -118,7 +118,7 @@ pub(crate) mod log_rotation {
 
 /// Live status of a service as seen at probe time.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ServiceStatus {
+pub(crate) enum ServiceStatus {
     Running(u32),
     Stopped,
     /// PID recorded but process is gone — state is stale.
@@ -127,7 +127,7 @@ pub enum ServiceStatus {
 
 /// One discovered process — its PID and start time (seconds since epoch).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DiscoveredProcess {
+pub(crate) struct DiscoveredProcess {
     pub pid: u32,
     pub started_at_epoch: u64,
 }
@@ -135,17 +135,17 @@ pub struct DiscoveredProcess {
 /// Start a service if it isn't already running. Idempotent.
 ///
 /// Returns the PID of the running (or newly started) process.
-pub fn start(state_store: &RigStateStore, rig: &RigSpec, service_id: &str) -> Result<u32> {
+pub(crate) fn start(state_store: &RigStateStore, rig: &RigSpec, service_id: &str) -> Result<u32> {
     platform::start(state_store, rig, service_id)
 }
 
 /// Stop a running service. Idempotent — if not running, returns immediately.
-pub fn stop(state_store: &RigStateStore, rig: &RigSpec, service_id: &str) -> Result<()> {
+pub(crate) fn stop(state_store: &RigStateStore, rig: &RigSpec, service_id: &str) -> Result<()> {
     platform::stop(state_store, rig, service_id)
 }
 
 /// Report current service status, cross-referencing rig state with live PID.
-pub fn status(
+pub(crate) fn status(
     state_store: &RigStateStore,
     rig_id: &str,
     service_id: &str,
@@ -154,7 +154,7 @@ pub fn status(
 }
 
 /// Log file path for a supervised service.
-pub fn log_path(
+pub(crate) fn log_path(
     state_store: &RigStateStore,
     rig_id: &str,
     service_id: &str,
@@ -162,28 +162,16 @@ pub fn log_path(
     Ok(state_store.log_file(rig_id, service_id))
 }
 
-/// Find the newest process whose command line contains `pattern`.
-///
-/// Used by `external` services (`stop` discovery) and the `newer_than`
-/// check (`process_start` time source). Returns `Ok(None)` when no
-/// process matches — both callers treat that as "nothing to do."
-///
-/// Implementation: shells out to `ps -axo pid=,lstart=,args=` and filters
-/// the output locally. We pick the newest match (largest start-time) so a stale +
-/// fresh pair surfaces the fresh one to consumers (the rig wants to know
-/// "is the live daemon stale?").
-pub fn discover_newest(pattern: &str) -> Result<Option<DiscoveredProcess>> {
-    platform::discover_newest(pattern, &[])
-}
-
 /// Find the newest process matching a full discovery spec.
-pub fn discover_newest_for_spec(discover: &DiscoverSpec) -> Result<Option<DiscoveredProcess>> {
+pub(crate) fn discover_newest_for_spec(
+    discover: &DiscoverSpec,
+) -> Result<Option<DiscoveredProcess>> {
     platform::discover_newest(&discover.pattern, &discover.argv_contains)
 }
 
 /// `discover_newest`, but returning the PID only. Convenience used by
 /// `service::stop` for the `external` kind.
-pub fn discover_external_pid(discover: &DiscoverSpec) -> Result<Option<u32>> {
+pub(crate) fn discover_external_pid(discover: &DiscoverSpec) -> Result<Option<u32>> {
     Ok(discover_newest_for_spec(discover)?.map(|p| p.pid))
 }
 
@@ -194,7 +182,11 @@ pub fn discover_external_pid(discover: &DiscoverSpec) -> Result<Option<u32>> {
 /// without needing to drive a real `ps` invocation. Production callers
 /// only see this through `discover_newest`.
 #[cfg(unix)]
-pub fn parse_etime_seconds(s: &str) -> Option<u64> {
+#[allow(
+    dead_code,
+    reason = "no production caller; exercised by the rig test suite"
+)]
+pub(crate) fn parse_etime_seconds(s: &str) -> Option<u64> {
     platform::parse_etime_seconds(s)
 }
 
@@ -213,7 +205,11 @@ mod platform {
     use super::ServiceStatus;
     use homeboy_core::error::{Error, Result};
 
-    pub fn start(state_store: &RigStateStore, rig: &RigSpec, service_id: &str) -> Result<u32> {
+    pub(crate) fn start(
+        state_store: &RigStateStore,
+        rig: &RigSpec,
+        service_id: &str,
+    ) -> Result<u32> {
         let spec = rig.services.get(service_id).ok_or_else(|| {
             Error::rig_service_failed(&rig.id, service_id, "service not declared in rig spec")
         })?;
@@ -297,7 +293,7 @@ mod platform {
         Ok(pid)
     }
 
-    pub fn stop(state_store: &RigStateStore, rig: &RigSpec, service_id: &str) -> Result<()> {
+    pub(crate) fn stop(state_store: &RigStateStore, rig: &RigSpec, service_id: &str) -> Result<()> {
         let spec = rig.services.get(service_id).ok_or_else(|| {
             Error::rig_service_failed(&rig.id, service_id, "service not declared in rig spec")
         })?;
@@ -358,7 +354,7 @@ mod platform {
         Ok(())
     }
 
-    pub fn status(
+    pub(crate) fn status(
         state_store: &RigStateStore,
         rig_id: &str,
         service_id: &str,
@@ -540,7 +536,7 @@ mod platform {
     /// (macOS) and procps `ps` (Linux). `etimes` (integer seconds) is
     /// procps-only, so the text format is the portable choice. Newest
     /// match = smallest elapsed seconds.
-    pub fn discover_newest(
+    pub(crate) fn discover_newest(
         pattern: &str,
         argv_contains: &[String],
     ) -> Result<Option<super::DiscoveredProcess>> {
@@ -673,15 +669,23 @@ mod platform {
 
     const UNSUPPORTED: &str = "rig services are not supported on this platform (Unix only)";
 
-    pub fn start(_state_store: &RigStateStore, rig: &RigSpec, service_id: &str) -> Result<u32> {
+    pub(crate) fn start(
+        _state_store: &RigStateStore,
+        rig: &RigSpec,
+        service_id: &str,
+    ) -> Result<u32> {
         Err(Error::rig_service_failed(&rig.id, service_id, UNSUPPORTED))
     }
 
-    pub fn stop(_state_store: &RigStateStore, rig: &RigSpec, service_id: &str) -> Result<()> {
+    pub(crate) fn stop(
+        _state_store: &RigStateStore,
+        rig: &RigSpec,
+        service_id: &str,
+    ) -> Result<()> {
         Err(Error::rig_service_failed(&rig.id, service_id, UNSUPPORTED))
     }
 
-    pub fn status(
+    pub(crate) fn status(
         _state_store: &RigStateStore,
         rig_id: &str,
         service_id: &str,
@@ -689,7 +693,7 @@ mod platform {
         Err(Error::rig_service_failed(rig_id, service_id, UNSUPPORTED))
     }
 
-    pub fn log_file_path(
+    pub(crate) fn log_file_path(
         _state_store: &RigStateStore,
         rig_id: &str,
         service_id: &str,
@@ -697,7 +701,7 @@ mod platform {
         Err(Error::rig_service_failed(rig_id, service_id, UNSUPPORTED))
     }
 
-    pub fn discover_newest(
+    pub(crate) fn discover_newest(
         _pattern: &str,
         _argv_contains: &[String],
     ) -> Result<Option<super::DiscoveredProcess>> {

--- a/crates/homeboy-rig/src/spec.rs
+++ b/crates/homeboy-rig/src/spec.rs
@@ -35,7 +35,9 @@ pub use pipeline::{
     GitOp, HostMutationOp, LifecycleWorkloadKind, LifecycleWorkloadRef, PatchOp, PipelineStep,
     ServiceOp, SharedPathOp, StackOp, SymlinkOp,
 };
-pub use toolchain::{PathDiscoverySort, PathDiscoverySpec, ToolchainSpec};
+pub use toolchain::PathDiscoverySort;
+pub use toolchain::PathDiscoverySpec;
+pub use toolchain::ToolchainSpec;
 pub use trace::{
     TraceDependencySpec, TraceExperimentArtifactSpec, TraceExperimentCommandSpec,
     TraceExperimentSpec, TraceGuardrailSpec, TraceNativePublicPreviewSpec,
@@ -250,7 +252,7 @@ pub enum RigCleanupSpec {
 }
 
 impl RigCleanupSpec {
-    pub fn resource_cleanup_intent(&self) -> ResourceCleanupIntent {
+    pub(crate) fn resource_cleanup_intent(&self) -> ResourceCleanupIntent {
         match self {
             Self::Legacy(intent) => *intent,
             Self::Object(spec) => spec
@@ -365,7 +367,7 @@ impl RigResourcesSpec {
     }
 
     /// Effective retention for one resource class.
-    pub fn retention_for_class(&self, class: &str) -> RigResourceRetentionSpec {
+    pub(crate) fn retention_for_class(&self, class: &str) -> RigResourceRetentionSpec {
         match self.lifecycle_by_class.get(class) {
             Some(override_spec) => override_spec.or(&self.lifecycle),
             None => self.lifecycle.clone(),
@@ -395,7 +397,7 @@ impl RigResourceRetentionSpec {
     }
 
     /// Fill unset fields from `fallback`.
-    pub fn or(&self, fallback: &Self) -> Self {
+    pub(crate) fn or(&self, fallback: &Self) -> Self {
         Self {
             ttl: self.ttl.clone().or_else(|| fallback.ttl.clone()),
             cleanup_policy: self.cleanup_policy.or(fallback.cleanup_policy),
@@ -534,12 +536,12 @@ pub enum FilesystemAssertionKind {
 }
 
 impl FilesystemAssertionKind {
-    pub fn is_path(&self) -> bool {
+    pub(crate) fn is_path(&self) -> bool {
         matches!(self, Self::Path)
     }
 
     /// Human-readable label for this assertion kind.
-    pub fn label(self) -> &'static str {
+    pub(crate) fn label(self) -> &'static str {
         match self {
             Self::Path => "path",
             Self::File => "file",
@@ -548,7 +550,7 @@ impl FilesystemAssertionKind {
     }
 
     /// Whether the given path satisfies this assertion kind.
-    pub fn matches_path(self, path: &std::path::Path) -> bool {
+    pub(crate) fn matches_path(self, path: &std::path::Path) -> bool {
         match self {
             Self::Path => path.exists(),
             Self::File => path.is_file(),
@@ -866,7 +868,7 @@ pub struct TracePhaseTemplateSpec {
 }
 
 impl WorkloadSpec {
-    pub fn apply_defaults(&mut self, defaults: &WorkloadDefaultsSpec) {
+    pub(crate) fn apply_defaults(&mut self, defaults: &WorkloadDefaultsSpec) {
         if self.trace_phase_template.is_none() {
             self.trace_phase_template = defaults.trace_phase_template.clone();
         }
@@ -904,7 +906,7 @@ impl WorkloadSpec {
         merge_defaults_map(&mut self.trace_variants, &defaults.trace_variants);
     }
 
-    pub fn apply_phase_template(&mut self, template: &TracePhaseTemplateSpec) {
+    pub(crate) fn apply_phase_template(&mut self, template: &TracePhaseTemplateSpec) {
         if self.trace.trace_default_phase_preset.is_none() {
             self.trace.trace_default_phase_preset =
                 template.trace.trace_default_phase_preset.clone();

--- a/crates/homeboy-rig/src/spec/dependencies.rs
+++ b/crates/homeboy-rig/src/spec/dependencies.rs
@@ -91,7 +91,7 @@ pub enum DependencyMaterializationOutputKind {
 }
 
 impl DependencyMaterializationOutputKind {
-    pub fn is_path(&self) -> bool {
+    pub(crate) fn is_path(&self) -> bool {
         matches!(self, Self::Path)
     }
 }
@@ -109,7 +109,7 @@ pub enum DependencyMaterializationSafety {
 }
 
 impl DependencyMaterializationSafety {
-    pub fn is_unspecified(&self) -> bool {
+    pub(crate) fn is_unspecified(&self) -> bool {
         matches!(self, Self::Unspecified)
     }
 }

--- a/crates/homeboy-rig/src/spec/pipeline.rs
+++ b/crates/homeboy-rig/src/spec/pipeline.rs
@@ -468,7 +468,7 @@ pub enum LifecycleWorkloadKind {
 
 impl LifecycleWorkloadKind {
     /// Spec-facing name, used verbatim in resolution error messages.
-    pub fn as_str(self) -> &'static str {
+    pub(crate) fn as_str(self) -> &'static str {
         match self {
             LifecycleWorkloadKind::Bench => "bench",
             LifecycleWorkloadKind::Fuzz => "fuzz",

--- a/crates/homeboy-rig/src/spec/workload.rs
+++ b/crates/homeboy-rig/src/spec/workload.rs
@@ -17,11 +17,11 @@ impl WorkloadSpec {
     /// Every other `WorkloadSpec` field has had an accessor since the type was
     /// introduced; `lifecycle` did not, which is why the contract was parsed
     /// and serialized but never reachable from an execution path.
-    pub fn lifecycle(&self) -> Option<&LifecycleContract> {
+    pub(crate) fn lifecycle(&self) -> Option<&LifecycleContract> {
         self.lifecycle.as_ref()
     }
 
-    pub fn env_provider_extensions(&self) -> &[String] {
+    pub(crate) fn env_provider_extensions(&self) -> &[String] {
         &self.env_provider_extensions
     }
 
@@ -29,15 +29,15 @@ impl WorkloadSpec {
         self.public_preview.as_ref()
     }
 
-    pub fn check_groups(&self) -> Option<&[String]> {
+    pub(crate) fn check_groups(&self) -> Option<&[String]> {
         self.check_groups.as_deref()
     }
 
-    pub fn port_range_size(&self) -> Option<u16> {
+    pub(crate) fn port_range_size(&self) -> Option<u16> {
         self.port_range_size
     }
 
-    pub fn named_leases(&self) -> &[String] {
+    pub(crate) fn named_leases(&self) -> &[String] {
         &self.named_leases
     }
 
@@ -72,11 +72,11 @@ impl WorkloadSpec {
         &self.trace_probes
     }
 
-    pub fn trace_dependencies(&self) -> &[TraceDependencySpec] {
+    pub(crate) fn trace_dependencies(&self) -> &[TraceDependencySpec] {
         &self.dependencies
     }
 
-    pub fn runner_capabilities(&self) -> &[String] {
+    pub(crate) fn runner_capabilities(&self) -> &[String] {
         &self.runner_capabilities
     }
 }

--- a/crates/homeboy-rig/src/stack.rs
+++ b/crates/homeboy-rig/src/stack.rs
@@ -13,7 +13,7 @@ use homeboy_core::plan::HomeboyPlan;
 use homeboy_stack::stack::{self, ConflictPolicy, StackSpec, SyncOutput};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct RigStackPlanEntry {
+pub(crate) struct RigStackPlanEntry {
     pub component_id: String,
     pub stack_id: String,
 }
@@ -53,7 +53,7 @@ fn is_zero(value: &usize) -> bool {
     *value == 0
 }
 
-pub fn plan_stack_sync(rig: &RigSpec) -> Vec<RigStackPlanEntry> {
+pub(crate) fn plan_stack_sync(rig: &RigSpec) -> Vec<RigStackPlanEntry> {
     let mut entries = rig
         .components
         .iter()
@@ -81,7 +81,7 @@ pub fn run_sync(rig: &RigSpec, dry_run: bool) -> Result<RigStackSyncReport> {
     ))
 }
 
-pub fn run_component_sync(
+pub(crate) fn run_component_sync(
     rig: &RigSpec,
     component_id: &str,
     dry_run: bool,

--- a/crates/homeboy-rig/src/state.rs
+++ b/crates/homeboy-rig/src/state.rs
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use homeboy_core::error::{Error, Result};
 use homeboy_core::paths;
@@ -18,7 +18,7 @@ use super::spec::RigResourcesSpec;
 
 /// Snapshot of a rig's running state.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct RigState {
+pub(crate) struct RigState {
     /// Timestamp of last successful `rig up`, RFC3339.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_up: Option<String>,
@@ -62,7 +62,7 @@ pub struct RigState {
 
 /// One live lifecycle snapshot handle owned by this rig.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct LifecycleSnapshotState {
+pub(crate) struct LifecycleSnapshotState {
     /// Pipeline step that captured the handle — the step `id` when declared,
     /// otherwise the component id, otherwise `lifecycle`. A successful
     /// `teardown` step reaps the handles it owns by this key.
@@ -98,7 +98,7 @@ pub struct MaterializedRigState {
 
 /// Per-service state: PID, start time, health.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ServiceState {
+pub(crate) struct ServiceState {
     /// Running process ID. `None` if the service isn't started.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pid: Option<u32>,
@@ -113,7 +113,7 @@ pub struct ServiceState {
 
 /// Per-shared-path ownership marker.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SharedPathState {
+pub(crate) struct SharedPathState {
     /// Expanded target path the rig linked to when it created the symlink.
     pub target: String,
 
@@ -132,47 +132,42 @@ pub struct SharedPathState {
 /// Service logs live beneath the same per-rig state directory, so the store owns
 /// those paths too.
 #[derive(Debug, Clone)]
-pub struct RigStateStore {
+pub(crate) struct RigStateStore {
     config_root: PathBuf,
 }
 
 impl RigStateStore {
     /// Bind the store to an already-resolved config root.
-    pub fn in_root(config_root: impl Into<PathBuf>) -> Self {
+    pub(crate) fn in_root(config_root: impl Into<PathBuf>) -> Self {
         Self {
             config_root: config_root.into(),
         }
     }
 
     /// Bind the store to the config root of an already-resolved [`PathRoots`].
-    pub fn in_roots(roots: &paths::PathRoots) -> Self {
+    pub(crate) fn in_roots(roots: &paths::PathRoots) -> Self {
         Self::in_root(roots.config())
     }
 
-    /// The config root this store reads and writes beneath.
-    pub fn config_root(&self) -> &Path {
-        &self.config_root
-    }
-
     /// Per-rig state directory (`<config_root>/rigs/{id}.state/`).
-    pub fn state_dir(&self, rig_id: &str) -> PathBuf {
+    pub(crate) fn state_dir(&self, rig_id: &str) -> PathBuf {
         paths::rig_state_dir_in_root(&self.config_root, rig_id)
     }
 
     /// Per-rig service log directory.
-    pub fn logs_dir(&self, rig_id: &str) -> PathBuf {
+    pub(crate) fn logs_dir(&self, rig_id: &str) -> PathBuf {
         paths::rig_logs_dir_in_root(&self.config_root, rig_id)
     }
 
     /// Log file for one supervised service.
-    pub fn log_file(&self, rig_id: &str, service_id: &str) -> PathBuf {
+    pub(crate) fn log_file(&self, rig_id: &str, service_id: &str) -> PathBuf {
         self.logs_dir(rig_id).join(format!("{}.log", service_id))
     }
 
     /// Load state for a rig, returning a default (empty) state if the file
     /// doesn't exist. Missing state is not an error — it just means the rig
     /// hasn't been brought up yet on this machine.
-    pub fn load(&self, rig_id: &str) -> Result<RigState> {
+    pub(crate) fn load(&self, rig_id: &str) -> Result<RigState> {
         let path = paths::rig_state_file_in_root(&self.config_root, rig_id);
         if !path.exists() {
             return Ok(RigState::default());
@@ -197,7 +192,7 @@ impl RigStateStore {
     }
 
     /// Persist state to disk. Creates the state directory if needed.
-    pub fn save(&self, rig_id: &str, state: &RigState) -> Result<()> {
+    pub(crate) fn save(&self, rig_id: &str, state: &RigState) -> Result<()> {
         let dir = self.state_dir(rig_id);
         fs::create_dir_all(&dir).map_err(|e| {
             Error::internal_unexpected(format!(

--- a/crates/homeboy-rig/src/toolchain.rs
+++ b/crates/homeboy-rig/src/toolchain.rs
@@ -48,7 +48,7 @@ pub(crate) fn builtin_default_spec() -> ToolchainSpec {
 /// `toolchain` field) uses [`builtin_default_spec`]. Declared directories are
 /// prepended before the inherited PATH; missing ones are skipped so the result
 /// stays portable across hosts.
-pub fn command_step_path(rig: Option<&RigSpec>) -> Option<OsString> {
+pub(crate) fn command_step_path(rig: Option<&RigSpec>) -> Option<OsString> {
     let home = homeboy_paths::home_root().ok();
     let existing_path = std::env::var_os("PATH");
     build_command_step_path(rig, home.as_deref(), existing_path.as_deref())

--- a/crates/homeboy-rig/src/workloads.rs
+++ b/crates/homeboy-rig/src/workloads.rs
@@ -105,7 +105,7 @@ pub fn required_component_id_for_workload(
 /// - `path` matching no declared workload → error naming the declared paths
 /// - no `path` and zero or multiple workloads carrying a contract → error
 /// - selected workload declares no `lifecycle` → error
-pub fn workload_lifecycle_contract<'a>(
+pub(crate) fn workload_lifecycle_contract<'a>(
     rig_spec: &'a RigSpec,
     reference: &LifecycleWorkloadRef,
 ) -> Result<&'a LifecycleContract> {


### PR DESCRIPTION
## What

`homeboy-rig` published **332 `pub` items behind 23 `pub mod`** declarations across 22k lines. `pub` suppresses `dead_code` independently of `#[allow(dead_code)]` — rustc cannot call a `pub` item dead because something outside the crate might call it — so all 332 were structurally invisible to the lint.

| | before | after |
|---|---|---|
| `pub` items | 332 | **237** |
| `pub mod` in `lib.rs` | 23 | **9** |
| `pub(crate)` items | 0 | **135** |

Three consumers, six files: `homeboy-cli` (aliased `homeboy::rig`), `homeboy-lab-runner`, and one `homeboy-triage` test.

## Where the reduction comes from

The nine modules that stay public are the ones a command names by path (`rig::spec::…`, `rig::lease::…`). Rather than re-open them, their **contents** are narrowed — which is the whole win:

- **`spec` holds 109 `pub` items and exactly two** (`DependencyCacheSpec`, `RigResourcesSpec`) are named outside the crate
- `runner` 32, `source` 22, `service` 21 — none of which escape

The other 14 modules are now fully private.

## Deleted — no caller anywhere (26 lines)

| item | why |
|---|---|
| `service.rs` `discover_newest` | one-line wrapper over `platform::discover_newest`; every real caller goes through `discover_newest_for_spec` |
| `state.rs` `RigStateStore::config_root` | zero callers |
| `lib.rs` re-export of the above | orphaned |

## Kept with a per-item allow (8 items)

Each names the item and states there is no production caller. No module-level allow was added.

| item | reason |
|---|---|
| `capabilities.rs` `plan_requirement_checks`, `runner_capability_preflight`, `RigRequirementCheckPlan`, `effective_tool_command` | the entire requirement-check planning path is reached only from this module's own `#[cfg(test)] mod tests` |
| `runner.rs` `run_down` | driven by `tests/core/rig/runner_test.rs` |
| `service.rs` `parse_etime_seconds` | its own doc comment already says it is module-scoped so tests can exercise the format parser without driving a real `ps` |
| `artifact_index.rs` `for_run` | `tests/core/rig/runner_observation_test.rs` |
| `dependency_materialization_cache.rs` `key` | rig test suite |

Also promoted the types reachable through a public field (`RigCleanupIntent`, `PathDiscoverySort`, `SymlinkStatusState`, `MaterializedRigState`, …) — those genuinely cross the boundary and are now declared rather than exported by accident.

## Verification

- **Gate:** `cargo check --workspace --all-targets -j2` — **zero errors, zero warnings**, re-run after rebasing onto `origin/main`.
- **Tests:** `cargo test -p homeboy-rig --lib` — **488 passed, 0 failed**.
- **Coverage integrity:** `#[test]` count is **518** across `crates/homeboy-rig/src` and `tests/core/rig` on both this branch and `main`, and the diff touches **no test function**. The green run is not hiding removed coverage.

No command spelling or JSON output shape changed.

## The trap, third time — and it got me

A `(lib)` dead-code warning means *"no production caller"*, not *"unused"*. This crate produced three separate instances:

1. `to_gates` / `artifact_postprocess` were reported **"never used"** while `homeboy-cli` was simultaneously failing with `E0624` for calling them — the warning was only produced because the CLI had not compiled that pass.
2. Every `trace_experiment` function was reported "never used" **and** raised `E0603` from `commands/trace/bundle.rs` in the same run.
3. `for_run` looked dead to a `for_run(` grep — but `tests/core/rig/runner_observation_test.rs` calls it through the **alias** `artifact_index_for_run`, so the grep missed it and only the compiler caught it.

Nothing was deleted on any of those signals. The rule I ended up using: a dead-code warning is only trustworthy once the **whole workspace** compiles, and even then grep for the symbol *and its aliases* before deleting.

## AI assistance

Tool(s): OpenCode
