### PR TITLE
fix(agents): skip provider rotation entries known to be over their usage cap (#13644)

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_provider.rs
@@ -58,6 +58,7 @@ mod runtime_types;
 mod secret_types;
 mod secrets;
 mod types;
+mod usage_cap;
 mod workspace_types;
 
 #[cfg(test)]
@@ -117,6 +118,10 @@ pub use secrets::{
 pub(crate) use types::wildcard_match;
 pub use types::*;
 use types::{default_metadata, is_empty_metadata};
+pub use usage_cap::{
+    detect_usage_cap, provider_usage_cap_key, reset_at_from_outcome, ProviderUsageCapRegistry,
+    AGENT_TASK_PROVIDER_USAGE_CAP_DIAGNOSTIC_CLASS,
+};
 pub use workspace_types::*;
 
 // AgentTaskProviderRunnerSource lives in the below-core contract (core reads its

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -418,6 +418,7 @@ fn classify_provider_policy_denial(
 fn classify_transient_provider_outcome(outcome: &mut AgentTaskOutcome) {
     if outcome_text_is_rate_limited(outcome) {
         outcome.failure_classification = Some(AgentTaskFailureClassification::RateLimited);
+        annotate_usage_cap(outcome);
         return;
     }
     let already_transient =
@@ -440,6 +441,38 @@ fn classify_transient_provider_outcome(outcome: &mut AgentTaskOutcome) {
     if outcome_text_is_transient(outcome) {
         outcome.failure_classification = Some(AgentTaskFailureClassification::Transient);
     }
+}
+
+/// Attach a [`super::usage_cap::AGENT_TASK_PROVIDER_USAGE_CAP_DIAGNOSTIC_CLASS`]
+/// diagnostic naming the reset time when the outcome text carries a usage-cap
+/// signature the scheduler's rotation-skip logic can act on (#13644). A
+/// generic rate-limit failure without a recognizable usage-cap reset stays a
+/// plain `RateLimited` classification, unchanged.
+fn annotate_usage_cap(outcome: &mut AgentTaskOutcome) {
+    let now = chrono::Utc::now();
+    let reset_at = outcome
+        .summary
+        .as_deref()
+        .and_then(|text| super::usage_cap::detect_usage_cap(text, now))
+        .or_else(|| {
+            outcome.diagnostics.iter().find_map(|diagnostic| {
+                super::usage_cap::detect_usage_cap(&diagnostic.message, now).or_else(|| {
+                    super::usage_cap::detect_usage_cap(&diagnostic.data.to_string(), now)
+                })
+            })
+        });
+    let Some(reset_at) = reset_at else {
+        return;
+    };
+    push_unique_diagnostic(
+        &mut outcome.diagnostics,
+        super::usage_cap::AGENT_TASK_PROVIDER_USAGE_CAP_DIAGNOSTIC_CLASS.to_string(),
+        format!(
+            "provider usage cap reached; resets at {}",
+            reset_at.to_rfc3339()
+        ),
+        json!({ "reset_at": reset_at.to_rfc3339() }),
+    );
 }
 
 fn outcome_text_is_rate_limited(outcome: &AgentTaskOutcome) -> bool {
@@ -519,6 +552,8 @@ pub(super) fn is_rate_limited_provider_error(text: &str) -> bool {
         "provider quota",
         "quota exceeded",
         "exceeded your quota",
+        "usage limit",
+        "usage cap",
     ]
     .iter()
     .any(|pattern| lowered.contains(pattern))

--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -1771,3 +1771,66 @@ fn plan_runtime_preflight_skips_provider_without_declared_checks() {
     enforce_runtime_preflight_checks_for_plan_with_providers(&plan, &[provider])
         .expect("provider without declared checks is a no-op");
 }
+
+#[test]
+fn a_flat_rate_usage_limit_is_classified_rate_limited_and_carries_its_reset_time() {
+    // #13644: "5-hour usage limit reached. Resets in 3hr 3min." (opencode-go)
+    // is not a generic rate-limit blip Homeboy should retry blindly — it is a
+    // known, temporary cap with a computable reset time rotation can act on.
+    let command = format!(
+        "node {}",
+        script(&format!(
+            "process.stdout.write(JSON.stringify({{schema:'{AGENT_TASK_OUTCOME_SCHEMA}',task_id:'task-usage-cap',status:'provider_error',summary:'5-hour usage limit reached. Resets in 3hr 3min.'}}));"
+        ))
+    );
+    let (request, provider) = request("task-usage-cap", command);
+
+    let outcome = run_provider_command(&request, &provider, None);
+
+    assert_eq!(
+        outcome.failure_classification,
+        Some(AgentTaskFailureClassification::RateLimited)
+    );
+    let diagnostic = outcome
+        .diagnostics
+        .iter()
+        .find(|diagnostic| {
+            diagnostic.class
+                == crate::agent_task_provider::AGENT_TASK_PROVIDER_USAGE_CAP_DIAGNOSTIC_CLASS
+        })
+        .expect("usage-cap diagnostic naming the reset time");
+    let reset_at = diagnostic.data["reset_at"]
+        .as_str()
+        .expect("reset_at string")
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .expect("reset_at is a valid RFC3339 timestamp");
+    assert!(
+        reset_at > chrono::Utc::now(),
+        "the reported reset time must be in the future relative to when the cap was observed"
+    );
+}
+
+#[test]
+fn a_bare_rate_limit_without_a_recognizable_usage_cap_reset_stays_plain_rate_limited() {
+    // A generic 429 with no reset-time signature is still `RateLimited` for
+    // retry/rotation purposes, but there is no known reset time to skip
+    // rotation entries against, so no usage-cap diagnostic is attached.
+    let command = format!(
+        "node {}",
+        script(&format!(
+            "process.stdout.write(JSON.stringify({{schema:'{AGENT_TASK_OUTCOME_SCHEMA}',task_id:'task-bare-429',status:'provider_error',summary:'429 Too Many Requests'}}));"
+        ))
+    );
+    let (request, provider) = request("task-bare-429", command);
+
+    let outcome = run_provider_command(&request, &provider, None);
+
+    assert_eq!(
+        outcome.failure_classification,
+        Some(AgentTaskFailureClassification::RateLimited)
+    );
+    assert!(!outcome.diagnostics.iter().any(|diagnostic| {
+        diagnostic.class
+            == crate::agent_task_provider::AGENT_TASK_PROVIDER_USAGE_CAP_DIAGNOSTIC_CLASS
+    }));
+}

--- a/crates/homeboy-agents/src/agent_task_provider/usage_cap.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/usage_cap.rs
@@ -1,0 +1,243 @@
+//! Provider usage caps: a distinct, temporary provider state carrying a known
+//! reset time.
+//!
+//! A flat-rate provider (`opencode-go`, `zai-coding-plan`, ...) that has hit
+//! its rolling usage window is not unhealthy, misconfigured, or lacking
+//! credentials — its credentials still resolve, so plain readiness reports it
+//! `ready`. Without this module, provider rotation has no way to tell a
+//! capped provider apart from a healthy one, so a large fanout keeps
+//! re-dispatching to it and burns a provider execution per task just to
+//! rediscover the same cap (#13644).
+//!
+//! This module owns two things:
+//! - detecting a usage-cap signature (plus its reset time) in provider output
+//!   text, and
+//! - an explicit, caller-owned registry recording which provider routes are
+//!   presently capped, mirroring `ProviderRuntimeReadinessCache`: a caller
+//!   creates one instance per scope (a plan's live dispatch loop, a batch
+//!   preflight) and threads it through so siblings share what one task's
+//!   failure already taught Homeboy, instead of each spending its own
+//!   execution to relearn it.
+
+use chrono::{DateTime, TimeZone, Utc};
+use regex::Regex;
+use std::collections::BTreeMap;
+use std::sync::OnceLock;
+
+use crate::agent_task::AgentTaskOutcome;
+
+/// Diagnostic class attached to an outcome when Homeboy detects a provider
+/// usage cap in its output. Distinct from the generic rate-limit text match
+/// so the reset time is legible in run diagnostics rather than buried in a
+/// free-text summary.
+pub const AGENT_TASK_PROVIDER_USAGE_CAP_DIAGNOSTIC_CLASS: &str = "agent_task.provider_usage_cap";
+
+/// The registry key identifying one rotation-selectable provider route. A
+/// rotation entry pins exactly this identity (backend + selector), so caps
+/// are recorded and consulted at the same granularity rotation dispatches at.
+pub fn provider_usage_cap_key(backend: &str, selector: Option<&str>) -> String {
+    match selector
+        .map(str::trim)
+        .filter(|selector| !selector.is_empty())
+    {
+        Some(selector) => format!("{backend}::{selector}"),
+        None => backend.to_string(),
+    }
+}
+
+/// Providers Homeboy has learned are presently over their usage cap, plus the
+/// instant each is expected to reset.
+///
+/// Explicit and caller-owned rather than global: a plan's live dispatch loop
+/// and a batch preflight each create their own instance so unrelated runs
+/// cannot leak cap state into each other, matching the existing
+/// `ProviderRuntimeReadinessCache` pattern.
+#[derive(Debug, Default, Clone)]
+pub struct ProviderUsageCapRegistry {
+    capped: BTreeMap<String, DateTime<Utc>>,
+}
+
+impl ProviderUsageCapRegistry {
+    /// Record (or extend) a usage cap for `key`. A later, later-resetting
+    /// observation wins; an earlier reset time already recorded is not
+    /// clobbered by a stale re-observation.
+    pub fn record(&mut self, key: impl Into<String>, reset_at: DateTime<Utc>) {
+        let key = key.into();
+        match self.capped.get(&key) {
+            Some(existing) if *existing >= reset_at => {}
+            _ => {
+                self.capped.insert(key, reset_at);
+            }
+        }
+    }
+
+    /// The still-active reset time for `key`, or `None` when unrecorded or
+    /// the recorded reset time has already passed. A passed cap is treated as
+    /// lifted rather than requiring an explicit prune pass.
+    pub fn active(&self, key: &str, now: DateTime<Utc>) -> Option<DateTime<Utc>> {
+        self.capped
+            .get(key)
+            .filter(|reset_at| **reset_at > now)
+            .copied()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.capped.is_empty()
+    }
+}
+
+/// Read the reset time Homeboy already attached to an outcome via
+/// [`AGENT_TASK_PROVIDER_USAGE_CAP_DIAGNOSTIC_CLASS`], if any.
+pub fn reset_at_from_outcome(outcome: &AgentTaskOutcome) -> Option<DateTime<Utc>> {
+    outcome
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.class == AGENT_TASK_PROVIDER_USAGE_CAP_DIAGNOSTIC_CLASS)
+        .and_then(|diagnostic| diagnostic.data.get("reset_at"))
+        .and_then(serde_json::Value::as_str)
+        .and_then(|reset_at| DateTime::parse_from_rfc3339(reset_at).ok())
+        .map(|reset_at| reset_at.with_timezone(&Utc))
+}
+
+fn usage_cap_phrase_regex() -> &'static Regex {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    PATTERN.get_or_init(|| {
+        Regex::new(r"(?i)usage[ _-]?(?:limit|cap)").expect("static usage-cap phrase regex")
+    })
+}
+
+fn relative_reset_regex() -> &'static Regex {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    PATTERN.get_or_init(|| {
+        Regex::new(
+            r"(?i)resets?\s+in\s+(?:(\d+)\s*h(?:ou)?r[s]?)?\s*,?\s*(?:(\d+)\s*min(?:ute)?[s]?)?",
+        )
+        .expect("static relative reset regex")
+    })
+}
+
+fn absolute_reset_regex() -> &'static Regex {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    PATTERN.get_or_init(|| {
+        Regex::new(r"(?i)resets?\s+at\s+(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2})")
+            .expect("static absolute reset regex")
+    })
+}
+
+/// Detect a usage-cap signature in provider output text and compute its reset
+/// time relative to `now`.
+///
+/// Requires both a usage-limit/usage-cap phrase and a parseable reset time:
+/// the phrase alone is not distinct enough evidence to skip a provider route,
+/// and a bare reset time without the phrase is not evidence of a cap at all.
+///
+/// Supports the two reset formats providers were observed emitting (#13644):
+/// - relative: "Resets in 3hr 3min."
+/// - absolute: "Resets at 2026-08-27 12:37:03." (treated as UTC; providers do
+///   not consistently name a timezone in this text)
+pub fn detect_usage_cap(text: &str, now: DateTime<Utc>) -> Option<DateTime<Utc>> {
+    if !usage_cap_phrase_regex().is_match(text) {
+        return None;
+    }
+    if let Some(captures) = absolute_reset_regex().captures(text) {
+        let raw = captures.get(1)?.as_str().replace(' ', "T");
+        let naive = chrono::NaiveDateTime::parse_from_str(&raw, "%Y-%m-%dT%H:%M:%S").ok()?;
+        return Some(Utc.from_utc_datetime(&naive));
+    }
+    if let Some(captures) = relative_reset_regex().captures(text) {
+        let hours: i64 = captures
+            .get(1)
+            .and_then(|value| value.as_str().parse().ok())
+            .unwrap_or(0);
+        let minutes: i64 = captures
+            .get(2)
+            .and_then(|value| value.as_str().parse().ok())
+            .unwrap_or(0);
+        if hours == 0 && minutes == 0 {
+            return None;
+        }
+        return Some(now + chrono::Duration::hours(hours) + chrono::Duration::minutes(minutes));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn now() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 8, 27, 9, 34, 0)
+            .single()
+            .unwrap()
+    }
+
+    #[test]
+    fn detects_a_relative_reset_window() {
+        let reset_at = detect_usage_cap("5-hour usage limit reached. Resets in 3hr 3min.", now())
+            .expect("relative reset parsed");
+        assert_eq!(
+            reset_at,
+            now() + chrono::Duration::hours(3) + chrono::Duration::minutes(3)
+        );
+    }
+
+    #[test]
+    fn detects_an_absolute_reset_timestamp() {
+        let reset_at = detect_usage_cap(
+            "Usage limit reached for 5 hour. Resets at 2026-08-27 12:37:03.",
+            now(),
+        )
+        .expect("absolute reset parsed");
+        assert_eq!(
+            reset_at,
+            Utc.with_ymd_and_hms(2026, 8, 27, 12, 37, 3)
+                .single()
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn a_bare_rate_limit_without_the_usage_cap_phrase_is_not_a_cap() {
+        assert!(detect_usage_cap("429 too many requests, try again shortly", now()).is_none());
+    }
+
+    #[test]
+    fn a_usage_cap_phrase_without_a_parseable_reset_time_is_not_recorded() {
+        assert!(detect_usage_cap("daily usage limit reached", now()).is_none());
+    }
+
+    #[test]
+    fn registry_reports_active_only_before_the_reset_time_passes() {
+        let mut registry = ProviderUsageCapRegistry::default();
+        let key = provider_usage_cap_key("zai-coding-plan", None);
+        let reset_at = now() + chrono::Duration::hours(1);
+        registry.record(&key, reset_at);
+
+        assert_eq!(registry.active(&key, now()), Some(reset_at));
+        assert_eq!(
+            registry.active(&key, reset_at + chrono::Duration::seconds(1)),
+            None
+        );
+        assert_eq!(registry.active("other-backend", now()), None);
+    }
+
+    #[test]
+    fn registry_key_includes_the_selector_when_present() {
+        assert_eq!(provider_usage_cap_key("opencode-go", None), "opencode-go");
+        assert_eq!(
+            provider_usage_cap_key("opencode-go", Some("secondary")),
+            "opencode-go::secondary"
+        );
+    }
+
+    #[test]
+    fn registry_keeps_the_later_reset_time_and_does_not_regress_on_a_stale_observation() {
+        let mut registry = ProviderUsageCapRegistry::default();
+        let key = provider_usage_cap_key("opencode-go", None);
+        let later = now() + chrono::Duration::hours(2);
+        registry.record(&key, later);
+        registry.record(&key, now() + chrono::Duration::minutes(5));
+
+        assert_eq!(registry.active(&key, now()), Some(later));
+    }
+}

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -7,6 +7,7 @@ use std::time::Instant;
 
 use crate::agent_task_service::DerivedCookBaselineCapability;
 
+use super::scheduling::UsageCapSkip;
 use super::*;
 
 /// Authoritative execution adapter consumed by the agent-task scheduler.
@@ -265,6 +266,11 @@ impl AgentTaskScheduler {
             .collect();
         let mut running: Vec<RunningTask> = Vec::new();
         let mut quarantined: Vec<QuarantinedTask> = Vec::new();
+        // Providers this run has already learned are over their usage cap,
+        // plus the reset time each carried. Shared across every task in this
+        // plan so a fanout sibling skips a known-capped rotation entry
+        // instead of spending its own execution rediscovering it (#13644).
+        let mut usage_caps = crate::agent_task_provider::ProviderUsageCapRegistry::default();
         let mut outcomes = recovered_outcomes;
         let mut completed_by_task: HashMap<String, AgentTaskOutcome> = outcomes
             .iter()
@@ -487,7 +493,42 @@ impl AgentTaskScheduler {
                     });
                     break;
                 };
