### PR TITLE
fix(agent-task): disclose substantive Cook retries

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -118,7 +118,9 @@ fn finalize_pr_with_backend_mode<B: AgentTaskPrFinalizationBackend>(
                 None,
             ));
         }
-        if eligibility == DurablePublicationEligibility::ProviderRun && !review_form_only_follow_up
+        if eligibility == DurablePublicationEligibility::ProviderRun
+            && !review_form_only_follow_up
+            && !options.composed_ai_model_disclosure
         {
             options.review_dossier.ai_assistance.model = durable_model(&lifecycle)?;
         }

--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -2950,6 +2950,7 @@ fn options() -> AgentTaskPrFinalizationOptions {
             source_relationships: Vec::new(),
             overrides: Vec::new(),
         },
+        composed_ai_model_disclosure: false,
         review_profile: crate::agent_task_review_dossier::default_profile(),
         manual_finalization: true,
         expected_candidate_sha: None,

--- a/crates/homeboy-agents/src/agent_task_finalization/types.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/types.rs
@@ -274,6 +274,9 @@ pub struct AgentTaskPrFinalizationOptions {
     pub evidence: AgentTaskPrEvidence,
     pub ai_used_for: String,
     pub review_dossier: AgentTaskReviewDossier,
+    /// The caller authenticated multiple concrete execution roles. Preserve the
+    /// composed model disclosure instead of replacing it with the terminal run.
+    pub composed_ai_model_disclosure: bool,
     pub review_profile: AgentTaskReviewProfile,
     /// Manual finalization is an explicit migration mode for work not produced by a durable run.
     pub manual_finalization: bool,

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -2606,18 +2606,24 @@ pub(crate) fn cook_finalization_options_with_stores(
                 None,
             )
         })?;
-    let mut review_dossier = cook_review_dossier_with_stores(
-        store,
-        lifecycle_store,
-        options,
-        promotion,
-        successful_run_id,
-    )?;
+    let (mut review_dossier, composed_ai_model_disclosure, preserve_used_for_disclosure) =
+        cook_review_dossier_with_stores(
+            store,
+            lifecycle_store,
+            options,
+            promotion,
+            successful_run_id,
+        )?;
     review_dossier.overrides = overrides;
     // A non-empty option is an explicit operator disclosure. Otherwise retain
     // the validated review form's process statement as durable PR provenance.
     let ai_used_for = if options.ai_used_for.trim().is_empty() {
         review_dossier.ai_assistance.used_for.clone()
+    } else if preserve_used_for_disclosure {
+        format!(
+            "{} {}",
+            review_dossier.ai_assistance.used_for, options.ai_used_for
+        )
     } else {
         options.ai_used_for.clone()
     };
@@ -2680,6 +2686,7 @@ pub(crate) fn cook_finalization_options_with_stores(
         },
         ai_used_for,
         review_dossier,
+        composed_ai_model_disclosure,
         review_profile: resolve_review_profile(&path)?,
         manual_finalization: false,
         expected_candidate_sha: None,
@@ -3878,6 +3885,7 @@ fn manual_finalization_options(
         evidence: report.evidence,
         ai_used_for: report.review_dossier.ai_assistance.used_for.clone(),
         review_dossier: report.review_dossier,
+        composed_ai_model_disclosure: false,
         review_profile: resolve_review_profile(&path)?,
         manual_finalization: true,
         expected_candidate_sha,
@@ -3972,7 +3980,7 @@ fn cook_review_dossier_with_stores(
     options: &AgentTaskCookServiceOptions,
     promotion: &AgentTaskPromotionReport,
     successful_run_id: &str,
-) -> Result<AgentTaskReviewDossier> {
+) -> Result<(AgentTaskReviewDossier, bool, bool)> {
     // A form-only run owns reviewer metadata but carries forward the durable
     // gate proof while its authenticated source owns candidate scope.
     let terminal_promotion = promotion;
@@ -4122,30 +4130,34 @@ fn cook_review_dossier_with_stores(
             },
         ]);
     }
