### PR TITLE
Stabilize retryable Cook test isolation

### DIFF
--- a/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_plan/mod.rs
@@ -2115,6 +2115,7 @@ mod tests {
 
     #[test]
     fn dispatch_plan_promotes_runtime_component_contracts_from_client_context_inputs() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
         let component = tempfile::tempdir().expect("agents-api component");
         init_git_repo(component.path());
         let component_path = component.path().display().to_string();
@@ -2175,6 +2176,7 @@ mod tests {
 
     #[test]
     fn dispatch_plan_accepts_component_contracts_from_provider_config() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
         let component = tempfile::tempdir().expect("runtime-helper component");
         init_git_repo(component.path());
         let component_path = component.path().display().to_string();

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -2640,12 +2640,14 @@ where
         metadata,
     };
     let mut preserved_controller_runtime = None;
+    let mut pre_execution_recovery = false;
     let mut pre_execution_runtime_recovery = false;
     if let Ok(existing) = lifecycle_store.read_record(&run_id) {
-        pre_execution_runtime_recovery = execution_runner_id.is_none()
-            && crate::agent_task_service::cook_pre_execution::retryable_pre_execution_failure(
+        pre_execution_recovery =
+            crate::agent_task_service::cook_pre_execution::retryable_pre_execution_failure(
                 &existing,
             );
+        pre_execution_runtime_recovery = execution_runner_id.is_none() && pre_execution_recovery;
         // A runner may re-submit the plan after the controller reserved a
         // side-effect claim. Claims are durable exactly-once ownership, not
         // plan-derived state, so replacing the record must retain them.
@@ -2665,6 +2667,21 @@ where
         ] {
             if let Some(value) = existing.metadata.get(key) {
                 record.metadata[key] = value.clone();
+            }
+        }
+        if pre_execution_recovery {
+            // Placement transition is durable continuation authority, not
+            // plan-derived decoration. Re-submitting the original semantic
+            // attempt must not restore its exhausted route over an operator's
+            // explicit local recovery decision (#11897).
+            for key in [
+                "execution_placement_decision",
+                "execution_placement_transition",
+                "transport_admission_reset",
+            ] {
+                if let Some(value) = existing.metadata.get(key) {
+                    record.metadata[key] = value.clone();
+                }
             }
         }
         // A runner re-submitting a retry must not erase the predecessor identity
@@ -2754,6 +2771,11 @@ where
             if pre_execution_runtime_recovery {
                 record = lifecycle_store
                     .rearm_pre_execution_record_with_runtime(&record, admission.runtime())?;
+            } else if pre_execution_recovery {
+                // Runner execution has its own runtime provenance. Clear the
+                // terminal pre-provider projection without rebinding the
+                // controller pin to the runner's executable (#13552).
+                record = lifecycle_store.rearm_pre_execution_record(&record)?;
             } else {
                 lifecycle_store.write_record(&record)?;
             }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -3002,6 +3002,11 @@ fn cancel_run_reclaims_stale_running_record() {
     record.state = AgentTaskRunState::Running;
     record.tasks[0].state = AgentTaskState::Running;
     record.metadata["runner_pid"] = json!(u32::MAX);
+    // Reserving provider execution records the libtest process as its owner.
+    // Leaving that live PID in this stale-owner fixture makes cancellation
+    // terminate every subprocess owned by parallel peer tests (#11897).
+    record.metadata["provider_executions"][0]["owner_pid"] = json!(u32::MAX);
+    record.metadata["provider_executions"][0]["owner_linux_starttime_ticks"] = Value::Null;
     lifecycle_store
         .write_record(&record)
         .expect("stored stale record");
@@ -3611,6 +3616,22 @@ fn provider_terminalization_observes_cancellation_that_won_the_race() {
             1,
         )
         .expect("reserved");
+        rewrite_record_for_test("provider-terminal-cancel-race", |record| {
+            let execution = record.metadata["provider_executions"][0]
+                .as_object_mut()
+                .expect("provider execution object");
+            // The test covers durable ordering, not process signalling. Remove
+            // the reservation's libtest PID so cancelling this fixture cannot
+            // kill subprocesses belonging to parallel tests (#11897).
+            execution.remove("owner_pid");
+            execution.remove("owner_linux_starttime_ticks");
+            execution.remove("owner_identity");
+            record.ensure_metadata_object().remove("runner_pid");
+            record
+                .ensure_metadata_object()
+                .remove("runner_process_start_identity");
+        })
+        .expect("remove ambient test-harness owner");
         cancel_run("provider-terminal-cancel-race", Some("stale owner"))
             .expect("cancellation recorded");
 

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -10915,7 +10915,12 @@ fn cook_transport_preparation_failure_is_durable_and_resumes_after_runner_recove
 
         let resumed = run_cook(CookContext::new(options, Arc::new(UnusedExecutor)))
             .expect("repaired runner resumes the immutable cook attempt");
-        assert_eq!(resumed.value.status, "in_flight");
+        let resumed_record = agent_task_lifecycle::status(cook_id).expect("resumed cook status");
+        assert_eq!(
+            resumed.value.status, "in_flight",
+            "resumed cook report: {:#?}\nresumed lifecycle: {:#?}",
+            resumed.value, resumed_record
+        );
         assert_eq!(
             agent_task_lifecycle::status(cook_id)
                 .expect("resumed cook alias")

--- a/crates/homeboy-agents/src/agent_task_service/loop_job.rs
+++ b/crates/homeboy-agents/src/agent_task_service/loop_job.rs
@@ -413,6 +413,7 @@ mod tests {
     #[test]
     fn cancellation_through_the_shared_harness_stops_the_coordinator() {
         with_isolated_home(|_| {
+            register_loop_work_job_handler();
             agent_task_loop_controller::create_controller("loop-cancel", "repair", "v1")
                 .expect("create controller");
             let child = std::process::Command::new("sh")

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -834,6 +834,24 @@ impl AgentTaskLifecycleStore {
         runtime: Value,
     ) -> Result<AgentTaskRunRecord> {
         homeboy_core::controller_runtime::validate(&runtime)?;
+        self.rearm_pre_execution_record_inner(record, Some(runtime))
+    }
+
+    /// Rearm a retryable zero-provider record without changing controller
+    /// runtime ownership. Runner-bound retries execute under a separate runner
+    /// runtime while the original controller pin remains authoritative.
+    pub(crate) fn rearm_pre_execution_record(
+        &self,
+        record: &AgentTaskRunRecord,
+    ) -> Result<AgentTaskRunRecord> {
+        self.rearm_pre_execution_record_inner(record, None)
+    }
+
+    fn rearm_pre_execution_record_inner(
+        &self,
+        record: &AgentTaskRunRecord,
+        runtime: Option<Value>,
+    ) -> Result<AgentTaskRunRecord> {
         self.with_config_lock(|| {
             let existing = self.read_record(&record.run_id)?;
             if !existing.state.is_terminal()
@@ -865,29 +883,55 @@ impl AgentTaskLifecycleStore {
             }
 
             let mut rebound = record.clone();
-            let previous = existing
-                .metadata
-                .get(homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY)
-                .cloned()
-                .unwrap_or(Value::Null);
-            rebound.metadata["controller_runtime_recovery"] = serde_json::json!({
-                "schema": "homeboy/controller-runtime-pre-execution-recovery/v1",
-                "reason": "retryable_pre_execution_failure",
-                "previous": previous,
-                "current": runtime.clone(),
-                "provider_executions_consumed": 0,
-                "recovered_at": super::now_timestamp(),
-            });
-            rebound.metadata
-                [homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] = runtime;
+            if let Some(runtime) = runtime {
+                let previous = existing
+                    .metadata
+                    .get(homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY)
+                    .cloned()
+                    .unwrap_or(Value::Null);
+                rebound.metadata["controller_runtime_recovery"] = serde_json::json!({
+                    "schema": "homeboy/controller-runtime-pre-execution-recovery/v1",
+                    "reason": "retryable_pre_execution_failure",
+                    "previous": previous,
+                    "current": runtime.clone(),
+                    "provider_executions_consumed": 0,
+                    "recovered_at": super::now_timestamp(),
+                });
+                rebound.metadata
+                    [homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] = runtime;
+            } else {
+                rebound.metadata["pre_execution_recovery"] = serde_json::json!({
+                    "schema": "homeboy/pre-execution-recovery/v1",
+                    "reason": "retryable_pre_execution_failure",
+                    "provider_executions_consumed": 0,
+                    "recovered_at": super::now_timestamp(),
+                });
+            }
             rebound.metadata["controller_identity"] =
                 serde_json::json!(homeboy_core::build_identity::current().display);
-            write_record_with_aggregate_without_workspace_authority_mode(
+            let committed = write_record_with_aggregate_without_workspace_authority_mode(
                 self,
                 &rebound,
                 read_mirrored_aggregate_in_store(self, &rebound.run_id)?,
                 false,
-            )
+            )?;
+            // A pre-execution failure writes a synthetic failed aggregate for
+            // durable diagnostics. Once the zero-provider attempt is rearmed,
+            // that file is no longer an execution result. Leaving it behind
+            // lets the next detached-handoff write mirror the stale failure
+            // back into the now-queued record (#13552).
+            let aggregate_path = self.aggregate_path(&rebound.run_id);
+            match fs::remove_file(&aggregate_path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(Error::internal_io(
+                        format!("remove rearmed pre-execution aggregate: {error}"),
+                        Some(aggregate_path.display().to_string()),
+                    ));
+                }
+            }
+            Ok(committed)
         })
     }
 


### PR DESCRIPTION
Fixes #13552. Advances #11897.

## Problem

Exact `origin/main` began with 21 failing `homeboy-agents` lib tests. Only two failed alone; the other 19 changed membership between runs.

The failures were not one class:

1. A retryable pre-provider Cook attempt rearmed its observation projection but left its synthetic failed aggregate on disk. The next detached handoff mirrored that aggregate back into the queued run, so successful runner acceptance returned `provider_failure`.
2. Explicit local continuation was durable, but re-submitting the same semantic attempt could restore the exhausted Lab placement over that operator-authorized decision.
3. Two cancellation tests reserved provider execution with the libtest process as owner. Cancelling their fixture traversed the entire test-harness process tree and killed subprocesses belonging to unrelated parallel tests. The resulting errors looked unrelated: missing worktrees, vanished current directories, failed Git commands, and changing lifecycle failure sets.
4. A loop-job test consumed a global handler without registering it itself, so it passed only after another test initialized the registry.
5. Dispatch-plan tests read ambient provider configuration without owning `HomeGuard`, allowing one test to resolve and clone another test's temporary runtime overlay.

## Change

- Split retryable lifecycle rearm from controller-runtime rebinding. Runner-bound replay clears terminal state while preserving the controller pin and recording runner runtime separately.
- Remove the synthetic pre-execution aggregate when a zero-provider attempt is rearmed, so later writes cannot resurrect stale terminal evidence.
- Preserve durable placement decision, transition, and one-shot transport reset metadata when the same semantic attempt is resubmitted.
- Make stale/race cancellation fixtures remove or replace the libtest owner PID before cancellation.
- Register the loop work-job handler in the exact test that consumes it.
- Give runtime-component dispatch tests an isolated home before they read ambient configuration.

## Verification

Focused results:

- `agent_task_dispatch_plan`: **47 passed, 0 failed**
- `cook_transport_preparation_failure_is_durable_and_resumes_after_runner_recovery`: passed
- `explicit_local_continuation_replaces_exhausted_auto_lab_transport_without_replaying_lab`: passed
- `cancel_run_reclaims_stale_running_record`: passed
- `provider_terminalization_observes_cancellation_that_won_the_race`: passed
- `cancellation_through_the_shared_harness_stops_the_coordinator`: passed

Parallel full-suite evidence:

- Exact main before change: **2071 passed, 21 failed** in 355s.
- First run after the process-owner and recovery fixes: **2076 passed, 16 failed** in 469s; the deterministic tests above passed and mass process-tree termination disappeared.
- A second run exposed the next #11897 slice: a legacy `HomeGuard` holder blocks peer Cook tests on the process-global home lock until the 40-minute gate timeout. This PR does not claim #11897 complete or bless those failures. It removes the deterministic failures and the test-harness process-tree destruction so the remaining global-home isolation defect can be repaired from clean evidence.

## Compatibility

No public CLI or persisted schema is removed. The new `homeboy/pre-execution-recovery/v1` metadata is additive. Existing local runtime recovery keeps its `homeboy/controller-runtime-pre-execution-recovery/v1` evidence.

## AI assistance

OpenCode with OpenAI GPT-5.6 Sol reproduced exact-main failures, compared parallel and isolated runs, traced cancellation to the libtest owner PID, separated lifecycle rearm from runtime rebinding, implemented the fixes, and ran focused and full-suite verification. Chris Huber directed the stabilization work and owns the change.
