### PR TITLE
Route composed capabilities from parsed preflight

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -787,6 +787,7 @@ impl CliRuntime {
                 );
                 return std::process::ExitCode::from(2);
             }
+            let mut routed_preflight = None;
             if let Some(route) = route {
                 let runner_env = matches
                     .get_many::<String>("runner_env")
@@ -821,21 +822,32 @@ impl CliRuntime {
                 ) {
                     return std::process::ExitCode::from(exit_code_to_u8(exit_code));
                 }
-                crate::commands::utils::execution_provenance::capture_composed(
-                    options.placement,
-                    options.runner,
-                    options.detach_after_handoff,
-                    options.allow_dirty_lab_workspace,
-                    options.skip_deps_hydration,
-                    options.runner_env,
-                    options.lab_env_json,
+                let preflight = match resolve_composed_capability_preflight(
+                    capability,
+                    capability_matches,
+                    &route,
+                    &options,
                     &normalized,
-                );
+                ) {
+                    Ok(preflight) => preflight,
+                    Err(error) => {
+                        output_runtime::emit_json_result_for_identity(
+                            Err(error),
+                            output_file.as_deref(),
+                            2,
+                            &command_identity,
+                        );
+                        return std::process::ExitCode::from(2);
+                    }
+                };
+                crate::core::parsed_command_preflight::capture_result(preflight.clone());
+                crate::commands::utils::execution_provenance::capture(&preflight);
                 match crate::commands::route::route_composed_lab_command(
                     &route,
                     options,
                     &normalized,
                     output_file.as_deref(),
+                    &preflight,
                 ) {
                     Ok(Some(exit_code)) => {
                         return std::process::ExitCode::from(exit_code_to_u8(exit_code));
@@ -851,11 +863,35 @@ impl CliRuntime {
                         return std::process::ExitCode::from(2);
                     }
                 }
+                routed_preflight = Some(preflight);
             }
             if let Some(path) = output_file.as_deref() {
                 if let Some(exit) = output_file_path_exit_code(path, &command_identity) {
                     return exit;
                 }
+            }
+            if let Some(preflight) = routed_preflight {
+                let (json_result, exit_code) = if matches!(
+                    preflight.resource_admission,
+                    crate::core::parsed_command_preflight::ResourceAdmissionDecision::Rejected { .. }
+                ) {
+                    (
+                        Err(resource_admission_error(&preflight.resource_admission)),
+                        2,
+                    )
+                } else {
+                    match capability.run(capability_matches) {
+                        Ok((value, exit_code)) => (Ok(value), exit_code),
+                        Err(error) => (Err(error), 2),
+                    }
+                };
+                output_runtime::emit_json_result_for_identity(
+                    json_result,
+                    output_file.as_deref(),
+                    exit_code,
+                    &command_identity,
+                );
+                return std::process::ExitCode::from(exit_code_to_u8(exit_code));
             }
             let input = capability.preflight(capability_matches, &normalized);
             // Capabilities declare their requirement and policy only. Runtime
@@ -2476,6 +2512,126 @@ fn preflight_composed_lab_route(
         return Some(2);
     }
     None
+}
+
+fn resolve_composed_capability_preflight(
+    capability: &dyn CliCapability,
+    matches: &ArgMatches,
+    route: &LabCommandRoute,
+    options: &crate::commands::route::ComposedLabRouteOptions<'_>,
+    normalized: &[String],
+) -> crate::core::Result<crate::core::parsed_command_preflight::ParsedCommandPreflightResult> {
+    use crate::core::parsed_command_preflight::{
+        ControllerExecution, GenericRoutePolicySnapshot, LabReadinessSnapshot, LabRouteIntent,
+        PlacementIntent, ResourceAdmissionEvidence, ResourceHeat, RunnerIntent,
+    };
+
+    let mut input = capability.preflight(matches, normalized);
+    input.controller_execution = ControllerExecution::Ordinary;
+    input.placement = match options.placement {
+        crate::cli_surface::Placement::Auto => PlacementIntent::Auto,
+        crate::cli_surface::Placement::Local => PlacementIntent::Local,
+        crate::cli_surface::Placement::Lab => PlacementIntent::Lab,
+        crate::cli_surface::Placement::LabOrLocal => PlacementIntent::LabOrLocal,
+    };
+    input.runner = options
+        .runner
+        .map(|runner| RunnerIntent::Explicit(runner.to_string()))
+        .unwrap_or(RunnerIntent::Default);
+    let route_contract = route.lab_route_contract().ok_or_else(|| {
+        crate::core::Error::validation_invalid_argument(
+            "placement",
+            "this composed command has no Lab route contract",
+            None,
+            None,
+        )
+    })?;
+    input.lab_route = LabRouteIntent::Supported {
+        automatic: matches!(
+            route_contract.command.portability,
+            crate::command_contract::LabCommandPortability::Portable
+        ),
+    };
+
+    let context = resource_policy::captured_context();
+    let readiness = context
+        .as_ref()
+        .map(|context| LabReadinessSnapshot {
+            state: context.runner_selection.readiness_state.clone(),
+            selected_runner_id: options
+                .runner
+                .map(str::to_string)
+                .or_else(|| context.runner_selection.runner_id.clone()),
+            available_runner_ids: context.runner_selection.available_runner_ids.clone(),
+            reasons: context.runner_selection.readiness_reasons.clone(),
+            remediation_commands: context.runner_selection.remediation_commands.clone(),
+        })
+        .or_else(|| {
+            (options.placement != crate::cli_surface::Placement::Local)
+                .then(|| crate::runner::lab_runner_readiness().ok())
+                .flatten()
+                .map(|readiness| resource_policy::lab_readiness_snapshot(&readiness))
+        });
+    let selected_runner_id = options.runner.map(str::to_string).or_else(|| {
+        readiness
+            .as_ref()
+            .and_then(|value| value.selected_runner_id.clone())
+    });
+    let runner_admitted = selected_runner_id.as_ref().is_some_and(|selected| {
+        readiness.as_ref().is_some_and(|readiness| {
+            readiness.state == "connected_ready"
+                && readiness
+                    .available_runner_ids
+                    .iter()
+                    .any(|runner| runner == selected)
+        })
+    });
+    let resource_admission_evidence = context
+        .as_ref()
+        .map(|context| ResourceAdmissionEvidence::Observed {
+            pressure: match context.severity.as_str() {
+                "hot" => ResourceHeat::Hot,
+                "warm" => ResourceHeat::Warm,
+                _ => ResourceHeat::None,
+            },
+        })
+        .unwrap_or_else(|| match input.resource_admission {
+            crate::core::parsed_command_preflight::ResourceAdmissionRequirement::Exempt => {
+                ResourceAdmissionEvidence::Unavailable
+            }
+            crate::core::parsed_command_preflight::ResourceAdmissionRequirement::Required {
+                ..
+            } => crate::commands::resources::run_preflight()
+                .map(|(resources, _)| resource_policy::resource_admission_evidence(&resources))
+                .unwrap_or(ResourceAdmissionEvidence::Unavailable),
+        });
+    let command = crate::core::lab_routing::lab_offload_command_from_route_contract(route_contract);
+    let automatic_authorized = options.runner.is_some()
+        || crate::core::lab_routing::authorizes_policy_lab_runner(
+            &command.command,
+            options.placement,
+            context.as_ref().map(|context| context.severity.as_str()),
+        );
+    let auto_local_capacity_fallback = context
+        .as_ref()
+        .is_some_and(|context| context.runner_selection.reason == "local_capacity_fallback");
+    let mut policy = capability.preflight_policy(matches, normalized);
+    policy.resource_admission_evidence = resource_admission_evidence;
+    policy.resource_policy = context;
+    policy.lab_readiness = readiness;
+    policy.selected_runner_id = selected_runner_id.clone();
+    policy.generic_route = GenericRoutePolicySnapshot {
+        command_supports_lab: true,
+        automatic_authorized,
+        selected_runner_id,
+    };
+    policy.runner_admitted = runner_admitted;
+    policy.auto_local_capacity_fallback = auto_local_capacity_fallback;
+    crate::core::parsed_command_preflight::resolve_parsed_command_preflight(
+        normalized.to_vec(),
+        input,
+        policy,
+    )
 }
 
 fn preflight_hot_command_with_input(

--- a/crates/homeboy-cli/src/command_contract/lab/tests.rs
+++ b/crates/homeboy-cli/src/command_contract/lab/tests.rs
@@ -440,6 +440,56 @@ fn composed_options(placement: crate::cli_surface::Placement) -> ComposedLabRout
     }
 }
 
