### PR TITLE
fix(worktree): pin commit identity to the target remote's host policy on create

### DIFF
--- a/crates/homeboy-core/src/git/mod.rs
+++ b/crates/homeboy-core/src/git/mod.rs
@@ -387,6 +387,25 @@ pub fn configure_identity(path: &str, identity: &GitIdentity) -> crate::error::R
     Ok(())
 }
 
+/// Resolve the configured commit identity policy for a repository's origin
+/// remote host, if one is declared in `git_hosts` config.
+///
+/// Returns `Ok(None)` when the repository has no usable origin remote host
+/// or no policy is configured for that host — callers should treat this as
+/// "no opinion" rather than an error, matching [`validate_identities`]'s
+/// `*_unrestricted` behavior.
+pub fn resolve_host_identity_policy(path: &str) -> crate::error::Result<Option<GitIdentity>> {
+    let remote = git_config(path, &["config", "--get", "remote.origin.url"])?;
+    let Some(host) = remote_host(&remote) else {
+        return Ok(None);
+    };
+    let config = crate::defaults::load_config();
+    Ok(config.git_hosts.get(&host).map(|expected| GitIdentity {
+        name: expected.name.clone(),
+        email: expected.email.clone(),
+    }))
+}
+
 /// Resolve a (component_id, path) pair for a git operation.
 ///
 /// Resolution order:

--- a/crates/homeboy-core/src/worktree/store_ops.rs
+++ b/crates/homeboy-core/src/worktree/store_ops.rs
@@ -165,6 +165,23 @@ fn cleanup_skip_reasons(safety: &WorktreeSafetyReport, force: bool) -> Vec<Strin
     reasons
 }
 
