### PR TITLE
Fix Windows compile after digest memo guard

### DIFF
--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -2703,6 +2703,7 @@ fn executable_digest(path: &Path) -> Result<String> {
     // hash it, in a process that is about to fork a controller runtime.
     #[cfg(all(test, unix))]
     EXECUTABLE_DIGEST_COMPUTATIONS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    #[cfg(unix)]
     let hashing_started = std::time::Instant::now();
     let digest = content_hash::sha256_file(path).map_err(|error| {
         Error::internal_io(
@@ -2710,6 +2711,7 @@ fn executable_digest(path: &Path) -> Result<String> {
             Some("hash pinned controller executable".to_string()),
         )
     })?;
+    #[cfg(unix)]
     if hashing_started.elapsed() >= digest_memo_min_hash_time() {
         memoize_executable_digest(identity, &digest);
     }


### PR DESCRIPTION
Closes #13422

## Summary

- gate digest hash timing behind the same Unix cfg as the executable memo
- avoid referencing the Unix-only threshold helper on Windows
- preserve existing Unix memo behavior

## Verification

- `cargo test -p homeboy-core --lib controller_runtime:: -- --test-threads=1`: 63 passed
- `cargo fmt --check`
- `git diff --check`
- local Windows GNU cross-check reached target dependencies but could not proceed because `x86_64-w64-mingw32-gcc` is not installed; native GitHub Windows Compile is the authoritative cross-platform gate

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed the Windows CI regression, aligned the cfg boundaries, and ran the verification above. Chris Huber remains responsible for the implementation and review.