### PR TITLE
Bind Cook preview lifecycle before unresolved-backend replay

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -296,13 +296,13 @@ pub(crate) fn preview_cook(
                 })?;
         }
     }
+    bind_cook_preview_lifecycle(&mut args);
     if let Some(backend) = unresolved_cook_backend_preview(&args)? {
         return Ok((backend, 0));
     }
     // Source policy is a static validation and must apply to preview exactly as
     // it applies before an execution route can inspect the destination.
     validate_cook_request_with_provenance(&args, provenance)?;
-    bind_cook_preview_lifecycle(&mut args);
     record_preview_phase(&mut progress, "destination_resolution");
     let (args, mut provision) =
         with_preview_heartbeat(&mut progress, "destination_resolution", || {

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -2,6 +2,8 @@
 mod agent_task_provider_flag_diagnostic;
 #[path = "cli_binary/agent_tool_dispatch.rs"]
 mod agent_tool_dispatch;
+#[path = "cli_binary/cook_preview_lifecycle.rs"]
+mod cook_preview_lifecycle;
 #[path = "cli_binary/cook_prompt_stdin.rs"]
 mod cook_prompt_stdin;
 #[path = "cli_binary/fanout_supervisor_cli.rs"]

--- a/tests/cli_binary/cook_preview_lifecycle.rs
+++ b/tests/cli_binary/cook_preview_lifecycle.rs
@@ -1,0 +1,92 @@
+use serde_json::Value;
+use std::path::PathBuf;
+use std::process::Command;
+
+#[test]
+fn unresolved_backend_preview_binds_stable_replay_lifecycle_without_mutation() {
+    let home = tempfile::tempdir().expect("home");
+    let output = Command::new(homeboy_bin())
+        .args([
+            "agent-task",
+            "cook",
+            "--repo",
+            "homeboy",
+            "--task-url",
+            "https://github.com/Extra-Chill/homeboy/issues/13490",
+            "--head",
+            "fix/13490-cook-preview-lifecycle-chubes",
+            "--base",
+            "main",
+            "--goal",
+            "Fix Cook preview lifecycle",
+            "--verify",
+            "cargo test -p homeboy-cli",
+            "--preview",
+        ])
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .env("XDG_DATA_HOME", home.path().join(".local/share"))
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .output()
+        .expect("run Cook preview");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let envelope: Value = serde_json::from_slice(&output.stdout).expect("preview JSON");
+    assert_eq!(envelope["schema"], "homeboy/command-result/v3");
+    assert_eq!(envelope["command"], "agent-task");
+    assert_eq!(envelope["operation"], "cook");
+    assert_eq!(envelope["success"], true);
+    let preview = &envelope["data"];
+    assert_eq!(preview["schema"], "homeboy/agent-task-cook-preview/v1");
+    assert_eq!(preview["mutates"], false);
+    assert_eq!(preview["resolved"]["backend"]["default_policy"], "missing");
+
+    let replay = preview["replay_argv"]
+        .as_array()
+        .expect("preview replay argv");
+    let run_id = replay_flag_value(replay, "--run-id");
+    let attempt_run_id = replay_flag_value(replay, "--attempt-run-id");
+    assert_eq!(run_id, attempt_run_id);
+    assert!(run_id.starts_with("agent-task-"), "{run_id}");
+
+    for choice in preview["resolved"]["backend"]["ready_choices"]
+        .as_array()
+        .expect("ready backend choices")
+    {
+        let choice_replay = choice["replay_argv"]
+            .as_array()
+            .expect("choice replay argv");
+        assert_eq!(replay_flag_value(choice_replay, "--run-id"), run_id);
+        assert_eq!(
+            replay_flag_value(choice_replay, "--attempt-run-id"),
+            attempt_run_id
+        );
+    }
+
+    assert_eq!(
+        std::fs::read_dir(home.path())
+            .expect("read isolated home")
+            .count(),
+        0,
+        "preview must not create Homeboy state"
+    );
+}
+
+fn replay_flag_value<'a>(argv: &'a [Value], flag: &str) -> &'a str {
+    let matches = argv
+        .windows(2)
+        .filter(|pair| pair[0].as_str() == Some(flag))
+        .collect::<Vec<_>>();
+    assert_eq!(matches.len(), 1, "{flag} must occur exactly once: {argv:?}");
+    matches[0][1].as_str().expect("replay flag value")
+}
+
+fn homeboy_bin() -> PathBuf {
+    PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
+}


### PR DESCRIPTION
## Summary

- bind Cook preview lifecycle IDs before resolving the unresolved-backend preview path
- prevent missing backend policy previews from panicking while constructing replay arguments
- cover the real CLI ordering path and stable replay lifecycle bindings

Closes #13490

## Testing

- added unresolved-backend Cook preview lifecycle regression coverage in `tests/cli_binary/cook_preview_lifecycle.rs`
- `git diff --check origin/main...HEAD`

## AI assistance

OpenAI GPT-5.6 Sol was used through OpenCode to inspect the completed repair, verify repository and tracker state, and prepare this pull request under Chris Huber’s direction.