### PR TITLE
fix(lab-runner-contract): pin RunnerWorkspaceSyncMode's wire string to its serde form

### DIFF
--- a/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
@@ -140,12 +140,25 @@ pub struct RunnerArtifactRef {
 pub enum RunnerWorkspaceSyncMode {
     #[default]
     Snapshot,
+    /// Deliberate exception to `rename_all`: this mode's wire string is
+    /// `snapshot-git`, the spelling every durable consumer already uses —
+    /// on-disk runner-workspace metadata (`.homeboy/runner-workspace.json`),
+    /// the materialization-mode allowlists that verify Lab provenance, and
+    /// the CLI surface. Renaming the variant or its serde attribute must
+    /// move `as_str` with it, or
+    /// `runner_workspace_sync_mode_matches_its_serialized_form` fails.
+    #[serde(rename = "snapshot-git")]
     SnapshotGit,
     Git,
 }
 
 impl RunnerWorkspaceSyncMode {
-    pub fn label(self) -> &'static str {
+    /// This mode as its own canonical wire string — the value `serde`
+    /// produces, pinned to it by
+    /// `runner_workspace_sync_mode_matches_its_serialized_form`. Replaced
+    /// `label`, which restated the same strings by hand with nothing tying
+    /// them to the serde attributes (#13400).
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::Snapshot => "snapshot",
             Self::SnapshotGit => "snapshot-git",
@@ -406,10 +419,25 @@ pub enum RunnerTunnelMode {
 }
 
 impl RunnerTunnelMode {
+    /// This mode rendered for humans — `direct SSH`, `reverse-connected`.
+    ///
+    /// A different vocabulary, not a different format of
+    /// [`RunnerTunnelMode::metadata_value`]: this is prose for operator-facing
+    /// output, and it is deliberately not the wire string. Merging the two
+    /// would put a space and a hyphen into persisted metadata that
+    /// `#[serde(rename_all = "snake_case")]` spells `direct_ssh`, with no
+    /// compile error to catch it.
     pub fn label(&self) -> &'static str {
         self.labels().0
     }
 
+    /// This mode as its own canonical wire string — the value `serde` already
+    /// produces, pinned to it by
+    /// `runner_tunnel_mode_metadata_value_matches_its_serialized_form`.
+    ///
+    /// Unlike [`RunnerTunnelMode::label`], this is a hand-written restatement
+    /// of the derived form, so it can drift silently on a variant rename or a
+    /// serde attribute change (#13400). The pin is what stops that.
     pub fn metadata_value(&self) -> &'static str {
         self.labels().1
     }
@@ -871,6 +899,62 @@ fn advertised_capability_versions(
             .insert(capability.version);
     }
     versions
+}
+
+#[cfg(test)]
+mod runner_workspace_sync_mode_tests {
+    use super::RunnerWorkspaceSyncMode;
+
+    /// `as_str` must stay the value `serde` produces. It replaced `label`,
+    /// which drifted from the derived serde form: it returned
+    /// `"snapshot-git"` while `#[serde(rename_all = "snake_case")]`
+    /// serialized `SnapshotGit` as `"snapshot_git"`, a spelling every
+    /// materialization-mode allowlist rejects (#13400). The variant now
+    /// carries an explicit rename and this pin fails if either side moves.
+    #[test]
+    fn runner_workspace_sync_mode_matches_its_serialized_form() {
+        for mode in [
+            RunnerWorkspaceSyncMode::Snapshot,
+            RunnerWorkspaceSyncMode::SnapshotGit,
+            RunnerWorkspaceSyncMode::Git,
+        ] {
+            assert_eq!(
+                serde_json::to_value(mode).expect("serialize"),
+                serde_json::json!(mode.as_str()),
+                "{mode:?}"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod runner_tunnel_mode_label_tests {
+    use super::RunnerTunnelMode;
+
+    /// `metadata_value` restates what `#[serde(rename_all = "snake_case")]`
+    /// already produces. It agrees today, which is exactly the state
+    /// `RunnerWorkspaceSyncMode` was in before it drifted — nothing tied the
+    /// copy to its source. This is that tie (#13400).
+    #[test]
+    fn runner_tunnel_mode_metadata_value_matches_its_serialized_form() {
+        for mode in [RunnerTunnelMode::DirectSsh, RunnerTunnelMode::Reverse] {
+            assert_eq!(
+                serde_json::to_value(&mode).expect("serialize"),
+                serde_json::json!(mode.metadata_value()),
+                "{mode:?}"
+            );
+        }
+    }
+
+    /// `label` is a different vocabulary, not a different format, and merging
+    /// it into `metadata_value` would push prose into persisted metadata
+    /// through a string assignment with no compile error. It fails here
+    /// instead.
+    #[test]
+    fn the_operator_facing_vocabulary_stays_prose() {
+        assert_eq!(RunnerTunnelMode::DirectSsh.label(), "direct SSH");
+        assert_eq!(RunnerTunnelMode::Reverse.label(), "reverse-connected");
+    }
 }
 
 #[cfg(test)]

--- a/crates/homeboy-cli/src/commands/runner/exec.rs
+++ b/crates/homeboy-cli/src/commands/runner/exec.rs
@@ -403,7 +403,7 @@ pub(super) fn exec_workspace_context(
         runner_id,
         Path::new(&synced.local_path),
         Some(&synced.remote_path),
-        synced.sync_mode.label(),
+        synced.sync_mode.as_str(),
     );
 
     Ok((Some(synced.remote_path), Some(source_snapshot)))

--- a/crates/homeboy-lab-runner/src/dev_run.rs
+++ b/crates/homeboy-lab-runner/src/dev_run.rs
@@ -208,7 +208,7 @@ pub(crate) fn run_extension_dev_run_with(
         &plan.runner_id,
         Path::new(&synced.local_path),
         Some(&synced.remote_path),
-        synced.sync_mode.label(),
+        synced.sync_mode.as_str(),
     );
     source_snapshot.workspace_snapshot_identity = Some(synced.snapshot_identity.clone());
     let lifecycle = extension_dev_run_overlay_lifecycle(&plan, &synced, &source_snapshot);
@@ -217,7 +217,7 @@ pub(crate) fn run_extension_dev_run_with(
         runner_id: plan.runner_id.clone(),
         local_source: synced.local_path.clone(),
         remote_source: remote_install_source.clone(),
-        sync_mode: synced.sync_mode.label().to_string(),
+        sync_mode: synced.sync_mode.as_str().to_string(),
         snapshot_identity: synced.snapshot_identity.clone(),
         source_revision: lifecycle.source_revision.clone(),
         install_mode: lifecycle.install_mode.clone(),

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -2302,7 +2302,7 @@ pub(crate) fn run_lab_offload_inner(
     });
     lab_metadata["workspace_cleanliness"] = serde_json::json!({
         "schema": "homeboy/lab-workspace-cleanliness/v1",
-        "mode": sync_mode.label(),
+        "mode": sync_mode.as_str(),
         "remote_workspace": remote_cwd,
         "status": synced.workspace_cleanliness,
         "allow_dirty_lab_workspace": request.allow_dirty_lab_workspace,

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -314,7 +314,7 @@ fn prepare_lab_offload_workspace_stage_inner(
         .materialization_plan
         .actual_materialization_mode
         .as_deref()
-        .unwrap_or_else(|| sync_mode.label());
+        .unwrap_or_else(|| sync_mode.as_str());
     let remote_cwd = synced.remote_path.clone();
     let mut workspace_mapping = vec![workspace_mapping_entry("primary", &synced)];
     // The primary workspace sync materializes each declared dependency checkout
@@ -661,7 +661,7 @@ fn prepare_lab_offload_workspace_stage_inner(
     let path_materialization_plan = workspace_path_materialization_plan(
         &workspace_mapping,
         PATH_MATERIALIZATION_OWNER_LAB_EXECUTION_CONTEXT,
-        sync_mode.label(),
+        sync_mode.as_str(),
     );
     let path_remaps = path_remaps_from_materialization_plan(
         &path_materialization_plan,
@@ -1026,7 +1026,7 @@ fn lab_path_materialization_mode(
     ) {
         return "existing_remote".to_string();
     }
-    sync_mode.label().to_string()
+    sync_mode.as_str().to_string()
 }
 
 fn rewrite_lab_offload_remote_command_args(
@@ -2382,7 +2382,7 @@ mod tests {
         let plan = workspace_path_materialization_plan(
             &workspace_mapping,
             PATH_MATERIALIZATION_OWNER_LAB_EXECUTION_CONTEXT,
-            RunnerWorkspaceSyncMode::Snapshot.label(),
+            RunnerWorkspaceSyncMode::Snapshot.as_str(),
         );
         let path_remaps = path_remaps_from_materialization_plan(
             &plan,
@@ -2666,7 +2666,7 @@ mod tests {
         let plan = workspace_path_materialization_plan(
             &workspace_mapping,
             PATH_MATERIALIZATION_OWNER_LAB_EXECUTION_CONTEXT,
-            RunnerWorkspaceSyncMode::Snapshot.label(),
+            RunnerWorkspaceSyncMode::Snapshot.as_str(),
         );
 
         assert_eq!(plan.entries.len(), 1);

--- a/crates/homeboy-lab-runner/src/lab_workspaces/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces/mod.rs
@@ -204,7 +204,7 @@ pub(super) fn workspace_mapping_entry(
         role: role.into(),
         local_path: synced.local_path.clone(),
         remote_path: synced.remote_path.clone(),
-        sync_mode: synced.sync_mode.label().to_string(),
+        sync_mode: synced.sync_mode.as_str().to_string(),
         snapshot_identity: synced.snapshot_identity.clone(),
         dependency_freshness: None,
         source_provenance: None,
@@ -244,7 +244,7 @@ pub(super) fn workspace_mapping_entry_for_validation_dependency(
         role: dependency.role.clone(),
         local_path: dependency.local_path.clone(),
         remote_path: dependency.remote_path.clone(),
-        sync_mode: RunnerWorkspaceSyncMode::Snapshot.label().to_string(),
+        sync_mode: RunnerWorkspaceSyncMode::Snapshot.as_str().to_string(),
         snapshot_identity: dependency.id.clone(),
         dependency_freshness: Some(serde_json::json!({
             "id": dependency.id.as_str(),
@@ -264,7 +264,7 @@ pub(super) fn workspace_mapping_entry_for_git_dependency(
         role: role.into(),
         local_path: dependency.local_path.clone(),
         remote_path: dependency.remote_path.clone(),
-        sync_mode: dependency.sync_mode.label().to_string(),
+        sync_mode: dependency.sync_mode.as_str().to_string(),
         snapshot_identity: dependency.head.clone(),
         dependency_freshness: Some(serde_json::json!({
             "local_path": dependency.local_path.as_str(),
@@ -311,7 +311,7 @@ pub(super) fn workspace_mapping_entries_for_git_dependency(
                 .join(subpath)
                 .display()
                 .to_string(),
-            sync_mode: dependency.sync_mode.label().to_string(),
+            sync_mode: dependency.sync_mode.as_str().to_string(),
             snapshot_identity: dependency.head.clone(),
             dependency_freshness: None,
             source_provenance: None,

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -260,7 +260,7 @@ pub fn sync_workspace_in_roots(
                 // Snapshot-git deliberately retains Git metadata for callers
                 // that need a checkout baseline.
                 materialization_plan.actual_materialization_mode =
-                    Some(RunnerWorkspaceSyncMode::SnapshotGit.label().to_string());
+                    Some(RunnerWorkspaceSyncMode::SnapshotGit.as_str().to_string());
             }
             materialization_plan.fallback_reason = fallback_reason;
             let metadata = workspace_metadata(WorkspaceMetadataRequest {
@@ -1028,7 +1028,7 @@ pub fn reuse_compatible_snapshot_workspace(
     )?;
     let local_path_string = local_path.display().to_string();
     let Some(snapshot) = snapshots.snapshots.into_iter().find(|snapshot| {
-        snapshot.sync_mode == RunnerWorkspaceSyncMode::Snapshot.label()
+        snapshot.sync_mode == RunnerWorkspaceSyncMode::Snapshot.as_str()
             && snapshot.local_path == local_path_string
             && snapshot.source_commit.as_deref() == Some(source_commit.as_str())
             && snapshot.source_dirty == Some(false)
@@ -1141,7 +1141,7 @@ fn compatible_incremental_snapshot(
     )?;
     let local_path = local_path.display().to_string();
     Ok(snapshots.snapshots.into_iter().find_map(|snapshot| {
-        (snapshot.sync_mode == RunnerWorkspaceSyncMode::Snapshot.label()
+        (snapshot.sync_mode == RunnerWorkspaceSyncMode::Snapshot.as_str()
             && snapshot.local_path == local_path
             && snapshot.snapshot_excludes == excludes)
             .then(|| {
@@ -1938,7 +1938,7 @@ fn workspace_metadata(request: WorkspaceMetadataRequest<'_>) -> RunnerWorkspaceM
         )),
         local_path: request.local_path.display().to_string(),
         remote_path: request.remote_path.to_string(),
-        sync_mode: request.sync_mode.label().to_string(),
+        sync_mode: request.sync_mode.as_str().to_string(),
         actual_materialization_mode: request.actual_materialization_mode.map(str::to_string),
         fallback_reason: request.fallback_reason.map(str::to_string),
         snapshot_identity: request.snapshot_identity.to_string(),
@@ -4265,7 +4265,7 @@ fn workspace_lease(
         runner_id: runner_id.to_string(),
         local_path: current.local_path.clone(),
         remote_path: current.remote_path.clone(),
-        sync_mode: current.sync_mode.label().to_string(),
+        sync_mode: current.sync_mode.as_str().to_string(),
         materialized: current.materialized,
         lifecycle_owner: RunnerLifecycleOwner::Controller,
         source_commit: current.source_commit.clone(),

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -212,7 +212,7 @@ fn snapshot_git_reports_checkout_provenance_for_committed_harvest() {
                 .materialization_plan
                 .actual_materialization_mode
                 .as_deref(),
-            Some(RunnerWorkspaceSyncMode::SnapshotGit.label())
+            Some(RunnerWorkspaceSyncMode::SnapshotGit.as_str())
         );
         assert_eq!(
             git_output(Path::new(&synced.remote_path), &["rev-parse", "HEAD"])


### PR DESCRIPTION
Implements the **"Cheap partial"** of #13400. Does **not** build the `serde_label_drift` detector — that half depends on a `homeboy-extensions` fact-extraction change and stays open.

## The bug

`RunnerWorkspaceSyncMode::label()` returned `snapshot-git` for `SnapshotGit` while `#[serde(rename_all = "snake_case")]` serialized the same variant as `snapshot_git`. Two spellings of one value, one `#[serde]` attribute apart, nothing tying them together.

Both reached JSON under the key name `sync_mode`, from two different fields:

- `LabWorkspaceMappingEntry.sync_mode: String` <- `label()` -> `snapshot-git`
- `RunnerWorkspaceCurrentSummary.sync_mode: RunnerWorkspaceSyncMode` <- serde -> `snapshot_git`

Every string consumer knows only `snapshot-git`, and the serde spelling sits on the **reject** side of the materialization allowlist in `workspace/provenance.rs` — so the typed field serialized a value `verify_lab_workspace_git_root` classifies as untrusted. `cargo check` cannot see it; both sides are `&'static str`.

## Which spelling survives

Kept `snapshot-git`, via an explicit `#[serde(rename = "snapshot-git")]`.

It is the **durable** spelling: written into `.homeboy/runner-workspace.json` via `RunnerWorkspaceMetadata.sync_mode`, read back by `worker/run.rs`, and accepted by all four materialization-mode allowlists. Standardizing on the `rename_all` form would have been a read-path migration against metadata already on every runner, for attribute uniformity and nothing else.

`label` becomes `as_str`, matching `JobStatus`, `RunStatus`, `CookStatus`, and the extension contracts.

**No behavior change.** `as_str` returns what `label` returned at all 15 call sites. The only value that moves is the typed field's serialization, from the rejected spelling to the accepted one.

## RunnerTunnelMode

Checked. It is the **`JobStatus` shape**, not this one — two label fns where only one is redundant.

| fn | returns | disposition |
|---|---|---|
| `metadata_value()` | `direct_ssh` / `reverse` | exactly what `rename_all` produces, restated by hand. **Pinned.** Same unpinned-copy defect; it agrees today, which is precisely the state `RunnerWorkspaceSyncMode` was in before it drifted. |
| `label()` | `direct SSH` / `reverse-connected` | **Kept.** A different *vocabulary*, not a different *format* — prose for operator output. Merging would push a space and a hyphen into persisted metadata through a string assignment with no compile error. A second test pins the prose to stop that merge. |

That reading follows the rule from #6761's closing comment, filed as #13401: shape similarity is not semantic identity.

## Verification

- `cargo fmt --check` — clean
- `cargo check --workspace --all-targets -j2` — clean
- `cargo test -p homeboy-lab-runner-contract --lib` — 5 passed
- **Negative control**: deleting the new `#[serde(rename)]` fails `runner_workspace_sync_mode_matches_its_serialized_form` with `left: "snapshot_git", right: "snapshot-git"`, confirming the pin is load-bearing rather than vacuous.

## Provenance

Change produced by `homeboy agent-task cook` (`cook-detached-2d7d855d`, backend `opencode`). The provider timed out mid-commit with `candidate_recoverable` / `patch_available`; the patch was promoted by hand after `cook-continue --artifact-id` was rejected by #13421. The `RunnerTunnelMode` disposition, the negative control, and this description were added on top of the recovered candidate.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** `homeboy agent-task cook` with opencode; OpenCode/Claude via Kimaki for recovery, the `RunnerTunnelMode` triage, and verification.
- **Used for:** Produced the call-site rewrite and the sync-mode pin; verified durability of the surviving spelling, triaged `RunnerTunnelMode`, and negative-controlled the pin. Chris reviewed and owns the change.

Refs #13400
