### PR TITLE
Rebind Cook pre-execution runtime

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2640,7 +2640,12 @@ where
         metadata,
     };
     let mut preserved_controller_runtime = None;
+    let mut pre_execution_runtime_recovery = false;
     if let Ok(existing) = lifecycle_store.read_record(&run_id) {
+        pre_execution_runtime_recovery = execution_runner_id.is_none()
+            && crate::agent_task_service::cook_pre_execution::retryable_pre_execution_failure(
+                &existing,
+            );
         // A runner may re-submit the plan after the controller reserved a
         // side-effect claim. Claims are durable exactly-once ownership, not
         // plan-derived state, so replacing the record must retain them.
@@ -2729,7 +2734,7 @@ where
             // it once more before recording runtime provenance or dispatching
             // any provider work in case cancellation won immediately after.
             if let Ok(cancelled) = lifecycle_store.read_record(&run_id) {
-                if cancelled.state.is_terminal() {
+                if cancelled.state.is_terminal() && !pre_execution_runtime_recovery {
                     return Ok(cancelled);
                 }
             }
@@ -2746,7 +2751,12 @@ where
                     [homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] =
                     admission.runtime();
             }
-            lifecycle_store.write_record(&record)?;
+            if pre_execution_runtime_recovery {
+                record = lifecycle_store
+                    .rearm_pre_execution_record_with_runtime(&record, admission.runtime())?;
+            } else {
+                lifecycle_store.write_record(&record)?;
+            }
         }
         Err(error) => {
             // Cancellation is persisted before removing a queue entry. Do not

--- a/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_pre_execution.rs
@@ -969,9 +969,29 @@ mod tests {
             let record = lifecycle_store.read_record(run_id).expect("read record");
             assert!(record.state.is_terminal());
             assert!(!runtime_admission_cancellation_requested(&record));
-            lifecycle_store
+            let rearmed = lifecycle_store
                 .submit_plan_with_current_runtime(&plan, run_id)
                 .expect("retryable pre-execution record reacquires runtime admission");
+            assert_eq!(
+                rearmed.state,
+                agent_task_lifecycle::AgentTaskRunState::Queued
+            );
+            assert_eq!(
+                rearmed.metadata["controller_runtime_recovery"]["reason"],
+                "retryable_pre_execution_failure"
+            );
+            assert_eq!(
+                rearmed.metadata["controller_runtime_recovery"]["provider_executions_consumed"],
+                0
+            );
+            assert_eq!(
+                rearmed.metadata["controller_runtime_recovery"]["previous"]["runtime"],
+                "test"
+            );
+            assert_eq!(
+                rearmed.metadata["controller_runtime_recovery"]["current"],
+                rearmed.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]
+            );
         });
     }
 

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -816,6 +816,69 @@ impl AgentTaskLifecycleStore {
         )
     }
 
