### PR TITLE
Redact retained private gates from review commands

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -570,6 +570,11 @@ pub struct PromoteArgs {
     /// Include complete promotion and gate evidence.
     #[arg(long)]
     pub full: bool,
+    /// Replay the exact gate policy from the source run's durable Cook recipe.
+    /// Homeboy-generated review commands use this reference so private gate
+    /// programs remain outside reviewer-facing command output.
+    #[arg(long = "gates-from-cook-recipe")]
+    pub gates_from_cook_recipe: bool,
     #[command(flatten)]
     pub gates: VerifyGateArgs,
 }

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -44,7 +44,7 @@ use super::super::CmdResult;
 use super::candidate::{canonical_candidate_projection, classify_candidates};
 use super::{
     AdoptArgs, FinalizePrArgs, GateFeedbackArgs, PromoteArgs, ProvidersArgs,
-    RecordReplacementGateProofArgs, ReviewArgs, VerifyReplacementArgs,
+    RecordReplacementGateProofArgs, ReviewArgs, VerifyGateArgs, VerifyReplacementArgs,
 };
 
 #[derive(Args, Debug)]
@@ -456,7 +456,6 @@ fn compact_fields(value: &Value, fields: &[&str]) -> Value {
 }
 
 pub(crate) fn promote_artifact(mut args: PromoteArgs) -> CmdResult<Value> {
-    args.gates.snapshot_file_inputs()?;
     let to_worktree = args.to_worktree.clone();
     let source_reference = parse_promotion_run_artifact_reference(&args.source)?;
     let source_spec = source_reference
@@ -485,6 +484,12 @@ pub(crate) fn promote_artifact(mut args: PromoteArgs) -> CmdResult<Value> {
             None => None,
         },
     };
