### PR TITLE
Separate applied deploys from unreadable verification

### DIFF
--- a/crates/homeboy-cli/src/commands/deploy.rs
+++ b/crates/homeboy-cli/src/commands/deploy.rs
@@ -684,7 +684,9 @@ fn multi_deploy_actionable(
             .with_kind(CommandNextActionKind::Show),
         );
     }
-    if let Some(run_id) = resume_run_id {
+    if let Some(run_id) = resume_run_id.filter(|_| {
+        has_retryable_multi_target_failures(projects.iter().map(|project| project.status.as_str()))
+    }) {
         metadata.next_actions.push(
             CommandNextAction::new(
                 "resume deploy checkpoint",
@@ -694,6 +696,10 @@ fn multi_deploy_actionable(
         );
     }
     metadata
+}
+
+fn has_retryable_multi_target_failures<'a>(statuses: impl IntoIterator<Item = &'a str>) -> bool {
+    statuses.into_iter().any(|status| status == "failed")
 }
 
 /// Reconstruct the CLI inputs whose lifecycle identity is stored by the

--- a/crates/homeboy-deploy/src/effect.rs
+++ b/crates/homeboy-deploy/src/effect.rs
@@ -52,8 +52,8 @@ pub(super) fn remote_version_after_deploy_effect(
         observe_remote_version_from_applied_tree(component, project, base_path, client)
     else {
         return Ok(PostDeployVerification::AppliedUnverified(format!(
-            "Deploy command completed for '{}' at '{}', and Homeboy retried post-deploy remote_version verification against the applied tree, but the postcondition remained unreadable. Artifact mutation evidence is preserved; reverify with 'homeboy deploy {} --check'.",
-            component.id, effect.remote_path, project.id
+            "Deploy command completed for '{}' at '{}', and Homeboy retried post-deploy remote_version verification against the applied tree, but the postcondition remained unreadable. Artifact mutation evidence is preserved; reverify with 'homeboy deploy --project {} --component {} --check'.",
+            component.id, effect.remote_path, project.id, component.id
         )));
     };
 
@@ -186,7 +186,7 @@ mod tests {
             "unexpected outcome: {message}"
         );
         assert!(
-            message.contains("homeboy deploy site --check"),
+            message.contains("homeboy deploy --project site --component plugin --check"),
             "unexpected outcome: {message}"
         );
     }

--- a/crates/homeboy-deploy/src/effect.rs
+++ b/crates/homeboy-deploy/src/effect.rs
@@ -1,9 +1,19 @@
 use homeboy_core::component::Component;
 use homeboy_core::project::Project;
 use homeboy_core::server::SshClient;
+use std::time::Duration;
 
 use super::types::DeployEffect;
 use super::version_overrides::fetch_remote_versions_for_project;
+
+const POST_DEPLOY_VERSION_PROBE_ATTEMPTS: usize = 3;
+const POST_DEPLOY_VERSION_PROBE_SETTLE_DELAY: Duration = Duration::from_millis(200);
+
+#[derive(Debug)]
+pub(super) enum PostDeployVerification {
+    Verified(Option<String>),
+    AppliedUnverified(String),
+}
 
 pub(super) fn remote_version_after_deploy_effect(
     component: &Component,
@@ -12,9 +22,9 @@ pub(super) fn remote_version_after_deploy_effect(
     client: &SshClient,
     effect: Option<&DeployEffect>,
     local_version: Option<&String>,
-) -> std::result::Result<Option<String>, String> {
+) -> std::result::Result<PostDeployVerification, String> {
     let Some(effect) = effect else {
-        return Ok(local_version.cloned());
+        return Ok(PostDeployVerification::Verified(local_version.cloned()));
     };
     let has_version_targets = component
         .version_targets
@@ -35,22 +45,17 @@ pub(super) fn remote_version_after_deploy_effect(
                 component.id, effect.remote_path
             ));
         }
-        return Ok(local_version.cloned());
+        return Ok(PostDeployVerification::Verified(local_version.cloned()));
     }
 
