### PR TITLE
refactor(api-jobs): pin JobStatus's wire string to its serde form

### DIFF
--- a/crates/contracts/homeboy-api-jobs-contract/src/types.rs
+++ b/crates/contracts/homeboy-api-jobs-contract/src/types.rs
@@ -25,6 +25,17 @@ impl JobStatus {
         matches!(self, Self::Succeeded | Self::Failed | Self::Cancelled)
     }
 
+    /// This status projected onto the observation/run-listing vocabulary,
+    /// where a finished job reads `pass`/`fail`.
+    ///
+    /// A different vocabulary, not a different format of [`JobStatus::as_str`]:
+    /// `RunStatus` spells its terminal states `Pass`/`Fail`, and
+    /// `homeboy runs list --status pass` filters on these strings. Merging the
+    /// two breaks that filter with no compile error.
+    ///
+    /// Partial in the other direction — `queued` and `cancelled` have no
+    /// `RunStatus` counterpart and pass through as themselves, so the output is
+    /// not parseable into `RunStatus`.
     pub fn run_status_label(self) -> &'static str {
         match self {
             Self::Queued => "queued",
@@ -35,7 +46,10 @@ impl JobStatus {
         }
     }
 
-    pub fn daemon_status_label(self) -> &'static str {
+    /// This status as its own canonical wire string — the value `serde`
+    /// already produces, pinned to it by
+    /// `job_status_matches_its_serialized_form`.
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::Queued => "queued",
             Self::Running => "running",
@@ -350,5 +364,40 @@ impl DaemonLeaseJobDiagnostics {
         self.matching_count()
             .saturating_sub(self.protected_count())
             .saturating_sub(self.preserved_remote_job_ids.len())
+    }
+}
+
+#[cfg(test)]
+mod job_status_label_tests {
+    use super::JobStatus;
+
+    /// `as_str` must stay the value `serde` produces. It replaced
+    /// `daemon_status_label`, which restated the same strings by hand with
+    /// nothing tying them to `#[serde(rename_all)]`. This is that tie.
+    #[test]
+    fn job_status_matches_its_serialized_form() {
+        for status in [
+            JobStatus::Queued,
+            JobStatus::Running,
+            JobStatus::Succeeded,
+            JobStatus::Failed,
+            JobStatus::Cancelled,
+        ] {
+            assert_eq!(
+                serde_json::to_value(status).expect("serialize"),
+                serde_json::json!(status.as_str()),
+                "{status:?}"
+            );
+        }
+    }
+
+    /// `run_status_label` is a different vocabulary, not a different format,
+    /// and `homeboy runs list --status pass` depends on it staying that way.
+    /// Merging it into `as_str` is a string-comparison break with no compile
+    /// error, so it fails here instead.
+    #[test]
+    fn the_run_listing_vocabulary_keeps_pass_and_fail() {
+        assert_eq!(JobStatus::Succeeded.run_status_label(), "pass");
+        assert_eq!(JobStatus::Failed.run_status_label(), "fail");
     }
 }

--- a/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
+++ b/crates/homeboy-lab-runner/src/controller_fallback_projection.rs
@@ -243,10 +243,7 @@ impl ControllerFallbackProjectionStore {
                     self.record_observation(
                         &mission_id,
                         "pending",
-                        format!(
-                            "runner job remains {}",
-                            snapshot.job.status.daemon_status_label()
-                        ),
+                        format!("runner job remains {}", snapshot.job.status.as_str()),
                     )?;
                     continue;
                 }
@@ -278,7 +275,7 @@ impl ControllerFallbackProjectionStore {
                 &mut state,
                 &mission_id,
                 RunnerTerminalEvidence {
-                    outcome: snapshot.job.status.daemon_status_label().to_string(),
+                    outcome: snapshot.job.status.as_str().to_string(),
                     artifacts: receipt.runner_receipt.artifacts,
                 },
             )?;

