### PR TITLE
fix(agent-task): recover default backend from live provider readiness

### DIFF
--- a/crates/homeboy-agents/src/agent_task_dispatch_service.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_service.rs
@@ -590,12 +590,19 @@ fn config_default_backend() -> Option<String> {
 /// declared backend and reports each verdict, so the operator is sent to one
 /// command that answers "which backend is usable here?" instead of guessing a
 /// backend per invocation (#12569).
+///
+/// A fresh or reset `agent_task` config (`{}`) hits this same path with no
+/// discoverable way back to a working default short of reading source or an
+/// old backup, so the remediation also names `providers --set-default`, which
+/// derives and writes a live-verified `default_backend`/`rotation` in one
+/// step (#13634).
 fn missing_default_backend_error(available_backends: &[String]) -> Error {
     const PROBLEM: &str =
         "agent-task cook requires --backend because no default backend policy is configured";
 
     let mut tried = vec![
         "Set agent_task.default_backend in component, extension, or Homeboy config policy, or pass --backend explicitly.".to_string(),
+        "Run `homeboy agent-task providers --set-default` to derive and persist a working default_backend (and rotation) from live backend readiness.".to_string(),
     ];
 
     let problem = if available_backends.is_empty() {
@@ -853,7 +860,14 @@ mod tests {
             error.details["tried"][0].as_str(),
             Some("Set agent_task.default_backend in component, extension, or Homeboy config policy, or pass --backend explicitly.")
         );
+        // A lost or empty `agent_task` config must recover without archaeology:
+        // point at the command that derives and writes a working default from
+        // live readiness (#13634).
         assert!(error.details["tried"][1]
+            .as_str()
+            .expect("set-default remediation")
+            .contains("--set-default"));
+        assert!(error.details["tried"][2]
             .as_str()
             .expect("readiness caveat")
             .contains("--validate-readiness"));
@@ -869,7 +883,7 @@ mod tests {
             "an empty catalog must not advertise an empty list: {}",
             error.message
         );
-        assert!(error.details["tried"][1]
+        assert!(error.details["tried"][2]
             .as_str()
             .expect("discovery hint")
             .contains("homeboy agent-task providers"));

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
@@ -80,7 +80,7 @@ pub enum AgentTaskCommand {
     /// `--detach-after-handoff` rather than rely on the default, and read the
     /// terminal outcome from `agent-task status <run-id>` in either case.
     #[command(
-        after_help = "Quick start:\n  homeboy agent-task cook --repo REPO --task-url URL --prompt @task.md --verify 'cargo test'\n\nBackend selection: pass --backend explicitly, configure agent_task.default_backend, or use --preview to see the ready backend routes. Preview adds --backend to its replay command only when exactly one ready route is eligible; multiple ready routes require an explicit choice.\n\nInspect inferred inputs without side effects:\n  homeboy agent-task cook --repo REPO --task-url URL --prompt @task.md --verify 'cargo test' --preview\n\nUse --help-full for the complete advanced option reference."
+        after_help = "Quick start:\n  homeboy agent-task cook --repo REPO --task-url URL --prompt @task.md --verify 'cargo test'\n\nBackend selection: pass --backend explicitly, configure agent_task.default_backend, or use --preview to see the ready backend routes. Preview adds --backend to its replay command only when exactly one ready route is eligible; multiple ready routes require an explicit choice.\n\nNo default configured (agent_task.default_backend unset, e.g. a fresh or reset agent_task: {}): run `homeboy agent-task providers --set-default` to live-probe every declared backend and write a working default_backend/rotation from what actually authenticates here.\n\nInspect inferred inputs without side effects:\n  homeboy agent-task cook --repo REPO --task-url URL --prompt @task.md --verify 'cargo test' --preview\n\nUse --help-full for the complete advanced option reference."
     )]
     Cook(Box<AgentTaskCookArgs>),
     /// Continue a detached Cook from its durable Cook ID or provider attempt ID.
@@ -202,6 +202,8 @@ pub enum AgentTaskCommand {
     ///
     /// `--backend X` filters the presentation to X so output stays within caller
     /// display limits; pass `--catalog` for the full multi-backend catalog.
+    /// `--set-default` recovers a lost or empty `agent_task` config by writing
+    /// a live-verified `default_backend`/`rotation` (#13634).
     Providers(ProvidersArgs),
     /// Manage markdown prompts in Homeboy-owned storage.
     ///
@@ -449,6 +451,25 @@ pub struct ProvidersArgs {
     /// Emit the unfiltered provider DTO catalog for machine admission clients.
     #[arg(long, hide = true)]
     pub machine_catalog: bool,
+    /// Live-probe every declared backend and, if at least one is ready right
+    /// now, persist it as `agent_task.default_backend` with the remaining
+    /// ready backends recorded as an `agent_task.rotation` fallback chain.
+    ///
+    /// Recovers a lost or empty `agent_task` config (`{}`) — which otherwise
+    /// silently disables `agent-task cook` with no default and no documented
+    /// shape to restore one — without reading source or an old backup
+    /// (#13634). Implies `--validate-readiness`. Writes nothing and fails if
+    /// no declared backend is currently ready; run `agent-task providers
+    /// --validate-readiness` to see why each one failed.
+    ///
+    /// Written `agent_task.rotation` shape:
+    /// `{"entries": [{"backend": "NAME"}, ...], "max_attempts": N,
+    /// "liveness_timeout_ms": N}` — each entry may also set `selector`,
+    /// `model`, and `provider_config`, and both `max_attempts` and
+    /// `liveness_timeout_ms` are optional. Edit it directly with `homeboy
+    /// config set /agent_task/rotation <json> --json`.
+    #[arg(long = "set-default")]
+    pub set_default: bool,
 }
 #[derive(Args, Debug)]
 pub struct AgentTaskDoctorArgs {

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -1758,7 +1758,65 @@ pub(crate) fn providers(args: ProvidersArgs) -> CmdResult<Value> {
     } else {
         AgentTaskProviderCatalog::discover()
     };
+    if args.set_default {
+        return write_default_backend_from_readiness(&catalog);
+    }
     providers_with_catalog(args, catalog)
+}
+
+/// Live-probes every declared backend and, when at least one is dispatchable
+/// right now, persists it as `agent_task.default_backend` with the remaining
+/// ready backends recorded as an `agent_task.rotation` fallback chain.
+///
+/// A fresh or reset `agent_task` config (`{}`) offers no default and no
+/// discoverable path back to one short of reading source or an old backup
+/// (#13634). This closes that gap by deriving a working configuration from
+/// what actually authenticates here, rather than only documenting the shape.
+fn write_default_backend_from_readiness(catalog: &AgentTaskProviderCatalog) -> CmdResult<Value> {
+    let ready_backends = dispatchable_backend_choices(catalog, true)
+        .into_iter()
+        .map(|choice| choice.backend)
+        .collect::<Vec<_>>();
+
+    let Some((default_backend, rotation_backends)) = ready_backends.split_first() else {
+        return Err(homeboy::core::Error::validation_invalid_argument(
+            "backend",
+            "cannot set a default backend: no declared backend passed a live readiness probe here",
+            None,
+            Some(vec![
+                "Run `homeboy agent-task providers --validate-readiness` to see why each declared backend is not ready.".to_string(),
+                "Fix credentials/config for at least one backend, then retry `homeboy agent-task providers --set-default`.".to_string(),
+            ]),
+        ));
+    };
+
+    let rotation = if rotation_backends.is_empty() {
+        None
+    } else {
+        Some(serde_json::json!({
+            "entries": rotation_backends
+                .iter()
+                .map(|backend| serde_json::json!({ "backend": backend }))
+                .collect::<Vec<_>>(),
+        }))
+    };
+
+    let mut config = homeboy::core::defaults::load_config();
+    config.agent_task.default_backend = Some(default_backend.clone());
+    config.agent_task.rotation = rotation.clone();
+    homeboy::core::defaults::save_config(&config)?;
+
+    Ok((
+        serde_json::json!({
+            "schema": "homeboy/agent-task-providers-default-written/v1",
+            "written": true,
+            "default_backend": default_backend,
+            "rotation": rotation,
+            "ready_backends": ready_backends,
+            "config_path": homeboy::core::defaults::config_path().ok(),
+        }),
+        0,
+    ))
 }
 
 fn providers_with_catalog(
@@ -3296,6 +3354,7 @@ mod tests {
             catalog: false,
             full: false,
             machine_catalog: false,
+            set_default: false,
         });
 
         assert_eq!(
@@ -3349,6 +3408,7 @@ mod tests {
             catalog: false,
             full: false,
             machine_catalog: false,
+            set_default: false,
         }
     }
 
@@ -3554,6 +3614,95 @@ mod tests {
                 ])
             );
             assert_eq!(validation["validated"], false);
+        });
+    }
+
+    /// The reported defect (#13634): a fresh/reset `agent_task` config (`{}`)
+    /// offers no default and no discoverable path back to one short of
+    /// reading source or an old backup. `--set-default` must derive a working
+    /// `default_backend`/`rotation` from what actually authenticates *right
+    /// now* and persist it, not merely print a suggestion.
+    #[test]
+    fn providers_set_default_writes_default_backend_and_rotation_from_live_readiness() {
+        crate::test_support::with_isolated_home(|_| {
+            // Starts exactly at the reported defect: no default_backend, no
+            // rotation.
+            let before = homeboy::core::defaults::load_config();
+            assert_eq!(before.agent_task.default_backend, None);
+            assert_eq!(before.agent_task.rotation, None);
+
+            let mut alpha = provider("alpha.provider", "alpha");
+            alpha.readiness_invocation = Some(
+                serde_json::from_value(serde_json::json!({
+                    "argv": ["sh", "-c", "cat >/dev/null; printf '%s' '{\"schema\":\"homeboy/agent-task-provider-readiness-result/v1\",\"ready\":true,\"classification\":\"ready\",\"retryable\":false,\"remediation\":\"\",\"reason\":\"\",\"cache_key\":\"test\",\"identity\":{}}'"]
+                }))
+                .expect("alpha readiness invocation"),
+            );
+            let mut zeta = provider("zeta.provider", "zeta");
+            zeta.readiness_invocation = Some(
+                serde_json::from_value(serde_json::json!({
+                    "argv": ["sh", "-c", "cat >/dev/null; printf '%s' '{\"schema\":\"homeboy/agent-task-provider-readiness-result/v1\",\"ready\":true,\"classification\":\"ready\",\"retryable\":false,\"remediation\":\"\",\"reason\":\"\",\"cache_key\":\"test\",\"identity\":{}}'"]
+                }))
+                .expect("zeta readiness invocation"),
+            );
+            // A backend whose declared credential is not configured here —
+            // the shape of a revoked/never-set credential (#11479) — must
+            // never be chosen as the written default.
+            let mut revoked = credential_declaring_provider();
+            revoked.id = "revoked.provider".to_string();
+            revoked.backend = "revoked".to_string();
+
+            let catalog = provider_catalog(vec![alpha, zeta, revoked]);
+            let output = write_default_backend_from_readiness(&catalog)
+                .expect("at least one backend is live-ready")
+                .0;
+
+            assert_eq!(output["written"], true);
+            assert_eq!(output["default_backend"], "alpha");
+            assert_eq!(
+                output["rotation"],
+                serde_json::json!({ "entries": [ { "backend": "zeta" } ] })
+            );
+            assert_eq!(
+                output["ready_backends"],
+                serde_json::json!(["alpha", "zeta"])
+            );
+
+            // The fix must durably repair the config on disk — a printed
+            // suggestion reproduces the reported defect, it does not fix it.
+            let persisted = homeboy::core::defaults::load_config();
+            assert_eq!(
+                persisted.agent_task.default_backend.as_deref(),
+                Some("alpha")
+            );
+            assert_eq!(
+                persisted.agent_task.rotation,
+                Some(serde_json::json!({ "entries": [ { "backend": "zeta" } ] }))
+            );
+        });
+    }
+
+    #[test]
+    fn providers_set_default_fails_closed_and_writes_nothing_when_no_backend_is_ready() {
+        crate::test_support::with_isolated_home(|_| {
+            let mut dead = credential_declaring_provider();
+            dead.id = "dead.provider".to_string();
+            dead.backend = "dead".to_string();
+            let catalog = provider_catalog(vec![dead]);
+
+            let error = write_default_backend_from_readiness(&catalog)
+                .expect_err("no declared backend passes a live readiness probe");
+            assert!(
+                error.message.contains("no declared backend"),
+                "{}",
+                error.message
+            );
+
+            // A written default that cannot dispatch is worse than the
+            // explicit `selection_required` failure it would replace.
+            let after = homeboy::core::defaults::load_config();
+            assert_eq!(after.agent_task.default_backend, None);
+            assert_eq!(after.agent_task.rotation, None);
         });
     }
 

