### PR TITLE
Preserve queued Cook provider liveness

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -3675,7 +3675,7 @@ pub fn record_cook_progress_with_activity_in_store(
             metadata.insert("cook_progress".to_string(), progress);
         }
         if !record.state.is_terminal()
-            && (!record.is_runner_backed() || record.has_fresh_controller_pre_provider_heartbeat())
+            && (!record.is_runner_backed() || record.is_controller_pre_provider_phase())
         {
             record.updated_at = Some(now_timestamp());
             update_lifecycle_heartbeat(record);

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -897,10 +897,9 @@ impl AgentTaskRunRecord {
                 .is_some_and(|runner_id| self.runner_id() == Some(runner_id))
     }
 
-    /// A controller-owned pre-provider phase is live only while its heartbeat
-    /// is fresh. Once runner submission begins, runner identity remains the
-    /// fail-closed ownership boundary.
-    pub(crate) fn has_fresh_controller_pre_provider_heartbeat(&self) -> bool {
+    /// Whether Cook is still in the controller-owned phase before runner or
+    /// provider execution can supply its own durable identity.
+    pub(crate) fn is_controller_pre_provider_phase(&self) -> bool {
         self.runner_job_id().is_none()
             && self.provider_handles.is_empty()
             && matches!(
@@ -909,7 +908,13 @@ impl AgentTaskRunRecord {
                     .and_then(Value::as_str),
                 Some("worktree_provider_lookup" | "worktree_provider_ensure")
             )
-            && self.has_fresh_update()
+    }
+
+    /// A controller-owned pre-provider phase is live only while its heartbeat
+    /// is fresh. Once runner submission begins, runner identity remains the
+    /// fail-closed ownership boundary.
+    pub(crate) fn has_fresh_controller_pre_provider_heartbeat(&self) -> bool {
+        self.is_controller_pre_provider_phase() && self.has_fresh_update()
     }
 
     /// A run is runner-backed when its durable record carries a runner id or

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -682,6 +682,13 @@ fn classify_liveness(
     if live_local_cook_retry_supervisor(record) {
         return AgentTaskLiveness::Active;
     }
+    // Worktree lookup and materialization are controller-owned even when the
+    // eventual provider execution is destined for a runner. They precede the
+    // queued-to-running transition, so their fresh Cook heartbeat is the only
+    // possible owner during this phase.
+    if record.has_fresh_controller_pre_provider_heartbeat() {
+        return AgentTaskLiveness::Active;
+    }
     if record.state != agent_task_lifecycle::AgentTaskRunState::Running {
         if agent_task_lifecycle::has_expired_pending_runner_submission_intent(record, now) {
             return AgentTaskLiveness::Unreconciled;

--- a/crates/homeboy-agents/src/agent_task_service/reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_service/reconcile.rs
@@ -89,6 +89,16 @@ fn rooted_exact_status(
     .record)
 }
 
+fn fenced_record_is_live(record: &agent_task_lifecycle::AgentTaskRunRecord) -> bool {
+    record.state.is_terminal()
+        || record.has_fresh_controller_pre_provider_heartbeat()
+        || (record.has_planned_runner_execution() && record.has_fresh_update())
+        || agent_task_lifecycle::has_live_pending_runner_submission_intent(
+            record,
+            chrono::Utc::now(),
+        )
+}
+
 pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileReport> {
     // One store for the whole sweep. Every run this classifies, expires, and
     // cancels is decided from a record read here; a decision taken against one
@@ -235,13 +245,7 @@ pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileRe
             let _lock =
                 agent_task_lifecycle::LabHandoffLock::lock_in_store(&lifecycle_store, &run.run_id)?;
             let fenced = lifecycle_store.read_record(&run.run_id)?;
-            if fenced.state.is_terminal()
-                || (fenced.has_planned_runner_execution() && fenced.has_fresh_update())
-                || agent_task_lifecycle::has_live_pending_runner_submission_intent(
-                    &fenced,
-                    chrono::Utc::now(),
-                )
-            {
+            if fenced_record_is_live(&fenced) {
                 continue;
             }
             agent_task_lifecycle::cancel_run_in_store(&lifecycle_store, &run.run_id, Some(&reason))
@@ -1246,13 +1250,12 @@ mod tests {
     }
 
     #[test]
-    fn controller_heartbeat_keeps_slow_pre_provider_materialization_out_of_runner_pid_watchdog() {
+    fn controller_heartbeat_keeps_queued_pre_provider_materialization_out_of_runner_pid_watchdog() {
         with_isolated_home(|_| {
             register_orchestration_driver();
             let run_id = "reconcile-controller-pre-provider-heartbeat";
             let plan = AgentTaskPlan::new("reconcile-tick-plan", Vec::new());
             agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("submitted");
-            agent_task_lifecycle::mark_running(run_id).expect("running");
             agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
                 record
                     .metadata
@@ -1281,6 +1284,10 @@ mod tests {
             .expect("record slow provider evidence");
 
             let status = agent_task_lifecycle::status(run_id).expect("status while ensure runs");
+            assert!(
+                status.has_fresh_controller_pre_provider_heartbeat(),
+                "{status:?}"
+            );
             assert!(status.metadata.get("stale_running").is_none());
             assert_eq!(
                 status.metadata["cook_progress"]["phase"],
@@ -1297,9 +1304,45 @@ mod tests {
             let retained = agent_task_lifecycle::status(run_id).expect("retained run");
             assert_eq!(
                 retained.state,
-                agent_task_lifecycle::AgentTaskRunState::Running
+                agent_task_lifecycle::AgentTaskRunState::Queued
             );
             assert!(retained.metadata.get("cancel_reason").is_none());
+        });
+    }
+
+    #[test]
+    fn fenced_recheck_preserves_heartbeat_recorded_after_stale_discovery_snapshot() {
+        with_isolated_home(|_| {
+            let run_id = "reconcile-controller-heartbeat-after-snapshot";
+            let plan = AgentTaskPlan::new("reconcile-tick-plan", Vec::new());
+            agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("submitted");
+
+            let snapshot = discover_runs(AgentTaskDiscoveryFilter::Active)
+                .expect("ownerless queued run discovered");
+            let discovered = snapshot
+                .runs
+                .iter()
+                .find(|run| run.run_id == run_id)
+                .expect("stale snapshot contains run");
+            assert_eq!(discovered.liveness, Some(AgentTaskLiveness::Stale));
+
+            agent_task_lifecycle::record_cook_progress_in_store(
+                &test_lifecycle_store(),
+                run_id,
+                "worktree_provider_lookup",
+                1,
+                Some("provider lookup started after discovery"),
+            )
+            .expect("controller heartbeat");
+
+            let fenced =
+                agent_task_lifecycle::exact_record_in_store(&test_lifecycle_store(), run_id)
+                    .expect("fenced record");
+            assert!(fenced_record_is_live(&fenced));
+            assert_eq!(
+                fenced.state,
+                agent_task_lifecycle::AgentTaskRunState::Queued
+            );
         });
     }
 


### PR DESCRIPTION
## Summary

- allow the first controller-owned worktree lookup heartbeat to establish liveness on queued runner-destined Cooks
- classify fresh pre-provider heartbeats as active before the queued/running split
- revalidate that heartbeat under the Lab handoff fence before acting on a stale discovery snapshot
- retain fail-closed cancellation after runner submission begins

## Evidence

- Reproduced by Cook run `agent-task-bd8208c0-2b90-4f09-a970-d5a4ffa4a694-attempt-1-a09c7bdc`, where DMC safety commands were cancelled while the daemon recorded `missing_runner_pid` before provider execution.
- `cargo fmt --all --check`
- `cargo test -p homeboy-agents agent_task_service::reconcile::tests` (24 passed)
- `cargo test -p homeboy-agents agent_task_lifecycle::tests::submit_and_persist -- --test-threads=1` (54 passed)

Closes #13597.

## AI assistance

Implemented and verified with OpenCode using `openai/gpt-5.6-sol`; AI assistance correlated lifecycle evidence, isolated the queued first-heartbeat and fenced stale-snapshot races, and added deterministic regression coverage.