### PR TITLE
Renew Cook heartbeat during provider materialization

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -7345,11 +7345,49 @@ fn restore_legacy_cook_provision(plan: &mut AgentTaskPlan) -> Result<()> {
 /// A pending lookup carries no provider path. Resolve the declared exact handle
 /// only after Cook's recipe and first run record exist, then persist that path
 /// before any provider can receive work.
+fn with_controller_pre_provider_heartbeat<T>(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    phase: &str,
+    detail: &str,
+    interval: Duration,
+    operation: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    agent_task_lifecycle::record_cook_progress_in_store(
+        lifecycle_store,
+        run_id,
+        phase,
+        1,
+        Some(detail),
+    )?;
+    let (stop, wait) = mpsc::channel();
+    std::thread::scope(|scope| {
+        scope.spawn(move || loop {
+            match wait.recv_timeout(interval) {
+                Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    let _ = agent_task_lifecycle::record_cook_progress_in_store(
+                        lifecycle_store,
+                        run_id,
+                        phase,
+                        1,
+                        Some(detail),
+                    );
+                }
+            }
+        });
+        let result = operation();
+        let _ = stop.send(());
+        result
+    })
+}
+
 fn materialize_pending_cook_workspace(
     lifecycle_store: &AgentTaskLifecycleStore,
     options: &mut AgentTaskCookServiceOptions,
     effective_lookup_timeout_ms: Option<u64>,
 ) -> Result<()> {
+    let initial_run_id = options.initial_run_id.clone();
     restore_legacy_cook_provision(&mut options.initial_plan)?;
     if options.task_base_sha.is_none() {
         options.task_base_sha = options
@@ -7393,17 +7431,24 @@ fn materialize_pending_cook_workspace(
         ),
     }
     };