-    Ok(AgentTaskReviewDossier {
-        schema: "homeboy/agent-task-review-dossier/v1".to_string(),
-        summary: lineage.summary,
-        what_changed: lineage.what_changed,
-        how_to_test,
-        compatibility: lineage.compatibility,
-        // Deterministic evidence: orchestrator-owned. The task objective, scope,
-        // gate count, and adoption provenance are factual records, not prose the
-        // AI restates.
-        evidence,
-        verified_commands,
-        changed_public_contracts: Vec::new(),
-        public_contract_evidence: None,
-        ai_assistance: AgentTaskReviewAiAssistance {
-            // Deterministic: the orchestrator knows whether/what tool+model ran,
-            // and attributes Homeboy as the harness that drove the change.
-            used: true,
-            tool: lineage.tool,
-            model: lineage.model,
-            used_for: lineage.used_for,
+    Ok((
+        AgentTaskReviewDossier {
+            schema: "homeboy/agent-task-review-dossier/v1".to_string(),
+            summary: lineage.summary,
+            what_changed: lineage.what_changed,
+            how_to_test,
+            compatibility: lineage.compatibility,
+            // Deterministic evidence: orchestrator-owned. The task objective, scope,
+            // gate count, and adoption provenance are factual records, not prose the
+            // AI restates.
+            evidence,
+            verified_commands,
+            changed_public_contracts: Vec::new(),
+            public_contract_evidence: None,
+            ai_assistance: AgentTaskReviewAiAssistance {
+                // Deterministic: the orchestrator knows whether/what tool+model ran,
+                // and attributes Homeboy as the harness that drove the change.
+                used: true,
+                tool: lineage.tool,
+                model: lineage.model,
+                used_for: lineage.used_for,
+            },
+            source_relationships: Vec::new(),
+            overrides: Vec::new(),
         },
-        source_relationships: Vec::new(),
-        overrides: Vec::new(),
-    })
+        lineage.composed_model_disclosure,
+        lineage.preserve_used_for_disclosure,
+    ))
 }
 
 struct CookAiLineage {
@@ -4155,6 +4167,8 @@ struct CookAiLineage {
     tool: String,
     model: String,
     used_for: String,
+    composed_model_disclosure: bool,
+    preserve_used_for_disclosure: bool,
 }
 
 struct CookAttemptExecution {
@@ -4163,6 +4177,17 @@ struct CookAttemptExecution {
     tool: String,
     model: Option<String>,
     review_form_only: bool,
+}
+
+struct CookContribution {
+    run_id: String,
+    execution: CookAttemptExecution,
+}
+
+struct CookContributionSource {
+    run_id: String,
+    task_id: String,
+    patch_sha256: String,
 }
 
 fn concrete_provider_model(value: Option<&str>) -> Option<String> {
@@ -4371,6 +4396,225 @@ fn cook_attempt_execution_in_store(
     })
 }
 
+fn cook_contribution_source(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<Option<CookContributionSource>> {
+    let plan = lifecycle_store.read_controller_plan(run_id)?;
+    let outcome = selected_outcome_for_attempt_in_store(lifecycle_store, run_id)?;
+    let task = plan
+        .tasks
+        .iter()
+        .find(|task| task.task_id == outcome.task_id)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "cook_recipe.attempts",
+                "Cook lineage outcome does not match a task in its durable execution plan",
+                Some(run_id.to_string()),
+                None,
+            )
+        })?;
+    let provenance = &task.inputs["cook_loop"]["artifact_provenance"];
+    if provenance.is_null() {
+        return Ok(None);
+    }
+    let source = CookContributionSource {
+        run_id: provenance["source_run_id"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string(),
+        task_id: provenance["source_task_id"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string(),
+        patch_sha256: provenance["source_patch_artifact_sha256"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string(),
+    };
+    if source.run_id.is_empty() || source.task_id.is_empty() || source.patch_sha256.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "cook_loop.artifact_provenance",
+            "Cook contribution source binding is incomplete",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+    Ok(Some(source))
+}
+
+fn exact_promotion_for_contribution(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<AgentTaskPromotionReport> {
+    let record = lifecycle_store.read_record(run_id)?;
+    let value = record.metadata.get("latest_promotion").ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "latest_promotion",
+            "Cook contribution source has no persisted promotion",
+            Some(run_id.to_string()),
+            None,
+        )
+    })?;
+    let promotion: AgentTaskPromotionReport =
+        serde_json::from_value(value.clone()).map_err(|error| {
+            Error::validation_invalid_argument(
+                "latest_promotion",
+                format!("persisted Cook contribution promotion is invalid: {error}"),
+                Some(run_id.to_string()),
+                None,
+            )
+        })?;
+    if promotion.source.run_id.as_deref() != Some(run_id) {
+        return Err(Error::validation_invalid_argument(
+            "latest_promotion.source.run_id",
+            "persisted Cook contribution promotion belongs to another attempt",
+            Some(run_id.to_string()),
+            None,
+        ));
+    }
+    Ok(promotion)
+}
+
+fn substantive_contribution_chain(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    attempts: &[super::AgentTaskCookRecipeAttempt],
+    terminal_run_id: &str,
+) -> Result<Vec<CookContribution>> {
+    let positions = attempts
+        .iter()
+        .enumerate()
+        .map(|(index, attempt)| (attempt.run_id.as_str(), index))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    let mut contributions = Vec::new();
+    let mut current_run_id = terminal_run_id.to_string();
+    let mut visited = std::collections::BTreeSet::new();
+    loop {
+        if !visited.insert(current_run_id.clone()) {
+            return Err(Error::validation_invalid_argument(
+                "cook_loop.artifact_provenance",
+                "Cook contribution lineage contains a cycle",
+                Some(current_run_id),
+                None,
+            ));
+        }
+        let current_position =
+            positions
+                .get(current_run_id.as_str())
+                .copied()
+                .ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        "cook_recipe.attempts",
+                        "Cook contribution is absent from the persisted recipe",
+                        Some(current_run_id.clone()),
+                        None,
+                    )
+                })?;
+        let execution = cook_attempt_execution_in_store(lifecycle_store, &current_run_id)?;
+        if execution.review_form_only {
+            return Err(Error::validation_invalid_argument(
+                "cook_recipe.attempts",
+                "metadata-only review-form attempts cannot contribute implementation patches",
+                Some(current_run_id),
+                None,
+            ));
+        }
+        let source = cook_contribution_source(lifecycle_store, &current_run_id)?;
+        contributions.push(CookContribution {
+            run_id: current_run_id.clone(),
+            execution,
+        });
+        let Some(source) = source else {
+            break;
+        };
+        let source_position = positions
+            .get(source.run_id.as_str())
+            .copied()
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "cook_loop.artifact_provenance.source_run_id",
+                    "Cook contribution source is absent from the persisted recipe",
+                    Some(source.run_id.clone()),
+                    None,
+                )
+            })?;
+        if source_position >= current_position {
+            return Err(Error::validation_invalid_argument(
+                "cook_loop.artifact_provenance.source_run_id",
+                "Cook contribution source must precede its consumer",
+                Some(source.run_id),
+                None,
+            ));
+        }
+        let source_promotion = exact_promotion_for_contribution(lifecycle_store, &source.run_id)?;
+        if !source_promotion.status.patch_promoted()
+            || source_promotion.source.task_id.as_str() != source.task_id.as_str()
+            || source_promotion.patch_artifact.sha256.as_deref()
+                != Some(source.patch_sha256.as_str())
+        {
+            return Err(Error::validation_invalid_argument(
+                "cook_loop.artifact_provenance",
+                "Cook contribution source binding does not match its persisted promotion",
+                Some(source.run_id),
+                None,
+            ));
+        }
+        current_run_id = source.run_id;
+    }
+    contributions.reverse();
+    Ok(contributions)
+}
+
+fn substantive_lineage(
+    contributions: Vec<CookContribution>,
+    terminal_form: &crate::agent_task_review_dossier::AiFilledReviewForm,
+) -> Result<CookAiLineage> {
+    let Some(terminal) = contributions.last() else {
+        return Err(Error::internal_unexpected(
+            "substantive Cook lineage has no authenticated contribution",
+        ));
+    };
+    if contributions.len() == 1 {
+        let model = required_execution_model(&terminal.execution, &terminal.run_id)?;
+        return Ok(CookAiLineage {
+            summary: terminal_form.summary.clone(),
+            what_changed: terminal_form.what_changed.clone(),
+            compatibility: terminal_form.compatibility.clone(),
+            tool: crate::agent_task_review_dossier::homeboy_tool_disclosure(
+                &terminal.execution.tool,
+            ),
+            model,
+            used_for: terminal_form.used_for.clone(),
+            composed_model_disclosure: false,
+            preserve_used_for_disclosure: false,
+        });
+    }
+    let mut tools = Vec::new();
+    let mut models = Vec::new();
+    let mut roles = Vec::new();
+    for (index, contribution) in contributions.iter().enumerate() {
+        let role = format!("Implementation {}", index + 1);
+        let tool =
+            crate::agent_task_review_dossier::homeboy_tool_disclosure(&contribution.execution.tool);
+        let model = required_execution_model(&contribution.execution, &contribution.run_id)?;
+        tools.push(format!("{role}: {tool}"));
+        models.push(format!("{role}: {model}"));
+        roles.push(format!(
+            "{role}: {tool} authored an authenticated contribution retained in the delivered candidate."
+        ));
+    }
+    Ok(CookAiLineage {
+        summary: terminal_form.summary.clone(),
+        what_changed: terminal_form.what_changed.clone(),
+        compatibility: terminal_form.compatibility.clone(),
+        tool: tools.join("; "),
+        model: models.join("; "),
+        used_for: roles.join(" "),
+        composed_model_disclosure: true,
+        preserve_used_for_disclosure: true,
+    })
+}
+
 fn required_execution_model(execution: &CookAttemptExecution, run_id: &str) -> Result<String> {
     execution.model.clone().ok_or_else(|| {
         Error::validation_invalid_argument(
@@ -4417,30 +4661,14 @@ fn cook_ai_lineage_with_stores(
         ));
     };
     attempts.truncate(terminal_index + 1);
-    // Preserve the byte-for-byte single-attempt output. Multi-attempt form-only
-    // recovery instead makes each authenticated role visible to reviewers.
-    if terminal_index == 0 {
-        let execution = cook_attempt_execution_in_store(lifecycle_store, successful_run_id)?;
-        let model = required_execution_model(&execution, successful_run_id)?;
-        return Ok(CookAiLineage {
-            summary: terminal_form.summary.clone(),
-            what_changed: terminal_form.what_changed.clone(),
-            compatibility: terminal_form.compatibility.clone(),
-            tool: crate::agent_task_review_dossier::homeboy_tool_disclosure(&execution.tool),
-            model,
-            used_for: terminal_form.used_for.clone(),
-        });
-    }
     let terminal = cook_attempt_execution_in_store(lifecycle_store, successful_run_id)?;
-    let terminal_model = required_execution_model(&terminal, successful_run_id)?;
     if !terminal.review_form_only {
-        return Err(Error::validation_invalid_argument(
-            "cook_recipe.attempts",
-            "multi-attempt Cook finalization only composes role disclosures for a metadata-only review-form follow-up",
-            Some(successful_run_id.to_string()),
-            None,
-        ));
+        return substantive_lineage(
+            substantive_contribution_chain(lifecycle_store, &attempts, successful_run_id)?,
+            terminal_form,
+        );
     }
+    let terminal_model = required_execution_model(&terminal, successful_run_id)?;
     let source_run_id = promotion
         .provenance
         .pointer("/cook_follow_up/source_run_id")
@@ -4526,6 +4754,8 @@ fn cook_ai_lineage_with_stores(
         tool,
         model,
         used_for,
+        composed_model_disclosure: true,
+        preserve_used_for_disclosure: false,
     })
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -17784,6 +17784,148 @@ fn empty_intentional_no_change_remediation_preserves_applied_candidate_recovery(
 }
 
 #[test]
+fn interrupted_attempt_does_not_change_the_only_substantive_disclosure() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-11252-interrupted";
+        let first_run_id = cook_id;
+        let second_run_id = "cook-11252-interrupted-attempt-2";
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = first_run_id.to_string();
+        options.initial_plan.tasks[0].executor.backend = "second-provider".to_string();
+        options.initial_plan.tasks[0].executor.model = Some("second-model".to_string());
+        options.gates.verify = vec!["cargo test --locked agent_task_promotion --lib".to_string()];
+        persist_initial_recipe(&options).expect("persist interrupted recipe");
+        super::super::record_recipe_attempt(cook_id, 2, second_run_id, &options.initial_plan)
+            .expect("persist substantive retry");
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(first_run_id))
+            .expect("materialize interrupted attempt");
+        agent_task_lifecycle::submit_plan(&options.initial_plan, Some(second_run_id))
+            .expect("materialize substantive retry");
+        agent_task_lifecycle::record_cook_attempt_in_store(
+            &test_lifecycle_store(),
+            cook_id,
+            1,
+            first_run_id,
+        )
+        .expect("index interrupted attempt");
+        agent_task_lifecycle::record_cook_attempt_in_store(
+            &test_lifecycle_store(),
+            cook_id,
+            2,
+            second_run_id,
+        )
+        .expect("index substantive retry");
+        seed_review_form_aggregate(second_run_id, &options.initial_plan);
+
+        let mut backend = CaptureBackend::default();
+        finalize_cook_pr_with_backend(
+            &options,
+            second_run_id,
+            &promotion(second_run_id),
+            &mut backend,
+        )
+        .expect("finalize the only authenticated implementation");
+
+        assert!(
+            backend.body.contains("Homeboy (second-provider)")
+                && backend.body.contains("openai/gpt-5.6-terra"),
+            "{}",
+            backend.body
+        );
+        assert!(
+            backend.body.contains(options.ai_used_for.as_str()),
+            "{}",
+            backend.body
+        );
+        assert!(
+            !backend.body.contains("Implementation 1:"),
+            "{}",
+            backend.body
+        );
+    });
+}
+
+#[test]
+fn substantive_retry_discloses_each_authenticated_contribution() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-11252-contributions";
+        let first_run_id = "cook-11252-contributions-attempt-1";
+        let second_run_id = "cook-11252-contributions-attempt-2";
+        let patch_sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.initial_run_id = first_run_id.to_string();
+        options.initial_plan.tasks[0].executor.backend = "first-provider".to_string();
+        options.initial_plan.tasks[0].executor.model = Some("first-model".to_string());
+        options.gates.verify = vec!["cargo test --locked agent_task_promotion --lib".to_string()];
+        let first_plan = options.initial_plan.clone();
+        persist_initial_recipe(&options).expect("persist contribution recipe");
+
+        let mut second_plan = first_plan.clone();
+        second_plan.tasks[0].executor.backend = "second-provider".to_string();
+        second_plan.tasks[0].executor.model = Some("second-model".to_string());
+        second_plan.tasks[0].inputs["cook_loop"]["artifact_provenance"] = serde_json::json!({
+            "source_run_id": first_run_id,
+            "source_task_id": first_plan.tasks[0].task_id,
+            "source_patch_artifact_sha256": patch_sha,
+        });
+        super::super::record_recipe_attempt(cook_id, 2, second_run_id, &second_plan)
+            .expect("persist bound substantive retry");
+        agent_task_lifecycle::submit_plan(&first_plan, Some(first_run_id))
+            .expect("materialize first contribution");
+        agent_task_lifecycle::submit_plan(&second_plan, Some(second_run_id))
+            .expect("materialize second contribution");
+        agent_task_lifecycle::record_cook_attempt_in_store(
+            &test_lifecycle_store(),
+            cook_id,
+            1,
+            first_run_id,
+        )
+        .expect("index first contribution");
+        agent_task_lifecycle::record_cook_attempt_in_store(
+            &test_lifecycle_store(),
+            cook_id,
+            2,
+            second_run_id,
+        )
+        .expect("index second contribution");
+        seed_review_form_aggregate(first_run_id, &first_plan);
+        seed_review_form_aggregate(second_run_id, &second_plan);
+
+        let mut first_promotion = promotion(first_run_id);
+        first_promotion.source.task_id = first_plan.tasks[0].task_id.clone();
+        first_promotion.patch_artifact.sha256 = Some(patch_sha.to_string());
+        agent_task_lifecycle::record_promotion(
+            first_run_id,
+            serde_json::to_value(first_promotion).unwrap(),
+        )
+        .expect("persist authenticated source promotion");
+
+        let mut backend = CaptureBackend::default();
+        finalize_cook_pr_with_backend(
+            &options,
+            second_run_id,
+            &promotion(second_run_id),
+            &mut backend,
+        )
+        .expect("finalize contribution chain");
+
+        for expected in [
+            "Implementation 1: Homeboy (first-provider)",
+            "Implementation 2: Homeboy (second-provider)",
+            "Implementation 1: first-model",
+            "Implementation 2: second-model",
+            "authored an authenticated contribution retained in the delivered candidate",
+        ] {
+            assert!(
+                backend.body.contains(expected),
+                "missing {expected}: {}",
+                backend.body
+            );
+        }
+    });
+}
+
+#[test]
 fn manual_preflight_intent_does_not_block_normal_cook_finalization() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let cook_id = "cook-10980-normal";

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -1023,6 +1023,7 @@ pub(crate) fn finalize_pull_request(mut args: FinalizePrArgs) -> CmdResult<Value
         evidence,
         ai_used_for: args.ai_used_for,
         review_dossier,
