### PR TITLE
fix(agent-task): measure liveness from provider artifact activity

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -1698,6 +1698,18 @@ where
     })
 }
 
+/// Size every file the provider owns under its artifacts directory.
+///
+/// `artifacts_path` is handed to the provider as its private output directory,
+/// so a file growing there is the provider doing work — whatever it is named.
+///
+/// This deliberately does not filter on the file name. It used to require the
+/// name to contain `progress`, which made liveness depend on a runtime's naming
+/// convention rather than on observable activity (#13623). A runtime that
+/// streams its telemetry into, say, `<task>-<backend>-runtime-stdout.log` was
+/// invisible: the watchdog read zero progress while that file grew to 94KB, and
+/// killed a healthy provider as stalled. Nothing else writes here, so counting
+/// every file cannot manufacture liveness the provider did not earn.
 fn runtime_progress_snapshot(root: &Path) -> BTreeMap<PathBuf, u64> {
     let Ok(entries) = std::fs::read_dir(root) else {
         return BTreeMap::new();
@@ -1705,10 +1717,6 @@ fn runtime_progress_snapshot(root: &Path) -> BTreeMap<PathBuf, u64> {
     entries
         .flatten()
         .filter_map(|entry| {
-            let name = entry.file_name().to_string_lossy().to_ascii_lowercase();
-            if !name.contains("progress") {
-                return None;
-            }
             let path = entry.path();
             let metadata = path.metadata().ok()?;
             metadata.is_file().then_some((path, metadata.len()))

--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -950,6 +950,57 @@ fn structured_runtime_progress_keeps_provider_alive_until_completion() {
     );
 }
 
+/// A runtime that streams telemetry into an artifact whose name does not
+/// contain `progress` is still working, and must not be killed as stalled.
+///
+/// Regression for #13623: liveness filtered artifacts by file name, so an
+/// OpenCode Cook writing `cook-homeboy-opencode-runtime-stdout.log` was read as
+/// producing nothing. It was killed at the liveness deadline with
+/// `stdout_bytes: 0` and `runtime_progress_events: 0` while that file already
+/// held 94KB. The script below reproduces that shape: it writes only to a
+/// non-`progress` artifact and keeps its stdout silent until the end, so the
+/// parent pipes stay empty and the artifact is the only evidence of life.
+#[test]
+fn non_progress_named_runtime_artifact_keeps_provider_alive_until_completion() {
+    let command = format!(
+        "node {}",
+        script("let fs=require('fs'); let path=require('path'); let req=JSON.parse(fs.readFileSync(0,'utf8')); let log=path.join(req.artifacts_path,'task-runtime-stdout.log'); let timer=setInterval(()=>fs.appendFileSync(log,'working\\n'),10); setTimeout(()=>{clearInterval(timer); process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'succeeded',summary:'completed while streaming a runtime log'}));},900);")
+    );
+    let (mut request, provider) = request("task-liveness-runtime-log", command);
+    request.limits.timeout_ms = Some(1_500);
+    request.limits.liveness_timeout_ms = Some(500);
+
+    let outcome = run_provider_command_once(&request, &provider);
+
+    assert_eq!(outcome.status, AgentTaskOutcomeStatus::Succeeded);
+    assert_eq!(
+        outcome.summary.as_deref(),
+        Some("completed while streaming a runtime log")
+    );
+}
+
+/// Counting every artifact file must not blunt the watchdog: a provider that
+/// writes nothing anywhere is still stalled and still gets killed.
+#[test]
+fn provider_writing_no_artifacts_is_still_killed_for_liveness() {
+    let command = format!("node {}", script("setInterval(() => {}, 1000);"));
+    let (mut request, provider) = request("task-liveness-no-artifacts", command);
+    request.limits.timeout_ms = Some(5_000);
+    request.limits.liveness_timeout_ms = Some(300);
+
+    let outcome = run_provider_command_once(&request, &provider);
+
+    assert_eq!(
+        outcome.diagnostics[0].class,
+        "agent_task.provider_liveness_timeout"
+    );
+    assert_eq!(outcome.diagnostics[0].data["deadline"], json!("liveness"));
+    assert_eq!(
+        outcome.diagnostics[0].data["runtime_progress_events"],
+        json!(0)
+    );
+}
+
 #[test]
 fn stalled_provider_retains_declared_attempt_workspace_artifact() {
     let temp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
Fixes #13623.

## Problem

`runtime_progress_snapshot` decided what counted as provider activity by matching a substring of the file name:

```rust
let name = entry.file_name().to_string_lossy().to_ascii_lowercase();
if !name.contains("progress") {
    return None;
}
```

So liveness depended on a runtime's naming convention rather than on observable work.

In the reported run, the OpenCode executor streamed its telemetry into `cook-homeboy-opencode-runtime-stdout.log` inside `artifacts_path`. That name has no `progress` in it, so the watchdog ignored it. The child also buffered its own stdout until exit, so Homeboy's mirrors — `provider-runtime-stdout-1.log` and `provider-runtime-stderr-1.log` — stayed at 0 bytes.

Both liveness inputs therefore read zero while the provider was working:

```
      2679  18:43:59  cook-homeboy-opencode-progress.jsonl
         0  18:38:58  cook-homeboy-opencode-runtime-stderr.log
     94321  18:39:39  cook-homeboy-opencode-runtime-stdout.log
         0  18:38:57  provider-runtime-stderr-1.log
         0  18:38:57  provider-runtime-stdout-1.log
```

Run started 18:38:53 and was killed 18:44:23, reporting `stdout_bytes: 0`, `runtime_progress_events: 0`, and `failure_classification: stalled` — with 94KB already on disk at 18:39:39. The progress JSONL records a coherent session running `git status`, `git log`, reading a test file and grepping the tree. The provider was doing exactly the task it was given.

## Change

Size every file under `artifacts_path` instead of only `progress`-named ones.

`artifacts_path` is handed to the provider as its private output directory, so a file growing there *is* the provider doing work, whatever it is called. Nothing else writes into that directory, so this cannot manufacture liveness a provider did not earn.

The poll shape is unchanged — same non-recursive `read_dir` on the same interval — so there is no added cost per tick.

## Coverage

- `non_progress_named_runtime_artifact_keeps_provider_alive_until_completion` — reproduces the reported shape: the provider writes only to a non-`progress` artifact and keeps stdout silent until the end, so the artifact is the sole evidence of life. **Verified to fail without the fix** (`ProviderError` from the liveness kill) and pass with it.
- `provider_writing_no_artifacts_is_still_killed_for_liveness` — a provider writing nothing anywhere is still killed with `agent_task.provider_liveness_timeout` and `runtime_progress_events: 0`, so counting every file does not blunt the watchdog.

`structured_runtime_progress_keeps_provider_alive_until_completion` (#13584) and the existing silent-provider deadline tests continue to pass unchanged.

## Verification

- `cargo test -p homeboy-agents --lib agent_task_provider::tests::scheduler_tests` — 52 passed.
- `cargo test -p homeboy-agents --lib agent_task_timeout` — 12 passed.
- `cargo fmt --all --check` and `git diff --check` — clean.

`agent_task_provider::tests::scheduler_tests::provider_empty_stdout_captures_bounded_stderr_and_exit_context` and `..._records_failed_run_with_executor_evidence` fail when the whole module runs, and pass individually. Both fail identically on unmodified `main` (192 passed there, 194 here with the two added tests), so they are pre-existing shared-state leakage rather than a regression from this change — consistent with #9774 and #10097.

## Note on scope

The scan stays non-recursive, matching current behaviour and cost. A runtime that writes telemetry only into a subdirectory of `artifacts_path` would still be invisible; that did not occur here and is left alone rather than paying a recursive walk every tick.

## AI assistance

OpenAI GPT-5.6 Sol through OpenCode diagnosed this from the killed run's own artifact sizes and mtimes, located the name filter, wrote the fix, and confirmed the regression test fails without it. Chris Huber directed the work and remains responsible for the change.