### PR TITLE
Preserve generated release mutations through packaging

### DIFF
--- a/crates/homeboy-release/src/release/execution_dispatch.rs
+++ b/crates/homeboy-release/src/release/execution_dispatch.rs
@@ -5,7 +5,7 @@ use homeboy_core::error::{Error, Result};
 use homeboy_core::git;
 use homeboy_core::plan::{PlanStep, PlanStepStatus};
 use homeboy_extension::ExtensionManifest;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 use std::process::Command;
 
@@ -828,7 +828,7 @@ fn failed_result(id: &str, step_type: &str, err: Error) -> ReleaseStepResult {
 fn tracked_dirty_snapshot_for_step(
     step: &PlanStep,
     context: &ReleaseExecutionContext,
-) -> Result<Option<BTreeSet<String>>> {
+) -> Result<Option<BTreeMap<String, String>>> {
     if !release_step_dirty_side_effects_are_guarded(step) {
         return Ok(None);
     }
@@ -842,7 +842,7 @@ fn tracked_dirty_snapshot_for_step(
 fn guard_step_dirty_side_effects(
     step: &PlanStep,
     context: &ReleaseExecutionContext,
-    before: Option<BTreeSet<String>>,
+    before: Option<BTreeMap<String, String>>,
     result: ReleaseStepResult,
 ) -> Result<ReleaseStepResult> {
     if !matches!(result.status, ReleaseStepStatus::Success) {
@@ -854,13 +854,20 @@ fn guard_step_dirty_side_effects(
     };
 
     let after = tracked_dirty_snapshot(&context.component.local_path)?;
-    let introduced: Vec<String> = after.difference(&before).cloned().collect();
-    let introduced = release_step_unexpected_dirty_files(step, context, introduced)?;
-    if introduced.is_empty() {
+    let changed = before
+        .keys()
+        .chain(after.keys())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .filter(|file| before.get(*file) != after.get(*file))
+        .cloned()
+        .collect();
+    let changed = release_step_unexpected_dirty_files(step, context, changed)?;
+    if changed.is_empty() {
         return Ok(result);
     }
 
-    Ok(dirty_side_effect_failure(step, introduced))
+    Ok(dirty_side_effect_failure(step, changed))
 }
 
 fn release_step_dirty_side_effects_are_guarded(step: &PlanStep) -> bool {
@@ -944,16 +951,43 @@ fn release_prepare_allowed_dirty_files(
     ))
 }
 
-fn tracked_dirty_snapshot(path: &str) -> Result<BTreeSet<String>> {
+fn tracked_dirty_snapshot(path: &str) -> Result<BTreeMap<String, String>> {
     let changes = git::get_uncommitted_changes(path)?;
     let files = changes
         .staged
         .into_iter()
         .chain(changes.unstaged)
         .collect::<Vec<_>>();
-    Ok(super::planning_worktree::filter_homeboy_managed(files)
+    super::planning_worktree::filter_homeboy_managed(files)
         .into_iter()
-        .collect())
+        .map(|file| {
+            let output = git::execute_git_for_release(
+                path,
+                &[
+                    "diff",
+                    "--binary",
+                    "--no-ext-diff",
+                    "--no-textconv",
+                    "HEAD",
+                    "--",
+                    &file,
+                ],
+            )
+            .map_err(|error| {
+                Error::internal_io(error.to_string(), Some(format!("git diff HEAD -- {file}")))
+            })?;
+            if !output.status.success() {
+                return Err(Error::git_command_failed(format!(
+                    "git diff failed for tracked release path {file}: {}",
+                    String::from_utf8_lossy(&output.stderr).trim()
+                )));
+            }
+            Ok((
+                file,
+                homeboy_engine_primitives::content_hash::sha256_hex(&output.stdout),
+            ))
+        })
+        .collect()
 }
 
 fn dirty_side_effect_failure(step: &PlanStep, files: Vec<String>) -> ReleaseStepResult {
@@ -1010,7 +1044,7 @@ mod tests {
     use super::{
         dependency_preflight_result, execute_release_plan_step, planned_release_tag_name,
         release_step_is_plan_only, release_step_is_show_stopper,
-        release_step_unexpected_dirty_files, ReleaseExecutionContext,
+        release_step_unexpected_dirty_files, tracked_dirty_snapshot, ReleaseExecutionContext,
     };
     use crate::release::types::{
         ReleaseOptions, ReleasePipelineOptions, ReleaseState, ReleaseStepResult, ReleaseStepStatus,
@@ -1175,6 +1209,70 @@ mod tests {
                 std::fs::read(repo.path().join("build/fixture.zip")).expect("source artifact"),
                 std::fs::read(durable).expect("uploaded artifact"),
             );
+        });
+    }
+
+    #[test]
+    fn release_package_cannot_rewrite_an_existing_release_mutation() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let repo = tempfile::tempdir().expect("repo");
+            std::fs::write(repo.path().join("VERSION"), "1.2.2\n").expect("version");
+            run_in(repo.path(), &["git", "init", "-q"]);
+            configure_git_user(repo.path());
+            run_in(repo.path(), &["git", "add", "VERSION"]);
+            run_in(repo.path(), &["git", "commit", "-qm", "Initial commit"]);
+            std::fs::write(repo.path().join("VERSION"), "1.2.3\n").expect("release version");
+            assert!(tracked_dirty_snapshot(&repo.path().to_string_lossy())
+                .expect("dirty snapshot")
+                .contains_key("VERSION"));
+
+            let package = package_extension(
+                "printf '9.9.9\n' > VERSION; printf artifact > fixture.zip; \
+                 printf '[{\"path\":\"fixture.zip\",\"type\":\"archive\"}]'",
+            );
+            homeboy_extension::save_manifest(&package).expect("save package extension");
+            let component = Component {
+                id: "fixture".to_string(),
+                local_path: repo.path().to_string_lossy().to_string(),
+                ..Component::default()
+            };
+            let options = ReleaseOptions {
+                skip_build_validation: true,
+                ..ReleaseOptions::default()
+            };
+            let extensions = vec![package];
+            let mut context = ReleaseExecutionContext {
+                component: &component,
+                extensions: &extensions,
+                component_id: "fixture",
+                options: &options,
+                roots: test_roots(),
+                state: ReleaseState {
+                    version: Some("1.2.3".to_string()),
+                    ..ReleaseState::default()
+                },
+                publish_failed: false,
+            };
+
+            let result = execute_release_plan_step(&plan_step("package"), &mut context)
+                .expect("package dispatch")
+                .expect("package result");
+
+            assert_eq!(
+                std::fs::read_to_string(repo.path().join("VERSION"))
+                    .expect("version after package"),
+                "9.9.9\n"
+            );
+            assert_eq!(result.status, ReleaseStepStatus::Failed);
+            assert!(release_step_is_show_stopper(&result));
+            assert!(result
+                .data
+                .as_ref()
+                .and_then(|data| data.get("dirty_tracked_files"))
+                .and_then(|files| files.as_array())
+                .expect("changed tracked files")
+                .iter()
+                .any(|file| file.as_str() == Some("VERSION")));
         });
     }
 

--- a/tests/release_mutation_transaction.rs
+++ b/tests/release_mutation_transaction.rs
@@ -1,0 +1,319 @@
+use homeboy_core::test_support::{HermeticTestContext, TestBinary};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const ORIGINAL_VERSION: &str = "1.2.2";
+const RELEASE_VERSION: &str = "1.2.3";
+const TAG: &str = "v1.2.3";
+
+#[test]
+fn release_package_commit_and_tag_share_the_declared_version_identity() {
+    let context = HermeticTestContext::new();
+    let fixture = ReleaseFixture::new(&context, false);
+
+    let output = fixture.release(&context);
+
+    assert_success(&output);
+    let release_head = git(&fixture.repo, &["rev-parse", "HEAD"]);
+    assert_ne!(release_head, fixture.original_head);
+    assert_eq!(
+        git(&fixture.repo, &["log", "-1", "--format=%s"]),
+        "release: v1.2.3"
+    );
+    assert_eq!(
+        git(&fixture.repo, &["rev-parse", &format!("{TAG}^{{commit}}")]),
+        release_head
+    );
+    assert_eq!(
+        git(&fixture.remote, &["rev-parse", "refs/heads/main"]),
+        release_head
+    );
+    assert_eq!(
+        git(&fixture.remote, &["rev-parse", "refs/tags/v1.2.3^{commit}"]),
+        release_head
+    );
+
+    let committed_target = git(&fixture.repo, &["show", "HEAD:fixture.php"]);
+    assert_release_targets(&committed_target);
+    assert!(git(&fixture.repo, &["show", "HEAD:CHANGELOG.md"]).contains(RELEASE_VERSION));
+
+    let artifact = durable_artifact(&context);
+    assert!(artifact
+        .to_string_lossy()
+        .contains("/release/fixture/1_2_3/01-fixture.zip"));
+    assert_release_targets(&unzip_file(&artifact, "fixture.php"));
+}
+
+#[test]
+fn package_that_discards_release_mutations_rolls_back_without_a_tag() {
+    let context = HermeticTestContext::new();
+    let fixture = ReleaseFixture::new(&context, true);
+
+    let output = fixture.release(&context);
+
+    assert!(
+        !output.status.success(),
+        "release unexpectedly succeeded: {}",
+        output_text(&output)
+    );
+    let rendered = output_text(&output);
+    assert!(
+        rendered.contains("package dirtied tracked files"),
+        "{rendered}"
+    );
+    assert!(
+        rendered.contains("fixture.php") && rendered.contains("CHANGELOG.md"),
+        "{rendered}"
+    );
+    assert!(
+        rendered.contains("rollback") || rendered.contains("Rollback"),
+        "{rendered}"
+    );
+    assert_eq!(
+        git(&fixture.repo, &["rev-parse", "HEAD"]),
+        fixture.original_head
+    );
+    assert_eq!(git(&fixture.repo, &["status", "--porcelain=v1"]), "");
+    assert!(std::fs::read_to_string(fixture.repo.join("fixture.php"))
+        .expect("restored version target")
+        .contains(ORIGINAL_VERSION));
+    assert!(std::fs::read_to_string(fixture.repo.join("CHANGELOG.md"))
+        .expect("restored changelog")
+        .contains("## Unreleased"));
+    assert!(!ref_exists(&fixture.repo, &format!("refs/tags/{TAG}")));
+    assert!(!ref_exists(&fixture.remote, &format!("refs/tags/{TAG}")));
+    assert_eq!(
+        git(&fixture.remote, &["rev-parse", "refs/heads/main"]),
+        fixture.original_head
+    );
+
+    // The package was built from the bumped checkout before its action restored
+    // tracked files. Its durable bytes remain diagnostic evidence, but cannot
+    // authorize a commit, tag, or push after the ownership violation.
+    assert_release_targets(&unzip_file(&durable_artifact(&context), "fixture.php"));
+}
+
+struct ReleaseFixture {
+    _root: tempfile::TempDir,
+    repo: PathBuf,
+    remote: PathBuf,
+    original_head: String,
+}
+
+impl ReleaseFixture {
+    fn new(context: &HermeticTestContext, discard_mutations: bool) -> Self {
+        let root = tempfile::tempdir().expect("release fixture root");
+        let repo = root.path().join("component");
+        let remote = root.path().join("origin.git");
+        std::fs::create_dir(&repo).expect("component repo");
+        run(&repo, &["git", "init", "-q", "--initial-branch", "main"]);
+        run(&repo, &["git", "config", "user.name", "Homeboy Fixture"]);
+        run(
+            &repo,
+            &["git", "config", "user.email", "fixture@example.com"],
+        );
+
+        std::fs::write(
+            repo.join("fixture.php"),
+            format!(
+                "<?php\n/* Version: {ORIGINAL_VERSION} */\ndefine('FIXTURE_VERSION', '{ORIGINAL_VERSION}');\n"
+            ),
+        )
+        .expect("version targets");
+        std::fs::write(
+            repo.join("CHANGELOG.md"),
+            "# Changelog\n\n## Unreleased\n\n- Preserve generated release mutations\n",
+        )
+        .expect("changelog");
+        std::fs::write(
+            repo.join("homeboy.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "id": "fixture",
+                "extensions": { "fixture-packager": {} },
+                "version_targets": [
+                    {
+                        "file": "fixture.php",
+                        "pattern": "Version:\\s*([0-9.]+)"
+                    },
+                    {
+                        "file": "fixture.php",
+                        "pattern": "FIXTURE_VERSION',\\s*'([0-9.]+)'"
+                    }
+                ],
+                "changelog_target": "CHANGELOG.md"
+            }))
+            .expect("portable component config"),
+        )
+        .expect("homeboy config");
+        run(&repo, &["git", "add", "."]);
+        run(&repo, &["git", "commit", "-qm", "Initial fixture"]);
+
+        run(
+            root.path(),
+            &["git", "init", "-q", "--bare", remote.to_str().unwrap()],
+        );
+        run(
+            &repo,
+            &["git", "remote", "add", "origin", remote.to_str().unwrap()],
+        );
+        run(&repo, &["git", "push", "-q", "-u", "origin", "main"]);
+        run(&remote, &["git", "symbolic-ref", "HEAD", "refs/heads/main"]);
+
+        install_package_extension(context, discard_mutations);
+        let original_head = git(&repo, &["rev-parse", "HEAD"]);
+        Self {
+            _root: root,
+            repo,
+            remote,
+            original_head,
+        }
+    }
+
+    fn release(&self, context: &HermeticTestContext) -> Output {
+        context
+            .command(TestBinary::HomeboyFixture)
+            .args([
+                "release",
+                "fixture",
+                "--path",
+                self.repo.to_str().expect("repo path"),
+                "--bump",
+                "patch",
+                "--skip-checks",
+                "--apply",
+                "--full",
+            ])
+            .output()
+            .expect("run release fixture")
+    }
+}
+
+fn install_package_extension(context: &HermeticTestContext, discard_mutations: bool) {
+    let extension_dir = context.config_dir().join("extensions/fixture-packager");
+    std::fs::create_dir_all(&extension_dir).expect("extension dir");
+    let restore = if discard_mutations {
+        "git restore fixture.php CHANGELOG.md;"
+    } else {
+        ""
+    };
+    let package_command = format!(
+        "rm -rf build; mkdir -p build/stage; cp fixture.php CHANGELOG.md build/stage/; \
+         (cd build/stage && zip -q ../fixture.zip fixture.php CHANGELOG.md); {restore} \
+         printf '[{{\"path\":\"build/fixture.zip\",\"type\":\"archive\"}}]'"
+    );
+    let manifest = serde_json::json!({
+        "name": "Fixture Packager",
+        "version": "1.0.0",
+        "actions": [
+            {
+                "id": "release.package",
+                "label": "Package release",
+                "type": "command",
+                "command": package_command
+            },
+            {
+                "id": "release.publish",
+                "label": "Publish release",
+                "type": "command",
+                "command": "true"
+            }
+        ]
+    });
+    std::fs::write(
+        extension_dir.join("fixture-packager.json"),
+        serde_json::to_vec_pretty(&manifest).expect("extension manifest"),
+    )
+    .expect("write extension manifest");
+}
+
+fn durable_artifact(context: &HermeticTestContext) -> PathBuf {
+    let directory = context.artifact_dir().join("release/fixture/1_2_3");
+    let mut artifacts = std::fs::read_dir(&directory)
+        .unwrap_or_else(|error| {
+            panic!("read durable artifacts at {}: {error}", directory.display())
+        })
+        .map(|entry| entry.expect("artifact entry").path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|value| value.to_str())
+                .is_some_and(|name| name.starts_with("01-") && name.ends_with(".zip"))
+        })
+        .collect::<Vec<_>>();
+    artifacts.sort();
+    assert_eq!(
+        artifacts.len(),
+        1,
+        "durable artifact inventory: {artifacts:?}"
+    );
+    artifacts.remove(0)
+}
+
+fn unzip_file(archive: &Path, file: &str) -> String {
+    let output = Command::new("unzip")
+        .args(["-p", archive.to_str().expect("archive path"), file])
+        .output()
+        .expect("read release archive");
+    assert_success(&output);
+    String::from_utf8(output.stdout).expect("archive text")
+}
+
+fn assert_release_targets(contents: &str) {
+    assert!(
+        contents.contains(&format!("Version: {RELEASE_VERSION}")),
+        "{contents}"
+    );
+    assert!(
+        contents.contains(&format!("FIXTURE_VERSION', '{RELEASE_VERSION}'")),
+        "{contents}"
+    );
+    assert!(!contents.contains(ORIGINAL_VERSION), "{contents}");
+}
+
+fn ref_exists(repo: &Path, reference: &str) -> bool {
+    Command::new("git")
+        .args(["show-ref", "--verify", "--quiet", reference])
+        .current_dir(repo)
+        .status()
+        .expect("inspect git ref")
+        .success()
+}
+
+fn git(repo: &Path, args: &[&str]) -> String {
+    let mut command = vec!["git"];
+    command.extend_from_slice(args);
+    let output = run_output(repo, &command);
+    assert_success(&output);
+    String::from_utf8(output.stdout)
+        .expect("git output")
+        .trim()
+        .to_string()
+}
+
+fn run(repo: &Path, command: &[&str]) {
+    let output = run_output(repo, command);
+    assert_success(&output);
+}
+
+fn run_output(repo: &Path, command: &[&str]) -> Output {
+    Command::new(command[0])
+        .args(&command[1..])
+        .current_dir(repo)
+        .output()
+        .unwrap_or_else(|error| panic!("run {command:?}: {error}"))
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "command failed: {}",
+        output_text(output)
+    );
+}
+
+fn output_text(output: &Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}


### PR DESCRIPTION
## Summary
- snapshot tracked dirty paths by content identity rather than path membership alone
- reject package actions that restore, remove, or rewrite existing version/changelog mutations
- preserve generic per-step side-effect allowlists
- prove successful release package, commit, branch, tag, and durable artifact version identity
- prove destructive package actions roll back with no local or remote tag

Fixes #13466.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p homeboy-release release_package_cannot_rewrite_an_existing_release_mutation -- --nocapture`
- `cargo test --test release_mutation_transaction -- --nocapture`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode traced the failed Intelligence release transaction, implemented the content-aware side-effect guard, added process-level release/rollback fixtures, and ran focused verification. Chris Huber directed the work and remains responsible.