### PR TITLE
test(controller): add reusable driver handle harness

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_job.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_job.rs
@@ -834,6 +834,69 @@ mod tests {
         });
     }
 
+    #[test]
+    fn resume_supervises_then_replays_a_completed_checkpoint_idempotently() {
+        with_isolated_home(|_| {
+            let cook_id = "cook-controller-resume-harness";
+            agent_task_lifecycle::record_detached_cook_handoff_parent_in_store(
+                &test_lifecycle_store(),
+                cook_id,
+            )
+            .expect("persist handoff parent");
+            let request = request_of(cook_id, u32::MAX);
+            let driver: Arc<dyn ControllerJobDriver> = Arc::new(CookJobDriver);
+            let harness = ControllerJobHarness::new(Arc::clone(&driver), request.clone())
+                .expect("construct controller job harness");
+            let supervising = driver.prepare(request).expect("prepare cook job");
+
+            let observed = driver
+                .resume(supervising.clone(), harness.handle())
+                .expect("resume supervision of dead child");
+
+            assert_eq!(observed["phase"], "completed");
+            assert_eq!(observed["terminal_state"], "failed");
+            let mut completed = supervising;
+            completed["phase"] = json!("completed");
+            completed["terminal_state"] = json!("failed");
+            let first = driver
+                .resume(completed.clone(), harness.handle())
+                .expect("first completed replay");
+            let second = driver
+                .resume(completed, harness.handle())
+                .expect("second completed replay");
+            assert_eq!(first, second);
+            assert_eq!(first, observed);
+        });
+    }
+
+    #[test]
+    fn cancellation_requested_through_the_harness_stops_supervision() {
+        with_isolated_home(|_| {
+            let cook_id = "cook-controller-cancel-harness";
+            agent_task_lifecycle::record_detached_cook_handoff_parent_in_store(
+                &test_lifecycle_store(),
+                cook_id,
+            )
+            .expect("persist handoff parent");
+            let request = request_of(cook_id, u32::MAX);
+            let driver: Arc<dyn ControllerJobDriver> = Arc::new(CookJobDriver);
+            let harness = ControllerJobHarness::new(Arc::clone(&driver), request.clone())
+                .expect("construct controller job harness");
+            harness
+                .request_cancellation("test cancellation")
+                .expect("request cancellation");
+            let handle = harness.handle();
+            assert!(handle.is_cancelled());
+
+            let result = driver
+                .execute(driver.prepare(request).expect("prepare cook job"), handle)
+                .expect("stop supervision after cancellation");
+
+            assert_eq!(result["phase"], "completed");
+            assert_eq!(result["terminal_state"], "failed");
+        });
+    }
+
     /// A child that ended without ever publishing durable identity is not a
     /// success. Reporting it as one would reproduce the dishonesty detachment
     /// exists to remove.

--- a/crates/homeboy-agents/src/agent_task_service/cook_job.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_job.rs
@@ -589,7 +589,9 @@ mod tests {
             .expect("lifecycle store")
     }
     use super::*;
-    use homeboy_core::test_support::with_isolated_home;
+    use homeboy_core::api_jobs::JobEventKind;
+    use homeboy_core::test_support::{with_isolated_home, ControllerJobHarness};
+    use std::sync::Arc;
 
     const IDENTITY: ProcessStartIdentity = ProcessStartIdentity::Linux {
         starttime_ticks: 4242,
@@ -790,6 +792,46 @@ mod tests {
             job.resume_disposition(),
             CookJobResumeDisposition::ObserveTerminalOutcome
         );
+    }
+
+    #[test]
+    fn execute_supervises_through_the_controller_job_handle() {
+        with_isolated_home(|_| {
+            let cook_id = "cook-controller-harness";
+            agent_task_lifecycle::record_detached_cook_handoff_parent_in_store(
+                &test_lifecycle_store(),
+                cook_id,
+            )
+            .expect("persist handoff parent");
+            let mut request = request_of(cook_id, u32::MAX);
+            request["phase"] = json!("queued");
+            let driver: Arc<dyn ControllerJobDriver> = Arc::new(CookJobDriver);
+            let harness = ControllerJobHarness::new(Arc::clone(&driver), request.clone())
+                .expect("construct controller job harness");
+            let prepared = driver.prepare(request).expect("prepare cook job");
+
+            let result = driver
+                .execute(prepared, harness.handle())
+                .expect("supervise dead child to durable outcome");
+
+            assert_eq!(result["terminal_state"], "failed");
+            assert_eq!(result["phase"], "completed");
+            let checkpoint = harness
+                .checkpoint()
+                .expect("read checkpoint")
+                .expect("supervision checkpoint");
+            assert_eq!(checkpoint["phase"], "supervising");
+            let progress = harness
+                .events()
+                .expect("read controller events")
+                .into_iter()
+                .find(|event| event.kind == JobEventKind::Progress)
+                .and_then(|event| event.data)
+                .expect("projected supervision progress");
+            assert_eq!(progress["phase"], "supervising");
+            assert_eq!(progress["cook_id"], cook_id);
+            assert!(progress.get("durable_run_id").is_none());
+        });
     }
 
     /// A child that ended without ever publishing durable identity is not a

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -3942,7 +3942,7 @@ fn controller_job_id_from_path(path: &str, suffix: &str) -> Result<Uuid> {
     })
 }
 
