### PR TITLE
fix(cook): converge initial lifecycle admission

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
@@ -99,8 +99,9 @@ pub(crate) use conversion::*;
 pub(crate) use lifecycle_record_ops::*;
 pub(crate) use runner_continuation::with_runner_continuation;
 
-#[cfg(test)]
-pub(crate) fn fail_next_record_write_for_test() {
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
+pub fn fail_next_record_write_for_test() {
     store::fail_next_record_write_for_test();
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -4094,7 +4094,24 @@ fn run_cook_reported(
         allow_historical_terminal,
     ) {
         Ok(result) => result,
-        Err(error) => {
+        Err(mut error) => {
+            // Recipe persistence is the first half of Cook admission. If the
+            // initial lifecycle write failed transiently, complete the same
+            // immutable attempt now rather than returning a recipe-only Cook
+            // whose advertised continuation has no record to address (#10849).
+            if store.recipe_exists(&failure_options.cook_id)
+                && !lifecycle_store.record_exists(&failure_options.initial_run_id)?
+                && super::cook_pre_execution::recover_recipe_attempt_with_stores(
+                    store,
+                    lifecycle_store,
+                    &failure_options.initial_run_id,
+                )
+                .ok()
+                .flatten()
+                .is_some()
+            {
+                error.details["cook_materialized_by_invocation"] = Value::Bool(true);
+            }
             // Once the attempt exists, a controller-side validation failure has
             // not reached a provider and must retain the pre-execution contract.
             if let Ok(mut record) = lifecycle_store.read_record(&failure_options.initial_run_id) {

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -9516,6 +9516,41 @@ fn recipe_only_initial_attempt_recovers_once_without_provider_dispatch() {
 }
 
 #[test]
+fn normal_cook_repairs_a_transient_initial_lifecycle_write_before_reporting_failure() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-initial-lifecycle-write-recovery";
+        let run_id = "cook-initial-lifecycle-write-recovery-attempt-1";
+        let dispatches = Arc::new(AtomicUsize::new(0));
+        let mut options = batch_cook_options(
+            cook_id,
+            Arc::new(RecordingDetachedAttemptDispatcher {
+                dispatches: Arc::clone(&dispatches),
+            }),
+        );
+        options.initial_run_id = run_id.to_string();
+
+        agent_task_lifecycle::fail_next_record_write_for_test();
+        let report = run_cook(CookContext::new(options, Arc::new(UnusedExecutor)))
+            .expect("normal Cook converges its durable admission");
+
+        assert_eq!(report.exit_code, 1);
+        assert_eq!(report.value.status, "pre_execution_failure");
+        assert_eq!(report.value.latest_run_id.as_deref(), Some(run_id));
+        assert_eq!(dispatches.load(Ordering::SeqCst), 0);
+        assert!(agent_task_lifecycle::run_record_exists(run_id).expect("lifecycle exists"));
+        let index = agent_task_lifecycle::cook_index(cook_id).expect("Cook index exists");
+        assert_eq!(index.latest_run_id, run_id);
+        assert_eq!(index.attempts.len(), 1);
+        let record = agent_task_lifecycle::exact_record(run_id).expect("recovered record");
+        assert_eq!(record.metadata["provider_executions_consumed"], 0);
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["phase"],
+            "cook_pre_execution"
+        );
+    });
+}
+
+#[test]
 fn recipe_recovery_rejects_foreign_lifecycle_record_before_indexing() {
     let context = homeboy_core::test_support::HermeticTestContext::new();
     let lifecycle_store =

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -367,7 +367,8 @@ pub mod lifecycle {
     };
     #[cfg(feature = "test-support")]
     pub use super::super::agent_task_lifecycle::{
-        inject_raw_record_metadata_for_corruption_test, rewrite_record_for_test,
+        fail_next_record_write_for_test, inject_raw_record_metadata_for_corruption_test,
+        rewrite_record_for_test,
     };
     pub use super::super::agent_task_lifecycle::{record_completed_run, record_promotion};
 }

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -3,7 +3,7 @@ use std::io::Read;
 use std::path::PathBuf;
 use std::time::Duration;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde_json::{json, Value};
@@ -927,7 +927,7 @@ fn default_store() -> Result<AgentTaskLifecycleStore> {
     AgentTaskLifecycleStore::from_current_environment()
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 static FAIL_NEXT_RECORD_WRITE: AtomicBool = AtomicBool::new(false);
 #[cfg(test)]
 static INTERRUPT_AFTER_TERMINAL_COMMIT: AtomicBool = AtomicBool::new(false);
@@ -1153,7 +1153,7 @@ pub(super) fn write_aggregate_and_record(
     default_store()?.write_aggregate_and_record(record, aggregate)
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 pub(super) fn fail_next_record_write_for_test() {
     FAIL_NEXT_RECORD_WRITE.store(true, Ordering::SeqCst);
 }
@@ -1168,7 +1168,7 @@ fn write_record_with_aggregate_without_workspace_authority(
     record: &AgentTaskRunRecord,
     aggregate: Option<AgentTaskAggregate>,
 ) -> Result<AgentTaskRunRecord> {
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-support"))]
     if FAIL_NEXT_RECORD_WRITE.swap(false, Ordering::SeqCst) {
         return Err(Error::internal_io(
             "injected lifecycle record persistence failure",

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -894,32 +894,37 @@ fn recoverable_runner_cook_args(source: &std::path::Path) -> AgentTaskCookArgs {
     *cook
 }
 
+fn recoverable_runner_worktree() -> (tempfile::TempDir, std::path::PathBuf) {
+    let root = tempfile::tempdir().expect("fixture root");
+    let primary = root.path().join("primary");
+    let source = root.path().join("worktree");
+    std::fs::create_dir(&primary).expect("create primary checkout");
+    init_runtime_component_checkout(&primary);
+    let remote = Command::new("git")
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/example/fixture.git",
+        ])
+        .current_dir(&primary)
+        .status()
+        .expect("configure fixture remote");
+    assert!(remote.success());
+    let worktree = Command::new("git")
+        .args(["worktree", "add", "-b", "fixture-recovery"])
+        .arg(&source)
+        .current_dir(&primary)
+        .status()
+        .expect("create fixture worktree");
+    assert!(worktree.success());
+    (root, source)
+}
+
 #[test]
 fn cook_runner_preflight_failure_is_visible_and_resumable_through_public_commands() {
     with_temp_home(|| {
-        let root = tempfile::tempdir().expect("fixture root");
-        let primary = root.path().join("primary");
-        let source = root.path().join("worktree");
-        std::fs::create_dir(&primary).expect("create primary checkout");
-        init_runtime_component_checkout(&primary);
-        let remote = Command::new("git")
-            .args([
-                "remote",
-                "add",
-                "origin",
-                "https://github.com/example/fixture.git",
-            ])
-            .current_dir(&primary)
-            .status()
-            .expect("configure fixture remote");
-        assert!(remote.success());
-        let worktree = Command::new("git")
-            .args(["worktree", "add", "-b", "fixture-recovery"])
-            .arg(&source)
-            .current_dir(&primary)
-            .status()
-            .expect("create fixture worktree");
-        assert!(worktree.success());
+        let (_root, source) = recoverable_runner_worktree();
         let dispatcher = Arc::new(RecoverableRunnerDispatcher {
             unavailable: AtomicBool::new(true),
         });
@@ -977,6 +982,41 @@ fn cook_runner_preflight_failure_is_visible_and_resumable_through_public_command
             .0["metadata"]["worktree_provision"]["action"],
             "existing",
             "resuming preserves Cook worktree evidence"
+        );
+    });
+}
+
+#[test]
+fn cli_cook_converges_recipe_lifecycle_and_index_after_transient_first_write_failure() {
+    with_temp_home(|| {
+        let (_root, source) = recoverable_runner_worktree();
+        let dispatcher = Arc::new(RecoverableRunnerDispatcher {
+            unavailable: AtomicBool::new(false),
+        });
+        agent_task_lifecycle::fail_next_record_write_for_test();
+
+        let (failed, exit_code) = run_cook_with_executor_and_dispatcher(
+            recoverable_runner_cook_args(&source),
+            Arc::new(CapturingExecutor::default()),
+            Some(dispatcher),
+        )
+        .expect("CLI Cook converges its durable admission");
+
+        assert_eq!(exit_code, 1);
+        assert_eq!(failed["status"], "pre_execution_failure");
+        let run_id = failed["latest_run_id"]
+            .as_str()
+            .expect("report names the repaired attempt");
+        assert!(agent_task_lifecycle::run_record_exists_readonly(run_id).expect("lifecycle exists"));
+        let index = agent_task_lifecycle::cook_index("cook-cli-preflight-recovery")
+            .expect("Cook index exists");
+        assert_eq!(index.latest_run_id, run_id);
+        assert_eq!(index.attempts.len(), 1);
+        assert_eq!(
+            agent_task_lifecycle::exact_record(run_id)
+                .expect("recovered attempt")
+                .metadata["provider_executions_consumed"],
+            0
         );
     });
 }


### PR DESCRIPTION
## Summary

- recover a transiently failed first lifecycle write from the immutable Cook recipe before returning a durable result
- persist the recovered attempt and Cook index as a zero-provider pre-execution failure
- add service-level and public CLI regressions that execute the normal Cook boundary

Closes #10849.

## Verification

- `cargo test -p homeboy-agents normal_cook_repairs_a_transient_initial_lifecycle_write_before_reporting_failure -- --nocapture`
- `cargo test -p homeboy-cli --features test-support cli_cook_converges_recipe_lifecycle_and_index_after_transient_first_write_failure -- --nocapture` (passed before the final rebase; latest-main rebuild reached linking but the local filesystem filled)
- `cargo check --workspace --tests` (passed before the final rebase; latest-main rerun was blocked by local artifact capacity)
- `cargo fmt --package homeboy-agents --package homeboy-cli -- --check`
- `git diff --check`

CI is the authoritative latest-main full-matrix verification because local Rust build artifacts exhausted the workspace filesystem during the final CLI relink.

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode traced the live recipe-only failures through the detached Cook and lifecycle admission paths, implemented the bounded repair, added the regressions, and ran verification. Chris Huber directed the work and remains responsible for review.