### PR TITLE
Root promotion scratch in its observation store

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -341,6 +341,7 @@ fn resume_promoted_patch_internal<'a>(
         target_path,
         expected_candidate.as_ref(),
         gate_workspace,
+        observation_store,
     )?;
     let target =
         AgentTaskPromotionTarget::from_worktree(options.to_worktree.clone(), Some(target_path));
@@ -651,11 +652,25 @@ pub(super) fn promote_with_provider_and_checkpoint(
     provider: &mut impl AgentTaskPromotionWorkspaceProvider,
     checkpoint: &mut impl FnMut(&AgentTaskPromotionReport) -> Result<()>,
 ) -> Result<AgentTaskPromotionReport> {
-    // One promotion is one unit of work, so the store it records against
-    // resolves once here and is passed down. The interior used to receive
-    // `None` and re-resolve the environment partway through (#7505).
-    let observation_store = homeboy_core::observation::ObservationStore::open_initialized()?;
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let observation_store = homeboy_core::observation::ObservationStore::open_initialized_in_roots(
+        &context.path_roots(),
+    )?;
     promote_with_provider_and_checkpoint_internal(options, provider, checkpoint, &observation_store)
+}
+
+#[cfg(test)]
+pub(super) fn promote_with_provider_in_observation_store(
+    options: AgentTaskPromotionOptions,
+    provider: &mut impl AgentTaskPromotionWorkspaceProvider,
+    observation_store: &homeboy_core::observation::ObservationStore,
+) -> Result<AgentTaskPromotionReport> {
+    promote_with_provider_and_checkpoint_internal(
+        options,
+        provider,
+        &mut |_| Ok(()),
+        observation_store,
+    )
 }
 
 #[cfg(test)]
@@ -835,7 +850,14 @@ fn promote_with_provider_and_checkpoint_internal(
         let target =
             AgentTaskPromotionTarget::from_worktree(options.to_worktree.clone(), worktree_path);
         let gates = if let Some(worktree_path) = worktree_path {
-            run_promotion_gates(&options, provider, worktree_path, None, None)?
+            run_promotion_gates(
+                &options,
+                provider,
+                worktree_path,
+                None,
+                None,
+                observation_store,
+            )?
         } else {
             PromotionGateRun::without_gates(options.dry_run)
         };
@@ -1028,6 +1050,7 @@ fn promote_with_provider_and_checkpoint_internal(
                     })?
                     .as_ref(),
                 None,
+                observation_store,
             )?,
             verified_base,
         )
@@ -1729,6 +1752,7 @@ fn promote_committed_changes(
                     })?
                     .as_ref(),
                 None,
+                observation_store,
             )?,
             verified_base,
         )