+fn composed_preflight(
+    placement: crate::cli_surface::Placement,
+) -> homeboy::core::parsed_command_preflight::ParsedCommandPreflightResult {
+    use homeboy::core::parsed_command_preflight::{
+        ControllerExecution, DeferredWorkloadPolicy, GenericRoutePolicySnapshot, LabRouteIntent,
+        ParsedCommandIdentity, ParsedCommandPolicySnapshot, ParsedCommandPreflightInput,
+        PlacementIntent, ProvenanceRequirement, ResourceAdmissionEvidence,
+        ResourceAdmissionRequirement, RunnerIntent, RunnerNormalization,
+    };
+    let placement_intent = match placement {
+        crate::cli_surface::Placement::Auto => PlacementIntent::Auto,
+        crate::cli_surface::Placement::Local => PlacementIntent::Local,
+        crate::cli_surface::Placement::Lab => PlacementIntent::Lab,
+        crate::cli_surface::Placement::LabOrLocal => PlacementIntent::LabOrLocal,
+    };
+    homeboy::core::parsed_command_preflight::resolve_parsed_command_preflight(
+        vec!["homeboy".to_string(), "composed-lab".to_string()],
+        ParsedCommandPreflightInput {
+            identity: ParsedCommandIdentity {
+                family: "composed-lab".to_string(),
+                operation: Vec::new(),
+            },
+            resource_admission: ResourceAdmissionRequirement::Exempt,
+            controller_execution: ControllerExecution::Ordinary,
+            deferred_workload: DeferredWorkloadPolicy::Forbidden,
+            placement: placement_intent,
+            runner: RunnerIntent::Default,
+            runner_normalization: RunnerNormalization::None,
+            lab_route: LabRouteIntent::Supported { automatic: true },
+            provenance: ProvenanceRequirement::CaptureExecution,
+        },
+        ParsedCommandPolicySnapshot {
+            resource_admission_evidence: ResourceAdmissionEvidence::Unavailable,
+            resource_policy: None,
+            lab_readiness: None,
+            selected_runner_id: None,
+            generic_route: GenericRoutePolicySnapshot {
+                command_supports_lab: true,
+                automatic_authorized: false,
+                selected_runner_id: None,
+            },
+            deferred_pressure_refusal: false,
+            runner_admitted: false,
+            runner_incompatible: false,
+            auto_local_capacity_fallback: false,
+        },
+    )
+    .expect("composed preflight resolves")
+}
+
 #[test]
 fn composed_routes_enter_generic_lab_dispatch_and_reject_local_only_lab_placement() {
     let portable = LabCommandRoute::new(
@@ -457,6 +507,7 @@ fn composed_routes_enter_generic_lab_dispatch_and_reject_local_only_lab_placemen
         composed_options(crate::cli_surface::Placement::Lab),
         &["homeboy".to_string(), "composed-lab".to_string()],
         None,
+        &composed_preflight(crate::cli_surface::Placement::Lab),
     )
     .expect_err("required Lab placement enters the generic dispatcher and requires a runner");
     assert!(error
@@ -483,6 +534,7 @@ fn composed_routes_enter_generic_lab_dispatch_and_reject_local_only_lab_placemen
         composed_options(crate::cli_surface::Placement::Lab),
         &["homeboy".to_string(), "composed-lab".to_string()],
         None,
+        &composed_preflight(crate::cli_surface::Placement::Lab),
     )
     .expect_err("local-only composed routes fail closed for explicit Lab placement");
     assert!(error

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -621,6 +621,7 @@ pub(crate) fn route_composed_lab_command(
     options: ComposedLabRouteOptions<'_>,
     normalized_args: &[String],
     output_file: Option<&str>,
+    preflight: &homeboy::core::parsed_command_preflight::ParsedCommandPreflightResult,
 ) -> homeboy::core::Result<Option<i32>> {
     let Some(route_contract) = route.lab_route_contract() else {
         if options.placement == homeboy::cli_surface::Placement::Lab || options.runner.is_some() {
@@ -658,21 +659,18 @@ pub(crate) fn route_composed_lab_command(
     let read_only_polling = route_contract.command.routing_policy.read_only_polling;
     let command = lab_routing::lab_offload_command_from_route_contract(route_contract);
     let task = command.command.hot_label;
-    let inferred_runner = options.runner.map(ToOwned::to_owned).or_else(|| {
-        (command.command.routing_policy.default_lab_offload
-            || options.placement == homeboy::cli_surface::Placement::Lab)
-            .then(|| runners::lab_runner_readiness().ok())
-            .flatten()
-            .and_then(|readiness| readiness.selected_runner_id)
-    });
-    let runner_id = inferred_runner.as_deref().filter(|_| {
-        options.runner.is_some()
-            || lab_routing::authorizes_policy_lab_runner(
-                &command.command,
-                options.placement,
-                lab_routing::captured_pressure_severity().as_deref(),
-            )
-    });
+    let runner_id = preflight.generic_route_runner_id.as_deref();
+    if preflight.placement.required
+        == homeboy_lab_runner_contract::ExecutionPlacementRequirement::Lab
+        && runner_id.is_none()
+    {
+        return Err(Error::validation_invalid_argument(
+            "placement",
+            "required Lab placement has no selected ready runner",
+            Some("lab".to_string()),
+            None,
+        ));
+    }
     if runner_id.is_none() && options.placement != homeboy::cli_surface::Placement::Lab {
         return Ok(None);
     }
@@ -683,13 +681,19 @@ pub(crate) fn route_composed_lab_command(
             Some("resolve composed Lab source path".to_string()),
         )
     })?;
-    let decision = composed_placement_decision(
-        options.placement,
-        options.runner.is_some(),
-        runner_id,
-        task,
-        &source_path,
-    )?;
+    let decision =
+        preflight
+            .placement
+            .finalize(homeboy_lab_runner_contract::ExecutionPlacementIdentity {
+                repository: source_path
+                    .file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| "controller-cwd".to_string()),
+                workspace: source_path.display().to_string(),
+                task: task.to_string(),
+                candidate: homeboy::core::git::head_sha(&source_path),
+                base: homeboy::core::git::rev_parse(&source_path, "origin/HEAD"),
+            });
     let outcome = lab_routing::dispatch_lab_offload(
         LabRoutingRequest {
             placement_decision: decision,
@@ -734,70 +738,6 @@ pub(crate) fn route_composed_lab_command(
             Ok(Some(output.exit_code))
         }
     }
-}
-
-fn composed_placement_decision(
-    placement: homeboy::cli_surface::Placement,
-    explicit_runner: bool,
-    runner_id: Option<&str>,
-    task: &str,
-    source_path: &Path,
-) -> homeboy::core::Result<homeboy_lab_runner_contract::ExecutionPlacementDecision> {
-    use homeboy_lab_runner_contract::{
-        EffectiveExecutionPlacement, ExecutionPlacementFallback, ExecutionPlacementIdentity,
-        ExecutionPlacementOverrideAuthorization, ExecutionPlacementRequirement,
-        ExecutionPlacementRunnerSelection, RunnerSelectionSource,
-    };
-    if placement == homeboy::cli_surface::Placement::Lab && runner_id.is_none() {
-        return Err(Error::validation_invalid_argument(
-            "placement",
-            "required Lab placement has no selected ready runner",
-            Some("lab".to_string()),
-            None,
-        ));
-    }
-    let required = (placement == homeboy::cli_surface::Placement::Lab || explicit_runner)
-        .then_some(ExecutionPlacementRequirement::Lab)
-        .unwrap_or(ExecutionPlacementRequirement::Either);
-    Ok(
-        homeboy_lab_runner_contract::ExecutionPlacementDecision::new(
-            "lab-route-contract",
-            "v1",
-            ExecutionPlacementIdentity {
-                repository: source_path
-                    .file_name()
-                    .map(|name| name.to_string_lossy().into_owned())
-                    .unwrap_or_else(|| "controller-cwd".to_string()),
-                workspace: source_path.display().to_string(),
-                task: task.to_string(),
-                candidate: homeboy::core::git::head_sha(source_path),
-                base: homeboy::core::git::rev_parse(source_path, "origin/HEAD"),
-            },
-            placement,
-            required,
-            runner_id
-                .map(|_| EffectiveExecutionPlacement::Lab)
-                .unwrap_or(EffectiveExecutionPlacement::Local),
-            runner_id.map(|runner_id| ExecutionPlacementRunnerSelection {
-                runner_id: runner_id.to_string(),
-                source: if explicit_runner {
-                    RunnerSelectionSource::Explicit
-                } else {
-                    RunnerSelectionSource::Policy
-                },
-            }),
-            ExecutionPlacementFallback {
-                local_allowed: required != ExecutionPlacementRequirement::Lab
-                    && placement.allows_local_fallback(),
-                reason: None,
-            },
-            ExecutionPlacementOverrideAuthorization {
-                authorized: placement == homeboy::cli_surface::Placement::Local,
-                authority: (placement == homeboy::cli_surface::Placement::Local)
-                    .then(|| "operator --placement local".to_string()),
-            },
-        ),
-    )
 }
 
 fn composed_lab_job_overrides(
@@ -892,17 +832,6 @@ fn authoritative_preflight(
         Error::internal_unexpected("route requires a completed parsed-command preflight result")
     })
 }
-
-/// The runner the *generic* Lab route may use, given what the command's
-/// contract actually authorizes.
-///
-/// An operator-pinned `--runner` always passes: pinning names the runner
-/// directly and is its own authority. A policy-selected default runner has to
-/// earn its place through
-/// [`lab_routing::authorizes_policy_lab_runner`], which is the same predicate
-/// the offload executor applies — so the canonical placement decision this
-/// controller writes and the dispatch the executor performs can never disagree
-/// about whether a command was entitled to leave this machine.
 
 fn finalize_placement(
     directive: &homeboy::core::parsed_command_preflight::PlacementDirective,


### PR DESCRIPTION
Refs #13215
Builds on #13270 and #13379

## Change

- Resolves one `ParsedCommandPreflightResult` for descriptor-composed Lab capabilities before routing.
- Feeds the existing composed resource probe, runner readiness, pressure evidence, fallback decision, global placement, explicit runner, and capability policy into the shared parser-independent resolver.
- Captures standard execution provenance from that result instead of the separate composed provenance builder.
- Makes `route_composed_lab_command` consume the preflight-selected runner and late-bind only `ExecutionPlacementIdentity` through `PlacementDirective::finalize`.
- Deletes composed-route readiness lookup, policy reauthorization, and direct `ExecutionPlacementDecision` construction.
- Executes locally routed capabilities directly from the already captured result instead of resolving preflight a second time.
- Preserves fail-closed explicit Lab behavior when no admitted runner exists and local-only route diagnostics.

## Verification

- `cargo test -p homeboy-cli --features test-support command_contract::lab::tests --lib`: 8 passed after rebasing current main.
- `cargo check -p homeboy-cli -p homeboy`: passed in 1m46s warm.
- `homeboy review lint homeboy --changed-only --placement local --summary`: passed with zero findings before the current-main rebase.
- `cargo fmt --check` and `git diff --check`: passed.
- A combined full workspace check timed out after 20 minutes while still compiling, without an emitted compiler error; focused root/CLI checks passed afterward.

## Scope

This is the #13270-to-#13379 integration slice. It removes duplicated composed Lab placement policy but does not yet introduce the deterministic metadata/contract/reference registry or remove Fuzz/Tunnel Cargo edges. Those remain in #13215, #13175, and #13176.

Source delta: +243/-106 lines across three files. No binary-size or dependency-graph reduction is claimed.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode inspected the merged Lab route and parsed preflight boundaries, implemented the integration, ran the recorded checks, and drafted this PR. Chris Huber remains responsible for every line.