### PR TITLE
Stream dependency setup progress from local reviews

### DIFF
--- a/crates/homeboy-cli/src/commands/review/mod.rs
+++ b/crates/homeboy-cli/src/commands/review/mod.rs
@@ -30,6 +30,8 @@ use homeboy_review::review::{
 use serde::Serialize;
 use serde_json::Value;
 use std::path::Path;
+use std::sync::Arc;
+use std::time::Instant;
 
 use super::parse_key_val;
 use super::utils::args::{
@@ -340,6 +342,7 @@ pub fn run(args: ReviewArgs) -> CmdResult<Value> {
         Some(ReviewCommand::Audit(args)) => {
             let requested_source = args.audit.release_readiness_source.clone();
             let component = args.audit.comp.load()?;
+            prepare_local_review_dependencies(&component)?;
             to_value_with_readiness_provenance(
                 audit::run(args.audit),
                 &component,
@@ -350,6 +353,7 @@ pub fn run(args: ReviewArgs) -> CmdResult<Value> {
         Some(ReviewCommand::Lint(args)) => {
             let requested_source = args.release_readiness_source.clone();
             let component = args.comp.load()?;
+            prepare_local_review_dependencies(&component)?;
             to_value_with_readiness_provenance(
                 lint::run(review_lint_args(args)),
                 &component,
@@ -359,6 +363,7 @@ pub fn run(args: ReviewArgs) -> CmdResult<Value> {
         Some(ReviewCommand::Test(args)) => {
             let requested_source = args.release_readiness_source.clone();
             let component = args.comp.load()?;
+            prepare_local_review_dependencies(&component)?;
             to_value_with_readiness_provenance(
                 test::run(args),
                 &component,
@@ -501,6 +506,10 @@ pub(crate) fn run_umbrella(args: ReviewArgs) -> CmdResult<ReviewCommandOutput> {
         changed_file_count,
     })?);
     observation::emit_early_lifecycle(&review_observation);
+    if let Err(error) = prepare_local_review_dependencies(&component) {
+        observation::finish_error(review_observation, &error);
+        return Err(error);
+    }
 
     let mut top_hints: Vec<String> = Vec::new();
 
@@ -668,6 +677,147 @@ pub(crate) fn run_umbrella(args: ReviewArgs) -> CmdResult<ReviewCommandOutput> {
     observation::finish_success(review_observation, &output, overall_exit);
 
     Ok((output, overall_exit))
+}
+
+fn prepare_local_review_dependencies(
+    component: &homeboy::core::component::Component,
+) -> homeboy::core::Result<()> {
+    let policy = homeboy::core::deps::DependencyHydrationPolicy::default();
+    let deadline_ms = policy.timeout.as_millis();
+    let started = Instant::now();
+    emit_local_review_setup_progress(LocalReviewSetupProgress {
+        phase: "dependency_setup",
+        status: "running",
+        component: &component.id,
+        provider: None,
+        current: None,
+        elapsed_ms: 0,
+        last_progress_ms_ago: None,
+        deadline_ms,
+    });
+
+    let component_id = component.id.clone();
+    let progress = Arc::new(
+        move |progress: &homeboy::core::deps::DependencyHydrationProgress| {
+            emit_local_review_setup_progress(LocalReviewSetupProgress {
+                phase: &progress.phase,
+                status: "heartbeat",
+                component: &component_id,
+                provider: Some(&progress.provider_id),
+                current: progress.current.as_deref(),
+                elapsed_ms: progress.elapsed_ms,
+                last_progress_ms_ago: progress.last_progress_ms_ago,
+                deadline_ms,
+            });
+        },
+    );
+    let policy = homeboy::core::deps::DependencyHydrationPolicy {
+        on_progress: progress,
+        ..policy
+    };
+    let outcomes = homeboy::core::deps::hydrate_declared_dependencies(
+        Path::new(&component.local_path),
+        "local_review",
+        ".",
+        &policy,
+    )?;
+
+    if let Some(failed) = outcomes
+        .iter()
+        .find(|outcome| outcome.status == homeboy::core::deps::DependencyHydrationStatus::Failed)
+    {
+        emit_local_review_setup_progress(LocalReviewSetupProgress {
+            phase: "dependency_setup",
+            status: "failed",
+            component: &component.id,
+            provider: Some(&failed.provider_id),
+            current: None,
+            elapsed_ms: started.elapsed().as_millis(),
+            last_progress_ms_ago: None,
+            deadline_ms,
+        });
+        return Err(homeboy::core::Error::dependency_step_failed(
+            "dependency.setup",
+            &component.id,
+            failed.exit_code,
+            vec![format!(
+                "provider={} termination={:?} reason={}",
+                failed.provider_id, failed.termination, failed.reason
+            )],
+            Vec::new(),
+            Some(format!(
+                "homeboy component setup {} --path {}",
+                component.id, component.local_path
+            )),
+            serde_json::to_value(failed).ok(),
+        ));
+    }
+
+    emit_local_review_setup_progress(LocalReviewSetupProgress {
+        phase: "dependency_setup",
+        status: "completed",
+        component: &component.id,
+        provider: None,
+        current: None,
+        elapsed_ms: started.elapsed().as_millis(),
+        last_progress_ms_ago: None,
+        deadline_ms,
+    });
+    Ok(())
+}
+
+struct LocalReviewSetupProgress<'a> {
+    phase: &'a str,
+    status: &'a str,
+    component: &'a str,
+    provider: Option<&'a str>,
+    current: Option<&'a str>,
+    elapsed_ms: u128,
+    last_progress_ms_ago: Option<u128>,
+    deadline_ms: u128,
+}
+
+fn emit_local_review_setup_progress(progress: LocalReviewSetupProgress<'_>) {
+    eprintln!("{}", format_local_review_setup_progress(&progress));
+    eprintln!(
+        "HOMEBOY_PROGRESS {}",
+        serde_json::json!({
+            "phase": progress.phase,
+            "current": progress.current.or(progress.provider).unwrap_or(progress.component),
+            "status": progress.status,
+            "component": progress.component,
+            "provider": progress.provider,
+            "elapsed_ms": progress.elapsed_ms,
+            "last_progress_ms_ago": progress.last_progress_ms_ago,
+            "deadline_ms": progress.deadline_ms,
+        })
+    );
+}
+
+fn format_local_review_setup_progress(progress: &LocalReviewSetupProgress<'_>) -> String {
+    let provider = progress
+        .provider
+        .map(|provider| format!(" provider={provider}"))
+        .unwrap_or_default();
+    let current = progress
+        .current
+        .map(|current| format!(" current={current}"))
+        .unwrap_or_default();
+    let last_progress = progress
+        .last_progress_ms_ago
+        .map(|elapsed| format!(" last_progress={elapsed}ms"))
+        .unwrap_or_default();
+    format!(
+        "[review] phase={} status={} component={}{}{} elapsed={}ms{} deadline={}ms",
+        progress.phase,
+        progress.status,
+        progress.component,
+        provider,
+        current,
+        progress.elapsed_ms,
+        last_progress,
+        progress.deadline_ms,
+    )
 }
 
 /// Return the persisted record rather than silently starting another expensive
@@ -1415,6 +1565,25 @@ mod tests {
         assert!(
             !args.should_use_self_check_dispatch(),
             "direct review lint must run the main lint workflow for every target form"
+        );
+    }
+
+    #[test]
+    fn local_review_setup_heartbeat_names_phase_current_elapsed_and_deadline() {
+        let rendered = format_local_review_setup_progress(&LocalReviewSetupProgress {
+            phase: "building",
+            status: "heartbeat",
+            component: "fixture",
+            provider: Some("declared-provider"),
+            current: Some("shared-component"),
+            elapsed_ms: 12_500,
+            last_progress_ms_ago: Some(250),
+            deadline_ms: 1_800_000,
+        });
+
+        assert_eq!(
+            rendered,
+            "[review] phase=building status=heartbeat component=fixture provider=declared-provider current=shared-component elapsed=12500ms last_progress=250ms deadline=1800000ms"
         );
     }
 

--- a/crates/homeboy-core/src/deps.rs
+++ b/crates/homeboy-core/src/deps.rs
@@ -118,6 +118,7 @@ pub struct DependencyHydrationOutcome {
 pub struct DependencyHydrationProgress {
     pub provider_id: String,
     pub phase: String,
+    pub current: Option<String>,
     pub elapsed_ms: u128,
     pub last_progress_ms_ago: Option<u128>,
 }
@@ -172,6 +173,7 @@ pub fn hydrate_declared_dependencies(
         (policy.on_progress)(&DependencyHydrationProgress {
             provider_id: provider_id.clone(),
             phase: "assessing_reusable_state".to_string(),
+            current: None,
             elapsed_ms: 0,
             last_progress_ms_ago: None,
         });
@@ -240,6 +242,7 @@ pub fn hydrate_declared_dependencies(
         (policy.on_progress)(&DependencyHydrationProgress {
             provider_id: provider_id.clone(),
             phase: "installing".to_string(),
+            current: None,
             elapsed_ms: started.elapsed().as_millis(),
             last_progress_ms_ago: None,
         });
@@ -348,14 +351,7 @@ fn run_hydration_command(
             policy.heartbeat_interval.max(Duration::from_millis(1)),
             move || cancellation(),
             |heartbeat| {
-                progress(&DependencyHydrationProgress {
-                    provider_id: provider_id.to_string(),
-                    phase: phase.to_string(),
-                    elapsed_ms: heartbeat.elapsed.as_millis(),
-                    last_progress_ms_ago: heartbeat
-                        .last_progress_elapsed
-                        .map(|value| value.as_millis()),
-                });
+                progress(&hydration_progress(provider_id, phase, &heartbeat));
                 Ok(())
             },
         )
@@ -368,6 +364,27 @@ fn run_hydration_command(
         SupervisedCommandTermination::Cancelled => Err(DependencyHydrationTermination::Cancelled),
         SupervisedCommandTermination::TimedOut => Err(DependencyHydrationTermination::TimedOut),
         SupervisedCommandTermination::NoProgress => Err(DependencyHydrationTermination::NoProgress),
+    }
+}
+
+fn hydration_progress(
+    provider_id: &str,
+    fallback_phase: &str,
+    heartbeat: &homeboy_engine_primitives::command::SupervisedCommandHeartbeat,
+) -> DependencyHydrationProgress {
+    let command_progress = heartbeat.progress.as_ref();
+    DependencyHydrationProgress {
+        provider_id: provider_id.to_string(),
+        phase: command_progress
+            .map(|progress| progress.phase.clone())
+            .unwrap_or_else(|| fallback_phase.to_string()),
+        current: command_progress
+            .and_then(|progress| progress.current.as_deref())
+            .map(crate::redaction::redact_string),
+        elapsed_ms: heartbeat.elapsed.as_millis(),
+        last_progress_ms_ago: heartbeat
+            .last_progress_elapsed
+            .map(|value| value.as_millis()),
     }
 }
 
@@ -1010,6 +1027,27 @@ mod tests {
                 progress.lock().unwrap().push(event.phase.clone());
             }),
         }
+    }
+
+    #[test]
+    fn hydration_heartbeat_preserves_generic_child_phase_and_current() {
+        let heartbeat = homeboy_engine_primitives::command::SupervisedCommandHeartbeat {
+            elapsed: Duration::from_millis(4_200),
+            last_progress_elapsed: Some(Duration::from_millis(175)),
+            progress: Some(homeboy_engine_primitives::command::CommandProgress {
+                phase: "building".to_string(),
+                current: Some("shared-component".to_string()),
+            }),
+            output_tail: String::new(),
+        };
+
+        let progress = hydration_progress("fixture-provider", "installing", &heartbeat);
+
+        assert_eq!(progress.provider_id, "fixture-provider");
+        assert_eq!(progress.phase, "building");
+        assert_eq!(progress.current.as_deref(), Some("shared-component"));
+        assert_eq!(progress.elapsed_ms, 4_200);
+        assert_eq!(progress.last_progress_ms_ago, Some(175));
     }
 
     #[test]


### PR DESCRIPTION
Closes #13511.

## Summary
- hydrate declared dependencies through the bounded core contract before direct local review execution
- stream phase, provider/current work, elapsed time, last progress, and deadline as human and `HOMEBOY_PROGRESS` output
- preserve child progress markers through the generic hydration heartbeat

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p homeboy-core deps::tests:: -- --test-threads=1`
- `cargo test -p homeboy-cli --features test-support commands::review::tests::local_review_setup_heartbeat_names_phase_current_elapsed_and_deadline -- --exact`
- `cargo check -p homeboy-core -p homeboy-cli`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode traced direct review and dependency hydration, implemented the candidate and focused tests, and assisted with verification. Chris Huber reviewed the diff and owns the final change.