### PR TITLE
Isolate parallel worktree patch preservation

### DIFF
--- a/crates/homeboy-agents/src/agent_task_dispatch_plan/command_policy.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_plan/command_policy.rs
@@ -21,6 +21,7 @@ use homeboy_core::{defaults, Error, Result};
 /// exists to prevent.
 pub(super) fn resolve_dispatch_command_policy(
     request: &AgentTaskDispatchRequest,
+    managed_worktree: bool,
 ) -> Result<AgentCommandPolicy> {
     let mut policy = match defaults::load_config().agent_task.command_policy {
         Some(raw) => serde_json::from_value::<AgentCommandPolicy>(raw).map_err(|error| {
@@ -59,6 +60,12 @@ homeboy/agent-command-policy/v1 document: {error}"
     }
     if let Some(reason) = &request.core.command_policy_reason {
         policy.reason = Some(reason.clone());
+    }
+    if managed_worktree {
+        policy.deny.push(AgentCommandRule::with_reason(
+            "git stash*",
+            "Git's stash stack is repository-global and unsafe for parallel managed worktrees; preserve changes with an operation-owned patch artifact",
+        ));
     }
 
     Ok(policy)

--- a/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
@@ -203,7 +203,10 @@ pub fn build_dispatch_plan_with_provider_requirements(
     let secret_env = dispatch_secret_env(request, &provider_config);
     let runtime_dependency_graph_evidence = (!runtime_dependency_graph.is_empty())
         .then(|| runtime_dependency_graph.to_evidence_value());
-    let command_policy = resolve_dispatch_command_policy(request)?;
+    let managed_worktree = workspace_target
+        .as_ref()
+        .is_some_and(DispatchWorkspaceTarget::is_managed);
+    let command_policy = resolve_dispatch_command_policy(request, managed_worktree)?;
     let mut tasks = Vec::new();
     for (index, prompt_spec) in prompt_specs.iter().enumerate() {
         let resolved_prompt = if prompt_spec.is_literal {
@@ -218,6 +221,7 @@ pub fn build_dispatch_plan_with_provider_requirements(
             resolved_prompt.content.clone(),
             request.task_url.as_deref(),
             &command_policy,
+            managed_worktree,
         );
         let task_id = prompt_spec.task_id.clone().unwrap_or_else(|| {
             request
@@ -521,6 +525,7 @@ fn dispatch_instructions(
     instructions: String,
     task_url: Option<&str>,
     command_policy: &AgentCommandPolicy,
+    managed_worktree: bool,
 ) -> String {
     // The command policy is stated in the prompt as well as enforced. Homeboy
     // structurally refuses a denied command at its own tool boundary, but a
@@ -528,12 +533,17 @@ fn dispatch_instructions(
     // crosses that boundary — for those runtimes the agent has to be told, in
     // terms it cannot miss, what it may not run and what to do instead.
     let constraints = command_policy.prompt_constraints();
-    let instructions = match constraints {
+    let mut instructions = match constraints {
         Some(constraints) if !instructions.contains("Command policy (declared by the operator") => {
             format!("{instructions}\n\n{constraints}")
         }
         _ => instructions,
     };
+    if managed_worktree && !instructions.contains("Parallel worktree patch preservation:") {
+        instructions.push_str(
+            "\n\nParallel worktree patch preservation:\n- Never use `git stash`; its stack is shared by every worktree in the repository.\n- Before current-base reconciliation, run `homeboy git patch preserve <operation-id> --path <worktree>`. Restore only with `homeboy git patch restore <operation-id> --path <worktree>`, never by stack position.\n- Keep the durable patch evidence until restoration and cleanup state are recorded.",
+        );
+    }
 
     if task_url.is_none() || instructions.contains("Generated change guardrails") {
         return instructions;
@@ -655,6 +665,13 @@ pub(crate) struct DispatchWorkspaceTarget {
 }
 
 impl DispatchWorkspaceTarget {
+    fn is_managed(&self) -> bool {
+        matches!(
+            self.kind.as_deref(),
+            Some("homeboy-worktree" | "worktree-provider")
+        )
+    }
+
     fn path(root: std::path::PathBuf, kind: &str) -> Self {
         let slug = root
             .file_name()
@@ -812,6 +829,7 @@ mod tests {
             "Implement the tracked change.".to_string(),
             Some("https://example.test/issues/1"),
             &AgentCommandPolicy::default(),
+            false,
         );
 
         assert!(instructions.contains("successful gates remain authoritative"));
@@ -826,6 +844,7 @@ mod tests {
             "Implement the tracked change.".to_string(),
             None,
             &AgentCommandPolicy::default(),
+            false,
         );
 
         assert_eq!(instructions, "Implement the tracked change.");
@@ -839,12 +858,38 @@ mod tests {
             ..AgentCommandPolicy::default()
         };
 
-        let instructions =
-            dispatch_instructions("Implement the tracked change.".to_string(), None, &policy);
+        let instructions = dispatch_instructions(
+            "Implement the tracked change.".to_string(),
+            None,
+            &policy,
+            false,
+        );
 
         assert!(instructions.contains("`cargo test`"));
         assert!(instructions.contains("this host routes builds to CI"));
         assert!(instructions.contains("Make your edits, commit"));
+    }
+
+    #[test]
+    fn managed_worktree_refuses_repository_global_stash_and_guides_safe_recovery() {
+        let request = dispatch_request(DispatchRequestOverrides::default());
+        let policy = resolve_dispatch_command_policy(&request, true).expect("managed policy");
+
+        let decision = policy.evaluate("git stash push -u");
+        let denial = decision.denial().expect("stash denied");
+        assert_eq!(denial.matched_pattern.as_deref(), Some("git stash*"));
+        assert!(denial.reason.contains("repository-global"));
+
+        let instructions = dispatch_instructions(
+            "Reconcile with the current base.".to_string(),
+            None,
+            &policy,
+            true,
+        );
+        assert!(instructions.contains("Never use `git stash`"));
+        assert!(instructions.contains("homeboy git patch preserve <operation-id>"));
+        assert!(instructions.contains("homeboy git patch restore <operation-id>"));
+        assert!(instructions.contains("durable patch evidence"));
     }
 
     #[test]

--- a/crates/homeboy-cli/src/command_contract/public_variants.rs
+++ b/crates/homeboy-cli/src/command_contract/public_variants.rs
@@ -171,6 +171,13 @@ pub const PUBLIC_OUTPUT_VARIANT_CONTRACTS: &[PublicOutputVariantContract] = &[
         golden_fixture: None,
     },
     PublicOutputVariantContract {
+        command: "git",
+        variant: "patch",
+        discriminator_field: Some("variant"),
+        discriminator_value: Some("patch"),
+        golden_fixture: None,
+    },
+    PublicOutputVariantContract {
         command: "api",
         variant: "response",
         discriminator_field: Some("variant"),

--- a/crates/homeboy-cli/src/command_contract/spec.rs
+++ b/crates/homeboy-cli/src/command_contract/spec.rs
@@ -840,6 +840,11 @@ const GIT_PR_WRITE_PATHS: &[&str] = &[
 
 const GIT_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
     paths_safety(
+        &["patch preserve", "patch restore"],
+        mutating_safety(),
+        "captures and cleans or restores exact worktree changes using operation-owned evidence",
+    ),
+    paths_safety(
         GIT_ISSUE_WRITE_PATHS,
         with_risk_exemption(
             operator_safety(None, &[]),

--- a/crates/homeboy-cli/src/commands/git/mod.rs
+++ b/crates/homeboy-cli/src/commands/git/mod.rs
@@ -201,6 +201,11 @@ enum GitCommand {
         #[arg(long, value_name = "PATH")]
         path: Option<String>,
     },
+    /// Preserve or restore an operation-owned worktree patch without refs/stash.
+    Patch {
+        #[command(subcommand)]
+        command: PatchCommand,
+    },
     /// Pull remote changes
     Pull {
         /// JSON input spec for bulk operations.
@@ -242,6 +247,22 @@ enum GitCommand {
     Issue(IssueArgs),
     /// Manage GitHub pull requests for a component
     Pr(PrArgs),
+}
+
+#[derive(Subcommand)]
+enum PatchCommand {
+    /// Capture staged, unstaged, and untracked changes, then leave the worktree clean.
+    Preserve {
+        operation_id: String,
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
+    },
+    /// Restore a previously captured patch by its operation identity.
+    Restore {
+        operation_id: String,
+        #[arg(long, value_name = "PATH")]
+        path: Option<String>,
+    },
 }
 
 pub fn run(args: GitArgs) -> CmdResult<GitCommandOutput> {
@@ -467,6 +488,23 @@ pub fn run(args: GitArgs) -> CmdResult<GitCommandOutput> {
             )?;
             let exit_code = output.exit_code;
             Ok((GitCommandOutput::Single(output), exit_code))
+        }
+        GitCommand::Patch { command } => {
+            let (operation_id, path, restore) = match command {
+                PatchCommand::Preserve { operation_id, path } => (operation_id, path, false),
+                PatchCommand::Restore { operation_id, path } => (operation_id, path, true),
+            };
+            let path = path
+                .map(std::path::PathBuf::from)
+                .map(Ok)
+                .unwrap_or_else(std::env::current_dir)
+                .map_err(|error| homeboy::core::Error::internal_io(error.to_string(), None))?;
+            let evidence = if restore {
+                git::restore_worktree_patch(&path, &operation_id)?
+            } else {
+                git::preserve_worktree_patch(&path, &operation_id)?
+            };
+            Ok((GitCommandOutput::Patch(evidence), 0))
         }
         GitCommand::Issue(args) => issue::run_issue(args),
         GitCommand::Pr(args) => pr::run_pr(args),

--- a/crates/homeboy-cli/src/commands/git/output.rs
+++ b/crates/homeboy-cli/src/commands/git/output.rs
@@ -2,8 +2,8 @@ use serde::{Serialize, Serializer};
 
 use homeboy::core::git::{
     GitOutput, GithubFindOutput, GithubIssueOutput, GithubPrFleetOutput, GithubPrOutput,
-    GithubPrReadinessOutput, PrLandOutput, PrMergeabilityReconcileOutput, PrPolicyDecision,
-    PrRefreshOutput,
+    GithubPrReadinessOutput, PatchPreservationEvidence, PrLandOutput,
+    PrMergeabilityReconcileOutput, PrPolicyDecision, PrRefreshOutput,
 };
 use homeboy::core::BulkResult;
 
@@ -19,6 +19,7 @@ pub enum GitCommandOutput {
     Policy(PrPolicyDecision),
     Fleet(GithubPrFleetOutput),
     Land(PrLandOutput),
+    Patch(PatchPreservationEvidence),
 }
 
 impl Serialize for GitCommandOutput {
@@ -40,6 +41,7 @@ impl Serialize for GitCommandOutput {
             GitCommandOutput::Policy(output) => ("policy", serde_json::to_value(output)),
             GitCommandOutput::Fleet(output) => ("fleet", serde_json::to_value(output)),
             GitCommandOutput::Land(output) => ("land", serde_json::to_value(output)),
+            GitCommandOutput::Patch(output) => ("patch", serde_json::to_value(output)),
         };
 
         let mut payload = payload.map_err(serde::ser::Error::custom)?;

--- a/crates/homeboy-cli/src/commands/git/tests.rs
+++ b/crates/homeboy-cli/src/commands/git/tests.rs
@@ -1,5 +1,5 @@
 use super::args::{ComponentPathArgs, IssueArgs, IssueCommand, PrArgs, PrCommand};
-use super::GitCommand;
+use super::{GitCommand, PatchCommand};
 use clap::Parser;
 
 #[derive(Parser)]
@@ -137,5 +137,31 @@ fn issue_find_path_flag_parses() {
             assert_eq!(path.as_deref(), Some("/tmp/homeboy"));
         }
         _ => panic!("expected issue find command"),
+    }
+}
+
+#[test]
+fn operation_owned_patch_commands_parse() {
+    for (action, restore) in [("preserve", false), ("restore", true)] {
+        let cli = TestCli::try_parse_from([
+            "git",
+            "patch",
+            action,
+            "cook-123",
+            "--path",
+            "/tmp/worktree",
+        ])
+        .expect("patch command parses");
+
+        let GitCommand::Patch { command } = cli.command else {
+            panic!("expected patch command");
+        };
+        let (operation_id, path, parsed_restore) = match command {
+            PatchCommand::Preserve { operation_id, path } => (operation_id, path, false),
+            PatchCommand::Restore { operation_id, path } => (operation_id, path, true),
+        };
+        assert_eq!(operation_id, "cook-123");
+        assert_eq!(path.as_deref(), Some("/tmp/worktree"));
+        assert_eq!(parsed_restore, restore);
     }
 }

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -347,7 +347,7 @@ fn filesystem_available_bytes(path: &Path) -> Option<u64> {
     let mut stat = std::mem::MaybeUninit::<libc::statvfs>::uninit();
     (unsafe { libc::statvfs(path.as_ptr(), stat.as_mut_ptr()) } == 0).then(|| unsafe {
         let stat = stat.assume_init();
-        stat.f_bavail.saturating_mul(stat.f_frsize)
+        u64::from(stat.f_bavail).saturating_mul(stat.f_frsize)
     })
 }
 

--- a/crates/homeboy-core/src/git/mod.rs
+++ b/crates/homeboy-core/src/git/mod.rs
@@ -11,6 +11,7 @@ mod operations_changes;
 mod operations_commit;
 mod operations_push;
 mod operations_tags;
+mod patch_preservation;
 mod pr_land;
 mod pr_policy;
 mod pr_refresh;
@@ -73,6 +74,10 @@ pub use operations_tags::{
     delete_local_tag, delete_remote_tag, fetch_origin, fetch_tags, get_head_commit, get_tag_commit,
     is_ancestor, remote_branch_commit, remote_tag_commit, short_head_revision_at, tag, tag_at,
     tag_exists_locally, tag_exists_on_remote, tags_pointing_at_commit,
+};
+pub use patch_preservation::{
+    preserve_worktree_patch, restore_worktree_patch, PatchPreservationEvidence,
+    PatchPreservationState, PreservedPatchArtifact,
 };
 pub use pr_land::{land_prs, PrCheckWaiver, PrLandOptions, PrLandOutput, PrLandRefreshHelper};
 pub use pr_policy::{

--- a/crates/homeboy-core/src/git/patch_preservation.rs
+++ b/crates/homeboy-core/src/git/patch_preservation.rs
@@ -1,0 +1,575 @@
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use homeboy_engine_primitives::content_hash;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+
+const EVIDENCE_SCHEMA: &str = "homeboy/git-patch-preservation/v1";
+const STORE_DIRECTORY: &str = "homeboy/patch-preservations";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PatchPreservationState {
+    Captured,
+    Cleaned,
+    Restored,
+    CleanupFailed,
+    RestoreFailed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PreservedPatchArtifact {
+    pub path: String,
+    pub sha256: String,
+    pub bytes: u64,
+}
+
+/// Durable evidence for one operation-owned working-tree patch.
+///
+/// The evidence and patch streams live below this worktree's own Git directory,
+/// not in repository-global refs. The explicit operation id remains stable
+/// across process restarts and never depends on stack position.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PatchPreservationEvidence {
+    pub schema: String,
+    pub operation_id: String,
+    pub worktree_git_dir: String,
+    pub captured_head: String,
+    pub state: PatchPreservationState,
+    pub staged_patch: PreservedPatchArtifact,
+    pub unstaged_patch: PreservedPatchArtifact,
+    pub untracked_patch: PreservedPatchArtifact,
+    pub untracked_paths: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<String>,
+}
+
+impl PatchPreservationEvidence {
+    pub fn evidence_path(&self) -> PathBuf {
+        Path::new(&self.worktree_git_dir)
+            .join(STORE_DIRECTORY)
+            .join(&self.operation_id)
+            .join("evidence.json")
+    }
+}
+
+/// Capture all staged, unstaged, and untracked changes as exact binary patch
+/// streams, durably publish their evidence, and leave the worktree clean.
+pub fn preserve_worktree_patch(
+    worktree: &Path,
+    operation_id: &str,
+) -> Result<PatchPreservationEvidence> {
+    validate_operation_id(operation_id)?;
+    let git_dir = worktree_git_dir(worktree)?;
+    let operation_dir = git_dir.join(STORE_DIRECTORY).join(operation_id);
+    if operation_dir.exists() {
+        return Err(Error::validation_invalid_argument(
+            "operation_id",
+            "patch preservation evidence already exists for this worktree",
+            Some(operation_id.to_string()),
+            None,
+        ));
+    }
+    fs::create_dir_all(&operation_dir).map_err(io("create patch preservation directory"))?;
+
+    let staged = git_output(
+        worktree,
+        &[
+            "diff",
+            "--cached",
+            "--binary",
+            "--full-index",
+            "--no-ext-diff",
+        ],
+        "capture staged patch",
+    )?;
+    let unstaged = git_output(
+        worktree,
+        &["diff", "--binary", "--full-index", "--no-ext-diff"],
+        "capture unstaged patch",
+    )?;
+    let untracked_paths = untracked_paths(worktree)?;
+    let untracked = untracked_patch(worktree, &untracked_paths)?;
+
+    let mut evidence = PatchPreservationEvidence {
+        schema: EVIDENCE_SCHEMA.to_string(),
+        operation_id: operation_id.to_string(),
+        worktree_git_dir: git_dir.display().to_string(),
+        captured_head: git_text(worktree, &["rev-parse", "HEAD"], "resolve patch base")?,
+        state: PatchPreservationState::Captured,
+        staged_patch: write_patch(&operation_dir, "staged.patch", &staged)?,
+        unstaged_patch: write_patch(&operation_dir, "unstaged.patch", &unstaged)?,
+        untracked_patch: write_patch(&operation_dir, "untracked.patch", &untracked)?,
+        untracked_paths,
+        failure: None,
+    };
+    write_evidence(&evidence)?;
+
+    if let Err(error) = clean_worktree(worktree, &evidence.untracked_paths) {
+        evidence.state = PatchPreservationState::CleanupFailed;
+        evidence.failure = Some(error.to_string());
+        write_evidence(&evidence)?;
+        return Err(error);
+    }
+    evidence.state = PatchPreservationState::Cleaned;
+    write_evidence(&evidence)?;
+    Ok(evidence)
+}
+
+/// Restore a patch by its operation id after verifying every persisted byte.
+pub fn restore_worktree_patch(
+    worktree: &Path,
+    operation_id: &str,
+) -> Result<PatchPreservationEvidence> {
+    validate_operation_id(operation_id)?;
+    let git_dir = worktree_git_dir(worktree)?;
+    let evidence_path = git_dir
+        .join(STORE_DIRECTORY)
+        .join(operation_id)
+        .join("evidence.json");
+    let mut evidence = read_evidence(&evidence_path)?;
+    if Path::new(&evidence.worktree_git_dir) != git_dir {
+        return Err(Error::validation_invalid_argument(
+            "operation_id",
+            "patch preservation belongs to a different worktree",
+            Some(operation_id.to_string()),
+            None,
+        ));
+    }
+    if evidence.state != PatchPreservationState::Cleaned {
+        return Err(Error::validation_invalid_argument(
+            "operation_id",
+            format!(
+                "patch preservation is not ready to restore (state: {:?})",
+                evidence.state
+            ),
+            Some(operation_id.to_string()),
+            None,
+        ));
+    }
+
+    let operation_dir = evidence_path.parent().expect("evidence has parent");
+    let staged = verified_patch(operation_dir, &evidence.staged_patch)?;
+    let unstaged = verified_patch(operation_dir, &evidence.unstaged_patch)?;
+    let untracked = verified_patch(operation_dir, &evidence.untracked_patch)?;
+    let restore = || -> Result<()> {
+        apply_patch(worktree, &staged, true, "restore staged patch")?;
+        apply_patch(worktree, &unstaged, false, "restore unstaged patch")?;
+        apply_patch(worktree, &untracked, false, "restore untracked patch")?;
+        Ok(())
+    };
+    if let Err(error) = restore() {
+        evidence.state = PatchPreservationState::RestoreFailed;
+        evidence.failure = Some(error.to_string());
+        write_evidence(&evidence)?;
+        return Err(error);
+    }
+    evidence.state = PatchPreservationState::Restored;
+    evidence.failure = None;
+    write_evidence(&evidence)?;
+    Ok(evidence)
+}
+
+fn validate_operation_id(operation_id: &str) -> Result<()> {
+    let valid = !operation_id.is_empty()
+        && operation_id.len() <= 128
+        && operation_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+        && operation_id != "."
+        && operation_id != "..";
+    if valid {
+        Ok(())
+    } else {
+        Err(Error::validation_invalid_argument(
+            "operation_id",
+            "expected 1-128 ASCII letters, digits, dots, dashes, or underscores",
+            Some(operation_id.to_string()),
+            None,
+        ))
+    }
+}
+
+fn worktree_git_dir(worktree: &Path) -> Result<PathBuf> {
+    let path = git_text(
+        worktree,
+        &["rev-parse", "--absolute-git-dir"],
+        "resolve worktree Git directory",
+    )?;
+    fs::canonicalize(&path).map_err(io("canonicalize worktree Git directory"))
+}
+
+fn untracked_paths(worktree: &Path) -> Result<Vec<String>> {
+    let bytes = git_output(
+        worktree,
+        &["ls-files", "--others", "--exclude-standard", "-z"],
+        "enumerate untracked paths",
+    )?;
+    bytes
+        .split(|byte| *byte == 0)
+        .filter(|path| !path.is_empty())
+        .map(|path| {
+            let path = std::str::from_utf8(path).map_err(|_| {
+                Error::validation_invalid_argument(
+                    "worktree",
+                    "patch preservation requires UTF-8 worktree paths",
+                    None,
+                    None,
+                )
+            })?;
+            validate_relative_path(path)?;
+            Ok(path.to_string())
+        })
+        .collect()
+}
+
+fn untracked_patch(worktree: &Path, paths: &[String]) -> Result<Vec<u8>> {
+    let mut patch = Vec::new();
+    for path in paths {
+        let output = Command::new("git")
+            .args([
+                "diff",
+                "--no-index",
+                "--binary",
+                "--full-index",
+                "--no-ext-diff",
+                "--",
+                "/dev/null",
+                path,
+            ])
+            .current_dir(worktree)
+            .output()
+            .map_err(|error| Error::git_command_failed(error.to_string()))?;
+        if !matches!(output.status.code(), Some(0 | 1)) {
+            return Err(git_failure("capture untracked patch", &output.stderr));
+        }
+        patch.extend_from_slice(&output.stdout);
+    }
+    Ok(patch)
+}
+
+fn clean_worktree(worktree: &Path, untracked_paths: &[String]) -> Result<()> {
+    git_output(
+        worktree,
+        &["reset", "--hard", "HEAD"],
+        "clean tracked patch",
+    )?;
+    for relative in untracked_paths {
+        let path = worktree.join(relative);
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.file_type().is_dir() => {
+                fs::remove_dir_all(&path).map_err(io("remove preserved untracked directory"))?
+            }
+            Ok(_) => fs::remove_file(&path).map_err(io("remove preserved untracked file"))?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(io("inspect preserved untracked path")(error)),
+        }
+        remove_empty_parents(path.parent(), worktree)?;
+    }
+    Ok(())
+}
+
+fn remove_empty_parents(mut path: Option<&Path>, worktree: &Path) -> Result<()> {
+    while let Some(parent) = path {
+        if parent == worktree || !parent.starts_with(worktree) {
+            break;
+        }
+        match fs::remove_dir(parent) {
+            Ok(()) => path = parent.parent(),
+            Err(error) if error.kind() == std::io::ErrorKind::DirectoryNotEmpty => break,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => path = parent.parent(),
+            Err(error) => return Err(io("remove empty untracked parent")(error)),
+        }
+    }
+    Ok(())
+}
+
+fn write_patch(directory: &Path, name: &str, bytes: &[u8]) -> Result<PreservedPatchArtifact> {
+    let path = directory.join(name);
+    let mut file = File::create(&path).map_err(io("create preserved patch"))?;
+    file.write_all(bytes).map_err(io("write preserved patch"))?;
+    file.sync_all().map_err(io("sync preserved patch"))?;
+    Ok(PreservedPatchArtifact {
+        path: name.to_string(),
+        sha256: content_hash::sha256_hex(bytes),
+        bytes: bytes.len() as u64,
+    })
+}
+
+fn verified_patch(directory: &Path, artifact: &PreservedPatchArtifact) -> Result<Vec<u8>> {
+    validate_relative_path(&artifact.path)?;
+    let bytes = fs::read(directory.join(&artifact.path)).map_err(io("read preserved patch"))?;
+    if bytes.len() as u64 != artifact.bytes || content_hash::sha256_hex(&bytes) != artifact.sha256 {
+        return Err(Error::validation_invalid_argument(
+            "patch",
+            format!(
+                "preserved patch {} failed byte identity verification",
+                artifact.path
+            ),
+            None,
+            None,
+        ));
+    }
+    Ok(bytes)
+}
+
+fn write_evidence(evidence: &PatchPreservationEvidence) -> Result<()> {
+    let path = evidence.evidence_path();
+    let temporary = path.with_extension("json.tmp");
+    let bytes = serde_json::to_vec_pretty(evidence)
+        .map_err(|error| Error::internal_json(error.to_string(), None))?;
+    let mut file = File::create(&temporary).map_err(io("create patch evidence"))?;
+    file.write_all(&bytes).map_err(io("write patch evidence"))?;
+    file.write_all(b"\n").map_err(io("write patch evidence"))?;
+    file.sync_all().map_err(io("sync patch evidence"))?;
+    fs::rename(&temporary, &path).map_err(io("publish patch evidence"))?;
+    File::open(path.parent().expect("evidence has parent"))
+        .and_then(|directory| directory.sync_all())
+        .map_err(io("sync patch evidence directory"))
+}
+
+fn read_evidence(path: &Path) -> Result<PatchPreservationEvidence> {
+    let bytes = fs::read(path).map_err(io("read patch evidence"))?;
+    let evidence: PatchPreservationEvidence = serde_json::from_slice(&bytes)
+        .map_err(|error| Error::internal_json(error.to_string(), None))?;
+    if evidence.schema != EVIDENCE_SCHEMA {
+        return Err(Error::validation_invalid_argument(
+            "patch",
+            "unsupported patch preservation evidence schema",
+            Some(evidence.schema),
+            None,
+        ));
+    }
+    Ok(evidence)
+}
+
+fn apply_patch(worktree: &Path, patch: &[u8], index: bool, context: &str) -> Result<()> {
+    if patch.is_empty() {
+        return Ok(());
+    }
+    let mut command = Command::new("git");
+    command.args(["apply", "--binary"]);
+    if index {
+        command.arg("--index");
+    }
+    let mut child = command
+        .arg("-")
+        .current_dir(worktree)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| Error::git_command_failed(error.to_string()))?;
+    child
+        .stdin
+        .take()
+        .expect("piped stdin")
+        .write_all(patch)
+        .map_err(io("write patch to git apply"))?;
+    let output = child
+        .wait_with_output()
+        .map_err(|error| Error::git_command_failed(error.to_string()))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(git_failure(context, &output.stderr))
+    }
+}
+
+fn git_output(worktree: &Path, args: &[&str], context: &str) -> Result<Vec<u8>> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(worktree)
+        .output()
+        .map_err(|error| Error::git_command_failed(error.to_string()))?;
+    if output.status.success() {
+        Ok(output.stdout)
+    } else {
+        Err(git_failure(context, &output.stderr))
+    }
+}
+
+fn git_text(worktree: &Path, args: &[&str], context: &str) -> Result<String> {
+    let bytes = git_output(worktree, args, context)?;
+    Ok(String::from_utf8_lossy(&bytes).trim().to_string())
+}
+
+fn git_failure(context: &str, stderr: &[u8]) -> Error {
+    Error::git_command_failed(format!(
+        "{context} failed: {}",
+        String::from_utf8_lossy(stderr).trim()
+    ))
+}
+
+fn validate_relative_path(path: &str) -> Result<()> {
+    let path = Path::new(path);
+    if !path.is_absolute()
+        && path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
+    {
+        Ok(())
+    } else {
+        Err(Error::validation_invalid_argument(
+            "patch",
+            "preserved patch contains an unsafe relative path",
+            Some(path.display().to_string()),
+            None,
+        ))
+    }
+}
+
+fn io(context: &'static str) -> impl FnOnce(std::io::Error) -> Error {
+    move |error| Error::internal_io(error.to_string(), Some(context.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    #[test]
+    fn sibling_worktrees_preserve_and_restore_only_their_operation_patch() {
+        let repository = tempfile::tempdir().expect("repository");
+        let primary = repository.path().join("primary");
+        run(
+            None,
+            &["init", "-q", "-b", "main", primary.to_str().unwrap()],
+        );
+        run(Some(&primary), &["config", "user.name", "Test"]);
+        run(
+            Some(&primary),
+            &["config", "user.email", "test@example.test"],
+        );
+        fs::write(primary.join("base.txt"), b"base\n").unwrap();
+        fs::write(primary.join("alpha.txt"), b"alpha base\n").unwrap();
+        fs::write(primary.join("beta.txt"), b"beta base\n").unwrap();
+        run(Some(&primary), &["add", "."]);
+        run(Some(&primary), &["commit", "-qm", "base"]);
+
+        let alpha = repository.path().join("alpha");
+        let beta = repository.path().join("beta");
+        run(
+            Some(&primary),
+            &[
+                "worktree",
+                "add",
+                "-q",
+                "-b",
+                "alpha",
+                alpha.to_str().unwrap(),
+            ],
+        );
+        run(
+            Some(&primary),
+            &[
+                "worktree",
+                "add",
+                "-q",
+                "-b",
+                "beta",
+                beta.to_str().unwrap(),
+            ],
+        );
+
+        fs::write(alpha.join("alpha.txt"), b"alpha staged\n").unwrap();
+        run(Some(&alpha), &["add", "alpha.txt"]);
+        fs::write(alpha.join("alpha.txt"), b"alpha staged\nalpha unstaged\n").unwrap();
+        fs::write(alpha.join("alpha.bin"), [0, 1, 2, 255]).unwrap();
+        fs::write(beta.join("beta.txt"), b"beta staged\n").unwrap();
+        run(Some(&beta), &["add", "beta.txt"]);
+        fs::write(beta.join("beta.txt"), b"beta staged\nbeta unstaged\n").unwrap();
+        fs::write(beta.join("beta.bin"), [255, 2, 1, 0]).unwrap();
+
+        let barrier = Arc::new(Barrier::new(3));
+        let alpha_thread = preserve_after_barrier(alpha.clone(), Arc::clone(&barrier));
+        let beta_thread = preserve_after_barrier(beta.clone(), Arc::clone(&barrier));
+        barrier.wait();
+        let alpha_evidence = alpha_thread.join().unwrap();
+        let beta_evidence = beta_thread.join().unwrap();
+
+        assert_eq!(alpha_evidence.state, PatchPreservationState::Cleaned);
+        assert_eq!(beta_evidence.state, PatchPreservationState::Cleaned);
+        assert_ne!(
+            alpha_evidence.worktree_git_dir,
+            beta_evidence.worktree_git_dir
+        );
+        assert!(!alpha.join("alpha.bin").exists());
+        assert!(!beta.join("beta.bin").exists());
+
+        fs::write(primary.join("base.txt"), b"new base\n").unwrap();
+        run(Some(&primary), &["add", "base.txt"]);
+        run(Some(&primary), &["commit", "-qm", "advance base"]);
+        run(Some(&alpha), &["rebase", "main"]);
+        run(Some(&beta), &["rebase", "main"]);
+
+        let beta_restored = restore_worktree_patch(&beta, "same-operation").unwrap();
+        let alpha_restored = restore_worktree_patch(&alpha, "same-operation").unwrap();
+        assert_eq!(beta_restored.state, PatchPreservationState::Restored);
+        assert_eq!(alpha_restored.state, PatchPreservationState::Restored);
+        assert_eq!(
+            fs::read(alpha.join("alpha.txt")).unwrap(),
+            b"alpha staged\nalpha unstaged\n"
+        );
+        assert_eq!(fs::read(alpha.join("alpha.bin")).unwrap(), [0, 1, 2, 255]);
+        assert_eq!(
+            fs::read(beta.join("beta.txt")).unwrap(),
+            b"beta staged\nbeta unstaged\n"
+        );
+        assert_eq!(fs::read(beta.join("beta.bin")).unwrap(), [255, 2, 1, 0]);
+        assert_eq!(fs::read(alpha.join("beta.txt")).unwrap(), b"beta base\n");
+        assert_eq!(fs::read(beta.join("alpha.txt")).unwrap(), b"alpha base\n");
+        assert!(git(&primary, &["rev-parse", "--verify", "refs/stash"]).is_err());
+
+        let alpha_status = git(&alpha, &["status", "--porcelain=v1"]).unwrap();
+        let beta_status = git(&beta, &["status", "--porcelain=v1"]).unwrap();
+        assert!(alpha_status.contains("alpha.txt"));
+        assert!(alpha_status.contains("alpha.bin"));
+        assert!(!alpha_status.contains("beta.txt"));
+        assert!(beta_status.contains("beta.txt"));
+        assert!(beta_status.contains("beta.bin"));
+        assert!(!beta_status.contains("alpha.txt"));
+    }
+
+    fn preserve_after_barrier(
+        worktree: PathBuf,
+        barrier: Arc<Barrier>,
+    ) -> thread::JoinHandle<PatchPreservationEvidence> {
+        thread::spawn(move || {
+            barrier.wait();
+            preserve_worktree_patch(&worktree, "same-operation").unwrap()
+        })
+    }
+
+    fn run(worktree: Option<&Path>, args: &[&str]) {
+        let mut command = Command::new("git");
+        command.args(args);
+        if let Some(worktree) = worktree {
+            command.current_dir(worktree);
+        }
+        let output = command.output().unwrap();
+        assert!(
+            output.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git(worktree: &Path, args: &[&str]) -> std::result::Result<String, String> {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(worktree)
+            .output()
+            .unwrap();
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).to_string())
+        } else {
+            Err(String::from_utf8_lossy(&output.stderr).to_string())
+        }
+    }
+}

--- a/docs/commands/git.md
+++ b/docs/commands/git.md
@@ -115,6 +115,21 @@ homeboy git rebase --continue
 homeboy git rebase --abort
 ```
 
+### Preserve a worktree patch
+
+Use an operation-owned patch artifact instead of Git's repository-global stash
+stack when reconciling parallel worktrees:
+
+```bash
+homeboy git patch preserve <operation-id> [--path <path>]
+homeboy git patch restore <operation-id> [--path <path>]
+```
+
+The preserve command captures staged, unstaged, and untracked binary changes,
+records exact durable evidence beneath that worktree's Git directory, and then
+cleans the checkout. Restore verifies the recorded bytes and operation identity
+before applying only that worktree's patch.
+
 On conflict, Homeboy returns a failed result with git's stderr. Resolve conflicts manually, then re-run with `--continue` or `--abort`.
 
 ### Cherry-pick


### PR DESCRIPTION
Closes #13403
Closes #13487

## Summary
- add `homeboy git patch preserve|restore` with operation-owned, worktree-local staged/unstaged/untracked binary artifacts and durable byte identity evidence
- deny repository-global `git stash` in managed agent worktrees and provide exact executable recovery guidance
- prove two sibling worktrees can capture concurrently and restore in reverse order without cross-task files or `refs/stash`
- normalize macOS `statvfs` arithmetic so current Rust can compile the focused gates

## Verification
- `cargo test -p homeboy-cli commands::git::tests::operation_owned_patch_commands_parse --lib -- --exact`
- `cargo test -p homeboy-agents agent_task_dispatch_plan::tests::managed_worktree_refuses_repository_global_stash_and_guides_safe_recovery -- --exact`
- `cargo test -p homeboy-core git::patch_preservation::tests::sibling_worktrees_preserve_and_restore_only_their_operation_patch -- --exact`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode traced the repository-global stash failure, implemented the worktree-local primitive, CLI adapter, policy and concurrent regression, isolated the macOS compiler blocker, and ran the listed gates under human orchestration.