### PR TITLE
Persist explicit agent-task provider launch context

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -3420,6 +3420,62 @@ pub fn reserve_provider_execution_in_store(
     Ok(reservation)
 }
 
+/// Attach the complete, redacted launch contract to the reservation before the
+/// provider subprocess exists. Recovery can then distinguish a portable launch
+/// from one still bound to ambient controller credentials.
+pub fn record_provider_launch_context_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    task_id: &str,
+    attempt: u32,
+    context: &crate::agent_task_provider::AgentTaskProviderLaunchContext,
+) -> Result<AgentTaskRunRecord> {
+    let run_id = sanitize_run_id(run_id);
+    let key = format!("{task_id}:{attempt}");
+    if context.run_id.as_deref() != Some(run_id.as_str())
+        || context.task_id != task_id
+        || context.attempt != attempt
+    {
+        return Err(Error::validation_invalid_argument(
+            "provider_launch_context",
+            "provider launch context identity does not match its reservation",
+            Some(key),
+            None,
+        ));
+    }
+    let value = serde_json::to_value(context).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize provider launch context".to_string()),
+        )
+    })?;
+    let record = lifecycle_store.mutate_record(&run_id, |record| {
+        let Some(execution) = record.metadata["provider_executions"]
+            .as_array_mut()
+            .and_then(|executions| {
+                executions
+                    .iter_mut()
+                    .find(|execution| execution["key"] == key)
+            })
+        else {
+            return false;
+        };
+        if execution.get("launch_context").is_some() {
+            return execution["launch_context"] == value;
+        }
+        execution["launch_context"] = value.clone();
+        true
+    })?;
+    record.ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "provider_execution",
+            "cannot attach launch context to an unreserved or conflicting provider execution",
+            Some(key),
+            None,
+        )
+    })
+}
+
 /// Bind a reserved provider execution to the subprocess that actually runs it.
 ///
 /// Fanout workers are threads and therefore share the coordinator PID. The

--- a/crates/homeboy-agents/src/agent_task_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_provider.rs
@@ -43,6 +43,7 @@ pub mod discovery;
 mod dispatchability;
 mod executor;
 mod fixture_gate;
+mod launch_context;
 // The `fixture` backend is a test double, not an agent runtime. Its
 // implementation is compiled only into test builds; see `fixture_gate`.
 #[cfg(any(test, feature = "test-support"))]
@@ -89,6 +90,10 @@ pub use dispatchability::{
 };
 pub(crate) use fixture_gate::fixture_provider_outcome;
 pub use fixture_gate::is_fixture_backend;
