### PR TITLE
Terminalize orphaned Lab staging dispatch jobs

### DIFF
--- a/crates/homeboy-agents/src/api_jobs_terminal_recovery.rs
+++ b/crates/homeboy-agents/src/api_jobs_terminal_recovery.rs
@@ -9,7 +9,9 @@ use homeboy_core::api_jobs::agent_task_terminal_recovery::{
     recovered_terminal_job, register_agent_task_terminal_recovery_provider,
     AgentTaskTerminalRecoveryProvider,
 };
-use homeboy_core::api_jobs::{JobArtifactMetadata, JobStatus, RecoveredTerminalJob};
+use homeboy_core::api_jobs::{
+    DaemonLinkedDurableRunState, JobArtifactMetadata, JobStatus, RecoveredTerminalJob,
+};
 
 use crate::agent_task_scheduler::AgentTaskAggregateStatus;
 use crate::agent_task_service;
@@ -60,6 +62,15 @@ impl AgentTaskTerminalRecoveryProvider for AgentTaskTerminalRecoveryProviderImpl
             run_id,
             artifacts,
         ))
+    }
+
+    fn linked_durable_run_state(&self, run_id: &str) -> Option<DaemonLinkedDurableRunState> {
+        let record = crate::agent_task_lifecycle::status(run_id).ok()?;
+        if record.state.is_terminal() {
+            Some(DaemonLinkedDurableRunState::Terminal)
+        } else {
+            Some(DaemonLinkedDurableRunState::Active)
+        }
     }
 }
 

--- a/crates/homeboy-core/src/api_jobs/agent_task_terminal_recovery.rs
+++ b/crates/homeboy-core/src/api_jobs/agent_task_terminal_recovery.rs
@@ -13,18 +13,30 @@
 use serde_json::Value;
 
 use super::store::RecoveredTerminalJob;
+use super::types::DaemonLinkedDurableRunState;
 
 /// Resolves a durable agent-task run's terminal outcome into a recovered job.
 pub trait AgentTaskTerminalRecoveryProvider: Send + Sync {
     /// Recover the terminal job for the durable agent-task `run_id`, or `None`
     /// when the run has no terminal result.
     fn recovered_terminal_agent_task_job(&self, run_id: &str) -> Option<RecoveredTerminalJob>;
+
+    /// Classify a linked durable run for replacement evidence. `None` means
+    /// the run cannot be resolved at all, which stays fail-closed.
+    fn linked_durable_run_state(&self, run_id: &str) -> Option<DaemonLinkedDurableRunState> {
+        (self.recovered_terminal_agent_task_job(run_id).is_some())
+            .then_some(DaemonLinkedDurableRunState::Terminal)
+    }
 }
 
 struct NoopProvider;
 
 impl AgentTaskTerminalRecoveryProvider for NoopProvider {
     fn recovered_terminal_agent_task_job(&self, _run_id: &str) -> Option<RecoveredTerminalJob> {
+        None
+    }
+
+    fn linked_durable_run_state(&self, _run_id: &str) -> Option<DaemonLinkedDurableRunState> {
         None
     }
 }
