### PR TITLE
fix(agent-task): contain deterministic gate process trees

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -18,6 +18,8 @@ use homeboy_core::gate::{
 use homeboy_core::plan::{PlanStep, PlanStepStatus, PlanValues};
 use homeboy_core::{Error, Result};
 
+use crate::agent_task_process_containment::AgentTaskProcessContainment;
+
 // `Skipped` is a new durable terminal state with a structured blocker. Keep it
 // out of v1 so typed consumers can distinguish the expanded state machine.
 pub const AGENT_TASK_GATE_REPORT_SCHEMA: &str = "homeboy/agent-task-gate-report/v3";
@@ -1333,7 +1335,13 @@ mod baseline_tests {
         failure_fingerprint, run_gate_command_with_timeout, AgentTaskGateEnvironmentPolicy,
         AgentTaskGateRevealPolicy, AgentTaskGateStatus, AgentTaskGateVisibility,
     };
+    #[cfg(unix)]
+    use std::path::PathBuf;
+    #[cfg(unix)]
+    use std::process::{Command, Stdio};
     use std::time::Duration;
+    #[cfg(unix)]
+    use std::time::Instant;
 
     #[test]
     fn matching_baseline_failure_is_distinct_from_a_new_failure() {
@@ -1423,6 +1431,99 @@ mod baseline_tests {
             !homeboy_engine_primitives::command::process_is_running(descendant_pid as u32),
             "bounded baseline gate left descendant {descendant_pid} runnable"
         );
+    }
+
+    /// Re-exec target for [`killing_the_gate_controller_reaps_its_background_descendant`].
+    /// Runs a deterministic gate whose command backgrounds a SIGTERM-ignoring
+    /// descendant and then blocks on it, standing in for an agent process that
+    /// is mid-gate (e.g. running `cargo test -p ... --lib`) when it is killed.
+    /// Only runs under the env var the parent test sets; a bare `cargo test`
+    /// invocation of the full suite exercises this as a no-op.
+    #[cfg(unix)]
+    #[test]
+    fn gate_process_containment_worker() {
+        let Ok(dir) = std::env::var("HOMEBOY_GATE_CONTAINMENT_WORKER_DIR") else {
+            return;
+        };
+        let dir = PathBuf::from(dir);
+        let pid_file = dir.join("descendant.pid");
+        let _ = run_gate_command_with_timeout(
+            &dir,
+            1,
+            &format!(
+                "sh -c 'trap \"\" TERM; while :; do sleep 1; done' & echo $! > '{}'; wait",
+                pid_file.display()
+            ),
+            AgentTaskGateVisibility::Visible,
+            AgentTaskGateRevealPolicy::FullEvidence,
+            &dir,
+            Duration::from_secs(30),
+            &AgentTaskGateEnvironmentPolicy::default(),
+            &[],
+        );
+    }
+
+    /// The #13649 regression: an agent gets killed (operator `kill -9`, OOM,
+    /// supervisor teardown) while a deterministic gate it launched is still
+    /// running. Before containment, the gate's `sh -lc` leader and whatever
+    /// build/test tooling it spawned were reparented to init and kept running
+    /// — and kept holding the shared cargo build lock — because nothing was
+    /// left alive to signal them. This drives that exact scenario through a
+    /// real OS process (not just an in-process drop) so the assertion is that
+    /// the reported orphan survives or does not, not that a particular type
+    /// gets constructed.
+    #[cfg(unix)]
+    #[test]
+    fn killing_the_gate_controller_reaps_its_background_descendant() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let pid_file = temp.path().join("descendant.pid");
+        let test_binary = std::env::current_exe().expect("test binary path");
+        let mut worker = Command::new(&test_binary)
+            .args([
+                "--exact",
+                "agent_task_gate::baseline_tests::gate_process_containment_worker",
+            ])
+            .env(
+                "HOMEBOY_GATE_CONTAINMENT_WORKER_DIR",
+                temp.path().as_os_str(),
+            )
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("start gate containment worker");
+
+        let start_deadline = Instant::now() + Duration::from_secs(10);
+        while !pid_file.exists() {
+            assert!(
+                Instant::now() < start_deadline,
+                "gate containment worker never started its background descendant"
+            );
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        let descendant_pid = std::fs::read_to_string(&pid_file)
+            .expect("descendant pid")
+            .trim()
+            .parse::<libc::pid_t>()
+            .expect("numeric descendant pid");
+        assert!(
+            homeboy_engine_primitives::command::process_is_running(descendant_pid as u32),
+            "descendant must still be running for this test to prove anything"
+        );
+
+        // The kill an operator or OOM issues: it lands on the agent process
+        // (here, the worker), not on the gate's descendants. The worker gets
+        // no chance to run its own cleanup — that is the entire point.
+        worker.kill().expect("kill gate containment worker");
+        worker.wait().expect("reap gate containment worker");
+
+        let reaped_deadline = Instant::now() + Duration::from_secs(10);
+        while homeboy_engine_primitives::command::process_is_running(descendant_pid as u32) {
+            assert!(
+                Instant::now() < reaped_deadline,
+                "descendant {descendant_pid} survived its controller being killed"
+            );
+            std::thread::sleep(Duration::from_millis(25));
+        }
     }
 }
 
