### PR TITLE
Converge a base that advanced during a Cook run

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -199,8 +199,35 @@ fn finalize_pr_with_backend_mode<B: AgentTaskPrFinalizationBackend>(
         )
     })?;
     let base = backend.resolve_verified_base(&options.path, verified_base_sha)?;
-    let candidate = backend.candidate_state(&options.path, &base, &head)?;
+    let mut candidate = backend.candidate_state(&options.path, &base, &head)?;
+    if let AgentTaskPrCandidateState::BehindBase { .. } = &candidate {
+        // A manually verified candidate asserts an immutable commit identity, and
+        // merging would move HEAD out from under that proof. Those runs keep the
+        // pre-#13695 refusal and stay a human decision.
+        if options.verified_candidate_sha.is_none() {
+            if let AgentTaskPrBaseConvergence::Converged =
+                backend.converge_base(&options.path, &base)?
+            {
+                candidate = backend.candidate_state(&options.path, &base, &head)?;
+            }
+        }
+    }
     let (mut changed_files, commit_required, push_required) = match candidate {
+        AgentTaskPrCandidateState::BehindBase {
+            behind,
+            base_ref,
+            base_sha,
+            ..
+        } => {
+            return Err(Error::validation_invalid_argument(
+                "base",
+                &format!(
+                    "HEAD is behind or diverged from resolved base `{base_ref}` at `{base_sha}` ({behind} base-only commit(s)) and could not be merged automatically; resolve the conflict in the worktree before finalizing"
+                ),
+                None,
+                None,
+            ));
+        }
         AgentTaskPrCandidateState::Dirty { changed_files } => (changed_files, true, true),
         AgentTaskPrCandidateState::Committed {
             changed_files,

--- a/crates/homeboy-agents/src/agent_task_finalization/backend.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/backend.rs
@@ -1,8 +1,8 @@
 use super::{
     AgentTaskPrBaseConvergence, AgentTaskPrCandidateState, AgentTaskPrDurableGateProof,
-    AgentTaskPrFinalizationBackend,
-    AgentTaskPrFinalizationOptions, AgentTaskPrQuarantineCapability, AgentTaskPrRef,
-    AgentTaskPrResolvedBase, AgentTaskPublicationBinding, AgentTaskPublicationGitTracking,
+    AgentTaskPrFinalizationBackend, AgentTaskPrFinalizationOptions,
+    AgentTaskPrQuarantineCapability, AgentTaskPrRef, AgentTaskPrResolvedBase,
+    AgentTaskPublicationBinding, AgentTaskPublicationGitTracking,
 };
 use crate::agent_task_promotion::{AgentTaskPromotionCandidate, AgentTaskPromotionReport};
 use homeboy_core::error::{Error, Result};
@@ -1568,7 +1568,8 @@ mod remote_base_tests {
         let advanced = git_output(path, &["rev-parse", "HEAD"]).expect("advanced base sha");
 
         git(repo.path(), &["checkout", "-b", "feature", "HEAD~1"]);
-        std::fs::write(repo.path().join("shared.txt"), "from the agent\n").expect("write shared.txt");
+        std::fs::write(repo.path().join("shared.txt"), "from the agent\n")
+            .expect("write shared.txt");
         git(repo.path(), &["add", "."]);
         git(repo.path(), &["commit", "-m", "candidate work"]);
 

--- a/crates/homeboy-agents/src/agent_task_finalization/backend.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/backend.rs
@@ -1,5 +1,6 @@
 use super::{
-    AgentTaskPrCandidateState, AgentTaskPrDurableGateProof, AgentTaskPrFinalizationBackend,
+    AgentTaskPrBaseConvergence, AgentTaskPrCandidateState, AgentTaskPrDurableGateProof,
+    AgentTaskPrFinalizationBackend,
     AgentTaskPrFinalizationOptions, AgentTaskPrQuarantineCapability, AgentTaskPrRef,
     AgentTaskPrResolvedBase, AgentTaskPublicationBinding, AgentTaskPublicationGitTracking,
 };
@@ -286,8 +287,11 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
             });
         };
         if behind != 0 {
-            return Ok(AgentTaskPrCandidateState::Invalid {
-                diagnostic: format!("HEAD is behind or diverged from resolved base `{base_ref}` at `{}` ({behind} base-only commit(s)); rebase or merge that ref before finalizing", base.sha),
+            return Ok(AgentTaskPrCandidateState::BehindBase {
+                behind,
+                ahead,
+                base_ref: base_ref.clone(),
+                base_sha: base.sha.clone(),
             });
         }
         let dirty = self.changed_files(path)?;
@@ -344,6 +348,38 @@ impl AgentTaskPrFinalizationBackend for RealAgentTaskPrFinalizationBackend {
         expected: Option<&homeboy_core::git::GitIdentityProof>,
     ) -> Result<homeboy_core::git::GitIdentityProof> {
         homeboy_core::git::validate_committed_publication_identity(path, expected)
+    }
+
+    fn converge_base(
+        &mut self,
+        path: &str,
+        base: &AgentTaskPrResolvedBase,
+    ) -> Result<AgentTaskPrBaseConvergence> {
+        let merge = std::process::Command::new("git")
+            .args(["merge", "--no-edit", &base.reference])
+            .current_dir(path)
+            .output()
+            .map_err(|error| Error::git_command_failed(error.to_string()))?;
+        if merge.status.success() {
+            return Ok(AgentTaskPrBaseConvergence::Converged);
+        }
+        // Leave the worktree exactly as the run left it. A conflicted merge that
+        // stays in the index would masquerade as candidate dirt on the next pass.
+        let paths = git_output(path, &["diff", "--name-only", "--diff-filter=U"])
+            .map(|output| {
+                output
+                    .lines()
+                    .map(str::trim)
+                    .filter(|line| !line.is_empty())
+                    .map(str::to_string)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let _ = std::process::Command::new("git")
+            .args(["merge", "--abort"])
+            .current_dir(path)
+            .output();
+        Ok(AgentTaskPrBaseConvergence::Conflicted { paths })
     }
 
     fn commit_all(&mut self, path: &str, message: &str) -> Result<()> {
@@ -1467,6 +1503,91 @@ mod remote_base_tests {
                 "feature",
             )
             .expect("newer snapshot compares candidate");
-        assert!(matches!(stale, AgentTaskPrCandidateState::Invalid { .. }));
+        // The classifier reports the lineage gap rather than a verdict: an
+        // advanced base is a convergence question, and only a failed merge is
+        // terminal (#13695).
+        let AgentTaskPrCandidateState::BehindBase { behind, .. } = stale else {
+            panic!("newer snapshot reports the candidate as behind its base, got {stale:?}");
+        };
+        assert!(behind > 0, "advanced base contributes base-only commits");
+    }
+
+    #[test]
+    fn finalization_converges_a_base_that_advanced_during_the_run() {
+        // `publication_repo` leaves the repo on `feature`, one commit ahead of
+        // `main`, which is a run that has already produced its candidate.
+        let (repo, _origin) = publication_repo();
+        let path = repo.path().to_str().unwrap();
+
+        // main then gains a commit in a file the candidate never touches, which
+        // is the shape of every stoppage in #13695.
+        git(repo.path(), &["checkout", "main"]);
+        std::fs::write(repo.path().join("base-only.txt"), "from main\n")
+            .expect("write base-only.txt");
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "advance main"]);
+        let advanced = git_output(path, &["rev-parse", "HEAD"]).expect("advanced base sha");
+        git(repo.path(), &["checkout", "feature"]);
+
+        let resolved = base("main", &advanced);
+        let before = RealAgentTaskPrFinalizationBackend
+            .candidate_state(path, &resolved, "feature")
+            .expect("classifies the stale candidate");
+        assert!(
+            matches!(before, AgentTaskPrCandidateState::BehindBase { .. }),
+            "candidate starts behind its base, got {before:?}"
+        );
+
+        let convergence = RealAgentTaskPrFinalizationBackend
+            .converge_base(path, &resolved)
+            .expect("merges the advanced base");
+        assert_eq!(convergence, AgentTaskPrBaseConvergence::Converged);
+
+        let after = RealAgentTaskPrFinalizationBackend
+            .candidate_state(path, &resolved, "feature")
+            .expect("reclassifies after convergence");
+        assert!(
+            matches!(after, AgentTaskPrCandidateState::Committed { .. }),
+            "converged candidate is publishable, got {after:?}"
+        );
+        // The agent's work and the base commit both survive the merge.
+        assert!(repo.path().join("feature.txt").exists());
+        assert!(repo.path().join("base-only.txt").exists());
+    }
+
+    #[test]
+    fn finalization_hands_back_a_real_conflict_and_leaves_the_worktree_clean() {
+        let repo = repo();
+        let path = repo.path().to_str().unwrap();
+
+        // Both sides edit the same file, which is the case that genuinely needs
+        // a human and must keep refusing.
+        std::fs::write(repo.path().join("shared.txt"), "from main\n").expect("write shared.txt");
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "advance main"]);
+        let advanced = git_output(path, &["rev-parse", "HEAD"]).expect("advanced base sha");
+
+        git(repo.path(), &["checkout", "-b", "feature", "HEAD~1"]);
+        std::fs::write(repo.path().join("shared.txt"), "from the agent\n").expect("write shared.txt");
+        git(repo.path(), &["add", "."]);
+        git(repo.path(), &["commit", "-m", "candidate work"]);
+
+        let resolved = base("main", &advanced);
+        let convergence = RealAgentTaskPrFinalizationBackend
+            .converge_base(path, &resolved)
+            .expect("attempts the merge");
+        let AgentTaskPrBaseConvergence::Conflicted { paths } = convergence else {
+            panic!("a same-file conflict is handed back, got {convergence:?}");
+        };
+        assert_eq!(paths, vec!["shared.txt".to_string()]);
+
+        // An aborted merge leaves no conflict markers and no staged state, so the
+        // next pass sees the candidate the run produced rather than merge debris.
+        let status = git_output(path, &["status", "--porcelain"]).expect("worktree status");
+        assert_eq!(status, "", "aborted merge leaves the worktree clean");
+        assert_eq!(
+            std::fs::read_to_string(repo.path().join("shared.txt")).expect("candidate content"),
+            "from the agent\n"
+        );
     }
 }