+pub use launch_context::{
+    AgentTaskProviderLaunchContext, AGENT_TASK_PROVIDER_LAUNCH_CONTEXT_JSON_ENV,
+    AGENT_TASK_PROVIDER_LAUNCH_CONTEXT_SCHEMA,
+};
 pub use resolution::{resolve_provider_for_backend, ProviderResolution};
 pub(crate) use resolution::{
     role_aliases_for_executor, role_aliases_for_provider, selector_runtime_provider_hint,

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -103,8 +103,7 @@ impl ProviderOutputCapture {
 pub(super) fn run_materialized_provider_command(
     request: &AgentTaskExecutorRequest,
     provider: &AgentTaskExecutorProvider,
-    run_id: Option<&str>,
-    execution_attempt: u32,
+    execution: &AgentTaskExecutionContext,
 ) -> AgentTaskOutcome {
     let mut retry_attempt = 1;
     // This state belongs to one invocation's retry sequence. It cannot couple
@@ -112,8 +111,7 @@ pub(super) fn run_materialized_provider_command(
     let mut prior_immediate_failure = None;
     loop {
         let started = Instant::now();
-        let mut outcome =
-            run_materialized_provider_command_once(request, provider, run_id, execution_attempt);
+        let mut outcome = run_materialized_provider_command_once(request, provider, execution);
         classify_provider_policy_denial(request, &mut outcome);
         classify_transient_provider_outcome(&mut outcome);
 
@@ -142,7 +140,7 @@ pub(super) fn run_materialized_provider_command(
                     }),
                 });
                 attach_runtime_tool_provenance(request, &mut outcome);
-                link_latest_executor_evidence(request, &mut outcome, run_id);
+                link_latest_executor_evidence(request, &mut outcome, execution.run_id.as_deref());
                 return outcome;
             }
             prior_immediate_failure = Some(failure.signature);
@@ -160,7 +158,7 @@ pub(super) fn run_materialized_provider_command(
             attach_runtime_tool_provenance(request, &mut outcome);
             // Preserve and link the latest raw executor input/result as
             // first-class run evidence before returning the final outcome.
-            link_latest_executor_evidence(request, &mut outcome, run_id);
+            link_latest_executor_evidence(request, &mut outcome, execution.run_id.as_deref());
             return outcome;
         }
 
@@ -611,16 +609,14 @@ impl ProviderContainmentReport {
 pub(super) fn run_materialized_provider_command_once(
     request: &AgentTaskExecutorRequest,
     provider: &AgentTaskExecutorProvider,
-    run_id: Option<&str>,
-    attempt: u32,
+    execution: &AgentTaskExecutionContext,
 ) -> AgentTaskOutcome {
     let mut containment_report = ProviderContainmentReport::default();
     let mut outcome = run_materialized_provider_command_once_contained(
         request,
         provider,
         &mut containment_report,
-        run_id,
-        attempt,
+        execution,
     );
     containment_report.annotate(&mut outcome);
     if let Err(error) = retain_failed_workspace_artifacts(&mut outcome, request) {
@@ -639,9 +635,10 @@ fn run_materialized_provider_command_once_contained(
     request: &AgentTaskExecutorRequest,
     provider: &AgentTaskExecutorProvider,
     containment_report: &mut ProviderContainmentReport,
-    run_id: Option<&str>,
-    attempt: u32,
+    execution: &AgentTaskExecutionContext,
 ) -> AgentTaskOutcome {
+    let run_id = execution.run_id.as_deref();
+    let attempt = execution.attempt;
     let command = render_provider_command_display(provider);
     let deadline_remaining_ms = crate::agent_task_timeout::remaining_execution_deadline_ms(
         request.limits.execution_deadline_unix_ms,
@@ -811,7 +808,54 @@ fn run_materialized_provider_command_once_contained(
         ));
     }
 
+    let launch_context = match AgentTaskProviderLaunchContext::materialize(
+        &request.request,
+        provider,
+        execution,
+        cwd.as_deref(),
+        &env,
+    ) {
+        Ok(context) => context,
+        Err(error) => {
+            return failure_outcome(
+                request,
+                AgentTaskOutcomeStatus::ProviderError,
+                AgentTaskFailureClassification::InvalidInput,
+                "agent_task.provider_launch_context_invalid",
+                error.to_string(),
+                json!({ "provider": provider.id }),
+            )
+        }
+    };
+    if let (Some(store), Some(run_id)) = (execution.lifecycle_store(), run_id) {
+        if let Err(error) = store.record_provider_launch_context(
+            run_id,
+            &request.request.task_id,
+            attempt,
+            &launch_context,
+        ) {
+            return failure_outcome(
+                request,
+                AgentTaskOutcomeStatus::ProviderError,
+                AgentTaskFailureClassification::Provider,
+                "agent_task.provider_launch_context_persistence_failed",
+                error.to_string(),
+                json!({ "provider": provider.id, "run_id": run_id }),
+            );
+        }
+    }
+
     let mut command_builder = Command::new(&program);
+    if let Err(error) = launch_context.apply_declared_environment(&mut command_builder) {
+        return failure_outcome(
+            request,
+            AgentTaskOutcomeStatus::ProviderError,
+            AgentTaskFailureClassification::InvalidInput,
+            "agent_task.provider_launch_environment_invalid",
+            error.to_string(),
+            json!({ "provider": provider.id }),
+        );
+    }
     command_builder.args(&args).envs(
         env.iter()
             .map(|(key, value)| (key.as_str(), value.as_str())),
@@ -916,12 +960,22 @@ fn run_materialized_provider_command_once_contained(
     if let Some(run_id) = run_id {
         // Failure to record this diagnostic identity must not interrupt provider
         // execution. The reservation remains the execution authority.
-        let _ = crate::agent_task_lifecycle::record_provider_execution_process(
-            run_id,
-            &request.request.task_id,
-            attempt,
-            child.id(),
-        );
+        if let Some(store) = execution.lifecycle_store() {
+            let _ = crate::agent_task_lifecycle::record_provider_execution_process_in_store(
+                store,
+                run_id,
+                &request.request.task_id,
+                attempt,
+                child.id(),
+            );
+        } else {
+            let _ = crate::agent_task_lifecycle::record_provider_execution_process(
+                run_id,
+                &request.request.task_id,
+                attempt,
+                child.id(),
+            );
+        }
     }
 
     if let Err(error) = containment.attach(&child) {
@@ -1503,7 +1557,8 @@ pub(super) fn run_provider_command(
     run_id: Option<&str>,
 ) -> AgentTaskOutcome {
     let materialized = test_executor_request(request);
-    run_materialized_provider_command(&materialized, provider, run_id, 1)
+    let context = test_execution_context(run_id);
+    run_materialized_provider_command(&materialized, provider, &context)
 }
 
 #[cfg(test)]
@@ -1512,7 +1567,19 @@ pub(super) fn run_provider_command_once(
     provider: &AgentTaskExecutorProvider,
 ) -> AgentTaskOutcome {
     let materialized = test_executor_request(request);
-    run_materialized_provider_command_once(&materialized, provider, None, 1)
+    let context = test_execution_context(None);
+    run_materialized_provider_command_once(&materialized, provider, &context)
+}
+
+#[cfg(test)]
+fn test_execution_context(run_id: Option<&str>) -> AgentTaskExecutionContext {
+    AgentTaskExecutionContext {
+        plan_id: "provider-unit-test".to_string(),
+        run_id: run_id.map(str::to_string),
+        attempt: 1,
+        cancellation: crate::agent_task_scheduler::AgentTaskCancellationToken::default(),
+        lifecycle_store: None,
+    }
 }
 
 #[cfg(test)]
@@ -2673,7 +2740,7 @@ pub(super) fn provider_command_env(
     env.extend(provider_executable_env(provider).map_err(ProviderCommandEnvError::Executable)?);
     env.extend(
         resolve_secret_env_with_fallbacks(
-            &request.executor.secret_env,
+            &secret_env_plan.secret_env_names(),
             &provider_secret_sources(provider, Some(request)),
         )
         .map_err(ProviderCommandEnvError::Secret)?,

--- a/crates/homeboy-agents/src/agent_task_provider/executor.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/executor.rs
@@ -235,12 +235,7 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
                 &ready_tools,
             ));
 
-        run_materialized_provider_command(
-            &request,
-            &provider,
-            context.run_id.as_deref(),
-            context.attempt,
-        )
+        run_materialized_provider_command(&request, &provider, &context)
     }
 }
 
@@ -505,6 +500,7 @@ mod tests {
             run_id: Some("blocked-run".to_string()),
             attempt: 1,
             cancellation: Default::default(),
+            lifecycle_store: None,
         };
 
         let (_, path, error) = materialize_executor_request_at_root(

--- a/crates/homeboy-agents/src/agent_task_provider/launch_context.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/launch_context.rs
@@ -1,0 +1,271 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+use super::{AgentTaskExecutorProvider, AgentTaskRequest};
+use crate::agent_task_scheduler::AgentTaskExecutionContext;
+use homeboy_core::secret_env_plan::SecretEnvPlan;
+use homeboy_core::{Error, Result};
+
+pub const AGENT_TASK_PROVIDER_LAUNCH_CONTEXT_SCHEMA: &str =
+    "homeboy/agent-task-provider-launch-context/v1";
+pub const AGENT_TASK_PROVIDER_LAUNCH_CONTEXT_JSON_ENV: &str =
+    "HOMEBOY_AGENT_TASK_PROVIDER_LAUNCH_CONTEXT_JSON";
+
+// These are process mechanics, not credentials. Provider-specific additions
+// must be declared by the provider invocation instead of widening this list.
+const BASE_INHERITED_ENV: &[&str] = &[
+    "PATH",
+    "HOME",
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+    "USER",
+    "LOGNAME",
+    "SHELL",
+    "LANG",
+    "LC_ALL",
+    "TERM",
+    "XDG_CONFIG_HOME",
+    "XDG_CACHE_HOME",
+    "XDG_DATA_HOME",
+    "XDG_STATE_HOME",
+    "RUSTUP_HOME",
+    "CARGO_HOME",
+    "NVM_DIR",
+    "VOLTA_HOME",
+    "PNPM_HOME",
+    "BUN_INSTALL",
+];
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AgentTaskProviderLaunchContext {
+    pub schema: String,
+    pub plan_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    pub task_id: String,
+    pub attempt: u32,
+    pub provider_id: String,
+    pub backend: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_root: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub inherited_env_names: Vec<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub public_env: BTreeMap<String, String>,
+    pub secret_env_plan: SecretEnvPlan,
+    pub portable: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub portability_blockers: Vec<String>,
+}
+
+impl AgentTaskProviderLaunchContext {
+    pub fn materialize(
+        request: &AgentTaskRequest,
+        provider: &AgentTaskExecutorProvider,
+        execution: &AgentTaskExecutionContext,
+        cwd: Option<&Path>,
+        declared_env: &[(String, String)],
+    ) -> Result<Self> {
+        let mut inherited_env_names = BASE_INHERITED_ENV
+            .iter()
+            .filter(|name| std::env::var_os(name).is_some())
+            .map(|name| (*name).to_string())
+            .collect::<BTreeSet<_>>();
+        let secret_env_plan =
+            super::secrets::provider_secret_env_plan_with_status(provider, request);
+        let secret_env_names = secret_env_plan
+            .secret_env_names()
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+        let mut public_env = BTreeMap::new();
+
+        for env_ref in &provider.invocation.env {
+            if let Some(value) = env_ref.value.as_ref() {
+                if env_ref.redacted.unwrap_or(false) || secret_env_names.contains(&env_ref.name) {
+                    return Err(Error::validation_invalid_argument(
+                        "provider.invocation.env",
+                        "provider launch context rejects inline secret environment values",
+                        Some(env_ref.name.clone()),
+                        None,
+                    ));
+                }
+                public_env.insert(env_ref.name.clone(), value.clone());
+                continue;
+            }
+            if secret_env_names.contains(&env_ref.name) {
+                continue;
+            }
+            if matches!(env_ref.source.as_deref(), Some("env" | "inherit")) {
+                if std::env::var_os(&env_ref.name).is_none() && env_ref.required.unwrap_or(false) {
+                    return Err(Error::validation_invalid_argument(
+                        "provider.invocation.env",
+                        "provider launch context is missing a required inherited environment variable",
+                        Some(env_ref.name.clone()),
+                        None,
+                    ));
+                }
+                if std::env::var_os(&env_ref.name).is_some() {
+                    inherited_env_names.insert(env_ref.name.clone());
+                }
+            }
+        }
+
+        for (name, value) in declared_env {
+            if !secret_env_names.contains(name) {
+                public_env.insert(name.clone(), value.clone());
+            }
+        }
+        let ambient_secret_env_names = secret_env_plan
+            .status
+            .iter()
+            .filter(|status| status.configured && status.source == "env")
+            .map(|status| status.name.clone())
+            .collect::<Vec<_>>();
+        let portability_blockers = (!ambient_secret_env_names.is_empty())
+            .then(|| format!("ambient_secret_env:{}", ambient_secret_env_names.join(",")))
+            .into_iter()
+            .collect::<Vec<_>>();
+
+        Ok(Self {
+            schema: AGENT_TASK_PROVIDER_LAUNCH_CONTEXT_SCHEMA.to_string(),
+            plan_id: execution.plan_id.clone(),
+            run_id: execution.run_id.clone(),
+            task_id: request.task_id.clone(),
+            attempt: execution.attempt,
+            provider_id: provider.id.clone(),
+            backend: provider.backend.clone(),
+            runtime_id: provider.runtime_id.clone(),
+            workspace_root: request.workspace.root.clone(),
+            execution_cwd: cwd.map(|path| path.display().to_string()),
+            inherited_env_names: inherited_env_names.into_iter().collect(),
+            public_env,
+            secret_env_plan,
+            portable: portability_blockers.is_empty(),
+            portability_blockers,
+        })
+    }
+
+    pub fn apply_declared_environment(&self, command: &mut Command) -> Result<()> {
+        if self.schema != AGENT_TASK_PROVIDER_LAUNCH_CONTEXT_SCHEMA {
+            return Err(Error::validation_invalid_argument(
+                "provider_launch_context.schema",
+                "provider launch context has an unsupported schema",
+                Some(self.schema.clone()),
+                None,
+            ));
+        }
+
+        command.env_clear();
+        for name in &self.inherited_env_names {
+            let value = std::env::var_os(name).ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "provider_launch_context.inherited_env_names",
+                    "declared inherited environment changed before provider spawn",
+                    Some(name.clone()),
+                    None,
+                )
+            })?;
+            command.env(name, value);
+        }
+        command.envs(&self.public_env);
+        command.env(
+            AGENT_TASK_PROVIDER_LAUNCH_CONTEXT_JSON_ENV,
+            serde_json::to_string(self).map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("serialize provider launch context".to_string()),
+                )
+            })?,
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_task_scheduler::{AgentTaskPlan, AgentTaskScheduler};
+    use serde_json::json;
+    use std::sync::Arc;
+
+    fn request(task_id: &str, secret_name: &str) -> AgentTaskRequest {
+        serde_json::from_value(json!({
+            "task_id": task_id,
+            "executor": {
+                "backend": "test",
+                "secret_env": [secret_name]
+            },
+            "instructions": "run"
+        }))
+        .expect("request")
+    }
+
+    fn provider(secret_name: &str) -> AgentTaskExecutorProvider {
+        serde_json::from_value(json!({
+            "id": "test.provider",
+            "backend": "test",
+            "runtime_id": "test-runtime",
+            "invocation": {
+                "argv": ["true"],
+                "env": [
+                    { "name": secret_name, "source": "secret_env", "redacted": true },
+                    { "name": "PROVIDER_MODE", "value": "test" }
+                ]
+            }
+        }))
+        .expect("provider")
+    }
+
+    #[test]
+    fn launch_context_is_redacted_and_durably_bound_to_the_provider_reservation() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        let secret_name = format!("HOMEBOY_TEST_LAUNCH_SECRET_{}", std::process::id());
+        let secret_value = format!("launch-secret-value-{}", std::process::id());
+        let _secret = homeboy_core::test_support::EnvVarGuard::set(&secret_name, &secret_value);
+        let request = request("launch-context-task", &secret_name);
+        let provider = provider(&secret_name);
+        let run_id = "launch-context-run";
+        let plan = AgentTaskPlan::new("launch-context-plan", vec![request.clone()]);
+        crate::agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("durable run");
+        let store =
+            crate::agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()
+                .expect("lifecycle store");
+        AgentTaskScheduler::new(Arc::new(
+            super::super::ExtensionProviderAgentTaskExecutor::with_providers(vec![provider]),
+        ))
+        .with_run_id(run_id)
+        .with_lifecycle_store(store.clone())
+        .run(plan);
+
+        let record = store.read_record(run_id).expect("durable record");
+        let context = &record.metadata["provider_executions"][0]["launch_context"];
+        assert_eq!(context["schema"], AGENT_TASK_PROVIDER_LAUNCH_CONTEXT_SCHEMA);
+        assert_eq!(context["provider_id"], "test.provider");
+        assert_eq!(context["public_env"]["PROVIDER_MODE"], "test");
+        assert_eq!(
+            context["public_env"]["HOMEBOY_AGENT_TASK_PROVIDER_ID"],
+            "test.provider"
+        );
+        assert_eq!(context["portable"], false);
+        assert!(context["portability_blockers"][0]
+            .as_str()
+            .expect("portability blocker")
+            .contains(&secret_name));
+        assert!(context["public_env"].get(&secret_name).is_none());
+        assert!(!context["inherited_env_names"]
+            .as_array()
+            .expect("inherited environment names")
+            .iter()
+            .any(|name| name == &secret_name));
+        assert!(!record.metadata.to_string().contains(&secret_value));
+    }
+}

--- a/crates/homeboy-agents/src/agent_task_provider/secrets.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/secrets.rs
@@ -49,6 +49,16 @@ fn provider_secret_env(
     request: Option<&AgentTaskRequest>,
 ) -> Vec<String> {
     let mut names = Vec::new();
+    names.extend(
+        provider
+            .invocation
+            .env
+            .iter()
+            .filter(|env| {
+                env.source.as_deref() == Some("secret_env") || env.redacted.unwrap_or(false)
+            })
+            .map(|env| env.name.clone()),
+    );
     for readiness in &provider.runner_readiness {
         names.extend(readiness.secret_env.iter().cloned());
     }

--- a/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
@@ -189,6 +189,7 @@ fn provider_missing_chains_matching_runtime_discovery_diagnostics() {
             run_id: None,
             attempt: 1,
             cancellation: AgentTaskCancellationToken::default(),
+            lifecycle_store: None,
         },
     );
 
@@ -277,6 +278,7 @@ process.stdin.on('end', () => {
             ),
             attempt: 1,
             cancellation: Default::default(),
+            lifecycle_store: None,
         },
     );
     assert_eq!(outcome.status, AgentTaskOutcomeStatus::ProviderError);