@@ -1533,17 +1634,28 @@ pub(crate) fn run_gate_command_with_supervision(
     selected_environment.configure_cargo_target(cwd, gate_environment.shared_cargo_target)?;
     selected_environment.report.package_artifacts = package_artifacts;
     selected_environment.apply(&mut process);
-    if supervision.is_some() {
-        if !homeboy_core::engine::command::supports_process_tree_isolation() {
-            return Err(Error::validation_invalid_argument(
-                "gate_supervision",
-                "durable gate cancellation requires Unix process-group isolation on this host",
-                None,
-                None,
-            ));
-        }
-        homeboy_core::engine::command::isolate_process_tree(&mut process);
+    if supervision.is_some() && !homeboy_core::engine::command::supports_process_tree_isolation() {
+        return Err(Error::validation_invalid_argument(
+            "gate_supervision",
+            "durable gate cancellation requires Unix process-group isolation on this host",
+            None,
+            None,
+        ));
     }
+    // Every deterministic gate is contained the same way regardless of
+    // whether the caller supervises it: the gate spawns build/test tooling
+    // (`cargo test -p ... --lib` and friends) that outlives a plain
+    // `Command::spawn`. Without a process group of its own and a controller-
+    // death guard, killing the agent process that is running this gate
+    // (operator `kill -9`, OOM, supervisor teardown) leaves that tooling
+    // reparented to init and holding the shared cargo build/artifact lock
+    // indefinitely (#13649).
+    let mut containment = AgentTaskProcessContainment::prepare(&mut process).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("contain deterministic gate {command}")),
+        )
+    })?;
     let target_started = Instant::now();
     let mut child = process.spawn().map_err(|error| {
         Error::internal_io(
@@ -1551,11 +1663,16 @@ pub(crate) fn run_gate_command_with_supervision(
             Some(format!("run deterministic gate {command}")),
         )
     })?;
+    if let Err(error) = containment.attach(&child) {
+        let _ = containment.terminate_live(&mut child);
+        return Err(Error::internal_io(
+            error.to_string(),
+            Some(format!("guard deterministic gate {command}")),
+        ));
+    }
     let (output, termination) = if let Some(supervision) = supervision {
         if let Err(error) = (supervision.on_spawn)(child.id(), command) {
-            if let Err(cleanup_error) =
-                homeboy_core::engine::command::terminate_process_tree_and_reap(&mut child)
-            {
+            if let Err(cleanup_error) = containment.terminate_live(&mut child) {
                 return Err(Error::internal_io(
                     format!(
                         "durable gate registration failed ({error}); failed to terminate and reap its child: {cleanup_error}"
@@ -1620,6 +1737,11 @@ pub(crate) fn run_gate_command_with_supervision(
             homeboy_core::engine::command::SupervisedCommandTermination::Completed,
         )
     };
+    // The wait loops above already reap survivors once they observe the
+    // leader exit; this is the belt-and-suspenders reap for every remaining
+    // return path (including the ones below that can still error out before
+    // the report is built).
+    let _ = containment.reap_after_exit();
     let termination = match termination {
         homeboy_core::engine::command::SupervisedCommandTermination::Completed => {
             AgentTaskGateTermination::Completed
@@ -1715,7 +1837,15 @@ pub(crate) fn run_gate_command_with_timeout(
     selected_environment.configure_cargo_target(cwd, gate_environment.shared_cargo_target)?;
     selected_environment.report.package_artifacts = package_artifacts;
     selected_environment.apply(&mut process);
-    homeboy_core::engine::command::isolate_process_tree(&mut process);
+    // See the matching comment in `run_gate_command_with_supervision`: this
+    // gate spawns build/test tooling that must not outlive an agent process
+    // killed out from under it (#13649).
+    let mut containment = AgentTaskProcessContainment::prepare(&mut process).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!("contain bounded deterministic gate {command}")),
+        )
+    })?;
     let target_started = Instant::now();
     let mut child = process.spawn().map_err(|error| {
         Error::internal_io(
@@ -1723,6 +1853,13 @@ pub(crate) fn run_gate_command_with_timeout(
             Some(format!("run bounded deterministic gate {command}")),
         )
     })?;
+    if let Err(error) = containment.attach(&child) {
+        let _ = containment.terminate_live(&mut child);
+        return Err(Error::internal_io(
+            error.to_string(),
+            Some(format!("guard bounded deterministic gate {command}")),
+        ));
+    }
     let started = std::time::Instant::now();
     let mut timed_out = false;
     let output = homeboy_core::engine::command::wait_with_bounded_output_until_cancelled(
@@ -1739,6 +1876,7 @@ pub(crate) fn run_gate_command_with_timeout(
             Some(format!("run bounded deterministic gate {command}")),
         )
     })?;
+    let _ = containment.reap_after_exit();
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let mut stderr = String::from_utf8_lossy(&output.stderr).to_string();
     let runner_exit_code = if timed_out {


### PR DESCRIPTION
Fixes #13649

Killing an agent left its spawned build processes running, reparented to `launchd`, holding the cargo lock indefinitely. Three orphans aged 2h15m, 1h44m and 1h31m starved five healthy agents behind them — invisibly. Killing the orphans unblocked the fleet instantly.

## Changes

```
 crates/homeboy-agents/src/agent_task_gate.rs | 166 ++++++++++++++++++++++++---
 1 file changed, 152 insertions(+), 14 deletions(-)
```

---

*AI assistance: Claude Sonnet 4.5 via opencode, dispatched as a parallel general coding subagent against this worktree. The agent found the root cause, implemented the fix, added coverage, and ran scoped verification. I filed the issue from an observed failure, reviewed the diff against the merge-base, and corrected commit authorship. CI is the authoritative gate.*
