### PR TITLE
fix(cook): surface causal provider failures

### DIFF
--- a/crates/homeboy-agents/src/agent_task_notify_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_notify_tests.rs
@@ -34,6 +34,7 @@ fn report(status: &str, finalization: Option<serde_json::Value>) -> AgentTaskCoo
         stop_reason: None,
         terminal_phase: None,
         terminal_failure_classification: None,
+        primary_failure: None,
         moving_base_recovery: None,
         failure_context: None,
     }

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -1257,6 +1257,9 @@ pub struct AgentTaskCookReport {
     /// provider dispatch instead of collapsing it into an attempt-budget result.
     pub terminal_phase: Option<String>,
     pub terminal_failure_classification: Option<String>,
+    /// Bounded causal facts for an initial provider-command failure. Complete
+    /// command evidence remains in the durable run named by `evidence_ref`.
+    pub primary_failure: Option<AgentTaskCookPrimaryFailure>,
     pub moving_base_recovery: Option<MovingBaseCookRecovery>,
     /// Generic durable recovery coordinates for a Cook that stopped after its
     /// recipe was materialized. It may contain a bounded causal provider-command
@@ -1384,6 +1387,8 @@ impl serde::Serialize for AgentTaskCookReport {
             #[serde(skip_serializing_if = "Option::is_none")]
             terminal_failure_classification: Option<&'a String>,
             #[serde(skip_serializing_if = "Option::is_none")]
+            primary_failure: Option<&'a AgentTaskCookPrimaryFailure>,
+            #[serde(skip_serializing_if = "Option::is_none")]
             moving_base_recovery: Option<&'a MovingBaseCookRecovery>,
             #[serde(skip_serializing_if = "Option::is_none")]
             failure_context: Option<&'a AgentTaskCookFailureContext>,
@@ -1413,6 +1418,7 @@ impl serde::Serialize for AgentTaskCookReport {
             stop_reason: self.stop_reason.as_ref(),
             terminal_phase: self.terminal_phase.as_ref(),
             terminal_failure_classification: self.terminal_failure_classification.as_ref(),
+            primary_failure: self.primary_failure.as_ref(),
             moving_base_recovery: self.moving_base_recovery.as_ref(),
             failure_context: self.failure_context.as_ref(),
             completion,
@@ -1747,6 +1753,19 @@ impl ContinuationAdmissionTrace {
 pub struct AgentTaskCookRecoveryAction {
     pub action: String,
     pub command: String,
+}
+
+/// Bounded primary cause for a provider command that failed before dispatch.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AgentTaskCookPrimaryFailure {
+    pub schema: &'static str,
+    pub provider_id: String,
+    pub operation: String,
+    pub phase: String,
+    pub exit_code: i64,
+    pub stderr_excerpt: String,
+    pub evidence_ref: String,
+    pub next_action: AgentTaskCookRecoveryAction,
 }
 
 /// A bounded collection of independently durable cooks. Each cook retains the
@@ -2097,6 +2116,7 @@ mod run_lifecycle_projection_tests {
             stop_reason: None,
             terminal_phase: None,
             terminal_failure_classification: None,
+            primary_failure: None,
             moving_base_recovery: None,
             failure_context: None,
         }

--- a/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
@@ -21,8 +21,8 @@ use homeboy_core::cook_status::CookDisposition;
 use homeboy_core::{Error, Result};
 
 use super::cook::{
-    AgentTaskCookAttemptDispatcher, AgentTaskCookAttemptReport, AgentTaskCookReport,
-    AgentTaskCookServiceOptions,
+    AgentTaskCookAttemptDispatcher, AgentTaskCookAttemptReport, AgentTaskCookPrimaryFailure,
+    AgentTaskCookRecoveryAction, AgentTaskCookReport, AgentTaskCookServiceOptions,
 };
 use super::cook_promotion::{cook_report, CookReportInput};
 use super::cook_recipe::CookRecipeStore;
@@ -575,7 +575,10 @@ pub(crate) fn pre_execution_failure_report(
     error: Error,
     invocation_latest_run_id: Option<&str>,
 ) -> AgentTaskRunResult<AgentTaskCookReport> {
-    let phase = failure.phase.as_deref().unwrap_or("cook_pre_execution");
+    let phase = failure
+        .phase
+        .clone()
+        .unwrap_or_else(|| "cook_pre_execution".to_string());
     let classification = failure.classification.as_deref().unwrap_or("unknown");
     let mut report = cook_report(CookReportInput {
         cook_id,
@@ -591,7 +594,53 @@ pub(crate) fn pre_execution_failure_report(
     });
     report.value.terminal_phase = failure.phase;
     report.value.terminal_failure_classification = failure.classification;
+    report.value.primary_failure = provider_primary_failure(
+        report.value.latest_run_id.as_deref(),
+        &phase,
+        &error.details,
+    );
     report
+}
+
+fn provider_primary_failure(
+    run_id: Option<&str>,
+    phase: &str,
+    details: &Value,
+) -> Option<AgentTaskCookPrimaryFailure> {
+    let run_id = run_id?.trim();
+    if run_id.is_empty() {
+        return None;
+    }
+    let compact = homeboy_core::worktree_providers::compact_provider_failure_details(details)?;
+    let provider_id = compact.get("provider_id")?.as_str()?.to_string();
+    let operation = compact.get("operation")?.as_str()?.to_string();
+    let exit_code = compact.get("exit_code")?.as_i64()?;
+    let stderr_excerpt = compact.get("stderr_excerpt")?.as_str()?.to_string();
+    let repair = details
+        .get("worktree_provider_cwd_recovery_command")
+        .and_then(Value::as_str)
+        .filter(|command| !command.trim().is_empty());
+    let (action, command) = repair
+        .map(|command| ("repair", command.to_string()))
+        .unwrap_or_else(|| {
+            (
+                "diagnose",
+                format!("homeboy agent-task diagnose {run_id} --full"),
+            )
+        });
+    Some(AgentTaskCookPrimaryFailure {
+        schema: "homeboy/agent-task-cook-primary-failure/v1",
+        provider_id,
+        operation,
+        phase: phase.to_string(),
+        exit_code,
+        stderr_excerpt,
+        evidence_ref: format!("homeboy://agent-task/run/{run_id}/status"),
+        next_action: AgentTaskCookRecoveryAction {
+            action: action.to_string(),
+            command,
+        },
+    })
 }
 
 /// Pre-execution failures happen before a provider can receive work. Persist a
@@ -794,6 +843,92 @@ mod tests {
     use crate::agent_task_service::cook_recipe::{
         AgentTaskCookRecipe, AgentTaskCookRecipeAttempt, COOK_RECIPE_SCHEMA,
     };
+
+    #[test]
+    fn provider_primary_failure_prefers_known_repair_and_references_full_evidence() {
+        let details = serde_json::json!({
+            "worktree_provider_id": "dmc",
+            "worktree_provider_operation": "resolve",
+            "worktree_provider_cwd_recovery_command": "homeboy agent-task cook --cwd /repo --to-worktree repo@fix",
+            "command_evidence": {
+                "command": "studio wp datamachine-code workspace show repo@fix",
+                "exit_code": 1,
+                "stderr": "DMC standalone identity does not provide tracker ownership.\nfull context remains durable",
+            },
+        });
+
+        let failure = provider_primary_failure(
+            Some("agent-task-provider-failure"),
+            "transport_dispatcher_prepare",
+            &details,
+        )
+        .expect("typed provider failure");
+
+        assert_eq!(failure.provider_id, "dmc");
+        assert_eq!(failure.operation, "resolve");
+        assert_eq!(failure.phase, "transport_dispatcher_prepare");
+        assert_eq!(failure.exit_code, 1);
+        assert_eq!(
+            failure.stderr_excerpt,
+            "DMC standalone identity does not provide tracker ownership."
+        );
+        assert_eq!(
+            failure.evidence_ref,
+            "homeboy://agent-task/run/agent-task-provider-failure/status"
+        );
+        assert_eq!(failure.next_action.action, "repair");
+        assert_eq!(
+            failure.next_action.command,
+            "homeboy agent-task cook --cwd /repo --to-worktree repo@fix"
+        );
+        let projected = serde_json::to_string(&failure).expect("serialize primary failure");
+        assert!(!projected.contains("full context remains durable"));
+        assert!(!projected.contains("command_evidence"));
+    }
+
+    #[test]
+    fn provider_primary_failure_falls_back_to_exact_diagnosis() {
+        let details = serde_json::json!({
+            "worktree_provider_id": "dmc",
+            "worktree_provider_operation": "resolve",
+            "command_evidence": {
+                "exit_code": 1,
+                "stderr": "",
+            },
+        });
+
+        let failure = provider_primary_failure(
+            Some("agent-task-provider-failure"),
+            "worktree_provider_lookup",
+            &details,
+        )
+        .expect("typed provider failure");
+
+        assert_eq!(failure.stderr_excerpt, "");
+        assert_eq!(failure.next_action.action, "diagnose");
+        assert_eq!(
+            failure.next_action.command,
+            "homeboy agent-task diagnose agent-task-provider-failure --full"
+        );
+    }
+
+    #[test]
+    fn non_provider_pre_execution_failure_has_no_provider_primary_failure() {
+        let details = serde_json::json!({
+            "field": "gate_declaration",
+            "command_evidence": {
+                "exit_code": 1,
+                "stderr": "not a provider failure",
+            },
+        });
+
+        assert!(provider_primary_failure(
+            Some("agent-task-preflight-failure"),
+            "gate_declaration_preflight",
+            &details,
+        )
+        .is_none());
+    }
 
     fn recipe(cook_id: &str, run_id: &str, plan: AgentTaskPlan) -> AgentTaskCookRecipe {
         AgentTaskCookRecipe {

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -4644,6 +4644,7 @@ pub(crate) fn cook_report(input: CookReportInput<'_>) -> AgentTaskRunResult<Agen
             stop_reason,
             terminal_phase: None,
             terminal_failure_classification: None,
+            primary_failure: None,
             moving_base_recovery: None,
             failure_context,
         },

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -6151,6 +6151,7 @@ pub(crate) fn compact_cook_report(value: Value, full: bool) -> Value {
         "stop_reason": bounded_value(value.get("stop_reason").unwrap_or(&Value::Null)),
         "terminal_phase": value.get("terminal_phase"),
         "terminal_failure_classification": value.get("terminal_failure_classification"),
+        "primary_failure": value.get("primary_failure"),
         "attempts": attempts.iter().take(COMPACT_TASK_LIMIT).map(|attempt| compact_fields(attempt, &["attempt", "run_id", "run_state", "aggregate_path"])).collect::<Vec<_>>(),
         "attempts_omitted": attempts.len().saturating_sub(COMPACT_TASK_LIMIT),
         "finalization": value.get("finalization").map(|finalization| compact_fields(finalization, &["schema", "status", "pr_number", "pr_url", "updated_at", "created_at"])),

--- a/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
@@ -82,7 +82,8 @@ fn render_providers_summary(payload: &Value) -> Option<String> {
 }
 
 fn render_cook_summary(payload: &Value) -> Option<String> {
-    let run_id = string_value(payload, &["run_id"])?;
+    let run_id =
+        string_value(payload, &["run_id"]).or_else(|| string_value(payload, &["latest_run_id"]))?;
     let raw_state = string_value(payload, &["state"])
         .or_else(|| string_value(payload, &["record", "state"]))
         .unwrap_or("unknown");
@@ -115,13 +116,37 @@ fn render_cook_summary(payload: &Value) -> Option<String> {
         )
     });
 
-    let mut lines = vec![
-        "Agent task cook".to_string(),
+    let primary_failure = payload
+        .get("primary_failure")
+        .filter(|value| value.is_object());
+    let mut lines = vec!["Agent task cook".to_string()];
+    if let Some(failure) = primary_failure {
+        lines.push(format!(
+            "Primary failure: provider {} {} failed during {} (exit {})",
+            string_value(failure, &["provider_id"]).unwrap_or("unknown"),
+            string_value(failure, &["operation"]).unwrap_or("unknown operation"),
+            string_value(failure, &["phase"]).unwrap_or("pre-execution"),
+            failure
+                .get("exit_code")
+                .and_then(Value::as_i64)
+                .map(|code| code.to_string())
+                .unwrap_or_else(|| "unknown".to_string()),
+        ));
+        let stderr = string_value(failure, &["stderr_excerpt"]).unwrap_or("");
+        lines.push(format!(
+            "Provider stderr: {}",
+            if stderr.is_empty() { "(empty)" } else { stderr }
+        ));
+        if let Some(command) = string_value(failure, &["next_action", "command"]) {
+            lines.push(format!("Next: {command}"));
+        }
+    }
+    lines.extend([
         format!("Run: {run_id}"),
         format!("Status: {state}"),
         format!("Tasks planned: {tasks_planned}"),
         format!("Tasks attempted: {tasks_attempted}"),
-    ];
+    ]);
     lines.extend(code_production_lines(&metrics));
     if let Some(path) = aggregate_path {
         lines.push(format!("Aggregate: {path}"));
@@ -130,7 +155,9 @@ fn render_cook_summary(payload: &Value) -> Option<String> {
     if let Some(artifact) = first_artifact {
         lines.push(format!("First artifact: {artifact}"));
     }
-    if metrics.candidate_state.is_available() {
+    if primary_failure.is_some() {
+        // Its exact action already leads the report.
+    } else if metrics.candidate_state.is_available() {
         lines.push(format!("Next: homeboy agent-task review {run_id}"));
     } else {
         lines.push(format!("Next: homeboy agent-task logs {run_id}"));
@@ -756,6 +783,56 @@ mod tests {
         assert!(summary.contains("First artifact: /tmp/patch.diff\n"));
         assert!(summary.contains("Next: homeboy agent-task review homeboy-4345\n"));
         assert!(!summary.contains("{\n"));
+    }
+
+    #[test]
+    fn cook_summary_leads_with_provider_primary_failure_and_one_exact_action() {
+        let payload = json!({
+            "run_id": "agent-task-provider-failure",
+            "state": "failed",
+            "task_count": 1,
+            "primary_failure": {
+                "schema": "homeboy/agent-task-cook-primary-failure/v1",
+                "provider_id": "dmc",
+                "operation": "resolve",
+                "phase": "transport_dispatcher_prepare",
+                "exit_code": 1,
+                "stderr_excerpt": "DMC standalone identity does not provide tracker ownership.",
+                "evidence_ref": "homeboy://agent-task/run/agent-task-provider-failure/status",
+                "next_action": {
+                    "action": "diagnose",
+                    "command": "homeboy agent-task diagnose agent-task-provider-failure --full"
+                }
+            }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Cook, &payload).unwrap();
+
+        assert!(summary.starts_with(
+            "Agent task cook\nPrimary failure: provider dmc resolve failed during transport_dispatcher_prepare (exit 1)\nProvider stderr: DMC standalone identity does not provide tracker ownership.\nNext: homeboy agent-task diagnose agent-task-provider-failure --full\nRun: agent-task-provider-failure"
+        ));
+        assert_eq!(summary.matches("Next:").count(), 1);
+    }
+
+    #[test]
+    fn cook_summary_labels_empty_provider_stderr() {
+        let payload = json!({
+            "run_id": "agent-task-provider-failure",
+            "state": "failed",
+            "primary_failure": {
+                "provider_id": "dmc",
+                "operation": "resolve",
+                "phase": "worktree_provider_lookup",
+                "exit_code": 1,
+                "stderr_excerpt": "",
+                "next_action": {
+                    "command": "homeboy agent-task diagnose agent-task-provider-failure --full"
+                }
+            }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Cook, &payload).unwrap();
+        assert!(summary.contains("Provider stderr: (empty)\n"));
     }
 
     #[test]

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -2730,20 +2730,20 @@ fn annotate_provider_lookup_error(
 pub fn compact_provider_failure_details(details: &Value) -> Option<Value> {
     const STDERR_EXCERPT_LIMIT: usize = 512;
 
+    let provider_id = details.get("worktree_provider_id")?.as_str()?;
     let operation = details.get("worktree_provider_operation")?.as_str()?;
     let evidence = details.get("command_evidence")?;
     let stderr = evidence.get("stderr")?.as_str()?;
-    let stderr_excerpt: String = stderr
+    let stderr_excerpt = crate::redaction::redact_string(stderr);
+    let stderr_excerpt: String = stderr_excerpt
         .lines()
         .find(|line| !line.trim().is_empty())
-        .unwrap_or(stderr)
+        .unwrap_or(&stderr_excerpt)
         .chars()
         .take(STDERR_EXCERPT_LIMIT)
         .collect();
-    if stderr_excerpt.trim().is_empty() {
-        return None;
-    }
     Some(serde_json::json!({
+        "provider_id": provider_id,
         "operation": operation,
         "exit_code": evidence.get("exit_code"),
         "replay_command": details.get("worktree_provider_replay_command").or_else(|| evidence.get("command")),
@@ -2782,6 +2782,7 @@ mod compact_provider_failure_details_tests {
     fn projects_short_stderr_for_ensure_resolve_and_plan_failures() {
         for operation in ["ensure", "resolve", "plan"] {
             let details = json!({
+                "worktree_provider_id": "fixture",
                 "worktree_provider_operation": operation,
                 "worktree_provider_replay_command": format!("fixture-provider {operation}"),
                 "command_evidence": {
@@ -2794,6 +2795,7 @@ mod compact_provider_failure_details_tests {
             assert_eq!(
                 compact_provider_failure_details(&details),
                 Some(json!({
+                    "provider_id": "fixture",
                     "operation": operation,
                     "exit_code": 17,
                     "replay_command": format!("fixture-provider {operation}"),
@@ -2807,6 +2809,7 @@ mod compact_provider_failure_details_tests {
     fn bounds_large_stderr_without_changing_durable_evidence() {
         let stderr = format!("Error: {}", "x".repeat(2_048));
         let details = json!({
+            "worktree_provider_id": "fixture",
             "worktree_provider_operation": "ensure",
             "worktree_provider_replay_command": "fixture-provider ensure",
             "command_evidence": {
@@ -2829,6 +2832,42 @@ mod compact_provider_failure_details_tests {
             details["command_evidence"]["stderr"].as_str(),
             Some(stderr.as_str())
         );
+    }
+
+    #[test]
+    fn preserves_empty_stderr_as_a_typed_provider_failure() {
+        let details = json!({
+            "worktree_provider_id": "fixture",
+            "worktree_provider_operation": "resolve",
+            "command_evidence": {
+                "command": "fixture-provider resolve",
+                "exit_code": 1,
+                "stderr": "",
+            },
+        });
+
+        let projection = compact_provider_failure_details(&details).expect("compact evidence");
+        assert_eq!(projection["stderr_excerpt"], "");
+    }
+
+    #[test]
+    fn redacts_sensitive_stderr_in_the_compact_projection() {
+        let details = json!({
+            "worktree_provider_id": "fixture",
+            "worktree_provider_operation": "resolve",
+            "command_evidence": {
+                "command": "fixture-provider resolve",
+                "exit_code": 1,
+                "stderr": "Authorization: Bearer provider-secret\nretry denied",
+            },
+        });
+
+        let projection = compact_provider_failure_details(&details).expect("compact evidence");
+        assert_eq!(
+            projection["stderr_excerpt"],
+            "Authorization: Bearer [REDACTED]"
+        );
+        assert!(!projection.to_string().contains("provider-secret"));
     }
 }
 


### PR DESCRIPTION
## Summary

- project bounded provider operation evidence into a typed Cook `primary_failure`
- lead compact human output with causal stderr and one exact next action
- retain complete redacted command evidence by durable reference
- keep non-provider pre-execution failures on their existing path

Closes #13428.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p homeboy-core -p homeboy-agents -p homeboy-cli`
- focused provider evidence compaction tests
- focused Cook primary-failure projection tests
- feature-scoped CLI summary tests

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced durable command evidence through Cook reporting and compact presentation, implemented the bounded causal projection, added redaction and rendering coverage, and ran verification. Chris Huber directed the work and remains responsible.