### PR TITLE
fix(ci): budget the from-source build like the phases beside it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,9 @@ jobs:
           expected-commands: review audit,review lint,review test
           differential-gating: true
           execution-timeout-seconds: ${{ matrix.execution_timeout_seconds }}
+          # See the note on the other call site: a from-source release build of
+          # this workspace does not fit the shared 900s setup default.
+          setup-timeout-seconds: '2400'
           app-token: ${{ steps.app-token.outputs.token || github.token }}
           comment-section-key: ${{ matrix.section_key }}
           comment-section-title: ${{ matrix.section_title }}
@@ -322,6 +325,14 @@ jobs:
       test-shards: ${{ needs.ci-capacity-admission.outputs.test-shards }}
       execution-timeout-seconds: '2100'
       test-timeout-seconds: '1800'
+      # Homeboy builds itself from source in `release`. That is the most
+      # expensive setup step this action has, and the shared 900s default is
+      # scoped to downstream components that download a prebuilt binary. A cold
+      # or partially-warm cargo cache pushes this workspace past 900s, the setup
+      # wrapper terminates the build, and the action then reports every expected
+      # command as failed -- so an unrelated PR sees a red `Audit` with no
+      # findings and no digest. Budget it like the other two phases already are.
+      setup-timeout-seconds: '2400'
       comment-section-key: test
       comment-section-title: Test
     secrets: inherit


### PR DESCRIPTION
## What

`Audit` has been red on **every recently merged PR** — #13496, #13498, #13499, #13500, #13507 — with no findings, no digest, and nothing in the job log naming a rule.

**The audit never ran.** From the job log:

```
##[error] build Homeboy from source exceeded its 900s execution timeout
##[error] Current Homeboy command results were missing, malformed, interrupted,
          or incomplete; marking all expected commands failed
          No output directory available; skipping failure digest
```

Homeboy builds itself from source in `release` — 38 crates, ~230k lines. That is the most expensive setup step the action has, and `setup-timeout-seconds` defaults to **900s**, a budget scoped to downstream components that *download a prebuilt binary*.

On a cold or partially-warm cargo cache this workspace doesn't fit. The setup wrapper terminates the build, and the action then marks every expected command failed.

## The inconsistency this closes

This workflow already declares, for exactly this reason:

```yaml
execution-timeout-seconds: '2100'
test-timeout-seconds:      '1800'
```

`setup-timeout-seconds` was the **one phase left on the shared default** — despite being the phase this repository stresses hardest. Now set to `2400` at both call sites.

## Why it read as an audit problem

The failure mode is worth naming, because every symptom points at the wrong thing:

| symptom | what you'd conclude |
|---|---|
| `Audit` red | the audit found something |
| no findings artifact | the artifact upload is broken |
| observation store shows run still `running` | the store is broken |
| digest says `head artifact unavailable` | the digest is broken |

**None of them point at the build.** I spent a chunk of this session chasing the digest and the artifact plumbing before the job log gave it up.

## Evidence that 900s is the boundary, not a cliff

- `Audit` on #13508 **failed after 16m47s** — 900s build + overhead
- `Audit` on #13486 **passed with a 34m35s job** — same build, cache warm enough to fit

That intermittency is precisely why this has been reading as flake rather than misconfiguration.

<callout accent="#f59e0b">
## Verification is CI itself

This can't be reproduced locally — the timeout only binds against a GitHub runner's cache state. The check is that `Audit` reports a **real** result (pass, or a failure *with findings*) instead of an empty red.

If it still fails after this, the build needs more than 40 minutes and the answer is caching, not budget.
</callout>

## AI assistance

Tool(s): OpenCode
