### PR TITLE
fix(lint): refuse incomparable legacy baselines

### DIFF
--- a/crates/homeboy-extension/src/lint/baseline.rs
+++ b/crates/homeboy-extension/src/lint/baseline.rs
@@ -28,10 +28,21 @@ pub struct LintBaselineMetadata {
 /// latter contains findings the former deliberately did not ask producers to
 /// inspect. The digest is used as the persisted key while this full value is
 /// returned as provenance for humans and automation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LintBaselineResolution {
+    Unavailable,
+    Scoped,
+    LegacyFull,
+    LegacyEmptyIncomparable,
+    GitBase,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct LintBaselineProvenance {
     pub baseline_key: String,
     pub compared: bool,
+    pub resolution: LintBaselineResolution,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub base_ref: Option<String>,
     pub files: Vec<String>,
@@ -77,6 +88,7 @@ impl LintBaselineProvenance {
         Self {
             baseline_key: format!("{BASELINE_KEY}:{digest}"),
             compared: false,
+            resolution: LintBaselineResolution::Unavailable,
             base_ref: None,
             files,
             tools,
@@ -223,12 +235,18 @@ pub fn load_baseline_for_scope_or_legacy_full(
     provenance: &mut LintBaselineProvenance,
 ) -> Option<LintBaseline> {
     if let Some(baseline) = load_baseline_for_scope(source_path, Some(provenance)) {
+        provenance.resolution = LintBaselineResolution::Scoped;
         return Some(baseline);
     }
 
     if provenance.permits_legacy_full_baseline() {
         if let Some(baseline) = load_baseline(source_path) {
             provenance.baseline_key = BASELINE_KEY.to_string();
+            if baseline.known_fingerprints.is_empty() {
+                provenance.resolution = LintBaselineResolution::LegacyEmptyIncomparable;
+                return None;
+            }
+            provenance.resolution = LintBaselineResolution::LegacyFull;
             return Some(baseline);
         }
     }
@@ -418,6 +436,7 @@ mod tests {
             .expect("load scoped baseline");
 
         assert_eq!(baseline.context_id, "scoped");
+        assert_eq!(provenance.resolution, LintBaselineResolution::Scoped);
         assert_ne!(provenance.baseline_key, BASELINE_KEY);
     }
 
@@ -444,7 +463,30 @@ mod tests {
             .expect("load legacy baseline");
 
         assert_eq!(baseline.context_id, "legacy");
+        assert_eq!(provenance.resolution, LintBaselineResolution::LegacyFull);
         assert_eq!(provenance.baseline_key, BASELINE_KEY);
+    }
+
+    #[test]
+    fn empty_legacy_baseline_is_explicitly_incomparable() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut provenance = LintBaselineProvenance::new(
+            Vec::new(),
+            vec!["eslint".to_string()],
+            "full",
+            None,
+            false,
+            None,
+            None,
+        );
+        save_baseline(dir.path(), "legacy", &[]).expect("save empty legacy baseline");
+
+        assert!(load_baseline_for_scope_or_legacy_full(dir.path(), &mut provenance).is_none());
+        assert_eq!(provenance.baseline_key, BASELINE_KEY);
+        assert_eq!(
+            provenance.resolution,
+            LintBaselineResolution::LegacyEmptyIncomparable
+        );
     }
 
     #[test]

--- a/crates/homeboy-extension/src/lint/run/tests/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/tests/workflow.rs
@@ -194,7 +194,187 @@ exit 1
             .as_ref()
             .expect("baseline provenance");
         assert!(provenance.compared);
+        assert_eq!(
+            provenance.resolution,
+            crate::lint::baseline::LintBaselineResolution::LegacyFull
+        );
         assert_eq!(provenance.baseline_key, "lint");
+    });
+}
+
+#[test]
+fn empty_legacy_full_baseline_is_incomparable_instead_of_new_drift() {
+    homeboy_core::test_support::with_isolated_home(|home| {
+        let source = tempfile::tempdir().expect("source dir");
+        crate::lint::baseline::save_baseline(source.path(), "legacy", &[])
+            .expect("save empty legacy baseline");
+        let component = routed_lint_component(
+            home.path(),
+            source.path(),
+            r#"#!/bin/sh
+printf '[{"tool":"phpcs","message":"standing warning","fingerprint":"standing","file":"src/lib.php"}]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+printf '[{"tool":"phpcs","status":"passed","finding_count":1}]' > "$HOMEBOY_LINT_PRODUCERS_FILE"
+exit 1
+"#,
+        );
+
+        let workflow = run_main_lint_workflow(
+            &component,
+            source.path(),
+            lint_args(),
+            &RunDir::create().expect("run dir"),
+        )
+        .expect("workflow result");
+
+        assert_eq!(workflow.status, "passed");
+        assert_eq!(workflow.exit_code, 0);
+        assert!(workflow.baseline_comparison.is_none());
+        let provenance = workflow
+            .baseline_provenance
+            .as_ref()
+            .expect("baseline provenance");
+        assert!(!provenance.compared);
+        assert_eq!(provenance.baseline_key, "lint");
+        assert_eq!(
+            provenance.resolution,
+            crate::lint::baseline::LintBaselineResolution::LegacyEmptyIncomparable
+        );
+    });
+}
+
+#[test]
+fn scoped_empty_full_baseline_still_blocks_a_genuine_increase() {
+    homeboy_core::test_support::with_isolated_home(|home| {
+        let source = tempfile::tempdir().expect("source dir");
+        let provenance = crate::lint::baseline::LintBaselineProvenance::new(
+            Vec::new(),
+            vec!["phpcs".to_string()],
+            "full",
+            None,
+            false,
+            None,
+            None,
+        );
+        crate::lint::baseline::save_baseline_for_scope(
+            source.path(),
+            "scoped",
+            &[],
+            Some(&provenance),
+        )
+        .expect("save scoped empty baseline");
+        let component = routed_lint_component(
+            home.path(),
+            source.path(),
+            r#"#!/bin/sh
+printf '[{"tool":"phpcs","message":"introduced warning","fingerprint":"introduced","file":"src/lib.php"}]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+printf '[{"tool":"phpcs","status":"passed","finding_count":1}]' > "$HOMEBOY_LINT_PRODUCERS_FILE"
+exit 1
+"#,
+        );
+
+        let workflow = run_main_lint_workflow(
+            &component,
+            source.path(),
+            lint_args(),
+            &RunDir::create().expect("run dir"),
+        )
+        .expect("workflow result");
+
+        assert_eq!(workflow.status, "failed");
+        assert_eq!(workflow.exit_code, 1);
+        assert!(workflow
+            .baseline_comparison
+            .as_ref()
+            .is_some_and(|comparison| comparison.new_items.len() == 1));
+        assert_eq!(
+            workflow
+                .baseline_provenance
+                .as_ref()
+                .map(|provenance| &provenance.resolution),
+            Some(&crate::lint::baseline::LintBaselineResolution::Scoped)
+        );
+    });
+}
+
+#[test]
+fn accepted_pr_finding_stays_accepted_on_full_default_branch_run() {
+    homeboy_core::test_support::with_isolated_home(|home| {
+        let source = tempfile::tempdir().expect("source dir");
+        let run_git = |args: &[&str]| {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(source.path())
+                .output()
+                .expect("git command");
+            assert!(
+                output.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        run_git(&["init", "-q"]);
+        run_git(&["config", "user.email", "homeboy@example.com"]);
+        run_git(&["config", "user.name", "Homeboy Test"]);
+        std::fs::write(
+            source.path().join("legacy.php"),
+            "<?php // standing warning\n",
+        )
+        .expect("base source");
+        run_git(&["add", "."]);
+        run_git(&["commit", "-q", "-m", "base"]);
+        run_git(&["branch", "baseline"]);
+        std::fs::write(
+            source.path().join("legacy.php"),
+            "<?php // standing warning\n// harmless change\n",
+        )
+        .expect("candidate source");
+        run_git(&["add", "."]);
+        run_git(&["commit", "-q", "-m", "candidate"]);
+        crate::lint::baseline::save_baseline(source.path(), "legacy", &[])
+            .expect("save empty legacy baseline");
+        let component = routed_lint_component(
+            home.path(),
+            source.path(),
+            r#"#!/bin/sh
+printf '[{"tool":"phpcs","message":"standing warning","fingerprint":"standing","file":"legacy.php"}]' > "$HOMEBOY_LINT_FINDINGS_FILE"
+printf '[{"tool":"phpcs","status":"passed","finding_count":1}]' > "$HOMEBOY_LINT_PRODUCERS_FILE"
+exit 1
+"#,
+        );
+
+        let mut pr_args = lint_args();
+        pr_args.changed_since = Some("baseline".to_string());
+        pr_args.precomputed_changed_files = Some(vec!["legacy.php".to_string()]);
+        let pr = run_main_lint_workflow(
+            &component,
+            source.path(),
+            pr_args,
+            &RunDir::create().expect("PR run dir"),
+        )
+        .expect("PR workflow result");
+        let push = run_main_lint_workflow(
+            &component,
+            source.path(),
+            lint_args(),
+            &RunDir::create().expect("push run dir"),
+        )
+        .expect("push workflow result");
+
+        assert_eq!((pr.status.as_str(), pr.exit_code), ("passed", 0));
+        assert_eq!((push.status.as_str(), push.exit_code), ("passed", 0));
+        assert_eq!(
+            pr.baseline_provenance
+                .as_ref()
+                .map(|provenance| &provenance.resolution),
+            Some(&crate::lint::baseline::LintBaselineResolution::GitBase)
+        );
+        assert_eq!(
+            push.baseline_provenance
+                .as_ref()
+                .map(|provenance| &provenance.resolution),
+            Some(&crate::lint::baseline::LintBaselineResolution::LegacyEmptyIncomparable)
+        );
     });
 }
 

--- a/crates/homeboy-extension/src/lint/run/workflow.rs
+++ b/crates/homeboy-extension/src/lint/run/workflow.rs
@@ -694,6 +694,12 @@ fn process_baseline(
             }
 
             baseline_comparison = Some(comparison);
+        } else if provenance.resolution
+            == lint_baseline::LintBaselineResolution::LegacyEmptyIncomparable
+        {
+            eprintln!(
+                "[lint] Legacy full baseline is incomparable: it has no fingerprints or scope provenance"
+            );
         }
     }
 
@@ -783,6 +789,7 @@ fn process_changed_since_baseline(
 
     let mut provenance = provenance.clone();
     provenance.compared = true;
+    provenance.resolution = lint_baseline::LintBaselineResolution::GitBase;
     provenance.base_ref = Some(base_ref);
     let comparison = lint_baseline::compare_against_findings(lint_findings, &baseline_findings);
     let exit_override = Some(if comparison.drift_increased { 1 } else { 0 });


### PR DESCRIPTION
Fixes #13616.

## Problem

`static-site-importer` stores a pre-scope `baselines.lint` entry with `item_count: 0` and `known_fingerprints: []`, created before lint baselines carried scope provenance.

Since `c95094a8d` (shipped in `v0.359.7`), an unfiltered full-scope run falls back to that legacy entry whenever no scope-keyed baseline exists. The fallback repaired #13328, where a non-empty legacy baseline could still establish continuity through matching fingerprints. It also began comparing empty legacy baselines, which cannot.

Comparing a repository-wide finding set against zero known fingerprints classifies every standing finding as new, so `main` pushes started failing with `DRIFT INCREASED: 51 new finding(s) since baseline` while PR differential lint stayed green.

## Change

Baseline resolution now reports an explicit typed state instead of only returning an optional baseline:

- a scope-keyed baseline stays authoritative and is unchanged,
- a non-empty legacy baseline still resolves and keeps ratcheting, preserving the #13328 repair,
- an empty legacy baseline resolves to `legacy_empty_incomparable`, is not compared, and leaves the run's measured verdict intact,
- changed-since runs report `git_base`.

`baseline_provenance.resolution` is serialized, so the reason a run did or did not ratchet is now visible in lint output rather than inferred from `compared`.

This deliberately does not suppress findings: it removes a comparison that had no evidence behind it. Genuine increases still fail.

## Coverage

Added to `crates/homeboy-extension/src/lint`:

- `empty_legacy_baseline_is_explicitly_incomparable` — resolution-level typing.
- `empty_legacy_full_baseline_is_incomparable_instead_of_new_drift` — the exact `0.359.6` pass / `0.359.7` failure shape with an unchanged full finding set.
- `scoped_empty_full_baseline_still_blocks_a_genuine_increase` — an empty *scoped* baseline remains authoritative and still fails a new finding.
- `accepted_pr_finding_stays_accepted_on_full_default_branch_run` — the same standing finding passes both as a PR run against its Git base and as a full default-branch run.

`full_scope_legacy_baseline_is_compared_with_legacy_provenance` now also asserts `LegacyFull`, so the #13328 path stays covered.

## Verification

- `cargo test -p homeboy-extension lint::` — 72 passed.
- `cargo fmt --all --check` and `git diff --check` — clean.

Two failures on this branch are pre-existing on `main` and unrelated to this change:

- `homeboy-cli` `agent_task_fanout_dispatch_id_matches_the_canonical_plan_identity` panics at `fanout.rs:2554` (`Cook-batch base is resolved before planning`). Verified by stashing this patch and rerunning on an otherwise clean tree — it fails identically.
- `homeboy-extension` `declared_result_parser_rejects_malformed_successful_stdout_json` fails only under full-suite concurrency and passes when run alone.

Also worth noting for the "floating resolution" part of the issue: `cargo test -p homeboy-cli` does not compile without `--features test-support`, because `tests/external_check_detail_resolver_fixture.rs` calls a `test-support`-gated symbol unconditionally. Left out of scope here.

## Scope

The action-pin/floating-release half of #13616 is not addressed by this PR. The gating defect was in Homeboy's own baseline resolution and is fixed at that layer; version-resolution semantics can be tracked separately.

## AI assistance

OpenAI GPT-5.6 Sol through OpenCode traced the regression from the linked `static-site-importer` runs to `c95094a8d`, inspected the persisted `homeboy.json` baseline, implemented the resolution typing, and wrote the regression tests. Chris Huber directed the work and remains responsible for the change.