### PR TITLE
fix(core): restore Unix digest memo boundary

### DIFF
--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -195,8 +195,8 @@ const DIGEST_MEMO_MIN_HASH_TIME: std::time::Duration = std::time::Duration::from
 static DIGEST_MEMO_MIN_HASH_TIME_MS: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(u64::MAX);
 
-/// The memo guard. `executable_digest` is not platform-gated, so neither is
-/// this. Only the test override is unix-only, because the memo it overrides is.
+/// Unix memo guard with a test-only threshold override.
+#[cfg(unix)]
 fn digest_memo_min_hash_time() -> std::time::Duration {
     #[cfg(all(test, unix))]
     {


### PR DESCRIPTION
## Summary

- restore `#[cfg(unix)]` on the primary digest memo threshold implementation
- retain the explicit `#[cfg(not(unix))]` `Duration::MAX` fallback
- remove the Windows-only duplicate definition created when #13416 and #13426 merged

Closes #13464.

## Verification

```text
cargo fmt --all --check
cargo test -p homeboy-core controller_runtime::tests::a_hash_faster_than_the_timestamp_clock_is_not_memoized -- --exact
cargo test -p homeboy-core controller_runtime::tests::executable_digests_are_memoized_per_observed_file_identity -- --exact
```

All passed. Local Windows cross-compilation reached native dependency compilation but could not proceed because this macOS host does not provide `x86_64-w64-mingw32-gcc`; the required hosted Windows Compile and External Resolver Fixtures jobs provide the target-specific acceptance proof.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed the incompatible merged fixes, implemented the minimal platform-boundary repair, and ran focused verification in an isolated DMC-managed worktree. Chris Huber directed the work and remains responsible.