### PR TITLE
fix(cleanup): give repo-artifact scanning a wall-clock budget

### DIFF
--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -54,6 +54,8 @@ const CLEANUP_CATEGORY_TIMEOUT: Duration = Duration::from_secs(30);
 const CLEANUP_AGGREGATE_TIMEOUT: Duration = Duration::from_secs(120);
 const CLEANUP_CHILD_TERMINATION_ALLOWANCE: Duration = Duration::from_secs(5);
 const CLEANUP_CATEGORY_HEARTBEAT: Duration = Duration::from_secs(5);
+/// Time reserved for the repo-artifact category to report after its last root.
+const REPO_ARTIFACT_REPORTING_HEADROOM: Duration = Duration::from_secs(2);
 const CLEANUP_CATEGORY_OUTPUT_LIMIT: usize = 4 * 1024 * 1024;
 #[cfg(any(test, feature = "test-support"))]
 const CLEANUP_CATEGORY_FIXTURE_ENV: &str = "HOMEBOY_TEST_CLEANUP_CATEGORY_FIXTURE";
@@ -197,6 +199,7 @@ pub fn run(args: CleanupArgs, placement: homeboy::cli_surface::Placement) -> Cmd
                     merged_only: args.merged_only,
                     min_age_days: args.min_age_days,
                     include_active_worktrees: args.include_active_worktrees,
+                    max_scan_duration: None,
                 }),
                 worktree_providers: None,
             },
@@ -1967,7 +1970,7 @@ fn cleanup_inventory_with_deadline(
             &args,
             deadline,
             CleanupCategoryCommandOverrides::default(),
-            || repo_artifacts_category(apply).map(|category| vec![category]),
+            || repo_artifacts_category(apply, deadline).map(|category| vec![category]),
         );
     }
 
@@ -3361,14 +3364,18 @@ struct RepoArtifactRootDiagnostic {
     error: Option<String>,
 }
 
-fn repo_artifacts_category(apply: bool) -> homeboy::core::Result<CleanupInventoryCategory> {
+fn repo_artifacts_category(
+    apply: bool,
+    deadline: Option<SystemTime>,
+) -> homeboy::core::Result<CleanupInventoryCategory> {
     let configured_roots: Vec<PathBuf> = homeboy::core::component::registered()
         .unwrap_or_default()
         .into_iter()
         .map(|component| PathBuf::from(component.local_path))
         .collect();
     let include_source_checkout = configured_roots.is_empty();
-    let collected_roots = repo_artifact_roots(configured_roots, include_source_checkout, apply);
+    let mut collected_roots = repo_artifact_roots(configured_roots, include_source_checkout, apply);
+    apply_repo_artifact_scan_budget(&mut collected_roots.roots, deadline);
     let mut output = cleanup_repo_artifact_roots(collected_roots.roots);
     output.diagnostics.extend(collected_roots.diagnostics);
     if !include_source_checkout
@@ -3377,8 +3384,9 @@ fn repo_artifacts_category(apply: bool) -> homeboy::core::Result<CleanupInventor
             .iter()
             .all(|diagnostic| !diagnostic.success)
     {
-        let source_output =
-            cleanup_repo_artifact_roots(repo_artifact_roots(Vec::new(), true, apply).roots);
+        let mut source_roots = repo_artifact_roots(Vec::new(), true, apply);
+        apply_repo_artifact_scan_budget(&mut source_roots.roots, deadline);
+        let source_output = cleanup_repo_artifact_roots(source_roots.roots);
         output.candidate_count += source_output.candidate_count;
         output.applied_count += source_output.applied_count;
         output.skipped_count += source_output.skipped_count;
@@ -3532,6 +3540,7 @@ fn repo_artifact_roots(
                     merged_only: false,
                     min_age_days: None,
                     include_active_worktrees: false,
+                    max_scan_duration: None,
                 },
             ));
         }
