### PR TITLE
fix(cook): delete BaselineInconclusive instead of excusing a red candidate

### DIFF
--- a/crates/homeboy-agents/src/agent_task_cook_loop.rs
+++ b/crates/homeboy-agents/src/agent_task_cook_loop.rs
@@ -85,7 +85,6 @@ pub enum AgentTaskCookLoopStatus {
     BaselineRed,
     /// Immutable-base replay could not establish whether the candidate failed
     /// differently, so provider remediation is intentionally withheld.
-    BaselineInconclusive,
     IntentionalNoChange,
     NoChanges,
     NoOpGateFailed,
@@ -243,17 +242,6 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
                         && comparison.matches_candidate_failure
                 })
         });
-    let baseline_inconclusive = options
-        .promotion_report
-        .deterministic_gates
-        .iter()
-        .any(|gate| {
-            gate.status == AgentTaskGateStatus::Failed
-                && gate.baseline_comparison.as_ref().is_some_and(|comparison| {
-                    comparison.result
-                        == crate::agent_task_gate::AgentTaskGateDifferentialResult::Inconclusive
-                })
-        });
     let intentional_no_change = (options.promotion_report.status
         == AgentTaskPromotionStatus::VerifiedNoChanges)
         .then(|| {
@@ -333,8 +321,6 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
         AgentTaskCookLoopStatus::NoChanges
     } else if baseline_red {
         AgentTaskCookLoopStatus::BaselineRed
-    } else if baseline_inconclusive {
-        AgentTaskCookLoopStatus::BaselineInconclusive
     } else if !failed_gates.is_empty() {
         AgentTaskCookLoopStatus::RetriesExhausted
     } else if matches!(&review_form_gap, Some(Some(_))) {
@@ -359,12 +345,7 @@ pub fn evaluate_cook_loop(options: AgentTaskCookLoopOptions) -> AgentTaskCookLoo
         failed_gate_results,
         follow_up_request,
         intentional_no_change,
-        metadata: report_metadata(
-            options.metadata,
-            &failure_progression,
-            baseline_red,
-            baseline_inconclusive,
-        ),
+        metadata: report_metadata(options.metadata, &failure_progression, baseline_red),
     }
 }
 
@@ -816,7 +797,6 @@ fn report_metadata(
     metadata: Value,
     progression: &AgentTaskCookLoopFailureProgression,
     baseline_red: bool,
-    baseline_inconclusive: bool,
 ) -> Value {
     let mut metadata = metadata.as_object().cloned().unwrap_or_default();
     metadata.insert("failure_progression".to_string(), json!(progression));
@@ -825,19 +805,6 @@ fn report_metadata(
         metadata.insert(
             "failure_origin".to_string(),
             Value::String("inherited_infrastructure".to_string()),
-        );
-    }
-    if baseline_inconclusive {
-        metadata.insert("baseline_inconclusive".to_string(), Value::Bool(true));
-        metadata.insert(
-            "failure_origin".to_string(),
-            Value::String("baseline_replay_inconclusive".to_string()),
-        );
-        metadata.insert(
-            "next_action".to_string(),
-            Value::String(
-                "repair the gate baseline setup or replay environment, then rerun Cook".to_string(),
-            ),
         );
     }
     Value::Object(metadata)
@@ -1181,8 +1148,14 @@ mod tests {
         }
     }
 
+    /// An inconclusive baseline must not retry and must not excuse the
+    /// candidate. `should_retry` already refuses to spend an attempt unless
+    /// every failed gate proved `CandidateRegression`, so the run is terminal
+    /// on that alone -- it does not need a status of its own, and giving it one
+    /// reported a red candidate gate as broken infrastructure. The specific
+    /// reason now travels on `baseline_comparison.diagnostic`.
     #[test]
-    fn inconclusive_baseline_replay_is_terminal_with_recovery_action() {
+    fn inconclusive_baseline_replay_is_terminal_without_excusing_the_candidate() {
         let mut gate = failed_gate();
         gate.baseline_comparison
             .as_mut()
@@ -1200,15 +1173,16 @@ mod tests {
             metadata: Value::Null,
         });
 
-        assert_eq!(report.status, AgentTaskCookLoopStatus::BaselineInconclusive);
+        // Terminal: no attempt is spent on a comparison that proved nothing.
         assert!(report.follow_up_request.is_none());
-        assert_eq!(
+        // The candidate gate is red and stays the candidate's problem.
+        assert_eq!(report.status, AgentTaskCookLoopStatus::RetriesExhausted);
+        // No infrastructure remediation is asserted, because none was proven.
+        assert!(report.metadata.get("baseline_inconclusive").is_none());
+        assert_ne!(
             report.metadata["failure_origin"],
             "baseline_replay_inconclusive"
         );
-        assert!(report.metadata["next_action"]
-            .as_str()
-            .is_some_and(|action| action.contains("replay environment")));
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -6456,21 +6456,6 @@ fn run_cook_spine(
                     invocation_latest_run_id: Some(&run_id),
                 }));
             }