@@ -44,6 +56,12 @@ homeboy_engine_primitives::provider_registry! {
 /// provider (or none when the agent-task subsystem is absent).
 pub(crate) fn recovered_terminal_agent_task_job(run_id: &str) -> Option<RecoveredTerminalJob> {
     with_provider(|p| p.recovered_terminal_agent_task_job(run_id))
+}
+
+/// Classify a linked durable run via the registered provider, or `None` when
+/// no provider can resolve the run.
+pub(crate) fn linked_durable_run_state(run_id: &str) -> Option<DaemonLinkedDurableRunState> {
+    with_provider(|p| p.linked_durable_run_state(run_id))
 }
 
 /// Build a [`RecoveredTerminalJob`] from its parts. Used by the agent-task

--- a/crates/homeboy-core/src/api_jobs/store/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/store/mod.rs
@@ -16,9 +16,9 @@ use super::persistence::read_durable_store;
 use super::persistence::reconcile_stale_jobs;
 use super::persistence::{
     apply_event_retention, compact_terminal_jobs, job_not_found, lookup_tombstone,
-    prepare_tombstone_store, timestamp_ms, tombstone_store_report, validate_transition,
-    write_durable_store_with_tombstones, JobStoreCompactionEvidence, ReplayTombstoneKind,
-    DEFAULT_EVENT_RETENTION_LIMIT, DEFAULT_TERMINAL_JOB_RETENTION_BYTES,
+    prepare_tombstone_store, recovered_terminal_from_result, timestamp_ms, tombstone_store_report,
+    validate_transition, write_durable_store_with_tombstones, JobStoreCompactionEvidence,
+    ReplayTombstoneKind, DEFAULT_EVENT_RETENTION_LIMIT, DEFAULT_TERMINAL_JOB_RETENTION_BYTES,
     DEFAULT_TERMINAL_JOB_RETENTION_LIMIT,
 };
 use super::remote_runner;
@@ -126,6 +126,13 @@ pub(crate) struct ControllerJobState {
     /// Driver-owned safe projection exposed in the queued event and API logs.
     pub(crate) public_request: Value,
     pub(crate) request_digest: String,
+    /// The controller-minted durable run this job executes for, declared by
+    /// the driver from its typed request and persisted at admission — before
+    /// any driver work can escape the daemon lifecycle. Recovery reconciles
+    /// this job from the linked run's terminal state without parsing the
+    /// opaque request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) linked_durable_run_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) checkpoint: Option<Value>,
     #[serde(default)]
@@ -2999,8 +3006,8 @@ impl RecoveredTerminalJob {
 }
 
 /// The controller-minted `durable_run_id` a stored job was enqueued for, from
-/// whichever runner-lifecycle carries it (remote-runner request or local-runner
-/// direct-daemon offload).
+/// whichever runner-lifecycle carries it (remote-runner request, local-runner
+/// direct-daemon offload, or a driver-declared controller-job linkage).
 fn stored_job_durable_run_id(stored: &StoredJob) -> Option<String> {
     stored
         .remote_runner
@@ -3013,30 +3020,66 @@ fn stored_job_durable_run_id(stored: &StoredJob) -> Option<String> {
                 .and_then(|local| local.lifecycle.as_ref())
         })
         .and_then(|lifecycle| lifecycle.durable_run_id.clone())
+        .or_else(|| {
+            stored
+                .controller_job
+                .as_ref()
+                .and_then(|controller| controller.linked_durable_run_id.as_deref())
+                .map(str::trim)
+                .map(str::to_string)
+        })
         .filter(|run_id| !run_id.trim().is_empty())
 }
 
 /// A remote runner workload records its agent-task run ID in a typed execution
-/// envelope. That durable run is authoritative after the runner child exits.
+/// envelope, and a controller job declares its linked durable run at
+/// admission. That durable run is authoritative once the owning execution
+/// cannot be observed in process.
 fn recovered_terminal_agent_task_result(stored: &StoredJob) -> Option<RecoveredTerminalJob> {
-    // Extract the durable agent-task run id from the (opaque) workload; the
-    // agent-task terminal-recovery hook resolves it into a recovered job so the
-    // job store does not depend on the agent-task subsystem.
+    // Extract the durable agent-task run id from the (opaque) workload or the
+    // driver-declared controller linkage; the agent-task terminal-recovery
+    // hook resolves it into a recovered job so the job store does not depend
+    // on the agent-task subsystem.
     let run_id = stored
         .remote_runner
-        .as_ref()?
-        .request
-        .lab_runner_workload
-        .as_ref()?
-        .agent_task
-        .as_ref()?
-        .run_id
-        .trim()
-        .to_string();
-    if run_id.is_empty() {
-        return None;
-    }
+        .as_ref()
+        .and_then(|remote| remote.request.lab_runner_workload.as_ref())
+        .and_then(|workload| workload.agent_task.as_ref())
+        .map(|agent_task| agent_task.run_id.trim().to_string())
+        .or_else(|| {
+            stored
+                .controller_job
+                .as_ref()
+                .and_then(|controller| controller.linked_durable_run_id.as_deref())
+                .map(str::trim)
+                .map(str::to_string)
+        })
+        .filter(|run_id| !run_id.is_empty())?;
     super::agent_task_terminal_recovery::recovered_terminal_agent_task_job(&run_id)
+}
+
+/// Durable terminal evidence for one active job: either its own event log
+/// already recorded a terminal result, or its linked durable run terminalized.
+/// Both prove no workload remains without inspecting or altering live
+/// children, so replacement gates may reconcile on them without an operator
+/// attestation.
+fn recovered_terminal_agent_task_evidence(stored: &StoredJob) -> Option<RecoveredTerminalJob> {
+    if let Some((status, exit_code)) = recovered_terminal_from_result(&stored.events) {
+        let terminal_result = stored
+            .events
+            .iter()
+            .rev()
+            .find(|event| event.kind == JobEventKind::Result)
+            .and_then(|event| event.data.clone())
+            .unwrap_or_else(|| serde_json::json!({ "status": status, "exit_code": exit_code }));
+        return Some(RecoveredTerminalJob::new(
+            status,
+            terminal_result,
+            stored_job_durable_run_id(stored).unwrap_or_else(|| stored.job.id.to_string()),
+            Vec::new(),
+        ));
+    }
+    recovered_terminal_agent_task_result(stored)
 }
 
 impl JobHandle {

--- a/crates/homeboy-core/src/api_jobs/store/reconciliation.rs
+++ b/crates/homeboy-core/src/api_jobs/store/reconciliation.rs
@@ -60,7 +60,10 @@ impl JobStore {
 
     /// Read active-job recovery evidence without reconciling or persisting jobs.
     /// Typed local-child identity is authoritative; legacy progress payloads are
-    /// intentionally not used to infer ownership.
+    /// intentionally not used to infer ownership. A linked durable run that is
+    /// already terminal is durable terminal evidence: it proves no workload for
+    /// that job remains, so the job is classified reconcilable instead of
+    /// blocking-ambiguous.
     pub fn active_daemon_job_recovery_evidence(
         &self,
         current_lease_id: Option<&str>,
@@ -77,6 +80,15 @@ impl JobStore {
                 }
                 let terminal_evidence =
                     recovered_terminal_from_result(&stored.events).map(|(status, _)| status);
+                let linked_durable_run_id = stored_job_durable_run_id(stored);
+                let linked_terminal = linked_durable_run_id.as_deref().and_then(
+                    super::super::agent_task_terminal_recovery::recovered_terminal_agent_task_job,
+                );
+                let linked_durable_run_state = linked_durable_run_id
+                    .as_deref()
+                    .and_then(super::super::agent_task_terminal_recovery::linked_durable_run_state);
+                let terminal_evidence = terminal_evidence
+                    .or_else(|| linked_terminal.as_ref().map(|recovered| recovered.status));
                 let child_pid = stored
                     .local_child
                     .as_ref()
@@ -112,9 +124,11 @@ impl JobStore {
                     terminal_evidence,
                     child_pid,
                     child_started_at: None,
-                    linked_durable_run_id: None,
-                    linked_durable_run_state: None,
-                    linked_durable_run_terminal_status: None,
+                    linked_durable_run_id,
+                    linked_durable_run_state,
+                    linked_durable_run_terminal_status: linked_terminal
+                        .as_ref()
+                        .map(|recovered| recovered.status),
                     disposition,
                 })
             })
@@ -396,13 +410,15 @@ impl JobStore {
         })
     }
 
-    /// Reconcile only jobs whose linked durable run has already reached a
-    /// terminal state. This deliberately does not inspect, stop, or alter live
-    /// children, so it is safe when a daemon's aggregate count includes both
-    /// stale handoffs and genuine work.
+    /// Reconcile only active jobs whose durable terminal evidence proves no
+    /// workload remains: their linked durable run already reached a terminal
+    /// state, or their own event log recorded a terminal result. This
+    /// deliberately does not inspect, stop, or alter live children, so it is
+    /// safe when a daemon's aggregate count includes both stale handoffs and
+    /// genuine work.
     pub fn reconcile_terminal_linked_daemon_jobs(&self) -> Result<Vec<Uuid>> {
         self.reconcile_terminal_linked_daemon_jobs_with_resolver(
-            recovered_terminal_agent_task_result,
+            recovered_terminal_agent_task_evidence,
         )
     }
 

--- a/crates/homeboy-core/src/api_jobs/tests/part_b.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_b.rs
@@ -140,6 +140,170 @@ fn terminal_linked_reconciliation_preserves_live_jobs_and_is_idempotent() {
     );
 }
 