-    let observed_versions = fetch_remote_versions_for_project(
-        std::slice::from_ref(component),
-        Some(project),
-        base_path,
-        client,
-    )
-    .versions;
-    let observed = observed_versions.get(&component.id).cloned().ok_or_else(|| {
-        format!(
-            "Deploy command completed for '{}' at '{}', but Homeboy could not read remote_version from the applied tree. Refusing to report success from stale pre-deploy observations.",
-            component.id, effect.remote_path
-        )
-    })?;
+    let Some(observed) =
+        observe_remote_version_from_applied_tree(component, project, base_path, client)
+    else {
+        return Ok(PostDeployVerification::AppliedUnverified(format!(
+            "Deploy command completed for '{}' at '{}', and Homeboy retried post-deploy remote_version verification against the applied tree, but the postcondition remained unreadable. Artifact mutation evidence is preserved; reverify with 'homeboy deploy {} --check'.",
+            component.id, effect.remote_path, project.id
+        )));
+    };
 
     if let Some(expected) = local_version {
         if &observed != expected {
@@ -61,12 +66,36 @@ pub(super) fn remote_version_after_deploy_effect(
         }
     }
 
-    Ok(Some(observed))
+    Ok(PostDeployVerification::Verified(Some(observed)))
+}
+
+fn observe_remote_version_from_applied_tree(
+    component: &Component,
+    project: &Project,
+    base_path: &str,
+    client: &SshClient,
+) -> Option<String> {
+    for attempt in 0..POST_DEPLOY_VERSION_PROBE_ATTEMPTS {
+        let observed_versions = fetch_remote_versions_for_project(
+            std::slice::from_ref(component),
+            Some(project),
+            base_path,
+            client,
+        )
+        .versions;
+        if let Some(observed) = observed_versions.get(&component.id).cloned() {
+            return Some(observed);
+        }
+        if attempt + 1 < POST_DEPLOY_VERSION_PROBE_ATTEMPTS {
+            std::thread::sleep(POST_DEPLOY_VERSION_PROBE_SETTLE_DELAY);
+        }
+    }
+    None
 }
 
 #[cfg(test)]
 mod tests {
-    use super::remote_version_after_deploy_effect;
+    use super::{remote_version_after_deploy_effect, PostDeployVerification};
     use crate::types::DeployEffect;
     use homeboy_core::component::{Component, VersionTarget};
     use homeboy_core::project::Project;
@@ -105,14 +134,17 @@ mod tests {
             Some(&effect),
             Some(&expected_version),
         )
-        .expect("post-effect version")
-        .expect("observed version");
+        .expect("post-effect version");
+
+        let PostDeployVerification::Verified(Some(version)) = version else {
+            panic!("expected verified post-effect version");
+        };
 
         assert_eq!(version, "1.2.3");
     }
 
     #[test]
-    fn post_effect_version_read_rejects_unobserved_configured_version_target() {
+    fn post_effect_version_read_returns_applied_unverified_when_probe_remains_unreadable() {
         let temp = tempfile::tempdir().expect("tempdir");
         let remote_dir = temp.path().join("plugin");
         std::fs::create_dir_all(&remote_dir).expect("remote dir");
@@ -133,19 +165,29 @@ mod tests {
         };
         let expected_version = "1.2.3".to_string();
 
-        let error = remote_version_after_deploy_effect(
+        let result = remote_version_after_deploy_effect(
             &component,
-            &Project::default(),
+            &Project {
+                id: "site".to_string(),
+                ..Project::default()
+            },
             temp.path().to_str().expect("base path"),
             &local_client(),
             Some(&effect),
             Some(&expected_version),
         )
-        .expect_err("missing post-effect remote version should fail");
+        .expect("missing post-effect remote version should stay typed");
 
+        let PostDeployVerification::AppliedUnverified(message) = result else {
+            panic!("expected applied_unverified outcome");
+        };
         assert!(
-            error.contains("could not read remote_version from the applied tree"),
-            "unexpected error: {error}"
+            message.contains("postcondition remained unreadable"),
+            "unexpected outcome: {message}"
+        );
+        assert!(
+            message.contains("homeboy deploy site --check"),
+            "unexpected outcome: {message}"
         );
     }
 
@@ -213,6 +255,9 @@ mod tests {
         )
         .expect("verified artifact deploy without version_targets should succeed");
 
+        let PostDeployVerification::Verified(version) = version else {
+            panic!("expected verified outcome");
+        };
         assert_eq!(version.as_deref(), Some("0.14.0"));
     }
 
@@ -238,6 +283,9 @@ mod tests {
         )
         .expect("no-effect deploy should return local_version");
 
+        let PostDeployVerification::Verified(version) = version else {
+            panic!("expected verified outcome");
+        };
         assert_eq!(version.as_deref(), Some("1.0.0"));
     }
 

--- a/crates/homeboy-deploy/src/execution/strategies.rs
+++ b/crates/homeboy-deploy/src/execution/strategies.rs
@@ -6,7 +6,7 @@ use homeboy_core::context::RemoteProjectContext;
 use homeboy_core::error::Result;
 use homeboy_core::project::Project;
 