+    let gates = resolve_promotion_gates(
+        &mut args.gates,
+        args.gates_from_cook_recipe,
+        source_run_id.as_deref(),
+        &args.source,
+    )?;
     let artifact_id = if let Some(run_id) = source_run_id.as_deref() {
         requested_artifact_id
             .as_deref()
@@ -518,7 +523,7 @@ pub(crate) fn promote_artifact(mut args: PromoteArgs) -> CmdResult<Value> {
         task_id,
         artifact_id,
         dry_run: args.dry_run,
-        gates: args.gates.into(),
+        gates,
         provider_command: args.provider_command,
         provider_invocation: (!args.provider_argv.is_empty()).then(|| CommandInvocation {
             argv: args.provider_argv,
@@ -553,6 +558,54 @@ pub(crate) fn promote_artifact(mut args: PromoteArgs) -> CmdResult<Value> {
     }
 
     Ok((value, exit_code))
+}
+
+pub(crate) fn resolve_promotion_gates(
+    gates: &mut VerifyGateArgs,
+    from_cook_recipe: bool,
+    source_run_id: Option<&str>,
+    source: &str,
+) -> homeboy::core::Result<VerifyGateOptions> {
+    if !from_cook_recipe {
+        gates.snapshot_file_inputs()?;
+        return Ok(gates.clone().into());
+    }
+    let supplied_gates = VerifyGateOptions::from(gates.clone());
+    if gates.has_deterministic_gate()
+        || !gates.input_sources.is_empty()
+        || supplied_gates != VerifyGateOptions::default()
+    {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "gates-from-cook-recipe",
+            "cannot combine a durable Cook gate reference with explicit gate options",
+            None,
+            None,
+        ));
+    }
+    let run_id = source_run_id.ok_or_else(|| {
+        homeboy::core::Error::validation_invalid_argument(
+            "gates-from-cook-recipe",
+            "requires a source owned by a durable Cook attempt",
+            Some(source.to_string()),
+            None,
+        )
+    })?;
+    let recipe = agent_task_service::load_recipe_for_attempt(run_id)?.ok_or_else(|| {
+        homeboy::core::Error::validation_invalid_argument(
+            "gates-from-cook-recipe",
+            "source run has no durable Cook recipe",
+            Some(run_id.to_string()),
+            None,
+        )
+    })?;
+    serde_json::from_value(recipe.gate_policy).map_err(|error| {
+        homeboy::core::Error::validation_invalid_argument(
+            "cook_recipe.gate_policy",
+            format!("durable Cook recipe has an invalid gate policy: {error}"),
+            Some(recipe.cook_id),
+            None,
+        )
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2699,15 +2752,16 @@ fn promotion_candidates(
                     if let Some(contract) = continuation
                         .and_then(|promotion| promotion.pointer("/provenance/resume_contract"))
                     {
-                        append_resume_contract(&mut command, contract);
+                        if context.cook_gates.is_some() {
+                            append_resume_base(&mut command, contract);
+                        } else {
+                            append_resume_contract(&mut command, contract);
+                        }
                     } else if let Some(base) = context.cook_base {
                         command.extend(["--base".to_string(), base.to_string()]);
-                        if let Some(gates) = context.cook_gates {
-                            homeboy::agents::agent_tasks::gate::append_promotion_gate_argv(
-                                &mut command,
-                                gates,
-                            );
-                        }
+                    }
+                    if context.cook_gates.is_some() {
+                        command.push("--gates-from-cook-recipe".to_string());
                     }
                     if let Some(provider_command) = context.provider_command {
                         command.push("--provider-command".to_string());
@@ -2737,12 +2791,20 @@ fn promotion_candidates(
 
 /// Render the durable gate contract rather than relying on evolving CLI defaults.
 fn append_resume_contract(command: &mut Vec<String>, contract: &Value) {
-    if let Some(base) = contract.pointer("/inputs/base_ref").and_then(Value::as_str) {
-        command.extend(["--base".to_string(), base.to_string()]);
-    }
+    append_resume_base(command, contract);
     let Some(gates) = contract.get("gates") else {
         return;
     };
+    append_resume_gates(command, gates);
+}
+
+fn append_resume_base(command: &mut Vec<String>, contract: &Value) {
+    if let Some(base) = contract.pointer("/inputs/base_ref").and_then(Value::as_str) {
+        command.extend(["--base".to_string(), base.to_string()]);
+    }
+}
+
+fn append_resume_gates(command: &mut Vec<String>, gates: &Value) {
     for (key, flag) in [
         ("verify", "--verify"),
         ("private_verify", "--private-verify"),
@@ -4126,29 +4188,21 @@ mod tests {
             .iter()
             .map(|value| value.as_str().expect("command argument").to_string())
             .collect::<Vec<_>>();
-        assert!(command
-            .windows(2)
-            .any(|args| args == ["--verify", "cargo test"]));
-        assert!(command
-            .windows(2)
-            .any(|args| args == ["--private-verify", "private-check"]));
-        assert_eq!(
-            command
+        assert!(command.contains(&"--gates-from-cook-recipe".to_string()));
+        for private_value in [
+            "private-check",
+            "printf 'file-backed private gate'",
+            "private-gate.sh",
+            "sha256:file-private",
+        ] {
+            assert!(!command
                 .iter()
-                .filter(|argument| argument.as_str() == "--gate-input-source")
-                .count(),
-            4
-        );
-        let provenance = command
-            .windows(2)
-            .filter(|args| args[0] == "--gate-input-source")
-            .map(|args| serde_json::from_str::<Value>(&args[1]).expect("gate provenance"))
-            .collect::<Vec<_>>();
-        assert_eq!(provenance[3]["sha256"], "sha256:file-private");
-        assert!(provenance[3].get("path").is_none());
+                .any(|argument| argument.contains(private_value)));
+        }
+        assert!(!command.iter().any(|argument| argument == "--verify"));
         assert!(!command
             .iter()
-            .any(|argument| argument.contains("private-gate.sh")));
+            .any(|argument| argument == "--private-verify"));
         assert!(crate::cli_surface::Cli::try_parse_from(&command).is_ok());
     }
 

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -2,6 +2,7 @@
 
 use super::support::*;
 use crate::agents::agent_task_service::DerivedCookBaselineCapability;
+use clap::Parser;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
@@ -80,6 +81,78 @@ fn cli_promotion_resume_policy_matches_the_shared_service() {
             ),
         );
     }
+}
+
+#[test]
+fn promotion_recipe_reference_hydrates_exact_private_gate_contract() {
+    with_temp_home(|| {
+        let run_id = "cook-retained-gates-attempt-1";
+        let private_program = "printf 'private $TOKEN'\n";
+        let gates = homeboy::agents::agent_tasks::gate::VerifyGateOptions {
+            verify: vec!["cargo test --lib".to_string()],
+            private_verify: vec![private_program.to_string()],
+            input_sources: vec![serde_json::from_value(json!({
+                "visibility": "private",
+                "source_kind": "file",
+                "sha256": "sha256:private-fixture",
+                "size_bytes": private_program.len(),
+                "redaction_policy": "summary_only"
+            }))
+            .expect("private source provenance")],
+            ..Default::default()
+        };
+        let options = homeboy::agents::agent_task_service::AgentTaskCookServiceOptions {
+            cook_id: "cook-retained-gates".to_string(),
+            initial_run_id: run_id.to_string(),
+            initial_plan: test_plan(),
+            to_worktree: "fixture@retained-gates".to_string(),
+            source_worktree_path: None,
+            provider_command: None,
+            provider_invocation: None,
+            gates: gates.clone(),
+            max_attempts: 1,
+            no_finalize: true,
+            draft_pr: false,
+            base: "main".to_string(),
+            task_base_sha: None,
+            head: None,
+            title: "Retained gates".to_string(),
+            commit_message: "Retained gates".to_string(),
+            source_refs: Vec::new(),
+            protected_branches: Vec::new(),
+            ai_tool: "fixture".to_string(),
+            ai_model: None,
+            ai_used_for: "test".to_string(),
+            attempt_dispatcher: None,
+            harvest_context: homeboy::agents::agent_task_scheduler::HarvestExecutionContext::from_current_process()
+                .expect("harvest context"),
+        };
+        homeboy::agents::agent_task_service::persist_initial_recipe(&options)
+            .expect("persist Cook recipe");
+        let cli = crate::cli_surface::Cli::try_parse_from([
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "fixture",
+            "--no-finalize",
+        ])
+        .expect("parse default gate options");
+        let crate::cli_surface::Commands::AgentTask(agent_task) = cli.command else {
+            panic!("agent-task command");
+        };
+        let super::super::AgentTaskCommand::Cook(cook) = agent_task.command else {
+            panic!("Cook command");
+        };
+        let mut cli_gates = cook.gates;
+
+        let hydrated = review::resolve_promotion_gates(&mut cli_gates, true, Some(run_id), run_id)
+            .expect("hydrate durable Cook gates");
+
+        assert_eq!(hydrated, gates);
+        assert_eq!(hydrated.private_verify, [private_program]);
+        assert_eq!(hydrated.input_sources[0].path, None);
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- replace reviewer-visible replay of retained private gate argv and provenance with a durable Cook recipe reference
- resolve the exact gate contract from the source attempt only when promotion executes
- reject mixed explicit and recipe-backed gate options
- keep private programs, paths, and hashes out of generated review commands

Follow-up to #13454.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p homeboy-cli promotion_recipe_reference_hydrates_exact_private_gate_contract --lib --no-fail-fast`
- `git merge-tree --write-tree origin/main HEAD`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode audited the merged gate-retention flow, identified reviewer-visible private gate leakage, implemented durable recipe-backed replay, reviewed the diff, and ran focused verification. Chris Huber directed the work and is responsible for the change.