### PR TITLE
Delete unused recover_completed_cook_operation

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs
@@ -194,50 +194,12 @@ pub fn complete_cook_operation_in_store(
 /// Restore a completed claim only when the caller has independently recovered
 /// the durable side effect. This repairs an interrupted source-record rewrite
 /// without allowing an arbitrary completion marker to invent work.
-pub fn recover_completed_cook_operation(
-    run_id: &str,
-    operation_key: &str,
-    result: Value,
-) -> Result<()> {
-    let run_id = sanitize_run_id(run_id);
-    let now = now_timestamp();
-    store::mutate_record(&run_id, |record| {
-        let metadata = record.ensure_metadata_object();
-        let claims = metadata
-            .entry(OPERATION_CLAIMS_KEY.to_string())
-            .or_insert_with(|| json!([]));
-        if !claims.is_array() {
-            *claims = json!([]);
-        }
-        let claims = claims.as_array_mut().expect("operation claims array");
-        if let Some(claim) = claims
-            .iter()
-            .find(|claim| claim["operation_key"] == json!(operation_key))
-        {
-            return claim["state"] != json!("completed");
-        }
-        claims.push(json!({
-            "operation_key": operation_key,
-            "state": "completed",
-            "leased_at": now,
-            "completed_at": now,
-            "owner_pid": std::process::id(),
-            "result": result,
-            "recovered_from_authoritative_successor": true,
-        }));
-        record.updated_at = Some(now.clone());
-        true
-    })?;
-    Ok(())
-}
-
-/// [`recover_completed_cook_operation`] against an explicitly injected durable
-/// lifecycle root.
 ///
-/// The claim this repairs was taken in some installation and the side effect it
-/// vouches for was recovered there. Restoring the completion marker in a
-/// different home would leave the real claim un-completed while inventing a
-/// completed one beside a record nobody is retrying (#7505).
+/// Takes the lifecycle root explicitly. The claim this repairs was taken in
+/// some installation and the side effect it vouches for was recovered there.
+/// Restoring the completion marker in a different home would leave the real
+/// claim un-completed while inventing a completed one beside a record nobody
+/// is retrying (#7505).
 pub fn recover_completed_cook_operation_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,


### PR DESCRIPTION
## What

`recover_completed_cook_operation` (`crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs:197`) has **no caller anywhere** — not production, not tests. Its only other mention was an intra-doc link from its `_in_store` twin.

It is invisible to `dead_code` because it is `pub` in a `pub mod`, which is why the crate builds clean with it present.

## How it was found

Not by the lint — by scanning the crate's **120 `X` / `X_in_store` twin pairs** for wrappers nobody calls. Three looked unused; two were false positives (passed as function pointers, so a `name(` scan misses them). This is the one real hit.

## Not a thin shim — a second implementation

Worth noting for reviewers: the two were **not** wrapper-and-delegate. The deleted ambient form reached `store::mutate_record` directly rather than calling its own `_in_store` counterpart, so it was a duplicate implementation of the same claim repair, drifting independently.

`recover_completed_cook_operation_in_store` is live (`agent_task_service/execution.rs:1411`) and keeps the behaviour. Its doc comment linked the deleted item, so it now states the behaviour itself rather than referring to a name that no longer resolves.

43 lines deleted.

## Gate

```
$ cargo check --workspace --all-targets -j2      # exit 0, 0 warnings, 0 errors
$ cargo fmt --all -- --check                     # clean
```

`main` itself is currently warning-clean, so this was not something the build would have surfaced.

## AI assistance

Tool(s): OpenCode