### PR TITLE
fix(agent-task): distinguish presence-only readiness from live verification

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/catalog.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/catalog.rs
@@ -5,8 +5,8 @@ use super::resolution::{
 };
 use super::runner_readiness::provider_executable_env;
 use super::secrets::{
-    apply_provider_runner_secret_env_contracts_with_providers, provider_config_secret_sources,
-    provider_runner_secret_env_for_plan_with_providers, provider_secret_sources,
+    apply_provider_runner_secret_env_contracts_with_providers, provider_declared_secret_sources,
+    provider_runner_secret_env_for_plan_with_providers,
     provider_secret_sources_for_plan_with_providers,
 };
 use super::*;
@@ -624,10 +624,7 @@ pub fn provider_secret_sources_for_providers(
 ) -> HashMap<String, defaults::AgentTaskSecretSource> {
     let mut sources = HashMap::new();
     for provider in providers {
-        sources.extend(provider_secret_sources(provider, None));
-        for defaults in provider.provider_defaults.values() {
-            sources.extend(provider_config_secret_sources(defaults));
-        }
+        sources.extend(provider_declared_secret_sources(provider));
     }
     sources
 }
@@ -649,10 +646,7 @@ pub fn provider_secret_sources_for_backend(
         .collect();
     let mut sources = HashMap::new();
     for provider in scoped {
-        sources.extend(provider_secret_sources(provider, None));
-        for defaults in provider.provider_defaults.values() {
-            sources.extend(provider_config_secret_sources(defaults));
-        }
+        sources.extend(provider_declared_secret_sources(provider));
     }
     sources
 }

--- a/crates/homeboy-agents/src/agent_task_provider/credential_readiness.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/credential_readiness.rs
@@ -39,7 +39,7 @@
 //! A provider that declares nothing required stays `available`. Silence is not
 //! evidence of a missing credential, so this never invents a requirement.
 
-use super::secrets::{provider_config_secret_sources, provider_secret_sources};
+use super::secrets::provider_declared_secret_sources;
 use super::*;
 
 pub const AGENT_TASK_PROVIDER_CREDENTIAL_READINESS_SCHEMA: &str =
@@ -249,19 +249,6 @@ fn sole_provider_default_required_secret_env(provider: &AgentTaskExecutorProvide
     Vec::new()
 }
 