-    let mut identity = match resolve(options) {
+    let mut identity = match with_controller_pre_provider_heartbeat(
+        lifecycle_store,
+        &initial_run_id,
+        "worktree_provider_lookup",
+        "resolving controller-owned provider workspace identity",
+        COOK_HEARTBEAT_INTERVAL,
+        || resolve(options),
+    ) {
         Ok(identity) => identity,
         Err(error) if error.details["worktree_provider_lookup"] == "not_found" => {
-            agent_task_lifecycle::record_cook_progress_in_store(
+            match with_controller_pre_provider_heartbeat(
                 lifecycle_store,
-                &options.initial_run_id,
+                &initial_run_id,
                 "worktree_provider_ensure",
-                1,
-                Some("starting controller-owned provider workspace materialization"),
-            )?;
-            match provision_pending_cook_workspace(lifecycle_store, options, &config) {
+                "materializing controller-owned provider workspace",
+                COOK_HEARTBEAT_INTERVAL,
+                || provision_pending_cook_workspace(lifecycle_store, options, &config),
+            ) {
                 Ok(provision) => {
                     // Pin the provider that performed the durable mutation. A later
                     // continuation re-resolves this exact destination through its owner.
@@ -7411,10 +7456,17 @@ fn materialize_pending_cook_workspace(
                         Value::String(provision.resolution.provider_id);
                     agent_task_lifecycle::persist_controller_plan_in_store(
                         lifecycle_store,
-                        &options.initial_run_id,
+                        &initial_run_id,
                         &options.initial_plan,
                     )?;
-                    resolve(options)?
+                    with_controller_pre_provider_heartbeat(
+                        lifecycle_store,
+                        &initial_run_id,
+                        "worktree_provider_lookup",
+                        "resolving materialized provider workspace identity",
+                        COOK_HEARTBEAT_INTERVAL,
+                        || resolve(options),
+                    )?
                 }
                 Err(ensure_error) if provider_ensure_timeout(&ensure_error) => {
                     // Ensure is a mutation and must never be retried after its
@@ -7436,7 +7488,14 @@ fn materialize_pending_cook_workspace(
                         &options.initial_run_id,
                         &options.initial_plan,
                     )?;
-                    match resolve(options) {
+                    match with_controller_pre_provider_heartbeat(
+                        lifecycle_store,
+                        &options.initial_run_id,
+                        "worktree_provider_lookup",
+                        "reconciling provider workspace identity after ensure timeout",
+                        COOK_HEARTBEAT_INTERVAL,
+                        || resolve(options),
+                    ) {
                         Ok(identity) => identity,
                         Err(resolve_error) if provider_resolve_timeout(&resolve_error) => {
                             return Err(resolve_error);

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -6341,6 +6341,56 @@ fn persistent_slow_provider_with_known_path_returns_exhausted_cwd_recovery() {
     });
 }
 
+#[test]
+fn controller_pre_provider_heartbeat_renews_until_the_blocking_call_returns() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let lifecycle_store =
+            AgentTaskLifecycleStore::from_current_environment().expect("lifecycle store");
+        let run_id = "slow-pre-provider-heartbeat";
+        let plan = AgentTaskPlan::new("slow-pre-provider-plan", Vec::new());
+        submit_plan_in_test_store(&lifecycle_store, &plan, Some(run_id)).expect("submitted plan");
+
+        with_controller_pre_provider_heartbeat(
+            &lifecycle_store,
+            run_id,
+            "worktree_provider_ensure",
+            "slow provider ensure remains active",
+            Duration::from_millis(5),
+            || {
+                let initial = lifecycle_store
+                    .read_record(run_id)
+                    .expect("initial progress record")
+                    .updated_at;
+                std::thread::sleep(Duration::from_millis(25));
+                let renewed = lifecycle_store
+                    .read_record(run_id)
+                    .expect("renewed progress record");
+                assert_ne!(renewed.updated_at, initial);
+                assert_eq!(
+                    renewed.metadata["cook_progress"]["phase"],
+                    "worktree_provider_ensure"
+                );
+                Ok(())
+            },
+        )
+        .expect("blocking provider call completes");
+
+        let stopped = lifecycle_store
+            .read_record(run_id)
+            .expect("stopped heartbeat record")
+            .updated_at;
+        std::thread::sleep(Duration::from_millis(15));
+        assert_eq!(
+            lifecycle_store
+                .read_record(run_id)
+                .expect("heartbeat remains stopped")
+                .updated_at,
+            stopped,
+            "heartbeat ownership ends when the provider call returns"
+        );
+    });
+}
+
 #[cfg(unix)]
 #[test]
 fn timed_out_ensure_reconciles_its_created_workspace_without_a_second_mutation() {


### PR DESCRIPTION
## Summary

- renew controller-owned lifecycle progress throughout blocking worktree-provider lookup and ensure calls
- stop heartbeat ownership immediately when each provider call returns or unwinds
- retain exactly-once ensure timeout reconciliation and fail-closed runner submission semantics

Closes #13377.

## Verification

- `cargo fmt --check`
- `cargo check -p homeboy-agents`
- `cargo test -p homeboy-agents controller_pre_provider_heartbeat_renews_until_the_blocking_call_returns`
- `cargo test -p homeboy-agents timed_out_ensure_reconciles_its_created_workspace_without_a_second_mutation`
- `cargo test -p homeboy-agents controller_heartbeat_keeps_slow_pre_provider_materialization_out_of_runner_pid_watchdog`
- `git diff --check`

`cargo clippy -p homeboy-agents --all-targets -- -D warnings` is currently blocked by 22 unrelated Rust 1.95 warnings in untouched `homeboy-core`.

## Evidence

- Failed Cook: `agent-task-6057783f-ac55-4a2f-8e1f-2301fa782d64`
- Observed cancellation: `missing_runner_pid` during `worktree_provider_ensure` after 45.273 seconds, before provider execution

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the cancellation, traced the stale heartbeat boundary, implemented scoped renewal around provider materialization, and ran focused verification. Chris Huber authorized local execution, directed the work, and is responsible for the change.