@@ -363,6 +365,7 @@ process.stdin.once('data', input => {
             run_id: None,
             attempt: 1,
             cancellation: Default::default(),
+            lifecycle_store: None,
         },
     );
 
@@ -428,6 +431,7 @@ fn runtime_tool_cannot_claim_capability_without_a_probe() {
             run_id: None,
             attempt: 1,
             cancellation: Default::default(),
+            lifecycle_store: None,
         },
     );
 
@@ -475,6 +479,7 @@ fn runtime_tool_without_capabilities_is_usable_without_a_probe() {
             run_id: None,
             attempt: 1,
             cancellation: Default::default(),
+            lifecycle_store: None,
         },
     );
 
@@ -516,6 +521,7 @@ fn runtime_tool_readiness_obeys_the_command_policy() {
             run_id: None,
             attempt: 1,
             cancellation: Default::default(),
+            lifecycle_store: None,
         },
     );
 
@@ -562,6 +568,7 @@ fn runtime_tool_capability_probe_obeys_the_command_policy() {
             run_id: None,
             attempt: 1,
             cancellation: Default::default(),
+            lifecycle_store: None,
         },
     );
 

--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -1053,6 +1053,35 @@ fn provider_command_receives_declared_secret_env() {
 }
 
 #[test]
+fn provider_command_receives_only_the_declared_launch_environment() {
+    let secret_name = format!("HOMEBOY_TEST_DECLARED_LAUNCH_SECRET_{}", std::process::id());
+    let ambient_name = format!("HOMEBOY_TEST_UNDECLARED_LAUNCH_ENV_{}", std::process::id());
+    std::env::set_var(&secret_name, "declared-secret");
+    std::env::set_var(&ambient_name, "must-not-leak");
+    let command = format!(
+        "node {}",
+        script(&format!(
+            "let fs=require('fs');let req=JSON.parse(fs.readFileSync(0,'utf8'));let launch=JSON.parse(process.env.{});let secretOk=process.env.{secret_name}==='declared-secret';let ambientAbsent=process.env.{ambient_name}===undefined;let redacted=!JSON.stringify(launch).includes('declared-secret');let identity=launch.task_id===req.task_id&&launch.schema==='homeboy/agent-task-provider-launch-context/v1';process.stdout.write(JSON.stringify({{schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:secretOk&&ambientAbsent&&redacted&&identity?'succeeded':'failed',summary:'launch context checked'}}));",
+            crate::agent_task_provider::AGENT_TASK_PROVIDER_LAUNCH_CONTEXT_JSON_ENV
+        ))
+    );
+    let (mut request, provider) = request("task-declared-launch-env", command);
+    request.executor.secret_env = vec![secret_name.clone()];
+    let scheduler = AgentTaskScheduler::new(Arc::new(
+        ExtensionProviderAgentTaskExecutor::with_providers(vec![provider]),
+    ));
+
+    let aggregate = scheduler.run(AgentTaskPlan::new(
+        "plan-declared-launch-env",
+        vec![request],
+    ));
+
+    assert_eq!(aggregate.totals.succeeded, 1, "{aggregate:?}");
+    std::env::remove_var(secret_name);
+    std::env::remove_var(ambient_name);
+}
+
+#[test]
 fn provider_command_receives_canonical_secret_env_plan_without_values() {
     let secret_name = format!("HOMEBOY_TEST_AGENT_TASK_PLAN_SECRET_{}", std::process::id());
     std::env::set_var(&secret_name, "hydrated-secret");

--- a/crates/homeboy-agents/src/agent_task_provider/tests/selection_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/selection_tests.rs
@@ -191,6 +191,7 @@ fn repo_local_gate_execution_kind_runs_without_extension_provider() {
             run_id: Some("gate-run".to_string()),
             attempt: 1,
             cancellation: AgentTaskCancellationToken::default(),
+            lifecycle_store: None,
         },
     );
 