-/// Secret sources this provider declares for its own credentials, so a
-/// credential backed by a provider-declared source (a runtime auth JSON file,
-/// for example) resolves instead of being reported missing.
-fn provider_fallback_sources(
-    provider: &AgentTaskExecutorProvider,
-) -> HashMap<String, defaults::AgentTaskSecretSource> {
-    let mut sources = provider_secret_sources(provider, None);
-    for provider_default in provider.provider_defaults.values() {
-        sources.extend(provider_config_secret_sources(provider_default));
-    }
-    sources
-}
-
 /// Resolve a provider's declared credentials against the observed scope.
 pub fn provider_credential_readiness(
     provider: &AgentTaskExecutorProvider,
@@ -283,7 +270,8 @@ pub fn provider_credential_readiness(
         .iter()
         .map(|entry| entry.env.clone())
         .collect::<Vec<_>>();
-    let status = secret_env_status_with_fallbacks(&names, &provider_fallback_sources(provider));
+    let status =
+        secret_env_status_with_fallbacks(&names, &provider_declared_secret_sources(provider));
 
     let requirements = declared
         .into_iter()

--- a/crates/homeboy-agents/src/agent_task_provider/dispatchability.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/dispatchability.rs
@@ -39,6 +39,15 @@ pub struct AgentTaskProviderDispatchabilityCheck {
 pub struct AgentTaskProviderDispatchabilityCredentialCheck {
     pub ready: bool,
     pub missing: Vec<String>,
+    /// `true` only when a provider-declared live readiness probe
+    /// (`readiness_invocation`) actually ran and confirmed the credential
+    /// works. `false` means `ready` reflects presence only: the declared
+    /// credential material was found somewhere Homeboy can read it, which is
+    /// not proof it is still valid — a revoked or expired token is still
+    /// present on disk (#13628). Callers that need a go/no-go signal for
+    /// provider-owned auth must not treat presence-only readiness as
+    /// equivalent to a live-verified one.
+    pub verified: bool,
 }
 
 pub fn evaluate_provider_dispatchability(
@@ -102,6 +111,9 @@ pub fn evaluate_provider_dispatchability_with_config(
                 credentials: AgentTaskProviderDispatchabilityCredentialCheck {
                     ready: credentials_ready,
                     missing: Vec::new(),
+                    // A route that never resolved to one provider was never
+                    // probed, so nothing here was live-verified.
+                    verified: false,
                 },
                 configuration: AgentTaskProviderDispatchabilityCheck {
                     ready: configuration_ready,
@@ -182,6 +194,15 @@ pub fn evaluate_provider_dispatchability_with_config(
             reason: (!probe_runtime).then_some("not requested".to_string()),
         }
     };
+    // `runtime.ready` alone conflates two very different situations: a
+    // provider-declared probe actually ran and passed, versus no probe being
+    // declared at all (in which case `run_provider_readiness_invocation`
+    // trivially returns ready). Only the former is a live verification of the
+    // provider's credentials; the latter is still presence-only, and reporting
+    // it as "ready" without qualification is exactly how a revoked-but-present
+    // credential gets reported dispatchable (#13628).
+    let credentials_verified =
+        probe_runtime && provider.readiness_invocation.is_some() && runtime.ready;
     let (state, ready, reason) = if !model_ready {
         (
             "model_unavailable",
@@ -208,8 +229,16 @@ pub fn evaluate_provider_dispatchability_with_config(
         )
     } else if !probe_runtime {
         ("ready", true, "live runtime readiness was not requested")
-    } else {
+    } else if credentials_verified {
         ("ready", true, "all dispatchability checks passed")
+    } else {
+        (
+            "ready",
+            true,
+            "credentials and configuration are present, but the provider declares no live \
+             readiness probe to confirm them; presence is not proof a provider-owned credential \
+             is still valid",
+        )
     };
     AgentTaskProviderDispatchability {
         state,
@@ -227,6 +256,7 @@ pub fn evaluate_provider_dispatchability_with_config(
             credentials: AgentTaskProviderDispatchabilityCredentialCheck {
                 ready: credentials.dispatchable,
                 missing: credentials.missing,
+                verified: credentials_verified,
             },
             configuration,
             runtime,
@@ -371,6 +401,105 @@ mod tests {
             providers: vec![provider],
             ..Default::default()
         }
+    }
+
+    /// The exact shape of #13628: a provider whose declared credential is
+    /// physically present (a `json-file` source Homeboy can read) but that
+    /// declares no live readiness probe of its own. `--validate-readiness`
+    /// used to report this as fully "ready" with no way to tell presence
+    /// apart from a genuine live check — indistinguishable from a provider
+    /// whose token had actually been confirmed to still work. A revoked
+    /// refresh token is still present on disk, so presence-only readiness
+    /// must not be reported the same way as a live-verified one.
+    fn provider_with_present_but_unverifiable_credential(
+        auth_path: &std::path::Path,
+    ) -> super::super::AgentTaskExecutorProvider {
+        serde_json::from_value(json!({
+            "id": "revocable.agent-task-executor",
+            "backend": "revocable",
+            "capabilities": ["cli_runtime", "provider_owned_auth"],
+            "provider_defaults": {
+                "revocable": {
+                    "required_secret_env": ["HOMEBOY_TEST_REVOCABLE_REFRESH_TOKEN"],
+                    "secret_env_sources": {
+                        "HOMEBOY_TEST_REVOCABLE_REFRESH_TOKEN": {
+                            "source": "json-file",
+                            "path": auth_path,
+                            "field": "token"
+                        }
+                    }
+                }
+            }
+        }))
+        .expect("provider fixture")
+    }
+
+    #[test]
+    fn presence_only_credentials_report_ready_but_not_verified() {
+        let auth = tempfile::NamedTempFile::new().expect("auth file");
+        // The credential material is present, exactly like a revoked-but-still-
+        // on-disk refresh token (#13628): Homeboy can read it, but reading it
+        // is not proof the issuing account still honors it.
+        std::fs::write(auth.path(), r#"{"token":"revoked-but-present-token"}"#)
+            .expect("write auth");
+        let provider = provider_with_present_but_unverifiable_credential(auth.path());
+        let catalog = catalog(provider);
+
+        let verdict = evaluate_provider_dispatchability(&catalog, "revocable", None, None, true);
+
+        assert_eq!(verdict.state, "ready");
+        assert!(
+            verdict.ready,
+            "Homeboy has no contrary evidence, so dispatch must not be blocked"
+        );
+        assert!(
+            verdict.checks.credentials.ready,
+            "the declared credential is present"
+        );
+        assert!(
+            !verdict.checks.credentials.verified,
+            "no provider-declared readiness probe ran, so this is presence only, not a live \
+             verification — reporting it as verified is exactly the #13628 defect"
+        );
+        assert!(
+            !verdict.reason.contains("all dispatchability checks passed"),
+            "the reason must not claim full validation when only presence was checked: {}",
+            verdict.reason
+        );
+    }
+
+    #[test]
+    fn a_live_readiness_probe_that_passes_reports_verified_credentials() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let script = root.path().join("readiness.js");
+        std::fs::write(
+            &script,
+            "process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-provider-readiness-result/v1',ready:true,classification:'ready',retryable:false,remediation:'',reason:'',cache_key:'k',identity:{}}));",
+        )
+        .expect("readiness script");
+        let mut live_provider = provider_with_present_but_unverifiable_credential(
+            root.path().join("unused-auth.json").as_path(),
+        );
+        std::fs::write(
+            root.path().join("unused-auth.json"),
+            r#"{"token":"present-and-live-checked"}"#,
+        )
+        .expect("write auth");
+        live_provider.readiness_invocation = Some(CommandInvocation {
+            argv: vec!["node".to_string(), script.display().to_string()],
+            ..CommandInvocation::default()
+        });
+        let catalog = catalog(live_provider);
+
+        let verdict = evaluate_provider_dispatchability(&catalog, "revocable", None, None, true);
+
+        assert!(verdict.ready);
+        assert!(
+            verdict.checks.credentials.verified,
+            "a provider-declared readiness probe ran and passed, so this is a genuine live \
+             verification"
+        );
+        assert_eq!(verdict.reason, "all dispatchability checks passed");
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_provider/secrets.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/secrets.rs
@@ -155,6 +155,30 @@ pub(super) fn provider_secret_sources(
     sources
 }
 
+/// Every secret source a provider declares for itself, independent of any
+/// dispatch request: its unconditional `secret_env_requirements` sources plus
+/// every `provider_defaults` entry's `secret_env_sources` (regardless of which
+/// default a request would eventually select).
+///
+/// This is the single source-resolution path behind `agent-task auth status`,
+/// `agent-task providers --secret-env`, and provider credential readiness
+/// (`--validate-readiness`). Those three surfaces used to assemble this same
+/// merge independently; a provider whose declared source resolved differently
+/// under one assembly than another could report a secret as configured in one
+/// place and missing in another for no reason a caller could see (#13629).
+/// Routing all three through this one function makes that divergence
+/// structurally impossible rather than something each call site has to keep
+/// in sync by hand.
+pub(super) fn provider_declared_secret_sources(
+    provider: &AgentTaskExecutorProvider,
+) -> HashMap<String, defaults::AgentTaskSecretSource> {
+    let mut sources = provider_secret_sources(provider, None);
+    for provider_default in provider.provider_defaults.values() {
+        sources.extend(provider_config_secret_sources(provider_default));
+    }
+    sources
+}
+
 fn secret_source_map_from_extra(
     extra: &BTreeMap<String, Value>,
 ) -> HashMap<String, defaults::AgentTaskSecretSource> {

--- a/crates/homeboy-agents/src/agent_task_secrets.rs
+++ b/crates/homeboy-agents/src/agent_task_secrets.rs
@@ -71,6 +71,28 @@ pub fn secret_env_plan_status(plan: &SecretEnvPlan) -> Vec<AgentTaskSecretEnvSta
     secret_env_status(&plan.secret_env_names())
 }
 
+/// Redacted secret-env status for a scope, defaulting to every secret that
+/// scope declares a source for when the caller names none explicitly.
+///
+/// `agent-task auth status` and `agent-task providers --secret-env` both
+/// answer "what is this scope's secret-env readiness" and must agree: a
+/// secret that reads as configured from one must read as configured from the
+/// other, since they are the same question about the same underlying state
+/// (#13629). Routing both through this one function, rather than each
+/// assembling its own default name list, makes that agreement structural
+/// instead of something each call site has to maintain by hand.
+pub fn secret_env_status_for_scope(
+    explicit_names: &[String],
+    fallback_sources: &HashMap<String, AgentTaskSecretSource>,
+) -> Vec<AgentTaskSecretEnvStatus> {
+    if !explicit_names.is_empty() {
+        return secret_env_status_with_fallbacks(explicit_names, fallback_sources);
+    }
+    let mut names: Vec<String> = fallback_sources.keys().cloned().collect();
+    names.sort();
+    secret_env_status_with_fallbacks(&names, fallback_sources)
+}
+
 pub fn map_secret_to_env(
     name: &str,
     env_var: Option<&str>,
@@ -594,6 +616,62 @@ mod tests {
         let serialized = serde_json::to_string(&status).expect("status json");
         assert!(!serialized.contains("secret-value"));
         std::env::remove_var(present);
+    }
+
+    #[test]
+    fn secret_env_status_for_scope_defaults_to_every_declared_secret_and_agrees_with_explicit_lookup(
+    ) {
+        let configured = unique_env("SCOPE_CONFIGURED");
+        let missing = unique_env("SCOPE_MISSING");
+        std::env::set_var(&configured, "configured-value");
+        std::env::remove_var(&missing);
+        let source = |env_var: &str| AgentTaskSecretSource {
+            source: "env".to_string(),
+            env_var: Some(env_var.to_string()),
+            path: None,
+            scope: None,
+            name: None,
+            field: None,
+            value: None,
+        };
+        let mut fallback_sources = HashMap::new();
+        fallback_sources.insert(configured.clone(), source(&configured));
+        fallback_sources.insert(missing.clone(), source(&missing));
+
+        // `agent-task auth status` and `agent-task providers --secret-env`
+        // both call this with no explicit names when the operator names none,
+        // and must report the identical scope the same way (#13629): every
+        // secret this scope declares a source for, not an empty list.
+        let defaulted = secret_env_status_for_scope(&[], &fallback_sources);
+        let mut names: Vec<&str> = defaulted.iter().map(|entry| entry.name.as_str()).collect();
+        names.sort();
+        let mut expected = vec![configured.as_str(), missing.as_str()];
+        expected.sort();
+        assert_eq!(names, expected);
+        assert!(defaulted
+            .iter()
+            .any(|entry| entry.name == configured && entry.configured));
+        assert!(defaulted
+            .iter()
+            .any(|entry| entry.name == missing && !entry.configured));
+
+        // An explicit name list still wins and is not silently expanded, and
+        // it must resolve to the same verdict the default sweep produced for
+        // that name — one resolution path, one answer.
+        let explicit =
+            secret_env_status_for_scope(std::slice::from_ref(&configured), &fallback_sources);
+        assert_eq!(explicit.len(), 1);
+        assert_eq!(explicit[0].name, configured);
+        assert_eq!(
+            explicit[0].configured,
+            defaulted
+                .iter()
+                .find(|entry| entry.name == configured)
+                .expect("configured entry present in default sweep")
+                .configured
+        );
+
+        std::env::remove_var(configured);
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -492,8 +492,8 @@ pub mod secrets {
     pub use super::super::agent_task_secrets::{
         map_secret_to_env, map_secret_to_keychain_bundle, remove_secret_mapping,
         resolve_secret_env, resolve_secret_env_with_fallbacks, secret_env_status,
-        secret_env_status_with_fallbacks, set_config_secret, set_keychain_bundle,
-        set_keychain_secret, validate_secret_env, AgentTaskSecretEnvStatus,
+        secret_env_status_for_scope, secret_env_status_with_fallbacks, set_config_secret,
+        set_keychain_bundle, set_keychain_secret, validate_secret_env, AgentTaskSecretEnvStatus,
         AgentTaskSecretResolutionError,
     };
 }

--- a/crates/homeboy-cli/src/commands/agent_task/auth.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/auth.rs
@@ -138,18 +138,13 @@ fn auth_status(status_args: AgentTaskAuthStatusArgs) -> Value {
         None => agent_task_provider::provider_secret_sources_for_providers(providers),
     };
 
-    // Required secret env names: explicit operator-supplied names win; otherwise
-    // report every secret the selected backend declares.
-    let names: Vec<String> = if status_args.secret_env.is_empty() {
-        let mut names: Vec<String> = fallback_sources.keys().cloned().collect();
-        names.sort();
-        names
-    } else {
-        status_args.secret_env.clone()
-    };
-
-    let secret_env =
-        agent_task_secrets::secret_env_status_with_fallbacks(&names, &fallback_sources);
+    // Explicit operator-supplied names win; otherwise report every secret the
+    // selected backend declares. Shared with `agent-task providers
+    // --secret-env` so the two commands agree about the same secrets (#13629).
+    let secret_env = agent_task_secrets::secret_env_status_for_scope(
+        &status_args.secret_env,
+        &fallback_sources,
+    );
 
     serde_json::json!({
         "schema": "homeboy/agent-task-auth-status/v1",

--- a/crates/homeboy-cli/src/commands/agent_task/auth.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/auth.rs
@@ -141,10 +141,8 @@ fn auth_status(status_args: AgentTaskAuthStatusArgs) -> Value {
     // Explicit operator-supplied names win; otherwise report every secret the
     // selected backend declares. Shared with `agent-task providers
     // --secret-env` so the two commands agree about the same secrets (#13629).
-    let secret_env = agent_task_secrets::secret_env_status_for_scope(
-        &status_args.secret_env,
-        &fallback_sources,
-    );
+    let secret_env =
+        agent_task_secrets::secret_env_status_for_scope(&status_args.secret_env, &fallback_sources);
 
     serde_json::json!({
         "schema": "homeboy/agent-task-auth-status/v1",

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -1965,7 +1965,10 @@ fn providers_with_catalog(
                 declared_backends,
             ),
             "diagnostics": shown_diagnostics,
-            "secret_env": homeboy::agents::agent_tasks::secrets::secret_env_status_with_fallbacks(&args.secret_env, &fallback_sources),
+            // Explicit `--secret-env` names win; otherwise report every secret
+            // the shown providers declare, so this agrees with `agent-task
+            // auth status` about the same secrets by construction (#13629).
+            "secret_env": homeboy::agents::agent_tasks::secrets::secret_env_status_for_scope(&args.secret_env, &fallback_sources),
         }),
         0,
     ))
@@ -3623,6 +3626,64 @@ mod tests {
                 Some(
                     "Agent task providers\nStatus: credentials_missing\nProviders shown: 1\nNext: homeboy agent-task providers --backend claude-code --selector claude-code.agent-task-executor --validate-readiness".to_string()
                 )
+            );
+        });
+    }
+
+    /// #13629: `agent-task providers --secret-env` used to return an empty
+    /// list whenever the operator passed no explicit `--secret-env` names,
+    /// even though `agent-task auth status` defaults to reporting every
+    /// secret the scope declares. The two commands answer the same question
+    /// about the same backend and must agree.
+    #[test]
+    fn providers_secret_env_defaults_to_every_declared_secret_like_auth_status() {
+        crate::test_support::with_isolated_home(|_| {
+            save_provider_policy(None, None);
+            let provider: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
+                "id": "claude-code.agent-task-executor",
+                "backend": "claude-code",
+                "capabilities": ["cli_runtime", "provider_owned_auth"],
+                "provider_defaults": {
+                    "claude-code": {
+                        "secret_env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"],
+                        "required_secret_env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"],
+                        "secret_env_sources": {
+                            "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN": {
+                                "source": "env",
+                                "env_var": "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"
+                            }
+                        }
+                    }
+                }
+            }))
+            .expect("provider fixture");
+            let mut args = providers_args();
+            args.backend = Some("claude-code".to_string());
+            let output = providers_with_catalog(args, provider_catalog(vec![provider]))
+                .expect("provider report")
+                .0;
+
+            let secret_env = output["secret_env"]
+                .as_array()
+                .expect("secret_env is an array");
+            assert!(
+                !secret_env.is_empty(),
+                "no explicit --secret-env was passed, so the shown backend's declared secret \
+                 must still be reported by default, not silently omitted"
+            );
+            assert!(
+                secret_env
+                    .iter()
+                    .any(|entry| entry["name"] == "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"),
+                "the declared credential must be named: {secret_env:?}"
+            );
+            assert_eq!(
+                secret_env
+                    .iter()
+                    .find(|entry| entry["name"] == "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN")
+                    .expect("declared credential entry")["configured"],
+                false,
+                "unconfigured in this hermetic test environment, matching auth status"
             );
         });
     }

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -1100,6 +1100,16 @@ missing-`--backend` error instead of failing with the same precondition (#12569)
 A supplied `--backend` still fails fast: that query names one backend and has no
 fuller picture to report.
 
+A `ready` verdict means "no reason found to block dispatch," not "confirmed to
+work." `dispatchability.checks.credentials.verified` distinguishes the two: it
+is `true` only when the routed provider declared its own live readiness probe
+(`readiness_invocation`) and that probe ran and passed. When it is `false`,
+`ready: true` reflects presence only — the declared credential material is
+readable somewhere, which is not proof it is still valid. A revoked or expired
+provider-owned credential (e.g. an OAuth refresh token) stays present on disk
+after revocation, so presence-only readiness must not be read as a live
+go/no-go signal for that class of credential (#13628).
+
 ## Repo-Local Gate Tasks
 
 Use `execution_kind: repo_local_gate` for deterministic, repo-local gate


### PR DESCRIPTION
Fixes #13628

Readiness reported a backend as `ready` whenever credential material was merely *present*, so a revoked account passed preflight and failed at runtime. Related surfaces (`auth status`, `providers --secret-env`, `--validate-readiness`) also disagreed with each other about the same secrets.

Also addresses #13629.

## Changes

```
 .../src/agent_task_provider/dispatchability.rs     | 131 ++++++++++++++++++++-
 .../src/agent_task_provider/secrets.rs             |  24 ++++
 crates/homeboy-agents/src/agent_task_secrets.rs    |  78 ++++++++++++
 crates/homeboy-agents/src/agent_tasks.rs           |   4 +-
 crates/homeboy-cli/src/commands/agent_task/auth.rs |  19 ++-
 .../homeboy-cli/src/commands/agent_task/review.rs  |  63 +++++++++-
 docs/commands/agent-task.md                        |  10 ++
 9 files changed, 320 insertions(+), 41 deletions(-)
```

---

*AI assistance: Claude Sonnet 4.5 via opencode, dispatched as a parallel general coding subagent against this worktree. The agent located the root cause, implemented the fix, and ran scoped verification, reporting its commands and results. I filed the issue from an observed failure, reviewed the diff against the merge-base, and corrected commit authorship. Local re-verification of the full gate was constrained by cargo build-lock contention across concurrent worktrees (tracked as #13643); CI is the authoritative gate here.*
