### PR TITLE
test(controller): migrate all domain drivers to harness

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_batch_job.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_batch_job.rs
@@ -695,7 +695,9 @@ pub fn cook_batch_job_submission(
 mod tests {
     use super::*;
     use crate::agent_task_batch::FanoutRunBatchChild;
-    use homeboy_core::test_support::with_isolated_home;
+    use homeboy_core::api_jobs::JobEventKind;
+    use homeboy_core::test_support::{with_isolated_home, ControllerJobHarness};
+    use std::sync::Arc;
 
     const IDENTITY: ProcessStartIdentity = ProcessStartIdentity::Linux {
         starttime_ticks: 4242,
@@ -893,6 +895,52 @@ mod tests {
             job.resume_disposition(),
             CookBatchJobResumeDisposition::ObserveTerminalOutcome
         );
+    }
+
+    #[test]
+    fn execute_and_resume_supervise_through_the_controller_job_handle() {
+        with_isolated_home(|_| {
+            let batch_id = "fanout-controller-harness";
+            persist_batch(batch_id, &["unstarted"]);
+            let request = request_of(batch_id, u32::MAX);
+            let driver: Arc<dyn ControllerJobDriver> = Arc::new(CookBatchJobDriver);
+            let harness = ControllerJobHarness::new(Arc::clone(&driver), request.clone())
+                .expect("construct controller job harness");
+            let prepared = driver.prepare(request).expect("prepare batch job");
+
+            let result = driver
+                .execute(prepared, harness.handle())
+                .expect("supervise dead coordinator");
+
+            assert_eq!(result["phase"], "completed");
+            assert_eq!(result["terminal_state"], "partial_failure");
+            let checkpoint = harness
+                .checkpoint()
+                .expect("read checkpoint")
+                .expect("supervision checkpoint");
+            assert_eq!(checkpoint["phase"], "supervising");
+            let progress = harness
+                .events()
+                .expect("read controller events")
+                .into_iter()
+                .find(|event| event.kind == JobEventKind::Progress)
+                .and_then(|event| event.data)
+                .expect("projected supervision progress");
+            assert_eq!(progress["batch_id"], batch_id);
+            assert!(progress.get("child_pid").is_none());
+
+            let mut completed = checkpoint;
+            completed["phase"] = json!("completed");
+            completed["terminal_state"] = json!("partial_failure");
+            let first = driver
+                .resume(completed.clone(), harness.handle())
+                .expect("first completed replay");
+            let second = driver
+                .resume(completed, harness.handle())
+                .expect("second completed replay");
+            assert_eq!(first, second);
+            assert_eq!(first, result);
+        });
     }
 
     /// A coordinator that died before writing its batch record is not a

--- a/crates/homeboy-agents/src/agent_task_service/promotion_service.rs
+++ b/crates/homeboy-agents/src/agent_task_service/promotion_service.rs
@@ -483,6 +483,8 @@ pub fn promotion_is_resumable(previous: &Value, rerun_completed_gates: bool) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use homeboy_core::api_jobs::JobEventKind;
+    use homeboy_core::test_support::ControllerJobHarness;
 
     fn request() -> AgentTaskPromotionRequest {
         AgentTaskPromotionRequest {
@@ -556,6 +558,61 @@ mod tests {
         let result = job.completed_result().expect("completed result");
         assert_eq!(result["phase"], "completed");
         assert_eq!(result["promotion"]["status"], "applied");
+    }
+
+    #[test]
+    fn execute_and_resume_use_the_controller_job_handle_boundary() {
+        let job = AgentTaskPromotionJob::new(request()).expect("valid durable job");
+        let request = serde_json::to_value(&job).expect("serialize job");
+        let driver: Arc<dyn ControllerJobDriver> = Arc::new(AgentTaskPromotionJobDriver);
+        let harness = ControllerJobHarness::new(Arc::clone(&driver), request.clone())
+            .expect("construct controller job harness");
+        let prepared = driver.prepare(request).expect("prepare promotion");
+
+        driver
+            .execute(prepared, harness.handle())
+            .expect_err("fixture source cannot be promoted");
+
+        let checkpoint = harness
+            .checkpoint()
+            .expect("read checkpoint")
+            .expect("mutation checkpoint");
+        assert_eq!(checkpoint["phase"], "mutating_and_verifying");
+        let progress = harness
+            .events()
+            .expect("read controller events")
+            .into_iter()
+            .find(|event| event.kind == JobEventKind::Progress)
+            .and_then(|event| event.data)
+            .expect("projected mutation progress");
+        assert_eq!(
+            progress,
+            serde_json::json!({ "phase": "mutating_and_verifying" })
+        );
+
+        let mut completed = job;
+        completed.phase = AgentTaskPromotionJobPhase::Completed;
+        completed.report = Some(
+            serde_json::from_value(serde_json::json!({
+                "schema": "homeboy/agent-task-promotion-report/v1",
+                "status": "applied",
+                "source": { "kind": "aggregate", "task_id": "task" },
+                "to_worktree": "homeboy@promotion",
+                "target": { "worktree": "homeboy@promotion" },
+                "patch_artifact": { "id": "patch-1", "kind": "patch", "path": "patch" },
+                "operator_notification": { "status": "completed", "message": "complete" }
+            }))
+            .expect("promotion report"),
+        );
+        let checkpoint = serde_json::to_value(completed).expect("completed checkpoint");
+        let first = driver
+            .resume(checkpoint.clone(), harness.handle())
+            .expect("first completed replay");
+        let second = driver
+            .resume(checkpoint, harness.handle())
+            .expect("second completed replay");
+        assert_eq!(first, second);
+        assert_eq!(first["phase"], "completed");
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -4292,6 +4292,8 @@ mod count_unit_tests {
 
 #[cfg(test)]
 mod tests {
+    use homeboy::core::api_jobs::JobEventKind;
+    use homeboy::core::test_support::{with_isolated_home, ControllerJobHarness};
     use homeboy::core::worktree;
     use homeboy::runner::runners::{RunnerActiveJobState, RunnerSessionState, RunnerStatusReport};
     use serde_json::json;
@@ -4299,6 +4301,70 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+
+    fn controller_cleanup_request() -> Value {
+        serde_json::to_value(CleanupArgs {
+            apply: true,
+            include: vec![CleanupCategoryArg::ControllerScratch],
+            exclude: Vec::new(),
+            include_untagged: false,
+            older_than_days: None,
+            runtime_tmp_managed_older_than_days: None,
+            limit: None,
+            full: false,
+            cursor: None,
+            command: None,
+        })
+        .expect("serialize cleanup request")
+    }
+
+    #[test]
+    fn execute_and_resume_use_the_controller_job_handle_boundary() {
+        with_isolated_home(|_| {
+            let request = controller_cleanup_request();
+            let driver: Arc<dyn ControllerJobDriver> = Arc::new(CleanupJobDriver);
+            let harness = ControllerJobHarness::new(Arc::clone(&driver), request.clone())
+                .expect("construct controller job harness");
+
+            let result = driver
+                .execute(request.clone(), harness.handle())
+                .expect("execute isolated cleanup");
+            assert_eq!(result["phase"], "completed");
+            let checkpoint = harness
+                .checkpoint()
+                .expect("read checkpoint")
+                .expect("completed cleanup checkpoint");
+            assert_eq!(checkpoint["completed"]["phase"], "completed");
+            assert!(harness
+                .events()
+                .expect("read controller events")
+                .into_iter()
+                .any(|event| event.kind == JobEventKind::Progress
+                    && event.data.as_ref().and_then(|data| data.get("phase"))
+                        == Some(&json!("running"))));
+
+            let first = driver
+                .resume(checkpoint.clone(), harness.handle())
+                .expect("first completed replay");
+            let second = driver
+                .resume(checkpoint, harness.handle())
+                .expect("second completed replay");
+            assert_eq!(first, second);
+            assert_eq!(first, result);
+
+            let cancelled = ControllerJobHarness::new(Arc::clone(&driver), request.clone())
+                .expect("construct cancelled controller job harness");
+            cancelled
+                .request_cancellation("test cancellation")
+                .expect("request cancellation");
+            assert_eq!(
+                driver
+                    .execute(request, cancelled.handle())
+                    .expect("cancel before cleanup starts"),
+                json!({ "phase": "cancelled" })
+            );
+        });
+    }
 
     #[test]
     fn runtime_temp_retained_records_expose_producer_run_and_unknown_boundaries() {

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -4387,7 +4387,9 @@ pub fn register() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use homeboy_core::api_jobs::JobEventKind;
     use homeboy_core::lab_contract::LabCommandContract;
+    use homeboy_core::test_support::ControllerJobHarness;
     use std::io::{Read, Write};
     use std::net::{TcpListener, TcpStream};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -6662,6 +6664,134 @@ mod tests {
             self.0.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
+    }
+
+    struct HarnessAdapter {
+        executes: Arc<AtomicUsize>,
+        resumes: Arc<AtomicUsize>,
+    }
+
+    impl HarnessAdapter {
+        fn complete(
+            mut checkpoint: LabStagingCheckpoint,
+            job: ControllerJobHandle,
+        ) -> Result<LabStagingCheckpoint> {
+            checkpoint.phase = LabStagingPhase::Completed;
+            checkpoint.source_snapshot_id = Some("snapshot-harness".to_string());
+            checkpoint.workspace_id = Some("workspace-harness".to_string());
+            checkpoint.runtime_id = Some("runtime-harness".to_string());
+            checkpoint.hydration_id = Some("hydration-harness".to_string());
+            checkpoint.final_runner_job_id = Some("runner-job-harness".to_string());
+            job.progress(serde_json::to_value(&checkpoint).map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("serialize harness progress".to_string()),
+                )
+            })?)?;
+            Ok(checkpoint)
+        }
+    }
+
+    impl LabStagingExecutionAdapter for HarnessAdapter {
+        fn execute(
+            &self,
+            _request: &LabStagingExecutionRequest,
+            checkpoint: LabStagingCheckpoint,
+            _cancellation: LabStagingCancellationToken,
+            job: ControllerJobHandle,
+        ) -> Result<LabStagingCheckpoint> {
+            self.executes.fetch_add(1, Ordering::SeqCst);
+            Self::complete(checkpoint, job)
+        }
+
+        fn resume(
+            &self,
+            _request: &LabStagingExecutionRequest,
+            checkpoint: LabStagingCheckpoint,
+            _cancellation: LabStagingCancellationToken,
+            job: ControllerJobHandle,
+        ) -> Result<LabStagingCheckpoint> {
+            self.resumes.fetch_add(1, Ordering::SeqCst);
+            Self::complete(checkpoint, job)
+        }
+
+        fn cancel(
+            &self,
+            _request: &LabStagingExecutionRequest,
+            _checkpoint: &LabStagingCheckpoint,
+        ) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn execute_and_resume_use_the_controller_job_handle_boundary() {
+        let _serial = global_state_lock().lock().expect("lock");
+        homeboy_core::test_support::with_isolated_home(|_| {
+            clear_installed_adapter();
+            let run_id = "lab-controller-harness";
+            submit_recipe_run(run_id);
+            let args = vec!["agent-task".to_string(), "run-plan".to_string()];
+            persist_lab_staging_recipe(
+                run_id,
+                "lab-1",
+                &recipe_request(Some(recipe_command()), &args, HashMap::new()),
+            )
+            .expect("persist recipe");
+            let attachment = homeboy_agents::agent_task_lifecycle::load_private_run_attachment::<
+                LabStagingRecipe,
+            >(run_id, LAB_STAGING_RECIPE_ATTACHMENT_KIND)
+            .expect("recipe attachment");
+            let plan = homeboy_agents::agent_task_lifecycle::load_controller_plan(run_id)
+                .expect("durable plan");
+            let envelope = LabStagingDispatchEnvelope::new(
+                run_id,
+                "lab-1",
+                LabStagingInputRef::AgentTaskAttempt {
+                    run_id: run_id.to_string(),
+                    recipe: LabStagingRecipeRef::from_authority(attachment.payload_digest, &plan)
+                        .expect("recipe reference"),
+                },
+            );
+            let request = serde_json::to_value(envelope).expect("serialize envelope");
+            let driver: Arc<dyn ControllerJobDriver> = Arc::new(LabStagingDispatchDriver);
+            let harness = ControllerJobHarness::new(Arc::clone(&driver), request.clone())
+                .expect("construct controller job harness");
+            let prepared = driver.prepare(request).expect("prepare Lab staging");
+            let executes = Arc::new(AtomicUsize::new(0));
+            let resumes = Arc::new(AtomicUsize::new(0));
+            install_production_execution_adapter(Arc::new(HarnessAdapter {
+                executes: Arc::clone(&executes),
+                resumes: Arc::clone(&resumes),
+            }));
+
+            let result = driver
+                .execute(prepared, harness.handle())
+                .expect("execute Lab staging through harness");
+            assert_eq!(result["phase"], "completed");
+            assert_eq!(executes.load(Ordering::SeqCst), 1);
+            let checkpoint = harness
+                .checkpoint()
+                .expect("read checkpoint")
+                .expect("completed checkpoint");
+            assert_eq!(checkpoint["final_runner_job_id"], "runner-job-harness");
+            let progress = harness
+                .events()
+                .expect("read controller events")
+                .into_iter()
+                .find(|event| event.kind == JobEventKind::Progress)
+                .and_then(|event| event.data)
+                .expect("projected staging progress");
+            assert_eq!(progress["phase"], "completed");
+            assert!(progress.get("input").is_none());
+
+            let resumed = driver
+                .resume(result, harness.handle())
+                .expect("resume Lab staging through harness");
+            assert_eq!(resumed["phase"], "completed");
+            assert_eq!(resumes.load(Ordering::SeqCst), 1);
+            clear_installed_adapter();
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- migrate every remaining `ControllerJobDriver` to `ControllerJobHarness`-driven tests
- execute and resume Cook Batch supervision through durable checkpoints and projected progress
- exercise Promotion failure checkpointing and completed replay, Lab adapter execute/resume, and Cleanup execution/cancellation/replay through real handles
- complete the workspace-wide migration enabled by #13580 / #11858; all five controller drivers now consume the harness in tests

## Verification
- `cargo fmt --all -- --check`
- `cargo check -p homeboy-agents --tests`
- `cargo check -p homeboy-lab-runner --tests`
- `cargo check -p homeboy-cli --tests --features test-support`
- focused Cook Batch group: 14 passed
- focused Promotion group: 7 passed
- focused Lab harness test: passed
- focused Cleanup harness test: passed
- all four focused tests rerun after rebasing onto current `origin/main`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode inventoried all controller drivers, implemented the harness migrations, diagnosed and corrected the Cook Batch fixture, and ran the focused verification. Chris Huber directed the scope and remains responsible for the change.