### PR TITLE
fix(cli): stop reporting a zero-exit partial result as a failure

### DIFF
--- a/crates/homeboy-cli/src/commands/utils/response.rs
+++ b/crates/homeboy-cli/src/commands/utils/response.rs
@@ -1140,14 +1140,13 @@ fn tail_text(value: String) -> String {
 }
 
 fn status_for_result(data: Option<&Value>, exit_code: i32) -> String {
-    let payload_status = data
-        .and_then(|value| {
-            value
-                .get("status")
-                .and_then(Value::as_str)
-                .or_else(|| value.pointer("/batch/state").and_then(Value::as_str))
-        })
-        .and_then(normalize_status);
+    let raw_status = data.and_then(|value| {
+        value
+            .get("status")
+            .and_then(Value::as_str)
+            .or_else(|| value.pointer("/batch/state").and_then(Value::as_str))
+    });
+    let payload_status = raw_status.and_then(normalize_status);
     if exit_code != 0 {
         // A partial result is still a command failure, but retaining its precise
         // aggregate state lets machine consumers distinguish it from all-failed.
@@ -1160,6 +1159,17 @@ fn status_for_result(data: Option<&Value>, exit_code: i32) -> String {
                 .to_string();
         }
         return "failed".to_string();
+    }
+
+    // `partial` with a zero exit is a bounded pass that completed every category
+    // it ran and left a resumable continuation. `normalize_status` folds it into
+    // `partial_failure` because the canonical lifecycle vocabulary has no
+    // separate `partial`, which made schedulers record successful continuation
+    // passes as failures and eventually auto-disable them (#12727). The
+    // continuation itself stays legible in the payload's own `status` and
+    // `continuation_required`.
+    if raw_status.is_some_and(|status| status.eq_ignore_ascii_case("partial")) {
+        return "succeeded".to_string();
     }
 
     payload_status.unwrap_or("succeeded").to_string()
@@ -1538,6 +1548,42 @@ fn append_python_json_string(json: &mut String, value: &str) {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// A bounded pass that left a resumable continuation must not surface to
+    /// schedulers as a failure.
+    ///
+    /// The canonical lifecycle vocabulary has no `partial`, so `normalize_status`
+    /// folds it into `partial_failure`. With a zero exit that turned successful
+    /// continuation passes into recorded scheduler failures, which is what drove
+    /// `automatic-retention` to auto-disable after 49 of them (#12727).
+    #[test]
+    fn a_zero_exit_partial_result_is_not_reported_as_a_failure() {
+        let partial = json!({ "status": "partial", "continuation_required": true });
+        assert_eq!(status_for_result(Some(&partial), 0), "succeeded");
+
+        // Case-insensitive, matching `normalize_status`.
+        let shouty = json!({ "status": "PARTIAL" });
+        assert_eq!(status_for_result(Some(&shouty), 0), "succeeded");
+    }
+
+    /// The regression boundary: a real partial failure keeps its status, and a
+    /// non-zero exit is never laundered into success.
+    #[test]
+    fn genuine_partial_failures_keep_failing() {
+        let failed = json!({ "status": "partial_failure" });
+        assert_eq!(status_for_result(Some(&failed), 1), "partial_failure");
+
+        // `partial` with a non-zero exit stays a failure, keeping its precise
+        // aggregate state rather than collapsing to a bare `failed`.
+        let partial_but_failed = json!({ "status": "partial" });
+        assert_eq!(
+            status_for_result(Some(&partial_but_failed), 1),
+            "partial_failure"
+        );
+
+        let succeeded = json!({ "status": "succeeded" });
+        assert_eq!(status_for_result(Some(&succeeded), 0), "succeeded");
+    }
 
     #[test]
     fn runtime_inventory_fingerprint_matches_python_json_for_unicode_and_controls() {


### PR DESCRIPTION
Refs #12727. Follow-up to #13665.

## Problem

#13665 taught the cleanup aggregate to separate a resumable continuation from a fault. That half works — verified on a live host after it shipped:

```
data.status:                  partial
failed_category_count:        0
continuation_category_count:  1
exit_code:                    0
```

But the command-result envelope undoes it:

```
envelope status:  partial_failure
```

`normalize_status` has no canonical `partial` in the run-lifecycle vocabulary, so it folds the two together:

```rust
"partial_failure" | "partial-failure" | "partial" => Some("partial_failure"),
```

Schedulers read the **envelope** status, not the exit code. So a successful continuation pass is still recorded as a failure:

```
$ homeboy schedule run disk-pressure-retention
run status: partial_failure   exit: 0

$ homeboy schedule show disk-pressure-retention
last_exit_code:        0
last_status:           partial_failure
consecutive_failures:  19        # still climbing
```

That is the same counter that auto-disabled `automatic-retention` at 49. So the observable symptom in #12727 — scheduled cleanup disabling itself while reclaiming bytes — survived the first fix.

## Change

At the envelope, `partial` with a zero exit resolves to `succeeded`.

The continuation is not hidden: the payload keeps its own `status: "partial"` plus `continuation_required: true`, which is where machine consumers already look for it. The canonical status set is unchanged, so this adds no new lifecycle vocabulary.

A non-zero exit is untouched — `partial` still resolves to `partial_failure` there, retaining its precise aggregate state rather than collapsing to a bare `failed`.

## Scope note

`status: "partial"` is also emitted by `commands/upgrade.rs` and by `automatic_retention`, which returns exit 0 for `partial` already. Both were mislabelled the same way and both are corrected by this change — consistently, since they mean the same thing.

## Tests

- `a_zero_exit_partial_result_is_not_reported_as_a_failure` — covers the fix, including the case-insensitive path that `normalize_status` already honours.
- `genuine_partial_failures_keep_failing` — the regression boundary: an explicit `partial_failure` with exit 1 keeps its status, `partial` with exit 1 stays `partial_failure`, and a plain success is unaffected.

Verified the first test is a real regression test by surgically removing only the new branch and re-running it:

```
failures:
    commands::utils::response::tests::a_zero_exit_partial_result_is_not_reported_as_a_failure
```

It passes with the branch restored.

While writing the boundary test I initially asserted that `partial` + exit 1 should become `failed`. That was wrong — the existing code deliberately retains the precise aggregate state on failure, and the test now asserts the real, correct behaviour.

```
cargo test -p homeboy-cli --lib utils::response   28 passed
cargo test -p homeboy-cli --lib cleanup::         52 passed
cargo fmt --check                                 clean
cargo clippy -p homeboy-cli --all-targets         0 warnings in response.rs
```

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.6 via Claude Code
- **Used for:** Re-checked the live host after #13665 merged, found the envelope was still reporting failures and `consecutive_failures` still climbing, traced it to `normalize_status`, wrote the fix and tests, and proved the regression boundary. Reviewed by me before opening.
