### PR TITLE
fix(cli): stop reading forwarded arguments as Homeboy's own

### DIFF
--- a/crates/homeboy-cli/src/cli_surface/mod.rs
+++ b/crates/homeboy-cli/src/cli_surface/mod.rs
@@ -1301,7 +1301,11 @@ mod tests {
         ] {
             assert!(help.contains(flag), "bench must advertise {flag}");
         }
-        assert!(help.contains("without pinning a runner"));
+        // Both halves of the placement/runner choice stay documented in compact
+        // help: `--placement` selects where work executes, and `--runner` pins it.
+        // `c05305b09` reworded the placement help without updating this assertion,
+        // so it named prose the tree no longer contained.
+        assert!(help.contains("Select where eligible work executes"));
         assert!(help.contains("This implies Lab placement"));
     }
 

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -7095,7 +7095,7 @@ fi
     }
 
     fn with_materialized_cook_batch_worktrees(test: impl FnOnce()) {
-        with_isolated_home(|_| {
+        with_isolated_home(|home| {
             let mut config = homeboy::core::defaults::load_config();
             config.agent_task.default_backend = Some("sandbox".to_string());
             config.worktree_providers.clear();
@@ -7104,6 +7104,32 @@ fi
             );
             homeboy::core::defaults::save_config(&config)
                 .expect("configure fixture default backend");
+            // `--repo homeboy` only resolves against a registered primary, so the
+            // fixture has to own that registration as well as the worktrees it
+            // adopts. Without it every cook-batch case fails in repository
+            // resolution before reaching the behavior under test.
+            let primary = home.path().join("cook-batch-primary");
+            std::fs::create_dir_all(&primary).expect("create primary fixture");
+            for args in [
+                ["init", "-b", "main"].as_slice(),
+                ["config", "user.email", "test@example.com"].as_slice(),
+                ["config", "user.name", "Homeboy Test"].as_slice(),
+                ["commit", "--allow-empty", "-m", "initial"].as_slice(),
+                // The planned source ref has to resolve without a network, so the
+                // fixture publishes `origin/main` locally rather than fetching it.
+                ["update-ref", "refs/remotes/origin/main", "HEAD"].as_slice(),
+            ] {
+                assert!(
+                    Command::new("git")
+                        .args(args)
+                        .current_dir(&primary)
+                        .status()
+                        .expect("initialize primary fixture")
+                        .success(),
+                    "git {args:?} failed"
+                );
+            }
+            write_component_registration(home.path(), "homeboy", &primary);
             let worktrees = tempfile::tempdir().expect("managed worktree fixtures");
             for (handle, name) in [
                 ("homeboy@fix-issue-6453-homeboy", "issue-6453"),

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -1296,7 +1296,11 @@ fn stage_unmaterialized_cook_replay_intent(
     let mut index = 0usize;
     let mut has_run_id = false;
     let mut has_notification_route = false;
-    while index < normalized_args.len() {
+    // Only flags before the bare separator are Homeboy's own. Rewriting a
+    // forwarded `--prompt` or `--verify` into a replay reference would corrupt
+    // the argument the provider was asked to run (#11577).
+    let owned = crate::command_capability::homeboy_owned_args(normalized_args).len();
+    while index < owned {
         let arg = &normalized_args[index];
         if arg == "--notification-route" || arg.starts_with("--notification-route=") {
             has_notification_route = true;
@@ -1419,6 +1423,18 @@ fn stage_unmaterialized_cook_replay_intent(
             ]);
             input_refs.push(reference);
         }
+    }
+    // Carry the forwarded tail through verbatim, separator included, so the
+    // provider receives exactly what it was given. Secret and credential
+    // rejection still applies: a secret is no less secret past the separator.
+    for argument in &normalized_args[owned..] {
+        if homeboy::core::redaction::redact_string(argument) != *argument {
+            return Err(unsafe_inline_replay_error(
+                argument.split('=').next().unwrap_or(argument),
+            ));
+        }
+        reject_credential_bearing_url(argument)?;
+        argv.push(argument.clone());
     }
     let staging_prefix = root.display().to_string();
     let published_prefix = published_root.display().to_string();

--- a/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
@@ -470,12 +470,15 @@ fn record_retry_launcher_failure(
 /// concurrent caller advances the recipe.
 fn retry_child_args(normalized_args: &[String], run_id: &str) -> Vec<String> {
     let mut args = Vec::with_capacity(normalized_args.len() + 2);
+    // Only a run-id flag before the bare separator is Homeboy's own. Stripping one
+    // past it would rewrite a forwarded argument instead of this retry (#11577).
+    let owned = crate::command_capability::homeboy_owned_args(normalized_args).len();
     let mut index = usize::from(
         normalized_args
             .first()
             .is_some_and(|arg| arg == "homeboy" || arg.ends_with("/homeboy")),
     );
-    while index < normalized_args.len() {
+    while index < owned {
         let arg = &normalized_args[index];
         if arg == "--new-run-id" {
             index += 2;
@@ -486,8 +489,11 @@ fn retry_child_args(normalized_args: &[String], run_id: &str) -> Vec<String> {
         }
         index += 1;
     }
+    // The pin belongs to Homeboy, so it stays ahead of the separator and the
+    // forwarded tail is carried through untouched.
     args.push("--new-run-id".to_string());
     args.push(run_id.to_string());
+    args.extend_from_slice(&normalized_args[owned..]);
     args
 }
 

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
@@ -46,6 +46,10 @@ pub(crate) fn parsed_command_preflight_input(
         RunnerIntent, RunnerNormalization,
     };
 
+    // A runner flag Homeboy owns can only appear before the bare separator.
+    // Reading past it lets a forwarded `--runner` be mistaken for our own (#11577).
+    let normalized_args = crate::command_capability::homeboy_owned_args(normalized_args);
+
     let resource_admission =
         hot_command(&cli.command).map_or(ResourceAdmissionRequirement::Exempt, |command| {
             ResourceAdmissionRequirement::Required {
@@ -779,15 +783,19 @@ fn local_override_command(args: &[String]) -> Option<String> {
         return None;
     }
     let mut command = args.to_vec();
-    if let Some(index) = command
+    // Only a placement flag before the bare separator is Homeboy's own. Rewriting
+    // one past it would retarget a forwarded argument instead of this run (#11577).
+    let owned = crate::command_capability::homeboy_owned_args(args).len();
+    if let Some(index) = command[..owned]
         .iter()
         .position(|arg| arg == "--placement" || arg.starts_with("--placement="))
     {
         if command[index] == "--placement" {
-            if let Some(value) = command.get_mut(index + 1) {
-                *value = "local".to_string();
+            // The value has to be the flag's own, so it must also precede the separator.
+            if index + 1 < owned {
+                command[index + 1] = "local".to_string();
             } else {
-                command.push("local".to_string());
+                command.insert(index + 1, "local".to_string());
             }
         } else {
             command[index] = "--placement=local".to_string();


### PR DESCRIPTION
`main` is red for any change scoped to `homeboy-cli`. That is not a local annoyance: the differential Test gate rejects unrelated PRs because the candidate runs failures the baseline scope never reaches. #13493 was rejected with "3 candidate-only failed test identity(s)" — and there are exactly three tests failing on a clean checkout of `main`.

Verified on a pristine `origin/main` worktree with a zero-line diff.

## The guard was telling the truth

`a_new_raw_argv_flag_scan_is_a_failure` is not stale. It named four sites that read a flag literal out of raw argv without stopping at the bare separator, so an argument forwarded to a provider can be read as Homeboy's own (#11577):

| Site | What a forwarded argument did |
|---|---|
| `route.rs::stage_unmaterialized_cook_replay_intent` | a forwarded `--prompt`/`--verify` was rewritten into a replay reference |
| `local_detach.rs::retry_child_args` | a forwarded `--new-run-id` was stripped |
| `resource_policy::local_override_command` | a forwarded `--placement` was retargeted |
| `resource_policy::parsed_command_preflight_input` | a forwarded `--runner` was read as a pin |

Each now resolves its owned prefix through `homeboy_owned_args` first.

The replay-intent site is the one worth reading closely. It both rewrites owned flags and rejects secrets. Those were split deliberately: rewriting stops at the separator, while **secret and credential rejection still covers the forwarded tail**, matching the reasoning already recorded for `redact_execution_argv` — a secret is no less secret past the separator. `replay_intent_rejects_inline_secret_bearing_inputs` and `replay_intent_snapshots_all_arbitrary_text_and_rejects_credential_urls` both still pass.

## The other two were stale fixtures

- `lab_flags_remain_visible_for_portable_command_help` asserted `"without pinning a runner"`. `c05305b09` deliberately reworded the `--placement` help and dropped that phrase, leaving the assertion naming text the tree no longer contained. It now asserts the current placement contract.
- The cook-batch fixture adopted worktrees but never registered the primary that `--repo homeboy` resolves against, so every case in that family died in repository resolution before reaching the behavior under test. It now registers the primary and publishes `origin/main` locally, so the planned source ref resolves without a network.

## Verification

- `cargo fmt --all --check`
- owned args guard — 7 passed, including `an_acknowledged_scan_that_no_longer_exists_is_a_failure`, so no existing acknowledgement was invalidated
- `cli_surface` — 34 passed
- `resource_policy` — 58 passed
- `local_detach` — 64 passed
- replay intent — 4 passed
- `fanout` — **86 passed / 17 failed on `main`, 90 passed / 13 failed here**

Net: four tests fixed, zero regressions.

## Scope

The remaining 13 fanout failures predate this change and are part of #12914. They are deliberately left alone rather than folded into an argv-safety fix.

Refs #12914, #11577

## AI assistance
- **AI assistance:** Yes
- **Model:** Claude Sonnet 4.6
- **Tool:** OpenCode via Kimaki
- **Used for:** Bisected the three clean-checkout failures to their causes, attributed the help-text regression to `c05305b09`, implemented the four owned-argv routings and the fixture repair, and ran the before/after suites quoted above. Chris Huber directed the work and owns the change.