### PR TITLE
chore(ci): bump the action pin to v2.15.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,9 +286,17 @@ jobs:
     # (bounded action setup subprocesses), #448 (equivalent failed test identity
     # evidence), and suffixed measurement commands.
     #
-    # Refs #10997, #11751 W1-2, W1-5, W1-6, W1-7, W1-10, #13267, #13437, and
-    # #13536.
-    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@824a88fe781cb2a3394116f714483ef289fe6bb1
+    # v2.15.14 additionally carries the two halves of the phantom-red-gate
+    # diagnosis: 73ffaa1/#445 attributes a failed or timed-out setup to its
+    # owning step instead of fabricating command failures, and #451 stops a
+    # cancelled run from being reported as a failed gate at all. Together with
+    # #13510 (a realistic from-source build budget) those are the reasons
+    # `Audit` has been red on this repository with no findings and no digest.
+    # Also picks up #450 (differential tests compared against the live base).
+    #
+    # Refs #10997, #11751 W1-2, W1-5, W1-6, W1-7, W1-10, #13267, #13437,
+    # #13536, #445, #450, and #451.
+    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@295fda7811f675605209f9ee1a6c4bdd45412f09
     with:
       commands: review test
       # `review test` defaults to running the extension's pre-test lint, which
@@ -307,7 +315,7 @@ jobs:
       # workflow checks out to run the gate itself — it is what surfaces as
       # `ACTION_REVISION` in the Test job — so leaving it behind would keep the
       # old `apply-differential-gate.py` even with a newer workflow.
-      action-ref: 824a88fe781cb2a3394116f714483ef289fe6bb1
+      action-ref: 295fda7811f675605209f9ee1a6c4bdd45412f09
       # rust v1.37.4. Must move with the action pin, not after it: the action consumes
       # per-test identities, and homeboy-extensions#2699 (`fix(rust): canonicalize
       # failed test identities`, released in rust v1.37.2) is what produces them.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,7 @@ jobs:
     # (bounded action setup subprocesses), #448 (equivalent failed test identity
     # evidence), and suffixed measurement commands.
     #
-    # v2.15.14 additionally carries the two halves of the phantom-red-gate
+    # v2.15.16 additionally carries the two halves of the phantom-red-gate
     # diagnosis: 73ffaa1/#445 attributes a failed or timed-out setup to its
     # owning step instead of fabricating command failures, and #451 stops a
     # cancelled run from being reported as a failed gate at all. Together with
@@ -296,7 +296,7 @@ jobs:
     #
     # Refs #10997, #11751 W1-2, W1-5, W1-6, W1-7, W1-10, #13267, #13437,
     # #13536, #445, #450, and #451.
-    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@295fda7811f675605209f9ee1a6c4bdd45412f09
+    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@afc603872df61607f24f9356985da80cb00c03f5
     with:
       commands: review test
       # `review test` defaults to running the extension's pre-test lint, which
@@ -315,7 +315,7 @@ jobs:
       # workflow checks out to run the gate itself — it is what surfaces as
       # `ACTION_REVISION` in the Test job — so leaving it behind would keep the
       # old `apply-differential-gate.py` even with a newer workflow.
-      action-ref: 295fda7811f675605209f9ee1a6c4bdd45412f09
+      action-ref: afc603872df61607f24f9356985da80cb00c03f5
       # rust v1.37.4. Must move with the action pin, not after it: the action consumes
       # per-test identities, and homeboy-extensions#2699 (`fix(rust): canonicalize
       # failed test identities`, released in rust v1.37.2) is what produces them.


### PR DESCRIPTION
## What

The action pin sat at **v2.15.12, seven commits behind**. This moves both pin sites to `v2.15.14` (`295fda78`).

## Why now

The bump carries **both halves of the phantom-red-gate diagnosis**:

| PR | effect |
|---|---|
| **#445** | a failed or timed-out setup is attributed to its owning step, instead of fabricating a failure for every requested command |
| **#451** | a cancelled run is reported as `not_run` rather than as a failed gate |

Those are the two causes behind `Audit` being red on this repository with **no findings and no digest**:

- **slow failures** (15–20 min) — the from-source build exceeding its 900s budget, fixed separately by #13510
- **fast failures** (1–2 min) — runs superseded by a newer push

Neither was an audit finding, and until now neither could be told apart from one.

Also picks up **#450** (differential tests compared against the live base).

## Verification

Both pin sites move together, as the comment above them requires. YAML parses.

The real check is the next few PRs: `Audit` should now report a pass, or a failure that names a rule — instead of an empty red.

## AI assistance

Tool(s): OpenCode