### PR TITLE
Make self doctor inspect the composed CLI registry

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -8,7 +8,8 @@ use uuid::Uuid;
 use crate::capability_registry::CommandCapabilityRegistry;
 use crate::cli_surface::{
     command_safety_manifest_from_dynamic, command_surface_from, Cli, CommandSafetyManifest,
-    Commands, DynamicCommandDescriptor, ExtensionCommandArgContract, ExtensionCommandArgsContract,
+    CommandSurfaceCommandProvenance, CommandSurfaceDoctorReport, CommandSurfaceRegistry, Commands,
+    DynamicCommandDescriptor, ExtensionCommandArgContract, ExtensionCommandArgsContract,
     ExtensionCommandHealth, ExtensionCommandManifest,
 };
 use crate::command_capability::{
@@ -250,6 +251,11 @@ struct ExtensionCliHealth {
 struct ExtensionCliDiscovery {
     info: Vec<ExtensionCliInfo>,
     health: ExtensionCliHealth,
+}
+
+struct ComposedCommandRegistry {
+    command: Command,
+    provenance: Vec<CommandSurfaceCommandProvenance>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1347,21 +1353,33 @@ impl CliRuntime {
 
         run_startup_update_checks(&cli.command);
 
-        let exit_code = crate::core::notification_route::with_current_resolution(
-            Some(notification_resolution.evidence),
+        let command_surface_doctor_report = matches!(
+            &cli.command,
+            Commands::SelfCmd(crate::commands::self_cmd::SelfArgs {
+                command: crate::commands::self_cmd::SelfCommand::Doctor(_),
+            })
+        )
+        .then(|| self.command_surface_doctor_report());
+        let exit_code = crate::cli_surface::with_command_surface_doctor_report(
+            command_surface_doctor_report,
             || {
-                crate::core::notification_route::with_current(notification_route, || {
-                    #[cfg(test)]
-                    record_marker_context_before_run_command();
-                    commands::output_runtime::run_command(
-                        cli.command,
-                        command_spec,
-                        output_file.as_deref(),
-                        &command_identity,
-                        command_provenance,
-                        cli.placement,
-                    )
-                })
+                crate::core::notification_route::with_current_resolution(
+                    Some(notification_resolution.evidence),
+                    || {
+                        crate::core::notification_route::with_current(notification_route, || {
+                            #[cfg(test)]
+                            record_marker_context_before_run_command();
+                            commands::output_runtime::run_command(
+                                cli.command,
+                                command_spec,
+                                output_file.as_deref(),
+                                &command_identity,
+                                command_provenance,
+                                cli.placement,
+                            )
+                        })
+                    },
+                )
             },
         );
         // The command's initial outcome is now durable and returned. Historical
@@ -1374,12 +1392,47 @@ impl CliRuntime {
     }
 
     fn build_augmented_command(&self) -> Command {
+        self.composed_command_registry().command
+    }
+
+    fn command_surface_doctor_report(&self) -> CommandSurfaceDoctorReport {
+        let registry = self.composed_command_registry();
+        crate::cli_surface::command_surface_doctor_report_from_composed(
+            registry.command,
+            registry.provenance,
+        )
+    }
+
+    fn composed_command_registry(&self) -> ComposedCommandRegistry {
         let discovery = self.extension_discovery();
         self.capabilities
             .validate_external_names(discovery.info.iter().map(|info| info.tool.as_str()))
             .expect("dynamic and typed capability command names must not conflict");
         let mut command = build_augmented_command(&discovery.info, &discovery.health);
+        let mut provenance = Cli::command_with_scoped_lab_args()
+            .get_subcommands()
+            .filter(|subcommand| !subcommand.is_hide_set())
+            .map(|subcommand| CommandSurfaceCommandProvenance {
+                command: subcommand.get_name().to_string(),
+                registry: CommandSurfaceRegistry::Core,
+            })
+            .collect::<Vec<_>>();
+        provenance.extend(
+            discovery
+                .info
+                .iter()
+                .map(|info| CommandSurfaceCommandProvenance {
+                    command: info.descriptor.name.clone(),
+                    registry: CommandSurfaceRegistry::Extension,
+                }),
+        );
         for entry in self.capabilities.entries() {
+            if !entry.command.is_hide_set() {
+                provenance.push(CommandSurfaceCommandProvenance {
+                    command: entry.capability.name().to_string(),
+                    registry: CommandSurfaceRegistry::Descriptor,
+                });
+            }
             command = command.subcommand(entry.command.clone());
         }
         let support = self
@@ -1388,7 +1441,10 @@ impl CliRuntime {
             .iter()
             .filter_map(|entry| entry.capability.lab_command_route_support())
             .collect::<Vec<_>>();
-        crate::command_contract::scope_composed_lab_cli_arguments(command, &support)
+        ComposedCommandRegistry {
+            command: crate::command_contract::scope_composed_lab_cli_arguments(command, &support),
+            provenance,
+        }
     }
 
     fn capability_matches<'a>(
@@ -3536,6 +3592,45 @@ mod tests {
     static ADMISSION_FIXTURE_CAPABILITIES: [&'static dyn CliCapability; 1] =
         [&ADMISSION_FIXTURE_CAPABILITY];
 
+    struct ComposedDoctorCapability;
+    struct HiddenComposedDoctorCapability;
+
+    static COMPOSED_DOCTOR_CAPABILITY: ComposedDoctorCapability = ComposedDoctorCapability;
+    static HIDDEN_COMPOSED_DOCTOR_CAPABILITY: HiddenComposedDoctorCapability =
+        HiddenComposedDoctorCapability;
+    static COMPOSED_DOCTOR_CAPABILITIES: [&'static dyn CliCapability; 2] = [
+        &COMPOSED_DOCTOR_CAPABILITY,
+        &HIDDEN_COMPOSED_DOCTOR_CAPABILITY,
+    ];
+
+    impl CliCapability for ComposedDoctorCapability {
+        fn name(&self) -> &'static str {
+            "triage"
+        }
+
+        fn command(&self) -> Command {
+            Command::new(self.name()).about("composed doctor fixture")
+        }
+
+        fn run(&self, _matches: &ArgMatches) -> crate::core::Result<(serde_json::Value, i32)> {
+            unreachable!("the command-surface fixture is never dispatched")
+        }
+    }
+
+    impl CliCapability for HiddenComposedDoctorCapability {
+        fn name(&self) -> &'static str {
+            "hidden-doctor-fixture"
+        }
+
+        fn command(&self) -> Command {
+            Command::new(self.name()).hide(true)
+        }
+
+        fn run(&self, _matches: &ArgMatches) -> crate::core::Result<(serde_json::Value, i32)> {
+            unreachable!("the command-surface fixture is never dispatched")
+        }
+    }
+
     impl CliCapability for AdmissionFixtureCapability {
         fn name(&self) -> &'static str {
             "admission-fixture"
@@ -4675,6 +4770,54 @@ mod tests {
                 assert!(
                     help.contains("sample-cli"),
                     "`homeboy {flag}` should list the extension subcommand: {help}"
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn doctor_uses_the_same_composed_registry_as_root_help() {
+        crate::test_support::with_isolated_home(|home| {
+            write_cli_extension(home.path(), "sample-runtime", "sample-cli");
+            let runtime = CliRuntime::with_capabilities(&COMPOSED_DOCTOR_CAPABILITIES);
+            let registry = runtime.composed_command_registry();
+
+            let help = registry
+                .command
+                .clone()
+                .try_get_matches_from(["homeboy", "--help"])
+                .expect_err("root help should terminate Clap parsing")
+                .to_string();
+            let report = crate::cli_surface::command_surface_doctor_report_from_composed(
+                registry.command,
+                registry.provenance,
+            );
+
+            assert!(report.agrees, "{:?}", report.drift_notes);
+            assert!(help.contains("triage"), "root help omitted triage: {help}");
+            assert!(
+                help.contains("sample-cli"),
+                "root help omitted extension command: {help}"
+            );
+            assert!(!help.contains("hidden-doctor-fixture"));
+            assert!(!report
+                .source_registry_commands
+                .contains(&"hidden-doctor-fixture".to_string()));
+            assert!(report.help_commands.contains(&"triage".to_string()));
+            assert!(report
+                .source_registry_commands
+                .contains(&"triage".to_string()));
+            for (command, registry) in [
+                ("status", CommandSurfaceRegistry::Core),
+                ("triage", CommandSurfaceRegistry::Descriptor),
+                ("sample-cli", CommandSurfaceRegistry::Extension),
+            ] {
+                assert!(
+                    report
+                        .command_provenance
+                        .iter()
+                        .any(|entry| { entry.command == command && entry.registry == registry }),
+                    "missing {registry:?} provenance for {command}"
                 );
             }
         });

--- a/crates/homeboy-cli/src/cli_surface/mod.rs
+++ b/crates/homeboy-cli/src/cli_surface/mod.rs
@@ -1,6 +1,6 @@
 use clap::{ArgMatches, Args, Command, CommandFactory, FromArgMatches, Parser, Subcommand};
 use serde::Serialize;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 use crate::commands::{
@@ -452,6 +452,7 @@ pub struct CommandSafetyAuditFinding {
 pub struct CommandSurfaceDoctorReport {
     pub agrees: bool,
     pub source_registry_commands: Vec<String>,
+    pub command_provenance: Vec<CommandSurfaceCommandProvenance>,
     pub docs_index_commands: Vec<String>,
     pub help_commands: Vec<String>,
     pub runtime_extension_docs: Vec<String>,
@@ -459,7 +460,31 @@ pub struct CommandSurfaceDoctorReport {
     pub stale_docs_index: Vec<String>,
     pub missing_from_help: Vec<String>,
     pub missing_from_source_registry: Vec<String>,
+    pub drift_evidence: Vec<CommandSurfaceDriftEvidence>,
     pub drift_notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommandSurfaceRegistry {
+    Core,
+    Descriptor,
+    Extension,
+    DocsIndex,
+    Help,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CommandSurfaceCommandProvenance {
+    pub command: String,
+    pub registry: CommandSurfaceRegistry,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CommandSurfaceDriftEvidence {
+    pub command: String,
+    pub drift: String,
+    pub registry: CommandSurfaceRegistry,
 }
 
 impl CommandSafetyManifest {}
@@ -611,12 +636,15 @@ mod dynamic_impls {
 // entry points here so existing call sites keep importing them from
 // `crate::cli_surface` unchanged while this module leans toward clap shapes.
 mod safety_manifest;
-pub(crate) use safety_manifest::{
-    command_safety_manifest_from, command_safety_manifest_from_dynamic,
-};
+pub(crate) use safety_manifest::command_safety_manifest_from_dynamic;
 
 mod surface {
     use super::*;
+
+    thread_local! {
+        static CURRENT_DOCTOR_REPORT: std::cell::RefCell<Option<CommandSurfaceDoctorReport>> =
+            const { std::cell::RefCell::new(None) };
+    }
 
     pub(crate) fn current_command_surface() -> CommandSurface {
         command_surface_from(Cli::command())
@@ -633,13 +661,19 @@ mod surface {
     }
 
     pub(crate) fn current_command_surface_doctor_report() -> CommandSurfaceDoctorReport {
+        if let Some(report) = CURRENT_DOCTOR_REPORT.with(|current| current.borrow().clone()) {
+            return report;
+        }
+
         let surface = current_command_surface();
-        let manifest = command_safety_manifest_from(surface.clone());
-        let source_registry_commands = manifest
+        let command_provenance = surface
             .commands
             .iter()
-            .filter(|entry| visible_manifest_entry_with_docs_path(entry))
-            .map(|entry| entry.name.clone())
+            .filter(|entry| !entry.hidden)
+            .map(|entry| CommandSurfaceCommandProvenance {
+                command: entry.name.clone(),
+                registry: CommandSurfaceRegistry::Core,
+            })
             .collect();
         let help_commands = surface
             .commands
@@ -652,31 +686,109 @@ mod surface {
         ));
 
         command_surface_doctor_report(
-            source_registry_commands,
+            command_provenance,
             docs_index_commands,
             help_commands,
             runtime_extension_doc_commands(),
         )
     }
 
-    fn command_surface_doctor_report(
-        source_registry_commands: BTreeSet<String>,
+    pub(crate) fn with_command_surface_doctor_report<T>(
+        report: Option<CommandSurfaceDoctorReport>,
+        run: impl FnOnce() -> T,
+    ) -> T {
+        struct Reset(Option<CommandSurfaceDoctorReport>);
+
+        impl Drop for Reset {
+            fn drop(&mut self) {
+                CURRENT_DOCTOR_REPORT.with(|current| {
+                    current.replace(self.0.take());
+                });
+            }
+        }
+
+        let previous = CURRENT_DOCTOR_REPORT.with(|current| current.replace(report));
+        let _reset = Reset(previous);
+        run()
+    }
+
+    pub(crate) fn command_surface_doctor_report_from_composed(
+        command: Command,
+        command_provenance: Vec<CommandSurfaceCommandProvenance>,
+    ) -> CommandSurfaceDoctorReport {
+        let help_commands = command_surface_from(command)
+            .commands
+            .into_iter()
+            .filter(|entry| !entry.hidden)
+            .map(|entry| entry.name)
+            .collect();
+        let docs_index_commands = documented_command_index_entries(include_str!(
+            "../../../../docs/commands/commands-index.md"
+        ));
+
+        command_surface_doctor_report(
+            command_provenance,
+            docs_index_commands,
+            help_commands,
+            runtime_extension_doc_commands(),
+        )
+    }
+
+    pub(crate) fn command_surface_doctor_report(
+        mut command_provenance: Vec<CommandSurfaceCommandProvenance>,
         docs_index_commands: BTreeSet<String>,
         help_commands: BTreeSet<String>,
         runtime_extension_docs: BTreeSet<String>,
     ) -> CommandSurfaceDoctorReport {
+        command_provenance.sort_by(|left, right| left.command.cmp(&right.command));
+        let provenance_by_command: BTreeMap<_, _> = command_provenance
+            .iter()
+            .map(|entry| (entry.command.clone(), entry.registry))
+            .collect();
+        let source_registry_commands = provenance_by_command.keys().cloned().collect();
+        let docs_required_commands = command_provenance
+            .iter()
+            .filter(|entry| entry.registry != CommandSurfaceRegistry::Extension)
+            .map(|entry| entry.command.clone())
+            .collect();
         let documented_core_commands: BTreeSet<String> = docs_index_commands
             .difference(&runtime_extension_docs)
             .cloned()
             .collect();
 
         let missing_from_docs_index =
-            sorted_difference(&source_registry_commands, &docs_index_commands);
+            sorted_difference(&docs_required_commands, &docs_index_commands);
         let stale_docs_index =
-            sorted_difference(&documented_core_commands, &source_registry_commands);
+            sorted_difference(&documented_core_commands, &docs_required_commands);
         let missing_from_help = sorted_difference(&source_registry_commands, &help_commands);
         let missing_from_source_registry =
             sorted_difference(&help_commands, &source_registry_commands);
+
+        let mut drift_evidence = Vec::new();
+        extend_drift_evidence(
+            &mut drift_evidence,
+            &missing_from_docs_index,
+            "missing_from_docs_index",
+            |command| provenance_by_command[command],
+        );
+        extend_drift_evidence(
+            &mut drift_evidence,
+            &stale_docs_index,
+            "stale_docs_index",
+            |_| CommandSurfaceRegistry::DocsIndex,
+        );
+        extend_drift_evidence(
+            &mut drift_evidence,
+            &missing_from_help,
+            "missing_from_help",
+            |command| provenance_by_command[command],
+        );
+        extend_drift_evidence(
+            &mut drift_evidence,
+            &missing_from_source_registry,
+            "missing_from_source_registry",
+            |_| CommandSurfaceRegistry::Help,
+        );
 
         let mut drift_notes = Vec::new();
         push_drift_note(
@@ -703,6 +815,7 @@ mod surface {
         CommandSurfaceDoctorReport {
             agrees: drift_notes.is_empty(),
             source_registry_commands: source_registry_commands.into_iter().collect(),
+            command_provenance,
             docs_index_commands: docs_index_commands.into_iter().collect(),
             help_commands: help_commands.into_iter().collect(),
             runtime_extension_docs: runtime_extension_docs.into_iter().collect(),
@@ -710,12 +823,9 @@ mod surface {
             stale_docs_index,
             missing_from_help,
             missing_from_source_registry,
+            drift_evidence,
             drift_notes,
         }
-    }
-
-    fn visible_manifest_entry_with_docs_path(entry: &CommandSafetyEntry) -> bool {
-        !entry.hidden && entry.docs.path.is_some()
     }
 
     fn documented_command_index_entries(index: &str) -> BTreeSet<String> {
@@ -743,6 +853,19 @@ mod surface {
         if !commands.is_empty() {
             notes.push(format!("{label}: {}", commands.join(", ")));
         }
+    }
+
+    fn extend_drift_evidence(
+        evidence: &mut Vec<CommandSurfaceDriftEvidence>,
+        commands: &[String],
+        drift: &str,
+        registry: impl Fn(&String) -> CommandSurfaceRegistry,
+    ) {
+        evidence.extend(commands.iter().map(|command| CommandSurfaceDriftEvidence {
+            command: command.clone(),
+            drift: drift.to_string(),
+            registry: registry(command),
+        }));
     }
 
     fn visible_subcommands(command: &Command, remaining_depth: usize) -> Vec<CommandSurfaceEntry> {
@@ -803,6 +926,58 @@ mod tests {
             .filter(|subcommand| !subcommand.is_hide_set())
             .map(|subcommand| subcommand.get_name().to_string())
             .collect()
+    }
+
+    fn provenance(
+        command: &str,
+        registry: CommandSurfaceRegistry,
+    ) -> CommandSurfaceCommandProvenance {
+        CommandSurfaceCommandProvenance {
+            command: command.to_string(),
+            registry,
+        }
+    }
+
+    #[test]
+    fn doctor_reports_actual_missing_docs_with_registry_provenance() {
+        let report = command_surface_doctor_report(
+            vec![provenance("composed", CommandSurfaceRegistry::Descriptor)],
+            BTreeSet::new(),
+            BTreeSet::from(["composed".to_string()]),
+            BTreeSet::new(),
+        );
+
+        assert!(!report.agrees);
+        assert_eq!(report.missing_from_docs_index, ["composed"]);
+        assert_eq!(
+            report.drift_evidence,
+            [CommandSurfaceDriftEvidence {
+                command: "composed".to_string(),
+                drift: "missing_from_docs_index".to_string(),
+                registry: CommandSurfaceRegistry::Descriptor,
+            }]
+        );
+    }
+
+    #[test]
+    fn doctor_reports_actual_stale_docs_with_docs_registry_provenance() {
+        let report = command_surface_doctor_report(
+            vec![provenance("core", CommandSurfaceRegistry::Core)],
+            BTreeSet::from(["core".to_string(), "removed".to_string()]),
+            BTreeSet::from(["core".to_string()]),
+            BTreeSet::new(),
+        );
+
+        assert!(!report.agrees);
+        assert_eq!(report.stale_docs_index, ["removed"]);
+        assert_eq!(
+            report.drift_evidence,
+            [CommandSurfaceDriftEvidence {
+                command: "removed".to_string(),
+                drift: "stale_docs_index".to_string(),
+                registry: CommandSurfaceRegistry::DocsIndex,
+            }]
+        );
     }
 
     fn assert_docs_cover_subcommands(command_name: &str) {

--- a/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
+++ b/crates/homeboy-cli/src/cli_surface/safety_manifest.rs
@@ -25,10 +25,6 @@ use crate::cli_surface::{
 };
 use crate::command_contract::{registered_command, CommandSafetySpec};
 
-pub(crate) fn command_safety_manifest_from(surface: CommandSurface) -> CommandSafetyManifest {
-    command_safety_manifest_from_dynamic(surface, &[])
-}
-
 pub(crate) fn command_safety_manifest_from_dynamic(
     surface: CommandSurface,
     dynamic_commands: &[DynamicCommandDescriptor],

--- a/docs/commands/commands-index.md
+++ b/docs/commands/commands-index.md
@@ -42,6 +42,7 @@ cargo run -p homeboy-cli --bin generate-cli-reference -->
 - [stack](stack.md)
 - [status](status.md)
 - [trace](trace.md)
+- [triage](triage.md)
 - [tunnel](tunnel.md)
 - [upgrade](upgrade.md)
 - [worktree](worktree.md)


### PR DESCRIPTION
Closes #13385

## Summary
- derive doctor evidence from the same composed command registry used by root help
- retain provenance for core, extension, and typed descriptor commands
- report real documentation drift without classifying visible `triage` as stale

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-cli --lib cli_runtime::tests::doctor_uses_the_same_composed_registry_as_root_help -- --exact`
- `cargo test -p homeboy-cli --lib cli_surface::tests::doctor_reports_actual_missing_docs_with_registry_provenance -- --exact`
- `cargo test -p homeboy-cli --lib cli_surface::tests::doctor_reports_actual_stale_docs_with_docs_registry_provenance -- --exact`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode implemented the candidate; I reviewed the diff, resolved its capability-registry rebase conflict, and ran the listed focused gates.