### PR TITLE
fix(fanout): give registered primary fixtures a resolvable default branch

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -5498,6 +5498,7 @@ mod tests {
 
             let primary = home.path().join("primary");
             fs::create_dir(&primary).expect("primary");
+            init_git_primary(&primary);
             write_component_registration(home.path(), "homeboy", &primary);
         });
         with_materialized_cook_batch_worktrees(|| {
@@ -5989,6 +5990,7 @@ mod tests {
                 .status()
                 .expect("git commit")
                 .success());
+            init_git_primary(&source);
             write_component_registration(home.path(), "fixture", &source);
 
             let mut plan = test_batch_plan();
@@ -6902,6 +6904,39 @@ fi
         .expect("component registration");
     }
 
+    /// Make a registered primary answer default-branch resolution.
+    ///
+    /// `cook_batch_args` plans from `origin/main`, and repository planning now
+    /// resolves that against the registered primary before anything else runs.
+    /// A bare directory has no branch and no remote, so every case built on one
+    /// fails in repository resolution before reaching the behavior it asserts.
+    /// The remote ref is published locally because a fixture must not need a
+    /// network to resolve its own source ref.
+    ///
+    /// This is deliberately not folded into `write_component_registration`: the
+    /// large-registry case registers hundreds of unrelated components while
+    /// measuring elapsed time, and only the planning target needs a repository.
+    fn init_git_primary(path: &Path) {
+        std::fs::create_dir_all(path).expect("primary fixture directory");
+        for args in [
+            ["init", "-b", "main"].as_slice(),
+            ["config", "user.email", "test@example.com"].as_slice(),
+            ["config", "user.name", "Homeboy Test"].as_slice(),
+            ["commit", "--allow-empty", "-m", "initial"].as_slice(),
+            ["update-ref", "refs/remotes/origin/main", "HEAD"].as_slice(),
+        ] {
+            assert!(
+                Command::new("git")
+                    .args(args)
+                    .current_dir(path)
+                    .status()
+                    .expect("initialize primary fixture")
+                    .success(),
+                "git {args:?} failed"
+            );
+        }
+    }
+
     #[test]
     fn fanout_dry_run_bounds_gate_workspace_lookup_in_a_large_registry() {
         with_isolated_home(|home| {
@@ -6909,6 +6944,7 @@ fi
             std::fs::create_dir(&target).expect("target workspace");
             std::fs::write(target.join("homeboy.json"), r#"{"id":"fixture"}"#)
                 .expect("target manifest");
+            init_git_primary(&target);
             write_component_registration(home.path(), "fixture", &target);
 
             for index in 0..300 {
@@ -6959,6 +6995,7 @@ fi
         with_isolated_home(|home| {
             let primary = home.path().join("primary");
             std::fs::create_dir(&primary).expect("primary directory");
+            init_git_primary(&primary);
             write_component_registration(home.path(), "fixture", &primary);
 
             let mut slug = cook_batch_args();
@@ -6979,6 +7016,7 @@ fi
             let private_sentinel = "PRIVATE_GATE_SENTINEL_INVALID_REPO";
             let primary = home.path().join("primary");
             std::fs::create_dir(&primary).expect("primary directory");
+            init_git_primary(&primary);
             write_component_registration(home.path(), "fixture", &primary);
 
             let mut handle = cook_batch_args();
@@ -7129,6 +7167,7 @@ fi
                     "git {args:?} failed"
                 );
             }
+            init_git_primary(&primary);
             write_component_registration(home.path(), "homeboy", &primary);
             let worktrees = tempfile::tempdir().expect("managed worktree fixtures");
             for (handle, name) in [
@@ -7851,6 +7890,7 @@ fi
                 r#"{"scripts":{"lint":["check"]}}"#,
             )
             .expect("component manifest");
+            init_git_primary(&source);
             write_component_registration(home.path(), "fixture", &source);
 
             let mut args = cook_batch_args();
@@ -8517,6 +8557,7 @@ fi
                     .unwrap()
                     .success());
             }
+            init_git_primary(&source);
             write_component_registration(home.path(), "fanout-dry-run-fixture", &source);
 
             let mut args = cook_batch_args();
@@ -8694,6 +8735,7 @@ fi
                 r#"{"scripts":{"lint":["check"],"test":["check"]}}"#,
             )
             .expect("component manifest");
+            init_git_primary(&primary);
             write_component_registration(home.path(), "fixture", &primary);
 
             for gate in [
@@ -8763,6 +8805,7 @@ fi
                     .unwrap()
                     .success());
             }
+            init_git_primary(&source);
             write_component_registration(home.path(), "fanout-mixed-fixture", &source);
             worktree::queue_create(worktree::WorktreeQueueCreateOptions {
                 repo: "fanout-mixed-fixture".to_string(),


### PR DESCRIPTION
Thirteen fanout tests fail on a clean checkout of `main`. Three of them never reach the behavior they assert.

Repository planning resolves the registered primary's default branch before anything else runs. These fixtures register a **bare directory** — no branch, no remote — so planning fails with:

```
Invalid argument 'base': repository default branch could not be inferred from configured or remote evidence
```

The case under test never executes. The assertion is not wrong and the code is not broken; the fixture never got far enough to exercise either.

## The fix

`init_git_primary` gives a planning target the repository that resolution expects, and publishes `origin/main` locally — a fixture must not need a network to resolve its own source ref.

It is **deliberately not folded into `write_component_registration`.** The large-registry case registers hundreds of unrelated components while measuring elapsed time, and only the planning target needs a repository. Initializing all of them would measure the fixture's cost instead of the lookup bound that test exists to prove.

## Verification

- `cargo fmt --all --check`
- fanout suite: **90 passed / 13 failed on `main` → 93 passed / 10 failed here**

Three fixed, zero regressions.

## Scope: what the remaining 10 are

They share one cause, and it is not this one:

```
Invalid argument 'provider_dispatchability': agent-task backend `sandbox` is not dispatchable:
the requested backend/selector route did not resolve
  route: { ready: false, reason: "no matching provider" }
```

No provider is registered for the `sandbox`/`test` backends those fixtures request. Fixing it needs extension registration and provider discovery in the fixture, which is a different shape of change with a different review surface — so it is left to a separate PR rather than folded in here.

Refs #12914

## AI assistance
- **AI assistance:** Yes
- **Model:** Claude Sonnet 4.6
- **Tool:** OpenCode via Kimaki
- **Used for:** Reproduced the 13 failures on a pristine `main` checkout, separated them into two distinct causes by their typed errors, implemented the fixture repair, and measured the before/after suite counts quoted above. Chris Huber directed the work and owns the change.