### PR TITLE
perf(build): emit line tables instead of full DWARF in dev and test builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,38 @@ slow-tests = []
 # smoke gate in docs/commands/agent-task.md runnable from a source checkout.
 test-support = ["homeboy-core/test-support", "homeboy-cli/test-support"]
 
+# Debug info is line tables only.
+#
+# The default `debug = true` emits full DWARF: every variable, type, and lexical
+# scope. Measured on this workspace it is roughly a third of what a build
+# occupies on disk and half the size of the artifact produced.
+#
+# `cargo test -p homeboy-cli --lib --no-run`, cold, same machine, `-j2`:
+#
+#                        wall     target/    test binary
+#   debug = true         335 s      7.1 G        934 MB
+#   line-tables-only     294 s      4.8 G        445 MB     -12% / -32% / -52%
+#   debug = false        270 s      4.0 G        289 MB     -19% / -44% / -69%
+#
+# That is one crate. The saving is entirely in the back end: `LLVM_passes` and
+# `codegen_to_LLVM_IR` roughly halve, while `type_check_crate` and
+# `MIR_borrow_checking` do not move at all.
+#
+# `false` is faster still and is deliberately not chosen. It emits no `.debug_*`
+# sections whatsoever, so a panic backtrace has no file or line for any frame.
+# `line-tables-only` keeps `.debug_line`, which is what a CI failure or an issue
+# report is actually read from, and gives up only debugger variable inspection.
+# Recover that for one session without editing this file:
+#
+#   RUSTFLAGS="-C debuginfo=2" cargo test -p <crate>
+#
+# This matters most in CI and on the VPS, where disk -- not RAM -- is the binding
+# constraint on how many builds can coexist.
+#
+# `[profile.test]` inherits from `[profile.dev]`, so this covers test builds too.
+[profile.dev]
+debug = "line-tables-only"
+
 # Hash and compression crates run at optimization even in dev/test builds.
 #
 # `agent-task cook` pins an immutable content-addressed controller runtime, which


### PR DESCRIPTION
The workspace had **no `[profile.dev]` block at all**, so `debug` was the default `true` — full DWARF, every variable, type, and lexical scope, in every dev and test build.

## Measured, not estimated

Cold, same machine, `-j2`, `cargo test -p homeboy-cli --lib --no-run`:

| | wall | `target/` | test binary |
|---|---:|---:|---:|
| `debug = true` (before) | 335 s | 7.1 G | 934 MB |
| **`line-tables-only`** (this PR) | **294 s** | **4.8 G** | **445 MB** |
| | −12% | −32% | −52% |
| `debug = false` | 270 s | 4.0 G | 289 MB |
| | −19% | −44% | −69% |

**That is one crate's test binary at 934 MB.**

## The saving is entirely in the back end

`-Ztime-passes` on the same crate:

| pass | before | after |
|---|---:|---:|
| `LLVM_passes` | 29.1 s | **15.4 s** |
| `codegen_to_LLVM_IR` | 16.2 s | **5.8 s** |
| `type_check_crate` | 9.9 s | 11.0 s *(unchanged)* |
| `MIR_borrow_checking` | 10.5 s | 11.1 s *(unchanged)* |

Nothing in the front end moves. This is not a trade against compile-correctness work — only against how much DWARF the back end serializes.

## Why line tables rather than off

`debug = false` is faster still and is **deliberately not chosen**. Verified with `readelf -S` on the resulting test binary: it emits **no `.debug_*` sections at all**, so no frame in a panic backtrace carries a file or line.

`line-tables-only` keeps `.debug_line`, `.debug_info`, and `.debug_str` — what a CI failure or issue report is actually read from. What it gives up is debugger variable inspection, recoverable per-session without editing anything:

```bash
RUSTFLAGS="-C debuginfo=2" cargo test -p <crate>
```

## Compounds with the existing profile note

The comment above `[profile.dev.package.sha2]` records that cook integration tests each paid ~44 s hashing a **~700 MB unoptimized binary**. This shrinks that binary too, so the two changes compound rather than conflict.

## Context

RULES.md states disk — not RAM — is the binding constraint on the VPS, and that a `cargo test` build produces ~28 G so only one fits. A −32% `target/` moves that materially.

## Verification

- `cargo fmt --check`
- `cargo check --workspace --all-targets --features homeboy-cli/test-support -j2`
- `cargo test -p homeboy-cli --lib` builds and runs; 536 tests observed passing before a long-running case was interrupted (the hour-long local run in #7469).

<blockquote>

**On the 3 failures I saw:** they reproduce **identically with this change reverted**, and are host-config dependent (`agent-task backend 'test' is not dispatchable`). Not caused here.

`[profile.dev] debug` sets debug *info*. `debug-assertions` is a separate key and is untouched, so `cfg!(debug_assertions)` behaviour is unchanged.

</blockquote>

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode / Claude via Kimaki
- **Used for:** Profiled the workspace with `--timings` and `-Ztime-passes`, ran the three-way controlled build comparison, verified DWARF sections with `readelf`, and isolated the observed failures against a reverted build. Chris reviewed and owns the change.