--- a/crates/homeboy-agents/src/agent_task_schedule.rs
+++ b/crates/homeboy-agents/src/agent_task_schedule.rs
@@ -749,6 +749,15 @@ mod cancellation {
         pub run_id: Option<String>,
         pub attempt: u32,
         pub cancellation: AgentTaskCancellationToken,
+        pub(crate) lifecycle_store: Option<crate::agent_task_lifecycle::AgentTaskLifecycleStore>,
+    }
+
+    impl AgentTaskExecutionContext {
+        pub(crate) fn lifecycle_store(
+            &self,
+        ) -> Option<&crate::agent_task_lifecycle::AgentTaskLifecycleStore> {
+            self.lifecycle_store.as_ref()
+        }
     }
 }
 

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -718,6 +718,10 @@ impl AgentTaskScheduler {
                     run_id: self.run_id.clone(),
                     attempt,
                     cancellation: cancellation.clone(),
+                    lifecycle_store: self
+                        .run_id
+                        .as_ref()
+                        .and_then(|_| self.durable_lifecycle_store().ok().cloned()),
                 };
 
                 if let Some(run_id) = self.run_id.as_deref() {

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -310,6 +310,18 @@ impl AgentTaskLifecycleStore {
         super::lifecycle_ops::reserve_provider_execution_in_store(self, run_id, task, attempt)
     }
 
+    pub(crate) fn record_provider_launch_context(
+        &self,
+        run_id: &str,
+        task_id: &str,
+        attempt: u32,
+        context: &crate::agent_task_provider::AgentTaskProviderLaunchContext,
+    ) -> Result<AgentTaskRunRecord> {
+        super::lifecycle_ops::record_provider_launch_context_in_store(
+            self, run_id, task_id, attempt, context,
+        )
+    }
+
     pub(crate) fn record_provider_execution_terminal(
         &self,
         run_id: &str,


### PR DESCRIPTION
## Summary

- define the versioned `homeboy/agent-task-provider-launch-context/v1` contract
- durably bind each redacted launch context to its provider-execution reservation before spawn
- clear ambient provider environments and materialize only declared public, inherited, and secret-plan inputs
- keep credential-bearing SSH agent and proxy variables out of implicit inheritance

This advances the durable orchestration work tracked in #11839 and the lifecycle consolidation direction in #8010.

## Verification

- `cargo check -p homeboy-agents --tests`
- `cargo test -p homeboy-agents launch_context_is_redacted_and_durably_bound_to_the_provider_reservation -- --nocapture`
- `cargo test -p homeboy-agents provider_command_receives_only_the_declared_launch_environment -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`

The broader provider suite has 126 passing tests and three existing failures. Two were independently reproduced on exact `main`: bounded stderr truncation accounting and the remapped Cook component-resolution timeout. The third liveness fixture passes alone and intermittently races only in the parallel suite. Clippy is currently blocked by pre-existing Rust 1.95 warnings in untouched files.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode inspected the provider lifecycle and environment boundaries, implemented the contract and durable persistence, diagnosed baseline failures, and ran verification. Chris Huber directed and reviewed the work.