### PR TITLE
Lead blocked fanout output with causal evidence

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -100,6 +100,7 @@ const DRY_RUN_PHASE_TIMEOUT: Duration = Duration::from_secs(10);
 const DRY_RUN_MAX_ISSUES: usize = 128;
 const DRY_RUN_MAX_INLINE_JSON_BYTES: usize = 64 * 1024;
 const DRY_RUN_MAX_GATE_BYTES: usize = 8 * 1024;
+const COMPACT_FANOUT_FAILURE_LIMIT: usize = 3;
 
 #[cfg(test)]
 thread_local! {
@@ -2127,6 +2128,7 @@ fn cook_batch_inner(
     let resume_legal = run_result
         .as_ref()
         .is_some_and(|result| batch_resume_is_legal(&result["result"]));
+    let (primary_failure, causal_failures) = blocked_worktree_failure_projection(&worktrees);
 
     Ok((
         serde_json::json!({
@@ -2136,9 +2138,12 @@ fn cook_batch_inner(
                 "dry_run": args.dry_run,
                 "summary": {
                     "issues": plan.cooks.len(),
-                    "worktrees_total": worktrees.rows.len(),
-                    "worktrees_blocked": blocked,
-                },
+                     "worktrees_total": worktrees.rows.len(),
+                     "worktrees_blocked": blocked,
+                     "causal_worktree_failures": causal_failures["total"],
+                 },
+                "primary_failure": primary_failure,
+                "causal_failures": causal_failures,
                 "preflight": {
                     "provider_readiness_command": provider_readiness_command(&args),
                     "provider_selection": provider_selection_preflight(&args, args.dry_run),
@@ -2165,6 +2170,61 @@ fn cook_batch_inner(
             }),
         exit_code,
     ))
+}
+
+fn blocked_worktree_failure_projection(
+    worktrees: &worktree::WorktreeQueueCreateOutput,
+) -> (Option<Value>, Value) {
+    let causal_rows = worktrees
+        .rows
+        .iter()
+        .enumerate()
+        .filter(|(_, row)| {
+            matches!(
+                row.status,
+                worktree::WorktreeQueueCreateStatus::Failed
+                    | worktree::WorktreeQueueCreateStatus::ActiveLockHolder
+            )
+        })
+        .collect::<Vec<_>>();
+    let total = causal_rows.len();
+    let mut failures = causal_rows
+        .into_iter()
+        .take(COMPACT_FANOUT_FAILURE_LIMIT)
+        .map(|(index, row)| {
+            let fallback_classification = match row.status {
+                worktree::WorktreeQueueCreateStatus::ActiveLockHolder => "active_lock_holder",
+                _ => "worktree_creation_failed",
+            };
+            let reason = row
+                .failure
+                .as_ref()
+                .map(|failure| failure.message.as_str())
+                .or(row.error.as_deref())
+                .unwrap_or(fallback_classification);
+            serde_json::json!({
+                "phase": "worktree_preflight",
+                "cause_phase": row.failure.as_ref().map(|failure| failure.phase.as_str()),
+                "row": index,
+                "handle": row.handle,
+                "provider_id": row.failure.as_ref().and_then(|failure| failure.provider_id.as_deref()),
+                "classification": row.failure.as_ref().map(|failure| failure.classification.as_str()).unwrap_or(fallback_classification),
+                "reason": reason,
+                "next_action": quote_args(&row.command),
+                "evidence_path": format!("worktrees.rows[{index}]"),
+            })
+        })
+        .collect::<Vec<_>>();
+    let returned = failures.len();
+    let primary = (!failures.is_empty()).then(|| failures.remove(0));
+    let summary = serde_json::json!({
+        "total": total,
+        "returned": returned,
+        "omitted": total.saturating_sub(returned),
+        "additional_failures": failures,
+        "complete_evidence_path": "worktrees.rows",
+    });
+    (primary, summary)
 }
 
 /// Static dry-run deliberately stops before any repository, provider, workspace,
@@ -2787,6 +2847,7 @@ fn queue_or_reuse_worktrees(
                 active_lock_holder: None,
                 path: Some(workspace.path.clone()),
                 error: None,
+                failure: None,
             });
             continue;
         }
@@ -2803,6 +2864,7 @@ fn queue_or_reuse_worktrees(
                     active_lock_holder: None,
                     path: Some(path),
                     error: None,
+                    failure: None,
                 });
             }
             _ => to_create.push(cook),