+    pub(crate) fn rearm_pre_execution_record_with_runtime(
+        &self,
+        record: &AgentTaskRunRecord,
+        runtime: Value,
+    ) -> Result<AgentTaskRunRecord> {
+        homeboy_core::controller_runtime::validate(&runtime)?;
+        self.with_config_lock(|| {
+            let existing = self.read_record(&record.run_id)?;
+            if !existing.state.is_terminal()
+                || !crate::agent_task_service::cook_pre_execution::retryable_pre_execution_failure(
+                    &existing,
+                )
+                || existing.metadata["provider_executions_consumed"]
+                    .as_u64()
+                    .unwrap_or(0)
+                    != 0
+            {
+                return Err(Error::validation_invalid_argument(
+                    "controller_runtime_recovery",
+                    "controller runtime rebinding requires a retryable terminal pre-execution record with zero provider executions",
+                    Some(record.run_id.clone()),
+                    None,
+                ));
+            }
+            if record.state != AgentTaskRunState::Queued
+                || record.run_id != existing.run_id
+                || record.plan_id != existing.plan_id
+            {
+                return Err(Error::validation_invalid_argument(
+                    "controller_runtime_recovery",
+                    "controller runtime rebinding must preserve the durable run and plan identity while rearming it as queued",
+                    Some(record.run_id.clone()),
+                    None,
+                ));
+            }
+
+            let mut rebound = record.clone();
+            let previous = existing
+                .metadata
+                .get(homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY)
+                .cloned()
+                .unwrap_or(Value::Null);
+            rebound.metadata["controller_runtime_recovery"] = serde_json::json!({
+                "schema": "homeboy/controller-runtime-pre-execution-recovery/v1",
+                "reason": "retryable_pre_execution_failure",
+                "previous": previous,
+                "current": runtime.clone(),
+                "provider_executions_consumed": 0,
+                "recovered_at": super::now_timestamp(),
+            });
+            rebound.metadata
+                [homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] = runtime;
+            rebound.metadata["controller_identity"] =
+                serde_json::json!(homeboy_core::build_identity::current().display);
+            write_record_with_aggregate_without_workspace_authority_mode(
+                self,
+                &rebound,
+                read_mirrored_aggregate_in_store(self, &rebound.run_id)?,
+                false,
+            )
+        })
+    }
+
     /// Persist a record while the caller owns this store's config lock. Terminal
     /// authority is intentionally projected only after that lock is released.
     pub(crate) fn write_record_locked_without_terminal_projection(
@@ -1172,6 +1235,20 @@ fn write_record_with_aggregate_without_workspace_authority(
     record: &AgentTaskRunRecord,
     aggregate: Option<AgentTaskAggregate>,
 ) -> Result<AgentTaskRunRecord> {
+    write_record_with_aggregate_without_workspace_authority_mode(
+        lifecycle_store,
+        record,
+        aggregate,
+        true,
+    )
+}
+
+fn write_record_with_aggregate_without_workspace_authority_mode(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    record: &AgentTaskRunRecord,
+    aggregate: Option<AgentTaskAggregate>,
+    preserve_terminal: bool,
+) -> Result<AgentTaskRunRecord> {
     #[cfg(any(test, feature = "test-support"))]
     if FAIL_NEXT_RECORD_WRITE.swap(false, Ordering::SeqCst) {
         return Err(Error::internal_io(
@@ -1193,9 +1270,12 @@ fn write_record_with_aggregate_without_workspace_authority(
             record.metadata["cook_operation_claims"] = claims;
         }
     }
-    let metadata_json =
+    let mut metadata_json =
         merge_observation_metadata(existing_metadata, observation_metadata(&record, aggregate)?);
-    store.upsert_imported_run_preserving_terminal(&RunRecord {
+    if !preserve_terminal {
+        metadata_json["agent_task_aggregate"] = Value::Null;
+    }
+    let projected = RunRecord {
         id: record.run_id.clone(),
         kind: "agent-task".to_string(),
         component_id: plan_id_component(&record),
@@ -1208,7 +1288,12 @@ fn write_record_with_aggregate_without_workspace_authority(
         git_sha: None,
         rig_id: None,
         metadata_json,
-    })?;
+    };
+    if preserve_terminal {
+        store.upsert_imported_run_preserving_terminal(&projected)?;
+    } else {
+        store.upsert_imported_run(&projected)?;
+    }
     let committed = store.get_run(&record.run_id)?.ok_or_else(|| {
         Error::internal_unexpected(format!(
             "committed agent-task run record is unavailable: {}",


### PR DESCRIPTION
## Summary

- add a narrowly validated lifecycle operation that reopens retryable zero-provider pre-execution records
- bind the reopened record to the newly admitted current controller runtime
- preserve typed previous/current runtime provenance and clear the stale terminal aggregate projection
- retain terminal-preserving writes for every ordinary lifecycle mutation

This completes the current-runtime recovery path tracked by #13539. After #13550 allowed runtime admission, the real lineage reached lifecycle mutation and exposed the remaining immutable old-runtime pin.

## Verification

- `cargo test -p homeboy-agents runtime_admission -- --test-threads=1`
- `cargo test -p homeboy-agents existing_recipe_pre_execution_recovery_does_not_reapply_runtime_pin`
- `cargo test -p homeboy-cli --features test-support --lib cook_continue_preflight_ -- --test-threads=1`
- `cargo fmt --all --check`
- `git diff --check`
- the regression executes the full store-bound transition and proves the recovered record is queued, uses the admitted current pin, retains previous/current provenance, and still rejects ordinary terminal readmission
- real MDI evidence records `provider_executions_consumed: 0` and the exact old/new runtime mismatch at the lifecycle mutation boundary

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced the terminal-preserving lifecycle write and runtime mutation validation from the persisted MDI Cook evidence, implemented the authenticated rebind primitive, and ran focused regressions. Chris Huber directed and reviewed the work.
