### PR TITLE
feat(cook): adopt provider worktree tracker ownership

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -7435,6 +7435,56 @@ fn materialize_pending_cook_workspace(
             provider.lookup_timeout_ms = provider.lookup_timeout_ms.min(timeout_ms);
         }
     }
+    let task_url = options
+        .initial_plan
+        .metadata
+        .pointer("/cook_provision/provision_intent/task_url")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            options
+                .initial_plan
+                .tasks
+                .first()
+                .and_then(|task| task.workspace.task_url.as_deref())
+        })
+        .map(str::to_string);
+    let attachment = task_url
+        .as_deref()
+        .map(|task_url| {
+            homeboy_core::worktree_providers::preview_apply_enabled_worktree_provider_task_attachment_from_config(
+                &options.to_worktree,
+                task_url,
+                &config,
+            )
+        })
+        .transpose()?
+        .flatten();
+    if let Some(attachment) = &attachment {
+        options.initial_plan.metadata["cook_provision"]["worktree_provider_id"] =
+            Value::String(attachment.provider_id.clone());
+        agent_task_lifecycle::persist_controller_plan_in_store(
+            lifecycle_store,
+            &initial_run_id,
+            &options.initial_plan,
+        )?;
+        if attachment.status
+            == homeboy_core::worktree_providers::WorktreeProviderTaskAttachmentStatus::Eligible
+        {
+            with_controller_pre_provider_heartbeat(
+                lifecycle_store,
+                &initial_run_id,
+                "worktree_provider_task_attachment",
+                "attaching tracker ownership to controller-owned provider workspace",
+                COOK_HEARTBEAT_INTERVAL,
+                || {
+                    homeboy_core::worktree_providers::apply_worktree_provider_task_attachment_from_config(
+                        attachment,
+                        &config,
+                    )
+                },
+            )?;
+        }
+    }
     let resolve = |options: &AgentTaskCookServiceOptions| {
         match provider_id(options) {
         Some(provider_id) => homeboy_core::worktree_providers::resolve_apply_enabled_worktree_provider_identity_by_id_from_config(
@@ -7522,6 +7572,12 @@ fn materialize_pending_cook_workspace(
                 }
                 Err(error) => return Err(error),
             }
+        }
+        Err(_error) if task_url.is_some() && attachment.is_none() => {
+            return Err(homeboy_core::worktree_providers::unsupported_worktree_provider_task_attachment_error(
+                &options.to_worktree,
+                task_url.as_deref().expect("task URL checked"),
+            ));
         }
         Err(error) => return Err(error),
     };

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -6592,6 +6592,189 @@ fn timed_out_ensure_reconciles_its_created_workspace_without_a_second_mutation()
 
 #[cfg(unix)]
 #[test]
