### PR TITLE
fix(cook): bound explicit repository resolution

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -4338,14 +4338,13 @@ fn cook_components_for_repository_name(
         return Ok(vec![component]);
     }
     let repository_name = normalize_repository_name(repository_name);
-    let matches = homeboy::core::component::registered()?
+    let matches = homeboy::core::component::inventory::registered_base()?
         .into_iter()
         .filter(|component| {
-            component.id.eq_ignore_ascii_case(&repository_name)
-                || component
-                    .aliases
-                    .iter()
-                    .any(|alias| normalize_repository_name(alias) == repository_name)
+            component
+                .aliases
+                .iter()
+                .any(|alias| normalize_repository_name(alias) == repository_name)
                 || component
                     .remote_url
                     .as_deref()
@@ -4475,7 +4474,14 @@ pub(super) fn cook_repository_identities_for_workspace(
         })
         .collect::<Vec<_>>();
     let configured = match requested_repository {
-        Some(repository) => cook_components_for_repository_name(repository)?,
+        Some(repository) => {
+            let matches = cook_components_for_repository_name(repository)?;
+            if matches.is_empty() {
+                homeboy::core::component::inventory::registered_base()?
+            } else {
+                matches
+            }
+        }
         None => homeboy::core::component::registered()?,
     };
     let mut identities = Vec::new();
@@ -4501,6 +4507,21 @@ pub(super) fn cook_repository_identities_for_workspace(
                     provenance: format!("{flag}:git-remote:{remote_name}"),
                 });
             }
+        }
+        if requested_repository.is_some()
+            && !identities
+                .iter()
+                .any(|identity| identity.remote_identity == remote_identity)
+        {
+            let repository_name = normalize_repository_name(&remote_url);
+            identities.push(CookRepositoryIdentity {
+                repository_name: repository_name.clone(),
+                slug: repository_name,
+                aliases: Vec::new(),
+                remote_identity,
+                workspace_path: git_root.clone(),
+                provenance: format!("{flag}:git-remote:{remote_name}"),
+            });
         }
     }
     Ok(identities)

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -104,6 +104,28 @@ fn explicit_repo_identity_resolution_does_not_hydrate_unrelated_components() {
     });
 }
 
+#[test]
+fn explicit_unregistered_repo_is_proven_by_the_workspace_remote() {
+    with_isolated_home(|_| {
+        let checkout = tempfile::tempdir().expect("checkout");
+        init_runtime_component_checkout(checkout.path());
+        add_remote(
+            checkout.path(),
+            "origin",
+            "https://github.com/example/fixture.git",
+        );
+
+        let identities = super::super::run::cook_repository_identities_for_workspace(
+            "--cwd",
+            checkout.path().to_str().expect("UTF-8 checkout path"),
+            Some("fixture"),
+        )
+        .expect("resolve explicit repository identity from its remote");
+
+        assert_eq!(identities.len(), 1);
+    });
+}
+
 fn write_component_without_collision_validation(component: homeboy::core::component::Component) {
     let directory = homeboy::core::paths::components().expect("component config directory");
     std::fs::create_dir_all(&directory).expect("create component config directory");
@@ -516,10 +538,21 @@ fn cook_explicit_repo_skips_unrelated_portable_git_enrichment() {
 
         let bin = tempfile::tempdir().expect("fake git bin");
         let git = bin.path().join("git");
-        std::fs::write(&git, "#!/bin/sh\nsleep 30\n").expect("write fake git");
+        std::fs::write(
+            &git,
+            "#!/bin/sh\nif [ \"$PWD\" = \"$HOMEBOY_STALE_CHECKOUT\" ]; then sleep 30; exit 0; fi\nPATH=/usr/bin:/bin git \"$@\"\n",
+        )
+        .expect("write fake git");
         let mut permissions = std::fs::metadata(&git).expect("metadata").permissions();
         permissions.set_mode(0o755);
         std::fs::set_permissions(&git, permissions).expect("make fake git executable");
+        let _stale_checkout = homeboy::core::test_support::EnvVarGuard::set(
+            "HOMEBOY_STALE_CHECKOUT",
+            std::fs::canonicalize(stale.path())
+                .expect("canonical stale checkout")
+                .display()
+                .to_string(),
+        );
         let _path = homeboy::core::test_support::EnvVarGuard::set(
             "PATH",
             format!(


### PR DESCRIPTION
Closes #13504.

## Summary
- resolve explicit component aliases from the persisted base inventory instead of hydrating every portable checkout
- attest explicitly named, unregistered repositories from the supplied workspace Git remote
- preserve ambiguity and conflicting-workspace diagnostics without broad portable discovery
- make the stale-checkout regression isolate unrelated Git probes while allowing normal destination Git operations

## Verification
- `cargo test -p homeboy-cli --features test-support commands::agent_task::tests::dispatch::cook_ -- --test-threads=1` (35 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
- rebuilt the CLI and verified a real explicit-repository Cook preview reaches a terminal, non-mutating plan
- the full CLI suite exposed `agent_task_fanout_dispatch_id_matches_the_canonical_plan_identity`; the same isolated failure reproduces on clean current `main`, so it is baseline and unrelated

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode reproduced and sampled the blocked normalization path, implemented the bounded lookup and regression coverage, and ran verification under Chris Huber direction.