### PR TITLE
Preserve Cook lifecycle metadata through Lab mirroring

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -11668,6 +11668,47 @@ fn cook_returns_after_accepted_detached_attempt_without_waiting_for_daemon_compl
 }
 
 #[test]
+fn transport_retry_continuation_keeps_timeout_retry_budget_on_the_typed_attempt() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-lab-timeout-continuation";
+        let run_id = "cook-lab-timeout-continuation-attempt-1-transport-retry";
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = run_id.to_string();
+        options.max_attempts = 2;
+        super::super::persist_initial_recipe(&options).expect("persist Cook recipe");
+        super::super::materialize_initial_cook_attempt(&options)
+            .expect("materialize controller-owned transport retry");
+
+        let accepted = run_cook(CookContext::new(options.clone(), Arc::new(UnusedExecutor)))
+            .expect("accepted Lab attempt returns");
+        assert_eq!(accepted.value.status, "in_flight");
+        assert_eq!(accepted.value.attempts[0].run_id, run_id);
+        assert_eq!(
+            super::super::resolve_cook_continuation_run_id(run_id)
+                .expect("printed continuation resolves exact attempt"),
+            run_id
+        );
+
+        seed_timeout_review_form_aggregate(run_id, &options.initial_plan);
+        let timed_out =
+            agent_task_lifecycle::status(run_id).expect("typed timeout remains readable");
+        assert_eq!(
+            timed_out.state,
+            agent_task_lifecycle::AgentTaskRunState::Failed
+        );
+
+        let retry = crate::agent_task_service::retry(run_id, None, false, false)
+            .expect("remaining Cook retry budget is consumable");
+        let recipe = super::super::load_recipe(cook_id).expect("updated Cook recipe");
+        assert_eq!(retry.record.metadata["retry_of"], run_id);
+        assert_eq!(retry.record.metadata["cook_id"], cook_id);
+        assert_eq!(recipe.attempts.len(), 2);
+        assert_eq!(recipe.attempts[1].attempt, 2);
+        assert_eq!(recipe.attempts[1].run_id, retry.record.run_id);
+    });
+}
+
+#[test]
 fn orphaned_recipe_materializes_once_and_replays_from_durable_inputs() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let cook_id = "cook-orphan-recovery";

--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -52,10 +52,15 @@ pub(crate) struct MirrorEvidenceRequest<'a> {
     pub(crate) events: &'a [JobEvent],
     pub(crate) result: &'a Value,
     pub(crate) run_id: Option<&'a str>,
-    /// An explicit ad hoc runner-exec ID is created in the controller before
-    /// dispatch. It is not a runner `/runs/<id>` record to mirror.
-    pub(crate) generic_runner_exec_run: bool,
+    pub(crate) run_ownership: MirrorRunOwnership,
     pub(crate) notification_route: Option<&'a NotificationRoute>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MirrorRunOwnership {
+    Inferred,
+    AgentTask,
+    GenericRunnerExec,
 }
 
 impl<'a> MirrorEvidenceRequest<'a> {
@@ -81,13 +86,18 @@ impl<'a> MirrorEvidenceRequest<'a> {
             events,
             result,
             run_id,
-            generic_runner_exec_run: false,
+            run_ownership: MirrorRunOwnership::Inferred,
             notification_route,
         }
     }
 
+    pub(crate) fn with_agent_task_run(mut self) -> Self {
+        self.run_ownership = MirrorRunOwnership::AgentTask;
+        self
+    }
+
     pub(crate) fn with_generic_runner_exec_run(mut self) -> Self {
-        self.generic_runner_exec_run = true;
+        self.run_ownership = MirrorRunOwnership::GenericRunnerExec;
         self
     }
 }