@@ -2860,6 +2922,7 @@ fn static_worktrees_dry_run(
                 active_lock_holder: None,
                 path: None,
                 error: None,
+                failure: None,
             })
             .collect(),
     }
@@ -6941,6 +7004,7 @@ fi
                         active_lock_holder: None,
                         path: Some(workspace.path().display().to_string()),
                         error: None,
+                        failure: None,
                     }],
                 },
             );
@@ -7272,6 +7336,7 @@ fi
                 active_lock_holder: None,
                 path: Some(root.display().to_string()),
                 error: None,
+                failure: None,
             })
             .collect();
         bind_materialized_worktrees(
@@ -7325,6 +7390,7 @@ fi
                 active_lock_holder: None,
                 path: Some(materialized_root.display().to_string()),
                 error: None,
+                failure: None,
             })
             .collect();
         bind_materialized_worktrees(
@@ -8121,6 +8187,7 @@ fi
             active_lock_holder: None,
             path: None,
             error: None,
+            failure: None,
         }
     }
 
@@ -8209,6 +8276,56 @@ fi
         assert!(commands
             .iter()
             .any(|command| command == "homeboy agent-task fanout artifacts issue-wave"));
+    }
+
+    #[test]
+    fn blocked_worktree_projection_orders_distinct_causes_and_bounds_rows() {
+        let mut rows = (0..4)
+            .map(|index| {
+                worktree_row(
+                    &format!("homeboy@fix-{index}"),
+                    worktree::WorktreeQueueCreateStatus::Failed,
+                )
+            })
+            .collect::<Vec<_>>();
+        for (index, row) in rows.iter_mut().enumerate() {
+            row.error = Some(format!("cause {index}"));
+            row.failure = Some(worktree::WorktreeQueueCreateFailure {
+                code: "validation.invalid_argument".to_string(),
+                classification: format!("cause_{index}"),
+                phase: if index % 2 == 0 {
+                    "worktree_provider_ensure"
+                } else {
+                    "worktree_provider_resolve"
+                }
+                .to_string(),
+                message: format!("cause {index}"),
+                provider_id: Some(format!("provider-{index}")),
+                details: serde_json::json!({"complete": index}),
+            });
+        }
+
+        let (primary, projection) = blocked_worktree_failure_projection(&worktree_output(rows));
+        let primary = primary.expect("primary failure");
+
+        assert_eq!(projection["total"], 4);
+        assert_eq!(projection["returned"], COMPACT_FANOUT_FAILURE_LIMIT);
+        assert_eq!(projection["omitted"], 1);
+        assert_eq!(projection["complete_evidence_path"], "worktrees.rows");
+        assert_eq!(primary["row"], 0);
+        assert_eq!(primary["provider_id"], "provider-0");
+        assert_eq!(
+            projection["additional_failures"][0]["classification"],
+            "cause_1"
+        );
+        assert_eq!(
+            projection["additional_failures"][0]["cause_phase"],
+            "worktree_provider_resolve"
+        );
+        assert_eq!(
+            primary["next_action"],
+            "homeboy worktree create homeboy --branch fix/homeboy@fix-0 --from origin/main"
+        );
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
@@ -3,7 +3,9 @@ use serde_json::{json, Value};
 use super::agent_task::candidate::{
     changed_files_for_artifact, classify_candidates, CandidateState,
 };
-use super::agent_task::{AgentTaskArgs, AgentTaskCommand, AgentTaskControllerCommand};
+use super::agent_task::{
+    AgentTaskArgs, AgentTaskCommand, AgentTaskControllerCommand, AgentTaskFanoutCommand,
+};
 use super::summary_json::{array_len, string_value, u64_value, usize_value, value_at};
 
 mod controller;
@@ -16,6 +18,7 @@ pub(crate) enum AgentTaskSummaryKind {
     Review,
     Controller,
     Providers,
+    FanoutCookBatch,
 }
 
 pub(crate) fn agent_task_summary_kind(args: &AgentTaskArgs) -> Option<AgentTaskSummaryKind> {
@@ -25,6 +28,11 @@ pub(crate) fn agent_task_summary_kind(args: &AgentTaskArgs) -> Option<AgentTaskS
         AgentTaskCommand::Logs(_) => Some(AgentTaskSummaryKind::Logs),
         AgentTaskCommand::Review(_) => Some(AgentTaskSummaryKind::Review),
         AgentTaskCommand::Providers(_) => Some(AgentTaskSummaryKind::Providers),
+        AgentTaskCommand::Fanout(args)
+            if matches!(&args.command, AgentTaskFanoutCommand::CookBatch(_)) =>
+        {
+            Some(AgentTaskSummaryKind::FanoutCookBatch)
+        }
         AgentTaskCommand::Controller(controller_args) => match &controller_args.command {
             AgentTaskControllerCommand::Status(_)
             | AgentTaskControllerCommand::Diagnose(_)
@@ -51,7 +59,65 @@ pub(crate) fn render_agent_task_summary(
         AgentTaskSummaryKind::Review => render_review_summary(payload),
         AgentTaskSummaryKind::Controller => controller::render_controller_summary(payload),
         AgentTaskSummaryKind::Providers => render_providers_summary(payload),
+        AgentTaskSummaryKind::FanoutCookBatch => render_fanout_cook_batch_summary(payload),
     }
+}
+
+fn render_fanout_cook_batch_summary(payload: &Value) -> Option<String> {
+    if payload.get("schema")?.as_str()? != "homeboy/agent-task-cook-batch/v1"
+        || payload.get("status")?.as_str()? != "blocked"
+    {
+        return None;
+    }
+    let fanout_id = payload.get("fanout_id")?.as_str()?;
+    let primary = payload.get("primary_failure")?.as_object()?;
+    let phase = primary.get("phase")?.as_str()?;
+    let reason = primary.get("reason")?.as_str()?.lines().next()?.trim();
+    let next_action = primary.get("next_action")?.as_str()?;
+    let failures = payload.get("causal_failures")?;
+    let total = failures.get("total")?.as_u64()?;
+    let provider = primary
+        .get("provider_id")
+        .and_then(Value::as_str)
+        .map(|id| format!(" provider={id}"))
+        .unwrap_or_default();
+    let mut lines = vec![format!(
+        "Fanout {fanout_id}: blocked phase={phase} causal_rows={total}{provider} reason={reason}; next={next_action}"
+    )];
+    if let Some(additional) = failures
+        .get("additional_failures")
+        .and_then(Value::as_array)
+    {
+        for failure in additional {
+            let row = failure.get("row").and_then(Value::as_u64)?;
+            let handle = failure.get("handle").and_then(Value::as_str)?;
+            let classification = failure.get("classification").and_then(Value::as_str)?;
+            let reason = failure
+                .get("reason")
+                .and_then(Value::as_str)?
+                .lines()
+                .next()?
+                .trim();
+            lines.push(format!(
+                "Additional cause: row={row} handle={handle} classification={classification} reason={reason}"
+            ));
+        }
+    }
+    let returned = failures
+        .get("returned")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let evidence_path = failures
+        .get("complete_evidence_path")
+        .and_then(Value::as_str)
+        .unwrap_or("worktrees.rows");
+    lines.push(format!(
+        "Evidence: {evidence_path} (showing {returned} of {total} causal rows)"
+    ));
+    if let Some(sha256) = payload.pointer("/plan_ref/sha256").and_then(Value::as_str) {
+        lines.push(format!("Plan: plan_ref.sha256={sha256}"));
+    }
+    Some(lines.join("\n"))
 }
 
 fn render_providers_summary(payload: &Value) -> Option<String> {
@@ -2150,6 +2216,61 @@ mod tests {
         );
         assert!(summary.contains("Last failure: action-2: executor returned exit code 1\n"));
         assert!(summary.contains("Next: homeboy agent-task controller resume loop-456\n"));
+    }
+
+    #[test]
+    fn blocked_fanout_summary_leads_with_distinct_causes_without_repeating_shared_plan() {
+        let payload = json!({
+            "schema": "homeboy/agent-task-cook-batch/v1",
+            "fanout_id": "issue-wave",
+            "status": "blocked",
+            "summary": {"causal_worktree_failures": 2},
+            "primary_failure": {
+                "phase": "worktree_preflight",
+                "row": 0,
+                "handle": "repo@fix-a",
+                "provider_id": "workspace-owner",
+                "classification": "command",
+                "reason": "Component not found: repo\nprovider detail",
+                "next_action": "workspace-owner worktree add repo fix/a",
+                "evidence_path": "worktrees.rows[0]"
+            },
+            "causal_failures": {
+                "total": 2,
+                "returned": 2,
+                "omitted": 0,
+                "complete_evidence_path": "worktrees.rows",
+                "additional_failures": [{
+                    "phase": "worktree_preflight",
+                    "row": 1,
+                    "handle": "repo@fix-b",
+                    "provider_id": "workspace-owner",
+                    "classification": "timeout",
+                    "reason": "provider deadline exceeded",
+                    "next_action": "workspace-owner worktree add repo fix/b"
+                }]
+            },
+            "plan_ref": {"fanout_id": "issue-wave", "sha256": "sha256:shared-plan"},
+            "plan": {"shared_marker": "FULL_SHARED_PLAN_MUST_NOT_RENDER"},
+            "worktrees": {"rows": [{"command": ["FULL_ROW_COMMAND_A"]}, {"command": ["FULL_ROW_COMMAND_B"]}]},
+            "commands": {"run": "FULL_BATCH_COMMAND_MUST_NOT_RENDER"}
+        });
+        let lossless = payload.clone();
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::FanoutCookBatch, &payload)
+            .expect("blocked fanout summary");
+
+        assert!(summary.starts_with("Fanout issue-wave: blocked phase=worktree_preflight causal_rows=2 provider=workspace-owner reason=Component not found: repo; next=workspace-owner worktree add repo fix/a"), "{summary}");
+        assert!(summary.contains("Additional cause: row=1 handle=repo@fix-b classification=timeout reason=provider deadline exceeded"), "{summary}");
+        assert!(summary.contains("Evidence: worktrees.rows (showing 2 of 2 causal rows)"));
+        assert!(summary.contains("Plan: plan_ref.sha256=sha256:shared-plan"));
+        assert!(!summary.contains("FULL_SHARED_PLAN_MUST_NOT_RENDER"));
+        assert!(!summary.contains("FULL_ROW_COMMAND"));
+        assert!(!summary.contains("FULL_BATCH_COMMAND_MUST_NOT_RENDER"));
+        assert_eq!(
+            payload, lossless,
+            "rendering must not compact structured evidence"
+        );
     }
 
     #[test]

--- a/crates/homeboy-core/src/worktree/mod.rs
+++ b/crates/homeboy-core/src/worktree/mod.rs
@@ -8,6 +8,7 @@ use crate::ownership;
 use crate::{git, paths};
 use fs4::fs_std::FileExt;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 mod queue_ops;
 mod store_ops;
@@ -29,12 +30,12 @@ pub use types::{
     WorktreeCreateReconciliation, WorktreeInventoryApplyRefusal, WorktreeInventoryAuthorization,
     WorktreeInventoryCrossTab, WorktreeInventoryLocalEvidence, WorktreeInventoryOptions,
     WorktreeInventoryOutput, WorktreeInventoryRecord, WorktreeListOutput,
-    WorktreeLivenessAuthority, WorktreeQueueCreateOptions, WorktreeQueueCreateOutput,
-    WorktreeQueueCreateRequest, WorktreeQueueCreateRow, WorktreeQueueCreateStatus,
-    WorktreeQueueLockHolder, WorktreeReconciliationAction, WorktreeReconciliationAuthority,
-    WorktreeReconciliationResult, WorktreeRemoveOptions, WorktreeRemoveOutput,
-    WorktreeSafetyReport, WorktreeStatusOutput, TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY,
-    TERMINAL_WORKSPACE_AUTHORITY_SCHEMA,
+    WorktreeLivenessAuthority, WorktreeQueueCreateFailure, WorktreeQueueCreateOptions,
+    WorktreeQueueCreateOutput, WorktreeQueueCreateRequest, WorktreeQueueCreateRow,
+    WorktreeQueueCreateStatus, WorktreeQueueLockHolder, WorktreeReconciliationAction,
+    WorktreeReconciliationAuthority, WorktreeReconciliationResult, WorktreeRemoveOptions,
+    WorktreeRemoveOutput, WorktreeSafetyReport, WorktreeStatusOutput,
+    TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY, TERMINAL_WORKSPACE_AUTHORITY_SCHEMA,
 };
 
 /// The managed handle a repo and branch pair resolves to. Creation slugifies the
@@ -511,6 +512,7 @@ pub fn queue_create(options: WorktreeQueueCreateOptions) -> Result<WorktreeQueue
                         command,
                         WorktreeQueueCreateStatus::Failed,
                     );