+/// Admit one `controller.lab.staging-dispatch` job, optionally linked to a
+/// durable agent-task run exactly as the Lab driver declares at admission.
+fn admitted_staging_dispatch(store: &JobStore, linked_durable_run_id: Option<&str>) -> Uuid {
+    let outcome = store
+        .admit_controller_job(
+            "controller.lab.staging-dispatch".to_string(),
+            format!("lab-staging-{}", Uuid::new_v4()),
+            ControllerJobState {
+                job_type: "lab.staging-dispatch".to_string(),
+                version: 1,
+                request: json!({ "schema": "homeboy/lab-staging-dispatch/v1" }),
+                public_request: json!({ "schema": "homeboy/lab-staging-dispatch/v1" }),
+                request_digest: format!("digest-{}", Uuid::new_v4()),
+                linked_durable_run_id: linked_durable_run_id.map(str::to_string),
+                checkpoint: None,
+                cancellation_requested: false,
+                cancellation_reason: None,
+                execution_claim_id: None,
+                recovery_attempted: false,
+            },
+        )
+        .expect("admit staging dispatch");
+    let ControllerJobSubmissionOutcome::Submitted(job_id) = outcome else {
+        panic!("unique staging dispatch submission was unexpectedly replayed");
+    };
+    job_id
+}
+
+/// #13619: a staging dispatch whose linked agent task cancelled at the same
+/// timestamp it was created — before any child identity, checkpoint, or
+/// lifecycle-metadata linkage was recorded — must be classified and
+/// reconciled from its admission-time durable linkage instead of staying a
+/// permanent `running` orphan that blocks daemon replacement behind operator
+/// attestation.
+#[test]
+fn staging_dispatch_cancelled_before_child_identity_is_reconciled_not_orphaned() {
+    let fixtures = crate::test_support::AgentTaskTerminalRunFixtures::install();
+    let run_id = format!("run-13619-cancelled-{}", Uuid::new_v4());
+    fixtures.terminal_run(&run_id, JobStatus::Cancelled);
+    let store = JobStore::default().with_daemon_lease("lease-live".to_string());
+    let job_id = admitted_staging_dispatch(&store, Some(&run_id));
+    store
+        .start_controller_execution(job_id)
+        .expect("claim execution");
+
+    let evidence = store.active_daemon_job_recovery_evidence(None, |_| false);
+    let item = evidence
+        .iter()
+        .find(|evidence| evidence.job_id == job_id)
+        .expect("staging dispatch evidence");
+    assert_eq!(item.child_pid, None);
+    assert_eq!(
+        item.linked_durable_run_id.as_deref(),
+        Some(run_id.as_str()),
+        "the admission-time linkage is the durable identity"
+    );
+    assert_eq!(
+        item.linked_durable_run_state,
+        Some(DaemonLinkedDurableRunState::Terminal)
+    );
+    assert_eq!(
+        item.linked_durable_run_terminal_status,
+        Some(JobStatus::Cancelled)
+    );
+    assert_eq!(
+        item.disposition,
+        DaemonActiveJobRecoveryDisposition::TerminalEvidence
+    );
+
+    let reconciled = store
+        .reconcile_terminal_linked_daemon_jobs()
+        .expect("reconcile terminal evidence");
+    assert_eq!(reconciled, vec![job_id]);
+    let job = store.get(job_id).expect("staging dispatch");
+    assert_eq!(job.status, JobStatus::Cancelled);
+    assert!(
+        job.finished_at_ms.is_some(),
+        "the staging dispatch reached a terminal state"
+    );
+}
+
+/// A staging dispatch may already be `running` for a live attempt when that
+/// attempt terminalizes. The linked run's terminal state must deterministically
+/// reconcile the job; the live classification before that proves the fence
+/// held rather than the linkage suppressing protection.
+#[test]
+fn terminal_linked_agent_task_cannot_leave_running_staging_dispatch_job() {
+    let fixtures = crate::test_support::AgentTaskTerminalRunFixtures::install();
+    let run_id = format!("run-13619-late-{}", Uuid::new_v4());
+    fixtures.active_run(&run_id);
+    let store = JobStore::default().with_daemon_lease("lease-live".to_string());
+    let job_id = admitted_staging_dispatch(&store, Some(&run_id));
+    store
+        .start_controller_execution(job_id)
+        .expect("claim execution");
+
+    let evidence = store.active_daemon_job_recovery_evidence(None, |_| false);
+    let item = evidence
+        .iter()
+        .find(|evidence| evidence.job_id == job_id)
+        .expect("staging dispatch evidence");
+    assert_eq!(
+        item.linked_durable_run_state,
+        Some(DaemonLinkedDurableRunState::Active)
+    );
+    assert_eq!(
+        item.disposition,
+        DaemonActiveJobRecoveryDisposition::BlockingAmbiguous,
+        "a live linked attempt keeps the live workload protected"
+    );
+    assert!(store
+        .reconcile_terminal_linked_daemon_jobs()
+        .expect("reconcile live store")
+        .is_empty());
+    assert_eq!(
+        store.get(job_id).expect("still running").status,
+        JobStatus::Running
+    );
+
+    fixtures.terminal_run(&run_id, JobStatus::Succeeded);
+    let reconciled = store
+        .reconcile_terminal_linked_daemon_jobs()
+        .expect("reconcile after terminalization");
+    assert_eq!(reconciled, vec![job_id]);
+    assert_eq!(
+        store.get(job_id).expect("reconciled").status,
+        JobStatus::Succeeded
+    );
+}
+
+/// The fail-closed fence: an unknown, unlinked live job keeps
+/// `blocking_ambiguous` classification, is never reconciled implicitly, and so
+/// still requires explicit operator attestation before replacement.
+#[test]
+fn unknown_unlinked_live_job_still_blocks_replacement() {
+    crate::test_support::AgentTaskTerminalRunFixtures::install();
+    let store = JobStore::default().with_daemon_lease("lease-live".to_string());
+    let job_id = admitted_staging_dispatch(&store, None);
+    store
+        .start_controller_execution(job_id)
+        .expect("claim execution");
+
+    let evidence = store.active_daemon_job_recovery_evidence(None, |_| false);
+    let item = evidence
+        .iter()
+        .find(|evidence| evidence.job_id == job_id)
+        .expect("staging dispatch evidence");
+    assert_eq!(item.linked_durable_run_id, None);
+    assert_eq!(item.terminal_evidence, None);
+    assert_eq!(
+        item.disposition,
+        DaemonActiveJobRecoveryDisposition::BlockingAmbiguous
+    );
+
+    assert!(store
+        .reconcile_terminal_linked_daemon_jobs()
+        .expect("reconcile unknown store")
+        .is_empty());
+    assert_eq!(
+        store.get(job_id).expect("still running").status,
+        JobStatus::Running
+    );
+}
+
 #[test]
 fn reused_pid_with_a_different_start_identity_is_terminalized() {
     let store = JobStore::default().with_daemon_lease("lease-dead".to_string());

--- a/crates/homeboy-core/src/daemon/controller_job_driver.rs
+++ b/crates/homeboy-core/src/daemon/controller_job_driver.rs
@@ -33,6 +33,15 @@ pub trait ControllerJobDriver: Send + Sync {
     /// values. Domain drivers define their own reference vocabulary.
     fn validate_secret_references(&self, request: &Value) -> Result<()>;
 
+    /// The controller-minted durable run this job executes for, extracted from
+    /// the driver's typed request. The daemon persists the linkage at
+    /// admission — before any driver work can escape the daemon lifecycle — so
+    /// recovery can reconcile this job from its linked run's terminal state
+    /// without parsing the opaque request.
+    fn linked_durable_run_id(&self, _request: &Value) -> Option<String> {
+        None
+    }
+
     /// Prepare the persisted request inside the daemon worker. Drivers may
     /// override this to resolve controller-local inputs after durable admission.
     fn prepare(&self, request: Value) -> Result<Value> {

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -1114,9 +1114,17 @@ pub fn read_status() -> Result<DaemonStatus> {
             .flatten(),
         pid_is_running,
     );
-    let active_jobs = active_job_recovery_evidence.len();
+    // Durable terminal evidence proves no workload remains, so those jobs are
+    // reported as evidence but do not protect the daemon from replacement.
+    let blocking_active_jobs = active_job_recovery_evidence
+        .iter()
+        .filter(|evidence| {
+            evidence.disposition
+                != crate::api_jobs::DaemonActiveJobRecoveryDisposition::TerminalEvidence
+        })
+        .count();
     let process_candidates = control::daemon_process_candidates(&jobs_path)?;
-    let mut freshness = freshness_report_from_validation(&validation, active_jobs);
+    let mut freshness = freshness_report_from_validation(&validation, blocking_active_jobs);
     // A dead lease proves only its recorded PID is gone. It cannot authorize a
     // replacement while another foreground candidate might still own this store.
     // In particular, offering adoption here would lead it to the same candidate
@@ -1288,7 +1296,8 @@ where
         spawn_local_child_reservation_reconciler(job_store.clone(), local_shutdown_rx);
     let completion_notifier = spawn_completion_notifier(completion_shutdown_rx);
     let schedule_ticker = spawn_schedule_ticker(schedule_shutdown_rx);
-    let orchestration_reconciler = spawn_orchestration_reconciler(orchestration_shutdown_rx);
+    let orchestration_reconciler =
+        spawn_orchestration_reconciler(job_store.clone(), orchestration_shutdown_rx);
     let upload_reaper = spawn_upload_reaper(upload_shutdown_rx);
 
     let mut accepted = 0;
@@ -1450,7 +1459,10 @@ fn parse_orchestration_tick_interval(configured: Option<&str>) -> Option<std::ti
 /// `reconcile_stale_active_runs` had exactly two callers — `cleanup` and
 /// `agent-task active --reconcile --apply` — so a detached cook whose owner
 /// died stayed `running` forever. Loop Work jobs own controller waits.
-fn spawn_orchestration_reconciler(shutdown: mpsc::Receiver<()>) -> std::thread::JoinHandle<()> {
+fn spawn_orchestration_reconciler(
+    job_store: JobStore,
+    shutdown: mpsc::Receiver<()>,
+) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
         let Some(interval) = orchestration_tick_interval() else {
             // Disabled: still consume the shutdown signal so the join at
@@ -1458,7 +1470,7 @@ fn spawn_orchestration_reconciler(shutdown: mpsc::Receiver<()>) -> std::thread::
             let _ = shutdown.recv();
             return;
         };
-        orchestration_tick_loop(interval, shutdown)
+        orchestration_tick_loop(job_store, interval, shutdown)
     })
 }
 
@@ -1469,13 +1481,23 @@ fn spawn_orchestration_reconciler(shutdown: mpsc::Receiver<()>) -> std::thread::
 /// Overlap is impossible by construction — the sleep happens after all
 /// passes return, exactly as the schedule ticker does it — and across
 /// processes the daemon owner lock already guarantees a single ticker.
-fn orchestration_tick_loop(interval: std::time::Duration, shutdown: mpsc::Receiver<()>) {
+fn orchestration_tick_loop(
+    job_store: JobStore,
+    interval: std::time::Duration,
+    shutdown: mpsc::Receiver<()>,
+) {
     loop {
         isolated_tick(|| {
             let _ = orchestration::reconcile_stale_active_runs();
         });
         isolated_tick(|| {
             let _ = orchestration::reconcile_unmaterialized_cook_admissions();
+        });
+        // Terminalization of a linked durable run must deterministically
+        // terminalize its own daemon jobs, even when the job's in-process
+        // supervisor died without persisting anything.
+        isolated_tick(|| {
+            let _ = job_store.reconcile_terminal_linked_daemon_jobs();
         });
         if shutdown.recv_timeout(interval).is_ok() {
             return;
@@ -1873,7 +1895,7 @@ where
                     json!({
                         "reconciled_job_ids": reconciled,
                         "reconciled_count": reconciled.len(),
-                        "policy": "linked durable runs already terminalized; live and unresolved jobs are preserved",
+                        "policy": "jobs with durable terminal evidence (terminal linked durable run or recorded terminal result) are reconciled; live and unresolved jobs are preserved",
                     }),
                 ),
                 Err(err) => error_response(400, err),
@@ -2910,12 +2932,20 @@ fn validate_lifecycle_stop_request(request: &LifecycleStopRequest) -> Result<()>
 fn daemon_freshness_report(job_store: &JobStore) -> Result<DaemonFreshnessReport> {
     let path = state_path()?;
     let validation = validate_lease_file(&path)?;
-    let active_jobs = job_store
-        .list()
+    // Durable terminal evidence proves no workload remains, so those jobs do
+    // not protect this daemon from replacement either.
+    let blocking_active_jobs = job_store
+        .active_daemon_job_recovery_evidence(None, pid_is_running)
         .into_iter()
-        .filter(|job| matches!(job.status, JobStatus::Queued | JobStatus::Running))
+        .filter(|evidence| {
+            evidence.disposition
+                != crate::api_jobs::DaemonActiveJobRecoveryDisposition::TerminalEvidence
+        })
         .count();
-    Ok(freshness_report_from_validation(&validation, active_jobs))
+    Ok(freshness_report_from_validation(
+        &validation,
+        blocking_active_jobs,
+    ))
 }
 
 /// JSON pointer to an endpoint payload inside a fully written daemon response.
@@ -3534,12 +3564,22 @@ fn enqueue_controller_job(
     driver.validate_secret_references(&request.request)?;
     let public_request = driver.public_request(&request.request)?;
     let request_digest = hex_digest(&request.request)?;
+    // The driver-declared durable-run linkage is durable before any driver
+    // work can escape the daemon lifecycle, so later reconciliation never has
+    // to infer ownership from the opaque request.
+    let linked_durable_run_id = driver
+        .linked_durable_run_id(&request.request)
+        .as_deref()
+        .map(str::trim)
+        .filter(|run_id| !run_id.is_empty())
+        .map(str::to_string);
     let controller_job = ControllerJobState {
         job_type: request.job_type.clone(),
         version: request.version,
         request: request.request.clone(),
         public_request,
         request_digest,
+        linked_durable_run_id,
         checkpoint: None,
         cancellation_requested: false,
         cancellation_reason: None,
@@ -4161,8 +4201,9 @@ mod tests {
     fn orchestration_tick_loop_exits_promptly_on_shutdown() {
         crate::test_support::with_isolated_home(|_| {
             let (tx, rx) = std::sync::mpsc::channel();
+            let job_store = JobStore::default();
             let handle = std::thread::spawn(move || {
-                super::orchestration_tick_loop(Duration::from_secs(300), rx);
+                super::orchestration_tick_loop(job_store, Duration::from_secs(300), rx);
             });
 
             std::thread::sleep(Duration::from_millis(50));
@@ -4175,6 +4216,91 @@ mod tests {
                 "shutdown must not wait out the poll interval, took {:?}",
                 start.elapsed()
             );
+        });
+    }
+
+    /// Admit one `controller.lab.staging-dispatch` job in the isolated home's
+    /// durable daemon store, linked to `run_id` as the Lab driver declares at
+    /// admission, and leave it claimed `running` with no child identity — the
+    /// #13619 incident shape.
+    fn admitted_running_staging_dispatch(run_id: Option<&str>) -> uuid::Uuid {
+        let store =
+            JobStore::open_without_reconciliation(paths::daemon_jobs_file().expect("jobs path"))
+                .expect("durable store");
+        let outcome = store
+            .admit_controller_job(
+                "controller.lab.staging-dispatch".to_string(),
+                format!("lab-staging-{}", uuid::Uuid::new_v4()),
+                ControllerJobState {
+                    job_type: "lab.staging-dispatch".to_string(),
+                    version: 1,
+                    request: json!({ "schema": "homeboy/lab-staging-dispatch/v1" }),
+                    public_request: json!({ "schema": "homeboy/lab-staging-dispatch/v1" }),
+                    request_digest: format!("digest-{}", uuid::Uuid::new_v4()),
+                    linked_durable_run_id: run_id.map(str::to_string),
+                    checkpoint: None,
+                    cancellation_requested: false,
+                    cancellation_reason: None,
+                    execution_claim_id: None,
+                    recovery_attempted: false,
+                },
+            )
+            .expect("admit staging dispatch");
+        let crate::api_jobs::ControllerJobSubmissionOutcome::Submitted(job_id) = outcome else {
+            panic!("unique staging dispatch submission was unexpectedly replayed");
+        };
+        store
+            .start_controller_execution(job_id)
+            .expect("claim execution");
+        job_id
+    }
+
+    /// #13619: a lease-bound stop is the replacement gate. It must first
+    /// reconcile every active job whose durable terminal evidence proves no
+    /// workload remains, so daemon replacement proceeds without the operator's
+    /// `--confirm-workload-processes-absent` attestation.
+    #[test]
+    fn stop_gate_reconciles_terminal_evidenced_jobs_before_refusing() {
+        crate::test_support::with_isolated_home(|_| {
+            let fixtures = crate::test_support::AgentTaskTerminalRunFixtures::install();
+            let run_id = format!("run-13619-stop-gate-{}", uuid::Uuid::new_v4());
+            fixtures.terminal_run(&run_id, JobStatus::Cancelled);
+            let job_id = admitted_running_staging_dispatch(Some(&run_id));
+
+            let blocking = active_daemon_job_ids().expect("replacement gate");
+
+            assert!(
+                blocking.is_empty(),
+                "terminal evidence proves no workload remains: {blocking:?}"
+            );
+            let reconciled = JobStore::open_without_reconciliation(
+                paths::daemon_jobs_file().expect("jobs path"),
+            )
+            .expect("durable store")
+            .get(job_id)
+            .expect("staging dispatch");
+            assert_eq!(reconciled.status, JobStatus::Cancelled);
+        });
+    }
+
+    /// The fence: an unknown unlinked live job survives the stop gate's
+    /// terminal-evidence reconciliation and still blocks replacement.
+    #[test]
+    fn stop_gate_still_blocks_on_unknown_unlinked_live_jobs() {
+        crate::test_support::with_isolated_home(|_| {
+            crate::test_support::AgentTaskTerminalRunFixtures::install();
+            let job_id = admitted_running_staging_dispatch(None);
+
+            let blocking = active_daemon_job_ids().expect("replacement gate");
+
+            assert_eq!(blocking, vec![job_id]);
+            let untouched = JobStore::open_without_reconciliation(
+                paths::daemon_jobs_file().expect("jobs path"),
+            )
+            .expect("durable store")
+            .get(job_id)
+            .expect("staging dispatch");
+            assert_eq!(untouched.status, JobStatus::Running);
         });
     }
 

--- a/crates/homeboy-core/src/daemon/recovery_actions.rs
+++ b/crates/homeboy-core/src/daemon/recovery_actions.rs
@@ -242,9 +242,17 @@ pub fn plan_recovery(status: &DaemonStatus) -> DaemonRecoveryPlan {
     // no PID to check. The exact job set is a compare-and-swap over the
     // destructive scope, and the store refuses any mismatch — so the ids can be
     // filled from the report, while the workload attestation cannot be.
+    //
+    // Jobs with durable terminal evidence (a terminal linked durable run or a
+    // recorded terminal result) prove no workload remains, so they are
+    // reconciled by the stop gate and never require the attestation.
     let job_ids: Vec<Uuid> = status
         .active_job_recovery_evidence
         .iter()
+        .filter(|evidence| {
+            evidence.disposition
+                != crate::api_jobs::DaemonActiveJobRecoveryDisposition::TerminalEvidence
+        })
         .map(|evidence| evidence.job_id)
         .collect();
     if let Some(lease_id) = freshness.lease_id.as_deref() {
@@ -313,13 +321,17 @@ pub fn plan_recovery(status: &DaemonStatus) -> DaemonRecoveryPlan {
 ///
 /// This policy is intentionally independent of the command requesting daemon
 /// admission. It trusts only the authoritative status report and accepts only
-/// the bounded stop/start plan: zero durable jobs, an explicitly restartable
-/// lease, no attestations, and no other mutation mixed into the plan.
+/// the bounded stop/start plan: an explicitly restartable lease whose active
+/// jobs all carry durable terminal evidence (so no workload remains), no
+/// attestations, and no other mutation mixed into the plan.
 pub fn authorizes_automatic_idle_restart(status: &DaemonStatus) -> bool {
     let plan = plan_recovery(status);
     !status.fresh
         && status.freshness.active_jobs == 0
-        && status.active_job_recovery_evidence.is_empty()
+        && status.active_job_recovery_evidence.iter().all(|evidence| {
+            evidence.disposition
+                == crate::api_jobs::DaemonActiveJobRecoveryDisposition::TerminalEvidence
+        })
         && status.freshness.restartable
         && plan.executable
         && plan.required_confirmations.is_empty()
@@ -571,6 +583,61 @@ mod tests {
         );
     }
 
+    /// #13619: durable terminal evidence proves no workload remains, so those
+    /// jobs are reconciled by the stop gate without an operator attestation
+    /// and are excluded from the attestation job set. Only the genuinely
+    /// ambiguous live workload still demands the confirmation.
+    #[test]
+    fn terminal_evidence_jobs_are_reconciled_without_workload_attestation() {
+        let mut status = status(
+            Some(super::super::DaemonStaleReasonCode::LeaseCorrupt),
+            Vec::new(),
+            1,
+        );
+        let terminal = terminal_recovery_evidence(Uuid::from_u128(7));
+        let blocking = recovery_evidence(Uuid::from_u128(8));
+        status.active_job_recovery_evidence = vec![terminal, blocking];
+
+        let plan = plan_recovery(&status);
+
+        assert_eq!(plan.steps.len(), 1);
+        assert_eq!(plan.steps[0].code, DAEMON_RECONCILE_DEAD_LEASE_ORPHANS);
+        let args = &plan.steps[0].action.as_ref().expect("argv").args;
+        assert!(
+            !args.contains(&Uuid::from_u128(7).to_string()),
+            "terminal-evidence job never requires attestation: {args:?}"
+        );
+        assert!(
+            args.contains(&Uuid::from_u128(8).to_string()),
+            "the ambiguous live workload is still named: {args:?}"
+        );
+        assert_eq!(
+            plan.required_confirmations,
+            vec![CONFIRM_WORKLOAD_PROCESSES_ABSENT.to_string()],
+            "the ambiguous workload keeps the operator attestation"
+        );
+    }
+
+    /// Replacement may proceed without any attestation when every active job
+    /// carries durable terminal evidence: no workload remains.
+    #[test]
+    fn terminal_evidence_authorizes_automatic_idle_restart() {
+        let mut status = status(
+            Some(super::super::DaemonStaleReasonCode::VersionMismatch),
+            vec![
+                DaemonRepairStep::executable(DAEMON_STOP, stop_for_lease(LEASE_ID)),
+                DaemonRepairStep::executable(DAEMON_START, start()),
+            ],
+            0,
+        );
+        status.active_job_recovery_evidence = vec![terminal_recovery_evidence(Uuid::nil())];
+
+        let plan = plan_recovery(&status);
+        assert!(plan.executable);
+        assert!(plan.required_confirmations.is_empty());
+        assert!(authorizes_automatic_idle_restart(&status));
+    }
+
     fn recovery_evidence(job_id: Uuid) -> crate::api_jobs::DaemonActiveJobRecoveryEvidence {
         crate::api_jobs::DaemonActiveJobRecoveryEvidence {
             job_id,
@@ -588,6 +655,18 @@ mod tests {
             linked_durable_run_terminal_status: None,
             disposition:
                 crate::api_jobs::DaemonActiveJobRecoveryDisposition::MissingChildIdentityRecoverable,
+        }
+    }
+
+    fn terminal_recovery_evidence(
+        job_id: Uuid,
+    ) -> crate::api_jobs::DaemonActiveJobRecoveryEvidence {
+        crate::api_jobs::DaemonActiveJobRecoveryEvidence {
+            linked_durable_run_id: Some("run-13619".to_string()),
+            linked_durable_run_state: Some(crate::api_jobs::DaemonLinkedDurableRunState::Terminal),
+            linked_durable_run_terminal_status: Some(crate::api_jobs::JobStatus::Cancelled),
+            disposition: crate::api_jobs::DaemonActiveJobRecoveryDisposition::TerminalEvidence,
+            ..recovery_evidence(job_id)
         }
     }
 

--- a/crates/homeboy-core/src/daemon/stop.rs
+++ b/crates/homeboy-core/src/daemon/stop.rs
@@ -608,7 +608,13 @@ pub(super) fn stop_unlocked_with_force(force: bool) -> Result<DaemonStopResult> 
 }
 
 pub(super) fn active_daemon_job_ids() -> Result<Vec<Uuid>> {
-    let mut job_ids = JobStore::open_without_reconciliation(paths::daemon_jobs_file()?)?
+    let store = JobStore::open_without_reconciliation(paths::daemon_jobs_file()?)?;
+    // Replacement is authorized without an operator attestation when durable
+    // terminal evidence proves no workload remains, so first reconcile every
+    // active job whose evidence already proves it. Live children, live linked
+    // runs, and unknown-ownership jobs stay untouched and keep blocking.
+    let _ = store.reconcile_terminal_linked_daemon_jobs();
+    let mut job_ids = store
         .list()
         .into_iter()
         .filter(|job| matches!(job.status, JobStatus::Queued | JobStatus::Running))

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -43,6 +43,12 @@ impl ControllerJobHarness {
             ControllerJobState {
                 job_type: driver.job_type().to_string(),
                 version: driver.version(),
+                linked_durable_run_id: driver
+                    .linked_durable_run_id(&request)
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|run_id| !run_id.is_empty())
+                    .map(str::to_string),
                 request,
                 public_request,
                 request_digest,
@@ -82,9 +88,127 @@ impl ControllerJobHarness {
         Ok(self.store.controller_job_state(self.job_id)?.checkpoint)
     }
 
+    /// The driver-declared durable-run linkage persisted at admission.
+    pub fn linked_durable_run_id(&self) -> Result<Option<String>> {
+        Ok(self
+            .store
+            .controller_job_state(self.job_id)?
+            .linked_durable_run_id)
+    }
+
     pub fn request_cancellation(&self, reason: impl Into<String>) -> Result<Job> {
         self.store
             .request_controller_cancellation(self.job_id, reason.into())
+    }
+}
+
+/// The durable-run fixture one test programs for a linked agent-task run.
+#[derive(Clone)]
+pub enum AgentTaskTerminalRunFixture {
+    Terminal(crate::api_jobs::JobStatus),
+    Active,
+}
+
+/// A deterministic agent-task terminal-recovery provider shared by every test
+/// in the process.
+///
+/// The provider registry is process-global, so one shared fixture store is
+/// registered exactly once; each test programs only its own unique run ids and
+/// parallel tests cannot observe each other's resolutions.
+pub struct AgentTaskTerminalRunFixtures {
+    runs: Mutex<std::collections::HashMap<String, AgentTaskTerminalRunFixture>>,
+}
+
+impl AgentTaskTerminalRunFixtures {
+    /// Install the shared provider and return its fixture store.
+    pub fn install() -> &'static Self {
+        static FIXTURES: OnceLock<AgentTaskTerminalRunFixtures> = OnceLock::new();
+        FIXTURES.get_or_init(|| {
+            crate::api_jobs::agent_task_terminal_recovery::register_agent_task_terminal_recovery_provider(
+                Box::new(SharedProvider),
+            );
+            AgentTaskTerminalRunFixtures {
+                runs: Mutex::new(std::collections::HashMap::new()),
+            }
+        })
+    }
+
+    /// Program `run_id` as a terminal agent-task run recovering `status`.
+    pub fn terminal_run(&self, run_id: &str, status: crate::api_jobs::JobStatus) {
+        self.runs
+            .lock()
+            .expect("terminal-run fixtures lock")
+            .insert(
+                run_id.to_string(),
+                AgentTaskTerminalRunFixture::Terminal(status),
+            );
+    }
+
+    /// Program `run_id` as a live (non-terminal) agent-task run.
+    pub fn active_run(&self, run_id: &str) {
+        self.runs
+            .lock()
+            .expect("terminal-run fixtures lock")
+            .insert(run_id.to_string(), AgentTaskTerminalRunFixture::Active);
+    }
+
+    /// Remove one programmed run.
+    pub fn remove(&self, run_id: &str) {
+        self.runs
+            .lock()
+            .expect("terminal-run fixtures lock")
+            .remove(run_id);
+    }
+
+    fn get(&self, run_id: &str) -> Option<AgentTaskTerminalRunFixture> {
+        self.runs
+            .lock()
+            .expect("terminal-run fixtures lock")
+            .get(run_id)
+            .cloned()
+    }
+}
+
+struct SharedProvider;
+
+impl crate::api_jobs::agent_task_terminal_recovery::AgentTaskTerminalRecoveryProvider
+    for SharedProvider
+{
+    fn recovered_terminal_agent_task_job(
+        &self,
+        run_id: &str,
+    ) -> Option<crate::api_jobs::RecoveredTerminalJob> {
+        let AgentTaskTerminalRunFixture::Terminal(status) =
+            AgentTaskTerminalRunFixtures::install().get(run_id)?
+        else {
+            return None;
+        };
+        Some(
+            crate::api_jobs::agent_task_terminal_recovery::recovered_terminal_job(
+                status,
+                serde_json::json!({
+                    "kind": "test_agent_task_aggregate",
+                    "run_id": run_id,
+                    "status": status,
+                }),
+                run_id.to_string(),
+                Vec::new(),
+            ),
+        )
+    }
+
+    fn linked_durable_run_state(
+        &self,
+        run_id: &str,
+    ) -> Option<crate::api_jobs::DaemonLinkedDurableRunState> {
+        match AgentTaskTerminalRunFixtures::install().get(run_id)? {
+            AgentTaskTerminalRunFixture::Terminal(_) => {
+                Some(crate::api_jobs::DaemonLinkedDurableRunState::Terminal)
+            }
+            AgentTaskTerminalRunFixture::Active => {
+                Some(crate::api_jobs::DaemonLinkedDurableRunState::Active)
+            }
+        }
     }
 }
 

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -946,7 +946,13 @@ fn ensure_current_controller_daemon() -> Result<homeboy_core::daemon::DaemonStar
             if state.build_identity.display == expected {
                 return Ok(daemon);
             }
-            if !status.active_job_recovery_evidence.is_empty() {
+            // Durable terminal evidence proves an active job's workload is
+            // finished, so it is reconciled during the lease-bound stop below
+            // and does not block this admission.
+            if status.active_job_recovery_evidence.iter().any(|evidence| {
+                evidence.disposition
+                    != homeboy_core::api_jobs::DaemonActiveJobRecoveryDisposition::TerminalEvidence
+            }) {
                 return Err(Error::validation_invalid_argument(
                     "controller_daemon",
                     "controller daemon build does not match the submitting Homeboy binary while durable jobs are active",
@@ -4188,6 +4194,31 @@ impl Drop for CancellationGuard {
 
 pub struct LabStagingDispatchDriver;
 
+/// No staging work may begin for an attempt that already terminalized. Its
+/// controller lifecycle is closed, so the dispatch job must terminalize with
+/// it instead of admitting new work that could escape the controller.
+fn ensure_linked_attempt_not_terminal(run_id: &str) -> Result<()> {
+    let Ok(record) = homeboy_agents::agent_task_lifecycle::status(run_id) else {
+        // The durable recipe and plan attachments remain the staging
+        // authority; a missing run record is handled by their validation.
+        return Ok(());
+    };
+    if record.state.is_terminal() {
+        return Err(Error::validation_invalid_argument(
+            "run_id",
+            format!(
+                "Lab staging dispatch cannot start for agent-task run `{}` that already terminalized as {:?}",
+                run_id, record.state
+            ),
+            Some(run_id.to_string()),
+            Some(vec![
+                "The linked agent-task attempt is terminal; its staging dispatch job is reconciled from that terminal state.".to_string(),
+            ]),
+        ));
+    }
+    Ok(())
+}
+
 impl LabStagingDispatchDriver {
     fn envelope(value: &Value) -> Result<LabStagingDispatchEnvelope> {
         let envelope: LabStagingDispatchEnvelope =
@@ -4227,6 +4258,18 @@ impl LabStagingDispatchDriver {
         let lab_lifecycle_store =
             homeboy_agents::agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
         checkpoint.validate()?;
+        // A terminalized linked attempt closes the staging lifecycle before any
+        // pre-dispatch work can begin. Once a runner job was admitted the
+        // checkpoint's runner identity is the durable child evidence, and the
+        // linked run's terminal state reconciles this job instead.
+        if matches!(
+            checkpoint.phase,
+            LabStagingPhase::AcceptedMaterializeWorkspace
+                | LabStagingPhase::MaterializeRuntime
+                | LabStagingPhase::HydrateDependencies
+        ) {
+            ensure_linked_attempt_not_terminal(&checkpoint.run_id)?;
+        }
         let adapter = require_production_adapter()?;
         let request = match &checkpoint.input {
             LabStagingInputRef::AgentTaskAttempt { recipe, .. } => {
@@ -4307,6 +4350,9 @@ impl ControllerJobDriver for LabStagingDispatchDriver {
     fn validate_secret_references(&self, request: &Value) -> Result<()> {
         Self::envelope(request).map(|_| ())
     }
+    fn linked_durable_run_id(&self, request: &Value) -> Option<String> {
+        Self::envelope(request).ok().map(|envelope| envelope.run_id)
+    }
     fn prepare(&self, request: Value) -> Result<Value> {
         let envelope = Self::envelope(&request)?;
         // Cancellation ownership is durable before prepare can race with a
@@ -4316,6 +4362,9 @@ impl ControllerJobDriver for LabStagingDispatchDriver {
             .expect("Lab staging cancellation lock")
             .entry(envelope.run_id.clone())
             .or_default();
+        // A cancelled or otherwise terminal attempt must not admit staging
+        // work: its lifecycle is closed, so this job terminalizes with it.
+        ensure_linked_attempt_not_terminal(&envelope.run_id)?;
         // Resolve only durable, owner-controlled input before the daemon can
         // accept the job. Stage execution remains intentionally uninstalled.
         let recipe = match &envelope.input {
@@ -4931,6 +4980,111 @@ mod tests {
             artifacts: Vec::new(),
             runner_job_projection: None,
         }
+    }
+
+    fn envelope_for_run(run_id: &str) -> LabStagingDispatchEnvelope {
+        LabStagingDispatchEnvelope::new(
+            run_id,
+            "lab-1",
+            LabStagingInputRef::AgentTaskAttempt {
+                run_id: run_id.to_string(),
+                recipe: recipe_ref(),
+            },
+        )
+    }
+
+    /// Terminalize one durable attempt record directly, the way a cancellation
+    /// landing between controller-job creation and lifecycle-metadata recording
+    /// leaves it: terminal with no `lab_staging_controller_job_id` linkage.
+    fn terminalize_attempt_record(run_id: &str) {
+        let lifecycle =
+            homeboy_agents::agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()
+                .expect("lifecycle store");
+        let mut record = lifecycle.read_record(run_id).expect("attempt record");
+        record.state = homeboy_agents::agent_task_lifecycle::AgentTaskRunState::Cancelled;
+        lifecycle
+            .write_record(&record)
+            .expect("terminalize attempt");
+    }
+
+    /// #13619: the driver declares its durable-run linkage so the daemon
+    /// persists it at admission — before any staging work can escape the
+    /// controller lifecycle — and the durable admission keeps it.
+    #[test]
+    fn staging_dispatch_declares_and_persists_its_linked_durable_run_id() {
+        let run_id = format!("run-13619-linkage-{}", uuid::Uuid::new_v4());
+        let envelope = envelope_for_run(&run_id);
+        let request = serde_json::to_value(&envelope).expect("serialize envelope");
+
+        assert_eq!(
+            LabStagingDispatchDriver
+                .linked_durable_run_id(&request)
+                .as_deref(),
+            Some(run_id.as_str())
+        );
+
+        let harness = ControllerJobHarness::new(Arc::new(LabStagingDispatchDriver), request)
+            .expect("admit through the durable boundary");
+        assert_eq!(
+            harness
+                .linked_durable_run_id()
+                .expect("controller state")
+                .as_deref(),
+            Some(run_id.as_str()),
+            "admission persists the driver-declared linkage"
+        );
+    }
+
+    /// #13619: a staging dispatch whose linked attempt cancelled before any
+    /// child identity was recorded must not admit staging work — the job
+    /// terminalizes with its attempt instead of orphaning `running`.
+    #[test]
+    fn staging_prepare_fails_fast_when_linked_attempt_already_terminal() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let run_id = format!("run-13619-prepare-{}", uuid::Uuid::new_v4());
+            submit_recipe_run(&run_id);
+            terminalize_attempt_record(&run_id);
+            let request =
+                serde_json::to_value(envelope_for_run(&run_id)).expect("serialize envelope");
+
+            let error = LabStagingDispatchDriver
+                .prepare(request)
+                .expect_err("a terminal attempt closes the staging lifecycle");
+
+            assert!(
+                error.message.contains("already terminalized"),
+                "{}",
+                error.message
+            );
+        });
+    }
+
+    /// The same fence guards claimed execution: pre-dispatch phases refuse to
+    /// begin work for a terminal attempt even when the job already reached
+    /// `running`, so no workspace or runner admission escapes the controller
+    /// lifecycle after its attempt terminalized.
+    #[test]
+    fn staging_execute_refuses_pre_dispatch_work_for_terminal_attempt() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let run_id = format!("run-13619-execute-{}", uuid::Uuid::new_v4());
+            submit_recipe_run(&run_id);
+            let request =
+                serde_json::to_value(envelope_for_run(&run_id)).expect("serialize envelope");
+            let harness = ControllerJobHarness::new(Arc::new(LabStagingDispatchDriver), request)
+                .expect("admit and claim");
+            terminalize_attempt_record(&run_id);
+            let checkpoint = LabStagingCheckpoint::initial(&envelope_for_run(&run_id));
+
+            let error = LabStagingDispatchDriver
+                .execute_checkpoint(checkpoint, harness.handle(), false)
+                .expect_err("pre-dispatch work refuses a terminal attempt");
+
+            assert!(
+                error.message.contains("already terminalized"),
+                "{}",
+                error.message
+            );
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Problem

A `controller.lab.staging-dispatch` daemon job (`bbbba146-e0ea-449b-8618-6e4cdb7e4c66`) stayed `running` indefinitely after its linked Lab agent task had already terminalized as `cancelled` at the same timestamp. The daemon record carried:

```json
{
  "child_pid": null,
  "child_started_at": null,
  "linked_durable_run_id": null,
  "disposition": "blocking_ambiguous"
}
```

With no child identity and no durable linkage, `homeboy daemon status` could not attribute the job, so it classified the daemon unreplaceable and the only supported recovery was operator attestation via `--confirm-workload-processes-absent`.

A completed async Lab handoff therefore became a **global control-plane blocker**: daemon upgrade was refused, and clearing it required manual process spelunking to prove a negative the control plane should have known.

## Fix

**Linkage before escape.** Staging dispatch now declares and persists its linked durable run id before work can escape the controller lifecycle, so a dispatched job is always attributable.

**Terminal propagation.** Terminal evidence on a linked agent task now deterministically reconciles its staging daemon job. A terminal linked attempt cannot leave a `running` staging job behind, and staging prepare/execute fail fast for an already-terminal attempt instead of dispatching work that nothing will collect.

**Attestation only where it is genuinely needed.** Jobs carrying durable terminal evidence are reconciled without workload attestation, and that evidence authorizes automatic idle restart — the daemon can be replaced because the control plane can *prove* no workload remains.

**The fail-closed fence is preserved.** An unknown, unlinked, live job still blocks replacement and still requires explicit operator attestation. That is the case where absence genuinely cannot be proven in process, and it is covered by its own tests.

## Tests

- `staging_dispatch_cancelled_before_child_identity_is_reconciled_not_orphaned` — the reported incident
- `terminal_linked_agent_task_cannot_leave_running_staging_dispatch_job`
- `staging_dispatch_declares_and_persists_its_linked_durable_run_id`
- `staging_prepare_fails_fast_when_linked_attempt_already_terminal`
- `staging_execute_refuses_pre_dispatch_work_for_terminal_attempt`
- `terminal_evidence_jobs_are_reconciled_without_workload_attestation`
- `terminal_evidence_authorizes_automatic_idle_restart`
- `stop_gate_reconciles_terminal_evidenced_jobs_before_refusing`
- **Safety fence:** `unknown_unlinked_live_job_still_blocks_replacement`, `stop_gate_still_blocks_on_unknown_unlinked_live_jobs`

## Verification

| Command | Result |
| --- | --- |
| `cargo test -p homeboy-lab-runner --lib lab_staging_controller::tests::staging` | 7 passed, 0 failed |
| `cargo test -p homeboy-core --lib api_jobs` | 112 passed, 0 failed |
| `cargo check --workspace --tests --locked` | clean |
| `cargo fmt --all --check` | clean |
| `git diff --check` | clean |

Rebased onto latest `origin/main` and re-verified after rebase.

### Pre-existing hang in the wider module

Running the whole `lab_staging_controller` module (`cargo test -p homeboy-lab-runner --lib lab_staging_controller`) hangs for >10 minutes without completing. **This reproduces identically on clean `origin/main` with this branch's changes stashed**, so it is pre-existing and not introduced here. Verification above therefore uses the narrower `::tests::staging` filter, which terminates in 0.51s and covers every test this PR adds or affects. Tracked separately.

Fixes #13619

## AI assistance disclosure

Z.AI GLM 5.3 via OpenCode implemented the linkage persistence, terminal propagation, reconciliation paths, and the test suite. Claude Fable 5 via OpenCode (Claude Code CLI) diagnosed the original incident from live daemon and agent-task evidence, filed the issue, reviewed the diff, completed verification after the authoring session hit a provider usage limit, bisected the module hang against a stashed baseline to prove it pre-existing, and published this PR. Chris Huber directed the control-plane ergonomics audit.