### PR TITLE
fix(release): pass extension settings to packagers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,7 @@ jobs:
     # (bounded action setup subprocesses), and suffixed measurement commands.
     #
     # Refs #10997, #11751 W1-2, W1-5, W1-6, W1-7, W1-10, #13267, and #13437.
-    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@83110d6638ec1c2f63352fcb004920524add0377
+    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@95924a6c4841d1db8d6dedc8a337fa07c6ac7b6a
     with:
       commands: review test
       # `review test` defaults to running the extension's pre-test lint, which
@@ -302,7 +302,7 @@ jobs:
       # workflow checks out to run the gate itself — it is what surfaces as
       # `ACTION_REVISION` in the Test job — so leaving it behind would keep the
       # old `apply-differential-gate.py` even with a newer workflow.
-      action-ref: 83110d6638ec1c2f63352fcb004920524add0377
+      action-ref: 95924a6c4841d1db8d6dedc8a337fa07c6ac7b6a
       # v3.38.8. Must move with the action pin, not after it: the action consumes
       # per-test identities, and homeboy-extensions#2699 (`fix(rust): canonicalize
       # failed test identities`, released in rust v1.37.2) is what produces them.

--- a/crates/homeboy-release/src/release/executor.rs
+++ b/crates/homeboy-release/src/release/executor.rs
@@ -555,7 +555,7 @@ mod tests {
     use super::{github_release, package_preflight, run_cleanup, run_package, PackageRequest};
     use crate::release::types::ReleaseState;
     use crate::release::types::{ReleaseArtifact, ReleaseStepStatus};
-    use homeboy_core::component::Component;
+    use homeboy_core::component::{Component, ScopedExtensionConfig};
     use homeboy_core::git::release_download::GitHubRepo;
     use homeboy_extension::ExtensionManifest;
     fn test_repo() -> GitHubRepo {
@@ -1375,6 +1375,86 @@ mod tests {
                 state.artifacts[0].path,
                 "build/intelligence-horse-theme.zip"
             );
+        });
+    }
+
+    #[test]
+    fn run_package_passes_only_provider_settings_with_release_overrides() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let component_dir = tempfile::tempdir().expect("component tempdir");
+            let payload_out = component_dir.path().join("package-payload.json");
+            let package = release_package_extension(
+                "nodejs",
+                &format!(
+                    "printf '%s' \"$HOMEBOY_SETTINGS_JSON\" > '{}'; \
+                     mkdir -p dist; printf artifact > dist/fixture.tgz; \
+                     printf '[{{\"path\":\"dist/fixture.tgz\"}}]'",
+                    payload_out.display()
+                ),
+            );
+            homeboy_extension::save_manifest(&package).expect("save package extension");
+
+            let mut component = Component::default();
+            component.extensions = Some(std::collections::HashMap::from([
+                (
+                    "nodejs".to_string(),
+                    ScopedExtensionConfig {
+                        settings: std::collections::HashMap::from([
+                            (
+                                "release_package_script".to_string(),
+                                serde_json::json!("release:package"),
+                            ),
+                            (
+                                "skip_build_validation".to_string(),
+                                serde_json::json!(false),
+                            ),
+                        ]),
+                        ..ScopedExtensionConfig::default()
+                    },
+                ),
+                (
+                    "other".to_string(),
+                    ScopedExtensionConfig {
+                        settings: std::collections::HashMap::from([(
+                            "must_not_leak".to_string(),
+                            serde_json::json!(true),
+                        )]),
+                        ..ScopedExtensionConfig::default()
+                    },
+                ),
+            ]));
+
+            let mut state = ReleaseState::default();
+            let result = run_package(
+                &test_roots(),
+                &[package],
+                &mut state,
+                &component,
+                "fixture",
+                &component_dir.path().to_string_lossy(),
+                PackageRequest {
+                    component_source_path: None,
+                    declared_build_artifact: None,
+                    skip_build_validation: true,
+                },
+            )
+            .expect("package step");
+
+            assert_eq!(result.status, ReleaseStepStatus::Success);
+            let payload: serde_json::Value = serde_json::from_slice(
+                &std::fs::read(payload_out).expect("captured package payload"),
+            )
+            .expect("valid package payload");
+            assert_eq!(
+                payload["config"]["release_package_script"],
+                serde_json::json!("release:package")
+            );
+            assert_eq!(
+                payload["config"]["skip_build_validation"],
+                serde_json::json!(true),
+                "release-owned transient config overrides component settings"
+            );
+            assert!(payload["config"].get("must_not_leak").is_none());
         });
     }
 

--- a/crates/homeboy-release/src/release/executor/package.rs
+++ b/crates/homeboy-release/src/release/executor/package.rs
@@ -107,15 +107,16 @@ pub(crate) fn run_package(
         ));
         }
 
-        let extra_config = package_build_config(skip_build_validation);
         let mut responses = Vec::new();
         for extension in package_extensions {
+            let provider_config =
+                package_provider_config(component, &extension.id, skip_build_validation);
             let payload = build_release_payload(
                 state,
                 component_id,
                 component_local_path,
                 component_source_path,
-                extra_config.as_ref(),
+                provider_config.as_ref(),
             );
             let response = run_package_action_with_retry(&extension.id, &payload)
                 .map_err(|err| package_provider_error(&extension.id, err))?;
@@ -804,6 +805,21 @@ fn package_build_config(
         serde_json::Value::Bool(true),
     );
     Some(config)
+}
+
+fn package_provider_config(
+    component: &Component,
+    extension_id: &str,
+    skip_build_validation: bool,
+) -> Option<std::collections::HashMap<String, serde_json::Value>> {
+    let mut config: std::collections::HashMap<_, _> =
+        extension::extract_component_extension_settings(component, extension_id)
+            .into_iter()
+            .collect();
+    if let Some(release_config) = package_build_config(skip_build_validation) {
+        config.extend(release_config);
+    }
+    (!config.is_empty()).then_some(config)
 }
 
 pub(crate) fn build_release_payload(


### PR DESCRIPTION
## Summary
- merge each package provider's component-scoped settings into `payload.config`
- keep settings isolated between multiple `release.package` providers
- let release-owned transient flags override conflicting static settings

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p homeboy-release run_package`
- 10 package executor tests passed, including real `HOMEBOY_SETTINGS_JSON` capture

## Context
WP Codebox releases v0.24.4 and v0.24.5 proved the prior payload always contained `config: null`, preventing the Node provider from consuming its configured project artifact manifest. Homeboy core already handles the resulting multi-artifact array once settings reach the provider.

Fixes #13505