+                    row.failure = Some(queue_failure(&error));
                     row.error = Some(error.message);
                     rows.push(row);
                 }
@@ -562,6 +564,7 @@ pub fn queue_create(options: WorktreeQueueCreateOptions) -> Result<WorktreeQueue
                     command,
                     WorktreeQueueCreateStatus::Failed,
                 );
+                row.failure = Some(queue_failure(&error));
                 row.error = Some(error.message);
                 rows.push(row);
                 for queued_request in options.requests.iter().take(total).skip(index + 1) {
@@ -584,6 +587,34 @@ pub fn queue_create(options: WorktreeQueueCreateOptions) -> Result<WorktreeQueue
         dry_run: options.dry_run,
         rows,
     })
+}
+
+fn queue_failure(error: &Error) -> WorktreeQueueCreateFailure {
+    let provider_id = error
+        .details
+        .get("worktree_provider_id")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let classification = error
+        .details
+        .get("worktree_provider_call_classification")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| error.code.as_str())
+        .to_string();
+    let phase = error
+        .details
+        .get("worktree_provider_phase")
+        .and_then(Value::as_str)
+        .unwrap_or("worktree_preflight")
+        .to_string();
+    WorktreeQueueCreateFailure {
+        code: error.code.as_str().to_string(),
+        classification,
+        phase,
+        message: error.message.clone(),
+        provider_id,
+        details: error.details.clone(),
+    }
 }
 
 /// Validate a prospective native worktree creation and return the exact path

