### PR TITLE
Preserve release artifact identity through deploy execution

### DIFF
--- a/crates/homeboy-deploy/src/orchestration/mod.rs
+++ b/crates/homeboy-deploy/src/orchestration/mod.rs
@@ -864,6 +864,7 @@ mod tests {
         checkout_deploy_tags, deploy_tag_for_version, restore_branches, TagCheckout,
     };
     use crate::planning::{load_project_components, ExtensionSkippedComponent};
+    use crate::types::DeployArtifactSource;
     use homeboy_core::component::ComponentScriptsConfig;
     use homeboy_core::project::ProjectComponentAttachment;
     use homeboy_core::test_support::{home_env_guard, with_isolated_home};
@@ -2683,6 +2684,117 @@ mod tests {
             !artifact.starts_with(&component.local_path),
             "the stale configured-checkout artifact must not be reused"
         );
+    }
+
+    #[test]
+    fn explicit_version_release_asset_keeps_release_identity_and_ignores_stale_local_zip() {
+        with_isolated_home(|_| {
+            let temp = TempDir::new().expect("temp dir");
+            let component_path = temp.path().join("plugin");
+            std::fs::create_dir_all(component_path.join("build")).expect("build dir");
+            std::fs::write(component_path.join("plugin.php"), "Version: 1.7.0\n")
+                .expect("source version");
+
+            let stale_artifact = component_path.join("build/plugin.zip");
+            write_versioned_zip(&stale_artifact, "plugin/plugin.php", "Version: 1.6.0\n");
+
+            let release_artifact_path = temp.path().join("release-plugin.zip");
+            write_versioned_zip(
+                &release_artifact_path,
+                "plugin/plugin.php",
+                "Version: 1.7.0\n",
+            );
+            let release_bytes = std::fs::read(&release_artifact_path).expect("release bytes");
+            let release = ReleaseArtifactLease::test_new(
+                homeboy_core::git::release_download::ReleaseArtifact {
+                    path: release_artifact_path.clone(),
+                    tag: "v1.7.0".to_string(),
+                    commit: Some("release-commit".to_string()),
+                    url: "https://example.test/plugin/releases/download/v1.7.0/plugin.zip"
+                        .to_string(),
+                    name: "plugin.zip".to_string(),
+                    size: release_bytes.len() as u64,
+                    sha256: crate::sha256_file(&release_artifact_path).expect("sha"),
+                },
+            )
+            .expect("lease");
+
+            let component = Component {
+                id: "plugin".to_string(),
+                local_path: component_path.to_string_lossy().to_string(),
+                remote_path: "plugins/plugin".to_string(),
+                remote_url: Some("https://github.com/example/plugin".to_string()),
+                build_artifact: Some("build/plugin.zip".to_string()),
+                extract_command: Some("unzip -o {{artifact}}".to_string()),
+                version_targets: Some(vec![homeboy_core::component::VersionTarget {
+                    file: "plugin.php".to_string(),
+                    pattern: Some(r"Version:\s*([0-9.]+)".to_string()),
+                    artifact_path: Some("plugin/plugin.php".to_string()),
+                }]),
+                ..Component::default()
+            };
+            let mut config = base_deploy_config();
+            config.component_ids = vec!["plugin".to_string()];
+            config.expected_version = Some("1.7.0".to_string());
+
+            let dry_run = run_dry_run_mode(
+                std::slice::from_ref(&component),
+                &HashMap::from([("plugin".to_string(), "1.7.0".to_string())]),
+                &HashMap::new(),
+                &Project::default(),
+                "/srv/site",
+                &DeployConfig {
+                    dry_run: true,
+                    ..config.clone()
+                },
+            )
+            .expect("dry-run plan");
+            assert_eq!(
+                dry_run.results[0].artifact_source,
+                Some(DeployArtifactSource::ReleaseAsset)
+            );
+
+            let prepared = prepare_component_deployments(
+                std::slice::from_ref(&component),
+                &config,
+                &Project::default(),
+                "/srv/site",
+                &HashMap::from([("plugin".to_string(), "1.7.0".to_string())]),
+                &HashMap::new(),
+                &HashMap::from([("plugin".to_string(), release)]),
+            )
+            .expect("prepare explicit-version release deploy");
+
+            assert_eq!(
+                prepared[0].artifact_source,
+                Some(DeployArtifactSource::ReleaseAsset)
+            );
+            assert!(
+                prepared[0].config.prepared_artifact.is_none(),
+                "canonical release assets must not be rewritten into prepared_artifact inputs"
+            );
+            assert_eq!(
+                prepared[0].artifact_path.as_deref(),
+                Some(release_artifact_path.as_path())
+            );
+            let deployed_bytes =
+                std::fs::read(prepared[0].artifact_path.as_ref().expect("artifact path"))
+                    .expect("prepared bytes");
+            assert_eq!(
+                deployed_bytes, release_bytes,
+                "execution must use the resolved release asset instead of the stale local zip"
+            );
+        });
+    }
+
+    fn write_versioned_zip(path: &Path, entry: &str, contents: &str) {
+        let file = std::fs::File::create(path).expect("zip file");
+        let mut zip = zip::ZipWriter::new(file);
+        zip.start_file(entry, zip::write::FileOptions::default())
+            .expect("zip entry");
+        use std::io::Write as _;
+        zip.write_all(contents.as_bytes()).expect("zip contents");
+        zip.finish().expect("zip finish");
     }
 
     #[test]

