### PR TITLE
Route loop supervision through Work jobs

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/loop_job.rs
+++ b/crates/homeboy-agents/src/agent_task_service/loop_job.rs
@@ -1,0 +1,450 @@
+//! Shared-work supervision for one detached loop-controller coordinator.
+
+use std::time::Duration;
+
+use homeboy_core::daemon::controller_job_driver::ControllerJobPublicError;
+use homeboy_core::process::{
+    process_identity_state_with_start_identity, ProcessIdentityState, ProcessStartIdentity,
+};
+use homeboy_core::Result;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use super::work_job::{
+    register_work_job_handler, work_job_submission, WorkJobHandle, WorkJobHandler,
+    WorkJobInvocation,
+};
+use crate::agent_task_loop_controller::{self, AgentTaskLoopControllerState};
+
+pub const AGENT_TASK_LOOP_JOB_TYPE: &str = "agent-task-loop";
+pub const AGENT_TASK_LOOP_JOB_VERSION: u32 = 1;
+const AGENT_TASK_LOOP_JOB_SCHEMA: &str = "homeboy/agent-task-loop-job/v1";
+const SUPERVISION_POLL: Duration = Duration::from_millis(500);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AgentTaskLoopJobRequest {
+    pub schema: String,
+    pub loop_id: String,
+    pub child_pid: u32,
+    pub child_start_identity: ProcessStartIdentity,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskLoopJobPhase {
+    #[default]
+    Queued,
+    Supervising,
+    Completed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AgentTaskLoopJob {
+    pub schema: String,
+    pub idempotency_key: String,
+    pub request: AgentTaskLoopJobRequest,
+    #[serde(default)]
+    pub phase: AgentTaskLoopJobPhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub controller_state: Option<AgentTaskLoopControllerState>,
+}
+
+impl AgentTaskLoopJob {
+    fn new(request: AgentTaskLoopJobRequest) -> Result<Self> {
+        if request.schema != AGENT_TASK_LOOP_JOB_SCHEMA || request.loop_id.trim().is_empty() {
+            return Err(invalid_loop_job(
+                "loop jobs require a recognized schema and durable loop id",
+            ));
+        }
+        if request.child_pid == 0 {
+            return Err(invalid_loop_job(
+                "loop jobs require the detached coordinator's process id",
+            ));
+        }
+        Ok(Self {
+            schema: AGENT_TASK_LOOP_JOB_SCHEMA.to_string(),
+            idempotency_key: format!("agent-task-loop:{}", request.loop_id),
+            request,
+            phase: AgentTaskLoopJobPhase::Queued,
+            controller_state: None,
+        })
+    }
+
+    fn parse(value: Value) -> Result<Self> {
+        let job: Self = serde_json::from_value(value)
+            .map_err(|error| invalid_loop_job(&format!("invalid durable loop job: {error}")))?;
+        let expected = Self::new(job.request.clone())?;
+        if job.schema != AGENT_TASK_LOOP_JOB_SCHEMA
+            || job.idempotency_key != expected.idempotency_key
+        {
+            return Err(invalid_loop_job(
+                "loop job identity does not match its immutable request",
+            ));
+        }
+        if job.phase == AgentTaskLoopJobPhase::Completed
+            && !job
+                .controller_state
+                .is_some_and(controller_state_is_terminal)
+        {
+            return Err(invalid_loop_job(
+                "completed loop jobs require a terminal controller state",
+            ));
+        }
+        Ok(job)
+    }
+
+    fn to_checkpoint(&self) -> Result<Value> {
+        serde_json::to_value(self).map_err(|error| {
+            homeboy_core::Error::internal_json(
+                error.to_string(),
+                Some("serialize loop work checkpoint".to_string()),
+            )
+        })
+    }
+
+    fn public_projection(&self) -> Value {
+        json!({
+            "schema": self.schema,
+            "idempotency_key": self.idempotency_key,
+            "phase": self.phase,
+            "loop_id": self.request.loop_id,
+            "controller_state": self.controller_state,
+        })
+    }
+
+    fn result(&self) -> Value {
+        json!({
+            "phase": self.phase,
+            "loop_id": self.request.loop_id,
+            "controller_state": self.controller_state,
+        })
+    }
+
+    fn refresh_controller_state(&mut self) -> bool {
+        let Ok(record) = agent_task_loop_controller::controller_status(&self.request.loop_id)
+        else {
+            return false;
+        };
+        let changed = self.controller_state != Some(record.state);
+        self.controller_state = Some(record.state);
+        changed
+    }
+}
+
+struct LoopWorkHandler;
+
+impl WorkJobHandler for LoopWorkHandler {
+    fn work_type(&self) -> &'static str {
+        AGENT_TASK_LOOP_JOB_TYPE
+    }
+
+    fn version(&self) -> u32 {
+        AGENT_TASK_LOOP_JOB_VERSION
+    }
+
+    fn public_request(&self, request: &Value) -> Result<Value> {
+        Ok(AgentTaskLoopJob::parse(request.clone())?.public_projection())
+    }
+
+    fn public_progress(&self, progress: &Value) -> Result<Value> {
+        Ok(json!({
+            "phase": progress.get("phase").cloned().unwrap_or(Value::Null),
+            "loop_id": progress.get("loop_id").cloned().unwrap_or(Value::Null),
+            "controller_state": progress.get("controller_state").cloned().unwrap_or(Value::Null),
+        }))
+    }
+
+    fn public_result(&self, result: &Value) -> Result<Value> {
+        self.public_progress(result)
+    }
+
+    fn public_error(&self, error: &homeboy_core::Error) -> ControllerJobPublicError {
+        ControllerJobPublicError {
+            message: "controller-owned loop supervision failed".to_string(),
+            data: json!({ "code": format!("{:?}", error.code) }),
+        }
+    }
+
+    fn validate_secret_references(&self, request: &Value) -> Result<()> {
+        AgentTaskLoopJob::parse(request.clone()).map(|_| ())
+    }
+
+    fn prepare(&self, request: Value) -> Result<Value> {
+        let mut job = AgentTaskLoopJob::parse(request)?;
+        if job.phase != AgentTaskLoopJobPhase::Queued || job.controller_state.is_some() {
+            return Err(invalid_loop_job(
+                "new loop jobs must start queued without controller state",
+            ));
+        }
+        job.phase = AgentTaskLoopJobPhase::Supervising;
+        job.refresh_controller_state();
+        job.to_checkpoint()
+    }
+
+    fn advance(
+        &self,
+        checkpoint: Value,
+        handle: WorkJobHandle,
+        invocation: WorkJobInvocation,
+    ) -> Result<Value> {
+        let mut job = AgentTaskLoopJob::parse(checkpoint)?;
+        if invocation == WorkJobInvocation::Resume && job.phase == AgentTaskLoopJobPhase::Completed
+        {
+            return Ok(job.result());
+        }
+        self.supervise(&mut job, handle)
+    }
+
+    fn cancel(&self, checkpoint: &Value) -> Result<()> {
+        let job = AgentTaskLoopJob::parse(checkpoint.clone())?;
+        if job.phase == AgentTaskLoopJobPhase::Completed || !coordinator_is_live(&job.request) {
+            return Ok(());
+        }
+        homeboy_core::process::terminate_process_tree(job.request.child_pid).map(|_| ())
+    }
+}
+
+impl LoopWorkHandler {
+    fn supervise(&self, job: &mut AgentTaskLoopJob, handle: WorkJobHandle) -> Result<Value> {
+        job.phase = AgentTaskLoopJobPhase::Supervising;
+        job.refresh_controller_state();
+        handle.checkpoint(job.to_checkpoint()?)?;
+        handle.progress(job.result())?;
+
+        loop {
+            if job.refresh_controller_state() {
+                handle.checkpoint(job.to_checkpoint()?)?;
+                handle.progress(job.result())?;
+            }
+            if job
+                .controller_state
+                .is_some_and(controller_state_is_terminal)
+            {
+                job.phase = AgentTaskLoopJobPhase::Completed;
+                return Ok(job.result());
+            }
+            if handle.is_cancelled() {
+                let _ = self.cancel(&job.to_checkpoint()?);
+                return terminalize_interrupted(job, AgentTaskLoopControllerState::Abandoned);
+            }
+            if !coordinator_is_live(&job.request) {
+                return terminalize_interrupted(job, AgentTaskLoopControllerState::Failed);
+            }
+            std::thread::sleep(SUPERVISION_POLL);
+        }
+    }
+}
+
+fn terminalize_interrupted(
+    job: &mut AgentTaskLoopJob,
+    interrupted_state: AgentTaskLoopControllerState,
+) -> Result<Value> {
+    job.refresh_controller_state();
+    if !job
+        .controller_state
+        .is_some_and(controller_state_is_terminal)
+    {
+        let mut record = agent_task_loop_controller::load_controller(&job.request.loop_id)?;
+        record.state = interrupted_state;
+        agent_task_loop_controller::write_controller(&record)?;
+        job.controller_state = Some(interrupted_state);
+    }
+    job.phase = AgentTaskLoopJobPhase::Completed;
+    Ok(job.result())
+}
+
+fn coordinator_is_live(request: &AgentTaskLoopJobRequest) -> bool {
+    matches!(
+        process_identity_state_with_start_identity(
+            request.child_pid,
+            None,
+            Some(&request.child_start_identity),
+        ),
+        ProcessIdentityState::Live
+    )
+}
+
+fn controller_state_is_terminal(state: AgentTaskLoopControllerState) -> bool {
+    matches!(
+        state,
+        AgentTaskLoopControllerState::HumanReady
+            | AgentTaskLoopControllerState::Completed
+            | AgentTaskLoopControllerState::Abandoned
+            | AgentTaskLoopControllerState::Escalated
+            | AgentTaskLoopControllerState::Failed
+    )
+}
+
+pub fn register_loop_work_job_handler() {
+    static REGISTERED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    REGISTERED.get_or_init(|| {
+        register_work_job_handler(std::sync::Arc::new(LoopWorkHandler))
+            .expect("register loop work job handler");
+    });
+}
+
+pub fn loop_work_job_submission(
+    loop_id: &str,
+    child_pid: u32,
+    child_start_identity: &ProcessStartIdentity,
+) -> Result<Value> {
+    let job = AgentTaskLoopJob::new(AgentTaskLoopJobRequest {
+        schema: AGENT_TASK_LOOP_JOB_SCHEMA.to_string(),
+        loop_id: loop_id.to_string(),
+        child_pid,
+        child_start_identity: child_start_identity.clone(),
+    })?;
+    work_job_submission(
+        &LoopWorkHandler,
+        job.idempotency_key.clone(),
+        job.to_checkpoint()?,
+    )
+}
+
+fn invalid_loop_job(message: &str) -> homeboy_core::Error {
+    homeboy_core::Error::validation_invalid_argument("loop_job", message, None, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use homeboy_core::daemon::controller_job_driver::ControllerJobDriver;
+    use homeboy_core::test_support::{with_isolated_home, ControllerJobHarness};
+
+    use super::*;
+    use crate::agent_task_service::work_job::{
+        WorkJobDriver, WORK_JOB_CHECKPOINT_SCHEMA, WORK_JOB_TYPE, WORK_JOB_VERSION,
+    };
+
+    const IDENTITY: ProcessStartIdentity = ProcessStartIdentity::Linux {
+        starttime_ticks: 4242,
+    };
+
+    fn submission(loop_id: &str, pid: u32) -> Value {
+        register_loop_work_job_handler();
+        loop_work_job_submission(loop_id, pid, &IDENTITY).expect("build loop work submission")
+    }
+
+    #[test]
+    fn new_loop_submissions_use_the_shared_work_driver() {
+        let submission = submission("loop-shared", 4242);
+
+        assert_eq!(submission["type"], WORK_JOB_TYPE);
+        assert_eq!(submission["version"], WORK_JOB_VERSION);
+        assert_eq!(submission["idempotency_key"], "agent-task-loop:loop-shared");
+        assert_eq!(submission["request"]["work_type"], AGENT_TASK_LOOP_JOB_TYPE);
+        assert_eq!(
+            submission["request"]["request"]["request"]["loop_id"],
+            "loop-shared"
+        );
+        WorkJobDriver
+            .validate_secret_references(&submission["request"])
+            .expect("reference-only loop request validates");
+        let public = WorkJobDriver
+            .public_request(&submission["request"])
+            .expect("safe public projection");
+        assert_eq!(public["loop_id"], "loop-shared");
+        assert!(public.get("child_pid").is_none());
+        assert!(!public.to_string().contains("starttime_ticks"));
+    }
+
+    #[test]
+    fn dead_coordinator_terminalizes_through_the_shared_harness() {
+        with_isolated_home(|_| {
+            agent_task_loop_controller::create_controller("loop-dead", "repair", "v1")
+                .expect("create controller");
+            let request = submission("loop-dead", u32::MAX)["request"].clone();
+            let driver: Arc<dyn ControllerJobDriver> = Arc::new(WorkJobDriver);
+            let harness = ControllerJobHarness::new(Arc::clone(&driver), request.clone())
+                .expect("construct work harness");
+            let prepared = driver.prepare(request).expect("prepare loop work");
+
+            let result = driver
+                .execute(prepared, harness.handle())
+                .expect("observe dead coordinator");
+
+            assert_eq!(result["result"]["phase"], "completed");
+            assert_eq!(result["result"]["controller_state"], "failed");
+            assert_eq!(
+                agent_task_loop_controller::load_controller("loop-dead")
+                    .expect("read terminal controller")
+                    .state,
+                AgentTaskLoopControllerState::Failed
+            );
+            let checkpoint = harness
+                .checkpoint()
+                .expect("read checkpoint")
+                .expect("loop supervision checkpoint");
+            assert_eq!(checkpoint["schema"], WORK_JOB_CHECKPOINT_SCHEMA);
+            assert_eq!(checkpoint["work_type"], AGENT_TASK_LOOP_JOB_TYPE);
+        });
+    }
+
+    #[test]
+    fn completed_loop_checkpoint_replays_without_reexecution() {
+        with_isolated_home(|_| {
+            let mut record =
+                agent_task_loop_controller::create_controller("loop-complete", "repair", "v1")
+                    .expect("create controller");
+            record.state = AgentTaskLoopControllerState::Completed;
+            agent_task_loop_controller::write_controller(&record).expect("complete controller");
+            let request = submission("loop-complete", u32::MAX)["request"].clone();
+            let driver: Arc<dyn ControllerJobDriver> = Arc::new(WorkJobDriver);
+            let harness = ControllerJobHarness::new(Arc::clone(&driver), request.clone())
+                .expect("construct work harness");
+            let mut checkpoint = driver.prepare(request).expect("prepare loop work");
+            checkpoint["checkpoint"]["phase"] = json!("completed");
+
+            let first = driver
+                .resume(checkpoint.clone(), harness.handle())
+                .expect("first replay");
+            let second = driver
+                .resume(checkpoint, harness.handle())
+                .expect("second replay");
+
+            assert_eq!(first, second);
+            assert_eq!(first["result"]["controller_state"], "completed");
+        });
+    }
+
+    #[test]
+    fn cancellation_through_the_shared_harness_stops_the_coordinator() {
+        with_isolated_home(|_| {
+            agent_task_loop_controller::create_controller("loop-cancel", "repair", "v1")
+                .expect("create controller");
+            let child = std::process::Command::new("sh")
+                .args(["-c", "sleep 30"])
+                .spawn()
+                .expect("spawn coordinator fixture");
+            let identity = homeboy_core::process::process_start_identity(child.id())
+                .expect("inspect fixture")
+                .expect("fixture identity");
+            let request = loop_work_job_submission("loop-cancel", child.id(), &identity)
+                .expect("build submission")["request"]
+                .clone();
+            let driver: Arc<dyn ControllerJobDriver> = Arc::new(WorkJobDriver);
+            let harness = ControllerJobHarness::new(Arc::clone(&driver), request.clone())
+                .expect("construct work harness");
+            let prepared = driver.prepare(request).expect("prepare loop work");
+            harness
+                .request_cancellation("test cancellation")
+                .expect("request cancellation");
+
+            driver
+                .cancel(&prepared)
+                .expect("cancel coordinator process tree");
+            let result = driver
+                .execute(prepared, harness.handle())
+                .expect("terminalize cancelled loop work");
+
+            assert_eq!(result["result"]["controller_state"], "abandoned");
+            assert!(matches!(
+                homeboy_core::process::process_identity_state(child.id(), None),
+                ProcessIdentityState::Dead
+            ));
+        });
+    }
+}

--- a/crates/homeboy-agents/src/agent_task_service/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_service/mod.rs
@@ -21,6 +21,8 @@ mod cook_recipe;
 mod cook_supervision;
 mod discovery;
 mod execution;
+/// Shared-work supervision for a detached loop coordinator.
+mod loop_job;
 /// Read-only process-tree activity sampling for a running Cook.
 ///
 /// Lived in `homeboy-core` as a top-level module even though `cook_activity`
@@ -50,6 +52,7 @@ pub use cook_recipe::*;
 pub use cook_supervision::{resolve_supervision_policy, CookSupervisionTick, CookSupervisor};
 pub use discovery::*;
 pub use execution::*;
+pub use loop_job::*;
 pub use promotion_service::*;
 pub use reconcile::*;
 pub use status_support::*;

--- a/crates/homeboy-agents/src/agent_task_service/reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_service/reconcile.rs
@@ -522,7 +522,7 @@ pub fn reconcile_run(run_id: &str, dry_run: bool) -> Result<AgentTaskReconcileRe
 /// `reconcile_stale_active_runs` used to have exactly two callers — `cleanup`
 /// and `agent-task active --reconcile --apply` — both of which require a human
 /// to type them. A detached cook whose owner died therefore stayed `running`
-/// forever. Controller wait resolution had no automatic caller at all.
+/// forever. Loop Work jobs now own controller wait advancement.
 struct AgentTaskOrchestrationDriver;
 
 impl homeboy_core::daemon::orchestration::OrchestrationDriver for AgentTaskOrchestrationDriver {
@@ -542,12 +542,6 @@ impl homeboy_core::daemon::orchestration::OrchestrationDriver for AgentTaskOrche
                 run.stale_reason.as_deref(),
             );
         }
-        serde_json::to_value(&report)
-            .map_err(|error| homeboy_core::Error::internal_json(error.to_string(), None))
-    }
-
-    fn reconcile_controller_waits(&self) -> Result<serde_json::Value> {
-        let report = crate::agent_task_controller_service::reconcile_waiting_controllers()?;
         serde_json::to_value(&report)
             .map_err(|error| homeboy_core::Error::internal_json(error.to_string(), None))
     }
