### PR TITLE
Isolate timeout harvest from linked Git indexes

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -1886,7 +1886,7 @@ fn recoverable_patch_proof(
     if homeboy_engine_primitives::content_hash::sha256_hex(&patch) != expected_sha256 {
         return Err("patch artifact content hash does not match its finalized record".to_string());
     }
-    if !crate::controller_scratch::workspace_matches_staged_patch(
+    if !crate::controller_scratch::workspace_matches_patch(
         workspace.root(),
         workspace.base_sha(),
         &patch,

--- a/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
@@ -50,7 +50,7 @@ pub(super) fn harvest_uncommitted_patch(
     let mut add_args = vec!["add", "--all", "--", "."];
     add_args.extend_from_slice(RUNNER_METADATA_EXCLUDE_PATHSPECS);
     git_output_with_env(root, &add_args, index_env)?;
-    let mut uncommitted_patch_args = vec![
+    let mut uncommitted_check_args = vec![
         "diff",
         "--cached",
         "--binary",
@@ -60,12 +60,30 @@ pub(super) fn harvest_uncommitted_patch(
         "--",
         ".",
     ];
-    uncommitted_patch_args.extend_from_slice(RUNNER_METADATA_EXCLUDE_PATHSPECS);
-    let patch = git_output_raw_with_env(root, &uncommitted_patch_args, index_env)?;
-    if patch.trim().is_empty() {
+    uncommitted_check_args.extend_from_slice(RUNNER_METADATA_EXCLUDE_PATHSPECS);
+    if git_output_raw_with_env(root, &uncommitted_check_args, index_env)?
+        .trim()
+        .is_empty()
+    {
         return Ok(());
     }
-    let mut uncommitted_changed_args = vec!["diff", "--cached", "--name-only", "HEAD", "--", "."];
+    // If the provider committed before its final edits, preserve one complete
+    // candidate against the immutable task base. Otherwise this artifact would
+    // omit the commits while still claiming `base` as its application base, and
+    // committed harvest would skip it because a patch already exists.
+    let mut candidate_patch_args = vec![
+        "diff",
+        "--cached",
+        "--binary",
+        "--full-index",
+        "--find-renames",
+        base,
+        "--",
+        ".",
+    ];
+    candidate_patch_args.extend_from_slice(RUNNER_METADATA_EXCLUDE_PATHSPECS);
+    let patch = git_output_raw_with_env(root, &candidate_patch_args, index_env)?;
+    let mut uncommitted_changed_args = vec!["diff", "--cached", "--name-only", base, "--", "."];
     uncommitted_changed_args.extend_from_slice(RUNNER_METADATA_EXCLUDE_PATHSPECS);
     let changed_files = git_changed_files_with_env(root, &uncommitted_changed_args, index_env)?;
     let path = attempt_patch_path(running, "uncommitted")?;
@@ -987,7 +1005,7 @@ mod committed_harvest_tests {
     }
 
     #[test]
-    fn uncommitted_harvest_ignores_the_linked_worktree_index_lock() {
+    fn uncommitted_harvest_ignores_the_linked_index_lock_and_preserves_commits() {
         let temp = tempfile::tempdir().expect("tempdir");
         let source = temp.path().join("source");
         let workspace = temp.path().join("workspace");
@@ -1018,8 +1036,13 @@ mod committed_harvest_tests {
         );
         let base = git(&workspace, &["rev-parse", "HEAD"]);
 
-        // The provider edits one file; the runner rewrites its metadata (drift).
+        // The provider commits one edit, then makes another uncommitted edit;
+        // the runner also rewrites its metadata (drift).
         std::fs::write(workspace.join("file.txt"), "provider change\n").expect("provider edit");
+        git(&workspace, &["add", "file.txt"]);
+        git(&workspace, &["commit", "-m", "provider commit"]);
+        std::fs::write(workspace.join("late.txt"), "late provider change\n")
+            .expect("late provider edit");
         std::fs::write(
             workspace.join(".homeboy/runner-workspace.json"),
             "{\"stage\":\"final\"}\n",
@@ -1114,11 +1137,25 @@ mod committed_harvest_tests {
         let patch = std::fs::read_to_string(&patch_path).expect("read patch");
         assert!(
             patch.contains("file.txt") && patch.contains("+provider change"),
-            "the provider edit must be captured: {patch}"
+            "the provider commit must be captured: {patch}"
+        );
+        assert!(
+            patch.contains("late.txt") && patch.contains("+late provider change"),
+            "the provider's uncommitted edit must be captured: {patch}"
         );
         assert!(
             !patch.contains("runner-workspace.json"),
             "Homeboy runner metadata drift must be excluded from the candidate patch: {patch}"
+        );
+        git(&source, &["apply", "--check", &patch_path]);
+        git(&source, &["apply", &patch_path]);
+        assert_eq!(
+            std::fs::read_to_string(source.join("file.txt")).expect("applied committed edit"),
+            "provider change\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(source.join("late.txt")).expect("applied uncommitted edit"),
+            "late provider change\n"
         );
     }
 

--- a/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
@@ -35,21 +35,21 @@ pub(super) fn harvest_uncommitted_patch(
     if outcome.artifacts.iter().any(is_actionable_patch_artifact) {
         return Ok(());
     }
-    // This checkout belongs solely to this dispatch. Staging all changes makes
-    // Git's binary patch generation include tracked, staged, and untracked files.
-    // Homeboy-owned runner metadata is excluded from the diff so it never lands
-    // in a candidate patch as checkout drift. (#8534)
-    git_output(
-        root,
-        &[
-            "add",
-            "--all",
-            "--",
-            ".",
-            RUNNER_METADATA_EXCLUDE_PATHSPECS[0],
-            RUNNER_METADATA_EXCLUDE_PATHSPECS[1],
-        ],
-    )?;
+    // Reconstruct the working-tree candidate without writing the attempt's live
+    // index. Timeout recovery can overlap a provider's final Git operation, and
+    // a linked worktree keeps that index lock in the source repository's
+    // administrative directory (#13448).
+    let index = tempfile::NamedTempFile::new().map_err(|error| HarvestError::Git {
+        command: "create attempt harvest Git index".to_string(),
+        cwd: root.to_path_buf(),
+        message: error.to_string(),
+    })?;
+    let index_path = index.path().display().to_string();
+    let index_env: &[(&str, &str)] = &[("GIT_INDEX_FILE", index_path.as_str())];
+    git_output_with_env(root, &["read-tree", "HEAD"], index_env)?;
+    let mut add_args = vec!["add", "--all", "--", "."];
+    add_args.extend_from_slice(RUNNER_METADATA_EXCLUDE_PATHSPECS);
+    git_output_with_env(root, &add_args, index_env)?;
     let mut uncommitted_patch_args = vec![
         "diff",
         "--cached",
@@ -61,13 +61,13 @@ pub(super) fn harvest_uncommitted_patch(
         ".",
     ];
     uncommitted_patch_args.extend_from_slice(RUNNER_METADATA_EXCLUDE_PATHSPECS);
-    let patch = git_output_raw(root, &uncommitted_patch_args)?;
+    let patch = git_output_raw_with_env(root, &uncommitted_patch_args, index_env)?;
     if patch.trim().is_empty() {
         return Ok(());
     }
     let mut uncommitted_changed_args = vec!["diff", "--cached", "--name-only", "HEAD", "--", "."];
     uncommitted_changed_args.extend_from_slice(RUNNER_METADATA_EXCLUDE_PATHSPECS);
-    let changed_files = git_changed_files(root, &uncommitted_changed_args)?;
+    let changed_files = git_changed_files_with_env(root, &uncommitted_changed_args, index_env)?;
     let path = attempt_patch_path(running, "uncommitted")?;
     std::fs::write(&path, patch.as_bytes()).map_err(|error| HarvestError::ArtifactWrite {
         path: path.clone(),
@@ -334,7 +334,15 @@ fn committed_change_metadata_for_range(
 }
 
 fn git_changed_files(cwd: &Path, args: &[&str]) -> Result<Vec<String>, HarvestError> {
-    Ok(git_output(cwd, args)?
+    git_changed_files_with_env(cwd, args, &[])
+}
+
+fn git_changed_files_with_env(
+    cwd: &Path,
+    args: &[&str],
+    env: &[(&str, &str)],
+) -> Result<Vec<String>, HarvestError> {
+    Ok(git_output_with_env(cwd, args, env)?
         .lines()
         .filter(|path| !path.is_empty())
         .map(ToOwned::to_owned)
@@ -979,24 +987,35 @@ mod committed_harvest_tests {
     }
 
     #[test]
-    fn uncommitted_harvest_excludes_homeboy_runner_metadata_drift() {
+    fn uncommitted_harvest_ignores_the_linked_worktree_index_lock() {
         let temp = tempfile::tempdir().expect("tempdir");
+        let source = temp.path().join("source");
         let workspace = temp.path().join("workspace");
-        std::fs::create_dir(&workspace).expect("workspace");
-        git(&workspace, &["init", "-b", "main"]);
-        git(&workspace, &["config", "user.email", "test@example.com"]);
-        git(&workspace, &["config", "user.name", "Homeboy Test"]);
-        std::fs::write(workspace.join("file.txt"), "base\n").expect("base file");
+        std::fs::create_dir(&source).expect("source");
+        git(&source, &["init", "-b", "main"]);
+        git(&source, &["config", "user.email", "test@example.com"]);
+        git(&source, &["config", "user.name", "Homeboy Test"]);
+        std::fs::write(source.join("file.txt"), "base\n").expect("base file");
         // The runner metadata exists at the baseline; the runner rewrites it after
         // materialization, which is checkout drift, not provider output. (#8534)
-        std::fs::create_dir_all(workspace.join(".homeboy")).expect(".homeboy dir");
+        std::fs::create_dir_all(source.join(".homeboy")).expect(".homeboy dir");
         std::fs::write(
-            workspace.join(".homeboy/runner-workspace.json"),
+            source.join(".homeboy/runner-workspace.json"),
             "{\"stage\":\"baseline\"}\n",
         )
         .expect("runner metadata baseline");
-        git(&workspace, &["add", "-A"]);
-        git(&workspace, &["commit", "-m", "base"]);
+        git(&source, &["add", "-A"]);
+        git(&source, &["commit", "-m", "base"]);
+        git(
+            &source,
+            &[
+                "worktree",
+                "add",
+                "--detach",
+                workspace.to_str().expect("UTF-8 worktree path"),
+                "HEAD",
+            ],
+        );
         let base = git(&workspace, &["rev-parse", "HEAD"]);
 
         // The provider edits one file; the runner rewrites its metadata (drift).
@@ -1006,6 +1025,9 @@ mod committed_harvest_tests {
             "{\"stage\":\"final\"}\n",
         )
         .expect("runner metadata drift");
+        let index_lock =
+            PathBuf::from(git(&workspace, &["rev-parse", "--absolute-git-dir"])).join("index.lock");
+        std::fs::write(&index_lock, b"held by provider").expect("hold linked-worktree index lock");
 
         let request = AgentTaskRequest {
             schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
@@ -1074,6 +1096,16 @@ mod committed_harvest_tests {
         let mut outcome = committed_harvest_preflight_outcome("task-1".to_string());
         outcome.status = AgentTaskOutcomeStatus::Succeeded;
         harvest_uncommitted_patch(&mut outcome, &running).expect("harvest uncommitted patch");
+
+        assert!(
+            index_lock.exists(),
+            "harvest must not remove another owner's lock"
+        );
+        assert_eq!(
+            git(&workspace, &["diff", "--cached", "--name-only"]),
+            "",
+            "harvest must not stage candidate bytes in the linked-worktree index"
+        );
 
         let patch_path = outcome.artifacts[0]
             .path

--- a/crates/homeboy-agents/src/controller_scratch.rs
+++ b/crates/homeboy-agents/src/controller_scratch.rs
@@ -1702,7 +1702,7 @@ fn promoted_attempt_workspace_matches(
     if sha256(&patch) != artifact_sha256 {
         return false;
     }
-    workspace_matches_staged_patch(workspace, base, &patch)
+    workspace_matches_patch(workspace, base, &patch)
 }
 
 /// A scheduler may stop after persisting authorization but before it can call
@@ -1786,20 +1786,34 @@ fn terminal_evidence_attempt_workspace_matches(
     let Ok(patch) = fs::read(path) else {
         return false;
     };
-    sha256(&patch) == expected_sha256 && workspace_matches_staged_patch(workspace, base, &patch)
+    sha256(&patch) == expected_sha256 && workspace_matches_patch(workspace, base, &patch)
 }
 
-/// Verify that a checkout contains only the supplied staged patch against its
-/// immutable base. Scheduler compaction reuses this promotion proof rather
-/// than treating a persisted patch as sufficient evidence on its own.
-pub(crate) fn workspace_matches_staged_patch(workspace: &Path, base: &str, patch: &[u8]) -> bool {
+/// Verify that a checkout contains only the supplied patch against its immutable
+/// base. Scheduler compaction reuses this promotion proof rather than treating a
+/// persisted patch as sufficient evidence on its own.
+pub(crate) fn workspace_matches_patch(workspace: &Path, base: &str, patch: &[u8]) -> bool {
     let Ok(head) = git::run_git(workspace, &["rev-parse", "HEAD"], "git rev-parse HEAD") else {
         return false;
     };
     if head.trim() != base {
         return false;
     }
-    let Ok(status) = git::run_git(
+    let Ok(git_dir) = git::run_git(
+        workspace,
+        &["rev-parse", "--absolute-git-dir"],
+        "git rev-parse absolute git dir",
+    ) else {
+        return false;
+    };
+    // The path is per-worktree for linked checkouts. Never unregister a
+    // checkout while another process may own its exact index lock; a later
+    // controller-scratch pass can converge after the lock clears (#13448).
+    if Path::new(git_dir.trim()).join("index.lock").exists() {
+        return false;
+    }
+    let readonly_env = &[("GIT_OPTIONAL_LOCKS".to_string(), "0".to_string())];
+    let Ok(status) = git::run_git_with_env(
         workspace,
         &[
             "status",
@@ -1811,17 +1825,47 @@ pub(crate) fn workspace_matches_staged_patch(workspace: &Path, base: &str, patch
             ":(exclude).homeboy/lab-at-files/**",
         ],
         "git status",
+        readonly_env,
     ) else {
         return false;
     };
-    // Harvest stages the complete candidate. Any worktree-side, untracked, or
-    // ignored path is therefore outside the authenticated patch.
-    if status.lines().any(|line| {
-        line.starts_with("??") || line.starts_with("!!") || line.as_bytes().get(1) != Some(&b' ')
-    }) {
+    // Ignored provider output is outside a Git patch and therefore outside the
+    // authenticated candidate. Tracked and untracked bytes are compared below.
+    if status.lines().any(|line| line.starts_with("!!")) {
         return false;
     }
-    git::run_git(
+    let Ok(index) = tempfile::NamedTempFile::new() else {
+        return false;
+    };
+    let index_env = &[(
+        "GIT_INDEX_FILE".to_string(),
+        index.path().display().to_string(),
+    )];
+    if git::run_git_with_env(
+        workspace,
+        &["read-tree", base],
+        "git read-tree scratch index",
+        index_env,
+    )
+    .is_err()
+        || git::run_git_with_env(
+            workspace,
+            &[
+                "add",
+                "--all",
+                "--",
+                ".",
+                ":(exclude).homeboy/runner-workspace.json",
+                ":(exclude).homeboy/lab-at-files/**",
+            ],
+            "git add scratch index",
+            index_env,
+        )
+        .is_err()
+    {
+        return false;
+    }
+    git::run_git_with_env(
         workspace,
         &[
             "diff",
@@ -1835,7 +1879,8 @@ pub(crate) fn workspace_matches_staged_patch(workspace: &Path, base: &str, patch
             ":(exclude).homeboy/runner-workspace.json",
             ":(exclude).homeboy/lab-at-files/**",
         ],
-        "git diff cached",
+        "git diff scratch index",
+        index_env,
     )
     .is_ok_and(|current| current.as_bytes() == patch)
 }
@@ -3782,7 +3827,7 @@ mod tests {
     }
 
     #[test]
-    fn staged_patch_proof_rejects_extra_files_and_commits() {
+    fn patch_proof_waits_for_the_linked_index_lock_and_rejects_extra_state() {
         let root = tempfile::tempdir().expect("root");
         let lease = root.path().join("lease");
         let (_source, worktree) = attempt_worktree(root.path(), &lease);
@@ -3812,23 +3857,41 @@ mod tests {
         )
         .expect("candidate patch")
         .into_bytes();
+        run_git(&worktree, &["reset", "--quiet"]);
+
+        let index_lock = PathBuf::from(
+            git::run_git(
+                &worktree,
+                &["rev-parse", "--absolute-git-dir"],
+                "git rev-parse absolute git dir",
+            )
+            .expect("linked worktree git dir")
+            .trim(),
+        )
+        .join("index.lock");
+        fs::write(&index_lock, b"held by provider").expect("hold linked-worktree index lock");
+        assert!(
+            !workspace_matches_patch(&worktree, &base, &patch),
+            "an owned index lock must retain the linked worktree"
+        );
+        fs::remove_file(&index_lock).expect("release linked-worktree index lock");
 
         assert!(
-            workspace_matches_staged_patch(&worktree, &base, &patch),
-            "the harvested staged candidate must match exactly"
+            workspace_matches_patch(&worktree, &base, &patch),
+            "the unstaged candidate must converge after its exact lock clears"
         );
 
         fs::create_dir_all(worktree.join(".homeboy/lab-at-files")).expect("runner metadata");
         fs::write(worktree.join(".homeboy/runner-workspace.json"), "{}").expect("runner metadata");
         fs::write(worktree.join(".homeboy/lab-at-files/plan.json"), "{}").expect("runner metadata");
         assert!(
-            workspace_matches_staged_patch(&worktree, &base, &patch),
+            workspace_matches_patch(&worktree, &base, &patch),
             "Homeboy runner metadata excluded from harvest must not block compaction"
         );
 
         fs::write(worktree.join("untracked.txt"), "not in the patch\n").expect("extra file");
         assert!(
-            !workspace_matches_staged_patch(&worktree, &base, &patch),
+            !workspace_matches_patch(&worktree, &base, &patch),
             "an untracked file is unrelated state and must retain the worktree"
         );
         fs::remove_file(worktree.join("untracked.txt")).expect("remove extra file");
@@ -3836,14 +3899,15 @@ mod tests {
         fs::create_dir_all(worktree.join("vendor/package")).expect("vendor tree");
         fs::write(worktree.join("vendor/package/index.js"), "generated\n").expect("vendor file");
         assert!(
-            !workspace_matches_staged_patch(&worktree, &base, &patch),
+            !workspace_matches_patch(&worktree, &base, &patch),
             "an untracked dependency tree is outside the authenticated patch"
         );
         fs::remove_dir_all(worktree.join("vendor")).expect("remove vendor tree");
 
+        run_git(&worktree, &["add", "generated.rs"]);
         run_git(&worktree, &["commit", "-m", "provider commit"]);
         assert!(
-            !workspace_matches_staged_patch(&worktree, &base, &patch),
+            !workspace_matches_patch(&worktree, &base, &patch),
             "a provider commit must remain recoverable even when its diff matches"
         );
     }


### PR DESCRIPTION
## Summary

- isolate timeout harvest and compaction checks from a linked worktree's live Git index
- seed temporary indexes from `HEAD` while preserving fail-closed cleanup and lock safety
- retain the complete timeout candidate rather than only uncommitted working-tree state
- cover linked `index.lock`, deferred cleanup, committed plus uncommitted candidate state, and compaction convergence

Closes #13448.

## Verification

- focused timeout harvest, lock, deferred-cleanup, and compaction tests passed
- post-rebase linked-index-lock harvest regression passed
- `cargo fmt --all -- --check` passed
- `git diff --check` passed

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode general coding subagents traced the timeout cleanup collision, implemented temporary-index harvesting, audited complete candidate preservation, added deterministic coverage, and ran focused verification. Chris Huber directed the work and remains responsible.
