### PR TITLE
fix(lifecycle): stop collapsing recoverable runs into partial failure

### DIFF
--- a/crates/contracts/homeboy-lifecycle-contract/src/run_lifecycle_record.rs
+++ b/crates/contracts/homeboy-lifecycle-contract/src/run_lifecycle_record.rs
@@ -115,16 +115,46 @@ impl Default for RunExecutionLifecycle {
     }
 }
 
+/// The generic execution state carried by [`RunLifecycleRecord`].
+///
+/// # Recoverable states are distinct from partial failure
+///
+/// `CandidateRecoverable` and `PartialRecoverable` used to collapse into
+/// `PartialFailure` on the way in from `AgentTaskRunState`. They are not the
+/// same situation: a recoverable run stopped holding something a consumer can
+/// still act on — a promotable candidate, or partial work that can be resumed —
+/// whereas `PartialFailure` is the terminal, unsuccessful, nothing-left-to-do
+/// case. Collapsing them meant a consumer reading only the serialized record
+/// (an `activity` listing, an HTTP response, a chat-plane message) could not
+/// tell "there is a candidate waiting to be promoted" from "this partially
+/// failed", because both arrived as the same string.
+///
+/// All three remain terminal and unsuccessful. The distinction is *what an
+/// operator or orchestrator can do next*, not whether the run is finished.
+///
+/// # Unknown is the tolerance hatch
+///
+/// `Unknown` is `#[serde(other)]`, so a record written by a newer binary that
+/// has learned a state this one has not degrades to `Unknown` instead of
+/// failing the whole record parse. Without it, adding a variant here breaks
+/// every older reader of the durable record. Do not remove it, and do not add
+/// a second catch-all.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum RunExecutionState {
-    Unknown,
     Queued,
     Running,
     Succeeded,
+    /// Stopped, unsuccessful, but a promotable candidate survived.
+    CandidateRecoverable,
+    /// Stopped, unsuccessful, but the partial work can be resumed.
+    PartialRecoverable,
     PartialFailure,
     Failed,
     Cancelled,
+    /// A state minted by a producer this binary does not know. Never guessed.
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -319,5 +349,84 @@ mod tests {
         let round_trip: RunLifecycleRecord =
             serde_json::from_value(json).expect("deserialize lifecycle record");
         assert_eq!(round_trip, record);
+    }
+}
+
+#[cfg(test)]
+mod run_execution_state_compatibility_tests {
+    use super::*;
+
+    /// A record written before #6761 added the recoverable variants must still
+    /// read. This is the read-path migration test: every label the previous
+    /// vocabulary could persist is listed, so a rename or reorder that would
+    /// strand durable records fails here.
+    #[test]
+    fn every_pre_existing_durable_label_still_deserializes() {
+        for (label, expected) in [
+            ("unknown", RunExecutionState::Unknown),
+            ("queued", RunExecutionState::Queued),
+            ("running", RunExecutionState::Running),
+            ("succeeded", RunExecutionState::Succeeded),
+            ("partial_failure", RunExecutionState::PartialFailure),
+            ("failed", RunExecutionState::Failed),
+            ("cancelled", RunExecutionState::Cancelled),
+        ] {
+            let parsed: RunExecutionState =
+                serde_json::from_value(label.into()).expect("legacy label must parse");
+            assert_eq!(parsed, expected, "{label}");
+            assert_eq!(
+                serde_json::to_value(parsed).expect("serialize"),
+                serde_json::json!(label),
+                "{label} must round-trip to the same durable string"
+            );
+        }
+    }
+
+    /// The variants added by #6761, pinned to their wire strings. These are
+    /// now persisted, so changing them is a durable-format break.
+    #[test]
+    fn recoverable_states_have_stable_wire_labels() {
+        for (label, state) in [
+            (
+                "candidate_recoverable",
+                RunExecutionState::CandidateRecoverable,
+            ),
+            ("partial_recoverable", RunExecutionState::PartialRecoverable),
+        ] {
+            assert_eq!(
+                serde_json::to_value(state).expect("serialize"),
+                serde_json::json!(label)
+            );
+            let parsed: RunExecutionState = serde_json::from_value(label.into()).expect("parse");
+            assert_eq!(parsed, state);
+        }
+    }
+
+    /// The tolerance hatch, and the reason adding a variant here is safe from
+    /// now on: a state minted by a newer binary degrades to `Unknown` instead
+    /// of failing the enclosing record parse.
+    ///
+    /// Without `#[serde(other)]` this test fails and, more importantly, every
+    /// older reader of a record containing a new state fails with it.
+    #[test]
+    fn a_state_from_a_newer_binary_degrades_to_unknown() {
+        let parsed: RunExecutionState =
+            serde_json::from_value("some_state_from_a_newer_binary".into())
+                .expect("unknown state must not fail the parse");
+
+        assert_eq!(parsed, RunExecutionState::Unknown);
+    }
+
+    /// The degradation must hold through the enclosing record, which is the
+    /// shape that actually lands on disk.
+    #[test]
+    fn an_unknown_state_does_not_fail_the_enclosing_record() {
+        let record: RunLifecycleRecord = serde_json::from_value(serde_json::json!({
+            "schema": RUN_LIFECYCLE_RECORD_SCHEMA,
+            "execution": { "state": "a_state_this_binary_has_never_heard_of" },
+        }))
+        .expect("record with an unknown execution state must still parse");
+
+        assert_eq!(record.execution.state, RunExecutionState::Unknown);
     }
 }

