### PR TITLE
fix(fanout): main does not compile — construct WorktreeQueueCreateRow with its new failure field

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -2884,6 +2884,7 @@ fn queue_or_reuse_worktrees_with_terminal_paths(
                 active_lock_holder: None,
                 path: Some(path.clone()),
                 error: None,
+                failure: None,
             });
             continue;
         }
@@ -3010,6 +3011,7 @@ fn queue_or_reuse_worktrees_with_terminal_paths(
                         active_lock_holder: None,
                         path: Some(resolution.worktree.path),
                         error: None,
+                        failure: None,
                     });
                     states.insert(
                         cook.to_worktree.clone(),


### PR DESCRIPTION
`origin/main` does not compile.

```
$ cargo check -p homeboy-cli --lib
error[E0063]: missing field `failure` in initializer of `WorktreeQueueCreateRow`
    --> crates/homeboy-cli/src/commands/agent_task/fanout.rs:2878:25
error[E0063]: missing field `failure` in initializer of `WorktreeQueueCreateRow`
    --> crates/homeboy-cli/src/commands/agent_task/fanout.rs:3004:33
```

This is the ordinary `(lib)` target, not a test-only one.

## How it landed

Two commits with the **same timestamp**:

```
7b20153c2  2026-08-25 08:33:44  fix(fanout): compact blocked worktree evidence
af3241387  2026-08-25 08:33:44  fix(agent-task): re-resolve recovered fanout worktrees
```

The first added `failure: Option<WorktreeQueueCreateFailure>` to `WorktreeQueueCreateRow` and updated the construction sites it could see. The second added two new construction sites in `fanout.rs`.

**Each was green against its own base. Their merge is not.** No PR CI run ever evaluated the combination.

## The fix

Both new sites are reuse paths — a reused terminal worktree and a re-resolved one — which already pass `error: None` because nothing failed. `failure: None` is the same statement in the typed form the first commit introduced.

## Why this one is worth a second look

This is precisely the class the pre-push gate is specified for, and the reason it is `--all-targets` rather than a bare `cargo check`: a struct gains a field, a construction site the author never opened does not, and only the compiler notices.

Nothing here required judgement. It required running `cargo check --workspace --all-targets` **on the merge result**. Worth considering whether a post-merge compile check on `main` is warranted — noting that a full post-merge gate was removed deliberately and `tests/audit_debt_workflow_test.rs` pins its absence, so this would need to be a compile-only check, not a suite.

## Verification

- `cargo fmt --check`
- `cargo check --workspace --all-targets --features homeboy-cli/test-support -j2` — clean
- The same command reproduces both errors on unmodified `39c930ef9`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode / Claude via Kimaki
- **Used for:** Hit the break while benchmarking build times, bisected it to the two same-timestamp commits, applied the field. Chris reviewed and owns the change.
