### PR TITLE
Canonicalize provider worktrees for Cook continuation

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -3990,10 +3990,9 @@ pub fn terminal_review_form_continuation_is_eligible(
 /// This deliberately stops before recipe/lifecycle materialization, transport
 /// preparation, provider dispatch, and finalization.
 pub fn preflight_cook_continuation_admission(options: &AgentTaskCookServiceOptions) -> Result<()> {
-    // Continuation can lead directly to promotion/finalization. Apply the same
-    // durable model-provenance boundary here so it cannot admit a legacy null
-    // model candidate that publication will deterministically reject.
-    super::cook_promotion::validate_cook_attempt_model_provenance(&options.initial_run_id)?;
+    let mut options = options.clone();
+    canonicalize_cook_provider_workspace(&mut options)?;
+    let options = &options;
     let moving_base_continuation = agent_task_lifecycle::status(&options.initial_run_id)
         .ok()
         .and_then(|record| record.metadata.get("cook_moving_base_recovery").cloned())
@@ -4007,8 +4006,43 @@ pub fn preflight_cook_continuation_admission(options: &AgentTaskCookServiceOptio
                 .and_then(Value::as_str)
                 == Some("verification_pending")
         });
+    let record = agent_task_lifecycle::status(&options.initial_run_id).ok();
+    let review_form_continuation = record.as_ref().is_some_and(|record| {
+        review_form_attempt_is_ready_for_cook_continuation(&options.initial_plan, record)
+            .unwrap_or(false)
+    });
+    if review_form_continuation
+        && !record.as_ref().is_some_and(|record| {
+            terminal_review_form_continuation_is_eligible(&options.initial_plan, record)
+                .unwrap_or(false)
+        })
+    {
+        let mut error = Error::validation_invalid_argument(
+            "cook_continuation",
+            "terminal review-form continuation is not eligible for execution",
+            Some(options.initial_run_id.clone()),
+            None,
+        );
+        error.details["continuation_admission"] = serde_json::json!({
+            "first_authoritative_denial": "terminal_review_form_eligibility",
+            "predicates": [{ "name": "terminal_review_form_eligibility", "outcome": "fail" }],
+        });
+        return Err(error);
+    }
+    // Continuation can lead directly to promotion/finalization. Apply the same
+    // durable model-provenance boundary after terminal-form eligibility so
+    // preflight reports the same first authoritative denial as execution.
+    super::cook_promotion::validate_cook_attempt_model_provenance(&options.initial_run_id)?;
     let authenticated_historical_review_continuation =
         authenticated_historical_review_form_workspace_with_trace(options, false)?;
+    if review_form_continuation && !authenticated_historical_review_continuation {
+        return Err(Error::validation_invalid_argument(
+            "cook_continuation",
+            "terminal review-form continuation workspace could not be authenticated",
+            Some(options.initial_run_id.clone()),
+            None,
+        ));
+    }
     if !moving_base_continuation
         && !verification_pending_continuation
         && !authenticated_historical_review_continuation
@@ -4534,6 +4568,7 @@ fn run_cook_spine(
     durable_observer: Option<&CookProgressObserver<'_>>,
     allow_historical_terminal: bool,
 ) -> Result<AgentTaskRunResult<AgentTaskCookReport>> {
+    canonicalize_cook_provider_workspace(&mut options)?;
     // The local detached launcher persists this fence before spawn. Recheck it
     // at each durable/external boundary so a dead launcher cannot revive work.
     lifecycle_store.require_detached_cook_handoff_fence_open(&options.cook_id)?;
@@ -4661,6 +4696,7 @@ fn run_cook_spine(
     } else {
         options
     };
+    canonicalize_cook_provider_workspace(&mut options)?;
     // Candidate adoption records the concrete external model on the lifecycle
     // attempt. Reuse it only when the persisted promotion authenticates the
     // same candidate/model pair, including after a detached continuation.
@@ -8870,6 +8906,40 @@ fn rebind_baseline_continuation_workspace(
             options.source_worktree_path = Some(worktree.path().into());
         }
     }
+    Ok(())
+}
+
+/// Normalize path-spelled legacy recipes and explicit CWDs to the provider's
+/// canonical handle before any continuation admission or execution decision.
+/// Safety remains a separate admission check so a retained dirty candidate can
+/// still prove itself against its durable promotion baseline.
+fn canonicalize_cook_provider_workspace(options: &mut AgentTaskCookServiceOptions) -> Result<()> {
+    let path = options.source_worktree_path.as_deref().or_else(|| {
+        std::path::Path::new(&options.to_worktree)
+            .is_dir()
+            .then_some(std::path::Path::new(&options.to_worktree))
+    });
+    let Some(path) = path else {
+        return Ok(());
+    };
+    let config = homeboy_core::defaults::load_config();
+    let Some(identity) = homeboy_core::worktree_providers::resolve_apply_enabled_worktree_provider_identity_by_path_from_config(path, &config)? else {
+        return Ok(());
+    };
+    if !std::path::Path::new(&options.to_worktree).is_dir()
+        && options.to_worktree != identity.handle
+    {
+        return Err(Error::validation_invalid_argument(
+            "to_worktree",
+            "Cook source path and provider handle identify different worktrees",
+            Some(options.to_worktree.clone()),
+            None,
+        ));
+    }
+    options.to_worktree = identity.handle.clone();
+    options.source_worktree_path = Some(PathBuf::from(&identity.path));
+    options.initial_plan.metadata["cook_provision"]["workspace_identity"] =
+        serde_json::to_value(identity).expect("provider identity serializes");
     Ok(())
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -4479,6 +4479,7 @@ fn initial_cook_adopts_only_clean_issue_owned_unpushed_provider_worktree() {
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy_core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![provider.display().to_string()]),
+                    list: Some(vec![provider.display().to_string()]),
                     ..Default::default()
                 },
                 list_result_mapping: Some(
@@ -15181,6 +15182,7 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
                 lookup_output_limit_bytes: 64 * 1024,
                 commands: homeboy_core::defaults::WorktreeProviderCommands {
                     resolve: Some(vec![provider.display().to_string()]),
+                    resolve_path: Some(vec![provider.display().to_string()]),
                     ..Default::default()
                 },
                 list_result_mapping: Some(
@@ -15199,6 +15201,18 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
         );
         homeboy_core::defaults::save_config(&config).expect("save provider config");
         crate::agent_task_candidate_baseline::register();
+
+        let mut legacy_path_recipe = options.clone();
+        legacy_path_recipe.to_worktree = target.display().to_string();
+        legacy_path_recipe.source_worktree_path = Some(target.clone());
+        canonicalize_cook_provider_workspace(&mut legacy_path_recipe)
+            .expect("legacy path identity remains recoverable through provider ownership");
+        assert_eq!(legacy_path_recipe.to_worktree, options.to_worktree);
+        assert_eq!(
+            legacy_path_recipe.initial_plan.metadata["cook_provision"]["workspace_identity"]
+                ["handle"],
+            options.to_worktree
+        );
 
         // Fanout coordinators re-resolve the destination from the identity
         // persisted when their child was admitted; they do not retain a CWD.
@@ -15420,6 +15434,13 @@ fn cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate() 
         assert!(
             !authenticated_historical_review_form_workspace(&historical).unwrap(),
             "cancelled review-form attempts never authorize the bypass"
+        );
+        let preflight = preflight_cook_continuation_admission(&historical)
+            .expect_err("preflight rejects the same ineligible terminal review form");
+        assert_eq!(
+            preflight.details["continuation_admission"]["first_authoritative_denial"],
+            "terminal_review_form_eligibility",
+            "{preflight:?}"
         );
         let result = run_cook(CookContext {
             side_effects: Some(Box::new(DefaultCookSideEffects::new(|_, _, _, _| {

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -3182,8 +3182,7 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
             homeboy::core::Error::internal_io(error.to_string(), Some(cwd.display().to_string()))
         })?;
         validate_cook_destination_identity(args, &path)?;
-        let logical_provider_provenance =
-            validate_cook_cwd_destination_identity(&path, to_worktree)?;
+        let provider_identity = validate_cook_cwd_destination_identity(&path, to_worktree)?;
         let mut provision = serde_json::json!({
             "action": "existing",
             "kind": "explicit_cwd",
@@ -3207,8 +3206,21 @@ pub(crate) fn provision_cook_destination(args: &AgentTaskCookArgs) -> homeboy::c
                 },
             });
         }
-        if let Some(provenance) = logical_provider_provenance {
-            provision["logical_provider_provenance"] = provenance;
+        if let Some((identity, safety)) = provider_identity {
+            provision["provider"] = Value::String(identity.provider_id.clone());
+            provision["workspace_identity"] =
+                serde_json::to_value(&identity).expect("provider identity serializes");
+            provision["workspace_safety"] =
+                serde_json::to_value(&safety).expect("provider safety serializes");
+        } else if !Path::new(to_worktree).is_dir()
+            && homeboy::core::worktree::resolve_workspace_ref_if_present(to_worktree)?.is_none()
+        {
+            provision["logical_provider_provenance"] = serde_json::json!({
+                "schema": "homeboy/logical-worktree-handle-provenance/v1",
+                "handle": to_worktree,
+                "canonical_path": path,
+                "validation": "exact_handle_basename",
+            });
         }
         return Ok(provision);
     }
@@ -3433,8 +3445,13 @@ fn ensure_active_managed_cook_destination(to_worktree: &str) -> homeboy::core::R
 fn validate_cook_cwd_destination_identity(
     cwd: &Path,
     to_worktree: &str,
-) -> homeboy::core::Result<Option<Value>> {
-    let (destination, logical_provider_provenance) = if Path::new(to_worktree).is_dir() {
+) -> homeboy::core::Result<
+    Option<(
+        homeboy::core::worktree_providers::WorktreeProviderExactIdentity,
+        homeboy::core::worktree_providers::WorktreeProviderSafetyAttestation,
+    )>,
+> {
+    let (destination, provider_identity) = if Path::new(to_worktree).is_dir() {
         std::fs::canonicalize(to_worktree).map(|path| (path, None))
     } else if let Some(record) =
         homeboy::core::worktree::resolve_workspace_ref_if_present(to_worktree)?
@@ -3442,19 +3459,33 @@ fn validate_cook_cwd_destination_identity(
         ensure_active_managed_cook_destination(to_worktree)?;
         std::fs::canonicalize(record.path()).map(|path| (path, None))
     } else {
-        // The supplied CWD is authoritative. An external handle must retain
-        // the complete canonical checkout basename, which is injective and
-        // avoids a provider lookup on this local authority boundary.
-        validate_logical_worktree_handle_path_relationship(cwd, to_worktree)?;
-        Ok((
-            cwd.to_path_buf(),
-            Some(serde_json::json!({
-                "schema": "homeboy/logical-worktree-handle-provenance/v1",
-                "handle": to_worktree,
-                "canonical_path": cwd,
-                "validation": "exact_handle_basename",
-            })),
-        ))
+        let config = defaults::load_config();
+        match homeboy::core::worktree_providers::resolve_apply_enabled_worktree_provider_identity_by_path_from_config(cwd, &config)? {
+            Some(identity) => {
+                if identity.handle != to_worktree {
+                    return Err(homeboy::core::Error::validation_invalid_argument(
+                        "to_worktree",
+                        "--cwd and --to-worktree resolve to different provider worktrees",
+                        Some(to_worktree.to_string()),
+                        None,
+                    ));
+                }
+                let safety = homeboy::core::worktree_providers::attest_apply_enabled_worktree_provider_safety_from_config(&identity, &config)?;
+                if !safety.fresh || safety.dirty || safety.unpushed || identity.primary {
+                    return Err(homeboy::core::Error::validation_invalid_argument(
+                        "to_worktree",
+                        "worktree provider safety attestation is not safe for Cook execution",
+                        Some(to_worktree.to_string()),
+                        None,
+                    ));
+                }
+                Ok((PathBuf::from(&identity.path), Some((identity, safety))))
+            }
+            None => {
+                validate_logical_worktree_handle_path_relationship(cwd, to_worktree)?;
+                Ok((cwd.to_path_buf(), None))
+            }
+        }
     }
     .map_err(|error| {
         homeboy::core::Error::internal_io(error.to_string(), Some(to_worktree.to_string()))
@@ -3467,7 +3498,7 @@ fn validate_cook_cwd_destination_identity(
             None,
         ));
     }
-    Ok(logical_provider_provenance)
+    Ok(provider_identity)
 }
 
 pub(crate) fn validate_logical_worktree_handle_path_relationship(
@@ -3512,9 +3543,11 @@ pub(crate) fn resolve_cook_destination(
         let cwd = std::fs::canonicalize(cwd).map_err(|error| {
             homeboy::core::Error::internal_io(error.to_string(), Some(cwd.to_string()))
         })?;
-        // A supplied checkout is the writable Cook authority. Preserve its
-        // canonical path instead of deriving an unrelated issue handle.
-        args.to_worktree = Some(cwd.display().to_string());
+        let config = defaults::load_config();
+        args.to_worktree = Some(match homeboy::core::worktree_providers::resolve_apply_enabled_worktree_provider_identity_by_path_from_config(&cwd, &config)? {
+            Some(identity) => identity.handle,
+            None => cwd.display().to_string(),
+        });
         resolve_cook_base(&mut args)?;
         return Ok(args);
     }

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -2213,6 +2213,104 @@ fn cook_cwd_matching_external_handle_never_invokes_a_sleeping_resolver() {
 
 #[cfg(unix)]
 #[test]
+fn cook_cwd_is_canonicalized_to_its_provider_handle_before_provisioning() {
+    use std::os::unix::fs::PermissionsExt;
+
+    with_isolated_home(|_| {
+        let primary = tempfile::tempdir().expect("primary checkout");
+        init_runtime_component_checkout(primary.path());
+        let worktree_root = tempfile::tempdir().expect("worktree root");
+        let cwd = worktree_root.path().join("provider-owned-checkout");
+        assert!(Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "fix/13421",
+                cwd.to_str().expect("worktree path"),
+                "HEAD",
+            ])
+            .current_dir(primary.path())
+            .status()
+            .expect("create linked worktree")
+            .success());
+        let provider_dir = tempfile::tempdir().expect("provider directory");
+        let provider = provider_dir.path().join("provider");
+        std::fs::write(
+            &provider,
+            format!(
+                "#!/bin/sh\nprintf '%s\\n' '{}'\n",
+                serde_json::json!({ "worktrees": [{
+                    "handle": "homeboy@fix-13421",
+                    "path": cwd,
+                    "branch": "fix/13421",
+                    "safety": { "dirty": false, "unpushed": false, "primary": false }
+                }] })
+            ),
+        )
+        .expect("write provider");
+        let mut permissions = std::fs::metadata(&provider).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&provider, permissions).unwrap();
+        let mut config = homeboy::core::defaults::HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "dmc".to_string(),
+            homeboy::core::defaults::WorktreeProviderConfig {
+                enabled: true,
+                kind: homeboy::core::defaults::WorktreeProviderKind::Command,
+                apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: homeboy::core::defaults::WorktreeProviderCommands {
+                    resolve_path: Some(vec![provider.display().to_string(), "{path}".to_string()]),
+                    resolve: Some(vec![provider.display().to_string(), "{handle}".to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(
+                    homeboy::core::defaults::WorktreeProviderListResultMapping {
+                        items: "$.worktrees".to_string(),
+                        handle: "$.handle".to_string(),
+                        path: "$.path".to_string(),
+                        branch: "$.branch".to_string(),
+                        dirty: "$.safety.dirty".to_string(),
+                        unpushed: "$.safety.unpushed".to_string(),
+                        primary: "$.safety.primary".to_string(),
+                        task_url: None,
+                    },
+                ),
+            },
+        );
+        homeboy::core::defaults::save_config(&config).expect("save provider config");
+        let args = cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "retain the candidate".to_string(),
+            "--cwd".to_string(),
+            cwd.display().to_string(),
+            "--repo".to_string(),
+            "homeboy".to_string(),
+            "--no-finalize".to_string(),
+        ]);
+
+        let args = super::super::run::resolve_cook_destination(args)
+            .expect("map provider path to canonical handle");
+        assert_eq!(args.to_worktree.as_deref(), Some("homeboy@fix-13421"));
+        let provision = super::super::run::provision_cook_destination(&args)
+            .expect("provision the same canonical identity");
+        assert_eq!(provision["handle"], "homeboy@fix-13421");
+        assert_eq!(
+            provision["workspace_identity"]["handle"],
+            "homeboy@fix-13421"
+        );
+        assert_eq!(provision["workspace_safety"]["fresh"], true);
+    });
+}
+
+#[cfg(unix)]
+#[test]
 fn cook_cwd_rejects_a_mismatched_external_provider_handle_before_dispatch() {
     use std::os::unix::fs::PermissionsExt;
 

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -570,6 +570,69 @@ pub fn resolve_worktree_provider_path_from_config(
     resolve_worktree_provider_path_with_policy_from_config(path, config, false, None, None)
 }
 
+/// Map a canonical local checkout path to the exact identity issued by its
+/// apply-enabled provider. Path lookup establishes ownership only; callers must
+/// attest the returned identity separately at their admission boundary.
+pub fn resolve_apply_enabled_worktree_provider_identity_by_path_from_config(
+    path: &std::path::Path,
+    config: &HomeboyConfig,
+) -> Result<Option<WorktreeProviderExactIdentity>> {
+    let requested = match std::fs::canonicalize(path) {
+        Ok(path) => path,
+        Err(_) => return Ok(None),
+    };
+    let mut provider_ids = config
+        .worktree_providers
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    provider_ids.sort();
+    for provider_id in provider_ids {
+        let provider = &config.worktree_providers[&provider_id];
+        if !provider.enabled || !provider.apply_enabled {
+            continue;
+        }
+        let Some(command) = provider.commands.resolve_path.as_ref() else {
+            continue;
+        };
+        let worktree = targeted_path_result(
+            &provider_id,
+            run_provider_resolve_path_command(
+                &provider_id,
+                provider,
+                command,
+                requested.as_path(),
+            )?,
+            requested.as_path(),
+        )?;
+        let Some(worktree) = worktree else {
+            continue;
+        };
+        let identity = resolve_apply_enabled_worktree_provider_identity_by_id_from_config(
+            &worktree.handle,
+            &provider_id,
+            config,
+        )?;
+        let identity_path = std::fs::canonicalize(&identity.path)
+            .map_err(|error| Error::internal_io(error.to_string(), Some(identity.path.clone())))?;
+        if identity_path != requested
+            || identity.handle != worktree.handle
+            || identity.branch != worktree.branch
+        {
+            return Err(Error::validation_invalid_argument(
+                "cwd",
+                format!(
+                    "worktree provider `{provider_id}` path lookup disagrees with its exact identity"
+                ),
+                Some(requested.display().to_string()),
+                None,
+            ));
+        }
+        return Ok(Some(identity));
+    }
+    Ok(None)
+}
+
 /// Resolve an exact provider-owned checkout path for mutation while applying
 /// the same destination safety policy as handle-based promotion.
 pub fn resolve_apply_enabled_worktree_provider_path_from_config(
@@ -5858,6 +5921,47 @@ mod tests {
         assert_eq!(
             resolution.worktree.path,
             workspace.path().display().to_string()
+        );
+    }
+
+    #[test]
+    fn provider_path_maps_to_exact_handle_without_admitting_dirty_safety() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        git_init(workspace.path(), "fix/13421");
+        let script = fake_list_provider_script(json!({ "worktrees": [{
+            "handle": "fixture@fix-13421",
+            "path": workspace.path(),
+            "branch": "fix/13421",
+            "safety": { "dirty": true, "unpushed": false, "primary": false }
+        }]}));
+        let config = config_with_provider(WorktreeProviderConfig {
+            enabled: true,
+            kind: WorktreeProviderKind::Command,
+            apply_enabled: true,
+            lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
+            lookup_output_limit_bytes: 64 * 1024,
+            commands: WorktreeProviderCommands {
+                resolve_path: Some(vec![script.clone(), "{path}".to_string()]),
+                resolve: Some(vec![script, "{handle}".to_string()]),
+                ..Default::default()
+            },
+            list_result_mapping: Some(worktrees_mapping()),
+        });
+
+        let identity = resolve_apply_enabled_worktree_provider_identity_by_path_from_config(
+            workspace.path(),
+            &config,
+        )
+        .expect("path ownership resolves independently from safety")
+        .expect("provider owns path");
+
+        assert_eq!(identity.provider_id, "fixture");
+        assert_eq!(identity.handle, "fixture@fix-13421");
+        assert_eq!(identity.branch, "fix/13421");
+        assert_eq!(
+            std::fs::canonicalize(identity.path).unwrap(),
+            std::fs::canonicalize(workspace.path()).unwrap()
         );
     }
 


### PR DESCRIPTION
## Summary
- resolve provider-owned Cook paths to their canonical provider handles before continuation admission
- retain explicit-CWD authority by using only targeted provider path resolution
- make continuation preflight report the same first authoritative denial as execution
- exclude preview-resolution work already owned by #13456

Closes #13421.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p homeboy-core provider_path_maps_to_exact_handle_without_admitting_dirty_safety`
- `cargo test -p homeboy-cli --features test-support cook_cwd_is_canonicalized_to_its_provider_handle_before_provisioning`
- `cargo test -p homeboy-cli --features test-support cook_cwd_is_authoritative_when_provider_lookup_times_out`
- `cargo test -p homeboy-agents cook_continuation_authenticates_only_its_exact_tracked_promotion_candidate`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode reviewed and rebased the candidate, removed overlap with #13456, preserved explicit-CWD authority, aligned preflight denial ordering, and ran focused regressions. Chris Huber directed the work and is responsible for the change.