### PR TITLE
Recover queued Cook retries across controller runtimes

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -1845,14 +1845,34 @@ pub fn reconstruct_options_for_pre_execution_recovery(
 
 /// Whether an attempt that never reached provider execution may be rebuilt by
 /// the current controller without replaying a historical external transport.
+/// A queued retry proves that boundary through its immutable retry origin.
 pub fn local_pre_execution_runtime_recovery_is_eligible(
     recipe: &AgentTaskCookRecipe,
     record: &agent_task_lifecycle::AgentTaskRunRecord,
     explicit_local_override: bool,
 ) -> bool {
-    super::cook_pre_execution::retryable_pre_execution_failure(record)
-        && (explicit_local_override
-            || recipe.promotion_transport["attempt_dispatch"]["kind"].as_str() == Some("local"))
+    let local_transport = explicit_local_override
+        || recipe.promotion_transport["attempt_dispatch"]["kind"].as_str() == Some("local");
+    if !local_transport {
+        return false;
+    }
+    if super::cook_pre_execution::retryable_pre_execution_failure(record) {
+        return true;
+    }
+
+    let origin = &record.metadata["retry_origin"]["pre_execution_failure"];
+    let current_runtime = homeboy_core::build_identity::current().display;
+    record.state == agent_task_lifecycle::AgentTaskRunState::Queued
+        && recipe.runtime_generation != current_runtime
+        && record.metadata["controller_identity"].as_str() == Some(current_runtime.as_str())
+        && record.metadata["retry_of"].is_string()
+        && record.metadata["provider_executions_consumed"].as_u64() == Some(0)
+        && record.metadata["provider_run_ids"]
+            .as_array()
+            .is_some_and(Vec::is_empty)
+        && (origin["retryable"] == Value::Bool(true)
+            || origin["phase"].as_str() == Some("local_retry_supervisor"))
+        && origin["provider_executions_consumed"].as_u64() == Some(0)
 }
 
 /// Reconstruct the policy used to adopt an already-prepared candidate. Adoption

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -2724,8 +2724,16 @@ where
         }
         agent_task_lifecycle::ClaimOutcome::Acquired => {
             let dispatched: CmdResult<Value> = (|| {
-                let dispatcher =
-                    reconstruct_dispatcher(&recipe.promotion_transport["attempt_dispatch"])?;
+                let record = lifecycle_store.read_record(run_id)?;
+                let pre_execution_runtime_recovery =
+                    agent_task_service::local_pre_execution_runtime_recovery_is_eligible(
+                        recipe, &record, false,
+                    );
+                let dispatcher = if pre_execution_runtime_recovery {
+                    None
+                } else {
+                    reconstruct_dispatcher(&recipe.promotion_transport["attempt_dispatch"])?
+                };
                 let attempt = recipe
                     .attempts
                     .iter()
@@ -2738,8 +2746,11 @@ where
                             None,
                         )
                     })?;
-                let mut options =
-                    agent_task_service::reconstruct_options_with_dispatcher(recipe, dispatcher)?;
+                let mut options = if pre_execution_runtime_recovery {
+                    agent_task_service::reconstruct_options_for_pre_execution_recovery(recipe)?
+                } else {
+                    agent_task_service::reconstruct_options_with_dispatcher(recipe, dispatcher)?
+                };
                 options.initial_run_id = attempt.run_id.clone();
                 options.initial_plan = attempt.plan.clone();
                 agent_task_service::authorize_cook_continue_route(&options)?;

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -1439,6 +1439,149 @@ fn cook_continue_preflight_bypasses_model_provenance_for_retryable_pre_execution
 }
 
 #[test]
