### PR TITLE
Separate executing work from open resources in activity counts

### DIFF
--- a/crates/homeboy-cli/src/commands/activity.rs
+++ b/crates/homeboy-cli/src/commands/activity.rs
@@ -135,12 +135,20 @@ pub(crate) fn render_activity_summary(payload: &serde_json::Value) -> Option<Str
     let counts = report.get("counts")?;
     let items = report.get("items")?.as_array()?;
     let mut lines = Vec::new();
+    // Both work dimensions on one line: executing liveness (jobs, controllers,
+    // agent tasks, providers) and held resource inventory (worktrees). Open
+    // worktrees must not inflate the execution answer an operator relies on
+    // before daemon maintenance (#13620).
     lines.push(format!(
-        "activity: total={} active={} running={} queued={} failed={} stale={}",
+        "activity: total={} executing={} (running={} queued={}) open_resources={} failed={} stale={}",
         counts.get("total")?.as_u64()?,
         counts.get("active")?.as_u64()?,
         counts.get("running")?.as_u64()?,
         counts.get("queued")?.as_u64()?,
+        counts
+            .get("open_resources")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0),
         counts.get("failed")?.as_u64()?,
         counts.get("stale")?.as_u64()?,
     ));
@@ -726,6 +734,50 @@ mod tests {
         }))
         .expect("summary");
         assert!(rendered.contains("No active or recent Homeboy activity."));
+    }
+
+    /// #13620: the compact summary must answer both dimensions at a glance —
+    /// how much work is executing, and how much resource inventory is open —
+    /// without item-by-item interpretation.
+    #[test]
+    fn summary_presents_executing_and_open_resource_dimensions() {
+        let rendered = render_activity_summary(&json!({
+            "counts": {
+                "total": 4,
+                "active": 1,
+                "running": 1,
+                "queued": 0,
+                "failed": 0,
+                "stale": 0,
+                "open_resources": 3
+            },
+            "items": []
+        }))
+        .expect("summary");
+        assert!(
+            rendered
+                .contains("activity: total=4 executing=1 (running=1 queued=0) open_resources=3"),
+            "summary line: {rendered}"
+        );
+
+        let zero_executing = render_activity_summary(&json!({
+            "counts": {
+                "total": 3,
+                "active": 0,
+                "running": 0,
+                "queued": 0,
+                "failed": 0,
+                "stale": 0,
+                "open_resources": 3
+            },
+            "items": []
+        }))
+        .expect("summary");
+        assert!(
+            zero_executing
+                .contains("activity: total=3 executing=0 (running=0 queued=0) open_resources=3"),
+            "summary line: {zero_executing}"
+        );
     }
 
     #[test]

--- a/crates/homeboy-core/src/activity.rs
+++ b/crates/homeboy-core/src/activity.rs
@@ -174,6 +174,10 @@ pub fn activity_report_filtered(
     report.agent_task_record_health = agent_task_record_health;
     report.partial = federation.partial;
     report.runner_federation = federation;
+    // A partial report cannot prove zero executing work: a connected runner
+    // that did not answer may be holding executing work this report cannot
+    // see, so the maintenance precondition must fall back to `false`.
+    report.sync_zero_executing_work();
     Ok(report)
 }
 
@@ -279,6 +283,7 @@ pub fn show_activity_with(id: &str, options: ActivityOptions) -> Result<Activity
     // an incomplete corpus, and the caller is entitled to know that.
     report.partial = federation.partial;
     report.runner_federation = federation;
+    report.sync_zero_executing_work();
     Ok(report)
 }
 