+        composed_ai_model_disclosure: false,
         review_profile,
         manual_finalization: args.manual_finalization,
         expected_candidate_sha: None,


### PR DESCRIPTION
## Summary

- recover the previously implemented but unmerged #11252 substantive-retry disclosure repair
- resolve contribution lineage through the current explicit recipe and lifecycle stores
- ignore non-contributing interrupted attempts while authenticating retained contribution chains by run, task, and promoted patch SHA
- preserve existing single-attempt and metadata-only review-form disclosure output
- retain multi-implementation tool, model, and `used_for` roles through generic PR finalization

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-agents interrupted_attempt_does_not_change_the_only_substantive_disclosure -- --nocapture`
- `cargo test -p homeboy-agents substantive_retry_discloses_each_authenticated_contribution -- --nocapture`
- `cargo test -p homeboy-agents adoption_green_candidate_missing_review_form_runs_form_only_follow_up_and_finalizes -- --nocapture`
- `cargo test -p homeboy-agents cook_successful_concrete_attempt_publishes_reviewer_body -- --nocapture`
- `cargo test -p homeboy-agents finalization_dossier_and_backend_hydration_use_explicit_lifecycle_store -- --nocapture`
- `cargo test -p homeboy-agents cook_finalization_adopts_validated_review_form_used_for_when_option_is_empty -- --nocapture`
- `cargo build -p homeboy --bin homeboy`
- live recovery: resumed the blocked Cook from its persisted applied promotion and four passing gates; Homeboy finalized https://github.com/Extra-Chill/homeboy-extensions/pull/2724 without provider re-execution

Closes #11252.

Stacked on #13609 and #13604 because those repairs were required to reach this finalization boundary.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode recovered the prior implementation, adapted it to current explicit-store contracts, resolved integration regressions, and verified it against the blocked Cook under operator control.