### PR TITLE
Treat a supervising local cook lease as ownership

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -705,8 +705,8 @@ impl AgentTaskRunRecord {
             supervisor["state"].as_str(),
             Some("pending" | "supervising")
         ) && self.metadata["cook_id"]
-                .as_str()
-                .is_some_and(|cook_id| !cook_id.trim().is_empty())
+            .as_str()
+            .is_some_and(|cook_id| !cook_id.trim().is_empty())
             && supervisor["pinned_run_id"] == self.run_id
             && started_at <= now
             && now < expires_at

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -694,8 +694,17 @@ impl AgentTaskRunRecord {
         else {
             return false;
         };
-        supervisor["state"] == "pending"
-            && self.metadata["cook_id"]
+        // A lease that has advanced to `supervising` is holding this exact run,
+        // which is stronger ownership evidence than one still requesting it.
+        // Admitting only `pending` cancelled every detached local Cook the
+        // moment its supervisor started supervising and before it published an
+        // owner pid. The lease window below is what keeps an abandoned lease
+        // from protecting a genuinely dead run, and it bounds both states
+        // identically.
+        matches!(
+            supervisor["state"].as_str(),
+            Some("pending" | "supervising")
+        ) && self.metadata["cook_id"]
                 .as_str()
                 .is_some_and(|cook_id| !cook_id.trim().is_empty())
             && supervisor["pinned_run_id"] == self.run_id

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -2919,6 +2919,53 @@ mod tests {
             .has_live_pending_local_cook_supervisor(started_at + chrono::Duration::seconds(1)));
     }
 
+    /// A supervisor that has begun supervising still owns its run. Admitting
+    /// only `pending` reconciled every detached local Cook as ownerless the
+    /// moment its lease advanced, cancelling a healthy attempt before it had
+    /// published an owner pid (#13692). The lease window remains the bound that
+    /// keeps an abandoned lease from protecting a dead run.
+    #[test]
+    fn supervising_local_cook_lease_still_owns_its_run() {
+        let run_id = "local-supervising-reservation";
+        let started_at = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .expect("lease timestamp")
+            .with_timezone(&chrono::Utc);
+        let launcher_pid = std::process::id();
+        let launcher_start_identity = homeboy_core::process::process_start_identity(launcher_pid)
+            .expect("inspect launcher identity")
+            .expect("launcher is live");
+        let mut metadata = local_cook_retry_reservation_metadata(
+            "local-supervising-cook",
+            run_id,
+            started_at,
+            launcher_pid,
+            launcher_start_identity,
+        );
+        metadata["local_cook_supervisor"]["state"] = json!("supervising");
+        let record: agent_task_lifecycle::AgentTaskRunRecord = serde_json::from_value(json!({
+            "schema": "homeboy/agent-task-run/v1",
+            "run_id": run_id,
+            "plan_id": "local-supervising-plan",
+            "state": "running",
+            "submitted_at": started_at.to_rfc3339(),
+            "plan_path": "plan.json",
+            "metadata": metadata,
+        }))
+        .expect("supervising record");
+
+        assert!(record
+            .has_live_pending_local_cook_supervisor(started_at + chrono::Duration::seconds(1)));
+
+        // The lease window still bounds ownership: once it expires, a
+        // supervising state no longer shields the run from reconciliation.
+        assert!(!record.has_live_pending_local_cook_supervisor(
+            started_at
+                + chrono::Duration::seconds(
+                    agent_task_lifecycle::LOCAL_COOK_SUPERVISOR_LEASE_SECONDS + 1,
+                )
+        ));
+    }
+
     #[test]
     fn local_execution_isolates_identical_run_ids_in_explicit_lifecycle_stores() {
         let first = homeboy_core::test_support::HermeticTestContext::new();


### PR DESCRIPTION
## Summary

Every detached local Cook cancelled its first attempt as `missing_runner_pid` and completed through a `-transport-retry` successor. Five consecutive Cooks, same shape, each losing roughly four minutes and one attempt against its retry budget to a run that was healthy.

`annotate_stale_running` guards such a run with `has_live_pending_local_cook_supervisor`, which admitted only `supervisor["state"] == "pending"`. Once the lease advances to `supervising` — holding the run rather than merely requesting it — the protection dropped, and a Cook that had not yet published an owner pid fell through to the ownerless branch.

A supervising lease is the stronger ownership claim, so it is admitted alongside a pending one. Every other predicate is unchanged: the pinned run id, the cook id, and the lease window bounded by `LOCAL_COOK_SUPERVISOR_LEASE_SECONDS`. That window is what stops an abandoned lease from shielding a genuinely dead run, and it bounds both states identically.

Fixes #13692

## Verification

`cargo test -p homeboy-agents --lib -- supervising_local_cook_lease local_retry_reservation_is_live` — 2 passed

`cargo test -p homeboy-agents --lib -- agent_task_service::reconcile agent_task_lifecycle::tests::handoff_and_proxy` — 73 passed

The new test also asserts the negative: once the lease expires, a supervising state no longer shields the run.

## AI assistance

OpenCode (xAI Grok-4.6) traced the cancellation reason through the reconciliation guard chain to the supervisor-state predicate, applied the fix, and added the test. Chris Huber directed the work.