### PR TITLE
fix(cook): recover adopted candidate artifacts

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -209,6 +209,7 @@ pub fn resume_promoted_patch(
         &observation_store,
         false,
         None,
+        None,
     )
 }
 
@@ -225,17 +226,19 @@ pub(crate) fn resume_promoted_patch_in_observation_store(
         observation_store,
         false,
         None,
+        None,
     )
 }
 
 /// Re-run corrected gates against an already-applied candidate while preserving
 /// all candidate, base, target, source, and artifact resume validation.
-pub(crate) fn resume_promoted_patch_replacement_gates_in_observation_store(
+pub(crate) fn resume_promoted_patch_replacement_gates_in_observation_store<'a>(
     options: AgentTaskPromotionOptions,
     target_path: &Path,
     previous: &Value,
     gate_workspace: Option<&Path>,
     observation_store: &homeboy_core::observation::ObservationStore,
+    before_gates: impl FnOnce() -> Result<()> + 'a,
 ) -> Result<AgentTaskPromotionReport> {
     resume_promoted_patch_internal(
         options,
@@ -244,16 +247,18 @@ pub(crate) fn resume_promoted_patch_replacement_gates_in_observation_store(
         observation_store,
         true,
         gate_workspace,
+        Some(Box::new(before_gates)),
     )
 }
 
-fn resume_promoted_patch_internal(
+fn resume_promoted_patch_internal<'a>(
     options: AgentTaskPromotionOptions,
     target_path: &Path,
     previous: &Value,
     observation_store: &homeboy_core::observation::ObservationStore,
     replacement_gates: bool,
     gate_workspace: Option<&Path>,
+    before_gates: Option<Box<dyn FnOnce() -> Result<()> + 'a>>,
 ) -> Result<AgentTaskPromotionReport> {
     validate_resume_provenance(&options, target_path, previous)?;
     let source_value: Value = serde_json::from_str(&options.source).map_err(|error| {
@@ -327,6 +332,9 @@ fn resume_promoted_patch_internal(
                 None,
             )
         })?;
+    if let Some(before_gates) = before_gates {
+        before_gates()?;
+    }
     let gates = run_promotion_gates(
         &options,
         &mut provider,

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -1249,11 +1249,8 @@ fn verify_replacement_gates_owned(
         .pointer("/resume_contract/inputs")
         .or_else(|| original.provenance.pointer("/resume_inputs"));
     let (source, source_path) = promotion_source(&run_id)?;
+    let source = bind_persisted_promotion_artifact(source, &original)?;
     let observation_store = lifecycle_store.open_observation_initialized()?;
-    // This fence is deliberately irreversible. Shell gates can have external
-    // side effects, so a dead owner after this point must recover with external
-    // candidate-bound proof rather than replaying an unknown partial execution.
-    mark_replacement_gate_execution_started(lifecycle_store, run_id)?;
     let replacement_gate_workspace = replacement_component_workspace(&original, &target_path)?;
     let mut replacement = resume_promoted_patch_replacement_gates_in_observation_store(
         AgentTaskPromotionOptions {
@@ -1285,6 +1282,11 @@ fn verify_replacement_gates_owned(
             .map_err(|error| Error::internal_json(error.to_string(), None))?,
         replacement_gate_workspace.as_deref(),
         &observation_store,
+        || {
+            // This fence is deliberately irreversible. Artifact hydration and
+            // candidate validation are retryable; shell gates are not.
+            mark_replacement_gate_execution_started(lifecycle_store, run_id)
+        },
     )?;
     // #11290's import boundary requires command evidence for each green gate.
     // The shared gate runner retains that evidence in detailed gate reports, so
@@ -1307,7 +1309,68 @@ fn verify_replacement_gates_owned(
     record_replacement_gate_proof(&run_id, replacement, Some(external_authorization))
 }
 
-fn replacement_gate_execution_started(
+fn bind_persisted_promotion_artifact(
+    source: String,
+    promotion: &AgentTaskPromotionReport,
+) -> Result<String> {
+    let mut source_value: Value = serde_json::from_str(&source).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("deserialize replacement gate promotion source".to_string()),
+        )
+    })?;
+    let outcome = if let Some(outcomes) = source_value
+        .get_mut("outcomes")
+        .and_then(Value::as_array_mut)
+    {
+        outcomes
+            .iter_mut()
+            .find(|outcome| {
+                outcome.get("task_id").and_then(Value::as_str)
+                    == Some(promotion.source.task_id.as_str())
+            })
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "promotion.source.task_id",
+                    "replacement gate source aggregate has no outcome for the persisted promotion",
+                    Some(promotion.source.task_id.clone()),
+                    None,
+                )
+            })?
+    } else {
+        &mut source_value
+    };
+    let artifacts = outcome
+        .get_mut("artifacts")
+        .and_then(Value::as_array_mut)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "promotion.source.artifacts",
+                "replacement gate source outcome has no artifact inventory",
+                Some(promotion.source.task_id.clone()),
+                None,
+            )
+        })?;
+    if !artifacts.iter().any(|artifact| {
+        artifact.get("id").and_then(Value::as_str) == Some(promotion.patch_artifact.id.as_str())
+    }) {
+        artifacts.push(json!({
+            "id": promotion.patch_artifact.id,
+            "kind": promotion.patch_artifact.kind,
+            "path": promotion.patch_artifact.path,
+            "sha256": promotion.patch_artifact.sha256,
+            "metadata": {
+                "actionable": true,
+                "role": "patch",
+                "source": "persisted_promotion",
+            },
+        }));
+    }
+    serde_json::to_string(&source_value)
+        .map_err(|error| Error::internal_json(error.to_string(), None))
+}
+
+pub(crate) fn replacement_gate_execution_started(
     lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     run_id: &str,
 ) -> Result<bool> {

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -21,8 +21,8 @@ use super::super::cook_promotion::{
     persisted_promotion_for_attempt_in_store, prepare_manual_finalization_identity,
     record_replacement_gate_proof, recover_cook_pr_with_backend,
     recover_moving_base_cook_candidate_in_store, refreshed_moving_base_recovery,
-    selected_candidate_task_id_in_store, verify_replacement_gates, CookReportInput,
-    MovingBaseCookRecovery,
+    replacement_gate_execution_started, selected_candidate_task_id_in_store,
+    verify_replacement_gates, CookReportInput, MovingBaseCookRecovery,
 };
 use super::super::cook_recipe::{
     persist_initial_recipe, set_initial_recipe_creation_barrier_for_test,
@@ -14975,6 +14975,7 @@ fn verify_replacement_gates_replays_completed_proof_without_rerunning_gates() {
         .expect("serialize failed promotion");
         failed["source"]["task_id"] =
             serde_json::json!(options.initial_plan.tasks[0].task_id.clone());
+        failed["patch_artifact"]["id"] = serde_json::json!("committed-changes");
         failed["target"]["dirty"] = serde_json::json!(true);
         agent_task_lifecycle::record_promotion("run-verify-replacement", failed)
             .expect("align source task evidence");
@@ -14999,6 +15000,23 @@ fn verify_replacement_gates_replays_completed_proof_without_rerunning_gates() {
             gate_log.display()
         );
         let reviewer_gate = "test \"$(cat \"$(git rev-parse --show-toplevel)/figma-transformer/tracked.txt\")\" = promoted".to_string();
+        let unavailable_patch = patch_path.with_extension("unavailable");
+        std::fs::rename(&patch_path, &unavailable_patch).expect("hide promotion artifact");
+        verify_replacement_gates(
+            "cook-verify-replacement",
+            VerifyGateOptions {
+                verify: vec![reviewer_gate.clone()],
+                ..Default::default()
+            },
+            "Chris approved corrected gate evidence".to_string(),
+        )
+        .expect_err("artifact preflight fails before shell execution");
+        assert!(!replacement_gate_execution_started(
+            &test_lifecycle_store(),
+            "run-verify-replacement"
+        )
+        .expect("read replacement gate fence"));
+        std::fs::rename(&unavailable_patch, &patch_path).expect("restore promotion artifact");
         let replacement = verify_replacement_gates(
             "cook-verify-replacement",
             VerifyGateOptions {
@@ -15011,6 +15029,7 @@ fn verify_replacement_gates_replays_completed_proof_without_rerunning_gates() {
         .expect("replacement gates complete");
 
         assert_eq!(replacement.status, AgentTaskPromotionStatus::Applied);
+        assert_eq!(replacement.patch_artifact.id, "committed-changes");
         assert_eq!(
             replacement.provenance["candidate"]["fingerprint"]["target_path"],
             serde_json::json!(std::fs::canonicalize(&target)


### PR DESCRIPTION
## Summary
- rebind the controller-persisted promotion artifact into replacement verification when it is absent from the provider aggregate
- move the irreversible replacement-gate execution fence past artifact hydration and candidate validation to the exact pre-shell boundary
- cover missing `committed-changes` artifacts, retry-safe preflight failure, and successful candidate-bound replacement proof

Addresses the artifact recovery and poisoned retry path in #13556. Current adoption coverage also proves candidate and baseline gates replay before remediation; the terminal aggregate-free recovery invariant remains tracked by #13556.

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-agents replacement_gate`
- `cargo test -p homeboy-agents resume_promoted_patch`
- `cargo test -p homeboy-agents adoption_replays_candidate_and_baseline_gates_from_the_persisted_component_workspace`
- `cargo test -p homeboy-agents candidate_recoverable_manual_preflight_binds_canonical_candidate_and_recovers_once`
- `cargo test -p homeboy-agents adoption_rejects_aggregate_free_cancelled_runs_without_pre_provider_evidence`

`cargo clippy -p homeboy-agents --tests -- -D warnings` remains baseline-red on pre-existing Rust 1.95 warnings outside this change.

## AI Assistance
- **Model:** GPT-5.6 Sol
- **Tool:** OpenCode
- **Used for:** durable recovery analysis, implementation, regression tests, and verification. Chris Huber remains responsible for the resulting change.