--- a/crates/homeboy-agents/src/agent_task_finalization/types.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/types.rs
@@ -344,8 +344,29 @@ pub enum AgentTaskPrCandidateState {
         push_required: bool,
     },
     Equivalent,
+    /// HEAD does not contain the resolved base. `ahead == 0` is a clean
+    /// fast-forward; `ahead > 0` is a divergence that may still merge cleanly.
+    /// Distinguishing the two is what lets finalization converge a base that
+    /// moved during the run instead of discarding the work (#13695).
+    BehindBase {
+        behind: u64,
+        ahead: u64,
+        base_ref: String,
+        base_sha: String,
+    },
     Invalid {
         diagnostic: String,
+    },
+}
+
+/// Outcome of merging the resolved base into the candidate branch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentTaskPrBaseConvergence {
+    Converged,
+    /// Convergence needs a human. `paths` names the unmerged files when git
+    /// reported them, so the refusal says which content actually conflicts.
+    Conflicted {
+        paths: Vec<String>,
     },
 }
 
@@ -452,6 +473,18 @@ pub trait AgentTaskPrFinalizationBackend {
         } else {
             AgentTaskPrCandidateState::Dirty { changed_files }
         })
+    }
+    /// Merges the resolved base into the candidate branch so a run whose base
+    /// advanced can still finalize.
+    ///
+    /// Backends that cannot merge report [`AgentTaskPrBaseConvergence::Conflicted`]
+    /// with no paths, which keeps the caller on the pre-#13695 refusal.
+    fn converge_base(
+        &mut self,
+        _path: &str,
+        _base: &AgentTaskPrResolvedBase,
+    ) -> Result<AgentTaskPrBaseConvergence> {
+        Ok(AgentTaskPrBaseConvergence::Conflicted { paths: Vec::new() })
     }
     /// Validates the effective prospective identity before commit mutation.
     fn validate_publication_identity(&mut self, path: &str) -> Result<GitIdentityProof>;