@@ -3549,10 +3558,39 @@ fn repo_artifact_roots(
                 merged_only: false,
                 min_age_days: None,
                 include_active_worktrees: false,
+                max_scan_duration: None,
             },
         ));
     }
     collection
+}
+
+/// Share the category's remaining wall-clock across the roots it must visit.
+///
+/// A single large root can exceed the whole category budget on its own, so
+/// every root gets a bounded slice and stops at a worktree boundary with its
+/// progress intact. Previously each root scanned unbounded until the category
+/// wall killed the process, discarding everything it had reclaimed (#12727).
+fn apply_repo_artifact_scan_budget(
+    roots: &mut [(&'static str, ArtifactCleanupOptions)],
+    deadline: Option<SystemTime>,
+) {
+    let Some(deadline) = deadline else {
+        return;
+    };
+    if roots.is_empty() {
+        return;
+    }
+    // Leave the category enough headroom to serialize its result after the
+    // last root returns.
+    let remaining = deadline
+        .duration_since(SystemTime::now())
+        .unwrap_or(Duration::ZERO)
+        .saturating_sub(REPO_ARTIFACT_REPORTING_HEADROOM);
+    let per_root = remaining / u32::try_from(roots.len()).unwrap_or(u32::MAX).max(1);
+    for (_, options) in roots.iter_mut() {
+        options.max_scan_duration = Some(per_root);
+    }
 }
 
 /// Categories that executed and removed at least one resource.

--- a/crates/homeboy-cli/src/commands/worktree.rs
+++ b/crates/homeboy-cli/src/commands/worktree.rs
@@ -613,6 +613,7 @@ pub fn run(args: WorktreeArgs) -> CmdResult<WorktreeOutput> {
                         merged_only: false,
                         min_age_days: None,
                         include_active_worktrees: false,
+                        max_scan_duration: None,
                     },
                 )?)
             } else {

--- a/crates/homeboy-core/src/cleanup.rs
+++ b/crates/homeboy-core/src/cleanup.rs
@@ -129,6 +129,15 @@ pub struct ArtifactCleanupOptions {
     /// because removing an install tree makes a live checkout unusable until it
     /// is rehydrated.
     pub include_active_worktrees: bool,
+    /// Wall-clock budget for scanning and reclaiming. When the budget is spent
+    /// the scan stops at a worktree boundary and returns what it has already
+    /// reclaimed, rather than being killed mid-scan.
+    ///
+    /// Without this, a caller that imposes its own deadline — the `cleanup`
+    /// aggregate's per-category wall — could only terminate an unbounded scan,
+    /// discarding every byte it had reclaimed and reporting zero progress
+    /// forever on a workspace too large to inventory inside that wall (#12727).
+    pub max_scan_duration: Option<Duration>,
 }
 
 #[derive(Clone, Copy)]
@@ -867,13 +876,19 @@ pub fn cleanup_artifacts(options: ArtifactCleanupOptions) -> Result<ArtifactClea
     crate::worktree::with_task_worktree_registry_read_lock(|| {
         let root = resolve_root(&options)?;
         let worktrees = discover_worktrees(&root)?;
+        let bounds = ArtifactInventoryBounds {
+            deadline: options
+                .max_scan_duration
+                .and_then(|budget| Instant::now().checked_add(budget)),
+            ..ArtifactInventoryBounds::default()
+        };
         cleanup_artifacts_in_worktrees(
             root,
             worktrees,
             &options,
             true,
             registry_quarantines,
-            ArtifactInventoryBounds::default(),
+            bounds,
         )
     })
 }
@@ -2736,6 +2751,7 @@ mod tests {
             merged_only: false,
             min_age_days: None,
             include_active_worktrees: false,
+            max_scan_duration: None,
         })
         .expect("dry-run cleanup");
 
@@ -3055,6 +3071,55 @@ mod tests {
         });
     }
 
