### PR TITLE
fix(refactor): restore test fixtures corrupted by the visibility narrowing

### DIFF
--- a/crates/homeboy-refactor/src/decompose.rs
+++ b/crates/homeboy-refactor/src/decompose.rs
@@ -834,7 +834,7 @@ mod tests {
         let content = r#"
 macro_rules! entity_crud {
     ($Entity:ty $(; $($feature:ident),+ )?) => {
-        pub(crate) fn load(id: &str) -> Result<$Entity> {
+        pub fn load(id: &str) -> Result<$Entity> {
             config::load::<$Entity>(id)
         }
     };
@@ -875,7 +875,7 @@ macro_rules! entity_crud {
     #[test]
     fn identify_parent_kept_functions_keeps_root_orchestrator() {
         let content = r#"
-pub(crate) fn audit_component(component_id: &str) -> Result<CodeAuditResult> {
+pub fn audit_component(component_id: &str) -> Result<CodeAuditResult> {
     audit_path_with_id(component_id, ".")
 }
 
@@ -921,10 +921,10 @@ fn audit_internal(component_id: &str, source_path: &str) -> Result<CodeAuditResu
     #[test]
     fn effective_module_root_detects_public_surface_regular_file() {
         let content = r#"
-pub(crate) fn load() {}
-pub(crate) fn list() {}
-pub(crate) fn save() {}
-pub(crate) fn delete() {}
+pub fn load() {}
+pub fn list() {}
+pub fn save() {}
+pub fn delete() {}
 "#;
         assert!(has_established_module_surface(content));
         assert!(is_effective_module_root("src/core/config.rs", content));
@@ -933,8 +933,8 @@ pub(crate) fn delete() {}
     #[test]
     fn rebalance_for_viable_parent_surface_preserves_public_root_surface() {
         let content = r#"
-pub(crate) fn a() {}
-pub(crate) fn b() {}
+pub fn a() {}
+pub fn b() {}
 fn helper() {}
 "#;
         let items = [
@@ -986,7 +986,7 @@ use something;
 // Models
 // ============================================================================
 
-pub(crate) struct Foo {}
+pub struct Foo {}
 
 // ============================================================================
 // Git operations

--- a/crates/homeboy-refactor/src/plan/generate/compiler_warning_fixes.rs
+++ b/crates/homeboy-refactor/src/plan/generate/compiler_warning_fixes.rs
@@ -289,7 +289,7 @@ mod tests {
         std::fs::create_dir_all(dir.join("src")).unwrap();
 
         let content = r#"
-pub(crate) fn public_function() {}
+pub fn public_function() {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## What

**#13353 shipped a defect and I am the author.** Its `pub` → `pub(crate)` narrowing used a line-wise regex with no notion of string literals, so it also rewrote **six `r#"..."#` test fixtures** — Rust source samples that the decompose and compiler-warning-fix tests analyse as *input*, not as this crate's own code.

## Why it was invisible

Nothing failed. `homeboy-refactor` was green at **346 passed / 0 failed** both before and after, because `has_established_module_surface` and the fix generators accept `pub(crate)` and `pub` alike.

That is precisely what makes it worth fixing. Two of the affected tests state the intent in their own names:

```
effective_module_root_detects_public_surface_regular_file
rebalance_for_viable_parent_surface_preserves_public_root_surface
```

Both assert behaviour about a **public** surface while being fed a crate-private one. A future change that distinguishes `pub` from `pub(crate)` — which is plausible in a crate whose whole job is visibility-aware refactoring — would have been validated against the wrong input and looked correct.

## The fix

Restores all six blocks to their pre-#13353 content:

| file | fixtures |
|---|---|
| `crates/homeboy-refactor/src/decompose.rs` | 5 |
| `crates/homeboy-refactor/src/plan/generate/compiler_warning_fixes.rs` | 1 |

**Fixture content only** — no production code, no test logic, no assertion changed.

Verified mechanically: every `r#"..."#` block in the crate was compared against `f81f6f5be` (the parent of `4e79a5e20`), and only blocks that differ were restored.

## Blast radius of the original bug

I ran the same block-by-block comparison across every crate I narrowed in this campaign:

| crate | raw-string fixtures with Rust `pub` items | corrupted |
|---|---|---|
| `homeboy-refactor` (#13353, merged) | 7 | **6** |
| `homeboy-tunnel` (#13360, merged) | 0 | 0 |
| `homeboy-fuzz` (#13367) | 0 | 0 |
| `homeboy-rig` (#13374) | 0 | 0 |
| `homeboy-code-audit` (in review) | 25 | 19 — restored in-branch |

Only crates that embed Rust source as test fixtures were exposed, which is why it clustered in the two crates that analyse Rust source for a living. `homeboy-code-audit` is where it finally surfaced as a hard failure: `test_basic_rust_fingerprint` asserts `visibility == "public"` on its fixture, so a corrupted fixture broke the test instead of passing quietly.

## Verification

- `cargo test -p homeboy-refactor --lib` — **346 passed, 0 failed**
- `#[test]` count unchanged; the diff touches no test function and no assertion

## AI assistance

Tool(s): OpenCode