--- a/crates/homeboy-core/src/worktree/queue_ops.rs
+++ b/crates/homeboy-core/src/worktree/queue_ops.rs
@@ -75,6 +75,7 @@ pub(super) fn queue_row(
         active_lock_holder: None,
         path: None,
         error: None,
+        failure: None,
     }
 }
 

--- a/crates/homeboy-core/src/worktree/types.rs
+++ b/crates/homeboy-core/src/worktree/types.rs
@@ -1,6 +1,7 @@
 use crate::workspace_claim::{WorkspaceClaim, WorkspaceIdentity};
 use crate::Result;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// Canonical, portable identity for a managed task worktree. The registry
 /// handle and registered component identify the physical allocation; paths and
@@ -646,6 +647,20 @@ pub struct WorktreeQueueCreateRow {
     pub path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure: Option<WorktreeQueueCreateFailure>,
+}
+
+/// Lossless structured cause for a queue row that failed before creation.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct WorktreeQueueCreateFailure {
+    pub code: String,
+    pub classification: String,
+    pub phase: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_id: Option<String>,
+    pub details: Value,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
- put the causal worktree failure before repeated fanout plan data
- bound and deduplicate blocked worktree rows while preserving exact recovery commands
- retain private/public evidence boundaries in compact output

## Testing
- `cargo test -p homeboy-cli --features test-support blocked_worktree` (2 passed)
- `cargo fmt --all -- --check`

Fixes #12823

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to investigate, implement, rebase, and verify this change under human orchestration.