### PR TITLE
Honor configured worktree-provider cleanup timeouts

### DIFF
--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -29,6 +29,9 @@ use homeboy::core::worktree::WorktreeCleanupOutput;
 use homeboy::core::worktree_provider::{
     cleanup_worktrees_from_config, WorktreeCleanupRequest, WorktreeCleanupScope,
 };
+use homeboy::core::worktree_providers::{
+    max_configured_provider_cleanup_timeout, WorktreeProviderCleanupMode,
+};
 use homeboy::runner::runners::{
     self as runner, RunnerBinaryCachePruneOptions, RunnerBinaryCachePruneOutput,
     RunnerWorkspacePruneOptions, RunnerWorkspacePruneOutput,
@@ -50,8 +53,6 @@ const AUTOMATIC_RETENTION_LOCK_FILE: &str = "automatic-retention-controller.lock
 const AUTOMATIC_RETENTION_STATE_FILE: &str = "automatic-retention-controller.json";
 const CLEANUP_CATEGORY_CHILD_ENV: &str = "HOMEBOY_INTERNAL_CLEANUP_CATEGORY_CHILD";
 const CLEANUP_CATEGORY_CHILD_TIMEOUT_ENV: &str = "HOMEBOY_INTERNAL_CLEANUP_CATEGORY_TIMEOUT_MS";
-const CLEANUP_CATEGORY_TIMEOUT: Duration = Duration::from_secs(30);
-const CLEANUP_AGGREGATE_TIMEOUT: Duration = Duration::from_secs(120);
 const CLEANUP_CHILD_TERMINATION_ALLOWANCE: Duration = Duration::from_secs(5);
 const CLEANUP_CATEGORY_HEARTBEAT: Duration = Duration::from_secs(5);
 /// Time reserved for the repo-artifact category to report after its last root.
@@ -672,8 +673,8 @@ fn bounded_retained_storage_report(args: CleanupRetainedStorageArgs) -> CmdResul
             .map(|output| (output, 0));
     }
 