@@ -1866,6 +1890,7 @@ fn run_promotion_gates(
     worktree_path: &Path,
     expected_candidate: Option<&crate::agent_task_promotion::AgentTaskPromotionCandidate>,
     gate_workspace: Option<&Path>,
+    observation_store: &homeboy_core::observation::ObservationStore,
 ) -> Result<PromotionGateRun> {
     emit_promotion_progress(
         "hydration",
@@ -1891,6 +1916,7 @@ fn run_promotion_gates(
             .as_deref()
             .unwrap_or("unrecorded-promotion"),
         expected_candidate,
+        observation_store,
     )?;
     // The immutable candidate establishes source identity only. Dependency
     // setup is intentionally destination-only: gates must consume the exact
@@ -1988,6 +2014,7 @@ fn run_promotion_gates(
                 command,
                 visibility,
                 reveal_policy,
+                observation_store,
             )?
         };
         if gate.status == AgentTaskGateStatus::Failed
@@ -2108,6 +2135,7 @@ impl ImmutableCandidateCheckout {
         source_root: &Path,
         run_id: &str,
         expected_candidate: Option<&crate::agent_task_promotion::AgentTaskPromotionCandidate>,
+        observation_store: &homeboy_core::observation::ObservationStore,
     ) -> Result<Option<Self>> {
         if !source_root.is_dir() {
             // An external provider can report an opaque or not-yet-mounted
@@ -2156,7 +2184,11 @@ impl ImmutableCandidateCheckout {
                 "homeboy: immutable promotion candidate",
             ],
         )?;
-        let allocation = crate::controller_scratch::allocate_attempt(
+        let data_root = observation_store.data_root().ok_or_else(|| {
+            Error::internal_unexpected("promotion observation store has no data root")
+        })?;
+        let allocation = crate::controller_scratch::allocate_attempt_at(
+            data_root,
             run_id,
             "promotion-candidate-checkout",
             "candidate",
@@ -2246,12 +2278,17 @@ fn run_promotion_gate(
     command: &str,
     visibility: AgentTaskGateVisibility,
     reveal_policy: AgentTaskGateRevealPolicy,
+    observation_store: &homeboy_core::observation::ObservationStore,
 ) -> Result<crate::agent_task_gate::AgentTaskGateReport> {
     let run_id = options
         .source_run_id
         .as_deref()
         .unwrap_or("unrecorded-promotion");
-    let allocation = crate::controller_scratch::allocate_attempt(
+    let data_root = observation_store.data_root().ok_or_else(|| {
+        Error::internal_unexpected("promotion observation store has no data root")
+    })?;
+    let allocation = crate::controller_scratch::allocate_attempt_at(
+        data_root,
         run_id,
         "promotion-verification",
         &format!("gate-{index}"),

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
@@ -10,7 +10,8 @@ use super::super::apply::{
 use super::super::promote::{
     normalize_promotion_patch, promote, promote_with_provider,
     promote_with_provider_and_checkpoint,
-    promote_with_provider_and_checkpoint_in_observation_store, resume_promoted_patch,
+    promote_with_provider_and_checkpoint_in_observation_store,
+    promote_with_provider_in_observation_store, resume_promoted_patch,
     retain_committed_changes_artifact,
 };
 use super::super::types::{AgentTaskPromotionOptions, AgentTaskPromotionStatus};
@@ -166,6 +167,8 @@ fn adopted_workspace_wins_over_a_rejecting_configured_provider() {
 #[test]
 fn promotion_rejects_missing_or_mismatched_recovered_controller_projection() {
     homeboy_core::test_support::with_isolated_home(|_| {
+        let observation_store =
+            homeboy_core::observation::ObservationStore::open_initialized().expect("store");
         let run_id = "recovered-lab-run";
         let task_id = "implement";
         let artifact_id = "patch";
@@ -197,15 +200,23 @@ fn promotion_rejects_missing_or_mismatched_recovered_controller_projection() {
             provider_invocation: None,
         };
 
-        let missing = promote_with_provider(options(), &mut provider)
-            .expect_err("missing projection rejected");
+        let missing = promote_with_provider_in_observation_store(
+            options(),
+            &mut provider,
+            &observation_store,
+        )
+        .expect_err("missing projection rejected");
         assert!(missing
             .message
             .contains("verified controller-side artifact projection"));
 
         record_controller_projection(run_id, task_id, artifact_id, "different patch bytes");
-        let mismatched = promote_with_provider(options(), &mut provider)
-            .expect_err("mismatched projection rejected");
+        let mismatched = promote_with_provider_in_observation_store(
+            options(),
+            &mut provider,
+            &observation_store,
+        )
+        .expect_err("mismatched projection rejected");
         assert!(mismatched
             .message
             .contains("does not match the aggregate SHA-256 and size"));
@@ -216,6 +227,8 @@ fn promotion_rejects_missing_or_mismatched_recovered_controller_projection() {
 #[test]
 fn promotion_uses_recovered_controller_projection_without_public_artifact_path() {
     homeboy_core::test_support::with_isolated_home(|_| {
+        let observation_store =
+            homeboy_core::observation::ObservationStore::open_initialized().expect("store");
         let run_id = "recovered-lab-run";
         let task_id = "implement";
         let artifact_id = "patch";
@@ -237,7 +250,7 @@ fn promotion_uses_recovered_controller_projection_without_public_artifact_path()
             ..Default::default()
         };
 
-        let result = promote_with_provider(
+        let result = promote_with_provider_in_observation_store(
             AgentTaskPromotionOptions {
                 source: source.to_string(),
                 source_run_id: Some(run_id.to_string()),
@@ -255,6 +268,7 @@ fn promotion_uses_recovered_controller_projection_without_public_artifact_path()
                 provider_invocation: None,
             },
             &mut provider,
+            &observation_store,
         )
         .expect("controller projection is promoted without a public artifact path");
 

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -7,7 +7,8 @@ use super::super::apply::{
 };
 use super::super::promote::{
     normalize_promotion_patch, promote_with_provider, promote_with_provider_and_checkpoint,
-    resume_promoted_patch, select_patch_artifact, validate_artifact_content,
+    promote_with_provider_in_observation_store, resume_promoted_patch, select_patch_artifact,
+    validate_artifact_content,
 };
 use super::super::types::{AgentTaskPromotionOptions, AgentTaskPromotionStatus};
 use super::*;
@@ -228,7 +229,7 @@ fn bridge_reconciliation_recovers_mixed_runner_artifacts_for_local_promotion_ide
             workspace_path: Some(temp.path().join("target")),
             ..Default::default()
         };
-        let report = promote_with_provider(
+        let report = promote_with_provider_in_observation_store(
             AgentTaskPromotionOptions {
                 source: serde_json::to_string(&aggregate).expect("aggregate json"),
                 source_run_id: Some(run_id.to_string()),
@@ -246,6 +247,7 @@ fn bridge_reconciliation_recovers_mixed_runner_artifacts_for_local_promotion_ide
                 provider_invocation: None,
             },
             &mut provider,
+            &store,
         )
         .expect("promote recovered controller projection");
         assert_ne!(report.patch_artifact.path, patch.path);
@@ -260,6 +262,8 @@ fn bridge_reconciliation_recovers_mixed_runner_artifacts_for_local_promotion_ide
 #[test]
 fn aggregate_promotion_forwards_canonical_gate_feedback_baseline() {
     homeboy_core::test_support::with_isolated_home(|_| {
+        let observation_store =
+            homeboy_core::observation::ObservationStore::open_initialized().expect("store");
         let temp = tempfile::tempdir().expect("tempdir");
         let patch_path = temp.path().join("remediation.patch");
         std::fs::write(&patch_path, VALID_PATCH).expect("write remediation patch");
@@ -326,7 +330,7 @@ fn aggregate_promotion_forwards_canonical_gate_feedback_baseline() {
             workspace_path: Some(temp.path().to_path_buf()),
             ..Default::default()
         };
-        promote_with_provider(
+        promote_with_provider_in_observation_store(
             AgentTaskPromotionOptions {
                 source,
                 source_run_id: Some("follow-up-run".to_string()),
@@ -344,6 +348,7 @@ fn aggregate_promotion_forwards_canonical_gate_feedback_baseline() {
                 provider_invocation: None,
             },
             &mut provider,
+            &observation_store,
         )
         .expect("aggregate promotion");
         let forwarded = provider.apply_calls[0]

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_d.rs
@@ -5,7 +5,9 @@ use super::super::apply::{
     AgentTaskPromotionApplyRequest, AgentTaskPromotionWorkspaceProvider,
     ExternalPromotionWorkspaceProvider, AGENT_TASK_PROMOTION_APPLY_REQUEST_SCHEMA,
 };
-use super::super::promote::{normalize_promotion_patch, promote_with_provider};
+use super::super::promote::{
+    normalize_promotion_patch, promote_with_provider, promote_with_provider_in_observation_store,
+};
 use super::super::types::{
     AgentTaskPromotionArtifactRef, AgentTaskPromotionNotification, AgentTaskPromotionOptions,
     AgentTaskPromotionReport, AgentTaskPromotionSource, AgentTaskPromotionStatus,
@@ -26,6 +28,8 @@ use std::path::{Path, PathBuf};
 #[test]
 fn promotion_uses_verified_controller_projection_for_recovered_runner_aggregate_sources() {
     homeboy_core::test_support::with_isolated_home(|_| {
+        let observation_store =
+            homeboy_core::observation::ObservationStore::open_initialized().expect("store");
         let run_id = "recovered-lab-run";
         let task_id = "implement";
         let artifact_id = "patch";
@@ -48,7 +52,7 @@ fn promotion_uses_verified_controller_projection_for_recovered_runner_aggregate_
                 ..Default::default()
             };
 
-            let report = promote_with_provider(
+            let report = promote_with_provider_in_observation_store(
                 AgentTaskPromotionOptions {
                     source: source.clone(),
                     source_run_id: Some(run_id.to_string()),
@@ -66,6 +70,7 @@ fn promotion_uses_verified_controller_projection_for_recovered_runner_aggregate_
                     provider_invocation: None,
                 },
                 &mut provider,
+                &observation_store,
             )
             .expect("recovered aggregate promotes from controller projection");
 
@@ -382,6 +387,8 @@ fn promote_exports_committed_changes_when_patch_artifact_is_empty() {
 #[test]
 fn committed_changes_retain_a_controller_baseline_before_source_cleanup() {
     homeboy_core::test_support::with_isolated_home(|_| {
+        let observation_store =
+            homeboy_core::observation::ObservationStore::open_initialized().expect("store");
         let temp = tempfile::tempdir().expect("tempdir");
         let repo = temp.path().join("repo");
         std::fs::create_dir(&repo).expect("create repo");
@@ -401,7 +408,7 @@ fn committed_changes_retain_a_controller_baseline_before_source_cleanup() {
             ..Default::default()
         };
 
-        let report = promote_with_provider(
+        let report = promote_with_provider_in_observation_store(
             AgentTaskPromotionOptions {
                 source,
                 source_run_id: Some("baseline-run".to_string()),
@@ -419,6 +426,7 @@ fn committed_changes_retain_a_controller_baseline_before_source_cleanup() {
                 provider_invocation: None,
             },
             &mut provider,
+            &observation_store,
         )
         .expect("committed changes promote");
         let original_path = temp.path().join(format!(


### PR DESCRIPTION
## Summary
- derive promotion candidate and gate scratch from the operation's existing observation store
- replace ambient provider-test storage with a private rooted test context
- pass durable projection stores explicitly in tests that inspect persisted promotion evidence

This removes cross-root scratch allocation instead of adding another global lock or `HomeGuard` wrapper.

## Evidence
- `cargo test -p homeboy-agents --lib agent_task_promotion::tests`: 88 passed, 0 failed
- `cargo check -p homeboy-agents --features test-support`: passed
- full `cargo test -p homeboy-agents --lib`: 2086 passed, 6 failed, 6 ignored, down from 16 parallel failures before this slice

Refs #11897.

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to trace cross-root scratch allocation, implement the explicit-store simplification, and run verification. I reviewed and directed the resulting changes and evidence.