@@ -585,28 +595,49 @@ pub fn mirror_daemon_job_progress(
     events: &[JobEvent],
     run_id: Option<&str>,
 ) -> Result<RunRecord> {
-    let store = ObservationStore::open_initialized()?;
-    mirror_job_run_request(
-        &store,
-        MirrorEvidenceRequest::new(runner, cwd, command, job, events, &json!({}), run_id, None),
+    mirror_daemon_job_progress_with_ownership(
+        runner,
+        cwd,
+        command,
+        job,
+        events,
+        run_id,
+        MirrorRunOwnership::Inferred,
     )
-    .map(|run| run.run)
 }
 
-pub fn mirror_reverse_broker_job_progress(
+pub(crate) fn mirror_daemon_job_progress_with_ownership(
+    runner: &Runner,
+    cwd: &str,
+    command: &[String],
+    job: &Job,
+    events: &[JobEvent],
+    run_id: Option<&str>,
+    run_ownership: MirrorRunOwnership,
+) -> Result<RunRecord> {
+    let store = ObservationStore::open_initialized()?;
+    let result = json!({});
+    let mut request =
+        MirrorEvidenceRequest::new(runner, cwd, command, job, events, &result, run_id, None);
+    request.run_ownership = run_ownership;
+    mirror_job_run_request(&store, request).map(|run| run.run)
+}
+
+pub(crate) fn mirror_reverse_broker_job_progress_with_ownership(
     runner: &Runner,
     broker_url: &str,
     cwd: &str,
     command: &[String],
     job: &Job,
     run_id: Option<&str>,
+    run_ownership: MirrorRunOwnership,
 ) -> Result<RunRecord> {
     let store = ObservationStore::open_initialized()?;
-    let run = mirror_job_run_request(
-        &store,
-        MirrorEvidenceRequest::new(runner, cwd, command, job, &[], &json!({}), run_id, None),
-    )?
-    .run;
+    let result = json!({});
+    let mut request =
+        MirrorEvidenceRequest::new(runner, cwd, command, job, &[], &result, run_id, None);
+    request.run_ownership = run_ownership;
+    let run = mirror_job_run_request(&store, request)?.run;
     record_reverse_broker_metadata(
         run,
         ReverseBrokerMetadataContext {
@@ -972,7 +1003,7 @@ pub(super) fn mirrored_patch_result(
     Ok(Some(patched))
 }
 
-fn mirror_job_run_request(
+pub(super) fn mirror_job_run_request(
     store: &ObservationStore,
     request: MirrorEvidenceRequest<'_>,
 ) -> Result<MirroredJobRun> {
@@ -984,7 +1015,7 @@ fn mirror_job_run_request(
         events,
         result,
         run_id,
-        generic_runner_exec_run,
+        run_ownership,
         notification_route,
         ..
     } = request;
@@ -1037,7 +1068,16 @@ fn mirror_job_run_request(
         lab["synthetic_publication_token"] = Value::String(synthetic_token.clone());
     }
     if let Some(run_id) = run_id {
-        if generic_runner_exec_run {
+        let run_ownership = if run_ownership == MirrorRunOwnership::Inferred
+            && store
+                .get_run(run_id)?
+                .is_some_and(|run| run.metadata_json.get("agent_task_run").is_some())
+        {
+            MirrorRunOwnership::AgentTask
+        } else {
+            run_ownership
+        };
+        if run_ownership == MirrorRunOwnership::GenericRunnerExec {
             let mut metadata_json = store
                 .get_run(run_id)?
                 .ok_or_else(|| {
@@ -1057,10 +1097,17 @@ fn mirror_job_run_request(
                     synthetic_ownership: None,
                 });
         }
-        if store
-            .get_run(run_id)?
-            .is_some_and(|existing| existing.metadata_json.get("agent_task_run").is_some())
-        {
+        if run_ownership == MirrorRunOwnership::AgentTask {
+            let existing = store.get_run(run_id)?.ok_or_else(|| {
+                Error::internal_unexpected(format!(
+                    "controller-owned agent-task run {run_id} disappeared while mirroring Lab evidence"
+                ))
+            })?;
+            if existing.metadata_json.get("agent_task_run").is_none() {
+                return Err(Error::internal_unexpected(format!(
+                    "controller-owned agent-task run {run_id} lost agent_task_run metadata before Lab evidence mirroring"
+                )));
+            }
             let lifecycle_store = match store.roots() {
                 Some(roots) => homeboy_agents::agent_task_lifecycle::AgentTaskLifecycleStore::new(
                     roots.clone(),

--- a/crates/homeboy-lab-runner/src/evidence/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mod.rs
@@ -22,12 +22,13 @@ pub use download::{
 pub use homeboy_core::api_jobs::RunnerJobLogSnapshot;
 pub use mirror::{
     controller_artifact_metadata, mirror_connected_runner_run, mirror_daemon_job_progress,
-    mirror_reverse_broker_job_progress, mirrored_runner_job_identity,
-    refresh_mirrored_daemon_evidence, runner_job_log_snapshot, terminalize_mirrored_daemon_job,
+    mirrored_runner_job_identity, refresh_mirrored_daemon_evidence, runner_job_log_snapshot,
+    terminalize_mirrored_daemon_job,
 };
 pub(crate) use mirror::{
-    mirror_daemon_evidence, mirror_reverse_broker_evidence, MirrorEvidenceRequest,
-    ReverseBrokerEvidenceContext,
+    mirror_daemon_evidence, mirror_daemon_job_progress_with_ownership,
+    mirror_reverse_broker_evidence, mirror_reverse_broker_job_progress_with_ownership,
+    MirrorEvidenceRequest, MirrorRunOwnership, ReverseBrokerEvidenceContext,
 };
 pub use mirror::{runner_job_log_snapshot_for_session, runner_job_log_snapshot_for_session_until};
 pub(crate) use util::{local_job_run_id, runner_exec_run_label};

--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -34,7 +34,8 @@ use super::detail::{
 use super::download::{content_disposition_filename, download_remote_artifact, resolve_placement};
 use super::mirror::{
     bounded_remote_events, controller_artifact_metadata, import_mirrored_artifact_with_downloader,
-    mirror_daemon_evidence, mirror_job_run, mirror_remote_observation_runs_by_id_with,
+    mirror_daemon_evidence, mirror_job_run, mirror_job_run_request,
+    mirror_remote_observation_runs_by_id_with,
     mirror_remote_observation_runs_by_id_with_downloader, mirror_reverse_broker_evidence,
     mirror_terminal_job_artifacts_with, mirrored_patch_result, primary_mirrored_run,
     refresh_mirrored_daemon_evidence, refresh_mirrored_daemon_evidence_with, MirrorEvidenceRequest,
@@ -958,90 +959,176 @@ fn runner_exec_explicit_run_id_overrides_inferred_name() {
 
 #[test]
 fn mirroring_lab_job_preserves_agent_task_lifecycle_metadata() {
-    let context = homeboy_core::test_support::HermeticTestContext::new();
-    let roots = context.path_roots();
-    let store = ObservationStore::open_initialized_in_roots(&roots).expect("store");
-    let lifecycle_store =
-        homeboy_agents::agent_task_lifecycle::AgentTaskLifecycleStore::new(roots.clone());
-    let command = vec![
-        "homeboy".to_string(),
-        "agent-task".to_string(),
-        "cook".to_string(),
-    ];
-    lifecycle_store
-        .record_lab_offload_planned(homeboy_agents::agent_task_lifecycle::LabOffloadProxyPlan {
-            run_id: "agent-task-lab-mirror",
-            runner_id: "lab",
-            remote_workspace: "/srv/homeboy/project",
-            remote_command: &command,
-            durable_plan: None,
-        })
-        .expect("planned controller proxy");
-    let job_id = Uuid::new_v4();
-    let job = Job {
-        id: job_id,
-        operation: "exec".to_string(),
-        status: JobStatus::Running,
-        created_at_ms: 1_700_000_000_000,
-        updated_at_ms: 1_700_000_001_000,
-        started_at_ms: Some(1_700_000_000_000),
-        finished_at_ms: None,
-        event_count: 0,
-        source_snapshot: None,
-        path_materialization_plan: None,
-        stale_reason: None,
-        daemon_lease_id: None,
-        target_runner_id: None,
-        target_project_id: None,
-        claim_id: None,
-        claimed_by_runner_id: None,
-        claimed_at_ms: None,
-        claim_expires_at_ms: None,
-        artifacts: Vec::new(),
-        runner_job_projection: None,
-    };
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let store = ObservationStore::open_initialized().expect("store");
+        let lifecycle_store = homeboy_agents::agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment().expect("lifecycle store");
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+        ];
+        lifecycle_store
+            .record_lab_offload_planned(homeboy_agents::agent_task_lifecycle::LabOffloadProxyPlan {
+                run_id: "agent-task-lab-mirror",
+                runner_id: "lab",
+                remote_workspace: "/srv/homeboy/project",
+                remote_command: &command,
+                durable_plan: None,
+            })
+            .expect("planned controller proxy");
+        let job_id = Uuid::new_v4();
+        let job = Job {
+            id: job_id,
+            operation: "exec".to_string(),
+            status: JobStatus::Running,
+            created_at_ms: 1_700_000_000_000,
+            updated_at_ms: 1_700_000_001_000,
+            started_at_ms: Some(1_700_000_000_000),
+            finished_at_ms: None,
+            event_count: 0,
+            source_snapshot: None,
+            path_materialization_plan: None,
+            stale_reason: None,
+            daemon_lease_id: None,
+            target_runner_id: None,
+            target_project_id: None,
+            claim_id: None,
+            claimed_by_runner_id: None,
+            claimed_at_ms: None,
+            claim_expires_at_ms: None,
+            artifacts: Vec::new(),
+            runner_job_projection: None,
+        };
 
-    mirror_job_run(
-        &store,
-        &ssh_runner(),
-        "/srv/homeboy/project",
-        &command,
-        &job,
-        &[],
-        &json!({}),
-        Some("agent-task-lab-mirror"),
-        None,
-    )
-    .expect("mirror Lab job");
-    let terminal_job = Job {
-        status: JobStatus::Succeeded,
-        finished_at_ms: Some(1_700_000_002_000),
-        ..job.clone()
-    };
-    let run = mirror_job_run(
-        &store,
-        &ssh_runner(),
-        "/srv/homeboy/project",
-        &command,
-        &terminal_job,
-        &[],
-        &json!({"exit_code": 0}),
-        Some("agent-task-lab-mirror"),
-        None,
-    )
-    .expect("mirror terminal Lab job");
-    let lifecycle = lifecycle_store
-        .read_record("agent-task-lab-mirror")
-        .expect("typed lifecycle remains readable");
+        mirror_job_run(
+            &store,
+            &ssh_runner(),
+            "/srv/homeboy/project",
+            &command,
+            &job,
+            &[],
+            &json!({}),
+            Some("agent-task-lab-mirror"),
+            None,
+        )
+        .expect("mirror Lab job");
+        let terminal_job = Job {
+            status: JobStatus::Succeeded,
+            finished_at_ms: Some(1_700_000_002_000),
+            ..job.clone()
+        };
+        let run = mirror_job_run(
+            &store,
+            &ssh_runner(),
+            "/srv/homeboy/project",
+            &command,
+            &terminal_job,
+            &[],
+            &json!({"exit_code": 0}),
+            Some("agent-task-lab-mirror"),
+            None,
+        )
+        .expect("mirror terminal Lab job");
+        let lifecycle = lifecycle_store
+            .read_record("agent-task-lab-mirror")
+            .expect("typed lifecycle remains readable");
 
-    assert_eq!(run.kind, "agent-task");
-    assert!(run.metadata_json.get("agent_task_run").is_some());
-    assert_eq!(lifecycle.metadata["runner_id"], "lab");
-    assert_eq!(lifecycle.metadata["runner_job_id"], job_id.to_string());
-    assert_eq!(
-        run.metadata_json["lab"]["remote_job"]["id"],
-        job_id.to_string()
-    );
+        assert_eq!(run.kind, "agent-task");
+        assert!(run.metadata_json.get("agent_task_run").is_some());
+        assert_eq!(lifecycle.metadata["runner_id"], "lab");
+        assert_eq!(lifecycle.metadata["runner_job_id"], job_id.to_string());
+        assert_eq!(
+            run.metadata_json["lab"]["remote_job"]["id"],
+            job_id.to_string()
+        );
+    });
+}
+
+#[test]
+fn transport_retry_lab_mirror_requires_and_preserves_the_controller_agent_task() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let store = ObservationStore::open_initialized().expect("store");
+        let lifecycle_store = homeboy_agents::agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment().expect("lifecycle store");
+        let run_id = "agent-task-cook-attempt-1-transport-retry";
+        let runner = ssh_runner();
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--attempt-run-id".to_string(),
+            run_id.to_string(),
+        ];
+        let job_id = Uuid::new_v4();
+        let job = Job {
+            id: job_id,
+            operation: "exec".to_string(),
+            status: JobStatus::Running,
+            created_at_ms: 1_700_000_000_000,
+            updated_at_ms: 1_700_000_001_000,
+            started_at_ms: Some(1_700_000_000_000),
+            finished_at_ms: None,
+            event_count: 0,
+            source_snapshot: None,
+            path_materialization_plan: None,
+            stale_reason: None,
+            daemon_lease_id: None,
+            target_runner_id: None,
+            target_project_id: None,
+            claim_id: None,
+            claimed_by_runner_id: None,
+            claimed_at_ms: None,
+            claim_expires_at_ms: None,
+            artifacts: Vec::new(),
+            runner_job_projection: None,
+        };
+        let result = json!({});
+
+        let missing_proxy = MirrorEvidenceRequest::new(
+            &runner,
+            "/srv/homeboy/project",
+            &command,
+            &job,
+            &[],
+            &result,
+            Some(run_id),
+            None,
+        )
+        .with_agent_task_run();
+        let error = mirror_job_run_request(&store, missing_proxy).unwrap_err();
+        assert!(error.message.contains("controller-owned agent-task run"));
+        assert!(store.get_run(run_id).expect("read run").is_none());
+
+        lifecycle_store
+            .record_lab_offload_planned(homeboy_agents::agent_task_lifecycle::LabOffloadProxyPlan {
+                run_id,
+                runner_id: "lab",
+                remote_workspace: "/srv/homeboy/project",
+                remote_command: &command,
+                durable_plan: None,
+            })
+            .expect("planned controller proxy");
+        let accepted = MirrorEvidenceRequest::new(
+            &runner,
+            "/srv/homeboy/project",
+            &command,
+            &job,
+            &[],
+            &result,
+            Some(run_id),
+            None,
+        )
+        .with_agent_task_run();
+        let mirrored = mirror_job_run_request(&store, accepted).expect("mirror accepted Lab job");
+        let lifecycle = lifecycle_store
+            .read_record(run_id)
+            .expect("continuation identity remains typed");
+
+        assert_eq!(mirrored.kind, "agent-task");
+        assert_eq!(lifecycle.run_id, run_id);
+        assert_eq!(lifecycle.metadata["runner_id"], "lab");
+        assert_eq!(lifecycle.metadata["runner_job_id"], job_id.to_string());
+        assert!(mirrored.metadata_json.get("agent_task_run").is_some());
+    });
 }
 
 #[test]

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -329,6 +329,8 @@ pub(super) fn exec_via_reverse_broker(
             );
             let request = if run_id_owns_generic_exec {
                 request.with_generic_runner_exec_run()
+            } else if run_id.is_some() {
+                request.with_agent_task_run()
             } else {
                 request
             };

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -306,6 +306,8 @@ pub(super) fn exec_via_daemon(
             );
             let request = if run_id_owns_generic_exec {
                 request.with_generic_runner_exec_run()
+            } else if run_id.is_some() {
+                request.with_agent_task_run()
             } else {
                 request
             };

--- a/crates/homeboy-lab-runner/src/execution/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/handoff.rs
@@ -10,7 +10,10 @@ use homeboy_core::error::{Error, Result};
 use crate::daemon_http_get::parse_daemon_response_json;
 
 use super::super::broker_http;
-use super::super::evidence::{mirror_daemon_job_progress, mirror_reverse_broker_job_progress};
+use super::super::evidence::{
+    mirror_daemon_job_progress_with_ownership, mirror_reverse_broker_job_progress_with_ownership,
+    MirrorRunOwnership,
+};
 use super::super::{load, status, Runner, RunnerTunnelMode};
 
 #[allow(unused_imports)]
@@ -393,13 +396,35 @@ pub(super) fn persist_lab_offload_handoff_run(
     command: &[String],
     job: &Job,
     run_id: Option<&str>,
+    run_id_owns_generic_exec: bool,
     reverse_broker_url: Option<&str>,
 ) -> Option<String> {
+    let run_ownership = if run_id_owns_generic_exec {
+        MirrorRunOwnership::GenericRunnerExec
+    } else if run_id.is_some() {
+        MirrorRunOwnership::AgentTask
+    } else {
+        MirrorRunOwnership::Inferred
+    };
     let mirrored = match reverse_broker_url {
-        Some(broker_url) => {
-            mirror_reverse_broker_job_progress(runner, broker_url, cwd, command, job, run_id)
-        }
-        None => mirror_daemon_job_progress(runner, cwd, command, job, &[], run_id),
+        Some(broker_url) => mirror_reverse_broker_job_progress_with_ownership(
+            runner,
+            broker_url,
+            cwd,
+            command,
+            job,
+            run_id,
+            run_ownership,
+        ),
+        None => mirror_daemon_job_progress_with_ownership(
+            runner,
+            cwd,
+            command,
+            job,
+            &[],
+            run_id,
+            run_ownership,
+        ),
     };
     match mirrored {
         Ok(run) => Some(run.id),

--- a/crates/homeboy-lab-runner/src/execution/job_flow.rs
+++ b/crates/homeboy-lab-runner/src/execution/job_flow.rs
@@ -133,6 +133,7 @@ where
                 &flow.command,
                 &job,
                 flow.run_id.as_deref(),
+                flow.run_id_owns_generic_exec,
                 flow.handoff_endpoint,
             )
         })

--- a/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
@@ -404,6 +404,7 @@ fn lab_offload_handoff_persists_run_when_job_is_accepted() {
             &["homeboy".to_string(), "trace".to_string()],
             &job,
             None,
+            false,
             None,
         )
         .expect("persist handoff run");
@@ -435,6 +436,7 @@ fn reverse_handoff_persists_broker_transport_for_post_disconnect_refresh() {
             &command,
             &job,
             None,
+            false,
             Some("http://127.0.0.1:4321"),
         )
         .expect("persist reverse handoff run");
@@ -472,6 +474,7 @@ fn accepted_job_that_disappears_persists_a_terminal_controller_failure() {
             &command,
             &job,
             None,
+            false,
             None,
         )
         .expect("accepted handoff mirror");
@@ -548,6 +551,7 @@ fn transient_daemon_transport_drop_keeps_the_durable_job_recoverable() {
             &command,
             &job,
             None,
+            false,
             None,
         )
         .expect("accepted handoff mirror");


### PR DESCRIPTION
## Summary
- make Lab evidence mirroring distinguish agent-task, generic runner-exec, and inferred run ownership
- update controller-owned agent-task rows without replacing their typed lifecycle metadata
- carry ownership through daemon, reverse-broker, and detached handoff progress paths

Closes #13446.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p homeboy-lab-runner agent_task` (113 passed)

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode reviewed and rebased the candidate, fixed parallel lifecycle fixtures, removed dead wrappers, and ran the Lab regression suite. Chris Huber directed the work and is responsible for the change.