### PR TITLE
Reject empty detached Cook handoffs

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2599,6 +2599,16 @@ where
             .expect("submission metadata is an object")
             .extend(submission_metadata);
     }
+    if let Ok(job_id) = std::env::var("HOMEBOY_LOCAL_COOK_SUPERVISOR_JOB_ID") {
+        if !job_id.trim().is_empty() {
+            metadata["local_cook_supervisor"] = json!({
+                "state": "supervising",
+                "job_id": job_id,
+                "job_type": crate::agent_task_service::AGENT_TASK_COOK_JOB_TYPE,
+                "pinned_run_id": run_id,
+            });
+        }
+    }
 
     let mut record = AgentTaskRunRecord {
         schema: schemas::RUN.to_string(),

--- a/crates/homeboy-agents/src/agent_task_service/cook_job.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_job.rs
@@ -220,6 +220,7 @@ impl AgentTaskCookJob {
             "idempotency_key": self.idempotency_key,
             "phase": self.phase,
             "cook_id": self.request.cook_id,
+            "durable_run_id": self.request.cook_id,
             "run_id": self.run_id,
             "terminal_state": self.terminal_state,
         })
@@ -436,6 +437,7 @@ impl AgentTaskCookJob {
         json!({
             "phase": self.phase,
             "cook_id": self.request.cook_id,
+            "durable_run_id": self.request.cook_id,
             "run_id": self.run_id,
         })
     }

--- a/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
@@ -65,6 +65,7 @@ const HANDOFF_POLL: Duration = Duration::from_millis(100);
 const HANDOFF_TIMEOUT_ENV: &str = "HOMEBOY_COOK_DETACH_HANDOFF_TIMEOUT_MS";
 const LOCAL_COOK_LAUNCH_TOKEN_ENV: &str = "HOMEBOY_LOCAL_COOK_LAUNCH_TOKEN";
 const LOCAL_COOK_LAUNCH_TOKEN_PATH_ENV: &str = "HOMEBOY_LOCAL_COOK_LAUNCH_TOKEN_PATH";
+const LOCAL_COOK_SUPERVISOR_JOB_ID_ENV: &str = "HOMEBOY_LOCAL_COOK_SUPERVISOR_JOB_ID";
 // Hermetic E2E control: keep the launcher observable after ownership was
 // accepted so the test can signal it. Normal invocations still return at handoff.
 const TEST_LOCAL_COOK_RETRY_FOLLOW_ENV: &str = "HOMEBOY_TEST_LOCAL_COOK_RETRY_FOLLOW";
@@ -544,9 +545,22 @@ fn consume_local_cook_launch_token_at(token: &std::ffi::OsStr, path: &Path) -> b
     if std::fs::rename(path, &claimed).is_err() {
         return false;
     }
-    let valid = std::fs::read_to_string(&claimed)
-        .ok()
-        .is_some_and(|stored| stored.trim_end() == token);
+    let stored = std::fs::read_to_string(&claimed).ok();
+    let valid = stored.as_deref().is_some_and(|stored| {
+        if stored.trim_end() == token {
+            return true;
+        }
+        let Ok(publication) = serde_json::from_str::<Value>(stored) else {
+            return false;
+        };
+        if publication["token"].as_str().map(std::ffi::OsStr::new) != Some(token) {
+            return false;
+        }
+        if let Some(job_id) = publication["supervisor_job_id"].as_str() {
+            std::env::set_var(LOCAL_COOK_SUPERVISOR_JOB_ID_ENV, job_id);
+        }
+        true
+    });
     let _ = std::fs::remove_file(claimed);
     valid
 }
