### PR TITLE
Fix provider liveness for structured runtime progress

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -15,7 +15,9 @@ use crate::agent_task_executor_evidence::link_latest_executor_evidence;
 use crate::agent_task_process_containment::{
     contained_group_recovery_commands, AgentTaskProcessContainment,
 };
+use std::collections::BTreeMap;
 use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -1003,6 +1005,8 @@ fn run_materialized_provider_command_once_contained(
     // Progress and the wall timeout must share a monotonic clock. A system-clock
     // adjustment must never turn a stale provider into a live one.
     let last_progress_ms: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
+    let mut runtime_progress = runtime_progress_snapshot(&request.artifacts_path);
+    let mut runtime_progress_events = 0_u64;
 
     let (stdout_runtime_capture, stderr_runtime_capture) =
         runtime_output_captures(request, run_id, attempt);
@@ -1058,6 +1062,13 @@ fn run_materialized_provider_command_once_contained(
             Ok(Some(status)) => break (Some(status), false, false),
             Ok(None) => {
                 let elapsed = started.elapsed();
+                let current_runtime_progress = runtime_progress_snapshot(&request.artifacts_path);
+                if runtime_progress_advanced(&runtime_progress, &current_runtime_progress) {
+                    let elapsed_ms = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX);
+                    last_progress_ms.store(elapsed_ms, Ordering::SeqCst);
+                    runtime_progress_events = runtime_progress_events.saturating_add(1);
+                }
+                runtime_progress = current_runtime_progress;
                 if elapsed >= process_timeout {
                     break (None, false, true);
                 }
@@ -1137,6 +1148,7 @@ fn run_materialized_provider_command_once_contained(
                 "liveness_timeout_ms": liveness_timeout_ms,
                 "stdout_bytes": stdout_capture.total_bytes,
                 "stderr_bytes": stderr_capture.total_bytes,
+                "runtime_progress_events": runtime_progress_events,
             }),
         );
     }
@@ -1686,6 +1698,33 @@ where
     })
 }
 
+fn runtime_progress_snapshot(root: &Path) -> BTreeMap<PathBuf, u64> {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return BTreeMap::new();
+    };
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let name = entry.file_name().to_string_lossy().to_ascii_lowercase();
+            if !name.contains("progress") {
+                return None;
+            }
+            let path = entry.path();
+            let metadata = path.metadata().ok()?;
+            metadata.is_file().then_some((path, metadata.len()))
+        })
+        .collect()
+}
+
+fn runtime_progress_advanced(
+    previous: &BTreeMap<PathBuf, u64>,
+    current: &BTreeMap<PathBuf, u64>,
+) -> bool {
+    current
+        .iter()
+        .any(|(path, size)| *size > previous.get(path).copied().unwrap_or_default())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn provider_timeout_diagnostic_data(
     request: &AgentTaskExecutorRequest,
@@ -1797,7 +1836,7 @@ fn classify_stall_or_rate_limit(
         AgentTaskOutcomeStatus::ProviderError,
         AgentTaskFailureClassification::Stalled,
         format!(
-            "provider '{provider_id}' produced no stdout/stderr progress before liveness_timeout_ms={liveness_timeout_ms}"
+            "provider '{provider_id}' produced no process output or structured runtime progress before liveness_timeout_ms={liveness_timeout_ms}"
         ),
     )
 }

--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -932,6 +932,25 @@ fn parent_visible_progress_keeps_provider_alive_until_wall_deadline() {
 }
 
 #[test]
+fn structured_runtime_progress_keeps_provider_alive_until_completion() {
+    let command = format!(
+        "node {}",
+        script("let fs=require('fs'); let path=require('path'); let req=JSON.parse(fs.readFileSync(0,'utf8')); let progress=path.join(req.artifacts_path,'provider-progress.jsonl'); let timer=setInterval(()=>fs.appendFileSync(progress,'{}\\n'),10); setTimeout(()=>{clearInterval(timer); process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'succeeded',summary:'completed with structured progress'}));},900);")
+    );
+    let (mut request, provider) = request("task-liveness-runtime-progress", command);
+    request.limits.timeout_ms = Some(1_500);
+    request.limits.liveness_timeout_ms = Some(500);
+
+    let outcome = run_provider_command_once(&request, &provider);
+
+    assert_eq!(outcome.status, AgentTaskOutcomeStatus::Succeeded);
+    assert_eq!(
+        outcome.summary.as_deref(),
+        Some("completed with structured progress")
+    );
+}
+
+#[test]
 fn stalled_provider_retains_declared_attempt_workspace_artifact() {
     let temp = tempfile::tempdir().expect("tempdir");
     let workspace = linked_cook_source(&temp);


### PR DESCRIPTION
## Summary
- count growth in recognized provider progress artifacts as liveness
- retain the monotonic process-output deadline and silent-provider timeout behavior
- expose structured runtime progress counts in liveness diagnostics

Closes #13584.

## Verification
- `cargo fmt --all --check`
- `cargo test -p homeboy-agents agent_task_provider::tests::scheduler_tests` (50 passed)
- `cargo clippy -p homeboy-agents --all-targets -- -D warnings` remains blocked by pre-existing Rust 1.95 warnings outside the changed lines

## Reproduction evidence
- Cook `agent-task-e34d42dd-f830-4039-9c4a-dcac13d36756` persisted 14 OpenCode progress events but was killed after 300 seconds because wrapper stdout/stderr remained empty
- owner-bound retry `agent-task-e34d42dd-f830-4039-9c4a-dcac13d36756-retry` reproduced the same failure

## AI assistance
OpenCode with `openai/gpt-5.6-sol` was used to inspect durable Cook evidence, trace the liveness monitor and runtime evidence contracts, implement the bounded progress probe, and run deterministic verification.