### PR TITLE
Recover an idle stale daemon during Cook preflight

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
@@ -673,12 +673,16 @@ pub(super) fn intercept_local_detached_cook(
     materialize_stdin_prompt(&mut child_args, &session_root)?;
     let log_path = session_root.join("cook.log");
 
-    // A daemon build mismatch cannot be resumed from the handoff parent: it has
-    // no materialized Cook recipe yet. Reject it before the first durable write
-    // so the supplied repair command can be followed by the same invocation.
+    // This is still before the first durable Cook write, but the validated
+    // request is already held in `child_args`. When authoritative daemon status
+    // authorizes a confirmation-free idle restart, recover under the exact
+    // lease and continue this same request instead of making the operator
+    // reconstruct it after `homeboy daemon recover --yes` (#13513).
     let preflight_controller_client = cli
         .detach_after_handoff
-        .then(homeboy::core::daemon::LocalControllerJobClient::connect_current_build)
+        .then(
+            homeboy::core::daemon::LocalControllerJobClient::connect_current_build_recovering_idle,
+        )
         .transpose()?;
 
     // One store for the whole handoff. The parent record, the child record, the

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -218,6 +218,29 @@ impl LocalControllerJobClient {
         Self::connect()
     }
 
+    /// Connect to the current daemon build, first applying its canonical idle
+    /// restart when authoritative status proves that no durable jobs are active.
+    ///
+    /// The lease-bound stop is a compare-and-swap on the daemon observed by the
+    /// report. A concurrent replacement therefore causes the stop to refuse
+    /// rather than terminating an unobserved owner, and the final connection
+    /// re-runs exact-build validation before any controller job is submitted.
+    pub fn connect_current_build_recovering_idle() -> Result<Self> {
+        let status = read_status()?;
+        if recovery_actions::authorizes_automatic_idle_restart(&status) {
+            match status.freshness.lease_id.as_deref() {
+                Some(lease_id) => {
+                    stop_for_lease(lease_id)?;
+                }
+                None => {
+                    stop()?;
+                }
+            }
+            start_background(DEFAULT_ADDR)?;
+        }
+        Self::connect_current_build()
+    }
+
     pub fn connect() -> Result<Self> {
         let daemon = ensure_running(DEFAULT_ADDR)?;
         let client = reqwest::blocking::Client::builder()

--- a/crates/homeboy-core/src/daemon/recovery_actions.rs
+++ b/crates/homeboy-core/src/daemon/recovery_actions.rs
@@ -308,6 +308,26 @@ pub fn plan_recovery(status: &DaemonStatus) -> DaemonRecoveryPlan {
     }
 }
 
+/// Whether an admission preflight may apply this daemon's canonical idle
+/// restart without asking an operator to supply any additional evidence.
+///
+/// This policy is intentionally independent of the command requesting daemon
+/// admission. It trusts only the authoritative status report and accepts only
+/// the bounded stop/start plan: zero durable jobs, an explicitly restartable
+/// lease, no attestations, and no other mutation mixed into the plan.
+pub fn authorizes_automatic_idle_restart(status: &DaemonStatus) -> bool {
+    let plan = plan_recovery(status);
+    !status.fresh
+        && status.freshness.active_jobs == 0
+        && status.active_job_recovery_evidence.is_empty()
+        && status.freshness.restartable
+        && plan.executable
+        && plan.required_confirmations.is_empty()
+        && plan.steps.len() == 2
+        && plan.steps[0].code == DAEMON_STOP
+        && plan.steps[1].code == DAEMON_START
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -443,6 +463,40 @@ mod tests {
         for step in &plan.steps {
             assert!(step.action.is_some(), "{} carries no argv", step.code);
         }
+        assert!(authorizes_automatic_idle_restart(&status));
+    }
+
+    #[test]
+    fn automatic_idle_restart_refuses_active_jobs_and_non_restart_plans() {
+        let active = status(
+            Some(super::super::DaemonStaleReasonCode::VersionMismatch),
+            vec![
+                DaemonRepairStep::executable(DAEMON_STOP, stop_for_lease(LEASE_ID)),
+                DaemonRepairStep::executable(DAEMON_START, start()),
+            ],
+            1,
+        );
+        assert!(!authorizes_automatic_idle_restart(&active));
+
+        let mut inconsistent = status(
+            Some(super::super::DaemonStaleReasonCode::VersionMismatch),
+            vec![
+                DaemonRepairStep::executable(DAEMON_STOP, stop_for_lease(LEASE_ID)),
+                DaemonRepairStep::executable(DAEMON_START, start()),
+            ],
+            0,
+        );
+        inconsistent
+            .active_job_recovery_evidence
+            .push(recovery_evidence(Uuid::nil()));
+        assert!(!authorizes_automatic_idle_restart(&inconsistent));
+
+        let diagnosis = status(
+            Some(super::super::DaemonStaleReasonCode::VersionMismatch),
+            vec![DaemonRepairStep::executable(DAEMON_DIAGNOSE, diagnose())],
+            0,
+        );
+        assert!(!authorizes_automatic_idle_restart(&diagnosis));
     }
 
     #[test]


### PR DESCRIPTION
Closes #13513.

## Summary
- centralize confirmation-free idle restart authorization in daemon recovery policy
- recover only an executable stop/start plan with zero active jobs and no required attestations
- continue the already validated detached Cook request after exact-build reconnection

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p homeboy-core daemon::recovery_actions::tests::`
- `cargo check -p homeboy-core -p homeboy-cli`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode traced Cook preflight and daemon recovery policy, implemented the candidate and safety tests, and assisted with verification. Chris Huber reviewed the diff and owns the final change.