### PR TITLE
Readmit Cook pre-execution retries

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -400,7 +400,11 @@ pub fn submit_plan_in_store(
             homeboy_core::controller_runtime::admit_current_for_with_cancellation_check_in_root(
                 &runtime_root,
                 run_id,
-                || Ok(lifecycle_store.read_record(run_id)?.state.is_terminal()),
+                || {
+                    Ok(crate::agent_task_service::cook_pre_execution::runtime_admission_cancellation_requested(
+                        &lifecycle_store.read_record(run_id)?,
+                    ))
+                },
             )
         },
     )

--- a/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
@@ -384,7 +384,11 @@ pub(crate) fn production_runtime_admission(
         homeboy_core::controller_runtime::admit_current_for_with_cancellation_check_in_root(
             &runtime_root,
             run_id,
-            || Ok(lifecycle_store.read_record(run_id)?.state.is_terminal()),
+            || {
+                Ok(runtime_admission_cancellation_requested(
+                    &lifecycle_store.read_record(run_id)?,
+                ))
+            },
         )
         .map(|admission| admission.runtime)
     }
@@ -520,6 +524,12 @@ pub(crate) fn retryable_pre_execution_failure(
                 .as_u64()
                 .unwrap_or(0)
                 == 0)
+}
+
+pub(crate) fn runtime_admission_cancellation_requested(
+    record: &agent_task_lifecycle::AgentTaskRunRecord,
+) -> bool {
+    record.state.is_terminal() && !retryable_pre_execution_failure(record)
 }
 
 #[derive(Debug)]
@@ -933,6 +943,67 @@ mod tests {
             &details,
         )
         .is_none());
+    }
+
+    #[test]
+    fn retryable_pre_execution_terminal_does_not_cancel_runtime_admission() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let lifecycle_store =
+                AgentTaskLifecycleStore::from_current_environment().expect("lifecycle store");
+            let run_id = "retryable-pre-execution-admission";
+            let plan = plan("retryable-pre-execution-plan", "retry");
+            lifecycle_store
+                .submit_plan_with_runtime_admission_status(&plan, run_id, None, &|_| None, |_| {
+                    Ok(serde_json::json!({ "runtime": "test" }))
+                })
+                .expect("submit plan");
+            lifecycle_store
+                .record_pre_execution_failure(
+                    run_id,
+                    &plan,
+                    "local_retry_supervisor",
+                    &Error::internal_unexpected("launcher failed").with_retryable(true),
+                )
+                .expect("record retryable pre-execution failure");
+
+            let record = lifecycle_store.read_record(run_id).expect("read record");
+            assert!(record.state.is_terminal());
+            assert!(!runtime_admission_cancellation_requested(&record));
+            lifecycle_store
+                .submit_plan_with_current_runtime(&plan, run_id)
+                .expect("retryable pre-execution record reacquires runtime admission");
+        });
+    }
+
+    #[test]
+    fn ordinary_terminal_record_cancels_runtime_admission() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let lifecycle_store =
+                AgentTaskLifecycleStore::from_current_environment().expect("lifecycle store");
+            let run_id = "ordinary-terminal-admission";
+            let plan = plan("ordinary-terminal-plan", "stop");
+            lifecycle_store
+                .submit_plan_with_runtime_admission_status(&plan, run_id, None, &|_| None, |_| {
+                    Ok(serde_json::json!({ "runtime": "test" }))
+                })
+                .expect("submit plan");
+            lifecycle_store
+                .record_pre_execution_failure(
+                    run_id,
+                    &plan,
+                    "validate_inputs",
+                    &Error::validation_invalid_argument("input", "invalid fixture", None, None),
+                )
+                .expect("record terminal failure");
+
+            let record = lifecycle_store.read_record(run_id).expect("read record");
+            assert!(runtime_admission_cancellation_requested(&record));
+            let error = lifecycle_store
+                .submit_plan_with_current_runtime(&plan, run_id)
+                .expect_err("ordinary terminal record cancels runtime admission");
+            assert_eq!(error.retryable, Some(true));
+            assert!(error.message.contains("admission request was cancelled"));
+        });
     }
 
     fn recipe(cook_id: &str, run_id: &str, plan: AgentTaskPlan) -> AgentTaskCookRecipe {

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -206,7 +206,11 @@ impl AgentTaskLifecycleStore {
                 homeboy_core::controller_runtime::admit_current_for_with_cancellation_check_in_root(
                     &runtime_root,
                     run_id,
-                    || Ok(self.read_record(run_id)?.state.is_terminal()),
+                    || {
+                        Ok(crate::agent_task_service::cook_pre_execution::runtime_admission_cancellation_requested(
+                            &self.read_record(run_id)?,
+                        ))
+                    },
                 )
                 .map(|admission| admission.runtime)
             },


### PR DESCRIPTION
## Summary

- distinguish retryable pre-execution terminal records from true cancellation at controller runtime admission
- allow zero-provider pre-execution retries to reacquire the current controller runtime
- keep ordinary terminal records cancellation-authoritative
- apply the shared predicate to store-bound, ambient, and Cook runtime admission

This completes the execution path tracked by #13539. After #13545 fixed stale recipe reconstruction, the real lineage reached runtime admission and exposed this terminal-state cancellation conflict.

## Verification

- `cargo test -p homeboy-agents runtime_admission -- --test-threads=1`
- `cargo test -p homeboy-cli --features test-support --lib cook_continue_preflight_ -- --test-threads=1`
- `cargo test -p homeboy-agents existing_recipe_pre_execution_recovery_does_not_reapply_runtime_pin`
- `cargo fmt --all --check`
- `git diff --check`
- the regression invokes `submit_plan_with_current_runtime()` on both retryable pre-execution and ordinary terminal records, proving readmission and cancellation respectively
- real MDI evidence records `provider_executions_consumed: 0` and the exact pre-provider failure `controller admission request was cancelled`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced the runtime admission cancellation callback from the persisted MDI Cook evidence, implemented the shared terminal-state predicate, and ran focused regressions. Chris Huber directed and reviewed the work.
