### PR TITLE
Collapse dead ambient twins and narrow the agent_tasks facade

### DIFF
--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -445,7 +445,7 @@ pub fn status(batch_id: &str) -> Result<AgentTaskBatchStatusReport> {
 /// Expire a live coordinator only when its durable record proves it never
 /// advanced beyond pre-child admission. Detached supervision uses this to stop
 /// the stranded process as soon as the durable terminal blocker is written.
-pub fn expire_stalled_fanout_admission(batch_id: &str) -> Result<bool> {
+pub(crate) fn expire_stalled_fanout_admission(batch_id: &str) -> Result<bool> {
     AgentTaskBatchStore::from_current_data_root()?.expire_stalled_fanout_admission(batch_id)
 }
 
@@ -891,7 +891,7 @@ where
 
 /// Read the graph-projected executable frontier. Resume callers use this to
 /// avoid finalizing a dependent before its upstream candidate is accepted.
-pub fn fanout_ready_child_run_ids(batch_id: &str) -> Result<Option<HashSet<String>>> {
+pub(crate) fn fanout_ready_child_run_ids(batch_id: &str) -> Result<Option<HashSet<String>>> {
     AgentTaskBatchStore::from_current_data_root()?.fanout_ready_child_run_ids(batch_id)
 }
 
@@ -1545,7 +1545,7 @@ pub fn read_batch_record_in_store(
 /// record's metadata, keyed by the child run id. Repeated resume calls overwrite
 /// the same key so the batch record stays a single, convergent view of what has
 /// been harvested — no duplicate finalization state accumulates (#9525).
-pub fn record_child_finalization(
+pub(crate) fn record_child_finalization(
     batch_id: &str,
     child_run_id: &str,
     finalization: Value,
@@ -1602,7 +1602,7 @@ pub fn record_child_finalization_in_store(
 /// reads exactly this. It is deliberately kept in `metadata` rather than in
 /// `state`, because [`status`] recomputes `state` from live child observation
 /// on every read and would erase a marker written there.
-pub fn record_coordinator_cancellation(batch_id: &str, reason: &str) -> Result<()> {
+pub(crate) fn record_coordinator_cancellation(batch_id: &str, reason: &str) -> Result<()> {
     AgentTaskBatchStore::from_current_data_root()?.record_coordinator_cancellation(batch_id, reason)
 }
 
@@ -1638,7 +1638,7 @@ pub fn record_coordinator_cancellation_in_store(
 /// An unreadable or absent batch record is reported as "not cancelled" rather
 /// than as an error: this is consulted from the coordinator's claim loop, where
 /// a transient read failure must not be allowed to abandon a live batch.
-pub fn coordinator_is_cancelled(batch_id: &str) -> bool {
+pub(crate) fn coordinator_is_cancelled(batch_id: &str) -> bool {
     AgentTaskBatchStore::from_current_data_root()
         .map(|store| store.coordinator_is_cancelled(batch_id))
         .unwrap_or(false)
@@ -1654,7 +1654,7 @@ pub fn coordinator_is_cancelled_in_store(store: &AgentTaskBatchStore, batch_id: 
 
 const COORDINATOR_CANCELLATION_KEY: &str = "coordinator_cancellation";
 
-pub fn dependency_action_receipt(batch_id: &str, key: &str) -> Result<Option<Value>> {
+pub(crate) fn dependency_action_receipt(batch_id: &str, key: &str) -> Result<Option<Value>> {
     AgentTaskBatchStore::from_current_data_root()?.dependency_action_receipt(batch_id, key)
 }
 
@@ -1669,7 +1669,11 @@ pub fn dependency_action_receipt_in_store(
         .map(|_| batch.metadata["dependency_action_receipts"][key].clone()))
 }
 
-pub fn record_dependency_action_receipt(batch_id: &str, key: &str, receipt: Value) -> Result<()> {
+pub(crate) fn record_dependency_action_receipt(
+    batch_id: &str,
+    key: &str,
+    receipt: Value,
+) -> Result<()> {
     AgentTaskBatchStore::from_current_data_root()?
         .record_dependency_action_receipt(batch_id, key, receipt)
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -1382,7 +1382,7 @@ fn terminal_artifact_projection_is_verified_with(
 /// from a verified controller-owned projection. Missing aggregates remain
 /// outside this check so historical terminal records keep their existing
 /// recovery behavior.
-pub fn terminal_artifact_projection_readiness(run_id: &str) -> Result<Option<String>> {
+pub(crate) fn terminal_artifact_projection_readiness(run_id: &str) -> Result<Option<String>> {
     let record = store::read_record(&super::sanitize_run_id(run_id))?;
     terminal_artifact_projection_readiness_for_record(
         &record,
@@ -1421,7 +1421,9 @@ pub fn terminal_artifact_projection_readiness_in_store(
 
 /// Bounded read-only counterpart used by fanout status while coordinators are
 /// writing observations. It intentionally leaves reconciliation to `resume`.
-pub fn terminal_artifact_projection_readiness_bounded(run_id: &str) -> Result<Option<String>> {
+pub(crate) fn terminal_artifact_projection_readiness_bounded(
+    run_id: &str,
+) -> Result<Option<String>> {
     let record = store::read_record_bounded(&super::sanitize_run_id(run_id))?;
     terminal_artifact_projection_readiness_for_record(
         &record,
@@ -2220,7 +2222,7 @@ pub fn verified_controller_artifact_projection_path_in_store(
 /// Resolve a controller-retained artifact by its durable logical identity. This
 /// is intentionally independent of the runner-reported path: Lab workspaces
 /// are disposable after their aggregate has been mirrored.
-pub fn verified_controller_artifact_projection(
+pub(crate) fn verified_controller_artifact_projection(
     run_id: &str,
     task_id: &str,
     logical_artifact_id: &str,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
@@ -102,7 +102,7 @@ pub fn start_candidate_adoption_with_rerun_policy(
     )
 }
 
-pub fn start_candidate_adoption_with_policy(
+pub(crate) fn start_candidate_adoption_with_policy(
     run_id: &str,
     candidate_sha: &str,
     ai_model: &str,
@@ -403,14 +403,6 @@ pub(crate) fn checkpoint_candidate_adoption_in_store(
     Ok(())
 }
 
-pub fn finish_candidate_adoption(
-    run_id: &str,
-    error: Option<String>,
-) -> Result<AgentTaskRunRecord> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    finish_candidate_adoption_in_store(&lifecycle_store, run_id, error)
-}
-
 pub fn finish_candidate_adoption_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
@@ -440,11 +432,6 @@ pub fn finish_candidate_adoption_in_store(
         true
     })?;
     Ok(record.unwrap_or(lifecycle_store.read_record(&run_id)?))
-}
-
-pub fn record_candidate_adoption_result(run_id: &str, result: Value) -> Result<()> {
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    record_candidate_adoption_result_in_store(&lifecycle_store, run_id, result)
 }
 
 pub fn record_candidate_adoption_result_in_store(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -3010,7 +3010,7 @@ pub fn load_controller_plan_in_store(
 
 /// Load a durable plan for a scheduler or provider execution. This is the only
 /// read path allowed to upgrade a legacy execution-budget envelope.
-pub fn load_plan_for_execution(run_id: &str) -> Result<AgentTaskPlan> {
+pub(crate) fn load_plan_for_execution(run_id: &str) -> Result<AgentTaskPlan> {
     let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
     load_plan_for_execution_in_store(&lifecycle_store, run_id)
 }
@@ -3401,7 +3401,7 @@ pub fn reserve_provider_execution_in_store(
 /// Fanout workers are threads and therefore share the coordinator PID. The
 /// provider subprocess is the first process identity unique to one child run;
 /// using it keeps liveness and activity evidence from crossing child records.
-pub fn record_provider_execution_process(
+pub(crate) fn record_provider_execution_process(
     run_id: &str,
     task_id: &str,
     attempt: u32,
@@ -3494,7 +3494,7 @@ pub fn record_cook_progress_in_store(
 
 /// Retain a redacted, bounded controller failure independently of continuation
 /// claim transitions. Claims describe ownership; they must not replace cause.
-pub fn record_cook_controller_failure(
+pub(crate) fn record_cook_controller_failure(
     run_id: &str,
     diagnostic: &Value,
 ) -> Result<AgentTaskRunRecord> {
@@ -3878,7 +3878,7 @@ pub fn record_provider_execution_runtime_evidence_in_store(
     })
 }
 
-pub fn record_provider_execution_runtime_evidence(
+pub(crate) fn record_provider_execution_runtime_evidence(
     run_id: &str,
     task_id: &str,
     attempt: u32,
@@ -4202,7 +4202,7 @@ pub fn claim_next_eligible_queued_run_with_preflight_and_filter_in_store(
 
 /// Scoped queued admission with an explicit remaining budget shared with other
 /// admission phases in the same dispatch invocation.
-pub fn claim_next_eligible_queued_run_with_preflight_and_filter_and_limit(
+pub(crate) fn claim_next_eligible_queued_run_with_preflight_and_filter_and_limit(
     include: impl Fn(&AgentTaskRunRecord) -> bool,
     limit: usize,
     preflight: impl Fn(&AgentTaskRunRecord, &AgentTaskPlan) -> Result<()>,
@@ -5388,8 +5388,8 @@ pub fn list_records_with_health_in_store(
 /// Read the durable registry snapshot without runner reconciliation. Bounded
 /// recovery readers use this path so disconnected historical runner mirrors
 /// cannot delay access to controller-owned state.
-pub fn read_records_with_health() -> Result<(Vec<AgentTaskRunRecord>, AgentTaskRecordHealthSummary)>
-{
+pub(crate) fn read_records_with_health(
+) -> Result<(Vec<AgentTaskRunRecord>, AgentTaskRecordHealthSummary)> {
     read_records_with_health_bounded(1000)
 }
 
@@ -5401,7 +5401,7 @@ pub fn read_records_with_health_in_store(
     read_records_with_health_bounded_in_store(lifecycle_store, 1000)
 }
 
-pub fn read_records_with_health_bounded(
+pub(crate) fn read_records_with_health_bounded(
     limit: usize,
 ) -> Result<(Vec<AgentTaskRunRecord>, AgentTaskRecordHealthSummary)> {
     let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
@@ -5423,7 +5423,7 @@ pub fn read_records_with_health_bounded_in_store(
 ///
 /// Exact-match discovery uses this path so filtering happens before a result is
 /// selected rather than against the ordinary bounded display snapshot.
-pub fn read_all_records_with_health(
+pub(crate) fn read_all_records_with_health(
 ) -> Result<(Vec<AgentTaskRunRecord>, AgentTaskRecordHealthSummary)> {
     let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
     read_all_records_with_health_in_store(&lifecycle_store)
@@ -6307,7 +6307,7 @@ fn durable_local_read_record_in_store(
 
 /// Read the aggregate after a transport reconciliation completed it without
 /// scheduling the controller-side synthetic handoff task.
-pub fn read_aggregate(run_id: &str) -> Result<AgentTaskAggregate> {
+pub(crate) fn read_aggregate(run_id: &str) -> Result<AgentTaskAggregate> {
     let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
     read_aggregate_in_store(&lifecycle_store, run_id)
 }
@@ -6323,7 +6323,7 @@ pub fn read_aggregate_in_store(
 
 /// Read an immutable attempt directly; unlike `read_aggregate`, this never
 /// treats a Cook ID as an alias for its latest attempt.
-pub fn read_attempt_aggregate(run_id: &str) -> Result<AgentTaskAggregate> {
+pub(crate) fn read_attempt_aggregate(run_id: &str) -> Result<AgentTaskAggregate> {
     store::read_aggregate(&sanitize_run_id(run_id))
 }
 
@@ -6560,7 +6560,7 @@ pub fn record_cook_recovery_checkpoint_in_store(
 /// Re-arm a finalized candidate after a dependency rebase. The original
 /// provider output remains authoritative; Cook resumes at the promotion/gate
 /// boundary and finalizes a fresh review only after those gates pass again.
-pub fn invalidate_cook_finalization_for_dependency(
+pub(crate) fn invalidate_cook_finalization_for_dependency(
     run_id: &str,
     dependency_revision: &str,
     next_command: &str,
@@ -6744,7 +6744,7 @@ const COOK_CANDIDATE_SELECTION_WINDOW: usize = 64;
 /// Select the latest attempt with controller-readable actionable patch bytes.
 /// Ties use run ID so duplicate attempt numbers remain deterministic. When no
 /// attempt has candidate bytes, retain the legacy latest attempt for old runs.
-pub fn select_cook_candidate(cook_id: &str) -> Result<AgentTaskCookCandidateSelection> {
+pub(crate) fn select_cook_candidate(cook_id: &str) -> Result<AgentTaskCookCandidateSelection> {
     let index = cook_index(cook_id)?;
     select_cook_candidate_from_index(cook_id, index, None)
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_transport_proxy.rs
@@ -48,7 +48,7 @@ impl TransportProxyRecovery {
 
 /// Reconnect a transport-owned proxy through its durable runner execution
 /// record. `None` means the run is a normal scheduler-owned plan.
-pub fn recover_transport_proxy(run_id: &str) -> Result<Option<TransportProxyRecovery>> {
+pub(crate) fn recover_transport_proxy(run_id: &str) -> Result<Option<TransportProxyRecovery>> {
     recover_transport_proxy_in_store(
         &AgentTaskLifecycleStore::from_current_environment()?,
         run_id,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/logs_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/logs_projection.rs
@@ -20,7 +20,7 @@ pub fn logs_in_store(
     logs_with_raw_in_store(lifecycle_store, run_id, false)
 }
 
-pub fn logs_with_raw(run_id: &str, include_raw: bool) -> Result<AgentTaskRunLog> {
+pub(crate) fn logs_with_raw(run_id: &str, include_raw: bool) -> Result<AgentTaskRunLog> {
     let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
     logs_with_raw_in_store(&lifecycle_store, run_id, include_raw)
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/operation_claims.rs
@@ -194,46 +194,8 @@ pub fn complete_cook_operation_in_store(
 /// Restore a completed claim only when the caller has independently recovered
 /// the durable side effect. This repairs an interrupted source-record rewrite
 /// without allowing an arbitrary completion marker to invent work.
-pub fn recover_completed_cook_operation(
-    run_id: &str,
-    operation_key: &str,
-    result: Value,
-) -> Result<()> {
-    let run_id = sanitize_run_id(run_id);
-    let now = now_timestamp();
-    store::mutate_record(&run_id, |record| {
-        let metadata = record.ensure_metadata_object();
-        let claims = metadata
-            .entry(OPERATION_CLAIMS_KEY.to_string())
-            .or_insert_with(|| json!([]));
-        if !claims.is_array() {
-            *claims = json!([]);
-        }
-        let claims = claims.as_array_mut().expect("operation claims array");
-        if let Some(claim) = claims
-            .iter()
-            .find(|claim| claim["operation_key"] == json!(operation_key))
-        {
-            return claim["state"] != json!("completed");
-        }
-        claims.push(json!({
-            "operation_key": operation_key,
-            "state": "completed",
-            "leased_at": now,
-            "completed_at": now,
-            "owner_pid": std::process::id(),
-            "result": result,
-            "recovered_from_authoritative_successor": true,
-        }));
-        record.updated_at = Some(now.clone());
-        true
-    })?;
-    Ok(())
-}
-
-/// [`recover_completed_cook_operation`] against an explicitly injected durable
-/// lifecycle root.
 ///
+/// Takes the lifecycle root explicitly.
 /// The claim this repairs was taken in some installation and the side effect it
 /// vouches for was recovered there. Restoring the completion marker in a
 /// different home would leave the real claim un-completed while inventing a
@@ -317,7 +279,7 @@ pub fn fail_cook_operation_in_store(
 }
 
 /// Read a single operation claim for reconciliation, if present.
-pub fn operation_claim(run_id: &str, operation_key: &str) -> Result<Option<OperationClaim>> {
+pub(crate) fn operation_claim(run_id: &str, operation_key: &str) -> Result<Option<OperationClaim>> {
     let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
     operation_claim_in_store(&lifecycle_store, run_id, operation_key)
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -1117,7 +1117,7 @@ fn initial_attempt_inputs_match(
     attempt_inputs_match(&left, &right)
 }
 
-pub fn record_recipe_attempt(
+pub(crate) fn record_recipe_attempt(
     cook_id: &str,
     attempt: u32,
     run_id: &str,
@@ -1126,7 +1126,7 @@ pub fn record_recipe_attempt(
     default_store()?.record_recipe_attempt(cook_id, attempt, run_id, plan)
 }
 
-pub fn record_recipe_attempt_replacement(
+pub(crate) fn record_recipe_attempt_replacement(
     cook_id: &str,
     replaced_run_id: &str,
     replacement_run_id: &str,

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -12122,12 +12122,14 @@ fn legacy_adoption_budget_failure_reenters_once_through_review_authority() {
             "historical gate",
         )
         .unwrap();
-        agent_task_lifecycle::finish_candidate_adoption(
+        agent_task_lifecycle::finish_candidate_adoption_in_store(
+            &test_lifecycle_store(),
             &fixture.run_id,
             Some("candidate remediation budget exhausted".to_string()),
         )
         .unwrap();
-        agent_task_lifecycle::record_candidate_adoption_result(
+        agent_task_lifecycle::record_candidate_adoption_result_in_store(
+            &test_lifecycle_store(),
             &fixture.run_id,
             serde_json::json!({
                 "status": "execution_budget_exhausted",

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -178,7 +178,7 @@ pub mod controller_service {
         init_from_spec_for_resume, list, load_materialize_spec_source, mark_human_ready,
         optional_bool, optional_string, optional_string_array, optional_u32, optional_usize,
         plan_from_controller_request, plan_from_spec, prepare_controller_proof,
-        resolve_proof_profile, resume, resume_with_options, run_action, run_next, status,
+        resolve_proof_profile, resume, resume_with_options, run_action, run_next,
         AgentTaskRepoLoopSpec, AgentTaskRepoLoopSpecAbility, AgentTaskRepoLoopSpecAgent,
         AgentTaskRepoLoopSpecArtifact, AgentTaskRepoLoopSpecDependency,
         AgentTaskRepoLoopSpecEntity, AgentTaskRepoLoopSpecEvent, AgentTaskRepoLoopSpecGate,
@@ -206,14 +206,16 @@ pub mod cook_loop {
 
 /// Durable batch/fanout lifecycle records built from independent child runs.
 pub mod batch {
+    pub use super::super::agent_task_batch::status;
     pub use super::super::agent_task_batch::{
-        artifacts, claim_fanout_run_batch, coordinator_is_cancelled, fanout_aggregate_state,
-        fanout_dependency_graph_with_finalization_statuses, fanout_ready_child_run_ids,
+        artifacts, claim_fanout_run_batch, fanout_dependency_graph_with_finalization_statuses,
         heartbeat_fanout_run_batch, owned_child_run_ids, persist_fanout_run_batch,
-        read_batch_record, record_coordinator_cancellation,
-        record_fanout_run_batch_failed_admissions, record_fanout_run_batch_failure, status,
-        submit_plan_batch, AgentTaskBatchArtifactsReport, AgentTaskBatchChildArtifacts,
-        AgentTaskBatchChildRun, AgentTaskBatchCommands, AgentTaskBatchRecord, AgentTaskBatchState,
+        read_batch_record, record_fanout_run_batch_failure,
+    };
+    pub use super::super::agent_task_batch::{
+        fanout_aggregate_state, record_fanout_run_batch_failed_admissions, submit_plan_batch,
+        AgentTaskBatchArtifactsReport, AgentTaskBatchChildArtifacts, AgentTaskBatchChildRun,
+        AgentTaskBatchCommands, AgentTaskBatchRecord, AgentTaskBatchState,
         AgentTaskBatchStatusReport, AgentTaskBatchTotals, FanoutRunBatchChild,
         AGENT_TASK_BATCH_ARTIFACTS_SCHEMA, AGENT_TASK_BATCH_SCHEMA, AGENT_TASK_BATCH_STATUS_SCHEMA,
     };
@@ -301,46 +303,41 @@ pub mod gate {
 /// Durable run lifecycle: submit, run-record state, log/artifact loaders.
 pub mod lifecycle {
     pub use super::super::agent_task_lifecycle::{
-        aggregate_source, artifacts, cancel, cancel_run, claim_cook_operation_in_store,
-        claim_local_cook_retry_launch_in_store,
-        claim_next_eligible_queued_run_with_preflight_and_filter_and_limit,
+        aggregate_source, artifacts, cancel_run, cook_index, durable_local_read,
+        fail_detached_cook_handoff_parent, list_records, load_plan, logs, persisted_status,
+        reconcile_terminal_artifact_projection, record_cook_finalization,
+        recover_unmaterialized_cook_input_publication, retry, run_id_for_aggregate_path,
+        run_record_exists, run_record_exists_readonly, run_status, submit_plan,
+    };
+    pub use super::super::agent_task_lifecycle::{
+        cancel, claim_cook_operation_in_store, claim_local_cook_retry_launch_in_store,
         complete_cook_operation_in_store, consume_unmaterialized_cook_replay_claim,
-        cook_attempt_run_id, cook_index, cook_index_exists, cook_index_exists_in_store,
-        cook_index_in_store, cook_terminal_notification_outcome, durable_local_read,
-        durable_local_read_in_store, exact_durable_local_read_in_store, exact_record,
-        fail_cook_operation_in_store, fail_detached_cook_handoff_parent,
+        cook_attempt_run_id, cook_index_exists_in_store, cook_index_in_store,
+        cook_terminal_notification_outcome, durable_local_read_in_store,
+        exact_durable_local_read_in_store, fail_cook_operation_in_store,
         fail_detached_cook_handoff_parent_in_store, has_accepted_runner_handoff,
-        invalidate_cook_finalization_for_dependency, is_unmaterialized_cook_admission,
-        lifecycle_action_eligibility, list_records, load_controller_plan, load_plan,
-        load_plan_in_store, logs, mark_running, materialize_recovered_patch_artifact,
-        persisted_status, pin_current_controller_runtime, pinned_runtime_for_mutation,
-        precheck_unmaterialized_cook_admission, prepare_unmaterialized_cook_admission,
-        prune_controller_runtime_pins, quarantine_queued_run_exact_in_store,
-        rearm_quarantined_run_in_store, rearm_unmaterialized_cook_admission,
-        reconcile_record_health_in_store, reconcile_terminal_artifact_projection,
-        record_acceptance_verdict_with_feedback_in_store, record_completed_run,
-        record_cook_attempt_in_store, record_cook_finalization, record_cook_finalization_in_store,
-        record_cook_force_with_lease_receipt_in_store, record_detached_cook_handoff_child_in_store,
-        record_detached_cook_handoff_parent_in_store, record_detached_cook_supervisor_in_store,
-        record_detached_lab_run, record_lab_offload_phase, record_lab_offload_planned,
-        record_local_cook_retry_child_in_store, record_local_cook_retry_supervisor_in_store,
-        record_manual_finalization_failure, record_manual_finalization_retry,
-        record_pre_dispatch_failure, record_pre_execution_failure,
-        record_pre_execution_failure_in_store, record_promotion, record_remote_dispatch_failure,
-        record_run_aggregate, record_runner_job_identity,
-        record_unmaterialized_cook_admission_in_store,
-        recover_unmaterialized_cook_input_publication, register_acceptance_verifier,
+        is_unmaterialized_cook_admission, lifecycle_action_eligibility, load_plan_in_store,
+        materialize_recovered_patch_artifact, pin_current_controller_runtime,
+        pinned_runtime_for_mutation, precheck_unmaterialized_cook_admission,
+        prepare_unmaterialized_cook_admission, prune_controller_runtime_pins,
+        quarantine_queued_run_exact_in_store, rearm_quarantined_run_in_store,
+        rearm_unmaterialized_cook_admission, reconcile_record_health_in_store,
+        record_acceptance_verdict_with_feedback_in_store, record_cook_attempt_in_store,
+        record_cook_finalization_in_store, record_cook_force_with_lease_receipt_in_store,
+        record_detached_cook_handoff_child_in_store, record_detached_cook_handoff_parent_in_store,
+        record_detached_cook_supervisor_in_store, record_local_cook_retry_child_in_store,
+        record_local_cook_retry_supervisor_in_store, record_manual_finalization_failure,
+        record_manual_finalization_retry, record_pre_execution_failure_in_store,
+        record_unmaterialized_cook_admission_in_store, register_acceptance_verifier,
         register_acceptance_verifier_from_config,
         release_unmaterialized_cook_replay_claim_after_worker_exit,
         renew_unmaterialized_cook_replay_claim, require_detached_cook_handoff_fence_open_in_store,
         reserve_detached_cook_handoff_materialization_in_store,
         resolve_detached_cook_materializing_attempt_in_store, resolve_promotion_patch_artifact_id,
-        retry, run_id_for_aggregate_path, run_record_exists, run_record_exists_readonly,
-        run_record_exists_resolved_in_store, run_status, runner_diagnostic_probe,
+        run_record_exists_resolved_in_store, runner_diagnostic_probe,
         runner_pinned_runtime_for_mutation, runner_probe_plan, select_cook_candidate_from_attempts,
-        status, status_in_store, status_with_options, submit_plan,
-        transition_execution_placement_for_continuation_in_store,
-        verified_controller_artifact_projection_path, AgentTaskAcceptanceAttestation,
+        status_in_store, status_with_options,
+        transition_execution_placement_for_continuation_in_store, AgentTaskAcceptanceAttestation,
         AgentTaskAcceptanceRecord, AgentTaskAcceptanceRequirement, AgentTaskAcceptanceVerdict,
         AgentTaskAcceptanceVerificationRequest, AgentTaskAcceptanceVerifier,
         AgentTaskAcceptanceVerifierProvenance, AgentTaskActionAvailability,
@@ -359,10 +356,20 @@ pub mod lifecycle {
         RUNNER_PROBE_SKIPPED_CALLER_OPTED_OUT, RUNNER_PROBE_SKIPPED_CONTROLLER_LOCAL,
         RUNNER_PROBE_SKIPPED_NOT_RUNNING,
     };
+    pub use super::super::agent_task_lifecycle::{
+        cook_index_exists, mark_running, record_run_aggregate, record_runner_job_identity,
+        verified_controller_artifact_projection_path,
+    };
+    pub use super::super::agent_task_lifecycle::{
+        exact_record, load_controller_plan, record_detached_lab_run, record_lab_offload_phase,
+        record_lab_offload_planned, record_pre_dispatch_failure, record_pre_execution_failure,
+        record_remote_dispatch_failure, status,
+    };
     #[cfg(feature = "test-support")]
     pub use super::super::agent_task_lifecycle::{
         inject_raw_record_metadata_for_corruption_test, rewrite_record_for_test,
     };
+    pub use super::super::agent_task_lifecycle::{record_completed_run, record_promotion};
 }
 
 /// Durable agent-task loop controller state, events, and policy.
@@ -491,36 +498,34 @@ pub mod secrets {
 
 /// High-level service entry points combining lifecycle and scheduling.
 pub mod service {
+    pub use super::super::agent_task_service::status;
     pub use super::super::agent_task_service::{
         adopt_cook_candidate, adopt_cook_candidate_with_dispatcher,
         adopt_cook_candidate_with_options_and_dispatcher,
         adopt_cook_candidate_with_options_dispatcher_and_executor,
         adopt_cook_candidate_with_options_dispatcher_and_executor_for_attempt, aggregate_exit_code,
-        artifacts, authorize_cook_continue_route, authorize_cook_continue_route_with_artifact,
-        cancel, claim_continuation_for, claim_continuation_for_recovery_in_store,
-        compile_cook_attempt, compile_cook_attempt_with_catalog_and_readiness_cache,
+        authorize_cook_continue_route, authorize_cook_continue_route_with_artifact, cancel,
+        claim_continuation_for, claim_continuation_for_recovery_in_store, compile_cook_attempt,
+        compile_cook_attempt_with_catalog_and_readiness_cache,
         compile_cook_attempt_with_readiness_cache, consume_claimed_terminal_with_dispatcher,
         consume_claimed_with_dispatcher, continuation_state_in_store, cook_batch_job_submission,
         detached_batch_coordinator_control, discover_runs, enqueue_terminal_continuation,
         evidence_ref_task_id, execute_promotion, execute_promotion_with_progress,
-        hydrate_evidence_ref, hydrate_evidence_summary, load_recipe, load_recipe_for_attempt, logs,
-        normalize_plan_workspaces, offloaded_status_remediation, persist_initial_recipe,
+        hydrate_evidence_ref, hydrate_evidence_summary, load_recipe, load_recipe_for_attempt,
+        normalize_plan_workspaces, offloaded_status_remediation,
         persist_manual_finalization_intent, persist_manual_finalization_receipt,
         persist_manual_finalization_retry_intent, persist_provider_boundary_replay_evidence,
-        persisted_status, preflight_cook_continuation_admission,
-        prepare_manual_finalization_identity, promotion_is_resumable, promotion_source, read_plan,
-        reconcile_recipe_attempt_for_continuation, reconcile_terminal_artifact_projection,
+        preflight_cook_continuation_admission, prepare_manual_finalization_identity,
+        promotion_is_resumable, read_plan, reconcile_recipe_attempt_for_continuation,
         reconstruct_adoption_options_with_dispatcher, reconstruct_options_with_dispatcher,
         record_replacement_gate_proof, recover_cook_pr, recover_terminal_transport_proxy_evidence,
-        register_cook_batch_job_driver, register_promotion_job_driver,
-        resolve_cook_continuation_run_id, resolve_supervision_policy, resume, resume_cook,
-        resume_cook_batch, retry, run_cook, run_cook_batch, run_cook_batch_with_control,
-        run_loaded_plan, run_next, run_next_with_cook_dispatcher, run_status, run_submitted,
-        run_submitted_with_timeout, run_terminal_cook_continuation, source_worktree_path, status,
-        submit_plan_spec, terminal_review_form_continuation_is_eligible,
-        terminal_transport_recovery_required, validate_initial_recipe_compatibility,
-        validate_recipe_attempt_record, verify_replacement_gates,
-        AgentTaskCandidateAdoptionOptions, AgentTaskCookAttemptReport,
+        register_cook_batch_job_driver, register_promotion_job_driver, resolve_supervision_policy,
+        resume, resume_cook, resume_cook_batch, run_cook, run_cook_batch,
+        run_cook_batch_with_control, run_loaded_plan, run_next, run_next_with_cook_dispatcher,
+        run_submitted, run_submitted_with_timeout, run_terminal_cook_continuation,
+        source_worktree_path, submit_plan_spec, terminal_review_form_continuation_is_eligible,
+        terminal_transport_recovery_required, validate_recipe_attempt_record,
+        verify_replacement_gates, AgentTaskCandidateAdoptionOptions, AgentTaskCookAttemptReport,
         AgentTaskCookBatchCellReport, AgentTaskCookBatchControl, AgentTaskCookBatchJob,
         AgentTaskCookBatchJobPhase, AgentTaskCookBatchJobRequest, AgentTaskCookBatchOptions,
         AgentTaskCookBatchReport, AgentTaskCookCellError, AgentTaskCookReport,
@@ -533,5 +538,10 @@ pub mod service {
         CookSupervisionTick, CookSupervisor, AGENT_TASK_COOK_BATCH_JOB_TYPE,
         AGENT_TASK_COOK_BATCH_JOB_VERSION, AGENT_TASK_PROMOTION_JOB_TYPE,
         AGENT_TASK_PROMOTION_JOB_VERSION, DETACHED_BATCH_COORDINATOR_ENV,
+    };
+    pub use super::super::agent_task_service::{
+        artifacts, logs, persist_initial_recipe, persisted_status, promotion_source,
+        reconcile_terminal_artifact_projection, resolve_cook_continuation_run_id, retry,
+        run_status, validate_initial_recipe_compatibility,
     };
 }


### PR DESCRIPTION
## The pattern

`homeboy-agents` carries **90 `X` / `X_in_store` pairs**. `X` resolves `AgentTaskLifecycleStore::from_current_environment()` and delegates to the store-rooted form. Every ambient half is `pub` inside a `pub mod`, so `dead_code` cannot see any of them — an unused one costs nothing to keep and nothing surfaces it.

## Grep could not answer this. The compiler could.

My first pass used a caller scan and had a **1-in-3 hit rate**. It missed:

- calls passed as **function pointers** (`terminal_artifact_projection_is_verified` is handed to a higher-order fn, never written as `name(`)
- calls to an **identically-named method** on `AgentTaskLifecycleStore` — a different item that a name grep cannot distinguish

So I used the compiler as the oracle instead: narrow all 90 ambient wrappers **and** their `agent_tasks` facade entries to `pub(crate)`, then let `E0603` name what genuinely escapes. Four restore rounds to convergence.

**87 of 90 are reachable. Three were not.**

## The three

| function | why it was invisible |
|---|---|
| `recover_completed_cook_operation` | no caller anywhere |
| `finish_candidate_adoption` | only `cook_tests.rs` reached the free function; all 14 other hits are the same-named **method** on `AgentTaskLifecycleStore` |
| `record_candidate_adoption_result` | same shape |

<callout accent="#8b5cf6">
`recover_completed_cook_operation` was **not a delegating shim**. It reached `store::mutate_record` directly instead of calling its own `_in_store` twin — a second implementation of the same claim repair, free to drift from the one that is actually used (`agent_task_service/execution.rs:1411`).
</callout>

The two test call sites now use `*_in_store` with `test_lifecycle_store()` — which the rest of `cook_tests.rs` already does. **A test reaching for the ambient environment store is what made these wrappers look alive.**

## Second-order

Deleting them left six `agent_tasks` re-exports provably unused inside the crate too, so they went as well: `status`, `coordinator_is_cancelled`, `fanout_ready_child_run_ids`, `record_coordinator_cancellation`, `invalidate_cook_finalization_for_dependency`, `claim_next_eligible_queued_run_with_preflight_and_filter_and_limit`.

## Net

```
10 files changed, 106 insertions(+), 139 deletions(-)

  3  ambient wrappers deleted
  6  dead facade re-exports removed
 28  ambient wrappers narrowed to pub(crate)  <- dead_code now watches them
  0  items widened
```

The 28 narrowings are the durable part: the next one of these that loses its caller fails the build instead of sitting invisible.

## Audit note

The restore script matches by name, and once widened `cook_pre_execution::record_pre_execution_failure` from `pub(crate)` to `pub` off an unrelated `E0603` for a same-named function in `agent_task_lifecycle`. Caught and reverted. Verified zero remaining widenings:

```
$ git diff -U0 | grep -B1 '^+pub fn ' | grep -c '^-pub(crate) fn '
0
```

## Supersedes #13380

That PR deletes `recover_completed_cook_operation` alone; it is included here with the other two. Close whichever you prefer — do not merge both.

## Gate

```
$ cargo check --workspace --all-targets -j2      # exit 0, 0 warnings, 0 errors
$ cargo fmt --all -- --check                     # clean
```

## AI assistance

Tool(s): OpenCode