+fn pending_cook_attaches_task_before_exact_provider_resolution() {
+    use std::os::unix::fs::PermissionsExt;
+
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let recipe_context = homeboy_core::test_support::HermeticTestContext::new();
+        let lifecycle_context = homeboy_core::test_support::HermeticTestContext::new();
+        let recipe_store = CookRecipeStore::new(recipe_context.path_roots());
+        let lifecycle_store = AgentTaskLifecycleStore::new(lifecycle_context.path_roots());
+        let root = tempfile::tempdir().expect("workspace root");
+        let source = root.path().join("source");
+        let workspace = root.path().join("workspace");
+        for args in [
+            vec!["init", "--quiet", "-b", "main", source.to_str().unwrap()],
+            vec![
+                "-C",
+                source.to_str().unwrap(),
+                "config",
+                "user.email",
+                "test@example.com",
+            ],
+            vec![
+                "-C",
+                source.to_str().unwrap(),
+                "config",
+                "user.name",
+                "Homeboy Test",
+            ],
+            vec![
+                "-C",
+                source.to_str().unwrap(),
+                "commit",
+                "--quiet",
+                "--allow-empty",
+                "-m",
+                "base",
+            ],
+            vec![
+                "-C",
+                source.to_str().unwrap(),
+                "worktree",
+                "add",
+                "--quiet",
+                "-b",
+                "fix-13427",
+                workspace.to_str().unwrap(),
+            ],
+        ] {
+            assert!(Command::new("git")
+                .args(args)
+                .status()
+                .expect("git runs")
+                .success());
+        }
+        let provider_dir = tempfile::tempdir().expect("provider directory");
+        let attached = provider_dir.path().join("attached");
+        let apply_count = provider_dir.path().join("apply-count");
+        let provider = provider_dir.path().join("provider");
+        std::fs::write(
+            &provider,
+            format!(
+                r#"#!/bin/sh
+case "$1" in
+preview)
+  status=eligible
+  test -f '{}' && status=already_attached
+  printf '{{"schema":"homeboy/worktree-provider-task-attachment/v1","provider_id":"fixture","handle":"fixture@fix-13427","task_url":"https://example.test/issues/13427","path":"{}","branch":"fix-13427","primary":false,"status":"%s"}}\n' "$status"
+  ;;
+apply)
+  printf '1\n' >> '{}'
+  touch '{}'
+  printf '%s\n' '{{"schema":"homeboy/worktree-provider-task-attachment/v1","provider_id":"fixture","handle":"fixture@fix-13427","task_url":"https://example.test/issues/13427","path":"{}","branch":"fix-13427","primary":false,"status":"attached"}}'
+  ;;
+resolve)
+  if test -f '{}'; then
+    printf '%s\n' '{{"worktrees":[{{"handle":"fixture@fix-13427","path":"{}","branch":"fix-13427","safety":{{"dirty":false,"unpushed":false,"primary":false}}}}]}}'
+  else
+    printf 'exact worktree has no tracker ownership\n' >&2
+    exit 23
+  fi
+  ;;
+esac
+"#,
+                attached.display(),
+                workspace.display(),
+                apply_count.display(),
+                attached.display(),
+                workspace.display(),
+                attached.display(),
+                workspace.display(),
+            ),
+        )
+        .expect("write provider");
+        let mut permissions = std::fs::metadata(&provider).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&provider, permissions).expect("make provider executable");
+
+        let mut config = homeboy_core::defaults::HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            homeboy_core::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: homeboy_core::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: homeboy_core::defaults::WorktreeProviderCommands {
+                    task_attachment_preview: Some(vec![
+                        provider.display().to_string(),
+                        "preview".to_string(),
+                        "{handle}".to_string(),
+                        "{task_url}".to_string(),
+                        "{idempotency_key}".to_string(),
+                    ]),
+                    task_attachment_apply: Some(vec![
+                        provider.display().to_string(),
+                        "apply".to_string(),
+                        "{handle}".to_string(),
+                        "{task_url}".to_string(),
+                        "{idempotency_key}".to_string(),
+                    ]),
+                    resolve: Some(vec![
+                        provider.display().to_string(),
+                        "resolve".to_string(),
+                        "{handle}".to_string(),
+                    ]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(
+                    homeboy_core::defaults::WorktreeProviderListResultMapping {
+                        items: "$.worktrees".to_string(),
+                        handle: "$.handle".to_string(),
+                        path: "$.path".to_string(),
+                        branch: "$.branch".to_string(),
+                        dirty: "$.safety.dirty".to_string(),
+                        unpushed: "$.safety.unpushed".to_string(),
+                        primary: "$.safety.primary".to_string(),
+                        task_url: None,
+                    },
+                ),
+            },
+        );
+        homeboy_core::defaults::save_config(&config).expect("save provider config");
+
+        let mut options =
+            batch_cook_options("fix-13427", Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = "fix-13427-run".to_string();
+        options.to_worktree = "fixture@fix-13427".to_string();
+        options.task_base_sha = Some("fixture-base".to_string());
+        options.initial_plan.metadata["cook_provision"] = serde_json::json!({
+            "action": "lookup_pending",
+            "kind": "provider",
+            "handle": options.to_worktree,
+            "provision_intent": {
+                "repo": "fixture",
+                "base": "main",
+                "head": "fix-13427",
+                "task_url": "https://example.test/issues/13427"
+            }
+        });
+        recipe_store
+            .persist_initial_recipe(&options)
+            .expect("persist recipe");
+        materialize_initial_cook_attempt_with_stores(&recipe_store, &lifecycle_store, &options)
+            .expect("materialize durable run");
+
+        materialize_pending_cook_workspace(&lifecycle_store, &mut options, None)
+            .expect("attach ownership and resolve exact workspace");
+
+        assert_eq!(std::fs::read_to_string(apply_count).unwrap(), "1\n");
+        assert_eq!(
+            options.initial_plan.metadata["cook_provision"]["worktree_provider_id"],
+            "fixture"
+        );
+        assert_eq!(
+            options.source_worktree_path.as_deref(),
+            Some(workspace.as_path())
+        );
+    });
+}
+
+#[cfg(unix)]
+#[test]
 fn timed_out_ensure_does_not_adopt_a_competing_provider_destination() {
     use std::os::unix::fs::PermissionsExt;
 

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -25,8 +25,10 @@ use homeboy::core::defaults;
 use homeboy::core::engine::shell::quote_args;
 use homeboy::core::worktree_providers::{
     plan_apply_enabled_worktree_provider_with_lifecycle_from_config,
+    preview_apply_enabled_worktree_provider_task_attachment_from_config,
     provision_apply_enabled_worktree_provider_from_config, WorktreeProviderCleanupPolicy,
     WorktreeProviderCreateIntent, WorktreeProviderCreatePlan, WorktreeProviderLifecycleIntent,
+    WorktreeProviderTaskAttachmentStatus,
 };
 
 use super::super::agent_task_dispatch::DispatchArgs;
@@ -3631,7 +3633,47 @@ fn resolve_cook_preview_destination(
         path
     } else {
         let config = defaults::load_config();
-        let identity = match homeboy::core::worktree_providers::resolve_apply_enabled_worktree_provider_identity_from_config(&handle, &config) {
+        let task_attachment = args
+            .dispatch
+            .task_url
+            .as_deref()
+            .map(|task_url| {
+                preview_apply_enabled_worktree_provider_task_attachment_from_config(
+                    &handle, task_url, &config,
+                )
+            })
+            .transpose()?
+            .flatten();
+        if let Some(attachment) = task_attachment.as_ref().filter(|attachment| {
+            attachment.status == WorktreeProviderTaskAttachmentStatus::Eligible
+        }) {
+            let path = PathBuf::from(&attachment.path);
+            homeboy::core::worktree_providers::validate_task_worktree_root(&path, &handle)?;
+            validate_cook_destination_identity(&args, &path)?;
+            resolve_cook_base(&mut args)?;
+            return Ok((
+                args,
+                serde_json::json!({
+                    "action": "planned_task_attachment",
+                    "kind": "provider",
+                    "handle": attachment.handle,
+                    "path": attachment.path,
+                    "branch": attachment.branch,
+                    "provider_id": attachment.provider_id,
+                    "task_url": attachment.task_url,
+                    "attachment_status": attachment.status,
+                }),
+            ));
+        }
+        let identity_result = match task_attachment.as_ref() {
+            Some(attachment) => homeboy::core::worktree_providers::resolve_apply_enabled_worktree_provider_identity_by_id_from_config(
+                &handle,
+                &attachment.provider_id,
+                &config,
+            ),
+            None => homeboy::core::worktree_providers::resolve_apply_enabled_worktree_provider_identity_from_config(&handle, &config),
+        };
+        let identity = match identity_result {
             Ok(identity) => identity,
             Err(error)
                 if issue_derived && error.details["worktree_provider_lookup"] == "not_found" =>
@@ -3646,22 +3688,17 @@ fn resolve_cook_preview_destination(
                     cleanup_policy: WorktreeProviderCleanupPolicy::RemoveOnSuccess,
                 };
                 let plan = match plan_apply_enabled_worktree_provider_with_lifecycle_from_config(
-                    &intent,
-                    &lifecycle,
-                    &config,
+                    &intent, &lifecycle, &config,
                 ) {
                     Ok(plan) => plan,
                     Err(error) => {
-                        return Ok((
-                            args,
-                            unresolved_provider_preview(&handle, error, &config),
-                        ));
+                        return Ok((args, unresolved_provider_preview(&handle, error, &config)));
                     }
                 };
-                let WorktreeProviderCreatePlan::WouldCreate(resolution) = plan
-                else {
+                let WorktreeProviderCreatePlan::WouldCreate(resolution) = plan else {
                     return Err(homeboy::core::Error::internal_unexpected(
-                        "worktree provider changed from absent to existing while previewing Cook".to_string(),
+                        "worktree provider changed from absent to existing while previewing Cook"
+                            .to_string(),
                     ));
                 };
                 let planning_timeout =
@@ -3682,9 +3719,12 @@ fn resolve_cook_preview_destination(
                 ));
             }
             Err(error) if issue_derived => {
-                return Ok((
-                    args,
-                    unresolved_provider_preview(&handle, error, &config),
+                return Ok((args, unresolved_provider_preview(&handle, error, &config)));
+            }
+            Err(_error) if args.dispatch.task_url.is_some() && task_attachment.is_none() => {
+                return Err(homeboy::core::worktree_providers::unsupported_worktree_provider_task_attachment_error(
+                    &handle,
+                    args.dispatch.task_url.as_deref().expect("task URL checked"),
                 ));
             }
             Err(error) => return Err(error),

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -679,6 +679,16 @@ pub struct WorktreeProviderCommands {
     /// absent destination.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolve_task: Option<Vec<String>>,
+    /// Read-only eligibility check for attaching `{task_url}` to one exact
+    /// `{handle}`. It also receives a stable `{idempotency_key}` and returns a
+    /// `homeboy/worktree-provider-task-attachment/v1` envelope.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_attachment_preview: Option<Vec<String>>,
+    /// Provider-owned mutation that attaches `{task_url}` to one exact
+    /// `{handle}` after the matching preview succeeds. It receives the same
+    /// stable `{idempotency_key}` and returns the same versioned envelope.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_attachment_apply: Option<Vec<String>>,
     /// Targeted tracker lookup exit statuses that mean the requested task is
     /// absent. This is independent from exact handle/path resolution.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -742,6 +752,8 @@ impl Default for WorktreeProviderCommands {
             attest_safety: None,
             resolve: None,
             resolve_task: None,
+            task_attachment_preview: None,
+            task_attachment_apply: None,
             resolve_task_not_found_exit_codes: Vec::new(),
             resolve_path: None,
             resolve_not_found_exit_codes: Vec::new(),
@@ -1212,6 +1224,8 @@ mod tests {
             attest_safety: None,
             resolve: None,
             resolve_task: None,
+            task_attachment_preview: None,
+            task_attachment_apply: None,
             resolve_task_not_found_exit_codes: Vec::new(),
             resolve_path: None,
             resolve_not_found_exit_codes: Vec::new(),

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -196,6 +196,30 @@ pub struct WorktreeProviderResolution {
     pub worktree: WorktreeProviderHandle,
 }
 
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorktreeProviderTaskAttachmentStatus {
+    Eligible,
+    AlreadyAttached,
+    Attached,
+}
+
+/// Provider-owned assessment for attaching tracker ownership to one exact
+/// existing allocation. Product-specific ownership predicates remain opaque to
+/// Homeboy; the echoed checkout identity prevents a provider from broadening
+/// the requested mutation.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct WorktreeProviderTaskAttachment {
+    pub schema: String,
+    pub provider_id: String,
+    pub handle: String,
+    pub task_url: String,
+    pub path: String,
+    pub branch: String,
+    pub primary: bool,
+    pub status: WorktreeProviderTaskAttachmentStatus,
+}
+
 /// Non-mutating provider answer for one explicit workspace creation intent.
 /// Existing destinations retain their resolved metadata; absent destinations
 /// require a provider-declared path projection before they can be represented
@@ -934,6 +958,310 @@ fn compatibility_identity_token(resolution: &WorktreeProviderResolution) -> Stri
         resolution.worktree.branch.as_str(),
     ]);
     format!("compat-v1:{digest}")
+}
+
+/// Ask every eligible provider whether it owns the exact allocation and can
+/// attach the supplied tracker identity. Providers return `not_owned` to
+/// decline; every ownership or safety denial is a strict failure.
+pub fn preview_apply_enabled_worktree_provider_task_attachment_from_config(
+    handle: &str,
+    task_url: &str,
+    config: &HomeboyConfig,
+) -> Result<Option<WorktreeProviderTaskAttachment>> {
+    let task_url = normalize_task_url(task_url);
+    let idempotency_key = task_attachment_idempotency_key(handle, &task_url);
+    let mut assessments = Vec::new();
+    for (provider_id, provider) in &config.worktree_providers {
+        if !provider.enabled || !provider.apply_enabled {
+            continue;
+        }
+        let command = match (
+            &provider.commands.task_attachment_preview,
+            &provider.commands.task_attachment_apply,
+        ) {
+            (Some(command), Some(_)) => command,
+            (None, None) => continue,
+            _ => {
+                return Err(Error::validation_invalid_argument(
+                    "worktree_providers.commands",
+                    format!("worktree provider `{provider_id}` must configure both task_attachment_preview and task_attachment_apply"),
+                    Some(provider_id.clone()),
+                    None,
+                ));
+            }
+        };
+        let command = expand_task_attachment_command(command, handle, &task_url, &idempotency_key);
+        let (payload, _, _) =
+            run_provider_split_command(provider_id, provider, &command, "task_attachment_preview")?;
+        if task_attachment_not_owned(&payload) {
+            continue;
+        }
+        assessments.push(parse_task_attachment(
+            provider_id,
+            handle,
+            &task_url,
+            &command,
+            "task_attachment_preview",
+            payload,
+            false,
+        )?);
+    }
+    match assessments.len() {
+        0 => Ok(None),
+        1 => Ok(assessments.pop()),
+        _ => Err(task_attachment_error(
+            handle,
+            &task_url,
+            "multiple providers claim the exact worktree for task attachment",
+            "ambiguous",
+            None,
+        )),
+    }
+}
+
+/// Execute one provider-owned attachment after repeating the same read-only
+/// assessment used by preview. Already-attached ownership is idempotent and
+/// does not invoke the mutation command.
+pub fn apply_worktree_provider_task_attachment_from_config(
+    assessment: &WorktreeProviderTaskAttachment,
+    config: &HomeboyConfig,
+) -> Result<WorktreeProviderTaskAttachment> {
+    let current = preview_apply_enabled_worktree_provider_task_attachment_from_config(
+        &assessment.handle,
+        &assessment.task_url,
+        config,
+    )?
+    .ok_or_else(|| {
+        task_attachment_error(
+            &assessment.handle,
+            &assessment.task_url,
+            "the provider no longer owns the exact worktree for task attachment",
+            "not_owned",
+            Some(&assessment.provider_id),
+        )
+    })?;
+    if current.provider_id != assessment.provider_id
+        || current.path != assessment.path
+        || current.branch != assessment.branch
+        || current.primary != assessment.primary
+    {
+        return Err(task_attachment_error(
+            &assessment.handle,
+            &assessment.task_url,
+            "worktree provider task-attachment identity changed after preview",
+            "conflict",
+            Some(&assessment.provider_id),
+        ));
+    }
+    if current.status == WorktreeProviderTaskAttachmentStatus::AlreadyAttached {
+        return Ok(current);
+    }
+    let provider = &config.worktree_providers[&current.provider_id];
+    let command = provider
+        .commands
+        .task_attachment_apply
+        .as_ref()
+        .expect("paired task attachment command");
+    let task_url = normalize_task_url(&current.task_url);
+    let idempotency_key = task_attachment_idempotency_key(&current.handle, &task_url);
+    let command =
+        expand_task_attachment_command(command, &current.handle, &task_url, &idempotency_key);
+    let output = run_provider_mutation_command(
+        &current.provider_id,
+        provider,
+        &command,
+        "task_attachment_apply",
+    )?;
+    let payload = serde_json::from_slice(&output).map_err(|error| {
+        provider_lookup_error(
+            &current.provider_id,
+            &command,
+            "task_attachment_apply",
+            "malformed",
+            "worktree_providers.commands.task_attachment_apply",
+            format!(
+                "worktree provider `{}` returned invalid task-attachment evidence: {error}",
+                current.provider_id
+            ),
+            false,
+        )
+    })?;
+    parse_task_attachment(
+        &current.provider_id,
+        &current.handle,
+        &task_url,
+        &command,
+        "task_attachment_apply",
+        payload,
+        true,
+    )
+}
+
+pub fn unsupported_worktree_provider_task_attachment_error(handle: &str, task_url: &str) -> Error {
+    let task_url = normalize_task_url(task_url);
+    task_attachment_error(
+        handle,
+        &task_url,
+        "the exact worktree is not tracker-owned and its provider does not support task attachment",
+        "unsupported",
+        None,
+    )
+}
+
+fn task_attachment_idempotency_key(handle: &str, task_url: &str) -> String {
+    homeboy_engine_primitives::content_hash::nul_separated_digest([
+        "worktree_provider_task_attachment_v1",
+        handle,
+        task_url,
+    ])
+}
+
+fn expand_task_attachment_command(
+    command: &[String],
+    handle: &str,
+    task_url: &str,
+    idempotency_key: &str,
+) -> Vec<String> {
+    command
+        .iter()
+        .map(|argument| {
+            argument
+                .replace("{handle}", handle)
+                .replace("{task_url}", task_url)
+                .replace("{idempotency_key}", idempotency_key)
+        })
+        .collect()
+}
+
+fn task_attachment_not_owned(payload: &Value) -> bool {
+    payload.get("status").and_then(Value::as_str) == Some("not_owned")
+}
+
+fn parse_task_attachment(
+    provider_id: &str,
+    handle: &str,
+    task_url: &str,
+    command: &[String],
+    operation: &str,
+    payload: Value,
+    applied: bool,
+) -> Result<WorktreeProviderTaskAttachment> {
+    if let Some(
+        status @ ("conflicting_task" | "foreign_owner" | "dirty" | "ambiguous" | "inactive"
+        | "unsafe"),
+    ) = payload.get("status").and_then(Value::as_str)
+    {
+        return Err(task_attachment_error(
+            handle,
+            task_url,
+            payload
+                .get("reason")
+                .and_then(Value::as_str)
+                .unwrap_or("worktree provider rejected task attachment"),
+            status,
+            Some(provider_id),
+        ));
+    }
+    let attachment: WorktreeProviderTaskAttachment =
+        serde_json::from_value(payload).map_err(|error| {
+            provider_lookup_error(
+                provider_id,
+                command,
+                operation,
+                "malformed",
+                &format!("worktree_providers.commands.{operation}"),
+                format!("worktree provider `{provider_id}` returned an invalid task-attachment envelope: {error}"),
+                false,
+            )
+        })?;
+    let valid_status = if applied {
+        matches!(
+            attachment.status,
+            WorktreeProviderTaskAttachmentStatus::Attached
+                | WorktreeProviderTaskAttachmentStatus::AlreadyAttached
+        )
+    } else {
+        matches!(
+            attachment.status,
+            WorktreeProviderTaskAttachmentStatus::Eligible
+                | WorktreeProviderTaskAttachmentStatus::AlreadyAttached
+        )
+    };
+    if attachment.schema != "homeboy/worktree-provider-task-attachment/v1"
+        || attachment.provider_id != provider_id
+        || attachment.handle != handle
+        || normalize_task_url(&attachment.task_url) != task_url
+        || attachment.primary
+        || !valid_status
+    {
+        return Err(provider_lookup_error(
+            provider_id,
+            command,
+            operation,
+            "malformed",
+            &format!("worktree_providers.commands.{operation}"),
+            format!("worktree provider `{provider_id}` returned task-attachment evidence that does not bind the exact request"),
+            false,
+        ));
+    }
+    validate_task_attachment_checkout(provider_id, &attachment)?;
+    Ok(WorktreeProviderTaskAttachment {
+        task_url: task_url.to_string(),
+        ..attachment
+    })
+}
+
+fn validate_task_attachment_checkout(
+    provider_id: &str,
+    attachment: &WorktreeProviderTaskAttachment,
+) -> Result<()> {
+    let path = std::path::Path::new(&attachment.path);
+    let canonical = std::fs::canonicalize(path).map_err(|error| {
+        task_attachment_error(
+            &attachment.handle,
+            &attachment.task_url,
+            &format!("provider `{provider_id}` returned an unresolvable task-attachment checkout: {error}"),
+            "unsafe",
+            Some(provider_id),
+        )
+    })?;
+    if canonical != path
+        || attachment.branch.trim().is_empty()
+        || crate::git::current_branch(&canonical).as_deref() != Some(attachment.branch.as_str())
+    {
+        return Err(task_attachment_error(
+            &attachment.handle,
+            &attachment.task_url,
+            "provider task-attachment checkout identity does not match the exact linked checkout",
+            "unsafe",
+            Some(provider_id),
+        ));
+    }
+    validate_task_worktree_root(&canonical, &attachment.handle)
+}
+
+fn task_attachment_error(
+    handle: &str,
+    task_url: &str,
+    message: &str,
+    status: &str,
+    provider_id: Option<&str>,
+) -> Error {
+    let mut error = Error::validation_invalid_argument(
+        "to_worktree",
+        message,
+        Some(handle.to_string()),
+        Some(vec![format!(
+            "Attach task `{task_url}` to exact worktree `{handle}` through its workspace provider, then rerun Cook."
+        )]),
+    );
+    error.details["worktree_provider_task_attachment"] = Value::String(status.to_string());
+    error.details["handle"] = Value::String(handle.to_string());
+    error.details["task_url"] = Value::String(task_url.to_string());
+    if let Some(provider_id) = provider_id {
+        error.details["worktree_provider_id"] = Value::String(provider_id.to_string());
+    }
+    error
 }
 /// Find the sole apply-enabled provider worktree owned by a tracker URL.
 /// Providers must map `task_url` to participate, preserving existing provider
@@ -3910,6 +4238,8 @@ mod tests {
                     "apply_enabled": true,
                     "commands": {
                         "resolve_task": ["fixture-bin", "resolve-task", "{task_url}"],
+                        "task_attachment_preview": ["fixture-bin", "attach-preview", "{handle}", "{task_url}"],
+                        "task_attachment_apply": ["fixture-bin", "attach", "{handle}", "{task_url}", "{idempotency_key}"],
                         "resolve_task_not_found_exit_codes": [42],
                         "cleanup_preview": ["fixture-bin", "preview"],
                         "cleanup_apply": ["fixture-bin", "apply"],
@@ -3936,6 +4266,14 @@ mod tests {
         assert_eq!(
             provider.commands.resolve_task_not_found_exit_codes,
             vec![42]
+        );
+        assert_eq!(
+            provider
+                .commands
+                .task_attachment_apply
+                .as_ref()
+                .expect("command")[1],
+            "attach"
         );
         assert_eq!(
             provider.commands.cleanup_preview.as_ref().expect("command"),
@@ -6503,6 +6841,177 @@ mod tests {
         )
         .expect_err("duplicate ownership must be explicit");
         assert!(error.message.contains("project@first, project@second"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn task_attachment_contract_is_previewable_bounded_and_idempotent() {
+        let (_root, workspace) = linked_workspace("fix-13427");
+        let fixture = unique_fixture_script_dir();
+        let state = fixture.join("attached");
+        let calls = fixture.join("apply-calls");
+        let script = fixture.join("provider");
+        fs::write(
+            &script,
+            format!(
+                r#"#!/bin/sh
+schema=homeboy/worktree-provider-task-attachment/v1
+if [ "$1" = preview ]; then
+  status=eligible
+  [ -f '{}' ] && status=already_attached
+else
+  printf 'apply\n' >> '{}'
+  touch '{}'
+  status=attached
+fi
+printf '{{"schema":"%s","provider_id":"fixture","handle":"%s","task_url":"%s","path":"{}","branch":"fix-13427","primary":false,"status":"%s"}}\n' "$schema" "$2" "$3" "$status"
+"#,
+                state.display(),
+                calls.display(),
+                state.display(),
+                workspace.display(),
+            ),
+        )
+        .expect("write provider");
+        make_executable(&script);
+        let mut provider = WorktreeProviderConfig {
+            enabled: true,
+            kind: WorktreeProviderKind::Command,
+            apply_enabled: true,
+            lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
+            lookup_output_limit_bytes: 64 * 1024,
+            commands: WorktreeProviderCommands {
+                task_attachment_preview: Some(vec![
+                    script.display().to_string(),
+                    "preview".to_string(),
+                    "{handle}".to_string(),
+                    "{task_url}".to_string(),
+                    "{idempotency_key}".to_string(),
+                ]),
+                task_attachment_apply: Some(vec![
+                    script.display().to_string(),
+                    "apply".to_string(),
+                    "{handle}".to_string(),
+                    "{task_url}".to_string(),
+                    "{idempotency_key}".to_string(),
+                ]),
+                ..Default::default()
+            },
+            list_result_mapping: None,
+        };
+        let task_url = " HTTPS://Example.TEST:443/project/issues/13427/?from=cook ";
+        let config = config_with_provider(provider.clone());
+
+        let preview = preview_apply_enabled_worktree_provider_task_attachment_from_config(
+            "fixture@fix-13427",
+            task_url,
+            &config,
+        )
+        .expect("preview succeeds")
+        .expect("provider owns exact handle");
+        assert_eq!(
+            preview.status,
+            WorktreeProviderTaskAttachmentStatus::Eligible
+        );
+        assert_eq!(
+            preview.task_url,
+            "https://example.test/project/issues/13427"
+        );
+        assert!(!state.exists(), "preview must not mutate provider state");
+
+        let applied = apply_worktree_provider_task_attachment_from_config(&preview, &config)
+            .expect("attachment succeeds");
+        assert_eq!(
+            applied.status,
+            WorktreeProviderTaskAttachmentStatus::Attached
+        );
+        assert_eq!(fs::read_to_string(&calls).unwrap(), "apply\n");
+
+        let replay = preview_apply_enabled_worktree_provider_task_attachment_from_config(
+            "fixture@fix-13427",
+            task_url,
+            &config,
+        )
+        .expect("replay preview succeeds")
+        .expect("same provider still owns handle");
+        assert_eq!(
+            replay.status,
+            WorktreeProviderTaskAttachmentStatus::AlreadyAttached
+        );
+        apply_worktree_provider_task_attachment_from_config(&replay, &config)
+            .expect("same-task replay is idempotent");
+        assert_eq!(
+            fs::read_to_string(&calls).unwrap(),
+            "apply\n",
+            "idempotent replay must not repeat the mutation"
+        );
+
+        provider.commands.task_attachment_apply =
+            Some(vec![fake_failing_provider_script(), "{handle}".to_string()]);
+        fs::remove_file(&state).expect("restore eligible state");
+        let failure = apply_worktree_provider_task_attachment_from_config(
+            &preview,
+            &config_with_provider(provider),
+        )
+        .expect_err("provider mutation failure remains fail-closed");
+        assert_eq!(
+            failure.details["worktree_provider_operation"],
+            "task_attachment_apply"
+        );
+        assert_eq!(
+            failure.details["worktree_provider_call_classification"],
+            "command"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn task_attachment_contract_rejects_conflicts_and_reports_unsupported_repair() {
+        let (_root, workspace) = linked_workspace("fix-13427-conflict");
+        let script = fake_provider_script_body(&format!(
+            "printf '%s\\n' '{{\"schema\":\"homeboy/worktree-provider-task-attachment/v1\",\"provider_id\":\"fixture\",\"handle\":\"fixture@fix-13427\",\"task_url\":\"https://example.test/issues/other\",\"path\":\"{}\",\"branch\":\"fix-13427-conflict\",\"primary\":false,\"status\":\"conflicting_task\",\"reason\":\"exact worktree already belongs to another task\"}}'\n",
+            workspace.display()
+        ));
+        let provider = WorktreeProviderConfig {
+            enabled: true,
+            kind: WorktreeProviderKind::Command,
+            apply_enabled: true,
+            lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
+            lookup_output_limit_bytes: 64 * 1024,
+            commands: WorktreeProviderCommands {
+                task_attachment_preview: Some(vec![script, "{handle}".to_string()]),
+                task_attachment_apply: Some(vec!["false".to_string()]),
+                ..Default::default()
+            },
+            list_result_mapping: None,
+        };
+        let error = preview_apply_enabled_worktree_provider_task_attachment_from_config(
+            "fixture@fix-13427",
+            "https://example.test/issues/13427",
+            &config_with_provider(provider),
+        )
+        .expect_err("conflicting tracker ownership must fail closed");
+        assert_eq!(
+            error.details["worktree_provider_task_attachment"],
+            "conflicting_task"
+        );
+        assert!(error.message.contains("another task"));
+
+        let unsupported = unsupported_worktree_provider_task_attachment_error(
+            "fixture@fix-13427",
+            "https://example.test/issues/13427",
+        );
+        assert_eq!(
+            unsupported.details["worktree_provider_task_attachment"],
+            "unsupported"
+        );
+        assert_eq!(unsupported.details["tried"].as_array().unwrap().len(), 1);
+        assert!(unsupported.details["tried"][0]
+            .as_str()
+            .unwrap()
+            .contains("fixture@fix-13427"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a generic optional worktree-provider tracker attachment preview/apply contract
- let Cook attach its supplied task URL to an exact untracked provider worktree before normal resolution
- preserve strict conflict, ownership, safety, idempotency, and preview/execution parity
- provide an exact repair when the selected provider does not support attachment

Closes #13427.

Owning provider primitive: Extra-Chill/data-machine-code#1221.
Integration wiring: Extra-Chill/wp-coding-agents#448.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p homeboy-core -p homeboy-agents -p homeboy-cli`
- focused core task-attachment contract tests
- focused Cook exact-provider attachment test

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced the provider and Cook preflight contracts, implemented the provider-neutral attachment capability, added focused coverage, and ran verification. Chris Huber directed the architecture and remains responsible.