### PR TITLE
fix(release): distinguish absent recovery releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -765,6 +765,7 @@ jobs:
       tag-flag: ${{ format('--tag={0}', needs.prepare.outputs['release-tag']) }}
       expected-assets: ${{ steps.plan.outputs.expected-assets }}
       draft-complete: ${{ steps.draft-probe.outputs.draft-complete }}
+      release-exists: ${{ steps.draft-probe.outputs.release-exists }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -848,29 +849,39 @@ jobs:
           set +e
           set -uo pipefail
           COMPLETE=false
+          RELEASE_EXISTS=unknown
           REASON=''
 
           if ! gh release view "${RELEASE_TAG}" --json isDraft,assets > draft.json 2> draft.err; then
-            REASON="the inventory for ${RELEASE_TAG} could not be read"
-            sed 's/^/gh: /' draft.err >&2 || true
-          elif [ "$(jq -r '.isDraft' draft.json)" != "true" ]; then
-            REASON="${RELEASE_TAG} is not an unpublished draft"
-          else
-            WANTED="$(jq -Sc 'unique' <<< "${EXPECTED_ASSETS}")"
-            USABLE="$(jq -Sc '[.assets[] | select(.state == "uploaded" and .size > 0) | .name] | unique' draft.json)"
-            TOTAL="$(jq -r '.assets | length' draft.json)"
-            WANTED_COUNT="$(jq -r 'length' <<< "${WANTED}")"
-            # Exact inventory: every expected asset usable, and nothing else
-            # present. `TOTAL` catches duplicates and strays that `unique`
-            # would otherwise collapse away.
-            if [ "${USABLE}" = "${WANTED}" ] && [ "${TOTAL}" = "${WANTED_COUNT}" ]; then
-              COMPLETE=true
+            if grep -Fq 'release not found' draft.err; then
+              RELEASE_EXISTS=false
+              REASON="no GitHub Release exists for ${RELEASE_TAG} yet"
             else
-              REASON="the inventory differs (expected ${WANTED_COUNT}: ${WANTED}; usable: ${USABLE}; total on release: ${TOTAL})"
+              REASON="the inventory for ${RELEASE_TAG} could not be read"
+            fi
+            sed 's/^/gh: /' draft.err >&2 || true
+          else
+            RELEASE_EXISTS=true
+            if [ "$(jq -r '.isDraft' draft.json)" != "true" ]; then
+              REASON="${RELEASE_TAG} is not an unpublished draft"
+            else
+              WANTED="$(jq -Sc 'unique' <<< "${EXPECTED_ASSETS}")"
+              USABLE="$(jq -Sc '[.assets[] | select(.state == "uploaded" and .size > 0) | .name] | unique' draft.json)"
+              TOTAL="$(jq -r '.assets | length' draft.json)"
+              WANTED_COUNT="$(jq -r 'length' <<< "${WANTED}")"
+              # Exact inventory: every expected asset usable, and nothing else
+              # present. `TOTAL` catches duplicates and strays that `unique`
+              # would otherwise collapse away.
+              if [ "${USABLE}" = "${WANTED}" ] && [ "${TOTAL}" = "${WANTED_COUNT}" ]; then
+                COMPLETE=true
+              else
+                REASON="the inventory differs (expected ${WANTED_COUNT}: ${WANTED}; usable: ${USABLE}; total on release: ${TOTAL})"
+              fi
             fi
           fi
 
           echo "draft-complete=${COMPLETE}" >> "$GITHUB_OUTPUT"
+          echo "release-exists=${RELEASE_EXISTS}" >> "$GITHUB_OUTPUT"
           if [ "${COMPLETE}" = "true" ]; then
             echo "::notice::${RELEASE_TAG} already holds every expected asset; skipping the cross-platform rebuild and re-upload, and going straight to draft adoption (#10519)"
             {
@@ -1164,6 +1175,16 @@ jobs:
           name: homeboy-binary
           path: .homeboy-bin
 
+      - name: Require resolved recovery release routing
+        if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete != 'true'
+        env:
+          RELEASE_EXISTS: ${{ needs.plan.outputs.release-exists }}
+        run: |
+          if [ "${RELEASE_EXISTS}" != "true" ] && [ "${RELEASE_EXISTS}" != "false" ]; then
+            echo "::error::Could not determine whether the recovery tag already has a GitHub Release. Refusing to bypass byte-preserving existing-release recovery or run remote reconciliation against an absent Release."
+            exit 1
+          fi
+
       - name: Create fresh artifact source-authority manifest
         if: needs.prepare.outputs.recovery-release != 'true' && needs.plan.outputs.draft-complete != 'true'
         env:
@@ -1179,7 +1200,7 @@ jobs:
             --commit "$(git rev-parse "${RELEASE_TAG}^{commit}")"
 
       - name: Preserve existing published asset bytes
-        if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete != 'true'
+        if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.release-exists == 'true' && needs.plan.outputs.draft-complete != 'true'
         env:
           RELEASE_TAG: ${{ needs.prepare.outputs['release-tag'] }}
           EXPECTED_ASSETS: ${{ needs.plan.outputs.expected-assets }}
@@ -1257,7 +1278,7 @@ jobs:
             '{schema: $schema, schema_version: $schema_version, component_id: $component_id, tag: $tag, version: $version, commit: $commit, artifacts: $artifacts}' > artifacts/manifest.json
 
       - name: Reconcile rebuilt recovery assets
-        if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete != 'true'
+        if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.release-exists == 'true' && needs.plan.outputs.draft-complete != 'true'
         env:
           RELEASE_TAG: ${{ needs.prepare.outputs['release-tag'] }}
           EXPECTED_ASSETS: ${{ needs.plan.outputs.expected-assets }}

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -1183,7 +1183,7 @@ fn incomplete_recovery_delivers_identity_bound_artifacts_to_the_finalizer() {
     let adoption = release_step_block(host, "name: Create remote draft adoption manifest");
 
     assert!(preserve.contains(
-        "if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete != 'true'"
+        "if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.release-exists == 'true' && needs.plan.outputs.draft-complete != 'true'"
     ));
     assert!(preserve.contains(".isDraft' existing-release.json)\" != \"false\""));
     assert!(preserve.contains("done < <(jq -r '.[]' <<< \"${EXPECTED_ASSETS}\")"));
@@ -1294,7 +1294,7 @@ fn release_recovery_reconciles_rebuilt_assets_before_the_finalizer() {
         "recovery must reconcile authoritative local artifacts before finalization"
     );
     assert!(reconcile.contains(
-        "if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete != 'true'"
+        "if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.release-exists == 'true' && needs.plan.outputs.draft-complete != 'true'"
     ));
     assert!(reconcile.contains("ASSET_DIR=artifacts RECONCILE=true REQUIRE_ANNOUNCE_ASSETS=false"));
     assert!(reconcile.contains("git show \"${CONTROL_SHA}:.github/release-asset-completeness.sh\""));
@@ -1305,6 +1305,53 @@ fn release_recovery_reconciles_rebuilt_assets_before_the_finalizer() {
         helper.contains("gh release upload \"${RELEASE_TAG}\" \"${ASSET_DIR}/${asset}\" --clobber")
     );
     assert!(helper.contains("Could not re-read the asset inventory"));
+}
+
+/// Runs 32977620578 and 32994515251 reached recovery with a fresh tag but no
+/// GitHub Release. Remote reconciliation cannot precede the finalizer that owns
+/// creation of that Release; an existing remote inventory is the discriminator.
+#[test]
+fn release_routes_remote_recovery_only_when_a_release_inventory_exists() {
+    let workflow = release_workflow();
+    let plan = job_section(workflow, "plan");
+    let host = job_section(workflow, "host");
+    let probe = release_step_block(
+        plan,
+        "name: Probe existing draft for a complete asset inventory",
+    );
+    let preserve = release_step_block(host, "name: Preserve existing published asset bytes");
+    let recovery = release_step_block(host, "name: Create authoritative recovery manifest");
+    let reconcile = release_step_block(host, "name: Reconcile rebuilt recovery assets");
+
+    assert!(plan.contains("release-exists: ${{ steps.draft-probe.outputs.release-exists }}"));
+    assert!(probe.contains("RELEASE_EXISTS=unknown"));
+    assert!(probe.contains("RELEASE_EXISTS=false"));
+    assert!(probe.contains("RELEASE_EXISTS=true"));
+    assert!(probe.contains("release-exists=${RELEASE_EXISTS}"));
+
+    let route_guard = release_step_block(host, "name: Require resolved recovery release routing");
+    assert!(route_guard.contains(
+        "if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete != 'true'"
+    ));
+    assert!(route_guard.contains("RELEASE_EXISTS: ${{ needs.plan.outputs.release-exists }}"));
+    assert!(route_guard.contains("exit 1"));
+
+    let existing_release_route = "needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.release-exists == 'true' && needs.plan.outputs.draft-complete != 'true'";
+    for (name, step) in [("preservation", preserve), ("reconciliation", reconcile)] {
+        assert!(
+            step.contains(existing_release_route),
+            "remote {name} must require an observed Release inventory: {step}"
+        );
+    }
+
+    assert!(recovery.contains(
+        "if: needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete != 'true'"
+    ));
+    assert!(
+        !recovery.contains("release-exists"),
+        "an absent Release must still receive the authoritative rebuilt-artifact manifest"
+    );
+    assert!(host.contains("release-from-artifacts: ${{ needs.prepare.outputs.recovery-release == 'true' && needs.plan.outputs.draft-complete == 'true' && 'draft-adoption' || 'artifacts' }}"));
 }
 
 /// Recovery is allowed — required — to run a control binary NEWER than the tag


### PR DESCRIPTION
## Summary

- project the recovery probe's observed GitHub Release existence to downstream jobs
- run byte preservation and remote reconciliation only when a Release inventory actually exists
- keep absent-release recovery on the authoritative rebuilt-artifact path and fail closed when existence is unknown
- add deterministic workflow coverage for absent, existing, and unknown recovery routing

Fixes #13594.

## Evidence

Reproduced by release runs [32977620578](https://github.com/Extra-Chill/homeboy/actions/runs/32977620578) and [32994515251](https://github.com/Extra-Chill/homeboy/actions/runs/32994515251): both had a valid tag and rebuilt artifacts but no GitHub Release, then failed because `Reconcile rebuilt recovery assets` required a remote inventory before the finalizer could create it.

- `cargo fmt --all --check`
- `cargo test --test release_workflow_test`: 69 passed
- `cargo test -p homeboy-release`: 551 passed, 3 failed in pre-existing extension-lint tests
- Baseline confirmation: `cargo test -p homeboy-release extension_release_lint_blocks_finding_in_file_changed_since_prior_tag -- --nocapture --test-threads=1` fails identically on unchanged `main` at `d64d1ae295d1b0005e79dc2b379a1acfbc651792`

The patch changes workflow routing only. It does not publish, mutate, or bypass the finalizer's existing byte and inventory verification.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode was used to inspect the failed workflow evidence, review the generated patch, run deterministic verification, confirm the unrelated baseline failure, and prepare this pull request. Chris Huber remains responsible for the change.