-use super::super::effect::remote_version_after_deploy_effect;
+use super::super::effect::{remote_version_after_deploy_effect, PostDeployVerification};
 use super::super::generated_artifacts::GeneratedBuildArtifactCleanupGuard;
 use super::super::lifecycle::DeployObservation;
 use super::super::planning::{calculate_directory_size, format_bytes};
@@ -384,7 +384,21 @@ pub(super) fn execute_artifact_deploy(
                 effect.as_ref(),
                 prepared.local_version.as_ref(),
             ) {
-                Ok(version) => version,
+                Ok(PostDeployVerification::Verified(version)) => version,
+                Ok(PostDeployVerification::AppliedUnverified(error)) => {
+                    let result = ComponentDeployResult::applied_unverified(
+                        component,
+                        base_path,
+                        prepared.local_version.clone(),
+                        prepared.remote_version.clone(),
+                        error,
+                    )
+                    .with_remote_path(install_dir.to_string())
+                    .with_artifact_inputs(artifact_input_metadata)
+                    .with_build_exit_code(prepared.build_exit_code)
+                    .with_deploy_exit_code(Some(exit_code));
+                    return with_prepared_artifact_source(result, prepared);
+                }
                 Err(error) => {
                     let result = ComponentDeployResult::failed(
                         component,

--- a/crates/homeboy-deploy/src/lib.rs
+++ b/crates/homeboy-deploy/src/lib.rs
@@ -514,7 +514,7 @@ pub fn run_multi(
                 error: Some(match status {
                     lifecycle::DeployTargetStatus::AppliedUnverified => {
                         format!(
-                            "Mutation already applied in the resumed deploy run; reverify with 'homeboy deploy {} --check'",
+                            "Mutation already applied in the resumed deploy run; reverify with 'homeboy deploy --project {} --check'",
                             project_id
                         )
                     }

--- a/crates/homeboy-deploy/src/lib.rs
+++ b/crates/homeboy-deploy/src/lib.rs
@@ -498,16 +498,28 @@ pub fn run_multi(
 
         if lifecycle_run
             .as_ref()
-            .is_some_and(|run| run.target_is_succeeded(project_id))
+            .is_some_and(|run| run.target_skips_mutation_retry(project_id))
         {
             let mut timer = PhaseTimer::new();
             timer.record_skipped("transfer");
             timer.record_skipped("install");
             timer.record_skipped("verify");
+            let status = lifecycle_run
+                .as_ref()
+                .and_then(|run| run.target_status(project_id))
+                .expect("skip status from lifecycle state");
             project_results.push(ProjectDeployResult {
                 project_id: project_id.to_string(),
                 status: "skipped".to_string(),
-                error: Some("Already succeeded in the resumed deploy run".to_string()),
+                error: Some(match status {
+                    lifecycle::DeployTargetStatus::AppliedUnverified => {
+                        format!(
+                            "Mutation already applied in the resumed deploy run; reverify with 'homeboy deploy {} --check'",
+                            project_id
+                        )
+                    }
+                    _ => "Already succeeded in the resumed deploy run".to_string(),
+                }),
                 results: vec![],
                 summary: DeploySummary {
                     total: 0,
@@ -560,10 +572,19 @@ pub fn run_multi(
                         .iter()
                         .find_map(|r| r.error.clone())
                         .unwrap_or_else(|| "Deployment failed".to_string());
+                    let applied_unverified_only = result
+                        .results
+                        .iter()
+                        .any(|row| row.status == "applied_unverified")
+                        && result.results.iter().all(|row| row.status != "failed");
 
                     project_results.push(ProjectDeployResult {
                         project_id: project_id.to_string(),
-                        status: "failed".to_string(),
+                        status: if applied_unverified_only {
+                            "applied_unverified".to_string()
+                        } else {
+                            "failed".to_string()
+                        },
                         error: Some(error_msg),
                         results: result.results,
                         summary: result.summary,
@@ -573,7 +594,11 @@ pub fn run_multi(
                     if let Some(run) = lifecycle_run.as_mut() {
                         run.update_target(
                             project_id,
-                            lifecycle::DeployTargetStatus::Failed,
+                            if applied_unverified_only {
+                                lifecycle::DeployTargetStatus::AppliedUnverified
+                            } else {
+                                lifecycle::DeployTargetStatus::Failed
+                            },
                             project_results.last().and_then(|entry| entry.error.clone()),
                             Some(timings.clone()),
                         );

--- a/crates/homeboy-deploy/src/lifecycle.rs
+++ b/crates/homeboy-deploy/src/lifecycle.rs
@@ -161,6 +161,7 @@ pub(crate) enum DeployTargetStatus {
     Planned,
     Running,
     Succeeded,
+    AppliedUnverified,
     Failed,
 }
 
@@ -236,10 +237,21 @@ impl DeployLifecycleRun {
         Ok(())
     }
 
-    pub(crate) fn target_is_succeeded(&self, target: &str) -> bool {
+    pub(crate) fn target_skips_mutation_retry(&self, target: &str) -> bool {
+        self.targets.iter().any(|entry| {
+            entry.target == target
+                && matches!(
+                    entry.status,
+                    DeployTargetStatus::Succeeded | DeployTargetStatus::AppliedUnverified
+                )
+        })
+    }
+
+    pub(crate) fn target_status(&self, target: &str) -> Option<DeployTargetStatus> {
         self.targets
             .iter()
-            .any(|entry| entry.target == target && entry.status == DeployTargetStatus::Succeeded)
+            .find(|entry| entry.target == target)
+            .map(|entry| entry.status.clone())
     }
 
     pub(crate) fn update_target(
@@ -337,8 +349,8 @@ mod tests {
             Some("boom".to_string()),
             None,
         );
-        assert!(run.target_is_succeeded("a"));
-        assert!(!run.target_is_succeeded("b"));
+        assert!(run.target_skips_mutation_retry("a"));
+        assert!(!run.target_skips_mutation_retry("b"));
         assert_eq!(run.targets[1].error.as_deref(), Some("boom"));
     }
 
@@ -348,8 +360,25 @@ mod tests {
         run.update_target("a", DeployTargetStatus::Succeeded, None, None);
         run.update_target("b", DeployTargetStatus::Running, None, None);
         run.resume(&identity()).expect("matching resume");
-        assert!(run.target_is_succeeded("a"));
+        assert!(run.target_skips_mutation_retry("a"));
         assert_eq!(run.targets[1].status, DeployTargetStatus::Planned);
+    }
+
+    #[test]
+    fn applied_unverified_targets_are_terminal_without_mutation_retry() {
+        let mut run = DeployLifecycleRun::new("run".to_string(), identity());
+        run.update_target(
+            "a",
+            DeployTargetStatus::AppliedUnverified,
+            Some("post-deploy verification unavailable".to_string()),
+            None,
+        );
+        run.resume(&identity()).expect("matching resume");
+        assert!(run.target_skips_mutation_retry("a"));
+        assert_eq!(
+            run.target_status("a"),
+            Some(DeployTargetStatus::AppliedUnverified)
+        );
     }
 
     #[test]

--- a/crates/homeboy-deploy/src/types.rs
+++ b/crates/homeboy-deploy/src/types.rs
@@ -676,6 +676,19 @@ impl ComponentDeployResult {
             .with_error(error)
     }
 
+    pub(super) fn applied_unverified(
+        component: &Component,
+        base_path: &str,
+        local_version: Option<String>,
+        remote_version: Option<String>,
+        error: String,
+    ) -> Self {
+        Self::new(component, base_path)
+            .with_status("applied_unverified")
+            .with_versions(local_version, remote_version)
+            .with_error(error)
+    }
+
     pub(super) fn with_status(mut self, status: &str) -> Self {
         self.status = status.to_string();
         self
@@ -974,6 +987,25 @@ mod tests {
         assert_eq!(result.local_version.as_deref(), Some("1.0.0"));
         assert_eq!(result.remote_version.as_deref(), Some("0.9.0"));
         assert_eq!(result.error.as_deref(), Some("deploy failed"));
+    }
+
+    #[test]
+    fn test_applied_unverified() {
+        let result = ComponentDeployResult::applied_unverified(
+            &component(),
+            "/var/www/example",
+            Some("1.0.0".to_string()),
+            Some("0.9.0".to_string()),
+            "post-deploy verification unavailable".to_string(),
+        );
+
+        assert_eq!(result.status, "applied_unverified");
+        assert_eq!(result.local_version.as_deref(), Some("1.0.0"));
+        assert_eq!(result.remote_version.as_deref(), Some("0.9.0"));
+        assert_eq!(
+            result.error.as_deref(),
+            Some("post-deploy verification unavailable")
+        );
     }
 
     #[test]

--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -82,7 +82,7 @@ If no component IDs are provided and none of `--all`, `--outdated`, `--behind-up
   "results": [
     {
       "id": "<component_id>",
-      "status": "deployed|failed|skipped|planned|checked",
+      "status": "deployed|applied_unverified|failed|skipped|planned|checked",
       "deploy_reason": "explicitly_selected|all_selected|version_mismatch|unknown_local_version|unknown_remote_version",
       "component_status": "up_to_date|version_up_to_date_content_unverified|needs_update|behind_remote|behind_upstream|source_stale|remote_modified|missing|mixed_drift|unknown",
       "local_version": "<v>|null",
@@ -113,6 +113,7 @@ If no component IDs are provided and none of `--all`, `--outdated`, `--behind-up
 Notes:
 
 - `deploy_reason` is omitted when not applicable.
+- `status: "applied_unverified"` means the artifact mutation completed, but Homeboy could not complete a post-deploy verification read from the applied tree after bounded retries. Treat it as terminal-no-retry for mutation, inspect the preserved artifact and exit-code evidence, and reverify with `homeboy deploy <project> --check`.
 - `component_status` is only present when using `--check` or `--check --dry-run`.
 - `artifact_path` is the component build artifact path as configured; it may be relative but must include a filename.
 - Deploy output does not include `build_command`. Builds are resolved from the linked extension, and deploy records only build/deploy exit codes plus the artifact path used.
@@ -187,7 +188,7 @@ When using `--projects`, the output structure differs:
   "projects": [
     {
       "project_id": "extra-chill",
-      "status": "deployed|failed|planned|checked",
+      "status": "deployed|applied_unverified|failed|planned|checked",
       "error": "<string>|null",
       "results": [...],
       "summary": { "total": 1, "succeeded": 1, "skipped": 0, "failed": 0 }

--- a/tests/commands/deploy_test.rs
+++ b/tests/commands/deploy_test.rs
@@ -1,4 +1,7 @@
-use super::{resolve_multi_args, resume_deploy_command, run, DeployArgs, DeployTargetArg};
+use super::{
+    has_retryable_multi_target_failures, resolve_multi_args, resume_deploy_command, run,
+    DeployArgs, DeployTargetArg,
+};
 use crate::cli_surface::{Cli, Commands};
 use clap::Parser;
 use std::collections::BTreeMap;
@@ -259,6 +262,19 @@ fn generated_resume_action_round_trips_all_multi_target_identity_inputs() {
     assert!(parsed_config.allow_stale_source);
     assert!(parsed_config.allow_downgrade);
     assert!(parsed_config.head);
+}
+
+#[test]
+fn applied_unverified_projects_do_not_count_as_retryable_multi_target_failures() {
+    assert!(!has_retryable_multi_target_failures([
+        "applied_unverified",
+        "deployed",
+        "skipped",
+    ]));
+    assert!(has_retryable_multi_target_failures([
+        "applied_unverified",
+        "failed",
+    ]));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #13413.

## Summary

- add typed `applied_unverified` component, project, and lifecycle outcomes when mutation succeeds but bounded post-deploy version reads remain unreadable
- retry post-deploy reads within a bounded settle window against the applied tree
- preserve artifact source, build/deploy exit codes, prepared artifact identity, build provenance, remote path, and the verification diagnostic
- make `applied_unverified` terminal for mutation resume so an already-applied artifact is never deployed again
- suppress resume actionables when no genuinely failed target remains and emit explicit project/component `--check` commands for reverification

## Verification

- `cargo fmt --all`
- `cargo test -p homeboy-deploy post_effect_version_read_returns_applied_unverified_when_probe_remains_unreadable -- --nocapture`
- `cargo test -p homeboy-deploy applied_unverified_targets_are_terminal_without_mutation_retry -- --nocapture`
- `cargo test -p homeboy-cli --lib applied_unverified_projects_do_not_count_as_retryable_multi_target_failures -- --nocapture`
- `cargo test -p homeboy-deploy --lib` completed 316 tests before five unrelated existing exact-ref/filesystem-mode failures
- full `homeboy-cli --lib` remains non-green in unrelated agent-task fixtures; the affected deploy CLI slice passes

## AI Assistance

OpenAI GPT-5.4 via OpenCode traced the effect/report split, implemented typed outcomes and resume safety, added coverage and docs, and ran verification. OpenAI GPT-5.6 Sol via OpenCode coordinated the tracked work, reviewed summary/lifecycle semantics and evidence propagation, made reverification commands explicit and scoped, and independently reran all focused gates. Chris Huber directed the work and remains responsible.
