### PR TITLE
Keep extension inventory metadata-fast

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -24,6 +24,7 @@ use homeboy::extension::{
     ExtensionManifest as InstalledExtensionManifest, ExtensionReadinessMode, ExtensionSummary,
 };
 use homeboy_agents::agent_task_service::cook_continue_command;
+#[cfg(test)]
 use homeboy_core::extension_readiness::READY_CHECK_SKIPPED_REASON;
 use homeboy_upgrade::upgrade;
 
@@ -2047,7 +2048,7 @@ fn collect_extension_cli_info() -> ExtensionCliDiscovery {
 /// Neither reads readiness, so the rendered `--help` surface and the augmented
 /// parser are byte-identical either way (#10616).
 fn collect_extension_cli_info_metadata_only() -> ExtensionCliDiscovery {
-    collect_extension_cli_info_with(ExtensionReadinessMode::Skip)
+    collect_extension_cli_info_with(ExtensionReadinessMode::Cached)
 }
 
 fn collect_extension_cli_info_with(readiness: ExtensionReadinessMode) -> ExtensionCliDiscovery {
@@ -2158,28 +2159,28 @@ fn extension_command_manifest(
 
 fn extension_command_health_from_summary(summary: &ExtensionSummary) -> ExtensionCommandHealth {
     // An extension whose `ready_check` was never run is `unknown`, not `ready`.
-    // `ExtensionReadinessMode::Skip` reports `ready: true` so that inventory
-    // output is not mistaken for a *failed* probe, but a command-health
-    // contract that copied that through would be asserting a readiness nobody
-    // measured — the fail-open defect class in #10685. Report the absence of a
-    // measurement as an absence. (#10616)
-    let readiness_skipped = summary.ready_reason.as_deref() == Some(READY_CHECK_SKIPPED_REASON);
+    // A command-health contract that treated an absent measurement as ready
+    // would reproduce the fail-open defect class in #10685. (#10616)
+    let readiness_unknown =
+        summary.readiness == homeboy_extension::ExtensionReadinessState::Unknown;
 
     let status = if summary.error.is_some() {
         "error"
     } else if !summary.compatible {
         "incompatible"
-    } else if readiness_skipped {
+    } else if readiness_unknown {
         "unknown"
-    } else if summary.ready {
+    } else if summary.ready == Some(true) {
         "ready"
+    } else if summary.readiness == homeboy_extension::ExtensionReadinessState::TimedOut {
+        "timed_out"
     } else {
         "not_ready"
     };
 
     ExtensionCommandHealth {
         status: status.to_string(),
-        ready: summary.ready && !readiness_skipped,
+        ready: summary.ready == Some(true),
         compatible: summary.compatible,
         linked: summary.linked,
         reason: summary

--- a/crates/homeboy-cli/src/commands/extension.rs
+++ b/crates/homeboy-cli/src/commands/extension.rs
@@ -34,9 +34,11 @@ enum ExtensionCommand {
         /// Project ID to filter compatible extensions
         #[arg(short, long)]
         project: Option<String>,
-        /// Report installed metadata only. Skips each extension's ready_check,
-        /// so `ready_reason` is `ready_check_skipped` instead of a live answer
-        #[arg(long)]
+        /// Run live readiness probes concurrently and refresh cached readiness
+        #[arg(long, conflicts_with = "skip_ready_check")]
+        live_readiness: bool,
+        /// Deprecated compatibility flag; inventory is metadata-only by default
+        #[arg(long, hide = true)]
         skip_ready_check: bool,
     },
     /// Compare installed extension revisions with their current checkout HEADs
@@ -51,9 +53,11 @@ enum ExtensionCommand {
     Show {
         /// Extension ID
         extension_id: String,
-        /// Report installed metadata only. Skips the extension's ready_check,
-        /// so `ready_reason` is `ready_check_skipped` instead of a live answer
-        #[arg(long)]
+        /// Run the live readiness probe and refresh cached readiness
+        #[arg(long, conflicts_with = "skip_ready_check")]
+        live_readiness: bool,
+        /// Deprecated compatibility flag; inspection is metadata-only by default
+        #[arg(long, hide = true)]
         skip_ready_check: bool,
     },
     /// Execute a extension
@@ -207,16 +211,21 @@ pub fn run(args: ExtensionArgs) -> CmdResult<ExtensionOutput> {
     match args.command {
         ExtensionCommand::List {
             project,
+            live_readiness,
             skip_ready_check,
-        } => list(project, readiness_mode(skip_ready_check)),
+        } => list(project, readiness_mode(live_readiness, skip_ready_check)),
         ExtensionCommand::DiffInstalled {
             extension_id,
             runner,
         } => diff_installed(extension_id.as_deref(), runner.as_deref()),
         ExtensionCommand::Show {
             extension_id,
+            live_readiness,
             skip_ready_check,
-        } => show_extension(&extension_id, readiness_mode(skip_ready_check)),
+        } => show_extension(
+            &extension_id,
+            readiness_mode(live_readiness, skip_ready_check),
+        ),
         ExtensionCommand::Run {
             extension_id,
             project,
@@ -512,11 +521,20 @@ pub struct ExtensionDetail {
     pub has_setup: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub has_ready_check: Option<bool>,
-    pub ready: bool,
+    pub readiness: homeboy_extension::ExtensionReadinessState,
+    pub ready: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ready_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ready_detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub readiness_cache_age_seconds: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub readiness_probe_duration_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub readiness_timeout_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub readiness_follow_up_command: Option<String>,
     pub linked: bool,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -623,7 +641,7 @@ pub struct InstalledExtensionDiff {
     pub manifest_path: String,
     pub linked: bool,
     pub copied: bool,
-    pub ready: bool,
+    pub ready: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ready_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -644,13 +662,12 @@ pub struct InstalledExtensionDiff {
     pub next_command: String,
 }
 
-/// Inventory commands answer "what is installed"; readiness is a separate,
-/// expensive question that `--skip-ready-check` opts out of (#10517).
-fn readiness_mode(skip_ready_check: bool) -> ExtensionReadinessMode {
-    if skip_ready_check {
-        ExtensionReadinessMode::Skip
-    } else {
+/// Inventory is static by default; callers must explicitly request live probes.
+fn readiness_mode(live_readiness: bool, _skip_ready_check: bool) -> ExtensionReadinessMode {
+    if live_readiness {
         ExtensionReadinessMode::Probe
+    } else {
+        ExtensionReadinessMode::Cached
     }
 }
 
@@ -675,7 +692,7 @@ fn diff_installed(
         return runner_diff_installed(extension_id, runner_id);
     }
 
-    let rows = extension::list_summaries(None)
+    let rows = extension::list_summaries_with(None, ExtensionReadinessMode::Cached)
         .into_iter()
         .filter(|summary| extension_id.is_none_or(|id| summary.id == id))
         .map(installed_extension_diff)
@@ -830,7 +847,7 @@ fn installed_extension_diff(summary: ExtensionSummary) -> InstalledExtensionDiff
         source_url,
         source_path,
         has_setup,
-        setup_status: if summary.ready {
+        setup_status: if summary.ready == Some(true) {
             "ready".to_string()
         } else if has_setup {
             "setup_required".to_string()
@@ -899,12 +916,15 @@ fn runner_diff_diagnostic_tail(stderr: &str, stdout: &str) -> String {
 }
 
 fn installed_extension_diff_status(
-    ready: bool,
+    ready: Option<bool>,
     installed_revision: Option<&str>,
     checkout_revision: Option<&str>,
 ) -> String {
-    if !ready {
+    if ready == Some(false) {
         return "unready".to_string();
+    }
+    if ready.is_none() {
+        return "unknown".to_string();
     }
     match (installed_revision, checkout_revision) {
         (Some(installed), Some(checkout)) if installed == checkout => "current".to_string(),
@@ -997,9 +1017,14 @@ fn show_extension(
         runtime_requirements: extension.runtime.clone(),
         has_setup,
         has_ready_check,
+        readiness: ready_status.state,
         ready: ready_status.ready,
         ready_reason: ready_status.reason,
         ready_detail: ready_status.detail,
+        readiness_cache_age_seconds: ready_status.cache_age_seconds,
+        readiness_probe_duration_ms: ready_status.probe_duration_ms,
+        readiness_timeout_ms: ready_status.timeout_ms,
+        readiness_follow_up_command: ready_status.follow_up_command,
         linked,
         path: extension.extension_path.clone().unwrap_or_default(),
         source_revision,
@@ -1884,13 +1909,13 @@ mod tests {
     /// produced by a probe that ran anyway.
     #[cfg(unix)]
     #[test]
-    fn extension_list_with_skip_ready_check_never_spawns_the_ready_check() {
+    fn cached_extension_list_never_spawns_the_ready_check() {
         with_isolated_home(|home| {
             let sentinel = home.path().join("ready-check-ran");
             write_extension_with_observable_ready_check(home.path(), "readiness", &sentinel);
 
             let (output, exit_code) =
-                list(None, ExtensionReadinessMode::Skip).expect("extension list");
+                list(None, ExtensionReadinessMode::Cached).expect("extension list");
 
             assert_eq!(exit_code, 0);
             assert!(
@@ -1911,11 +1936,10 @@ mod tests {
         });
     }
 
-    /// The default is deliberately unchanged: dropping readiness from the
-    /// default answer would be a silent, user-visible contract change.
+    /// The explicit live mode is the control for the cached inventory test.
     #[cfg(unix)]
     #[test]
-    fn extension_list_still_probes_readiness_by_default() {
+    fn live_extension_list_probes_readiness() {
         with_isolated_home(|home| {
             let sentinel = home.path().join("ready-check-ran");
             write_extension_with_observable_ready_check(home.path(), "readiness", &sentinel);
@@ -1924,7 +1948,7 @@ mod tests {
 
             assert!(
                 sentinel.exists(),
-                "the default inventory answer still reports live readiness"
+                "live inventory must report live readiness"
             );
             let ExtensionOutput::List { extensions, .. } = output else {
                 panic!("expected extension list output");
@@ -1933,9 +1957,16 @@ mod tests {
                 .iter()
                 .find(|summary| summary.id == "readiness")
                 .expect("fixture extension");
-            assert!(entry.ready);
+            assert_eq!(entry.ready, Some(true));
             assert_eq!(entry.ready_reason, None);
         });
+    }
+
+    #[test]
+    fn extension_inventory_defaults_to_cached_readiness() {
+        assert_eq!(readiness_mode(false, false), ExtensionReadinessMode::Cached);
+        assert_eq!(readiness_mode(false, true), ExtensionReadinessMode::Cached);
+        assert_eq!(readiness_mode(true, false), ExtensionReadinessMode::Probe);
     }
 
     #[test]
@@ -2077,8 +2108,8 @@ mod tests {
             )
             .expect("extension manifest");
 
-            let (output, exit_code) =
-                show_extension(extension_id, ExtensionReadinessMode::Skip).expect("show extension");
+            let (output, exit_code) = show_extension(extension_id, ExtensionReadinessMode::Cached)
+                .expect("show extension");
             assert_eq!(exit_code, 0);
             let ExtensionOutput::Show { extension } = output else {
                 panic!("expected extension show output");
@@ -2098,7 +2129,7 @@ mod tests {
             );
 
             let (output, exit_code) =
-                list(None, ExtensionReadinessMode::Skip).expect("list extensions");
+                list(None, ExtensionReadinessMode::Cached).expect("list extensions");
             assert_eq!(exit_code, 0);
             let ExtensionOutput::List { extensions, .. } = output else {
                 panic!("expected extension list output");
@@ -2189,8 +2220,8 @@ mod tests {
             )
             .expect("extension manifest");
 
-            let (output, exit_code) =
-                show_extension(extension_id, ExtensionReadinessMode::Skip).expect("show extension");
+            let (output, exit_code) = show_extension(extension_id, ExtensionReadinessMode::Cached)
+                .expect("show extension");
             assert_eq!(exit_code, 0);
             let ExtensionOutput::Show { extension } = output else {
                 panic!("expected extension show output");
@@ -2247,20 +2278,24 @@ mod tests {
     #[test]
     fn installed_extension_diff_status_reports_stale_current_and_unknown() {
         assert_eq!(
-            installed_extension_diff_status(true, Some("abc1234"), Some("abc1234")),
+            installed_extension_diff_status(Some(true), Some("abc1234"), Some("abc1234")),
             "current"
         );
         assert_eq!(
-            installed_extension_diff_status(true, Some("abc1234"), Some("def5678")),
+            installed_extension_diff_status(Some(true), Some("abc1234"), Some("def5678")),
             "stale"
         );
         assert_eq!(
-            installed_extension_diff_status(true, Some("abc1234"), None),
+            installed_extension_diff_status(Some(true), Some("abc1234"), None),
             "current"
         );
         assert_eq!(
-            installed_extension_diff_status(false, Some("abc1234"), Some("abc1234")),
+            installed_extension_diff_status(Some(false), Some("abc1234"), Some("abc1234")),
             "unready"
+        );
+        assert_eq!(
+            installed_extension_diff_status(None, Some("abc1234"), Some("abc1234")),
+            "unknown"
         );
     }
 
@@ -2274,9 +2309,14 @@ mod tests {
             runtime: "platform".to_string(),
             compatible: true,
             core_compatibility: homeboy_extension::CoreCompatibilityReport::undeclared(None),
-            ready: true,
+            readiness: homeboy_extension::ExtensionReadinessState::Ready,
+            ready: Some(true),
             ready_reason: None,
             ready_detail: None,
+            readiness_cache_age_seconds: None,
+            readiness_probe_duration_ms: None,
+            readiness_timeout_ms: None,
+            readiness_follow_up_command: None,
             linked: true,
             path: "/tmp/homeboy-extensions/rust".to_string(),
             manifest_path: None,
@@ -2332,9 +2372,14 @@ mod tests {
                 runtime: "platform".to_string(),
                 compatible: true,
                 core_compatibility: homeboy_extension::CoreCompatibilityReport::undeclared(None),
-                ready: true,
+                readiness: homeboy_extension::ExtensionReadinessState::Ready,
+                ready: Some(true),
                 ready_reason: None,
                 ready_detail: None,
+                readiness_cache_age_seconds: None,
+                readiness_probe_duration_ms: None,
+                readiness_timeout_ms: None,
+                readiness_follow_up_command: None,
                 linked: false,
                 path: extension_dir.to_string_lossy().to_string(),
                 manifest_path: None,
@@ -2379,9 +2424,14 @@ mod tests {
                 runtime: "platform".to_string(),
                 compatible: true,
                 core_compatibility: homeboy_extension::CoreCompatibilityReport::undeclared(None),
-                ready: true,
+                readiness: homeboy_extension::ExtensionReadinessState::Ready,
+                ready: Some(true),
                 ready_reason: None,
                 ready_detail: None,
+                readiness_cache_age_seconds: None,
+                readiness_probe_duration_ms: None,
+                readiness_timeout_ms: None,
+                readiness_follow_up_command: None,
                 manifest_path: None,
                 error: None,
                 diagnostic: None,
@@ -2411,7 +2461,7 @@ mod tests {
             fs::create_dir_all(&extension_dir).expect("extension dir");
             fs::write(extension_dir.join("broken.json"), "{secret-value").expect("manifest");
 
-            let error = match show_extension(extension_id, ExtensionReadinessMode::Skip) {
+            let error = match show_extension(extension_id, ExtensionReadinessMode::Cached) {
                 Err(error) => error,
                 Ok(_) => panic!("show must report the manifest failure"),
             };

--- a/crates/homeboy-cli/src/commands/fuzz/doctor.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/doctor.rs
@@ -13,7 +13,7 @@ pub(super) fn run_doctor(args: FuzzDoctorArgs) -> homeboy::core::Result<FuzzDoct
     let source_revision = read_source_revision(&extension.id);
     let update = check_update_available(&extension.id);
     let update_command = format!("homeboy extension update {}", extension.id);
-    let status = if ready.ready && update.is_none() {
+    let status = if ready.ready == Some(true) && update.is_none() {
         "ok"
     } else {
         "attention"
@@ -31,6 +31,7 @@ pub(super) fn run_doctor(args: FuzzDoctorArgs) -> homeboy::core::Result<FuzzDoct
             version: extension.version.clone(),
             path: extension.extension_path.clone().unwrap_or_default(),
             linked,
+            readiness: ready.state,
             ready: ready.ready,
             ready_reason: ready.reason,
             ready_detail: ready.detail,

--- a/crates/homeboy-cli/src/commands/fuzz/types_extra.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/types_extra.rs
@@ -50,7 +50,8 @@ pub struct FuzzDoctorExtensionOutput {
     pub version: String,
     pub path: String,
     pub linked: bool,
-    pub ready: bool,
+    pub readiness: homeboy_extension::ExtensionReadinessState,
+    pub ready: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ready_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/homeboy-core/src/context/report.rs
+++ b/crates/homeboy-core/src/context/report.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use serde::Serialize;
 
 use crate::component::{self, Component};
-use crate::extension_readiness::{extension_ready_status, is_extension_compatible};
+use crate::extension_readiness::is_extension_compatible;
 use crate::extension_store::{is_extension_linked, load_all_extensions};
 use crate::project::{self, Project};
 use crate::release_provider::{self, ReleaseStateEntry};
@@ -120,11 +120,20 @@ pub struct ExtensionEntry {
     pub description: String,
     pub runtime: String,
     pub compatible: bool,
-    pub ready: bool,
+    pub readiness: crate::extension_readiness::ExtensionReadinessState,
+    pub ready: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ready_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ready_detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub readiness_cache_age_seconds: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub readiness_probe_duration_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub readiness_timeout_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub readiness_follow_up_command: Option<String>,
     pub linked: bool,
 }
 
@@ -265,7 +274,10 @@ fn build_report_at(
         .iter()
         .filter(|m| show_all || linked_extension_ids.contains(&m.id) || m.executable.is_none())
         .map(|m| {
-            let ready_status = extension_ready_status(m);
+            let ready_status = crate::extension_readiness::extension_ready_status_with(
+                m,
+                crate::extension_readiness::ExtensionReadinessMode::Cached,
+            );
             ExtensionEntry {
                 id: m.id.clone(),
                 name: m.name.clone(),
@@ -283,9 +295,14 @@ fn build_report_at(
                 }
                 .to_string(),
                 compatible: is_extension_compatible(m, None),
+                readiness: ready_status.state,
                 ready: ready_status.ready,
                 ready_reason: ready_status.reason,
                 ready_detail: ready_status.detail,
+                readiness_cache_age_seconds: ready_status.cache_age_seconds,
+                readiness_probe_duration_ms: ready_status.probe_duration_ms,
+                readiness_timeout_ms: ready_status.timeout_ms,
+                readiness_follow_up_command: ready_status.follow_up_command,
                 linked: is_extension_linked(&m.id),
             }
         })

--- a/crates/homeboy-core/src/extension_readiness.rs
+++ b/crates/homeboy-core/src/extension_readiness.rs
@@ -1,6 +1,7 @@
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::project::Project;
 use crate::server::execute_local_command_in_dir_with_timeout;
@@ -9,13 +10,31 @@ use homeboy_engine_primitives::template;
 use crate::extension_store::load_extension;
 use homeboy_extension_contract::ExtensionManifest;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionReadinessState {
+    Ready,
+    NotReady,
+    Unknown,
+    TimedOut,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ExtensionReadyStatus {
-    pub ready: bool,
+    pub state: ExtensionReadinessState,
+    pub ready: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_age_seconds: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub probe_duration_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub follow_up_command: Option<String>,
 }
 
 /// Whether a caller wants readiness actually probed, or only the metadata that
@@ -30,8 +49,8 @@ pub struct ExtensionReadyStatus {
 pub enum ExtensionReadinessMode {
     /// Run the declared `ready_check`, bounded by [`ready_check_timeout`].
     Probe,
-    /// Do not spawn anything; report the probe as deliberately not run.
-    Skip,
+    /// Do not spawn anything; return matching cached evidence or `unknown`.
+    Cached,
 }
 
 /// Wall-clock bound applied to a single `ready_check`.
@@ -73,6 +92,16 @@ pub const READY_CHECK_SKIPPED_REASON: &str = "ready_check_skipped";
 /// `ready_reason` reported when a `ready_check` hit its wall-clock bound.
 pub const READY_CHECK_TIMEOUT_REASON: &str = "ready_check_timeout";
 
+const READINESS_CACHE_SCHEMA: &str = "homeboy/extension-readiness-cache/v1";
+
+#[derive(Deserialize, Serialize)]
+struct ExtensionReadinessCache {
+    schema: String,
+    identity: String,
+    checked_at: u64,
+    status: ExtensionReadyStatus,
+}
+
 pub fn extension_ready_status(extension: &ExtensionManifest) -> ExtensionReadyStatus {
     extension_ready_status_with(extension, ExtensionReadinessMode::Probe)
 }
@@ -82,32 +111,28 @@ pub fn extension_ready_status_with(
     mode: ExtensionReadinessMode,
 ) -> ExtensionReadyStatus {
     let Some(runtime) = extension.runtime() else {
-        return ExtensionReadyStatus {
-            ready: true,
-            reason: None,
-            detail: None,
-        };
+        return static_ready_status();
     };
 
     let Some(ready_check) = runtime.ready_check.as_ref() else {
-        return ExtensionReadyStatus {
-            ready: true,
-            reason: None,
-            detail: None,
-        };
+        return static_ready_status();
     };
 
-    // The caller asked for metadata only. Mirror the re-entrant case below: the
-    // check did not run, the reason says so, and the answer does not pretend to
-    // be a failed probe. (#10517)
-    if matches!(mode, ExtensionReadinessMode::Skip) {
-        return ExtensionReadyStatus {
-            ready: true,
+    let follow_up_command = format!("homeboy extension show {} --live-readiness", extension.id);
+    let identity = readiness_identity(extension, ready_check, runtime.entrypoint.as_deref());
+    if matches!(mode, ExtensionReadinessMode::Cached) {
+        return read_cached_status(extension, &identity).unwrap_or_else(|| ExtensionReadyStatus {
+            state: ExtensionReadinessState::Unknown,
+            ready: None,
             reason: Some(READY_CHECK_SKIPPED_REASON.to_string()),
-            detail: Some(
-                "ready_check not run: this command was asked for metadata only. Run `homeboy extension show <id>` without --skip-ready-check for live readiness.".to_string(),
-            ),
-        };
+            detail: Some(format!(
+                "Metadata-only inspection did not run ready_check and no matching live readiness probe is cached. Run `{follow_up_command}`."
+            )),
+            cache_age_seconds: None,
+            probe_duration_ms: None,
+            timeout_ms: Some(duration_ms(ready_check_timeout())),
+            follow_up_command: Some(follow_up_command),
+        });
     }
 
     // Re-entry guard: if we are already inside a `ready_check`, do not run it
@@ -116,19 +141,29 @@ pub fn extension_ready_status_with(
     // nested inspection completes instead of spawning another check. (#8115)
     if std::env::var_os(READY_CHECK_ACTIVE_ENV).is_some() {
         return ExtensionReadyStatus {
-            ready: true,
+            state: ExtensionReadinessState::Unknown,
+            ready: None,
             reason: Some("ready_check_reentrant_skipped".to_string()),
             detail: Some(
                 "ready_check skipped: already evaluating readiness for this extension (re-entrant invocation)".to_string(),
             ),
+            cache_age_seconds: None,
+            probe_duration_ms: None,
+            timeout_ms: Some(duration_ms(ready_check_timeout())),
+            follow_up_command: Some(follow_up_command),
         };
     }
 
     let Some(extension_path) = extension.extension_path.as_ref() else {
         return ExtensionReadyStatus {
-            ready: false,
+            state: ExtensionReadinessState::NotReady,
+            ready: Some(false),
             reason: Some("missing_extension_path".to_string()),
             detail: Some("ready_check configured but extension_path is missing".to_string()),
+            cache_age_seconds: None,
+            probe_duration_ms: None,
+            timeout_ms: Some(duration_ms(ready_check_timeout())),
+            follow_up_command: Some(follow_up_command),
         };
     };
 
@@ -139,6 +174,7 @@ pub fn extension_ready_status_with(
     ];
     let command = template::render(ready_check, &vars);
     let timeout = ready_check_timeout();
+    let started = Instant::now();
     // Mark the child (and anything it spawns) as running inside a ready_check so
     // a re-entrant `homeboy` invocation trips the guard above.
     let output = execute_local_command_in_dir_with_timeout(
@@ -147,56 +183,156 @@ pub fn extension_ready_status_with(
         Some(&[(READY_CHECK_ACTIVE_ENV, "1")]),
         timeout,
     );
+    let probe_duration_ms = duration_ms(started.elapsed());
 
-    if output.success {
-        return ExtensionReadyStatus {
-            ready: true,
+    let status = if output.success {
+        ExtensionReadyStatus {
+            state: ExtensionReadinessState::Ready,
+            ready: Some(true),
             reason: None,
             detail: None,
-        };
-    }
-
-    // A probe that ran out of wall clock is not the same answer as a probe that
-    // ran and said no. Naming it keeps "the doctor is slow" distinguishable from
-    // "the extension is broken", and keeps the surrounding metadata usable.
-    if output.timed_out {
-        return ExtensionReadyStatus {
-            ready: false,
+            cache_age_seconds: Some(0),
+            probe_duration_ms: Some(probe_duration_ms),
+            timeout_ms: Some(duration_ms(timeout)),
+            follow_up_command: Some(follow_up_command.clone()),
+        }
+    } else if output.timed_out {
+        // The process did not answer. Keep that distinct from a negative answer.
+        ExtensionReadyStatus {
+            state: ExtensionReadinessState::TimedOut,
+            ready: None,
             reason: Some(READY_CHECK_TIMEOUT_REASON.to_string()),
             detail: Some(format!(
                 "ready_check '{}' exceeded its {}s bound and its process group was terminated; \
-                 extension metadata is unaffected. Set {} to change the bound, or pass \
-                 --skip-ready-check to inventory commands.",
+                 extension metadata is unaffected. Set {} to change the bound, or retry with `{}`.",
                 command,
                 timeout.as_secs(),
-                READY_CHECK_TIMEOUT_ENV
+                READY_CHECK_TIMEOUT_ENV,
+                follow_up_command
             )),
+            cache_age_seconds: Some(0),
+            probe_duration_ms: Some(probe_duration_ms),
+            timeout_ms: Some(duration_ms(timeout)),
+            follow_up_command: Some(follow_up_command.clone()),
+        }
+    } else {
+        let detail_output = if output.stderr.trim().is_empty() {
+            output.stdout
+        } else {
+            output.stderr
         };
-    }
+        let detail = detail_output.trim();
+        let detail = if detail.is_empty() {
+            format!(
+                "ready_check '{}' failed with exit code {}",
+                command, output.exit_code
+            )
+        } else {
+            format!(
+                "ready_check '{}' failed with exit code {}: {}",
+                command, output.exit_code, detail
+            )
+        };
 
-    let detail_output = if output.stderr.trim().is_empty() {
-        output.stdout
-    } else {
-        output.stderr
-    };
-    let detail = detail_output.trim();
-    let detail = if detail.is_empty() {
-        format!(
-            "ready_check '{}' failed with exit code {}",
-            command, output.exit_code
-        )
-    } else {
-        format!(
-            "ready_check '{}' failed with exit code {}: {}",
-            command, output.exit_code, detail
-        )
+        ExtensionReadyStatus {
+            state: ExtensionReadinessState::NotReady,
+            ready: Some(false),
+            reason: Some("ready_check_failed".to_string()),
+            detail: Some(detail),
+            cache_age_seconds: Some(0),
+            probe_duration_ms: Some(probe_duration_ms),
+            timeout_ms: Some(duration_ms(timeout)),
+            follow_up_command: Some(follow_up_command.clone()),
+        }
     };
 
+    write_cached_status(extension, identity, &status);
+    status
+}
+
+fn static_ready_status() -> ExtensionReadyStatus {
     ExtensionReadyStatus {
-        ready: false,
-        reason: Some("ready_check_failed".to_string()),
-        detail: Some(detail),
+        state: ExtensionReadinessState::Ready,
+        ready: Some(true),
+        reason: None,
+        detail: None,
+        cache_age_seconds: None,
+        probe_duration_ms: None,
+        timeout_ms: None,
+        follow_up_command: None,
     }
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    duration.as_millis().try_into().unwrap_or(u64::MAX)
+}
+
+fn readiness_identity(
+    extension: &ExtensionManifest,
+    ready_check: &str,
+    entrypoint: Option<&str>,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(extension.id.as_bytes());
+    hasher.update([0]);
+    hasher.update(extension.version.as_bytes());
+    hasher.update([0]);
+    hasher.update(
+        extension
+            .extension_path
+            .as_deref()
+            .unwrap_or_default()
+            .as_bytes(),
+    );
+    hasher.update([0]);
+    if let Some(revision) = extension
+        .extension_path
+        .as_deref()
+        .and_then(|path| crate::extension_update_check::read_source_revision_at(path.as_ref()))
+    {
+        hasher.update(revision.as_bytes());
+    }
+    hasher.update([0]);
+    hasher.update(ready_check.as_bytes());
+    hasher.update([0]);
+    hasher.update(entrypoint.unwrap_or_default().as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn readiness_cache_filename(extension_id: &str) -> String {
+    let digest = Sha256::digest(extension_id.as_bytes());
+    format!("extension-readiness.{digest:x}.json")
+}
+
+fn read_cached_status(
+    extension: &ExtensionManifest,
+    identity: &str,
+) -> Option<ExtensionReadyStatus> {
+    let cache: ExtensionReadinessCache =
+        crate::update_check_cache::read_cache(&readiness_cache_filename(&extension.id))?;
+    if cache.schema != READINESS_CACHE_SCHEMA || cache.identity != identity {
+        return None;
+    }
+    let mut status = cache.status;
+    status.cache_age_seconds =
+        Some(crate::update_check_cache::now_unix().saturating_sub(cache.checked_at));
+    Some(status)
+}
+
+fn write_cached_status(
+    extension: &ExtensionManifest,
+    identity: String,
+    status: &ExtensionReadyStatus,
+) {
+    crate::update_check_cache::write_cache(
+        &readiness_cache_filename(&extension.id),
+        &ExtensionReadinessCache {
+            schema: READINESS_CACHE_SCHEMA.to_string(),
+            identity,
+            checked_at: crate::update_check_cache::now_unix(),
+            status: status.clone(),
+        },
+    );
 }
 
 /// Check if a extension is compatible with a project.
@@ -228,6 +364,46 @@ pub fn is_extension_compatible(extension: &ExtensionManifest, project: Option<&P
 mod tests {
     use super::*;
 
+    struct ReadinessEnvironment {
+        _home: crate::test_support::HomeGuard,
+        active: Option<std::ffi::OsString>,
+        timeout: Option<std::ffi::OsString>,
+    }
+
+    impl ReadinessEnvironment {
+        fn new(active: Option<&str>, timeout: Option<&str>) -> Self {
+            let home = crate::test_support::HomeGuard::new();
+            let prior_active = std::env::var_os(READY_CHECK_ACTIVE_ENV);
+            let prior_timeout = std::env::var_os(READY_CHECK_TIMEOUT_ENV);
+            match active {
+                Some(value) => std::env::set_var(READY_CHECK_ACTIVE_ENV, value),
+                None => std::env::remove_var(READY_CHECK_ACTIVE_ENV),
+            }
+            match timeout {
+                Some(value) => std::env::set_var(READY_CHECK_TIMEOUT_ENV, value),
+                None => std::env::remove_var(READY_CHECK_TIMEOUT_ENV),
+            }
+            Self {
+                _home: home,
+                active: prior_active,
+                timeout: prior_timeout,
+            }
+        }
+    }
+
+    impl Drop for ReadinessEnvironment {
+        fn drop(&mut self) {
+            match &self.active {
+                Some(value) => std::env::set_var(READY_CHECK_ACTIVE_ENV, value),
+                None => std::env::remove_var(READY_CHECK_ACTIVE_ENV),
+            }
+            match &self.timeout {
+                Some(value) => std::env::set_var(READY_CHECK_TIMEOUT_ENV, value),
+                None => std::env::remove_var(READY_CHECK_TIMEOUT_ENV),
+            }
+        }
+    }
+
     fn manifest_with_ready_check(extension_path: &str, ready_check: &str) -> ExtensionManifest {
         let mut manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
             "name": "fixture",
@@ -249,20 +425,12 @@ mod tests {
         // A ready_check that would fail if executed proves the command is never
         // run when the re-entry sentinel is already set. (#8115)
         let manifest = manifest_with_ready_check("/tmp", "exit 1");
-        let prior = std::env::var_os(READY_CHECK_ACTIVE_ENV);
-        std::env::set_var(READY_CHECK_ACTIVE_ENV, "1");
+        let _environment = ReadinessEnvironment::new(Some("1"), None);
 
         let status = extension_ready_status(&manifest);
 
-        match prior {
-            Some(value) => std::env::set_var(READY_CHECK_ACTIVE_ENV, value),
-            None => std::env::remove_var(READY_CHECK_ACTIVE_ENV),
-        }
-
-        assert!(
-            status.ready,
-            "a re-entrant ready_check must report ready instead of recursing"
-        );
+        assert_eq!(status.ready, None);
+        assert_eq!(status.state, ExtensionReadinessState::Unknown);
         assert_eq!(
             status.reason.as_deref(),
             Some("ready_check_reentrant_skipped")
@@ -272,17 +440,12 @@ mod tests {
     #[test]
     fn ready_check_runs_when_not_reentrant() {
         let manifest = manifest_with_ready_check("/tmp", "true");
-        let prior = std::env::var_os(READY_CHECK_ACTIVE_ENV);
-        std::env::remove_var(READY_CHECK_ACTIVE_ENV);
+        let _environment = ReadinessEnvironment::new(None, None);
 
         let status = extension_ready_status(&manifest);
 
-        match prior {
-            Some(value) => std::env::set_var(READY_CHECK_ACTIVE_ENV, value),
-            None => std::env::remove_var(READY_CHECK_ACTIVE_ENV),
-        }
-
-        assert!(status.ready, "a passing ready_check reports ready");
+        assert_eq!(status.ready, Some(true));
+        assert_eq!(status.state, ExtensionReadinessState::Ready);
         assert_eq!(status.reason, None);
     }
 
@@ -292,21 +455,14 @@ mod tests {
     #[test]
     fn a_skipped_ready_check_never_runs_the_command() {
         let manifest = manifest_with_ready_check("/tmp", "exit 1");
-        let prior = std::env::var_os(READY_CHECK_ACTIVE_ENV);
-        std::env::remove_var(READY_CHECK_ACTIVE_ENV);
+        let _environment = ReadinessEnvironment::new(None, None);
 
-        let status = extension_ready_status_with(&manifest, ExtensionReadinessMode::Skip);
-
-        if let Some(value) = prior {
-            std::env::set_var(READY_CHECK_ACTIVE_ENV, value);
-        }
+        let status = extension_ready_status_with(&manifest, ExtensionReadinessMode::Cached);
 
         assert_eq!(status.reason.as_deref(), Some(READY_CHECK_SKIPPED_REASON));
-        assert!(
-            status.ready,
-            "a skipped probe reports 'not evaluated', not 'not ready'"
-        );
-        assert!(status.detail.unwrap_or_default().contains("metadata only"));
+        assert_eq!(status.ready, None);
+        assert_eq!(status.state, ExtensionReadinessState::Unknown);
+        assert!(status.detail.unwrap_or_default().contains("Metadata-only"));
     }
 
     /// A `ready_check` that outlives its budget must produce an answer rather
@@ -315,27 +471,59 @@ mod tests {
     #[test]
     fn a_ready_check_that_outlives_its_bound_reports_a_timeout_instead_of_hanging() {
         let manifest = manifest_with_ready_check("/tmp", "sleep 30");
-        let prior_active = std::env::var_os(READY_CHECK_ACTIVE_ENV);
-        let prior_timeout = std::env::var_os(READY_CHECK_TIMEOUT_ENV);
-        std::env::remove_var(READY_CHECK_ACTIVE_ENV);
-        std::env::set_var(READY_CHECK_TIMEOUT_ENV, "1");
+        let _environment = ReadinessEnvironment::new(None, Some("1"));
 
         let status = extension_ready_status(&manifest);
 
-        match prior_active {
-            Some(value) => std::env::set_var(READY_CHECK_ACTIVE_ENV, value),
-            None => std::env::remove_var(READY_CHECK_ACTIVE_ENV),
-        }
-        match prior_timeout {
-            Some(value) => std::env::set_var(READY_CHECK_TIMEOUT_ENV, value),
-            None => std::env::remove_var(READY_CHECK_TIMEOUT_ENV),
-        }
-
-        assert!(!status.ready);
+        assert_eq!(status.ready, None);
+        assert_eq!(status.state, ExtensionReadinessState::TimedOut);
         assert_eq!(status.reason.as_deref(), Some(READY_CHECK_TIMEOUT_REASON));
         let detail = status.detail.unwrap_or_default();
         assert!(detail.contains("exceeded its 1s bound"), "{detail}");
         assert!(detail.contains("metadata is unaffected"), "{detail}");
+    }
+
+    #[test]
+    fn a_failed_ready_check_is_typed_not_ready() {
+        let manifest = manifest_with_ready_check("/tmp", "exit 7");
+        let _environment = ReadinessEnvironment::new(None, None);
+
+        let status = extension_ready_status(&manifest);
+
+        assert_eq!(status.state, ExtensionReadinessState::NotReady);
+        assert_eq!(status.ready, Some(false));
+        assert_eq!(status.reason.as_deref(), Some("ready_check_failed"));
+        assert!(status.probe_duration_ms.is_some());
+        assert_eq!(status.timeout_ms, Some(30_000));
+    }
+
+    #[test]
+    fn a_live_probe_refreshes_the_static_readiness_cache() {
+        crate::test_support::with_isolated_home(|home| {
+            let sentinel = home.path().join("ready");
+            let command = format!("test -f {}", sentinel.display());
+            let manifest =
+                manifest_with_ready_check(home.path().to_string_lossy().as_ref(), &command);
+
+            let missing = extension_ready_status(&manifest);
+            assert_eq!(missing.ready, Some(false));
+            assert_eq!(
+                extension_ready_status_with(&manifest, ExtensionReadinessMode::Cached).ready,
+                Some(false)
+            );
+
+            std::fs::write(&sentinel, "ready").expect("sentinel");
+            let refreshed = extension_ready_status(&manifest);
+            assert_eq!(refreshed.ready, Some(true));
+            let cached = extension_ready_status_with(&manifest, ExtensionReadinessMode::Cached);
+            assert_eq!(cached.ready, Some(true));
+            assert_eq!(cached.state, ExtensionReadinessState::Ready);
+            assert_eq!(cached.cache_age_seconds, Some(0));
+            assert_eq!(
+                cached.follow_up_command.as_deref(),
+                Some("homeboy extension show fixture --live-readiness")
+            );
+        });
     }
 
     #[test]

--- a/crates/homeboy-extension/src/execution.rs
+++ b/crates/homeboy-extension/src/execution.rs
@@ -30,7 +30,7 @@ use homeboy_core::extension_invocation_context::ResolvedExtensionInvocationConte
 pub use action::execute_action;
 pub use homeboy_core::extension_readiness::{
     extension_ready_status, extension_ready_status_with, is_extension_compatible,
-    ExtensionReadinessMode, ExtensionReadyStatus,
+    ExtensionReadinessMode, ExtensionReadinessState, ExtensionReadyStatus,
 };
 use settings::serialize_settings;
 pub(crate) use settings::{build_settings_json_from_manifest, load_extension_manifest_from_dir};
@@ -237,7 +237,7 @@ pub fn run_deployment_provider(
             None,
         ))?;
     let readiness = extension_ready_status(&extension);
-    if !readiness.ready {
+    if readiness.ready != Some(true) {
         return Err(Error::validation_invalid_argument(
             "deployment_provider.extension",
             format!("Deployment extension '{extension_id}' is not ready"),

--- a/crates/homeboy-extension/src/lib.rs
+++ b/crates/homeboy-extension/src/lib.rs
@@ -70,8 +70,8 @@ pub use execution::execute_action;
 pub use execution::{
     extension_ready_status, extension_ready_status_with, is_extension_compatible, run_action,
     run_deployment_provider, run_extension, run_setup, ExtensionExecutionMode,
-    ExtensionReadinessMode, ExtensionReadyStatus, ExtensionRunResult, ExtensionSetupResult,
-    ExtensionStepFilter,
+    ExtensionReadinessMode, ExtensionReadinessState, ExtensionReadyStatus, ExtensionRunResult,
+    ExtensionSetupResult, ExtensionStepFilter,
 };
 pub use fingerprint::{
     run_fingerprint_script, AggregateConstructionSeam, AggregateDefinitionFact, AggregateFieldFact,

--- a/crates/homeboy-extension/src/summary.rs
+++ b/crates/homeboy-extension/src/summary.rs
@@ -2,6 +2,7 @@ use serde::Serialize;
 
 use super::execution::{
     extension_ready_status_with, is_extension_compatible, ExtensionReadinessMode,
+    ExtensionReadinessState,
 };
 use super::manifest::ActionType;
 use super::{evaluate_core_compatibility, CoreCompatibilityReport};
@@ -20,11 +21,20 @@ pub struct ExtensionSummary {
     pub runtime: String,
     pub compatible: bool,
     pub core_compatibility: CoreCompatibilityReport,
-    pub ready: bool,
+    pub readiness: ExtensionReadinessState,
+    pub ready: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ready_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ready_detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub readiness_cache_age_seconds: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub readiness_probe_duration_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub readiness_timeout_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub readiness_follow_up_command: Option<String>,
     pub linked: bool,
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -62,113 +72,139 @@ pub struct ActionSummary {
 
 /// List all extensions with pre-computed summary fields.
 ///
-/// Aggregates ready status, compatibility, linked status, CLI info, actions,
-/// and runtime details into a single summary per extension.
+/// Aggregates cached readiness, compatibility, linked status, CLI info,
+/// actions, and runtime details into a single summary per extension.
 pub fn list_summaries(project: Option<&homeboy_core::project::Project>) -> Vec<ExtensionSummary> {
-    list_summaries_with(project, ExtensionReadinessMode::Probe)
+    list_summaries_with(project, ExtensionReadinessMode::Cached)
 }
 
 /// [`list_summaries`], with control over whether readiness is actually probed.
 ///
-/// Every field except `ready`/`ready_reason`/`ready_detail` is read from the
-/// installed manifest and costs nothing. Readiness is the only part that spawns
-/// an operator-authored shell command, so it is the only part a caller should
-/// ever have to opt out of (#10517).
+/// Every field except live readiness is read from installed metadata and costs
+/// nothing. Callers that need a fresh answer must explicitly request `Probe`.
 pub fn list_summaries_with(
     project: Option<&homeboy_core::project::Project>,
     readiness: ExtensionReadinessMode,
 ) -> Vec<ExtensionSummary> {
     let extensions = discover_extensions();
 
-    let mut summaries: Vec<ExtensionSummary> = extensions
-        .into_iter()
-        .map(|extension| match extension {
-            DiscoveredExtension::Valid(ext) => {
-                let ready_status = extension_ready_status_with(&ext, readiness);
-                let compatible = is_extension_compatible(&ext, project);
-                let linked = is_extension_linked(&ext.id);
-
-                let (cli_tool, cli_display_name) = ext
-                    .cli
-                    .as_ref()
-                    .map(|cli| (Some(cli.tool.clone()), Some(cli.display_name.clone())))
-                    .unwrap_or((None, None));
-
-                let actions: Vec<ActionSummary> = ext
-                    .actions
-                    .iter()
-                    .map(|a| ActionSummary {
-                        id: a.id.clone(),
-                        label: a.label.clone(),
-                        action_type: a.action_type.clone(),
-                    })
-                    .collect();
-                let notification_transports = ext
-                    .notification_transports
-                    .iter()
-                    .map(|transport| transport.descriptor())
-                    .collect();
-
-                let has_setup = ext
-                    .runtime()
-                    .and_then(|r| r.setup_command.as_ref())
-                    .map(|_| true);
-                let has_ready_check = ext
-                    .runtime()
-                    .and_then(|r| r.ready_check.as_ref())
-                    .map(|_| true);
-
-                let source_revision =
-                    homeboy_core::extension_update_check::read_source_revision(&ext.id);
-                let core_compatibility = evaluate_core_compatibility(
-                    ext.requires
-                        .as_ref()
-                        .and_then(|requires| requires.homeboy.as_deref()),
-                    source_revision.clone(),
-                )
-                .unwrap_or_else(|_| CoreCompatibilityReport::undeclared(source_revision.clone()));
-
-                ExtensionSummary {
-                    id: ext.id.clone(),
-                    name: ext.name.clone(),
-                    version: ext.version.clone(),
-                    description: ext
-                        .description
-                        .as_ref()
-                        .and_then(|d| d.lines().next())
-                        .unwrap_or("")
-                        .to_string(),
-                    runtime: if ext.executable.is_some() {
-                        "executable".to_string()
-                    } else {
-                        "platform".to_string()
-                    },
-                    compatible,
-                    core_compatibility,
-                    ready: ready_status.ready,
-                    ready_reason: ready_status.reason,
-                    ready_detail: ready_status.detail,
-                    linked,
-                    path: ext.extension_path.clone().unwrap_or_default(),
-                    manifest_path: None,
-                    error: None,
-                    diagnostic: None,
-                    symlink_target: None,
-                    source_revision,
-                    cli_tool,
-                    cli_display_name,
-                    actions,
-                    notification_transports,
-                    has_setup,
-                    has_ready_check,
-                }
-            }
-            DiscoveredExtension::Invalid(failure) => invalid_summary(failure),
+    let mut summaries: Vec<ExtensionSummary> = if readiness == ExtensionReadinessMode::Probe {
+        std::thread::scope(|scope| {
+            let probes = extensions
+                .into_iter()
+                .map(|extension| {
+                    scope.spawn(move || summary_for_extension(extension, project, readiness))
+                })
+                .collect::<Vec<_>>();
+            probes
+                .into_iter()
+                .map(|probe| probe.join().expect("extension readiness probe panicked"))
+                .collect()
         })
-        .collect();
+    } else {
+        extensions
+            .into_iter()
+            .map(|extension| summary_for_extension(extension, project, readiness))
+            .collect()
+    };
 
     summaries.sort_by(|a, b| a.id.cmp(&b.id));
     summaries
+}
+
+fn summary_for_extension(
+    extension: DiscoveredExtension,
+    project: Option<&homeboy_core::project::Project>,
+    readiness: ExtensionReadinessMode,
+) -> ExtensionSummary {
+    match extension {
+        DiscoveredExtension::Valid(ext) => {
+            let ready_status = extension_ready_status_with(&ext, readiness);
+            let compatible = is_extension_compatible(&ext, project);
+            let linked = is_extension_linked(&ext.id);
+
+            let (cli_tool, cli_display_name) = ext
+                .cli
+                .as_ref()
+                .map(|cli| (Some(cli.tool.clone()), Some(cli.display_name.clone())))
+                .unwrap_or((None, None));
+
+            let actions: Vec<ActionSummary> = ext
+                .actions
+                .iter()
+                .map(|a| ActionSummary {
+                    id: a.id.clone(),
+                    label: a.label.clone(),
+                    action_type: a.action_type.clone(),
+                })
+                .collect();
+            let notification_transports = ext
+                .notification_transports
+                .iter()
+                .map(|transport| transport.descriptor())
+                .collect();
+
+            let has_setup = ext
+                .runtime()
+                .and_then(|r| r.setup_command.as_ref())
+                .map(|_| true);
+            let has_ready_check = ext
+                .runtime()
+                .and_then(|r| r.ready_check.as_ref())
+                .map(|_| true);
+
+            let source_revision =
+                homeboy_core::extension_update_check::read_source_revision(&ext.id);
+            let core_compatibility = evaluate_core_compatibility(
+                ext.requires
+                    .as_ref()
+                    .and_then(|requires| requires.homeboy.as_deref()),
+                source_revision.clone(),
+            )
+            .unwrap_or_else(|_| CoreCompatibilityReport::undeclared(source_revision.clone()));
+
+            ExtensionSummary {
+                id: ext.id.clone(),
+                name: ext.name.clone(),
+                version: ext.version.clone(),
+                description: ext
+                    .description
+                    .as_ref()
+                    .and_then(|d| d.lines().next())
+                    .unwrap_or("")
+                    .to_string(),
+                runtime: if ext.executable.is_some() {
+                    "executable".to_string()
+                } else {
+                    "platform".to_string()
+                },
+                compatible,
+                core_compatibility,
+                readiness: ready_status.state,
+                ready: ready_status.ready,
+                ready_reason: ready_status.reason,
+                ready_detail: ready_status.detail,
+                readiness_cache_age_seconds: ready_status.cache_age_seconds,
+                readiness_probe_duration_ms: ready_status.probe_duration_ms,
+                readiness_timeout_ms: ready_status.timeout_ms,
+                readiness_follow_up_command: ready_status.follow_up_command,
+                linked,
+                path: ext.extension_path.clone().unwrap_or_default(),
+                manifest_path: None,
+                error: None,
+                diagnostic: None,
+                symlink_target: None,
+                source_revision,
+                cli_tool,
+                cli_display_name,
+                actions,
+                notification_transports,
+                has_setup,
+                has_ready_check,
+            }
+        }
+        DiscoveredExtension::Invalid(failure) => invalid_summary(failure),
+    }
 }
 
 fn invalid_summary(failure: ExtensionManifestFailure) -> ExtensionSummary {
@@ -184,9 +220,14 @@ fn invalid_summary(failure: ExtensionManifestFailure) -> ExtensionSummary {
         runtime: String::new(),
         compatible: false,
         core_compatibility: CoreCompatibilityReport::undeclared(None),
-        ready: false,
+        readiness: ExtensionReadinessState::NotReady,
+        ready: Some(false),
         ready_reason: Some(failure.category.to_string()),
         ready_detail: Some(failure.diagnostic.to_string()),
+        readiness_cache_age_seconds: None,
+        readiness_probe_duration_ms: None,
+        readiness_timeout_ms: None,
+        readiness_follow_up_command: None,
         linked: failure.path.is_symlink(),
         path: failure.path.to_string_lossy().to_string(),
         manifest_path: Some(failure.manifest_path.to_string_lossy().to_string()),
@@ -209,6 +250,22 @@ mod tests {
     use homeboy_core::paths;
 
     #[cfg(unix)]
+    fn write_ready_check_extension(home: &std::path::Path, id: &str, ready_check: String) {
+        let extension_dir = home.join(".config/homeboy/extensions").join(id);
+        std::fs::create_dir_all(&extension_dir).expect("extension dir");
+        std::fs::write(
+            extension_dir.join(format!("{id}.json")),
+            serde_json::json!({
+                "name": id,
+                "version": "1.0.0",
+                "executable": { "runtime": { "ready_check": ready_check } }
+            })
+            .to_string(),
+        )
+        .expect("extension manifest");
+    }
+
+    #[cfg(unix)]
     #[test]
     fn list_summaries_includes_broken_extension_symlinks() {
         homeboy_core::test_support::with_isolated_home(|_| {
@@ -222,7 +279,7 @@ mod tests {
 
             assert_eq!(summaries.len(), 1);
             assert_eq!(summaries[0].id, "sample-runtime");
-            assert!(!summaries[0].ready);
+            assert_eq!(summaries[0].ready, Some(false));
             assert!(summaries[0].linked);
             assert_eq!(summaries[0].error.as_deref(), Some("target_missing"));
             assert_eq!(summaries[0].ready_reason.as_deref(), Some("target_missing"));
@@ -266,6 +323,32 @@ mod tests {
                 .is_some_and(|path| path.ends_with("invalid/invalid.json")));
             assert_eq!(summaries[1].id, "valid");
             assert_eq!(summaries[1].name, "Valid");
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn live_readiness_probes_independent_extensions_concurrently() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let first = home.path().join("first-started");
+            let second = home.path().join("second-started");
+            let wait_for_peer = |own: &std::path::Path, peer: &std::path::Path| {
+                format!(
+                    "touch '{}' && i=0; while [ ! -f '{}' ] && [ $i -lt 200 ]; do i=$((i + 1)); sleep 0.01; done; test -f '{}'",
+                    own.display(),
+                    peer.display(),
+                    peer.display()
+                )
+            };
+            write_ready_check_extension(home.path(), "first", wait_for_peer(&first, &second));
+            write_ready_check_extension(home.path(), "second", wait_for_peer(&second, &first));
+
+            let summaries = list_summaries_with(None, ExtensionReadinessMode::Probe);
+
+            assert_eq!(summaries.len(), 2);
+            assert!(summaries
+                .iter()
+                .all(|summary| summary.readiness == ExtensionReadinessState::Ready));
         });
     }
 }

--- a/crates/homeboy-lab-runner/src/execution/extension_parity.rs
+++ b/crates/homeboy-lab-runner/src/execution/extension_parity.rs
@@ -524,7 +524,7 @@ fn show_runner_extension(
     extension_id: &str,
 ) -> Result<server::CommandOutput> {
     let command = format!(
-        "cd {} && {} extension show {}",
+        "cd {} && {} extension show {} --live-readiness",
         shell::quote_path(cwd),
         shell::quote_path(homeboy_path),
         shell::quote_arg(extension_id)


### PR DESCRIPTION
## Summary
- make default extension inventory use static/cached readiness rather than spawning live doctors
- model ready, not-ready, unknown, and timed-out states explicitly
- retain explicit bounded live readiness with concurrent independent probes
- bind readiness cache entries to extension identity and expose age, duration, budget, and follow-up evidence

Fixes #13352.

## Verification
- `cargo check -p homeboy-cli --lib`
- `cargo test -p homeboy-core extension_readiness --lib`
- `cargo test -p homeboy-extension summary::tests --lib`
- `cargo fmt --all -- --check`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented the candidate, rebased it onto current main, audited the readiness contract, and ran focused compile/test gates. Chris Huber directed the work and remains responsible.