### PR TITLE
fix(controller-runtime): compile the digest memo guard on non-unix

### DIFF
--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -183,7 +183,6 @@ static TEST_CONTROLLER_FIXTURE_DIGESTS: OnceLock<Mutex<BTreeMap<ExecutableFileId
 /// not durable and is not memoized -- which costs nothing, because a file that
 /// hashes that fast is cheap to hash again. The controller binaries this memo
 /// exists for are hundreds of megabytes and take seconds.
-#[cfg(unix)]
 const DIGEST_MEMO_MIN_HASH_TIME: std::time::Duration = std::time::Duration::from_millis(10);
 
 /// Test override for [`DIGEST_MEMO_MIN_HASH_TIME`], in milliseconds.
@@ -196,9 +195,10 @@ const DIGEST_MEMO_MIN_HASH_TIME: std::time::Duration = std::time::Duration::from
 static DIGEST_MEMO_MIN_HASH_TIME_MS: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(u64::MAX);
 
-#[cfg(unix)]
+/// The memo guard. `executable_digest` is not platform-gated, so neither is
+/// this. Only the test override is unix-only, because the memo it overrides is.
 fn digest_memo_min_hash_time() -> std::time::Duration {
-    #[cfg(test)]
+    #[cfg(all(test, unix))]
     {
         let configured = DIGEST_MEMO_MIN_HASH_TIME_MS.load(std::sync::atomic::Ordering::Relaxed);
         if configured != u64::MAX {


### PR DESCRIPTION
## What

`digest_memo_min_hash_time` is declared `#[cfg(unix)]` but called from `executable_digest`, which is **not** platform-gated:

```
error[E0425]: cannot find function `digest_memo_min_hash_time` in this scope
  --> crates\homeboy-core\src\controller_runtime.rs:2713:37
```

`homeboy-core` has not compiled on Windows since `cede7014e`.

## Why it went unnoticed

The `Windows Compile` job reports `skipping` on most PRs. It only runs when the change set touches the right paths — so the break sat on `main` until a PR happened to trigger it. Every one of my crate-sealing PRs inherited the failure without causing it.

## The fix

The surrounding code already establishes a convention. Every memo helper `executable_digest` reaches for has a `#[cfg(unix)]` implementation **and** a `#[cfg(not(unix))]` stub:

| helper | unix | non-unix |
|---|---|---|
| `observed_executable_identity` | real | `Option<()>` stub |
| `memoized_executable_digest` | real | `Option<&()>` stub |
| `memoize_executable_digest` | real | no-op stub |
| `digest_memo_min_hash_time` | real | **missing** ← |

Rather than add a fourth stub, this **ungates the guard itself**. The threshold is a `Duration` with nothing platform-specific about it, and `memoize_executable_digest` is already a no-op on non-unix, so the comparison is simply never acted on there.

Only the test override stays unix-only, because the memo it overrides is:

```diff
-    #[cfg(test)]
+    #[cfg(all(test, unix))]
```

That now matches `DIGEST_MEMO_MIN_HASH_TIME_MS` and the `SettleThresholdOverride` guard that drives it. **Unix behaviour is byte-for-byte unchanged** — three lines.

## Verified by cross-compiling, not by reasoning

I installed the Windows target and mingw so this could be reproduced locally rather than argued about:

| check | result |
|---|---|
| `cargo check -p homeboy-core --lib --target x86_64-pc-windows-gnu` **before** | `EXIT=101` — `E0425` at `controller_runtime.rs:2713:37`, exactly CI's error |
| same, **after** | `EXIT=0` |
| `cargo check --workspace --lib --target x86_64-pc-windows-gnu` | `EXIT=0` — **this was the only `cfg` break in the workspace** |
| `cargo check --workspace --all-targets` (linux) | zero errors, zero warnings |

The two tests that exercise this path pass: `a_hash_faster_than_the_timestamp_clock_is_not_memoized` and `executable_digests_are_memoized_per_observed_file_identity`.

## Pre-existing failures, baselined not assumed

`homeboy-core` has five failures unrelated to this change:

```
observation::store::artifacts::tests::lifecycle_open_does_not_wait_for_rollback_writer_maintenance_lock
process::tests::scope_cleanup_fails_closed_for_confirmed_run_owned_survivors
process::tests::scope_cleanup_keeps_unreadable_same_owner_environments_as_diagnostics
worktree::tests::create_restores_worktree_with_relative_gitdir_pointers
worktree::tests::create_reuses_existing_worktree_with_a_relative_gitdir_pointer
```

Each was run **alone with `--test-threads=1`** on this branch and on stashed-clean `main`, and failed identically on both. The branch-unique set is empty.

A sixth — `validation_dependency_lifecycle_reports_failed_step_with_artifact_ref` — fails only under `--test-threads=2` and **passes alone on both sides**, so it is a parallelism flake, not a regression.

> Worth noting separately: `External Resolver Fixtures (windows-latest)` fails on every recent PR (#13387, #13391, #13392) independently of this. Not addressed here.

## AI assistance

Tool(s): OpenCode
