### PR TITLE
Collapse five twin report declarations in homeboy-rig

### DIFF
--- a/crates/homeboy-rig/src/install.rs
+++ b/crates/homeboy-rig/src/install.rs
@@ -49,8 +49,15 @@ pub(crate) struct PreparedSource {
     pub source_content_hash: String,
 }
 
+/// One spec installed by an install run.
+///
+/// Rigs and stacks are different concepts, but the record of having installed
+/// one is not: both carried these five fields from their own declaration, with
+/// no conversion between them, and both land in the same `RigInstallResult`.
+/// A field added to one and not the other compiled clean and left the two
+/// lists in a single JSON payload describing the same thing differently.
 #[derive(Debug, Clone, Serialize)]
-pub struct InstalledRig {
+pub struct InstalledSpec {
     pub id: String,
     pub description: String,
     pub path: PathBuf,
@@ -58,14 +65,11 @@ pub struct InstalledRig {
     pub source_revision: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
-pub struct InstalledStack {
-    pub id: String,
-    pub description: String,
-    pub path: PathBuf,
-    pub spec_path: PathBuf,
-    pub source_revision: Option<String>,
-}
+/// A rig installed by an install run.
+pub type InstalledRig = InstalledSpec;
+
+/// A stack installed by an install run.
+pub type InstalledStack = InstalledSpec;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RigSourceMetadata {

--- a/crates/homeboy-rig/src/runner.rs
+++ b/crates/homeboy-rig/src/runner.rs
@@ -41,9 +41,19 @@ use homeboy_core::resource_lifecycle_index::{
     ResourceLifecycleIndex, ResourceLifecycleResourceStatus,
 };
 
-/// Report from `rig up`.
+/// The outcome of one rig pipeline run.
+///
+/// `rig up`, `rig check` / `rig lint`, and fuzz preparation each reported these
+/// five fields from their own declaration, with identical serde attributes and
+/// no conversion between them. Three copies meant a field added for one command
+/// compiled clean and silently never reached the other two, even though all
+/// three serialize into the same `CommandReport<T>` envelope. One declaration
+/// makes that a compile error instead.
+///
+/// The per-command aliases below are kept because the names are the readable
+/// spelling at each call site and in `RigUpOutput` / `RigCheckOutput`.
 #[derive(Debug, Clone, Serialize)]
-pub struct UpReport {
+pub struct RigPipelineReport {
     pub rig_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub run_id: Option<String>,
@@ -53,17 +63,11 @@ pub struct UpReport {
     pub artifact_index: Option<RigRunArtifactIndex>,
 }
 
+/// Report from `rig up`.
+pub type UpReport = RigPipelineReport;
+
 /// Report from `rig check`.
-#[derive(Debug, Clone, Serialize)]
-pub struct CheckReport {
-    pub rig_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub run_id: Option<String>,
-    pub pipeline: PipelineOutcome,
-    pub success: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub artifact_index: Option<RigRunArtifactIndex>,
-}
+pub type CheckReport = RigPipelineReport;
 
 /// Report from a bench preparation pipeline.
 #[derive(Debug, Clone, Serialize)]
@@ -74,16 +78,7 @@ pub struct BenchPrepareReport {
 }
 
 /// Report from a fuzz preparation pipeline.
-#[derive(Debug, Clone, Serialize)]
-pub struct FuzzPrepareReport {
-    pub rig_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub run_id: Option<String>,
-    pub pipeline: PipelineOutcome,
-    pub success: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub artifact_index: Option<RigRunArtifactIndex>,
-}
+pub type FuzzPrepareReport = RigPipelineReport;
 
 /// Report from `rig down`.
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
## What

`homeboy-rig` declared the same struct **five times** across two files:

```
UpReport == CheckReport == FuzzPrepareReport    runner.rs   5 fields, x3
InstalledRig == InstalledStack                  install.rs  5 fields, x2
```

Each group shares every field name, every field type, every serde attribute, and the same derive list. **No conversion exists between any pair**, so nothing made them move together — a field added for `rig check` compiles clean and silently never reaches `rig up` or fuzz preparation, even though all three serialize into the same `CommandReport<T>` envelope.

That is the exact failure mode #10220 shipped with `Component`/`RawComponent`.

## Change

```rust
pub struct RigPipelineReport { .. }
pub type UpReport         = RigPipelineReport;
pub type CheckReport      = RigPipelineReport;
pub type FuzzPrepareReport = RigPipelineReport;

pub struct InstalledSpec { .. }
pub type InstalledRig   = InstalledSpec;
pub type InstalledStack = InstalledSpec;
```

Aliases rather than a rename, because the names are the readable spelling at each call site and in `RigUpOutput` / `RigCheckOutput`. Every construction site, `pub use`, and test compiles unchanged. **The change is that a sixth field can now only be added once.**

## Output is unaffected — and I checked the sharp edge

`serde_json` serializes a struct as a map and **ignores the Rust type name**, so renaming the declaration cannot move the JSON. That is only true because JSON is the only serializer these types reach:

```
$ grep -rn 'toml::to_\|serde_yaml\|bincode\|rmp_serde\|ron::' \
    crates/homeboy-rig/src crates/homeboy-cli/src/commands/{rig,fuzz}
(no output)
```

In a self-describing format the struct name *is* emitted and this would be a breaking change. It is not here.

## The other 15 clusters — triaged, most correctly left alone

Seventeen exist repo-wide. Applying the rule *"does this remove a place where a correct-looking change is wrong"*, **not** lines removed:

**Leave — arg-parser and its serialized echo:**
`RunsRefsArgs`/`RunsRefsFilters`, `CiFailureTriageRequest`/`CiTriageArgs`

**Leave — parse boundary or differing serialized shape:**
`RawLinkedPr`/`TriageLinkedPr`, `PublicOutputVariantContract`/`PublicOutputVariantExport`

**Worth a look, cross-crate so needs more care than this PR:**
`PreparedDaemonExec`/`PreparedDaemonExecRequest` (11 fields, same file), `AgentTaskQueuedRunSkip`/`AgentTaskRunNextSkip` (11 fields), `AgentTaskArtifactDeclaration`/`RunnerExecutionArtifactDeclaration`, `MultiDeploySummary`/`ReleaseDeploymentSummary`, `InstallResult`/`InstalledExtensionResult`

I deliberately did not batch those in. Cross-crate twins usually encode a real layering boundary, and deciding that per pair is review work, not sweep work.

## Note on tooling

The `twin_type_declaration` detector (#13358) exists in the tree and `homeboy-extensions#2697` released its recall fix as `rust-v1.37.1`, but the installed CLI here is `0.350.3` and predates the finding kind, so `--only twin_type_declaration` is rejected. I replicated the shape analysis directly rather than spend a full release build on it. Once a newer homeboy is installed the detector should report these natively.

## Gate

```
$ cargo check --workspace --all-targets -j2      # exit 0, 0 warnings, 0 errors
$ cargo fmt --all -- --check                     # clean
```

## AI assistance

Tool(s): OpenCode