### PR TITLE
fix(daemon): exclude environments from process status

### DIFF
--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -52,10 +52,9 @@ const ENSURE_RUNNING_STARTUP_WAIT: Duration = Duration::from_secs(15);
 /// store resolves to this durable store and its executable is the active binary;
 /// absent evidence remains ambiguous.
 pub(super) fn daemon_process_candidates(jobs_path: &Path) -> Result<Vec<DaemonProcessCandidate>> {
-    // macOS cannot expose another process's environment through `ps`, so a live
-    // operator daemon has no durable-store evidence there. Test harnesses opt
-    // into this debug-only namespace to exclude every process except ones that
-    // explicitly name the test store in their argv.
+    // Never request process environments here: candidates are serialized into
+    // operator diagnostics. Linux recovers bounded store identity from procfs;
+    // other platforms retain fail-closed argv-only evidence.
     let test_namespace = cfg!(debug_assertions)
         && std::env::var_os("HOMEBOY_TEST_DAEMON_NAMESPACE").is_some_and(|namespace| {
             jobs_path
@@ -63,7 +62,7 @@ pub(super) fn daemon_process_candidates(jobs_path: &Path) -> Result<Vec<DaemonPr
                 .is_some_and(|state_dir| Path::new(&namespace) == state_dir)
         });
     let output = Command::new("ps")
-        .args(["-axeww", "-o", "pid=", "-o", "comm=", "-o", "command="])
+        .args(["-axww", "-o", "pid=", "-o", "comm=", "-o", "command="])
         .output()
         .map_err(|error| {
             Error::internal_io(

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -451,6 +451,44 @@ fn candidate_attribution_reads_command_env_store_identity_from_procfs() {
     assert_eq!(store, state_dir.path().join("jobs.json"));
 }
 
+#[cfg(unix)]
+#[test]
+fn daemon_process_scan_never_serializes_inherited_environment() {
+    let state_dir = tempfile::tempdir().expect("state directory");
+    let secret = "ghp_daemon_status_must_not_expose_this_value";
+    let mut process = Command::new("sh")
+        .args([
+            "-c",
+            "trap 'kill \"$child\" 2>/dev/null' TERM EXIT; sleep 30 & child=$!; wait \"$child\"",
+            "homeboy",
+            "daemon",
+            "serve",
+            "--addr",
+            "127.0.0.1:0",
+            "--state-dir",
+            state_dir.path().to_str().expect("UTF-8 state path"),
+        ])
+        .env("GH_TOKEN", secret)
+        .spawn()
+        .expect("daemon-shaped process");
+
+    let candidates = super::daemon_process_candidates(&state_dir.path().join("jobs.json"))
+        .expect("candidate scan");
+    let candidate = candidates
+        .iter()
+        .find(|candidate| candidate.pid == process.id())
+        .expect("spawned candidate");
+    let serialized = serde_json::to_string(candidate).expect("serialized candidate");
+
+    assert!(!candidate.cmdline.contains("GH_TOKEN"));
+    assert!(!candidate.cmdline.contains(secret));
+    assert!(!serialized.contains("GH_TOKEN"));
+    assert!(!serialized.contains(secret));
+
+    process.kill().expect("stop candidate process");
+    process.wait().expect("reap candidate process");
+}
+
 #[test]
 fn ambiguous_command_state_uses_explicit_process_store_without_home_fallback() {
     let selected_state = tempfile::tempdir().expect("selected state directory");


### PR DESCRIPTION
## Summary
- stop requesting process environments from `ps` during daemon candidate discovery
- preserve argv-only candidate diagnostics and existing bounded Linux procfs store attribution
- cover the real process scan with a credential-shaped inherited environment value and assert neither candidate state nor serialized JSON exposes it

Closes #13522.

## Root cause

`ps -axeww` appends each process environment (`e`) without truncation (`ww`). Homeboy treated the resulting argv-plus-environment text as `process_candidates[].cmdline` and serialized it into operator-facing daemon status output.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p homeboy-core daemon_process_scan_never_serializes_inherited_environment --lib`
- `cargo test -p homeboy-core daemon::control::control_test --lib` (40 passed)

AI assistance: OpenAI gpt-5.6-sol via OpenCode was used to trace the exposure path, implement the source fix and regression test, and run verification. Chris Huber reviewed and owns the change.