### PR TITLE
fix(cook): carry the reason a baseline comparison could not conclude

### DIFF
--- a/crates/homeboy-agents/src/agent_task_cook_loop.rs
+++ b/crates/homeboy-agents/src/agent_task_cook_loop.rs
@@ -1381,6 +1381,7 @@ mod tests {
                 failure_fingerprint: "rustup unavailable".to_string(),
                 matches_candidate_failure: true,
                 result: crate::agent_task_gate::AgentTaskGateDifferentialResult::BaselineRed,
+                diagnostic: None,
             });
         let baseline_red = evaluate_cook_loop(AgentTaskCookLoopOptions {
             source_request: source_request(),
@@ -2314,6 +2315,7 @@ mod tests {
             failure_fingerprint: String::new(),
             matches_candidate_failure: false,
             result: crate::agent_task_gate::AgentTaskGateDifferentialResult::CandidateRegression,
+            diagnostic: None,
         });
         gate
     }
@@ -2367,6 +2369,7 @@ mod tests {
             failure_fingerprint: String::new(),
             matches_candidate_failure: false,
             result: crate::agent_task_gate::AgentTaskGateDifferentialResult::CandidateRegression,
+            diagnostic: None,
         });
         gate
     }

--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -642,6 +642,15 @@ pub struct AgentTaskGateBaselineComparison {
     pub matches_candidate_failure: bool,
     #[serde(default)]
     pub result: AgentTaskGateDifferentialResult,
+    /// Why the comparison could not conclude.
+    ///
+    /// An `Inconclusive` result used to be indistinguishable from every other
+    /// `Inconclusive` result: the baseline replay error was discarded at the
+    /// point it was produced, so an operator was told to "repair the gate
+    /// baseline setup" with nothing naming what was actually wrong. This
+    /// carries that reason forward. Conclusive results leave it `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diagnostic: Option<String>,
 }
 
 /// The durable outcome of replaying a candidate gate against its immutable base.
@@ -3654,6 +3663,63 @@ fn gate_result_evidence(report: &AgentTaskGateReport) -> serde_json::Value {
 
 #[cfg(test)]
 mod tests {
+
+    /// A conclusive comparison carries no diagnostic, and the field is omitted
+    /// from the wire form so persisted reports written before it existed still
+    /// round-trip.
+    #[test]
+    fn baseline_comparison_omits_an_absent_diagnostic() {
+        let comparison = AgentTaskGateBaselineComparison {
+            base_ref: "abc".to_string(),
+            exit_code: 1,
+            failure_fingerprint: "fp".to_string(),
+            matches_candidate_failure: true,
+            result: AgentTaskGateDifferentialResult::BaselineRed,
+            diagnostic: None,
+        };
+        let json = serde_json::to_value(&comparison).expect("serialize");
+        assert!(
+            json.get("diagnostic").is_none(),
+            "absent diagnostic must not widen the wire form: {json}"
+        );
+    }
+
+    /// A report persisted before the field existed must still deserialize.
+    #[test]
+    fn baseline_comparison_reads_reports_written_without_a_diagnostic() {
+        let json = serde_json::json!({
+            "base_ref": "abc",
+            "exit_code": 124,
+            "failure_fingerprint": "",
+            "matches_candidate_failure": false,
+            "result": "inconclusive"
+        });
+        let comparison: AgentTaskGateBaselineComparison =
+            serde_json::from_value(json).expect("deserialize legacy report");
+        assert_eq!(comparison.diagnostic, None);
+        assert_eq!(
+            comparison.result,
+            AgentTaskGateDifferentialResult::Inconclusive
+        );
+    }
+
+    /// An inconclusive comparison round-trips the reason it could not conclude.
+    #[test]
+    fn baseline_comparison_round_trips_its_diagnostic() {
+        let comparison = AgentTaskGateBaselineComparison {
+            base_ref: "abc".to_string(),
+            exit_code: 124,
+            failure_fingerprint: String::new(),
+            matches_candidate_failure: false,
+            result: AgentTaskGateDifferentialResult::Inconclusive,
+            diagnostic: Some("baseline replay failed: boom".to_string()),
+        };
+        let json = serde_json::to_value(&comparison).expect("serialize");
+        assert_eq!(json["diagnostic"], "baseline replay failed: boom");
+        let back: AgentTaskGateBaselineComparison =
+            serde_json::from_value(json).expect("deserialize");
+        assert_eq!(back, comparison);
+    }
     use super::*;
     use std::sync::{Arc, Mutex};
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
@@ -411,6 +411,10 @@ pub(crate) fn compare_gate_failures_to_verified_base(
                     failure_fingerprint: String::new(),
                     matches_candidate_failure: false,
                     result: AgentTaskGateDifferentialResult::Inconclusive,
+                    diagnostic: Some(
+                        "candidate gate declares package artifacts without recorded digests, so the immutable base cannot reconstruct the same inputs"
+                            .to_string(),
+                    ),
                 });
                 continue;
             };
