### PR TITLE
Persist runner exec runs for declared outputs

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/exec.rs
+++ b/crates/homeboy-cli/src/commands/runner/exec.rs
@@ -61,15 +61,6 @@ pub(super) fn exec_with_hydration(
         || !artifact_dir_outputs.is_empty()
         || !summary_outputs.is_empty();
 
-    if !dry_run && has_declared_outputs && run_id.is_none() {
-        return Err(homeboy::core::Error::validation_invalid_argument(
-            "run_id",
-            "runner exec --artifact/--artifact-dir/--summary requires --run-id so evidence can be attached to a persisted run",
-            None,
-            None,
-        ));
-    }
-
     // A read-only retrieval hydrates evidence the runner already retains; it
     // must not declare new artifact outputs or capture a mutation patch, so the
     // read never rewrites a draining generation (Extra-Chill/homeboy#9420).
@@ -96,7 +87,8 @@ pub(super) fn exec_with_hydration(
         );
     }
 
-    let validated_run_id = validate_runner_exec_run_id(run_id)?;
+    let validated_run_id =
+        validate_runner_exec_run_id(persisted_runner_exec_run_id(run_id, has_declared_outputs))?;
     let hydration_source = sync_workspace.clone();
     let (cwd, source_snapshot) = exec_workspace_context(runner_id, cwd, sync_workspace, false)?;
     if hydrate_deps {
@@ -208,6 +200,9 @@ pub(super) fn exec_with_hydration(
             read_only_artifact_access: read_only_artifact,
         },
     )?;
+    if output.mirror_run_id.is_none() {
+        output.mirror_run_id.clone_from(&validated_run_id);
+    }
     if let (Some(run_id), Some(lifecycle_store)) =
         (validated_run_id.as_deref(), lifecycle_store.as_ref())
     {
@@ -423,6 +418,13 @@ fn validate_runner_exec_run_id(run_id: Option<String>) -> homeboy::core::Result<
         ));
     }
     Ok(Some(trimmed.to_string()))
+}
+
+fn persisted_runner_exec_run_id(
+    run_id: Option<String>,
+    has_declared_outputs: bool,
+) -> Option<String> {
+    run_id.or_else(|| has_declared_outputs.then(|| format!("runner-exec-{}", uuid::Uuid::new_v4())))
 }
 
 /// Maximum number of bytes retained when reading a runner exec script into

--- a/crates/homeboy-cli/src/commands/runner/tests/exec.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/exec.rs
@@ -19,6 +19,68 @@ fn test_lifecycle_store() -> homeboy::agents::agent_tasks::lifecycle::AgentTaskL
     homeboy::agents::agent_tasks::lifecycle::AgentTaskLifecycleStore::from_current_environment()
         .expect("lifecycle store")
 }
+
+#[test]
+fn runner_exec_generates_a_persisted_run_for_declared_outputs() {
+    homeboy::test_support::with_isolated_home(|_| {
+        let workspace = tempfile::tempdir().expect("workspace");
+        runner::create(
+            &format!(
+                r#"{{"id":"lab-local","kind":"local","workspace_root":"{}"}}"#,
+                workspace.path().display()
+            ),
+            false,
+        )
+        .expect("create local runner");
+
+        let (output, exit_code) = exec_with_hydration(
+            "lab-local",
+            Some(workspace.path().display().to_string()),
+            None,
+            false,
+            None,
+            false,
+            false,
+            Vec::new(),
+            None,
+            Vec::new(),
+            Vec::new(),
+            None,
+            None,
+            false,
+            None,
+            Vec::new(),
+            vec!["output".to_string()],
+            Vec::new(),
+            false,
+            false,
+            vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "mkdir output && printf generated > output/result.txt".to_string(),
+            ],
+            Vec::new(),
+        )
+        .expect("runner exec with generated run id");
+
+        assert_eq!(exit_code, 0);
+        let run_id = output.mirror_run_id.expect("persisted runner exec run id");
+        let generated = run_id
+            .strip_prefix("runner-exec-")
+            .expect("generated runner exec prefix");
+        uuid::Uuid::parse_str(generated).expect("generated UUID");
+        let store = ObservationStore::open_initialized().expect("store");
+        let run = store
+            .get_run(&run_id)
+            .expect("read generated run")
+            .expect("generated run persisted");
+        assert_eq!(run.metadata_json["kind"], "runner_exec");
+        let artifacts = store.list_artifacts(&run_id).expect("generated artifacts");
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(artifacts[0].kind, "result_txt");
+        assert_eq!(artifacts[0].metadata_json["artifact_dir"], "output");
+    });
+}
 use homeboy::runner::runners::{
     self as runner, promote_runner_exec_artifact_dirs, promote_runner_exec_artifacts_in_store,
     RunnerExecMode, RunnerExecOutput,

--- a/crates/homeboy-core/src/observation/store/runs.rs
+++ b/crates/homeboy-core/src/observation/store/runs.rs
@@ -465,6 +465,43 @@ impl ObservationStore {
         Ok(rows == 1)
     }
 
+    /// Atomically bind an accepted daemon job to a generic runner-exec run and
+    /// claim its foreground source lease. Keeping both mutations in one update
+    /// prevents a concurrent stale metadata projection from erasing the binding
+    /// between handoff and lease acquisition.
+    pub fn bind_and_claim_running_runner_exec_source(
+        &self,
+        run_id: &str,
+        owner_id: &str,
+        source_token: &str,
+        runner_job_id: &str,
+    ) -> Result<bool> {
+        let claim = serde_json::to_string(&serde_json::json!({
+            "owner_id": owner_id,
+            "source_token": source_token,
+            "runner_job_id": runner_job_id,
+            "expires_at_ms": chrono::Utc::now().timestamp_millis() + 30_000,
+        }))
+        .map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize runner exec source claim".to_string()),
+            )
+        })?;
+        let rows = execute_with_retry("bind and claim runner exec source", || {
+            self.connection.execute(
+                "UPDATE runs SET metadata_json = json_set(metadata_json, '$.runner_job_id', ?1, '$.runner_exec_source_lease', json(?2)) WHERE id = ?3 AND status = 'running' AND json_extract(metadata_json, '$.kind') = 'runner_exec' AND (COALESCE(json_extract(metadata_json, '$.runner_job_id'), json_extract(metadata_json, '$.agent_task_run.metadata.runner_job_id')) IS NULL OR COALESCE(json_extract(metadata_json, '$.runner_job_id'), json_extract(metadata_json, '$.agent_task_run.metadata.runner_job_id')) = ?1) AND (json_extract(metadata_json, '$.runner_exec_source_lease.expires_at_ms') IS NULL OR CAST(json_extract(metadata_json, '$.runner_exec_source_lease.expires_at_ms') AS INTEGER) < ?4)",
+                params![
+                    runner_job_id,
+                    claim,
+                    run_id,
+                    chrono::Utc::now().timestamp_millis()
+                ],
+            )
+        })?;
+        Ok(rows == 1)
+    }
+
     /// Terminalize evidence loss only for the child that still owns this exact
     /// running source/job identity. A stale child cannot overwrite a retry or a
     /// concurrently settled source record.
