### PR TITLE
fix(core): restore the non-unix digest_memo_min_hash_time fallback

### DIFF
--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -208,6 +208,19 @@ fn digest_memo_min_hash_time() -> std::time::Duration {
     DIGEST_MEMO_MIN_HASH_TIME
 }
 
+/// Non-unix has no digest memo. `memoized_executable_digest` always misses and
+/// `memoize_executable_digest` is a no-op, so no elapsed hash time can make
+/// memoization reachable. `MAX` states that, rather than implying a threshold
+/// that decides nothing.
+///
+/// `executable_digest` is not itself `cfg`-gated, so the unix-only definition
+/// above escaped its call site and only Windows could see it (E0425). The two
+/// helpers beside it already carry `cfg(not(unix))` stubs; this one was missed.
+#[cfg(not(unix))]
+fn digest_memo_min_hash_time() -> std::time::Duration {
+    std::time::Duration::MAX
+}
+
 #[cfg(unix)]
 static EXECUTABLE_DIGESTS: OnceLock<Mutex<BTreeMap<ExecutableFileIdentity, String>>> =
     OnceLock::new();


### PR DESCRIPTION
## Problem

`homeboy-core` does not compile for Windows on `main`:

```
error[E0425]: cannot find function `digest_memo_min_hash_time` in this scope
  --> crates\homeboy-core\src\controller_runtime.rs:2713:37
```

`executable_digest` (`controller_runtime.rs:2696`) is not `cfg`-gated, but the memo threshold it calls is defined only under `#[cfg(unix)]` (`:199`). On Windows the call site exists and the definition does not.

The surrounding memo subsystem is deliberately unix-only and the author handled that correctly for the other two helpers — `memoized_executable_digest` has a `cfg(not(unix))` stub returning `None` (`:2764`), `memoize_executable_digest` has one that is a no-op (`:2781`). Only the threshold was missed.

## Fix

Add the matching `cfg(not(unix))` fallback. It returns `Duration::MAX`, which states that memoization is unreachable off unix rather than implying a threshold that decides nothing — the memo always misses and the store is a no-op there regardless.

Thirteen added lines, no behaviour change on unix.

## Impact

This is red on `main` right now. It surfaces as two failing required contexts:

- `homeboy / Windows Compile`
- `homeboy / External Resolver Fixtures (windows-latest)` — same crate, same error

It reads as green on most PRs only because `Windows Compile` is `SKIPPED` unless a change widens the scope enough to schedule it. It was skipped on the five most recent PRs before #13402 triggered it.

Both are among the eight contexts required by the `main` ruleset, so this blocks merges on any PR that schedules them.

## Why the local gate cannot catch this class

`cargo check --workspace --all-targets` on Linux compiles with `cfg(unix)` **true**. A unix-only definition escaping an ungated call site is invisible to it by construction, not by bad luck — structurally the same blindness `--tests` has toward `#[cfg(test)]`, on the platform axis instead of the test axis.

Catching it before CI would require `--target x86_64-pc-windows-msvc` in the pre-push gate, which is not currently possible on the dev host: `ring` needs a C toolchain to cross-compile.

## Verification

```
rustc --print cfg --target x86_64-pc-windows-msvc   'unix' not set
                                                    -> the new branch is what Windows compiles
two definitions, mutually exclusive cfgs            no duplicate-definition risk
cargo check -p homeboy-core --all-targets -j2       clean on Linux (1m54s)
cargo fmt -- --check                                clean
```

A full Windows-target check was attempted and is not possible on this host (`ring` build script needs a C compiler). CI is the verification.

## AI assistance

Diagnosed and fixed by Claude (chubes-bot) while investigating two Windows failures on #13402, which turned out to be pre-existing on `main` rather than caused by that PR. Chris Huber directed the work and remains responsible.
