### PR TITLE
Fix fanout primary worktree failure output

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -1965,6 +1965,90 @@ fn batch_cook_result(
     )
 }
 
+fn cook_batch_failure_projection(
+    worktrees: &worktree::WorktreeQueueCreateOutput,
+) -> (usize, Option<Value>) {
+    let causal_rows = worktrees
+        .rows
+        .iter()
+        .filter(|row| {
+            matches!(
+                row.status,
+                worktree::WorktreeQueueCreateStatus::Failed
+                    | worktree::WorktreeQueueCreateStatus::ActiveLockHolder
+            )
+        })
+        .collect::<Vec<_>>();
+    let primary_failure = causal_rows.first().map(|row| {
+        let (classification, reason, next_action) = match row.status {
+            worktree::WorktreeQueueCreateStatus::Failed => (
+                "worktree_creation_failed",
+                row.error
+                    .clone()
+                    .unwrap_or_else(|| "worktree creation failed".to_string()),
+                CommandNextAction::new(
+                    format!("create blocked worktree {}", row.handle),
+                    quote_args(if row.command.is_empty() {
+                        &[]
+                    } else {
+                        row.command.as_slice()
+                    }),
+                )
+                .with_kind(CommandNextActionKind::Repair),
+            ),
+            worktree::WorktreeQueueCreateStatus::ActiveLockHolder => (
+                "worktree_active_lock",
+                row.active_lock_holder
+                    .as_ref()
+                    .map(|holder| format!("worktree is held by active lock {}", holder.lock_key))
+                    .unwrap_or_else(|| "worktree is held by an active lock".to_string()),
+                CommandNextAction::new(
+                    format!("inspect locked worktree {}", row.handle),
+                    row.active_lock_holder
+                        .as_ref()
+                        .and_then(|holder| holder.command.clone())
+                        .filter(|command| !command.trim().is_empty())
+                        .unwrap_or_else(|| {
+                            quote_args(&[
+                                "homeboy".to_string(),
+                                "worktree".to_string(),
+                                "status".to_string(),
+                                row.handle.clone(),
+                            ])
+                        }),
+                )
+                .with_kind(CommandNextActionKind::Show),
+            ),
+            _ => unreachable!("causal rows are filtered above"),
+        };
+        let next_action = if next_action.command.is_empty() {
+            CommandNextAction::new(
+                format!("inspect blocked worktree {}", row.handle),
+                quote_args(&[
+                    "homeboy".to_string(),
+                    "worktree".to_string(),
+                    "status".to_string(),
+                    row.handle.clone(),
+                ]),
+            )
+            .with_kind(CommandNextActionKind::Show)
+        } else {
+            next_action
+        };
+        serde_json::json!({
+            "phase": "worktree_preflight",
+            "row": row.handle,
+            "handle": row.handle,
+            "provider_id": row.provider_id,
+            "classification": classification,
+            "reason": reason,
+            "next_action": next_action,
+            "complete_evidence": "$.worktrees.rows",
+        })
+    });
+    (causal_rows.len(), primary_failure)
+}
+
 #[cfg(test)]
 fn cook_batch(args: AgentTaskFanoutCookBatchArgs) -> CmdResult<Value> {
     cook_batch_with_placement(args, Placement::Auto)
@@ -2127,6 +2211,7 @@ fn cook_batch_inner(
     let resume_legal = run_result
         .as_ref()
         .is_some_and(|result| batch_resume_is_legal(&result["result"]));
+    let (causal_failures, primary_failure) = cook_batch_failure_projection(&worktrees);
 
     Ok((
         serde_json::json!({
@@ -2138,7 +2223,11 @@ fn cook_batch_inner(
                     "issues": plan.cooks.len(),
                     "worktrees_total": worktrees.rows.len(),
                     "worktrees_blocked": blocked,
+                    "causal_failures": causal_failures,
+                    "causal_failures_shown": usize::from(primary_failure.is_some()),
+                    "failure_evidence": "$.worktrees.rows",
                 },
+                "primary_failure": primary_failure,
                 "preflight": {
                     "provider_readiness_command": provider_readiness_command(&args),
                     "provider_selection": provider_selection_preflight(&args, args.dry_run),
@@ -2783,6 +2872,7 @@ fn queue_or_reuse_worktrees(
                 handle: cook.to_worktree.clone(),
                 status: worktree::WorktreeQueueCreateStatus::Created,
                 command: vec!["adopted".to_string(), cook.to_worktree.clone()],
+                provider_id: Some(resolution.provider_id.clone()),
                 retry_after_seconds: None,
                 active_lock_holder: None,
                 path: Some(workspace.path.clone()),
@@ -2799,6 +2889,7 @@ fn queue_or_reuse_worktrees(
                     handle: cook.to_worktree.clone(),
                     status: worktree::WorktreeQueueCreateStatus::Created,
                     command: worktree_create_command(args, branch),
+                    provider_id: None,
                     retry_after_seconds: None,
                     active_lock_holder: None,
                     path: Some(path),
@@ -2820,17 +2911,13 @@ fn queue_or_reuse_worktrees(
         }
     }
 
-    with_workspace_owner_repair_commands(
-        args,
-        plan,
-        worktree::WorktreeQueueCreateOutput {
-            schema: "homeboy/worktree-queue-create/v1",
-            repo: args.repo.clone(),
-            base_ref: args.from.clone(),
-            dry_run: false,
-            rows,
-        },
-    )
+    Ok(worktree::WorktreeQueueCreateOutput {
+        schema: "homeboy/worktree-queue-create/v1",
+        repo: args.repo.clone(),
+        base_ref: args.from.clone(),
+        dry_run: false,
+        rows,
+    })
 }
 
 /// A preview must not contact a worktree provider, inspect existing worktrees,
@@ -2856,6 +2943,7 @@ fn static_worktrees_dry_run(
                 handle: cook.to_worktree.clone(),
                 status: worktree::WorktreeQueueCreateStatus::WouldCreate,
                 command: worktree_create_command(args, cook.head.as_deref().expect("head exists")),
+                provider_id: None,
                 retry_after_seconds: None,
                 active_lock_holder: None,
                 path: None,
@@ -2863,48 +2951,6 @@ fn static_worktrees_dry_run(
             })
             .collect(),
     }
-}
-
-fn with_workspace_owner_repair_commands(
-    args: &AgentTaskFanoutCookBatchArgs,
-    plan: &BatchCookFanoutPlan,
-    mut worktrees: worktree::WorktreeQueueCreateOutput,
-) -> Result<worktree::WorktreeQueueCreateOutput> {
-    if !configured_provider_workspace_creation()? {
-        return Ok(worktrees);
-    }
-
-    let config = homeboy::core::defaults::load_config();
-    for row in &mut worktrees.rows {
-        let Some(cook) = plan
-            .cooks
-            .iter()
-            .find(|cook| cook.to_worktree == row.handle)
-        else {
-            continue;
-        };
-        let intent = homeboy::core::worktree_providers::WorktreeProviderCreateIntent {
-            handle: row.handle.clone(),
-            repo: args.repo.clone(),
-            base: args.from.clone(),
-            head: row.branch.clone(),
-            task_url: cook
-                .task_url
-                .clone()
-                .expect("generated cooks have task URLs"),
-        };
-        let lifecycle = homeboy::core::worktree_providers::WorktreeProviderLifecycleIntent {
-            purpose: "agent_task_cook".to_string(),
-            owner_run_ref: cook.run_id(),
-            cleanup_policy:
-                homeboy::core::worktree_providers::WorktreeProviderCleanupPolicy::RemoveOnSuccess,
-        };
-        row.command =
-            homeboy::core::worktree_providers::worktree_provider_lifecycle_ensure_argv_from_config(
-                &intent, &lifecycle, &config,
-            )?;
-    }
-    Ok(worktrees)
 }
 
 fn configured_provider_workspace_creation() -> Result<bool> {
@@ -6848,7 +6894,8 @@ fi
                 .iter()
                 .all(|cook| ensured.contains(&cook.to_worktree)));
             assert!(worktrees.rows.iter().all(|row| {
-                row.command.first() == Some(&provider.display().to_string())
+                row.provider_id.as_deref() == Some("fixture")
+                    && row.command.first() == Some(&provider.display().to_string())
                     && !row
                         .command
                         .windows(3)
@@ -6937,6 +6984,7 @@ fi
                         handle: "homeboy@fix-issue-6453-homeboy".to_string(),
                         status: worktree::WorktreeQueueCreateStatus::Created,
                         command: Vec::new(),
+                        provider_id: None,
                         retry_after_seconds: None,
                         active_lock_holder: None,
                         path: Some(workspace.path().display().to_string()),
@@ -7268,6 +7316,7 @@ fi
                 handle: cook.to_worktree.clone(),
                 status: worktree::WorktreeQueueCreateStatus::Created,
                 command: Vec::new(),
+                provider_id: None,
                 retry_after_seconds: None,
                 active_lock_holder: None,
                 path: Some(root.display().to_string()),
@@ -7321,6 +7370,7 @@ fi
                 handle: cook.to_worktree.clone(),
                 status: worktree::WorktreeQueueCreateStatus::Created,
                 command: Vec::new(),
+                provider_id: None,
                 retry_after_seconds: None,
                 active_lock_holder: None,
                 path: Some(materialized_root.display().to_string()),
@@ -8117,6 +8167,7 @@ fi
                 "--from".to_string(),
                 "origin/main".to_string(),
             ],
+            provider_id: None,
             retry_after_seconds: None,
             active_lock_holder: None,
             path: None,
@@ -8355,6 +8406,69 @@ fi
 
         result["cooks"][1]["result"]["failure_context"]["recovery_legal"] = json!(true);
         assert!(batch_resume_is_legal(&result));
+    }
+
+    #[test]
+    fn blocked_worktree_projection_is_ordered_bounded_and_provider_owned() {
+        let mut first = worktree_row("homeboy@first", worktree::WorktreeQueueCreateStatus::Failed);
+        first.error = Some("Component not found".to_string());
+        first.command = vec![
+            "dmc".to_string(),
+            "worktree".to_string(),
+            "ensure".to_string(),
+            "homeboy@first".to_string(),
+        ];
+        let mut second = worktree_row(
+            "homeboy@second",
+            worktree::WorktreeQueueCreateStatus::Failed,
+        );
+        second.error = Some("independent provider failure".to_string());
+        let mut worktrees = worktree_output(vec![first, second]);
+
+        worktrees.rows[0].provider_id = Some("dmc".to_string());
+        let (count, primary) = cook_batch_failure_projection(&worktrees);
+        let primary = primary.expect("primary failure");
+
+        assert_eq!(count, 2);
+        assert_eq!(primary["phase"], "worktree_preflight");
+        assert_eq!(primary["handle"], "homeboy@first");
+        assert_eq!(primary["provider_id"], "dmc");
+        assert_eq!(primary["classification"], "worktree_creation_failed");
+        assert_eq!(primary["reason"], "Component not found");
+        assert_eq!(
+            primary["next_action"]["command"],
+            "dmc worktree ensure homeboy@first"
+        );
+        assert_eq!(primary["complete_evidence"], "$.worktrees.rows");
+        assert_eq!(
+            worktrees.rows.len(),
+            2,
+            "complete row evidence stays lossless"
+        );
+    }
+
+    #[test]
+    fn active_lock_projection_inspects_the_owner_instead_of_recreating() {
+        let mut row = worktree_row(
+            "homeboy@locked",
+            worktree::WorktreeQueueCreateStatus::ActiveLockHolder,
+        );
+        row.active_lock_holder = Some(worktree::WorktreeQueueLockHolder {
+            lock_key: "agent-task:123".to_string(),
+            scope: "worktree".to_string(),
+            path: None,
+            command: Some("homeboy agent-task status 123".to_string()),
+        });
+
+        let (_, primary) = cook_batch_failure_projection(&worktree_output(vec![row]));
+        let primary = primary.expect("primary failure");
+
+        assert_eq!(primary["classification"], "worktree_active_lock");
+        assert_eq!(
+            primary["next_action"]["command"],
+            "homeboy agent-task status 123"
+        );
+        assert_eq!(primary["next_action"]["kind"], "show");
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
@@ -3,7 +3,9 @@ use serde_json::{json, Value};
 use super::agent_task::candidate::{
     changed_files_for_artifact, classify_candidates, CandidateState,
 };
-use super::agent_task::{AgentTaskArgs, AgentTaskCommand, AgentTaskControllerCommand};
+use super::agent_task::{
+    AgentTaskArgs, AgentTaskCommand, AgentTaskControllerCommand, AgentTaskFanoutCommand,
+};
 use super::summary_json::{array_len, string_value, u64_value, usize_value, value_at};
 
 mod controller;
@@ -16,6 +18,7 @@ pub(crate) enum AgentTaskSummaryKind {
     Review,
     Controller,
     Providers,
+    Fanout,
 }
 
 pub(crate) fn agent_task_summary_kind(args: &AgentTaskArgs) -> Option<AgentTaskSummaryKind> {
@@ -25,6 +28,11 @@ pub(crate) fn agent_task_summary_kind(args: &AgentTaskArgs) -> Option<AgentTaskS
         AgentTaskCommand::Logs(_) => Some(AgentTaskSummaryKind::Logs),
         AgentTaskCommand::Review(_) => Some(AgentTaskSummaryKind::Review),
         AgentTaskCommand::Providers(_) => Some(AgentTaskSummaryKind::Providers),
+        AgentTaskCommand::Fanout(fanout)
+            if matches!(&fanout.command, AgentTaskFanoutCommand::CookBatch(_)) =>
+        {
+            Some(AgentTaskSummaryKind::Fanout)
+        }
         AgentTaskCommand::Controller(controller_args) => match &controller_args.command {
             AgentTaskControllerCommand::Status(_)
             | AgentTaskControllerCommand::Diagnose(_)
@@ -51,7 +59,30 @@ pub(crate) fn render_agent_task_summary(
         AgentTaskSummaryKind::Review => render_review_summary(payload),
         AgentTaskSummaryKind::Controller => controller::render_controller_summary(payload),
         AgentTaskSummaryKind::Providers => render_providers_summary(payload),
+        AgentTaskSummaryKind::Fanout => render_fanout_summary(payload),
     }
+}
+
+fn render_fanout_summary(payload: &Value) -> Option<String> {
+    let fanout_id = string_value(payload, &["fanout_id"])?;
+    let status = string_value(payload, &["status"]).unwrap_or("unknown");
+    let Some(failure) = payload
+        .get("primary_failure")
+        .filter(|value| value.is_object())
+    else {
+        return Some(format!("Fanout {fanout_id}: {status}\n"));
+    };
+    let phase = string_value(failure, &["phase"]).unwrap_or("unknown");
+    let handle = string_value(failure, &["handle"]).unwrap_or("unknown");
+    let reason = string_value(failure, &["reason"]).unwrap_or("unknown failure");
+    let next = string_value(failure, &["next_action", "command"]).unwrap_or("unavailable");
+    let count = usize_value(payload, &["summary", "causal_failures"]).unwrap_or(1);
+    let provider = string_value(failure, &["provider_id"])
+        .map(|provider| format!("; provider {provider}"))
+        .unwrap_or_default();
+    Some(format!(
+        "Fanout {fanout_id}: {status} at {phase}; {count} causal row(s); {handle}{provider}: {reason}; next: {next}\nEvidence: $.worktrees.rows ({count} causal row(s))\n"
+    ))
 }
 
 fn render_providers_summary(payload: &Value) -> Option<String> {
@@ -756,6 +787,35 @@ mod tests {
             summary,
             "Agent task providers\nStatus: selection_required\nProviders shown: 2\nChoose backend: alpha, zeta\nNext: homeboy agent-task providers --backend alpha --validate-readiness"
         );
+    }
+
+    #[test]
+    fn fanout_summary_leads_with_the_causal_row_and_omits_repeated_payloads() {
+        let payload = json!({
+            "fanout_id": "issue-wave",
+            "status": "blocked",
+            "summary": { "causal_failures": 2 },
+            "primary_failure": {
+                "phase": "worktree_preflight",
+                "handle": "homeboy@first",
+                "provider_id": "dmc",
+                "reason": "Component not found",
+                "next_action": { "command": "dmc worktree ensure homeboy@first" }
+            },
+            "plan": { "prompt": "FULL_PLAN_SENTINEL" },
+            "commands": { "run": "FULL_COMMAND_SENTINEL" },
+            "worktrees": { "rows": [{ "handle": "homeboy@first" }] }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Fanout, &payload)
+            .expect("fanout summary");
+
+        assert!(summary.starts_with(
+            "Fanout issue-wave: blocked at worktree_preflight; 2 causal row(s); homeboy@first; provider dmc: Component not found; next: dmc worktree ensure homeboy@first"
+        ));
+        assert!(summary.contains("Evidence: $.worktrees.rows (2 causal row(s))"));
+        assert!(!summary.contains("FULL_PLAN_SENTINEL"));
+        assert!(!summary.contains("FULL_COMMAND_SENTINEL"));
     }
 
     #[test]

--- a/crates/homeboy-core/src/worktree/mod.rs
+++ b/crates/homeboy-core/src/worktree/mod.rs
@@ -489,8 +489,9 @@ pub fn queue_create(options: WorktreeQueueCreateOptions) -> Result<WorktreeQueue
     let mut rows = Vec::new();
     let total = options.requests.len();
     for (index, request) in options.requests.iter().enumerate() {
-        let command = worktree_create_command(&options, request);
+        let mut command = worktree_create_command(&options, request);
         let handle = worktree_handle(&options.repo, &request.branch);
+        let mut provider_id = None;
 
         if options.dry_run {
             match planned_create_path(&options.repo, &request.branch, &options.from) {
@@ -527,12 +528,33 @@ pub fn queue_create(options: WorktreeQueueCreateOptions) -> Result<WorktreeQueue
                     None,
                 )
             })?;
-            crate::worktree_providers::provision_apply_enabled_worktree_provider_with_lifecycle_from_config(
-                &crate::worktree_providers::WorktreeProviderCreateIntent {
-                    handle: handle.clone(), repo: options.repo.clone(), base: options.from.clone(),
-                    head: request.branch.clone(), task_url,
-                }, lifecycle, &crate::defaults::load_config(),
-            ).map(|provision| provision.resolution.worktree.path)
+            let intent = crate::worktree_providers::WorktreeProviderCreateIntent {
+                handle: handle.clone(),
+                repo: options.repo.clone(),
+                base: options.from.clone(),
+                head: request.branch.clone(),
+                task_url,
+            };
+            let config = crate::defaults::load_config();
+            crate::worktree_providers::select_apply_enabled_worktree_provider_from_config(
+                &intent, &config,
+            )
+            .and_then(|selected_provider| {
+                command = crate::worktree_providers::worktree_provider_lifecycle_ensure_argv_for_provider_from_config(
+                    &intent,
+                    lifecycle,
+                    &selected_provider,
+                    &config,
+                )?;
+                provider_id = Some(selected_provider.clone());
+                crate::worktree_providers::provision_apply_enabled_worktree_provider_with_selected_lifecycle_from_config(
+                    &intent,
+                    lifecycle,
+                    &selected_provider,
+                    &config,
+                )
+            })
+            .map(|provision| provision.resolution.worktree.path)
         } else {
             create(WorktreeCreateOptions {
                 component_id: options.repo.clone(),
@@ -552,6 +574,7 @@ pub fn queue_create(options: WorktreeQueueCreateOptions) -> Result<WorktreeQueue
                     command,
                     WorktreeQueueCreateStatus::Created,
                 );
+                row.provider_id = provider_id.clone();
                 row.path = Some(path);
                 rows.push(row);
             }
@@ -562,6 +585,7 @@ pub fn queue_create(options: WorktreeQueueCreateOptions) -> Result<WorktreeQueue
                     command,
                     WorktreeQueueCreateStatus::Failed,
                 );
+                row.provider_id = provider_id.clone();
                 row.error = Some(error.message);
                 rows.push(row);
                 for queued_request in options.requests.iter().take(total).skip(index + 1) {

--- a/crates/homeboy-core/src/worktree/queue_ops.rs
+++ b/crates/homeboy-core/src/worktree/queue_ops.rs
@@ -71,6 +71,7 @@ pub(super) fn queue_row(
         handle,
         status,
         command,
+        provider_id: None,
         retry_after_seconds: None,
         active_lock_holder: None,
         path: None,

--- a/crates/homeboy-core/src/worktree/types.rs
+++ b/crates/homeboy-core/src/worktree/types.rs
@@ -639,6 +639,8 @@ pub struct WorktreeQueueCreateRow {
     pub status: WorktreeQueueCreateStatus,
     pub command: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub retry_after_seconds: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub active_lock_holder: Option<WorktreeQueueLockHolder>,

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -1366,7 +1366,7 @@ pub fn provision_apply_enabled_worktree_provider_from_config(
     intent: &WorktreeProviderCreateIntent,
     config: &HomeboyConfig,
 ) -> Result<WorktreeProviderProvision> {
-    provision_apply_enabled_worktree_provider_from_config_with_lifecycle(intent, None, config)
+    provision_apply_enabled_worktree_provider_from_config_with_lifecycle(intent, None, None, config)
 }
 
 /// Determine the provider that will own an ensure before the external command
@@ -1713,13 +1713,9 @@ fn escape_json_pointer_token(token: &str) -> String {
 fn provision_apply_enabled_worktree_provider_from_config_with_lifecycle(
     intent: &WorktreeProviderCreateIntent,
     lifecycle: Option<&WorktreeProviderLifecycleIntent>,
+    lifecycle_provider: Option<String>,
     config: &HomeboyConfig,
 ) -> Result<WorktreeProviderProvision> {
-    // Purpose-owned callers select once using the creation capability contract.
-    // Keep that exact identity through ensure and postcondition lookup.
-    let lifecycle_provider = lifecycle
-        .map(|_| select_apply_enabled_worktree_provider_from_config(intent, config))
-        .transpose()?;
     match resolve_apply_enabled_worktree_provider_from_config(&intent.handle, config, None) {
         Ok(resolution) => {
             if let Some(lifecycle) = lifecycle {
@@ -1877,9 +1873,27 @@ pub fn provision_apply_enabled_worktree_provider_with_lifecycle_from_config(
     lifecycle: &WorktreeProviderLifecycleIntent,
     config: &HomeboyConfig,
 ) -> Result<WorktreeProviderProvision> {
+    let provider_id = select_apply_enabled_worktree_provider_from_config(intent, config)?;
     provision_apply_enabled_worktree_provider_from_config_with_lifecycle(
         intent,
         Some(lifecycle),
+        Some(provider_id),
+        config,
+    )
+}
+
+/// Provision through a provider selected before queue execution so failure
+/// evidence and repair argv retain the exact attempted workspace authority.
+pub fn provision_apply_enabled_worktree_provider_with_selected_lifecycle_from_config(
+    intent: &WorktreeProviderCreateIntent,
+    lifecycle: &WorktreeProviderLifecycleIntent,
+    provider_id: &str,
+    config: &HomeboyConfig,
+) -> Result<WorktreeProviderProvision> {
+    provision_apply_enabled_worktree_provider_from_config_with_lifecycle(
+        intent,
+        Some(lifecycle),
+        Some(provider_id.to_string()),
         config,
     )
 }
@@ -1963,10 +1977,28 @@ pub fn worktree_provider_lifecycle_ensure_argv_from_config(
     config: &HomeboyConfig,
 ) -> Result<Vec<String>> {
     let provider_id = select_apply_enabled_worktree_provider_from_config(intent, config)?;
-    let provider = config
-        .worktree_providers
-        .get(&provider_id)
-        .expect("selected provider is configured");
+    worktree_provider_lifecycle_ensure_argv_for_provider_from_config(
+        intent,
+        lifecycle,
+        &provider_id,
+        config,
+    )
+}
+
+pub fn worktree_provider_lifecycle_ensure_argv_for_provider_from_config(
+    intent: &WorktreeProviderCreateIntent,
+    lifecycle: &WorktreeProviderLifecycleIntent,
+    provider_id: &str,
+    config: &HomeboyConfig,
+) -> Result<Vec<String>> {
+    let provider = config.worktree_providers.get(provider_id).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "worktree_provider",
+            "selected provider is no longer configured",
+            Some(provider_id.to_string()),
+            None,
+        )
+    })?;
     let command = provider
         .commands
         .ensure


### PR DESCRIPTION
Closes #12823

## Summary
- retain the selected worktree provider identity through queue creation failures
- project the first causal worktree failure and bounded counts ahead of repeated plan data
- render compact fanout summaries with an exact repair or inspection action

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-cli --lib commands::agent_task::fanout::tests::blocked_worktree_projection_is_ordered_bounded_and_provider_owned -- --exact`
- `cargo test -p homeboy-cli --lib commands::agent_task::fanout::tests::active_lock_projection_inspects_the_owner_instead_of_recreating -- --exact`
- `cargo test -p homeboy-cli --lib commands::agent_task_summary::tests::fanout_summary_leads_with_the_causal_row_and_omits_repeated_payloads -- --exact`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode implemented and reconciled the candidate; I reviewed the diff, resolved current-base interactions, and ran the listed focused gates.