-fn hex_digest(value: &serde_json::Value) -> Result<String> {
+pub(crate) fn hex_digest(value: &serde_json::Value) -> Result<String> {
     let encoded =
         serde_json::to_vec(value).map_err(|error| Error::internal_unexpected(error.to_string()))?;
     Ok(content_hash::sha256_hex(&encoded))

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -11,8 +11,82 @@ use std::{
 };
 
 use tempfile::TempDir;
+use uuid::Uuid;
 
-use crate::api_jobs::{Job, JobEventKind, JobStore, RemoteRunnerJobRequest, RemoteRunnerJobResult};
+use crate::api_jobs::{
+    ControllerJobState, ControllerJobSubmissionOutcome, Job, JobEvent, JobEventKind, JobStore,
+    RemoteRunnerJobRequest, RemoteRunnerJobResult,
+};
+use crate::daemon::controller_job_driver::{ControllerJobDriver, ControllerJobHandle};
+use crate::error::{Error, Result};
+
+/// A real in-memory controller job boundary for domain-driver tests.
+///
+/// The harness keeps construction internals out of the production API while
+/// letting feature crates execute drivers against durable checkpoint,
+/// progress, and cancellation behavior.
+pub struct ControllerJobHarness {
+    store: JobStore,
+    job_id: Uuid,
+    driver: Arc<dyn ControllerJobDriver>,
+}
+
+impl ControllerJobHarness {
+    pub fn new(driver: Arc<dyn ControllerJobDriver>, request: serde_json::Value) -> Result<Self> {
+        driver.validate_secret_references(&request)?;
+        let public_request = driver.public_request(&request)?;
+        let request_digest = crate::daemon::hex_digest(&request)?;
+        let store = JobStore::default();
+        let outcome = store.admit_controller_job(
+            format!("controller.{}", driver.job_type()),
+            format!("test-controller-job:{}", Uuid::new_v4()),
+            ControllerJobState {
+                job_type: driver.job_type().to_string(),
+                version: driver.version(),
+                request,
+                public_request,
+                request_digest,
+                checkpoint: None,
+                cancellation_requested: false,
+                cancellation_reason: None,
+                execution_claim_id: None,
+                recovery_attempted: false,
+            },
+        )?;
+        let ControllerJobSubmissionOutcome::Submitted(job_id) = outcome else {
+            return Err(Error::internal_unexpected(
+                "unique controller test job was unexpectedly replayed",
+            ));
+        };
+        store.claim_controller_execution(job_id, false)?;
+        Ok(Self {
+            store,
+            job_id,
+            driver,
+        })
+    }
+
+    pub fn handle(&self) -> ControllerJobHandle {
+        ControllerJobHandle::new(self.store.handle(self.job_id), Arc::clone(&self.driver))
+    }
+
+    pub fn job(&self) -> Result<Job> {
+        self.store.get(self.job_id)
+    }
+
+    pub fn events(&self) -> Result<Vec<JobEvent>> {
+        self.store.events(self.job_id)
+    }
+
+    pub fn checkpoint(&self) -> Result<Option<serde_json::Value>> {
+        Ok(self.store.controller_job_state(self.job_id)?.checkpoint)
+    }
+
+    pub fn request_cancellation(&self, reason: impl Into<String>) -> Result<Job> {
+        self.store
+            .request_controller_cancellation(self.job_id, reason.into())
+    }
+}
 
 const TEST_DAEMON_NAMESPACE_ENV: &str = "HOMEBOY_TEST_DAEMON_NAMESPACE";
 /// Test-only contract between the hermetic context and the Cargo test runner.


### PR DESCRIPTION
## Summary
- add a `test-support`-gated `ControllerJobHarness` backed by the real in-memory job store
- expose controller checkpoints, projected events, job state, and cancellation to domain-driver tests without widening the production handle constructor
- execute `CookJobDriver` through its real execute and resume supervision paths
- prove completed recovery is idempotent, cancellation reaches the real handle, and private progress fields do not enter the durable public event log

## Verification
- `cargo fmt --all -- --check`
- `cargo check -p homeboy-core --features test-support`
- `cargo test -p homeboy-agents --lib cook_job` (16 passed)
- `cargo test -p homeboy-core --lib controller_job_driver` (command passed; 0 matching tests)
- `git diff --check origin/main...HEAD`

Closes #11858. Prerequisite test surface for #11839 and #8010.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode and Homeboy inspected the controller job boundary, implemented the reusable harness and Cook proofs, and ran the focused verification commands. Chris Huber directed and reviewed the workflow and remains responsible.