### PR TITLE
fix(cook): accept inherited replacement proof

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -774,6 +774,7 @@ pub fn record_replacement_gate_proof(
     run_id: &str,
     mut replacement: AgentTaskPromotionReport,
     external_authorization: Option<String>,
+    accept_inherited_failures: bool,
 ) -> Result<AgentTaskPromotionReport> {
     let original = persisted_promotion_for_attempt(run_id)?.ok_or_else(|| {
         Error::validation_invalid_argument(
@@ -783,18 +784,25 @@ pub fn record_replacement_gate_proof(
             None,
         )
     })?;
-    if original.status == AgentTaskPromotionStatus::Applied
-        && original.provenance.get("replacement_gate_proof").is_some()
-        && replacement.source == original.source
-        && replacement.target == original.target
-        && replacement.to_worktree == original.to_worktree
-        && replacement.patch_artifact == original.patch_artifact
-        && replacement.changed_files == original.changed_files
-        && replacement.verified_base == original.verified_base
-        && replacement.deterministic_gates == original.deterministic_gates
-        && replacement.command_evidence == original.command_evidence
-    {
-        return Ok(original);
+    if original.provenance.get("replacement_gate_proof").is_some() {
+        if original.finalization_eligible(accept_inherited_failures)
+            && replacement.source == original.source
+            && replacement.target == original.target
+            && replacement.to_worktree == original.to_worktree
+            && replacement.patch_artifact == original.patch_artifact
+            && replacement.changed_files == original.changed_files
+            && replacement.verified_base == original.verified_base
+            && replacement.deterministic_gates == original.deterministic_gates
+            && replacement.command_evidence == original.command_evidence
+        {
+            return Ok(original);
+        }
+        return Err(Error::validation_invalid_argument(
+            "replacement_gate_proof",
+            "replacement proof is already recorded; replay its exact evidence and inherited-failure policy",
+            Some(run_id.to_string()),
+            None,
+        ));
     }
     if original.status != AgentTaskPromotionStatus::GateFailed || !original.status.patch_promoted()
     {
@@ -817,7 +825,11 @@ pub fn record_replacement_gate_proof(
         ));
     }
     replacement.normalize_gate_outcome();
-    validate_replacement_proof_finalization_eligibility(run_id, &replacement)?;
+    validate_replacement_proof_finalization_eligibility(
+        run_id,
+        &replacement,
+        accept_inherited_failures,
+    )?;
     validate_legacy_replacement_candidate_checkout(run_id, &original, &replacement)?;
     let expected_candidate = original.provenance.get("candidate");
     let observed_candidate = replacement.provenance.get("candidate");
@@ -894,6 +906,7 @@ pub fn record_replacement_gate_proof(
         "reason": "infrastructure_invalid_original_gates",
         "operator_authorization": external_authorization,
         "externally_produced": true,
+        "accept_inherited_failures": accept_inherited_failures,
         // `Inherit` serializes as the default in gate reports; recording the
         // resolved policy here keeps that valid standard policy explicit.
         "environment_policy": replacement.deterministic_gates.iter().map(|gate| serde_json::json!({
@@ -1018,6 +1031,7 @@ fn validate_legacy_replacement_candidate_checkout(
 fn validate_replacement_proof_finalization_eligibility(
     run_id: &str,
     replacement: &AgentTaskPromotionReport,
+    accept_inherited_failures: bool,
 ) -> Result<()> {
     let failed = |predicate: &'static str, gate_id: Option<&str>| {
         let mut error = Error::validation_invalid_argument(
@@ -1033,8 +1047,8 @@ fn validate_replacement_proof_finalization_eligibility(
         error
     };
 
-    if replacement.status != AgentTaskPromotionStatus::Applied {
-        return Err(failed("applied_status", None));
+    if !replacement.status.patch_promoted() {
+        return Err(failed("promoted_status", None));
     }
     if replacement.deterministic_gates.is_empty() {
         return Err(failed("non_empty_deterministic_gates", None));
@@ -1042,7 +1056,7 @@ fn validate_replacement_proof_finalization_eligibility(
     if replacement.verified_base.is_none() {
         return Err(failed("verified_base", None));
     }
-    if !replacement.finalization_eligible(false) {
+    if !replacement.finalization_eligible(accept_inherited_failures) {
         return Err(failed("green_gate_status", None));
     }
     let candidate_checkout = replacement.provenance.get("candidate_checkout");
@@ -1050,11 +1064,18 @@ fn validate_replacement_proof_finalization_eligibility(
         if gate.command.is_empty() {
             return Err(failed("command", Some(&gate.id)));
         }
-        if !replacement
-            .command_evidence
-            .iter()
-            .any(|evidence| evidence.exit_code == 0 && evidence.command == gate.command)
-        {
+        if !replacement.command_evidence.iter().any(|evidence| {
+            evidence.command == gate.command
+                && match gate.status {
+                    crate::agent_task_gate::AgentTaskGateStatus::Succeeded => {
+                        evidence.exit_code == 0
+                    }
+                    crate::agent_task_gate::AgentTaskGateStatus::AcceptedInheritedFailure => {
+                        accept_inherited_failures && evidence.exit_code == gate.exit_code
+                    }
+                    _ => false,
+                }
+        }) {
             return Err(failed("matching_command_evidence", Some(&gate.id)));
         }
         if candidate_checkout.is_none()
@@ -1087,7 +1108,13 @@ fn validate_replacement_proof_finalization_eligibility(
     let candidate_bound_gates = shell_gates
         .iter()
         .copied()
-        .filter(|gate| replacement.has_visible_passed_gate_for_command(&gate.command[2]))
+        .filter(|gate| match gate.status {
+            crate::agent_task_gate::AgentTaskGateStatus::Succeeded => gate.exit_code == 0,
+            crate::agent_task_gate::AgentTaskGateStatus::AcceptedInheritedFailure => {
+                accept_inherited_failures
+            }
+            _ => false,
+        })
         .collect::<Vec<_>>();
     if candidate_bound_gates.is_empty() {
         return Err(failed("candidate_checkout", None));
@@ -1123,12 +1150,22 @@ pub fn verify_replacement_gates(
         REPLACEMENT_GATE_PROOF_CLAIM_LEASE,
     )? {
         agent_task_lifecycle::ClaimOutcome::AlreadyCompleted(result) => {
-            serde_json::from_value(result).map_err(|error| {
-                Error::internal_json(
-                    error.to_string(),
-                    Some("deserialize completed replacement gate proof".to_string()),
-                )
-            })
+            let report: AgentTaskPromotionReport =
+                serde_json::from_value(result).map_err(|error| {
+                    Error::internal_json(
+                        error.to_string(),
+                        Some("deserialize completed replacement gate proof".to_string()),
+                    )
+                })?;
+            if !report.finalization_eligible(gates.accept_inherited_failures) {
+                return Err(Error::validation_invalid_argument(
+                    "accept_inherited_failures",
+                    "completed replacement proof contains accepted inherited failures; reauthorize them explicitly",
+                    Some(run_id),
+                    None,
+                ));
+            }
+            Ok(report)
         }
         agent_task_lifecycle::ClaimOutcome::LeaseHeld => {
             let claim = lifecycle_store.operation_claim(&run_id, &operation_key)?;
@@ -1180,6 +1217,8 @@ fn verify_replacement_gates_owned(
     gates: crate::agent_task_gate::VerifyGateOptions,
     external_authorization: String,
 ) -> Result<AgentTaskPromotionReport> {
+    let accept_inherited_failures = gates.accept_inherited_failures;
+    let gate_timeout = gates.gate_timeout();
     let original = persisted_promotion_for_attempt(&run_id)?.ok_or_else(|| {
         Error::validation_invalid_argument(
             "latest_promotion",
@@ -1191,10 +1230,16 @@ fn verify_replacement_gates_owned(
     // A process can die after `record_replacement_gate_proof()` commits and
     // before its operation claim is completed. Recover that durable success
     // without repeating the gate execution that produced the proof.
-    if original.status == AgentTaskPromotionStatus::Applied
-        && original.provenance.get("replacement_gate_proof").is_some()
-    {
-        return Ok(original);
+    if original.provenance.get("replacement_gate_proof").is_some() {
+        if original.finalization_eligible(accept_inherited_failures) {
+            return Ok(original);
+        }
+        return Err(Error::validation_invalid_argument(
+            "accept_inherited_failures",
+            "completed replacement proof contains accepted inherited failures; reauthorize them explicitly",
+            Some(run_id.to_string()),
+            None,
+        ));
     }
     if replacement_gate_execution_started(lifecycle_store, run_id)? {
         return Err(interrupted_replacement_gate_execution_error(run_id));
@@ -1288,14 +1333,29 @@ fn verify_replacement_gates_owned(
             mark_replacement_gate_execution_started(lifecycle_store, run_id)
         },
     )?;
-    // #11290's import boundary requires command evidence for each green gate.
+    super::cook_baseline::compare_gate_failures_to_verified_base(
+        &mut replacement,
+        &target_path,
+        replacement_gate_workspace
+            .as_deref()
+            .unwrap_or(&target_path),
+        &verified_base.sha,
+        gate_timeout,
+        |_, _| Ok(()),
+    )?;
+    // #11290's import boundary requires command evidence for each accepted gate.
     // The shared gate runner retains that evidence in detailed gate reports, so
     // project it into the typed promotion command-evidence view before recording.
     replacement.command_evidence.extend(
         replacement
             .deterministic_gates
             .iter()
-            .filter(|gate| gate.exit_code == 0)
+            .filter(|gate| {
+                gate.exit_code == 0
+                    || (accept_inherited_failures
+                        && gate.status
+                            == crate::agent_task_gate::AgentTaskGateStatus::AcceptedInheritedFailure)
+            })
             .map(
                 |gate| crate::agent_task_promotion::AgentTaskPromotionCommandReport {
                     command: gate.command.clone(),
@@ -1306,7 +1366,12 @@ fn verify_replacement_gates_owned(
                 },
             ),
     );
-    record_replacement_gate_proof(&run_id, replacement, Some(external_authorization))
+    record_replacement_gate_proof(
+        &run_id,
+        replacement,
+        Some(external_authorization),
+        accept_inherited_failures,
+    )
 }
 
 fn bind_persisted_promotion_artifact(

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -14947,6 +14947,7 @@ fn verify_replacement_gates_replays_completed_proof_without_rerunning_gates() {
         options.initial_run_id = "run-verify-replacement".to_string();
         options.to_worktree = "fixture@cook-candidate".to_string();
         options.source_worktree_path = Some(target.clone());
+        options.gates.accept_inherited_failures = true;
         persist_initial_recipe(&options).expect("persist recipe");
         record_tracked_promotion_continuation(&options, &target);
         agent_task_lifecycle::record_cook_attempt_in_store(
@@ -14976,6 +14977,10 @@ fn verify_replacement_gates_replays_completed_proof_without_rerunning_gates() {
         failed["source"]["task_id"] =
             serde_json::json!(options.initial_plan.tasks[0].task_id.clone());
         failed["patch_artifact"]["id"] = serde_json::json!("committed-changes");
+        failed["verified_base"]["sha"] =
+            serde_json::json!(
+                git_output(&source, &["rev-parse", "HEAD"]).expect("resolve fixture base")
+            );
         failed["target"]["dirty"] = serde_json::json!(true);
         agent_task_lifecycle::record_promotion("run-verify-replacement", failed)
             .expect("align source task evidence");
@@ -14996,7 +15001,7 @@ fn verify_replacement_gates_replays_completed_proof_without_rerunning_gates() {
 
         let gate_log = temp.path().join("replacement-gate-runs");
         let gate = format!(
-            "test \"$(cat ../figma-transformer/tracked.txt)\" = promoted; printf ran >> {}",
+            "printf ran >> {}; printf inherited >&2; exit 1",
             gate_log.display()
         );
         let reviewer_gate = "test \"$(cat \"$(git rev-parse --show-toplevel)/figma-transformer/tracked.txt\")\" = promoted".to_string();
@@ -15006,6 +15011,7 @@ fn verify_replacement_gates_replays_completed_proof_without_rerunning_gates() {
             "cook-verify-replacement",
             VerifyGateOptions {
                 verify: vec![reviewer_gate.clone()],
+                accept_inherited_failures: true,
                 ..Default::default()
             },
             "Chris approved corrected gate evidence".to_string(),
@@ -15022,13 +15028,15 @@ fn verify_replacement_gates_replays_completed_proof_without_rerunning_gates() {
             VerifyGateOptions {
                 verify: vec![reviewer_gate.clone()],
                 private_verify: vec![gate.clone()],
+                execution_policy: crate::agent_task_gate::AgentTaskGateExecutionPolicy::ContinueAll,
+                accept_inherited_failures: true,
                 ..Default::default()
             },
             "Chris approved corrected gate evidence".to_string(),
         )
         .expect("replacement gates complete");
 
-        assert_eq!(replacement.status, AgentTaskPromotionStatus::Applied);
+        assert_eq!(replacement.status, AgentTaskPromotionStatus::GateFailed);
         assert_eq!(replacement.patch_artifact.id, "committed-changes");
         assert_eq!(
             replacement.provenance["candidate"]["fingerprint"]["target_path"],
@@ -15063,10 +15071,25 @@ fn verify_replacement_gates_replays_completed_proof_without_rerunning_gates() {
             homeboy_core::gate::HomeboyGateVisibility::Private,
             "a private required gate remains durable runtime evidence"
         );
+        assert_eq!(
+            replacement.deterministic_gates[1].status,
+            crate::agent_task_gate::AgentTaskGateStatus::AcceptedInheritedFailure
+        );
+        let error = verify_replacement_gates(
+            "cook-verify-replacement",
+            VerifyGateOptions {
+                verify: vec![replacement.deterministic_gates[0].command[2].clone()],
+                ..Default::default()
+            },
+            "Chris approved corrected gate evidence".to_string(),
+        )
+        .expect_err("completed inherited failure needs renewed authorization");
+        assert_eq!(error.details["field"], "accept_inherited_failures");
         let replay = verify_replacement_gates(
             "cook-verify-replacement",
             VerifyGateOptions {
                 verify: vec![replacement.deterministic_gates[0].command[2].clone()],
+                accept_inherited_failures: true,
                 ..Default::default()
             },
             "Chris approved corrected gate evidence".to_string(),
@@ -15076,7 +15099,7 @@ fn verify_replacement_gates_replays_completed_proof_without_rerunning_gates() {
         assert_eq!(replay.command_evidence, replacement.command_evidence);
         assert_eq!(
             std::fs::read_to_string(gate_log).expect("read gate log"),
-            "ran"
+            "ranran"
         );
         let record = agent_task_lifecycle::status("run-verify-replacement").expect("read record");
         assert_eq!(record.metadata["promotions"].as_array().unwrap().len(), 3);
@@ -15094,6 +15117,11 @@ fn verify_replacement_gates_replays_completed_proof_without_rerunning_gates() {
             record.metadata["latest_promotion"]["provenance"]["replacement_gate_proof"]
                 ["original_history"]["status"],
             "gate_failed"
+        );
+        assert_eq!(
+            record.metadata["latest_promotion"]["provenance"]["replacement_gate_proof"]
+                ["accept_inherited_failures"],
+            true
         );
     });
 }
@@ -18212,7 +18240,7 @@ fn replacement_gate_proof_recovers_failed_candidate_without_hiding_evidence_or_r
                 capture: Default::default(),
             },
         ];
-        let error = record_replacement_gate_proof(run_id, replacement.clone(), None)
+        let error = record_replacement_gate_proof(run_id, replacement.clone(), None, false)
             .expect_err("external proof requires operator authorization");
         assert!(error.message.contains("explicit operator authorization"));
 
@@ -18222,6 +18250,7 @@ fn replacement_gate_proof_recovers_failed_candidate_without_hiding_evidence_or_r
             run_id,
             drifted,
             Some("Chris approved external proof".to_string()),
+            false,
         )
         .expect_err("base drift is refused");
         assert!(error.message.contains("drifted"));
@@ -18236,6 +18265,7 @@ fn replacement_gate_proof_recovers_failed_candidate_without_hiding_evidence_or_r
             run_id,
             mismatched_evidence,
             Some("Chris approved external proof".to_string()),
+            false,
         )
         .expect_err("each gate needs matching command evidence");
         assert!(error.message.contains("matching_command_evidence"));
@@ -18251,6 +18281,7 @@ fn replacement_gate_proof_recovers_failed_candidate_without_hiding_evidence_or_r
             run_id,
             private_gate,
             Some("Chris approved external proof".to_string()),
+            false,
         )
         .expect_err("private gates cannot hydrate reviewer test instructions");
         assert_eq!(error.details["failed_eligibility_predicate"], "visibility");
@@ -18270,6 +18301,7 @@ fn replacement_gate_proof_recovers_failed_candidate_without_hiding_evidence_or_r
             run_id,
             unrelated_legacy_checkout,
             Some("Chris approved external proof".to_string()),
+            false,
         )
         .expect_err("legacy replacement checkout must match the original immutable fingerprint");
         assert_eq!(
@@ -18305,6 +18337,7 @@ fn replacement_gate_proof_recovers_failed_candidate_without_hiding_evidence_or_r
             run_id,
             mixed_gates,
             Some("Chris approved external proof".to_string()),
+            false,
         )
         .expect_err("an unbound private gate cannot be persisted beside a valid visible gate");
         assert_eq!(
@@ -18319,12 +18352,14 @@ fn replacement_gate_proof_recovers_failed_candidate_without_hiding_evidence_or_r
             run_id,
             replacement,
             Some("Chris approved external proof".to_string()),
+            false,
         )
         .expect("record bound green replacement proof");
         let replay = record_replacement_gate_proof(
             run_id,
             replacement_for_replay,
             Some("Chris approved external proof".to_string()),
+            false,
         )
         .expect("identical proof replay is idempotent");
         assert_eq!(

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -680,6 +680,9 @@ pub struct RecordReplacementGateProofArgs {
     /// Explicit operator authorization for externally produced proof.
     #[arg(long, value_name = "TEXT")]
     pub authorize_external_proof: Option<String>,
+    /// Accept candidate failures proven identical against the immutable base.
+    #[arg(long)]
+    pub accept_inherited_failures: bool,
 }
 #[derive(Args, Debug)]
 pub struct VerifyReplacementArgs {

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -1098,6 +1098,7 @@ pub(crate) fn record_replacement_gate_proof(
         &args.run_id,
         replacement,
         args.authorize_external_proof,
+        args.accept_inherited_failures,
     )?;
     Ok((serde_json::to_value(report).unwrap_or(Value::Null), 0))
 }

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -4762,6 +4762,7 @@ fn replacement_gate_proof_command_requires_typed_proof_and_operator_authorizatio
         "@replacement.json",
         "--authorize-external-proof",
         "Chris approved durable evidence",
+        "--accept-inherited-failures",
     ])
     .expect("replacement proof command parses");
     let Commands::AgentTask(args) = cli.command else {
@@ -4776,6 +4777,7 @@ fn replacement_gate_proof_command_requires_typed_proof_and_operator_authorizatio
         args.authorize_external_proof.as_deref(),
         Some("Chris approved durable evidence")
     );
+    assert!(args.accept_inherited_failures);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- run immutable-base comparison during replacement verification instead of dropping `--accept-inherited-failures` at the recovery boundary
- accept candidate-bound replacement reports containing explicitly authorized inherited failures and retain that policy in durable proof
- require renewed inherited-failure authorization when replaying completed automated or external proof
- add `--accept-inherited-failures` to externally recorded replacement proof

Continues #13556 and unblocks the baseline-red required gate in [homeboy-extensions#2719](https://github.com/Extra-Chill/homeboy-extensions/issues/2719).

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-agents replacement_gate`
- `cargo test -p homeboy-agents resume_promoted_patch`
- `cargo test -p homeboy-agents adoption_accepts_an_identical_immutable_baseline_failure_when_explicitly_authorized`
- `cargo test -p homeboy-cli --features test-support replacement_gate_proof_command_requires_typed_proof_and_operator_authorization`

The replacement regression runs a visible green gate plus a second gate that fails identically on candidate and immutable base, records accepted inherited evidence, and proves replay does not execute shell gates again.

## AI Assistance
- **Model:** GPT-5.6 Sol
- **Tool:** OpenCode
- **Used for:** durable recovery analysis, policy-boundary implementation, regression coverage, and verification. Chris Huber remains responsible for the resulting change.