### PR TITLE
fix(agent-task): key the provider catalog by the config root it came from

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/catalog.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/catalog.rs
@@ -12,8 +12,16 @@ use super::secrets::{
 use super::*;
 use homeboy_engine_primitives::content_hash;
 
+/// The discovered catalog, keyed by the config root it was discovered from.
+///
+/// Providers come from agent-runtime manifests under the config root, so a
+/// catalog is only valid for the root that produced it. Caching it unkeyed made
+/// the first root a process ever looked at answer for every later one, which is
+/// invisible in production (one root per process) and load-bearing under test,
+/// where each hermetic home is a new root in the same process.
 #[cfg(not(test))]
-static PROVIDER_CATALOG: OnceLock<RwLock<AgentTaskProviderCatalog>> = OnceLock::new();
+static PROVIDER_CATALOG: OnceLock<RwLock<Option<(PathBuf, AgentTaskProviderCatalog)>>> =
+    OnceLock::new();
 
 #[derive(Debug, Clone, Default)]
 pub struct ExtensionProviderAgentTaskExecutor {
@@ -36,8 +44,16 @@ impl AgentTaskProviderCatalog {
     pub fn discover() -> Self {
         #[cfg(not(test))]
         {
-            let catalog = PROVIDER_CATALOG.get_or_init(|| RwLock::new(discover_provider_catalog()));
-            return catalog.read().expect("provider catalog lock").clone();
+            let root = catalog_config_root();
+            let cache = PROVIDER_CATALOG.get_or_init(|| RwLock::new(None));
+            if let Ok(slot) = cache.read() {
+                if let Some((cached_root, catalog)) = slot.as_ref() {
+                    if *cached_root == root {
+                        return catalog.clone();
+                    }
+                }
+            }
+            return Self::refresh();
         }
         #[cfg(test)]
         {
@@ -49,8 +65,10 @@ impl AgentTaskProviderCatalog {
         #[cfg(not(test))]
         {
             let refreshed = discover_provider_catalog();
-            let catalog = PROVIDER_CATALOG.get_or_init(|| RwLock::new(refreshed.clone()));
-            *catalog.write().expect("provider catalog lock") = refreshed.clone();
+            let cache = PROVIDER_CATALOG.get_or_init(|| RwLock::new(None));
+            if let Ok(mut slot) = cache.write() {
+                *slot = Some((catalog_config_root(), refreshed.clone()));
+            }
             refreshed
         }
         #[cfg(test)]
@@ -216,6 +234,15 @@ impl AgentTaskProviderCatalog {
     ) -> HashMap<String, defaults::AgentTaskSecretSource> {
         provider_secret_sources_for_providers(&self.providers)
     }
+}
+
+/// The config root a cached catalog belongs to.
+///
+/// An unresolvable root is its own key, so a failed resolution never adopts the
+/// catalog of whatever root resolved last.
+#[cfg(not(test))]
+fn catalog_config_root() -> PathBuf {
+    homeboy_core::paths::homeboy().unwrap_or_else(|_| PathBuf::from("<unresolved-config-root>"))
 }
 
 fn discover_provider_catalog() -> AgentTaskProviderCatalog {


### PR DESCRIPTION
Providers are discovered from agent-runtime manifests **under the config root**, so a catalog is only ever valid for the root that produced it. The cache held one catalog with no key:

```rust
static PROVIDER_CATALOG: OnceLock<RwLock<AgentTaskProviderCatalog>> = OnceLock::new();
```

So the first root a process ever looked at answers for every later one.

## Why this looked like flakiness

In production a process has one config root, so this is invisible. Under test it is load-bearing: **every hermetic home is a new root in the same process**, so whichever case ran first decided what every later case saw.

That is the actual explanation for a signature I kept writing off during this queue — cases that **pass alone and fail in the suite**. They were reading a catalog discovered against a different home. Deterministic cache-ordering, not nondeterminism.

## The fix

The cache carries the root it was discovered from and re-discovers when the root changes. An unresolvable root is its own key, so a failed resolution never adopts the catalog of whatever root resolved last.

Refreshing after installing a provider (#13685) is still correct and still required — keying fixes a **stale root**, not **changed content under the same root**. I verified that by removing the refresh: the suite drifted back to 99-100 passed / 3-4 failed. Both are needed, and they solve different problems.

## Verification

- fanout: **100 passed / 3 failed, stable across three consecutive runs** (it drifted run to run before)
- `agent_task_provider`: 206 passed / 2 failed — **identical to `main`**, verified by stashing this change and re-running
- `cargo fmt --all --check`

Refs #12914

## AI assistance
- **AI assistance:** Yes
- **Model:** Claude Sonnet 4.6
- **Tool:** OpenCode via Kimaki
- **Used for:** Traced repeated pass-alone/fail-in-suite behavior to this unkeyed cache rather than accepting it as flake, implemented the keying, and confirmed by experiment that the existing refresh is still required for content changes. Chris Huber directed the work and owns the change.