### PR TITLE
Preserve repository identity during fanout provisioning

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -4216,6 +4216,8 @@ fn build_cook_batch_plan_with_profiles(
     args: &AgentTaskFanoutCookBatchArgs,
     profiles: VerificationProfiles,
 ) -> Result<BatchCookFanoutPlan> {
+    let worktree_repo =
+        cook_batch_provision_repository(args, configured_provider_workspace_creation()?)?;
     let bindings = parse_explicit_worktree_bindings(&args.worktrees)?;
     if !bindings.is_empty()
         && bindings
@@ -4241,7 +4243,7 @@ fn build_cook_batch_plan_with_profiles(
             issue.number,
             slugify(&issue.repo)
         );
-        let worktree = format!("{}@{}", args.repo, slugify(&branch));
+        let worktree = format!("{}@{}", worktree_repo, slugify(&branch));
         let explicit_worktree = bindings.get(issue_url).cloned();
         let prompt = render_prompt(
             args.prompt_template.as_deref(),
@@ -7167,37 +7169,18 @@ fi
             homeboy::core::defaults::save_config(&config).expect("save provider config");
 
             let plan = build_cook_batch_plan(&args).expect("fanout plan");
-            assert!(plan
-                .cooks
+            assert!(plan.cooks.iter().all(|cook| {
+                cook.repo.as_deref() == Some("php-transformer")
+                    && cook.to_worktree.starts_with("blocks-engine@")
+            }));
+            args.dry_run = false;
+            let worktrees = queue_or_reuse_worktrees(&args, &plan).expect("provider worktrees");
+            assert_eq!(worktrees.repo, "blocks-engine");
+            assert!(worktrees
+                .rows
                 .iter()
-                .all(|cook| cook.repo.as_deref() == Some("php-transformer")));
-            let rows = plan
-                .cooks
-                .iter()
-                .map(|cook| worktree::WorktreeQueueCreateRow {
-                    branch: cook.head.clone().expect("child branch"),
-                    handle: cook.to_worktree.clone(),
-                    status: worktree::WorktreeQueueCreateStatus::Failed,
-                    command: Vec::new(),
-                    retry_after_seconds: None,
-                    active_lock_holder: None,
-                    path: None,
-                    error: None,
-                    failure: None,
-                })
-                .collect();
-            let worktrees = with_workspace_owner_repair_commands(
-                &args,
-                &plan,
-                worktree::WorktreeQueueCreateOutput {
-                    schema: "homeboy/worktree-queue-create/v1",
-                    repo: "blocks-engine".to_string(),
-                    base_ref: "origin/main".to_string(),
-                    dry_run: false,
-                    rows,
-                },
-            )
-            .expect("provider repair commands");
+                .zip(&plan.cooks)
+                .all(|(row, cook)| { row.handle == cook.to_worktree }));
             assert!(worktrees.rows.iter().all(|row| {
                 row.command.iter().any(|arg| arg == "blocks-engine")
                     && !row.command.iter().any(|arg| arg == "php-transformer")

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -5830,7 +5830,9 @@ mod tests {
     }
 
     #[cfg(unix)]
-    fn provider_finalization_fixture() -> (tempfile::TempDir, PathBuf, BatchCookFanoutPlan) {
+    fn provider_finalization_fixture(
+        dirty: bool,
+    ) -> (tempfile::TempDir, PathBuf, BatchCookFanoutPlan) {
         let fixture = tempfile::tempdir().expect("provider fixture");
         let workspace = fixture.path().join("workspace");
         let records = fixture.path().join("records");
@@ -5845,8 +5847,9 @@ mod tests {
         std::fs::write(
             &script,
             format!(
-                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  printf '{{\"worktrees\":[{{\"handle\":\"%s\",\"path\":\"{}\",\"branch\":\"fixture\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}\\n' \"$2\"\nelse\n  printf '%s|%s|%s|%s|%s|%s\\n' \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" \"$7\" >> '{}'\nfi\n",
+                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  printf '{{\"worktrees\":[{{\"handle\":\"%s\",\"path\":\"{}\",\"branch\":\"fixture\",\"safety\":{{\"dirty\":{},\"unpushed\":false,\"primary\":false}}}}]}}\\n' \"$2\"\nelse\n  printf '%s|%s|%s|%s|%s|%s\\n' \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" \"$7\" >> '{}'\nfi\n",
                 workspace.display(),
+                dirty,
                 records.display(),
             ),
         )
@@ -5905,7 +5908,7 @@ mod tests {
     #[test]
     fn dispatcher_fanout_terminalization_finalizes_success_and_failure_provider_records() {
         with_isolated_home(|_| {
-            let (_fixture, records, plan) = provider_finalization_fixture();
+            let (_fixture, records, plan) = provider_finalization_fixture(false);
             let report = agent_task_service::AgentTaskCookBatchReport {
                 schema: "homeboy/agent-task-cook-batch/v1",
                 batch_id: plan.fanout_id.clone(),
@@ -5955,10 +5958,51 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn dispatcher_fanout_finalizes_a_terminal_provider_owned_dirty_candidate() {
+        with_isolated_home(|_| {
+            let (_fixture, records, mut plan) = provider_finalization_fixture(true);
+            plan.cooks.truncate(1);
+            let cook = &plan.cooks[0];
+            let report = agent_task_service::AgentTaskCookBatchReport {
+                schema: "homeboy/agent-task-cook-batch/v1",
+                batch_id: plan.fanout_id.clone(),
+                status: "succeeded".to_string(),
+                total: 1,
+                queued: 0,
+                running: 0,
+                succeeded: 1,
+                failed: 0,
+                cancelled: 0,
+                timed_out: 0,
+                cooks: vec![agent_task_service::AgentTaskCookBatchCellReport {
+                    cook_id: cook.cook_id.clone(),
+                    initial_run_id: cook.run_id(),
+                    status: "succeeded".to_string(),
+                    exit_code: 0,
+                    result: None,
+                    error: None,
+                }],
+            };
+
+            finalize_provider_worktrees(&plan, &report, None)
+                .expect("terminal owner may finalize its dirty candidate");
+
+            let records = std::fs::read_to_string(records).expect("provider finalization record");
+            assert!(records.contains(&format!(
+                "homeboy@{}|agent_task_cook|{}|remove_on_success|succeeded|finalize:{}",
+                cook.cook_id,
+                cook.run_id(),
+                cook.run_id(),
+            )));
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn dispatcher_fanout_execution_finalizes_failed_provider_lifecycle() {
         with_isolated_home(|home| {
             install_fanout_agent_task_providers(home.path());
-            let (_fixture, records, mut plan) = provider_finalization_fixture();
+            let (_fixture, records, mut plan) = provider_finalization_fixture(false);
             plan.cooks.truncate(1);
             let dispatcher: &CookAttemptDispatcherFactory =
                 &|_| std::sync::Arc::new(FailingFanoutDispatcher);

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -2868,9 +2868,10 @@ fn queue_or_reuse_worktrees_with_terminal_paths(
     retry: bool,
 ) -> Result<(worktree::WorktreeQueueCreateOutput, Value)> {
     let provider_workspace_creation = configured_provider_workspace_creation()?;
+    let provision_repo = cook_batch_provision_repository(args, provider_workspace_creation)?;
     let queue_create = |cooks: Vec<&BatchCookSpec>, dry_run: bool| {
         worktree::queue_create(worktree::WorktreeQueueCreateOptions {
-            repo: args.repo.clone(),
+            repo: provision_repo.clone(),
             requests: cooks.into_iter().map(|cook| worktree::WorktreeQueueCreateRequest {
                 branch: cook.head.clone().expect("generated cooks have heads"),
                 task_url: cook.task_url.clone(),
@@ -3099,7 +3100,7 @@ fn queue_or_reuse_worktrees_with_terminal_paths(
         plan,
         worktree::WorktreeQueueCreateOutput {
             schema: "homeboy/worktree-queue-create/v1",
-            repo: args.repo.clone(),
+            repo: provision_repo,
             base_ref: cook_batch_from(args).to_string(),
             dry_run: false,
             rows,
@@ -3201,6 +3202,7 @@ fn with_workspace_owner_repair_commands(
     }
 
     let config = homeboy::core::defaults::load_config();
+    let provision_repo = cook_batch_provision_repository(args, true)?;
     for row in &mut worktrees.rows {
         // An empty command on a created row is explicit evidence that current
         // provider authority resolved the exact destination. Do not replace it
@@ -3223,7 +3225,7 @@ fn with_workspace_owner_repair_commands(
         };
         let intent = homeboy::core::worktree_provider::WorktreeProvisionIntent {
             handle: row.handle.clone(),
-            repo: args.repo.clone(),
+            repo: provision_repo.clone(),
             base: cook_batch_from(args).to_string(),
             head: row.branch.clone(),
             task_url: cook
@@ -3243,6 +3245,20 @@ fn with_workspace_owner_repair_commands(
             )?;
     }
     Ok(worktrees)
+}
+
+fn cook_batch_provision_repository(
+    args: &AgentTaskFanoutCookBatchArgs,
+    provider_workspace_creation: bool,
+) -> Result<String> {
+    if !provider_workspace_creation {
+        return Ok(args.repo.clone());
+    }
+    Ok(homeboy::core::component::registered_by_id(&args.repo)?
+        .and_then(|component| component.remote_url)
+        .map(|remote| super::run::normalize_repository_name(&remote))
+        .filter(|repository| !repository.is_empty())
+        .unwrap_or_else(|| args.repo.clone()))
 }
 
 fn configured_provider_workspace_creation() -> Result<bool> {
@@ -6941,11 +6957,24 @@ fi
     }
 
     fn write_component_registration(home: &Path, id: &str, local_path: &Path) {
+        write_component_registration_with_identity(home, id, local_path, None);
+    }
+
+    fn write_component_registration_with_identity(
+        home: &Path,
+        id: &str,
+        local_path: &Path,
+        remote_url: Option<&str>,
+    ) {
         let components = home.join(".config/homeboy/components");
         std::fs::create_dir_all(&components).expect("components directory");
         std::fs::write(
             components.join(format!("{id}.json")),
-            serde_json::json!({ "local_path": local_path }).to_string(),
+            serde_json::json!({
+                "local_path": local_path,
+                "remote_url": remote_url,
+            })
+            .to_string(),
         )
         .expect("component registration");
     }
@@ -7053,6 +7082,126 @@ fi
             path.repo = primary.to_string_lossy().to_string();
             normalize_cook_batch_repo(&mut path).expect("primary path resolves");
             assert_eq!(path.repo, "fixture");
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fanout_keeps_component_identity_but_provisions_its_repository() {
+        use std::os::unix::fs::PermissionsExt;
+
+        with_isolated_home(|home| {
+            let primary = home.path().join("blocks-engine");
+            let component = primary.join("php-transformer");
+            std::fs::create_dir_all(&component).expect("nested component directory");
+            init_git_primary(&primary);
+            write_component_registration_with_identity(
+                home.path(),
+                "php-transformer",
+                &component,
+                Some("https://github.com/example/blocks-engine.git"),
+            );
+
+            let mut args = cook_batch_args();
+            args.repo = "php-transformer".to_string();
+            normalize_cook_batch_repo(&mut args).expect("component identity resolves");
+            assert_eq!(args.repo, "php-transformer");
+            assert_eq!(
+                cook_batch_provision_repository(&args, true).expect("provider repository"),
+                "blocks-engine"
+            );
+
+            let provider = home.path().join("dmc-worktree-provider");
+            std::fs::write(&provider, "#!/bin/sh\nexit 1\n").expect("provider fixture");
+            let mut permissions = std::fs::metadata(&provider)
+                .expect("provider metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&provider, permissions).expect("provider executable");
+            let mut config = homeboy::core::defaults::HomeboyConfig::default();
+            config.worktree_providers.insert(
+                "dmc".to_string(),
+                homeboy::core::defaults::WorktreeProviderConfig {
+                    enabled: true,
+                    kind: homeboy::core::defaults::WorktreeProviderKind::Command,
+                    apply_enabled: true,
+                    lookup_timeout_ms: 10_000,
+                    mutation_timeout_ms: 30_000,
+                    lookup_output_limit_bytes: 64 * 1024,
+                    commands: homeboy::core::defaults::WorktreeProviderCommands {
+                        resolve: Some(vec![
+                            provider.display().to_string(),
+                            "resolve".to_string(),
+                            "{handle}".to_string(),
+                        ]),
+                        resolve_not_found_exit_codes: vec![1],
+                        ensure: Some(vec![
+                            provider.display().to_string(),
+                            "ensure".to_string(),
+                            "{repo}".to_string(),
+                            "{handle}".to_string(),
+                            "{base}".to_string(),
+                            "{head}".to_string(),
+                            "{task_url}".to_string(),
+                            "{idempotency_key}".to_string(),
+                            "{purpose}".to_string(),
+                            "{owner_run_ref}".to_string(),
+                            "{cleanup_policy}".to_string(),
+                        ]),
+                        ..Default::default()
+                    },
+                    list_result_mapping: Some(
+                        homeboy::core::defaults::WorktreeProviderListResultMapping {
+                            items: "$.worktrees".to_string(),
+                            handle: "$.handle".to_string(),
+                            path: "$.path".to_string(),
+                            branch: "$.branch".to_string(),
+                            dirty: "$.safety.dirty".to_string(),
+                            unpushed: "$.safety.unpushed".to_string(),
+                            primary: "$.safety.primary".to_string(),
+                            task_url: None,
+                        },
+                    ),
+                },
+            );
+            homeboy::core::defaults::save_config(&config).expect("save provider config");
+
+            let plan = build_cook_batch_plan(&args).expect("fanout plan");
+            assert!(plan
+                .cooks
+                .iter()
+                .all(|cook| cook.repo.as_deref() == Some("php-transformer")));
+            let rows = plan
+                .cooks
+                .iter()
+                .map(|cook| worktree::WorktreeQueueCreateRow {
+                    branch: cook.head.clone().expect("child branch"),
+                    handle: cook.to_worktree.clone(),
+                    status: worktree::WorktreeQueueCreateStatus::Failed,
+                    command: Vec::new(),
+                    retry_after_seconds: None,
+                    active_lock_holder: None,
+                    path: None,
+                    error: None,
+                    failure: None,
+                })
+                .collect();
+            let worktrees = with_workspace_owner_repair_commands(
+                &args,
+                &plan,
+                worktree::WorktreeQueueCreateOutput {
+                    schema: "homeboy/worktree-queue-create/v1",
+                    repo: "blocks-engine".to_string(),
+                    base_ref: "origin/main".to_string(),
+                    dry_run: false,
+                    rows,
+                },
+            )
+            .expect("provider repair commands");
+            assert!(worktrees.rows.iter().all(|row| {
+                row.command.iter().any(|arg| arg == "blocks-engine")
+                    && !row.command.iter().any(|arg| arg == "php-transformer")
+            }));
         });
     }
 

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -4531,7 +4531,7 @@ fn repository_component_identity_ambiguity_error(
     )
 }
 
-fn normalize_repository_name(repository: &str) -> String {
+pub(crate) fn normalize_repository_name(repository: &str) -> String {
     repository
         .trim()
         .trim_end_matches(".git")

--- a/crates/homeboy-core/src/worktree_provider.rs
+++ b/crates/homeboy-core/src/worktree_provider.rs
@@ -1184,10 +1184,9 @@ impl WorktreeFinalizationProvider for CommandWorktreeProvider<'_> {
         disposition: WorktreeTerminalDisposition,
     ) -> Result<WorktreeFinalizationLookup> {
         let resolution =
-            match worktree_providers::resolve_apply_enabled_worktree_provider_from_config(
+            match worktree_providers::observe_apply_enabled_worktree_provider_from_config(
                 handle,
                 self.config,
-                None,
             ) {
                 Ok(resolution) => resolution,
                 Err(error) if worktree_providers::is_worktree_provider_not_found(&error) => {

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -740,6 +740,16 @@ pub(crate) fn observe_worktree_provider_from_config(
     resolve_worktree_provider_with_policy_from_config(handle, config, false, false, None, None)
 }
 
+/// Resolve lifecycle ownership without reapplying mutation-admission safety.
+/// A terminal owner is expected to have changed its workspace; the configured
+/// provider remains responsible for enforcing cleanup safety during finalization.
+pub(crate) fn observe_apply_enabled_worktree_provider_from_config(
+    handle: &str,
+    config: &HomeboyConfig,
+) -> Result<WorktreeProviderResolution> {
+    resolve_worktree_provider_with_policy_from_config(handle, config, true, false, None, None)
+}
+
 /// Resolve a workspace only from providers explicitly authorized for apply operations.
 pub fn resolve_apply_enabled_worktree_provider_from_config(
     handle: &str,


### PR DESCRIPTION
## Summary

- keep the registered component identity for fanout planning and execution
- derive the owning repository name from the targeted component remote at configured worktree-provider boundaries
- resolve terminal lifecycle ownership without reapplying pre-cook mutation safety to the candidate the child just produced
- retain provider-owned cleanup safety and prove dirty destinations remain rejected during initial mutation admission

## Defect evidence

A real three-child fanout admitted every configured-provider worktree and all provider attempts completed with candidate edits. During terminalization, the coordinator called the mutation-admission resolver again; the provider correctly reported the child workspace as dirty, so Homeboy rejected its own candidate as `workspace.resolved_but_dirty` before invoking lifecycle finalization.

Repository-native reproduction:

1. Configure an apply-enabled command worktree provider whose resolver reports a child destination as clean during fanout admission.
2. Run a child that changes the destination and reaches a terminal state.
3. Have the provider report `safety.dirty: true` during terminal finalization.
4. Before this change, `finalize_provider_worktrees` fails with `workspace.resolved_but_dirty`; with this change, Homeboy invokes the provider lifecycle finalizer using the existing owner run reference.

The regression test `dispatcher_fanout_finalizes_a_terminal_provider_owned_dirty_candidate` executes this lifecycle directly. `rejects_provider_handles_with_unsafe_safety_metadata` separately proves initial admission remains fail-closed.

## Verification

- `cargo test -p homeboy-cli fanout_keeps_component_identity_but_provisions_its_repository`
- `cargo test -p homeboy-cli cook_batch_repo_normalization`
- `cargo test -p homeboy-cli cook_preserves_repository_and_component_identity_for_every_destination_form`
- `cargo test -p homeboy-cli fanout_uses_an_ensure_resolve_provider_without_a_finalizer_for_creation_binding_and_repair`
- `cargo test -p homeboy-cli dispatcher_fanout_finalizes_a_terminal_provider_owned_dirty_candidate`
- `cargo test -p homeboy-cli dispatcher_fanout_terminalization_finalizes_success_and_failure_provider_records`
- `cargo test -p homeboy-core rejects_provider_handles_with_unsafe_safety_metadata`
- `cargo check -p homeboy-cli`
- real three-issue dry-run against a registered component whose owning repository has a different identity

Closes #12844.

## AI assistance

OpenCode with OpenAI `openai/gpt-5.6-sol` was used to reproduce the fanout identity and lifecycle-finalization failures, inspect the single-Cook and worktree-provider contracts, implement the provider-boundary repairs, add regression coverage, and run verification. Chris Huber remains responsible for the change.