### PR TITLE
fix(cleanup): seed per-worktree cargo targets instead of sharing one

### DIFF
--- a/crates/homeboy-core/src/cleanup/cargo_targets.rs
+++ b/crates/homeboy-core/src/cleanup/cargo_targets.rs
@@ -316,7 +316,11 @@ fn acquire_managed_cargo_target_for_compatibility(
     // Touch the base store's liveness so it isn't reclaimed as unused while
     // it exists only to seed worktree-private stores, then release it
     // immediately: nothing compiles directly into it any more.
-    drop(acquire_shared_cargo_target_in(&root, &base_owner, SystemTime::now())?);
+    drop(acquire_shared_cargo_target_in(
+        &root,
+        &base_owner,
+        SystemTime::now(),
+    )?);
 
     let canonical_source =
         fs::canonicalize(source_path).unwrap_or_else(|_| source_path.to_path_buf());
@@ -354,7 +358,10 @@ fn seed_worktree_cargo_target(base_dir: &Path, private_dir: &Path) -> Result<Sys
 }
 
 fn shared_store_dir(root: &Path, owner: &str) -> PathBuf {
-    root.join(format!("homeboy-{}", content_hash::sha256_hex(owner.as_bytes())))
+    root.join(format!(
+        "homeboy-{}",
+        content_hash::sha256_hex(owner.as_bytes())
+    ))
 }
 
 fn read_marker_time(path: &Path) -> Option<SystemTime> {

--- a/crates/homeboy-core/src/cleanup/cargo_targets.rs
+++ b/crates/homeboy-core/src/cleanup/cargo_targets.rs
@@ -17,6 +17,7 @@ const LOCK_FILE: &str = ".homeboy-lock";
 const LEASE_FILE: &str = ".homeboy-lease";
 const OWNER_FILE: &str = ".homeboy-owner";
 const LAST_USED_FILE: &str = ".homeboy-last-used-ms";
+const SEED_MARKER_FILE: &str = ".homeboy-seeded-at-ms";
 const LEGACY_LIFECYCLE_INFERRED: &str = "legacy lifecycle metadata inferred";
 static ISOLATED_TARGET_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
@@ -98,6 +99,12 @@ pub struct ManagedCargoTarget {
     target_dir: PathBuf,
     resolution: &'static str,
     owner: String,
+    /// A worktree-private store (see `acquire_managed_cargo_target_for_compatibility`)
+    /// promotes artifacts it produced back to this base store on release, so
+    /// the next worktree provisioned for the same repository identity seeds
+    /// warmer. The `SystemTime` is when this store was seeded from base:
+    /// only files touched since then are new output worth promoting.
+    promote_to: Option<(PathBuf, SystemTime)>,
     _lease: Option<SharedCargoTargetLease>,
 }
 
@@ -134,6 +141,17 @@ impl ManagedCargoTarget {
 
     pub fn size_bytes(&self) -> Result<u64> {
         path_size(&self.target_dir)
+    }
+}
+
+impl Drop for ManagedCargoTarget {
+    fn drop(&mut self) {
+        // Best-effort warmth hand-off: promoting is never a build
+        // correctness requirement, only an optimization for the next
+        // worktree that seeds from this repository identity's base store.
+        if let Some((base_dir, seeded_at)) = self.promote_to.take() {
+            hardlink_tree_since(&self.target_dir, &base_dir, Some(seeded_at));
+        }
     }
 }
 
@@ -216,6 +234,7 @@ pub fn acquire_isolated_cargo_target(
         target_dir: lease.target_dir().to_path_buf(),
         resolution: "isolated",
         owner: owner.to_string(),
+        promote_to: None,
         _lease: Some(lease),
     })
 }
@@ -262,6 +281,24 @@ pub fn acquire_managed_cargo_target_for_environment(
     )
 }
 
