### PR TITLE
fix(test): derive the required-gates fixtures from the manifest so the terminal-verdict tests measure again

### DIFF
--- a/tests/required_gates_policy_test.rs
+++ b/tests/required_gates_policy_test.rs
@@ -128,16 +128,6 @@ fn no_required_checks() -> String {
     .expect("live rules fixture")
 }
 
-fn reporting_only_policy() -> String {
-    serde_json::to_string_pretty(&serde_json::json!({
-        "rules": [
-            { "type": "deletion" },
-            { "type": "non_fast_forward" }
-        ]
-    }))
-    .expect("reporting-only policy fixture")
-}
-
 fn ruleset_detail(bypass_actors: serde_json::Value, current_user_can_bypass: &str) -> String {
     serde_json::to_string_pretty(&serde_json::json!({
         "id": 13680120,
@@ -169,11 +159,58 @@ fn run_validator(mode: &str, env: &[(&str, &str)]) -> Output {
         .expect("required-gates validator should run")
 }
 
+/// Every non-terminal gate's declared producer JOB ID.
+///
+/// This is the key GitHub types into the `needs` context, and since #13125 it is
+/// what the terminal gate joins on — matrix legs and reusable-workflow calls
+/// arrive pre-aggregated, so nothing in `needs` matches a display context.
+fn producer_jobs() -> Vec<String> {
+    let mut jobs: Vec<String> = gates()
+        .iter()
+        .filter(|gate| gate["required_status_check"] == true && gate["terminal"] != true)
+        .map(|gate| {
+            gate["producer"]["job"]
+                .as_str()
+                .expect("manifest producer job")
+                .to_string()
+        })
+        .collect();
+    jobs.sort();
+    jobs.dedup();
+    jobs
+}
+
+/// `toJSON(needs)` as the terminal gate reads it.
+///
+/// Derived from the manifest for the same reason everything else here is: this
+/// fixture used to be the literal `{"gates":{"result":"success"}}`, which
+/// predated the producer-job keying above. `gates` matches no producer job, so
+/// every declared gate resolved to `missing-from-needs`, the run short-circuited
+/// to `outcome=skipped`, and six tests below spent that time asserting against
+/// the short-circuit instead of the contract they are named for (#13561). A
+/// fixture that restates the thing it pins cannot catch the drift it exists to
+/// prevent.
+fn typed_needs(exception: Option<(&str, &str)>) -> String {
+    serde_json::to_string(
+        &producer_jobs()
+            .into_iter()
+            .map(|job| {
+                let result = exception
+                    .filter(|(candidate, _)| *candidate == job)
+                    .map(|(_, result)| result)
+                    .unwrap_or("success");
+                (job, serde_json::json!({ "result": result }))
+            })
+            .collect::<serde_json::Map<String, serde_json::Value>>(),
+    )
+    .expect("typed needs fixture")
+}
+
 fn run_execution_gate(env: &[(&str, &str)]) -> Output {
     let mut command = Command::new("bash");
     command.arg(".github/ci-required-gates-executed.sh");
     command.env_remove("GITHUB_STEP_SUMMARY");
-    command.env("CI_GATE_RESULTS", r#"{"gates":{"result":"success"}}"#);
+    command.env("CI_GATE_RESULTS", typed_needs(None));
     command.env(
         "REQUIRED_GATES_HEAD_SHA",
         "0000000000000000000000000000000000000000",
@@ -185,6 +222,57 @@ fn run_execution_gate(env: &[(&str, &str)]) -> Output {
     command
         .output()
         .expect("required-gates execution gate should run")
+}
+
+/// A mutated copy of the declaration, written to scratch.
+///
+/// `REQUIRED_GATES_CONFIG` names the derived ruleset payload, not the
+/// declaration. Since #13125 both the validator and the terminal gate read
+/// `REQUIRED_GATES_MANIFEST`, so a test that mutates the payload mutates
+/// something neither script consults and asserts against the real eight-gate
+/// policy without noticing (#13561).
+fn scratch_manifest(scratch: &Scratch, mutate: impl FnOnce(&mut serde_json::Value)) -> String {
+    let mut mutated = manifest().clone();
+    mutate(&mut mutated);
+    scratch.write(
+        "manifest.json",
+        &serde_json::to_string_pretty(&mutated).expect("mutated manifest"),
+    )
+}
+
+/// A mutated declaration plus the artifacts derived from it, in scratch.
+///
+/// The validator's first act is to reject a manifest that disagrees with its
+/// generated artifacts, so a mutated declaration reaches no other check until
+/// its own ruleset payload has been regenerated from it. Returns the env
+/// overrides that point every consumer at the scratch set; the documentation
+/// artifact is switched off, which the generator supports explicitly.
+fn scratch_declaration(
+    scratch: &Scratch,
+    mutate: impl FnOnce(&mut serde_json::Value),
+) -> Vec<(String, String)> {
+    let declaration = scratch_manifest(scratch, mutate);
+    let ruleset = scratch.missing("required-gates-ruleset.json");
+
+    let generated = Command::new("bash")
+        .arg(".github/generate-required-gates-artifacts.sh")
+        .env("REQUIRED_GATES_MANIFEST", &declaration)
+        .env("REQUIRED_GATES_RULESET_OUTPUT", &ruleset)
+        .env("REQUIRED_GATES_DOCS_OUTPUT", "")
+        .output()
+        .expect("required-gates generator should run");
+    assert!(
+        generated.status.success(),
+        "the mutated declaration must still be derivable, or the test is measuring the \
+         generator's refusal instead of the property it names: {}",
+        stderr_of(&generated)
+    );
+
+    vec![
+        ("REQUIRED_GATES_MANIFEST".to_string(), declaration),
+        ("REQUIRED_GATES_RULESET_OUTPUT".to_string(), ruleset),
+        ("REQUIRED_GATES_DOCS_OUTPUT".to_string(), String::new()),
+    ]
 }
 
 fn execution_jobs(contexts: &[String], exception: Option<(&str, serde_json::Value)>) -> String {
@@ -615,27 +703,18 @@ fn report_mode_reports_bypassable_when_actors_can_bypass_the_ruleset() {
 #[test]
 fn report_mode_still_fails_closed_on_declaration_drift() {
     let scratch = Scratch::new("drift");
-    let drifted = serde_json::json!({
-        "rules": [{
-            "type": "required_status_checks",
-            "parameters": {
-                "strict_required_status_checks_policy": true,
-                "required_status_checks": [{ "context": "homeboy / Nonexistent Gate" }],
-            }
-        }]
+    // Rename one declared gate's context to something `ci.yml` emits nowhere.
+    // The declaration is the manifest, so drifting it means drifting that.
+    let declaration = scratch_declaration(&scratch, |manifest| {
+        manifest["gates"][0]["context"] = serde_json::json!("homeboy / Nonexistent Gate");
     });
-    let config = scratch.write(
-        "config.json",
-        &serde_json::to_string_pretty(&drifted).expect("config fixture"),
-    );
     let rules = scratch.write("rules.json", &no_required_checks());
-    let output = run_validator(
-        "--report",
-        &[
-            ("REQUIRED_GATES_CONFIG", config.as_str()),
-            ("REQUIRED_GATES_LIVE_RULES", rules.as_str()),
-        ],
-    );
+    let mut env: Vec<(&str, &str)> = declaration
+        .iter()
+        .map(|(key, value)| (key.as_str(), value.as_str()))
+        .collect();
+    env.push(("REQUIRED_GATES_LIVE_RULES", rules.as_str()));
+    let output = run_validator("--report", &env);
 
     assert!(
         !output.status.success(),
@@ -724,6 +803,43 @@ fn github_mode_rejects_rulesets_that_omit_the_terminal_execution_verdict() {
     );
 }
 
+/// **The reason the six tests below can be trusted at all.**
+///
+/// Every one of them injects job conclusions and asserts on the verdict. None
+/// of that is reachable if the typed-needs join fails first: an unmatched
+/// producer job is `missing-from-needs`, which lands in the skipped class and
+/// returns `outcome=skipped` before a single conclusion is read. That is
+/// exactly what happened for as long as `CI_GATE_RESULTS` was the literal
+/// `{"gates":{"result":"success"}}` (#13561).
+///
+/// So the join is asserted directly, rather than assumed by the tests that
+/// depend on it. A guard that only fires when something else is already broken
+/// is a guard that reports the symptom; this one reports the cause.
+#[test]
+fn the_typed_needs_fixture_resolves_every_declared_producer_job() {
+    let contexts = declared_contexts();
+    let scratch = Scratch::new("typed-needs-join");
+    let jobs = scratch.write("jobs.json", &execution_jobs(&contexts, None));
+    let output = run_execution_gate(&[("REQUIRED_GATES_EXECUTED_JOBS", jobs.as_str())]);
+
+    assert!(
+        !stdout_of(&output).contains("missing-from-needs"),
+        "the typed-needs fixture no longer resolves every producer job, so every test below is \
+         asserting against a short-circuit rather than the contract it names: {}",
+        stdout_of(&output)
+    );
+    assert!(
+        stdout_of(&output).contains("required-gates-executed-status=executed"),
+        "a fully successful run must reach the executed verdict: {}",
+        stdout_of(&output)
+    );
+    assert!(
+        !producer_jobs().is_empty(),
+        "the fixture is derived from the manifest, so an empty producer set would make the \
+         assertions above pass vacuously"
+    );
+}
+
 /// GitHub only allows a merge once a required context succeeds. These fixtures
 /// exercise the terminal context's fail-closed contract for every non-success
 /// check state that could otherwise leave a candidate unverified.
@@ -779,9 +895,16 @@ fn terminal_execution_verdict_rejects_pending_skipped_cancelled_failed_and_absen
 #[test]
 fn terminal_execution_verdict_reports_reporting_only_policy_without_probing_jobs() {
     let scratch = Scratch::new("reporting-only-execution");
-    let policy = scratch.write("ruleset.json", &reporting_only_policy());
+    // A reporting-only stance is a declaration that requires no status check,
+    // and the terminal gate reads that from the manifest's own
+    // `zero_context_policy` -- not from the derived ruleset payload.
+    let declaration = scratch_manifest(&scratch, |manifest| {
+        for gate in manifest["gates"].as_array_mut().expect("manifest gates") {
+            gate["required_status_check"] = serde_json::json!(false);
+        }
+    });
     let output = run_execution_gate(&[
-        ("REQUIRED_GATES_CONFIG", policy.as_str()),
+        ("REQUIRED_GATES_MANIFEST", declaration.as_str()),
         // A reporting-only policy has no execution evidence to verify.
         (
             "REQUIRED_GATES_EXECUTED_JOBS",


### PR DESCRIPTION
## Summary

Eight tests in `tests/required_gates_policy_test.rs` fail on a clean `origin/main` checkout (#13561). Deterministically, single-threaded, in isolation.

**None of them asserts the wrong thing.** In every case the script under test short-circuits *before the asserted property is evaluated*, because a fixture still describes the pre-#13125 contract. They cover the terminal execution verdict's fail-closed contract — the contract #12833 is about — and they have been proving nothing. Failing is the only reason anyone noticed.

This fixes both causes and then proves, by mutation, that all eight actually measure again.

## What changed

**Cause A — `CI_GATE_RESULTS` (6 tests).** #13125 keyed typed needs by each gate's declared producer **job id**; matrix legs and reusable-workflow calls arrive pre-aggregated, so nothing in `needs` matches a display context. The harness still supplied the literal from before that change:

```rust
command.env("CI_GATE_RESULTS", r#"{"gates":{"result":"success"}}"#);
```

`gates` matches no producer job → all seven gates `missing-from-needs` → skipped class → `outcome=skipped`, reached before a single job conclusion is read:

```
typed=[declaration/required-gates-declaration=missing-from-needs
       ... all 7 ... ] outcome=skipped
```

Now derived from the manifest. This file already opens by stating the rule — *"nothing here restates the gate list. A test that hardcodes the thing it pins cannot catch the drift it was written to prevent"* — and that literal was the one place violating it.

**Cause B — `REQUIRED_GATES_CONFIG` (2 tests).** It names the derived ruleset payload, not the declaration. Both scripts read `REQUIRED_GATES_MANIFEST`, and `ci-required-gates-executed.sh` never references `REQUIRED_GATES_CONFIG`. Both tests now mutate a scratch **manifest**. Since the validator's first act is to reject a manifest that disagrees with its generated artifacts, `scratch_declaration` regenerates the payload through the generator's already-documented `REQUIRED_GATES_RULESET_OUTPUT` / `REQUIRED_GATES_DOCS_OUTPUT` hooks first.

**New guard.** `the_typed_needs_fixture_resolves_every_declared_producer_job` asserts the join directly instead of leaving it to be inferred from six downstream failures. A guard that only fires once something else is already broken reports the symptom; this one reports the cause.

No production code changes. `.github/*.sh` is untouched.

## How to test

1. `cargo test --test required_gates_policy_test -- --test-threads=1` → **32 passed, 0 failed**. On `main`: 23 passed, 8 failed.
2. `cargo check --workspace --all-targets` → clean, no warnings.

## Evidence: the eight are live, not merely green

Six of these were inert long enough that passing after a port proves nothing about whether they measure anything — the same absence-of-evidence failure `measurement_registry_test` exists to catch, one layer up. So each property was violated in the script and the suite re-run:

| # | mutation of the script under test | caught by |
|---|---|---|
| M1 | an absent context reports `success` | `rejects_pending_skipped_cancelled_failed_and_absent_contexts` |
| M2 | every non-success conclusion laundered into `success` | `keeps_duplicate_failures…`, `rejects_pending…`, `rejects_skipped_only…` |
| M3 | `head_sha` scoping dropped from job matching | `rejects_skipped_only_and_ignores_other_head_duplicates` |
| M4 | skipped planning duplicate no longer tolerated | `accepts_a_skipped_planning_duplicate_after_success` |
| M5 | terminal gate demands its own conclusion | `does_not_require_its_own_in_progress_conclusion`, `accepts_a_skipped_planning_duplicate…` |
| M6 | duplicate success rejected | `accepts_duplicate_success`, `accepts_a_skipped_planning_duplicate…` |
| M7 | **typed needs keyed by display context** (the original defect) | all 6 **and the new guard, by name** |
| M8 | manifest's `zero_context_policy` outcome ignored | `reports_reporting_only_policy_without_probing_jobs` |
| M9 | declaration stops requiring the context be emitted by `ci.yml` | `report_mode_still_fails_closed_on_declaration_drift` |

All eight are covered, each by a mutation of the specific property it names. M7 is the whole point of the new guard: reintroduce the exact bug this PR fixes and the guard fails by name while the other six report their symptoms.

Every mutation was reverted; `git status` shows only `tests/required_gates_policy_test.rs`.

## Compatibility

Test-only. `reporting_only_policy()` is deleted — its sole caller now derives a reporting-only stance from the manifest, and leaving it would break the `Warning Clean` gate.

Touches the same file as #13560 but in disjoint regions; no production overlap.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Used for:** read the actual short-circuit output rather than inferring a cause from one trace, ported both fixtures onto the post-#13125 contract, and designed the nine-mutation matrix to prove the ported tests are live. An earlier pass generalised a single root cause across all eight and was wrong; Chris Huber caught it, and this PR is the corrected work. Chris reviewed and owns this change.

Closes #13561
Refs #13125, #12833, #8010
