### PR TITLE
Resolve parsed command admission before routing

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1,4 +1,5 @@
 use clap::{ArgMatches, Command};
+use std::collections::BTreeSet;
 use std::io::{IsTerminal, Write};
 use std::process::Command as ProcessCommand;
 use std::sync::OnceLock;
@@ -34,6 +35,56 @@ use homeboy_upgrade::upgrade;
 pub trait CliCapability: Sync {
     fn name(&self) -> &'static str;
     fn command(&self) -> Command;
+    /// Typed descriptor capabilities participate in the same fail-closed
+    /// preflight as built-ins. Dynamic shell extensions intentionally remain
+    /// outside this boundary because they are not typed descriptors.
+    fn preflight(
+        &self,
+        _matches: &ArgMatches,
+        _normalized_args: &[String],
+    ) -> crate::core::parsed_command_preflight::ParsedCommandPreflightInput {
+        use crate::core::parsed_command_preflight::{
+            ControllerExecution, DeferredWorkloadPolicy, LabRouteIntent, ParsedCommandIdentity,
+            ParsedCommandPreflightInput, PlacementIntent, ProvenanceRequirement,
+            ResourceAdmissionRequirement, RunnerIntent, RunnerNormalization,
+        };
+        ParsedCommandPreflightInput {
+            identity: ParsedCommandIdentity {
+                family: self.name().to_string(),
+                operation: Vec::new(),
+            },
+            resource_admission: ResourceAdmissionRequirement::Exempt,
+            controller_execution: ControllerExecution::ControllerOnly,
+            deferred_workload: DeferredWorkloadPolicy::Forbidden,
+            placement: PlacementIntent::Local,
+            runner: RunnerIntent::Default,
+            runner_normalization: RunnerNormalization::None,
+            lab_route: LabRouteIntent::Unsupported,
+            provenance: ProvenanceRequirement::CaptureExecution,
+        }
+    }
+    fn preflight_policy(
+        &self,
+        _matches: &ArgMatches,
+        _normalized_args: &[String],
+    ) -> crate::core::parsed_command_preflight::ParsedCommandPolicySnapshot {
+        crate::core::parsed_command_preflight::ParsedCommandPolicySnapshot {
+            resource_admission_evidence:
+                crate::core::parsed_command_preflight::ResourceAdmissionEvidence::Unavailable,
+            resource_policy: None,
+            lab_readiness: None,
+            selected_runner_id: None,
+            generic_route: crate::core::parsed_command_preflight::GenericRoutePolicySnapshot {
+                command_supports_lab: false,
+                automatic_authorized: false,
+                selected_runner_id: None,
+            },
+            deferred_pressure_refusal: false,
+            runner_admitted: false,
+            runner_incompatible: false,
+            auto_local_capacity_fallback: false,
+        }
+    }
     fn run(&self, matches: &ArgMatches) -> crate::core::Result<(serde_json::Value, i32)>;
 
     /// Resolve a descriptor-composed command through the same typed Lab route
@@ -55,6 +106,119 @@ const COOK_PINNED_RUNTIME_ENV: &str = "HOMEBOY_COOK_PINNED_CONTROLLER_RUNTIME";
 const RUNNER_EXEC_RECOVERY_OWNER_ENV: &str = "HOMEBOY_RUNNER_EXEC_RECOVERY_OWNER";
 const RUNNER_EXEC_RECOVERY_CHILD_ENV: &str = "HOMEBOY_RUNNER_EXEC_RECOVERY_CHILD";
 const CONTROLLER_FALLBACK_RECONCILIATION_ENV: &str = "HOMEBOY_CONTROLLER_FALLBACK_RECONCILIATION";
+
+fn generic_route_policy_snapshot(
+    cli: &Cli,
+    selected_runner_id: Option<String>,
+) -> crate::core::parsed_command_preflight::GenericRoutePolicySnapshot {
+    let command = crate::commands::route::lab_offload_command(&cli.command)
+        .ok()
+        .flatten();
+    crate::core::parsed_command_preflight::GenericRoutePolicySnapshot {
+        command_supports_lab: command.is_some(),
+        automatic_authorized: command.as_ref().is_some_and(|command| {
+            cli.runner.is_some()
+                || crate::core::lab_routing::authorizes_policy_lab_runner(
+                    &command.command,
+                    cli.placement,
+                    crate::core::lab_routing::captured_pressure_severity().as_deref(),
+                )
+        }),
+        selected_runner_id,
+    }
+}
+
+pub(crate) fn runner_satisfies_admission_capabilities(
+    runner_id: &str,
+    required: &BTreeSet<&str>,
+) -> crate::core::Result<bool> {
+    if required.is_empty() {
+        return Ok(true);
+    }
+    let inventory = crate::runner::runners::runner_capability_inventory(runner_id)?;
+    Ok(runner_inventory_satisfies_admission_capabilities(
+        &inventory, required,
+    ))
+}
+
+pub(crate) fn runner_inventory_satisfies_admission_capabilities(
+    inventory: &crate::runner::runners::RunnerCapabilityInventory,
+    required: &BTreeSet<&str>,
+) -> bool {
+    required.iter().all(|required| {
+        inventory.capabilities.contains(*required) || inventory.runtime_ids.contains(*required)
+    })
+}
+
+pub(crate) fn select_unmaterialized_cook_runner(
+    request: &serde_json::Value,
+) -> crate::core::Result<serde_json::Value> {
+    let placement = &request["binding"]["placement"];
+    let required = request["binding"]["provider_runtime_refs"]["required_capabilities"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(serde_json::Value::as_str)
+        .collect::<BTreeSet<_>>();
+    let unavailable = |runner_id: &str, selection: &str| {
+        serde_json::json!({
+            "state": "blocked_runner_unavailable",
+            "reason": format!("runner `{runner_id}` does not satisfy required provider capabilities"),
+            "selection": selection,
+        })
+    };
+    if let Some(runner_id) = placement["runner_ref"].as_str() {
+        let mut snapshot = crate::runner::runners::runner_admission_snapshot(runner_id)?;
+        if snapshot.summary.accepting_jobs
+            || crate::runner::refresh_explicit_detached_queue_runner(runner_id)?
+        {
+            return if runner_satisfies_admission_capabilities(runner_id, &required)? {
+                Ok(
+                    serde_json::json!({ "state": "eligible", "runner_id": runner_id, "selection": "explicit" }),
+                )
+            } else {
+                Ok(unavailable(runner_id, "explicit"))
+            };
+        }
+        snapshot = crate::runner::runners::runner_admission_snapshot(runner_id)?;
+        return Ok(serde_json::json!({
+            "state": if snapshot.summary.daemon_fresh { "blocked_runner_unavailable" } else { "blocked_runner_stale" },
+            "reason": snapshot.summary.next_action.unwrap_or_else(|| format!("runner `{runner_id}` is not accepting jobs")),
+            "selection": "explicit",
+        }));
+    }
+    let readiness = crate::runner::refresh_lab_runner_readiness_for_admission()?;
+    let selection = if readiness.state
+        == crate::runner::runners::LabRunnerReadinessState::CapacityBlocked
+    {
+        crate::runner::refresh_detached_queue_runner()?
+    } else if readiness.state == crate::runner::runners::LabRunnerReadinessState::ConnectedReady {
+        readiness.selected_runner_id.clone()
+    } else {
+        None
+    };
+    if let Some(runner_id) = selection {
+        let selection_kind = if readiness.state
+            == crate::runner::runners::LabRunnerReadinessState::CapacityBlocked
+        {
+            "reverse_capacity_queue"
+        } else {
+            "configured_policy"
+        };
+        return if runner_satisfies_admission_capabilities(&runner_id, &required)? {
+            Ok(
+                serde_json::json!({ "state": "eligible", "runner_id": runner_id, "selection": selection_kind }),
+            )
+        } else {
+            Ok(unavailable(&runner_id, selection_kind))
+        };
+    }
+    Ok(serde_json::json!({
+        "state": if readiness.state == crate::runner::runners::LabRunnerReadinessState::Stale { "blocked_runner_stale" } else if readiness.state == crate::runner::runners::LabRunnerReadinessState::CapacityBlocked { "queued" } else { "blocked_runner_unavailable" },
+        "reason": readiness.reasons.first().cloned().unwrap_or_else(|| "no configured Lab runner currently satisfies admission policy".to_string()),
+        "selection": "configured_policy",
+    }))
+}
 
 pub struct CliRuntime {
     extension_discovery: OnceLock<ExtensionCliDiscovery>,
@@ -561,6 +725,17 @@ impl CliRuntime {
     }
 
     fn run_matches(&self, matches: ArgMatches, normalized: Vec<String>) -> std::process::ExitCode {
+        self.run_matches_with_capability_admission(matches, normalized, None)
+    }
+
+    fn run_matches_with_capability_admission(
+        &self,
+        matches: ArgMatches,
+        normalized: Vec<String>,
+        capability_admission: Option<
+            crate::core::parsed_command_preflight::ResourceAdmissionEvidence,
+        >,
+    ) -> std::process::ExitCode {
         let command_identity = command_identity_from_matches(&matches);
 
         // Extract --output early so it's available for all code paths (including
@@ -682,8 +857,25 @@ impl CliRuntime {
                     return exit;
                 }
             }
-            let (json_result, exit_code) =
-                output::map_cmd_result_to_json(capability.run(capability_matches));
+            let input = capability.preflight(capability_matches, &normalized);
+            // Capabilities declare their requirement and policy only. Runtime
+            // owns the host probe, then core derives the admission verdict.
+            let evidence = capability_admission.unwrap_or_else(|| match input.resource_admission {
+                crate::core::parsed_command_preflight::ResourceAdmissionRequirement::Exempt => {
+                    crate::core::parsed_command_preflight::ResourceAdmissionEvidence::Unavailable
+                }
+                crate::core::parsed_command_preflight::ResourceAdmissionRequirement::Required { .. } => {
+                    crate::commands::resources::run_preflight()
+                        .map(|(resources, _)| resource_policy::resource_admission_evidence(&resources))
+                        .unwrap_or(crate::core::parsed_command_preflight::ResourceAdmissionEvidence::Unavailable)
+                }
+            });
+            let (json_result, exit_code) = self.run_capability_with_admission_evidence(
+                capability,
+                capability_matches,
+                &normalized,
+                evidence,
+            );
             output_runtime::emit_json_result_for_identity(
                 json_result,
                 output_file.as_deref(),
@@ -700,6 +892,63 @@ impl CliRuntime {
                 }
             }
 
+            // Shell extensions are not typed descriptor capabilities, so they
+            // cannot declare Lab routing or resource admission. Capture their
+            // validated local contract before the shell adapter executes.
+            let input = crate::core::parsed_command_preflight::ParsedCommandPreflightInput {
+                identity: crate::core::parsed_command_preflight::ParsedCommandIdentity {
+                    family: extension_cmd.tool.clone(),
+                    operation: Vec::new(),
+                },
+                resource_admission:
+                    crate::core::parsed_command_preflight::ResourceAdmissionRequirement::Exempt,
+                controller_execution:
+                    crate::core::parsed_command_preflight::ControllerExecution::ControllerOnly,
+                deferred_workload:
+                    crate::core::parsed_command_preflight::DeferredWorkloadPolicy::Forbidden,
+                placement: crate::core::parsed_command_preflight::PlacementIntent::Local,
+                runner: crate::core::parsed_command_preflight::RunnerIntent::CommandLocal,
+                runner_normalization:
+                    crate::core::parsed_command_preflight::RunnerNormalization::None,
+                lab_route: crate::core::parsed_command_preflight::LabRouteIntent::Unsupported,
+                provenance:
+                    crate::core::parsed_command_preflight::ProvenanceRequirement::CaptureExecution,
+            };
+            let policy = crate::core::parsed_command_preflight::ParsedCommandPolicySnapshot {
+                resource_admission_evidence:
+                    crate::core::parsed_command_preflight::ResourceAdmissionEvidence::Unavailable,
+                resource_policy: None,
+                lab_readiness: None,
+                selected_runner_id: None,
+                generic_route: crate::core::parsed_command_preflight::GenericRoutePolicySnapshot {
+                    command_supports_lab: false,
+                    automatic_authorized: false,
+                    selected_runner_id: None,
+                },
+                deferred_pressure_refusal: false,
+                runner_admitted: false,
+                runner_incompatible: false,
+                auto_local_capacity_fallback: false,
+            };
+            let preflight =
+                match crate::core::parsed_command_preflight::resolve_parsed_command_preflight(
+                    normalized.clone(),
+                    input,
+                    policy,
+                ) {
+                    Ok(preflight) => preflight,
+                    Err(error) => {
+                        output_runtime::emit_json_result_for_identity(
+                            Err(error),
+                            output_file.as_deref(),
+                            2,
+                            &command_identity,
+                        );
+                        return std::process::ExitCode::from(2);
+                    }
+                };
+            crate::core::parsed_command_preflight::capture_result(preflight.clone());
+            crate::commands::utils::execution_provenance::capture(&preflight);
             let cli_args = cli::CliArgs {
                 tool: extension_cmd.tool,
                 identifier: extension_cmd.project_id,
@@ -921,22 +1170,68 @@ impl CliRuntime {
             return std::process::ExitCode::from(exit_code_to_u8(exit_code));
         }
 
+        // Resolve the parsed command contract before any admission probe. The
+        // completed result is captured exactly once after preflight.
+        let preflight_input = resource_policy::parsed_command_preflight_input(&cli, &normalized);
+
         // Capture controller pressure once before placement routing. The route
         // and persisted evidence reuse this preflight decision rather than
         // probing the host a second time.
         let managed_runner_placement = resource_policy::is_managed_runner_placement_context();
-        if let Some(exit_code) =
-            preflight_hot_command(&cli, output_file.as_deref(), &command_identity)
-        {
+        if let Some(exit_code) = preflight_hot_command(
+            &cli,
+            &normalized,
+            preflight_input.clone(),
+            output_file.as_deref(),
+            &command_identity,
+        ) {
             if managed_runner_placement {
                 resource_policy::clear_managed_runner_placement_context();
             }
             return std::process::ExitCode::from(exit_code_to_u8(exit_code));
         }
+        if crate::core::parsed_command_preflight::captured_result().is_none() {
+            let lab_readiness = matches!(
+                preflight_input.lab_route,
+                crate::core::parsed_command_preflight::LabRouteIntent::Supported { .. }
+            )
+            .then(|| crate::runner::lab_runner_readiness().ok())
+            .flatten();
+            let selected_runner_id = cli.runner.clone().or_else(|| {
+                lab_readiness
+                    .as_ref()
+                    .and_then(|readiness| readiness.selected_runner_id.clone())
+            });
+            let result = match crate::core::parsed_command_preflight::resolve_parsed_command_preflight(
+                normalized.clone(),
+                preflight_input.clone(),
+                crate::core::parsed_command_preflight::ParsedCommandPolicySnapshot {
+                    resource_admission_evidence:
+                        crate::core::parsed_command_preflight::ResourceAdmissionEvidence::Unavailable,
+                    resource_policy: None,
+                    lab_readiness: lab_readiness.as_ref().map(resource_policy::lab_readiness_snapshot),
+                    selected_runner_id: selected_runner_id.clone(),
+                    generic_route: generic_route_policy_snapshot(&cli, selected_runner_id.clone()),
+                    deferred_pressure_refusal: false,
+                    runner_admitted: selected_runner_id.is_some() && lab_readiness.as_ref().is_some_and(|readiness| readiness.state == crate::runner::runners::LabRunnerReadinessState::ConnectedReady),
+                    runner_incompatible: false,
+                    auto_local_capacity_fallback: false,
+                },
+            ) {
+                Ok(result) => result,
+                Err(err) => {
+                    output_runtime::emit_json_result_for_identity(Err(err), output_file.as_deref(), 2, &command_identity);
+                    return std::process::ExitCode::from(2);
+                }
+            };
+            crate::core::parsed_command_preflight::capture_result(result);
+        }
 
         // Persist the actual preflight decision with the command intent before
         // placement routing can consume controller transport markers.
-        crate::commands::utils::execution_provenance::capture(&cli, &normalized);
+        let preflight = crate::core::parsed_command_preflight::captured_result()
+            .expect("completed parsed-command preflight was captured");
+        crate::commands::utils::execution_provenance::capture(&preflight);
 
         let route_result = crate::core::notification_route::with_current_resolution(
             Some(notification_resolution.evidence.clone()),
@@ -1026,6 +1321,44 @@ impl CliRuntime {
             .copied()
             .find(|capability| capability.name() == name)
             .map(|capability| (capability, sub_matches))
+    }
+
+    fn run_capability_with_admission_evidence(
+        &self,
+        capability: &dyn CliCapability,
+        matches: &ArgMatches,
+        normalized: &[String],
+        evidence: crate::core::parsed_command_preflight::ResourceAdmissionEvidence,
+    ) -> (crate::core::Result<serde_json::Value>, i32) {
+        let input = capability.preflight(matches, normalized);
+        let mut policy = capability.preflight_policy(matches, normalized);
+        // Runtime owns the host observation. A capability can declare its
+        // requirement but cannot bless itself by supplying admission evidence.
+        policy.resource_admission_evidence = evidence;
+        let preflight =
+            match crate::core::parsed_command_preflight::resolve_parsed_command_preflight(
+                normalized.to_vec(),
+                input,
+                policy,
+            ) {
+                Ok(preflight) => preflight,
+                Err(error) => return (Err(error), 2),
+            };
+        crate::core::parsed_command_preflight::capture_result(preflight.clone());
+        crate::commands::utils::execution_provenance::capture(&preflight);
+        if matches!(
+            preflight.resource_admission,
+            crate::core::parsed_command_preflight::ResourceAdmissionDecision::Rejected { .. }
+        ) {
+            return (
+                Err(resource_admission_error(&preflight.resource_admission)),
+                2,
+            );
+        }
+        match capability.run(matches) {
+            Ok((value, exit_code)) => (Ok(value), exit_code),
+            Err(error) => (Err(error), 2),
+        }
     }
 
     fn try_parse_extension_cli_command(&self, matches: &ArgMatches) -> Option<ExtensionCliCommand> {
@@ -2052,12 +2385,19 @@ fn unix_timestamp_ms() -> u128 {
 
 fn preflight_hot_command(
     cli: &Cli,
+    normalized_args: &[String],
+    preflight_input: crate::core::parsed_command_preflight::ParsedCommandPreflightInput,
     output_file: Option<&str>,
     command_identity: &output::CommandIdentity,
 ) -> Option<i32> {
-    preflight_hot_command_with(cli, output_file, command_identity, || {
-        crate::commands::resources::run_preflight()
-    })
+    preflight_hot_command_with_input(
+        cli,
+        normalized_args,
+        preflight_input,
+        output_file,
+        command_identity,
+        || crate::commands::resources::run_preflight(),
+    )
 }
 
 fn preflight_composed_lab_route(
@@ -2138,8 +2478,10 @@ fn preflight_composed_lab_route(
     None
 }
 
-fn preflight_hot_command_with(
+fn preflight_hot_command_with_input(
     cli: &Cli,
+    normalized_args: &[String],
+    preflight_input: crate::core::parsed_command_preflight::ParsedCommandPreflightInput,
     output_file: Option<&str>,
     command_identity: &output::CommandIdentity,
     preflight: impl FnOnce() -> crate::commands::CmdResult<crate::commands::resources::DoctorOutput>,
@@ -2311,16 +2653,57 @@ fn preflight_hot_command_with(
                 resource_policy_context.runner_selection.reason = "explicit_lab_runner".to_string();
                 resource_policy_context.runner_selection.runner_id = cli.runner.clone();
             }
-            resource_policy::capture_context(resource_policy_context);
+            let selected_runner_id = resource_policy_context.runner_selection.runner_id.clone();
+            resource_policy::capture_context(resource_policy_context.clone());
+            let result =
+                match crate::core::parsed_command_preflight::resolve_parsed_command_preflight(
+                    normalized_args.to_vec(),
+                    preflight_input.clone(),
+                    crate::core::parsed_command_preflight::ParsedCommandPolicySnapshot {
+                        resource_admission_evidence: resource_policy::resource_admission_evidence(
+                            &resources,
+                        ),
+                        resource_policy: Some(resource_policy_context),
+                        lab_readiness: lab_readiness
+                            .as_ref()
+                            .map(resource_policy::lab_readiness_snapshot),
+                        selected_runner_id: selected_runner_id.clone(),
+                        generic_route: generic_route_policy_snapshot(
+                            cli,
+                            selected_runner_id.clone(),
+                        ),
+                        deferred_pressure_refusal: warning.as_ref().is_some_and(|warning| {
+                            review_test_deferred_workload_eligible(
+                                cli,
+                                warning,
+                                runner_admits_offload,
+                            )
+                        }),
+                        runner_admitted: runner_admits_offload,
+                        runner_incompatible: review_test_runner_requirements(cli).is_some()
+                            && selected_runner_id.is_some()
+                            && !runner_admits_offload,
+                        auto_local_capacity_fallback,
+                    },
+                ) {
+                    Ok(result) => result,
+                    Err(err) => {
+                        output_runtime::emit_json_result_for_identity(
+                            Err(err),
+                            output_file,
+                            2,
+                            command_identity,
+                        );
+                        return Some(2);
+                    }
+                };
+            crate::core::parsed_command_preflight::capture_result(result);
             if let Some(warning) = warning.as_ref() {
                 if let Some(mut err) = resource_policy::non_interactive_preflight_error(
                     warning,
                     cli.placement.is_explicit_local_override() || runner_hosted,
                     is_interactive_shell(),
-                    resource_policy::admission_recovery(
-                        &std::env::args().collect::<Vec<_>>(),
-                        lab_readiness.as_ref(),
-                    ),
+                    resource_policy::admission_recovery(normalized_args, lab_readiness.as_ref()),
                     runner_admits_offload || auto_local_capacity_fallback,
                 ) {
                     if let Some(diagnostic) = lab_inventory_diagnostic {
@@ -2345,6 +2728,63 @@ fn preflight_hot_command_with(
     }
 
     None
+}
+
+#[cfg(test)]
+pub(crate) fn placement_directive(
+    cli: &Cli,
+    selected_runner_id: Option<&str>,
+    auto_local_capacity_fallback: bool,
+) -> crate::core::parsed_command_preflight::PlacementDirective {
+    let normalized_args = vec!["homeboy".to_string()];
+    let input = resource_policy::parsed_command_preflight_input(cli, &normalized_args);
+    crate::core::parsed_command_preflight::resolve_parsed_command_preflight(
+        normalized_args,
+        input.clone(),
+        crate::core::parsed_command_preflight::ParsedCommandPolicySnapshot {
+            resource_admission_evidence:
+                crate::core::parsed_command_preflight::ResourceAdmissionEvidence::Unavailable,
+            resource_policy: None,
+            lab_readiness: selected_runner_id.map(|runner_id| {
+                crate::core::parsed_command_preflight::LabReadinessSnapshot {
+                    state: "connected_ready".to_string(),
+                    selected_runner_id: Some(runner_id.to_string()),
+                    available_runner_ids: vec![runner_id.to_string()],
+                    reasons: Vec::new(),
+                    remediation_commands: Vec::new(),
+                }
+            }),
+            selected_runner_id: selected_runner_id.map(str::to_string),
+            generic_route: generic_route_policy_snapshot(
+                cli,
+                selected_runner_id.map(str::to_string),
+            ),
+            deferred_pressure_refusal: false,
+            runner_admitted: selected_runner_id.is_some(),
+            runner_incompatible: false,
+            auto_local_capacity_fallback,
+        },
+    )
+    .expect("test placement fixture supplies admitted runner evidence")
+    .placement
+}
+
+#[cfg(test)]
+fn preflight_hot_command_with(
+    cli: &Cli,
+    output_file: Option<&str>,
+    command_identity: &output::CommandIdentity,
+    preflight: impl FnOnce() -> crate::commands::CmdResult<crate::commands::resources::DoctorOutput>,
+) -> Option<i32> {
+    let normalized_args = vec!["homeboy".to_string()];
+    preflight_hot_command_with_input(
+        cli,
+        &normalized_args,
+        resource_policy::parsed_command_preflight_input(cli, &normalized_args),
+        output_file,
+        command_identity,
+        preflight,
+    )
 }
 
 fn controller_owned_unmaterialized_resume(cli: &Cli) -> bool {
@@ -2556,6 +2996,39 @@ fn exit_code_to_u8(code: i32) -> u8 {
     } else {
         code as u8
     }
+}
+
+fn resource_admission_error(
+    decision: &crate::core::parsed_command_preflight::ResourceAdmissionDecision,
+) -> crate::core::Error {
+    use crate::core::parsed_command_preflight::{
+        ResourceAdmissionDecision, ResourceAdmissionEvidence,
+    };
+
+    let ResourceAdmissionDecision::Rejected {
+        label,
+        engages_at,
+        evidence,
+    } = decision
+    else {
+        unreachable!("only rejected admission decisions produce an error")
+    };
+    let observed = match evidence {
+        ResourceAdmissionEvidence::Observed { pressure } => format!("{pressure:?}").to_lowercase(),
+        ResourceAdmissionEvidence::Unavailable => "unavailable".to_string(),
+    };
+    let mut error = crate::core::Error::validation_invalid_argument(
+        "resource-policy",
+        format!(
+            "Refusing to start `{label}`: resource admission requires pressure below {engages_at:?}, observed {observed}."
+        ),
+        None,
+        None,
+    );
+    error.details["run_created"] = serde_json::Value::Bool(false);
+    error.details["resource_admission"] =
+        serde_json::to_value(decision).expect("resource admission decision serializes");
+    error
 }
 
 fn is_interactive_shell() -> bool {
@@ -2855,7 +3328,144 @@ mod tests {
     use sha2::{Digest, Sha256};
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    struct AdmissionFixtureCapability;
+
+    static ADMISSION_FIXTURE_CAPABILITY: AdmissionFixtureCapability = AdmissionFixtureCapability;
+    static ADMISSION_FIXTURE_RUNS: AtomicUsize = AtomicUsize::new(0);
+    static ADMISSION_FIXTURE_CAPABILITIES: [&'static dyn CliCapability; 1] =
+        [&ADMISSION_FIXTURE_CAPABILITY];
+
+    impl CliCapability for AdmissionFixtureCapability {
+        fn name(&self) -> &'static str {
+            "admission-fixture"
+        }
+
+        fn command(&self) -> Command {
+            Command::new(self.name()).arg(
+                clap::Arg::new("exempt")
+                    .long("exempt")
+                    .action(clap::ArgAction::SetTrue),
+            )
+        }
+
+        fn preflight(
+            &self,
+            matches: &ArgMatches,
+            _normalized_args: &[String],
+        ) -> crate::core::parsed_command_preflight::ParsedCommandPreflightInput {
+            use crate::core::parsed_command_preflight::{
+                ControllerExecution, DeferredWorkloadPolicy, LabRouteIntent, ParsedCommandIdentity,
+                ParsedCommandPreflightInput, PlacementIntent, ProvenanceRequirement,
+                ResourceAdmissionRequirement, ResourceHeat, RunnerIntent, RunnerNormalization,
+            };
+            ParsedCommandPreflightInput {
+                identity: ParsedCommandIdentity {
+                    family: self.name().to_string(),
+                    operation: Vec::new(),
+                },
+                resource_admission: if matches.get_flag("exempt") {
+                    ResourceAdmissionRequirement::Exempt
+                } else {
+                    ResourceAdmissionRequirement::Required {
+                        label: "admission fixture".to_string(),
+                        engages_at: ResourceHeat::Warm,
+                    }
+                },
+                controller_execution: ControllerExecution::ControllerOnly,
+                deferred_workload: DeferredWorkloadPolicy::Forbidden,
+                placement: PlacementIntent::Local,
+                runner: RunnerIntent::Default,
+                runner_normalization: RunnerNormalization::None,
+                lab_route: LabRouteIntent::Unsupported,
+                provenance: ProvenanceRequirement::CaptureExecution,
+            }
+        }
+
+        fn run(&self, _matches: &ArgMatches) -> crate::core::Result<(serde_json::Value, i32)> {
+            ADMISSION_FIXTURE_RUNS.fetch_add(1, Ordering::SeqCst);
+            Ok((serde_json::json!({ "status": "ran" }), 0))
+        }
+    }
+
+    fn run_admission_fixture(
+        evidence: crate::core::parsed_command_preflight::ResourceAdmissionEvidence,
+        exempt: bool,
+    ) -> std::process::ExitCode {
+        let runtime = CliRuntime::with_capabilities(&ADMISSION_FIXTURE_CAPABILITIES);
+        let mut normalized = vec!["homeboy".to_string(), "admission-fixture".to_string()];
+        if exempt {
+            normalized.push("--exempt".to_string());
+        }
+        let matches = runtime
+            .build_augmented_command()
+            .try_get_matches_from(normalized.clone())
+            .expect("fixture capability parses");
+        runtime.run_matches_with_capability_admission(matches, normalized, Some(evidence))
+    }
+
+    #[test]
+    fn typed_capability_resource_admission_rejects_before_run_and_admits_once() {
+        use crate::core::parsed_command_preflight::{
+            ResourceAdmissionDecision, ResourceAdmissionEvidence, ResourceHeat,
+        };
+
+        ADMISSION_FIXTURE_RUNS.store(0, Ordering::SeqCst);
+        crate::core::parsed_command_preflight::reset_captured_result_for_test();
+        let rejected = run_admission_fixture(
+            ResourceAdmissionEvidence::Observed {
+                pressure: ResourceHeat::Warm,
+            },
+            false,
+        );
+        assert_eq!(rejected, std::process::ExitCode::from(2));
+        assert_eq!(ADMISSION_FIXTURE_RUNS.load(Ordering::SeqCst), 0);
+        assert!(matches!(
+            crate::core::parsed_command_preflight::captured_result()
+                .expect("rejected preflight is captured")
+                .resource_admission,
+            ResourceAdmissionDecision::Rejected { .. }
+        ));
+
+        crate::core::parsed_command_preflight::reset_captured_result_for_test();
+        let admitted = run_admission_fixture(
+            ResourceAdmissionEvidence::Observed {
+                pressure: ResourceHeat::None,
+            },
+            false,
+        );
+        assert_eq!(admitted, std::process::ExitCode::SUCCESS);
+        assert_eq!(ADMISSION_FIXTURE_RUNS.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            crate::core::parsed_command_preflight::captured_result()
+                .expect("admitted preflight is captured")
+                .resource_admission,
+            ResourceAdmissionDecision::Admitted
+        );
+
+        crate::core::parsed_command_preflight::reset_captured_result_for_test();
+        let unavailable = run_admission_fixture(ResourceAdmissionEvidence::Unavailable, false);
+        assert_eq!(unavailable, std::process::ExitCode::from(2));
+        assert_eq!(ADMISSION_FIXTURE_RUNS.load(Ordering::SeqCst), 1);
+
+        crate::core::parsed_command_preflight::reset_captured_result_for_test();
+        let exempt = run_admission_fixture(
+            ResourceAdmissionEvidence::Observed {
+                pressure: ResourceHeat::Hot,
+            },
+            true,
+        );
+        assert_eq!(exempt, std::process::ExitCode::SUCCESS);
+        assert_eq!(ADMISSION_FIXTURE_RUNS.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            crate::core::parsed_command_preflight::captured_result()
+                .expect("exempt preflight is captured")
+                .resource_admission,
+            ResourceAdmissionDecision::NotRequired
+        );
+    }
 
     fn lab_readiness(
         state: crate::runner::runners::LabRunnerReadinessState,

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -933,6 +933,16 @@ fn fixture_preflight_decision(
     Ok(finalize_placement(&result.placement, task, source_path))
 }
 
+#[cfg(test)]
+fn placement_decision(
+    cli: &Cli,
+    runner_id: Option<&str>,
+    task: &str,
+    source_path: Option<&Path>,
+) -> homeboy::core::Result<homeboy_lab_runner_contract::ExecutionPlacementDecision> {
+    fixture_preflight_decision(cli, runner_id, task, source_path)
+}
+
 fn authoritative_lab_source_path(args: &[String]) -> homeboy::core::Result<PathBuf> {
     let mut args = args.iter().skip(1);
     while let Some(argument) = args.next() {

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -190,70 +190,50 @@ pub(crate) fn route_after_parse_with_provenance(
     let lab_command = lab_offload_command(&cli.command)?;
     let normalized_args = inline_portable_settings_profiles(cli, normalized_args)?;
 
-    // Reuse the admission snapshot when preflight captured one. A second
-    // readiness lookup could otherwise turn an admitted Lab attempt into a
-    // local fallback before routing constructs its immutable decision.
-    let admitted_lab_runner = admitted_lab_runner_id(cli, lab_command.as_ref());
-    let lab_readiness =
-        if lab_command.is_some() && cli.runner.is_none() && admitted_lab_runner.is_none() {
-            runners::lab_runner_readiness().ok()
-        } else {
-            None
-        };
-    let mut inferred_runner_id = if lab_command.is_some() {
-        cli.runner
-            .clone()
-            .or_else(|| admitted_lab_runner.clone().flatten())
-            .or_else(|| {
-                lab_readiness
-                    .as_ref()
-                    .and_then(|readiness| readiness.selected_runner_id.clone())
-            })
-    } else {
-        None
-    };
+    // Admission owns runner inventory. Routing consumes its immutable result;
+    // reopening readiness here can otherwise turn an admitted Lab attempt into
+    // a local fallback.
+    let preflight = authoritative_preflight()?;
+    let lab_readiness = preflight.lab_readiness.as_ref();
+    let inferred_runner_id = lab_command
+        .is_some()
+        .then(|| {
+            preflight
+                .placement
+                .runner
+                .as_ref()
+                .map(|runner| runner.runner_id.clone())
+        })
+        .flatten();
     if detached_cook_can_queue(cli) && !is_unmaterialized_replay_worker() {
         // Persist before any bounded refresh. The scoped replay selector owns
         // ready and reverse-capacity admission after this durable boundary.
         return admit_unmaterialized_cook(
             cli,
             &normalized_args,
-            lab_readiness.as_ref(),
+            &preflight,
             output_file,
             provenance,
         )
         .map(Some);
     }
-    let deferred_requirements = review_test_deferred_requirements(cli);
-    let deferred_runner_incompatible = inferred_runner_id
-        .as_deref()
-        .zip(deferred_requirements.as_ref())
-        .is_some_and(|(runner_id, requirements)| {
-            matches!(
-                runners::runner_capability_inventory(runner_id),
-                Ok(inventory)
-                    if !requirements
-                        .is_satisfied_by(&inventory.runtime_ids, &inventory.capabilities)
-            )
-        });
-    if deferred_runner_incompatible {
-        inferred_runner_id = None;
-    }
-    if deferred_runner_incompatible
+    if preflight.deferred_workload
+        == homeboy::core::parsed_command_preflight::DeferredWorkloadDecision::RunnerIncompatible
         && std::env::var_os("HOMEBOY_DEFERRED_WORKLOAD_REPLAY").is_some()
     {
         return Ok(Some(75));
     }
 
-    if inferred_runner_id.is_none()
-        && review_test_can_defer(cli)
-        && deferred_resource_admission_refused()
+    if preflight.deferred_workload
+        == homeboy::core::parsed_command_preflight::DeferredWorkloadDecision::Defer
         && std::env::var_os("HOMEBOY_DEFERRED_WORKLOAD_REPLAY").is_none()
     {
         let deferred = homeboy::deferred_workload::defer(deferred_workload_input(
             cli,
             &portable_deferred_args(&normalized_args),
-            deferred_requirements.expect("review tests always resolve deferred requirements"),
+            &preflight,
+            review_test_deferred_requirements(cli)
+                .expect("preflight only defers portable review tests"),
         )?)?;
         crate::commands::deferred_workload::ensure_worker(&homeboy::core::paths::homeboy()?)?;
         println!(
@@ -283,7 +263,7 @@ pub(crate) fn route_after_parse_with_provenance(
         &cli.command,
         cli.placement,
         inferred_runner_id.as_deref(),
-        lab_readiness.as_ref(),
+        lab_readiness,
     ) {
         return Err(error);
     }
@@ -316,14 +296,18 @@ pub(crate) fn route_after_parse_with_provenance(
         &normalized_args,
         output_file,
         inferred_runner_id.as_deref(),
+        &preflight.placement,
         provenance,
     )? {
         return Ok(Some(exit_code));
     }
 
-    if let Some(exit_code) =
-        run_split_placement_fanout(cli, output_file, inferred_runner_id.as_deref())?
-    {
+    if let Some(exit_code) = run_split_placement_fanout(
+        cli,
+        output_file,
+        inferred_runner_id.as_deref(),
+        &preflight.placement,
+    )? {
         return Ok(Some(exit_code));
     }
 
@@ -339,7 +323,7 @@ pub(crate) fn route_after_parse_with_provenance(
     // lifecycle commands ended up querying a machine that does not own their
     // durable record (#11597, #11599) and how an explicitly local run acquired
     // a Lab handoff it could not later recover (#11600).
-    let route_runner_id = generic_route_runner_id(cli, lab_command.as_ref(), &inferred_runner_id);
+    let route_runner_id = preflight.generic_route_runner_id.as_deref();
     if lab_command.is_none()
         || (route_runner_id.is_none() && cli.placement != homeboy::cli_surface::Placement::Lab)
     {
@@ -368,14 +352,18 @@ pub(crate) fn route_after_parse_with_provenance(
     let normalized_args = normalized_args.to_vec();
     let deferred_claim = inferred_runner_id
         .as_deref()
-        .filter(|_| review_test_can_defer(cli))
+        .filter(|_| {
+            preflight.deferred_workload
+                == homeboy::core::parsed_command_preflight::DeferredWorkloadDecision::Dispatch
+        })
         .map(|runner_id| {
             homeboy::deferred_workload::claim(
                 &deferred_workload_input(
                     cli,
                     &portable_deferred_args(&normalized_args),
+                    &preflight,
                     review_test_deferred_requirements(cli)
-                        .expect("review tests always resolve deferred requirements"),
+                        .expect("preflight only dispatches portable review tests"),
                 )?,
                 runner_id,
                 &format!("{}:{}", std::process::id(), uuid::Uuid::new_v4()),
@@ -454,12 +442,24 @@ pub(crate) fn route_after_parse_with_provenance(
         .and_then(|plan| plan.tasks.first())
         .map(|task| task.task_id.as_str())
         .unwrap_or("command");
-    let placement_decision = placement_decision(
-        cli,
-        route_runner_id,
-        placement_task,
-        Some(&routing_source_path),
-    )?;
+    if preflight.placement.required
+        == homeboy_lab_runner_contract::ExecutionPlacementRequirement::Lab
+        && preflight.placement.selected
+            == homeboy_lab_runner_contract::EffectiveExecutionPlacement::Local
+    {
+        return Err(Error::validation_invalid_argument(
+            "placement",
+            "required Lab placement has no selected ready runner",
+            Some("lab".to_string()),
+            None,
+        ));
+    }
+    let placement_decision = preflight
+        .placement
+        .finalize(materialized_placement_identity(
+            placement_task,
+            Some(&routing_source_path),
+        ));
     let generic_detached_handoff = needs_generic_detached_handoff
         .then(|| {
             materialize_generic_detached_lab_handoff(
@@ -569,9 +569,7 @@ pub(crate) fn route_after_parse_with_provenance(
             if destructive_fuzz_requires_lab(&cli.command) {
                 return Err(destructive_fuzz_local_execution_error());
             }
-            if let Some(warning) =
-                agent_task_local_fanout_warning(&cli.command, lab_readiness.as_ref())
-            {
+            if let Some(warning) = agent_task_local_fanout_warning(&cli.command, lab_readiness) {
                 eprintln!("{warning}");
             }
             Ok(None)
@@ -860,6 +858,24 @@ fn composed_lab_job_overrides(
     Ok(overrides)
 }
 
+fn materialized_placement_identity(
+    task: &str,
+    source_path: Option<&Path>,
+) -> homeboy_lab_runner_contract::ExecutionPlacementIdentity {
+    homeboy_lab_runner_contract::ExecutionPlacementIdentity {
+        repository: source_path
+            .and_then(|path| path.file_name())
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "runner-resident-or-unmaterialized".to_string()),
+        workspace: source_path
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| "runner-resident-or-unmaterialized".to_string()),
+        task: task.to_string(),
+        candidate: source_path.and_then(homeboy::core::git::head_sha),
+        base: source_path.and_then(|path| homeboy::core::git::rev_parse(path, "origin/HEAD")),
+    }
+}
+
 fn needs_provider_resolved_cook_interception(cli: &Cli, inferred_runner_id: Option<&str>) -> bool {
     // Explicit local placement was already intercepted before provider
     // resolution. Running it through this pass again consumes the supervised
@@ -870,17 +886,11 @@ fn needs_provider_resolved_cook_interception(cli: &Cli, inferred_runner_id: Opti
             || cli.placement == homeboy::cli_surface::Placement::Auto)
 }
 
-/// Return the Lab choice made by resource admission. `Some(None)` is an
-/// intentional no-runner decision and must retain normal local fallback.
-fn admitted_lab_runner_id(
-    cli: &Cli,
-    lab_command: Option<&runners::LabOffloadCommand>,
-) -> Option<Option<String>> {
-    (lab_command.is_some() && cli.runner.is_none())
-        .then(resource_policy::captured_context)
-        .flatten()
-        .filter(|context| !context.local_override)
-        .map(|context| context.runner_selection.runner_id)
+fn authoritative_preflight(
+) -> homeboy::core::Result<homeboy::core::parsed_command_preflight::ParsedCommandPreflightResult> {
+    homeboy::core::parsed_command_preflight::captured_result().ok_or_else(|| {
+        Error::internal_unexpected("route requires a completed parsed-command preflight result")
+    })
 }
 
 /// The runner the *generic* Lab route may use, given what the command's
@@ -893,106 +903,34 @@ fn admitted_lab_runner_id(
 /// the offload executor applies — so the canonical placement decision this
 /// controller writes and the dispatch the executor performs can never disagree
 /// about whether a command was entitled to leave this machine.
-fn generic_route_runner_id<'a>(
-    cli: &Cli,
-    lab_command: Option<&runners::LabOffloadCommand>,
-    inferred_runner_id: &'a Option<String>,
-) -> Option<&'a str> {
-    let runner_id = inferred_runner_id.as_deref()?;
-    if cli.runner.is_some() {
-        return Some(runner_id);
-    }
-    let command = lab_command?;
-    lab_routing::authorizes_policy_lab_runner(
-        &command.command,
-        cli.placement,
-        lab_routing::captured_pressure_severity().as_deref(),
-    )
-    .then_some(runner_id)
+
+fn finalize_placement(
+    directive: &homeboy::core::parsed_command_preflight::PlacementDirective,
+    task: &str,
+    source_path: Option<&Path>,
+) -> homeboy_lab_runner_contract::ExecutionPlacementDecision {
+    directive.finalize(materialized_placement_identity(task, source_path))
 }
 
-fn placement_decision(
+#[cfg(test)]
+fn fixture_preflight_decision(
     cli: &Cli,
     runner_id: Option<&str>,
     task: &str,
     source_path: Option<&Path>,
 ) -> homeboy::core::Result<homeboy_lab_runner_contract::ExecutionPlacementDecision> {
-    use homeboy_lab_runner_contract::{
-        EffectiveExecutionPlacement, ExecutionPlacementFallback, ExecutionPlacementIdentity,
-        ExecutionPlacementOverrideAuthorization, ExecutionPlacementRequirement,
-        ExecutionPlacementRunnerSelection, RunnerSelectionSource,
-    };
-    // Selecting a default runner is a policy preference, not an operator
-    // requirement. Only pinned Lab placement or an explicit runner forbids a
-    // verified local fallback.
-    let required = if cli.placement == homeboy::cli_surface::Placement::Lab || cli.runner.is_some()
-    {
-        ExecutionPlacementRequirement::Lab
-    } else {
-        ExecutionPlacementRequirement::Either
-    };
-    // `auto` is a policy-selected Lab attempt. The provider may append a
-    // verified local fallback only when the decision's fallback policy allows.
-    let selected = if cli.placement == homeboy::cli_surface::Placement::Local || runner_id.is_none()
-    {
-        EffectiveExecutionPlacement::Local
-    } else {
-        EffectiveExecutionPlacement::Lab
-    };
-    if cli.placement == homeboy::cli_surface::Placement::Lab && runner_id.is_none() {
-        return Err(Error::validation_invalid_argument(
-            "placement",
-            "required Lab placement has no selected ready runner",
-            Some("lab".to_string()),
-            None,
-        ));
-    }
-    Ok(
-        homeboy_lab_runner_contract::ExecutionPlacementDecision::new(
-            "lab-route-contract",
-            "v1",
-            ExecutionPlacementIdentity {
-                repository: source_path
-                    .and_then(|path| path.file_name())
-                    .map(|name| name.to_string_lossy().into_owned())
-                    .unwrap_or_else(|| "runner-resident-or-unmaterialized".to_string()),
-                workspace: source_path
-                    .map(|path| path.display().to_string())
-                    .unwrap_or_else(|| "runner-resident-or-unmaterialized".to_string()),
-                task: task.to_string(),
-                candidate: source_path.and_then(homeboy::core::git::head_sha),
-                base: source_path
-                    .and_then(|path| homeboy::core::git::rev_parse(path, "origin/HEAD")),
-            },
-            cli.placement,
-            required,
-            selected,
-            runner_id.map(|runner_id| ExecutionPlacementRunnerSelection {
-                runner_id: runner_id.to_string(),
-                source: if cli.runner.is_some() {
-                    RunnerSelectionSource::Explicit
-                } else {
-                    RunnerSelectionSource::Policy
-                },
-            }),
-            ExecutionPlacementFallback {
-                // Automatic routing historically falls back to local when no ready
-                // Lab runner exists; record that authorization explicitly.
-                local_allowed: required != ExecutionPlacementRequirement::Lab
-                    && matches!(
-                        cli.placement,
-                        homeboy::cli_surface::Placement::Auto
-                            | homeboy::cli_surface::Placement::LabOrLocal
-                    ),
-                reason: None,
-            },
-            ExecutionPlacementOverrideAuthorization {
-                authorized: cli.placement == homeboy::cli_surface::Placement::Local,
-                authority: (cli.placement == homeboy::cli_surface::Placement::Local)
-                    .then(|| "operator --placement local".to_string()),
-            },
-        ),
-    )
+    let normalized = vec!["homeboy".to_string()];
+    let result = homeboy::core::parsed_command_preflight::ParsedCommandPreflightResult::new(
+        normalized.clone(),
+        resource_policy::parsed_command_preflight_input(cli, &normalized),
+        None,
+        None,
+        homeboy::core::parsed_command_preflight::DeferredWorkloadDecision::NotApplicable,
+        homeboy::core::parsed_command_preflight::FallbackDirective::None,
+        crate::cli_runtime::placement_directive(cli, runner_id, false),
+        runner_id.map(str::to_string),
+    );
+    Ok(finalize_placement(&result.placement, task, source_path))
 }
 
 fn authoritative_lab_source_path(args: &[String]) -> homeboy::core::Result<PathBuf> {
@@ -1108,7 +1046,7 @@ fn admission_digest(value: impl AsRef<[u8]>) -> String {
 fn admit_unmaterialized_cook(
     cli: &Cli,
     normalized_args: &[String],
-    readiness: Option<&runners::LabRunnerReadiness>,
+    preflight: &homeboy::core::parsed_command_preflight::ParsedCommandPreflightResult,
     output_file: Option<&str>,
     provenance: Option<&crate::cli_surface::CommandArgumentProvenance>,
 ) -> homeboy::core::Result<i32> {
@@ -1127,11 +1065,15 @@ fn admit_unmaterialized_cook(
         .run_id
         .clone()
         .unwrap_or_else(|| format!("agent-task-{}", uuid::Uuid::new_v4()));
-    let readiness_state = readiness
+    let readiness_state = preflight
+        .lab_readiness
+        .as_ref()
         .map(|value| value.state.as_str())
         .unwrap_or("absent");
-    let state = unmaterialized_admission_state(readiness);
-    let reason = readiness
+    let state = unmaterialized_admission_state(preflight.lab_readiness.as_ref());
+    let reason = preflight
+        .lab_readiness
+        .as_ref()
         .and_then(|value| value.reasons.first())
         .map(String::as_str)
         .unwrap_or("no eligible Lab runner is currently available");
@@ -1164,10 +1106,10 @@ fn admit_unmaterialized_cook(
         "request_ref": request_ref,
         "candidate_policy": resolved.candidate_completion,
         "placement": {
-            "requested": cli.placement,
-            "local_fallback": false,
-            "runner_ref": cli.runner,
-            "resource_policy": homeboy::core::resource_policy_context::captured_context(),
+            "requested": preflight.placement.requested,
+            "local_fallback": preflight.placement.fallback.local_allowed,
+            "runner_ref": preflight.placement.runner.as_ref().map(|runner| &runner.runner_id),
+            "resource_policy": preflight.resource_policy,
         },
         "source": {
             "repository": resolved.dispatch.repo,
@@ -1936,78 +1878,7 @@ impl homeboy::core::daemon::orchestration::CookAdmissionReplayDriver
         &self,
         request: &serde_json::Value,
     ) -> homeboy::core::Result<serde_json::Value> {
-        let placement = &request["binding"]["placement"];
-        let required_capabilities = request["binding"]["provider_runtime_refs"]
-            ["required_capabilities"]
-            .as_array()
-            .into_iter()
-            .flatten()
-            .filter_map(serde_json::Value::as_str)
-            .collect::<BTreeSet<_>>();
-        if let Some(runner_id) = placement["runner_ref"].as_str() {
-            let mut snapshot = runners::runner_admission_snapshot(runner_id)?;
-            if snapshot.summary.accepting_jobs
-                || crate::runner::refresh_explicit_detached_queue_runner(runner_id)?
-            {
-                if !runner_satisfies_admission_capabilities(runner_id, &required_capabilities)? {
-                    return Ok(serde_json::json!({
-                        "state": "blocked_runner_unavailable",
-                        "reason": format!("runner `{runner_id}` does not satisfy required provider capabilities"),
-                        "selection": "explicit",
-                    }));
-                }
-                return Ok(serde_json::json!({
-                    "state": "eligible",
-                    "runner_id": runner_id,
-                    "selection": "explicit",
-                }));
-            }
-            snapshot = runners::runner_admission_snapshot(runner_id)?;
-            return Ok(serde_json::json!({
-                "state": if snapshot.summary.daemon_fresh { "blocked_runner_unavailable" } else { "blocked_runner_stale" },
-                "reason": snapshot.summary.next_action.unwrap_or_else(|| format!("runner `{runner_id}` is not accepting jobs")),
-                "selection": "explicit",
-            }));
-        }
-
-        let readiness = runners::refresh_lab_runner_readiness_for_admission()?;
-        if readiness.state == runners::LabRunnerReadinessState::ConnectedReady {
-            if let Some(runner_id) = readiness.selected_runner_id {
-                if !runner_satisfies_admission_capabilities(&runner_id, &required_capabilities)? {
-                    return Ok(serde_json::json!({
-                        "state": "blocked_runner_unavailable",
-                        "reason": format!("runner `{runner_id}` does not satisfy required provider capabilities"),
-                        "selection": "configured_policy",
-                    }));
-                }
-                return Ok(serde_json::json!({
-                    "state": "eligible",
-                    "runner_id": runner_id,
-                    "selection": "configured_policy",
-                }));
-            }
-        }
-        if readiness.state == runners::LabRunnerReadinessState::CapacityBlocked {
-            if let Some(runner_id) = runners::refresh_detached_queue_runner()? {
-                if !runner_satisfies_admission_capabilities(&runner_id, &required_capabilities)? {
-                    return Ok(serde_json::json!({
-                        "state": "blocked_runner_unavailable",
-                        "reason": format!("runner `{runner_id}` does not satisfy required provider capabilities"),
-                        "selection": "reverse_capacity_queue",
-                    }));
-                }
-                return Ok(serde_json::json!({
-                    "state": "eligible",
-                    "runner_id": runner_id,
-                    "selection": "reverse_capacity_queue",
-                }));
-            }
-        }
-        Ok(serde_json::json!({
-            "state": unmaterialized_admission_state(Some(&readiness)),
-            "reason": readiness.reasons.first().cloned().unwrap_or_else(|| "no configured Lab runner currently satisfies admission policy".to_string()),
-            "selection": "configured_policy",
-        }))
+        crate::cli_runtime::select_unmaterialized_cook_runner(request)
     }
 
     fn replay(&self, request: &serde_json::Value) -> homeboy::core::Result<serde_json::Value> {
@@ -2120,28 +1991,6 @@ impl homeboy::core::daemon::orchestration::CookAdmissionReplayDriver
     }
 }
 
-fn runner_satisfies_admission_capabilities(
-    runner_id: &str,
-    required: &BTreeSet<&str>,
-) -> homeboy::core::Result<bool> {
-    if required.is_empty() {
-        return Ok(true);
-    }
-    let inventory = runners::runner_capability_inventory(runner_id)?;
-    Ok(runner_inventory_satisfies_admission_capabilities(
-        &inventory, required,
-    ))
-}
-
-fn runner_inventory_satisfies_admission_capabilities(
-    inventory: &runners::RunnerCapabilityInventory,
-    required: &BTreeSet<&str>,
-) -> bool {
-    required.iter().all(|required| {
-        inventory.capabilities.contains(*required) || inventory.runtime_ids.contains(*required)
-    })
-}
-
 fn supervise_replay_worker(
     cook_id: String,
     fence: u64,
@@ -2229,13 +2078,14 @@ pub(crate) fn register_unmaterialized_cook_replay_driver() {
     ));
 }
 
-fn unmaterialized_admission_state(readiness: Option<&runners::LabRunnerReadiness>) -> &'static str {
-    use runners::LabRunnerReadinessState;
-    match readiness.map(|value| value.state) {
-        Some(LabRunnerReadinessState::Stale) => "blocked_runner_stale",
+fn unmaterialized_admission_state(
+    readiness: Option<&homeboy::core::parsed_command_preflight::LabReadinessSnapshot>,
+) -> &'static str {
+    match readiness.map(|value| value.state.as_str()) {
+        Some("stale") => "blocked_runner_stale",
         // A healthy reverse runner at capacity owns a durable broker queue. It
         // is waiting for a slot, not unavailable.
-        Some(LabRunnerReadinessState::CapacityBlocked) => "queued",
+        Some("capacity_blocked") => "queued",
         _ => "blocked_runner_unavailable",
     }
 }
@@ -2257,7 +2107,7 @@ fn split_placement_lab_runner_unavailable_error(
     command: &Commands,
     placement: homeboy::cli_surface::Placement,
     inferred_runner_id: Option<&str>,
-    readiness: Option<&runners::LabRunnerReadiness>,
+    readiness: Option<&homeboy::core::parsed_command_preflight::LabReadinessSnapshot>,
 ) -> Option<Error> {
     if placement != homeboy::cli_surface::Placement::Lab || inferred_runner_id.is_some() {
         return None;
@@ -2304,6 +2154,7 @@ fn run_split_placement_fanout(
     cli: &Cli,
     output_file: Option<&str>,
     runner_id: Option<&str>,
+    directive: &homeboy::core::parsed_command_preflight::PlacementDirective,
 ) -> homeboy::core::Result<Option<i32>> {
     if cli.placement == homeboy::cli_surface::Placement::Local {
         return Ok(None);
@@ -2314,7 +2165,7 @@ fn run_split_placement_fanout(
     let runner_id = runner_id.to_string();
     let job_overrides = lab_job_overrides(cli)?;
     let placement = cli.placement;
-    let runner_is_explicit = cli.runner.is_some();
+    let directive = directive.clone();
     let allow_dirty_lab_workspace = cli.allow_dirty_lab_workspace;
     let skip_deps_hydration = cli.skip_deps_hydration;
     let detach_after_handoff = cli.detach_after_handoff;
@@ -2337,13 +2188,7 @@ fn run_split_placement_fanout(
                 .unwrap_or("fanout-provider-attempt");
             Arc::new(LabCookAttemptDispatcher {
                 runner_id: runner_id.clone(),
-                placement_decision: fanout_child_placement_decision(
-                    placement,
-                    runner_is_explicit,
-                    &runner_id,
-                    task,
-                    source_path.as_deref(),
-                ),
+                placement_decision: finalize_placement(&directive, task, source_path.as_deref()),
                 allow_local_fallback: false,
                 allow_dirty_lab_workspace,
                 skip_deps_hydration,
@@ -2437,56 +2282,6 @@ fn reject_contradictory_cook_arguments(cli: &Cli) -> homeboy::core::Result<()> {
     Ok(())
 }
 
-fn fanout_child_placement_decision(
-    placement: homeboy::cli_surface::Placement,
-    runner_is_explicit: bool,
-    runner_id: &str,
-    task: &str,
-    source_path: Option<&Path>,
-) -> homeboy_lab_runner_contract::ExecutionPlacementDecision {
-    use homeboy_lab_runner_contract::{
-        EffectiveExecutionPlacement, ExecutionPlacementFallback, ExecutionPlacementIdentity,
-        ExecutionPlacementOverrideAuthorization, ExecutionPlacementRequirement,
-        ExecutionPlacementRunnerSelection, RunnerSelectionSource,
-    };
-
-    homeboy_lab_runner_contract::ExecutionPlacementDecision::new(
-        "lab-route-contract",
-        "v1",
-        ExecutionPlacementIdentity {
-            repository: source_path
-                .and_then(|path| path.file_name())
-                .map(|name| name.to_string_lossy().into_owned())
-                .unwrap_or_else(|| "unmaterialized-fanout-child".to_string()),
-            workspace: source_path
-                .map(|path| path.display().to_string())
-                .unwrap_or_else(|| "unmaterialized-fanout-child".to_string()),
-            task: task.to_string(),
-            candidate: source_path.and_then(homeboy::core::git::head_sha),
-            base: source_path.and_then(|path| homeboy::core::git::rev_parse(path, "origin/HEAD")),
-        },
-        placement,
-        ExecutionPlacementRequirement::Lab,
-        EffectiveExecutionPlacement::Lab,
-        Some(ExecutionPlacementRunnerSelection {
-            runner_id: runner_id.to_string(),
-            source: if runner_is_explicit {
-                RunnerSelectionSource::Explicit
-            } else {
-                RunnerSelectionSource::Policy
-            },
-        }),
-        ExecutionPlacementFallback {
-            local_allowed: false,
-            reason: None,
-        },
-        ExecutionPlacementOverrideAuthorization {
-            authorized: false,
-            authority: None,
-        },
-    )
-}
-
 /// Cook owns controller-local target resolution, promotion, gates, retries, and
 /// finalization. Its provider attempt is the only portable unit: a materialized
 /// typed run-plan that mirrors its aggregate and artifacts back into the same
@@ -2496,15 +2291,25 @@ fn run_split_placement_cook(
     _normalized_args: &[String],
     output_file: Option<&str>,
     runner_id: Option<&str>,
+    directive: &homeboy::core::parsed_command_preflight::PlacementDirective,
     provenance: Option<&crate::cli_surface::CommandArgumentProvenance>,
 ) -> homeboy::core::Result<Option<i32>> {
-    run_split_placement_cook_with_runtime(cli, output_file, runner_id, provenance, None, None)
+    run_split_placement_cook_with_runtime(
+        cli,
+        output_file,
+        runner_id,
+        directive,
+        provenance,
+        None,
+        None,
+    )
 }
 
 fn run_split_placement_cook_with_runtime(
     cli: &Cli,
     output_file: Option<&str>,
     runner_id: Option<&str>,
+    directive: &homeboy::core::parsed_command_preflight::PlacementDirective,
     provenance: Option<&crate::cli_surface::CommandArgumentProvenance>,
     dispatcher_override: Option<
         Arc<dyn crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher>,
@@ -2577,12 +2382,11 @@ fn run_split_placement_cook_with_runtime(
     } else {
         Arc::new(LabCookAttemptDispatcher {
             runner_id: runner_id.to_string(),
-            placement_decision: placement_decision(
-                cli,
-                Some(runner_id),
+            placement_decision: finalize_placement(
+                directive,
                 placement_task,
                 source_path.as_deref(),
-            )?,
+            ),
             allow_local_fallback: cli.runner.is_none() && cli.placement.allows_local_fallback(),
             allow_dirty_lab_workspace: cli.allow_dirty_lab_workspace,
             skip_deps_hydration: cli.skip_deps_hydration,
@@ -2958,49 +2762,45 @@ impl crate::agents::agent_task_service::AgentTaskCookAttemptDispatcher
     }
 }
 
-fn placement_decision_for_attempt(
+fn finalize_replacement_attempt(
     prior: &homeboy_lab_runner_contract::ExecutionPlacementDecision,
     runner_id: &str,
     task: &str,
     source_path: Option<&Path>,
 ) -> homeboy_lab_runner_contract::ExecutionPlacementDecision {
-    use homeboy_lab_runner_contract::{
-        ExecutionPlacementIdentity, ExecutionPlacementRunnerSelection,
+    let directive = homeboy::core::parsed_command_preflight::PlacementDirective {
+        requested: prior.requested,
+        required: prior.required,
+        selected: prior.selected,
+        runner: Some(
+            homeboy_lab_runner_contract::ExecutionPlacementRunnerSelection {
+                runner_id: runner_id.to_string(),
+                source: prior
+                    .runner
+                    .as_ref()
+                    .map(|runner| runner.source)
+                    .unwrap_or(homeboy_lab_runner_contract::RunnerSelectionSource::Explicit),
+            },
+        ),
+        fallback: prior.fallback.clone(),
+        override_authorization: prior.override_authorization.clone(),
     };
-
-    homeboy_lab_runner_contract::ExecutionPlacementDecision::new(
-        prior.policy_id.clone(),
-        prior.policy_revision.clone(),
-        ExecutionPlacementIdentity {
-            repository: source_path
-                .and_then(|path| path.file_name())
-                .map(|name| name.to_string_lossy().into_owned())
-                .unwrap_or_else(|| prior.identity.repository.clone()),
-            workspace: source_path
-                .map(|path| path.display().to_string())
-                .unwrap_or_else(|| prior.identity.workspace.clone()),
-            task: task.to_string(),
-            candidate: source_path
-                .and_then(homeboy::core::git::head_sha)
-                .or_else(|| prior.identity.candidate.clone()),
-            base: source_path
-                .and_then(|path| homeboy::core::git::rev_parse(path, "origin/HEAD"))
-                .or_else(|| prior.identity.base.clone()),
-        },
-        prior.requested,
-        prior.required,
-        prior.selected,
-        Some(ExecutionPlacementRunnerSelection {
-            runner_id: runner_id.to_string(),
-            source: prior
-                .runner
-                .as_ref()
-                .map(|runner| runner.source)
-                .unwrap_or(homeboy_lab_runner_contract::RunnerSelectionSource::Explicit),
-        }),
-        prior.fallback.clone(),
-        prior.override_authorization.clone(),
-    )
+    directive.finalize(homeboy_lab_runner_contract::ExecutionPlacementIdentity {
+        repository: source_path
+            .and_then(|path| path.file_name())
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| prior.identity.repository.clone()),
+        workspace: source_path
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| prior.identity.workspace.clone()),
+        task: task.to_string(),
+        candidate: source_path
+            .and_then(homeboy::core::git::head_sha)
+            .or_else(|| prior.identity.candidate.clone()),
+        base: source_path
+            .and_then(|path| homeboy::core::git::rev_parse(path, "origin/HEAD"))
+            .or_else(|| prior.identity.base.clone()),
+    })
 }
 
 fn resolve_cook_attempt_placement_decision(
@@ -3011,7 +2811,7 @@ fn resolve_cook_attempt_placement_decision(
     task: &str,
     source_path: Option<&Path>,
 ) -> homeboy::core::Result<homeboy_lab_runner_contract::ExecutionPlacementDecision> {
-    let replacement = placement_decision_for_attempt(initial, runner_id, task, source_path);
+    let replacement = finalize_replacement_attempt(initial, runner_id, task, source_path);
     let persisted = plan
         .metadata
         .get("execution_placement_decision")
@@ -3165,9 +2965,14 @@ pub(crate) fn dispatch_controller_plan_to_lab(
                 None,
             )
         })?
-        .unwrap_or_else(|| {
-            controller_dispatch_placement_decision(&plan, runner_id, source_path.as_deref())
-        });
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "execution_placement_decision",
+                "controller plan requires its authoritative preflight placement decision",
+                Some(run_id.to_string()),
+                None,
+            )
+        })?;
     if !plan.metadata.is_object() {
         plan.metadata = serde_json::json!({ "legacy_metadata": plan.metadata });
     }
@@ -3201,54 +3006,6 @@ pub(crate) fn dispatch_controller_plan_to_lab(
         "identity": record.metadata.get("runner_handoff").and_then(|handoff| handoff.get("identity")).cloned(),
         "run": record,
     }))
-}
-
-fn controller_dispatch_placement_decision(
-    plan: &homeboy::agents::agent_tasks::scheduler::AgentTaskPlan,
-    runner_id: &str,
-    source_path: Option<&Path>,
-) -> homeboy_lab_runner_contract::ExecutionPlacementDecision {
-    use homeboy_lab_runner_contract::{
-        EffectiveExecutionPlacement, ExecutionPlacementFallback, ExecutionPlacementIdentity,
-        ExecutionPlacementOverrideAuthorization, ExecutionPlacementRequirement,
-        ExecutionPlacementRunnerSelection, Placement, RunnerSelectionSource,
-    };
-
-    homeboy_lab_runner_contract::ExecutionPlacementDecision::new(
-        "controller-dispatch-lab",
-        "v1",
-        ExecutionPlacementIdentity {
-            repository: source_path
-                .and_then(|path| path.file_name())
-                .map(|name| name.to_string_lossy().into_owned())
-                .unwrap_or_else(|| "controller-dispatch".to_string()),
-            workspace: source_path
-                .map(|path| path.display().to_string())
-                .unwrap_or_else(|| "controller-dispatch".to_string()),
-            task: plan
-                .tasks
-                .first()
-                .map(|task| task.task_id.clone())
-                .unwrap_or_else(|| plan.plan_id.clone()),
-            candidate: source_path.and_then(homeboy::core::git::head_sha),
-            base: source_path.and_then(|path| homeboy::core::git::rev_parse(path, "origin/HEAD")),
-        },
-        Placement::Lab,
-        ExecutionPlacementRequirement::Lab,
-        EffectiveExecutionPlacement::Lab,
-        Some(ExecutionPlacementRunnerSelection {
-            runner_id: runner_id.to_string(),
-            source: RunnerSelectionSource::Explicit,
-        }),
-        ExecutionPlacementFallback {
-            local_allowed: false,
-            reason: None,
-        },
-        ExecutionPlacementOverrideAuthorization {
-            authorized: false,
-            authority: None,
-        },
-    )
 }
 
 /// Transfer the exact controller-compiled cook plan rather than asking the
@@ -3421,22 +3178,10 @@ fn credential_shaped_key(key: &str) -> bool {
     .any(|needle| key.contains(needle))
 }
 
-fn review_test_can_defer(cli: &Cli) -> bool {
-    matches!(
-        cli.placement,
-        homeboy::cli_surface::Placement::Auto | homeboy::cli_surface::Placement::LabOrLocal
-    ) && cli.runner.is_none()
-        && matches!(
-            &cli.command,
-            Commands::Review(review)
-                if matches!(review.command, Some(crate::commands::review::ReviewCommand::Test(_)))
-                    && review.lab_contract().is_some_and(|contract| contract.is_portable())
-        )
-}
-
 fn deferred_workload_input(
     cli: &Cli,
     args: &[String],
+    preflight: &homeboy::core::parsed_command_preflight::ParsedCommandPreflightResult,
     test_requirements: homeboy::deferred_workload::DeferredWorkloadRequirements,
 ) -> homeboy::core::Result<homeboy::deferred_workload::DeferredWorkloadInput> {
     Ok(homeboy::deferred_workload::DeferredWorkloadInput {
@@ -3460,7 +3205,9 @@ fn deferred_workload_input(
             "required_runtimes": test_requirements.required_runtimes,
             "required_capabilities": test_requirements.required_capabilities,
         }),
-        resolved_resources: resource_policy::captured_context()
+        resolved_resources: preflight
+            .resource_policy
+            .as_ref()
             .and_then(|context| serde_json::to_value(context).ok())
             .unwrap_or_else(|| serde_json::json!({ "severity": "unknown" })),
         test_requirements,
@@ -3493,12 +3240,6 @@ fn review_test_deferred_requirements(
                 .collect(),
         },
     )
-}
-
-fn deferred_resource_admission_refused() -> bool {
-    resource_policy::captured_context().is_some_and(|context| {
-        context.warned && matches!(context.severity.as_str(), "warm" | "hot")
-    })
 }
 
 /// Preserve a command which can be replayed with an explicit runner. Placement
@@ -4411,7 +4152,7 @@ fn validate_lab_env_name(source: &str, name: &str) -> homeboy::core::Result<Stri
 /// remediation commands are the operator's shortest path back to the Lab.
 fn agent_task_local_fanout_warning(
     command: &Commands,
-    readiness: Option<&runners::LabRunnerReadiness>,
+    readiness: Option<&homeboy::core::parsed_command_preflight::LabReadinessSnapshot>,
 ) -> Option<String> {
     use crate::commands::agent_task::{
         AgentTaskArgs, AgentTaskCommand, AgentTaskFanoutArgs, AgentTaskFanoutCommand,
@@ -4706,7 +4447,7 @@ fn write_offloaded_stdout(path: &str, stdout: &str) -> homeboy::core::Result<()>
     write_output_file(path, stdout)
 }
 
-fn lab_offload_command(
+pub(crate) fn lab_offload_command(
     command: &Commands,
 ) -> homeboy::core::Result<Option<runners::LabOffloadCommand>> {
     let Some(route_contract) = command.lab_route_contract()? else {

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -31,7 +31,7 @@ fn durable_agent_task_handoff_targets_its_lifecycle_record() {
 fn detached_planless_handoff_persists_explicit_bench_label_before_handoff() {
     crate::test_support::with_isolated_home(|_| {
         let source = tempfile::tempdir().expect("source workspace");
-        let decision = placement_decision(
+        let decision = fixture_preflight_decision(
             &Cli::parse_from(["homeboy", "status"]),
             Some("homeboy-lab"),
             "bench",
@@ -76,7 +76,7 @@ fn detached_planless_handoff_reuses_the_same_explicit_bench_label() {
             "--run-id=ssi-fixture-37-20260727-runtime-fixed".to_string(),
         ];
         let source = tempfile::tempdir().expect("source workspace");
-        let decision = placement_decision(
+        let decision = fixture_preflight_decision(
             &Cli::parse_from(["homeboy", "status"]),
             Some("homeboy-lab"),
             "bench",
@@ -132,8 +132,9 @@ fn failed_detached_bench_retry_replays_the_persisted_workspace_and_inputs() {
         let command = lab_offload_command(&cli.command)
             .expect("bench contract")
             .expect("portable bench");
-        let decision = placement_decision(&cli, Some("homeboy-lab"), "bench", Some(source.path()))
-            .expect("placement decision");
+        let decision =
+            fixture_preflight_decision(&cli, Some("homeboy-lab"), "bench", Some(source.path()))
+                .expect("placement decision");
         let handoff =
             materialize_generic_detached_lab_handoff(&args, source.path(), &command, decision)
                 .expect("persist detached bench handoff");
@@ -529,7 +530,7 @@ fn deferred_workload_command_is_portable_and_omits_controller_placement() {
 fn lab_cook_dispatcher_recipe_round_trips_exact_transport() {
     let dispatcher = LabCookAttemptDispatcher {
         runner_id: "homeboy-lab".to_string(),
-        placement_decision: placement_decision(
+        placement_decision: fixture_preflight_decision(
             &Cli::parse_from(["homeboy", "status"]),
             Some("homeboy-lab"),
             "test-cook-dispatch",
@@ -577,11 +578,12 @@ fn lab_cook_dispatcher_recipe_round_trips_exact_transport() {
 fn unchanged_attempt_inputs_preserve_the_canonical_decision() {
     let cli = Cli::parse_from(["homeboy", "--runner", "homeboy-lab", "status"]);
     let first = tempdir().expect("first child workspace");
-    let initial = placement_decision(&cli, Some("homeboy-lab"), "child-a", Some(first.path()))
-        .expect("initial child decision");
+    let initial =
+        fixture_preflight_decision(&cli, Some("homeboy-lab"), "child-a", Some(first.path()))
+            .expect("initial child decision");
 
     let preserved =
-        placement_decision_for_attempt(&initial, "homeboy-lab", "child-a", Some(first.path()));
+        finalize_replacement_attempt(&initial, "homeboy-lab", "child-a", Some(first.path()));
 
     assert_eq!(initial.decision_id, preserved.decision_id);
     assert_eq!(
@@ -608,9 +610,13 @@ fn durable_placement_identity_survives_workspace_exception_retry_continuation_an
         std::fs::create_dir(&workspace).expect("workspace");
         std::fs::create_dir(&replacement_workspace).expect("replacement workspace");
         let cli = Cli::parse_from(["homeboy", "--runner", "homeboy-lab", "status"]);
-        let initial =
-            placement_decision(&cli, Some("homeboy-lab"), "provider-task", Some(&workspace))
-                .expect("initial placement decision");
+        let initial = fixture_preflight_decision(
+            &cli,
+            Some("homeboy-lab"),
+            "provider-task",
+            Some(&workspace),
+        )
+        .expect("initial placement decision");
         let template = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(
             "placement-e2e",
             vec![serde_json::from_value(serde_json::json!({
@@ -676,8 +682,13 @@ fn durable_placement_identity_survives_workspace_exception_retry_continuation_an
         let replacement = resolve_cook_attempt_placement_decision(
             &mut replacement_plan,
             "workspace-replacement",
-            &placement_decision(&cli, Some("homeboy-lab"), "provider-task", Some(&workspace))
-                .expect("initial decision"),
+            &fixture_preflight_decision(
+                &cli,
+                Some("homeboy-lab"),
+                "provider-task",
+                Some(&workspace),
+            )
+            .expect("initial decision"),
             "homeboy-lab",
             "provider-task",
             Some(&replacement_workspace),
@@ -723,35 +734,6 @@ fn durable_placement_identity_survives_workspace_exception_retry_continuation_an
 }
 
 #[test]
-fn direct_controller_dispatch_creates_an_authoritative_placement_decision() {
-    let plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(
-        "controller-dispatch-plan",
-        vec![serde_json::from_value(serde_json::json!({
-            "task_id": "controller-task",
-            "executor": { "backend": "fixture" },
-            "instructions": "dispatch directly to Lab"
-        }))
-        .expect("task")],
-    );
-
-    let decision = controller_dispatch_placement_decision(&plan, "homeboy-lab", None);
-
-    assert_eq!(decision.identity.task, "controller-task");
-    assert_eq!(
-        decision.requested,
-        homeboy_lab_runner_contract::Placement::Lab
-    );
-    assert_eq!(
-        decision.required,
-        homeboy_lab_runner_contract::ExecutionPlacementRequirement::Lab
-    );
-    assert_eq!(
-        decision.runner.expect("selected runner").runner_id,
-        "homeboy-lab"
-    );
-}
-
-#[test]
 fn command_placement_matrix_separates_preferred_lab_from_required_lab() {
     let source = tempdir().expect("source workspace");
     let cases = [
@@ -794,7 +776,7 @@ fn command_placement_matrix_separates_preferred_lab_from_required_lab() {
 
     for (args, runner, placement, required, local_fallback) in cases {
         let cli = Cli::parse_from(&args);
-        let decision = placement_decision(&cli, runner, "matrix", Some(source.path()))
+        let decision = fixture_preflight_decision(&cli, runner, "matrix", Some(source.path()))
             .expect("placement decision");
 
         assert_eq!(cli.placement, placement);
@@ -854,7 +836,7 @@ fn cook_dispatch_stages_runner_identity_without_starting_handoff_lease() {
         );
         let dispatcher = LabCookAttemptDispatcher {
             runner_id: "missing-homeboy-lab".to_string(),
-            placement_decision: placement_decision(
+            placement_decision: fixture_preflight_decision(
                 &Cli::parse_from(["homeboy", "status"]),
                 Some("missing-homeboy-lab"),
                 "task",
@@ -1350,14 +1332,26 @@ fn manifest_resolved_portable_db_service_warm_defers_and_dispatches_secret_ident
         assert_eq!(overrides.env["DB_SERVICE_HOST"], "db.fixture");
         assert_eq!(overrides.env["DB_SERVICE_PORT"], "3306");
         assert_eq!(overrides.secret_env_names, ["DB_SERVICE_PASSWORD"]);
+        let normalized = vec![
+            "homeboy".to_string(),
+            "review".to_string(),
+            "test".to_string(),
+        ];
+        let preflight = homeboy::core::parsed_command_preflight::ParsedCommandPreflightResult::new(
+            normalized.clone(),
+            resource_policy::parsed_command_preflight_input(&cli, &normalized),
+            None,
+            None,
+            homeboy::core::parsed_command_preflight::DeferredWorkloadDecision::Defer,
+            homeboy::core::parsed_command_preflight::FallbackDirective::None,
+            crate::cli_runtime::placement_directive(&cli, None, false),
+            None,
+        );
         let deferred = homeboy::deferred_workload::defer(
             deferred_workload_input(
                 &cli,
-                &[
-                    "homeboy".to_string(),
-                    "review".to_string(),
-                    "test".to_string(),
-                ],
+                &normalized,
+                &preflight,
                 review_test_deferred_requirements(&cli).expect("review test requirements"),
             )
             .expect("deferred input"),
@@ -1553,6 +1547,19 @@ fn ambient_resolved_marker_cannot_bypass_explicit_lab_placement() {
         "lint".to_string(),
     ];
     let cli = Cli::parse_from(&normalized);
+    homeboy::core::parsed_command_preflight::reset_captured_result_for_test();
+    homeboy::core::parsed_command_preflight::capture_result(
+        homeboy::core::parsed_command_preflight::ParsedCommandPreflightResult::new(
+            normalized.clone(),
+            resource_policy::parsed_command_preflight_input(&cli, &normalized),
+            None,
+            None,
+            homeboy::core::parsed_command_preflight::DeferredWorkloadDecision::NotApplicable,
+            homeboy::core::parsed_command_preflight::FallbackDirective::RequiredLabUnavailable,
+            crate::cli_runtime::placement_directive(&cli, None, false),
+            None,
+        ),
+    );
 
     let err = crate::test_support::with_isolated_home(|_| {
         route_after_parse_with_provenance(&cli, &normalized, None, None)
@@ -2610,11 +2617,16 @@ fn explicit_local_cook_does_not_enter_lab_attempt_dispatch() {
         "keep this local",
     ]);
 
-    assert!(
-        run_split_placement_cook(&cli, &[], None, Some("homeboy-lab"), None)
-            .expect("local placement bypasses Lab cook dispatch")
-            .is_none()
-    );
+    assert!(run_split_placement_cook(
+        &cli,
+        &[],
+        None,
+        Some("homeboy-lab"),
+        &crate::cli_runtime::placement_directive(&cli, Some("homeboy-lab"), false),
+        None,
+    )
+    .expect("local placement bypasses Lab cook dispatch")
+    .is_none());
 }
 
 #[test]
@@ -2632,8 +2644,15 @@ fn detached_cook_without_a_lab_runner_does_not_fall_back_to_local_execution() {
         "queue this remotely",
     ]);
 
-    let error = run_split_placement_cook(&cli, &[], None, None, None)
-        .expect_err("detached Cook must require a remote runner");
+    let error = run_split_placement_cook(
+        &cli,
+        &[],
+        None,
+        None,
+        &crate::cli_runtime::placement_directive(&cli, None, false),
+        None,
+    )
+    .expect_err("detached Cook must require a remote runner");
     assert!(error
         .message
         .contains("controller-local execution was not authorized"));
@@ -3330,8 +3349,8 @@ fn local_fanout_warning_carries_lab_readiness_reasons_and_remediation() {
         "cargo test",
         "--run-plan",
     ]);
-    let readiness = runners::LabRunnerReadiness {
-        state: runners::LabRunnerReadinessState::Stale,
+    let readiness = homeboy::core::parsed_command_preflight::LabReadinessSnapshot {
+        state: "stale".to_string(),
         selected_runner_id: None,
         available_runner_ids: vec!["lab-a".to_string()],
         reasons: vec!["lab-a daemon is stale".to_string()],
@@ -3439,27 +3458,23 @@ fn detached_cook_is_the_only_split_placement_command_eligible_for_queue_admissio
 
 #[test]
 fn unmaterialized_cook_admission_keeps_stale_unavailable_and_capacity_distinct() {
-    let readiness = |state| runners::LabRunnerReadiness {
-        state,
+    let readiness = |state: &str| homeboy::core::parsed_command_preflight::LabReadinessSnapshot {
+        state: state.to_string(),
         selected_runner_id: None,
         available_runner_ids: Vec::new(),
         reasons: Vec::new(),
         remediation_commands: Vec::new(),
     };
     assert_eq!(
-        unmaterialized_admission_state(Some(&readiness(runners::LabRunnerReadinessState::Stale))),
+        unmaterialized_admission_state(Some(&readiness("stale"))),
         "blocked_runner_stale"
     );
     assert_eq!(
-        unmaterialized_admission_state(Some(&readiness(
-            runners::LabRunnerReadinessState::Disconnected
-        ))),
+        unmaterialized_admission_state(Some(&readiness("disconnected"))),
         "blocked_runner_unavailable"
     );
     assert_eq!(
-        unmaterialized_admission_state(Some(&readiness(
-            runners::LabRunnerReadinessState::CapacityBlocked
-        ))),
+        unmaterialized_admission_state(Some(&readiness("capacity_blocked"))),
         "queued"
     );
 }
@@ -3470,14 +3485,18 @@ fn admission_capability_contract_accepts_runtime_or_capability_and_rejects_missi
         runtime_ids: ["runtime-a".to_string()].into_iter().collect(),
         capabilities: ["capability-a".to_string()].into_iter().collect(),
     };
-    assert!(runner_inventory_satisfies_admission_capabilities(
-        &inventory,
-        &["runtime-a", "capability-a"].into_iter().collect(),
-    ));
-    assert!(!runner_inventory_satisfies_admission_capabilities(
-        &inventory,
-        &["missing"].into_iter().collect(),
-    ));
+    assert!(
+        crate::cli_runtime::runner_inventory_satisfies_admission_capabilities(
+            &inventory,
+            &["runtime-a", "capability-a"].into_iter().collect(),
+        )
+    );
+    assert!(
+        !crate::cli_runtime::runner_inventory_satisfies_admission_capabilities(
+            &inventory,
+            &["missing"].into_iter().collect(),
+        )
+    );
 }
 
 #[test]
@@ -3527,7 +3546,10 @@ fn replay_intent_reconstructs_cook_from_references_without_secret_values() {
             .argv
             .iter()
             .any(|arg| arg == "--detach-after-handoff"));
-        assert!(!intent.argv.iter().any(|arg| arg == "--placement"));
+        assert!(intent
+            .argv
+            .windows(2)
+            .any(|pair| pair[0] == "--placement" && pair[1] == "auto"));
         assert!(intent.argv.iter().any(|arg| arg == "--prompt"));
         assert!(intent.argv.iter().any(|arg| arg == "--private-verify-file"));
         assert_eq!(intent.input_refs.len(), 3);
@@ -3544,7 +3566,7 @@ fn replay_intent_reconstructs_cook_from_references_without_secret_values() {
             .windows(2)
             .any(|pair| pair[0] == "--prompt" && pair[1].starts_with("homeboy-replay-ref:")));
         let mut replay = intent.argv.clone();
-        replay.splice(1..1, ["--runner".to_string(), "lab".to_string()]);
+        replay.extend(["--runner".to_string(), "lab".to_string()]);
         let replay =
             Cli::try_parse_from(replay).expect("intent reconstructs normal Cook CLI inputs");
         assert_eq!(replay.runner.as_deref(), Some("lab"));
@@ -4160,6 +4182,11 @@ fn reconnect_replay_reuses_normal_cook_path_without_local_or_duplicate_materiali
                         &cli,
                         None,
                         Some("fake-reconnected-runner"),
+                        &crate::cli_runtime::placement_directive(
+                            &cli,
+                            Some("fake-reconnected-runner"),
+                            false,
+                        ),
                         None,
                         Some(dispatcher.clone()),
                         Some(Arc::clone(&local_executor)),
@@ -4284,8 +4311,8 @@ fn split_placement_cook_without_a_runner_reports_readiness_not_a_placement_contr
         "--prompt",
         "route this attempt to Lab",
     ]);
-    let readiness = runners::LabRunnerReadiness {
-        state: runners::LabRunnerReadinessState::Disconnected,
+    let readiness = homeboy::core::parsed_command_preflight::LabReadinessSnapshot {
+        state: "disconnected".to_string(),
         selected_runner_id: None,
         available_runner_ids: vec!["homeboy-lab".to_string()],
         reasons: vec!["homeboy-lab is disconnected".to_string()],
@@ -4371,8 +4398,9 @@ fn cold_lab_or_local_records_an_admitted_local_fallback() {
         "fall back locally when admitted",
     ]);
 
-    let decision = placement_decision(&cli, None, "cook-provider-attempt", Some(source.path()))
-        .expect("cold controller may select local fallback");
+    let decision =
+        fixture_preflight_decision(&cli, None, "cook-provider-attempt", Some(source.path()))
+            .expect("cold controller may select local fallback");
 
     assert!(decision.permits_local_execution());
     assert!(decision.fallback.local_allowed);
@@ -4396,8 +4424,9 @@ fn explicit_local_placement_records_audited_override_authorization() {
         "run locally with operator authorization",
     ]);
 
-    let decision = placement_decision(&cli, None, "cook-provider-attempt", Some(source.path()))
-        .expect("explicit local placement resolves");
+    let decision =
+        fixture_preflight_decision(&cli, None, "cook-provider-attempt", Some(source.path()))
+            .expect("explicit local placement resolves");
 
     assert!(decision.permits_local_execution());
     assert!(decision.override_authorization.authorized);

--- a/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
@@ -5,6 +5,22 @@ use clap::Parser;
 use std::fs;
 use tempfile::tempdir;
 
+fn capture_fixture_preflight(cli: &Cli, normalized: &[String]) {
+    homeboy::core::parsed_command_preflight::reset_captured_result_for_test();
+    homeboy::core::parsed_command_preflight::capture_result(
+        homeboy::core::parsed_command_preflight::ParsedCommandPreflightResult::new(
+            normalized.to_vec(),
+            resource_policy::parsed_command_preflight_input(cli, normalized),
+            None,
+            None,
+            homeboy::core::parsed_command_preflight::DeferredWorkloadDecision::NotApplicable,
+            homeboy::core::parsed_command_preflight::FallbackDirective::None,
+            crate::cli_runtime::placement_directive(cli, cli.runner.as_deref(), false),
+            cli.runner.clone(),
+        ),
+    );
+}
+
 #[test]
 fn rig_install_offload_translates_source_path_instead_of_forwarding_it() {
     let source_dir = tempdir().expect("source dir");
@@ -53,6 +69,7 @@ fn linked_local_rig_check_stays_local_without_runner() {
         "linked-local".to_string(),
     ];
     let cli = Cli::parse_from(&normalized);
+    capture_fixture_preflight(&cli, &normalized);
 
     let outcome = route_after_parse_with_provenance(&cli, &normalized, None, None)
         .expect("linked local rig check should skip automatic Lab offload");
@@ -97,6 +114,7 @@ fn extension_update_routes_locally_without_explicit_lab_runner() {
         "wordpress".to_string(),
     ];
     let cli = Cli::parse_from(&normalized);
+    capture_fixture_preflight(&cli, &normalized);
 
     let outcome = route_after_parse_with_provenance(&cli, &normalized, None, None)
         .expect("extension update without --runner should not offload");
@@ -123,6 +141,7 @@ fn extension_dev_run_keeps_its_runner_workflow_on_the_controller() {
         "wordpress".to_string(),
     ];
     let cli = Cli::parse_from(&normalized);
+    capture_fixture_preflight(&cli, &normalized);
 
     let outcome = route_after_parse_with_provenance(&cli, &normalized, None, None)
         .expect("dev-run should execute its own runner lifecycle");
@@ -142,6 +161,7 @@ fn fuzz_doctor_routes_locally_without_explicit_lab_runner() {
         "nodejs".to_string(),
     ];
     let cli = Cli::parse_from(&normalized);
+    capture_fixture_preflight(&cli, &normalized);
 
     let outcome = route_after_parse_with_provenance(&cli, &normalized, None, None)
         .expect("fuzz doctor without --runner should remain a local diagnostic");
@@ -427,40 +447,38 @@ fn default_placement_provider_discovery_stays_local_despite_connected_default_ru
 #[test]
 fn hot_cook_with_explicit_lab_placement_uses_the_admitted_ready_runner() {
     homeboy::core::resource_policy_context::reset_captured_context_for_test();
-    homeboy::core::resource_policy_context::capture_context(
-        homeboy::core::resource_policy_context::ResourcePolicyContext {
-            command: "agent-task cook".to_string(),
-            severity: "hot".to_string(),
-            local_override: false,
-            warned: true,
-            message: None,
-            runner_selection:
-                homeboy::core::resource_policy_context::ResourcePolicyRunnerSelection {
-                    runner_id: Some("admitted-lab".to_string()),
-                    available_runner_ids: vec!["admitted-lab".to_string()],
-                    readiness_state: "connected_ready".to_string(),
-                    readiness_reasons: Vec::new(),
-                    remediation_commands: Vec::new(),
-                    reason: "default_lab_runner".to_string(),
-                },
-            host: homeboy::core::resource_policy_context::ResourcePolicyHostSnapshot {
-                load_severity: "hot".to_string(),
-                load_one: None,
-                load_five: None,
-                load_fifteen: None,
-                cpu_count: 1,
-                memory_severity: None,
-                memory_used_percent: None,
-                memory_available_mb: None,
-                memory_total_mb: None,
-                relevant_process_count: 0,
-                process_severity: "ok".to_string(),
-                active_rig_lease_count: 0,
-                rig_lease_severity: "ok".to_string(),
-                rig_lease_concurrency_limit: None,
-            },
+    homeboy::core::parsed_command_preflight::reset_captured_result_for_test();
+    let context = homeboy::core::resource_policy_context::ResourcePolicyContext {
+        command: "agent-task cook".to_string(),
+        severity: "hot".to_string(),
+        local_override: false,
+        warned: true,
+        message: None,
+        runner_selection: homeboy::core::resource_policy_context::ResourcePolicyRunnerSelection {
+            runner_id: Some("admitted-lab".to_string()),
+            available_runner_ids: vec!["admitted-lab".to_string()],
+            readiness_state: "connected_ready".to_string(),
+            readiness_reasons: Vec::new(),
+            remediation_commands: Vec::new(),
+            reason: "default_lab_runner".to_string(),
         },
-    );
+        host: homeboy::core::resource_policy_context::ResourcePolicyHostSnapshot {
+            load_severity: "hot".to_string(),
+            load_one: None,
+            load_five: None,
+            load_fifteen: None,
+            cpu_count: 1,
+            memory_severity: None,
+            memory_used_percent: None,
+            memory_available_mb: None,
+            memory_total_mb: None,
+            relevant_process_count: 0,
+            process_severity: "ok".to_string(),
+            active_rig_lease_count: 0,
+            rig_lease_severity: "ok".to_string(),
+            rig_lease_concurrency_limit: None,
+        },
+    };
     let cli = Cli::parse_from([
         "homeboy",
         "agent-task",
@@ -470,15 +488,49 @@ fn hot_cook_with_explicit_lab_placement_uses_the_admitted_ready_runner() {
         "--to-worktree",
         "repo@hot-cook",
     ]);
-    let command = lab_offload_command(&cli.command)
-        .expect("Lab route contract resolves")
-        .expect("Cook has a Lab route contract");
-
-    let selected = admitted_lab_runner_id(&cli, Some(&command))
-        .flatten()
-        .expect("hot controller admission retains the ready runner");
-    let decision = placement_decision(&cli, Some(&selected), "cook", None)
-        .expect("explicit Lab placement is admissible with a ready runner");
+    homeboy::core::parsed_command_preflight::capture_result(
+        homeboy::core::parsed_command_preflight::ParsedCommandPreflightResult::new(
+            vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+            ],
+            resource_policy::parsed_command_preflight_input(
+                &cli,
+                &[
+                    "homeboy".to_string(),
+                    "agent-task".to_string(),
+                    "cook".to_string(),
+                ],
+            ),
+            Some(context),
+            Some(
+                homeboy::core::parsed_command_preflight::LabReadinessSnapshot {
+                    state: "connected_ready".to_string(),
+                    selected_runner_id: Some("admitted-lab".to_string()),
+                    available_runner_ids: vec!["admitted-lab".to_string()],
+                    reasons: Vec::new(),
+                    remediation_commands: Vec::new(),
+                },
+            ),
+            homeboy::core::parsed_command_preflight::DeferredWorkloadDecision::NotApplicable,
+            homeboy::core::parsed_command_preflight::FallbackDirective::None,
+            crate::cli_runtime::placement_directive(&cli, Some("admitted-lab"), false),
+            Some("admitted-lab".to_string()),
+        ),
+    );
+    let preflight =
+        homeboy::core::parsed_command_preflight::captured_result().expect("fixture preflight");
+    assert_eq!(
+        preflight
+            .placement
+            .runner
+            .as_ref()
+            .expect("hot controller admission retains the ready runner")
+            .runner_id,
+        "admitted-lab"
+    );
+    let decision = finalize_placement(&preflight.placement, "cook", None);
     assert_eq!(decision.requested, crate::cli_surface::Placement::Lab);
     assert_eq!(
         decision.selected,
@@ -489,6 +541,7 @@ fn hot_cook_with_explicit_lab_placement_uses_the_admitted_ready_runner() {
         "admitted-lab"
     );
     homeboy::core::resource_policy_context::reset_captured_context_for_test();
+    homeboy::core::parsed_command_preflight::reset_captured_result_for_test();
 }
 
 #[test]
@@ -590,6 +643,7 @@ fn agent_task_fanout_submit_batch_requires_explicit_runner_under_lab_placement()
         "fanout.json".to_string(),
     ];
     let cli = Cli::parse_from(&normalized);
+    capture_fixture_preflight(&cli, &normalized);
 
     let command = lab_offload_command(&cli.command).unwrap().unwrap();
     assert_eq!(command.hot_label, "agent-task fanout submit-batch");
@@ -1038,7 +1092,15 @@ fn route_runner_for(args: &[&str], inferred: &Option<String>) -> Option<String> 
     let lab_command = lab_offload_command(&cli.command)
         .expect("lab route contract resolves")
         .expect("agent-task commands carry a Lab contract");
-    generic_route_runner_id(&cli, Some(&lab_command), inferred).map(str::to_string)
+    inferred.as_deref().and_then(|runner| {
+        (cli.runner.is_some()
+            || lab_routing::authorizes_policy_lab_runner(
+                &lab_command.command,
+                cli.placement,
+                lab_routing::captured_pressure_severity().as_deref(),
+            ))
+        .then(|| runner.to_string())
+    })
 }
 
 #[test]

--- a/crates/homeboy-cli/src/commands/utils/execution_provenance.rs
+++ b/crates/homeboy-cli/src/commands/utils/execution_provenance.rs
@@ -4,7 +4,7 @@ use std::sync::{OnceLock, RwLock};
 
 use serde_json::{json, Value};
 
-use crate::cli_surface::{Cli, Placement};
+use crate::cli_surface::Placement;
 
 const SCHEMA: &str = "homeboy/execution-provenance/v1";
 
@@ -16,12 +16,12 @@ fn captured_storage() -> &'static RwLock<Option<Value>> {
 /// Capture normalized, redacted intent before placement routing consumes its
 /// transport markers. The same original argv reaches a Lab child, where its
 /// resolved execution identity is recorded independently.
-pub fn capture(cli: &Cli, normalized_args: &[String]) {
+pub fn capture(result: &homeboy::core::parsed_command_preflight::ParsedCommandPreflightResult) {
     let mut slot = captured_storage()
         .write()
         .unwrap_or_else(|error| error.into_inner());
     if slot.is_none() {
-        *slot = Some(build(cli, normalized_args));
+        *slot = Some(build(result));
     }
 }
 
@@ -75,23 +75,63 @@ pub fn captured() -> Option<Value> {
     captured_storage().read().ok().and_then(|slot| slot.clone())
 }
 
-fn build(cli: &Cli, normalized_args: &[String]) -> Value {
-    let execution = homeboy::core::resource_policy_context::lab_execution_runner_id()
-        .map(|runner_id| ("lab", Some(runner_id)))
-        .unwrap_or(("controller", None));
-    build_with_execution(cli, normalized_args, execution.0, execution.1)
-}
-
-fn build_with_execution(
-    cli: &Cli,
-    normalized_args: &[String],
-    location: &str,
-    runner_id: Option<String>,
-) -> Value {
-    let argv = redact_execution_argv(normalized_args);
+fn build(result: &homeboy::core::parsed_command_preflight::ParsedCommandPreflightResult) -> Value {
+    let argv = redact_execution_argv(&result.normalized_args);
     let rerun_command = homeboy::core::redaction::redact_argv_shell_display(&argv);
-    let placement = placement_name(cli.placement);
-    let decision_origin = decision_origin(cli.placement, cli.runner.is_some(), location);
+    let placement = match result.placement.requested {
+        homeboy_lab_runner_contract::Placement::Auto => "auto",
+        homeboy_lab_runner_contract::Placement::Local => "local",
+        homeboy_lab_runner_contract::Placement::Lab => "lab",
+        homeboy_lab_runner_contract::Placement::LabOrLocal => "lab-or-local",
+    };
+    let directive_location = match result.placement.selected {
+        homeboy_lab_runner_contract::EffectiveExecutionPlacement::Lab => "lab",
+        homeboy_lab_runner_contract::EffectiveExecutionPlacement::Local => "controller",
+    };
+    // Split-placement coordinators dispatch children later; this invocation is
+    // still controller-owned even when its child placement directive is Lab.
+    let location = if result.input.controller_execution
+        == homeboy::core::parsed_command_preflight::ControllerExecution::Ordinary
+    {
+        directive_location
+    } else {
+        "controller"
+    };
+    let policy_runner_id = result
+        .placement
+        .runner
+        .as_ref()
+        .filter(|runner| {
+            runner.source == homeboy_lab_runner_contract::RunnerSelectionSource::Policy
+        })
+        .map(|runner| runner.runner_id.clone());
+    let explicit_runner_id = match &result.input.runner {
+        homeboy::core::parsed_command_preflight::RunnerIntent::Explicit(runner_id) => {
+            Some(runner_id.clone())
+        }
+        _ => None,
+    };
+    let runner_id = (location == "lab")
+        .then(|| {
+            explicit_runner_id
+                .clone()
+                .or_else(|| policy_runner_id.clone())
+        })
+        .flatten();
+    let decision_origin =
+        if result.placement.requested == homeboy_lab_runner_contract::Placement::Lab {
+            "explicit"
+        } else {
+            match result.placement.runner.as_ref().map(|runner| runner.source) {
+                Some(homeboy_lab_runner_contract::RunnerSelectionSource::Explicit) => "explicit",
+                Some(homeboy_lab_runner_contract::RunnerSelectionSource::Policy) => "automatic",
+                None if result.placement.override_authorization.authorized => "explicit",
+                None if result.placement.fallback.local_allowed => "fallback",
+                _ => "automatic",
+            }
+        };
+    let runner_env = flag_values(&argv, "--runner-env");
+    let lab_env_json = flag_values(&argv, "--lab-env-json").into_iter().last();
 
     json!({
         "schema": SCHEMA,
@@ -99,13 +139,13 @@ fn build_with_execution(
             "argv": argv,
             "rerun_command": rerun_command,
             "placement": placement,
-            "runner_id": cli.runner,
+            "runner_id": explicit_runner_id,
             "global_flags": {
-                "detach_after_handoff": cli.detach_after_handoff,
-                "allow_dirty_lab_workspace": cli.allow_dirty_lab_workspace,
-                "skip_deps_hydration": cli.skip_deps_hydration,
-                "runner_env": cli.runner_env.iter().map(|value| redact_env_assignment(value, &homeboy::core::redaction::RedactionPolicy::default())).collect::<Vec<_>>(),
-                "lab_env_json": cli.lab_env_json.as_ref().map(|value| redact_json_env(value, &homeboy::core::redaction::RedactionPolicy::default())),
+                "detach_after_handoff": argv.iter().any(|arg| arg == "--detach-after-handoff"),
+                "allow_dirty_lab_workspace": argv.iter().any(|arg| arg == "--allow-dirty-lab-workspace"),
+                "skip_deps_hydration": argv.iter().any(|arg| arg == "--skip-deps-hydration"),
+                "runner_env": runner_env,
+                "lab_env_json": lab_env_json,
             },
         },
         "resolved_execution": {
@@ -114,11 +154,26 @@ fn build_with_execution(
         },
         "resource_policy": {
             "decision_origin": decision_origin,
-            "preflight": crate::commands::utils::resource_policy::captured_context()
-                .as_ref()
+            "preflight": result.resource_policy.as_ref()
                 .map(crate::commands::utils::resource_policy::resource_policy_context_to_json),
         },
     })
+}
+
+fn flag_values(args: &[String], flag: &str) -> Vec<String> {
+    let mut values = Vec::new();
+    let mut next = false;
+    for arg in args {
+        if next {
+            values.push(arg.clone());
+            next = false;
+        } else if arg == flag {
+            next = true;
+        } else if let Some(value) = arg.strip_prefix(&format!("{flag}=")) {
+            values.push(value.to_string());
+        }
+    }
+    values
 }
 
 fn redact_execution_argv(args: &[String]) -> Vec<String> {
@@ -225,7 +280,21 @@ mod tests {
             .map(|arg| (*arg).to_string())
             .collect::<Vec<_>>();
         let cli = Cli::try_parse_from(&argv).expect("parse CLI");
-        build(&cli, &argv)
+        let runner_id = cli.runner.as_deref();
+        build(
+            &homeboy::core::parsed_command_preflight::ParsedCommandPreflightResult::new(
+                argv.clone(),
+                crate::commands::utils::resource_policy::parsed_command_preflight_input(
+                    &cli, &argv,
+                ),
+                None,
+                None,
+                homeboy::core::parsed_command_preflight::DeferredWorkloadDecision::NotApplicable,
+                homeboy::core::parsed_command_preflight::FallbackDirective::None,
+                crate::cli_runtime::placement_directive(&cli, runner_id, false),
+                runner_id.map(str::to_string),
+            ),
+        )
     }
 
     #[test]
@@ -301,12 +370,40 @@ mod tests {
             .map(|arg| (*arg).to_string())
             .collect::<Vec<_>>();
         let cli = Cli::try_parse_from(&argv).expect("parse CLI");
-        let value = build_with_execution(&cli, &argv, "lab", Some("runner-a".to_string()));
+        let value = build(
+            &homeboy::core::parsed_command_preflight::ParsedCommandPreflightResult::new(
+                argv.clone(),
+                crate::commands::utils::resource_policy::parsed_command_preflight_input(
+                    &cli, &argv,
+                ),
+                None,
+                None,
+                homeboy::core::parsed_command_preflight::DeferredWorkloadDecision::NotApplicable,
+                homeboy::core::parsed_command_preflight::FallbackDirective::None,
+                crate::cli_runtime::placement_directive(&cli, Some("runner-a"), false),
+                Some("runner-a".to_string()),
+            ),
+        );
 
         assert_eq!(value["operator_intent"]["placement"], "lab");
+        assert_eq!(value["operator_intent"]["runner_id"], Value::Null);
         assert_eq!(value["resolved_execution"]["location"], "lab");
         assert_eq!(value["resolved_execution"]["runner_id"], "runner-a");
+        assert!(value["resource_policy"].get("policy_runner_id").is_none());
         assert_eq!(value["resource_policy"]["decision_origin"], "explicit");
+    }
+
+    #[test]
+    fn v1_resource_policy_shape_has_no_policy_runner_field() {
+        let value = provenance(&["homeboy", "review"]);
+        let policy = value["resource_policy"].as_object().expect("policy object");
+        assert_eq!(
+            policy.keys().map(String::as_str).collect::<Vec<_>>(),
+            ["decision_origin", "preflight"]
+        );
+        assert!(!serde_json::to_string(&value)
+            .expect("serialize provenance")
+            .contains("policy_runner_id"));
     }
 
     #[test]
@@ -325,6 +422,27 @@ mod tests {
 
         assert!(command.contains("--placement local"));
         assert!(!command.contains("secret-value"));
+    }
+
+    #[test]
+    fn preserves_redacted_runner_and_lab_environment_flag_shapes() {
+        let value = provenance(&[
+            "homeboy",
+            "--runner-env",
+            "MODE=test",
+            "--runner-env=API_TOKEN=secret-value",
+            "--lab-env-json",
+            "{\"token\":\"secret-value\",\"mode\":\"test\"}",
+            "review",
+        ]);
+        assert_eq!(
+            value["operator_intent"]["global_flags"]["runner_env"],
+            json!(["MODE=test", "API_TOKEN=[redacted]"])
+        );
+        assert_eq!(
+            value["operator_intent"]["global_flags"]["lab_env_json"],
+            json!("{\"mode\":\"test\",\"token\":\"[REDACTED]\"}")
+        );
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
@@ -1,7 +1,7 @@
 mod classification;
 mod messages;
 
-use crate::cli_surface::Commands;
+use crate::cli_surface::{Cli, Commands, Placement};
 use crate::command_contract::LabCommandPortability;
 use crate::command_contract::LabCommandRoute;
 use crate::commands::agent_task;
@@ -31,6 +31,133 @@ pub use crate::core::resource_policy_context::{
     is_runner_hosted_exec, ResourcePolicyContext, ResourcePolicyHostSnapshot,
     ResourcePolicyRunnerSelection,
 };
+
+/// Translate the static parsed command tree into the parser-independent
+/// preflight contract. This is intentionally an adapter: command-family
+/// predicates remain above core, while capability-provided parsers can produce
+/// the same input without depending on `Cli` or `Commands`.
+pub(crate) fn parsed_command_preflight_input(
+    cli: &Cli,
+    normalized_args: &[String],
+) -> crate::core::parsed_command_preflight::ParsedCommandPreflightInput {
+    use crate::core::parsed_command_preflight::{
+        ControllerExecution, DeferredWorkloadPolicy, LabRouteIntent, ParsedCommandPreflightInput,
+        PlacementIntent, ProvenanceRequirement, ResourceAdmissionRequirement, ResourceHeat,
+        RunnerIntent, RunnerNormalization,
+    };
+
+    let resource_admission =
+        hot_command(&cli.command).map_or(ResourceAdmissionRequirement::Exempt, |command| {
+            ResourceAdmissionRequirement::Required {
+                label: command.label.to_string(),
+                engages_at: if command.offload_only_when_hot {
+                    ResourceHeat::Hot
+                } else {
+                    ResourceHeat::Warm
+                },
+            }
+        });
+    let controller_execution = if is_controller_owned_fanout_coordination(&cli.command)
+        || is_plan_only_command(&cli.command)
+        || is_bounded_agent_task_metadata_read(&cli.command)
+        || is_local_registry_management(&cli.command)
+    {
+        ControllerExecution::ControllerOnly
+    } else if hot_command(&cli.command)
+        .is_some_and(|command| command.allows_warm_runner_coordination)
+    {
+        ControllerExecution::SplitPlacementCoordinator
+    } else {
+        ControllerExecution::Ordinary
+    };
+    let placement = match cli.placement {
+        Placement::Auto => PlacementIntent::Auto,
+        Placement::Local => PlacementIntent::Local,
+        Placement::Lab => PlacementIntent::Lab,
+        Placement::LabOrLocal => PlacementIntent::LabOrLocal,
+    };
+    let runner = if let Some(runner) = &cli.runner {
+        RunnerIntent::Explicit(runner.clone())
+    } else if matches!(&cli.command, Commands::Runs(_))
+        && normalized_args
+            .iter()
+            .any(|arg| arg == "--runner" || arg.starts_with("--runner="))
+    {
+        RunnerIntent::CommandLocal
+    } else {
+        RunnerIntent::Default
+    };
+    let runner_normalization = if matches!(
+        &cli.command,
+        Commands::AgentTask(agent_task::AgentTaskArgs {
+            command: agent_task::AgentTaskCommand::Cook(_),
+        })
+    ) && normalized_args
+        .iter()
+        .any(|arg| arg == "--runner" || arg.starts_with("--runner="))
+    {
+        RunnerNormalization::PinnedCookArgv
+    } else if matches!(&cli.command, Commands::Runs(_)) {
+        RunnerNormalization::RunsCommandOption
+    } else {
+        RunnerNormalization::None
+    };
+    let lab_route = cli
+        .command
+        .lab_contract()
+        .map_or(LabRouteIntent::Unsupported, |contract| {
+            LabRouteIntent::Supported {
+                automatic: matches!(contract.portability, LabCommandPortability::Portable),
+            }
+        });
+    let deferred_workload = if matches!(
+        &cli.command,
+        Commands::Review(review)
+            if matches!(review.command, Some(crate::commands::review::ReviewCommand::Test(_)))
+                && review.lab_contract().is_some_and(|contract| contract.is_portable())
+    ) {
+        DeferredWorkloadPolicy::Eligible
+    } else {
+        DeferredWorkloadPolicy::Forbidden
+    };
+    let contract_label = cli
+        .command
+        .lab_contract()
+        .map(|contract| contract.hot_label);
+    ParsedCommandPreflightInput {
+        // This is parsed-command metadata, never an argv position: globals may
+        // precede the command. #13241 supplies the equivalent metadata for
+        // dynamic capabilities; this branch intentionally leaves their runtime
+        // integration unchanged.
+        identity: parsed_command_identity(&cli.command),
+        resource_admission,
+        controller_execution,
+        deferred_workload,
+        placement,
+        runner,
+        runner_normalization,
+        lab_route,
+        provenance: contract_label
+            .is_some()
+            .then_some(ProvenanceRequirement::CaptureExecution)
+            .unwrap_or(ProvenanceRequirement::None),
+    }
+}
+
+fn parsed_command_identity(
+    command: &Commands,
+) -> crate::core::parsed_command_preflight::ParsedCommandIdentity {
+    let label = command
+        .lab_contract()
+        .map(|contract| contract.hot_label)
+        .or_else(|| hot_command(command).map(|command| command.label))
+        .unwrap_or("controller command");
+    let mut segments = label.split_whitespace();
+    crate::core::parsed_command_preflight::ParsedCommandIdentity {
+        family: segments.next().unwrap_or("controller").to_string(),
+        operation: segments.map(str::to_string).collect(),
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HotCommand {
@@ -72,10 +199,25 @@ impl HotCommand {
     /// Cheap commands only engage at `hot`; everything else engages once the
     /// machine leaves `ok` (i.e. at `warm`).
     fn engages_resource_admission(&self, recommendation: ResourceRecommendation) -> bool {
-        match recommendation {
-            ResourceRecommendation::Ok => false,
-            ResourceRecommendation::Warm => !self.offload_only_when_hot,
-            ResourceRecommendation::Hot => true,
+        matches!(
+            crate::core::parsed_command_preflight::evaluate_resource_admission(
+                &self.resource_admission_requirement(),
+                resource_admission_evidence_for_recommendation(recommendation),
+            ),
+            crate::core::parsed_command_preflight::ResourceAdmissionDecision::Rejected { .. }
+        )
+    }
+
+    fn resource_admission_requirement(
+        &self,
+    ) -> crate::core::parsed_command_preflight::ResourceAdmissionRequirement {
+        crate::core::parsed_command_preflight::ResourceAdmissionRequirement::Required {
+            label: self.label.to_string(),
+            engages_at: if self.offload_only_when_hot {
+                crate::core::parsed_command_preflight::ResourceHeat::Hot
+            } else {
+                crate::core::parsed_command_preflight::ResourceHeat::Warm
+            },
         }
     }
 }
@@ -174,6 +316,42 @@ pub(crate) fn resource_policy_context_to_json(
     context: &ResourcePolicyContext,
 ) -> serde_json::Value {
     serde_json::to_value(context).unwrap_or(serde_json::Value::Null)
+}
+
+/// Copy runner-owned readiness evidence into the parser-independent preflight
+/// result. Route consumers must not reopen the runner inventory.
+pub(crate) fn lab_readiness_snapshot(
+    readiness: &LabRunnerReadiness,
+) -> crate::core::parsed_command_preflight::LabReadinessSnapshot {
+    crate::core::parsed_command_preflight::LabReadinessSnapshot {
+        state: readiness.state.as_str().to_string(),
+        selected_runner_id: readiness.selected_runner_id.clone(),
+        available_runner_ids: readiness.available_runner_ids.clone(),
+        reasons: readiness.reasons.clone(),
+        remediation_commands: readiness.remediation_commands.clone(),
+    }
+}
+
+/// Preserve the built-in resource evaluator's pressure observation while
+/// delegating the requirement threshold and verdict to core.
+pub(crate) fn resource_admission_evidence(
+    resources: &DoctorOutput,
+) -> crate::core::parsed_command_preflight::ResourceAdmissionEvidence {
+    resource_admission_evidence_for_recommendation(resources.recommendation)
+}
+
+fn resource_admission_evidence_for_recommendation(
+    recommendation: ResourceRecommendation,
+) -> crate::core::parsed_command_preflight::ResourceAdmissionEvidence {
+    use crate::core::parsed_command_preflight::{ResourceAdmissionEvidence, ResourceHeat};
+
+    ResourceAdmissionEvidence::Observed {
+        pressure: match recommendation {
+            ResourceRecommendation::Ok => ResourceHeat::None,
+            ResourceRecommendation::Warm => ResourceHeat::Warm,
+            ResourceRecommendation::Hot => ResourceHeat::Hot,
+        },
+    }
 }
 
 fn runner_selection_context(
@@ -718,6 +896,258 @@ mod tests {
             allows_warm_runner_coordination: false,
             offload_only_when_hot: false,
         }
+    }
+
+    #[test]
+    fn generic_and_builtin_preflight_resolve_the_same_policy_matrix() {
+        use crate::core::parsed_command_preflight::{
+            ControllerExecution, DeferredWorkloadDecision, DeferredWorkloadPolicy,
+            GenericRoutePolicySnapshot, LabReadinessSnapshot, LabRouteIntent,
+            ParsedCommandIdentity, ParsedCommandPolicySnapshot, ParsedCommandPreflightInput,
+            PlacementIntent, ProvenanceRequirement, ResourceAdmissionEvidence,
+            ResourceAdmissionRequirement, ResourceHeat, RunnerIntent, RunnerNormalization,
+        };
+
+        let input = |placement, runner, controller_execution, identity, deferred_workload| {
+            ParsedCommandPreflightInput {
+                identity,
+                resource_admission: ResourceAdmissionRequirement::Required {
+                    label: "review test".to_string(),
+                    engages_at: ResourceHeat::Warm,
+                },
+                controller_execution,
+                deferred_workload,
+                placement,
+                runner,
+                runner_normalization: RunnerNormalization::None,
+                lab_route: LabRouteIntent::Supported { automatic: true },
+                provenance: ProvenanceRequirement::CaptureExecution,
+            }
+        };
+        let snapshot =
+            |selected_runner_id: Option<&str>, deferred_workload, fallback, state: &str| {
+                ParsedCommandPolicySnapshot {
+                    resource_admission_evidence: ResourceAdmissionEvidence::Observed {
+                        pressure: ResourceHeat::None,
+                    },
+                    resource_policy: None,
+                    lab_readiness: Some(LabReadinessSnapshot {
+                        state: state.to_string(),
+                        selected_runner_id: selected_runner_id.map(str::to_string),
+                        available_runner_ids: selected_runner_id
+                            .map(str::to_string)
+                            .into_iter()
+                            .collect(),
+                        reasons: Vec::new(),
+                        remediation_commands: Vec::new(),
+                    }),
+                    selected_runner_id: selected_runner_id.map(str::to_string),
+                    generic_route: GenericRoutePolicySnapshot {
+                        command_supports_lab: true,
+                        automatic_authorized: selected_runner_id.is_some(),
+                        selected_runner_id: selected_runner_id.map(str::to_string),
+                    },
+                    deferred_pressure_refusal: deferred_workload == DeferredWorkloadDecision::Defer,
+                    runner_admitted: selected_runner_id.is_some(),
+                    runner_incompatible: deferred_workload
+                        == DeferredWorkloadDecision::RunnerIncompatible,
+                    auto_local_capacity_fallback: fallback,
+                }
+            };
+        let cases = [
+            (
+                "cold",
+                vec!["homeboy", "review", "test"],
+                PlacementIntent::Auto,
+                RunnerIntent::Default,
+                ControllerExecution::Ordinary,
+                DeferredWorkloadDecision::NotApplicable,
+                false,
+                None,
+                "connected_ready",
+            ),
+            (
+                "hot pressure rejection",
+                vec!["homeboy", "review", "test"],
+                PlacementIntent::Auto,
+                RunnerIntent::Default,
+                ControllerExecution::Ordinary,
+                DeferredWorkloadDecision::Defer,
+                false,
+                None,
+                "disconnected",
+            ),
+            (
+                "controller-only",
+                vec!["homeboy", "review", "test"],
+                PlacementIntent::Auto,
+                RunnerIntent::Default,
+                ControllerExecution::ControllerOnly,
+                DeferredWorkloadDecision::NotApplicable,
+                false,
+                None,
+                "connected_ready",
+            ),
+            (
+                "deferred",
+                vec!["homeboy", "--placement", "lab-or-local", "review", "test"],
+                PlacementIntent::LabOrLocal,
+                RunnerIntent::Default,
+                ControllerExecution::Ordinary,
+                DeferredWorkloadDecision::Defer,
+                false,
+                None,
+                "disconnected",
+            ),
+            (
+                "explicit local",
+                vec!["homeboy", "--placement", "local", "review", "test"],
+                PlacementIntent::Local,
+                RunnerIntent::Default,
+                ControllerExecution::Ordinary,
+                DeferredWorkloadDecision::NotApplicable,
+                false,
+                None,
+                "connected_ready",
+            ),
+            (
+                "explicit Lab",
+                vec!["homeboy", "--placement", "lab", "review", "test"],
+                PlacementIntent::Lab,
+                RunnerIntent::Default,
+                ControllerExecution::Ordinary,
+                DeferredWorkloadDecision::NotApplicable,
+                false,
+                Some("lab-a"),
+                "connected_ready",
+            ),
+            (
+                "explicit runner",
+                vec!["homeboy", "--runner", "lab-a", "review", "test"],
+                PlacementIntent::Auto,
+                RunnerIntent::Explicit("lab-a".to_string()),
+                ControllerExecution::Ordinary,
+                DeferredWorkloadDecision::NotApplicable,
+                false,
+                Some("lab-a"),
+                "connected_ready",
+            ),
+            (
+                "stale",
+                vec!["homeboy", "review", "test"],
+                PlacementIntent::Auto,
+                RunnerIntent::Default,
+                ControllerExecution::Ordinary,
+                DeferredWorkloadDecision::NotApplicable,
+                false,
+                None,
+                "stale",
+            ),
+            (
+                "unavailable",
+                vec!["homeboy", "review", "test"],
+                PlacementIntent::Auto,
+                RunnerIntent::Default,
+                ControllerExecution::Ordinary,
+                DeferredWorkloadDecision::NotApplicable,
+                false,
+                None,
+                "disconnected",
+            ),
+            (
+                "capacity blocked",
+                vec!["homeboy", "review", "test"],
+                PlacementIntent::Auto,
+                RunnerIntent::Default,
+                ControllerExecution::Ordinary,
+                DeferredWorkloadDecision::NotApplicable,
+                false,
+                None,
+                "capacity_blocked",
+            ),
+            (
+                "fallback",
+                vec!["homeboy", "--placement", "lab-or-local", "review", "test"],
+                PlacementIntent::LabOrLocal,
+                RunnerIntent::Default,
+                ControllerExecution::Ordinary,
+                DeferredWorkloadDecision::NotApplicable,
+                true,
+                None,
+                "disconnected",
+            ),
+        ];
+        for (
+            name,
+            argv,
+            placement,
+            runner,
+            controller_execution,
+            deferred,
+            fallback,
+            selected,
+            state,
+        ) in cases
+        {
+            let normalized = argv
+                .iter()
+                .map(|arg| (*arg).to_string())
+                .collect::<Vec<_>>();
+            let cli = Cli::parse_from(&normalized);
+            let generic = crate::core::parsed_command_preflight::resolve_parsed_command_preflight(
+                normalized.clone(),
+                input(
+                    placement,
+                    runner,
+                    controller_execution,
+                    ParsedCommandIdentity {
+                        family: "review".to_string(),
+                        operation: vec!["test".to_string()],
+                    },
+                    DeferredWorkloadPolicy::Eligible,
+                ),
+                snapshot(selected, deferred.clone(), fallback, state),
+            )
+            .expect("generic fixture is internally consistent");
+            let builtin = crate::core::parsed_command_preflight::resolve_parsed_command_preflight(
+                normalized.clone(),
+                parsed_command_preflight_input(&cli, &normalized),
+                snapshot(selected, deferred, fallback, state),
+            )
+            .expect("builtin fixture is internally consistent");
+            assert_eq!(generic.placement, builtin.placement, "{name}");
+            assert_eq!(
+                generic.deferred_workload, builtin.deferred_workload,
+                "{name}"
+            );
+            assert_eq!(generic.fallback, builtin.fallback, "{name}");
+            assert_eq!(
+                generic.generic_route_runner_id, builtin.generic_route_runner_id,
+                "{name}"
+            );
+        }
+
+        let normalized = vec![
+            "homeboy".to_string(),
+            "--placement".to_string(),
+            "lab".to_string(),
+            "review".to_string(),
+            "test".to_string(),
+        ];
+        let cli = Cli::parse_from(&normalized);
+        let builtin = parsed_command_preflight_input(&cli, &normalized);
+        assert_eq!(
+            builtin.identity,
+            ParsedCommandIdentity {
+                family: "review".to_string(),
+                operation: vec!["test".to_string()]
+            }
+        );
+        assert_eq!(builtin.provenance, ProvenanceRequirement::CaptureExecution);
+        assert_eq!(
+            normalized,
+            vec!["homeboy", "--placement", "lab", "review", "test"]
+        );
     }
 
     #[test]

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -137,6 +137,7 @@ pub mod observation;
 pub mod output;
 pub(crate) mod ownership;
 pub use homeboy_lab_contract::path_materialization;
+pub mod parsed_command_preflight;
 pub mod performance_hotspots;
 // `phase_timing` (PhaseTimer/PhaseSpan/PhaseStatus/PhaseTimingReport) is a
 // std-only timing primitive shared by deploy, release, and the audit engine. It

--- a/crates/homeboy-core/src/parsed_command_preflight.rs
+++ b/crates/homeboy-core/src/parsed_command_preflight.rs
@@ -1,0 +1,655 @@
+//! Typed, parser-independent admission and placement preflight contract.
+//!
+//! Command families translate parsed values into this contract above core.
+//! Core deliberately does not know Clap, `Cli`, or a product command enum.
+
+use serde::{Deserialize, Serialize};
+use std::sync::{OnceLock, RwLock};
+
+use crate::resource_policy_context::ResourcePolicyContext;
+use homeboy_lab_runner_contract::{
+    EffectiveExecutionPlacement, ExecutionPlacementDecision, ExecutionPlacementFallback,
+    ExecutionPlacementIdentity, ExecutionPlacementOverrideAuthorization,
+    ExecutionPlacementRequirement, ExecutionPlacementRunnerSelection, Placement,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ParsedCommandIdentity {
+    pub family: String,
+    pub operation: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResourceHeat {
+    None,
+    Warm,
+    Hot,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ResourceAdmissionRequirement {
+    Exempt,
+    Required {
+        label: String,
+        engages_at: ResourceHeat,
+    },
+}
+
+/// Raw runtime pressure evidence. Adapters report observations, never an
+/// admission verdict; the shared evaluator owns the verdict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ResourceAdmissionEvidence {
+    Observed { pressure: ResourceHeat },
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ResourceAdmissionDecision {
+    NotRequired,
+    Admitted,
+    Rejected {
+        label: String,
+        engages_at: ResourceHeat,
+        evidence: ResourceAdmissionEvidence,
+    },
+}
+
+/// Derive admission solely from declared requirements and raw runtime evidence.
+/// Missing evidence rejects required work so adapters cannot accidentally bless
+/// execution by omitting a probe.
+pub fn evaluate_resource_admission(
+    requirement: &ResourceAdmissionRequirement,
+    evidence: ResourceAdmissionEvidence,
+) -> ResourceAdmissionDecision {
+    let ResourceAdmissionRequirement::Required { label, engages_at } = requirement else {
+        return ResourceAdmissionDecision::NotRequired;
+    };
+    let admitted = matches!(evidence, ResourceAdmissionEvidence::Observed { pressure } if pressure < *engages_at);
+    if admitted {
+        ResourceAdmissionDecision::Admitted
+    } else {
+        ResourceAdmissionDecision::Rejected {
+            label: label.clone(),
+            engages_at: *engages_at,
+            evidence,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ControllerExecution {
+    Ordinary,
+    ControllerOnly,
+    SplitPlacementCoordinator,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeferredWorkloadPolicy {
+    Forbidden,
+    Eligible,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlacementIntent {
+    Auto,
+    Local,
+    Lab,
+    LabOrLocal,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerIntent {
+    Default,
+    Explicit(String),
+    CommandLocal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerNormalization {
+    None,
+    RunsCommandOption,
+    PinnedCookArgv,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum LabRouteIntent {
+    Unsupported,
+    Supported { automatic: bool },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProvenanceRequirement {
+    None,
+    CaptureExecution,
+}
+
+/// All policy facts required before executing a parsed command.
+///
+/// Nested enums replace optional bags: adapters state every policy axis and
+/// unrecognized command shapes naturally remain non-routable/non-deferred.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ParsedCommandPreflightInput {
+    pub identity: ParsedCommandIdentity,
+    pub resource_admission: ResourceAdmissionRequirement,
+    pub controller_execution: ControllerExecution,
+    pub deferred_workload: DeferredWorkloadPolicy,
+    pub placement: PlacementIntent,
+    pub runner: RunnerIntent,
+    pub runner_normalization: RunnerNormalization,
+    pub lab_route: LabRouteIntent,
+    pub provenance: ProvenanceRequirement,
+}
+
+/// Typed runner inventory consumed by a parsed-command preflight.  This is
+/// deliberately independent of the Lab runner implementation so any command
+/// parser can provide the same evidence to the generic execution contract.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LabReadinessSnapshot {
+    pub state: String,
+    pub selected_runner_id: Option<String>,
+    pub available_runner_ids: Vec<String>,
+    pub reasons: Vec<String>,
+    pub remediation_commands: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeferredWorkloadDecision {
+    NotApplicable,
+    Dispatch,
+    Defer,
+    RunnerIncompatible,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FallbackDirective {
+    None,
+    LocalCapacity,
+    LocalAllowed,
+    RequiredLabUnavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GenericRoutePolicySnapshot {
+    pub command_supports_lab: bool,
+    pub automatic_authorized: bool,
+    pub selected_runner_id: Option<String>,
+}
+
+/// Runtime evidence gathered by a command adapter before resolution. Keeping
+/// this separate from parsed intent lets non-Clap command surfaces use the
+/// same resolver without importing runner or resource-policy implementations.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ParsedCommandPolicySnapshot {
+    /// Raw controller-pressure evidence consumed by the shared admission
+    /// evaluator. This is deliberately not a caller-provided decision.
+    pub resource_admission_evidence: ResourceAdmissionEvidence,
+    pub resource_policy: Option<ResourcePolicyContext>,
+    pub lab_readiness: Option<LabReadinessSnapshot>,
+    pub selected_runner_id: Option<String>,
+    pub generic_route: GenericRoutePolicySnapshot,
+    /// Raw admission facts. The resolver derives the deferred outcome from the
+    /// command policy instead of accepting a preassembled result axis.
+    pub deferred_pressure_refusal: bool,
+    pub runner_admitted: bool,
+    pub runner_incompatible: bool,
+    pub auto_local_capacity_fallback: bool,
+}
+
+/// Resolve generic Lab routing from immutable adapter facts. The caller records
+/// command-contract and pressure authorization before route begins.
+pub fn resolve_generic_route_runner(
+    input: &ParsedCommandPreflightInput,
+    policy: &GenericRoutePolicySnapshot,
+) -> Option<String> {
+    if !policy.command_supports_lab || input.controller_execution != ControllerExecution::Ordinary {
+        return None;
+    }
+    match (&input.runner, &input.placement) {
+        (_, PlacementIntent::Local) => None,
+        (RunnerIntent::Explicit(_), _) => policy.selected_runner_id.clone(),
+        _ if policy.automatic_authorized => policy.selected_runner_id.clone(),
+        _ => None,
+    }
+}
+
+/// Resolve every execution-policy axis from parser-independent command intent
+/// and one immutable runtime snapshot. Consumers receive this completed result
+/// and must not reconstruct individual decisions from ambient state.
+pub fn resolve_parsed_command_preflight(
+    normalized_args: Vec<String>,
+    input: ParsedCommandPreflightInput,
+    policy: ParsedCommandPolicySnapshot,
+) -> crate::Result<ParsedCommandPreflightResult> {
+    if policy.generic_route.command_supports_lab
+        && !matches!(input.lab_route, LabRouteIntent::Supported { .. })
+    {
+        return Err(crate::Error::validation_invalid_argument(
+            "generic_route",
+            "generic Lab routing requires a supported Lab route intent",
+            None,
+            None,
+        ));
+    }
+    if policy.generic_route.selected_runner_id != policy.selected_runner_id {
+        return Err(crate::Error::validation_invalid_argument(
+            "generic_route.selected_runner_id",
+            "generic route runner must equal the primary selected runner",
+            policy.generic_route.selected_runner_id.clone(),
+            None,
+        ));
+    }
+    if policy.selected_runner_id.is_some()
+        && (!policy.runner_admitted
+            || !policy.lab_readiness.as_ref().is_some_and(|readiness| {
+                readiness.state == "connected_ready"
+                    && readiness.selected_runner_id == policy.selected_runner_id
+                    && readiness
+                        .available_runner_ids
+                        .iter()
+                        .any(|runner| Some(runner) == policy.selected_runner_id.as_ref())
+            }))
+    {
+        return Err(crate::Error::validation_invalid_argument(
+            "selected_runner_id",
+            "selected runner requires admitted connected readiness evidence",
+            policy.selected_runner_id.clone(),
+            None,
+        ));
+    }
+    if policy.runner_admitted && policy.runner_incompatible {
+        return Err(crate::Error::validation_invalid_argument(
+            "runner_admission",
+            "runner cannot be both admitted and incompatible",
+            None,
+            None,
+        ));
+    }
+    if policy.auto_local_capacity_fallback
+        && !matches!(
+            input.placement,
+            PlacementIntent::Auto | PlacementIntent::LabOrLocal
+        )
+    {
+        return Err(crate::Error::validation_invalid_argument(
+            "fallback",
+            "local capacity fallback requires auto or lab-or-local placement",
+            None,
+            None,
+        ));
+    }
+    let resource_admission = evaluate_resource_admission(
+        &input.resource_admission,
+        policy.resource_admission_evidence,
+    );
+    let deferred_workload = match input.deferred_workload {
+        DeferredWorkloadPolicy::Forbidden => {
+            if policy.deferred_pressure_refusal || policy.runner_incompatible {
+                return Err(crate::Error::validation_invalid_argument(
+                    "deferred_workload",
+                    "deferred evidence requires an eligible deferred workload policy",
+                    None,
+                    None,
+                ));
+            }
+            DeferredWorkloadDecision::NotApplicable
+        }
+        DeferredWorkloadPolicy::Eligible if policy.runner_admitted => {
+            DeferredWorkloadDecision::Dispatch
+        }
+        DeferredWorkloadPolicy::Eligible if policy.runner_incompatible => {
+            DeferredWorkloadDecision::RunnerIncompatible
+        }
+        DeferredWorkloadPolicy::Eligible if policy.deferred_pressure_refusal => {
+            DeferredWorkloadDecision::Defer
+        }
+        DeferredWorkloadPolicy::Eligible => DeferredWorkloadDecision::NotApplicable,
+    };
+    let required = if matches!(input.placement, PlacementIntent::Lab)
+        || matches!(input.runner, RunnerIntent::Explicit(_))
+    {
+        ExecutionPlacementRequirement::Lab
+    } else {
+        ExecutionPlacementRequirement::Either
+    };
+    let selected = if matches!(input.placement, PlacementIntent::Local)
+        || policy.selected_runner_id.is_none()
+    {
+        EffectiveExecutionPlacement::Local
+    } else {
+        EffectiveExecutionPlacement::Lab
+    };
+    let runner =
+        policy
+            .selected_runner_id
+            .as_ref()
+            .map(|runner_id| ExecutionPlacementRunnerSelection {
+                runner_id: runner_id.clone(),
+                source: if matches!(input.runner, RunnerIntent::Explicit(_)) {
+                    homeboy_lab_runner_contract::RunnerSelectionSource::Explicit
+                } else {
+                    homeboy_lab_runner_contract::RunnerSelectionSource::Policy
+                },
+            });
+    let fallback = if policy.auto_local_capacity_fallback {
+        FallbackDirective::LocalCapacity
+    } else if matches!(input.placement, PlacementIntent::Lab) && policy.selected_runner_id.is_none()
+    {
+        FallbackDirective::RequiredLabUnavailable
+    } else {
+        FallbackDirective::None
+    };
+    let placement = PlacementDirective {
+        requested: match input.placement {
+            PlacementIntent::Auto => Placement::Auto,
+            PlacementIntent::Local => Placement::Local,
+            PlacementIntent::Lab => Placement::Lab,
+            PlacementIntent::LabOrLocal => Placement::LabOrLocal,
+        },
+        required,
+        selected,
+        runner,
+        fallback: ExecutionPlacementFallback {
+            local_allowed: required != ExecutionPlacementRequirement::Lab
+                && (policy.auto_local_capacity_fallback
+                    || matches!(
+                        input.placement,
+                        PlacementIntent::Auto | PlacementIntent::LabOrLocal
+                    )),
+            reason: None,
+        },
+        override_authorization: ExecutionPlacementOverrideAuthorization {
+            authorized: matches!(input.placement, PlacementIntent::Local),
+            authority: matches!(input.placement, PlacementIntent::Local)
+                .then(|| "operator --placement local".to_string()),
+        },
+    };
+    let generic_route_runner_id = resolve_generic_route_runner(&input, &policy.generic_route);
+    Ok(ParsedCommandPreflightResult {
+        normalized_args,
+        input,
+        resource_admission,
+        resource_policy: policy.resource_policy,
+        lab_readiness: policy.lab_readiness,
+        deferred_workload,
+        fallback,
+        placement,
+        generic_route_runner_id,
+        selected_runner_id: policy.selected_runner_id,
+    })
+}
+
+/// Fully resolved placement policy. Parsed-command preflight owns every policy
+/// input; route only binds the identity produced by materialization.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlacementDirective {
+    pub requested: Placement,
+    pub required: ExecutionPlacementRequirement,
+    pub selected: EffectiveExecutionPlacement,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runner: Option<ExecutionPlacementRunnerSelection>,
+    pub fallback: ExecutionPlacementFallback,
+    pub override_authorization: ExecutionPlacementOverrideAuthorization,
+}
+
+impl PlacementDirective {
+    /// Bind materialized workload identity without observing command, runner,
+    /// resource, or process state. This is deliberately the only late phase.
+    pub fn finalize(&self, identity: ExecutionPlacementIdentity) -> ExecutionPlacementDecision {
+        ExecutionPlacementDecision::new(
+            "lab-route-contract",
+            "v1",
+            identity,
+            self.requested,
+            self.required,
+            self.selected,
+            self.runner.clone(),
+            self.fallback.clone(),
+            self.override_authorization.clone(),
+        )
+    }
+}
+
+/// The immutable controller-side decision consumed by execution and dispatch.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ParsedCommandPreflightResult {
+    /// The exact argv after runtime normalization. No downstream consumer may
+    /// inspect process argv to recreate any part of this decision.
+    pub normalized_args: Vec<String>,
+    pub input: ParsedCommandPreflightInput,
+    pub resource_admission: ResourceAdmissionDecision,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource_policy: Option<ResourcePolicyContext>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lab_readiness: Option<LabReadinessSnapshot>,
+    pub deferred_workload: DeferredWorkloadDecision,
+    pub fallback: FallbackDirective,
+    pub placement: PlacementDirective,
+    /// Generic Lab routing authority resolved during preflight. Route consumes
+    /// this value and never reopens command policy or pressure state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generic_route_runner_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_runner_id: Option<String>,
+}
+
+impl ParsedCommandPreflightResult {
+    pub fn new(
+        normalized_args: Vec<String>,
+        input: ParsedCommandPreflightInput,
+        resource_policy: Option<ResourcePolicyContext>,
+        lab_readiness: Option<LabReadinessSnapshot>,
+        deferred_workload: DeferredWorkloadDecision,
+        fallback: FallbackDirective,
+        placement: PlacementDirective,
+        selected_runner_id: Option<String>,
+    ) -> Self {
+        Self {
+            normalized_args,
+            input,
+            resource_admission: ResourceAdmissionDecision::NotRequired,
+            resource_policy,
+            lab_readiness,
+            deferred_workload,
+            fallback,
+            generic_route_runner_id: None,
+            placement,
+            selected_runner_id,
+        }
+    }
+}
+
+fn result_storage() -> &'static RwLock<Option<ParsedCommandPreflightResult>> {
+    static STORAGE: OnceLock<RwLock<Option<ParsedCommandPreflightResult>>> = OnceLock::new();
+    STORAGE.get_or_init(|| RwLock::new(None))
+}
+
+/// Capture exactly one completed controller decision for the process. Routing
+/// consumes this rather than repeating readiness or placement discovery.
+pub fn capture_result(result: ParsedCommandPreflightResult) {
+    let mut slot = result_storage()
+        .write()
+        .unwrap_or_else(|error| error.into_inner());
+    if slot.is_none() {
+        *slot = Some(result);
+    }
+}
+
+pub fn captured_result() -> Option<ParsedCommandPreflightResult> {
+    result_storage().read().ok().and_then(|slot| slot.clone())
+}
+
+#[cfg(any(test, feature = "test-support"))]
+pub fn reset_captured_result_for_test() {
+    if let Ok(mut slot) = result_storage().write() {
+        *slot = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generic_input_is_a_complete_serializable_contract() {
+        let input = ParsedCommandPreflightInput {
+            identity: ParsedCommandIdentity {
+                family: "fixture".into(),
+                operation: vec!["run".into()],
+            },
+            resource_admission: ResourceAdmissionRequirement::Required {
+                label: "fixture run".into(),
+                engages_at: ResourceHeat::Warm,
+            },
+            controller_execution: ControllerExecution::Ordinary,
+            deferred_workload: DeferredWorkloadPolicy::Eligible,
+            placement: PlacementIntent::LabOrLocal,
+            runner: RunnerIntent::Default,
+            runner_normalization: RunnerNormalization::None,
+            lab_route: LabRouteIntent::Supported { automatic: true },
+            provenance: ProvenanceRequirement::CaptureExecution,
+        };
+        let round_trip: ParsedCommandPreflightInput =
+            serde_json::from_value(serde_json::to_value(&input).expect("serialize"))
+                .expect("deserialize");
+        assert_eq!(round_trip, input);
+    }
+
+    #[test]
+    fn placement_directive_finalizes_only_late_identity() {
+        use homeboy_lab_runner_contract::{
+            EffectiveExecutionPlacement, ExecutionPlacementFallback, ExecutionPlacementIdentity,
+            ExecutionPlacementOverrideAuthorization, ExecutionPlacementRequirement, Placement,
+        };
+
+        let directive = PlacementDirective {
+            requested: Placement::LabOrLocal,
+            required: ExecutionPlacementRequirement::Either,
+            selected: EffectiveExecutionPlacement::Lab,
+            runner: None,
+            fallback: ExecutionPlacementFallback {
+                local_allowed: true,
+                reason: Some("ready runner admission".to_string()),
+            },
+            override_authorization: ExecutionPlacementOverrideAuthorization {
+                authorized: false,
+                authority: None,
+            },
+        };
+        let decision = directive.finalize(ExecutionPlacementIdentity {
+            repository: "fixture".to_string(),
+            workspace: "/tmp/fixture".to_string(),
+            task: "late-materialized-task".to_string(),
+            candidate: Some("candidate".to_string()),
+            base: Some("base".to_string()),
+        });
+
+        assert_eq!(decision.requested, directive.requested);
+        assert_eq!(decision.selected, directive.selected);
+        assert_eq!(decision.fallback, directive.fallback);
+        assert_eq!(decision.identity.task, "late-materialized-task");
+    }
+
+    #[test]
+    fn generic_resolver_requires_support_ordinary_execution_and_authorization() {
+        let input = ParsedCommandPreflightInput {
+            identity: ParsedCommandIdentity {
+                family: "fixture".into(),
+                operation: vec![],
+            },
+            resource_admission: ResourceAdmissionRequirement::Exempt,
+            controller_execution: ControllerExecution::Ordinary,
+            deferred_workload: DeferredWorkloadPolicy::Forbidden,
+            placement: PlacementIntent::Auto,
+            runner: RunnerIntent::Default,
+            runner_normalization: RunnerNormalization::None,
+            lab_route: LabRouteIntent::Supported { automatic: true },
+            provenance: ProvenanceRequirement::None,
+        };
+        let policy = GenericRoutePolicySnapshot {
+            command_supports_lab: true,
+            automatic_authorized: true,
+            selected_runner_id: Some("lab-a".into()),
+        };
+        assert_eq!(
+            resolve_generic_route_runner(&input, &policy).as_deref(),
+            Some("lab-a")
+        );
+        assert_eq!(
+            resolve_generic_route_runner(
+                &input,
+                &GenericRoutePolicySnapshot {
+                    automatic_authorized: false,
+                    ..policy
+                }
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn resolver_fails_closed_for_impossible_admission_and_deferred_evidence() {
+        let input = ParsedCommandPreflightInput {
+            identity: ParsedCommandIdentity {
+                family: "fixture".into(),
+                operation: vec![],
+            },
+            resource_admission: ResourceAdmissionRequirement::Exempt,
+            controller_execution: ControllerExecution::Ordinary,
+            deferred_workload: DeferredWorkloadPolicy::Forbidden,
+            placement: PlacementIntent::Auto,
+            runner: RunnerIntent::Default,
+            runner_normalization: RunnerNormalization::None,
+            lab_route: LabRouteIntent::Unsupported,
+            provenance: ProvenanceRequirement::None,
+        };
+        let policy = ParsedCommandPolicySnapshot {
+            resource_admission_evidence: ResourceAdmissionEvidence::Unavailable,
+            resource_policy: None,
+            lab_readiness: None,
+            selected_runner_id: Some("lab-a".into()),
+            generic_route: GenericRoutePolicySnapshot {
+                command_supports_lab: false,
+                automatic_authorized: false,
+                selected_runner_id: Some("lab-a".into()),
+            },
+            deferred_pressure_refusal: false,
+            runner_admitted: false,
+            runner_incompatible: false,
+            auto_local_capacity_fallback: false,
+        };
+        assert!(
+            resolve_parsed_command_preflight(vec!["fixture".into()], input.clone(), policy)
+                .is_err()
+        );
+
+        let policy = ParsedCommandPolicySnapshot {
+            resource_admission_evidence: ResourceAdmissionEvidence::Unavailable,
+            resource_policy: None,
+            lab_readiness: None,
+            selected_runner_id: None,
+            generic_route: GenericRoutePolicySnapshot {
+                command_supports_lab: false,
+                automatic_authorized: false,
+                selected_runner_id: None,
+            },
+            deferred_pressure_refusal: true,
+            runner_admitted: false,
+            runner_incompatible: false,
+            auto_local_capacity_fallback: false,
+        };
+        assert!(resolve_parsed_command_preflight(vec!["fixture".into()], input, policy).is_err());
+    }
+}


### PR DESCRIPTION
Refs #13262
Supports #13215 and #13175

## Delivered boundary

- Adds parser-independent `ParsedCommandPreflightInput`, raw policy/readiness evidence, fail-closed admission/deferred/fallback resolution, immutable `ParsedCommandPreflightResult`, and a pure late `PlacementDirective::finalize(identity)` phase in `homeboy-core`.
- Adapts built-in `Cli`/`Commands` policy above core while keeping core free of Clap and command-family types.
- Captures normalized argv, resource admission, runner readiness, deferred outcome, placement directive, selected runner, and provenance once before built-in routing.
- Deletes built-in route-side readiness lookup, generic runner reauthorization, ambient resource-context fallback, and direct placement reconstruction.
- Makes typed `CliCapability` resource admission active: runtime owns host evidence, required work rejects under pressure or unavailable evidence before execution, admitted work executes once, and exempt work remains runnable.
- Gives dynamic shell extensions an explicit local/no-admission preflight contract without changing their execution behavior.
- Preserves `homeboy/execution-provenance/v1`, including redacted runner/Lab environment fields, explicit operator runner intent, and controller identity for split-placement coordinators.

## Lifecycle

Parsed preflight cannot know the final Cook/run/retry task and workspace identity. It therefore resolves every policy choice into immutable `PlacementDirective`; after materialization, one pure finalizer binds `ExecutionPlacementIdentity` without reading `Cli`, readiness, pressure, or ambient state.

## Verification

- `cargo check --workspace`: passed on rebased current main.
- `cargo test -p homeboy-core parsed_command_preflight --lib`: 4 passed.
- `cargo test -p homeboy-cli --features test-support typed_capability_resource_admission_rejects_before_run_and_admits_once --lib`: passed; proves warm and unavailable rejection before run, no-pressure admission exactly once, exempt hot execution, and standard `homeboy/command-result/v3` failure envelope with `run_created: false`.
- `cargo test -p homeboy-cli --features test-support commands::utils::resource_policy --lib`: 58 passed.
- `cargo test -p homeboy-cli --features test-support hot_cook_with_explicit_lab_placement_uses_the_admitted_ready_runner --lib`: passed.
- Seven of eight provenance tests passed in the grouped run; `preserves_explicit_local_lab_and_runner_intent` blocked on process-global test state and timed out without an assertion failure when isolated.
- `homeboy review lint homeboy --changed-only --placement local --summary`: passed with zero findings before the current-main rebase.
- `cargo fmt --check` and `git diff --check`: passed.
- Generated docs remain unchanged.

## Scope and follow-up

PR #13270 merged while this branch was in progress and introduced descriptor-composed Lab dispatch. This branch preserves it, but that new composed route still constructs its own placement decision. Migrating #13270 to consume `ParsedCommandPreflightResult` remains explicit #13215 integration work; this PR does not claim that newly landed route is already optionalized.

No dependency-graph or binary-size reduction is claimed. The source delta is +2,266/-620 lines across eight files and establishes the reusable boundary required to delete capability edges later.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced resource admission, readiness, deferred routing, placement identity, provenance, and descriptor-capability paths; implemented and iteratively reviewed the extraction; resolved the current-main rebase; and ran the recorded verification. Chris Huber remains responsible for every line.