+/// Acquire a worktree-private Cargo target seeded from the shared,
+/// repository-identity-keyed base store.
+///
+/// Every worktree compatible with a given repository identity used to
+/// receive the *same* physical target directory: correct for warmth, but
+/// concurrent worktrees compiling into one directory serialize behind
+/// Cargo's own build lock (Cargo issue #6412), so N agents verifying in
+/// parallel cost roughly one build's wall time each, one at a time, rather
+/// than running concurrently.
+///
+/// Instead, each worktree gets its own physical store, keyed by the
+/// repository identity plus its own canonical checkout path, so concurrent
+/// worktrees never contend for the same Cargo lock. A freshly created
+/// worktree store is seeded once from the base store via hard links (an
+/// inode-table update, not a data copy, so it costs no meaningful time or
+/// disk regardless of target size); releasing a worktree store promotes the
+/// artifacts it produced back to base, so the next worktree provisioned
+/// against the same identity seeds warm too.
 fn acquire_managed_cargo_target_for_compatibility(
     owner: &str,
     source_path: &Path,
@@ -272,13 +309,121 @@ fn acquire_managed_cargo_target_for_compatibility(
         return Ok(local_managed_cargo_target(owner, source_path, target));
     }
 
-    let lease = acquire_shared_cargo_target(&format!("{owner}:{}", compatibility.identity()))?;
+    let root = shared_cargo_target_root()?;
+    admit_shared_cargo_target(&root)?;
+    let base_owner = format!("{owner}:{}", compatibility.identity());
+    let base_dir = shared_store_dir(&root, &base_owner);
+    // Touch the base store's liveness so it isn't reclaimed as unused while
+    // it exists only to seed worktree-private stores, then release it
+    // immediately: nothing compiles directly into it any more.
+    drop(acquire_shared_cargo_target_in(&root, &base_owner, SystemTime::now())?);
+
+    let canonical_source =
+        fs::canonicalize(source_path).unwrap_or_else(|_| source_path.to_path_buf());
+    let worktree_owner = format!(
+        "{base_owner}:worktree:{}",
+        canonical_source.to_string_lossy()
+    );
+    let lease = acquire_shared_cargo_target_in(&root, &worktree_owner, SystemTime::now())?;
+    let seeded_at = seed_worktree_cargo_target(&base_dir, lease.target_dir())?;
+
     Ok(ManagedCargoTarget {
         target_dir: lease.target_dir().to_path_buf(),
         resolution: "shared",
         owner: owner.to_string(),
+        promote_to: Some((base_dir, seeded_at)),
         _lease: Some(lease),
     })
+}
+
+/// Seed a freshly created worktree-private Cargo target from the shared base
+/// store once, recorded by a marker so later acquisitions of the same
+/// worktree store (repeat gate/provider runs in one worktree) skip the walk
+/// and simply keep using the store as Cargo left it.
+fn seed_worktree_cargo_target(base_dir: &Path, private_dir: &Path) -> Result<SystemTime> {
+    let marker = private_dir.join(SEED_MARKER_FILE);
+    if let Some(seeded_at) = read_marker_time(&marker) {
+        return Ok(seeded_at);
+    }
+    let seeded_at = SystemTime::now();
+    if base_dir.exists() {
+        hardlink_tree_since(base_dir, private_dir, None);
+    }
+    write_marker_time(&marker, seeded_at)?;
+    Ok(seeded_at)
+}
+
+fn shared_store_dir(root: &Path, owner: &str) -> PathBuf {
+    root.join(format!("homeboy-{}", content_hash::sha256_hex(owner.as_bytes())))
+}
+
+fn read_marker_time(path: &Path) -> Option<SystemTime> {
+    let millis: u64 = fs::read_to_string(path).ok()?.trim().parse().ok()?;
+    Some(UNIX_EPOCH + Duration::from_millis(millis))
+}
+
+fn write_marker_time(path: &Path, time: SystemTime) -> Result<()> {
+    fs::write(
+        path,
+        time.duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+            .to_string(),
+    )
+    .map_err(|error| io_error(error, "write Cargo target seed marker"))
+}
+
+/// Homeboy's own store-lifecycle sidecars. These describe the store, not
+/// Cargo's output, and must never be seeded or promoted between stores.
+fn is_lifecycle_sidecar(name: &std::ffi::OsStr) -> bool {
+    name == LOCK_FILE
+        || name == LEASE_FILE
+        || name == OWNER_FILE
+        || name == LAST_USED_FILE
+        || name == SEED_MARKER_FILE
+}
+
+/// Hard-link every regular file under `from` into `to`, mirroring the
+/// relative directory structure. A destination file that already exists is
+/// left in place (first writer wins), and per-entry errors are tolerated:
+/// seeding and promotion are a warmth optimization, never a build
+/// correctness requirement, and Cargo's own fingerprinting inside the
+/// destination store recompiles anything genuinely missing or stale.
+///
+/// `since`, when set, skips files last modified before that time: seeding
+/// copies an entire base store, but promotion only wants artifacts this
+/// worktree actually produced since it was seeded.
+fn hardlink_tree_since(from: &Path, to: &Path, since: Option<SystemTime>) {
+    let Ok(entries) = fs::read_dir(from) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        if is_lifecycle_sidecar(&name) {
+            continue;
+        }
+        let source = entry.path();
+        let Ok(metadata) = fs::symlink_metadata(&source) else {
+            continue;
+        };
+        let dest = to.join(&name);
+        if metadata.is_dir() && !metadata.file_type().is_symlink() {
+            if fs::create_dir_all(&dest).is_ok() {
+                hardlink_tree_since(&source, &dest, since);
+            }
+            continue;
+        }
+        if let Some(since) = since {
+            let modified = metadata.modified().unwrap_or(UNIX_EPOCH);
+            if modified < since {
+                continue;
+            }
+        }
+        if dest.exists() {
+            continue;
+        }
+        let _ = fs::hard_link(&source, &dest);
+    }
 }
 
 fn local_managed_cargo_target(owner: &str, source_path: &Path, target: &str) -> ManagedCargoTarget {
@@ -292,6 +437,7 @@ fn local_managed_cargo_target(owner: &str, source_path: &Path, target: &str) -> 
         target_dir,
         resolution: "local",
         owner: owner.to_string(),
+        promote_to: None,
         _lease: None,
     }
 }