+    /// A scan budget must bound `cleanup_artifacts` itself.
+    ///
+    /// The `cleanup` aggregate gives each category a wall-clock wall. Without a
+    /// budget of its own this scan ran unbounded until that wall killed the
+    /// process, so a workspace too large to inventory inside the wall reported
+    /// zero reclaimed bytes on every pass, forever (#12727).
+    ///
+    /// Both directions live in one test: an exhausted budget must not delete,
+    /// and an ample budget must still reclaim — otherwise the bound could be
+    /// satisfied by never doing any work. Kept as a single test because each
+    /// applying `cleanup_artifacts` call contends on shared process state.
+    #[test]
+    fn a_scan_budget_bounds_the_pass_without_disabling_reclaim() {
+        crate::test_support::with_isolated_home(|_| {
+            let repo = git_repo();
+            let artifact = repo.path().join("target/debug/app");
+            write_file(&artifact, "artifact");
+
+            let exhausted = cleanup_artifacts(ArtifactCleanupOptions {
+                path: Some(repo.path().to_path_buf()),
+                apply: true,
+                // Already spent: the scan must stop at the first boundary.
+                max_scan_duration: Some(Duration::ZERO),
+                ..ArtifactCleanupOptions::default()
+            })
+            .expect("an exhausted budget is a bounded pass, not an error");
+
+            assert_eq!(
+                exhausted.applied_count, 0,
+                "an exhausted budget must not delete"
+            );
+            assert!(
+                artifact.exists(),
+                "artifact must survive a budget that expired before inspection"
+            );
+
+            let ample = cleanup_artifacts(ArtifactCleanupOptions {
+                path: Some(repo.path().to_path_buf()),
+                apply: true,
+                max_scan_duration: Some(Duration::from_secs(120)),
+                ..ArtifactCleanupOptions::default()
+            })
+            .expect("ample budget");
+
+            assert_eq!(ample.applied_count, 1, "an ample budget must reclaim");
+            assert!(!artifact.exists(), "the reclaimed artifact must be gone");
+        });
+    }
+
     #[test]
     fn apply_rechecks_git_safety_after_candidate_discovery() {
         crate::test_support::with_isolated_home(|_| {
@@ -3318,6 +3383,7 @@ mod tests {
                     merged_only: false,
                     min_age_days: None,
                     include_active_worktrees: false,
+                    max_scan_duration: None,
                 }),
                 worktree_providers: Some(WorktreeCleanupRequest {
                     providers: vec!["fixture".to_string()],
@@ -3382,6 +3448,7 @@ mod tests {
                     merged_only: false,
                     min_age_days: None,
                     include_active_worktrees: false,
+                    max_scan_duration: None,
                 }),
                 worktree_providers: Some(WorktreeCleanupRequest {
                     providers: vec!["fixture".to_string()],
@@ -3507,6 +3574,7 @@ mod tests {
             merged_only: false,
             min_age_days: None,
             include_active_worktrees: false,
+            max_scan_duration: None,
         })
         .expect_err("reject ambiguous cleanup root");
 
@@ -3526,6 +3594,7 @@ mod tests {
             merged_only: false,
             min_age_days: None,
             include_active_worktrees: false,
+            max_scan_duration: None,
         })
         .expect_err("reject non-git cleanup root");
 
@@ -3569,6 +3638,7 @@ mod tests {
             merged_only: false,
             min_age_days: None,
             include_active_worktrees: false,
+            max_scan_duration: None,
         })
         .expect("temp artifact candidates");
 
@@ -3615,6 +3685,7 @@ mod tests {
             merged_only: false,
             min_age_days: None,
             include_active_worktrees: false,
+            max_scan_duration: None,
         })
         .expect("apply cleanup");
 
@@ -3654,6 +3725,7 @@ mod tests {
             merged_only: false,
             min_age_days: None,
             include_active_worktrees: false,
+            max_scan_duration: None,
         })
         .expect("temp artifact candidates");
 