@@ -354,13 +359,21 @@ fn report_from_items(
     // provider implementations that cannot express the selector natively.
     items.retain(|item| filter.matches(item));
     let counts = counts_for_items(&items);
+    // Truncation accounting spans both work classes: a stale record the
+    // default view omits is omitted whether it is executing work or a
+    // degraded resource, so the pre-view stale population is counted from the
+    // items directly rather than reusing the executing-scoped `counts.stale`.
+    let collected_stale = items
+        .iter()
+        .filter(|item| item.state == ActivityState::Stale)
+        .count();
     items.sort_by_key(|item| std::cmp::Reverse(activity_sort_key(item)));
     let collected_items = items.len();
     if scope == ActivityScope::ActiveRecent {
         items.retain(|item| is_active(item.state) || item.finished_at.is_some());
     }
     items.truncate(limit.max(1));
-    let stale_items_omitted = counts.stale.saturating_sub(
+    let stale_items_omitted = collected_stale.saturating_sub(
         items
             .iter()
             .filter(|item| item.state == ActivityState::Stale)
@@ -395,11 +408,15 @@ fn report_from_items(
         }
     }
     let displayed_items = items.len();
-    ActivityReport {
+    let mut report = ActivityReport {
         schema: ACTIVITY_REPORT_SCHEMA,
         command,
         counts,
         items,
+        // With no source degraded at this stage, the maintenance precondition
+        // is answered by the executing counts alone; callers that later mark
+        // the report `partial` must re-sync it.
+        zero_executing_work: false,
         // Activity never reconciles. This is a constant rather than a parameter
         // because there is no activity path that writes; if one is ever added
         // it must set this, not silently inherit `false` (#W3-15).
@@ -413,7 +430,9 @@ fn report_from_items(
             next_actions_omitted: all_next_actions.len().saturating_sub(next_actions.len()),
         },
         next_actions,
-    }
+    };
+    report.sync_zero_executing_work();
+    report
 }
 
 fn activity_sort_key(item: &ActivityItem) -> (bool, Option<chrono::DateTime<chrono::Utc>>, String) {
@@ -433,6 +452,20 @@ fn counts_for_items(items: &[ActivityItem]) -> ActivityCounts {
         ..Default::default()
     };
     for item in items {
+        // Resources are inventory, not executing work. An open worktree
+        // projects `running` because it is held, so counting it here would
+        // inflate execution liveness with records no daemon-maintenance
+        // precondition cares about (#13620). Held inventory — open or
+        // degraded — is counted in its own dimension instead.
+        if item.is_open_resource() {
+            if matches!(
+                item.state,
+                ActivityState::Running | ActivityState::Queued | ActivityState::Stale
+            ) {
+                counts.open_resources += 1;
+            }
+            continue;
+        }
         if is_active(item.state) {
             counts.active += 1;
         }
@@ -460,6 +493,7 @@ mod tests {
     use crate::observation::{NewRunRecord, ObservationStore, RunStatus};
     use crate::paths;
     use crate::test_support::with_isolated_home;
+    use crate::worktree;
 
     fn item(id: &str, state: ActivityState) -> ActivityItem {
         ActivityItem {
@@ -484,6 +518,30 @@ mod tests {
             source_projections: Vec::new(),
             state_conflicts: Vec::new(),
             next_actions: vec![action("show", format!("homeboy runs show {id}"))],
+        }
+    }
+
+    /// One standalone worktree-provider record, exactly as the source adapter
+    /// projects it: an open resource held for work (#13620).
+    fn worktree_item(handle: &str) -> ActivityItem {
+        ActivityItem {
+            id: format!("worktree:native:{handle}"),
+            kind: "worktree".to_string(),
+            source_store: WORKTREE_RESOURCE_SOURCE_STORE.to_string(),
+            state: ActivityState::Running,
+            created_at: "2026-07-04T00:00:00Z".to_string(),
+            updated_at: None,
+            finished_at: None,
+            command: None,
+            cwd: Some(format!("/workspace/{handle}")),
+            runner: ActivityRunnerRefs::default(),
+            refs: ActivityCrossRefs::default(),
+            context: ActivityContext::default(),
+            artifacts: Vec::new(),
+            evidence: Vec::new(),
+            source_projections: Vec::new(),
+            state_conflicts: Vec::new(),
+            next_actions: Vec::new(),
         }
     }
 
@@ -919,6 +977,192 @@ mod tests {
         assert_eq!(counts.queued, 1);
         assert_eq!(counts.running, 1);
         assert_eq!(counts.stale, 1);
+    }
+
+    /// #13620: three open worktree records plus one executing job must read
+    /// as exactly one unit of executing work and three open resources — never
+    /// `active=4 running=4`.
+    #[test]
+    fn open_worktrees_do_not_inflate_execution_liveness_counts() {
+        let items = vec![
+            worktree_item("repo@fix-one"),
+            worktree_item("repo@fix-two"),
+            worktree_item("repo@fix-three"),
+            item("daemon-job-1", ActivityState::Running),
+        ];
+
+        let report = report_from_items(
+            items,
+            ActivityScope::ActiveRecent,
+            20,
+            "activity",
+            &ActivityFilter::default(),
+        );
+
+        assert_eq!(report.counts.total, 4);
+        assert_eq!(report.counts.active, 1);
+        assert_eq!(report.counts.running, 1);
+        assert_eq!(report.counts.queued, 0);
+        assert_eq!(report.counts.open_resources, 3);
+        // Worktree discovery stays available: the records are classified, not
+        // deleted.
+        assert_eq!(
+            report
+                .items
+                .iter()
+                .filter(|item| item.is_open_resource())
+                .count(),
+            3
+        );
+    }
+
+    /// The maintenance precondition is a machine-readable assertion: open
+    /// resources alone never make it false, and one executing job always does.
+    #[test]
+    fn zero_executing_work_assertion_separates_resources_from_execution() {
+        let resources_only = report_from_items(
+            vec![worktree_item("repo@fix-one"), worktree_item("repo@fix-two")],
+            ActivityScope::ActiveRecent,
+            20,
+            "activity",
+            &ActivityFilter::default(),
+        );
+        assert_eq!(resources_only.counts.open_resources, 2);
+        assert_eq!(resources_only.counts.active, 0);
+        assert!(resources_only.zero_executing_work);
+
+        let with_executing = report_from_items(
+            vec![
+                worktree_item("repo@fix-one"),
+                item("daemon-job-1", ActivityState::Running),
+            ],
+            ActivityScope::ActiveRecent,
+            20,
+            "activity",
+            &ActivityFilter::default(),
+        );
+        assert!(!with_executing.zero_executing_work);
+
+        let queued_only = report_from_items(
+            vec![item("daemon-job-1", ActivityState::Queued)],
+            ActivityScope::ActiveRecent,
+            20,
+            "activity",
+            &ActivityFilter::default(),
+        );
+        assert!(!queued_only.zero_executing_work);
+    }
+
+    /// A partial report cannot *prove* zero executing work: a connected
+    /// runner that did not answer may be holding executing work the counts
+    /// cannot see, so the assertion must fall even when the local counts read
+    /// zero.
+    #[test]
+    fn a_partial_report_cannot_assert_zero_executing_work() {
+        let mut report = report_from_items(
+            vec![worktree_item("repo@fix-one")],
+            ActivityScope::ActiveRecent,
+            20,
+            "activity",
+            &ActivityFilter::default(),
+        );
+        assert!(report.zero_executing_work);
+        report.partial = true;
+        report.sync_zero_executing_work();
+        assert!(!report.zero_executing_work);
+    }
+
+    /// End-to-end over the real sources: adopted native worktrees (the open
+    /// worktree records from the report that motivated #13620) plus one
+    /// executing daemon job.
+    #[test]
+    fn activity_counts_separate_open_worktree_inventory_from_executing_daemon_jobs() {
+        with_isolated_home(|home| {
+            ObservationStore::open_initialized().expect("store");
+            for handle in ["repo@fix-one", "repo@fix-two", "repo@fix-three"] {
+                let path = home
+                    .path()
+                    .join(format!("worktree-{}", handle.replace('@', "-")));
+                std::fs::create_dir_all(&path).expect("worktree dir");
+                worktree::adopt(worktree::WorktreeAdoptOptions {
+                    handle: handle.to_string(),
+                    path: path.display().to_string(),
+                    kind: None,
+                    provenance: None,
+                })
+                .expect("adopt workspace");
+            }
+            let job_store_path = paths::daemon_jobs_file().expect("jobs path");
+            let job_store =
+                api_jobs::JobStore::open_without_reconciliation(&job_store_path).expect("jobs");
+            let job = job_store.create("runner.exec");
+            job_store.start(job.id).expect("start job");
+
+            let report = activity_report_with(
+                ActivityScope::All,
+                50,
+                ActivityOptions {
+                    federate_runners: false,
+                },
+            )
+            .expect("activity report");
+
+            assert_eq!(report.counts.total, 4);
+            assert_eq!(report.counts.active, 1);
+            assert_eq!(report.counts.running, 1);
+            assert_eq!(report.counts.open_resources, 3);
+            assert!(!report.zero_executing_work);
+            assert_eq!(
+                report
+                    .items
+                    .iter()
+                    .filter(|item| item.is_open_resource())
+                    .count(),
+                3
+            );
+            assert!(report
+                .items
+                .iter()
+                .any(|item| item.is_executing_work() && item.state == ActivityState::Running));
+        });
+    }
+
+    /// Runner federation changes which sources answer, never what an
+    /// executing count means: with no runner layer registered, federation on
+    /// and off must produce identical count semantics over the same
+    /// controller-local fixture (#13620).
+    #[test]
+    fn runner_federation_does_not_change_execution_count_meaning() {
+        with_isolated_home(|home| {
+            ObservationStore::open_initialized().expect("store");
+            let path = home.path().join("worktree-repo-at-fix-one");
+            std::fs::create_dir_all(&path).expect("worktree dir");
+            worktree::adopt(worktree::WorktreeAdoptOptions {
+                handle: "repo@fix-one".to_string(),
+                path: path.display().to_string(),
+                kind: None,
+                provenance: None,
+            })
+            .expect("adopt workspace");
+            let job_store_path = paths::daemon_jobs_file().expect("jobs path");
+            let job_store =
+                api_jobs::JobStore::open_without_reconciliation(&job_store_path).expect("jobs");
+            let job = job_store.create("runner.exec");
+            job_store.start(job.id).expect("start job");
+
+            let report_for = |federate_runners: bool| {
+                activity_report_with(ActivityScope::All, 50, ActivityOptions { federate_runners })
+                    .expect("activity report")
+            };
+            let federated = report_for(true);
+            let local = report_for(false);
+
+            assert_eq!(federated.counts, local.counts);
+            assert_eq!(federated.counts.running, 1);
+            assert_eq!(federated.counts.open_resources, 1);
+            assert_eq!(federated.zero_executing_work, local.zero_executing_work);
+            assert!(!federated.zero_executing_work);
+        });
     }
 
     #[test]

--- a/crates/homeboy-core/src/activity/model.rs
+++ b/crates/homeboy-core/src/activity/model.rs
@@ -184,6 +184,26 @@ pub struct ActivityItem {
     pub next_actions: Vec<ActivityNextAction>,
 }
 
+/// The `source_store` of the worktree provider projection. Items from this
+/// source are open resources, not executing work (#13620).
+pub const WORKTREE_RESOURCE_SOURCE_STORE: &str = "worktree.provider";
+
+/// What one activity item *is*, independent of its state.
+///
+/// Executing work is a unit of work the system runs to completion: an
+/// observation run, an agent-task record, a daemon job, or a runner-resident
+/// job. An open resource is inventory that work uses — a worktree — whose
+/// presence says nothing about whether anything is executing in it. The two
+/// classes share the state vocabulary but not its liveness meaning: an open
+/// worktree projects `running` because it is held, not because a process is
+/// executing, so counts that answer "what is executing right now" must scope
+/// to [`ActivityWorkClass::Executing`] (#13620).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivityWorkClass {
+    Executing,
+    OpenResource,
+}
+
 impl ActivityItem {
     /// Compact this item for the default coordination view.
     ///
@@ -202,6 +222,22 @@ impl ActivityItem {
         self.source_projections.clear();
         self.state_conflicts.clear();
         self.next_actions.truncate(COMPACT_NEXT_ACTIONS_PER_ITEM);
+    }
+
+    pub fn work_class(&self) -> ActivityWorkClass {
+        if self.source_store == WORKTREE_RESOURCE_SOURCE_STORE {
+            ActivityWorkClass::OpenResource
+        } else {
+            ActivityWorkClass::Executing
+        }
+    }
+
+    pub fn is_executing_work(&self) -> bool {
+        self.work_class() == ActivityWorkClass::Executing
+    }
+
+    pub fn is_open_resource(&self) -> bool {
+        self.work_class() == ActivityWorkClass::OpenResource
     }
 }
 
@@ -241,10 +277,20 @@ impl ActivityFilter {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ActivityCounts {
+    /// Every record in this report across both work classes: executing work
+    /// plus open resources.
     pub total: usize,
+    /// Executing work (jobs, controllers, agent tasks, providers) currently
+    /// queued or running. Open resources are excluded: an open worktree is
+    /// held inventory, not executing work, and must not inflate execution
+    /// liveness (#13620).
     pub active: usize,
+    /// Executing work waiting to start. Open resources are excluded.
     pub queued: usize,
+    /// Executing work currently running. Open resources are excluded.
     pub running: usize,
+    /// Executing work that succeeded. Terminal worktree dispositions are
+    /// resource history, not execution outcomes.
     pub succeeded: usize,
     /// Stopped with a promotable candidate. Counted separately from
     /// `partial_failure` since #6761 — before that both, plus
@@ -257,8 +303,15 @@ pub struct ActivityCounts {
     pub failed: usize,
     pub cancelled: usize,
     pub timed_out: usize,
+    /// Executing work whose claimed progress is no longer verifiable. A
+    /// missing worktree is a degraded *resource* and counts under
+    /// `open_resources`, not here.
     pub stale: usize,
     pub unknown: usize,
+    /// Open resource inventory held for work: worktrees without a terminal
+    /// disposition, including degraded-but-held ones. Presence of inventory
+    /// never implies execution (#13620).
+    pub open_resources: usize,
 }
 
 /// Records deliberately omitted from the default coordination view.
@@ -318,6 +371,15 @@ pub struct ActivityReport {
     pub command: &'static str,
     pub counts: ActivityCounts,
     pub items: Vec<ActivityItem>,
+    /// Machine-readable maintenance precondition: `true` only when this
+    /// report shows no queued or running executing work **and** is not
+    /// `partial` (a connected runner that did not answer could be holding
+    /// executing work this report cannot see). Open resources do not affect
+    /// it: an operator may hold worktrees open while zero work executes.
+    /// Assert on a `list` report — a `show` report's counts describe only the
+    /// resolved item (#13620).
+    #[serde(default)]
+    pub zero_executing_work: bool,
     /// Whether this surface reconciled while reading.
     ///
     /// `activity` is a deliberately **non**-reconciling read model, so this is
@@ -349,4 +411,14 @@ pub struct ActivityReport {
     pub truncation: ActivityTruncation,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub next_actions: Vec<String>,
+}
+
+impl ActivityReport {
+    /// Recompute [`ActivityReport::zero_executing_work`] from the current
+    /// counts and partiality. Report assembly calls this once the final
+    /// `partial` value is known, because a partial report cannot prove the
+    /// absence of runner-resident executing work.
+    pub(crate) fn sync_zero_executing_work(&mut self) {
+        self.zero_executing_work = self.counts.active == 0 && !self.partial;
+    }
 }

--- a/crates/homeboy-core/src/activity/worktrees.rs
+++ b/crates/homeboy-core/src/activity/worktrees.rs
@@ -1,6 +1,7 @@
 use super::{
     ActivityCollector, ActivityContext, ActivityCrossRefs, ActivityEvidenceRef, ActivityFilter,
     ActivityItem, ActivityRunnerRefs, ActivityState, ActivityTaskIdentity,
+    WORKTREE_RESOURCE_SOURCE_STORE,
 };
 use crate::worktree_provider::{self, WorktreeProviderIdentity, WorktreeProviderWorkspace};
 use crate::Result;
@@ -36,7 +37,9 @@ fn item_from_workspace(workspace: WorktreeProviderWorkspace) -> ActivityItem {
     ActivityItem {
         id: format!("worktree:{provider_id}:{handle}"),
         kind: "worktree".to_string(),
-        source_store: "worktree.provider".to_string(),
+        // Marks every item from this source as open-resource inventory for
+        // the work classification in `model` (#13620).
+        source_store: WORKTREE_RESOURCE_SOURCE_STORE.to_string(),
         state,
         created_at: workspace
             .created_at
@@ -75,6 +78,7 @@ fn item_from_workspace(workspace: WorktreeProviderWorkspace) -> ActivityItem {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::activity::ActivityWorkClass;
     use crate::worktree_provider::{
         WorktreeOwnership, WorktreeProviderSafety, WorktreeProviderWorkspace, WorktreeWorkspaceKind,
     };
@@ -107,5 +111,45 @@ mod tests {
         assert_eq!(item.refs.run_id.as_deref(), Some("run-8017"));
         assert_eq!(item.context.worktree.as_deref(), Some("repo@branch"));
         assert_eq!(item.evidence[0].id, "fixture");
+    }
+
+    /// #13620: an open worktree stays visible with its held state, but the
+    /// item itself classifies as open-resource inventory so report counts can
+    /// separate it from executing work.
+    #[test]
+    fn open_worktree_classifies_as_resource_not_executing_work() {
+        let workspace = |handle: &str, disposition: Option<&str>| WorktreeProviderWorkspace {
+            ownership: WorktreeOwnership {
+                provider: WorktreeProviderIdentity::Native,
+                handle: handle.to_string(),
+                path: format!("/workspace/{handle}"),
+                kind: WorktreeWorkspaceKind::AdoptedWorkspace,
+                branch: None,
+                task_url: None,
+                provenance: None,
+            },
+            repository: None,
+            owner_run_ref: None,
+            created_at: None,
+            terminal_disposition: disposition.map(str::to_string),
+            safety: WorktreeProviderSafety {
+                dirty: false,
+                unpushed: false,
+                primary: false,
+                missing: false,
+            },
+        };
+
+        let open = item_from_workspace(workspace("repo@fix-13620", None));
+        assert_eq!(open.state, ActivityState::Running);
+        assert_eq!(open.work_class(), ActivityWorkClass::OpenResource);
+        assert!(open.is_open_resource());
+        assert!(!open.is_executing_work());
+
+        // A terminally disposed workspace is closed history, not held
+        // inventory, and still classifies as a resource record.
+        let disposed = item_from_workspace(workspace("repo@merged", Some("succeeded")));
+        assert_eq!(disposed.state, ActivityState::Succeeded);
+        assert!(disposed.is_open_resource());
     }
 }

--- a/docs/commands/activity.md
+++ b/docs/commands/activity.md
@@ -31,7 +31,20 @@ The default (and `--limit`-bounded) view compacts every retained record to that 
 
 `reconciled` is always `false` here. It is emitted because `agent-task status <id> --bridge` is a reconciling read that *writes*, so the two surfaces can legitimately report different states for the same run at the same instant — and calling the reconciling one changes what this one returns next. The flag lets a consumer tell which kind of answer it received.
 
-Human output is a compact table followed by next-action command lines per item.
+## Counts: executing work vs open resources
+
+Activity items carry two work classes. **Executing work** is a unit of work the system runs to completion — an observation run, an agent-task record, a daemon job, or a runner-resident job. **Open resources** are inventory that work uses: worktree-provider records, whose presence says nothing about whether anything is executing in them (#13620).
+
+`counts` separates the classes:
+
+- `active`, `queued`, and `running` count executing work only. An open worktree projects state `running` because it is held, and is deliberately excluded from these counts so execution liveness is never inflated by inventory.
+- `open_resources` counts held resource inventory: worktrees without a terminal disposition, including degraded-but-held ones.
+- `total` counts every record in the report across both classes.
+- the remaining state buckets (`succeeded`, `failed`, `stale`, …) describe executing work; a worktree's terminal disposition is resource history, visible in `items`.
+
+`zero_executing_work` is the machine-readable maintenance precondition: `true` only when the report shows no queued or running executing work **and** is not `partial` (a connected runner that did not answer could be holding executing work this report cannot see). Open resources never affect it — an operator may hold worktrees open while zero work executes. Assert it on a `list` report; a `show` report's counts describe only the resolved item.
+
+Human output is a compact table preceded by a one-line summary presenting both dimensions, e.g. `activity: total=110 executing=1 (running=1 queued=0) open_resources=3 failed=9 stale=2`, followed by next-action command lines per item.
 
 The default view prioritizes active work, scans a bounded extra window for stale
 projections, and omits stale rows that would crowd out current records. Its


### PR DESCRIPTION
## Problem

`homeboy activity list` reported:

```
activity: total=110 active=4 running=4 queued=0 failed=9 stale=2
```

Only **one** of those four "running" records was an executable daemon job. The other three were open native worktrees (kind `worktree`, source store `worktree.provider`) projected as `running`.

That made the safety precondition "confirm zero active jobs before refreshing the daemon" unanswerable from the summary. The operator had to re-run the command and inspect each item's kind by hand to separate held inventory from executing work — exactly the manual spelunking the activity surface exists to remove.

## Fix

Activity items now declare what they *are*, independent of their state, via `ActivityWorkClass`:

- **Executing work** — a unit of work run to completion: observation runs, agent-task records, daemon jobs, runner-resident jobs.
- **Open resource** — inventory that work uses. A worktree projects `running` because it is *held*, not because a process is executing in it.

The two classes share the state vocabulary but not its liveness meaning, so the execution counts (`active`, `queued`, `running`, `succeeded`, `stale`, …) scope to executing work only. Open worktree inventory is counted separately under `open_resources`, and a missing worktree is reported as a degraded *resource* rather than stale execution.

Worktree discovery is unchanged — the data is classified correctly, not removed.

### Machine-readable maintenance precondition

`ActivityReport::zero_executing_work` is `true` only when the report shows no queued or running executing work **and** the report is not `partial`. A connected runner that did not answer could be holding executing work the report cannot see, so a partial report can never assert absence. Open resources do not affect it: an operator may hold worktrees open while zero work executes.

## Tests

- `open_worktrees_do_not_inflate_execution_liveness_counts`
- `activity_counts_separate_open_worktree_inventory_from_executing_daemon_jobs` — the reported incident shape: N open worktrees plus 1 executing job
- `zero_executing_work_assertion_separates_resources_from_execution`
- `a_partial_report_cannot_assert_zero_executing_work`
- `runner_federation_does_not_change_execution_count_meaning` — federation parity
- `open_worktree_classifies_as_resource_not_executing_work`
- `summary_presents_executing_and_open_resource_dimensions`

## Verification

| Command | Result |
| --- | --- |
| `cargo test -p homeboy-core --lib activity` | 41 passed, 0 failed |
| `cargo test -p homeboy-cli --lib commands::activity` | 16 passed, 0 failed |
| `cargo check --workspace --tests --locked` | clean |
| `cargo fmt --all --check` | clean |
| `git diff --check` | clean |

Rebased onto latest `origin/main` and re-verified after rebase.

## Coordination

#13617 (PR #13640) bounds the compact activity projection and touches the same files. The two were developed in isolated worktrees and are independently green; whichever lands second will need a small rebase.

Fixes #13620

## AI assistance disclosure

Z.AI GLM 5.3 via OpenCode implemented the work-class separation, the `zero_executing_work` precondition, and the seven tests. Claude Fable 5 via OpenCode (Claude Code CLI) captured the original miscount from a live report, filed the issue, reviewed the diff, ran the verification above after the authoring session hit a provider usage limit, and published this PR. Chris Huber directed the control-plane ergonomics audit.