### PR TITLE
fix(process): stop reporting a fully-read empty process scope as a possible escape

### DIFF
--- a/crates/homeboy-core/src/process.rs
+++ b/crates/homeboy-core/src/process.rs
@@ -1309,11 +1309,26 @@ fn scope_cleanup_report(
     // in /proc are diagnostic host noise, not evidence that this run survived.
     // Without a discovered target, unreadable entries can plausibly hide an
     // escaped descendant that removed its marker.
+    //
+    // That rationale is conditioned on unreadable entries EXISTING, and the
+    // guard must be too. When every same-owner `/proc` environment was read and
+    // none carried this scope, an empty target set is a measured zero: there is
+    // no unread entry left for an escapee to be hiding in. Requiring a marker
+    // regardless made the ordinary case -- a command whose processes all exited
+    // before teardown began -- indistinguishable from an escape, which is the
+    // #13128 contract `scope_cleanup_keeps_unreadable_same_owner_environments_as_diagnostics`
+    // has been asserting, red, on `main` (#13570).
+    //
+    // A command that exits FAST is the case that trips it in production: the
+    // `/proc` scan finds nothing because the process is already reaped, so its
+    // real error is discarded and replaced by a containment complaint about an
+    // escape that did not happen.
     let marker_scope_was_observed = !targets.pids.is_empty();
     let leader_reaped_cleanly =
         context == ProcessContainmentCleanupContext::LeaderReapedAfterSuccess;
-    let complete =
-        survivors.pids.is_empty() && (marker_scope_was_observed || leader_reaped_cleanly);
+    let discovery_was_complete = unreadable == 0;
+    let complete = survivors.pids.is_empty()
+        && (marker_scope_was_observed || leader_reaped_cleanly || discovery_was_complete);
     let detail = (!complete).then(|| {
         if !survivors.pids.is_empty() {
             format!(
@@ -1893,10 +1908,14 @@ mod tests {
         assert!(clean_with_unrelated_unreadables.complete);
         assert!(clean_with_unrelated_unreadables.forced);
         assert!(clean_with_unrelated_unreadables.detail.is_none());
+        // Asserted on the substring the message actually carries. `unrelated
+        // /proc` was prose this module stopped emitting; every live message here
+        // says `same-owner /proc environment entries`, and pinning wording no
+        // producer uses is how this expectation sat red without anyone reading it.
         assert!(clean_with_unrelated_unreadables
             .warning
             .as_deref()
-            .is_some_and(|warning| warning.contains("unrelated /proc")));
+            .is_some_and(|warning| warning.contains("same-owner /proc environment entries")));
 
         // A known run-owned survivor remains fail-closed even after a clean
         // leader exit.
@@ -1999,6 +2018,66 @@ mod tests {
         );
     }
 
+    /// A command that exits before teardown looks must not be reported as an
+    /// escape (#13570).
+    ///
+    /// This is keyed on the FAILING exit path on purpose. A fast non-zero exit
+    /// gets `LeaderMayBeRunning` — the context is chosen from the exit code, not
+    /// from whether the leader was reaped — so it reaches this function with no
+    /// observed marker and no clean-leader claim. Before this was fixed, that
+    /// combination discarded the command's real error and replaced it with a
+    /// containment complaint, which is how an archive-policy refusal surfaced as
+    /// "an escaped descendant may have removed HOMEBOY_PROCESS_SCOPE".
+    ///
+    /// The distinction that makes it safe is `unreadable`: every same-owner
+    /// `/proc` environment was read, so there is nowhere an escapee could be
+    /// hiding. The ambiguous case one test above — same shape, one unreadable
+    /// entry — must stay fail-closed, and does.
+    #[test]
+    fn scope_cleanup_accepts_a_command_that_exited_before_discovery_looked() {
+        let fast_failure = scope_cleanup_report(
+            LinuxScopeDiscovery {
+                pids: Vec::new(),
+                unreadable_environments: 0,
+            },
+            LinuxScopeDiscovery {
+                pids: Vec::new(),
+                unreadable_environments: 0,
+            },
+            false,
+            ProcessContainmentCleanupContext::LeaderMayBeRunning,
+        );
+
+        assert!(
+            fast_failure.complete,
+            "a fully-read scope with no members is a measured zero, not an escape: {:?}",
+            fast_failure.detail
+        );
+        assert_eq!(
+            fast_failure.detail, None,
+            "a complete cleanup must not attach a detail a caller will render as an error"
+        );
+
+        // The guard it must not weaken: one unreadable entry restores the
+        // fail-closed contract, because now something could be hidden.
+        let hidden_possible = scope_cleanup_report(
+            LinuxScopeDiscovery {
+                pids: Vec::new(),
+                unreadable_environments: 1,
+            },
+            LinuxScopeDiscovery {
+                pids: Vec::new(),
+                unreadable_environments: 1,
+            },
+            false,
+            ProcessContainmentCleanupContext::LeaderMayBeRunning,
+        );
+        assert!(
+            !hidden_possible.complete,
+            "an unread /proc environment can still hide an escapee and must fail closed"
+        );
+    }
+
     #[test]
     fn scope_cleanup_fails_closed_for_confirmed_run_owned_survivors() {
         let cleanup = scope_cleanup_report(
@@ -2016,10 +2095,13 @@ mod tests {
 
         assert!(!cleanup.complete);
         assert!(cleanup.forced);
+        // `surviving pids:` is the phrasing every other survivor message in this
+        // module uses; this expectation was the last one still pinning an older
+        // wording, and it named a pid the assertion above already proves.
         assert!(cleanup
             .detail
             .as_deref()
-            .is_some_and(|detail| detail.contains("run-owned survivors: 43")));
+            .is_some_and(|detail| detail.contains("surviving pids: 43")));
         assert!(cleanup.diagnostic.is_some());
     }
 


### PR DESCRIPTION
## Summary

A command that exits **before** containment teardown scans `/proc` leaves no marker-owned process to find. `scope_cleanup_report` read that absence as a possible escape, reported the cleanup incomplete, and the caller discarded the command's real error in favour of:

```
Install command failed (exit 1): Homeboy containment cleanup was incomplete:
process-scope discovery found no marker-owned process; an escaped descendant
may have removed HOMEBOY_PROCESS_SCOPE.
```

Nothing escaped. The leader was reaped — it just exited faster than discovery could look.

This is `local_exec`, so it is not test-only: any locally-executed build, install or deploy command that fails fast could have its diagnostic replaced this way. It bites hardest on the **validation-refusal path**, where the error text matters most and the process legitimately never lingers.

## Root cause

The guard was broader than the rationale written immediately above it:

```rust
// Without a discovered target, unreadable entries can plausibly hide an
// escaped descendant that removed its marker.
let complete = survivors.pids.is_empty() && (marker_scope_was_observed || leader_reaped_cleanly);
```

That reasoning is conditioned on unreadable entries **existing** — but the code required a marker regardless of `unreadable`. So the ordinary end state of every command whose processes exited became indistinguishable from an escape.

```diff
+let discovery_was_complete = unreadable == 0;
-let complete = survivors.pids.is_empty() && (marker_scope_was_observed || leader_reaped_cleanly);
+let complete = survivors.pids.is_empty()
+    && (marker_scope_was_observed || leader_reaped_cleanly || discovery_was_complete);
```

When every same-owner `/proc` environment was read and none carried this scope, an empty target set is a **measured zero** — there is nowhere left for an escapee to hide. One unreadable entry and the fail-closed contract returns unchanged.

## This restores a contract that was already asserted, and already red

`scope_cleanup_keeps_unreadable_same_owner_environments_as_diagnostics` has been failing on `main`, stating exactly this:

> A scope that is already empty when teardown starts is the ordinary end state of every command whose processes exited. It must report clean and say nothing (#13128).

The test was right and the production code contradicted it. **The logic fix is in the code, not the test.**

Two *separate* expectations in the same module pinned prose no producer emits any more — `run-owned survivors:` and `unrelated /proc`. Every live message says `surviving pids:` and `same-owner /proc environment entries`; these were the last two still pinning older wording, which is how they sat red without being read. Those two are repointed at the current strings. **No message text is changed by this PR.**

## How to test

1. `cargo nextest run -p homeboy-deploy --lib` → **323 passed, 0 failed**. On `main`: 322/1.
2. `cargo nextest run -p homeboy-core --lib` → 2650 passed, 3 failed. On `main`: 2648 passed, **5** failed. The 3 remaining are pre-existing and untouched by this change (see below).
3. `cargo check --workspace --all-targets` → clean, no warnings.

New test `scope_cleanup_accepts_a_command_that_exited_before_discovery_looked` pins both directions: the fast-exit case is complete with no detail, and the same shape with one unreadable entry still fails closed.

## Compatibility

Behavioural change is confined to the completeness **verdict**. On Linux, `context` reaches this function only through `scope_cleanup_report` — `terminate_linux_scope_members_with_grace` sends SIGTERM and escalates to SIGKILL before consulting it, and `cleanup_with_grace` tears down the process group unconditionally. **No termination behaviour changes.** A confirmed survivor still fails closed; incomplete discovery still fails closed.

**Pre-existing red, not caused here.** `cargo nextest run -p homeboy-core --lib` leaves 3 failures, verified identical on clean `main` by stashing this branch in the same worktree:

- `observation::store::artifacts::tests::lifecycle_open_does_not_wait_for_rollback_writer_maintenance_lock`
- `worktree::tests::create_restores_worktree_with_relative_gitdir_pointers`
- `worktree::tests::create_reuses_existing_worktree_with_a_relative_gitdir_pointer`

Another undeclared red spot on `main`, the third found today after #13561 and this one. Not folded in here.

## Note on #13273

This is the **only** genuine failure in `homeboy-deploy`. The other 9 in that issue's deploy half are a test-harness artifact — `cargo test` shares one hermetic `TMPDIR` across all 323 tests while `nextest` (which CI runs) gives each its own. Analysis: https://github.com/Extra-Chill/homeboy/issues/13273#issuecomment-5420745700

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Used for:** isolated this from the harness artifacts it was bundled with, traced the guard against its own stated rationale, confirmed on Linux that `context` cannot affect termination, and baselined the remaining core failures against clean `main`. Chris Huber reviewed and owns this change.

Closes #13570
Refs #13273, #13128, #8010