--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -1171,10 +1171,19 @@ fn validate_durable_publication_eligibility(
             .iter()
             .all(|runtime| runtime.state == ProviderRuntimeState::Succeeded)
         && (lifecycle.execution.state == RunExecutionState::Succeeded
-            || (lifecycle.execution.state == RunExecutionState::PartialFailure
-                && lifecycle.provider_runtime.iter().all(|runtime| {
-                    runtime.metadata["evidence_source"] == "durable_provider_execution"
-                })))
+            // `CandidateRecoverable` and `PartialRecoverable` were folded into
+            // `PartialFailure` before #6761, so they reached this check as
+            // `PartialFailure` and were eligible. They are listed explicitly
+            // now to keep that behavior — splitting the projection must not
+            // quietly narrow durable-publication eligibility.
+            || (matches!(
+                lifecycle.execution.state,
+                RunExecutionState::PartialFailure
+                    | RunExecutionState::CandidateRecoverable
+                    | RunExecutionState::PartialRecoverable
+            ) && lifecycle.provider_runtime.iter().all(|runtime| {
+                runtime.metadata["evidence_source"] == "durable_provider_execution"
+            })))
     {
         return Ok(DurablePublicationEligibility::ProviderRun);
     }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -1394,18 +1394,27 @@ impl AgentTaskRunState {
 }
 
 /// Canonical projection of a run's aggregate state onto the generic
