### PR TITLE
Fix head release recovery source authority

### DIFF
--- a/crates/homeboy-release/src/release/orchestrator.rs
+++ b/crates/homeboy-release/src/release/orchestrator.rs
@@ -38,7 +38,8 @@ pub(crate) fn run_with_plan(
     // cleanup, and the deploy checkpoint. A release therefore cannot package
     // into one home and then record its state against another (#7505).
     let component = super::context::load_component(component_id, options)?;
-    let mut workspace = super::workspace::ReleaseWorkspace::select(roots, &component)?;
+    let mut workspace =
+        super::workspace::ReleaseWorkspace::select(roots, &component, options.pipeline.head)?;
     let mut workspace_options = options.clone();
     workspace_options.path_override = Some(workspace.component.local_path.clone());
     let checkout_guard =

--- a/crates/homeboy-release/src/release/workspace.rs
+++ b/crates/homeboy-release/src/release/workspace.rs
@@ -39,9 +39,10 @@ impl ReleaseWorkspace {
     pub(super) fn select(
         roots: &homeboy_core::paths::PathRoots,
         component: &Component,
+        head_release: bool,
     ) -> Result<Self> {
         let store = OperationRecordStore::in_roots(roots);
-        if in_place_eligible(component) {
+        if in_place_eligible(component, head_release) {
             return Ok(Self {
                 component: component.clone(),
                 output: ReleaseWorkspaceOutput::in_place(&component.local_path),
@@ -482,16 +483,19 @@ fn finalize_record(
     }
 }
 
-fn in_place_eligible(component: &Component) -> bool {
+fn in_place_eligible(component: &Component, head_release: bool) -> bool {
     let path = Path::new(&component.local_path);
-    if !git::is_git_repo(&component.local_path)
-        || git::status_porcelain(path).as_deref() != Some("")
-    {
+    if !git::is_git_repo(&component.local_path) {
         return false;
     }
-    let Some(branch) = git::current_branch(path) else {
+    if head_release {
+        return git::head_sha(path).is_some();
+    }
+    if git::status_porcelain(path).as_deref() != Some("") {
         return false;
-    };
+    }
+    let branch = git::current_branch(path);
+    let Some(branch) = branch else { return false };
     let default_branch = git::default_branch_name(path).unwrap_or_else(|| "main".to_string());
     if branch != default_branch {
         return false;
@@ -621,9 +625,9 @@ mod tests {
             local_path: path.to_string_lossy().to_string(),
             ..Default::default()
         };
-        assert!(in_place_eligible(&component));
+        assert!(in_place_eligible(&component, false));
         std::fs::write(path.join("README.md"), "dirty\n").expect("dirty");
-        assert!(!in_place_eligible(&component));
+        assert!(!in_place_eligible(&component, false));
     }
 
     #[test]
@@ -689,7 +693,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let workspace = ReleaseWorkspace::select(&test_roots(), &component)
+            let workspace = ReleaseWorkspace::select(&test_roots(), &component, false)
                 .expect("built-in provider staging");
 
             assert_eq!(workspace.output.kind, "provider_owned");
@@ -707,7 +711,7 @@ mod tests {
     }
 
     #[test]
-    fn detached_tag_checkout_stages_from_verified_remote_default_sha() {
+    fn detached_tag_checkout_preserves_head_release_source_authority() {
         homeboy_core::test_support::with_isolated_home(|home| {
             let remote = home.path().join("origin.git");
             let source = home.path().join("source");
@@ -776,6 +780,12 @@ mod tests {
                 git::head_sha(&source).as_deref(),
                 Some(remote_main.as_str())
             );
+            std::fs::write(
+                source.join("release-notes.md"),
+                "persisted recovery notes\n",
+            )
+            .expect("recovery notes");
+            assert_ne!(git::status_porcelain(&source).as_deref(), Some(""));
 
             let components = home.path().join(".config/homeboy/components");
             std::fs::create_dir_all(&components).expect("component registry");
@@ -797,8 +807,19 @@ mod tests {
                 ..Default::default()
             };
 
-            let workspace = ReleaseWorkspace::select(&test_roots(), &component)
-                .expect("detached release staging");
+            let tagged_sha = git::head_sha(&source).expect("tagged head");
+            let head_workspace = ReleaseWorkspace::select(&test_roots(), &component, true)
+                .expect("detached head release");
+
+            assert_eq!(head_workspace.output.kind, "in_place");
+            assert_eq!(head_workspace.component.local_path, component.local_path);
+            assert_eq!(
+                git::head_sha(Path::new(&head_workspace.component.local_path)).as_deref(),
+                Some(tagged_sha.as_str())
+            );
+
+            let workspace = ReleaseWorkspace::select(&test_roots(), &component, false)
+                .expect("detached normal release staging");
 
             assert_eq!(workspace.output.kind, "provider_owned");
             assert_eq!(


### PR DESCRIPTION
Closes #13605

## Summary
- pass head-release mode into release workspace selection
- preserve the requested checkout for `--head` publication recovery, including detached tagged checkouts with persisted recovery notes
- keep normal release staging pinned to the verified immutable remote-default SHA

## Verification
- `cargo test -p homeboy-release release::workspace::tests::` (6 passed)
- `cargo test -p homeboy-release` (552 passed; 3 established unrelated extension-lint baseline failures)
- `cargo fmt --all --check`
- `git diff --check`

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to diagnose the failed recovery run, implement the source-authority boundary repair, and run verification.