@@ -441,6 +445,10 @@ pub(crate) fn compare_gate_failures_to_verified_base(
                         failure_fingerprint: String::new(),
                         matches_candidate_failure: false,
                         result: AgentTaskGateDifferentialResult::Inconclusive,
+                        diagnostic: Some(
+                            "baseline replay resolved different package artifacts than the candidate recorded, so the two runs are not comparable"
+                                .to_string(),
+                        ),
                     });
                     baseline_run_dir.finish(true);
                     continue;
@@ -463,6 +471,10 @@ pub(crate) fn compare_gate_failures_to_verified_base(
                         ),
                         matches_candidate_failure: false,
                         result: AgentTaskGateDifferentialResult::Inconclusive,
+                        diagnostic: Some(
+                            "baseline replay exceeded the gate timeout before producing a comparable result"
+                                .to_string(),
+                        ),
                     });
                     Ok(())
                 }
@@ -504,6 +516,7 @@ pub(crate) fn compare_gate_failures_to_verified_base(
                         } else {
                             AgentTaskGateDifferentialResult::CandidateRegression
                         },
+                        diagnostic: None,
                     });
                     if matches {
                         gate.accept_inherited_failure();
@@ -526,6 +539,7 @@ pub(crate) fn compare_gate_failures_to_verified_base(
                         ),
                         matches_candidate_failure: false,
                         result: AgentTaskGateDifferentialResult::CandidateRegression,
+                        diagnostic: None,
                     });
                     Ok(())
                 }
@@ -536,12 +550,12 @@ pub(crate) fn compare_gate_failures_to_verified_base(
                         failure_fingerprint: String::new(),
                         matches_candidate_failure: false,
                         result: AgentTaskGateDifferentialResult::Inconclusive,
+                        diagnostic: Some(format!("baseline replay failed: {error}")),
                     });
                     // Preserve the inconclusive evidence and leave the candidate
                     // gate red. A baseline execution failure must never convert a
                     // candidate failure into an infrastructure error that loses
                     // its durable comparison result.
-                    let _ = error;
                     Ok(())
                 }
             };

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -5839,6 +5839,23 @@ fn adoption_blocks_inherited_failure_when_candidate_package_artifact_differs_fro
             .artifacts[0]
             .sha256
             .is_some());
+
+        // An inconclusive baseline must say why. This one is inconclusive
+        // because the base cannot satisfy a package artifact the candidate
+        // introduced -- previously the replay error was discarded at the point
+        // it was produced, leaving an operator with "repair the gate baseline
+        // setup" and nothing naming the artifact at fault.
+        let diagnostic = promotion.deterministic_gates[0]
+            .baseline_comparison
+            .as_ref()
+            .unwrap()
+            .diagnostic
+            .as_deref()
+            .expect("an inconclusive baseline comparison carries its reason");
+        assert!(
+            diagnostic.contains("candidate-input") || diagnostic.contains("package artifact"),
+            "diagnostic should name the failing package artifact, got: {diagnostic}"
+        );
     });
 }
 
@@ -14629,6 +14646,7 @@ fn canonical_completion_accepts_green_and_recipe_authorized_inherited_gate_evide
             failure_fingerprint: "inherited".to_string(),
             matches_candidate_failure: true,
             result: crate::agent_task_gate::AgentTaskGateDifferentialResult::BaselineRed,