-/// `RunExecutionState` carried by `RunLifecycleRecord`. The two enums share
-/// every agent-task variant 1:1 (`RunExecutionState` additionally models the
-/// generic `Unknown` default), so this single `From` keeps `record.state` and
-/// `record.lifecycle.execution.state` in lockstep instead of a hand-synced map.
+/// `RunExecutionState` carried by `RunLifecycleRecord`.
+///
+/// The two enums share every agent-task variant 1:1 (`RunExecutionState`
+/// additionally models the generic `Unknown` default), so this single `From`
+/// keeps `record.state` and `record.lifecycle.execution.state` in lockstep
+/// instead of a hand-synced map.
+///
+/// That 1:1 claim was false until #6761: `CandidateRecoverable` and
+/// `PartialRecoverable` both mapped to `PartialFailure`, so three run states
+/// arrived at every serialized consumer as one string and the comment saying
+/// otherwise is why it went unnoticed. The projection is now injective, and
+/// `the_projection_is_injective` below fails if a future variant re-collapses
+/// it.
 impl From<AgentTaskRunState> for RunExecutionState {
     fn from(state: AgentTaskRunState) -> Self {
         match state {
             AgentTaskRunState::Queued => RunExecutionState::Queued,
             AgentTaskRunState::Running => RunExecutionState::Running,
             AgentTaskRunState::Succeeded => RunExecutionState::Succeeded,
-            AgentTaskRunState::CandidateRecoverable => RunExecutionState::PartialFailure,
-            AgentTaskRunState::PartialRecoverable => RunExecutionState::PartialFailure,
+            AgentTaskRunState::CandidateRecoverable => RunExecutionState::CandidateRecoverable,
+            AgentTaskRunState::PartialRecoverable => RunExecutionState::PartialRecoverable,
             AgentTaskRunState::PartialFailure => RunExecutionState::PartialFailure,
             AgentTaskRunState::Failed => RunExecutionState::Failed,
             AgentTaskRunState::Cancelled => RunExecutionState::Cancelled,
@@ -1435,10 +1444,13 @@ impl From<AgentTaskRunState> for RunLifecycleStatus {
             AgentTaskRunState::Running => RunLifecycleStatus::Running,
             AgentTaskRunState::Succeeded => RunLifecycleStatus::Succeeded,
             // A stopped run that still holds a recoverable candidate is
-            // terminal and not successful. `PartialFailure` matches what the
-            // `RunExecutionState` projection above already says about it.
-            AgentTaskRunState::CandidateRecoverable => RunLifecycleStatus::PartialFailure,
-            AgentTaskRunState::PartialRecoverable => RunLifecycleStatus::PartialFailure,
+            // terminal and not successful, but it is not a partial failure
+            // either — the candidate is promotable. Carrying the distinction
+            // through is the whole point of #6761; both routes were changed
+            // together so this still agrees with the `RunExecutionState`
+            // projection above.
+            AgentTaskRunState::CandidateRecoverable => RunLifecycleStatus::CandidateRecoverable,
+            AgentTaskRunState::PartialRecoverable => RunLifecycleStatus::PartialRecoverable,
             AgentTaskRunState::PartialFailure => RunLifecycleStatus::PartialFailure,
             AgentTaskRunState::Failed => RunLifecycleStatus::Failed,
             AgentTaskRunState::Cancelled => RunLifecycleStatus::Cancelled,
@@ -1449,6 +1461,87 @@ impl From<AgentTaskRunState> for RunLifecycleStatus {
 #[cfg(test)]
 mod run_state_lifecycle_projection_tests {
     use super::*;
+
+    /// Every `AgentTaskRunState`, so a new variant is a compile error in the
+    /// tests below rather than a silently unchecked one.
+    const ALL_RUN_STATES: [AgentTaskRunState; 8] = [
+        AgentTaskRunState::Queued,
+        AgentTaskRunState::Running,
+        AgentTaskRunState::Succeeded,
+        AgentTaskRunState::CandidateRecoverable,
+        AgentTaskRunState::PartialRecoverable,
+        AgentTaskRunState::PartialFailure,
+        AgentTaskRunState::Failed,
+        AgentTaskRunState::Cancelled,
+    ];
+
+    /// The defect #6761 fixed: `CandidateRecoverable`, `PartialRecoverable`,
+    /// and `PartialFailure` all projected to `PartialFailure`, so a consumer
+    /// reading only the serialized run could not tell "there is a candidate to
+    /// promote" from "this partially failed".
+    ///
+    /// Injectivity is the property that makes the projection safe to read as
+    /// the run's state. Asserting it directly means a future variant that
+    /// reuses an existing target fails here instead of silently re-collapsing
+    /// the vocabulary.
+    #[test]
+    fn the_projection_is_injective() {
+        let mut seen: Vec<(RunExecutionState, AgentTaskRunState)> = Vec::new();
+        for state in ALL_RUN_STATES {
+            let projected = RunExecutionState::from(state);
+            if let Some((_, first)) = seen.iter().find(|(target, _)| *target == projected) {
+                panic!(
+                    "{state:?} and {first:?} both project to {projected:?}; \
+                     the projection must stay injective (#6761)"
+                );
+            }
+            seen.push((projected, state));
+        }
+        assert_eq!(seen.len(), ALL_RUN_STATES.len());
+    }
+
+    /// The same property one hop further out, where the orchestrator actually
+    /// reads it — `ActivityState` is an alias of `RunLifecycleStatus`, so a
+    /// collapse here is a collapse in `activity` output.
+    #[test]
+    fn the_lifecycle_status_projection_is_injective() {
+        let mut seen: Vec<(RunLifecycleStatus, AgentTaskRunState)> = Vec::new();
+        for state in ALL_RUN_STATES {
+            let projected = RunLifecycleStatus::from(state);
+            if let Some((_, first)) = seen.iter().find(|(target, _)| *target == projected) {
+                panic!(
+                    "{state:?} and {first:?} both project to {projected:?}; \
+                     activity could not distinguish them (#6761)"
+                );
+            }
+            seen.push((projected, state));
+        }
+        assert_eq!(seen.len(), ALL_RUN_STATES.len());
+    }
+
+    /// A recoverable run is terminal and unsuccessful, but it is not an
+    /// invitation to retry — the next action is promotion or resumption.
+    /// Reporting it retryable is how an orchestrator builds a retry loop
+    /// around a run that is waiting on a decision.
+    #[test]
+    fn recoverable_states_are_terminal_unsuccessful_and_not_retryable() {
+        for state in [
+            AgentTaskRunState::CandidateRecoverable,
+            AgentTaskRunState::PartialRecoverable,
+        ] {
+            let projected = RunLifecycleStatus::from(state);
+            assert!(projected.is_terminal(), "{state:?} must be terminal");
+            assert!(!projected.is_success(), "{state:?} must not claim success");
+            assert!(
+                !projected.is_retryable(),
+                "{state:?} must not instruct a retry"
+            );
+            // Deliberately no `is_recoverable()` helper: a boolean would
+            // re-collapse `CandidateRecoverable` and `PartialRecoverable` into
+            // one bit, which is the exact loss this change removes. Consumers
+            // match the variant they care about.
+        }
+    }
 
     /// The direct projection must never diverge from composing the two that
     /// already existed. If it did, `record.state` and

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -2559,6 +2559,17 @@ fn run_state_bridges_one_to_one_onto_execution_state() {
         (AgentTaskRunState::Queued, RunExecutionState::Queued),
         (AgentTaskRunState::Running, RunExecutionState::Running),
         (AgentTaskRunState::Succeeded, RunExecutionState::Succeeded),
+        // These two were the exception the test name claimed did not exist:
+        // both mapped to `PartialFailure` until #6761, so the bridge was 8->6,
+        // not one-to-one. Listed explicitly now that they carry through.
+        (
+            AgentTaskRunState::CandidateRecoverable,
+            RunExecutionState::CandidateRecoverable,
+        ),
+        (
+            AgentTaskRunState::PartialRecoverable,
+            RunExecutionState::PartialRecoverable,
+        ),
         (
             AgentTaskRunState::PartialFailure,
             RunExecutionState::PartialFailure,

--- a/crates/homeboy-cli/src/commands/activity.rs
+++ b/crates/homeboy-cli/src/commands/activity.rs
@@ -936,6 +936,8 @@ mod tests {
             ActivityState::Queued,
             ActivityState::Running,
             ActivityState::Succeeded,
+            ActivityState::CandidateRecoverable,
+            ActivityState::PartialRecoverable,
             ActivityState::PartialFailure,
             ActivityState::Failed,
             ActivityState::Cancelled,

--- a/crates/homeboy-cli/src/commands/runner/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/runner/lifecycle.rs
@@ -276,6 +276,8 @@ fn status_label(status: RunLifecycleStatus) -> &'static str {
         RunLifecycleStatus::Queued => "queued",
         RunLifecycleStatus::Running => "running",
         RunLifecycleStatus::Succeeded => "succeeded",
+        RunLifecycleStatus::CandidateRecoverable => "candidate_recoverable",
+        RunLifecycleStatus::PartialRecoverable => "partial_recoverable",
         RunLifecycleStatus::PartialFailure => "partial_failure",
         RunLifecycleStatus::Failed => "failed",
         RunLifecycleStatus::Cancelled => "cancelled",

--- a/crates/homeboy-core/src/activity.rs
+++ b/crates/homeboy-core/src/activity.rs
@@ -424,6 +424,8 @@ fn counts_for_items(items: &[ActivityItem]) -> ActivityCounts {
             ActivityState::Queued => counts.queued += 1,
             ActivityState::Running => counts.running += 1,
             ActivityState::Succeeded => counts.succeeded += 1,
+            ActivityState::CandidateRecoverable => counts.candidate_recoverable += 1,
+            ActivityState::PartialRecoverable => counts.partial_recoverable += 1,
             ActivityState::PartialFailure => counts.partial_failure += 1,
             ActivityState::Failed => counts.failed += 1,
             ActivityState::Cancelled => counts.cancelled += 1,
@@ -808,7 +810,11 @@ mod tests {
 
     #[test]
     fn activity_policy_preserves_active_and_failure_sets() {
-        for case in "unknown:01,queued:10,running:10,succeeded:00,partial_failure:01,failed:01,cancelled:00,timed_out:01,stale:01".split(',') {
+        // `candidate_recoverable` and `partial_recoverable` reached this
+        // classifier as `partial_failure` before #6761. They keep exactly its
+        // flags (inactive, failure) so splitting the projection changed what
+        // an operator can *see*, not how activity classifies the run.
+        for case in "unknown:01,queued:10,running:10,succeeded:00,candidate_recoverable:01,partial_recoverable:01,partial_failure:01,failed:01,cancelled:00,timed_out:01,stale:01".split(',') {
             let (label, flags) = case.split_once(':').expect("policy case");
             let state: ActivityState = serde_json::from_value(label.into()).unwrap();
             let (active, failure) = (flags.starts_with('1'), flags.ends_with('1'));

--- a/crates/homeboy-core/src/activity/model.rs
+++ b/crates/homeboy-core/src/activity/model.rs
@@ -195,6 +195,13 @@ pub struct ActivityCounts {
     pub queued: usize,
     pub running: usize,
     pub succeeded: usize,
+    /// Stopped with a promotable candidate. Counted separately from
+    /// `partial_failure` since #6761 — before that both, plus
+    /// `partial_recoverable`, were summed into `partial_failure`, so an
+    /// operator could not see how many runs were waiting on a promotion.
+    pub candidate_recoverable: usize,
+    /// Stopped with resumable partial work. See `candidate_recoverable`.
+    pub partial_recoverable: usize,
     pub partial_failure: usize,
     pub failed: usize,
     pub cancelled: usize,

--- a/crates/homeboy-core/src/run_lifecycle_status.rs
+++ b/crates/homeboy-core/src/run_lifecycle_status.rs
@@ -7,18 +7,40 @@ use crate::run_lifecycle_record::RunExecutionState;
 pub const RUN_LIFECYCLE_STATUS_SCHEMA: &str = "homeboy/run-lifecycle-status/v1";
 
 /// Canonical run lifecycle status vocabulary for cross-runtime contracts.
+///
+/// # Recoverable is not retryable
+///
+/// `CandidateRecoverable` and `PartialRecoverable` are terminal and
+/// unsuccessful, like `PartialFailure`, and like it they are **not
+/// retryable** — re-running reproduces the same stop. They are separate
+/// because the *next action* differs: a candidate can be promoted, partial
+/// work can be resumed, and a partial failure offers neither. Folding them
+/// into `PartialFailure` (which is what happened before) left a consumer
+/// holding a serialized run unable to tell those three apart.
+///
+/// # Unknown is the tolerance hatch
+///
+/// `Unknown` is `#[serde(other)]` so a payload from a newer binary degrades to
+/// "no verdict" instead of failing to parse. It deliberately claims nothing:
+/// not terminal, not successful, not retryable.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum RunLifecycleStatus {
-    Unknown,
     Queued,
     Running,
     Succeeded,
+    /// Stopped, unsuccessful, but a promotable candidate survived.
+    CandidateRecoverable,
+    /// Stopped, unsuccessful, but the partial work can be resumed.
+    PartialRecoverable,
     PartialFailure,
     Failed,
     Cancelled,
     TimedOut,
     Stale,
+    /// A status minted by a producer this binary does not know. Never guessed.
+    #[serde(other)]
+    Unknown,
 }
 
 impl RunLifecycleStatus {
@@ -26,6 +48,8 @@ impl RunLifecycleStatus {
         matches!(
             self,
             Self::Succeeded
+                | Self::CandidateRecoverable
+                | Self::PartialRecoverable
                 | Self::PartialFailure
                 | Self::Failed
                 | Self::Cancelled
@@ -50,6 +74,8 @@ impl From<RunExecutionState> for RunLifecycleStatus {
             RunExecutionState::Queued => Self::Queued,
             RunExecutionState::Running => Self::Running,
             RunExecutionState::Succeeded => Self::Succeeded,
+            RunExecutionState::CandidateRecoverable => Self::CandidateRecoverable,
+            RunExecutionState::PartialRecoverable => Self::PartialRecoverable,
             RunExecutionState::PartialFailure => Self::PartialFailure,
             RunExecutionState::Failed => Self::Failed,
             RunExecutionState::Cancelled => Self::Cancelled,
@@ -135,10 +161,12 @@ impl From<&CookStatus> for RunLifecycleStatus {
             // Cook did not succeed either, and re-running it changes nothing.
             CookStatus::NoChanges => Self::PartialFailure,
             // A candidate exists and can still be recovered. This matches the
-            // existing `AgentTaskRunState::CandidateRecoverable ->
-            // RunExecutionState::PartialFailure` projection rather than
-            // inventing a second reading of the same situation.
-            CookStatus::CandidateRecoverable => Self::PartialFailure,
+            // `AgentTaskRunState::CandidateRecoverable ->
+            // RunExecutionState::CandidateRecoverable` projection rather than
+            // inventing a second reading of the same situation. Both used to
+            // say `PartialFailure`; they were changed together so the two
+            // routes still agree.
+            CookStatus::CandidateRecoverable => Self::CandidateRecoverable,
             // Stopped waiting on a verdict that is not this run's to produce.
             CookStatus::AwaitingAcceptance => Self::PartialFailure,
             // Re-running reproduces the block identically until the dependency
@@ -203,6 +231,11 @@ mod tests {
             (RunLifecycleStatus::Queued, false, false, false),
             (RunLifecycleStatus::Running, false, false, false),
             (RunLifecycleStatus::Succeeded, true, true, false),
+            // Terminal, unsuccessful, and NOT retryable: re-running reproduces
+            // the same stop. The next action is promotion or resumption, which
+            // is why these are separate variants rather than `PartialFailure`.
+            (RunLifecycleStatus::CandidateRecoverable, true, false, false),
+            (RunLifecycleStatus::PartialRecoverable, true, false, false),
             (RunLifecycleStatus::PartialFailure, true, false, false),
             (RunLifecycleStatus::Failed, true, false, true),
             (RunLifecycleStatus::Cancelled, true, false, false),
@@ -226,7 +259,8 @@ mod tests {
 
     #[test]
     fn source_states_project_to_canonical_status() {
-        for label in "unknown,queued,running,succeeded,partial_failure,failed,cancelled".split(',')
+        for label in "unknown,queued,running,succeeded,candidate_recoverable,partial_recoverable,partial_failure,failed,cancelled"
+            .split(',')
         {
             let source: RunExecutionState = serde_json::from_value(label.into()).unwrap();
             let expected: RunLifecycleStatus = serde_json::from_value(label.into()).unwrap();
@@ -289,7 +323,7 @@ mod tests {
                 CookStatus::NoOpGateFailed => RunLifecycleStatus::Failed,
                 CookStatus::GateFailed => RunLifecycleStatus::Failed,
                 CookStatus::AwaitingAcceptance => RunLifecycleStatus::PartialFailure,
-                CookStatus::CandidateRecoverable => RunLifecycleStatus::PartialFailure,
+                CookStatus::CandidateRecoverable => RunLifecycleStatus::CandidateRecoverable,
                 CookStatus::BlockedByDependency => RunLifecycleStatus::PartialFailure,
                 CookStatus::Blocked => RunLifecycleStatus::PartialFailure,
                 CookStatus::Cancelled => RunLifecycleStatus::Cancelled,


### PR DESCRIPTION
Step 1 of #6761. Fixes the first of the two defects recorded in [this comment](https://github.com/Extra-Chill/homeboy/issues/6761#issuecomment-5403663911), verified still live on `ac8f0004d`.

## The defect

`AgentTaskRunState` had eight variants and projected onto seven, twice:

```rust
AgentTaskRunState::CandidateRecoverable => RunExecutionState::PartialFailure,
AgentTaskRunState::PartialRecoverable   => RunExecutionState::PartialFailure,
AgentTaskRunState::PartialFailure       => RunExecutionState::PartialFailure,
```

`ActivityState` is a type alias of `RunLifecycleStatus`, and `activity_provider.rs` builds each item's state via `ActivityState::from(RunExecutionState::from(record.state))`. Both hops collapsed, so an orchestrator reading `activity` could not distinguish **"there is a promotable candidate here"** from **"this partially failed."** `cook_promotion.rs` branches on `CandidateRecoverable` in seven places, so the distinction is load-bearing internally — it just never survived serialization.

## Why it survived

The doc comment directly above the projection said:

> "The two enums share every agent-task variant **1:1** ... so this single `From` keeps `record.state` and `record.lifecycle.execution.state` in lockstep instead of a hand-synced map."

The match beneath it was 8 → 6. Anyone auditing the file read the comment and moved on. The comment is corrected, and `the_projection_is_injective` replaces the claim with a test, so a future variant that re-collapses the vocabulary fails instead of leaving a stale assertion in a comment.

## Both hops move together

`RunExecutionState` and `RunLifecycleStatus` are widened in the same change, and `CookStatus::CandidateRecoverable` moves with them. The pre-existing `the_direct_projection_agrees_with_the_composed_one` pins that the direct `AgentTaskRunState → RunLifecycleStatus` shortcut never diverges from composing the two hops — fixing only one hop would have broken it, which is a good sign the invariant was well chosen.

Recoverable is terminal and unsuccessful, and explicitly **not retryable**: re-running reproduces the same stop. The next action is promotion or resumption. This matches how `RetriesExhausted`/`Blocked` are already treated.

## Behavior preserved at every branch on the old value

The set of runs landing in `PartialFailure` shrinks, so every consumer branching on it was reviewed:

| site | handling |
|---|---|
| `validate_durable_publication_eligibility` | **`==` comparison — the compiler cannot flag this.** Recoverable runs reached it as `PartialFailure` and were eligible; now listed explicitly so publication is not silently narrowed. |
| `activity::is_failure` | Defined negatively (not active, not `Succeeded`/`Cancelled`), so the new states inherit the old classification unchanged. Pinned by `activity_policy_preserves_active_and_failure_sets`. |
| `activity::is_active` / `ActivityPoller::is_terminal` | `is_terminal` is literally `!is_active(...)`; new states are inactive exactly as `PartialFailure` was. |
| `ActivityCounts` | Gains `candidate_recoverable` and `partial_recoverable` instead of folding into `partial_failure`. Additive on the wire, and it is the number an operator actually wants. **This is the one intentional output change.** |
| `status_label` (runner lifecycle) | New arms. |
| `lifecycle_store` → `RunStatus`, `reconcile.rs` string labels | Untouched — separate vocabularies, already distinguished the states. |

## Durable-format hardening

`Unknown` becomes `#[serde(other)]` on both enums.

`RunExecutionState` is serialized into `RunLifecycleRecord` on disk. Without a tolerance hatch, every older reader hard-fails on a record containing a state it has not learned — meaning this would be the *last* variant addition that was safe to make. With it, unknown states degrade to `Unknown` and the enclosing record still parses. The precedent is `FuzzFailureDomain` in `homeboy-fuzz`.

Note this does not retroactively help binaries already deployed; it makes every future addition safe.

## Verification

- `cargo check --workspace --all-targets -j2` → **exit 0, zero warnings.**
- `cargo test -p homeboy-lifecycle-contract --lib` → **26 passed, 0 failed.** Run in isolation (the crate depends only on `serde`/`serde_json`, so this is a few MB, not the 28G workspace test build). This is what actually proves `#[serde(other)]` behaves at runtime rather than merely compiling.
- Full suite routed to CI per the repo's disk constraints.

New coverage: `the_projection_is_injective`, `the_lifecycle_status_projection_is_injective`, `recoverable_states_are_terminal_unsuccessful_and_not_retryable`, `every_pre_existing_durable_label_still_deserializes`, `recoverable_states_have_stable_wire_labels`, `a_state_from_a_newer_binary_degrades_to_unknown`, `an_unknown_state_does_not_fail_the_enclosing_record`.

## Deliberately not done

- **No `is_recoverable()` helper.** A boolean re-collapses the two states into one bit — the exact loss being removed. Consumers match the variant.
- **`JobStatus` not widened.** #6761's reasoning still holds: it is persisted in the job store, `ActiveRunnerJobSummary`, and `DaemonActiveJobRecoveryEvidence`, and widening it changes `is_terminal()` semantics. The separate `JobStatus` dual-label defect (`run_status_label` says `"pass"`, `daemon_status_label` says `"succeeded"`, both live) is step 3 and is a *deletion*, not a widening.
- **`LifecyclePhaseStatus` / `HomeboyGateStatus` untouched**, per the standing do-not-merge note.

Refs #6761