@@ -621,6 +635,18 @@ pub(super) fn intercept_local_detached_cook(
     provider_placement: Option<&str>,
     provider_runner_id: Option<&str>,
 ) -> homeboy::core::Result<Option<i32>> {
+    // The detached child cannot enter Cook admission until its parent publishes
+    // the one-use token carrying the exact durable supervisor identity.
+    if local_cook_launch_token_is_present() {
+        return if await_local_cook_launch_token(handoff_timeout()) {
+            Ok(None)
+        } else {
+            Err(empty_detached_plan_error(
+                None,
+                "detached Cook ownership was not published before the bounded admission deadline",
+            ))
+        };
+    }
     if !is_unsupervised_local_cook(cli)
         && !automatic_local_cook_needs_supervision(cli, provider_placement)
     {
@@ -681,26 +707,6 @@ pub(super) fn intercept_local_detached_cook(
         .then(homeboy::core::daemon::LocalControllerJobClient::connect_current_build)
         .transpose()?;
 
-    // One store for the whole handoff. The parent record, the child record, the
-    // supervisor projection, and every compensating failure below are one
-    // transaction: a parent opened in one installation and failed in another
-    // leaves the first one's fence standing open forever, so the detached Cook
-    // reads as live while nothing owns it — and the compensation that was
-    // supposed to release it reports success having touched a different home
-    // (#7505).
-    //
-    // Resolved here rather than at the top of the function so it stays on the
-    // same side of the early returns as the first durable write, and fails in
-    // the same place `record_detached_cook_handoff_parent` used to.
-    let lifecycle_store =
-        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
-    // Make the returned Cook ID resolvable before a child exists. If this fails,
-    // nothing has been spawned and no detached work can leak.
-    agent_task_lifecycle::record_detached_cook_handoff_parent_in_store(&lifecycle_store, &cook_id)?;
-    // Daemon startup can run reconciliation. Announce the durable admission
-    // handle before that potentially slow boundary so a disconnected caller can
-    // inspect or cancel it safely.
-    crate::commands::agent_task::run::announce_durable_cook_identity(Some(&cook_id), &cook_id);
     // A daemon-owned job is the authority that outlives this launcher. Prove it
     // is reachable before a provider-capable child exists, so unsupported
     // detachment is rejected before dispatch.
@@ -713,125 +719,72 @@ pub(super) fn intercept_local_detached_cook(
                 // daemon is an older build; #12581 owns that wait-policy path.
                 return Ok(None);
             }
-            Err(error) => {
-                let _ = agent_task_lifecycle::fail_detached_cook_handoff_parent_in_store(
-                    &lifecycle_store,
-                    &cook_id,
-                    "durable controller ownership could not be established",
-                );
-                return Err(error);
-            }
+            Err(error) => return Err(error),
         },
     };
     let route = detached_route(cli);
-    let launch_token = create_local_cook_launch_token(&session_root)?;
+    // Keep the token unpublished while the child starts. The child blocks in
+    // this interceptor and therefore cannot persist a run before its daemon job.
+    let launch_token = new_local_cook_launch_token(&session_root);
     let mut child = match spawn_detached_cook(&child_args, &log_path, route.as_ref(), &launch_token)
     {
         Ok(child) => child,
-        Err(error) => {
-            let _ = agent_task_lifecycle::fail_detached_cook_handoff_parent_in_store(
-                &lifecycle_store,
-                &cook_id,
-                "detached Cook could not be spawned",
-            );
-            return Err(error);
-        }
+        Err(error) => return Err(error),
     };
     let pid = child.id();
     let start_identity = match detached_child_start_identity(pid) {
         Ok(identity) => identity,
         Err(error) => {
             terminate_and_reap_detached_child(&mut child);
-            let _ = agent_task_lifecycle::fail_detached_cook_handoff_parent_in_store(
-                &lifecycle_store,
-                &cook_id,
-                "detached Cook child start identity could not be captured",
-            );
             return Err(error);
         }
     };
-    let handoff_parent = match agent_task_lifecycle::record_detached_cook_handoff_child_in_store(
-        &lifecycle_store,
-        &cook_id,
-        pid,
-        start_identity.clone(),
-    ) {
-        Ok(record) => record,
-        Err(error) => {
-            terminate_and_reap_detached_child(&mut child);
-            let _ = agent_task_lifecycle::fail_detached_cook_handoff_parent_in_store(
-                &lifecycle_store,
-                &cook_id,
-                "detached Cook child identity could not be persisted",
-            );
-            return Err(error);
-        }
-    };
-    // Cancellation can win in the narrow interval between `spawn` and child
-    // identity persistence. Attaching observes that terminal parent, and this
-    // launcher still owns the child handle, so terminate it before it can
-    // materialize an attempt after cancellation.
-    if handoff_parent.state.is_terminal() {
-        terminate_and_reap_detached_child(&mut child);
-        if handoff_parent.metadata["detached_cook_handoff"]["state"] == "exited_before_handoff" {
-            return Err(Error::validation_invalid_argument(
-                "detach-after-handoff",
-                "detached Cook exited before materializing its first attempt",
-                Some(cook_id),
-                None,
-            ));
-        }
-        return Err(Error::validation_invalid_argument(
-            "detach-after-handoff",
-            "detached Cook became terminal before durable controller ownership could be established",
-            Some(cook_id),
-            None,
-        ));
-    }
     let controller_job =
         match submit_cook_controller_job(&controller_client, &cook_id, pid, &start_identity) {
             Ok(job) => job,
             Err(error) => {
                 terminate_and_reap_detached_child(&mut child);
-                let _ = agent_task_lifecycle::fail_detached_cook_handoff_parent_in_store(
-                    &lifecycle_store,
-                    &cook_id,
-                    "durable controller ownership could not be established",
-                );
                 return Err(error);
             }
         };
-    project_supervisor_or_compensate(
-        agent_task_lifecycle::record_detached_cook_supervisor_in_store(
-            &lifecycle_store,
+    if let Err(error) =
+        publish_local_cook_launch_token_with_supervisor(&launch_token, controller_job.job_id())
+    {
+        compensate_supervisor_projection_failure(
+            &controller_client,
+            controller_job.job_id(),
+            &mut child,
+            &cook_id,
+        );
+        return Err(error);
+    }
+    if cli.detach_after_handoff {
+        let handoff = await_durable_linked_handoff(
             &cook_id,
             controller_job.job_id(),
-        ),
-        || {
-            compensate_supervisor_projection_failure(
-                &controller_client,
-                controller_job.job_id(),
-                &mut child,
-                &cook_id,
-            )
-        },
-    )?;
-    if cli.detach_after_handoff {
-        // Controller supervision makes the placeholder addressable, but
-        // acceptance requires the child to durably materialize its first
-        // executable attempt. Until then, callers receive an explicitly pending
-        // handoff instead of a success that could be followed by a zero-task
-        // terminal placeholder. Attached callers stream immediately; they do
-        // not receive a handoff acknowledgement to classify.
-        let handoff = await_durable_handoff(&cook_id, &mut child, handoff_timeout())?;
-        if handoff.state == DetachedHandoffState::ExitedBeforeHandoff {
-            return Err(Error::validation_invalid_argument(
-                "detach-after-handoff",
-                "detached Cook exited before materializing its first attempt",
-                Some(cook_id),
-                None,
+            &mut child,
+            handoff_timeout(),
+        )?;
+        if handoff.state != DetachedHandoffState::Accepted {
+            let reason = if handoff.state == DetachedHandoffState::ExitedBeforeHandoff {
+                "detached Cook exited before materializing an executable plan"
+            } else {
+                "detached Cook did not materialize an executable plan before the bounded handoff deadline"
+            };
+            let _ = controller_client.cancel(controller_job.job_id(), reason);
+            terminate_and_reap_detached_child(&mut child);
+            return Err(empty_detached_plan_error(
+                Some(controller_job.job_id()),
+                reason,
             ));
         }
+        crate::commands::agent_task::run::announce_durable_cook_identity(
+            Some(&cook_id),
+            handoff
+                .run_id
+                .as_deref()
+                .expect("accepted handoff has run id"),
+        );
         let envelope = handoff_envelope(
             &cook_id,
             pid,
@@ -848,11 +801,6 @@ pub(super) fn intercept_local_detached_cook(
                 terminate_and_reap_detached_child(&mut child);
                 let _ = controller_client.cancel(
                     controller_job.job_id(),
-                    "detached Cook handoff output could not be written",
-                );
-                let _ = agent_task_lifecycle::fail_detached_cook_handoff_parent_in_store(
-                    &lifecycle_store,
-                    &cook_id,
                     "detached Cook handoff output could not be written",
                 );
                 return Err(error);
@@ -1134,8 +1082,27 @@ fn new_local_cook_launch_token(session_root: &Path) -> (String, PathBuf) {
 }
 
 fn publish_local_cook_launch_token(launch_token: &(String, PathBuf)) -> homeboy::core::Result<()> {
+    publish_local_cook_launch_token_bytes(launch_token, launch_token.0.as_bytes())
+}
+
+fn publish_local_cook_launch_token_with_supervisor(
+    launch_token: &(String, PathBuf),
+    supervisor_job_id: &str,
+) -> homeboy::core::Result<()> {
+    let publication = serde_json::to_vec(&json!({
+        "token": launch_token.0,
+        "supervisor_job_id": supervisor_job_id,
+    }))
+    .map_err(|error| Error::internal_json(error.to_string(), None))?;
+    publish_local_cook_launch_token_bytes(launch_token, &publication)
+}
+
+fn publish_local_cook_launch_token_bytes(
+    launch_token: &(String, PathBuf),
+    bytes: &[u8],
+) -> homeboy::core::Result<()> {
     let pending = launch_token.1.with_extension("pending");
-    std::fs::write(&pending, &launch_token.0).map_err(|error| {
+    std::fs::write(&pending, bytes).map_err(|error| {
         Error::internal_io(error.to_string(), Some(pending.display().to_string()))
     })?;
     #[cfg(unix)]
@@ -1165,6 +1132,7 @@ impl Drop for LocalCookLaunchTokenCleanup {
     }
 }
 
+#[cfg(test)]
 fn create_local_cook_launch_token(session_root: &Path) -> homeboy::core::Result<(String, PathBuf)> {
     let launch_token = new_local_cook_launch_token(session_root);
     publish_local_cook_launch_token(&launch_token)?;
@@ -1225,6 +1193,7 @@ fn compensate_supervisor_projection_failure(
     );
 }
 
+#[cfg(test)]
 fn project_supervisor_or_compensate(
     projection: homeboy::core::Result<()>,
     compensate: impl FnOnce(),
@@ -1297,23 +1266,51 @@ fn handoff_timeout() -> Duration {
     Duration::from_millis(millis)
 }
 
-/// Poll durable state until the detached cook materializes an executable
-/// attempt, it dies, or the bound elapses. The placeholder is addressable while
-/// pending; an index whose named attempt can be read proves durable ownership.
+/// Poll durable state until the detached cook materializes an executable,
+/// supervisor-linked attempt, it dies, or the bound elapses.
 ///
 /// Liveness is read from the child handle rather than from the pid. The
 /// detached cook is still this process's direct child until this process exits,
 /// so an early exit leaves a zombie that a pid probe reports as running on
 /// platforms without a `/proc` state check — which would turn a cook that died
 /// on startup into an indefinite "pending" handoff.
+fn await_durable_linked_handoff(
+    cook_id: &str,
+    supervisor_job_id: &str,
+    child: &mut std::process::Child,
+    timeout: Duration,
+) -> homeboy::core::Result<DetachedCookHandoff> {
+    await_durable_handoff_inner(cook_id, Some(supervisor_job_id), child, timeout)
+}
+
+/// Read the exact durable attempt an accepted handoff names. An index file on
+/// its own is not sufficient: a caller must be able to resolve the attempt it
+/// receives immediately.
+#[cfg(test)]
 fn await_durable_handoff(
     cook_id: &str,
     child: &mut std::process::Child,
     timeout: Duration,
 ) -> homeboy::core::Result<DetachedCookHandoff> {
+    let handoff = await_durable_handoff_inner(cook_id, None, child, timeout)?;
+    if handoff.state == DetachedHandoffState::ExitedBeforeHandoff {
+        agent_task_lifecycle::fail_detached_cook_handoff_parent(
+            cook_id,
+            "detached Cook exited before materializing its first attempt",
+        )?;
+    }
+    Ok(handoff)
+}
+
+fn await_durable_handoff_inner(
+    cook_id: &str,
+    supervisor_job_id: Option<&str>,
+    child: &mut std::process::Child,
+    timeout: Duration,
+) -> homeboy::core::Result<DetachedCookHandoff> {
     let started = Instant::now();
     loop {
-        if let Some(run_id) = durable_attempt_id(cook_id) {
+        if let Some(run_id) = durable_attempt_id(cook_id, supervisor_job_id) {
             return Ok(DetachedCookHandoff {
                 state: DetachedHandoffState::Accepted,
                 run_id: Some(run_id),
@@ -1322,22 +1319,7 @@ fn await_durable_handoff(
         }
         match child.try_wait() {
             Ok(Some(_)) => {
-                // Process exit and index publication can cross. Re-read the
-                // durable ownership proof before failing, and let lifecycle
-                // reject a stale failure mutation if materialization wins this
-                // race afterward.
-                if let Some(run_id) = durable_attempt_id(cook_id) {
-                    return Ok(DetachedCookHandoff {
-                        state: DetachedHandoffState::Accepted,
-                        run_id: Some(run_id),
-                        waited_ms: started.elapsed().as_millis() as u64,
-                    });
-                }
-                agent_task_lifecycle::fail_detached_cook_handoff_parent(
-                    cook_id,
-                    "detached Cook exited before materializing its first attempt",
-                )?;
-                if let Some(run_id) = durable_attempt_id(cook_id) {
+                if let Some(run_id) = durable_attempt_id(cook_id, supervisor_job_id) {
                     return Ok(DetachedCookHandoff {
                         state: DetachedHandoffState::Accepted,
                         run_id: Some(run_id),
@@ -1350,8 +1332,6 @@ fn await_durable_handoff(
                     waited_ms: started.elapsed().as_millis() as u64,
                 });
             }
-            // An observation error is not proof that the child died. Preserve
-            // the pending contract and let durable supervision continue.
             Err(_) => {
                 return Ok(DetachedCookHandoff {
                     state: DetachedHandoffState::Pending,
@@ -1372,15 +1352,36 @@ fn await_durable_handoff(
     }
 }
 
-/// Read the exact durable attempt an accepted handoff names. An index file on
-/// its own is not sufficient: a caller must be able to resolve the attempt it
-/// receives immediately.
-fn durable_attempt_id(cook_id: &str) -> Option<String> {
+fn durable_attempt_id(cook_id: &str, supervisor_job_id: Option<&str>) -> Option<String> {
     let run_id = agent_task_lifecycle::cook_index(cook_id)
         .ok()?
         .latest_run_id;
-    (!run_id.trim().is_empty() && agent_task_lifecycle::exact_record(&run_id).is_ok())
-        .then_some(run_id)
+    let record = agent_task_lifecycle::exact_record(&run_id).ok()?;
+    let plan = agent_task_lifecycle::load_plan(&run_id).ok()?;
+    (!run_id.trim().is_empty()
+        && !plan.tasks.is_empty()
+        && supervisor_job_id
+            .is_none_or(|job_id| record.metadata["local_cook_supervisor"]["job_id"] == job_id))
+    .then_some(run_id)
+}
+
+fn empty_detached_plan_error(job_id: Option<&str>, problem: &str) -> Error {
+    let mut error = Error::validation_invalid_argument(
+        "detach-after-handoff",
+        problem,
+        None,
+        Some(vec![
+            "Re-run the original detached Cook command; do not resume a zero-task run.".to_string(),
+        ]),
+    );
+    error.details = json!({
+        "field": "detach-after-handoff",
+        "problem": problem,
+        "classification": "empty_detached_plan",
+        "controller_job_id": job_id,
+        "replay": "re-run the original detached Cook command",
+    });
+    error
 }
 
 /// The launcher's only output: a bounded, machine-readable handoff naming the
@@ -2524,7 +2525,7 @@ mod tests {
     }
 
     #[test]
-    fn a_materialized_attempt_is_the_boundary_for_accepted_handoff() {
+    fn an_empty_materialized_attempt_is_not_an_accepted_handoff() {
         crate::test_support::with_isolated_home(|_| {
             let cook_id = "cook-materialized-acceptance";
             let attempt_id = "cook-materialized-acceptance-attempt-1";
@@ -2552,10 +2553,10 @@ mod tests {
                 .expect("spawn live detached child");
 
             let handoff = await_durable_handoff(cook_id, &mut child, Duration::from_millis(0))
-                .expect("observe materialized handoff");
+                .expect("observe empty materialized handoff");
 
-            assert_eq!(handoff.state, DetachedHandoffState::Accepted);
-            assert_eq!(handoff.run_id.as_deref(), Some(attempt_id));
+            assert_eq!(handoff.state, DetachedHandoffState::Pending);
+            assert_eq!(handoff.run_id, None);
             terminate_and_reap_detached_child(&mut child);
         });
     }

--- a/crates/homeboy-core/src/api_jobs/store/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/store/mod.rs
@@ -1940,13 +1940,20 @@ impl JobStore {
             runner_job_projection: None,
         };
         let job_id = job.id;
+        let mut event_data = serde_json::json!({ "controller_job": controller_job.public_request });
+        if let Some(run_id) = event_data["controller_job"]["durable_run_id"]
+            .as_str()
+            .filter(|run_id| !run_id.trim().is_empty())
+        {
+            event_data["durable_run_id"] = serde_json::json!(run_id);
+        }
         let initial_event = JobEvent {
             sequence: self.next_event_sequence.fetch_add(1, Ordering::SeqCst) + 1,
             job_id,
             kind: JobEventKind::Status,
             timestamp_ms: now,
             message: Some("job queued".to_string()),
-            data: Some(serde_json::json!({ "controller_job": controller_job.public_request })),
+            data: Some(event_data),
         };
         let mut stored = StoredJob {
             job,

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -179,7 +179,7 @@ fn cook_rejects_invalid_controller_transport_before_worktree_resolution() {
 }
 
 /// A local detached Cook whose child exits before attempt materialization is
-/// rejected rather than falsely accepted (#12290).
+/// rejected without publishing a zero-task durable run (#12290, #13512).
 ///
 /// The launcher hands the Cook to a process in its own session, then observes
 /// whether it materializes the durable attempt. It performs no worktree or
@@ -220,24 +220,9 @@ fn cook_rejects_local_detachment_when_the_child_exits_before_attempt_materializa
             std::fs::File::create(&stderr_path).expect("create detached Cook stderr"),
         ));
     let mut child = command.spawn().expect("start detached Cook launcher");
-    let deadline = Instant::now() + Duration::from_secs(60);
-    loop {
-        let stderr = std::fs::read_to_string(&stderr_path).unwrap_or_default();
-        if stderr.contains("durable run id `local-detach-exits-before-attempt`") {
-            assert!(
-                child.try_wait().expect("poll detached Cook launcher").is_none(),
-                "the launcher must still be crossing child admission after it emits the durable parent identity"
-            );
-            break;
-        }
-        assert!(
-            Instant::now() < deadline,
-            "the parent identity was not emitted after daemon compatibility admission completed: {stderr}"
-        );
-        std::thread::sleep(Duration::from_millis(10));
-    }
     let status = child.wait().expect("wait for detached Cook launcher");
     let stdout = std::fs::read_to_string(&stdout_path).expect("read detached Cook stdout");
+    let stderr = std::fs::read_to_string(&stderr_path).expect("read detached Cook stderr");
     assert!(!status.success(), "{stdout}");
     assert!(
         !stdout.contains("cannot detach after handoff with --placement local"),
@@ -245,8 +230,13 @@ fn cook_rejects_local_detachment_when_the_child_exits_before_attempt_materializa
     );
     assert!(!stdout.contains("worktree provider"), "{stdout}");
     assert!(
-        stdout.contains("detached Cook exited before materializing its first attempt"),
-        "{stdout}"
+        stdout.contains("detached Cook exited before materializing an executable plan"),
+        "{stdout}\n{stderr}"
+    );
+    assert!(stdout.contains("empty_detached_plan"), "{stdout}");
+    assert!(
+        !stderr.contains("durable run id `local-detach-exits-before-attempt`"),
+        "a rejected empty plan must never be announced as durable: {stderr}"
     );
     let mut status = context.controller_runtime_command(TestBinary::HomeboyFixture);
     status.args([
@@ -257,25 +247,9 @@ fn cook_rejects_local_detachment_when_the_child_exits_before_attempt_materializa
     ]);
     let status = bounded_output(status);
     let status_stdout = String::from_utf8_lossy(&status.stdout);
-    assert!(status.status.success(), "{status_stdout}");
     assert!(
-        status_stdout.contains("\"admission_state\": \"failed\""),
-        "an abandoned admission must terminalize truthfully: {status_stdout}"
-    );
-    let status: serde_json::Value =
-        serde_json::from_str(&status_stdout).expect("status is structured JSON");
-    assert_eq!(status["subject_state"], "failed", "{status_stdout}");
-    assert_eq!(
-        status["data"]["metadata"]["task_count"], 0,
-        "{status_stdout}"
-    );
-    assert_eq!(
-        status["data"]["metadata"]["provider_executions_consumed"], 0,
-        "{status_stdout}"
-    );
-    assert_eq!(
-        status["data"]["metadata"]["detached_cook_handoff"]["state"], "exited_before_handoff",
-        "{status_stdout}"
+        !status.status.success(),
+        "a rejected empty plan must not remain externally visible: {status_stdout}"
     );
 }
 
@@ -438,6 +412,10 @@ fn cook_accepts_local_detachment_after_materializing_an_executable_attempt() {
         .unwrap_or_else(|| panic!("accepted handoff names an attempt\n{stdout}"))
         .to_string();
     assert_ne!(attempt_id, cook_id, "{stdout}");
+    let supervisor_job_id = handoff["controller_job"]["job_id"]
+        .as_str()
+        .and_then(|job_id| uuid::Uuid::parse_str(job_id).ok())
+        .unwrap_or_else(|| panic!("accepted handoff names its controller job\n{stdout}"));
     let mut status = context.controller_runtime_command(TestBinary::HomeboyFixture);
     status.args(["agent-task", "status", &attempt_id, "--full"]);
     let status = bounded_output(status);
@@ -445,6 +423,32 @@ fn cook_accepts_local_detachment_after_materializing_an_executable_attempt() {
     assert!(status.status.success(), "{status_stdout}");
     assert!(status_stdout.contains(&attempt_id), "{status_stdout}");
     assert!(!status_stdout.contains("\"tasks\": []"), "{status_stdout}");
+    let lifecycle_store = AgentTaskLifecycleStore::new(context.path_roots());
+    let attempt_record = lifecycle_store
+        .read_record(&attempt_id)
+        .expect("read accepted attempt record");
+    assert_eq!(
+        attempt_record.metadata["local_cook_supervisor"]["job_id"],
+        supervisor_job_id.to_string(),
+        "the executable run and controller job are linked before acceptance"
+    );
+    assert!(
+        lifecycle_store.read_record(cook_id).is_err(),
+        "local detach must not persist a zero-task handoff parent"
+    );
+    let job_store = JobStore::open_without_reconciliation(context.daemon_dir().join("jobs.json"))
+        .expect("open controller job store");
+    assert!(
+        job_store
+            .events(supervisor_job_id)
+            .expect("read controller job events")
+            .iter()
+            .any(|event| event
+                .data
+                .as_ref()
+                .is_some_and(|data| { data["durable_run_id"].as_str() == Some(cook_id) })),
+        "controller job admission must carry its durable Cook identity"
+    );
 
     // Cancel through the durable Cook alias, then wait on the returned attempt.
     // The controller job owns process-tree termination and reaping; this keeps
@@ -471,6 +475,7 @@ fn cook_accepts_local_detachment_after_materializing_an_executable_attempt() {
                     "/data/state",
                     "/data/child_run_state",
                     "/data/lifecycle/execution/state",
+                    "/data/status_scope/queried_attempt/state",
                 ]
                 .iter()
                 .filter_map(|pointer| status.pointer(pointer).and_then(serde_json::Value::as_str))


### PR DESCRIPTION
Closes #13512.

## Summary
- keep detached child admission blocked until its controller job identity is published
- accept handoff only after a non-empty executable plan is durably linked to that supervisor
- reject zero-task handoffs without publishing a misleading durable parent

## Verification
- `cargo fmt --all -- --check`
- `cargo test --test cook_lab_handoff_test cook_rejects_local_detachment_when_the_child_exits_before_attempt_materialization -- --exact`
- `cargo test --test cook_lab_handoff_test cook_accepts_local_detachment_after_materializing_an_executable_attempt -- --exact`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode traced detached Cook lifecycle ownership, implemented the candidate and end-to-end regressions, and assisted with verification. Chris Huber reviewed the diff and owns the final change.