--- a/crates/homeboy-deploy/src/orchestration/prepared_payloads.rs
+++ b/crates/homeboy-deploy/src/orchestration/prepared_payloads.rs
@@ -53,56 +53,59 @@ pub(super) fn prepare_component_deployments(
         let effective_config = config.clone();
         let is_artifact_deploy =
             !component.deploy_config().is_git_deploy() && !component.is_file_component();
-        let effective_config =
-            if is_artifact_deploy && !config.skip_build && config.prepared_artifact.is_none() {
-                let mut preparation_config = effective_config.clone();
-                // The existing detached checkout is the authoritative exact-ref source.
-                preparation_config.requested_ref = None;
-                preparation_config.requested_refs.clear();
-                let mut request =
-                    ComponentPayloadPreparationRequest::new(&component, &preparation_config);
-                request.config.exact_ref_materialized =
-                    config.requested_ref_for(&component.id).is_some();
-                if let Some(lease) = release_artifacts.get(&component.id).cloned() {
-                    if let Err(error) = payloads.insert(request.clone(), Some(lease)) {
-                        failures.push(ComponentDeployResult::failed(
-                            &component,
-                            base_path,
-                            local_versions.get(&component.id).cloned(),
-                            remote_versions.get(&component.id).cloned(),
-                            error.to_string(),
-                        ));
-                        continue;
-                    }
+        let effective_config = if is_artifact_deploy
+            && !config.skip_build
+            && config.prepared_artifact.is_none()
+            && !release_artifacts.contains_key(&component.id)
+        {
+            let mut preparation_config = effective_config.clone();
+            // The existing detached checkout is the authoritative exact-ref source.
+            preparation_config.requested_ref = None;
+            preparation_config.requested_refs.clear();
+            let mut request =
+                ComponentPayloadPreparationRequest::new(&component, &preparation_config);
+            request.config.exact_ref_materialized =
+                config.requested_ref_for(&component.id).is_some();
+            if let Some(lease) = release_artifacts.get(&component.id).cloned() {
+                if let Err(error) = payloads.insert(request.clone(), Some(lease)) {
+                    failures.push(ComponentDeployResult::failed(
+                        &component,
+                        base_path,
+                        local_versions.get(&component.id).cloned(),
+                        remote_versions.get(&component.id).cloned(),
+                        error.to_string(),
+                    ));
+                    continue;
                 }
-                match payloads.prepare(request, &mut release_artifact_store) {
-                    Ok(payload) => {
-                        binding_payloads.insert(component.id.clone(), payload.artifact.clone());
-                        let payload_build_ran = payload.build_ran;
-                        let mut prepared = effective_config;
-                        prepared.prepared_artifact = Some(payload.artifact.clone());
-                        prepared.skip_build = true;
-                        prepared.requested_ref = None;
-                        (prepared, payload_build_ran)
-                    }
-                    Err(error) => {
-                        let mut failure = ComponentDeployResult::failed(
-                            &component,
-                            base_path,
-                            local_versions.get(&component.id).cloned(),
-                            remote_versions.get(&component.id).cloned(),
-                            error.to_string(),
-                        );
-                        if let Some(exit_code) = preparation_build_exit_code(&error) {
-                            failure = failure.with_build_exit_code(Some(exit_code));
-                        }
-                        failures.push(failure);
-                        continue;
-                    }
+            }
+            match payloads.prepare(request, &mut release_artifact_store) {
+                Ok(payload) => {
+                    binding_payloads.insert(component.id.clone(), payload.artifact.clone());
+                    let payload_build_ran = payload.build_ran;
+                    let mut prepared = effective_config;
+                    prepared.prepared_artifact = Some(payload.artifact.clone());
+                    prepared.skip_build = true;
+                    prepared.requested_ref = None;
+                    (prepared, payload_build_ran)
                 }
-            } else {
-                (effective_config, false)
-            };
+                Err(error) => {
+                    let mut failure = ComponentDeployResult::failed(
+                        &component,
+                        base_path,
+                        local_versions.get(&component.id).cloned(),
+                        remote_versions.get(&component.id).cloned(),
+                        error.to_string(),
+                    );
+                    if let Some(exit_code) = preparation_build_exit_code(&error) {
+                        failure = failure.with_build_exit_code(Some(exit_code));
+                    }
+                    failures.push(failure);
+                    continue;
+                }
+            }
+        } else {
+            (effective_config, false)
+        };
 
         match prepare_component_deploy(
             &component,

--- a/crates/homeboy-deploy/src/orchestration/prepared_payloads.rs
+++ b/crates/homeboy-deploy/src/orchestration/prepared_payloads.rs
@@ -66,18 +66,6 @@ pub(super) fn prepare_component_deployments(
                 ComponentPayloadPreparationRequest::new(&component, &preparation_config);
             request.config.exact_ref_materialized =
                 config.requested_ref_for(&component.id).is_some();
-            if let Some(lease) = release_artifacts.get(&component.id).cloned() {
-                if let Err(error) = payloads.insert(request.clone(), Some(lease)) {
-                    failures.push(ComponentDeployResult::failed(
-                        &component,
-                        base_path,
-                        local_versions.get(&component.id).cloned(),
-                        remote_versions.get(&component.id).cloned(),
-                        error.to_string(),
-                    ));
-                    continue;
-                }
-            }
             match payloads.prepare(request, &mut release_artifact_store) {
                 Ok(payload) => {
                     binding_payloads.insert(component.id.clone(), payload.artifact.clone());

--- a/crates/homeboy-deploy/src/preparation.rs
+++ b/crates/homeboy-deploy/src/preparation.rs
@@ -316,60 +316,10 @@ pub(crate) struct PreparedPayloadCollection {
 }
 
 struct PreparedPayloadEntry {
-    request: ComponentPayloadPreparationRequest,
-    payload: Option<PreparedComponentPayload>,
-    release_artifact: Option<ReleaseArtifactLease>,
+    payload: PreparedComponentPayload,
 }
 
 impl PreparedPayloadCollection {
-    pub(crate) fn insert(
-        &mut self,
-        request: ComponentPayloadPreparationRequest,
-        release_artifact: Option<ReleaseArtifactLease>,
-    ) -> Result<()> {
-        let identity = request.identity();
-        match self.entries.entry(identity) {
-            std::collections::hash_map::Entry::Vacant(entry) => {
-                entry.insert(PreparedPayloadEntry {
-                    request,
-                    payload: None,
-                    release_artifact,
-                });
-                Ok(())
-            }
-            std::collections::hash_map::Entry::Occupied(mut entry) => {
-                let existing = entry.get_mut();
-                if let Some(payload) = existing.payload.as_ref() {
-                    return match (&payload._release_artifact, release_artifact) {
-                        (Some(existing), Some(candidate)) if **existing == *candidate => Ok(()),
-                        (_, None) => Ok(()),
-                        _ => Err(Error::validation_invalid_argument(
-                            "release_artifact",
-                            "Prepared payload cannot be rebound to a different release artifact",
-                            None,
-                            None,
-                        )),
-                    };
-                }
-                match (&existing.release_artifact, release_artifact) {
-                    (None, Some(release_artifact)) => {
-                        existing.release_artifact = Some(release_artifact);
-                        Ok(())
-                    }
-                    (Some(existing), Some(candidate)) if **existing != *candidate => {
-                        Err(Error::validation_invalid_argument(
-                            "release_artifact",
-                            "Equal payload preparation requests referenced incompatible release artifacts",
-                            None,
-                            None,
-                        ))
-                    }
-                    _ => Ok(()),
-                }
-            }
-        }
-    }
-
     /// Prepare a component once and return its immutable artifact identity. This
     /// boundary intentionally has no project or remote target inputs.
     pub(crate) fn prepare(
@@ -378,35 +328,12 @@ impl PreparedPayloadCollection {
         release_artifacts: &mut ReleaseArtifactStore,
     ) -> Result<&PreparedComponentPayload> {
         let identity = request.identity();
-        if let Some(existing) = self.entries.get_mut(&identity) {
-            if existing.payload.is_none() {
-                let release_artifact = existing.release_artifact.take();
-                existing.payload = Some(prepare_payload(
-                    &existing.request,
-                    release_artifacts,
-                    release_artifact,
-                )?);
-            }
-        } else {
+        if !self.entries.contains_key(&identity) {
             let payload = prepare_payload(&request, release_artifacts, None)?;
-            self.entries.insert(
-                identity.clone(),
-                PreparedPayloadEntry {
-                    request,
-                    payload: Some(payload),
-                    release_artifact: None,
-                },
-            );
+            self.entries
+                .insert(identity.clone(), PreparedPayloadEntry { payload });
         }
-        Ok(self.entries[&identity]
-            .payload
-            .as_ref()
-            .expect("prepared payload is populated exactly once"))
-    }
-
-    #[cfg(test)]
-    pub(crate) fn len(&self) -> usize {
-        self.entries.len()
+        Ok(&self.entries[&identity].payload)
     }
 }
 
@@ -896,11 +823,6 @@ mod tests {
             first_binding.deploy_strategy,
             second_binding.deploy_strategy
         );
-
-        let mut collection = PreparedPayloadCollection::default();
-        collection.insert(first, None).expect("first request");
-        collection.insert(second, None).expect("equal request");
-        assert_eq!(collection.len(), 1);
     }
 
     #[test]
@@ -942,11 +864,8 @@ mod tests {
         let entries_before = std::fs::read_dir(temp.path())
             .expect("read temp dir")
             .count();
-        let request = ComponentPayloadPreparationRequest::new(&component, &config());
-        let mut collection = PreparedPayloadCollection::default();
-        collection.insert(request, None).expect("pure insert");
+        let _request = ComponentPayloadPreparationRequest::new(&component, &config());
 
-        assert_eq!(collection.len(), 1);
         assert!(!source_path.exists());
         assert!(!artifact_path.exists());
         assert_eq!(
@@ -955,37 +874,6 @@ mod tests {
                 .count(),
             entries_before
         );
-    }
-
-    #[test]
-    fn collection_retains_release_artifact_lease_after_caller_drops_it() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        let artifact_path = temp.path().join("fixture.zip");
-        std::fs::write(&artifact_path, "payload").expect("artifact");
-        let lease = homeboy_core::git::release_download::ReleaseArtifactLease::test_new(
-            homeboy_core::git::release_download::ReleaseArtifact {
-                path: artifact_path,
-                tag: "v1.0.0".to_string(),
-                commit: None,
-                url: "https://example.test/fixture.zip".to_string(),
-                name: "fixture.zip".to_string(),
-                size: 7,
-                sha256: "hash".to_string(),
-            },
-        )
-        .expect("lease");
-        let observer = lease.clone();
-        let mut collection = PreparedPayloadCollection::default();
-        collection
-            .insert(
-                ComponentPayloadPreparationRequest::new(&component(), &config()),
-                Some(lease),
-            )
-            .expect("lease insert");
-
-        assert_eq!(observer.test_strong_count(), 2);
-        drop(collection);
-        assert_eq!(observer.test_strong_count(), 1);
     }
 
     #[test]
@@ -1066,54 +954,7 @@ mod tests {
     }
 
     #[test]
-    fn collection_merges_late_lease_and_rejects_conflicts() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        let artifact_path = temp.path().join("fixture.zip");
-        std::fs::write(&artifact_path, "payload").expect("artifact");
-        let lease = homeboy_core::git::release_download::ReleaseArtifactLease::test_new(
-            homeboy_core::git::release_download::ReleaseArtifact {
-                path: artifact_path,
-                tag: "v1.0.0".to_string(),
-                commit: None,
-                url: "https://example.test/fixture.zip".to_string(),
-                name: "fixture.zip".to_string(),
-                size: 7,
-                sha256: "hash".to_string(),
-            },
-        )
-        .expect("lease");
-        let observer = lease.clone();
-        let request = ComponentPayloadPreparationRequest::new(&component(), &config());
-        let mut collection = PreparedPayloadCollection::default();
-        collection.insert(request.clone(), None).expect("no lease");
-        collection
-            .insert(request.clone(), Some(lease.clone()))
-            .expect("late lease retained");
-        collection
-            .insert(request.clone(), Some(lease))
-            .expect("identical lease deduplicates");
-        assert_eq!(observer.test_strong_count(), 2);
-
-        let other_temp = tempfile::tempdir().expect("other temp dir");
-        let other_path = other_temp.path().join("fixture.zip");
-        std::fs::write(&other_path, "changed").expect("other artifact");
-        let conflicting = homeboy_core::git::release_download::ReleaseArtifactLease::test_new(
-            homeboy_core::git::release_download::ReleaseArtifact {
-                path: other_path,
-                tag: "v1.0.1".to_string(),
-                commit: Some("different".to_string()),
-                url: "https://example.test/other.zip".to_string(),
-                name: "fixture.zip".to_string(),
-                size: 7,
-                sha256: "different".to_string(),
-            },
-        )
-        .expect("conflicting lease");
-        assert!(collection.insert(request, Some(conflicting)).is_err());
-    }
-
-    #[test]
-    fn equal_inserted_request_builds_once_and_cleans_only_its_payload_copy() {
+    fn equal_preparation_request_builds_once_and_cleans_only_its_payload_copy() {
         let temp = tempfile::tempdir().expect("temp dir");
         let source_artifact = temp.path().join("build/fixture.zip");
         let build_count = temp.path().join("build-count");
@@ -1129,13 +970,10 @@ mod tests {
         });
         let request = ComponentPayloadPreparationRequest::new(&component, &config());
         let mut collection = PreparedPayloadCollection::default();
-        collection
-            .insert(request.clone(), None)
-            .expect("insert request");
 
         let payload_path = collection
             .prepare(request.clone(), &mut ReleaseArtifactStore::default())
-            .expect("prepare inserted request")
+            .expect("prepare request")
             .artifact
             .effective_path()
             .to_string();
@@ -1165,132 +1003,6 @@ mod tests {
         assert!(
             !Path::new(&payload_path).exists(),
             "dropping payload removes its owned copy"
-        );
-    }
-
-    #[test]
-    fn inserted_release_lease_is_consumed_by_equal_preparation_request() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        let artifact_path = temp.path().join("fixture.zip");
-        std::fs::write(&artifact_path, "payload").expect("artifact");
-        std::fs::write(temp.path().join("package.json"), r#"{"version":"1.0.0"}"#)
-            .expect("package manifest");
-        let lease =
-            ReleaseArtifactLease::test_new(homeboy_core::git::release_download::ReleaseArtifact {
-                path: artifact_path.clone(),
-                tag: "v1.0.0".to_string(),
-                commit: Some("0123456789abcdef".to_string()),
-                url: "https://example.test/fixture.zip".to_string(),
-                name: "fixture.zip".to_string(),
-                size: 7,
-                sha256: sha256_file(&artifact_path).expect("sha"),
-            })
-            .expect("lease");
-        let observer = lease.clone();
-        let mut component = component();
-        component.local_path = temp.path().display().to_string();
-        component.build_artifact = Some("fixture.zip".to_string());
-        component.remote_url = Some("https://github.com/example/fixture".to_string());
-        component.version_targets = Some(vec![homeboy_core::component::VersionTarget {
-            file: "package.json".to_string(),
-            pattern: Some(r#""version"\s*:\s*"([^"]+)""#.to_string()),
-            artifact_path: None,
-        }]);
-        let mut deploy_config = config();
-        deploy_config.expected_version = Some("1.0.0".to_string());
-        let request = ComponentPayloadPreparationRequest::new(&component, &deploy_config);
-        let mut collection = PreparedPayloadCollection::default();
-        collection
-            .insert(request.clone(), Some(lease))
-            .expect("insert lease");
-
-        let payload = collection
-            .prepare(request, &mut ReleaseArtifactStore::default())
-            .expect("prepare retained lease");
-        assert_eq!(Path::new(payload.artifact.effective_path()), artifact_path);
-        assert_eq!(observer.test_strong_count(), 2, "payload retains the lease");
-
-        collection
-            .insert(
-                ComponentPayloadPreparationRequest::new(&component, &deploy_config),
-                Some(observer.clone()),
-            )
-            .expect("equal consumer reuses the verified release artifact");
-        let conflicting_temp = tempfile::tempdir().expect("conflicting temp dir");
-        let conflicting_path = conflicting_temp.path().join("conflicting.zip");
-        std::fs::write(&conflicting_path, "changed").expect("conflicting artifact");
-        let conflicting =
-            ReleaseArtifactLease::test_new(homeboy_core::git::release_download::ReleaseArtifact {
-                path: conflicting_path,
-                tag: "v1.0.0".to_string(),
-                commit: Some("fedcba9876543210".to_string()),
-                url: "https://example.test/conflicting.zip".to_string(),
-                name: "fixture.zip".to_string(),
-                size: 7,
-                sha256: "different".to_string(),
-            })
-            .expect("conflicting lease");
-        assert!(collection
-            .insert(
-                ComponentPayloadPreparationRequest::new(&component, &deploy_config),
-                Some(conflicting),
-            )
-            .is_err());
-        assert_eq!(
-            observer.test_strong_count(),
-            2,
-            "equal consumers do not retain a redundant lease"
-        );
-        drop(collection);
-        assert_eq!(
-            observer.test_strong_count(),
-            1,
-            "payload releases its lease"
-        );
-    }
-
-    #[test]
-    fn retained_release_mismatch_creates_no_payload_or_local_build_effect() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        let artifact_path = temp.path().join("fixture.zip");
-        let build_counter = temp.path().join("build-count");
-        std::fs::write(&artifact_path, "payload").expect("artifact");
-        let lease =
-            ReleaseArtifactLease::test_new(homeboy_core::git::release_download::ReleaseArtifact {
-                path: artifact_path,
-                tag: "v1.0.0".to_string(),
-                commit: None,
-                url: "https://example.test/fixture.zip".to_string(),
-                name: "fixture.zip".to_string(),
-                size: 7,
-                sha256: "wrong".to_string(),
-            })
-            .expect("lease");
-        let mut component = component();
-        component.local_path = temp.path().display().to_string();
-        component.build_artifact = Some("fixture.zip".to_string());
-        component.remote_url = Some("https://github.com/example/fixture".to_string());
-        component.scripts = Some(homeboy_core::component::ComponentScriptsConfig {
-            build: vec![format!("printf build > {}", build_counter.display())],
-            ..Default::default()
-        });
-        let mut deploy_config = config();
-        deploy_config.expected_version = Some("1.0.0".to_string());
-        let request = ComponentPayloadPreparationRequest::new(&component, &deploy_config);
-        let mut collection = PreparedPayloadCollection::default();
-        collection
-            .insert(request.clone(), Some(lease))
-            .expect("insert lease");
-
-        let error = match collection.prepare(request, &mut ReleaseArtifactStore::default()) {
-            Ok(_) => panic!("mismatched retained release must fail"),
-            Err(error) => error,
-        };
-        assert!(error.to_string().contains("does not match"));
-        assert_eq!(collection.len(), 1, "request is retained without a payload");
-        assert!(
-            !build_counter.exists(),
-            "release mismatch must not build or target"
         );
     }
 
@@ -1385,8 +1097,6 @@ mod tests {
                 .next()
                 .unwrap()
                 .payload
-                .as_ref()
-                .unwrap()
                 .artifact
                 .source_commit,
             accepted_sha


### PR DESCRIPTION
Fixes #13412.

## Summary

- keep a resolved canonical release asset as a release asset through execution preparation
- prevent stale local prepared ZIPs from overriding explicit-version release selection
- remove the now-dead collection path for injecting release leases into synthetic prepared payloads
- prove dry-run/execution source parity with a stale `1.6.0` local ZIP beside a selected `1.7.0` release asset

## Verification

- `cargo fmt --all`
- `RUSTFLAGS=-Dwarnings cargo build --locked -p homeboy --bin homeboy`
- `cargo test -p homeboy-deploy preparation::tests -- --nocapture` (`12 passed`)
- `cargo test -p homeboy-deploy explicit_version_release_asset -- --nocapture`
- `cargo test -p homeboy-deploy release_asset -- --nocapture`
- `cargo test -p homeboy-deploy exact_ref_preparation_preserves_duplicate_source_version_target_artifact_paths -- --nocapture`
- `cargo test -p homeboy-deploy` reached six unrelated existing filesystem-mode/exact-ref failures; the exact-ref case passed in isolation

## AI Assistance

OpenAI GPT-5.4 via OpenCode traced the plan/execution divergence, implemented the root-cause fix, added coverage, and ran verification. OpenAI GPT-5.6 Sol via OpenCode coordinated the tracked work, reviewed the diff, removed an unreachable branch, and independently reran the focused regression. Chris Huber directed the work and remains responsible.