+            diagnostic: None,
         });
     assert!(canonical_finalization_eligible(&inherited, true, true));
     assert!(!canonical_finalization_eligible(&inherited, false, true));
@@ -15534,6 +15552,7 @@ fn adopted_baseline_gate_outcome_is_candidate_bound_and_recovery_safe() {
             failure_fingerprint: "inherited failure".to_string(),
             matches_candidate_failure: true,
             result: crate::agent_task_gate::AgentTaskGateDifferentialResult::BaselineRed,
+            diagnostic: None,
         });
     accepted.normalize_gate_outcome();
 
@@ -17958,6 +17977,7 @@ fn recovery_hydrates_adopted_baseline_gate_evidence_and_can_preflight_without_mu
                 failure_fingerprint: "inherited failure".to_string(),
                 matches_candidate_failure: true,
                 result: crate::agent_task_gate::AgentTaskGateDifferentialResult::BaselineRed,
+                diagnostic: None,
             });
         adopted.operator_notification =
             crate::agent_task_promotion::AgentTaskPromotionNotification {


### PR DESCRIPTION
## What

`AgentTaskGateBaselineComparison` recorded `Inconclusive` from **four different conditions and kept none of them**. The worst is the replay-error arm in `cook_baseline.rs`, which builds a fully-formed, operator-ready error and discards it one line later:

```rust
result: AgentTaskGateDifferentialResult::Inconclusive,
});
let _ = error;          // ← gone
```

All four surfaced to an operator as the same sentence:

> *immutable baseline replay was inconclusive; repair the gate baseline setup or replay environment before rerunning Cook*

Nothing named what was actually wrong. I had to patch in an `eprintln!` to diagnose one.

## The change

Adds `diagnostic: Option<String>` and populates every inconclusive path:

| condition | diagnostic |
|---|---|
| replay requirements unavailable | package artifacts declared without recorded digests, so the base cannot reconstruct the candidate's inputs |
| artifacts diverged | baseline replay resolved different package artifacts than the candidate recorded |
| replay timeout | baseline replay exceeded the gate timeout |
| **replay error** | `baseline replay failed: {error}` ← *the error that was being dropped* |

Conclusive results leave it `None`.

**Additive on the wire.** `#[serde(default, skip_serializing_if = "Option::is_none")]` — a conclusive comparison serializes byte-identically to before, and reports persisted before this field existed still deserialize. Both pinned by tests, not asserted in review.

## What it makes visible

Running the first of the nine failing `baseline_inconclusive` tests now reports:

```
package artifact readiness for `candidate-input` failed: required artifact
paths are unavailable or do not match their declared digest
invalid_paths: ["fixtures/input.bin"]
```

That is the entire diagnosis. Before, there was a bare status string.

<callout accent="#8b5cf6">
## This is deliberately only the visibility half

The nine tests still fail, on a **separate** defect.

`2e567439b` (#13152, Aug 23) added a `BaselineInconclusive` cook status that reclassifies a run whenever any failed gate has an inconclusive baseline. That contradicts the invariant stated in `cook_baseline.rs` **immediately above the arm this PR touches**:

> *"A baseline execution failure must never convert a candidate failure into an infrastructure error that loses its durable comparison result."*

The consequence is that a candidate which genuinely failed its own gate gets reported as *your environment being broken*. Restoring the invariant is a behavioural change across promotion and finalization, so it is left separate — I did not want to guess at what #13152 was solving.
</callout>

## Verification

- `cargo check --workspace --all-targets -j2` — zero errors, zero warnings
- `cargo test -p homeboy-agents --lib` — **1997 passed, 47 failed**, against **48 failing on main**
- The four failures unique to this branch each **pass alone under `--test-threads=1`** — pre-existing parallelism flakes, not regressions
- Three contract tests in `agent_task_gate.rs` cover the field unconditionally today

The new assertion in `adoption_blocks_inherited_failure_when_candidate_package_artifact_differs_from_base` sits downstream of the still-failing #13152 assertion. It was verified by temporarily skipping that assertion — the test then passes, confirming the diagnostic is populated and names the failing artifact.

## AI assistance

Tool(s): OpenCode
