### PR TITLE
Isolate lifecycle test fault providers

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
@@ -220,6 +220,7 @@ impl RunnerContinuationProvider for NoopProvider {
     }
 }
 
+#[cfg(not(test))]
 homeboy_engine_primitives::provider_registry! {
     provider: dyn RunnerContinuationProvider,
     noop: NoopProvider,
@@ -229,6 +230,30 @@ homeboy_engine_primitives::provider_registry! {
     /// Run `f` against the registered provider, falling back to the no-op provider
     /// when the runner subsystem is absent.
     with: pub(crate) fn with_runner_continuation,
+}
+
+#[cfg(test)]
+thread_local! {
+    static TEST_PROVIDER: std::cell::RefCell<Option<Box<dyn RunnerContinuationProvider>>> =
+        std::cell::RefCell::new(None);
+}
+
+#[cfg(test)]
+pub fn register_runner_continuation_provider(provider: Box<dyn RunnerContinuationProvider>) {
+    TEST_PROVIDER.with(|slot| *slot.borrow_mut() = Some(provider));
+}
+
+#[cfg(test)]
+pub(crate) fn with_runner_continuation<T>(
+    operation: impl FnOnce(&dyn RunnerContinuationProvider) -> T,
+) -> T {
+    TEST_PROVIDER.with(|slot| {
+        let provider = slot.borrow();
+        match provider.as_deref() {
+            Some(provider) => operation(provider),
+            None => operation(&NoopProvider),
+        }
+    })
 }
 
 /// Resolve the current provider's authoritative configuration state for a
@@ -243,10 +268,31 @@ pub fn runner_authority(runner_id: &str) -> RunnerAuthority {
 /// process, making lifecycle results order-dependent (#8964).
 #[cfg(any(test, feature = "test-support"))]
 pub fn clear_runner_continuation_provider_for_test() {
-    let mut slot = provider_slot()
+    let _guard = runner_continuation_test_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    *slot = None;
+    clear_runner_continuation_provider_for_test_unlocked();
+}
+
+#[cfg(any(test, feature = "test-support"))]
+fn clear_runner_continuation_provider_for_test_unlocked() {
+    #[cfg(test)]
+    {
+        TEST_PROVIDER.with(|slot| *slot.borrow_mut() = None);
+    }
+    #[cfg(not(test))]
+    {
+        let mut slot = provider_slot()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *slot = None;
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+fn runner_continuation_test_lock() -> &'static std::sync::Mutex<()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    &LOCK
 }
 
 /// RAII guard that installs a runner-continuation provider for the duration of a
@@ -254,21 +300,24 @@ pub fn clear_runner_continuation_provider_for_test() {
 /// registration cannot leak into another test.
 #[cfg(any(test, feature = "test-support"))]
 pub struct RunnerContinuationTestGuard {
-    _private: (),
+    _guard: std::sync::MutexGuard<'static, ()>,
 }
 
 #[cfg(any(test, feature = "test-support"))]
 impl RunnerContinuationTestGuard {
     pub fn install(provider: Box<dyn RunnerContinuationProvider>) -> Self {
+        let guard = runner_continuation_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         register_runner_continuation_provider(provider);
-        Self { _private: () }
+        Self { _guard: guard }
     }
 }
 
 #[cfg(any(test, feature = "test-support"))]
 impl Drop for RunnerContinuationTestGuard {
     fn drop(&mut self) {
-        clear_runner_continuation_provider_for_test();
+        clear_runner_continuation_provider_for_test_unlocked();
     }
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -1292,7 +1292,7 @@ fn cancelled_or_expired_pending_handoff_never_submits_new_runner_work() {
     with_isolated_home(|_| {
         let submitted = Arc::new(Mutex::new(Vec::new()));
         let lookups = Arc::new(Mutex::new(Vec::new()));
-        register_runner_continuation_provider(Box::new(IntentReplayProvider {
+        let _provider = RunnerContinuationTestGuard::install(Box::new(IntentReplayProvider {
             store: JobStore::default(),
             submitted: Arc::clone(&submitted),
             lookups: Arc::clone(&lookups),
@@ -1360,7 +1360,7 @@ fn preparing_crash_never_submits_or_queries_the_runner() {
     with_isolated_home(|_| {
         let submitted = Arc::new(Mutex::new(Vec::new()));
         let lookups = Arc::new(Mutex::new(Vec::new()));
-        register_runner_continuation_provider(Box::new(IntentReplayProvider {
+        let _provider = RunnerContinuationTestGuard::install(Box::new(IntentReplayProvider {
             store: JobStore::default(),
             submitted: Arc::clone(&submitted),
             lookups: Arc::clone(&lookups),
@@ -1409,7 +1409,7 @@ fn expired_or_cancelled_pending_submission_binds_and_cancels_the_accepted_job() 
         let store = JobStore::default();
         let submitted = Arc::new(Mutex::new(Vec::new()));
         let lookups = Arc::new(Mutex::new(Vec::new()));
-        register_runner_continuation_provider(Box::new(IntentReplayProvider {
+        let _provider = RunnerContinuationTestGuard::install(Box::new(IntentReplayProvider {
             store: store.clone(),
             submitted: Arc::clone(&submitted),
             lookups: Arc::clone(&lookups),

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -409,11 +409,9 @@ fn accepted_daemon_context_keeps_a_pidless_runner_submission_live() {
     assert!(status.metadata.get("stale_running_reason").is_none());
 }
 
-/// Stays on `with_isolated_home` (#7505). `store::fail_next_record_write_for_test`
-/// arms a process-global `AtomicBool` in `lifecycle_store`, not a per-store
-/// flag. The hermetic home's global mutex is the only thing serializing that
-/// fault injection against every peer test, so rooting this would arm a
-/// one-shot write failure that some *other* test could consume.
+/// Stays on `with_isolated_home` because the retry API still resolves its store
+/// from the ambient test home. The injected failure itself is thread-scoped, so
+/// parallel explicit-store tests cannot consume it (#11897).
 #[test]
 fn retry_first_visible_record_always_has_indexed_predecessor_identity() {
     with_isolated_home(|_| {
@@ -4555,9 +4553,9 @@ fn cancel_run_emits_recovery_commands_for_runner_backed_run() {
     assert!(cancelled.metadata.get("live_cancellation").is_none());
 }
 
-/// Stays on `with_isolated_home` (#7505). `store::fail_next_record_write_for_test`
-/// arms a process-global `AtomicBool`; see
-/// `retry_first_visible_record_always_has_indexed_predecessor_identity`.
+/// Stays on `with_isolated_home` because record-health reconciliation still
+/// resolves its store from the ambient test home. Fault injection is scoped to
+/// this thread, independently of that legacy path (#11897).
 #[test]
 fn record_health_recovers_after_interrupted_migration_without_changing_terminal_status() {
     with_isolated_home(|_| {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -3966,8 +3966,8 @@ fn snapshot_fence_transition_rejects_same_class_without_pre_provider_identity() 
 
 #[test]
 fn dead_retry_launcher_persists_terminal_failure_under_strict_config_locking() {
-    with_strict_config_lock(|| {
-        with_isolated_home(|_| {
+    with_isolated_home(|_| {
+        with_strict_config_lock(|| {
             let run_id = "cook-dead-retry-launcher-strict-attempt-2";
             let plan = test_plan();
             submit_plan(&plan, Some(run_id)).expect("persist retry reservation");

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -20597,21 +20597,12 @@ fn post_recipe_failure_without_lifecycle_retains_identity_but_offers_no_recovery
     });
 }
 
-/// Passes under `cargo nextest` (one process per test) and under
-/// `cargo test -- --test-threads=1`. It can fail under multi-threaded
-/// `cargo test`, at the `baseline_path.exists()` assertion.
-///
-/// That is a harness limitation, not a product defect. `HomeGuard` holds
-/// `home_lock()` for its lifetime, which serializes *writers* — but as its own
-/// doc states, readers never take it, including worker threads a test spawns.
-/// This test materializes and then deliberately deletes a worktree, so a
-/// concurrent test repointing the home root mid-flight can observe the path
-/// after deletion and before re-materialization.
-///
-/// CI runs nextest, so it does not see this. Do not "fix" it by making the hot
-/// path resolvers take the lock on every read.
+/// Baseline materialization still resolves its artifact root from the ambient
+/// test home. Own that root for the fixture's full lifetime so another test
+/// cannot repoint it between materialization, deletion, and recovery (#11897).
 #[test]
 fn re_materialize_follow_up_baseline_recovers_after_worktree_deletion() {
+    let _home = homeboy_core::test_support::HomeGuard::new();
     let temp = tempfile::tempdir().expect("tempdir");
     let root = &temp.path().join("repo");
     std::fs::create_dir(root).unwrap();

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 #[cfg(any(test, feature = "test-support"))]
+use std::cell::Cell;
+#[cfg(test)]
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde_json::{json, Value};
@@ -1051,7 +1053,11 @@ fn default_store() -> Result<AgentTaskLifecycleStore> {
 }
 
 #[cfg(any(test, feature = "test-support"))]
-static FAIL_NEXT_RECORD_WRITE: AtomicBool = AtomicBool::new(false);
+thread_local! {
+    /// One-shot write failure owned by the test thread that armed it. A global
+    /// atomic let unrelated parallel tests consume each other's fault (#11897).
+    static FAIL_NEXT_RECORD_WRITE: Cell<bool> = const { Cell::new(false) };
+}
 #[cfg(test)]
 static INTERRUPT_AFTER_TERMINAL_COMMIT: AtomicBool = AtomicBool::new(false);
 
@@ -1278,7 +1284,7 @@ pub(super) fn write_aggregate_and_record(
 
 #[cfg(any(test, feature = "test-support"))]
 pub(super) fn fail_next_record_write_for_test() {
-    FAIL_NEXT_RECORD_WRITE.store(true, Ordering::SeqCst);
+    FAIL_NEXT_RECORD_WRITE.set(true);
 }
 
 #[cfg(test)]
@@ -1306,7 +1312,7 @@ fn write_record_with_aggregate_without_workspace_authority_mode(
     preserve_terminal: bool,
 ) -> Result<AgentTaskRunRecord> {
     #[cfg(any(test, feature = "test-support"))]
-    if FAIL_NEXT_RECORD_WRITE.swap(false, Ordering::SeqCst) {
+    if FAIL_NEXT_RECORD_WRITE.replace(false) {
         return Err(Error::internal_io(
             "injected lifecycle record persistence failure",
             Some(record.run_id.clone()),


### PR DESCRIPTION
## Summary
- scope one-shot lifecycle write failures to the test thread that arms them
- isolate unit-test runner continuation providers while preserving the production registry
- make ambient-home and strict-lock fixtures own their global state for the full operation

## Evidence
- `cargo test -p homeboy-agents --lib agent_task_service::cook::tests`: 248 passed, 0 failed, 6 ignored
- `cargo test -p homeboy-agents --lib agent_task_lifecycle`: 345 passed, 0 failed
- `cargo check -p homeboy-agents --features test-support`: passed
- full `cargo test -p homeboy-agents --lib`: 2076 passed, 16 failed, 6 ignored; the remaining failures expose the next #11897 ambient-root/controller-scratch isolation slice through deleted per-test paths and cross-root lease state

Refs #11897.

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to reproduce the parallel failures, trace shared test state, implement the isolation changes, and run verification. I reviewed and directed the resulting changes and evidence.