@@ -427,10 +573,7 @@ pub(crate) fn acquire_shared_cargo_target_in(
     owner: &str,
     now: SystemTime,
 ) -> Result<SharedCargoTargetLease> {
-    let target_dir = root.join(format!(
-        "homeboy-{}",
-        content_hash::sha256_hex(owner.as_bytes())
-    ));
+    let target_dir = shared_store_dir(root, owner);
     fs::create_dir_all(&target_dir)
         .map_err(|error| io_error(error, "create shared Cargo target"))?;
     let lock = OpenOptions::new()
@@ -1156,9 +1299,10 @@ fn path_size(path: &Path) -> Result<u64> {
         let path = entry
             .map_err(|error| io_error(error, "read shared Cargo target entry"))?
             .path();
-        if path.file_name().is_some_and(|name| {
-            name == LOCK_FILE || name == LEASE_FILE || name == OWNER_FILE || name == LAST_USED_FILE
-        }) {
+        if path
+            .file_name()
+            .is_some_and(|name| is_lifecycle_sidecar(name))
+        {
             continue;
         }
         let metadata = fs::symlink_metadata(&path)

--- a/tests/core/extension/component_script_test.rs
+++ b/tests/core/extension/component_script_test.rs
@@ -176,7 +176,10 @@ fn homeboy_manifest_seeds_an_isolated_warm_cargo_target_per_checkout() {
             "printf '%s:%s' \"$HOMEBOY_CARGO_TARGET_RESOLUTION\" \"$CARGO_TARGET_DIR\" > cargo-target",
         ];
         let mut resolved_targets = Vec::new();
-        for (checkout, script) in [primary.path(), worktree.as_path()].into_iter().zip(scripts) {
+        for (checkout, script) in [primary.path(), worktree.as_path()]
+            .into_iter()
+            .zip(scripts)
+        {
             let mut component = manifest.clone();
             component.local_path = checkout.to_string_lossy().to_string();
             component.extensions = None;

--- a/tests/core/extension/component_script_test.rs
+++ b/tests/core/extension/component_script_test.rs
@@ -128,7 +128,7 @@ fn component_config_env_is_available_to_component_scripts_and_extra_env_wins() {
 }
 
 #[test]
-fn homeboy_manifest_preserves_shared_cargo_target_resolution_across_checkouts() {
+fn homeboy_manifest_seeds_an_isolated_warm_cargo_target_per_checkout() {
     with_isolated_home(|_| {
         let manifest = homeboy_manifest();
         assert!(manifest.managed_execution.shared_cargo_target);
@@ -165,8 +165,18 @@ fn homeboy_manifest_preserves_shared_cargo_target_resolution_across_checkouts() 
             .expect("commit divergent fixture");
         assert!(output.status.success());
 
+        // The primary checkout "compiles" first, writing a build artifact
+        // into its managed Cargo target. The worktree's own script never
+        // writes that artifact itself, so if it shows up in the worktree's
+        // resolved target, it can only have arrived by seeding from the
+        // primary's store rather than by the worktree recompiling it.
+        let scripts = [
+            "printf '%s:%s' \"$HOMEBOY_CARGO_TARGET_RESOLUTION\" \"$CARGO_TARGET_DIR\" > cargo-target; \
+             printf 'compiled output' > \"$CARGO_TARGET_DIR/build-artifact\"",
+            "printf '%s:%s' \"$HOMEBOY_CARGO_TARGET_RESOLUTION\" \"$CARGO_TARGET_DIR\" > cargo-target",
+        ];
         let mut resolved_targets = Vec::new();
-        for checkout in [primary.path(), worktree.as_path()] {
+        for (checkout, script) in [primary.path(), worktree.as_path()].into_iter().zip(scripts) {
             let mut component = manifest.clone();
             component.local_path = checkout.to_string_lossy().to_string();
             component.extensions = None;
@@ -176,10 +186,7 @@ fn homeboy_manifest_preserves_shared_cargo_target_resolution_across_checkouts() 
                 .env
                 .insert("CARGO_TARGET_DIR".to_string(), String::new());
             component.scripts = Some(ComponentScriptsConfig {
-                test: vec![
-                    "printf '%s:%s' \"$HOMEBOY_CARGO_TARGET_RESOLUTION\" \"$CARGO_TARGET_DIR\" > cargo-target"
-                        .to_string(),
-                ],
+                test: vec![script.to_string()],
                 ..Default::default()
             });
 
@@ -196,8 +203,33 @@ fn homeboy_manifest_preserves_shared_cargo_target_resolution_across_checkouts() 
                 .push(fs::read_to_string(checkout.join("cargo-target")).expect("resolved target"));
         }
 
-        assert_eq!(resolved_targets[0], resolved_targets[1]);
         assert!(resolved_targets[0].starts_with("shared:"));
+        assert!(resolved_targets[1].starts_with("shared:"));
+        let primary_target = resolved_targets[0]
+            .strip_prefix("shared:")
+            .expect("primary target path");
+        let worktree_target = resolved_targets[1]
+            .strip_prefix("shared:")
+            .expect("worktree target path");
+
+        // A divergent worktree must not receive the literal same physical
+        // Cargo target directory as the primary checkout: two worktrees
+        // compiling concurrently into one directory serialize behind
+        // Cargo's own build lock instead of running in parallel.
+        assert_ne!(
+            primary_target, worktree_target,
+            "each checkout must get its own physical Cargo target directory"
+        );
+
+        // The worktree's target was seeded from the primary's before its own
+        // script ran, so it already carries the primary's build output
+        // without having compiled anything itself: a freshly provisioned
+        // worktree starts warm, not cold.
+        let seeded_artifact = Path::new(worktree_target).join("build-artifact");
+        assert_eq!(
+            fs::read_to_string(&seeded_artifact).expect("worktree target seeded from base"),
+            "compiled output",
+        );
     });
 }
 


### PR DESCRIPTION
Fixes #13642
Also addresses #13643.

Worktrees had no build-cache strategy, so every fresh worktree was a cold compile (~4 min here) — longer than the 120s command timeout agents run under. A 9-agent parallel dispatch had **all 9 killed** at their first `cargo check`. The obvious workaround, one shared `CARGO_TARGET_DIR`, then serialized the fleet behind a single lock (81 recorded stalls).

## Changes

```
 crates/homeboy-core/src/cleanup/cargo_targets.rs | 160 +++++++++++++++++++++--
 tests/core/extension/component_script_test.rs    |  46 ++++++-
 2 files changed, 191 insertions(+), 15 deletions(-)
```

---

*AI assistance: Claude Sonnet 4.5 via opencode, dispatched as a parallel general coding subagent against this worktree. The agent found the root cause, implemented the fix, added coverage, and ran scoped verification. I filed the issue from an observed failure, reviewed the diff against the merge-base, and corrected commit authorship. CI is the authoritative gate.*