### PR DESCRIPTION
Fixes #13695.

## Problem

Finalization refused any candidate whose HEAD did not contain the resolved base:

```rust
if behind != 0 {
    return Ok(AgentTaskPrCandidateState::Invalid {
        diagnostic: format!("HEAD is behind or diverged from resolved base `{base_ref}` ... rebase or merge that ref before finalizing"),
    });
}
```

Two things made this expensive.

**It fires at finalization, not at run start.** The agent does the entire job, and only then is the result refused because the base moved while it worked. The longer the run, the likelier the work is discarded. In the session behind #13695 this happened four times on one branch, each time recovered by a human running `git merge origin/main` and re-invoking Cook.

**`behind != 0` collapses two different situations.** `rev-list --left-right` already returns both counts and the function already binds them. `behind > 0, ahead == 0` is a clean fast-forward. `behind > 0, ahead > 0` is a divergence that usually still merges cleanly. Neither was distinguished, which is why the diagnostic had to hedge with "behind or diverged" — it genuinely could not tell.

## Change

`candidate_state` stays a classifier and reports the lineage gap as a new `BehindBase { behind, ahead, base_ref, base_sha }` state rather than a verdict. Converging inside a predicate would hide a mutation behind an inspection, so the merge lives in a separate `converge_base` backend method and the caller decides.

