### PR TITLE
fix(agent-task): treat workspace file activity as provider liveness evidence

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -24,6 +24,17 @@ use std::time::Instant;
 
 const EXECUTOR_OUTPUT_CAPTURE_LIMIT_BYTES: usize = 16 * 1024;
 const REDACTED_VALUE: &str = "[redacted]";
+/// Floor and ceiling for how often the liveness watchdog re-samples the
+/// provider's execution workspace for file activity. A CLI agent that edits
+/// files without ever writing to stdout/stderr until its final JSON result is
+/// still doing verifiable work, and only the workspace on disk can prove that
+/// (#13626). Each sample forks `git`, so the interval is derived from the
+/// configured liveness deadline (a quarter of it) rather than fixed: a short
+/// deadline still gets several samples inside its own window, and a long one
+/// never turns into its own load source by sampling a large repository every
+/// tick of the poll loop.
+const WORKSPACE_PROGRESS_CHECK_INTERVAL_FLOOR_MS: u64 = 200;
+const WORKSPACE_PROGRESS_CHECK_INTERVAL_CEIL_MS: u64 = 5_000;
 pub const PROVIDER_READINESS_RESULT_SCHEMA: &str =
     "homeboy/agent-task-provider-readiness-result/v1";
 const PROVIDER_READINESS_TIMEOUT: Duration = Duration::from_secs(20);
@@ -1007,6 +1018,15 @@ fn run_materialized_provider_command_once_contained(
     let last_progress_ms: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
     let mut runtime_progress = runtime_progress_snapshot(&request.artifacts_path);
     let mut runtime_progress_events = 0_u64;
+    // Only sampled when the workspace root is known; a provider running
+    // without a declared workspace (e.g. a preflight or repo-less task) keeps
+    // relying on process output and artifacts-path progress alone.
+    let mut workspace_progress = attestation_root
+        .as_deref()
+        .map(workspace_progress_snapshot)
+        .unwrap_or_default();
+    let mut workspace_progress_events = 0_u64;
+    let mut next_workspace_progress_check_ms = 0_u64;
 
     let (stdout_runtime_capture, stderr_runtime_capture) =
         runtime_output_captures(request, run_id, attempt);
@@ -1057,18 +1077,46 @@ fn run_materialized_provider_command_once_contained(
     // grace first and misclassify the attempt as stalled.
     let liveness_timeout = (liveness_timeout_ms < requested_timeout_ms)
         .then_some(Duration::from_millis(liveness_timeout_ms));
+    // A quarter of the liveness deadline guarantees several workspace samples
+    // land inside any single liveness window, however short, while the floor
+    // and ceiling keep a very short test deadline or a very long production
+    // one from turning into an excessive or pointless `git` fork cadence.
+    let workspace_progress_check_interval_ms = (liveness_timeout_ms / 4).clamp(
+        WORKSPACE_PROGRESS_CHECK_INTERVAL_FLOOR_MS,
+        WORKSPACE_PROGRESS_CHECK_INTERVAL_CEIL_MS,
+    );
     let (status, killed_for_liveness, timed_out) = loop {
         match child.try_wait() {
             Ok(Some(status)) => break (Some(status), false, false),
             Ok(None) => {
                 let elapsed = started.elapsed();
+                let elapsed_ms = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX);
+                let mut progressed = false;
                 let current_runtime_progress = runtime_progress_snapshot(&request.artifacts_path);
                 if runtime_progress_advanced(&runtime_progress, &current_runtime_progress) {
-                    let elapsed_ms = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX);
-                    last_progress_ms.store(elapsed_ms, Ordering::SeqCst);
+                    progressed = true;
                     runtime_progress_events = runtime_progress_events.saturating_add(1);
                 }
                 runtime_progress = current_runtime_progress;
+                // Liveness is the only consumer of the workspace signal, so it
+                // is only worth the `git` fork when a liveness deadline is
+                // actually in force and due for a fresh sample.
+                if liveness_timeout.is_some() && elapsed_ms >= next_workspace_progress_check_ms {
+                    next_workspace_progress_check_ms =
+                        elapsed_ms.saturating_add(workspace_progress_check_interval_ms);
+                    if let Some(root) = attestation_root.as_deref() {
+                        let current_workspace_progress = workspace_progress_snapshot(root);
+                        if workspace_progress_advanced(&workspace_progress, &current_workspace_progress)
+                        {
+                            progressed = true;
+                            workspace_progress_events = workspace_progress_events.saturating_add(1);
+                        }
+                        workspace_progress = current_workspace_progress;
+                    }
+                }
+                if progressed {
+                    last_progress_ms.store(elapsed_ms, Ordering::SeqCst);
+                }
                 if elapsed >= process_timeout {
                     break (None, false, true);
                 }
@@ -1149,6 +1197,7 @@ fn run_materialized_provider_command_once_contained(
                 "stdout_bytes": stdout_capture.total_bytes,
                 "stderr_bytes": stderr_capture.total_bytes,
                 "runtime_progress_events": runtime_progress_events,
+                "workspace_progress_events": workspace_progress_events,
             }),
         );
     }
