### PR TITLE
fix(runner): surface admission readiness, not just connectivity

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -2817,27 +2817,15 @@ fn preflight_hot_command_with_input(
                     .as_ref()
                     .and_then(|readiness| readiness.selected_runner_id.as_deref()),
             );
-            let runner_admits_offload = if hot_command.allows_warm_runner_coordination {
-                resource_policy::admits_warm_runner_coordination(
-                    hot_command,
-                    &resources,
-                    selected_lab_runner
-                        .filter(|_| !matches!(cli.placement, crate::cli_surface::Placement::Local)),
-                    lab_readiness.as_ref(),
-                )
-            } else {
-                hot_command.lab_offload_supported
-                    && selected_lab_runner.is_some_and(|runner_id| {
-                        lab_readiness.as_ref().is_some_and(|readiness| {
-                            readiness.state
-                                == crate::runner::runners::LabRunnerReadinessState::ConnectedReady
-                                && readiness
-                                    .available_runner_ids
-                                    .iter()
-                                    .any(|available| available == runner_id)
-                        })
-                    })
-            };
+            let required_lab_placement = required_lab_placement(cli, hot_command);
+            let runner_admits_offload = resource_policy::runner_admits_lab_dispatch(
+                hot_command,
+                &resources,
+                selected_lab_runner
+                    .filter(|_| !matches!(cli.placement, crate::cli_surface::Placement::Local)),
+                lab_readiness.as_ref(),
+                required_lab_placement,
+            );
             let runner_admits_offload = runner_admits_offload
                 && selected_lab_runner.is_none_or(|runner_id| {
                     review_test_runner_requirements(cli).is_none_or(|requirements| {
@@ -2875,7 +2863,6 @@ fn preflight_hot_command_with_input(
                 lab_readiness.as_ref(),
                 cli.placement,
             );
-            let required_lab_placement = required_lab_placement(cli, hot_command);
             let required_lab_runner = required_lab_placement
                 .then_some(selected_lab_runner)
                 .flatten();

--- a/crates/homeboy-cli/src/commands/runner/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/status.rs
@@ -36,12 +36,19 @@ pub(super) fn status(
     if let Some(id) = id {
         let runners = runner::list()?;
         if is_controller_local_runner(&runners, id) {
+            // Best-effort: a controller-local query must not fail because a
+            // configured Lab runner could not be probed.
+            let lab_readiness = runner::lab_runner_readiness().ok();
             return Ok((
                 RunnerOutput {
                     command: "runner.status".to_string(),
                     id: Some(id.to_string()),
                     extra: RunnerExtra {
-                        execution_capabilities: Some(global_execution_capabilities(&runners, None)?),
+                        execution_capabilities: Some(global_execution_capabilities(
+                            &runners,
+                            None,
+                            lab_readiness.as_ref(),
+                        )?),
                         operator_hints: vec![
                             "Controller-local execution is available; use `homeboy --placement local agent-task cook ...`."
                                 .to_string(),
@@ -53,10 +60,12 @@ pub(super) fn status(
                 0,
             ));
         }
-        let preferred_lab_runner = runner::resolve_default_lab_runner()?;
+        let lab_readiness = runner::lab_runner_readiness()?;
+        let preferred_lab_runner = lab_readiness.selected_runner_id.clone();
         let admission_snapshot = runner::runner_admission_snapshot(id)?;
         let report = admission_snapshot.status;
-        let capabilities = global_execution_capabilities(&runners, Some(&report))?;
+        let capabilities =
+            global_execution_capabilities(&runners, Some(&report), Some(&lab_readiness))?;
         let generation_inventory = admission_snapshot.generation_inventory;
         // Lead with the compact authoritative admission answer, summarizing the
         // draining generations by count rather than expanding the full ledger
@@ -135,10 +144,11 @@ pub(super) fn status(
         ));
     }
 
-    let preferred_lab_runner = runner::resolve_default_lab_runner()?;
+    let lab_readiness = runner::lab_runner_readiness()?;
+    let preferred_lab_runner = lab_readiness.selected_runner_id.clone();
     let runners = runner::list()?;
     let sessions = non_local_sessions(&runners, runner::persisted_statuses()?);
-    let capabilities = execution_capabilities(&runners, &sessions);
+    let capabilities = execution_capabilities(&runners, &sessions, Some(&lab_readiness));
     if !full {
         let omitted = sessions.len().saturating_sub(DEFAULT_STATUS_SESSION_LIMIT);
         let sessions = sessions
@@ -167,7 +177,7 @@ pub(super) fn status(
         ));
     }
     let (sessions, inspection) = full_status_projections(sessions, runner::statuses_indexed());
-    let capabilities = execution_capabilities(&runners, &sessions);
+    let capabilities = execution_capabilities(&runners, &sessions, Some(&lab_readiness));
     let mut operator_hints: Vec<String> = sessions
         .iter()
         .flat_map(runner_status_operator_hints)
@@ -235,6 +245,7 @@ pub(super) fn non_local_sessions(
 fn global_execution_capabilities(
     runners: &[Runner],
     queried_report: Option<&RunnerStatusReport>,
+    lab_readiness: Option<&runner::LabRunnerReadiness>,
 ) -> homeboy::core::Result<RunnerExecutionCapabilities> {
     let mut sessions = runner::persisted_statuses()?;
     if let Some(queried_report) = queried_report {
@@ -247,20 +258,27 @@ fn global_execution_capabilities(
             sessions.push(queried_report.clone());
         }
     }
-    Ok(execution_capabilities(runners, &sessions))
+    Ok(execution_capabilities(runners, &sessions, lab_readiness))
 }
 
 fn execution_capabilities(
     runners: &[Runner],
     sessions: &[RunnerStatusReport],
+    lab_readiness: Option<&runner::LabRunnerReadiness>,
 ) -> RunnerExecutionCapabilities {
-    execution_capabilities_with_local_placement(true, runners, sessions)
+    execution_capabilities_with_local_placement(true, runners, sessions, lab_readiness)
 }
 
+/// `lab_readiness` is the same admission projection dispatch preflight
+/// consults (`resolve_parsed_command_preflight` requires
+/// `LabRunnerReadinessState::ConnectedReady`). Reusing it here keeps
+/// `runner status` from reporting a connected-but-not-admitted runner as
+/// dispatch-ready (#13631).
 pub(super) fn execution_capabilities_with_local_placement(
     local_placement_available: bool,
     runners: &[Runner],
     sessions: &[RunnerStatusReport],
+    lab_readiness: Option<&runner::LabRunnerReadiness>,
 ) -> RunnerExecutionCapabilities {
     let connected_runner_ids = sessions
         .iter()
@@ -268,16 +286,44 @@ pub(super) fn execution_capabilities_with_local_placement(
         .filter(|report| report.connected)
         .map(|report| report.runner_id.clone())
         .collect::<Vec<_>>();
-    let next_action = if connected_runner_ids.is_empty() {
-        sessions
-            .iter()
-            .find(|report| !is_controller_local_runner(runners, &report.runner_id))
-            .map(|report| {
-                terminal_daemon_ownership_diagnostic(report)
-                    .unwrap_or_else(|| report.status_action().render_command())
-            })
+    let admitted_runner_ids = lab_readiness
+        .map(|readiness| readiness.available_runner_ids.clone())
+        .unwrap_or_default();
+    let available = !admitted_runner_ids.is_empty();
+    let (reasons, next_action) = if available {
+        (Vec::new(), None)
+    } else if connected_runner_ids.is_empty() {
+        (
+            Vec::new(),
+            sessions
+                .iter()
+                .find(|report| !is_controller_local_runner(runners, &report.runner_id))
+                .map(|report| {
+                    terminal_daemon_ownership_diagnostic(report)
+                        .unwrap_or_else(|| report.status_action().render_command())
+                }),
+        )
     } else {
-        None
+        // Connected but not admitted: report the true state plainly instead of
+        // presenting connectivity as dispatch readiness, and surface the
+        // action that would admit the runner (#13631).
+        let reasons = lab_readiness
+            .map(|readiness| readiness.reasons.clone())
+            .unwrap_or_default();
+        let next_action = lab_readiness
+            .and_then(|readiness| readiness.remediation_commands.first().cloned())
+            .or_else(|| {
+                sessions
+                    .iter()
+                    .find(|report| {
+                        report.connected && !is_controller_local_runner(runners, &report.runner_id)
+                    })
+                    .map(|report| {
+                        terminal_daemon_ownership_diagnostic(report)
+                            .unwrap_or_else(|| report.status_action().render_command())
+                    })
+            });
+        (reasons, next_action)
     };
     RunnerExecutionCapabilities {
         local_placement: RunnerExecutionCapability {
@@ -294,8 +340,9 @@ pub(super) fn execution_capabilities_with_local_placement(
             },
         },
         lab_runner_connection: LabRunnerConnectionCapability {
-            available: !connected_runner_ids.is_empty(),
+            available,
             connected_runner_ids,
+            reasons,
             next_action,
         },
     }

--- a/crates/homeboy-cli/src/commands/runner/tests/status.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/status.rs
@@ -1680,8 +1680,13 @@ fn execution_capabilities_separate_local_placement_from_lab_connections() {
     ];
 
     for (name, runners, reports, local_available, connected_ids) in cases {
-        let capabilities =
-            execution_capabilities_with_local_placement(local_available, &runners, &reports);
+        let readiness = admitted_readiness(connected_ids.clone().unwrap_or_default());
+        let capabilities = execution_capabilities_with_local_placement(
+            local_available,
+            &runners,
+            &reports,
+            Some(&readiness),
+        );
         let lab_connection_available = connected_ids.is_some();
         assert_eq!(
             capabilities.local_placement.available, local_available,
@@ -1703,6 +1708,69 @@ fn execution_capabilities_separate_local_placement_from_lab_connections() {
                 .contains("runner connect"),
             "{name}"
         );
+    }
+}
+
+/// #13631: a runner can be connected without being admitted (e.g. its daemon
+/// is stale or its required capabilities never probed ready). `runner status`
+/// must report that gap plainly instead of presenting connectivity as
+/// dispatch readiness — the exact mismatch the issue reported between
+/// `runner status` and cook admission.
+#[test]
+fn connected_but_unadmitted_runner_is_not_reported_as_dispatch_ready() {
+    let connected = connected_report();
+    let remote = configured_runner("homeboy lab", RunnerKind::Ssh);
+    // The runner answered (connected) but the live admission projection found
+    // it ineligible (e.g. required capabilities never probed ready) and
+    // therefore excluded it from `available_runner_ids`.
+    let readiness = runner::LabRunnerReadiness {
+        state: runner::LabRunnerReadinessState::ConnectedIneligible,
+        selected_runner_id: None,
+        available_runner_ids: Vec::new(),
+        reasons: vec!["required_capabilities_unavailable".to_string()],
+        remediation_commands: vec!["homeboy runner status 'homeboy lab'".to_string()],
+    };
+
+    let capabilities = execution_capabilities_with_local_placement(
+        true,
+        &[remote],
+        &[connected],
+        Some(&readiness),
+    );
+
+    // Connectivity is still visible...
+    assert_eq!(
+        capabilities.lab_runner_connection.connected_runner_ids,
+        ["homeboy lab"]
+    );
+    // ...but admission readiness, not connectivity, gates `available`.
+    assert!(
+        !capabilities.lab_runner_connection.available,
+        "a connected but unadmitted runner must not be reported as dispatch-ready"
+    );
+    assert_eq!(
+        capabilities.lab_runner_connection.reasons,
+        ["required_capabilities_unavailable"]
+    );
+    assert_eq!(
+        capabilities.lab_runner_connection.next_action.as_deref(),
+        Some("homeboy runner status 'homeboy lab'")
+    );
+}
+
+fn admitted_readiness(available_runner_ids: Vec<&str>) -> runner::LabRunnerReadiness {
+    let available_runner_ids: Vec<String> =
+        available_runner_ids.into_iter().map(String::from).collect();
+    runner::LabRunnerReadiness {
+        state: if available_runner_ids.is_empty() {
+            runner::LabRunnerReadinessState::Disconnected
+        } else {
+            runner::LabRunnerReadinessState::ConnectedReady
+        },
+        selected_runner_id: available_runner_ids.first().cloned(),
+        available_runner_ids,
+        reasons: Vec::new(),
+        remediation_commands: Vec::new(),
     }
 }
 
@@ -1733,10 +1801,12 @@ fn global_capabilities_include_connected_lab_for_local_and_disconnected_remote_q
     let mut connected_report = connected_report();
     connected_report.runner_id = connected.id.clone();
 
+    let readiness = admitted_readiness(vec!["lab-connected"]);
     let capabilities = execution_capabilities_with_local_placement(
         true,
         &[local, disconnected, connected],
         &[disconnected_report, connected_report],
+        Some(&readiness),
     );
 
     assert!(capabilities.local_placement.available);

--- a/crates/homeboy-cli/src/commands/runner/types.rs
+++ b/crates/homeboy-cli/src/commands/runner/types.rs
@@ -235,11 +235,22 @@ pub struct RunnerExecutionCapability {
     pub next_action: String,
 }
 
+/// `available` reports Lab **admission** readiness (the same predicate cook
+/// dispatch enforces via `resolve_parsed_command_preflight`), not raw session
+/// connectivity. A runner can be connected without being admitted (stale
+/// daemon, missing capabilities, capacity blocked, ...); in that case
+/// `available` is `false` even though `connected_runner_ids` is non-empty, and
+/// `reasons`/`next_action` explain what would admit it (#13631).
 #[derive(Debug, Serialize, PartialEq, Eq)]
 pub struct LabRunnerConnectionCapability {
     pub available: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub connected_runner_ids: Vec<String>,
+    /// Non-empty exactly when at least one runner is connected but not
+    /// admitted, explaining the gap between connectivity and dispatch
+    /// readiness.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub reasons: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_action: Option<String>,
 }

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
@@ -599,15 +599,53 @@ pub(crate) fn admits_warm_runner_coordination(
             .as_ref()
             .is_none_or(|memory| memory.recommendation == ResourceRecommendation::Ok)
         && resources.processes.recommendation == ResourceRecommendation::Ok
-        && selected_runner.is_some_and(|runner_id| {
-            lab_readiness.is_some_and(|readiness| {
-                readiness.state == crate::runner::runners::LabRunnerReadinessState::ConnectedReady
-                    && readiness
-                        .available_runner_ids
-                        .iter()
-                        .any(|available| available == runner_id)
-            })
-        })
+        && selected_runner
+            .is_some_and(|runner_id| lab_readiness_admits_runner(runner_id, lab_readiness))
+}
+
+/// Whether `lab_readiness` reports `runner_id` as Lab-admitted: connected,
+/// ready, and present in the live available-runner set. This is the same
+/// predicate `resolve_parsed_command_preflight` re-verifies for any selected
+/// runner, so every caller deciding admission must agree with it.
+pub(crate) fn lab_readiness_admits_runner(
+    runner_id: &str,
+    lab_readiness: Option<&LabRunnerReadiness>,
+) -> bool {
+    lab_readiness.is_some_and(|readiness| {
+        readiness.state == crate::runner::runners::LabRunnerReadinessState::ConnectedReady
+            && readiness
+                .available_runner_ids
+                .iter()
+                .any(|available| available == runner_id)
+    })
+}
+
+/// Whether the selected Lab runner is admitted to run a warm-runner-
+/// coordination command's provider attempt.
+///
+/// `admits_warm_runner_coordination` gates *opportunistic* offload on
+/// controller pressure: a warm/hot controller may keep coordinating despite
+/// its own pressure because the provider attempt can move to Lab. Required
+/// Lab placement (`--runner <id>` or `--placement lab`) is a routing decision
+/// the operator already made, not a pressure trade-off, so its admission must
+/// depend only on the selected runner's own Lab readiness — the same plain
+/// check every other lab-offload command uses. Gating a required, genuinely
+/// `ConnectedReady` runner on unrelated controller pressure refused an
+/// explicit runner that `runner status` reported ready (#13631), and let
+/// `cook --preview` (which never evaluates pressure) appear to pass when the
+/// real dispatch would then refuse on this exact mismatch (#13632).
+pub(crate) fn runner_admits_lab_dispatch(
+    command: HotCommand,
+    resources: &DoctorOutput,
+    selected_runner: Option<&str>,
+    lab_readiness: Option<&LabRunnerReadiness>,
+    required_lab_placement: bool,
+) -> bool {
+    if !required_lab_placement && command.allows_warm_runner_coordination {
+        return admits_warm_runner_coordination(command, resources, selected_runner, lab_readiness);
+    }
+    command.lab_offload_supported
+        && selected_runner.is_some_and(|runner_id| lab_readiness_admits_runner(runner_id, lab_readiness))
 }
 
 /// Permit automatic controller execution only when Lab is disconnected and the
@@ -1727,6 +1765,70 @@ mod tests {
             &resources,
             Some("missing-lab"),
             Some(&ready),
+        ));
+    }
+
+    /// #13631/#13632: an operator who explicitly pins `--runner homeboy-lab`
+    /// (or forces `--placement lab`) to a genuinely `ConnectedReady` runner
+    /// has already made the routing decision; that admission must not
+    /// additionally require the *controller* to be under warm/hot pressure.
+    /// Before this fix, `runner_admits_offload` for a cook/fanout coordinator
+    /// was always `admits_warm_runner_coordination`'s pressure-gated result,
+    /// so an idle controller (`ResourceRecommendation::Ok`) refused an
+    /// explicitly requested, fully ready runner — exactly the dispatch
+    /// refusal the issue reported (`runner status` said ready, cook admission
+    /// refused), and exactly why `cook --preview` (which never evaluates
+    /// controller pressure) could report success for a placement the real,
+    /// pressure-gated dispatch would then refuse.
+    #[test]
+    fn required_lab_placement_admits_a_ready_runner_regardless_of_controller_pressure() {
+        let command = HotCommand {
+            label: "agent-task cook/run-plan/retry --run",
+            lab_offload_supported: true,
+            lab_offload_unsupported_reason: None,
+            allows_warm_runner_coordination: true,
+            offload_only_when_hot: false,
+        };
+        let ready = ready_lab();
+
+        for recommendation in [
+            ResourceRecommendation::Ok,
+            ResourceRecommendation::Warm,
+            ResourceRecommendation::Hot,
+        ] {
+            let idle_resources = resources(recommendation);
+            assert!(
+                runner_admits_lab_dispatch(
+                    command,
+                    &idle_resources,
+                    Some("homeboy-lab"),
+                    Some(&ready),
+                    true,
+                ),
+                "required lab placement of a ready runner must be admitted at {recommendation:?} controller pressure"
+            );
+        }
+
+        // The exact same idle-controller inputs, without required placement
+        // (automatic/default selection), still require warm/hot pressure —
+        // this fix does not change opportunistic offload semantics.
+        let idle_resources = resources(ResourceRecommendation::Ok);
+        assert!(!runner_admits_lab_dispatch(
+            command,
+            &idle_resources,
+            Some("homeboy-lab"),
+            Some(&ready),
+            false,
+        ));
+
+        // Required placement of a genuinely unready runner still refuses.
+        let not_ready = disconnected_lab();
+        assert!(!runner_admits_lab_dispatch(
+            command,
+            &idle_resources,
+            Some("homeboy-lab"),
+            Some(&not_ready),
+            true,
         ));
     }
 

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
@@ -645,7 +645,8 @@ pub(crate) fn runner_admits_lab_dispatch(
         return admits_warm_runner_coordination(command, resources, selected_runner, lab_readiness);
     }
     command.lab_offload_supported
-        && selected_runner.is_some_and(|runner_id| lab_readiness_admits_runner(runner_id, lab_readiness))
+        && selected_runner
+            .is_some_and(|runner_id| lab_readiness_admits_runner(runner_id, lab_readiness))
 }
 
 /// Permit automatic controller execution only when Lab is disconnected and the


### PR DESCRIPTION
Fixes #13631

`runner status` reported a lab runner as `connected` while cook admission refused it with `selected runner requires admitted connected readiness evidence`. That contradiction is what pushes an operator onto `--placement local` for work meant to run async on the lab.

Also addresses #13632.

## Changes

```
 crates/homeboy-cli/src/cli_runtime.rs              |  31 ++----
 crates/homeboy-cli/src/commands/runner/status.rs   |  83 ++++++++++----
 .../src/commands/runner/tests/status.rs            |  74 ++++++++++++-
 crates/homeboy-cli/src/commands/runner/types.rs    |  11 ++
 .../src/commands/utils/resource_policy/mod.rs      | 120 +++++++++++++++++++--
 5 files changed, 268 insertions(+), 51 deletions(-)
```

---

*AI assistance: Claude Sonnet 4.5 via opencode, dispatched as a parallel general coding subagent against this worktree. The agent located the root cause, implemented the fix, and ran scoped verification, reporting its commands and results. I filed the issue from an observed failure, reviewed the diff against the merge-base, and corrected commit authorship. Local re-verification of the full gate was constrained by cargo build-lock contention across concurrent worktrees (tracked as #13643); CI is the authoritative gate here.*
