### PR TITLE
fix(lab): honor replay snapshot includes

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -1311,6 +1311,32 @@ mod tests {
     }
 
     #[test]
+    fn replay_staging_fails_closed_when_effective_include_policy_changes() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        std::fs::write(workspace.path().join("generated.txt"), "recorded")
+            .expect("write recorded bytes");
+        let mut runner: crate::Runner = serde_json::from_value(serde_json::json!({
+            "kind": "local",
+            "policy": {
+                "snapshot_excludes": ["generated.txt"],
+                "snapshot_includes": ["generated.txt"],
+            },
+        }))
+        .expect("runner policy");
+        let recorded_excludes =
+            crate::generic_lab_replay_transfer_excludes(&runner, workspace.path());
+        let recorded =
+            crate::workspace::immutable_replay_snapshot(workspace.path(), &recorded_excludes)
+                .expect("recorded replay artifact");
+
+        runner.policy.snapshot_includes.clear();
+        let error = prepare_replay_snapshot(&runner, workspace.path(), Some(&recorded.identity))
+            .expect_err("changed effective policy must reject replay");
+
+        assert!(error.message.contains("exclusion policy no longer matches"));
+    }
+
+    #[test]
     fn old_daemon_evidence_refusal_precedes_workspace_sync() {
         let synced = Cell::new(false);
         let error = preflight_before_workspace_sync(

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -266,6 +266,8 @@ pub fn generic_lab_replay_transfer_excludes(
             excludes.push(exclude.clone());
         }
     }
+    let mut excludes =
+        workspace::effective_snapshot_excludes(excludes, &runner.policy.snapshot_includes);
     excludes.sort();
     excludes.dedup();
     excludes
@@ -1780,6 +1782,42 @@ mod tests {
     use super::*;
     use homeboy_core::daemon::{DaemonFreshnessReport, DaemonStaleReasonCode};
     use homeboy_core::test_support;
+
+    #[test]
+    fn replay_policy_includes_override_and_persist_all_effective_exclusions() {
+        let source = tempfile::tempdir().expect("source");
+        std::fs::create_dir(source.path().join("source-output")).expect("source output");
+        std::fs::write(source.path().join(".gitignore"), "source-output/\n")
+            .expect("source policy");
+        for path in [".env", "source-output/generated.txt", "runner-output"] {
+            std::fs::write(source.path().join(path), path).expect("write included input");
+        }
+        let runner: Runner = serde_json::from_value(serde_json::json!({
+            "kind": "local",
+            "policy": {
+                "snapshot_excludes": ["runner-output"],
+                "snapshot_includes": [".env", "source-output/generated.txt", "runner-output"],
+            },
+        }))
+        .expect("runner policy");
+
+        let effective = generic_lab_replay_transfer_excludes(&runner, source.path());
+        for overridden in [".env", "source-output", "source-output/**", "runner-output"] {
+            assert!(!effective.contains(&overridden.to_string()));
+        }
+        let replay = workspace::immutable_replay_snapshot(source.path(), &effective)
+            .expect("replay artifact");
+        assert_eq!(
+            generic_lab_replay_identity_excludes(&replay.identity).expect("persisted policy"),
+            effective
+        );
+        for path in [".env", "source-output/generated.txt", "runner-output"] {
+            assert!(
+                replay.path().join(path).is_file(),
+                "{path} must be included"
+            );
+        }
+    }
 
     #[test]
     fn admission_snapshot_keeps_identity_and_rotation_decisions_on_one_ledger() {


### PR DESCRIPTION
## Summary
- resolve replay exclusions with the same `snapshot_includes` overrides used by normal workspace sync
- persist the effective policy in the replay artifact identity
- fail closed when the effective include/exclude policy changes before staging

## Context
Follow-up to merged #13292 / #13278. The final reviewed include-policy commit landed on the source branch after #13292 merged and is not present in `main`.

## Verification
- replay include-overrides-exclude regression
- staging policy-drift rejection regression
- immutable replay snapshot suite
- workspace test compilation

## AI Assistance Disclosure
OpenAI GPT-5.6-sol via OpenCode inspected the replay identity/staging contract, implemented and tested effective include policy parity, and prepared this pull request. Chris Huber directed the work and remains responsible for the change.