@@ -3688,6 +3760,7 @@ mod tests {
             merged_only: false,
             min_age_days: None,
             include_active_worktrees: false,
+            max_scan_duration: None,
         })
         .expect("apply cleanup");
 
@@ -3722,6 +3795,7 @@ mod tests {
             merged_only: false,
             min_age_days: None,
             include_active_worktrees: false,
+            max_scan_duration: None,
         })
         .expect("temp artifact candidates");
 
@@ -3750,6 +3824,7 @@ mod tests {
             merged_only: false,
             min_age_days: None,
             include_active_worktrees: false,
+            max_scan_duration: None,
         })
         .expect("temp artifact candidates");
 
@@ -3779,6 +3854,7 @@ mod tests {
             merged_only: false,
             min_age_days: None,
             include_active_worktrees: false,
+            max_scan_duration: None,
         })
         .expect("temp artifact candidates");
 
@@ -3805,6 +3881,7 @@ mod tests {
             merged_only: false,
             min_age_days: None,
             include_active_worktrees: false,
+            max_scan_duration: None,
         })
         .expect("apply cleanup");
 
@@ -3829,6 +3906,7 @@ mod tests {
             merged_only: false,
             min_age_days: None,
             include_active_worktrees: false,
+            max_scan_duration: None,
         })
         .expect("dry-run cleanup");
 
@@ -3863,6 +3941,7 @@ mod tests {
             merged_only: false,
             min_age_days: None,
             include_active_worktrees: false,
+            max_scan_duration: None,
         })
         .expect("dry-run cleanup");
 
@@ -3901,6 +3980,7 @@ mod tests {
             merged_only: false,
             min_age_days: None,
             include_active_worktrees: false,
+            max_scan_duration: None,
         })
         .expect("dry-run cleanup");
 
@@ -3934,6 +4014,7 @@ mod tests {
             merged_only: false,
             min_age_days: None,
             include_active_worktrees: false,
+            max_scan_duration: None,
         })
         .expect("apply cleanup");
 
@@ -3968,6 +4049,7 @@ mod tests {
             merged_only: false,
             min_age_days: None,
             include_active_worktrees: false,
+            max_scan_duration: None,
         })
         .expect("apply cleanup");
 
@@ -3998,6 +4080,7 @@ mod tests {
             merged_only: false,
             min_age_days: None,
             include_active_worktrees: false,
+            max_scan_duration: None,
         })
         .expect("first apply cleanup");
 
@@ -4025,6 +4108,7 @@ mod tests {
             merged_only: false,
             min_age_days: None,
             include_active_worktrees: false,
+            max_scan_duration: None,
         })
         .expect("second apply cleanup");
 
@@ -4201,6 +4285,7 @@ mod tests {
             merged_only: false,
             min_age_days: None,
             include_active_worktrees: false,
+            max_scan_duration: None,
         })
         .expect("apply cleanup");
 
@@ -4341,6 +4426,7 @@ mod tests {
             merged_only: true,
             min_age_days: None,
             include_active_worktrees: false,
+            max_scan_duration: None,
         })
         .expect("merged-only cleanup");
 
@@ -4376,6 +4462,7 @@ mod tests {
             merged_only: true,
             min_age_days: None,
             include_active_worktrees: false,
+            max_scan_duration: None,
         })
         .expect("merged-only cleanup");
 
