### PR TITLE
Share the Cook and fanout work job lifecycle

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_batch_job.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_batch_job.rs
@@ -61,6 +61,10 @@ use homeboy_core::process::{
 use homeboy_core::Result;
 
 use super::cook::AgentTaskCookBatchControl;
+use super::work_job::{
+    register_work_job_handler, work_job_submission, WorkJobHandle, WorkJobHandler,
+    WorkJobInvocation,
+};
 use crate::agent_task_batch::{self, AgentTaskBatchState};
 use crate::agent_task_lifecycle;
 
@@ -341,8 +345,10 @@ fn invalid_cook_batch_job(message: &str) -> homeboy_core::Error {
 
 pub struct CookBatchJobDriver;
 
-impl ControllerJobDriver for CookBatchJobDriver {
-    fn job_type(&self) -> &'static str {
+struct CookBatchWorkHandler;
+
+impl WorkJobHandler for CookBatchWorkHandler {
+    fn work_type(&self) -> &'static str {
         AGENT_TASK_COOK_BATCH_JOB_TYPE
     }
 
@@ -355,8 +361,6 @@ impl ControllerJobDriver for CookBatchJobDriver {
     }
 
     fn public_progress(&self, progress: &Value) -> Result<Value> {
-        // Projected field by field rather than passed through, so a future
-        // private progress field cannot reach the public log by default.
         Ok(json!({
             "phase": progress.get("phase").cloned().unwrap_or(Value::Null),
             "batch_id": progress.get("batch_id").cloned().unwrap_or(Value::Null),
@@ -376,9 +380,6 @@ impl ControllerJobDriver for CookBatchJobDriver {
     }
 
     fn public_error(&self, error: &homeboy_core::Error) -> ControllerJobPublicError {
-        // A batch's error text can quote a child cook's error, which can quote
-        // provider output, which can quote the prompt. Only the typed code
-        // crosses into public job state.
         ControllerJobPublicError {
             message: "controller-owned cook batch supervision failed".to_string(),
             data: json!({ "code": format!("{:?}", error.code) }),
@@ -386,9 +387,6 @@ impl ControllerJobDriver for CookBatchJobDriver {
     }
 
     fn validate_secret_references(&self, request: &Value) -> Result<()> {
-        // `deny_unknown_fields` on both the job and its request makes any inline
-        // secret — a plan, a prompt, an env block, a token — a parse failure
-        // rather than an accepted field.
         AgentTaskCookBatchJob::parse(request.clone()).map(|_| ())
     }
 
@@ -403,9 +401,70 @@ impl ControllerJobDriver for CookBatchJobDriver {
         job.to_checkpoint()
     }
 
-    fn execute(&self, prepared: Value, handle: ControllerJobHandle) -> Result<Value> {
-        let mut job = AgentTaskCookBatchJob::parse(prepared)?;
+    fn advance(
+        &self,
+        checkpoint: Value,
+        handle: WorkJobHandle,
+        invocation: WorkJobInvocation,
+    ) -> Result<Value> {
+        let mut job = AgentTaskCookBatchJob::parse(checkpoint)?;
+        if invocation == WorkJobInvocation::Resume
+            && job.resume_disposition() == CookBatchJobResumeDisposition::AlreadyComplete
+        {
+            return job.completed_result();
+        }
         self.supervise(&mut job, handle)
+    }
+
+    fn cancel(&self, checkpoint: &Value) -> Result<()> {
+        let job = AgentTaskCookBatchJob::parse(checkpoint.clone())?;
+        if job.phase == AgentTaskCookBatchJobPhase::Completed {
+            return Ok(());
+        }
+        stop_batch(&job.request.batch_id)
+    }
+}
+
+/// Recovery-only adapter for persisted `agent-task-cook-batch` v1 jobs.
+impl ControllerJobDriver for CookBatchJobDriver {
+    fn job_type(&self) -> &'static str {
+        AGENT_TASK_COOK_BATCH_JOB_TYPE
+    }
+
+    fn version(&self) -> u32 {
+        AGENT_TASK_COOK_BATCH_JOB_VERSION
+    }
+
+    fn public_request(&self, request: &Value) -> Result<Value> {
+        CookBatchWorkHandler.public_request(request)
+    }
+
+    fn public_progress(&self, progress: &Value) -> Result<Value> {
+        CookBatchWorkHandler.public_progress(progress)
+    }
+
+    fn public_result(&self, result: &Value) -> Result<Value> {
+        CookBatchWorkHandler.public_result(result)
+    }
+
+    fn public_error(&self, error: &homeboy_core::Error) -> ControllerJobPublicError {
+        CookBatchWorkHandler.public_error(error)
+    }
+
+    fn validate_secret_references(&self, request: &Value) -> Result<()> {
+        CookBatchWorkHandler.validate_secret_references(request)
+    }
+
+    fn prepare(&self, request: Value) -> Result<Value> {
+        CookBatchWorkHandler.prepare(request)
+    }
+
+    fn execute(&self, prepared: Value, handle: ControllerJobHandle) -> Result<Value> {
+        CookBatchWorkHandler.advance(
+            prepared,
+            WorkJobHandle::legacy(handle, &CookBatchWorkHandler),
+            WorkJobInvocation::Execute,
+        )
     }
 
     /// Re-adopt supervision after a daemon restart.
@@ -421,20 +480,11 @@ impl ControllerJobDriver for CookBatchJobDriver {
     /// children through their original gates and finalization contract. Doing
     /// that from here would put two owners on the same children.
     fn resume(&self, checkpoint: Value, handle: ControllerJobHandle) -> Result<Value> {
-        let mut job = AgentTaskCookBatchJob::parse(checkpoint)?;
-        match job.resume_disposition() {
-            // Replaying a finished job reports its durable result and touches
-            // nothing. This is what makes repeated recovery safe.
-            CookBatchJobResumeDisposition::AlreadyComplete => job.completed_result(),
-            // Neither branch starts anything: supervision either re-attaches to
-            // a coordinator that is still provably ours, or observes on its
-            // first iteration that it is gone and terminalizes from durable
-            // state.
-            CookBatchJobResumeDisposition::ReadoptLiveCoordinator
-            | CookBatchJobResumeDisposition::ObserveTerminalOutcome => {
-                self.supervise(&mut job, handle)
-            }
-        }
+        CookBatchWorkHandler.advance(
+            checkpoint,
+            WorkJobHandle::legacy(handle, &CookBatchWorkHandler),
+            WorkJobInvocation::Resume,
+        )
     }
 
     /// Stop the wave through the one established cancellation path.
@@ -464,11 +514,7 @@ impl ControllerJobDriver for CookBatchJobDriver {
     /// terminalize cleanly. With no claimable work and no live children, the
     /// coordinator drains and exits on its own.
     fn cancel(&self, prepared: &Value) -> Result<()> {
-        let job = AgentTaskCookBatchJob::parse(prepared.clone())?;
-        if job.phase == AgentTaskCookBatchJobPhase::Completed {
-            return Ok(());
-        }
-        stop_batch(&job.request.batch_id)
+        CookBatchWorkHandler.cancel(prepared)
     }
 }
 
@@ -509,18 +555,14 @@ fn stop_batch(batch_id: &str) -> Result<()> {
     Ok(())
 }
 
-impl CookBatchJobDriver {
+impl CookBatchWorkHandler {
     /// Watch a detached coordinator to the wave's durable terminal state.
     ///
     /// Liveness is judged by PID *and* kernel start identity. An
     /// `IdentityMismatch` or `Unverifiable` reading is treated as "no longer our
     /// coordinator" rather than as death, so supervision can never attribute a
     /// stranger's process to this batch.
-    fn supervise(
-        &self,
-        job: &mut AgentTaskCookBatchJob,
-        handle: ControllerJobHandle,
-    ) -> Result<Value> {
+    fn supervise(&self, job: &mut AgentTaskCookBatchJob, handle: WorkJobHandle) -> Result<Value> {
         job.phase = AgentTaskCookBatchJobPhase::Supervising;
         job.refresh_observations();
         handle.checkpoint(job.to_checkpoint()?)?;
@@ -631,6 +673,8 @@ fn coordinator_is_live(request: &AgentTaskCookBatchJobRequest) -> bool {
 pub fn register_cook_batch_job_driver() {
     static REGISTERED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
     REGISTERED.get_or_init(|| {
+        register_work_job_handler(std::sync::Arc::new(CookBatchWorkHandler))
+            .expect("register cook batch work job handler");
         controller_job_driver::register_controller_job_driver(std::sync::Arc::new(
             CookBatchJobDriver,
         ))
@@ -683,33 +727,47 @@ pub fn cook_batch_job_submission(
         child_pid,
         child_start_identity: child_start_identity.clone(),
     })?;
-    Ok(json!({
-        "type": AGENT_TASK_COOK_BATCH_JOB_TYPE,
-        "version": AGENT_TASK_COOK_BATCH_JOB_VERSION,
-        "idempotency_key": job.idempotency_key,
-        "request": job.to_checkpoint()?,
-    }))
+    work_job_submission(
+        &CookBatchWorkHandler,
+        job.idempotency_key.clone(),
+        job.to_checkpoint()?,
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::agent_task_batch::FanoutRunBatchChild;
-    use homeboy_core::test_support::with_isolated_home;
+    use crate::agent_task_service::work_job::{
+        WorkJobDriver, WORK_JOB_CHECKPOINT_SCHEMA, WORK_JOB_PROGRESS_SCHEMA,
+        WORK_JOB_RESULT_SCHEMA, WORK_JOB_TYPE, WORK_JOB_VERSION,
+    };
+    use homeboy_core::api_jobs::JobEventKind;
+    use homeboy_core::test_support::{with_isolated_home, ControllerJobHarness};
+    use std::sync::Arc;
 
     const IDENTITY: ProcessStartIdentity = ProcessStartIdentity::Linux {
         starttime_ticks: 4242,
     };
 
     fn submission(batch_id: &str, pid: u32) -> Value {
+        register_cook_batch_job_driver();
         cook_batch_job_submission(batch_id, pid, &IDENTITY).expect("build batch job submission")
     }
 
     fn request_of(batch_id: &str, pid: u32) -> Value {
         submission(batch_id, pid)
             .get("request")
+            .and_then(|request| request.get("request"))
             .cloned()
             .expect("submission carries a request")
+    }
+
+    fn work_request_of(batch_id: &str, pid: u32) -> Value {
+        submission(batch_id, pid)
+            .get("request")
+            .cloned()
+            .expect("submission carries a work request")
     }
 
     fn persist_batch(batch_id: &str, children: &[&str]) {
@@ -730,15 +788,23 @@ mod tests {
     fn the_submission_round_trips_through_the_driver() {
         let submission = submission("fanout-round-trip", 4242);
 
-        assert_eq!(submission["type"], AGENT_TASK_COOK_BATCH_JOB_TYPE);
-        assert_eq!(submission["version"], AGENT_TASK_COOK_BATCH_JOB_VERSION);
+        assert_eq!(submission["type"], WORK_JOB_TYPE);
+        assert_eq!(submission["version"], WORK_JOB_VERSION);
         assert_eq!(
             submission["idempotency_key"],
             "agent-task-cook-batch:fanout-round-trip"
         );
+        assert_eq!(
+            submission["request"]["work_type"],
+            AGENT_TASK_COOK_BATCH_JOB_TYPE
+        );
+        assert_eq!(
+            submission["request"]["work_version"],
+            AGENT_TASK_COOK_BATCH_JOB_VERSION
+        );
 
-        let job =
-            AgentTaskCookBatchJob::parse(submission["request"].clone()).expect("parse request");
+        let job = AgentTaskCookBatchJob::parse(submission["request"]["request"].clone())
+            .expect("parse request");
         assert_eq!(job.request.batch_id, "fanout-round-trip");
         assert_eq!(job.request.child_pid, 4242);
         assert_eq!(job.request.child_start_identity, IDENTITY);
@@ -746,7 +812,7 @@ mod tests {
         assert!(job.observed_terminal_children.is_empty());
         assert_eq!(job.terminal_state, None);
 
-        let driver = CookBatchJobDriver;
+        let driver = WorkJobDriver;
         driver
             .validate_secret_references(&submission["request"])
             .expect("a reference-only request validates");
@@ -774,7 +840,7 @@ mod tests {
     /// `deny_unknown_fields` is what enforces that, so prove it rejects.
     #[test]
     fn inline_secrets_are_refused_rather_than_carried() {
-        let driver = CookBatchJobDriver;
+        let driver = WorkJobDriver;
         for smuggled in [
             json!({ "plan": { "cooks": [{ "prompt": "the private task text" }] } }),
             json!({ "prompt_template": "the private task text" }),
@@ -783,8 +849,12 @@ mod tests {
             json!({ "notification_route": "opaque-destination" }),
             json!({ "coordinator_log": "/home/operator/.homeboy/fanout.log" }),
         ] {
-            let mut request = request_of("fanout-secrets", 4242);
+            let mut request = work_request_of("fanout-secrets", 4242);
             let object = request.as_object_mut().expect("request is an object");
+            let object = object
+                .get_mut("request")
+                .and_then(Value::as_object_mut)
+                .expect("domain request is an object");
             for (key, value) in smuggled.as_object().expect("smuggled object") {
                 object.insert(key.clone(), value.clone());
             }
@@ -801,7 +871,7 @@ mod tests {
     /// issue, and counts are what public job state needs.
     #[test]
     fn public_projections_withhold_process_identity_and_the_child_roster() {
-        let driver = CookBatchJobDriver;
+        let driver = WorkJobDriver;
         let mut job =
             AgentTaskCookBatchJob::parse(request_of("fanout-public", 4242)).expect("parse request");
         job.phase = AgentTaskCookBatchJobPhase::Completed;
@@ -809,7 +879,8 @@ mod tests {
         job.observed_terminal_children
             .insert("cook-fanout-public-issue-1".to_string());
         job.terminal_state = Some(AgentTaskBatchState::PartialFailure);
-        let value = job.to_checkpoint().expect("serialize job");
+        let mut value = work_request_of("fanout-public", 4242);
+        value["request"] = job.to_checkpoint().expect("serialize job");
 
         let public = driver.public_request(&value).expect("public request");
         let public_text = public.to_string();
@@ -831,9 +902,23 @@ mod tests {
             "children_terminal": 1,
             "prompt": "the private task text",
         });
-        let progress = driver.public_progress(&private).expect("public progress");
+        let progress = driver
+            .public_progress(&json!({
+                "schema": WORK_JOB_PROGRESS_SCHEMA,
+                "work_type": AGENT_TASK_COOK_BATCH_JOB_TYPE,
+                "work_version": AGENT_TASK_COOK_BATCH_JOB_VERSION,
+                "progress": private.clone(),
+            }))
+            .expect("public progress");
         assert!(!progress.to_string().contains("private task text"));
-        let result = driver.public_result(&private).expect("public result");
+        let result = driver
+            .public_result(&json!({
+                "schema": WORK_JOB_RESULT_SCHEMA,
+                "work_type": AGENT_TASK_COOK_BATCH_JOB_TYPE,
+                "work_version": AGENT_TASK_COOK_BATCH_JOB_VERSION,
+                "result": private,
+            }))
+            .expect("public result");
         assert!(!result.to_string().contains("private task text"));
     }
 
@@ -893,6 +978,95 @@ mod tests {
             job.resume_disposition(),
             CookBatchJobResumeDisposition::ObserveTerminalOutcome
         );
+    }
+
+    #[test]
+    fn execute_supervises_through_the_shared_work_driver() {
+        with_isolated_home(|_| {
+            let batch_id = "fanout-work-harness";
+            persist_batch(batch_id, &["a"]);
+            let request = work_request_of(batch_id, u32::MAX);
+            let driver: Arc<dyn ControllerJobDriver> = Arc::new(WorkJobDriver);
+            let harness = ControllerJobHarness::new(Arc::clone(&driver), request.clone())
+                .expect("construct work job harness");
+            let prepared = driver.prepare(request).expect("prepare work job");
+
+            let result = driver
+                .execute(prepared, harness.handle())
+                .expect("observe dead coordinator");
+
+            assert_eq!(result["result"]["phase"], "completed");
+            let checkpoint = harness
+                .checkpoint()
+                .expect("read checkpoint")
+                .expect("batch supervision checkpoint");
+            assert_eq!(checkpoint["schema"], WORK_JOB_CHECKPOINT_SCHEMA);
+            assert_eq!(checkpoint["work_type"], AGENT_TASK_COOK_BATCH_JOB_TYPE);
+            assert_eq!(checkpoint["checkpoint"]["phase"], "supervising");
+            let progress = harness
+                .events()
+                .expect("read work events")
+                .into_iter()
+                .find(|event| event.kind == JobEventKind::Progress)
+                .and_then(|event| event.data)
+                .expect("projected batch progress");
+            assert_eq!(progress["batch_id"], batch_id);
+            assert_eq!(progress["children_total"], 1);
+            assert!(progress.get("work_type").is_none());
+        });
+    }
+
+    #[test]
+    fn resume_replays_a_completed_shared_work_checkpoint() {
+        with_isolated_home(|_| {
+            let batch_id = "fanout-work-resume";
+            let request = work_request_of(batch_id, u32::MAX);
+            let driver: Arc<dyn ControllerJobDriver> = Arc::new(WorkJobDriver);
+            let harness = ControllerJobHarness::new(Arc::clone(&driver), request.clone())
+                .expect("construct work job harness");
+            let mut checkpoint = driver.prepare(request).expect("prepare work job");
+            let mut batch = AgentTaskCookBatchJob::parse(checkpoint["checkpoint"].clone())
+                .expect("parse batch checkpoint");
+            batch.phase = AgentTaskCookBatchJobPhase::Completed;
+            batch.terminal_state = Some(AgentTaskBatchState::Succeeded);
+            checkpoint["checkpoint"] = batch.to_checkpoint().expect("serialize completion");
+
+            let first = driver
+                .resume(checkpoint.clone(), harness.handle())
+                .expect("first completed replay");
+            let second = driver
+                .resume(checkpoint, harness.handle())
+                .expect("second completed replay");
+
+            assert_eq!(first, second);
+            assert_eq!(first["result"]["terminal_state"], "succeeded");
+        });
+    }
+
+    #[test]
+    fn cancellation_requested_through_the_shared_work_harness_stops_the_batch() {
+        with_isolated_home(|_| {
+            let batch_id = "fanout-work-cancel";
+            persist_batch(batch_id, &["a", "b"]);
+            let request = work_request_of(batch_id, u32::MAX);
+            let driver: Arc<dyn ControllerJobDriver> = Arc::new(WorkJobDriver);
+            let harness = ControllerJobHarness::new(Arc::clone(&driver), request.clone())
+                .expect("construct work job harness");
+            let prepared = driver.prepare(request).expect("prepare work job");
+            harness
+                .request_cancellation("test cancellation")
+                .expect("request cancellation");
+
+            driver
+                .cancel(&prepared)
+                .expect("cancel through shared work driver");
+            let result = driver
+                .execute(prepared, harness.handle())
+                .expect("stop cancelled batch supervision");
+
+            assert!(agent_task_batch::coordinator_is_cancelled(batch_id));
+            assert_eq!(result["result"]["phase"], "completed");
+        });
     }
 
     /// A coordinator that died before writing its batch record is not a

--- a/crates/homeboy-agents/src/agent_task_service/cook_job.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_job.rs
@@ -47,6 +47,10 @@ use homeboy_core::process::{
 };
 use homeboy_core::Result;
 
+use super::work_job::{
+    register_work_job_handler, work_job_submission, WorkJobHandle, WorkJobHandler,
+    WorkJobInvocation,
+};
 use crate::agent_task_lifecycle;
 
 pub const AGENT_TASK_COOK_JOB_TYPE: &str = "agent-task-cook";
@@ -233,8 +237,10 @@ fn invalid_cook_job(message: &str) -> homeboy_core::Error {
 
 pub struct CookJobDriver;
 
-impl ControllerJobDriver for CookJobDriver {
-    fn job_type(&self) -> &'static str {
+struct CookWorkHandler;
+
+impl WorkJobHandler for CookWorkHandler {
+    fn work_type(&self) -> &'static str {
         AGENT_TASK_COOK_JOB_TYPE
     }
 
@@ -247,8 +253,6 @@ impl ControllerJobDriver for CookJobDriver {
     }
 
     fn public_progress(&self, progress: &Value) -> Result<Value> {
-        // Progress is projected field by field rather than passed through, so a
-        // future private progress field cannot reach the public log by default.
         Ok(json!({
             "phase": progress.get("phase").cloned().unwrap_or(Value::Null),
             "cook_id": progress.get("cook_id").cloned().unwrap_or(Value::Null),
@@ -266,8 +270,6 @@ impl ControllerJobDriver for CookJobDriver {
     }
 
     fn public_error(&self, error: &homeboy_core::Error) -> ControllerJobPublicError {
-        // A cook's error text can quote provider output, which can quote the
-        // prompt. Only the typed code crosses into public job state.
         ControllerJobPublicError {
             message: "controller-owned cook supervision failed".to_string(),
             data: json!({ "code": format!("{:?}", error.code) }),
@@ -275,9 +277,6 @@ impl ControllerJobDriver for CookJobDriver {
     }
 
     fn validate_secret_references(&self, request: &Value) -> Result<()> {
-        // `deny_unknown_fields` on both the job and its request makes any inline
-        // secret — a prompt, an env block, a provider invocation, a token — a
-        // parse failure rather than an accepted field.
         AgentTaskCookJob::parse(request.clone()).map(|_| ())
     }
 
@@ -292,9 +291,75 @@ impl ControllerJobDriver for CookJobDriver {
         job.to_checkpoint()
     }
 
-    fn execute(&self, prepared: Value, handle: ControllerJobHandle) -> Result<Value> {
-        let mut job = AgentTaskCookJob::parse(prepared)?;
+    fn advance(
+        &self,
+        checkpoint: Value,
+        handle: WorkJobHandle,
+        invocation: WorkJobInvocation,
+    ) -> Result<Value> {
+        let mut job = AgentTaskCookJob::parse(checkpoint)?;
+        if invocation == WorkJobInvocation::Resume
+            && job.resume_disposition() == CookJobResumeDisposition::AlreadyComplete
+        {
+            return job.completed_result();
+        }
         self.supervise(&mut job, handle)
+    }
+
+    fn cancel(&self, checkpoint: &Value) -> Result<()> {
+        let job = AgentTaskCookJob::parse(checkpoint.clone())?;
+        if job.phase == AgentTaskCookJobPhase::Completed {
+            return Ok(());
+        }
+        let run_id = job
+            .request
+            .pinned_retry_run_id
+            .as_deref()
+            .unwrap_or(&job.request.cook_id);
+        agent_task_lifecycle::cancel_run(run_id, Some("controller job cancelled")).map(|_| ())
+    }
+}
+
+/// Recovery-only adapter for persisted `agent-task-cook` v1 controller jobs.
+impl ControllerJobDriver for CookJobDriver {
+    fn job_type(&self) -> &'static str {
+        AGENT_TASK_COOK_JOB_TYPE
+    }
+
+    fn version(&self) -> u32 {
+        AGENT_TASK_COOK_JOB_VERSION
+    }
+
+    fn public_request(&self, request: &Value) -> Result<Value> {
+        CookWorkHandler.public_request(request)
+    }
+
+    fn public_progress(&self, progress: &Value) -> Result<Value> {
+        CookWorkHandler.public_progress(progress)
+    }
+
+    fn public_result(&self, result: &Value) -> Result<Value> {
+        CookWorkHandler.public_result(result)
+    }
+
+    fn public_error(&self, error: &homeboy_core::Error) -> ControllerJobPublicError {
+        CookWorkHandler.public_error(error)
+    }
+
+    fn validate_secret_references(&self, request: &Value) -> Result<()> {
+        CookWorkHandler.validate_secret_references(request)
+    }
+
+    fn prepare(&self, request: Value) -> Result<Value> {
+        CookWorkHandler.prepare(request)
+    }
+
+    fn execute(&self, prepared: Value, handle: ControllerJobHandle) -> Result<Value> {
+        CookWorkHandler.advance(
+            prepared,
+            WorkJobHandle::legacy(handle, &CookWorkHandler),
+            WorkJobInvocation::Execute,
+        )
     }
 
     /// Re-adopt supervision after a daemon restart.
@@ -304,18 +369,11 @@ impl ControllerJobDriver for CookJobDriver {
     /// unfinished one either re-attaches to a child still provably alive, or
     /// observes the durable outcome of one that is not.
     fn resume(&self, checkpoint: Value, handle: ControllerJobHandle) -> Result<Value> {
-        let mut job = AgentTaskCookJob::parse(checkpoint)?;
-        match job.resume_disposition() {
-            // Replaying a finished job reports its durable result and touches
-            // nothing. This is what makes repeated recovery safe.
-            CookJobResumeDisposition::AlreadyComplete => job.completed_result(),
-            // Neither branch spawns anything: supervision either re-attaches to
-            // a child that is still provably ours, or observes on its first
-            // iteration that the child is gone and terminalizes from durable
-            // state.
-            CookJobResumeDisposition::ReadoptLiveChild
-            | CookJobResumeDisposition::ObserveTerminalOutcome => self.supervise(&mut job, handle),
-        }
+        CookWorkHandler.advance(
+            checkpoint,
+            WorkJobHandle::legacy(handle, &CookWorkHandler),
+            WorkJobInvocation::Resume,
+        )
     }
 
     /// Stop the cook through the one established cancellation path.
@@ -329,29 +387,18 @@ impl ControllerJobDriver for CookJobDriver {
     /// `terminate_process_tree(std::process::id())` — the in-flight stop path.
     /// No second mechanism is introduced here.
     fn cancel(&self, prepared: &Value) -> Result<()> {
-        let job = AgentTaskCookJob::parse(prepared.clone())?;
-        if job.phase == AgentTaskCookJobPhase::Completed {
-            return Ok(());
-        }
-        // A retry supervisor owns one immutable attempt. Resolving its Cook
-        // alias here could instead cancel a later retry that became latest.
-        let run_id = job
-            .request
-            .pinned_retry_run_id
-            .as_deref()
-            .unwrap_or(&job.request.cook_id);
-        agent_task_lifecycle::cancel_run(run_id, Some("controller job cancelled")).map(|_| ())
+        CookWorkHandler.cancel(prepared)
     }
 }
 
-impl CookJobDriver {
+impl CookWorkHandler {
     /// Watch a detached child to its durable terminal state.
     ///
     /// Liveness is judged by PID *and* kernel start identity. An
     /// `IdentityMismatch` or `Unverifiable` reading is treated as "no longer our
     /// child" rather than as death, so supervision can never attribute a
     /// stranger's process to this cook.
-    fn supervise(&self, job: &mut AgentTaskCookJob, handle: ControllerJobHandle) -> Result<Value> {
+    fn supervise(&self, job: &mut AgentTaskCookJob, handle: WorkJobHandle) -> Result<Value> {
         job.phase = AgentTaskCookJobPhase::Supervising;
         handle.checkpoint(job.to_checkpoint()?)?;
         handle.progress(job.progress_projection())?;
@@ -525,6 +572,8 @@ fn child_is_live(request: &AgentTaskCookJobRequest) -> bool {
 pub fn register_cook_job_driver() {
     static REGISTERED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
     REGISTERED.get_or_init(|| {
+        register_work_job_handler(std::sync::Arc::new(CookWorkHandler))
+            .expect("register cook work job handler");
         controller_job_driver::register_controller_job_driver(std::sync::Arc::new(CookJobDriver))
             .expect("register cook controller job driver");
     });
@@ -547,12 +596,11 @@ pub fn cook_job_submission(
         supervisor_id: None,
         pinned_retry_run_id: None,
     })?;
-    Ok(json!({
-        "type": AGENT_TASK_COOK_JOB_TYPE,
-        "version": AGENT_TASK_COOK_JOB_VERSION,
-        "idempotency_key": job.idempotency_key,
-        "request": job.to_checkpoint()?,
-    }))
+    work_job_submission(
+        &CookWorkHandler,
+        job.idempotency_key.clone(),
+        job.to_checkpoint()?,
+    )
 }
 
 /// Build a retry-specific supervisor submission. The Cook alias remains the
@@ -571,12 +619,11 @@ pub fn cook_retry_job_submission(
         supervisor_id: Some(run_id.to_string()),
         pinned_retry_run_id: Some(run_id.to_string()),
     })?;
-    Ok(json!({
-        "type": AGENT_TASK_COOK_JOB_TYPE,
-        "version": AGENT_TASK_COOK_JOB_VERSION,
-        "idempotency_key": job.idempotency_key,
-        "request": job.to_checkpoint()?,
-    }))
+    work_job_submission(
+        &CookWorkHandler,
+        job.idempotency_key.clone(),
+        job.to_checkpoint()?,
+    )
 }
 
 #[cfg(test)]
@@ -589,6 +636,10 @@ mod tests {
             .expect("lifecycle store")
     }
     use super::*;
+    use crate::agent_task_service::work_job::{
+        WorkJobDriver, WORK_JOB_CHECKPOINT_SCHEMA, WORK_JOB_PROGRESS_SCHEMA,
+        WORK_JOB_RESULT_SCHEMA, WORK_JOB_TYPE, WORK_JOB_VERSION,
+    };
     use homeboy_core::api_jobs::JobEventKind;
     use homeboy_core::test_support::{with_isolated_home, ControllerJobHarness};
     use std::sync::Arc;
@@ -598,6 +649,7 @@ mod tests {
     };
 
     fn submission(cook_id: &str, pid: u32) -> Value {
+        register_cook_job_driver();
         cook_job_submission(cook_id, pid, &IDENTITY).expect("build cook job submission")
     }
 
@@ -617,9 +669,10 @@ mod tests {
         );
         assert_eq!(first["idempotency_key"], replay["idempotency_key"]);
         assert_ne!(first["idempotency_key"], successor["idempotency_key"]);
-        let first_job = AgentTaskCookJob::parse(first["request"].clone()).expect("first job");
-        let successor_job =
-            AgentTaskCookJob::parse(successor["request"].clone()).expect("successor job");
+        let first_job =
+            AgentTaskCookJob::parse(first["request"]["request"].clone()).expect("first job");
+        let successor_job = AgentTaskCookJob::parse(successor["request"]["request"].clone())
+            .expect("successor job");
         assert_eq!(first_job.run_id.as_deref(), Some("cook-retry-attempt-2"));
         assert_eq!(
             successor_job.run_id.as_deref(),
@@ -635,8 +688,16 @@ mod tests {
     fn request_of(cook_id: &str, pid: u32) -> Value {
         submission(cook_id, pid)
             .get("request")
+            .and_then(|request| request.get("request"))
             .cloned()
             .expect("submission carries a request")
+    }
+
+    fn work_request_of(cook_id: &str, pid: u32) -> Value {
+        submission(cook_id, pid)
+            .get("request")
+            .cloned()
+            .expect("submission carries a work request")
     }
 
     /// The wire payload the launcher sends must be exactly what the driver
@@ -645,14 +706,20 @@ mod tests {
     fn the_submission_round_trips_through_the_driver() {
         let submission = submission("cook-round-trip", 4242);
 
-        assert_eq!(submission["type"], AGENT_TASK_COOK_JOB_TYPE);
-        assert_eq!(submission["version"], AGENT_TASK_COOK_JOB_VERSION);
+        assert_eq!(submission["type"], WORK_JOB_TYPE);
+        assert_eq!(submission["version"], WORK_JOB_VERSION);
         assert_eq!(
             submission["idempotency_key"],
             "agent-task-cook:cook-round-trip"
         );
+        assert_eq!(submission["request"]["work_type"], AGENT_TASK_COOK_JOB_TYPE);
+        assert_eq!(
+            submission["request"]["work_version"],
+            AGENT_TASK_COOK_JOB_VERSION
+        );
 
-        let job = AgentTaskCookJob::parse(submission["request"].clone()).expect("parse request");
+        let job = AgentTaskCookJob::parse(submission["request"]["request"].clone())
+            .expect("parse request");
         assert_eq!(job.request.cook_id, "cook-round-trip");
         assert_eq!(job.request.child_pid, 4242);
         assert_eq!(job.request.child_start_identity, IDENTITY);
@@ -660,7 +727,7 @@ mod tests {
         assert_eq!(job.run_id, None);
         assert_eq!(job.terminal_state, None);
 
-        let driver = CookJobDriver;
+        let driver = WorkJobDriver;
         driver
             .validate_secret_references(&submission["request"])
             .expect("a reference-only request validates");
@@ -688,7 +755,7 @@ mod tests {
     /// `deny_unknown_fields` is what enforces that, so prove it rejects.
     #[test]
     fn inline_secrets_are_refused_rather_than_carried() {
-        let driver = CookJobDriver;
+        let driver = WorkJobDriver;
         for smuggled in [
             json!({ "prompt": "the private task text" }),
             json!({ "env": { "ANTHROPIC_API_KEY": "sk-live-secret" } }),
@@ -696,8 +763,12 @@ mod tests {
             json!({ "notification_route": "opaque-destination" }),
             json!({ "launcher_log": "/home/operator/.homeboy/cook.log" }),
         ] {
-            let mut request = request_of("cook-secrets", 4242);
+            let mut request = work_request_of("cook-secrets", 4242);
             let object = request.as_object_mut().expect("request is an object");
+            let object = object
+                .get_mut("request")
+                .and_then(Value::as_object_mut)
+                .expect("domain request is an object");
             for (key, value) in smuggled.as_object().expect("smuggled object") {
                 object.insert(key.clone(), value.clone());
             }
@@ -713,13 +784,14 @@ mod tests {
     /// locate the operator's filesystem or the child's kernel identity.
     #[test]
     fn public_projections_withhold_paths_and_process_identity() {
-        let driver = CookJobDriver;
+        let driver = WorkJobDriver;
         let mut job =
             AgentTaskCookJob::parse(request_of("cook-public", 4242)).expect("parse request");
         job.phase = AgentTaskCookJobPhase::Completed;
         job.run_id = Some("cook-public-attempt-1".to_string());
         job.terminal_state = Some(agent_task_lifecycle::AgentTaskRunState::Succeeded);
-        let value = job.to_checkpoint().expect("serialize job");
+        let mut value = work_request_of("cook-public", 4242);
+        value["request"] = job.to_checkpoint().expect("serialize job");
 
         let public = driver.public_request(&value).expect("public request");
         let public_text = public.to_string();
@@ -738,9 +810,23 @@ mod tests {
             "run_id": "cook-public-attempt-1",
             "prompt": "the private task text",
         });
-        let progress = driver.public_progress(&private).expect("public progress");
+        let progress = driver
+            .public_progress(&json!({
+                "schema": WORK_JOB_PROGRESS_SCHEMA,
+                "work_type": AGENT_TASK_COOK_JOB_TYPE,
+                "work_version": AGENT_TASK_COOK_JOB_VERSION,
+                "progress": private.clone(),
+            }))
+            .expect("public progress");
         assert!(!progress.to_string().contains("private task text"));
-        let result = driver.public_result(&private).expect("public result");
+        let result = driver
+            .public_result(&json!({
+                "schema": WORK_JOB_RESULT_SCHEMA,
+                "work_type": AGENT_TASK_COOK_JOB_TYPE,
+                "work_version": AGENT_TASK_COOK_JOB_VERSION,
+                "result": private,
+            }))
+            .expect("public result");
         assert!(!result.to_string().contains("private task text"));
     }
 
@@ -803,9 +889,8 @@ mod tests {
                 cook_id,
             )
             .expect("persist handoff parent");
-            let mut request = request_of(cook_id, u32::MAX);
-            request["phase"] = json!("queued");
-            let driver: Arc<dyn ControllerJobDriver> = Arc::new(CookJobDriver);
+            let request = work_request_of(cook_id, u32::MAX);
+            let driver: Arc<dyn ControllerJobDriver> = Arc::new(WorkJobDriver);
             let harness = ControllerJobHarness::new(Arc::clone(&driver), request.clone())
                 .expect("construct controller job harness");
             let prepared = driver.prepare(request).expect("prepare cook job");
@@ -814,13 +899,15 @@ mod tests {
                 .execute(prepared, harness.handle())
                 .expect("supervise dead child to durable outcome");
 
-            assert_eq!(result["terminal_state"], "failed");
-            assert_eq!(result["phase"], "completed");
+            assert_eq!(result["result"]["terminal_state"], "failed");
+            assert_eq!(result["result"]["phase"], "completed");
             let checkpoint = harness
                 .checkpoint()
                 .expect("read checkpoint")
                 .expect("supervision checkpoint");
-            assert_eq!(checkpoint["phase"], "supervising");
+            assert_eq!(checkpoint["schema"], WORK_JOB_CHECKPOINT_SCHEMA);
+            assert_eq!(checkpoint["work_type"], AGENT_TASK_COOK_JOB_TYPE);
+            assert_eq!(checkpoint["checkpoint"]["phase"], "supervising");
             let progress = harness
                 .events()
                 .expect("read controller events")
@@ -843,8 +930,8 @@ mod tests {
                 cook_id,
             )
             .expect("persist handoff parent");
-            let request = request_of(cook_id, u32::MAX);
-            let driver: Arc<dyn ControllerJobDriver> = Arc::new(CookJobDriver);
+            let request = work_request_of(cook_id, u32::MAX);
+            let driver: Arc<dyn ControllerJobDriver> = Arc::new(WorkJobDriver);
             let harness = ControllerJobHarness::new(Arc::clone(&driver), request.clone())
                 .expect("construct controller job harness");
             let supervising = driver.prepare(request).expect("prepare cook job");
@@ -853,11 +940,11 @@ mod tests {
                 .resume(supervising.clone(), harness.handle())
                 .expect("resume supervision of dead child");
 
-            assert_eq!(observed["phase"], "completed");
-            assert_eq!(observed["terminal_state"], "failed");
+            assert_eq!(observed["result"]["phase"], "completed");
+            assert_eq!(observed["result"]["terminal_state"], "failed");
             let mut completed = supervising;
-            completed["phase"] = json!("completed");
-            completed["terminal_state"] = json!("failed");
+            completed["checkpoint"]["phase"] = json!("completed");
+            completed["checkpoint"]["terminal_state"] = json!("failed");
             let first = driver
                 .resume(completed.clone(), harness.handle())
                 .expect("first completed replay");
@@ -878,8 +965,8 @@ mod tests {
                 cook_id,
             )
             .expect("persist handoff parent");
-            let request = request_of(cook_id, u32::MAX);
-            let driver: Arc<dyn ControllerJobDriver> = Arc::new(CookJobDriver);
+            let request = work_request_of(cook_id, u32::MAX);
+            let driver: Arc<dyn ControllerJobDriver> = Arc::new(WorkJobDriver);
             let harness = ControllerJobHarness::new(Arc::clone(&driver), request.clone())
                 .expect("construct controller job harness");
             harness
@@ -892,8 +979,8 @@ mod tests {
                 .execute(driver.prepare(request).expect("prepare cook job"), handle)
                 .expect("stop supervision after cancellation");
 
-            assert_eq!(result["phase"], "completed");
-            assert_eq!(result["terminal_state"], "failed");
+            assert_eq!(result["result"]["phase"], "completed");
+            assert_eq!(result["result"]["terminal_state"], "failed");
         });
     }
 
@@ -976,7 +1063,7 @@ mod tests {
                 .expect("build submission");
 
             CookJobDriver
-                .cancel(&submission["request"])
+                .cancel(&submission["request"]["request"])
                 .expect("driver cancellation reaches the lifecycle stop path");
 
             assert!(
@@ -1018,7 +1105,7 @@ mod tests {
                 cook_retry_job_submission(cook_id, "cook-retry-cancel-attempt-2", 4242, &IDENTITY)
                     .expect("build retry supervisor submission");
             CookJobDriver
-                .cancel(&submission["request"])
+                .cancel(&submission["request"]["request"])
                 .expect("cancel pinned retry supervisor");
 
             assert_eq!(

--- a/crates/homeboy-agents/src/agent_task_service/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_service/mod.rs
@@ -31,6 +31,8 @@ pub mod process_activity;
 mod promotion_service;
 mod reconcile;
 mod status_support;
+/// Shared daemon lifecycle for newly submitted orchestration work.
+mod work_job;
 
 pub use cook::*;
 pub use cook_activity::{CookActivityProbe, CookProviderActivity};
@@ -51,6 +53,7 @@ pub use execution::*;
 pub use promotion_service::*;
 pub use reconcile::*;
 pub use status_support::*;
+pub use work_job::*;
 
 #[cfg(test)]
 mod tests;

--- a/crates/homeboy-agents/src/agent_task_service/work_job.rs
+++ b/crates/homeboy-agents/src/agent_task_service/work_job.rs
@@ -1,0 +1,355 @@
+//! Shared controller-job lifecycle for agent-task orchestration work.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use homeboy_core::daemon::controller_job_driver::{
+    self, ControllerJobDriver, ControllerJobHandle, ControllerJobPublicError,
+};
+use homeboy_core::{Error, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+pub const WORK_JOB_TYPE: &str = "work";
+pub const WORK_JOB_VERSION: u32 = 1;
+pub(crate) const WORK_JOB_REQUEST_SCHEMA: &str = "homeboy/work-job-request/v1";
+pub(crate) const WORK_JOB_CHECKPOINT_SCHEMA: &str = "homeboy/work-job-checkpoint/v1";
+pub(crate) const WORK_JOB_PROGRESS_SCHEMA: &str = "homeboy/work-job-progress/v1";
+pub(crate) const WORK_JOB_RESULT_SCHEMA: &str = "homeboy/work-job-result/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct WorkJobRequest {
+    pub schema: String,
+    pub work_type: String,
+    pub work_version: u32,
+    pub request: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct WorkJobCheckpoint {
+    pub schema: String,
+    pub work_type: String,
+    pub work_version: u32,
+    pub checkpoint: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct WorkJobProgress {
+    schema: String,
+    work_type: String,
+    work_version: u32,
+    progress: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct WorkJobResult {
+    schema: String,
+    work_type: String,
+    work_version: u32,
+    result: Value,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkJobInvocation {
+    Execute,
+    Resume,
+}
+
+/// Domain behavior behind the one generic orchestration lifecycle driver.
+///
+/// Implementations receive only [`WorkJobHandle`], so they can publish domain
+/// checkpoints and progress but cannot mutate generic controller-job state.
+pub trait WorkJobHandler: Send + Sync {
+    fn work_type(&self) -> &'static str;
+    fn version(&self) -> u32;
+    fn public_request(&self, request: &Value) -> Result<Value>;
+    fn public_progress(&self, progress: &Value) -> Result<Value>;
+    fn public_result(&self, result: &Value) -> Result<Value>;
+    fn public_error(&self, error: &Error) -> ControllerJobPublicError;
+    fn validate_secret_references(&self, request: &Value) -> Result<()>;
+    fn prepare(&self, request: Value) -> Result<Value>;
+    fn advance(
+        &self,
+        checkpoint: Value,
+        handle: WorkJobHandle,
+        invocation: WorkJobInvocation,
+    ) -> Result<Value>;
+    fn cancel(&self, checkpoint: &Value) -> Result<()>;
+}
+
+#[derive(Clone, Copy)]
+enum WorkJobFraming {
+    Versioned,
+    Legacy,
+}
+
+/// The bounded event surface available to domain handlers.
+#[derive(Clone)]
+pub struct WorkJobHandle {
+    inner: ControllerJobHandle,
+    work_type: &'static str,
+    work_version: u32,
+    framing: WorkJobFraming,
+}
+
+impl WorkJobHandle {
+    fn versioned(inner: ControllerJobHandle, handler: &dyn WorkJobHandler) -> Self {
+        Self {
+            inner,
+            work_type: handler.work_type(),
+            work_version: handler.version(),
+            framing: WorkJobFraming::Versioned,
+        }
+    }
+
+    pub(crate) fn legacy(inner: ControllerJobHandle, handler: &dyn WorkJobHandler) -> Self {
+        Self {
+            inner,
+            work_type: handler.work_type(),
+            work_version: handler.version(),
+            framing: WorkJobFraming::Legacy,
+        }
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.is_cancelled()
+    }
+
+    pub fn job_id(&self) -> String {
+        self.inner.job_id()
+    }
+
+    pub fn progress(&self, progress: Value) -> Result<()> {
+        match self.framing {
+            WorkJobFraming::Versioned => self.inner.progress(to_value(WorkJobProgress {
+                schema: WORK_JOB_PROGRESS_SCHEMA.to_string(),
+                work_type: self.work_type.to_string(),
+                work_version: self.work_version,
+                progress,
+            })?),
+            WorkJobFraming::Legacy => self.inner.progress(progress),
+        }
+    }
+
+    pub fn checkpoint(&self, checkpoint: Value) -> Result<()> {
+        match self.framing {
+            WorkJobFraming::Versioned => self.inner.checkpoint(to_value(WorkJobCheckpoint {
+                schema: WORK_JOB_CHECKPOINT_SCHEMA.to_string(),
+                work_type: self.work_type.to_string(),
+                work_version: self.work_version,
+                checkpoint,
+            })?),
+            WorkJobFraming::Legacy => self.inner.checkpoint(checkpoint),
+        }
+    }
+}
+
+type WorkJobHandlerKey = (String, u32);
+type WorkJobHandlers = Mutex<HashMap<WorkJobHandlerKey, Arc<dyn WorkJobHandler>>>;
+
+fn handlers() -> &'static WorkJobHandlers {
+    static HANDLERS: std::sync::OnceLock<WorkJobHandlers> = std::sync::OnceLock::new();
+    HANDLERS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub fn register_work_job_handler(handler: Arc<dyn WorkJobHandler>) -> Result<()> {
+    let key = (handler.work_type().to_string(), handler.version());
+    let mut registry = handlers().lock().expect("work job handler lock");
+    if registry.contains_key(&key) {
+        return Err(Error::validation_invalid_argument(
+            "work_job_handler",
+            format!(
+                "work job handler `{}` version {} is already registered",
+                key.0, key.1
+            ),
+            Some(key.0),
+            None,
+        ));
+    }
+    registry.insert(key, handler);
+    Ok(())
+}
+
+fn handler(work_type: &str, version: u32) -> Result<Arc<dyn WorkJobHandler>> {
+    handlers()
+        .lock()
+        .expect("work job handler lock")
+        .get(&(work_type.to_string(), version))
+        .cloned()
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "work_type",
+                format!("no work job handler is registered for `{work_type}` version {version}"),
+                Some(work_type.to_string()),
+                None,
+            )
+        })
+}
+
+pub struct WorkJobDriver;
+
+impl ControllerJobDriver for WorkJobDriver {
+    fn job_type(&self) -> &'static str {
+        WORK_JOB_TYPE
+    }
+
+    fn version(&self) -> u32 {
+        WORK_JOB_VERSION
+    }
+
+    fn public_request(&self, request: &Value) -> Result<Value> {
+        let request = parse_request(request.clone())?;
+        handler(&request.work_type, request.work_version)?.public_request(&request.request)
+    }
+
+    fn public_progress(&self, progress: &Value) -> Result<Value> {
+        let progress: WorkJobProgress = parse_value(progress.clone(), "work progress")?;
+        validate_schema(&progress.schema, WORK_JOB_PROGRESS_SCHEMA, "work progress")?;
+        handler(&progress.work_type, progress.work_version)?.public_progress(&progress.progress)
+    }
+
+    fn public_result(&self, result: &Value) -> Result<Value> {
+        let result: WorkJobResult = parse_value(result.clone(), "work result")?;
+        validate_schema(&result.schema, WORK_JOB_RESULT_SCHEMA, "work result")?;
+        handler(&result.work_type, result.work_version)?.public_result(&result.result)
+    }
+
+    fn public_error(&self, error: &Error) -> ControllerJobPublicError {
+        ControllerJobPublicError {
+            message: "controller-owned work failed".to_string(),
+            data: json!({ "code": format!("{:?}", error.code) }),
+        }
+    }
+
+    fn validate_secret_references(&self, request: &Value) -> Result<()> {
+        let request = parse_request(request.clone())?;
+        handler(&request.work_type, request.work_version)?
+            .validate_secret_references(&request.request)
+    }
+
+    fn prepare(&self, request: Value) -> Result<Value> {
+        let request = parse_request(request)?;
+        let prepared =
+            handler(&request.work_type, request.work_version)?.prepare(request.request)?;
+        to_value(WorkJobCheckpoint {
+            schema: WORK_JOB_CHECKPOINT_SCHEMA.to_string(),
+            work_type: request.work_type,
+            work_version: request.work_version,
+            checkpoint: prepared,
+        })
+    }
+
+    fn execute(&self, prepared: Value, handle: ControllerJobHandle) -> Result<Value> {
+        self.advance(prepared, handle, WorkJobInvocation::Execute)
+    }
+
+    fn resume(&self, checkpoint: Value, handle: ControllerJobHandle) -> Result<Value> {
+        self.advance(checkpoint, handle, WorkJobInvocation::Resume)
+    }
+
+    fn cancel(&self, prepared: &Value) -> Result<()> {
+        let checkpoint = parse_checkpoint(prepared.clone())?;
+        handler(&checkpoint.work_type, checkpoint.work_version)?.cancel(&checkpoint.checkpoint)
+    }
+}
+
+impl WorkJobDriver {
+    fn advance(
+        &self,
+        prepared: Value,
+        handle: ControllerJobHandle,
+        invocation: WorkJobInvocation,
+    ) -> Result<Value> {
+        let checkpoint = parse_checkpoint(prepared)?;
+        let handler = handler(&checkpoint.work_type, checkpoint.work_version)?;
+        let result = handler.advance(
+            checkpoint.checkpoint,
+            WorkJobHandle::versioned(handle, handler.as_ref()),
+            invocation,
+        )?;
+        to_value(WorkJobResult {
+            schema: WORK_JOB_RESULT_SCHEMA.to_string(),
+            work_type: checkpoint.work_type,
+            work_version: checkpoint.work_version,
+            result,
+        })
+    }
+}
+
+pub fn register_work_job_driver() {
+    static REGISTERED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    REGISTERED.get_or_init(|| {
+        controller_job_driver::register_controller_job_driver(Arc::new(WorkJobDriver))
+            .expect("register work controller job driver");
+    });
+}
+
+pub fn work_job_submission(
+    handler: &dyn WorkJobHandler,
+    idempotency_key: String,
+    request: Value,
+) -> Result<Value> {
+    handler.validate_secret_references(&request)?;
+    let request = WorkJobRequest {
+        schema: WORK_JOB_REQUEST_SCHEMA.to_string(),
+        work_type: handler.work_type().to_string(),
+        work_version: handler.version(),
+        request,
+    };
+    Ok(json!({
+        "type": WORK_JOB_TYPE,
+        "version": WORK_JOB_VERSION,
+        "idempotency_key": idempotency_key,
+        "request": to_value(request)?,
+    }))
+}
+
+fn parse_request(value: Value) -> Result<WorkJobRequest> {
+    let request: WorkJobRequest = parse_value(value, "work request")?;
+    validate_schema(&request.schema, WORK_JOB_REQUEST_SCHEMA, "work request")?;
+    if request.work_type.trim().is_empty() {
+        return Err(invalid_work_job("work requests require a work type"));
+    }
+    Ok(request)
+}
+
+fn parse_checkpoint(value: Value) -> Result<WorkJobCheckpoint> {
+    let checkpoint: WorkJobCheckpoint = parse_value(value, "work checkpoint")?;
+    validate_schema(
+        &checkpoint.schema,
+        WORK_JOB_CHECKPOINT_SCHEMA,
+        "work checkpoint",
+    )?;
+    Ok(checkpoint)
+}
+
+fn validate_schema(actual: &str, expected: &str, context: &str) -> Result<()> {
+    if actual != expected {
+        return Err(invalid_work_job(&format!(
+            "{context} requires recognized schema `{expected}`"
+        )));
+    }
+    Ok(())
+}
+
+fn parse_value<T: for<'de> Deserialize<'de>>(value: Value, context: &str) -> Result<T> {
+    serde_json::from_value(value)
+        .map_err(|error| invalid_work_job(&format!("invalid durable {context}: {error}")))
+}
+
+fn to_value<T: Serialize>(value: T) -> Result<Value> {
+    serde_json::to_value(value).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("serialize work job state".to_string()),
+        )
+    })
+}
+
+fn invalid_work_job(message: &str) -> Error {
+    Error::validation_invalid_argument("work_job", message, None, None)
+}

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -457,6 +457,10 @@ fn register_startup_providers_after_reconcile(
     crate::agents::agent_task_service::register_orchestration_driver();
     crate::commands::route::register_unmaterialized_cook_replay_driver();
     crate::agents::agent_task_service::register_controller_upgrade_admission_provider();
+    // New orchestration submissions share one versioned lifecycle driver. The
+    // domain registrations below also retain their v1 recovery adapters for
+    // persisted jobs admitted before the migration.
+    crate::agents::agent_task_service::register_work_job_driver();
     // A locally-placed detached Cook is a daemon-owned durable job: the daemon
     // owns its record, checkpointing, cancellation and HTTP inspection, while
     // the launcher-spawned child keeps the operator's execution environment.


### PR DESCRIPTION
Part of #13582.

## Summary
- add versioned `WorkJobRequest` and `WorkJobCheckpoint` contracts behind one `WorkJobDriver`
- move Cook and fanout lifecycle behavior into bounded typed handlers and route every new submission through `work/v1`
- retain the old Cook and batch driver registrations only as raw-v1 recovery adapters for persisted jobs
- prove execute, resume/terminal replay, cancellation, and private/public projection through `ControllerJobHarness`

## Verification
- `cargo test -p homeboy-agents --lib cook_job`
- `cargo test -p homeboy-agents --lib cook_batch_job`
- `cargo test -p homeboy-cli --lib cli_runtime`
- `cargo test -p homeboy-cli --lib local_detach`
- `cargo check -p homeboy-agents -p homeboy-cli --all-targets --features test-support`
- `cargo check -p homeboy-agents -p homeboy-cli`

## Compatibility
Persisted `agent-task-cook/v1` and `agent-task-cook-batch/v1` jobs keep their original checkpoint and projection shapes. Only new submissions use `work/v1`. Loop/controller migration remains a subsequent #13582 slice.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode inspected the existing controller-job lifecycle, implemented the shared driver and handler migration directly in the managed worktree, and ran the focused verification. Chris Huber directed the architecture and reviewed the delivery scope.