-                let scheduled = queued.remove(next_index).expect("queued task");
+                let mut scheduled = queued.remove(next_index).expect("queued task");
+                let rotation_policy_for_skip =
+                    AgentTaskScheduleSupport::rotation_policy_for_request(
+                        &scheduled.request,
+                        plan_rotation.as_ref(),
+                    );
+                let usage_cap_skips = AgentTaskScheduleSupport::skip_capped_rotation_entries(
+                    &mut scheduled,
+                    rotation_policy_for_skip.as_ref(),
+                    &usage_caps,
+                    chrono::Utc::now(),
+                );
+                for skip in &usage_cap_skips {
+                    events.push(event(
+                        &scheduled.request.task_id,
+                        AgentTaskState::Queued,
+                        scheduled.attempt,
+                        Some(format!(
+                            "provider usage cap active: backend={} (selector={}) resets at {}; skipping without spending an attempt",
+                            skip.backend,
+                            skip.selector.as_deref().unwrap_or("<default>"),
+                            skip.reset_at.to_rfc3339(),
+                        )),
+                    ));
+                }
+                if usage_cap_skips.last().is_some_and(|skip| skip.exhausted) {
+                    let outcome = usage_cap_exhausted_outcome(&scheduled, &usage_cap_skips);
+                    events.push(event(
+                        &scheduled.request.task_id,
+                        AgentTaskState::Failed,
+                        scheduled.attempt,
+                        outcome.summary.clone(),
+                    ));
+                    record_completed_outcome(&mut completed_by_task, &mut outcomes, outcome);
+                    continue;
+                }
                 let mut request = scheduled.request;
                 if let Some(services) = services.as_ref() {
                     services.bind_into(&mut request.inputs, &mut request.metadata);
@@ -950,6 +991,20 @@ impl AgentTaskScheduler {
                     // late artifacts to this exact execution before selecting a
                     // recoverable candidate for promotion.
                     finalize_candidate_artifacts(&mut outcome, &running_task);
+                    // Learn a usage cap this attempt surfaced so a later task
+                    // in this same plan skips the same capped route instead of
+                    // spending its own execution rediscovering it (#13644).
+                    if let Some(reset_at) =
+                        crate::agent_task_provider::reset_at_from_outcome(&outcome)
+                    {
+                        usage_caps.record(
+                            crate::agent_task_provider::provider_usage_cap_key(
+                                &running_task.request.executor.backend,
+                                running_task.request.executor.selector.as_deref(),
+                            ),
+                            reset_at,
+                        );
+                    }
                     // A fingerprinted, non-empty patch is a durable candidate.
                     // Let Cook admit and gate it before spending another full
                     // implementation-provider budget. Independent candidate
@@ -1933,6 +1988,48 @@ fn scratch_allocation_failure(task_id: String, error: String) -> AgentTaskOutcom
             class: "agent_task.controller_scratch_allocation_failed".to_string(),
             message: error,
             data: serde_json::Value::Null,
+        }],
+        ..Default::default()
+    }
+}
+
+/// Terminal outcome for a task whose entire reachable rotation chain is
+/// presently over its usage cap. Built without ever dispatching a provider,
+/// so no attempt is spent chasing a provider Homeboy already knows will
+/// refuse the request (#13644). The diagnostic names every skipped entry and
+/// the earliest reset time so the reason for the failure is legible without
+/// spelunking provider output.
+fn usage_cap_exhausted_outcome(
+    scheduled: &ScheduledTask,
+    skipped: &[UsageCapSkip],
+) -> AgentTaskOutcome {
+    let earliest_reset_at = skipped
+        .iter()
+        .map(|skip| skip.reset_at)
+        .min()
+        .unwrap_or_else(chrono::Utc::now);
+    AgentTaskOutcome {
+        task_id: scheduled.request.task_id.clone(),
+        status: AgentTaskOutcomeStatus::Failed,
+        summary: Some(format!(
+            "every configured provider rotation entry is presently over its usage cap; earliest reset at {}",
+            earliest_reset_at.to_rfc3339()
+        )),
+        failure_classification: Some(AgentTaskFailureClassification::RateLimited),
+        diagnostics: vec![AgentTaskDiagnostic {
+            class: "agent_task.provider_usage_cap_exhausted".to_string(),
+            message: format!(
+                "no rotation entry is dispatchable; earliest usage-cap reset at {}",
+                earliest_reset_at.to_rfc3339()
+            ),
+            data: serde_json::json!({
+                "earliest_reset_at": earliest_reset_at.to_rfc3339(),
+                "skipped": skipped.iter().map(|skip| serde_json::json!({
+                    "backend": skip.backend,
+                    "selector": skip.selector,
+                    "reset_at": skip.reset_at.to_rfc3339(),
+                })).collect::<Vec<_>>(),
+            }),
         }],
         ..Default::default()
     }

--- a/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
@@ -30,6 +30,17 @@ use super::*;
 
 pub(crate) struct AgentTaskScheduleSupport;
 
+/// One rotation entry `skip_capped_rotation_entries` bypassed because Homeboy
+/// already knew its provider was over its usage cap. `exhausted` marks the
+/// final skip when no further rotation entry remains to try.
+#[derive(Debug, Clone)]
+pub(crate) struct UsageCapSkip {
+    pub(crate) backend: String,
+    pub(crate) selector: Option<String>,
+    pub(crate) reset_at: chrono::DateTime<chrono::Utc>,
+    pub(crate) exhausted: bool,
+}
+
 fn deferred_timeout_outcome(task_id: &str, timeout_ms: u64, source: &str) -> AgentTaskOutcome {
     AgentTaskOutcome {
         task_id: task_id.to_string(),
@@ -1364,6 +1375,60 @@ impl AgentTaskScheduleSupport {
         if request.limits.liveness_timeout_ms.is_none() {
             request.limits.liveness_timeout_ms = policy.liveness_timeout_ms;
         }
+    }
+
+    /// Advance a scheduled task past any rotation entries whose provider
+    /// Homeboy already knows is over its usage cap this run, so a fanout
+    /// sibling (or a later task in this same plan) does not spend a provider
+    /// execution rediscovering a cap another task already paid to learn
+    /// (#13644).
+    ///
+    /// A task with no rotation policy is returned unchanged: there is nothing
+    /// configured to fail over to, so existing single-attempt behavior is
+    /// preserved exactly. When every rotation entry reachable from the
+    /// task's current position is presently capped, the last skip's
+    /// `exhausted` flag is set so the caller can fail the task without
+    /// dispatching a provider already known to refuse it.
+    pub(super) fn skip_capped_rotation_entries(
+        scheduled: &mut ScheduledTask,
+        policy: Option<&AgentTaskProviderRotationPolicy>,
+        usage_caps: &crate::agent_task_provider::ProviderUsageCapRegistry,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Vec<UsageCapSkip> {
+        let mut skipped = Vec::new();
+        let Some(policy) = policy else {
+            return skipped;
+        };
+        loop {
+            let key = crate::agent_task_provider::provider_usage_cap_key(
+                &scheduled.request.executor.backend,
+                scheduled.request.executor.selector.as_deref(),
+            );
+            let Some(reset_at) = usage_caps.active(&key, now) else {
+                break;
+            };
+            let backend = scheduled.request.executor.backend.clone();
+            let selector = scheduled.request.executor.selector.clone();
+            if scheduled.rotation_index >= policy.entries.len() {
+                skipped.push(UsageCapSkip {
+                    backend,
+                    selector,
+                    reset_at,
+                    exhausted: true,
+                });
+                break;
+            }
+            skipped.push(UsageCapSkip {
+                backend,
+                selector,
+                reset_at,
+                exhausted: false,
+            });
+            let entry = &policy.entries[scheduled.rotation_index];
+            Self::apply_rotation_entry(&mut scheduled.request, entry, policy);
+            scheduled.rotation_index += 1;
+        }
+        skipped
     }
 
     /// Evidence record for one dispatch attempt under a rotation policy.

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
@@ -29,6 +29,48 @@ mod provider_rotation_tests {
         returns_patch: bool,
     }
 
+    /// Executor that reproduces the #13644 repro shape: the primary backend
+    /// ("test") is presently over its usage cap and reports that as a
+    /// `RateLimited` outcome carrying the usage-cap diagnostic Homeboy's
+    /// provider layer attaches (`annotate_usage_cap`); the rotation fallback
+    /// backend is healthy. Records every dispatched `(task_id, backend)` pair
+    /// so a test can prove a later task in the same plan skips the
+    /// already-known-capped backend entirely instead of spending an attempt
+    /// rediscovering it.
+    struct UsageCapAwareExecutor {
+        observed: Arc<Mutex<Vec<(String, String)>>>,
+        reset_at: chrono::DateTime<chrono::Utc>,
+    }
+
+    impl AgentTaskExecutorAdapter for UsageCapAwareExecutor {
+        fn execute(
+            &self,
+            request: AgentTaskRequest,
+            _context: AgentTaskExecutionContext,
+        ) -> AgentTaskOutcome {
+            self.observed
+                .lock()
+                .expect("observed requests")
+                .push((request.task_id.clone(), request.executor.backend.clone()));
+            if request.executor.backend == "test" {
+                let mut result = outcome(request.task_id, AgentTaskOutcomeStatus::ProviderError);
+                result.failure_classification = Some(AgentTaskFailureClassification::RateLimited);
+                result.diagnostics.push(AgentTaskDiagnostic {
+                    class:
+                        crate::agent_task_provider::AGENT_TASK_PROVIDER_USAGE_CAP_DIAGNOSTIC_CLASS
+                            .to_string(),
+                    message: format!(
+                        "provider usage cap reached; resets at {}",
+                        self.reset_at.to_rfc3339()
+                    ),
+                    data: json!({ "reset_at": self.reset_at.to_rfc3339() }),
+                });
+                return result;
+            }
+            outcome(request.task_id, AgentTaskOutcomeStatus::Succeeded)
+        }
+    }
+
     impl AgentTaskExecutorAdapter for ProviderReportedRotationExecutor {
         fn execute(
             &self,
@@ -1026,5 +1068,159 @@ mod provider_rotation_tests {
             .message
             .as_deref()
             .is_some_and(|message| { message.contains("provider rotation") })));
+    }
+
+    #[test]
+    fn a_later_task_skips_a_provider_usage_cap_learned_earlier_in_the_same_plan() {
+        // #13644: a flat-rate provider hitting its 5-hour usage cap is not
+        // unhealthy or misconfigured; it is temporarily out of quota until a
+        // known reset time. Once one task in a plan learns that, a fanout
+        // sibling must not spend its own attempt rediscovering the same cap —
+        // it should skip straight to the next rotation entry.
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let reset_at = chrono::Utc::now() + chrono::Duration::hours(1);
+        let scheduler = AgentTaskScheduler::new(Arc::new(UsageCapAwareExecutor {
+            observed: Arc::clone(&observed),
+            reset_at,
+        }));
+        let mut plan = plan_with_tasks(2);
+        // Force sequential dispatch so task-2 starts only after task-1's
+        // rotation has taught the scheduler about the cap.
+        plan.options.max_concurrency = 1;
+        plan.options.rotation = Some(rotation_policy(vec![entry("fallback-backend-a")]));
+        enable_rotation(&mut plan);
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+        assert_eq!(aggregate.totals.succeeded, 2);
+
+        let observed = observed.lock().expect("observed requests");
+        let backends_for = |task_id: &str| -> Vec<String> {
+            observed
+                .iter()
+                .filter(|(observed_task_id, _)| observed_task_id == task_id)
+                .map(|(_, backend)| backend.clone())
+                .collect()
+        };
+        assert_eq!(
+            backends_for("task-1"),
+            vec!["test".to_string(), "fallback-backend-a".to_string()],
+            "task-1 discovers the cap firsthand and rotates past it"
+        );
+        assert_eq!(
+            backends_for("task-2"),
+            vec!["fallback-backend-a".to_string()],
+            "task-2 must skip the already-known-capped primary backend entirely, \
+             spending no attempt rediscovering it"
+        );
+        assert!(aggregate.events.iter().any(|event| {
+            event.task_id == "task-2"
+                && event
+                    .message
+                    .as_deref()
+                    .is_some_and(|message| message.contains("provider usage cap active"))
+                && event
+                    .message
+                    .as_deref()
+                    .is_some_and(|message| message.contains("backend=test"))
+        }));
+    }
+
+    #[test]
+    fn a_task_fails_fast_when_every_reachable_rotation_entry_is_presently_capped() {
+        // #13644: when there is nowhere left to rotate to because every
+        // reachable entry is already known to be over its usage cap, Homeboy
+        // must fail the task without ever dispatching a provider already known
+        // to refuse the request.
+        struct AlwaysCappedExecutor {
+            calls: Arc<AtomicUsize>,
+            reset_at: chrono::DateTime<chrono::Utc>,
+            observed: Arc<Mutex<Vec<(String, String)>>>,
+        }
+
+        impl AgentTaskExecutorAdapter for AlwaysCappedExecutor {
+            fn execute(
+                &self,
+                request: AgentTaskRequest,
+                _context: AgentTaskExecutionContext,
+            ) -> AgentTaskOutcome {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                self.observed
+                    .lock()
+                    .expect("observed")
+                    .push((request.task_id.clone(), request.executor.backend.clone()));
+                let mut result = outcome(request.task_id, AgentTaskOutcomeStatus::ProviderError);
+                result.failure_classification = Some(AgentTaskFailureClassification::RateLimited);
+                result.diagnostics.push(AgentTaskDiagnostic {
+                    class:
+                        crate::agent_task_provider::AGENT_TASK_PROVIDER_USAGE_CAP_DIAGNOSTIC_CLASS
+                            .to_string(),
+                    message: format!(
+                        "provider usage cap reached; resets at {}",
+                        self.reset_at.to_rfc3339()
+                    ),
+                    data: json!({ "reset_at": self.reset_at.to_rfc3339() }),
+                });
+                result
+            }
+        }
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let reset_at = chrono::Utc::now() + chrono::Duration::hours(1);
+        let scheduler = AgentTaskScheduler::new(Arc::new(AlwaysCappedExecutor {
+            calls: Arc::clone(&calls),
+            reset_at,
+            observed: Arc::clone(&observed),
+        }));
+        // Three sequential tasks: between them, the first two genuinely
+        // dispatch to (and thereby cap) both the primary backend and the
+        // single rotation entry, in whichever order the scheduler's rotation
+        // requeueing happens to interleave with. By the third task, both
+        // routes are known-capped no matter that interleaving, so its
+        // dispatch is unambiguous: it must skip both and never call the
+        // executor at all.
+        let mut plan = plan_with_tasks(3);
+        plan.options.max_concurrency = 1;
+        plan.options.rotation = Some(rotation_policy(vec![entry("fallback-backend-a")]));
+        enable_rotation(&mut plan);
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Failed);
+        // task-1 and task-2 between them pay to learn both the primary and
+        // the fallback are capped; task-3 then has nowhere left to rotate to
+        // and must not dispatch at all.
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        let observed_for = |task_id: &str| -> usize {
+            observed
+                .lock()
+                .expect("observed requests")
+                .iter()
+                .filter(|(observed_task_id, _)| observed_task_id == task_id)
+                .count()
+        };
+        assert_eq!(
+            observed_for("task-3"),
+            0,
+            "task-3 must not spend an attempt on a route both prior tasks already learned is capped"
+        );
+        let task_3_outcome = aggregate
+            .outcomes
+            .iter()
+            .find(|outcome| outcome.task_id == "task-3")
+            .expect("task-3 outcome");
+        assert!(task_3_outcome
+            .diagnostics
+            .iter()
+            .any(|diagnostic| { diagnostic.class == "agent_task.provider_usage_cap_exhausted" }));
+        assert!(aggregate.events.iter().any(|event| {
+            event.task_id == "task-3"
+                && event
+                    .message
+                    .as_deref()
+                    .is_some_and(|message| message.contains("provider usage cap active"))
+        }));
     }
 }


### PR DESCRIPTION
Fixes #13644

Provider rotation had no concept of a usage cap. Both flat-rate entries in my rotation hit 5-hour limits mid-session (`opencode-go` and `zai-coding-plan`), but readiness still reported them `ready` because credentials resolved fine — so rotation kept selecting them and burning attempts against providers that could not answer until a known future timestamp.

A capped provider is not unhealthy or misconfigured; it is temporarily out of quota with a known reset time, and that is now a state the system can express.

## Changes

```
 crates/homeboy-agents/src/agent_task_provider.rs   |   5 +
 .../src/agent_task_provider/command_runner.rs      |  35 +++
 .../agent_task_provider/tests/scheduler_tests.rs   |  63 ++++++
 .../src/agent_task_provider/usage_cap.rs           | 243 +++++++++++++++++++++
 .../src/agent_task_scheduler/engine.rs             |  99 ++++++++-
 .../src/agent_task_scheduler/scheduling.rs         |  65 ++++++
 .../tests/scheduling_tests/provider_rotation.rs    | 196 +++++++++++++++++
 7 files changed, 705 insertions(+), 1 deletion(-)
```

---

*AI assistance: Claude Sonnet 4.5 via opencode, dispatched as a parallel general coding subagent. The agent found the root cause, implemented the fix, added coverage, and ran scoped verification. I filed the issue after hitting both caps during a 9-agent dispatch, reviewed the diff against the merge-base, and corrected commit authorship. CI is the authoritative gate.*
