### PR TITLE
Refresh stale Lab admission state

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -2354,6 +2354,7 @@ struct LabInventoryAdmissionDiagnostic {
     terminal_reason: &'static str,
     refresh_error_code: Option<String>,
     refresh_error: Option<String>,
+    refresh_error_details: Option<serde_json::Value>,
 }
 
 /// Resolve the inventory used by a terminal resource-policy placement decision.
@@ -2387,6 +2388,7 @@ where
                 terminal_reason: "no_ready_capacity",
                 refresh_error_code: None,
                 refresh_error: None,
+                refresh_error_details: None,
             },
         );
     }
@@ -2413,14 +2415,25 @@ where
                     terminal_reason,
                     refresh_error_code: None,
                     refresh_error: None,
+                    refresh_error_details: None,
                 },
             )
         }
         Err(error) => {
             let timed_out = error.code == crate::core::ErrorCode::RemoteCommandTimeout;
             let refresh_error_code = error.code.as_str().to_string();
+            let mut resolved = observed;
+            resolved.reasons.insert(
+                0,
+                if timed_out {
+                    "bounded_admission_refresh_timeout"
+                } else {
+                    "bounded_admission_refresh_failed"
+                }
+                .to_string(),
+            );
             (
-                observed,
+                resolved,
                 LabInventoryAdmissionDiagnostic {
                     observed_state,
                     observed_at_ms,
@@ -2435,6 +2448,7 @@ where
                     },
                     refresh_error_code: Some(refresh_error_code),
                     refresh_error: Some(error.message),
+                    refresh_error_details: Some(error.details),
                 },
             )
         }