@@ -1357,6 +1394,84 @@ mod tests {
                     serde_json::json!({ "terminal": "fixture" }),
                 )
                 .expect("terminalize lifecycle source"));
+        });
+    }
+
+    #[test]
+    fn generic_runner_exec_binding_and_foreground_claim_are_one_update() {
+        with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let run_id = "generic-runner-exec-source";
+            store
+                .start_run_with_id(
+                    NewRunRecord::builder("runner_execution")
+                        .metadata(serde_json::json!({
+                            "kind": "runner_exec",
+                            "runner_exec_artifact_declarations": {
+                                "artifact_dirs": ["output"]
+                            }
+                        }))
+                        .build(),
+                    run_id.to_string(),
+                )
+                .expect("generic runner exec run");
+
+            assert!(store
+                .bind_and_claim_running_runner_exec_source(
+                    run_id,
+                    "foreground-runner-exec",
+                    "source-token",
+                    "daemon-job",
+                )
+                .expect("bind and claim source"));
+
+            let run = store
+                .get_run(run_id)
+                .expect("read run")
+                .expect("persisted run");
+            assert_eq!(run.metadata_json["runner_job_id"], "daemon-job");
+            assert_eq!(
+                run.metadata_json["runner_exec_source_lease"]["source_token"],
+                "source-token"
+            );
+            assert_eq!(
+                run.metadata_json["runner_exec_artifact_declarations"]["artifact_dirs"][0],
+                "output"
+            );
+        });
+    }
+
+    #[test]
+    fn generic_runner_exec_atomic_binding_refuses_a_foreign_job() {
+        with_isolated_home(|_| {
+            let store = ObservationStore::open_initialized().expect("store");
+            let run_id = "foreign-generic-runner-exec-source";
+            store
+                .start_run_with_id(
+                    NewRunRecord::builder("runner_execution")
+                        .metadata(serde_json::json!({
+                            "kind": "runner_exec",
+                            "runner_job_id": "other-daemon-job"
+                        }))
+                        .build(),
+                    run_id.to_string(),
+                )
+                .expect("generic runner exec run");
+
+            assert!(!store
+                .bind_and_claim_running_runner_exec_source(
+                    run_id,
+                    "foreground-runner-exec",
+                    "source-token",
+                    "accepted-daemon-job",
+                )
+                .expect("foreign binding is rejected"));
+            let run = store
+                .get_run(run_id)
+                .expect("read run")
+                .expect("persisted run");
+            assert_eq!(run.metadata_json["runner_job_id"], "other-daemon-job");
+            assert!(run.metadata_json.get("runner_exec_source_lease").is_none());
         });
     }
 

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -232,16 +232,27 @@ pub(super) fn exec_via_daemon(
                 let store = lease_store
                     .as_ref()
                     .expect("lease store is opened whenever run_id is present");
-                if !store.claim_running_runner_exec_recovery_source(
-                    run_id,
-                    "foreground-runner-exec",
-                    &token,
-                    &job.id.to_string(),
-                )? {
+                let runner_job_id = job.id.to_string();
+                let claimed = if run_id_owns_generic_exec {
+                    store.bind_and_claim_running_runner_exec_source(
+                        run_id,
+                        "foreground-runner-exec",
+                        &token,
+                        &runner_job_id,
+                    )?
+                } else {
+                    store.claim_running_runner_exec_recovery_source(
+                        run_id,
+                        "foreground-runner-exec",
+                        &token,
+                        &runner_job_id,
+                    )?
+                };
+                if !claimed {
                     return Err(runner_exec_source_claim_error(
                         store,
                         run_id,
-                        &job.id.to_string(),
+                        &runner_job_id,
                     )?);
                 }
                 *foreground_source_lease.borrow_mut() = Some((run_id.to_string(), token));


### PR DESCRIPTION
## Summary
- allocate a durable runner-exec run when outputs are declared without `--run-id`
- atomically bind daemon jobs to generic runner-exec ownership before claiming the source lease
- return the persisted run ID and retain promoted artifact references

Closes #13407.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p homeboy-cli --features test-support runner_exec_generates_a_persisted_run_for_declared_outputs`
- `cargo test -p homeboy-core generic_runner_exec_`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode reviewed and rebased the candidate, fixed the generated run output contract, and ran focused regression tests. Chris Huber directed the work and is responsible for the change.