### PR TITLE
Fix Cook adoption of clean unpushed CWD candidates

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -3475,7 +3475,10 @@ fn validate_cook_cwd_destination_identity(
                     ));
                 }
                 let safety = homeboy::core::worktree_providers::attest_apply_enabled_worktree_provider_safety_from_config(&identity, &config)?;
-                if !safety.fresh || safety.dirty || safety.unpushed || identity.primary {
+                // Cook owns mutations in an explicit CWD, so a clean committed
+                // candidate may be unpushed. Durable admission rechecks its
+                // cleanliness and base ancestry before provider execution.
+                if !safety.fresh || safety.dirty || identity.primary {
                     return Err(homeboy::core::Error::validation_invalid_argument(
                         "to_worktree",
                         "worktree provider safety attestation is not safe for Cook execution",

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -2247,7 +2247,7 @@ fn cook_cwd_matching_external_handle_never_invokes_a_sleeping_resolver() {
 
 #[cfg(unix)]
 #[test]
-fn cook_cwd_is_canonicalized_to_its_provider_handle_before_provisioning() {
+fn cook_cwd_adopts_clean_unpushed_provider_candidate_before_provisioning() {
     use std::os::unix::fs::PermissionsExt;
 
     with_isolated_home(|_| {
@@ -2278,7 +2278,7 @@ fn cook_cwd_is_canonicalized_to_its_provider_handle_before_provisioning() {
                     "handle": "homeboy@fix-13421",
                     "path": cwd,
                     "branch": "fix/13421",
-                    "safety": { "dirty": false, "unpushed": false, "primary": false }
+                    "safety": { "dirty": false, "unpushed": true, "primary": false }
                 }] })
             ),
         )
@@ -2340,6 +2340,7 @@ fn cook_cwd_is_canonicalized_to_its_provider_handle_before_provisioning() {
             "homeboy@fix-13421"
         );
         assert_eq!(provision["workspace_safety"]["fresh"], true);
+        assert_eq!(provision["workspace_safety"]["unpushed"], true);
     });
 }
 


### PR DESCRIPTION
## Summary

- allow explicit `--cwd` Cook destinations to retain clean committed, unpushed candidate state
- continue rejecting stale, dirty, and primary provider worktrees before execution
- cover omitted-`--to-worktree` provider handle derivation and retained unpushed safety evidence

Fixes #13526.

## Verification

- `cargo test -p homeboy-cli --features test-support cook_cwd` (5 passed)
- `cargo fmt --check`
- `git diff --check`

The broader dispatch module passed 51/54. `cook_explicit_repo_skips_unrelated_portable_git_enrichment` reproduces identically on clean `main`; the other failures are unrelated repository-identity cases from the same shared-environment run. Strict Clippy is baseline-red in untouched `homeboy-core` under Rust 1.95.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the live Cook failure, traced the CLI and durable service admission boundaries, implemented the focused guard change, and ran verification. Chris Huber directed and reviewed the work.