### PR TITLE
Fix daemon capability preflight environment precedence

### DIFF
--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -1158,6 +1158,33 @@ mod admission_tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
+    fn daemon_capability_preflight_overlays_job_env_on_runner_env() {
+        let runner_env = HashMap::from([
+            (
+                "HOMEBOY_COMMAND".to_string(),
+                "/runner/bin/homeboy".to_string(),
+            ),
+            ("PATH".to_string(), "/runner/bin:/usr/bin".to_string()),
+        ]);
+        let request_env = HashMap::from([
+            ("PATH".to_string(), "/job/bin:/usr/bin".to_string()),
+            ("COOK_ATTEMPT".to_string(), "2".to_string()),
+        ]);
+
+        let effective = effective_capability_preflight_env(&runner_env, &request_env);
+
+        assert_eq!(
+            effective.get("HOMEBOY_COMMAND").map(String::as_str),
+            Some("/runner/bin/homeboy")
+        );
+        assert_eq!(
+            effective.get("PATH").map(String::as_str),
+            Some("/job/bin:/usr/bin")
+        );
+        assert_eq!(effective.get("COOK_ATTEMPT").map(String::as_str), Some("2"));
+    }
+
+    #[test]
     fn strict_admission_requires_protocol_token_and_server_expiry() {
         assert!(strict_admission_response_is_complete(
             true,
@@ -1480,9 +1507,18 @@ pub(super) fn preflight_runner_capability_plan(
     // Probe the command and state authority that this job will receive, not
     // merely the runner's persisted configuration.
     let mut effective_runner = runner.clone();
-    effective_runner.env = request_env.clone();
+    effective_runner.env = effective_capability_preflight_env(&runner.env, request_env);
     let capabilities = runner_capability_snapshot_for_preflight(&effective_runner, preflight)?;
     validate_runner_capability_preflight(&runner.id, preflight, &capabilities, request_env)
+}
+
+fn effective_capability_preflight_env(
+    runner_env: &HashMap<String, String>,
+    request_env: &HashMap<String, String>,
+) -> HashMap<String, String> {
+    let mut env = runner_env.clone();
+    env.extend(request_env.clone());
+    env
 }
 
 pub(super) fn fetch_daemon_job(client: &Client, local_url: &str, job_id: &str) -> Result<Job> {


### PR DESCRIPTION
## Summary

- retain configured runner environment during daemon-dispatch capability preflight
- overlay job-scoped request values with the same precedence used by execution
- cover configured Homeboy authority retention and request override precedence

Closes #13557.

## Verification

- `cargo test -p homeboy-lab-runner --lib execution::daemon::admission_tests` (8 passed)
- `cargo test -p homeboy-lab-runner --lib capabilities` (31 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol was used through OpenCode to reproduce the Lab Cook failure, trace daemon capability preflight, implement the environment-precedence repair, and run focused verification.