### PR TITLE
Separate daemon process liveness from build freshness

### DIFF
--- a/crates/homeboy-cli/src/commands/daemon.rs
+++ b/crates/homeboy-cli/src/commands/daemon.rs
@@ -1207,10 +1207,17 @@ mod tests {
         stale_reason_code: Option<daemon::DaemonStaleReasonCode>,
         repair_plan: Vec<daemon::DaemonRepairStep>,
     ) -> DaemonStatus {
-        DaemonStatus {
-            running: fresh,
+        // A version-mismatched daemon is live and reachable but stale; an
+        // unreachable transport is neither. Fresh is always live.
+        let live = matches!(
+            stale_reason_code,
+            None | Some(daemon::DaemonStaleReasonCode::VersionMismatch)
+        );
+        let replacement_blocked = !fresh && repair_plan.is_empty();
+        let mut status = DaemonStatus {
+            running: live,
             fresh,
-            reachable: fresh,
+            reachable: live,
             freshness: daemon::DaemonFreshnessReport {
                 fresh,
                 stale_reason_code,
@@ -1229,13 +1236,19 @@ mod tests {
                 repair_plan,
             },
             stale_reason: (!fresh).then(|| "test daemon remains stale".to_string()),
+            replacement_blocked,
+            replacement_blocked_reason: replacement_blocked
+                .then(|| "test daemon remains stale".to_string()),
+            summary: String::new(),
             state: None,
             state_path: "test".to_string(),
             state_identity: "test".to_string(),
             process_candidates: Vec::new(),
             active_job_recovery_evidence: Vec::new(),
             termination_evidence: None,
-        }
+        };
+        status.summary = status.render_summary();
+        status
     }
 
     /// A durable job whose daemon died before persisting any child identity:

--- a/crates/homeboy-cli/src/commands/status/mod.rs
+++ b/crates/homeboy-cli/src/commands/status/mod.rs
@@ -422,12 +422,12 @@ const GLOBAL_ACTIVITY_LIMIT: i64 = 100;
 /// registered inventory size.
 fn global_status(controller: ControllerStaleness) -> CmdResult<StatusResult> {
     let daemon_status = daemon::read_status()?;
-    let admitting_work = daemon_status.running && daemon_status.fresh && daemon_status.reachable;
+    let admitting_work = daemon_status.admits_work();
     let blocker = (!admitting_work).then(|| {
         daemon_status
             .stale_reason
             .clone()
-            .unwrap_or_else(|| "daemon is not running, fresh, and reachable".to_string())
+            .unwrap_or_else(|| "daemon is not live, fresh, and reachable".to_string())
     });
 
     let registered_runners = runner::list()?;

--- a/crates/homeboy-core/src/daemon/control.rs
+++ b/crates/homeboy-core/src/daemon/control.rs
@@ -1008,7 +1008,7 @@ fn start_state_loss_replacement(
     start_state_loss_replacement_with(receipt, receipt_path, |startup_token| {
         let replacement = start_or_return_live_unlocked_with_startup_token(addr, startup_token)?;
         let status = read_status()?;
-        if status.running
+        if status.admits_work()
             && status
                 .state
                 .as_ref()
@@ -1057,7 +1057,7 @@ fn replay_replacement_starting(
             Error::internal_unexpected("replacement-starting receipt has no startup token")
         })?;
     if let Some(state) = status.state.as_ref() {
-        if status.running && state.startup_token == token {
+        if status.admits_work() && state.startup_token == token {
             receipt.phase = StateLossRecoveryPhase::ReplacementStarted;
             receipt.replacement = Some(super::DaemonStartResult {
                 pid: state.pid,
@@ -1207,7 +1207,7 @@ fn replay_leaseless_recovery(
         return replay_leaseless_recovery(status, addr, replacement_operation_id);
     }
     if receipt.phase == StateLossRecoveryPhase::ReplacementStarting {
-        if let Some(state) = status.state.as_ref().filter(|_| status.running) {
+        if let Some(state) = status.state.as_ref().filter(|_| status.admits_work()) {
             if receipt.replacement_startup_token.as_deref() != Some(&state.startup_token) {
                 return Err(Error::validation_invalid_argument(
                     "reconcile_leaseless_orphans",
@@ -1235,7 +1235,7 @@ fn replay_leaseless_recovery(
                 })?;
             let replacement = start_or_return_live_unlocked_with_startup_token(addr, token)?;
             let started = read_status()?;
-            if !started.running
+            if !started.admits_work()
                 || started
                     .state
                     .as_ref()
@@ -1257,7 +1257,7 @@ fn replay_leaseless_recovery(
     let Some(state) = status.state.as_ref() else {
         return Ok(None);
     };
-    if status.freshness.active_jobs != 0 || !status.fresh || !status.running {
+    if status.freshness.active_jobs != 0 || !status.admits_work() {
         return Ok(None);
     }
     let replacement = receipt.replacement.as_ref().ok_or_else(|| {
@@ -1871,7 +1871,7 @@ pub fn reconcile_leaseless_orphans(
     write_leaseless_recovery_receipt(&receipt_path, &receipt)?;
     let replacement = start_or_return_live_unlocked_with_startup_token(addr, &startup_token)?;
     let status = read_status()?;
-    if !status.running
+    if !status.admits_work()
         || status
             .state
             .as_ref()
@@ -2485,7 +2485,10 @@ where
     Spawn: FnOnce() -> Result<DaemonStartResult>,
 {
     let existing = read_status()?;
-    if existing.running {
+    // A live-but-stale daemon must not be returned as if it were usable:
+    // `running` is pure process liveness, so the start path gates on the
+    // full live/reachable/current-build predicate before attaching (#13621).
+    if existing.admits_work() {
         if let Some(state) = existing.state {
             return Ok(DaemonStartResult {
                 pid: state.pid,
@@ -2539,8 +2542,9 @@ where
     };
     for attempt in 0..=observations {
         let status = read_status()?;
+        let admits_work = status.admits_work();
         if let Some(state) = status.state {
-            if status.running && state.startup_token == startup_token {
+            if admits_work && state.startup_token == startup_token {
                 return Ok(Ok(DaemonStartResult {
                     pid: state.pid,
                     address: state.address,
@@ -2789,7 +2793,8 @@ fn resolve_daemon_url(daemon_url: Option<String>) -> Result<String> {
         return Ok(url);
     }
     let status = read_status()?;
-    let Some(state) = status.state.filter(|_| status.running) else {
+    let admits_work = status.admits_work();
+    let Some(state) = status.state.filter(|_| admits_work) else {
         return Err(Error::validation_invalid_argument(
             "daemon-url",
             "daemon is not running; pass --daemon-url or start it with `homeboy daemon start`",

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -487,14 +487,43 @@ pub struct DaemonState {
     pub runtime_paths: DaemonRuntimeSnapshot,
 }
 
+/// Independent observations of one daemon session lease.
+///
+/// Each field answers exactly one question (#13621):
+///
+/// - [`DaemonStatus::running`] — is the recorded daemon process alive?
+/// - [`DaemonStatus::reachable`] — is the daemon API reachable from the lease?
+/// - [`DaemonStatus::fresh`] — does the daemon binary match this Homeboy build?
+/// - [`DaemonStatus::replacement_blocked`] — is replacing it blocked, and why?
+///
+/// A live daemon running an older build therefore reports
+/// `running: true, reachable: true, fresh: false`; process death is never
+/// inferred from a build mismatch. [`DaemonStatus::admits_work`] is the
+/// derived predicate for the one question that needs all three facts.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct DaemonStatus {
+    /// The daemon process recorded by the lease is alive. This is pure
+    /// process liveness: it says nothing about build compatibility.
     pub running: bool,
+    /// The daemon binary matches the invoking Homeboy build.
     pub fresh: bool,
+    /// The daemon API endpoint is reachable from a live lease.
     pub reachable: bool,
     pub freshness: DaemonFreshnessReport,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stale_reason: Option<String>,
+    /// Whether replacing this daemon is blocked right now. A fresh daemon is
+    /// never blocked (nothing to replace); a stale daemon is blocked when the
+    /// recorded evidence authorizes no repair and a replacement would destroy
+    /// protected durable work or act on unattributed ownership.
+    pub replacement_blocked: bool,
+    /// Evidence-drawn reason naming what blocks replacement. `None` when
+    /// replacement is not blocked.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replacement_blocked_reason: Option<String>,
+    /// Plain-language liveness, freshness, and replacement-safety summary,
+    /// rendered from the same evidence as the fields above.
+    pub summary: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<DaemonState>,
     pub state_path: String,
@@ -511,6 +540,49 @@ pub struct DaemonStatus {
     /// not imply an OS-level cause for a dead daemon.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub termination_evidence: Option<DaemonTerminationEvidence>,
+}
+
+impl DaemonStatus {
+    /// The daemon is a live, reachable session running this exact Homeboy
+    /// build — the daemon a caller may submit work to right now.
+    ///
+    /// Deliberately a predicate over the independent liveness, reachability,
+    /// and freshness fields rather than an overloaded `running` field: build
+    /// incompatibility must not masquerade as process death (#13621).
+    pub fn admits_work(&self) -> bool {
+        self.running && self.fresh && self.reachable
+    }
+
+    /// Render [`DaemonStatus::summary`] from the status's own evidence.
+    pub fn render_summary(&self) -> String {
+        let mut summary = if self.running && self.reachable {
+            "daemon process is live and its API is reachable".to_string()
+        } else if self.running {
+            "daemon process is live but its API is unreachable".to_string()
+        } else if self.state.is_some() {
+            "daemon process is dead".to_string()
+        } else {
+            "no daemon lease is recorded and the daemon API is unreachable".to_string()
+        };
+        if self.fresh {
+            summary.push_str("; binary is fresh (matches this Homeboy build)");
+        } else if let Some(reason) = &self.stale_reason {
+            summary.push_str(&format!("; binary is stale: {reason}"));
+        } else {
+            summary.push_str("; binary is stale");
+        }
+        if self.replacement_blocked {
+            summary.push_str(&format!(
+                "; replacement is blocked: {}",
+                self.replacement_blocked_reason
+                    .as_deref()
+                    .unwrap_or("the recorded evidence authorizes no replacement")
+            ));
+        } else if !self.fresh {
+            summary.push_str("; replacement is not blocked: an authorized repair plan is recorded");
+        }
+        summary
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -1162,12 +1234,34 @@ pub fn read_status() -> Result<DaemonStatus> {
     } else {
         validation.stale_reason.clone()
     };
-    Ok(DaemonStatus {
-        running: validation.running && validation.fresh && validation.reachable,
+    // A stale daemon with an authorized repair plan (a restartable stop/start,
+    // an adoption, or an explicit reconciliation) can be replaced through that
+    // plan. A stale daemon with no plan — protected active jobs, a corrupt
+    // lease, an unreachable transport, or conflicting foreground candidates —
+    // has its replacement blocked, with the blocker named in evidence terms.
+    let replacement_blocked = !freshness.fresh && freshness.repair_plan.is_empty();
+    let replacement_blocked_reason = replacement_blocked.then(|| {
+        if freshness.active_jobs > 0 {
+            format!(
+                "{} active durable job(s) are protected from implicit replacement",
+                freshness.active_jobs
+            )
+        } else {
+            freshness
+                .ownership_evidence
+                .clone()
+                .unwrap_or_else(|| "the recorded evidence authorizes no replacement".to_string())
+        }
+    });
+    let mut status = DaemonStatus {
+        running: validation.running,
         fresh: validation.fresh,
         reachable: validation.reachable,
         freshness,
         stale_reason,
+        replacement_blocked,
+        replacement_blocked_reason,
+        summary: String::new(),
         state: validation.state,
         state_path,
         state_identity,
@@ -1177,7 +1271,9 @@ pub fn read_status() -> Result<DaemonStatus> {
             .then(read_termination_evidence)
             .transpose()?
             .flatten(),
-    })
+    };
+    status.summary = status.render_summary();
+    Ok(status)
 }
 
 fn has_conflicting_process_candidates(candidates: &[DaemonProcessCandidate]) -> bool {

--- a/crates/homeboy-core/src/daemon/recovery_actions.rs
+++ b/crates/homeboy-core/src/daemon/recovery_actions.rs
@@ -407,12 +407,23 @@ mod tests {
         repair_plan: Vec<DaemonRepairStep>,
         active_jobs: usize,
     ) -> DaemonStatus {
-        DaemonStatus {
-            running: false,
-            fresh: stale_reason_code.is_none(),
+        let fresh = stale_reason_code.is_none();
+        let replacement_blocked = !fresh && repair_plan.is_empty();
+        let replacement_blocked_reason = replacement_blocked.then(|| {
+            if active_jobs > 0 {
+                format!(
+                    "{active_jobs} active durable job(s) are protected from implicit replacement"
+                )
+            } else {
+                "daemon lease evidence is inconclusive".to_string()
+            }
+        });
+        let mut status = DaemonStatus {
+            running: true,
+            fresh,
             reachable: true,
             freshness: super::super::DaemonFreshnessReport {
-                fresh: stale_reason_code.is_none(),
+                fresh,
                 stale_reason_code,
                 restartable: true,
                 lease_id: Some(LEASE_ID.to_string()),
@@ -429,13 +440,18 @@ mod tests {
                 repair_plan,
             },
             stale_reason: None,
+            replacement_blocked,
+            replacement_blocked_reason,
+            summary: String::new(),
             state: None,
             state_path: "/root/.config/homeboy/daemon/state.json".to_string(),
             state_identity: "identity".to_string(),
             process_candidates: Vec::new(),
             active_job_recovery_evidence: Vec::new(),
             termination_evidence: None,
-        }
+        };
+        status.summary = status.render_summary();
+        status
     }
 
     /// The live reproduction this fix was written against: a reachable daemon

--- a/tests/core/daemon/control_test.rs
+++ b/tests/core/daemon/control_test.rs
@@ -56,7 +56,7 @@ fn completed_leaseless_recovery_replays_the_exact_replacement_without_starting_a
     with_isolated_home(|_| {
         let replacement = fake_daemon(4343, "replacement-lease");
         let state = fake_daemon_state(replacement.clone());
-        let status = DaemonStatus {
+        let mut status = DaemonStatus {
             running: true,
             fresh: true,
             reachable: true,
@@ -78,6 +78,9 @@ fn completed_leaseless_recovery_replays_the_exact_replacement_without_starting_a
                 repair_plan: Vec::new(),
             },
             stale_reason: None,
+            replacement_blocked: false,
+            replacement_blocked_reason: None,
+            summary: String::new(),
             state: Some(state),
             state_path: "/fake/daemon-state.json".to_string(),
             state_identity: "fresh-replacement".to_string(),
@@ -85,6 +88,8 @@ fn completed_leaseless_recovery_replays_the_exact_replacement_without_starting_a
             active_job_recovery_evidence: Vec::new(),
             termination_evidence: None,
         };
+        status.summary = status.render_summary();
+        let status = status;
         let receipt = super::LeaselessRecoveryReceipt {
             affected_job_ids: Vec::new(),
             affected_jobs: Vec::new(),
@@ -1554,8 +1559,10 @@ fn write_legacy_recovery_state(lease_id: &str, pid: u32, endpoint: &str) {
 
 fn fake_status(daemon: Option<super::DaemonStartResult>, fresh: bool) -> DaemonStatus {
     let stale_reason_code = (!fresh).then_some(DaemonStaleReasonCode::VersionMismatch);
-    DaemonStatus {
-        running: fresh,
+    // The fixture models a live daemon whenever a lease is present, matching
+    // the real projection where a version-mismatched lease keeps its live PID.
+    let mut status = DaemonStatus {
+        running: daemon.is_some(),
         fresh,
         reachable: true,
         freshness: DaemonFreshnessReport {
@@ -1576,17 +1583,23 @@ fn fake_status(daemon: Option<super::DaemonStartResult>, fresh: bool) -> DaemonS
             repair_plan: Vec::new(),
         },
         stale_reason: (!fresh).then(|| "simulated stale daemon".to_string()),
+        replacement_blocked: !fresh,
+        replacement_blocked_reason: (!fresh)
+            .then(|| "the recorded evidence authorizes no replacement".to_string()),
+        summary: String::new(),
         state: daemon.map(fake_daemon_state),
         state_path: "/fake/daemon-state.json".to_string(),
         state_identity: "sha256:fake".to_string(),
         process_candidates: Vec::new(),
         active_job_recovery_evidence: Vec::new(),
         termination_evidence: None,
-    }
+    };
+    status.summary = status.render_summary();
+    status
 }
 
 fn fake_dead_status(daemon: super::DaemonStartResult) -> DaemonStatus {
-    DaemonStatus {
+    let mut status = DaemonStatus {
         running: false,
         fresh: false,
         reachable: false,
@@ -1608,13 +1621,20 @@ fn fake_dead_status(daemon: super::DaemonStartResult) -> DaemonStatus {
             repair_plan: Vec::new(),
         },
         stale_reason: Some("daemon lease pid is not running".to_string()),
+        replacement_blocked: true,
+        replacement_blocked_reason: Some(
+            "1 active durable job(s) are protected from implicit replacement".to_string(),
+        ),
+        summary: String::new(),
         state: Some(fake_daemon_state(daemon)),
         state_path: "/fake/daemon-state.json".to_string(),
         state_identity: "sha256:fake".to_string(),
         process_candidates: Vec::new(),
         active_job_recovery_evidence: Vec::new(),
         termination_evidence: None,
-    }
+    };
+    status.summary = status.render_summary();
+    status
 }
 
 fn dead_status_with_unexpected_termination(daemon: super::DaemonStartResult) -> DaemonStatus {

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -1553,9 +1553,13 @@ fn read_status_classifies_unknown_binary_freshness_as_stale() {
 
     let status = read_status().expect("status");
 
-    assert!(!status.running);
+    // #13621: a binary-hash mismatch is staleness, not process death. The
+    // recorded PID stays live and its endpoint stays reachable, so liveness
+    // and reachability are reported independently of freshness.
+    assert!(status.running);
     assert!(!status.fresh);
     assert!(status.reachable);
+    assert!(!status.admits_work());
     assert!(status
         .stale_reason
         .as_deref()
@@ -1624,6 +1628,160 @@ fn freshness_report_classifies_version_mismatch() {
     assert_eq!(
         status.freshness.stale_reason_code,
         Some(DaemonStaleReasonCode::VersionMismatch)
+    );
+}
+
+/// The four daemon-status fixtures of #13621, each pinned deterministically:
+/// liveness is this test process (live) or `u32::MAX` (dead), no daemon is
+/// started or signaled, and each fixture asserts the independent liveness,
+/// reachability, freshness, and replacement-safety fields plus the rendered
+/// operator summary.
+///
+/// This is the live reproduction the fix was written against: a reachable
+/// daemon with a live PID, a valid lease, and one protected active job used
+/// to report `running: false` because `running` encoded build compatibility.
+#[test]
+fn daemon_status_live_but_stale_daemon_reports_liveness_true_and_freshness_false() {
+    let _home = HomeGuard::new();
+    let mut state = daemon_state_for_test(std::process::id(), "127.0.0.1:49152");
+    state.build_identity.version = "0.0.0-stale".to_string();
+    state.build_identity.display = "homeboy 0.0.0-stale+fixture".to_string();
+    state.lease_id = "live-stale-lease".to_string();
+    write_daemon_state_for_test(&state);
+    let path = crate::paths::daemon_jobs_file().expect("jobs path");
+    let store = JobStore::open_without_reconciliation(&path)
+        .expect("store")
+        .with_daemon_lease(state.lease_id.clone());
+    let job = store.create("runner.exec");
+    store.start(job.id).expect("start job");
+
+    let status = read_status().expect("status");
+
+    assert!(
+        status.running,
+        "a live daemon process stays live regardless of build staleness"
+    );
+    assert!(status.reachable);
+    assert!(!status.fresh);
+    assert_eq!(
+        status.freshness.stale_reason_code,
+        Some(DaemonStaleReasonCode::VersionMismatch)
+    );
+    assert!(
+        !status.admits_work(),
+        "a stale build must not admit work just because the process is live"
+    );
+    assert!(
+        status.replacement_blocked,
+        "the protected active job blocks replacement"
+    );
+    assert_eq!(
+        status.replacement_blocked_reason.as_deref(),
+        Some("1 active durable job(s) are protected from implicit replacement")
+    );
+    assert!(
+        status
+            .summary
+            .contains("daemon process is live and its API is reachable"),
+        "{}",
+        status.summary
+    );
+    assert!(
+        status.summary.contains("binary is stale"),
+        "{}",
+        status.summary
+    );
+    assert!(
+        status.summary.contains("replacement is blocked"),
+        "{}",
+        status.summary
+    );
+}
+
+#[test]
+fn daemon_status_dead_lease_reports_a_dead_process_and_an_unblocked_idle_replacement() {
+    let _home = HomeGuard::new();
+    let state = daemon_state_for_test(u32::MAX, "127.0.0.1:49152");
+    write_daemon_state_for_test(&state);
+
+    let status = read_status().expect("status");
+
+    assert!(!status.running);
+    assert!(!status.reachable);
+    assert!(!status.fresh);
+    assert_eq!(
+        status.freshness.stale_reason_code,
+        Some(DaemonStaleReasonCode::PidDead)
+    );
+    assert!(!status.admits_work());
+    // The idle dead lease authorizes its stop/start repair, so a replacement
+    // is sequenced rather than blocked.
+    assert!(!status.replacement_blocked);
+    assert_eq!(status.replacement_blocked_reason, None);
+    assert!(
+        status.summary.contains("daemon process is dead"),
+        "{}",
+        status.summary
+    );
+    assert!(
+        !status.summary.contains("daemon process is live"),
+        "{}",
+        status.summary
+    );
+}
+
+#[test]
+fn daemon_status_without_a_lease_reports_no_live_process_and_an_unreachable_api() {
+    let _home = HomeGuard::new();
+
+    let status = read_status().expect("status");
+
+    assert!(!status.running);
+    assert!(!status.reachable);
+    assert!(!status.fresh);
+    assert_eq!(
+        status.freshness.stale_reason_code,
+        Some(DaemonStaleReasonCode::LeaseMissing)
+    );
+    assert!(!status.admits_work());
+    // An empty store authorizes a plain start; nothing durable is at risk.
+    assert!(!status.replacement_blocked);
+    assert_eq!(status.replacement_blocked_reason, None);
+    assert!(
+        status
+            .summary
+            .contains("no daemon lease is recorded and the daemon API is unreachable"),
+        "{}",
+        status.summary
+    );
+}
+
+#[test]
+fn daemon_status_live_and_fresh_daemon_reports_every_independent_field_true() {
+    let _home = HomeGuard::new();
+    let state = daemon_state_for_test(std::process::id(), "127.0.0.1:49152");
+    write_daemon_state_for_test(&state);
+
+    let status = read_status().expect("status");
+
+    assert!(status.running);
+    assert!(status.reachable);
+    assert!(status.fresh);
+    assert_eq!(status.freshness.stale_reason_code, None);
+    assert!(status.admits_work());
+    assert!(!status.replacement_blocked);
+    assert_eq!(status.replacement_blocked_reason, None);
+    assert!(
+        status
+            .summary
+            .contains("daemon process is live and its API is reachable"),
+        "{}",
+        status.summary
+    );
+    assert!(
+        status.summary.contains("binary is fresh"),
+        "{}",
+        status.summary
     );
 }
 


### PR DESCRIPTION
## Problem

A daemon that was demonstrably alive — pid `96932`, valid lease `299440df-2ab3-43ed-af11-f2a1a69e4528`, one protected active job, API reachable on `127.0.0.1:61287` — reported:

```json
{
  "reachable": true,
  "running": false,
  "fresh": false,
  "stale_reason": "daemon build identity does not match current Homeboy binary"
}
```

`running` was overloaded to mean "build-compatible with the invoking binary" rather than "the process is alive". Callers had to interpret `running: false` as a version mismatch, which contradicts the process and reachability evidence sitting next to it and makes maintenance decisions harder than they need to be.

## Fix

Each field now answers exactly one question:

| Field | Question |
| --- | --- |
| `running` | Is the recorded daemon process alive? |
| `reachable` | Is the daemon API reachable from the lease? |
| `fresh` | Does the daemon binary match this Homeboy build? |
| `replacement_blocked` / `replacement_blocked_reason` | Is replacing it blocked, and why? |
| `summary` | Plain-language liveness, freshness, and replacement-safety statement |

Process death is never inferred from a build mismatch. A live daemon on an older build now reports `running: true, reachable: true, fresh: false`.

The one question that genuinely needs all three facts — *may a caller submit work to this daemon right now?* — is the explicit derived predicate `DaemonStatus::admits_work()`. Every internal call site that previously gated on the overloaded `running` field (start/attach, ensure-running, leaseless recovery replay, state-loss replacement, daemon URL resolution) now gates on `admits_work()`, so a live-but-stale daemon is no longer returned as usable.

## Tests

Four fixtures covering the distinct states:

- `daemon_status_live_but_stale_daemon_reports_liveness_true_and_freshness_false`
- `daemon_status_live_and_fresh_daemon_reports_every_independent_field_true`
- `daemon_status_dead_lease_reports_a_dead_process_and_an_unblocked_idle_replacement`
- `daemon_status_without_a_lease_reports_no_live_process_and_an_unreachable_api`

## Verification

| Command | Result |
| --- | --- |
| `cargo test -p homeboy-core --lib daemon_test` | 85 passed, 0 failed |
| `cargo test -p homeboy-core --lib daemon -- --test-threads=1` | 260 passed, 0 failed |
| `cargo check --workspace --tests --locked` | clean |
| `cargo fmt --all --check` | clean |
| `git diff --check` | clean |

### Note on a pre-existing flake

Under the default parallel runner, `daemon::runner_files::tests::abort_and_expiry_remove_partial_uploads` and `unfinished_uploads_reserve_runner_workspace_quota_across_ids` intermittently fail. Both pass in isolation and the whole `daemon` module passes single-threaded (260/260). These tests exercise runner upload quota over shared filesystem state and are untouched by this change; the collision reproduces on the module alone. Tracked separately — not a regression from this PR.

Rebased onto latest `origin/main` and re-verified after rebase.

Fixes #13621

## AI assistance disclosure

Z.AI GLM 5.3 via OpenCode implemented the field separation, the `admits_work()` predicate, the call-site updates, and the four fixtures. Claude Fable 5 via OpenCode (Claude Code CLI) identified the defect from live daemon status evidence, filed the issue, reviewed the diff, completed formatting and verification after the authoring session hit a provider usage limit, isolated the pre-existing flake, and published this PR. Chris Huber directed the control-plane ergonomics audit.