### PR TITLE
Fix immutable unpushed candidate adoption

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -919,7 +919,7 @@ fn promote_with_provider_and_checkpoint_internal(
     // no patch applied and no durable post-apply state recorded, so the same
     // artifact/target can be retried with a corrected base (#9400).
     let pre_apply_verified_base = if !options.dry_run {
-        match resolve_promotion_target_path(&options.to_worktree)? {
+        match resolve_promotion_target_path(&options.to_worktree, None)? {
             Some(target_path) => capture_declared_base(&target_path, options.base_ref.as_deref())?,
             // No provider-owned pre-apply target path resolves; fall back to
             // validating against the applied worktree below.
@@ -1611,11 +1611,25 @@ fn promote_committed_changes(
     )?
     .unwrap_or_else(|| committed_patch.patch_path.clone());
     let normalized_patch = normalize_promotion_patch(&patch, &options.to_worktree)?;
+    let trusted_unpushed_candidate_destination =
+        options
+            .candidate_ref
+            .as_ref()
+            .map(|_| TrustedUnpushedCandidateDestination {
+                path: options
+                    .source_worktree_path
+                    .clone()
+                    .expect("candidate has source workspace"),
+                head: committed_patch.candidate.clone(),
+            });
     // Keep committed-change promotion on the same atomic base-validation
     // boundary as artifact promotion: no apply or checkpoint may precede a
     // failed declared base lookup.
     let pre_apply_verified_base = if !options.dry_run {
-        match resolve_promotion_target_path(&options.to_worktree)? {
+        match resolve_promotion_target_path(
+            &options.to_worktree,
+            trusted_unpushed_candidate_destination.as_ref(),
+        )? {
             Some(target_path) => capture_declared_base(&target_path, options.base_ref.as_deref())?,
             None => None,
         }
@@ -1644,15 +1658,7 @@ fn promote_committed_changes(
         changed_files: normalized_patch.changed_files.clone(),
         gate_feedback_baseline,
         dry_run: options.dry_run,
-        trusted_unpushed_candidate_destination: options.candidate_ref.as_ref().map(|_| {
-            TrustedUnpushedCandidateDestination {
-                path: options
-                    .source_worktree_path
-                    .clone()
-                    .expect("candidate has source workspace"),
-                head: committed_patch.candidate.clone(),
-            }
-        }),
+        trusted_unpushed_candidate_destination,
     })?;
     command_evidence.extend(target.command_evidence);
     let applied_worktree_path = (!options.dry_run).then_some(target.path);
@@ -2371,14 +2377,26 @@ fn promotion_source(
 /// Resolve a provider-owned target before the patch is applied, so the declared
 /// base can be validated against it without mutating the working tree (#9400).
 /// Genuinely unmanaged destinations retain the post-apply validation fallback.
-fn resolve_promotion_target_path(to_worktree: &str) -> Result<Option<PathBuf>> {
+fn resolve_promotion_target_path(
+    to_worktree: &str,
+    trusted_unpushed_candidate_destination: Option<&TrustedUnpushedCandidateDestination>,
+) -> Result<Option<PathBuf>> {
     if Path::new(to_worktree).is_dir() {
         return Ok(None);
     }
+    let trusted_unpushed_destination = trusted_unpushed_candidate_destination.map(|trusted| {
+        homeboy_core::worktree_provider::WorktreeTrustedUnpushedDestination {
+            path: trusted.path.clone(),
+            head: trusted.head.clone(),
+        }
+    });
     match homeboy_core::worktree_provider::resolve_worktree_mutation_target_from_config(
         to_worktree,
         &homeboy_core::defaults::load_config(),
-        homeboy_core::worktree_provider::WorktreeMutationContext::default(),
+        homeboy_core::worktree_provider::WorktreeMutationContext {
+            safety_baseline: None,
+            trusted_unpushed_destination: trusted_unpushed_destination.as_ref(),
+        },
     ) {
         Ok(target) => Ok(target.path.is_dir().then_some(target.path)),
         Err(error) if error.details["worktree_provider_lookup"] == "not_found" => Ok(None),

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
@@ -452,6 +452,119 @@ fn configured_provider_accepts_only_the_unpushed_immutable_candidate_destination
 }
 
 #[test]
+fn committed_candidate_pre_apply_resolution_trusts_only_its_exact_unpushed_destination() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let (temp, repo, base, candidate) = adopted_commit_repo();
+        let provider = temp.path().join("configured-provider.sh");
+        let response = serde_json::json!({
+            "schema": "homeboy/agent-task-promotion-apply-response/v1",
+            "workspace_path": repo,
+            "command_evidence": []
+        });
+        let invocation = CommandInvocation {
+            argv: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                format!("cat >/dev/null; printf '%s' '{response}'"),
+            ],
+            ..Default::default()
+        };
+        let configure_provider = |script: &str| {
+            std::fs::write(&provider, script).expect("write configured provider");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mut permissions = std::fs::metadata(&provider)
+                    .expect("provider metadata")
+                    .permissions();
+                permissions.set_mode(0o755);
+                std::fs::set_permissions(&provider, permissions).expect("make provider executable");
+            }
+            let mut config = HomeboyConfig::default();
+            config.worktree_providers.insert(
+                "fixture".to_string(),
+                WorktreeProviderConfig {
+                    enabled: true,
+                    kind: WorktreeProviderKind::Command,
+                    apply_enabled: true,
+                    lookup_timeout_ms: 10_000,
+                    mutation_timeout_ms: 30_000,
+                    lookup_output_limit_bytes: 64 * 1024,
+                    commands: WorktreeProviderCommands {
+                        resolve: Some(vec![provider.display().to_string(), "{handle}".to_string()]),
+                        ..Default::default()
+                    },
+                    list_result_mapping: Some(WorktreeProviderListResultMapping {
+                        items: "$.worktrees".to_string(),
+                        handle: "$.handle".to_string(),
+                        path: "$.path".to_string(),
+                        branch: "$.branch".to_string(),
+                        dirty: "$.safety.dirty".to_string(),
+                        unpushed: "$.safety.unpushed".to_string(),
+                        primary: "$.safety.primary".to_string(),
+                        task_url: None,
+                    }),
+                },
+            );
+            homeboy_core::defaults::save_config(&config).expect("save provider config");
+        };
+        let inventory = |before_output: &str| {
+            format!(
+                "#!/bin/sh\n{before_output}printf '%s\\n' '{}'\n",
+                serde_json::json!({
+                    "worktrees": [{
+                        "handle": "fixture@candidate",
+                        "path": repo,
+                        "branch": "main",
+                        "safety": { "dirty": false, "unpushed": true, "primary": false }
+                    }]
+                })
+            )
+        };
+        configure_provider(&inventory(""));
+        let mut options = adopted_commit_options(
+            &temp,
+            &repo,
+            base.clone(),
+            candidate.clone(),
+            VerifyGateOptions::default(),
+        );
+        options.to_worktree = "fixture@candidate".to_string();
+        options.provider_invocation = Some(invocation.clone());
+        promote(options.clone()).expect("exact clean unpushed candidate is admitted before apply");
+
+        let alternate = temp.path().join("alternate");
+        git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "--detach",
+                alternate.to_str().expect("alternate path"),
+                &candidate,
+            ],
+        );
+        let mut mismatched_path = options.clone();
+        mismatched_path.source_worktree_path = Some(alternate);
+        let error = promote(mismatched_path).expect_err("different source path is rejected");
+        assert_eq!(
+            error.details["workspace"]["classification"],
+            "workspace.untrusted_unpushed"
+        );
+
+        configure_provider(&inventory(&format!(
+            "git -C {} commit --allow-empty -m advanced >/dev/null\n",
+            repo.display()
+        )));
+        let error = promote(options).expect_err("advanced destination HEAD is rejected");
+        assert_eq!(
+            error.details["workspace"]["classification"],
+            "workspace.untrusted_unpushed"
+        );
+    });
+}
+
+#[test]
 fn validate_patch_extracts_safe_changed_files() {
     let patch = normalize_promotion_patch(VALID_PATCH, "repo@promoted-task").expect("valid patch");
 


### PR DESCRIPTION
## Summary

- carry the existing exact path-and-HEAD unpushed-candidate capability into pre-apply target resolution
- keep ordinary patch promotion on the default fail-closed mutation context
- cover configured-provider admission plus mismatched path and HEAD rejection

Fixes #13603.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-agents committed_candidate_pre_apply_resolution_trusts_only_its_exact_unpushed_destination -- --nocapture`
- `cargo test -p homeboy-agents configured_provider_accepts_only_the_unpushed_immutable_candidate_destination -- --nocapture`
- `cargo test -p homeboy-agents promote_applies_patch_with_fake_workspace_provider -- --nocapture`
- `cargo test -p homeboy-agents adoption_green_candidate_missing_review_form_runs_form_only_follow_up_and_finalizes -- --nocapture`
- `cargo build -p homeboy-cli`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the tracked-Cook failure, traced the configured-provider pre-apply boundary, implemented and reviewed the focused repair, added fail-closed regression coverage, and ran verification. Chris Huber directed the work and owns acceptance.