### PR TITLE
fix(cook): preserve live pending handoff

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
@@ -68,10 +68,12 @@ pub enum AgentTaskCommand {
     /// By default Cook observes until the lifecycle is terminal and returns the
     /// terminal Cook report.
     ///
-    /// `--detach-after-handoff` returns once the run is durably accepted. Its
-    /// result describes a submission, not an outcome. It is honored on every
-    /// placement: with `--placement local` the Cook is re-executed in its own
-    /// session, so it survives a client that is interrupted or times out.
+    /// `--detach-after-handoff` returns once the controller durably owns the
+    /// run. Its submission result reports `accepted` after executable-attempt
+    /// materialization or `pending` while a live supervised child is still
+    /// preparing. It is honored on every placement: with `--placement local`
+    /// the Cook is re-executed in its own session, so it survives a client that
+    /// is interrupted or times out.
     ///
     /// Do not infer the wait policy from client interactivity. An orchestration
     /// client that needs the detached contract should pass

--- a/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
@@ -782,12 +782,7 @@ pub(super) fn intercept_local_detached_cook(
             &mut child,
             handoff_timeout(),
         )?;
-        if handoff.state != DetachedHandoffState::Accepted {
-            let reason = if handoff.state == DetachedHandoffState::ExitedBeforeHandoff {
-                "detached Cook exited before materializing an executable plan"
-            } else {
-                "detached Cook did not materialize an executable plan before the bounded handoff deadline"
-            };
+        if let Some(reason) = detached_handoff_rejection_reason(handoff.state) {
             let _ = controller_client.cancel(controller_job.job_id(), reason);
             terminate_and_reap_detached_child(&mut child);
             return Err(empty_detached_plan_error(
@@ -795,13 +790,12 @@ pub(super) fn intercept_local_detached_cook(
                 reason,
             ));
         }
-        crate::commands::agent_task::run::announce_durable_cook_identity(
-            Some(&cook_id),
-            handoff
-                .run_id
-                .as_deref()
-                .expect("accepted handoff has run id"),
-        );
+        if let Some(run_id) = handoff.run_id.as_deref() {
+            crate::commands::agent_task::run::announce_durable_cook_identity(
+                Some(&cook_id),
+                run_id,
+            );
+        }
         let envelope = handoff_envelope(
             &cook_id,
             pid,
@@ -1273,6 +1267,11 @@ impl DetachedHandoffState {
             Self::ExitedBeforeHandoff => "exited_before_handoff",
         }
     }
+}
+
+fn detached_handoff_rejection_reason(state: DetachedHandoffState) -> Option<&'static str> {
+    (state == DetachedHandoffState::ExitedBeforeHandoff)
+        .then_some("detached Cook exited before materializing an executable plan")
 }
 
 fn handoff_timeout() -> Duration {
@@ -2534,6 +2533,7 @@ mod tests {
                 .expect("observe bounded pending handoff");
 
             assert_eq!(handoff.state, DetachedHandoffState::Pending);
+            assert_eq!(detached_handoff_rejection_reason(handoff.state), None);
             assert_eq!(
                 agent_task_lifecycle::status(cook_id)
                     .expect("pending status command resolves")
@@ -2855,6 +2855,10 @@ mod tests {
                     .expect("observe exited handoff");
 
             assert_eq!(handoff.state, DetachedHandoffState::ExitedBeforeHandoff);
+            assert_eq!(
+                detached_handoff_rejection_reason(handoff.state),
+                Some("detached Cook exited before materializing an executable plan")
+            );
             assert_eq!(handoff.run_id, None);
             let parent = agent_task_lifecycle::exact_record(cook_id)
                 .expect("the observer terminalizes the exited handoff parent");


### PR DESCRIPTION
## Summary

- preserve controller ownership when a live supervised detached Cook remains pending beyond the bounded handoff observation window
- reserve `empty_detached_plan` rejection for a child that actually exits before executable-attempt materialization
- announce a durable run identity only after one is available
- document the truthful `pending` versus `accepted` detached submission contract

## Verification

- `cargo fmt --all -- --check`
- `cargo build -p homeboy --bin homeboy`
- `cargo test -p homeboy-cli --features test-support preparation_past_the_handoff_window_keeps_follow_commands_resolvable -- --nocapture`
- `cargo test -p homeboy-cli --features test-support a_dead_detached_process_is_never_reported_as_an_accepted_handoff -- --nocapture`
- `git diff --check origin/main...HEAD`

Closes #13599.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode originally traced the detached-controller failure and implemented the repair. OpenCode rebased it onto current `main` and reran the focused verification under operator control.