### PR TITLE
fix(cook): bound explicit repository resolution

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -4131,7 +4131,7 @@ fn preview_destination_blocker(handle: &str, problem: &str) -> homeboy::core::Er
 }
 
 #[derive(Debug, Clone)]
-struct CookRepositoryIdentity {
+pub(super) struct CookRepositoryIdentity {
     repository_name: String,
     slug: String,
     aliases: Vec<String>,
@@ -4155,7 +4155,8 @@ fn normalize_cook_repository_identity(args: &mut AgentTaskCookArgs) -> homeboy::
         let Some(value) = value else {
             continue;
         };
-        let resolved = cook_repository_identities_for_workspace(flag, value)?;
+        let resolved =
+            cook_repository_identities_for_workspace(flag, value, args.dispatch.repo.as_deref())?;
         source_identities.push((flag, resolved.clone()));
         identities.extend(resolved);
     }
@@ -4383,9 +4384,10 @@ fn require_explicit_cook_repo(args: &AgentTaskCookArgs, reason: &str) -> homeboy
     ]))
 }
 
-fn cook_repository_identities_for_workspace(
+pub(super) fn cook_repository_identities_for_workspace(
     flag: &str,
     value: &str,
+    requested_repository: Option<&str>,
 ) -> homeboy::core::Result<Vec<CookRepositoryIdentity>> {
     let path = Path::new(value);
     let workspace_path = if path.is_dir() {
@@ -4409,7 +4411,10 @@ fn cook_repository_identities_for_workspace(
             homeboy::core::git::remote_url(&git_root, remote).map(|url| (remote.to_string(), url))
         })
         .collect::<Vec<_>>();
-    let configured = homeboy::core::component::registered()?;
+    let configured = match requested_repository {
+        Some(repository) => cook_components_for_repository_name(repository)?,
+        None => homeboy::core::component::registered()?,
+    };
     let mut identities = Vec::new();
     for (remote_name, remote_url) in remotes {
         let Some(remote_identity) = canonical_remote_identity(&remote_url) else {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -70,6 +70,40 @@ fn register_component_with_aliases(
     .expect("register component");
 }
 
+#[test]
+fn explicit_repo_identity_resolution_does_not_hydrate_unrelated_components() {
+    with_isolated_home(|_| {
+        let checkout = tempfile::tempdir().expect("checkout");
+        init_runtime_component_checkout(checkout.path());
+        add_remote(
+            checkout.path(),
+            "origin",
+            "https://github.com/example/fixture.git",
+        );
+        register_component(
+            "fixture",
+            checkout.path(),
+            "https://github.com/example/fixture.git",
+        );
+
+        let unrelated = tempfile::tempdir().expect("unrelated checkout");
+        register_component(
+            "unrelated",
+            unrelated.path(),
+            "https://github.com/example/fixture.git",
+        );
+
+        let identities = super::super::run::cook_repository_identities_for_workspace(
+            "--cwd",
+            checkout.path().to_str().expect("UTF-8 checkout path"),
+            Some("fixture"),
+        )
+        .expect("resolve explicit repository identity");
+
+        assert_eq!(identities.len(), 1);
+    });
+}
+
 fn write_component_without_collision_validation(component: homeboy::core::component::Component) {
     let directory = homeboy::core::paths::components().expect("component config directory");
     std::fs::create_dir_all(&directory).expect("create component config directory");


### PR DESCRIPTION
## Summary
- resolve an explicit `--repo` through its targeted component registration during workspace identity validation
- retain full inventory inference only when the caller omits `--repo`
- cover same-remote unrelated registrations with a focused regression test

## Root cause
`cook_repository_identities_for_workspace()` always hydrated the complete enriched component inventory. A stale registration caused portable component discovery to recursively scan a broad checkout parent, leaving Cook in `destination_resolution` even though `--repo` and `--cwd` already identified the destination.

Closes #13504.

## Verification
- `cargo test -p homeboy-cli --features test-support explicit_repo_identity_resolution_does_not_hydrate_unrelated_components -- --test-threads=1`
- `cargo test -p homeboy-cli --features test-support cook_cwd_ -- --test-threads=1`
- `cargo fmt --all -- --check`
- `git diff --check`
- Built the patched `homeboy` binary and successfully completed the previously hanging Static Site Importer #1317 Cook preview with explicit `--repo`, `--cwd`, and `--to-worktree`.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode profiled the blocked process, identified the full-inventory recursive scan, implemented the targeted resolution path and regression test, and ran verification under Chris Huber's direction.