### PR TITLE
fix(cook): consume retry launch token once

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
@@ -516,7 +516,12 @@ fn consume_local_cook_launch_token() -> bool {
     ) else {
         return false;
     };
-    consume_local_cook_launch_token_at(&token, &PathBuf::from(path))
+    let consumed = consume_local_cook_launch_token_at(&token, &PathBuf::from(path));
+    if consumed {
+        std::env::remove_var(LOCAL_COOK_LAUNCH_TOKEN_ENV);
+        std::env::remove_var(LOCAL_COOK_LAUNCH_TOKEN_PATH_ENV);
+    }
+    consumed
 }
 
 fn local_cook_launch_token_is_present() -> bool {
@@ -1677,6 +1682,22 @@ mod tests {
         let (token, path) = create_local_cook_launch_token(directory.path()).expect("launch token");
         assert!(consume_local_cook_launch_token_at(token.as_ref(), &path));
         assert!(!consume_local_cook_launch_token_at(token.as_ref(), &path));
+    }
+
+    #[test]
+    fn consumed_launch_token_is_not_inherited_by_nested_cook() {
+        let directory = tempfile::tempdir().expect("temporary token directory");
+        let (token, path) = create_local_cook_launch_token(directory.path()).expect("launch token");
+        let _env = super::super::tests::EnvGuard::set_many(&[
+            (LOCAL_COOK_LAUNCH_TOKEN_ENV, Some(token.as_str())),
+            (
+                LOCAL_COOK_LAUNCH_TOKEN_PATH_ENV,
+                Some(path.to_str().expect("UTF-8 token path")),
+            ),
+        ]);
+
+        assert!(consume_local_cook_launch_token());
+        assert!(!local_cook_launch_token_is_present());
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/infra/route/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/mod.rs
@@ -76,7 +76,7 @@ impl EnvGuard {
         Self::set_many(&[(name, None)])
     }
 
-    fn set_many(changes: &[(&'static str, Option<&str>)]) -> Self {
+    pub(super) fn set_many(changes: &[(&'static str, Option<&str>)]) -> Self {
         let guard = env_lock().lock().unwrap_or_else(|err| err.into_inner());
         let mut previous = Vec::with_capacity(changes.len());
         for (name, value) in changes {


### PR DESCRIPTION
## Summary

Fixes the next pre-provider continuation boundary tracked by #13539. A supervised local retry child consumed its one-use readiness token, then leaked the stale token environment into the nested provider-capable Cook. That Cook waited for the already-consumed token file and failed with `empty_detached_plan` before provider execution.

## Changes

- clear the launch-token value and path from the child environment after successful consumption
- cover the nested-Cook inheritance boundary with a focused regression

## Verification

- `cargo test -p homeboy-cli --features test-support consumed_launch_token_is_not_inherited_by_nested_cook -- --test-threads=1`
- `cargo test -p homeboy-cli --features test-support launch_token -- --test-threads=1`
- `cargo fmt --all --check`
- `git diff --check`

## Reproduction Evidence

The preserved #13539 Cook reached runtime admission and then exited with zero provider executions. Its detached child log reported:

```text
Invalid argument 'detach-after-handoff': detached Cook ownership was not published before the bounded admission deadline
classification: empty_detached_plan
```

The MDI candidate remained unchanged.

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode traced the durable Cook and detached-child log, identified the stale one-use token inheritance, implemented the bounded fix, and ran focused verification. Chris Huber directed the investigation and continuation.