### PR TITLE
fix(git): diff against merge-base instead of a moving branch tip

### DIFF
--- a/crates/homeboy-core/src/git/changes.rs
+++ b/crates/homeboy-core/src/git/changes.rs
@@ -341,13 +341,19 @@ pub fn base_advance_warning(path: &str, baseline_ref: &str) -> Option<String> {
     let merge_base = resolve_merge_base(path, baseline_ref).ok()?;
     let tip_output = execute_git(
         path,
-        &["rev-parse", "--verify", &format!("{baseline_ref}^{{commit}}")],
+        &[
+            "rev-parse",
+            "--verify",
+            &format!("{baseline_ref}^{{commit}}"),
+        ],
     )
     .ok()?;
     if !tip_output.status.success() {
         return None;
     }
-    let tip = String::from_utf8_lossy(&tip_output.stdout).trim().to_string();
+    let tip = String::from_utf8_lossy(&tip_output.stdout)
+        .trim()
+        .to_string();
     if tip == merge_base {
         return None;
     }
@@ -574,7 +580,10 @@ mod tests {
         git(&path, &["commit", "-q", "-m", "unrelated upstream change"]);
         fs::remove_file(dir.path().join("shared.txt")).unwrap();
         git(&path, &["add", "."]);
-        git(&path, &["commit", "-q", "-m", "unrelated upstream deletion"]);
+        git(
+            &path,
+            &["commit", "-q", "-m", "unrelated upstream deletion"],
+        );
 
         // The candidate makes its own, unrelated, intended change.
         git(&path, &["checkout", "-q", "candidate"]);
@@ -616,8 +625,7 @@ mod tests {
 
         git(&path, &["checkout", "-q", "candidate"]);
 
-        let warning =
-            base_advance_warning(&path, "main").expect("warning when base has advanced");
+        let warning = base_advance_warning(&path, "main").expect("warning when base has advanced");
         assert!(
             warning.contains("2 commits"),
             "expected the warning to report the exact advance count: {warning}"

--- a/crates/homeboy-core/src/git/changes.rs
+++ b/crates/homeboy-core/src/git/changes.rs
@@ -309,19 +309,76 @@ pub fn get_diff(path: &str) -> Result<String> {
 }
 
 /// Get diff between baseline ref and HEAD (commit range diff).
+///
+/// Diffs against the merge-base of `baseline_ref` and `HEAD`, not the
+/// literal tip of `baseline_ref`. `baseline_ref` is frequently a branch
+/// (e.g. `origin/main`) rather than an immutable tag, and long-running
+/// work can easily outlive it: if the branch has advanced since the
+/// current work diverged, a literal `baseline_ref..HEAD` diff would
+/// include every commit that landed on `baseline_ref` afterward,
+/// misrepresenting unrelated upstream changes as part of this diff. See
+/// [`base_advance_warning`] for surfacing how far the base has moved.
 pub fn get_range_diff(path: &str, baseline_ref: &str) -> Result<String> {
-    let output = execute_git(
-        path,
-        &["diff", &format!("{}..HEAD", baseline_ref), "--", "."],
-    )
-    .map_err(|e| Error::git_command_failed(e.to_string()))?;
+    let merge_base = resolve_merge_base(path, baseline_ref)?;
+    let output = execute_git(path, &["diff", &format!("{}..HEAD", merge_base), "--", "."])
+        .map_err(|e| Error::git_command_failed(e.to_string()))?;
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Report how far `baseline_ref` has advanced beyond its merge-base with
+/// `HEAD`, i.e. how many commits landed on the base branch after the
+/// current work diverged from it.
+///
+/// Returns `None` when the ref can't be resolved, a merge-base can't be
+/// found, or the ref hasn't moved past the merge-base (it's still an
+/// ancestor of `HEAD`, e.g. an immutable release tag). Returns `Some`
+/// with an operator-facing message when it has, so a reviewer knows a
+/// rebase may be needed before merging — diffs and commit lists computed
+/// against the merge-base reflect only the state at divergence, not
+/// whatever landed on the base branch since.
+pub fn base_advance_warning(path: &str, baseline_ref: &str) -> Option<String> {
+    let merge_base = resolve_merge_base(path, baseline_ref).ok()?;
+    let tip_output = execute_git(
+        path,
+        &["rev-parse", "--verify", &format!("{baseline_ref}^{{commit}}")],
+    )
+    .ok()?;
+    if !tip_output.status.success() {
+        return None;
+    }
+    let tip = String::from_utf8_lossy(&tip_output.stdout).trim().to_string();
+    if tip == merge_base {
+        return None;
+    }
+
+    let count_output = execute_git(
+        path,
+        &["rev-list", "--count", &format!("{merge_base}..{tip}")],
+    )
+    .ok()?;
+    if !count_output.status.success() {
+        return None;
+    }
+    let count: u64 = String::from_utf8_lossy(&count_output.stdout)
+        .trim()
+        .parse()
+        .ok()?;
+    if count == 0 {
+        return None;
+    }
+
+    Some(format!(
+        "'{baseline_ref}' has advanced {count} commit{} beyond the merge-base with HEAD; the commits and diff above reflect only the merge-base, not the moving tip. A rebase may be needed before merging.",
+        if count == 1 { "" } else { "s" }
+    ))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::process::Command;
 
     /// Regression: get_uncommitted_changes runs `git update-index --refresh`
     /// before reading status so stale stat info from upstream tooling
@@ -452,6 +509,138 @@ mod tests {
             .contains(&"untracked name.txt".to_string()));
         assert!(changes.untracked.contains(&"worktree name.txt".to_string()));
         assert!(changes.staged.iter().all(|path| !path.contains(" -> ")));
+    }
+
+    fn init_repo_with_initial_commit(path: &str) {
+        for args in [
+            ["init", "-q", "-b", "main"].as_slice(),
+            ["config", "user.email", "test@example.com"].as_slice(),
+            ["config", "user.name", "Test"].as_slice(),
+        ] {
+            assert!(Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .status()
+                .unwrap()
+                .success());
+        }
+        fs::write(Path::new(path).join("shared.txt"), "shared\n").unwrap();
+        for args in [
+            ["add", "."].as_slice(),
+            ["commit", "-q", "-m", "initial"].as_slice(),
+        ] {
+            assert!(Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .status()
+                .unwrap()
+                .success());
+        }
+    }
+
+    fn git(path: &str, args: &[&str]) {
+        assert!(
+            Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .status()
+                .unwrap()
+                .success(),
+            "git {args:?} failed"
+        );
+    }
+
+    /// Regression for the "moving base branch" bug: a long-running worktree
+    /// diverges from `main`, then `main` advances with unrelated commits
+    /// while the candidate branch keeps working. Diffing the candidate
+    /// against `main`'s literal tip would (incorrectly) include those
+    /// unrelated upstream commits, making the candidate look like it
+    /// deleted/changed things it never touched. Diffing against the
+    /// merge-base must show only the candidate's own change.
+    #[test]
+    fn get_range_diff_ignores_commits_added_to_base_after_divergence() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let path = dir.path().to_str().unwrap().to_string();
+        init_repo_with_initial_commit(&path);
+
+        // Branch the candidate off main before main advances.
+        git(&path, &["checkout", "-q", "-b", "candidate"]);
+
+        // main advances with unrelated commits after the candidate diverged
+        // (simulating other work landing on origin/main during a long cook).
+        git(&path, &["checkout", "-q", "main"]);
+        fs::write(dir.path().join("unrelated.txt"), "unrelated\n").unwrap();
+        git(&path, &["add", "."]);
+        git(&path, &["commit", "-q", "-m", "unrelated upstream change"]);
+        fs::remove_file(dir.path().join("shared.txt")).unwrap();
+        git(&path, &["add", "."]);
+        git(&path, &["commit", "-q", "-m", "unrelated upstream deletion"]);
+
+        // The candidate makes its own, unrelated, intended change.
+        git(&path, &["checkout", "-q", "candidate"]);
+        fs::write(dir.path().join("feature.txt"), "feature\n").unwrap();
+        git(&path, &["add", "."]);
+        git(&path, &["commit", "-q", "-m", "candidate feature"]);
+
+        let diff = get_range_diff(&path, "main").expect("range diff");
+
+        assert!(
+            diff.contains("feature.txt"),
+            "diff must include the candidate's own change: {diff}"
+        );
+        assert!(
+            !diff.contains("unrelated.txt"),
+            "diff must not include files only added to the moving base after divergence: {diff}"
+        );
+        assert!(
+            !diff.contains("shared.txt"),
+            "diff must not include files only deleted on the moving base after divergence: {diff}"
+        );
+    }
+
+    #[test]
+    fn base_advance_warning_reports_how_far_a_moved_base_has_advanced() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let path = dir.path().to_str().unwrap().to_string();
+        init_repo_with_initial_commit(&path);
+
+        git(&path, &["checkout", "-q", "-b", "candidate"]);
+
+        git(&path, &["checkout", "-q", "main"]);
+        fs::write(dir.path().join("a.txt"), "a\n").unwrap();
+        git(&path, &["add", "."]);
+        git(&path, &["commit", "-q", "-m", "advance 1"]);
+        fs::write(dir.path().join("b.txt"), "b\n").unwrap();
+        git(&path, &["add", "."]);
+        git(&path, &["commit", "-q", "-m", "advance 2"]);
+
+        git(&path, &["checkout", "-q", "candidate"]);
+
+        let warning =
+            base_advance_warning(&path, "main").expect("warning when base has advanced");
+        assert!(
+            warning.contains("2 commits"),
+            "expected the warning to report the exact advance count: {warning}"
+        );
+        assert!(
+            warning.contains("rebase"),
+            "expected the warning to hint that a rebase may be needed: {warning}"
+        );
+    }
+
+    #[test]
+    fn base_advance_warning_is_none_when_base_has_not_moved() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let path = dir.path().to_str().unwrap().to_string();
+        init_repo_with_initial_commit(&path);
+
+        git(&path, &["checkout", "-q", "-b", "candidate"]);
+        fs::write(dir.path().join("feature.txt"), "feature\n").unwrap();
+        git(&path, &["add", "."]);
+        git(&path, &["commit", "-q", "-m", "candidate feature"]);
+
+        // main never moved past the point candidate branched from.
+        assert_eq!(base_advance_warning(&path, "main"), None);
     }
 
     #[test]

--- a/crates/homeboy-core/src/git/mod.rs
+++ b/crates/homeboy-core/src/git/mod.rs
@@ -23,8 +23,9 @@ pub mod release_download;
 mod operation_tests;
 
 pub use changes::{
-    discard_worktree_changes, get_diff, get_dirty_files, get_files_changed_since, get_range_diff,
-    get_uncommitted_changes, resolve_merge_base, UncommittedChanges,
+    base_advance_warning, discard_worktree_changes, get_diff, get_dirty_files,
+    get_files_changed_since, get_range_diff, get_uncommitted_changes, resolve_merge_base,
+    UncommittedChanges,
 };
 pub use commits::extract_version_from_tag;
 pub use commits::{

--- a/crates/homeboy-core/src/git/operation_tests.rs
+++ b/crates/homeboy-core/src/git/operation_tests.rs
@@ -312,6 +312,81 @@ fn push_token_requires_github_remote_url() {
     assert!(!err.to_string().contains("secret-token"));
 }
 
+/// Regression: `homeboy release changes --since <branch> --git-diffs`
+/// diffs against the merge-base of the branch and HEAD, not the branch's
+/// literal (possibly-advanced) tip, and warns explicitly when the branch
+/// has moved past the merge-base since the current work diverged from it.
+#[test]
+fn changes_at_since_moving_branch_diffs_against_merge_base_and_warns() {
+    use std::fs;
+    let (dir, path) = init_repo_with_initial_commit();
+
+    Command::new("git")
+        .args(["checkout", "-q", "-b", "candidate"])
+        .current_dir(&path)
+        .status()
+        .unwrap();
+
+    // main advances with an unrelated commit after candidate diverged.
+    Command::new("git")
+        .args(["checkout", "-q", "main"])
+        .current_dir(&path)
+        .status()
+        .unwrap();
+    fs::write(dir.path().join("unrelated.txt"), "unrelated\n").unwrap();
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(&path)
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-q", "-m", "unrelated upstream change"])
+        .current_dir(&path)
+        .status()
+        .unwrap();
+
+    Command::new("git")
+        .args(["checkout", "-q", "candidate"])
+        .current_dir(&path)
+        .status()
+        .unwrap();
+    fs::write(dir.path().join("feature.txt"), "feature\n").unwrap();
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(&path)
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-q", "-m", "candidate feature"])
+        .current_dir(&path)
+        .status()
+        .unwrap();
+
+    let out = changes_at(None, Some("main"), true, Some(&path)).expect("changes_at with --since");
+
+    let diff = out.diff.expect("diff requested via include_diff");
+    assert!(
+        diff.contains("feature.txt"),
+        "diff must include the candidate's own change: {diff}"
+    );
+    assert!(
+        !diff.contains("unrelated.txt"),
+        "diff must not include upstream-only changes from the moving base: {diff}"
+    );
+
+    let warning = out
+        .warning
+        .expect("warning expected when the base has advanced past the merge-base");
+    assert!(
+        warning.contains("advanced"),
+        "expected an explicit moved-base warning: {warning}"
+    );
+    assert!(
+        warning.contains("rebase"),
+        "expected the warning to hint a rebase may be needed: {warning}"
+    );
+}
+
 #[test]
 fn test_short_head_revision_at() {
     let (_dir, path) = init_repo_with_initial_commit();

--- a/crates/homeboy-core/src/git/operations_changes.rs
+++ b/crates/homeboy-core/src/git/operations_changes.rs
@@ -343,6 +343,22 @@ pub fn changes_at(
         None
     };
 
+    // The baseline reference is frequently a branch rather than an
+    // immutable tag (e.g. an explicit `--since origin/main`). If it has
+    // advanced past its merge-base with HEAD since this checkout diverged,
+    // say so explicitly rather than letting the operator discover it only
+    // by noticing an unexpectedly large diff.
+    let advance_warning = baseline
+        .reference
+        .as_deref()
+        .and_then(|r| base_advance_warning(&path, r));
+    let warning = match (baseline.warning, advance_warning) {
+        (Some(existing), Some(advance)) => Some(format!("{existing} {advance}")),
+        (Some(existing), None) => Some(existing),
+        (None, Some(advance)) => Some(advance),
+        (None, None) => None,
+    };
+
     Ok(ChangesOutput {
         component_id: id,
         path,
@@ -354,7 +370,7 @@ pub fn changes_at(
         uncommitted,
         uncommitted_diff,
         diff,
-        warning: baseline.warning,
+        warning,
         error: None,
         changelog: changelog_info,
     })


### PR DESCRIPTION
Fixes #13645

Long cooks outlive their base branch. With `origin/main` advancing 8 commits mid-run, a diff against the branch tip showed a candidate apparently deleting 300+ lines of unrelated code; against the merge-base it was 3 files. I nearly rejected a correct candidate on that basis.

## Changes

```
 crates/homeboy-core/src/git/changes.rs            | 197 +++++++++++++++++++++-
 crates/homeboy-core/src/git/mod.rs                |   5 +-
 crates/homeboy-core/src/git/operation_tests.rs    |  75 ++++++++
 crates/homeboy-core/src/git/operations_changes.rs |  18 +-
 4 files changed, 288 insertions(+), 7 deletions(-)
```

---

*AI assistance: Claude Sonnet 4.5 via opencode, dispatched as a parallel general coding subagent against this worktree. The agent found the root cause, implemented the fix, added coverage, and ran scoped verification. I filed the issue from an observed failure, reviewed the diff against the merge-base, and corrected commit authorship. CI is the authoritative gate.*