Finalization attempts convergence once and re-classifies. A merge that actually conflicts still refuses, now naming the unmerged paths instead of hedging.

Three things are deliberately conservative:

- **A conflicted merge is aborted**, so the worktree is left exactly as the run produced it. Leaving conflict markers staged would masquerade as candidate dirt on the next pass.
- **Backends that cannot merge keep today's behaviour** via a trait default returning `Conflicted`, so test doubles and alternative backends are unchanged.
- **Runs carrying a `verified_candidate_sha` keep refusing.** That proof asserts an immutable commit identity and merging would move HEAD out from under it, so those stay a human decision.

## Verification

`agent_task_finalization` is **75 passed / 0 failed**, including two new tests:

- `finalization_converges_a_base_that_advanced_during_the_run` — base gains a commit in an untouched file; candidate is `BehindBase`, converges, re-classifies as `Committed`, and both the agent's work and the base commit survive.
- `finalization_hands_back_a_real_conflict_and_leaves_the_worktree_clean` — both sides edit one file; the conflict is handed back naming `shared.txt`, `git status --porcelain` is empty afterwards, and the candidate's content is intact.

One existing assertion changed by intent: `captured_base_survives_remote_advance_while_newer_snapshot_rejects_stale_candidate` asserted `Invalid` for an advanced base and now asserts `BehindBase` with `behind > 0`. That is the reclassification this PR is about — an advanced base is a convergence question, and only a failed merge is terminal.

**On the wider suite.** The full `homeboy-agents` lib run is red on `main` independently of this branch (#11897). Measured rather than assumed: `origin/main` in a clean worktree gives 18 failures, this branch gives 27, and the membership churns between runs exactly as #11897 documents. The `agent_task_promotion` module fails on baseline too (3 failures there, 4 here, overlapping but not identical names). The promotion- and finalization-adjacent candidates from this branch's list each pass when run alone:

- `agent_task_promotion::tests::part_b::adoption_scopes_a_rebased_two_file_candidate_to_its_parent` — ok
- `agent_task_promotion::tests::part_b::promote_no_op_outcome_uses_audited_committed_candidate` — ok
- `agent_task_service::cook::tests::follow_up_baseline_combines_adopted_candidate_with_overlapping_provider_delta` — ok

Until #11897 is fixed the differential gate will attribute some of that background noise to this branch. The module this PR touches is clean.

## AI assistance

Implemented with OpenCode using xAI Grok-4.6. The model traced the stoppage to `candidate_state`, designed the classifier/converger split, wrote the implementation and the two tests, and ran the baseline comparison against `origin/main` to separate this change from the known flakiness in #11897. Chris Huber directed the work and reviewed the approach.