-            AgentTaskCookLoopStatus::BaselineInconclusive => {
-                return Ok(cook_report(CookReportInput {
-                    cook_id,
-                    status: "baseline_inconclusive",
-                    disposition: CookDisposition::Terminal,
-                    attempts,
-                    finalization: None,
-                    stop_reason: Some(
-                        "immutable baseline replay was inconclusive; repair the gate baseline setup or replay environment before rerunning Cook"
-                            .to_string(),
-                    ),
-                    exit_code: 1,
-                    invocation_latest_run_id: Some(&run_id),
-                }));
-            }
             AgentTaskCookLoopStatus::NoChanges => {
                 return Ok(cook_report(CookReportInput {
                     cook_id,

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -858,20 +858,6 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
             }));
         }
     }
-    if feedback.status == AgentTaskCookLoopStatus::BaselineInconclusive {
-        let reason = "immutable baseline replay was inconclusive; repair the gate baseline setup or replay environment before retrying adoption";
-        lifecycle_store.finish_candidate_adoption(&record.run_id, Some(reason.to_string()))?;
-        return Ok(cook_report(CookReportInput {
-            cook_id: cook_id.to_string(),
-            status: "baseline_inconclusive",
-            disposition: CookDisposition::Terminal,
-            attempts: vec![attempt],
-            finalization: None,
-            stop_reason: Some(reason.to_string()),
-            exit_code: 1,
-            invocation_latest_run_id: Some(record.run_id.as_str()),
-        }));
-    }
     if feedback.status != AgentTaskCookLoopStatus::GreenCompleted
         && !(feedback.status == AgentTaskCookLoopStatus::BaselineRed
             && options.gates.accept_inherited_failures


### PR DESCRIPTION
## What

`2e567439b` (#13152) added `AgentTaskCookLoopStatus::BaselineInconclusive`, which fires whenever a **failed** gate has an inconclusive baseline comparison:

```rust
gate.status == AgentTaskGateStatus::Failed
    && comparison.result == AgentTaskGateDifferentialResult::Inconclusive
```

Because it requires the candidate gate to be red, **it can never fire for any other reason**. So it always converted a candidate failure into an infrastructure classification, and told the operator:

> *immutable baseline replay was inconclusive; repair the gate baseline setup or replay environment before rerunning Cook*

…for a candidate that had simply failed its own gate.

`cook_baseline.rs` states the invariant three lines above the arm that produces the inconclusive result:

> *"A baseline execution failure **must never** convert a candidate failure into an infrastructure error that loses its durable comparison result."*

## Why deleting it is the simplification

#13152's goal was real: **don't spend a provider attempt on a comparison that proved nothing.**

That is already enforced, independently, by `should_retry` — which refuses to retry unless *every* failed gate proved `CandidateRegression`. An inconclusive comparison fails that `.all(...)`, so `follow_up_request` is `None` and the run is terminal **without needing a status of its own**.

The status carried no behaviour. Only the misclassification.

| removed | |
|---|---|
| `BaselineInconclusive` enum variant | `agent_task_cook_loop.rs` |
| `baseline_inconclusive` predicate | |
| its branch in the status chain | |
| its `report_metadata` block + parameter | |
| its match arm | `cook.rs` |
| its early return | `cook_adoption.rs` |

**14 insertions, 69 deletions** across three files.

A run in this state now classifies as `RetriesExhausted`: terminal, no retry, and honest about whose failure it is.

## The reason isn't lost — it got better

#13496 put the specific cause on `baseline_comparison.diagnostic`. Where the deleted status said *"go repair your replay environment"*, the diagnostic now says:

```
package artifact readiness for `candidate-input` failed: required artifact
paths are unavailable or do not match their declared digest
invalid_paths: ["fixtures/input.bin"]
```

That is a true, specific statement about the candidate. The thing being deleted was a generic instruction to repair an environment that was never proven broken.

## #13152's test is kept, and inverted

`inconclusive_baseline_replay_is_terminal_with_recovery_action` becomes `..._without_excusing_the_candidate`, pinning the corrected contract:

- still terminal (`follow_up_request.is_none()`)
- **no longer excusing the candidate** (`status == RetriesExhausted`)
- **no longer asserting infrastructure remediation** (`metadata["baseline_inconclusive"]` absent)

The last two assertions pin the absence deliberately, so this cannot silently come back.

## Verification

- `cargo check --workspace --all-targets -j2` — zero errors, zero warnings
- `cargo test -p homeboy-agents --lib` — **2003 passed / 41 failed**, against **1997 / 48** on main

**Seven tests fixed, none broken.** Zero `baseline_inconclusive` assertion failures remain — that was the largest single shape in the 112-failure triage.

The two failures unique to this branch each **pass alone under `--test-threads=1`** — pre-existing parallelism flakes, verified rather than assumed.

## AI assistance

Tool(s): OpenCode