+fn cook_retry_run_recovers_a_historical_runtime_after_zero_provider_executions() {
+    with_temp_home(|| {
+        let root = tempfile::tempdir().expect("workspace root");
+        let primary = root.path().join("primary");
+        let workspace = root.path().join("runtime-recovery");
+        std::fs::create_dir(&primary).expect("create primary checkout");
+        init_runtime_component_checkout(&primary);
+        let remote_status = std::process::Command::new("git")
+            .args([
+                "-C",
+                primary.to_str().expect("UTF-8 primary path"),
+                "remote",
+                "add",
+                "origin",
+                primary.to_str().expect("UTF-8 primary path"),
+            ])
+            .status()
+            .expect("git remote command runs");
+        assert!(remote_status.success(), "configure fixture origin");
+        let worktree_status = std::process::Command::new("git")
+            .args([
+                "-C",
+                primary.to_str().expect("UTF-8 primary path"),
+                "worktree",
+                "add",
+                "-b",
+                "fixture-runtime-recovery",
+                workspace.to_str().expect("UTF-8 worktree path"),
+            ])
+            .status()
+            .expect("git worktree command runs");
+        assert!(worktree_status.success(), "create linked worktree");
+        let cook_id = "cook-pre-execution-runtime-recovery";
+        let run_id = "cook-pre-execution-runtime-recovery-attempt-1";
+        let plan = AgentTaskPlan::new(
+            "cook-pre-execution-runtime-recovery-plan",
+            vec![serde_json::from_value(json!({
+                "task_id": "provider",
+                "executor": { "backend": "fixture", "model": "fixture-model" },
+                "instructions": "recover with the current controller runtime",
+                "workspace": { "root": &workspace }
+            }))
+            .expect("provider task")],
+        );
+        let options = homeboy::agents::agent_task_service::AgentTaskCookServiceOptions {
+            cook_id: cook_id.to_string(),
+            initial_run_id: run_id.to_string(),
+            initial_plan: plan.clone(),
+            to_worktree: "fixture@pre-execution-runtime-recovery".to_string(),
+            source_worktree_path: Some(workspace.clone()),
+            provider_command: None,
+            provider_invocation: None,
+            gates: Default::default(),
+            max_attempts: 1,
+            no_finalize: true,
+            draft_pr: false,
+            base: "main".to_string(),
+            task_base_sha: None,
+            head: None,
+            title: "Pre-execution runtime recovery".to_string(),
+            commit_message: "Pre-execution runtime recovery".to_string(),
+            source_refs: Vec::new(),
+            protected_branches: Vec::new(),
+            ai_tool: "fixture".to_string(),
+            ai_model: Some("fixture-model".to_string()),
+            ai_used_for: "test".to_string(),
+            attempt_dispatcher: None,
+            harvest_context: homeboy::agents::agent_task_scheduler::HarvestExecutionContext::from_current_process()
+                .expect("harvest context"),
+        };
+        homeboy::agents::agent_task_service::persist_initial_recipe(&options)
+            .expect("persist recipe");
+        agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("submit attempt");
+        agent_task_lifecycle::record_cook_attempt_in_store(
+            &test_lifecycle_store(),
+            cook_id,
+            1,
+            run_id,
+        )
+        .expect("bind attempt to Cook");
+        agent_task_lifecycle::record_pre_execution_failure(
+            run_id,
+            &plan,
+            "local_retry_supervisor",
+            &Error::internal_unexpected("launcher exited before provider execution")
+                .with_retryable(true),
+        )
+        .expect("record retryable pre-execution failure");
+        let recipe_path = homeboy::core::paths::homeboy_data()
+            .expect("data root")
+            .join("agent-task-cooks")
+            .join(cook_id)
+            .join("recipe.json");
+        let mut persisted_recipe: Value =
+            serde_json::from_slice(&std::fs::read(&recipe_path).expect("read persisted recipe"))
+                .expect("parse persisted recipe");
+        persisted_recipe["runtime_generation"] = "homeboy 0.1.0+historical".into();
+        persisted_recipe["promotion_transport"]["attempt_dispatch"] = json!({ "kind": "local" });
+        std::fs::write(
+            &recipe_path,
+            serde_json::to_vec_pretty(&persisted_recipe).expect("encode historical recipe"),
+        )
+        .expect("persist historical local recipe");
+
+        let executor = Arc::new(CountingCookExecutor::default());
+        let retried = retry_with(
+            RetryArgs {
+                run_id: run_id.to_string(),
+                new_run_id: None,
+                run: true,
+                force: false,
+            },
+            executor.clone(),
+            |_| Ok(None),
+        )
+        .expect("queued retry recovers under the current runtime");
+
+        assert_eq!(
+            executor.executions.load(Ordering::SeqCst),
+            1,
+            "{retried:#?}"
+        );
+        let recipe = homeboy::agents::agent_task_service::load_recipe(cook_id)
+            .expect("read recovered recipe");
+        let recovered = test_lifecycle_store()
+            .read_record(&recipe.attempts.last().expect("replacement attempt").run_id)
+            .expect("read recovered replacement");
+        assert_eq!(recovered.metadata["retry_of"], run_id);
+        assert_eq!(recovered.metadata["provider_executions_consumed"], 1);
+        assert_eq!(
+            recovered.metadata["controller_identity"],
+            homeboy::core::build_identity::current().display
+        );
+        assert!(
+            !homeboy::agents::agent_task_service::local_pre_execution_runtime_recovery_is_eligible(
+                &recipe, &recovered, false,
+            ),
+            "provider execution restores the strict historical runtime fence"
+        );
+    });
+}
+
+#[test]
 fn cook_continue_reconciles_a_delayed_runner_attempt_then_advances_its_terminal_recipe_once() {
     with_temp_home(|| {
         let workspace = tempfile::tempdir().expect("workspace");


### PR DESCRIPTION
## Summary

- admit historical-runtime reconstruction for a newly queued local Cook retry only when its durable retry origin proves a retryable pre-execution failure with zero provider executions
- route the queued retry and Cook spine through the existing pre-execution recovery reconstruction
- retain strict runtime provenance after provider execution

Closes #13614.

## Verification

- `cargo test -p homeboy-cli --lib cook_retry_run_recovers_a_historical_runtime_after_zero_provider_executions`
- `cargo test -p homeboy-agents retryable_pre_execution_terminal_does_not_cancel_runtime_admission`
- `cargo test -p homeboy-agents provider_replay_keeps_runtime_pin_while_adoption_accepts_historical_policy`
- `cargo check -p homeboy-cli`
- `cargo fmt --all --check`
- `git diff --check`

## Baseline Observations

- The existing `cook_retry_run_executes_the_replacement_through_its_cook_lifecycle` fixture fails on current `main` because it expects hard-coded `attempt-2-retry` identity while the current pre-execution retry remains semantic attempt 1. This branch does not modify that fixture.
- The unrelated Ubuntu external-resolver fixture currently projects malformed output as `unavailable`; macOS and Windows pass. This branch does not touch resolver behavior.

## AI Assistance Disclosure

OpenAI gpt-5.6-sol via OpenCode was used to trace the durable retry lineage and failed operation claim, implement the bounded recovery predicate and dispatch routing, add the end-to-end regression, and run verification. The resulting code and evidence remain subject to normal maintainer review and CI.