+/// Pin the repository-local commit identity in a freshly materialized
+/// worktree to whatever the target remote's host policy declares, instead of
+/// leaving it to fall back to whatever ambient `~/.gitconfig` identity the
+/// provisioning environment happens to carry (#13647). Linked worktrees share
+/// their source checkout's repository config, so this also corrects the
+/// identity used by any sibling worktree of the same remote going forward.
+///
+/// A no-op when no policy is configured for the remote's host — Homeboy does
+/// not invent an identity, it only pins one that is already declared.
+fn pin_worktree_identity(worktree_path: &Path) -> Result<()> {
+    let path = worktree_path.to_string_lossy();
+    if let Some(identity) = git::resolve_host_identity_policy(&path)? {
+        git::configure_identity(&path, &identity)?;
+    }
+    Ok(())
+}
+
 pub(super) fn create_with_store(
     options: WorktreeCreateOptions,
     store_dir: &Path,
@@ -297,6 +314,7 @@ fn create_with_store_unlocked(
             true,
             "git worktree add",
         )?;
+        pin_worktree_identity(&worktree_path)?;
         let current = create_evidence(&record, "registered".to_string())?;
         return Ok(WorktreeCreateOutput {
             record,
@@ -323,6 +341,7 @@ fn create_with_store_unlocked(
         "git worktree add",
     )?;
     ownership::normalize_created_path(&worktree_path, worktree_owner, true, "git worktree add")?;
+    pin_worktree_identity(&worktree_path)?;
 
     let mut record = TaskWorktreeRecord {
         id,

--- a/crates/homeboy-core/src/worktree/tests.rs
+++ b/crates/homeboy-core/src/worktree/tests.rs
@@ -396,6 +396,75 @@ fn create_returns_existing_matching_task_worktree_idempotently() {
     });
 }
 
+/// #13647: worktree provisioning inherited whatever ambient global Git
+/// identity happened to be configured in the surrounding environment,
+/// instead of the identity the target remote's host actually requires. A
+/// commit made in a freshly created task worktree therefore carried the
+/// wrong author. Creation must pin the repository-local identity declared
+/// for the remote's host up front, so agent-authored commits carry the
+/// right author without anyone remembering to check.
+#[test]
+fn create_pins_worktree_identity_to_the_target_remotes_host_policy() {
+    crate::test_support::with_isolated_home(|home| {
+        let (source, options) = registered_create_fixture(home.path(), "identity-fixture");
+        run_git(
+            &source,
+            &[
+                "remote",
+                "add",
+                "origin",
+                "git@github-extrachill.example.test:extra-chill/homeboy.git",
+            ],
+        );
+
+        let mut config = crate::defaults::HomeboyConfig::default();
+        config.git_hosts.insert(
+            "github-extrachill.example.test".to_string(),
+            crate::defaults::GitHostConfig {
+                name: "Extra Chill Author".to_string(),
+                email: "author@extrachill.example.test".to_string(),
+            },
+        );
+        crate::defaults::save_config(&config).expect("save git host identity policy");
+
+        // Simulate the ambient identity a shared provisioning environment can
+        // inherit from an unrelated organization's global gitconfig (#13647).
+        run_git(home.path(), &["config", "--global", "user.name", "Chris Huber"]);
+        run_git(
+            home.path(),
+            &["config", "--global", "user.email", "chris.huber@automattic.com"],
+        );
+
+        let created = create(options).expect("create task worktree");
+        let path = PathBuf::from(&created.record.worktree_path);
+
+        assert_eq!(
+            git::run_git(&path, &["config", "user.name"], "git config user.name")
+                .unwrap()
+                .trim(),
+            "Extra Chill Author"
+        );
+        assert_eq!(
+            git::run_git(&path, &["config", "user.email"], "git config user.email")
+                .unwrap()
+                .trim(),
+            "author@extrachill.example.test"
+        );
+
+        // The reported defect is the *committed* author, not just config
+        // plumbing: make a commit in the new worktree and check it end to end.
+        fs::write(path.join("task.txt"), "task\n").unwrap();
+        run_git(&path, &["add", "."]);
+        run_git(&path, &["commit", "-q", "-m", "task work"]);
+        let author = git::run_git(&path, &["log", "-1", "--format=%an <%ae>"], "git log author")
+            .unwrap();
+        assert_eq!(
+            author.trim(),
+            "Extra Chill Author <author@extrachill.example.test>"
+        );
+    });
+}
+
 #[test]
 fn create_reuses_existing_worktree_with_a_relative_gitdir_pointer() {
     crate::test_support::with_isolated_home(|home| {

--- a/crates/homeboy-core/src/worktree/tests.rs
+++ b/crates/homeboy-core/src/worktree/tests.rs
@@ -429,10 +429,18 @@ fn create_pins_worktree_identity_to_the_target_remotes_host_policy() {
 
         // Simulate the ambient identity a shared provisioning environment can
         // inherit from an unrelated organization's global gitconfig (#13647).
-        run_git(home.path(), &["config", "--global", "user.name", "Chris Huber"]);
         run_git(
             home.path(),
-            &["config", "--global", "user.email", "chris.huber@automattic.com"],
+            &["config", "--global", "user.name", "Chris Huber"],
+        );
+        run_git(
+            home.path(),
+            &[
+                "config",
+                "--global",
+                "user.email",
+                "chris.huber@automattic.com",
+            ],
         );
 
         let created = create(options).expect("create task worktree");
@@ -456,8 +464,12 @@ fn create_pins_worktree_identity_to_the_target_remotes_host_policy() {
         fs::write(path.join("task.txt"), "task\n").unwrap();
         run_git(&path, &["add", "."]);
         run_git(&path, &["commit", "-q", "-m", "task work"]);
-        let author = git::run_git(&path, &["log", "-1", "--format=%an <%ae>"], "git log author")
-            .unwrap();
+        let author = git::run_git(
+            &path,
+            &["log", "-1", "--format=%an <%ae>"],
+            "git log author",
+        )
+        .unwrap();
         assert_eq!(
             author.trim(),
             "Extra Chill Author <author@extrachill.example.test>"


### PR DESCRIPTION
Fixes #13647

Task worktrees inherited ambient git identity, so agent-authored commits landed under the wrong author for the target remote. Observed live: commits to an Extra-Chill repo authored as `chris.huber@automattic.com`.

## Changes

```
 crates/homeboy-core/src/git/mod.rs            | 19 ++++++++
 crates/homeboy-core/src/worktree/store_ops.rs | 19 ++++++++
 crates/homeboy-core/src/worktree/tests.rs     | 69 +++++++++++++++++++++++++++
 3 files changed, 107 insertions(+)
```

---

*AI assistance: Claude Sonnet 4.5 via opencode, dispatched as a parallel general coding subagent against this worktree. The agent found the root cause, implemented the fix, added coverage, and ran scoped verification. I filed the issue from an observed failure, reviewed the diff against the merge-base, and corrected commit authorship. CI is the authoritative gate.*