@@ -4116,14 +4130,14 @@ mod tests {
     #[test]
     fn fresh_empty_inventory_does_not_open_a_refresh_probe() {
         let (resolved, diagnostic) = resolve_terminal_lab_inventory(
-            lab_readiness(crate::runner::runners::LabRunnerReadinessState::CapacityBlocked),
+            lab_readiness(crate::runner::runners::LabRunnerReadinessState::Absent),
             100,
             || -> crate::core::Result<_> { panic!("fresh inventory must not refresh") },
         );
 
         assert_eq!(
             resolved.state,
-            crate::runner::runners::LabRunnerReadinessState::CapacityBlocked
+            crate::runner::runners::LabRunnerReadinessState::Absent
         );
         assert!(!diagnostic.refresh_attempted);
         assert_eq!(diagnostic.observed_at_ms, 100);
@@ -4194,7 +4208,7 @@ mod tests {
             },
         );
         let (fresh_empty, fresh_diagnostic) = resolve_terminal_lab_inventory(
-            lab_readiness(crate::runner::runners::LabRunnerReadinessState::CapacityBlocked),
+            lab_readiness(crate::runner::runners::LabRunnerReadinessState::Absent),
             300,
             || -> crate::core::Result<_> { panic!("fresh inventory must not refresh") },
         );

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/messages.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/messages.rs
@@ -57,7 +57,7 @@ pub(super) fn primary_action(
         return "No configured Homeboy Lab runner is expected for this host. Wait for controller pressure to fall or defer verification to CI. Local execution requires an explicit, authorized `--placement local` override.".to_string();
     }
     if warning.message.contains("Lab runner inventory is") {
-        return "This portable command requires a ready Lab runner. Follow the listed runner recovery command or defer verification until Lab is available. Local execution requires an explicit, authorized `--placement local` override.".to_string();
+        return "This portable command requires a ready Lab runner. Follow the listed runner recovery command or retry the unchanged request after Lab admission recovers.".to_string();
     }
     if warning.message.contains("--runner") {
         "Pass --runner <id> when Lab offload supports this mode.".to_string()
@@ -90,8 +90,20 @@ pub(super) fn warning_message(
                 } else {
                     readiness.remediation_commands.join("; ")
                 };
+            let failed_predicate = readiness.reasons.iter().find(|reason| {
+                !matches!(
+                    reason.as_str(),
+                    "stale_daemon"
+                        | "daemon_freshness_unavailable"
+                        | "active_jobs_unavailable"
+                        | "active_jobs_not_queried"
+                )
+            });
+            let predicate = failed_predicate
+                .map(|reason| format!("Lab admission predicate `{reason}` failed. "))
+                .unwrap_or_default();
             return format!(
-                "Resource policy warning: machine is {severity}; starting `{}` may skew results or add pressure. {reason} Lab runner inventory is {} (available runner IDs: {}). {}",
+                "Resource policy warning: machine is {severity}; starting `{}` may skew results or add pressure. {reason} {predicate}Lab runner inventory is {} (available runner IDs: {}). {}",
                 command.label,
                 readiness.state.as_str(),
                 if readiness.available_runner_ids.is_empty() { "none".to_string() } else { readiness.available_runner_ids.join(", ") },

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
@@ -236,6 +236,7 @@ const PRESSURE_RETRY_AFTER_SECONDS: u64 = 60;
 #[serde(rename_all = "snake_case")]
 enum ResourceAdmissionRecoveryKind {
     Defer,
+    Retry,
     LocalOverride,
     RunnerConnection,
     RunnerAvailability,
@@ -676,11 +677,12 @@ pub(crate) fn non_interactive_preflight_error(
         None,
     );
     if let Some(recovery) = recovery {
-        if let Some(choice) = recovery
-            .choices
-            .iter()
-            .find(|choice| choice.kind == ResourceAdmissionRecoveryKind::LocalOverride)
-        {
+        if let Some(choice) = recovery.choices.iter().find(|choice| {
+            matches!(
+                choice.kind,
+                ResourceAdmissionRecoveryKind::Retry | ResourceAdmissionRecoveryKind::LocalOverride
+            )
+        }) {
             error.details["rerun_command"] = serde_json::Value::String(choice.command.clone());
         }
         error.details["recovery"] =
@@ -695,6 +697,8 @@ pub(crate) fn admission_recovery(
     lab_readiness: Option<&LabRunnerReadiness>,
 ) -> Option<ResourceAdmissionRecovery> {
     let local_override = local_override_command(args)?;
+    let retry = crate::core::engine::shell::quote_args(args);
+    let preserves_lab_request = lab_readiness.is_some();
     let mut choices = vec![
         ResourceAdmissionRecoveryChoice {
             kind: ResourceAdmissionRecoveryKind::Defer,
@@ -703,12 +707,32 @@ pub(crate) fn admission_recovery(
             requires_operator_authorization: None,
         },
         ResourceAdmissionRecoveryChoice {
+            kind: if preserves_lab_request {
+                ResourceAdmissionRecoveryKind::Retry
+            } else {
+                ResourceAdmissionRecoveryKind::LocalOverride
+            },
+            command: if preserves_lab_request {
+                retry
+            } else {
+                local_override.clone()
+            },
+            retry_after_seconds: None,
+            requires_operator_authorization: (!preserves_lab_request).then_some(true),
+        },
+    ];
+    if preserves_lab_request
+        && !lab_readiness.is_some_and(|readiness| {
+            readiness.state == crate::runner::runners::LabRunnerReadinessState::Stale
+        })
+    {
+        choices.push(ResourceAdmissionRecoveryChoice {
             kind: ResourceAdmissionRecoveryKind::LocalOverride,
             command: local_override,
             retry_after_seconds: None,
             requires_operator_authorization: Some(true),
-        },
-    ];
+        });
+    }
     // An absent inventory is intentional configuration, not a broken runner.
     // A ready inventory also cannot justify repair. Keep recovery action kinds
     // aligned with the observed state so repair is only advertised for stale
@@ -2189,7 +2213,7 @@ mod tests {
 
         assert_eq!(
             error.details["rerun_command"].as_str(),
-            Some("homeboy --placement local fuzz run")
+            Some("homeboy fuzz run")
         );
         assert!(error.details.get("resume_command").is_none());
         assert!(error
@@ -2226,13 +2250,16 @@ mod tests {
         assert_eq!(value["run_created"], false);
         assert_eq!(value["choices"][0]["kind"], "defer");
         assert_eq!(value["choices"][0]["retry_after_seconds"], 60);
-        assert_eq!(value["choices"][1]["kind"], "local_override");
+        assert_eq!(value["choices"][1]["kind"], "retry");
         assert_eq!(
             value["choices"][1]["command"],
-            "homeboy --placement local agent-task cook --prompt 'fix resource admission'"
+            "homeboy agent-task cook --prompt 'fix resource admission'"
         );
-        assert_eq!(value["choices"][1]["requires_operator_authorization"], true);
-        assert_eq!(value["choices"].as_array().expect("choices").len(), 2);
+        assert!(value["choices"][1]
+            .get("requires_operator_authorization")
+            .is_none());
+        assert_eq!(value["choices"][2]["kind"], "local_override");
+        assert_eq!(value["choices"].as_array().expect("choices").len(), 3);
 
         let warning = evaluate_with_runner_hint(
             lab_supported_hot("agent-task cook/run-plan/retry --run"),
@@ -2245,7 +2272,7 @@ mod tests {
         assert_eq!(error.details["run_created"], false);
         assert_eq!(
             error.details["rerun_command"],
-            "homeboy --placement local agent-task cook --prompt 'fix resource admission'"
+            "homeboy agent-task cook --prompt 'fix resource admission'"
         );
         assert!(error.details.get("resume_command").is_none());
         assert_eq!(
@@ -2286,11 +2313,18 @@ mod tests {
         .expect("argv produces recovery");
 
         let value = serde_json::to_value(recovery).expect("recovery serializes");
+        assert_eq!(value["choices"][1]["kind"], "retry");
+        assert_eq!(value["choices"][1]["command"], "homeboy audit");
         assert_eq!(value["choices"][2]["kind"], "runner_recovery");
         assert_eq!(
             value["choices"][2]["command"],
             "homeboy runner refresh homeboy-lab"
         );
+        assert!(value["choices"]
+            .as_array()
+            .expect("choices")
+            .iter()
+            .all(|choice| choice["kind"] != "local_override"));
     }
 
     #[test]
@@ -2324,7 +2358,7 @@ mod tests {
         .expect("argv produces recovery");
 
         let value = serde_json::to_value(recovery).expect("recovery serializes");
-        assert_eq!(value["choices"].as_array().expect("choices").len(), 2);
+        assert_eq!(value["choices"].as_array().expect("choices").len(), 3);
     }
 
     #[test]
@@ -2359,7 +2393,8 @@ mod tests {
         assert!(error.message.contains("homeboy runner connect homeboy-lab"));
         assert!(error
             .message
-            .contains("explicit, authorized `--placement local` override"));
+            .contains("retry the unchanged request after Lab admission recovers"));
+        assert!(!error.message.contains("--placement local"));
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/availability_provider.rs
+++ b/crates/homeboy-lab-runner/src/availability_provider.rs
@@ -19,7 +19,14 @@ impl RunnerAvailabilityProvider for RunnerAvailability {
             // gap without the runner dropping out of service (#11106).
             Ok(status)
                 if status.connected
-                    && status.admission_blocking_stale_daemon().is_none()
+                    && crate::load(runner_id).is_ok_and(|runner| {
+                        !crate::lab::offload::metadata::lab_runner_homeboy_has_blocking_status_drift(
+                            &status,
+                            crate::lab::offload::metadata::require_exact_runner_version(
+                                &runner.settings,
+                            ),
+                        )
+                    })
                     && status.active_job_state == RunnerActiveJobState::Available =>
             {
                 AgentTaskLoopRunnerAvailability::Available

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -1352,8 +1352,17 @@ fn refuses_nonfresh_daemon_execution(
     options: &RunnerExecOptions,
     status: &RunnerStatusReport,
 ) -> bool {
+    let admission_fresh = crate::load(&status.runner_id).map_or_else(
+        |_| status.daemon_fresh_for_admission(),
+        |runner| {
+            crate::lab::offload::metadata::lab_runner_daemon_fresh_for_admission(
+                status,
+                crate::lab::offload::metadata::require_exact_runner_version(&runner.settings),
+            )
+        },
+    );
     status.connected
-        && !status.daemon_fresh_for_admission()
+        && !admission_fresh
         && !allows_idle_stale_daemon_refresh(options, status)
         // A read-only retrieval routes to the generation that retains the run or
         // artifact and never rotates the shared tunnel, so admission-daemon

--- a/crates/homeboy-lab-runner/src/lab/offload/metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/metadata.rs
@@ -535,6 +535,40 @@ pub(crate) fn classify_runner_homeboy_version_drift(
     }
 }
 
+/// Whether the status-level daemon warning blocks Lab admission under the
+/// runner's configured version policy. A patch-only controller/version warning
+/// is compatible unless exact matching was explicitly requested; every other
+/// proven daemon mismatch remains blocking.
+pub(crate) fn lab_runner_homeboy_has_blocking_status_drift(
+    status: &RunnerStatusReport,
+    require_exact: bool,
+) -> bool {
+    status
+        .admission_blocking_stale_daemon()
+        .is_some_and(|warning| {
+            require_exact
+                || warning.compatibility_reason != Some("controller_configured_version_skew")
+                || classify_runner_homeboy_version_drift(status)
+                    != RunnerHomeboyVersionDrift::CompatiblePatch
+        })
+}
+
+pub(crate) fn lab_runner_daemon_fresh_for_admission(
+    status: &RunnerStatusReport,
+    require_exact: bool,
+) -> bool {
+    if lab_runner_homeboy_has_blocking_status_drift(status, require_exact) {
+        return false;
+    }
+    status.daemon_fresh()
+        || status.daemon_freshness.as_ref().is_some_and(|freshness| {
+            freshness.stale_reason_code
+                == Some(homeboy_core::daemon::DaemonStaleReasonCode::VersionMismatch)
+                && classify_runner_homeboy_version_drift(status)
+                    == RunnerHomeboyVersionDrift::CompatiblePatch
+        })
+}
+
 /// Direct SSH runners execute jobs with their configured executable rather
 /// than the controller binary. When that executable's immutable identity is
 /// available, it is the authoritative admission comparison for the active
@@ -571,7 +605,7 @@ pub(crate) fn lab_runner_homeboy_has_blocking_drift_against_configured_identity(
     // observed no drift, and this branch is exactly where every reverse runner
     // now lands (#11106) — blocking on it would take the whole class out of
     // service on the strength of a gap rather than a mismatch.
-    if status.admission_blocking_stale_daemon().is_some() {
+    if lab_runner_homeboy_has_blocking_status_drift(status, require_exact) {
         return true;
     }
     match classify_runner_homeboy_version_drift(status) {

--- a/crates/homeboy-lab-runner/src/lab_selection.rs
+++ b/crates/homeboy-lab-runner/src/lab_selection.rs
@@ -384,6 +384,7 @@ fn placement_readiness_with_transport(
             .expect("validated invocation has one source path"),
     );
     let observation = observe(request, source_path)?;
+    let runner = load(&request.runner_id)?;
     let provider_admission =
         provider_admission_for_request(request, observation.provider_catalog.as_deref());
     let routed = build_routed_lab_admission_command(
@@ -434,7 +435,7 @@ fn placement_readiness_with_transport(
             super::LabRunnerGateMode::Explicit,
         ),
         None => super::evaluate_lab_runner_capabilities_for_runner(
-            &load(&request.runner_id)?,
+            &runner,
             &plan.capability,
             super::LabRunnerGateMode::Explicit,
         )?,
@@ -446,6 +447,7 @@ fn placement_readiness_with_transport(
         observation.mode,
         capability,
         observation.provider_catalog.as_deref(),
+        super::lab::offload::metadata::require_exact_runner_version(&runner.settings),
     ))
 }
 
@@ -456,13 +458,19 @@ fn placement_readiness_from_status_with_catalog(
     mode: RunnerTunnelMode,
     capability: super::LabRunnerGateDecision,
     provider_catalog: Option<&[homeboy_agents::agent_tasks::provider::AgentTaskExecutorProvider]>,
+    require_exact_runner_version: bool,
 ) -> PlacementReadiness {
     let (workload_family, command, provider, source_path_inputs) = admission_identity(request);
     let provider_admission = provider_admission_for_request(request, provider_catalog);
+    let blocking_status_drift =
+        super::lab::offload::metadata::lab_runner_homeboy_has_blocking_status_drift(
+            status,
+            require_exact_runner_version,
+        );
     let availability = RunnerAvailability::from_status_parts(
         request.runner_id.clone(),
         status.connected,
-        status.admission_blocking_stale_daemon().is_some(),
+        blocking_status_drift,
         status.active_jobs.len(),
         &status.active_job_state,
         capacity,
@@ -540,7 +548,7 @@ fn placement_readiness_from_status_with_catalog(
             },
             PlacementReadinessPredicate {
                 id: "daemon_fresh".to_string(),
-                satisfied: status.admission_blocking_stale_daemon().is_none(),
+                satisfied: !blocking_status_drift,
             },
             PlacementReadinessPredicate {
                 id: "active_jobs_authoritative".to_string(),
@@ -1843,7 +1851,7 @@ mod placement_readiness_tests {
         capability: super::super::LabRunnerGateDecision,
     ) -> PlacementReadiness {
         placement_readiness_from_status_with_catalog(
-            request, status, capacity, mode, capability, None,
+            request, status, capacity, mode, capability, None, false,
         )
     }
 

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -894,21 +894,14 @@ pub fn lab_runner_readiness() -> Result<LabRunnerReadiness> {
                 .session
                 .as_ref()
                 .map_or(RunnerTunnelMode::DirectSsh, |session| session.mode.clone());
-            Some(DefaultLabRunnerCandidate {
-                id: runner.id,
+            Some(lab_runner_admission_candidate(
+                &runner.id,
                 mode,
-                connected: status.connected,
-                capacity: runner.settings.concurrency_limit,
-                stale_daemon: status.admission_blocking_stale_daemon().is_some(),
-                unverified_daemon: status.unverified_daemon().is_some(),
-                admission_fresh: status.daemon_fresh_for_admission(),
-                admission_remediation: status
-                    .admission_action()
-                    .map(|action| action.render_command()),
-                active_jobs: status.active_job_count.max(status.active_jobs.len()),
-                active_jobs_available: status.active_job_state == RunnerActiveJobState::Available,
+                runner.settings.concurrency_limit,
+                &status,
                 capabilities_ready,
-            })
+                lab::offload::metadata::require_exact_runner_version(&runner.settings),
+            ))
         })
         .collect();
     Ok(lab_runner_readiness_from_candidates(
@@ -924,7 +917,12 @@ pub fn lab_runner_readiness() -> Result<LabRunnerReadiness> {
 pub fn refresh_lab_runner_readiness_for_admission() -> Result<LabRunnerReadiness> {
     let preferred = defaults::load_config().lab.preferred_runner;
     let mut runner_ids = configured_lab_runner_ids()?;
-    runner_ids.sort();
+    runner_ids.sort_by_key(|runner_id| {
+        (
+            Some(runner_id.as_str()) != preferred.as_deref(),
+            runner_id.clone(),
+        )
+    });
     let deadline = std::time::Instant::now() + readonly_probe::readonly_probe_timeout();
     let mut observations = Vec::new();
     for runner_id in runner_ids.into_iter().take(DETACHED_QUEUE_REFRESH_LIMIT) {
@@ -947,21 +945,47 @@ fn observe_lab_runner_admission_candidate(
         .session
         .as_ref()
         .map_or(RunnerTunnelMode::DirectSsh, |session| session.mode.clone());
-    Ok(DefaultLabRunnerCandidate {
+    Ok(lab_runner_admission_candidate(
+        runner_id,
+        mode,
+        runner.settings.concurrency_limit,
+        &status,
+        capabilities_ready,
+        lab::offload::metadata::require_exact_runner_version(&runner.settings),
+    ))
+}
+
+fn lab_runner_admission_candidate(
+    runner_id: &str,
+    mode: RunnerTunnelMode,
+    capacity: Option<usize>,
+    status: &RunnerStatusReport,
+    capabilities_ready: bool,
+    exact_version: bool,
+) -> DefaultLabRunnerCandidate {
+    let admission_warning = status.admission_blocking_stale_daemon().filter(|_| {
+        lab::offload::metadata::lab_runner_homeboy_has_blocking_status_drift(status, exact_version)
+    });
+    DefaultLabRunnerCandidate {
         id: runner_id.to_string(),
         mode,
         connected: status.connected,
-        capacity: runner.settings.concurrency_limit,
-        stale_daemon: status.admission_blocking_stale_daemon().is_some(),
+        capacity,
+        stale_daemon: admission_warning.is_some(),
         unverified_daemon: status.unverified_daemon().is_some(),
-        admission_fresh: status.daemon_fresh_for_admission(),
-        admission_remediation: status
-            .admission_action()
+        admission_fresh: lab::offload::metadata::lab_runner_daemon_fresh_for_admission(
+            status,
+            exact_version,
+        ),
+        admission_failure_reason: admission_warning
+            .map(|warning| warning.mismatch_predicate.to_string()),
+        admission_remediation: admission_warning
+            .and_then(|_| status.admission_action())
             .map(|action| action.render_command()),
         active_jobs: status.active_job_count.max(status.active_jobs.len()),
         active_jobs_available: status.active_job_state == RunnerActiveJobState::Available,
         capabilities_ready,
-    })
+    }
 }
 
 fn lab_runner_readiness_from_refresh_observations(
@@ -980,8 +1004,9 @@ fn lab_runner_readiness_from_refresh_observations(
             })),
         }
     }
+    let observed_candidate = !candidates.is_empty();
     let readiness = lab_runner_readiness_from_candidates(preferred, candidates);
-    if readiness.state == LabRunnerReadinessState::ConnectedReady || failures.is_empty() {
+    if observed_candidate || failures.is_empty() {
         return Ok(readiness);
     }
     let timeout = failures.iter().all(|failure| {
@@ -1024,21 +1049,14 @@ pub fn refresh_detached_queue_runner() -> Result<Option<String>> {
             .map_or(RunnerTunnelMode::DirectSsh, |session| session.mode.clone());
         let capabilities_ready = runner_capability_inventory(&runner_id)
             .is_ok_and(|inventory| !inventory.runtime_ids.is_empty());
-        let candidate = DefaultLabRunnerCandidate {
-            id: runner_id,
+        let candidate = lab_runner_admission_candidate(
+            &runner_id,
             mode,
-            connected: status.connected,
-            capacity: runner.settings.concurrency_limit,
-            stale_daemon: status.admission_blocking_stale_daemon().is_some(),
-            unverified_daemon: status.unverified_daemon().is_some(),
-            admission_fresh: status.daemon_fresh_for_admission(),
-            admission_remediation: status
-                .admission_action()
-                .map(|action| action.render_command()),
-            active_jobs: status.active_job_count.max(status.active_jobs.len()),
-            active_jobs_available: status.active_job_state == RunnerActiveJobState::Available,
+            runner.settings.concurrency_limit,
+            &status,
             capabilities_ready,
-        };
+            lab::offload::metadata::require_exact_runner_version(&runner.settings),
+        );
         if let Some(runner_id) = detached_queue_runner_from_candidates([candidate]) {
             return Ok(Some(runner_id));
         }
@@ -1059,21 +1077,14 @@ pub fn refresh_explicit_detached_queue_runner(runner_id: &str) -> Result<bool> {
     let capabilities_ready = runner_capability_inventory(runner_id)
         .is_ok_and(|inventory| !inventory.runtime_ids.is_empty());
     Ok(
-        detached_queue_runner_from_candidates([DefaultLabRunnerCandidate {
-            id: runner_id.to_string(),
+        detached_queue_runner_from_candidates([lab_runner_admission_candidate(
+            runner_id,
             mode,
-            connected: status.connected,
-            capacity: runner.settings.concurrency_limit,
-            stale_daemon: status.admission_blocking_stale_daemon().is_some(),
-            unverified_daemon: status.unverified_daemon().is_some(),
-            admission_fresh: status.daemon_fresh_for_admission(),
-            admission_remediation: status
-                .admission_action()
-                .map(|action| action.render_command()),
-            active_jobs: status.active_job_count.max(status.active_jobs.len()),
-            active_jobs_available: status.active_job_state == RunnerActiveJobState::Available,
+            runner.settings.concurrency_limit,
+            &status,
             capabilities_ready,
-        }])
+            lab::offload::metadata::require_exact_runner_version(&runner.settings),
+        )])
         .as_deref()
             == Some(runner_id),
     )
@@ -1178,6 +1189,7 @@ struct DefaultLabRunnerCandidate {
     /// `DefaultLabRunnerCandidate::readiness`.
     unverified_daemon: bool,
     admission_fresh: bool,
+    admission_failure_reason: Option<String>,
     admission_remediation: Option<String>,
     active_jobs: usize,
     active_jobs_available: bool,
@@ -1214,6 +1226,9 @@ impl DefaultLabRunnerCandidate {
                 .reasons
                 .push("daemon_freshness_unavailable".to_string());
             availability.accepts_jobs = false;
+        }
+        if let Some(reason) = &self.admission_failure_reason {
+            availability.reasons.push(reason.clone());
         }
         if !self.active_jobs_available
             && !availability
@@ -1309,21 +1324,14 @@ pub(crate) fn default_lab_runner_availability() -> Result<Vec<RunnerAvailability
                 .session
                 .as_ref()
                 .map_or(RunnerTunnelMode::DirectSsh, |session| session.mode.clone());
-            let candidate = DefaultLabRunnerCandidate {
-                id: runner.id,
+            let candidate = lab_runner_admission_candidate(
+                &runner.id,
                 mode,
-                connected: status.connected,
-                capacity: runner.settings.concurrency_limit,
-                stale_daemon: status.admission_blocking_stale_daemon().is_some(),
-                unverified_daemon: status.unverified_daemon().is_some(),
-                admission_fresh: status.daemon_fresh_for_admission(),
-                admission_remediation: status
-                    .admission_action()
-                    .map(|action| action.render_command()),
-                active_jobs: status.active_job_count.max(status.active_jobs.len()),
-                active_jobs_available: status.active_job_state == RunnerActiveJobState::Available,
+                runner.settings.concurrency_limit,
+                &status,
                 capabilities_ready,
-            };
+                lab::offload::metadata::require_exact_runner_version(&runner.settings),
+            );
             Some(candidate.availability())
         })
         .collect();
@@ -2008,11 +2016,110 @@ mod tests {
             stale_daemon: false,
             unverified_daemon: false,
             admission_fresh: true,
+            admission_failure_reason: None,
             admission_remediation: None,
             active_jobs: 0,
             active_jobs_available: true,
             capabilities_ready: true,
         }
+    }
+
+    fn skewed_runner_status(version: String) -> RunnerStatusReport {
+        let controller_version = homeboy_product_identity::product_version();
+        let controller_build_identity = format!("homeboy {controller_version}+0123456789ab");
+        let runner_build_identity = format!("homeboy {version}+0123456789ab");
+        let warning = RunnerStaleDaemonWarning::new(
+            "homeboy-lab",
+            version.clone(),
+            version.clone(),
+            Some(runner_build_identity.clone()),
+            Some(runner_build_identity),
+        )
+        .with_controller_compatibility(
+            "homeboy-lab",
+            controller_version.to_string(),
+            controller_build_identity,
+            false,
+            true,
+            false,
+        );
+        RunnerStatusReport {
+            runner_id: "homeboy-lab".to_string(),
+            connected: true,
+            state: RunnerSessionState::Connected,
+            session: Some(RunnerSession {
+                runner_id: "homeboy-lab".to_string(),
+                mode: RunnerTunnelMode::Reverse,
+                role: RunnerSessionRole::Runner,
+                server_id: None,
+                controller_id: Some("controller".to_string()),
+                broker_url: Some("http://broker.invalid".to_string()),
+                remote_daemon_address: None,
+                local_port: None,
+                local_url: None,
+                tunnel_pid: None,
+                tunnel_process_start_identity: None,
+                proxy_forward: None,
+                remote_daemon_pid: Some(42),
+                remote_daemon_lease_id: Some("lease".to_string()),
+                homeboy_version: version,
+                homeboy_build_identity: None,
+                connected_at: "2026-08-24T00:00:00Z".to_string(),
+                worker_identity: Some("worker".to_string()),
+                worker_pid: Some(43),
+                last_seen_at: Some("2026-08-24T00:00:01Z".to_string()),
+                leaseless_recovery_evidence: None,
+            }),
+            stale_daemon: Some(warning),
+            configured_job_binary_build_identity: None,
+            daemon_freshness: Some(homeboy_core::daemon::DaemonFreshnessReport {
+                fresh: false,
+                stale_reason_code: Some(
+                    homeboy_core::daemon::DaemonStaleReasonCode::VersionMismatch,
+                ),
+                restartable: true,
+                lease_id: Some("lease".to_string()),
+                pid: Some(42),
+                recovery_evidence: None,
+                ownership_evidence: None,
+                adoption_command: None,
+                binary_hash: None,
+                daemon_version: None,
+                daemon_build_identity: None,
+                runtime_paths: None,
+                active_jobs: 0,
+                termination_evidence: None,
+                repair_plan: Vec::new(),
+            }),
+            active_jobs: Vec::new(),
+            active_runner_jobs: Vec::new(),
+            stale_runner_jobs: Vec::new(),
+            active_job_count: 0,
+            stale_runner_job_count: 0,
+            active_job_state: RunnerActiveJobState::Available,
+            active_job_source: None,
+            active_job_error: None,
+            active_job_recovery_evidence: None,
+            session_path: "fixture".to_string(),
+        }
+    }
+
+    fn patch_drift_version() -> String {
+        let controller = homeboy_product_identity::product_version();
+        let mut parts = controller.split('.');
+        let major = parts.next().expect("major");
+        let minor = parts.next().expect("minor");
+        let patch = parts
+            .next()
+            .and_then(|part| {
+                part.chars()
+                    .take_while(|character| character.is_ascii_digit())
+                    .collect::<String>()
+                    .parse::<u64>()
+                    .ok()
+            })
+            .unwrap_or_default();
+        format!("{major}.{minor}.{}", patch.wrapping_add(1))
     }
 
     #[test]
@@ -2033,6 +2140,82 @@ mod tests {
         );
         assert_eq!(refreshed.state, LabRunnerReadinessState::ConnectedReady);
         assert_eq!(refreshed.selected_runner_id.as_deref(), Some("lab-a"));
+    }
+
+    #[test]
+    fn current_release_refresh_selects_provider_ready_compatible_skewed_runner() {
+        let status = skewed_runner_status(patch_drift_version());
+        let candidate = lab_runner_admission_candidate(
+            "homeboy-lab",
+            RunnerTunnelMode::Reverse,
+            Some(1),
+            &status,
+            true,
+            false,
+        );
+        let readiness = lab_runner_readiness_from_candidates(None, vec![candidate]);
+
+        assert_eq!(readiness.state, LabRunnerReadinessState::ConnectedReady);
+        assert_eq!(readiness.selected_runner_id.as_deref(), Some("homeboy-lab"));
+        assert_eq!(readiness.available_runner_ids, ["homeboy-lab"]);
+    }
+
+    #[test]
+    fn current_release_refresh_respects_exact_version_admission() {
+        let status = skewed_runner_status(patch_drift_version());
+        let candidate = lab_runner_admission_candidate(
+            "homeboy-lab",
+            RunnerTunnelMode::Reverse,
+            Some(1),
+            &status,
+            true,
+            true,
+        );
+        let readiness = lab_runner_readiness_from_candidates(None, vec![candidate]);
+
+        assert_eq!(readiness.state, LabRunnerReadinessState::Stale);
+        assert!(readiness.selected_runner_id.is_none());
+        assert!(readiness
+            .reasons
+            .iter()
+            .any(|reason| reason == "controller_version != job_command_binary_version"));
+    }
+
+    #[test]
+    fn current_release_refresh_names_incompatible_skew_predicate_and_command() {
+        let controller = homeboy_product_identity::product_version();
+        let mut parts = controller.split('.');
+        let major = parts.next().expect("major");
+        let minor = parts
+            .next()
+            .and_then(|part| part.parse::<u64>().ok())
+            .expect("minor");
+        let mut status = skewed_runner_status(format!("{major}.{}.0", minor.wrapping_add(1)));
+        let freshness = status.daemon_freshness.as_mut().expect("fixture freshness");
+        freshness.fresh = true;
+        freshness.stale_reason_code = None;
+        let candidate = lab_runner_admission_candidate(
+            "homeboy-lab",
+            RunnerTunnelMode::Reverse,
+            Some(1),
+            &status,
+            true,
+            false,
+        );
+        let readiness = lab_runner_readiness_from_candidates(None, vec![candidate]);
+
+        assert_eq!(readiness.state, LabRunnerReadinessState::Stale);
+        assert_eq!(
+            readiness.reasons,
+            [
+                "stale_daemon",
+                "controller_version != job_command_binary_version"
+            ]
+        );
+        assert_eq!(
+            readiness.remediation_commands,
+            ["homeboy runner refresh-homeboy homeboy-lab --ref 0123456789ab --reconnect"]
+        );
     }
 
     #[test]
@@ -2059,11 +2242,11 @@ mod tests {
     }
 
     #[test]
-    fn admission_refresh_aggregates_failures_only_when_no_runner_is_ready() {
+    fn admission_refresh_preserves_authoritative_blocked_observation() {
         let mut full = default_lab_candidate("lab-b", RunnerTunnelMode::Reverse, true);
         full.capacity = Some(1);
         full.active_jobs = 1;
-        let error = lab_runner_readiness_from_refresh_observations(
+        let readiness = lab_runner_readiness_from_refresh_observations(
             None,
             vec![
                 Err(homeboy_core::error::Error::new(
@@ -2074,7 +2257,23 @@ mod tests {
                 Ok(full),
             ],
         )
-        .expect_err("aggregate failures only after every runner is unavailable");
+        .expect("an authoritative observation must not be discarded");
+
+        assert_eq!(readiness.state, LabRunnerReadinessState::CapacityBlocked);
+        assert_eq!(readiness.reasons, ["capacity_reached"]);
+    }
+
+    #[test]
+    fn admission_refresh_reports_timeout_when_every_observation_times_out() {
+        let error = lab_runner_readiness_from_refresh_observations(
+            None,
+            vec![Err(homeboy_core::error::Error::new(
+                homeboy_core::error::ErrorCode::RemoteCommandTimeout,
+                "lab-a timed out",
+                serde_json::Value::Null,
+            ))],
+        )
+        .expect_err("no authoritative observation completed");
 
         assert_eq!(
             error.code,
@@ -2083,10 +2282,6 @@ mod tests {
         assert_eq!(
             error.details["runner_failures"][0]["code"],
             "remote.command_timeout"
-        );
-        assert_eq!(
-            error.details["observed_readiness_state"],
-            "capacity_blocked"
         );
     }
 

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -2227,19 +2227,22 @@ impl RunnerStaleDaemonWarning {
         self.message = format!(
             "connected runner configured job command binary `{configured_binary}` is incompatible with controller `{controller_build_identity}`; the daemon matches the configured binary, but controller compatibility requires convergence before admission"
         );
-        if controller_version_matches {
-            if let Some(controller_commit) =
-                homeboy_upgrade::upgrade::parse_build_identity_display(&controller_build_identity)
-                    .filter(|identity| identity.git_dirty != Some(true))
-                    .and_then(|identity| identity.git_commit)
-            {
-                self.set_recovery(vec![
-                    crate::daemon_repair::refresh_homeboy_downgrade_action(
-                        runner_id,
-                        &controller_commit,
-                    ),
-                ]);
-            }
+        if let Some(controller_commit) =
+            homeboy_upgrade::upgrade::parse_build_identity_display(&controller_build_identity)
+                .filter(|identity| identity.git_dirty != Some(true))
+                .and_then(|identity| identity.git_commit)
+        {
+            self.set_recovery(vec![if controller_version_matches {
+                crate::daemon_repair::refresh_homeboy_downgrade_action(
+                    runner_id,
+                    &controller_commit,
+                )
+            } else {
+                crate::daemon_repair::refresh_homeboy_action_for_ref(
+                    runner_id,
+                    Some(&controller_commit),
+                )
+            }]);
         }
         self
     }


### PR DESCRIPTION
Closes #13383

## Summary
- refresh stale runner observations before auto-placement refuses Lab admission
- accept provider-ready compatible patch skew while preserving exact-version policy
- retain authoritative blocked observations and explicit timeout/incompatibility diagnostics

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner --lib tests::current_release_refresh`
- `cargo test -p homeboy-lab-runner --lib tests::admission_refresh`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode implemented the candidate; I reviewed and rebased the diff against current main and ran the listed focused gates.