### PR TITLE
Refactor CLI capabilities through deterministic registry

### DIFF
--- a/crates/homeboy-cli/src/capability_registry.rs
+++ b/crates/homeboy-cli/src/capability_registry.rs
@@ -1,0 +1,210 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use clap::Command;
+
+use crate::cli_runtime::CliCapability;
+
+pub struct RegisteredCliCapability {
+    pub capability: &'static dyn CliCapability,
+    pub command: Command,
+    spellings: Vec<String>,
+}
+
+pub struct CommandCapabilityRegistry {
+    entries: Vec<RegisteredCliCapability>,
+}
+
+impl CommandCapabilityRegistry {
+    pub fn compose(
+        capabilities: &'static [&'static dyn CliCapability],
+        required: &[&str],
+        builtin: &Command,
+    ) -> crate::core::Result<Self> {
+        let mut builtin_owners = BTreeMap::new();
+        for command in builtin.get_subcommands() {
+            builtin_owners.insert(command.get_name().to_string(), "built-in command");
+            for alias in command.get_all_aliases() {
+                builtin_owners.insert(alias.to_string(), "built-in command alias");
+            }
+        }
+
+        let mut owners = BTreeSet::new();
+        let mut spellings = builtin_owners;
+        let mut entries = Vec::with_capacity(capabilities.len());
+        for capability in capabilities {
+            let owner = capability.name();
+            if !owners.insert(owner) {
+                return Err(registry_error(format!(
+                    "capability owner `{owner}` is registered more than once"
+                )));
+            }
+            let command = capability.command();
+            if command.get_name() != owner {
+                return Err(registry_error(format!(
+                    "capability owner `{owner}` returned command `{}`",
+                    command.get_name()
+                )));
+            }
+            let mut entry_spellings = vec![owner.to_string()];
+            entry_spellings.extend(command.get_all_aliases().map(str::to_string));
+            entry_spellings.sort();
+            entry_spellings.dedup();
+            for spelling in &entry_spellings {
+                if let Some(existing) = spellings.insert(spelling.clone(), owner) {
+                    return Err(registry_error(format!(
+                        "capability `{owner}` spelling `{spelling}` conflicts with {existing}"
+                    )));
+                }
+            }
+            entries.push(RegisteredCliCapability {
+                capability: *capability,
+                command,
+                spellings: entry_spellings,
+            });
+        }
+
+        for owner in required {
+            if !owners.contains(owner) {
+                return Err(registry_error(format!(
+                    "required capability owner `{owner}` is not registered"
+                )));
+            }
+        }
+        entries.sort_by_key(|entry| entry.capability.name());
+        Ok(Self { entries })
+    }
+
+    pub fn entries(&self) -> &[RegisteredCliCapability] {
+        &self.entries
+    }
+
+    pub fn capabilities(&self) -> Vec<&'static dyn CliCapability> {
+        self.entries.iter().map(|entry| entry.capability).collect()
+    }
+
+    pub fn find(&self, spelling: &str) -> Option<&'static dyn CliCapability> {
+        self.entries
+            .iter()
+            .find(|entry| entry.spellings.iter().any(|value| value == spelling))
+            .map(|entry| entry.capability)
+    }
+
+    pub fn validate_external_names<'a>(
+        &self,
+        names: impl IntoIterator<Item = &'a str>,
+    ) -> crate::core::Result<()> {
+        for name in names {
+            if let Some(owner) = self.find(name) {
+                return Err(registry_error(format!(
+                    "capability `{}` spelling `{name}` conflicts with dynamic command `{name}`",
+                    owner.name()
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn registry_error(problem: String) -> crate::core::Error {
+    crate::core::Error::validation_invalid_argument("capabilities", problem, None, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::ArgMatches;
+
+    struct Alpha;
+    struct Beta;
+    struct AlphaAliasBeta;
+    struct Mismatched;
+    struct StatusCapability;
+
+    static ALPHA: Alpha = Alpha;
+    static BETA: Beta = Beta;
+    static ALPHA_ALIAS_BETA: AlphaAliasBeta = AlphaAliasBeta;
+    static MISMATCHED: Mismatched = Mismatched;
+    static STATUS_CAPABILITY: StatusCapability = StatusCapability;
+
+    macro_rules! capability {
+        ($type:ty, $name:literal, $command:expr) => {
+            impl CliCapability for $type {
+                fn name(&self) -> &'static str {
+                    $name
+                }
+
+                fn command(&self) -> Command {
+                    $command
+                }
+
+                fn run(
+                    &self,
+                    _matches: &ArgMatches,
+                ) -> crate::core::Result<(serde_json::Value, i32)> {
+                    Ok((serde_json::Value::Null, 0))
+                }
+            }
+        };
+    }
+
+    capability!(Alpha, "alpha", Command::new("alpha"));
+    capability!(Beta, "beta", Command::new("beta"));
+    capability!(AlphaAliasBeta, "alpha", Command::new("alpha").alias("beta"));
+    capability!(Mismatched, "declared", Command::new("actual"));
+    capability!(StatusCapability, "status", Command::new("status"));
+
+    fn builtin() -> Command {
+        Command::new("homeboy").subcommand(Command::new("status"))
+    }
+
+    fn error(
+        capabilities: &'static [&'static dyn CliCapability],
+        required: &[&str],
+    ) -> crate::core::Error {
+        CommandCapabilityRegistry::compose(capabilities, required, &builtin())
+            .err()
+            .expect("composition must fail")
+    }
+
+    #[test]
+    fn registry_order_is_stable_under_permuted_input() {
+        static FORWARD: [&'static dyn CliCapability; 2] = [&ALPHA, &BETA];
+        static REVERSE: [&'static dyn CliCapability; 2] = [&BETA, &ALPHA];
+        let names = |registry: CommandCapabilityRegistry| {
+            registry
+                .entries()
+                .iter()
+                .map(|entry| entry.capability.name())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            names(CommandCapabilityRegistry::compose(&FORWARD, &[], &builtin()).unwrap()),
+            names(CommandCapabilityRegistry::compose(&REVERSE, &[], &builtin()).unwrap())
+        );
+    }
+
+    #[test]
+    fn registry_rejects_conflicts_and_missing_required_owners() {
+        static ALIAS_CONFLICT: [&'static dyn CliCapability; 2] = [&ALPHA_ALIAS_BETA, &BETA];
+        static DUPLICATE: [&'static dyn CliCapability; 2] = [&ALPHA, &ALPHA];
+        static BUILTIN_CONFLICT: [&'static dyn CliCapability; 1] = [&STATUS_CAPABILITY];
+        static MISMATCH: [&'static dyn CliCapability; 1] = [&MISMATCHED];
+        static ONLY_ALPHA: [&'static dyn CliCapability; 1] = [&ALPHA];
+
+        for error in [
+            error(&ALIAS_CONFLICT, &[]),
+            error(&DUPLICATE, &[]),
+            error(&BUILTIN_CONFLICT, &[]),
+            error(&MISMATCH, &[]),
+            error(&ONLY_ALPHA, &["beta"]),
+        ] {
+            assert_eq!(error.details["field"], "capabilities");
+        }
+    }
+
+    #[test]
+    fn empty_kernel_registry_is_valid() {
+        let registry = CommandCapabilityRegistry::compose(&[], &[], &builtin()).unwrap();
+        assert!(registry.entries().is_empty());
+    }
+}

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1,10 +1,11 @@
-use clap::{ArgMatches, Command};
+use clap::{ArgMatches, Command, CommandFactory};
 use std::collections::BTreeSet;
 use std::io::{IsTerminal, Write};
 use std::process::Command as ProcessCommand;
 use std::sync::OnceLock;
 use uuid::Uuid;
 
+use crate::capability_registry::CommandCapabilityRegistry;
 use crate::cli_surface::{
     command_safety_manifest_from_dynamic, command_surface_from, Cli, CommandSafetyManifest,
     Commands, DynamicCommandDescriptor, ExtensionCommandArgContract, ExtensionCommandArgsContract,
@@ -222,7 +223,7 @@ pub(crate) fn select_unmaterialized_cook_runner(
 
 pub struct CliRuntime {
     extension_discovery: OnceLock<ExtensionCliDiscovery>,
-    capabilities: &'static [&'static dyn CliCapability],
+    capabilities: CommandCapabilityRegistry,
 }
 
 struct ExtensionCliCommand {
@@ -581,10 +582,22 @@ impl CliRuntime {
     }
 
     pub fn with_capabilities(capabilities: &'static [&'static dyn CliCapability]) -> Self {
-        Self {
+        Self::try_with_required_capabilities(capabilities, &[])
+            .expect("CLI capability composition must be valid")
+    }
+
+    pub fn try_with_required_capabilities(
+        capabilities: &'static [&'static dyn CliCapability],
+        required: &[&str],
+    ) -> crate::core::Result<Self> {
+        Ok(Self {
             extension_discovery: OnceLock::new(),
-            capabilities,
-        }
+            capabilities: CommandCapabilityRegistry::compose(
+                capabilities,
+                required,
+                &Cli::command(),
+            )?,
+        })
     }
 
     pub fn run_from_args(&self, args: Vec<String>) -> std::process::ExitCode {
@@ -598,8 +611,11 @@ impl CliRuntime {
         register_startup_providers_before_reconcile();
         if std::env::var_os(CONTROLLER_FALLBACK_RECONCILIATION_ENV).is_some() {
             let config = crate::core::defaults::load_config();
-            if register_startup_providers_after_reconcile(&config.agent_task, self.capabilities)
-                .is_err()
+            if register_startup_providers_after_reconcile(
+                &config.agent_task,
+                &self.capabilities.capabilities(),
+            )
+            .is_err()
             {
                 return std::process::ExitCode::from(2);
             }
@@ -654,9 +670,10 @@ impl CliRuntime {
             return std::process::ExitCode::SUCCESS;
         }
         let config = crate::core::defaults::load_config();
-        if let Err(error) =
-            register_startup_providers_after_reconcile(&config.agent_task, self.capabilities)
-        {
+        if let Err(error) = register_startup_providers_after_reconcile(
+            &config.agent_task,
+            &self.capabilities.capabilities(),
+        ) {
             eprintln!("error: {error}");
             return std::process::ExitCode::from(2);
         }
@@ -700,6 +717,13 @@ impl CliRuntime {
             {
                 Ok(matches) => matches,
                 Err(err) => {
+                    if matches!(
+                        err.kind(),
+                        clap::error::ErrorKind::DisplayHelp
+                            | clap::error::ErrorKind::DisplayVersion
+                    ) {
+                        err.exit();
+                    }
                     if let Some(output) = try_augment_clap_error(
                         &err,
                         &diagnostic_args,
@@ -1335,14 +1359,18 @@ impl CliRuntime {
 
     fn build_augmented_command(&self) -> Command {
         let discovery = self.extension_discovery();
+        self.capabilities
+            .validate_external_names(discovery.info.iter().map(|info| info.tool.as_str()))
+            .expect("dynamic and typed capability command names must not conflict");
         let mut command = build_augmented_command(&discovery.info, &discovery.health);
-        for capability in self.capabilities {
-            command = command.subcommand(capability.command());
+        for entry in self.capabilities.entries() {
+            command = command.subcommand(entry.command.clone());
         }
         let support = self
             .capabilities
+            .entries()
             .iter()
-            .filter_map(|capability| capability.lab_command_route_support())
+            .filter_map(|entry| entry.capability.lab_command_route_support())
             .collect::<Vec<_>>();
         crate::command_contract::scope_composed_lab_cli_arguments(command, &support)
     }
@@ -1353,9 +1381,7 @@ impl CliRuntime {
     ) -> Option<(&'a dyn CliCapability, &'a ArgMatches)> {
         let (name, sub_matches) = matches.subcommand()?;
         self.capabilities
-            .iter()
-            .copied()
-            .find(|capability| capability.name() == name)
+            .find(name)
             .map(|capability| (capability, sub_matches))
     }
 

--- a/crates/homeboy-cli/src/lib.rs
+++ b/crates/homeboy-cli/src/lib.rs
@@ -30,6 +30,7 @@ pub use homeboy_lab_runner as runner;
 // across this layer resolve at the crate root.
 pub use homeboy_core::{is_zero, is_zero_u32, log_status};
 
+pub mod capability_registry;
 pub mod cli_runtime;
 pub mod cli_surface;
 pub mod command_capability;

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,10 @@ fn main() -> std::process::ExitCode {
     if args.get(1).map(String::as_str) == Some("__homeboy_status_probe") {
         return homeboy::commands::status::run_status_probe_child(args.get(2));
     }
-    let runtime = CliRuntime::with_capabilities(&PRODUCT_CAPABILITIES);
+    let runtime = CliRuntime::try_with_required_capabilities(
+        &PRODUCT_CAPABILITIES,
+        &[homeboy_triage::COMMAND_NAME],
+    )
+    .expect("standard product capability composition must be complete");
     runtime.run_from_args(args)
 }


### PR DESCRIPTION
Advances #13215

## Summary

- compose typed CLI capabilities into one immutable, deterministically ordered registry
- reject duplicate owners, command names and aliases, built-in conflicts, mismatched grammar names, dynamic-command conflicts, and missing required owners
- drive composed grammar, dispatch, Lab support, and startup capability ordering from registry entries
- require Triage explicitly in the standard product while preserving valid zero-capability kernel composition

This is the focused registry foundation. Manifest, safety, contract, output, and generated-reference contributions remain follow-up work under #13215.

## Verification

- `cargo test -p homeboy-cli --features test-support capability_registry --lib`
- `cargo check -p homeboy-cli -p homeboy`
- `cargo fmt --check`
- `git diff --check`
- `cargo run --quiet -- triage --help`
- `cargo run --quiet -- triage component` retains `homeboy/command-result/v3` and `validation.missing_argument`
- `cargo run --quiet -- contract manifest` retains the `triage` registration

The Homeboy lint runner is currently unavailable because its installed Rust extension references a missing `scripts/lib`; run `be6bf287-8d67-4730-a225-a8731a9a9cfe` contains zero findings. Native `cargo clippy` is also blocked by existing warnings in unchanged workspace files.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode inspected the existing composition paths, implemented the deterministic registry foundation, added focused tests, and ran the verification above. Chris Huber remains responsible for the implementation and review.