--- a/crates/homeboy-cli/src/commands/agent_task/tests/contract.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/contract.rs
@@ -17,6 +17,7 @@ fn providers_output_includes_core_capability_contract() {
             catalog: false,
             full: false,
             machine_catalog: false,
+            set_default: false,
         })
         .expect("providers output");
 
@@ -66,6 +67,7 @@ fn providers_output_declares_the_scope_it_observed() {
             catalog: false,
             full: false,
             machine_catalog: false,
+            set_default: false,
         });
 
         if let Some(value) = previous {


### PR DESCRIPTION
Fixes #13634

An empty `agent_task` config silently disabled cooking with no default, no init path, and no documented rotation shape. Recovery required finding a months-old backup on disk.

## Changes

```
 .../src/agent_task_dispatch_service.rs             |  16 ++-
 .../agent_task/args/definitions/command.rs         |  23 +++-
 .../homeboy-cli/src/commands/agent_task/review.rs  | 149 +++++++++++++++++++++
 .../src/commands/agent_task/tests/contract.rs      |   2 +
 4 files changed, 188 insertions(+), 2 deletions(-)
```

---

*AI assistance: Claude Sonnet 4.5 via opencode, dispatched as a parallel general coding subagent against this worktree. The agent found the root cause, implemented the fix, added coverage, and ran scoped verification. I filed the issue from an observed failure, reviewed the diff against the merge-base, and corrected commit authorship. CI is the authoritative gate.*