-    let timeout =
-        cleanup_category_timeout(None).saturating_sub(CLEANUP_CHILD_TERMINATION_ALLOWANCE);
+    let timeout = cleanup_category_timeout(cleanup_category_base_budget(), None)
+        .saturating_sub(CLEANUP_CHILD_TERMINATION_ALLOWANCE);
     let executable = std::env::current_exe().map_err(|error| {
         homeboy::core::Error::internal_io(
             error.to_string(),
@@ -1914,18 +1915,32 @@ fn automatic_retention() -> CmdResult<Value> {
 }
 
 fn cleanup_inventory(args: CleanupArgs) -> homeboy::core::Result<CleanupInventoryResult> {
-    cleanup_inventory_with_deadline(
-        args,
-        SystemTime::now().checked_add(cleanup_inventory_timeout()),
-    )
+    let deadline = SystemTime::now().checked_add(cleanup_inventory_timeout(args.apply));
+    cleanup_inventory_with_deadline(args, deadline)
 }
 
-fn cleanup_inventory_timeout() -> Duration {
-    std::env::var(CLEANUP_CATEGORY_CHILD_TIMEOUT_ENV)
+/// Aggregate sweep budget, widened by whatever a category legitimately needs
+/// beyond the shared base.
+///
+/// Without the widening, raising a provider timeout would simply relocate the
+/// failure: the provider category would consume the whole aggregate and starve
+/// every category scheduled after it.
+fn cleanup_inventory_timeout(apply: bool) -> Duration {
+    if let Some(inherited) = std::env::var(CLEANUP_CATEGORY_CHILD_TIMEOUT_ENV)
         .ok()
         .and_then(|value| value.parse::<u64>().ok())
         .map(Duration::from_millis)
-        .unwrap_or(CLEANUP_AGGREGATE_TIMEOUT)
+    {
+        return inherited;
+    }
+    let configured = Duration::from_secs(
+        defaults::load_config()
+            .retention
+            .cleanup_aggregate_max_seconds,
+    );
+    let base = cleanup_category_base_budget();
+    let widest = cleanup_category_required_budget(WORKTREE_PROVIDERS_METADATA.category, apply);
+    configured.saturating_add(widest.saturating_sub(base))
 }
 
 fn cleanup_inventory_with_deadline(
@@ -2810,7 +2825,10 @@ fn run_cleanup_category_process(
     args: &CleanupArgs,
     deadline: Option<SystemTime>,
 ) -> std::result::Result<Vec<CleanupInventoryCategory>, Box<CleanupInventoryCategory>> {
-    let wall_clock_budget = cleanup_category_timeout(deadline);
+    let wall_clock_budget = cleanup_category_timeout(
+        cleanup_category_required_budget(metadata.category, args.apply),
+        deadline,
+    );
     if wall_clock_budget <= CLEANUP_CHILD_TERMINATION_ALLOWANCE.saturating_mul(2) {
         return Err(Box::new(cleanup_category_timeout_failure(
             metadata,
@@ -3030,10 +3048,54 @@ fn exhausted_category_budget(deadline: Option<SystemTime>) -> Option<Duration> {
     (remaining < CLEANUP_CATEGORY_MINIMUM_BUDGET).then_some(remaining)
 }
 
-fn cleanup_category_timeout(deadline: Option<SystemTime>) -> Duration {
-    let configured = test_cleanup_category_timeout().unwrap_or(CLEANUP_CATEGORY_TIMEOUT);
-    deadline.map_or(configured, |deadline| {
-        configured.min(
+/// Budget every cleanup category starts from, before category-specific needs.
+fn cleanup_category_base_budget() -> Duration {
+    test_cleanup_category_timeout().unwrap_or_else(|| {
+        Duration::from_secs(
+            defaults::load_config()
+                .retention
+                .cleanup_category_max_seconds,
+        )
+    })
+}
+
+/// Budget a specific category needs to finish the work it delegates.
+///
+/// `worktree_providers` shells out twice before reaching the provider, and each
+/// hop reserves [`CLEANUP_CHILD_TERMINATION_ALLOWANCE`]. Sizing the category at
+/// the configured provider timeout plus both allowances is what makes a
+/// configured provider budget reachable; the previous fixed constant capped
+/// every provider below even its own default.
+fn cleanup_category_required_budget(category: &str, apply: bool) -> Duration {
+    let base = cleanup_category_base_budget();
+    if category != WORKTREE_PROVIDERS_METADATA.category {
+        return base;
+    }
+    let mode = if apply {
+        WorktreeProviderCleanupMode::Apply
+    } else {
+        WorktreeProviderCleanupMode::Preview
+    };
+    provider_category_budget(
+        base,
+        max_configured_provider_cleanup_timeout(&defaults::load_config().worktree_providers, &mode),
+    )
+}
+
+/// Category budget that survives both subprocess hops with the configured
+/// provider timeout intact.
+///
+/// Kept free of global config so the arithmetic that guarantees
+/// `budget - 2 * allowance >= configured` is directly testable.
+fn provider_category_budget(base: Duration, provider: Option<Duration>) -> Duration {
+    provider.map_or(base, |provider| {
+        base.max(provider.saturating_add(CLEANUP_CHILD_TERMINATION_ALLOWANCE.saturating_mul(2)))
+    })
+}
+
+fn cleanup_category_timeout(required: Duration, deadline: Option<SystemTime>) -> Duration {
+    deadline.map_or(required, |deadline| {
+        required.min(
             deadline
                 .duration_since(SystemTime::now())
                 .unwrap_or(Duration::ZERO),
@@ -4413,6 +4475,45 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+
+    /// A configured provider budget must survive both subprocess hops.
+    ///
+    /// Regression for #13700: the category budget was a fixed 30s constant, so
+    /// the provider received `30s - 5s - 5s = 20s` no matter what was
+    /// configured. Even the 30s provider default was unreachable, and the
+    /// documented 300s maximum was ~93% dead range.
+    #[test]
+    fn provider_category_budget_delivers_the_configured_timeout_through_both_hops() {
+        let base = Duration::from_secs(30);
+        let hops = CLEANUP_CHILD_TERMINATION_ALLOWANCE.saturating_mul(2);
+
+        for configured_secs in [30, 45, 120, 180, 300] {
+            let configured = Duration::from_secs(configured_secs);
+            let budget = provider_category_budget(base, Some(configured));
+            // This subtraction mirrors run_cleanup_category_process: one
+            // allowance for the child, one for the grandchild env budget.
+            let delivered = budget.saturating_sub(hops);
+            assert!(
+                delivered >= configured,
+                "configured {configured:?} must reach the provider, got {delivered:?}"
+            );
+        }
+
+        // The old ceiling is genuinely gone, not merely widened.
+        assert!(
+            provider_category_budget(base, Some(Duration::from_secs(120))).saturating_sub(hops)
+                > Duration::from_secs(20),
+            "120s provider must exceed the previous 20s ceiling"
+        );
+
+        // A provider cheaper than the base never shrinks the category budget,
+        // and no configured provider leaves the base untouched.
+        assert_eq!(
+            provider_category_budget(base, Some(Duration::from_secs(1))),
+            base
+        );
+        assert_eq!(provider_category_budget(base, None), base);
+    }
 
     fn controller_cleanup_request() -> Value {
         serde_json::to_value(CleanupArgs {

--- a/crates/homeboy-core/src/defaults.rs
+++ b/crates/homeboy-core/src/defaults.rs
@@ -255,6 +255,21 @@ pub struct RetentionConfig {
     /// finish an in-progress safe mutation before the executor yields.
     #[serde(default = "default_automatic_retention_max_run_seconds")]
     pub automatic_retention_max_run_seconds: u64,
+    /// Wall-clock budget for a single cleanup category subprocess.
+    ///
+    /// This is a floor, not a ceiling: a category that delegates to a
+    /// configured external provider is additionally guaranteed enough time to
+    /// honor that provider's own configured timeout, so raising a provider
+    /// budget never has to be mirrored here.
+    #[serde(default = "default_cleanup_category_max_seconds")]
+    pub cleanup_category_max_seconds: u64,
+    /// Wall-clock budget for one aggregate `homeboy cleanup` sweep.
+    ///
+    /// Also a floor: the aggregate grows to absorb category budgets that
+    /// exceed [`Self::cleanup_category_max_seconds`], so a slow provider
+    /// cannot starve the categories scheduled after it.
+    #[serde(default = "default_cleanup_aggregate_max_seconds")]
+    pub cleanup_aggregate_max_seconds: u64,
 }
 
 impl Default for RetentionConfig {
@@ -279,6 +294,8 @@ impl Default for RetentionConfig {
             external_storage_max_bytes: default_external_storage_max_bytes(),
             external_storage_reserve_bytes: default_external_storage_reserve_bytes(),
             automatic_retention_max_run_seconds: default_automatic_retention_max_run_seconds(),
+            cleanup_category_max_seconds: default_cleanup_category_max_seconds(),
+            cleanup_aggregate_max_seconds: default_cleanup_aggregate_max_seconds(),
         }
     }
 }
@@ -351,6 +368,14 @@ fn default_external_storage_reserve_bytes() -> u64 {
 
 fn default_automatic_retention_max_run_seconds() -> u64 {
     60
+}
+
+fn default_cleanup_category_max_seconds() -> u64 {
+    30
+}
+
+fn default_cleanup_aggregate_max_seconds() -> u64 {
+    120
 }
 
 /// Timings for the global controller-generation admission queue.

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -4087,6 +4087,32 @@ fn run_provider_cleanup(
     }
 }
 
+/// Largest configured cleanup timeout across the providers that can actually
+/// run in `mode`.
+///
+/// The cleanup aggregate uses this to size the `worktree_providers` category
+/// budget. Without it the enclosing category constant silently truncates every
+/// configured provider timeout, making the documented configuration range
+/// unreachable and terminating slow providers mid-inventory.
+///
+/// Returns `None` when no provider is eligible, so the caller keeps its own
+/// default rather than inventing a budget for work that will not run.
+#[must_use]
+pub fn max_configured_provider_cleanup_timeout(
+    providers: &std::collections::HashMap<String, WorktreeProviderConfig>,
+    mode: &WorktreeProviderCleanupMode,
+) -> Option<Duration> {
+    providers
+        .values()
+        .filter(|provider| provider.enabled)
+        .filter(|provider| match mode {
+            WorktreeProviderCleanupMode::Preview => true,
+            WorktreeProviderCleanupMode::Apply => provider.apply_enabled,
+        })
+        .filter_map(|provider| provider_cleanup_timeout(provider, mode, None).ok())
+        .max()
+}
+
 fn provider_cleanup_timeout(
     provider: &WorktreeProviderConfig,
     mode: &WorktreeProviderCleanupMode,
@@ -5768,6 +5794,68 @@ mod tests {
             Some(json!({ "mode": "preview" }))
         );
         assert_eq!(output.providers[0].timeout_ms, 30_000);
+    }
+
+    #[test]
+    fn max_configured_cleanup_timeout_reports_the_budget_the_aggregate_must_reserve() {
+        let slow = WorktreeProviderConfig {
+            apply_enabled: true,
+            commands: WorktreeProviderCommands {
+                cleanup_preview_timeout_ms: 180_000,
+                cleanup_apply_timeout_ms: 240_000,
+                ..Default::default()
+            },
+            ..default_command_provider()
+        };
+        let fast = WorktreeProviderConfig {
+            apply_enabled: false,
+            commands: WorktreeProviderCommands {
+                cleanup_preview_timeout_ms: 5_000,
+                cleanup_apply_timeout_ms: 5_000,
+                ..Default::default()
+            },
+            ..default_command_provider()
+        };
+        let disabled = WorktreeProviderConfig {
+            enabled: false,
+            commands: WorktreeProviderCommands {
+                cleanup_preview_timeout_ms: 300_000,
+                cleanup_apply_timeout_ms: 300_000,
+                ..Default::default()
+            },
+            ..default_command_provider()
+        };
+
+        let providers = std::collections::HashMap::from([
+            ("slow".to_string(), slow),
+            ("fast".to_string(), fast.clone()),
+            ("disabled".to_string(), disabled),
+        ]);
+
+        // A disabled provider must never inflate the reserved budget.
+        assert_eq!(
+            max_configured_provider_cleanup_timeout(
+                &providers,
+                &WorktreeProviderCleanupMode::Preview
+            ),
+            Some(Duration::from_millis(180_000))
+        );
+        // `fast` cannot apply, so apply mode reserves only the apply-capable provider.
+        assert_eq!(
+            max_configured_provider_cleanup_timeout(
+                &providers,
+                &WorktreeProviderCleanupMode::Apply
+            ),
+            Some(Duration::from_millis(240_000))
+        );
+        // No apply-capable provider means no budget to reserve at all.
+        assert_eq!(
+            max_configured_provider_cleanup_timeout(
+                &std::collections::HashMap::from([("fast".to_string(), fast)]),
+                &WorktreeProviderCleanupMode::Apply
+            ),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #13700.

## What this is

A **configuration-contract fix**, not a performance fix.

`worktree_providers.<id>.commands.cleanup_preview_timeout_ms` and
`cleanup_apply_timeout_ms` validate against a documented 1ms–300s range, but
the value was silently discarded above ~20s. Setting it had no observable
effect at any value.

## Why

Reaching a provider costs two subprocess hops, and each reserves a 5s
termination allowance:

- `cleanup.rs:53` — `CLEANUP_CATEGORY_TIMEOUT = 30s` (const, no operator surface)
- `cleanup.rs:2826` — child budget = `30s - 5s` = 25s
- `cleanup.rs:2850` — grandchild budget = `25s - 5s` = 20s
- `worktree_providers.rs:4096` — `provider_cleanup_timeout()` returns `min(configured, remaining)`

So the enclosing constant, not the configuration, always won. Even the 30s
provider **default** was unreachable, and roughly 93% of the documented range
was dead. `provider_cleanup_timeout()`'s existing unit test encoded that
truncation as intended behavior.

## Change

- Size the `worktree_providers` category from the configured provider budget
  plus both termination allowances, so a configured value survives both hops.
- Widen the aggregate by the same delta, so a slow provider cannot starve the
  categories scheduled after it.
- Add `retention.cleanup_category_max_seconds` and
  `retention.cleanup_aggregate_max_seconds`, with the previous constants
  (30s / 120s) preserved as defaults.

Default-configured behavior is unchanged except that a provider now receives
the 30s it was already configured for instead of 20s.

## Verification

Against the live `dmc` provider on this controller:

| provider config | before | after |
|---|---|---|
| 30s (default)   | `timeout_ms: 19998` | `timeout_ms: 29996` |
| 180s            | `timeout_ms: 19998` | `timeout_ms: 179996` |

Regression coverage:
- `provider_category_budget_delivers_the_configured_timeout_through_both_hops`
  asserts `budget - 2 * allowance >= configured` across 30s–300s, mirroring the
  real subtraction in `run_cleanup_category_process`.
- `max_configured_cleanup_timeout_reports_the_budget_the_aggregate_must_reserve`
  covers disabled and non-apply-capable providers so they cannot inflate the
  reserved budget.

`cargo test -p homeboy-core --lib cleanup -- --test-threads=1` → 262 passed.
(Parallel runs show 3 pre-existing flaky failures with varying names; they fail
identically on unmodified `main`.)

## Scope note

This does **not** fix the DMC provider timing out in practice. That has a
separate root cause in Data Machine Code, where the safe-cleanup wall-clock
budget is not applied to the artifact stage — a 10s budget produces a ~104s
run. This PR deliberately does not paper over that by raising defaults; it only
makes the documented knob mean what it says.

---

*AI assistance disclosure: implemented with Claude Sonnet 4.5 (Anthropic) driving OpenCode via the Kimaki Discord bridge. The model traced the constants, wrote the change and tests, and captured the before/after provider timings above. A human directed the work and challenged an earlier framing of this change as a performance fix, which prompted the scope note.*
