### PR TITLE
fix(fanout): install the executor providers the fixtures dispatch against

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -5938,7 +5938,8 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn dispatcher_fanout_execution_finalizes_failed_provider_lifecycle() {
-        with_isolated_home(|_| {
+        with_isolated_home(|home| {
+            install_fanout_agent_task_providers(home.path());
             let (_fixture, records, mut plan) = provider_finalization_fixture();
             plan.cooks.truncate(1);
             let dispatcher: &CookAttemptDispatcherFactory =
@@ -6894,6 +6895,51 @@ fi
         });
     }
 
+    /// Install the executor providers the fanout fixtures dispatch against.
+    ///
+    /// Provider selection resolves a `--backend`/`--selector` pair against the
+    /// installed catalog, which core discovers from standalone agent-runtime
+    /// manifests under the config root. A hermetic home has none, so every case
+    /// that dispatches fails with "is not dispatchable: the requested
+    /// backend/selector route did not resolve" before reaching what it asserts.
+    ///
+    /// Both fixture argument builders are covered, and their selectors are
+    /// distinct provider ids, so one home can serve both without colliding.
+    fn install_fanout_agent_task_providers(home: &Path) {
+        for (provider_id, backend) in [("sample.executor-provider", "sandbox"), ("fixture", "test")]
+        {
+            let runtime_id = format!("{backend}-runtime");
+            let runtime_dir = home
+                .join(".config/homeboy/agent-runtimes")
+                .join(&runtime_id);
+            std::fs::create_dir_all(&runtime_dir).expect("agent runtime directory");
+            std::fs::write(
+                runtime_dir.join(format!("{runtime_id}.json")),
+                serde_json::json!({
+                    "schema": "homeboy/agent-runtime-manifest/v1",
+                    "id": runtime_id,
+                    "runtime_path": runtime_dir,
+                    "agent_task_executors": [{
+                        "schema": "homeboy/agent-task-executor-provider/v1",
+                        "id": provider_id,
+                        "backend": backend,
+                        "invocation": { "argv": ["node", "{{runtime_path}}/runner.cjs"] },
+                        "request_schema": "homeboy/agent-task-request/v1",
+                        "outcome_schema": "homeboy/agent-task-outcome/v1"
+                    }]
+                })
+                .to_string(),
+            )
+            .expect("agent runtime manifest");
+        }
+        // The catalog is discovered once per process and cached, and that cache
+        // is not keyed by config root. Without an explicit refresh the first
+        // hermetic home to look wins for the whole binary, so a fixture that
+        // installs a provider still sees the empty catalog of whichever test
+        // ran first. Re-discover against the home that just changed.
+        homeboy::agents::agent_tasks::provider::AgentTaskProviderCatalog::refresh();
+    }
+
     fn write_component_registration(home: &Path, id: &str, local_path: &Path) {
         let components = home.join(".config/homeboy/components");
         std::fs::create_dir_all(&components).expect("components directory");
@@ -7134,6 +7180,7 @@ fi
 
     fn with_materialized_cook_batch_worktrees(test: impl FnOnce()) {
         with_isolated_home(|home| {
+            install_fanout_agent_task_providers(home.path());
             let mut config = homeboy::core::defaults::load_config();
             config.agent_task.default_backend = Some("sandbox".to_string());
             config.worktree_providers.clear();
@@ -8233,7 +8280,8 @@ fi
 
     #[test]
     fn recipe_preflight_accepts_safe_pre_execution_recipe_corrections() {
-        with_isolated_home(|_| {
+        with_isolated_home(|home| {
+            install_fanout_agent_task_providers(home.path());
             let plan = test_batch_plan();
             let compiled = compile_batch_cooks(&plan, |_| {}).expect("compile batch cooks");
             let mut invocation = plan.cooks[0]
@@ -8257,7 +8305,8 @@ fi
 
     #[test]
     fn local_selected_fanout_recipes_remain_local_through_preflight() {
-        with_isolated_home(|_| {
+        with_isolated_home(|home| {
+            install_fanout_agent_task_providers(home.path());
             let plan = test_batch_plan();
 
             persist_batch_cook_recipes(&plan, |_| {}).expect("persist local child recipes");
@@ -8282,7 +8331,8 @@ fi
 
     #[test]
     fn lab_or_local_fanout_recipes_preserve_the_dispatcher_used_for_execution() {
-        with_isolated_home(|_| {
+        with_isolated_home(|home| {
+            install_fanout_agent_task_providers(home.path());
             let plan = test_batch_plan();
             let dispatcher = |_: &AgentTaskCookServiceOptions| {
                 std::sync::Arc::new(LabRecipeDispatcher)


### PR DESCRIPTION
Ten fanout tests fail on a clean checkout of `main` without ever reaching what they assert.

Provider selection resolves a `--backend`/`--selector` pair against the installed catalog, which core discovers from standalone agent-runtime manifests under the config root. A hermetic home has none, so dispatch dies in setup:

```
Invalid argument 'provider_dispatchability': agent-task backend `sandbox` is not dispatchable:
the requested backend/selector route did not resolve
  route: { ready: false, reason: "no matching provider" }
```

`install_fanout_agent_task_providers` writes one manifest per fixture argument builder — `sample.executor-provider`/`sandbox` and `fixture`/`test`. Their selectors are distinct provider ids, so one home serves both without colliding.

## The cache is the other half

Installing the manifests was not enough, and the reason is worth stating plainly:

```rust
static PROVIDER_CATALOG: OnceLock<RwLock<AgentTaskProviderCatalog>> = OnceLock::new();
```

The catalog is discovered **once per process** and cached, and that cache **is not keyed by config root**. Under `#[cfg(test)]` the agents crate re-discovers every call, but when it is compiled as a dependency of the CLI test binary that `cfg` is off — so the first hermetic home to look wins for the entire binary. A fixture that installed a provider still saw the empty catalog of whichever test happened to run first.

That is exactly why these cases **passed in isolation and failed in the suite**, which is what made them look like flakes. The fixture now refreshes the catalog against the home it just changed.

## Verification

- `cargo fmt --all --check`
- `RUSTFLAGS=-Dwarnings cargo build --locked -p homeboy --bin homeboy`
- fanout: **93 passed / 10 failed on `main` → 100 passed / 3 failed here**

Seven fixed, zero regressions. (`commands::agent_task::review::tests::compact_provider_bounds_extensions_and_large_diagnostics` fails identically before and after — it is pre-existing on `main`.)

## The three that remain are not this cause

| test | why |
|---|---|
| `compile_batch_cooks_delivers_controller_context_to_every_cell` | runs with **no hermetic home**, so it reads whatever catalog the developer or runner has. It also holds `env_lock`, and wrapping it in `with_isolated_home` **deadlocks** — so giving it a home is its own change, not a rider on this one. |
| `cook_batch_run_plan_binds_inferred_worktree_for_dispatch_and_promotion` | same missing-home problem, without the deadlock |
| `cook_batch_reuses_multiple_existing_issue_worktrees_before_lab_reconciliation` | fails on worktree **reuse**, reporting `would_create` for handles it should have adopted. Different subsystem. |

Refs #12914

## AI assistance
- **AI assistance:** Yes
- **Model:** Claude Sonnet 4.6
- **Tool:** OpenCode via Kimaki
- **Used for:** Traced provider discovery to the agent-runtime manifest layout, found the process-global catalog cache that made the fixtures look flaky, implemented the fixture and refresh, and measured the before/after counts quoted above. Chris Huber directed the work and owns the change.