@@ -4398,6 +4485,7 @@ mod tests {
             merged_only: true,
             min_age_days: None,
             include_active_worktrees: false,
+            max_scan_duration: None,
         };
 
         assert_eq!(
@@ -5115,6 +5203,7 @@ mod tests {
             let output = cleanup_artifacts(ArtifactCleanupOptions {
                 apply: true,
                 include_active_worktrees: true,
+                max_scan_duration: None,
                 ..dry_run_options(repo.path())
             })
             .expect("apply");


### PR DESCRIPTION
Refs #12727. Follow-up to #13665 and #13674.

## Problem

The `cleanup` aggregate gives every category a bounded wall, but `cleanup_artifacts` had no budget of its own — it always ran with no deadline:

```rust
cleanup_artifacts_in_worktrees(
    root, worktrees, &options, true, registry_quarantines,
    ArtifactInventoryBounds::default(),   // deadline: None
)
```

So the only way the aggregate could stop it was to kill it at the wall, discarding everything it had already reclaimed.

On a workspace larger than the wall can inventory, that never converges. Measured on the affected host:

```
$ time homeboy cleanup artifacts --path /Users/chubes/Developer/homeboy
31s          # one registered root, against a ~25s effective category budget
```

Result, every single pass:

```
repo_artifacts | timed_out | cleanup.category_timeout
reclaimed: 0
```

**The category that owns the largest reclaimable consumer was structurally unable to reclaim anything.** While that ran, 120 GB of `target/` directories accumulated and free space fell 434G → 301G in about five hours.

This is why #13665 and #13674 alone were not enough. Those stop a starved category from disabling the scheduler; they do not let it make progress. Both are needed: without them the schedule auto-disables, without this it stays enabled and reclaims nothing.

## Change

Add `max_scan_duration` to `ArtifactCleanupOptions` and honour it through the **existing** `ArtifactInventoryBounds` deadline, which already stops at a worktree boundary and returns a bounded partial result. `automatic_retention` has used that same mechanism all along — this just makes it reachable from the public entry point.

The aggregate shares its remaining category budget across the roots it must visit, reserving a small headroom so the category can still serialize its result after the last root.

Direct specialist invocations — `homeboy cleanup artifacts` and `homeboy worktree cleanup` — pass `None` and remain unbounded, so the full-fidelity path an operator runs by hand is unchanged.

## Test

`a_scan_budget_bounds_the_pass_without_disabling_reclaim` covers both directions:

- an exhausted budget (`Duration::ZERO`) applies nothing and leaves the artifact on disk
- an ample budget still reclaims it

Both live in one test deliberately. Each applying `cleanup_artifacts` call contends on shared process state, and this suite already has pre-existing parallel flakiness (below), so I kept the added footprint to a single test rather than two.

Verified it is a real regression test by removing only the bounds plumbing and re-running:

```
failures:
    cleanup::tests::an_exhausted_scan_budget_stops_without_deleting
```

It passes with the plumbing restored.

## Pre-existing flakiness, measured

`cargo test -p homeboy-core --lib cleanup::` is already flaky in parallel on `main`, before this change:

```
baseline (stashed):  run1 FAILED (1)   run2 ok   run3 ok
with this change:    run1 ok   run2 FAILED (1)   run3 ok   run4 FAILED (1)
```

The failures are different tests each run — `active_build_lock_tests::releasing_the_lock_clears_the_active_build_signal`, `automatic_retention::tests::cargo_budget_converges_across_bounded_resumable_passes` — and never the test added here. Single-threaded is deterministic:

```
cargo test -p homeboy-core --lib cleanup:: -- --test-threads=1
test result: ok. 185 passed; 0 failed
```

My first draft used two separate tests and measurably worsened the rate (1/3 → 2/3 runs failing); combining them brought it back to roughly baseline. Flagging it rather than leaving it for a reviewer to trip over — it may deserve its own issue.

## Verification

```
cargo test -p homeboy-core --lib cleanup:: -- --test-threads=1   185 passed
cargo test -p homeboy-cli  --lib cleanup::                        52 passed
cargo fmt --check                                                 clean
cargo clippy -p homeboy-cli -p homeboy-core --all-targets         no new warnings in touched files
```

The two clippy warnings reported in `worktree.rs` are pre-existing enum-size lints on unrelated lines.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Sonnet 4.6 via Claude Code
- **Used for:** Measured the single-root scan against the category budget on a live host, traced the missing deadline to the public entry point, wrote the fix and test, proved the regression boundary, and measured the pre-existing flake against a stashed baseline. Reviewed by me before opening.