@@ -1725,6 +1774,50 @@ fn runtime_progress_advanced(
         .any(|(path, size)| *size > previous.get(path).copied().unwrap_or_default())
 }
 
+/// Liveness evidence sampled from the provider's execution workspace rather
+/// than from process output. A provider that streams nothing to stdout/stderr
+/// until it serializes its final outcome still leaves a trail on disk: files
+/// it edits become uncommitted worktree changes, and files it commits move
+/// HEAD. Either is proof of live, ongoing work (#13626).
+#[derive(Default, Clone, PartialEq, Eq)]
+struct WorkspaceProgressSnapshot {
+    files_changed: Option<usize>,
+    head_sha: Option<String>,
+}
+
+fn workspace_progress_snapshot(root: &Path) -> WorkspaceProgressSnapshot {
+    WorkspaceProgressSnapshot {
+        files_changed: crate::agent_task_service::worktree_files_changed(root),
+        head_sha: homeboy_core::git::head_sha(root),
+    }
+}
+
+/// True when two workspace samples both produced a reading and those readings
+/// differ. A sample that failed to read (`None`, e.g. a transient `git`
+/// failure or a non-repository root) must never be compared against a
+/// present reading — that would either manufacture false progress or mask a
+/// real stall depending on which side went missing.
+fn workspace_progress_advanced(
+    previous: &WorkspaceProgressSnapshot,
+    current: &WorkspaceProgressSnapshot,
+) -> bool {
+    if let (Some(previous_files), Some(current_files)) =
+        (previous.files_changed, current.files_changed)
+    {
+        if previous_files != current_files {
+            return true;
+        }
+    }
+    if let (Some(previous_head), Some(current_head)) =
+        (previous.head_sha.as_deref(), current.head_sha.as_deref())
+    {
+        if previous_head != current_head {
+            return true;
+        }
+    }
+    false
+}
+
 #[allow(clippy::too_many_arguments)]
 fn provider_timeout_diagnostic_data(
     request: &AgentTaskExecutorRequest,
@@ -1836,7 +1929,7 @@ fn classify_stall_or_rate_limit(
         AgentTaskOutcomeStatus::ProviderError,
         AgentTaskFailureClassification::Stalled,
         format!(
-            "provider '{provider_id}' produced no process output or structured runtime progress before liveness_timeout_ms={liveness_timeout_ms}"
+            "provider '{provider_id}' produced no process output, structured runtime progress, or workspace file activity before liveness_timeout_ms={liveness_timeout_ms}"
         ),
     )
 }

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -1106,8 +1106,10 @@ fn run_materialized_provider_command_once_contained(
                         elapsed_ms.saturating_add(workspace_progress_check_interval_ms);
                     if let Some(root) = attestation_root.as_deref() {
                         let current_workspace_progress = workspace_progress_snapshot(root);
-                        if workspace_progress_advanced(&workspace_progress, &current_workspace_progress)
-                        {
+                        if workspace_progress_advanced(
+                            &workspace_progress,
+                            &current_workspace_progress,
+                        ) {
                             progressed = true;
                             workspace_progress_events = workspace_progress_events.saturating_add(1);
                         }

--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -951,6 +951,61 @@ fn structured_runtime_progress_keeps_provider_alive_until_completion() {
 }
 
 #[test]
+fn workspace_file_activity_keeps_silent_provider_alive_until_completion() {
+    // Reproduces #13626: a CLI agent that edits files without ever writing to
+    // stdout/stderr until its final JSON result is still doing real,
+    // verifiable work. Only the workspace on disk can prove that, so the
+    // liveness watchdog must treat file activity there as progress rather
+    // than killing (and mis-filing as `stalled`) a provider that is silently
+    // producing a valid patch. The provider here writes a new file every
+    // 100ms for 3 seconds straight — well past the 1.2s liveness deadline it
+    // would have tripped under process-chatter-only liveness — and prints
+    // nothing at all until it is done.
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = linked_cook_source(&temp);
+    let command = format!(
+        "node {}",
+        script(
+            "let fs=require('fs'); \
+             let req=JSON.parse(fs.readFileSync(0,'utf8')); \
+             let i=0; \
+             let timer=setInterval(()=>{ i++; fs.writeFileSync('agent-edit-'+i+'.txt','edit '+i+'\\n'); }, 100); \
+             setTimeout(()=>{ \
+               clearInterval(timer); \
+               process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-outcome/v1',task_id:req.task_id,status:'succeeded',summary:'completed silently after workspace edits'})); \
+             }, 3000);"
+        )
+    );
+    let (mut request, provider) = request("task-liveness-workspace-activity", command);
+    request.workspace.root = Some(workspace.display().to_string());
+    request.limits.timeout_ms = Some(10_000);
+    request.limits.liveness_timeout_ms = Some(1_200);
+
+    let outcome = run_provider_command_once(&request, &provider);
+
+    assert_eq!(
+        outcome.status,
+        AgentTaskOutcomeStatus::Succeeded,
+        "a provider silently editing its workspace must not be killed as stalled: {outcome:?}"
+    );
+    assert_ne!(
+        outcome.failure_classification,
+        Some(AgentTaskFailureClassification::Stalled)
+    );
+    assert_eq!(
+        outcome.summary.as_deref(),
+        Some("completed silently after workspace edits")
+    );
+
+    let files_changed = crate::agent_task_service::worktree_files_changed(&workspace)
+        .expect("git status readable after the run");
+    assert!(
+        files_changed >= 10,
+        "provider must have kept editing the workspace throughout the run, saw {files_changed} changed file(s)"
+    );
+}
+
+#[test]
 fn stalled_provider_retains_declared_attempt_workspace_artifact() {
     let temp = tempfile::tempdir().expect("tempdir");
     let workspace = linked_cook_source(&temp);

--- a/crates/homeboy-agents/src/agent_task_service/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_service/mod.rs
@@ -37,7 +37,7 @@ mod status_support;
 mod work_job;
 
 pub use cook::*;
-pub use cook_activity::{CookActivityProbe, CookProviderActivity};
+pub use cook_activity::{worktree_files_changed, CookActivityProbe, CookProviderActivity};
 pub use cook_adoption::*;
 pub use cook_baseline::*;
 pub use cook_batch_job::*;


### PR DESCRIPTION
Fixes #13626

The liveness watchdog killed providers whose stdout stayed quiet, even while they were actively editing the task workspace. A CLI agent that streams nothing until its final result was indistinguishable from a genuine hang, so long-running-but-silent providers were repeatedly misclassified as `stalled` and their valid work discarded.

This cost a real cook ~50 minutes and its entire provider rotation while producing correct, gate-passing work that was never promoted.

Workspace file activity now counts as liveness evidence, so a provider actively writing to its worktree is not reaped for being quiet.

## Changes

```
 .../src/agent_task_provider/command_runner.rs      | 101 ++++++++++++++++++++-
 .../agent_task_provider/tests/scheduler_tests.rs   |  55 +++++++++++
 .../homeboy-agents/src/agent_task_service/mod.rs   |   2 +-
 3 files changed, 154 insertions(+), 4 deletions(-)
```

---

*AI assistance: Claude Sonnet 4.5 via opencode, dispatched as a parallel general coding subagent against this worktree. The agent located the root cause, implemented the fix, and ran scoped verification, reporting its commands and results. I filed the issue from an observed failure, reviewed the diff against the merge-base, and corrected commit authorship. Local re-verification of the full gate was constrained by cargo build-lock contention across concurrent worktrees (tracked as #13643); CI is the authoritative gate here.*