@@ -1599,10 +1593,7 @@ mod tests {
             register_orchestration_driver();
             let runs = homeboy_core::daemon::orchestration::reconcile_stale_active_runs()
                 .expect("run pass");
-            let waits = homeboy_core::daemon::orchestration::reconcile_controller_waits()
-                .expect("wait pass");
             assert_eq!(runs["reconciled"], 0, "{runs}");
-            assert_eq!(waits["changed"], 0, "{waits}");
         });
     }
 

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -449,11 +449,9 @@ fn register_startup_providers_after_reconcile(
     crate::runner::register_lab_staging_controller_driver();
     crate::agents::agent_task_service::register_promotion_job_driver();
     // Register the agent-task orchestration driver so the daemon's
-    // orchestration tick can reconcile orphaned `running` records and resolve
-    // controller waits from durable state without core depending on the
-    // agent-task subsystem. Both mechanisms previously had no automatic
-    // caller: a detached cook whose owner died stayed `running` forever, and a
-    // controller parked in `Waiting` never left it.
+    // orchestration tick can reconcile orphaned `running` records without core
+    // depending on the agent-task subsystem. Loop waits are owned by their
+    // durable Work jobs below rather than this unrelated periodic sweep.
     crate::agents::agent_task_service::register_orchestration_driver();
     crate::commands::route::register_unmaterialized_cook_replay_driver();
     crate::agents::agent_task_service::register_controller_upgrade_admission_provider();
@@ -469,6 +467,7 @@ fn register_startup_providers_after_reconcile(
     // the daemon supervises a coordinator it did not spawn, so no branch of its
     // lifecycle can re-run a child that already completed.
     crate::agents::agent_task_service::register_cook_batch_job_driver();
+    crate::agents::agent_task_service::register_loop_work_job_handler();
     crate::commands::cleanup::register_cleanup_job_driver();
     // The configured acceptance verifier is the one registration that is
     // conditional: `register_acceptance_verifier_from_config` is a no-op when

--- a/crates/homeboy-cli/src/commands/agent_task/controller.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/controller.rs
@@ -2,7 +2,9 @@
 //! lifecycle, spec defaults, and the CLI dispatch bridge.
 
 use serde_json::Value;
+use std::process::{Command, Stdio};
 use std::sync::Arc;
+use std::time::Duration;
 
 use homeboy::agents::agent_task_controller_service::{
     build_run_failure_summary, controller_spec_fingerprint_for_status,
@@ -40,6 +42,11 @@ use super::args::{
     AgentTaskLoopStatusArgs,
 };
 use super::command_json_value;
+
+const LOOP_COORDINATOR_ENV: &str = "HOMEBOY_AGENT_TASK_LOOP_COORDINATOR";
+const LOOP_COORDINATOR_READY_ENV: &str = "HOMEBOY_AGENT_TASK_LOOP_COORDINATOR_READY";
+const LOOP_COORDINATOR_POLL: Duration = Duration::from_millis(500);
+const LOOP_COORDINATOR_READY_BUDGET: Duration = Duration::from_secs(30);
 
 pub(super) fn controller(args: AgentTaskControllerArgs) -> CmdResult<Value> {
     match args.command {
@@ -112,6 +119,12 @@ fn controller_status_report_value(
         homeboy::agents::agent_tasks::loop_controller::controller_status_report(&args.loop_id)?;
     let mut value = serde_json::to_value(report)
         .map_err(|error| homeboy::core::Error::internal_json(error.to_string(), None))?;
+    if let Some(record) = value.get("controller") {
+        let work = loop_work_projection(record);
+        if let Some(object) = value.as_object_mut() {
+            object.insert("work".to_string(), work);
+        }
+    }
     if args.spec.is_some()
         || args.dispatch.dispatch_backend.is_some()
         || args.dispatch.dispatch_selector.is_some()
@@ -262,12 +275,8 @@ fn loop_define(args: AgentTaskLoopDefineArgs) -> CmdResult<Value> {
     }
 
     let defaults = ControllerDispatchDefaults::from_loop_define_args(&args);
-    let (resume_report, exit_code) = loop_resume_with_executor(
-        report.loop_id.clone(),
-        args.revolution_limit,
-        Arc::new(ExtensionProviderAgentTaskExecutor::discover()),
-        defaults,
-    )?;
+    let (resume_report, exit_code) =
+        submit_loop_resume(report.loop_id.clone(), args.revolution_limit, defaults)?;
     Ok((
         serde_json::json!({
             "schema": "homeboy/agent-task-loop-define-result/v1",
@@ -285,10 +294,13 @@ fn loop_define(args: AgentTaskLoopDefineArgs) -> CmdResult<Value> {
 fn loop_status(args: AgentTaskLoopStatusArgs) -> CmdResult<Value> {
     let report =
         homeboy::agents::agent_tasks::loop_controller::controller_status_report(&args.loop_id)?;
+    let controller = serde_json::to_value(&report.controller)
+        .map_err(|error| homeboy::core::Error::internal_json(error.to_string(), None))?;
     Ok((
         command_json_value(serde_json::json!({
             "schema": "homeboy/agent-task-loop-status-result/v1",
             "runtime": loop_runtime_metadata(&report.controller.metadata),
+            "work": loop_work_projection(&controller),
             "status": report,
         }))?,
         0,
@@ -297,18 +309,12 @@ fn loop_status(args: AgentTaskLoopStatusArgs) -> CmdResult<Value> {
 
 fn loop_resume(args: AgentTaskLoopResumeArgs) -> CmdResult<Value> {
     let defaults = ControllerDispatchDefaults::from_loop_resume_args(&args);
-    loop_resume_with_executor(
-        args.loop_id,
-        args.revolution_limit,
-        Arc::new(ExtensionProviderAgentTaskExecutor::discover()),
-        defaults,
-    )
+    submit_loop_resume(args.loop_id, args.revolution_limit, defaults)
 }
 
-fn loop_resume_with_executor(
+fn submit_loop_resume(
     loop_id: String,
     revolution_limit: Option<u32>,
-    executor: SharedAgentTaskExecutor,
     defaults: ControllerDispatchDefaults,
 ) -> CmdResult<Value> {
     let mut record = homeboy::agents::agent_tasks::loop_controller::load_controller(&loop_id)?;
@@ -344,8 +350,7 @@ fn loop_resume_with_executor(
     stamp_record_loop_runtime_metadata(&mut record, true, limit, true)?;
     homeboy::agents::agent_tasks::loop_controller::write_controller(&record)?;
     let resumed_loop_id = loop_id.clone();
-    let (value, exit_code) =
-        controller_resume_with_executor_and_defaults(loop_id, executor, defaults)?;
+    let (value, exit_code) = detach_loop_coordinator(loop_id, defaults)?;
     Ok((
         serde_json::json!({
             "schema": "homeboy/agent-task-loop-resume-result/v1",
@@ -364,16 +369,62 @@ fn loop_stop(args: AgentTaskLoopStatusArgs) -> CmdResult<Value> {
         .map(|value| value as u32);
     stamp_record_loop_runtime_metadata(&mut record, false, limit, false)?;
     homeboy::agents::agent_tasks::loop_controller::write_controller(&record)?;
+    let work = cancel_loop_work(&record, "agent-task loop stop requested")?;
     Ok((
         serde_json::json!({
             "schema": "homeboy/agent-task-loop-stop-result/v1",
             "loop_id": record.loop_id,
             "on": false,
             "runtime": loop_runtime_metadata(&record.metadata),
+            "work": work,
             "controller": record,
         }),
         0,
     ))
+}
+
+fn loop_work_projection(controller: &Value) -> Value {
+    let Some(job_id) = controller
+        .pointer("/metadata/work_job/job_id")
+        .and_then(Value::as_str)
+    else {
+        return Value::Null;
+    };
+    match homeboy::core::daemon::LocalControllerJobClient::connect()
+        .and_then(|client| client.status(job_id))
+    {
+        Ok(job) => serde_json::json!({
+            "job_id": job_id,
+            "status": job.status,
+            "event_count": job.event_count,
+            "updated_at_ms": job.updated_at_ms,
+        }),
+        Err(error) => serde_json::json!({
+            "job_id": job_id,
+            "status": "unavailable",
+            "error": {
+                "code": format!("{:?}", error.code),
+            },
+        }),
+    }
+}
+
+fn cancel_loop_work(
+    record: &homeboy::agents::agent_task_loop_controller::AgentTaskLoopControllerRecord,
+    reason: &str,
+) -> homeboy::core::Result<Value> {
+    let Some(job_id) = record
+        .metadata
+        .pointer("/work_job/job_id")
+        .and_then(Value::as_str)
+    else {
+        return Ok(Value::Null);
+    };
+    let job = homeboy::core::daemon::LocalControllerJobClient::connect()?.cancel(job_id, reason)?;
+    Ok(serde_json::json!({
+        "job_id": job_id,
+        "status": job.status,
+    }))
 }
 
 /// One-command end-to-end controller proof (#6222).
@@ -1395,11 +1446,10 @@ fn controller_run_action(args: AgentTaskControllerRunArgs) -> CmdResult<Value> {
 
 fn controller_resume(args: AgentTaskControllerRunNextArgs) -> CmdResult<Value> {
     let defaults = ControllerDispatchDefaults::from_run_next_args(&args);
-    controller_resume_with_executor_and_defaults(
-        args.loop_id,
-        Arc::new(ExtensionProviderAgentTaskExecutor::discover()),
-        defaults,
-    )
+    if std::env::var(LOOP_COORDINATOR_ENV).ok().as_deref() == Some(args.loop_id.as_str()) {
+        return run_loop_coordinator(args.loop_id, defaults);
+    }
+    detach_loop_coordinator(args.loop_id, defaults)
 }
 
 #[cfg(test)]
@@ -1456,22 +1506,223 @@ fn controller_run_action_with_executor_and_defaults(
     Ok((command_json_value(result.value)?, result.exit_code))
 }
 
-fn controller_resume_with_executor_and_defaults(
+fn run_loop_coordinator(loop_id: String, defaults: ControllerDispatchDefaults) -> CmdResult<Value> {
+    wait_for_loop_coordinator_release()?;
+    let executor: SharedAgentTaskExecutor =
+        Arc::new(ExtensionProviderAgentTaskExecutor::discover());
+    loop {
+        let dispatch = CliDispatchHook {
+            executor: executor.clone(),
+            defaults: defaults.clone(),
+        };
+        let result = agent_task_controller_service::resume(&loop_id, executor.clone(), &dispatch)?;
+        let state = result.value.controller.state;
+        if result.exit_code != 0
+            || matches!(
+                state,
+                homeboy::agents::agent_tasks::loop_controller::AgentTaskLoopControllerState::HumanReady
+                    | homeboy::agents::agent_tasks::loop_controller::AgentTaskLoopControllerState::Completed
+                    | homeboy::agents::agent_tasks::loop_controller::AgentTaskLoopControllerState::Abandoned
+                    | homeboy::agents::agent_tasks::loop_controller::AgentTaskLoopControllerState::Escalated
+                    | homeboy::agents::agent_tasks::loop_controller::AgentTaskLoopControllerState::Failed
+            )
+        {
+            return Ok((command_json_value(result.value)?, result.exit_code));
+        }
+        if result.value.stopped_reason == "idle"
+            && state
+                != homeboy::agents::agent_tasks::loop_controller::AgentTaskLoopControllerState::Waiting
+        {
+            return Ok((command_json_value(result.value)?, result.exit_code));
+        }
+        std::thread::sleep(LOOP_COORDINATOR_POLL);
+    }
+}
+
+fn detach_loop_coordinator(
     loop_id: String,
-    executor: SharedAgentTaskExecutor,
     defaults: ControllerDispatchDefaults,
 ) -> CmdResult<Value> {
-    let dispatch = CliDispatchHook {
-        executor: executor.clone(),
-        defaults,
+    let controller_path =
+        homeboy::agents::agent_task_loop_controller::controller_record_path(&loop_id)?;
+    let loop_root = controller_path.parent().ok_or_else(|| {
+        homeboy::core::Error::internal_unexpected("loop controller record has no parent directory")
+    })?;
+    std::fs::create_dir_all(loop_root).map_err(|error| {
+        homeboy::core::Error::internal_io(error.to_string(), Some(loop_root.display().to_string()))
+    })?;
+    let log_path = loop_root.join("coordinator.log");
+    let ready_path = loop_root.join("coordinator.ready");
+    if let Err(error) = std::fs::remove_file(&ready_path) {
+        if error.kind() != std::io::ErrorKind::NotFound {
+            return Err(homeboy::core::Error::internal_io(
+                error.to_string(),
+                Some(ready_path.display().to_string()),
+            ));
+        }
+    }
+    let log = std::fs::File::create(&log_path).map_err(|error| {
+        homeboy::core::Error::internal_io(error.to_string(), Some(log_path.display().to_string()))
+    })?;
+    let log_err = log.try_clone().map_err(|error| {
+        homeboy::core::Error::internal_io(error.to_string(), Some(log_path.display().to_string()))
+    })?;
+    let executable = std::env::current_exe().map_err(|error| {
+        homeboy::core::Error::internal_io(
+            error.to_string(),
+            Some("resolve current executable for loop coordinator".to_string()),
+        )
+    })?;
+    let mut command = Command::new(executable);
+    command
+        .args(loop_coordinator_args(&loop_id, &defaults))
+        .env(LOOP_COORDINATOR_ENV, &loop_id)
+        .env(LOOP_COORDINATOR_READY_ENV, &ready_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(log))
+        .stderr(Stdio::from(log_err));
+    homeboy::core::process::detach_from_caller_session(&mut command);
+    let mut child = command.spawn().map_err(|error| {
+        homeboy::core::Error::internal_io(
+            error.to_string(),
+            Some("spawn detached loop coordinator".to_string()),
+        )
+    })?;
+    let start_identity = match homeboy::core::process::process_start_identity(child.id()) {
+        Ok(Some(identity)) => identity,
+        Ok(None) => {
+            let _ = homeboy::core::process::terminate_process_tree(child.id());
+            let _ = child.wait();
+            return Err(homeboy::core::Error::internal_unexpected(
+                "detached loop coordinator has no verifiable process identity",
+            ));
+        }
+        Err(error) => {
+            let _ = homeboy::core::process::terminate_process_tree(child.id());
+            let _ = child.wait();
+            return Err(homeboy::core::Error::internal_io(
+                error,
+                Some("inspect detached loop coordinator identity".to_string()),
+            ));
+        }
     };
-    let result = agent_task_controller_service::resume(&loop_id, executor, &dispatch)?;
-    Ok((command_json_value(result.value)?, result.exit_code))
+    let submission = homeboy::agents::agent_task_service::loop_work_job_submission(
+        &loop_id,
+        child.id(),
+        &start_identity,
+    )?;
+    let client = homeboy::core::daemon::LocalControllerJobClient::connect_current_build()?;
+    let job = match client.submit(submission) {
+        Ok(job) => job,
+        Err(error) => {
+            let _ = homeboy::core::process::terminate_process_tree(child.id());
+            let _ = child.wait();
+            return Err(error);
+        }
+    };
+    let job_id = job.id.to_string();
+    if let Err(error) = persist_loop_work_identity(&loop_id, &job_id) {
+        let _ = client.cancel(&job_id, "loop work identity could not be persisted");
+        let _ = homeboy::core::process::terminate_process_tree(child.id());
+        let _ = child.wait();
+        return Err(error);
+    }
+    if let Err(error) = client.start(&job_id) {
+        let _ = client.cancel(&job_id, "loop coordinator could not start supervision");
+        let _ = homeboy::core::process::terminate_process_tree(child.id());
+        let _ = child.wait();
+        return Err(error);
+    }
+    if let Err(error) = std::fs::write(&ready_path, format!("{job_id}\n")) {
+        let _ = client.cancel(
+            &job_id,
+            "loop coordinator launch gate could not be released",
+        );
+        let _ = homeboy::core::process::terminate_process_tree(child.id());
+        let _ = child.wait();
+        return Err(homeboy::core::Error::internal_io(
+            error.to_string(),
+            Some(ready_path.display().to_string()),
+        ));
+    }
+    Ok((
+        command_json_value(serde_json::json!({
+            "schema": "homeboy/agent-task-loop-work-submission/v1",
+            "loop_id": loop_id,
+            "job_id": job_id,
+            "state": "submitted",
+            "log_path": log_path,
+            "commands": {
+                "status": format!("homeboy agent-task controller status {loop_id}"),
+                "cancel": format!("homeboy agent-task loop stop {loop_id}"),
+            },
+        }))?,
+        0,
+    ))
+}
+
+fn wait_for_loop_coordinator_release() -> homeboy::core::Result<()> {
+    let Some(path) = std::env::var_os(LOOP_COORDINATOR_READY_ENV) else {
+        return Ok(());
+    };
+    let path = std::path::PathBuf::from(path);
+    let started = std::time::Instant::now();
+    while started.elapsed() < LOOP_COORDINATOR_READY_BUDGET {
+        if path.exists() {
+            let _ = std::fs::remove_file(path);
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    Err(homeboy::core::Error::internal_unexpected(
+        "loop coordinator was not released by its durable Work owner",
+    ))
+}
+
+fn persist_loop_work_identity(loop_id: &str, job_id: &str) -> homeboy::core::Result<()> {
+    let mut record = homeboy::agents::agent_task_loop_controller::load_controller(loop_id)?;
+    if !record.metadata.is_object() {
+        record.metadata = serde_json::json!({});
+    }
+    record.metadata["work_job"] = serde_json::json!({
+        "schema": "homeboy/agent-task-loop-work-ref/v1",
+        "job_id": job_id,
+        "state": "submitted",
+    });
+    homeboy::agents::agent_task_loop_controller::write_controller(&record)
+}
+
+fn loop_coordinator_args(loop_id: &str, defaults: &ControllerDispatchDefaults) -> Vec<String> {
+    let mut args = vec![
+        "agent-task".to_string(),
+        "controller".to_string(),
+        "resume".to_string(),
+        loop_id.to_string(),
+    ];
+    for (flag, value) in [
+        ("--dispatch-backend", defaults.backend.as_deref()),
+        ("--dispatch-selector", defaults.selector.as_deref()),
+        ("--dispatch-model", defaults.model.as_deref()),
+        (
+            "--dispatch-provider-config",
+            defaults.provider_config.as_deref(),
+        ),
+    ] {
+        if let Some(value) = value {
+            args.push(flag.to_string());
+            args.push(value.to_string());
+        }
+    }
+    args
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use homeboy::agents::agent_task_loop_controller::{
+        self, AgentTaskLoopControllerState, AgentTaskLoopWait, AgentTaskLoopWaitStatus,
+    };
+    use homeboy::core::test_support::with_isolated_home;
 
     #[test]
     fn controller_doctor_checks_never_compare_the_backend_name_by_string() {
@@ -1496,6 +1747,70 @@ mod tests {
         // binary.
         assert!(is_fixture_backend(TEST_DOUBLE));
         assert!(!is_fixture_backend("opencode"));
+    }
+
+    #[test]
+    fn loop_coordinator_wakes_an_expired_wait_without_manual_resume() {
+        with_isolated_home(|_| {
+            let mut record =
+                agent_task_loop_controller::create_controller("loop-timeout", "repair", "v1")
+                    .expect("create controller");
+            record.state = AgentTaskLoopControllerState::Waiting;
+            record.waits.push(AgentTaskLoopWait {
+                wait_key: "deadline".to_string(),
+                event_type: "operator.deadline".to_string(),
+                entity_id: None,
+                external_ref: None,
+                timeout_at: Some("2000-01-01T00:00:00+00:00".to_string()),
+                escalation_policy: None,
+                status: AgentTaskLoopWaitStatus::Open,
+                satisfied_by_event_id: None,
+            });
+            agent_task_loop_controller::write_controller(&record).expect("persist wait");
+
+            let (_, exit_code) = run_loop_coordinator(
+                "loop-timeout".to_string(),
+                ControllerDispatchDefaults::default(),
+            )
+            .expect("coordinator reconciles deadline");
+
+            assert_eq!(exit_code, 0);
+            let record = agent_task_loop_controller::load_controller("loop-timeout")
+                .expect("read reconciled controller");
+            assert_eq!(record.state, AgentTaskLoopControllerState::Running);
+            assert_eq!(record.waits[0].status, AgentTaskLoopWaitStatus::TimedOut);
+        });
+    }
+
+    #[test]
+    fn loop_coordinator_child_carries_dispatch_defaults() {
+        let args = loop_coordinator_args(
+            "loop-dispatch",
+            &ControllerDispatchDefaults {
+                backend: Some("backend".to_string()),
+                selector: Some("selector".to_string()),
+                model: Some("model".to_string()),
+                provider_config: Some(r#"{"runtime":"pinned"}"#.to_string()),
+            },
+        );
+
+        assert_eq!(
+            args,
+            vec![
+                "agent-task",
+                "controller",
+                "resume",
+                "loop-dispatch",
+                "--dispatch-backend",
+                "backend",
+                "--dispatch-selector",
+                "selector",
+                "--dispatch-model",
+                "model",
+                "--dispatch-provider-config",
+                r#"{"runtime":"pinned"}"#,
+            ]
+        );
     }
 
     #[test]

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -1449,7 +1449,7 @@ fn parse_orchestration_tick_interval(configured: Option<&str>) -> Option<std::ti
 ///
 /// `reconcile_stale_active_runs` had exactly two callers — `cleanup` and
 /// `agent-task active --reconcile --apply` — so a detached cook whose owner
-/// died stayed `running` forever. Controller waits had none at all.
+/// died stayed `running` forever. Loop Work jobs own controller waits.
 fn spawn_orchestration_reconciler(shutdown: mpsc::Receiver<()>) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
         let Some(interval) = orchestration_tick_interval() else {
@@ -1462,20 +1462,17 @@ fn spawn_orchestration_reconciler(shutdown: mpsc::Receiver<()>) -> std::thread::
     })
 }
 
-/// One pass per mechanism, per interval.
+/// One pass per remaining global mechanism, per interval.
 ///
-/// The two mechanisms are isolated from each other and from the loop: a
+/// The mechanisms are isolated from each other and from the loop: a
 /// reconcile that panics costs one pass, not the tick and not the daemon.
-/// Overlap is impossible by construction — the sleep happens after both
+/// Overlap is impossible by construction — the sleep happens after all
 /// passes return, exactly as the schedule ticker does it — and across
 /// processes the daemon owner lock already guarantees a single ticker.
 fn orchestration_tick_loop(interval: std::time::Duration, shutdown: mpsc::Receiver<()>) {
     loop {
         isolated_tick(|| {
             let _ = orchestration::reconcile_stale_active_runs();
-        });
-        isolated_tick(|| {
-            let _ = orchestration::reconcile_controller_waits();
         });
         isolated_tick(|| {
             let _ = orchestration::reconcile_unmaterialized_cook_admissions();

--- a/crates/homeboy-core/src/daemon/orchestration.rs
+++ b/crates/homeboy-core/src/daemon/orchestration.rs
@@ -1,7 +1,7 @@
 //! Daemon-driven orchestration hook.
 //!
-//! Stale-run reconciliation and controller wait resolution are implemented in
-//! `homeboy-agents` and were only ever advanced by a human typing a command.
+//! Stale-run reconciliation is implemented in `homeboy-agents` and was only
+//! ever advanced by a human typing a command.
 //! The daemon is the only long-lived process that can drive them, and it lives
 //! in `homeboy-core`, which must not depend on the agent-task subsystem.
 //!
@@ -25,14 +25,6 @@ pub trait OrchestrationDriver: Send + Sync {
     /// `agent-task active --reconcile --apply` command uses; the daemon only
     /// supplies the cadence.
     fn reconcile_stale_active_runs(&self) -> Result<Value>;
-
-    /// Resolve controller waits that durable state already satisfies.
-    ///
-    /// A controller parked in `Waiting` has no pending action, so `resume`
-    /// reports `idle` and exits. Nothing polls and nothing times out, which
-    /// makes `Waiting` a state with no automatic exit. Implementations resolve
-    /// only on unambiguous durable evidence.
-    fn reconcile_controller_waits(&self) -> Result<Value>;
 
     /// Advance durable Cooks that were admitted before a Lab destination was
     /// eligible. Implementations must not materialize work while blocked.
@@ -76,10 +68,6 @@ impl OrchestrationDriver for NoopOrchestrationDriver {
         Ok(Value::Null)
     }
 
-    fn reconcile_controller_waits(&self) -> Result<Value> {
-        Ok(Value::Null)
-    }
-
     fn reconcile_unmaterialized_cook_admissions(&self) -> Result<Value> {
         Ok(Value::Null)
     }
@@ -120,12 +108,6 @@ pub fn register_cook_admission_replay_driver(
 /// tick drives.
 pub fn reconcile_stale_active_runs() -> Result<Value> {
     active_driver().reconcile_stale_active_runs()
-}
-
-/// Drive one controller-wait reconcile pass. Public for the same reason as
-/// [`reconcile_stale_active_runs`].
-pub fn reconcile_controller_waits() -> Result<Value> {
-    active_driver().reconcile_controller_waits()
 }
 
 /// Drive one unmaterialized Cook admission pass.


### PR DESCRIPTION
## Summary

- register a typed loop handler behind the shared `WorkJobDriver`
- detach loop coordinators under daemon supervision with a persisted Work identity and bounded launch gate
- project status and cancellation through the Work job while removing the unrelated global controller-wait sweep
- automatically advance waiting loops by polling durable child/deadline evidence in the supervised coordinator

## Verification

- `cargo check -p homeboy-core -p homeboy-agents -p homeboy-cli`
- `cargo test -p homeboy-agents --lib loop_job` (4 passed)
- `cargo test -p homeboy-cli --lib commands::agent_task::controller::tests` (7 passed)

Tracks #13582.

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode inspected the shared Work lifecycle and loop/controller paths, implemented the typed loop handler and command integration, and ran the focused verification. Chris Huber directed the architecture and remains responsible for the change.