### PR TITLE
fix(agent-task): disclose legacy secrets file migration on auth mutations

### DIFF
--- a/crates/homeboy-agents/src/agent_task_secrets.rs
+++ b/crates/homeboy-agents/src/agent_task_secrets.rs
@@ -220,6 +220,19 @@ pub fn map_secret_to_keychain_bundle(
     })
 }
 
+/// Path of the legacy standalone secrets file when it still exists on disk.
+///
+/// Mappings live in the global config at `/agent_task/secrets`; this file is
+/// the superseded location, kept only as a read fallback for installs that
+/// never migrated. The next mutating `agent-task auth` command persists the
+/// mappings to the global config and removes this file, and the command
+/// output discloses the move.
+pub fn legacy_secrets_file() -> Option<PathBuf> {
+    AgentTaskSecretConfig::path()
+        .ok()
+        .filter(|path| path.is_file())
+}
+
 pub fn remove_secret_mapping(
     name: &str,
     remove_keychain: bool,
@@ -446,8 +459,27 @@ impl AgentTaskSecretConfig {
         let mut config = defaults::load_config();
         config.agent_task.secrets = self.secrets.clone();
         defaults::save_config(&config)?;
-        Ok(())
+        remove_superseded_legacy_file()
     }
+}
+
+/// Delete the legacy standalone secrets file once the mappings are persisted
+/// in the global config. The file is never written anymore; leaving it behind
+/// keeps stale mappings looking live, and `load` would fall back to them
+/// whenever the global config has no secrets.
+fn remove_superseded_legacy_file() -> homeboy_core::Result<()> {
+    let Some(path) = legacy_secrets_file() else {
+        return Ok(());
+    };
+    fs::remove_file(&path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!(
+                "remove superseded agent-task secrets file {} (mappings now live in homeboy.json at /agent_task/secrets)",
+                path.display()
+            )),
+        )
+    })
 }
 
 fn resolve_secret_source(
@@ -767,6 +799,78 @@ mod tests {
             assert!(!status.configured);
             assert_eq!(status.source, "missing");
             std::env::remove_var(source_name);
+        });
+    }
+
+    fn write_legacy_secrets_file(home: &std::path::Path, names: &[String]) -> PathBuf {
+        let legacy_path = home.join(".config/homeboy/agent-task-secrets.json");
+        std::fs::create_dir_all(legacy_path.parent().expect("config root"))
+            .expect("create config root");
+        let secrets: HashMap<String, Value> = names
+            .iter()
+            .map(|name| (name.clone(), serde_json::json!({ "source": "env" })))
+            .collect();
+        std::fs::write(
+            &legacy_path,
+            serde_json::json!({ "secrets": secrets }).to_string(),
+        )
+        .expect("write legacy secrets file");
+        legacy_path
+    }
+
+    #[test]
+    fn mutation_migrates_legacy_secrets_file_into_global_config_and_removes_it() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let kept = unique_env("LEGACY_KEPT_SECRET");
+            let removed = unique_env("LEGACY_REMOVED_SECRET");
+            std::env::remove_var(&kept);
+            std::env::remove_var(&removed);
+            let legacy_path =
+                write_legacy_secrets_file(home.path(), &[kept.clone(), removed.clone()]);
+            assert_eq!(legacy_secrets_file(), Some(legacy_path.clone()));
+
+            let status = remove_secret_mapping(&removed.clone(), false).expect("mapping removed");
+
+            // The mutation answered from the migrated state, and the superseded
+            // file is gone: exactly one authoritative location remains.
+            assert!(!status.configured);
+            assert!(!legacy_path.exists());
+            assert_eq!(legacy_secrets_file(), None);
+            let raw = std::fs::read_to_string(home.path().join(".config/homeboy/homeboy.json"))
+                .expect("global config written");
+            let config: Value = serde_json::from_str(&raw).expect("global config json");
+            let secrets = config
+                .pointer("/agent_task/secrets")
+                .expect("secrets migrated into global config");
+            assert!(secrets.get(&kept).is_some());
+            assert!(secrets.get(&removed).is_none());
+            // The process-global config memo is deliberately unkeyed (ambient
+            // only); force a fresh read of this isolated home's file rather
+            // than trust a memo another concurrently running test may have
+            // primed against a different root.
+            homeboy_core::defaults::reset_config_cache_for_test();
+            let loaded = AgentTaskSecretConfig::load();
+            assert!(loaded.secrets.contains_key(&kept));
+            assert!(!loaded.secrets.contains_key(&removed));
+        });
+    }
+
+    #[test]
+    fn removing_last_legacy_mapping_does_not_resurrect_the_superseded_file() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let name = unique_env("LEGACY_LAST_SECRET");
+            std::env::remove_var(&name);
+            let legacy_path = write_legacy_secrets_file(home.path(), std::slice::from_ref(&name));
+
+            remove_secret_mapping(&name, false).expect("mapping removed");
+
+            // The global config now holds zero secrets; had the legacy file
+            // survived, load() would fall back to it and resurrect the stale
+            // mapping. Force a fresh read (see comment in the sibling test
+            // above) rather than trust the ambient process-global memo.
+            assert!(!legacy_path.exists());
+            homeboy_core::defaults::reset_config_cache_for_test();
+            assert!(AgentTaskSecretConfig::load().secrets.is_empty());
         });
     }
 

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -490,11 +490,11 @@ pub mod scheduler {
 /// Secret-env mapping and resolution helpers.
 pub mod secrets {
     pub use super::super::agent_task_secrets::{
-        map_secret_to_env, map_secret_to_keychain_bundle, remove_secret_mapping,
-        resolve_secret_env, resolve_secret_env_with_fallbacks, secret_env_status,
-        secret_env_status_for_scope, secret_env_status_with_fallbacks, set_config_secret,
-        set_keychain_bundle, set_keychain_secret, validate_secret_env, AgentTaskSecretEnvStatus,
-        AgentTaskSecretResolutionError,
+        legacy_secrets_file, map_secret_to_env, map_secret_to_keychain_bundle,
+        remove_secret_mapping, resolve_secret_env, resolve_secret_env_with_fallbacks,
+        secret_env_status, secret_env_status_for_scope, secret_env_status_with_fallbacks,
+        set_config_secret, set_keychain_bundle, set_keychain_secret, validate_secret_env,
+        AgentTaskSecretEnvStatus, AgentTaskSecretResolutionError,
     };
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/auth.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/auth.rs
@@ -17,30 +17,20 @@ pub(super) fn auth(args: AgentTaskAuthArgs) -> CmdResult<Value> {
         AgentTaskAuthCommand::Status(status_args) => Ok((auth_status(status_args), 0)),
         AgentTaskAuthCommand::SetKeychain(set_args) => {
             let value = read_agent_task_secret_value(set_args.value, set_args.value_stdin)?;
+            let legacy_file = agent_task_secrets::legacy_secrets_file();
             let status = agent_task_secrets::set_keychain_secret(
                 &set_args.secret_env,
                 &value,
                 set_args.scope.as_deref(),
                 set_args.keychain_name.as_deref(),
             )?;
-            Ok((
-                serde_json::json!({
-                    "schema": "homeboy/agent-task-auth-configured/v1",
-                    "secret_env": status,
-                }),
-                0,
-            ))
+            Ok((configured_output(status, legacy_file), 0))
         }
         AgentTaskAuthCommand::SetConfig(set_args) => {
             let value = read_agent_task_secret_value(set_args.value, set_args.value_stdin)?;
+            let legacy_file = agent_task_secrets::legacy_secrets_file();
             let status = agent_task_secrets::set_config_secret(&set_args.secret_env, &value)?;
-            Ok((
-                serde_json::json!({
-                    "schema": "homeboy/agent-task-auth-configured/v1",
-                    "secret_env": status,
-                }),
-                0,
-            ))
+            Ok((configured_output(status, legacy_file), 0))
         }
         AgentTaskAuthCommand::SetKeychainBundle(set_args) => {
             let value = read_agent_task_secret_value(set_args.value, set_args.value_stdin)?;
@@ -61,19 +51,15 @@ pub(super) fn auth(args: AgentTaskAuthArgs) -> CmdResult<Value> {
             ))
         }
         AgentTaskAuthCommand::MapEnv(map_args) => {
+            let legacy_file = agent_task_secrets::legacy_secrets_file();
             let status = agent_task_secrets::map_secret_to_env(
                 &map_args.secret_env,
                 map_args.source_env.as_deref(),
             )?;
-            Ok((
-                serde_json::json!({
-                    "schema": "homeboy/agent-task-auth-configured/v1",
-                    "secret_env": status,
-                }),
-                0,
-            ))
+            Ok((configured_output(status, legacy_file), 0))
         }
         AgentTaskAuthCommand::MapKeychainBundle(map_args) => {
+            let legacy_file = agent_task_secrets::legacy_secrets_file();
             let status = agent_task_secrets::map_secret_to_keychain_bundle(
                 &map_args.secret_env,
                 &map_args.bundle,
@@ -81,28 +67,42 @@ pub(super) fn auth(args: AgentTaskAuthArgs) -> CmdResult<Value> {
                 map_args.scope.as_deref(),
                 map_args.keychain_name.as_deref(),
             )?;
-            Ok((
-                serde_json::json!({
-                    "schema": "homeboy/agent-task-auth-configured/v1",
-                    "secret_env": status,
-                }),
-                0,
-            ))
+            Ok((configured_output(status, legacy_file), 0))
         }
         AgentTaskAuthCommand::Remove(remove_args) => {
+            let legacy_file = agent_task_secrets::legacy_secrets_file();
             let status = agent_task_secrets::remove_secret_mapping(
                 &remove_args.secret_env,
                 remove_args.keychain,
             )?;
-            Ok((
-                serde_json::json!({
-                    "schema": "homeboy/agent-task-auth-configured/v1",
-                    "secret_env": status,
-                }),
-                0,
-            ))
+            Ok((configured_output(status, legacy_file), 0))
         }
     }
+}
+
+/// Build the `agent-task-auth-configured` output.
+///
+/// Secret mappings live in the global config at `/agent_task/secrets`. When a
+/// superseded standalone secrets file still existed at command start, the
+/// mutation just migrated any remaining mappings into the global config and
+/// removed that file — disclose both so exactly one storage location is
+/// authoritative and the user is not left trusting a stale file.
+fn configured_output(
+    status: agent_task_secrets::AgentTaskSecretEnvStatus,
+    legacy_file: Option<std::path::PathBuf>,
+) -> Value {
+    let mut output = serde_json::json!({
+        "schema": "homeboy/agent-task-auth-configured/v1",
+        "secret_env": status,
+    });
+    if let Some(legacy_file) = legacy_file {
+        output["secrets_storage"] = serde_json::json!({
+            "config_file": homeboy::core::defaults::config_path().ok(),
+            "config_pointer": "/agent_task/secrets",
+            "removed_legacy_file": legacy_file,
+        });
+    }
+    output
 }
 
 /// Report redacted secret-env readiness for the selected/default backend.

--- a/crates/homeboy-cli/src/commands/agent_task/tests/auth.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/auth.rs
@@ -1,0 +1,126 @@
+//! `agent-task auth` command tests: legacy secrets file migration disclosure.
+//!
+//! Regression coverage for #13627: a mutating `auth` subcommand used to
+//! silently migrate mappings out of the standalone `agent-task-secrets.json`
+//! file into the global config, reporting success while leaving that file on
+//! disk looking live. These tests exercise the real command handler end to
+//! end and assert on the reported outcome, not on internal helper shape.
+
+use super::support::*;
+
+use super::super::args::{AgentTaskAuthArgs, AgentTaskAuthCommand, AgentTaskAuthRemoveArgs};
+use super::super::auth::auth;
+
+use homeboy::core::defaults::AgentTaskSecretSource;
+
+/// Write the legacy standalone secrets file an unmigrated install would still
+/// have on disk, mirroring the format `agent-task auth` used to write before
+/// mappings moved into the global config.
+fn write_legacy_secrets_file(
+    home: &std::path::Path,
+    secrets: &[(&str, &str)],
+) -> std::path::PathBuf {
+    let legacy_path = home.join(".config/homeboy/agent-task-secrets.json");
+    std::fs::create_dir_all(legacy_path.parent().expect("config root"))
+        .expect("create config root");
+    let secrets: std::collections::HashMap<String, AgentTaskSecretSource> = secrets
+        .iter()
+        .map(|(name, env_var)| {
+            (
+                (*name).to_string(),
+                AgentTaskSecretSource {
+                    source: "env".to_string(),
+                    env_var: Some((*env_var).to_string()),
+                    path: None,
+                    scope: None,
+                    name: None,
+                    field: None,
+                    value: None,
+                },
+            )
+        })
+        .collect();
+    std::fs::write(
+        &legacy_path,
+        serde_json::json!({ "secrets": secrets }).to_string(),
+    )
+    .expect("write legacy secrets file");
+    legacy_path
+}
+
+#[test]
+fn auth_remove_discloses_legacy_file_migration_and_removes_it() {
+    with_isolated_home(|home| {
+        let legacy_path = write_legacy_secrets_file(
+            home.path(),
+            &[
+                ("KEPT_SECRET_ENV", "KEPT_SOURCE_ENV"),
+                ("REMOVED_SECRET_ENV", "REMOVED_SOURCE_ENV"),
+            ],
+        );
+        assert!(
+            legacy_path.is_file(),
+            "fixture must place the legacy secrets file on disk before the command runs"
+        );
+
+        let (value, status) = auth(AgentTaskAuthArgs {
+            command: AgentTaskAuthCommand::Remove(AgentTaskAuthRemoveArgs {
+                secret_env: "REMOVED_SECRET_ENV".to_string(),
+                keychain: false,
+            }),
+        })
+        .expect("auth remove succeeds");
+
+        assert_eq!(status, 0);
+
+        // The command must disclose that it just migrated the legacy file's
+        // remaining mappings into the global config and removed it — not just
+        // report the removal as if nothing else happened.
+        let storage = value
+            .get("secrets_storage")
+            .expect("auth remove discloses the legacy-file migration in its output");
+        assert_eq!(storage["config_pointer"], "/agent_task/secrets");
+        assert_eq!(
+            storage["removed_legacy_file"],
+            serde_json::json!(legacy_path.to_string_lossy())
+        );
+        assert!(storage["config_file"].is_string());
+
+        // The legacy file is gone, so it can no longer be mistaken for a live,
+        // authoritative source of secret mappings.
+        assert!(
+            !legacy_path.exists(),
+            "superseded legacy secrets file must be removed once migrated"
+        );
+
+        // The surviving mapping was carried into the global config, and the
+        // removed one is genuinely gone from it, not just from the legacy file.
+        let raw = std::fs::read_to_string(home.path().join(".config/homeboy/homeboy.json"))
+            .expect("global config written");
+        let config: serde_json::Value = serde_json::from_str(&raw).expect("global config json");
+        let secrets = config
+            .pointer("/agent_task/secrets")
+            .expect("secrets migrated into global config");
+        assert!(secrets.get("KEPT_SECRET_ENV").is_some());
+        assert!(secrets.get("REMOVED_SECRET_ENV").is_none());
+    });
+}
+
+#[test]
+fn auth_remove_omits_legacy_disclosure_when_no_legacy_file_exists() {
+    with_isolated_home(|_home| {
+        let (value, status) = auth(AgentTaskAuthArgs {
+            command: AgentTaskAuthCommand::Remove(AgentTaskAuthRemoveArgs {
+                secret_env: "NEVER_MAPPED_SECRET_ENV".to_string(),
+                keychain: false,
+            }),
+        })
+        .expect("auth remove succeeds even when nothing was mapped");
+
+        assert_eq!(status, 0);
+        assert!(
+            value.get("secrets_storage").is_none(),
+            "nothing to disclose when there was no legacy file to migrate away from"
+        );
+    });
+}

--- a/crates/homeboy-cli/src/commands/agent_task/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/mod.rs
@@ -6,6 +6,7 @@
 
 mod support;
 
+mod auth;
 mod contract;
 mod controller_proof;
 mod controller_run;


### PR DESCRIPTION
Fixes #13627
Also addresses #13629.

`agent-task auth remove` reported success while leaving the visible secrets file untouched, silently migrating mappings into `homeboy.json` and leaving a stale, still-parseable legacy file on disk to mislead the next reader.

## Changes

```
 crates/homeboy-agents/src/agent_task_secrets.rs    | 106 ++++++++++++++++-
 crates/homeboy-agents/src/agent_tasks.rs           |   8 +-
 crates/homeboy-cli/src/commands/agent_task/auth.rs |  70 ++++++------
 .../src/commands/agent_task/tests/auth.rs          | 126 +++++++++++++++++++++
 .../src/commands/agent_task/tests/mod.rs           |   1 +
 5 files changed, 271 insertions(+), 40 deletions(-)
```

---

*AI assistance: Claude Sonnet 4.5 via opencode, dispatched as a parallel general coding subagent against this worktree. The agent found the root cause, implemented the fix, added coverage, and ran scoped verification. I filed the issue from an observed failure, reviewed the diff against the merge-base, and corrected commit authorship. CI is the authoritative gate.*
