### PR TITLE
Count one archive referenced twice once in release package coverage

### DIFF
--- a/crates/homeboy-release/src/release/executor/package_preflight.rs
+++ b/crates/homeboy-release/src/release/executor/package_preflight.rs
@@ -38,15 +38,23 @@ pub(crate) fn validate_package_completeness(
     artifacts: &[ReleaseArtifact],
 ) -> Result<()> {
     component.release.validate_package_coverage()?;
+    // One archive can be referenced more than once, for example when a component
+    // declares it as its build artifact and the release package manifest reports
+    // the same path. Those references resolve to a single file on disk, so count
+    // each resolved path once and let coverage selectors stay `exact`.
+    let mut counted_paths: BTreeSet<PathBuf> = BTreeSet::new();
     let zip_artifacts: Vec<(&ReleaseArtifact, BTreeSet<String>)> = artifacts
         .iter()
         .filter_map(|artifact| {
             let artifact_path = resolve_artifact_path(component_path, artifact);
-            artifact_path
+            let is_zip = artifact_path
                 .extension()
                 .and_then(|extension| extension.to_str())
-                .is_some_and(|extension| extension.eq_ignore_ascii_case("zip"))
-                .then(|| read_zip_entries(&artifact_path).map(|entries| (artifact, entries)))
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("zip"));
+            if !is_zip || !counted_paths.insert(artifact_path.clone()) {
+                return None;
+            }
+            Some(read_zip_entries(&artifact_path).map(|entries| (artifact, entries)))
         })
         .collect::<Result<_>>()?;
 
@@ -479,6 +487,34 @@ mod tests {
         }];
         validate_package_completeness(&component, repo.path(), &artifacts)
             .expect("excluded runtime file should not fail");
+    }
+
+    #[test]
+    fn package_completeness_counts_one_archive_referenced_twice_once() {
+        let repo = tempfile::tempdir().expect("repo");
+        std::fs::create_dir_all(repo.path().join("source/runtime")).expect("runtime dir");
+        std::fs::write(repo.path().join("source/runtime/main.php"), "<?php\n").expect("main");
+        run_git(repo.path(), &["init"]);
+        run_git(repo.path(), &["add", "source/runtime/main.php"]);
+        let artifact_path = repo.path().join("build/runtime.zip");
+        std::fs::create_dir_all(artifact_path.parent().unwrap()).expect("build dir");
+        write_zip(&artifact_path, &[("bundle/main.php", "<?php\n")]);
+        let mut component = test_component(repo.path());
+        component.release.package_coverage = vec![PackageCoverageConfig {
+            artifact: "build/runtime.zip".to_string(),
+            artifact_match: PackageCoverageArtifactMatch::Exact,
+            source_roots: vec!["source/runtime".to_string()],
+            archive_root: "bundle".to_string(),
+        }];
+
+        // A component may declare an archive as its build artifact while the
+        // release package manifest reports the same path. Both references
+        // resolve to one file, so an exact selector still covers exactly one.
+        let mut artifacts = zip_artifacts("build/runtime.zip");
+        artifacts.extend(zip_artifacts("build/runtime.zip"));
+
+        validate_package_completeness(&component, repo.path(), &artifacts)
+            .expect("one archive referenced twice must count once");
     }
 
     #[test]


### PR DESCRIPTION
## What

Count each resolved archive path once when validating release package coverage.

## Why

`homeboy release wp-codebox` fails at the package-coverage gate, blocking all releases for that component:

```
Invalid argument 'release.package_coverage': Package coverage artifact selector
'packages/wordpress-plugin/dist/wp-codebox.zip' matched 2 ZIP artifacts; it must match exactly one
```

There is only ever one such file on disk. Instrumenting the packaging steps from a clean tree confirms it:

```
start:                           0 wp-codebox.zip
after package:wordpress-plugin:  1
after release:package:           1
```

The duplicate is a double count, not a second file. A component may reference the same archive twice, once as its component build artifact and again in the release package manifest. Both references resolve to a single path, so `validate_package_completeness` saw two entries and rejected an `exact` selector that was in fact satisfied by one archive.

The affected component is internally consistent and its own contract test requires both references, so it cannot resolve this on its side.

## Change

`validate_package_completeness` now deduplicates ZIP artifacts by resolved path before matching coverage selectors. Behaviour is otherwise unchanged: genuinely distinct archives still produce distinct matches, and selectors that match zero or more than one archive still fail closed.

## Verification

- Added `package_completeness_counts_one_archive_referenced_twice_once`, which registers the same archive path twice and asserts coverage still resolves.
- Confirmed the test is not vacuous: with the dedupe removed it fails with the exact production message (`matched 2 ZIP artifacts`), and passes with it restored.
- `cargo test -p homeboy-release`: 553 passed, 3 failed.
- The 3 failures are `release::planning_quality::tests::extension_release_lint_*` and are **pre-existing**, reproducing identically at `HEAD~1` without this change.

## AI Assistance

OpenCode with OpenAI `openai/gpt-5.6-sol`, orchestrated by Chris Huber. Used to trace the failing gate from a blocked release, instrument the packaging steps to disprove file duplication, isolate the double count, and implement and validate this fix.
