### PR TITLE
fix(runner): suppress the staged convergence items, not their module

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
@@ -25,11 +25,6 @@ mod local;
 mod probes;
 mod remote;
 mod repair;
-// The convergence decision lands ahead of the loop that executes it, so that the
-// half which is testable without a runner can be reviewed on its own (#13551).
-// `next_step` therefore has no production caller yet and the warning-clean gate
-// would otherwise reject it. The allowance comes off with the executing loop.
-#[allow(dead_code)]
 mod repair_policy;
 mod target;
 mod types;

--- a/crates/homeboy-cli/src/commands/runner/doctor/repair_policy.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/repair_policy.rs
@@ -34,11 +34,19 @@ use super::types::{RunnerCheck, RunnerDoctorStatus, RunnerRepairAction};
 /// Small on purpose. Each attempt is a network round trip plus a full re-probe,
 /// and a runner needing more than a handful of distinct repairs is not a
 /// convergence problem -- it is a runner an operator should look at.
+#[allow(
+    dead_code,
+    reason = "the convergence decision lands ahead of the loop that executes it (#13551); the allowance comes off with that loop"
+)]
 pub(crate) const DEFAULT_MAX_ATTEMPTS: usize = 4;
 
 /// The driver's next move.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "step", rename_all = "snake_case")]
+#[allow(
+    dead_code,
+    reason = "the convergence decision lands ahead of the loop that executes it (#13551); the allowance comes off with that loop"
+)]
 pub enum RepairStep {
     /// Run this action, then re-probe.
     Apply { action: RunnerRepairAction },
@@ -60,6 +68,10 @@ pub enum RepairStep {
 /// driver applies fixes in the order the probes found them; duplicates are
 /// dropped because two checks can legitimately want the same repair and running
 /// it twice in one pass would waste an attempt on the second.
+#[allow(
+    dead_code,
+    reason = "the convergence decision lands ahead of the loop that executes it (#13551); the allowance comes off with that loop"
+)]
 fn outstanding(checks: &[RunnerCheck]) -> Vec<RunnerRepairAction> {
     let mut seen: Vec<RunnerRepairAction> = Vec::new();
     for check in checks {
@@ -79,6 +91,10 @@ fn outstanding(checks: &[RunnerCheck]) -> Vec<RunnerRepairAction> {
 /// Decide the next step from the current report and the attempts already made.
 ///
 /// `history` is every action applied so far, in order.
+#[allow(
+    dead_code,
+    reason = "the convergence decision lands ahead of the loop that executes it (#13551); the allowance comes off with that loop"
+)]
 pub(crate) fn next_step(
     checks: &[RunnerCheck],
     history: &[RunnerRepairAction],


### PR DESCRIPTION
`main` is red on the dead-code ratchet, and it is my fault.

#13559 lands the convergence decision ahead of the loop that executes it, so `next_step` has no production caller yet and `-D warnings` rejects it. I reached for a module-level `#[allow(dead_code)]` on `mod repair_policy`, which is precisely the shape the ratchet exists to catch:

```
module-level dead_code suppression grew.
  ceiling: 2
  actual:  3   (+1)
```

```
a swept crate regained a module-level dead_code suppression
```

One line, and it silently removes an unbounded amount of code from the lint — the ratchet's own message says the repo reached 40 of them covering 52% of the tree that way.

## The fix

Take the ratchet's second option: suppress the four staged items individually, each stating why and naming the issue that retires the allowance. `repair_policy` keeps its lint coverage, and the module boundary stays honest.

## Verification

- `dead_code_suppression_ratchet_test` — **3 passed** (was 1 passed / 2 failed on `main`)
- `repair_policy` — 11 passed
- `RUSTFLAGS=-Dwarnings cargo build --locked -p homeboy --bin homeboy`
- `cargo fmt --all --check`

Refs #13551, #12914

## AI assistance
- **AI assistance:** Yes
- **Model:** Claude Sonnet 4.6
- **Tool:** OpenCode via Kimaki
- **Used for:** Noticed the ratchet failure while triaging another PR's differential gate, traced it to the module-level allowance I introduced in #13559, and replaced it with item-level suppressions. Chris Huber directed the work and owns the change.