--- a/crates/homeboy-lab-runner/src/evidence/provider.rs
+++ b/crates/homeboy-lab-runner/src/evidence/provider.rs
@@ -71,7 +71,7 @@ impl RunnerEvidenceProvider for RunnerEvidence {
                         durable_run_id: job.durable_run_id,
                         runner_id: job.runner_id,
                         job_id: job.job_id,
-                        status: job.status.daemon_status_label().to_string(),
+                        status: job.status.as_str().to_string(),
                         lifecycle_state: job.lifecycle_state,
                         stale_reason: job.stale_reason,
                         retryable: job.retryable,

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -2074,7 +2074,7 @@ pub(super) fn lab_terminal_result_transport_error(
         format!(
             "Lab offload runner `{}` daemon job `{job_id}` finished with status `{}`, but Homeboy could not retrieve or parse the daemon result report: {}. This is a Lab transport/reporting failure, not a remote command failure.",
             runner.id,
-            job.status.daemon_status_label(),
+            job.status.as_str(),
             err.message
         ),
         json!({
@@ -2083,7 +2083,7 @@ pub(super) fn lab_terminal_result_transport_error(
             "persisted_run_id": run_id,
             "remote_cwd": cwd,
             "command": redact_argv(command),
-            "job_status": job.status.daemon_status_label(),
+            "job_status": job.status.as_str(),
             "source": err.details,
         }),
     );

--- a/crates/homeboy-lab-runner/src/execution/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/handoff.rs
@@ -39,7 +39,7 @@ pub(crate) fn lab_offload_handoff_hints(
         )],
         DaemonJobHandoffState::Terminal(status) => vec![format!(
             "Lab offload handoff: runner `{runner_id}` daemon job `{job_id}` finished with status `{}`.",
-            status.daemon_status_label()
+            status.as_str()
         )],
     };
 

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -1601,7 +1601,7 @@ pub(super) fn fire_runner_direct_notification(
     let Some(route) = notification_route else {
         return;
     };
-    let status = job.status.daemon_status_label();
+    let status = job.status.as_str();
     let store = match homeboy_core::observation::ObservationStore::open_initialized() {
         Ok(store) => store,
         Err(_) => return,

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -3735,7 +3735,7 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
             run_id: request.recipe.run_id.clone(),
             runner_id: request.recipe.runner_id.clone(),
             runner_job_id: runner_job_id.to_string(),
-            status: observed.job.status.daemon_status_label().to_string(),
+            status: observed.job.status.as_str().to_string(),
         };
         receipt.validate(request, checkpoint)?;
         homeboy_agents::agent_task_lifecycle::persist_private_run_attachment(
@@ -3795,7 +3795,7 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
             if observed.job.status != homeboy_core::api_jobs::JobStatus::Cancelled {
                 return Err(Error::internal_unexpected(format!(
                     "Lab staging child cancellation for runner job `{job_id}` was not authoritative: observed `{}`",
-                    observed.job.status.daemon_status_label(),
+                    observed.job.status.as_str(),
                 )));
             }
         }
@@ -3826,7 +3826,7 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
         if observed.job.status != homeboy_core::api_jobs::JobStatus::Cancelled {
             return Err(Error::internal_unexpected(format!(
                 "Lab staging cancellation for runner job `{runner_job_id}` was not authoritative: observed `{}`",
-                observed.job.status.daemon_status_label(),
+                observed.job.status.as_str(),
             )));
         }
         homeboy_agents::agent_task_lifecycle::project_terminal_runner_result(


### PR DESCRIPTION
Step 3 of #6761. Independent of #13395 — different crate, different enum, based directly on `main`.

**This is not a deletion.** It removes one line and adds ~46 net, most of which is the reason this is not the obvious cleanup. Calling it a deletion up front was wrong, so here is the actual accounting:

```
7 files changed, 60 insertions(+), 14 deletions(-)
  ~10 lines  code (a rename + 10 call sites)
  ~17 lines  docs
  ~33 lines  tests
```

## The trap

`JobStatus` carried two label functions that disagreed on three of five variants:

```rust
run_status_label:     Succeeded => "pass"       Failed => "fail"
daemon_status_label:  Succeeded => "succeeded"  Failed => "failed"
```

Both live on `main`, 4 call sites vs 10, split along a crate boundary. It reads like two *formats* of one value, and the obvious cleanup is to merge them.

**Only one was redundant.** I went in intending to delete one and would have picked wrong.

## What was redundant

`daemon_status_label` returned exactly what `#[serde(rename_all = "snake_case")]` already produces, restated by hand with nothing tying the two together — a variant rename or serde change leaves a stale second spelling. That is #6761's hand-synced-vocabulary problem in miniature.

Now `as_str`, matching the convention already used by `RunStatus`, `CookStatus`, `FuzzFailureDomain`, and the extension contracts. `job_status_matches_its_serialized_form` ties it to the serialized form so it cannot drift again.

## What was not

`run_status_label` is a different **vocabulary**:

- `RunStatus` — the observation record's own enum — spells its terminal states `Pass`/`Fail`.
- `homeboy runs list --status pass` filters on these strings (`runs/handlers.rs`, `runs/remote.rs`, `http_api.rs`, `api_jobs/summary.rs`).

Merging it into `as_str` breaks that filter through a **string comparison — no compile error**. Nothing would catch it: not `cargo check`, not clippy, not the type system.

So it keeps its name and gains the doc explaining why, plus a two-line test. That test exists specifically because the merge is what a reader who notices "two label functions" reaches for first — which is exactly what I did.

Also recorded: the projection is **partial**. `queued` and `cancelled` have no `RunStatus` counterpart and pass through as themselves, so the output is not parseable into `RunStatus`. Previously undocumented and a live footgun given the function's name.

## Verification

- `cargo check --workspace --all-targets -j2` → **exit 0, zero warnings**
- `cargo test -p homeboy-api-jobs-contract --lib` → **2 passed**, run in isolation

## No behavior change

All ten `daemon_status_label` call sites are in `homeboy-lab-runner` and produced the serde spelling before and after. `run_status_label` is untouched at every call site.

`JobStatus` is **not** widened into `RunExecutionState` here, per #6761's standing note — it is persisted in the job store, `ActiveRunnerJobSummary`, and `DaemonActiveJobRecoveryEvidence`.

Refs #6761