### PR TITLE
fix(cli): gate the resolver fixture target on test-support

### DIFF
--- a/crates/homeboy-cli/tests/external_check_detail_resolver_fixture.rs
+++ b/crates/homeboy-cli/tests/external_check_detail_resolver_fixture.rs
@@ -1,3 +1,17 @@
+//! External check detail resolver fixtures.
+//!
+//! Both tests require the `test-support` feature: the first calls a fixture
+//! entry point that only exists under it, and the second is not a test anyone
+//! runs directly — `timeout_fixture_command` copies this binary and re-invokes
+//! it with `--exact resolver_fixture_hangs_until_killed` to get a process that
+//! hangs until the resolver's timeout kills it. So the two must stay in the
+//! same binary, and gating the file keeps them together.
+//!
+//! Without the gate this target failed to compile whenever the feature was
+//! absent, which broke a bare `cargo test -p homeboy-cli` (#13624). CI always
+//! passes `--features test-support`, so it never saw it.
+#![cfg(feature = "test-support")]
+
 #[test]
 fn resolver_fixture_is_bounded_and_cross_platform() {
     homeboy_cli::commands::ci::test_external_check_detail_resolver_fixture();


### PR DESCRIPTION
Fixes #13624.

## Problem

`crates/homeboy-cli/tests/external_check_detail_resolver_fixture.rs` called a `test-support`-gated entry point unconditionally, so the target failed to compile whenever the feature was absent:

```
error[E0425]: cannot find function `test_external_check_detail_resolver_fixture` in module `homeboy_cli::commands::ci`
note: found an item that was configured out
  |       ------------------------ the item is gated behind the `test-support` feature
```

A bare `cargo test -p homeboy-cli` therefore never got as far as running anything. CI always passes the feature (`.github/workflows/ci.yml:166`), so it never saw this.

## Change

Gate the file with `#![cfg(feature = "test-support")]`.

Gating the whole file rather than just the failing test is deliberate. `timeout_fixture_command` copies this test binary and re-invokes it:

```rust
vec![
    name.to_string(),
    "--ignored".to_string(),
    "--exact".to_string(),
    "resolver_fixture_hangs_until_killed".to_string(),
]
```

So `resolver_fixture_hangs_until_killed` is not a test anyone runs directly — it exists to give the resolver a process that hangs until its timeout kills it, and it has to be in the same binary as the test that drives it. Splitting the gate would leave the timeout fixture without its process.

Its only caller is itself `test-support`-gated, so nothing needs either test when the feature is off.

## Verification

- `cargo test -p homeboy-cli` — compiles; previously failed with E0425.
- `cargo test --locked -p homeboy-cli --features test-support --test external_check_detail_resolver_fixture` (CI's exact command) — `1 passed; 1 ignored`, run 3x for stability after an initial flake that turned out to be a race with an interleaved rebuild in the same shell invocation, not this change.
- `cargo test -p homeboy-cli --test external_check_detail_resolver_fixture` without the feature — target runs and reports 0 tests.
- `cargo fmt --all --check`, `git diff --check` — clean.

## Not addressed here

`RUSTFLAGS="-D warnings" cargo check -p homeboy-cli --all-targets` without the feature reports four dead-code warnings — `test_cross_platform_fixture`, `install_fixture_extension`, `timeout_fixture_command`, `fixture_program`. They come from the same feature-gating mismatch: the helpers are `#[cfg(any(test, feature = "test-support"))]` while their only caller is `#[cfg(feature = "test-support")]`, so under `cfg(test)` alone they compile with nothing calling them.

Verified pre-existing on unmodified `main`, and outside what #13624 asks for, so left alone rather than widened into this PR. Worth its own issue if `cargo test -p homeboy-cli` should be warning-clean too.

## AI assistance

OpenAI GPT-5.6 Sol through OpenCode reproduced the compile failure, traced why both tests must share a binary before choosing where to gate, and verified the CI command still passes. Chris Huber directed the work and remains responsible for the change.