### PR TITLE
Unify fanout preview help (#13704)

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/command.rs
@@ -226,12 +226,15 @@ pub enum AgentTaskCommand {
 
 #[derive(Args, Debug)]
 pub struct AcceptArgs {
+    /// Durable run ID whose candidate receives the verdict.
     pub run_id: String,
+    /// Acceptance decision: `accepted` permits finalization; `rejected` records a failure.
     #[arg(long, value_parser = ["accepted", "rejected"])]
     pub verdict: String,
     /// Opaque credential consumed by the configured acceptance verifier.
     #[arg(long)]
     pub token: String,
+    /// Durable evidence reference supporting the verdict. Repeatable.
     #[arg(long = "evidence-ref")]
     pub evidence_refs: Vec<String>,
     /// Bounded reviewer remediation feedback retained with a rejected Cook
@@ -270,25 +273,31 @@ pub struct CookContinueArgs {
 
 #[derive(Args, Debug)]
 pub struct ListArgs {
+    /// Maximum matching durable runs to return.
     #[arg(long = "limit", value_name = "N", conflicts_with = "full")]
     pub limit: Option<usize>,
     /// Continue at this zero-based offset. Reuse every filter from the prior page.
     #[arg(long, value_name = "N", conflicts_with = "full")]
     pub cursor: Option<usize>,
+    /// Restrict results to this repository identity.
     #[arg(long)]
     pub repo: Option<String>,
+    /// Restrict results to this workspace handle or path.
     #[arg(long)]
     pub worktree: Option<String>,
+    /// Restrict results to this task URL.
     #[arg(long = "task-url")]
     pub task_url: Option<String>,
     /// RFC3339 submission timestamp; excludes older records.
     #[arg(long = "submitted-after", value_name = "RFC3339")]
     pub submitted_after: Option<String>,
+    /// Restrict results to this durable lifecycle state.
     #[arg(long, value_parser = ["queued", "running", "succeeded", "failed", "cancelled"])]
     pub state: Option<String>,
     /// Filter by recorded execution placement, not the global routing policy.
     #[arg(long = "run-placement", value_parser = ["local", "remote", "runner"])]
     pub run_placement: Option<String>,
+    /// Restrict results to records owned by this parent run or group.
     #[arg(long = "parent-id")]
     pub parent_id: Option<String>,
     /// Return every matching record. This is intentionally explicit because
@@ -319,15 +328,19 @@ pub struct ActiveArgs {
     /// fleet-wide `--reconcile`.
     #[arg(long, conflicts_with = "reconcile")]
     pub full: bool,
+    /// Preview reconciliation for every active record in the selected scope.
     #[arg(long = "reconcile")]
     pub reconcile: bool,
+    /// Explicitly retain preview-only reconciliation mode.
     #[arg(long = "dry-run", requires = "reconcile", conflicts_with = "apply")]
     pub dry_run: bool,
+    /// Apply reconciliation to every selected active record.
     #[arg(long = "apply", requires = "reconcile", conflicts_with = "dry_run")]
     pub apply: bool,
 }
 #[derive(Args, Debug)]
 pub struct ReconcileArgs {
+    /// Durable run ID or Cook group ID to reconcile.
     pub run_id: String,
     /// Preview the selected durable run/group without persisted mutation. This
     /// is the default when `--apply` is omitted.
@@ -339,11 +352,13 @@ pub struct ReconcileArgs {
 }
 #[derive(Args, Debug)]
 pub struct ReconcileRecordsArgs {
+    /// Preview record reconciliation without persisting changes.
     #[arg(long = "dry-run")]
     pub dry_run: bool,
 }
 #[derive(Args, Debug)]
 pub struct LatestArgs {
+    /// Number of newest durable runs to inspect before selecting the latest.
     #[arg(long = "limit", value_name = "N")]
     pub limit: Option<usize>,
 }
@@ -399,9 +414,13 @@ pub struct RetainedArtifactsArgs {
 #[derive(Subcommand, Debug)]
 pub enum RetainedArtifactsCommand {
     /// Resolve the retained workspace and print bounded, run-ID-only attach guidance.
-    Discover { run_id: String },
+    Discover {
+        /// Terminal Lab Cook run ID whose retained workspace is discovered.
+        run_id: String,
+    },
     /// Attach one repository-relative file or directory from the retained workspace.
     Attach {
+        /// Terminal Lab Cook run ID that owns the retained workspace.
         run_id: String,
         /// Repository-relative path below the retained workspace.
         #[arg(long)]
@@ -413,8 +432,10 @@ pub enum RetainedArtifactsCommand {
 }
 #[derive(Args, Debug)]
 pub struct ProvidersArgs {
+    /// Restrict results to this executor backend.
     #[arg(long = "backend", value_name = "BACKEND")]
     pub backend: Option<String>,
+    /// Restrict results to this backend-specific provider selector.
     #[arg(
         long = "selector",
         visible_alias = "provider-id",
@@ -434,10 +455,13 @@ pub struct ProvidersArgs {
     /// credential (#11479).
     #[arg(long = "status", value_name = "STATUS")]
     pub status: Option<String>,
+    /// Declare a secret environment variable available for readiness checks. Repeatable.
     #[arg(long = "secret-env", value_name = "ENV")]
     pub secret_env: Vec<String>,
+    /// Live-probe matching providers and report their readiness.
     #[arg(long = "validate-readiness")]
     pub validate_readiness: bool,
+    /// Refresh cached provider discovery before listing results.
     #[arg(long = "refresh")]
     pub refresh: bool,
     /// Return the full multi-backend catalog even when `--backend` is set.
@@ -473,25 +497,34 @@ pub struct ProvidersArgs {
 }
 #[derive(Args, Debug)]
 pub struct AgentTaskDoctorArgs {
+    /// Runner to diagnose and optionally repair.
     #[arg(long, value_name = "RUNNER")]
     pub runner: String,
+    /// Restrict diagnostics to this executor backend.
     #[arg(long, value_name = "BACKEND")]
     pub backend: Option<String>,
+    /// Restrict diagnostics to this backend-specific provider selector.
     #[arg(long, visible_alias = "provider-id", value_name = "PROVIDER_ID")]
     pub selector: Option<String>,
+    /// Add this directory to the runner diagnostic path search.
     #[arg(long, value_name = "PATH")]
     pub path: Option<String>,
+    /// Require this extension to be available on the runner. Repeatable.
     #[arg(long = "extension", value_name = "EXTENSION")]
     pub extensions: Vec<String>,
+    /// Require this executable to be available on the runner. Repeatable.
     #[arg(long = "require-tool", value_name = "TOOL")]
     pub required_tools: Vec<String>,
+    /// Declare a secret environment variable available for readiness checks. Repeatable.
     #[arg(long = "secret-env", value_name = "ENV")]
     pub secret_env: Vec<String>,
+    /// Repair remediable runner readiness failures.
     #[arg(long)]
     pub repair: bool,
 }
 #[derive(Args, Debug)]
 pub struct ContractArgs {
+    /// Serialization format for the exported contract metadata.
     #[arg(long, default_value = "json", value_enum)]
     pub format: ContractFormat,
 }
@@ -501,6 +534,7 @@ pub enum ContractFormat {
 }
 #[derive(Args, Debug)]
 pub struct CompileLoopArgs {
+    /// Declarative loop definition to compile into an agent-task plan.
     #[arg(long, value_name = "SPEC")]
     pub definition: String,
 }

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -1021,6 +1021,7 @@ pub struct AgentTaskCookArgs {
     /// --prompt, it supplies the one provider task.
     #[arg(long, value_name = "TEXT")]
     pub goal: Option<String>,
+    /// Read-only workspace evidence supplied to the provider. Repeatable.
     #[arg(long = "provider-evidence", value_name = "JSON", help = PROVIDER_EVIDENCE_DECLARATION, value_parser = parse_provider_evidence_input)]
     pub provider_evidence_inputs: Vec<AgentTaskProviderEvidenceInput>,
     /// Workspace handle the cook edits, verifies, and finalizes into. The handle
@@ -1047,6 +1048,7 @@ pub struct AgentTaskCookArgs {
     /// provider must declare its repository under
     /// settings.worktree_provider_self_repair; normal Cook gates, review, PR
     /// finalization, and durable provenance remain active.
+    /// Deprecated shell command for the promotion apply-provider.
     #[arg(
         long,
         value_name = "PROVIDER_ID",
@@ -1054,12 +1056,15 @@ pub struct AgentTaskCookArgs {
         conflicts_with_all = ["workspace", "to_worktree", "no_finalize"]
     )]
     pub worktree_provider_self_repair: Option<String>,
+    /// Exact argv element for the promotion apply-provider. Repeat once per element.
     #[arg(
         long,
         value_name = "COMMAND",
         long_help = "Deprecated promotion apply-provider command string. Migrate `--provider-command 'provider --flag value'` to `--provider-argv provider --provider-argv --flag --provider-argv value`; argv preserves exact arguments without shell splitting. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with `workspace_path`."
     )]
     pub provider_command: Option<String>,
+    /// Exact argv element for the promotion apply-provider. Repeat once per
+    /// element; values are never shell-split.
     #[arg(
         long = "provider-argv",
         value_name = "ARG",
@@ -1171,6 +1176,7 @@ pub(crate) fn parse_provider_evidence_input(
 
 #[derive(Args, Clone, Debug)]
 pub struct PromotionProviderArgs {
+    /// Workspace path supplied to the promotion apply-provider.
     #[arg(long, value_name = "PATH")]
     pub workspace: String,
 }
@@ -1196,48 +1202,64 @@ pub enum AgentTaskLoopCommand {
 }
 #[derive(Args, Debug)]
 pub struct AgentTaskLoopDefineArgs {
+    /// Loop specification file or inline definition.
     #[arg(value_name = "SPEC")]
     pub spec: String,
+    /// Start the defined loop immediately.
     #[arg(long, conflicts_with = "off")]
     pub on: bool,
+    /// Save the defined loop in the stopped state.
     #[arg(long, conflicts_with = "on")]
     pub off: bool,
+    /// Maximum revolutions before the loop stops automatically.
     #[arg(long = "revolution-limit", value_name = "N")]
     pub revolution_limit: Option<u32>,
+    /// Continue an existing loop definition from its recorded state.
     #[arg(long)]
     pub resume: bool,
+    /// Backend used when the loop dispatches provider work.
     #[arg(long = "dispatch-backend", value_name = "BACKEND")]
     pub dispatch_backend: Option<String>,
+    /// Backend-specific provider selector used for loop dispatch.
     #[arg(
         long = "dispatch-selector",
         visible_alias = "dispatch-provider-id",
         value_name = "PROVIDER_ID"
     )]
     pub dispatch_selector: Option<String>,
+    /// Model used for loop dispatch.
     #[arg(long = "dispatch-model", value_name = "MODEL")]
     pub dispatch_model: Option<String>,
+    /// Backend-specific JSON configuration used for loop dispatch.
     #[arg(long = "dispatch-provider-config", value_name = "JSON")]
     pub dispatch_provider_config: Option<String>,
 }
 #[derive(Args, Debug)]
 pub struct AgentTaskLoopStatusArgs {
+    /// Durable loop ID to inspect or stop.
     pub loop_id: String,
 }
 #[derive(Args, Debug)]
 pub struct AgentTaskLoopResumeArgs {
+    /// Durable loop ID to resume.
     pub loop_id: String,
+    /// New maximum revolutions before the loop stops automatically.
     #[arg(long = "revolution-limit", value_name = "N")]
     pub revolution_limit: Option<u32>,
+    /// Backend used for resumed loop dispatches.
     #[arg(long = "dispatch-backend", value_name = "BACKEND")]
     pub dispatch_backend: Option<String>,
+    /// Backend-specific provider selector used for resumed loop dispatches.
     #[arg(
         long = "dispatch-selector",
         visible_alias = "dispatch-provider-id",
         value_name = "PROVIDER_ID"
     )]
     pub dispatch_selector: Option<String>,
+    /// Model used for resumed loop dispatches.
     #[arg(long = "dispatch-model", value_name = "MODEL")]
     pub dispatch_model: Option<String>,
+    /// Backend-specific JSON configuration used for resumed loop dispatches.
     #[arg(long = "dispatch-provider-config", value_name = "JSON")]
     pub dispatch_provider_config: Option<String>,
 }

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/fanout.rs
@@ -15,11 +15,24 @@ pub struct AgentTaskFanoutArgs {
 pub enum AgentTaskFanoutCommand {
     /// Cook a wave of independent tasks, one child cook per issue.
     ///
+    /// TWO-PHASE MODEL: this command plans first and executes only when told
+    /// to. Without `--run-plan` it resolves the batch — issues, repository,
+    /// default branch, gates, backend — and creates or reuses every child
+    /// worktree, but it does NOT dispatch any cook; run the returned
+    /// `fanout run-plan` command (or pass `--run-plan`) to execute the wave.
+    /// `--preview` (historical spelling `--dry-run`) is the fully static form:
+    /// it validates the same plan without touching repositories, providers,
+    /// worktrees, or files, mirroring `agent-task cook --preview`.
+    ///
     /// Every child requires a deterministic gate from shared --verify/
     /// --private-verify inputs or --verification-profiles. A child that cannot
     /// verify its work cannot promote it (#9838).
     CookBatch(Box<AgentTaskFanoutCookBatchArgs>),
     /// Normalize and inspect a batch-cook plan without submitting or running it.
+    ///
+    /// Reads an existing persisted plan with `--input <SPEC>`, or plans
+    /// statically from `--repo <REPO_SLUG>` plus one or more issue URLs — the
+    /// same input `fanout cook-batch` accepts, without any side effects.
     Plan(AgentTaskFanoutPlanArgs),
     /// Submit a batch of independent cooks and print the exact per-cook commands
     /// for runner or operator execution.
@@ -46,6 +59,8 @@ pub enum AgentTaskFanoutCommand {
 
 #[derive(Args, Debug, Clone)]
 pub struct AgentTaskFanoutCookBatchArgs {
+    /// GitHub issue URL cooked by one child of the wave. Repeat for multiple
+    /// issues; every URL must be unique and resolve through the tracker.
     #[arg(value_name = "ISSUE_URL", required = true)]
     pub issues: Vec<String>,
     /// Registered repository slug or exact registered primary checkout path.
@@ -66,8 +81,14 @@ pub struct AgentTaskFanoutCookBatchArgs {
     /// Controller-resolved default-branch provenance persisted with the plan.
     #[arg(skip)]
     pub base_resolution: Option<serde_json::Value>,
+    /// Prefix for generated child branches. Each child branch is
+    /// `<PREFIX>/issue-<number>-<repo-slug>` (default `fix`, yielding
+    /// `fix/issue-12-owner-repo`).
     #[arg(long = "branch-prefix", default_value = "fix", value_name = "PREFIX")]
     pub branch_prefix: String,
+    /// Explicit identity for this batch plan and its durable records. Defaults
+    /// to a content-derived `cook-batch-...` id from the resolved children;
+    /// supply your own to keep a stable identity across replans.
     #[arg(long = "fanout-id", value_name = "ID")]
     pub fanout_id: Option<String>,
     /// Bind one issue URL to an existing provider-managed worktree handle.
@@ -76,22 +97,39 @@ pub struct AgentTaskFanoutCookBatchArgs {
     /// instead of requesting provider creation.
     #[arg(long = "worktree", value_name = "ISSUE_URL=HANDLE")]
     pub worktrees: Vec<String>,
+    /// Prompt template rendered for every child cook. `{issue_url}`,
+    /// `{issue_ref}`, `{repo}`, `{branch}`, and `{worktree}` are substituted.
+    /// Omit for the default fix-the-issue prompt.
     #[arg(long = "prompt-template", value_name = "TEXT")]
     pub prompt_template: Option<String>,
+    /// Executor backend serving every child cook. Omit to use the configured
+    /// `agent_task.default_backend`; the resolved backend is validated up front
+    /// and pinned identically for all children.
     #[arg(long = "backend", value_name = "BACKEND")]
     pub backend: Option<String>,
+    /// Executor provider ID selecting which installed provider serves the
+    /// backend. Only needed when one backend is served by multiple providers.
     #[arg(
         long = "selector",
         visible_alias = "provider-id",
         value_name = "PROVIDER_ID"
     )]
     pub selector: Option<String>,
+    /// Model name forwarded to the selected provider for every child cook.
     #[arg(long = "model", value_name = "MODEL")]
     pub model: Option<String>,
+    /// Named provider profile declared by an installed provider's CLI,
+    /// supplying default backend/selector/model/provider-config values for
+    /// every child. Explicit flags win over the profile.
     #[arg(long = "provider-profile", value_name = "PROFILE")]
     pub provider_profile: Option<String>,
+    /// Name of an environment variable that holds a provider credential for
+    /// this batch. Repeatable. Values are resolved by the provider at
+    /// execution, never read or recorded here.
     #[arg(long = "secret-env", value_name = "ENV")]
     pub secret_env: Vec<String>,
+    /// Provider-specific configuration forwarded to every child's provider
+    /// invocation, as inline JSON, `@FILE`, or `-` for stdin.
     #[arg(long = "provider-config", value_name = "JSON")]
     pub provider_config: Option<String>,
     #[arg(long = "provider-evidence", value_name = "JSON", help = PROVIDER_EVIDENCE_DECLARATION, value_parser = parse_provider_evidence_input)]
@@ -135,47 +173,175 @@ pub struct AgentTaskFanoutCookBatchArgs {
         value_name = "SECONDS"
     )]
     pub max_duration: Option<u64>,
-    #[arg(long = "dry-run")]
-    pub dry_run: bool,
-    /// Maximum wall-clock budget for each bounded static dry-run planning phase.
+    /// Resolve and validate the batch without side effects: no repository
+    /// hydration, provider dispatch, worktree creation, or file reads. Prints
+    /// the static plan, worktree projection, preflight, and a replayable
+    /// command — the batch-wide counterpart of `agent-task cook --preview`.
+    /// `--dry-run` is accepted as the historical spelling of this flag.
+    #[arg(long = "preview", alias = "dry-run")]
+    pub preview: bool,
+    /// Maximum wall-clock budget for each bounded static --preview planning
+    /// phase (default 10 seconds per phase).
     #[arg(
         long = "dry-run-planner-timeout-seconds",
         value_parser = clap::value_parser!(u64).range(1..),
         value_name = "SECONDS"
     )]
     pub dry_run_planner_timeout_seconds: Option<u64>,
+    /// Execute the planned wave in this invocation. After admission and
+    /// worktree preflight, every child cook runs through the cook-loop service
+    /// and successful children open or update their own pull requests.
+    /// Without this flag the command only plans the batch and creates or
+    /// reuses the child worktrees — see the two-phase model above.
     #[arg(long = "run-plan")]
     pub run_plan: bool,
 }
 
 #[derive(Args, Debug, Clone)]
 pub struct AgentTaskFanoutInputArgs {
+    /// Plan input: inline JSON, `@FILE`, or `-` for stdin. `plan` and `submit`
+    /// expect a batch-cook fanout plan (`homeboy/agent-task-batch-cook-plan/v1`);
+    /// `submit-batch` and `run-plan` expect an `AgentTaskPlan` JSON spec.
     #[arg(long = "input", value_name = "SPEC")]
     pub input: String,
+    /// Stable identity recorded for the submitted batch. Omit to keep the
+    /// identity already carried by the plan.
     #[arg(long = "fanout-id", value_name = "ID")]
     pub fanout_id: Option<String>,
+    /// Executor backend override applied to the loaded plan's cooks.
     #[arg(long = "backend", value_name = "BACKEND")]
     pub backend: Option<String>,
+    /// Executor provider ID selecting which installed provider serves the
+    /// backend. Only needed when one backend is served by multiple providers.
     #[arg(
         long = "selector",
         visible_alias = "provider-id",
         value_name = "PROVIDER_ID"
     )]
     pub selector: Option<String>,
+    /// Model name override forwarded to the selected provider.
     #[arg(long = "model", value_name = "MODEL")]
     pub model: Option<String>,
 }
 
+/// `fanout plan` reads one of two mutually exclusive inputs: an existing
+/// persisted plan (`--input`), or the same `--repo` plus issue URLs surface
+/// `fanout cook-batch` accepts, planned statically with no side effects.
 #[derive(Args, Debug)]
 pub struct AgentTaskFanoutPlanArgs {
+    /// Existing batch-cook fanout plan to normalize and inspect: inline JSON,
+    /// `@FILE`, `-` for stdin, or the `@<path>` controller-owned private plan
+    /// artifact. Omit this and pass `--repo` plus issue URLs to plan statically
+    /// instead.
+    #[arg(
+        long = "input",
+        value_name = "SPEC",
+        required_unless_present_any = ["repo", "issues"],
+        conflicts_with_all = ["repo", "issues"]
+    )]
+    pub input: Option<String>,
+    /// Explicit identity for the planned batch. Only used with the `--repo`
+    /// issue-planning input; a loaded plan keeps its own identity.
+    #[arg(long = "fanout-id", value_name = "ID")]
+    pub fanout_id: Option<String>,
+    /// Executor backend serving every planned child cook. Omit to use the
+    /// configured `agent_task.default_backend`.
+    #[arg(long = "backend", value_name = "BACKEND")]
+    pub backend: Option<String>,
+    /// Executor provider ID selecting which installed provider serves the
+    /// backend. Only needed when one backend is served by multiple providers.
+    #[arg(
+        long = "selector",
+        visible_alias = "provider-id",
+        value_name = "PROVIDER_ID"
+    )]
+    pub selector: Option<String>,
+    /// Model name forwarded to the selected provider for every planned child.
+    #[arg(long = "model", value_name = "MODEL")]
+    pub model: Option<String>,
+    /// Registered repository slug or exact registered primary checkout path to
+    /// plan children for. Required with (and only with) issue URLs.
+    #[arg(
+        long = "repo",
+        value_name = "REPO_SLUG_OR_PRIMARY_PATH",
+        requires = "issues",
+        conflicts_with = "input"
+    )]
+    pub repo: Option<String>,
+    /// GitHub issue URL to plan one child cook for. Repeat for a wave. Every
+    /// child still requires a deterministic gate: pass shared --verify /
+    /// --private-verify inputs or --verification-profiles, exactly as
+    /// `fanout cook-batch --preview` requires.
+    #[arg(value_name = "ISSUE_URL", requires = "repo")]
+    pub issues: Vec<String>,
+    /// Source ref the planned child worktrees would be created from. When
+    /// omitted, this is inferred from the repository default branch.
+    #[arg(long = "from", value_name = "REF")]
+    pub from: Option<String>,
+    /// Pull-request base branch for the planned children. When omitted,
+    /// Homeboy resolves the registered repository's remote default branch.
+    #[arg(long = "base", value_name = "BRANCH")]
+    pub base: Option<String>,
+    /// Prefix for generated child branches (default `fix`).
+    #[arg(long = "branch-prefix", default_value = "fix", value_name = "PREFIX")]
+    pub branch_prefix: String,
+    /// Prompt template rendered for every planned child cook. `{issue_url}`,
+    /// `{issue_ref}`, `{repo}`, `{branch}`, and `{worktree}` are substituted.
+    #[arg(long = "prompt-template", value_name = "TEXT")]
+    pub prompt_template: Option<String>,
+    /// JSON verification profile declaration, inline or @file.json. Profiles
+    /// append to or replace shared --verify/--private-verify gates per issue.
+    #[arg(long = "verification-profiles", value_name = "JSON")]
+    pub verification_profiles: Option<String>,
     #[command(flatten)]
-    pub input: AgentTaskFanoutInputArgs,
+    pub gates: VerifyGateArgs,
+    /// Accepted for verb consistency with `agent-task cook --preview` and
+    /// `fanout cook-batch --preview`: `fanout plan` is always side-effect
+    /// free, so this flag changes nothing. `--dry-run` is accepted as the
+    /// historical spelling.
+    #[arg(long = "preview", alias = "dry-run")]
+    pub preview: bool,
+}
+
+impl AgentTaskFanoutPlanArgs {
+    /// Project the issue-planning inputs onto the cook-batch surface for
+    /// static preview planning. Gate inputs ride along untouched; execution
+    /// flags are pinned off because `fanout plan` never executes.
+    pub(crate) fn into_cook_batch_preview(self) -> AgentTaskFanoutCookBatchArgs {
+        AgentTaskFanoutCookBatchArgs {
+            issues: self.issues,
+            repo: self.repo.unwrap_or_default(),
+            from: self.from,
+            base: self.base,
+            base_resolution: None,
+            branch_prefix: self.branch_prefix,
+            fanout_id: self.fanout_id,
+            worktrees: Vec::new(),
+            prompt_template: self.prompt_template,
+            backend: self.backend,
+            selector: self.selector,
+            model: self.model,
+            provider_profile: None,
+            secret_env: Vec::new(),
+            provider_config: None,
+            provider_evidence_inputs: Vec::new(),
+            ai_tool: None,
+            gates: self.gates,
+            verification_profiles: self.verification_profiles,
+            max_concurrency: None,
+            max_duration: None,
+            preview: true,
+            dry_run_planner_timeout_seconds: None,
+            run_plan: false,
+        }
+    }
 }
 
 #[derive(Args, Debug)]
 pub struct AgentTaskFanoutSubmitArgs {
     #[command(flatten)]
     pub input: AgentTaskFanoutInputArgs,
+    /// Durable run ID to assign while submitting the loaded batch-cook plan.
     #[arg(long = "run-id", value_name = "ID")]
     pub run_id: Option<String>,
 }
@@ -184,12 +350,14 @@ pub struct AgentTaskFanoutSubmitArgs {
 pub struct AgentTaskFanoutSubmitBatchArgs {
     #[command(flatten)]
     pub input: AgentTaskFanoutInputArgs,
+    /// Durable batch ID to assign while submitting the loaded agent-task plan.
     #[arg(long = "batch-id", value_name = "ID")]
     pub batch_id: Option<String>,
 }
 
 #[derive(Args, Debug)]
 pub struct AgentTaskFanoutBatchStatusArgs {
+    /// Durable fanout batch ID whose status, resume result, or artifacts to read.
     pub batch_id: String,
 }
 
@@ -197,6 +365,7 @@ pub struct AgentTaskFanoutBatchStatusArgs {
 pub struct AgentTaskFanoutRunPlanArgs {
     #[command(flatten)]
     pub input: AgentTaskFanoutInputArgs,
+    /// Durable run id recorded for this execution of the plan.
     #[arg(long = "record-run-id", value_name = "ID")]
     pub record_run_id: Option<String>,
     /// AI tool disclosure recorded in every child PR's assistance attribution.

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/help_audit.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/help_audit.rs
@@ -1,0 +1,173 @@
+//! Generic help-text guards for the `agent-task` command tree.
+//!
+//! #13704: the two flags deciding whether a wave of cooks actually runs were
+//! the only undocumented ones on `fanout cook-batch`. Per-flag tests only fix
+//! today's typo; this walk fails for ANY future argument that ships with
+//! empty help text anywhere under `agent-task`.
+
+#[cfg(test)]
+mod tests {
+    use clap::Command;
+    use clap::CommandFactory;
+    use clap::Parser;
+
+    use crate::commands::agent_task::AgentTaskCommand;
+    use crate::commands::agent_task::AgentTaskFanoutCommand;
+
+    fn agent_task_command() -> Command {
+        crate::cli_surface::Cli::command()
+            .find_subcommand("agent-task")
+            .expect("agent-task command exists")
+            .clone()
+    }
+
+    fn argument_display_name(arg: &clap::Arg) -> String {
+        if arg.is_positional() {
+            format!(
+                "<{}>",
+                arg.get_value_names()
+                    .map(|names| names.join(" "))
+                    .unwrap_or_else(|| arg.get_id().as_str().to_string())
+            )
+        } else {
+            arg.get_long()
+                .map(|long| format!("--{long}"))
+                .unwrap_or_else(|| {
+                    arg.get_short()
+                        .map(|short| format!("-{short}"))
+                        .unwrap_or_else(|| arg.get_id().as_str().to_string())
+                })
+        }
+    }
+
+    fn audit_command(command: &Command, path: String, failures: &mut Vec<String>) {
+        for arg in command.get_arguments() {
+            // Hidden arguments never render, auto help/version flags carry
+            // clap's built-in text, and global flags are documented at the
+            // root surface that owns them.
+            if arg.is_hide_set() || arg.is_global_set() {
+                continue;
+            }
+            if matches!(arg.get_id().as_str(), "help" | "version") {
+                continue;
+            }
+            let documented = arg
+                .get_help()
+                .is_some_and(|help| !help.to_string().trim().is_empty());
+            if !documented {
+                failures.push(format!("{path} {}", argument_display_name(arg)));
+            }
+        }
+        for subcommand in command.get_subcommands() {
+            if subcommand.is_hide_set() || subcommand.get_name() == "help" {
+                continue;
+            }
+            let sub_path = format!("{path} {}", subcommand.get_name());
+            let about_is_blank = subcommand
+                .get_about()
+                .is_some_and(|about| about.to_string().trim().is_empty());
+            if about_is_blank {
+                failures.push(format!("{sub_path} <missing one-line about>"));
+            }
+            audit_command(subcommand, sub_path, failures);
+        }
+    }
+
+    #[test]
+    fn no_agent_task_argument_ships_with_empty_help_text() {
+        let root = agent_task_command();
+        let mut failures = Vec::new();
+        audit_command(&root, "agent-task".to_string(), &mut failures);
+        assert!(
+            failures.is_empty(),
+            "agent-task arguments with empty help text (every visible flag and \
+             positional must explain itself):\n  {}",
+            failures.join("\n  ")
+        );
+    }
+
+    #[test]
+    fn fanout_cook_batch_accepts_preview_and_hidden_dry_run_alias() {
+        let command = agent_task_command();
+        let cook_batch = command
+            .find_subcommand("fanout")
+            .expect("fanout command")
+            .find_subcommand("cook-batch")
+            .expect("cook-batch command");
+        let preview = cook_batch
+            .get_arguments()
+            .find(|arg| arg.get_long() == Some("preview"))
+            .expect("cook-batch exposes --preview");
+        assert!(
+            preview
+                .get_help()
+                .is_some_and(|help| !help.to_string().trim().is_empty()),
+            "--preview must carry help text"
+        );
+        let mut names: Vec<String> = preview
+            .get_aliases()
+            .into_iter()
+            .flatten()
+            .map(str::to_string)
+            .collect();
+        names.sort();
+        assert_eq!(names, vec!["dry-run".to_string()]);
+        assert!(
+            preview
+                .get_visible_aliases()
+                .map_or(true, |aliases| aliases.is_empty()),
+            "--dry-run stays a hidden alias so help advertises one canonical verb"
+        );
+    }
+
+    #[test]
+    fn fanout_plan_parses_from_repo_and_issue_urls_like_cook_batch() {
+        let cli = crate::cli_surface::Cli::try_parse_from([
+            "homeboy",
+            "agent-task",
+            "fanout",
+            "plan",
+            "--repo",
+            "owner/repo",
+            "https://example.test/issues/1",
+        ])
+        .expect("fanout plan accepts --repo plus issue URLs");
+        let crate::cli_surface::Commands::AgentTask(agent_task) = cli.command else {
+            panic!("agent-task command");
+        };
+        let AgentTaskCommand::Fanout(fanout) = agent_task.command else {
+            panic!("fanout command");
+        };
+        let AgentTaskFanoutCommand::Plan(plan) = fanout.command else {
+            panic!("plan command");
+        };
+        assert_eq!(plan.repo.as_deref(), Some("owner/repo"));
+        assert_eq!(
+            plan.issues,
+            vec!["https://example.test/issues/1".to_string()]
+        );
+
+        // --input remains the persisted-plan surface and excludes the
+        // issue-planning inputs.
+        assert!(
+            crate::cli_surface::Cli::try_parse_from([
+                "homeboy",
+                "agent-task",
+                "fanout",
+                "plan",
+                "--input",
+                "plan.json",
+                "--repo",
+                "owner/repo",
+                "https://example.test/issues/1",
+            ])
+            .is_err(),
+            "--input and --repo/ISSUE_URL planning are mutually exclusive"
+        );
+        assert!(
+            crate::cli_surface::Cli::try_parse_from(["homeboy", "agent-task", "fanout", "plan",])
+                .is_err(),
+            "fanout plan still requires an input: --input SPEC or --repo with issue URLs"
+        );
+    }
+}

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -9,8 +9,10 @@ pub struct RunPlanArgs {
     /// `-` to read stdin. A bare path is NOT accepted — use `@/path/plan.json`.
     #[arg(long, value_name = "JSON|@FILE|-")]
     pub plan: String,
+    /// Durable run ID to record for this planned lifecycle.
     #[arg(long, value_name = "ID")]
     pub record_run_id: Option<String>,
+    /// Maximum execution time in milliseconds.
     #[arg(long = "timeout-ms", value_name = "MS")]
     pub timeout_ms: Option<u64>,
 }
@@ -18,6 +20,7 @@ pub struct RunPlanArgs {
 pub struct RunArgs {
     /// Exact durable run id to execute. Use this to bypass older queued work.
     pub run_id: String,
+    /// Maximum execution time in milliseconds.
     #[arg(long = "timeout-ms", value_name = "MS")]
     pub timeout_ms: Option<u64>,
 }
@@ -33,6 +36,7 @@ pub struct SubmitArgs {
     /// `-` to read stdin. A bare path is NOT accepted — use `@/path/plan.json`.
     #[arg(long, value_name = "JSON|@FILE|-")]
     pub plan: String,
+    /// Optional durable run ID for the submitted plan.
     #[arg(long, value_name = "ID")]
     pub run_id: Option<String>,
 }
@@ -44,15 +48,19 @@ pub struct ValidatePlanArgs {
 }
 #[derive(Args, Debug)]
 pub struct LifecycleReadArgs {
+    /// Durable run or Cook ID to inspect.
     pub run_id: String,
     /// Inspect this exact lifecycle record instead of resolving a Cook ID to its
     /// current attempt.
     #[arg(long, conflicts_with = "bridge")]
     pub exact: bool,
+    /// Read through the runner bridge instead of controller-only state.
     #[arg(long)]
     pub bridge: bool,
+    /// Resume bridged events after this cursor.
     #[arg(long, value_name = "CURSOR", requires = "bridge")]
     pub since_cursor: Option<u64>,
+    /// Return complete lifecycle details instead of the bounded summary.
     #[arg(long, conflicts_with = "bridge")]
     pub full: bool,
     /// Answer from durable controller state only, without reaching the runner.
@@ -68,13 +76,18 @@ pub struct LifecycleReadArgs {
 #[cfg_attr(test, derive(Default))]
 #[derive(Args, Debug, Clone)]
 pub struct StatusArgs {
+    /// Durable run or Cook ID whose status to inspect.
     pub run_id: String,
+    /// Inspect this exact lifecycle record instead of resolving a Cook ID to its current attempt.
     #[arg(long, conflicts_with = "bridge")]
     pub exact: bool,
+    /// Read status through the runner bridge.
     #[arg(long)]
     pub bridge: bool,
+    /// Resume bridged status events after this cursor.
     #[arg(long, value_name = "CURSOR", requires = "bridge")]
     pub since_cursor: Option<u64>,
+    /// Return complete status details instead of the bounded summary.
     #[arg(long, conflicts_with = "bridge")]
     pub full: bool,
     /// Present `--full` as a bounded, outcome-first summary with drill-down refs.
@@ -87,6 +100,7 @@ pub struct StatusArgs {
     /// for scripts that deliberately gate on an actionable Cook.
     #[arg(long, conflicts_with = "bridge")]
     pub strict_subject_exit: bool,
+    /// Answer from durable controller state only, without reaching the runner.
     #[arg(long = "no-runner-probe", conflicts_with = "bridge")]
     pub no_runner_probe: bool,
     /// Follow this durable status until it reaches a terminal state or the timeout expires.
@@ -124,6 +138,7 @@ impl From<StatusArgs> for LifecycleReadArgs {
 }
 #[derive(Args, Debug)]
 pub struct LogsArgs {
+    /// Durable run or Cook ID whose logs to retrieve.
     pub run_id: String,
     /// Include unprojected runner transport frames under `raw_events` for diagnostics.
     #[arg(long)]
@@ -131,11 +146,15 @@ pub struct LogsArgs {
 }
 #[derive(Args, Debug)]
 pub struct EvidenceArgs {
+    /// Durable run or Cook ID whose evidence to retrieve.
     pub run_id: String,
+    /// Restrict results to this evidence kind.
     #[arg(long = "kind", value_name = "KIND")]
     pub kind: Option<String>,
+    /// Restrict results to this task ID.
     #[arg(long = "task", value_name = "TASK_ID")]
     pub task: Option<String>,
+    /// Return only evidence associated with failures.
     #[arg(long = "failure-only")]
     pub failure_only: bool,
     /// Return every matching evidence record rather than the bounded preview.
@@ -144,6 +163,7 @@ pub struct EvidenceArgs {
 }
 #[derive(Args, Debug)]
 pub struct DiagnoseArgs {
+    /// Durable run or Cook ID to diagnose.
     pub run_id: String,
     /// Hydrate every available evidence summary rather than the bounded preview.
     #[arg(long)]
@@ -484,15 +504,20 @@ mod tests {
 }
 #[derive(Args, Debug)]
 pub struct ReplayProviderBoundaryArgs {
+    /// Durable run whose provider boundary to replay.
     pub run_id: String,
+    /// Restrict the replay to this task ID.
     #[arg(long = "task", value_name = "TASK_ID")]
     pub task: Option<String>,
 }
 #[derive(Args, Debug)]
 pub struct RetryArgs {
+    /// Durable run or Cook ID to retry.
     pub run_id: String,
+    /// Durable ID to assign to the new retry run.
     #[arg(long, value_name = "ID")]
     pub new_run_id: Option<String>,
+    /// Execute the retry immediately after creating it.
     #[arg(long)]
     pub run: bool,
     /// Permit a new retry after every prior retry in this lineage is terminal.
@@ -501,7 +526,9 @@ pub struct RetryArgs {
 }
 #[derive(Args, Debug)]
 pub struct CancelArgs {
+    /// Durable run or Cook ID to cancel.
     pub run_id: String,
+    /// Optional explanation recorded with the cancellation.
     #[arg(long, value_name = "TEXT")]
     pub reason: Option<String>,
 }
@@ -509,6 +536,7 @@ pub struct CancelArgs {
 pub struct QuarantineArgs {
     /// Exact durable run id. Cook aliases are not accepted for mutations.
     pub run_id: String,
+    /// Explanation recorded with the quarantine action.
     #[arg(long, value_name = "TEXT")]
     pub reason: String,
 }
@@ -519,19 +547,23 @@ pub struct RearmArgs {
 }
 #[derive(Args, Debug)]
 pub struct ReviewArgs {
+    /// Durable run or Cook ID to review.
     pub run_id: String,
     /// Include complete lifecycle, promotion, and gate evidence. The default
     /// keeps one actionable candidate and bounded gate findings.
     #[arg(long)]
     pub full: bool,
+    /// Target managed worktree handle for the review candidate.
     #[arg(long, value_name = "HANDLE")]
     pub to_worktree: Option<String>,
+    /// Deprecated shell command for the promotion apply provider.
     #[arg(
         long,
         value_name = "COMMAND",
         long_help = "Deprecated promotion apply-provider command string. Migrate `--provider-command 'provider --flag value'` to `--provider-argv provider --provider-argv --flag --provider-argv value`; argv preserves exact arguments without shell splitting. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with `workspace_path`."
     )]
     pub provider_command: Option<String>,
+    /// Exact argv element for the promotion apply provider; repeat per element.
     #[arg(
         long = "provider-argv",
         value_name = "ARG",
@@ -542,18 +574,22 @@ pub struct ReviewArgs {
 }
 #[derive(Args, Debug)]
 pub struct PromoteArgs {
+    /// Durable run or Cook ID that supplies the promotion candidate.
     pub source: String,
+    /// Target managed worktree handle for the promoted candidate.
     #[arg(long, value_name = "HANDLE")]
     pub to_worktree: String,
     /// Declared base branch resolved immediately before promotion gates run.
     #[arg(long, default_value = "main", value_name = "BRANCH")]
     pub base: String,
+    /// Deprecated shell command for the promotion apply provider.
     #[arg(
         long,
         value_name = "COMMAND",
         long_help = "Deprecated promotion apply-provider command string. Migrate `--provider-command 'provider --flag value'` to `--provider-argv provider --provider-argv --flag --provider-argv value`; argv preserves exact arguments without shell splitting. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with `workspace_path`."
     )]
     pub provider_command: Option<String>,
+    /// Exact argv element for the promotion apply provider; repeat per element.
     #[arg(
         long = "provider-argv",
         value_name = "ARG",
@@ -561,10 +597,13 @@ pub struct PromoteArgs {
         long_help = "Promotion-only apply-provider invocation argument. Repeat once per exact argv element: the first is the executable and later values are its arguments; values are never shell-split. This cannot select an executor. The provider reads stdin request schema `homeboy/agent-task-promotion-apply-request/v1` and writes response schema `homeboy/agent-task-promotion-apply-response/v1` with required `workspace_path`."
     )]
     pub provider_argv: Vec<String>,
+    /// Restrict promotion to this task ID.
     #[arg(long, value_name = "TASK_ID")]
     pub task_id: Option<String>,
+    /// Restrict promotion to this artifact ID.
     #[arg(long, value_name = "ARTIFACT_ID")]
     pub artifact_id: Option<String>,
+    /// Validate the promotion without applying it.
     #[arg(long)]
     pub dry_run: bool,
     /// Include complete promotion and gate evidence.
@@ -575,6 +614,7 @@ pub struct PromoteArgs {
     /// programs remain outside reviewer-facing command output.
     #[arg(long = "gates-from-cook-recipe")]
     pub gates_from_cook_recipe: bool,
+    /// Verification gate configuration to run before promotion.
     #[command(flatten)]
     pub gates: VerifyGateArgs,
 }
@@ -618,41 +658,55 @@ pub struct FinalizePrArgs {
         conflicts_with = "manual_finalization"
     )]
     pub recover: Option<String>,
+    /// Durable run ID for a manual finalization record.
     #[arg(long, value_name = "ID", required_unless_present = "recover")]
     pub run_id: Option<String>,
+    /// Worktree path containing the manual finalization candidate.
     #[arg(long, value_name = "PATH", required_unless_present = "recover")]
     pub path: Option<String>,
+    /// Base branch for the manual finalization candidate.
     #[arg(long, default_value = "main", value_name = "BRANCH")]
     pub base: String,
     /// Immutable base commit SHA recorded before the declared verification gates ran.
     #[arg(long, value_name = "SHA")]
     pub verified_base_sha: Option<String>,
+    /// Head branch for the manual finalization candidate.
     #[arg(long, value_name = "BRANCH")]
     pub head: Option<String>,
+    /// Pull request title for the manual finalization candidate.
     #[arg(long, value_name = "TEXT", required_unless_present = "recover")]
     pub title: Option<String>,
+    /// Commit message for the manual finalization candidate.
     #[arg(long, value_name = "TEXT", required_unless_present = "recover")]
     pub commit_message: Option<String>,
+    /// Reviewer-facing evidence for the finalization dossier.
     #[command(flatten)]
     pub evidence: review::FinalizePrEvidenceArgs,
+    /// Recorded result for a verification gate: `NAME=STATUS[:DETAIL]`.
     #[arg(long = "gate-result", value_name = "NAME=STATUS[:DETAIL]")]
     pub gate_results: Vec<String>,
     /// Execute a deterministic verification command against the committed manual candidate. Repeat for multiple gates.
     #[arg(long, value_name = "COMMAND")]
     pub verify: Vec<String>,
+    /// Changed file path to include in the finalization dossier.
     #[arg(long = "changed-file", value_name = "PATH")]
     pub changed_files: Vec<String>,
+    /// Branch that must not be updated by finalization; repeat for multiple branches.
     #[arg(long = "protected-branch", default_values_t = review::default_protected_branches(), value_name = "BRANCH")]
     pub protected_branches: Vec<String>,
+    /// Description of how AI was used for the finalization.
     #[arg(long, default_value = "", value_name = "TEXT")]
     pub ai_used_for: String,
+    /// Summary of the finalization candidate.
     #[arg(long, value_name = "TEXT")]
     pub summary: Option<String>,
+    /// User-visible change description; repeat for multiple entries.
     #[arg(long = "what-changed", value_name = "TEXT")]
     pub what_changed: Vec<String>,
     /// Reviewer test step. Strict shape: COMMAND=>EXPECTED.
     #[arg(long = "test-step", value_name = "COMMAND=>EXPECTED")]
     pub test_steps: Vec<String>,
+    /// Compatibility notes for the finalization candidate.
     #[arg(long, value_name = "TEXT")]
     pub compatibility: Option<String>,
     /// Closing issue reference: #NUMBER, OWNER/REPO#NUMBER, or a github.com issue URL.
@@ -661,6 +715,7 @@ pub struct FinalizePrArgs {
     /// Related issue reference: #NUMBER, OWNER/REPO#NUMBER, or a github.com issue URL.
     #[arg(long = "relates-to", value_name = "ISSUE_REF")]
     pub relates_to: Vec<String>,
+    /// Explicit reviewer override in `TARGET=VALUE@PROVENANCE` form.
     #[arg(long = "review-override", value_name = "TARGET=VALUE@PROVENANCE")]
     pub review_overrides: Vec<String>,
     /// Validate the complete hydrated dossier and candidate without publishing.
@@ -692,6 +747,7 @@ pub struct VerifyReplacementArgs {
     /// Explicit operator authorization for the replacement proof recorded by this command.
     #[arg(long, value_name = "TEXT")]
     pub authorize_external_proof: String,
+    /// Verification gate configuration for the replacement candidate.
     #[command(flatten)]
     pub gates: VerifyGateArgs,
 }
@@ -706,12 +762,16 @@ pub struct GateFeedbackArgs {
     /// to read stdin. A bare path is NOT accepted — use `@/path/task.json`.
     #[arg(long = "source-task", value_name = "JSON|@FILE|-")]
     pub source_task: String,
+    /// Current feedback attempt number.
     #[arg(long, default_value_t = 1, value_name = "N")]
     pub attempt: u32,
+    /// Maximum feedback attempts before stopping.
     #[arg(long = "max-attempts", default_value_t = 3, value_name = "N")]
     pub max_attempts: u32,
+    /// Durable source run ID associated with the feedback.
     #[arg(long = "source-run-id", value_name = "ID")]
     pub source_run_id: Option<String>,
+    /// Current candidate diff as an inline or file-backed specification.
     #[arg(long = "current-diff", value_name = "SPEC")]
     pub current_diff: Option<String>,
 }

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/mod.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/mod.rs
@@ -3,6 +3,7 @@
 mod command;
 mod cook;
 mod fanout;
+mod help_audit;
 mod lifecycle;
 
 pub use command::*;

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -51,8 +51,8 @@ use crate::commands::utils::response::{CommandNextAction, CommandNextActionKind}
 use super::super::CmdResult;
 use super::args::{
     AgentTaskFanoutArgs, AgentTaskFanoutBatchStatusArgs, AgentTaskFanoutCommand,
-    AgentTaskFanoutCookBatchArgs, AgentTaskFanoutInputArgs, AgentTaskFanoutRunPlanArgs,
-    AgentTaskFanoutSubmitArgs, AgentTaskFanoutSubmitBatchArgs,
+    AgentTaskFanoutCookBatchArgs, AgentTaskFanoutInputArgs, AgentTaskFanoutPlanArgs,
+    AgentTaskFanoutRunPlanArgs, AgentTaskFanoutSubmitArgs, AgentTaskFanoutSubmitBatchArgs,
 };
 use super::command_json_value;
 use super::default_branch::{resolve_default_branch, DefaultBranchRequest};
@@ -71,9 +71,32 @@ pub(crate) fn fanout_with_placement(
             cook_batch_with_placement(*cook_batch_args, placement)
         }
         AgentTaskFanoutCommand::Plan(plan_args) => {
+            // `fanout plan` accepts the same --repo plus issue-URL inputs
+            // cook-batch accepts; those route through cook-batch's fully
+            // static preview planner so both surfaces validate identically
+            // (#13704). A persisted plan input keeps the read-only
+            // normalize-and-inspect contract below.
+            if !plan_args.issues.is_empty() {
+                return cook_batch_with_placement(plan_args.into_cook_batch_preview(), placement);
+            }
+            let AgentTaskFanoutPlanArgs {
+                input,
+                fanout_id,
+                backend,
+                selector,
+                model,
+                ..
+            } = plan_args;
+            let load_args = AgentTaskFanoutInputArgs {
+                input: input.unwrap_or_default(),
+                fanout_id,
+                backend,
+                selector,
+                model,
+            };
             // A private controller artifact is accepted only from its owned path,
             // then immediately projected before this read-only response renders.
-            let plan = load_batch_cook_fanout_plan(&plan_args.input, true)?;
+            let plan = load_batch_cook_fanout_plan(&load_args, true)?;
             Ok((command_json_value(public_batch_cook_plan(&plan))?, 0))
         }
         AgentTaskFanoutCommand::Submit(submit_args) => submit_batch_cook_fanout(submit_args),
@@ -2002,7 +2025,7 @@ fn cook_batch_inner(
     attempt_dispatcher: Option<&CookAttemptDispatcherFactory>,
     placement: Placement,
 ) -> CmdResult<Value> {
-    if args.dry_run {
+    if args.preview {
         return cook_batch_dry_run(args, placement);
     }
     args.gates.snapshot_file_inputs()?;
@@ -2025,7 +2048,7 @@ fn cook_batch_inner(
         .cooks
         .iter()
         .any(|cook| !cook.private_verify.is_empty());
-    let persisted = args.run_plan && !args.dry_run;
+    let persisted = args.run_plan && !args.preview;
     let claim = persisted
         .then(|| claim_fanout_run_batch_coordinator(&plan, placement))
         .transpose()?;
@@ -2087,7 +2110,7 @@ fn cook_batch_inner(
             }),
         )?;
     }
-    let can_run = !args.dry_run
+    let can_run = !args.preview
         && blocked == 0
         && worktrees
             .rows
@@ -2158,7 +2181,7 @@ fn cook_batch_inner(
             .unwrap_or("completed")
     } else if blocked > 0 {
         "blocked"
-    } else if args.dry_run {
+    } else if args.preview {
         "ready"
     } else {
         "ready"
@@ -2177,7 +2200,7 @@ fn cook_batch_inner(
                 "schema": "homeboy/agent-task-cook-batch/v1",
                 "fanout_id": plan.fanout_id,
                 "status": status,
-                "dry_run": args.dry_run,
+                "dry_run": args.preview,
                 "summary": {
                     "issues": plan.cooks.len(),
                      "worktrees_total": worktrees.rows.len(),
@@ -2189,7 +2212,7 @@ fn cook_batch_inner(
                 "preflight": {
                     "default_branch": args.base_resolution.clone(),
                     "provider_readiness_command": provider_readiness_command(&args),
-                    "provider_selection": provider_selection_preflight(&args, args.dry_run),
+                    "provider_selection": provider_selection_preflight(&args, args.preview),
                     "deterministic_gates": effective_batch_cook_gates(&plan)
                 },
                 "worktrees": worktrees,
@@ -2736,8 +2759,8 @@ fn cook_batch_argv_with_placement(
             value.to_string(),
         ]);
     }
-    if args.dry_run {
-        command.push("--dry-run".to_string());
+    if args.preview {
+        command.push("--preview".to_string());
     }
     if args.run_plan {
         command.push("--run-plan".to_string());
@@ -2891,7 +2914,7 @@ fn queue_or_reuse_worktrees_with_terminal_paths(
         })
     };
 
-    if args.dry_run {
+    if args.preview {
         let worktrees = static_worktrees_dry_run(args, plan);
         let states = worktrees
             .rows
@@ -4687,7 +4710,7 @@ fn resolve_and_validate_effective_backend_with_providers(
     // (e.g. CI compiling the plan), so a hard provider check there would reject
     // valid planning. Execution is where an unresolved backend fails late, so
     // that is exactly where we fail early instead.
-    let will_execute = args.run_plan && !args.dry_run;
+    let will_execute = args.run_plan && !args.preview;
     if will_execute {
         let selector = args.selector.as_deref();
         match provider::resolve_provider_for_backend(providers, &effective, selector) {
@@ -4873,7 +4896,7 @@ fn worktree_create_command(args: &AgentTaskFanoutCookBatchArgs, branch: &str) ->
 
 fn cook_batch_plan_command(args: &AgentTaskFanoutCookBatchArgs, placement: Placement) -> String {
     let mut planned = args.clone();
-    planned.dry_run = true;
+    planned.preview = true;
     planned.run_plan = false;
     quote_args(&cook_batch_argv_with_placement(&planned, placement))
 }
@@ -5033,7 +5056,7 @@ fn cook_batch_run_command_with_placement(
     placement: Placement,
 ) -> String {
     let mut runnable = args.clone();
-    runnable.dry_run = false;
+    runnable.preview = false;
     runnable.run_plan = true;
     quote_args(&cook_batch_argv_with_placement(&runnable, placement))
 }
@@ -5506,7 +5529,7 @@ mod tests {
 
             let mut dry = cook_batch_args();
             dry.verification_profiles = Some(profiles.clone());
-            dry.dry_run = true;
+            dry.preview = true;
             let plan = build_cook_batch_plan(&dry).expect("profile plan");
             let public = serde_json::to_string(&public_batch_cook_plan(&plan)).unwrap();
             assert!(!public.contains(sentinel));
@@ -5522,7 +5545,7 @@ mod tests {
         with_materialized_cook_batch_worktrees(|| {
             let mut executable = cook_batch_args();
             executable.verification_profiles = Some(profiles);
-            executable.dry_run = false;
+            executable.preview = false;
             executable.run_plan = false;
             let resolved = build_cook_batch_plan(&executable).expect("resolve executable profile");
             assert!(resolved
@@ -5589,7 +5612,7 @@ mod tests {
             let sentinel = "PRIVATE_UNPERSISTED_SENTINEL";
             let mut args = cook_batch_args();
             args.gates.private_verify = vec![sentinel.to_string()];
-            args.dry_run = true;
+            args.preview = true;
             let artifact = private_batch_plan_path("issue-wave").expect("artifact path");
             assert!(!artifact.exists(), "dry-run begins without an artifact");
             let commands = cook_batch_commands(&args, true, None);
@@ -6831,7 +6854,7 @@ fi
             verification_profiles: None,
             max_concurrency: None,
             max_duration: None,
-            dry_run: true,
+            preview: true,
             dry_run_planner_timeout_seconds: None,
             run_plan: false,
         }
@@ -7217,7 +7240,7 @@ fi
                 cook.repo.as_deref() == Some("php-transformer")
                     && cook.to_worktree.starts_with("blocks-engine@")
             }));
-            args.dry_run = false;
+            args.preview = false;
             let worktrees = queue_or_reuse_worktrees(&args, &plan).expect("provider worktrees");
             assert_eq!(worktrees.repo, "blocks-engine");
             assert!(worktrees
@@ -7531,7 +7554,7 @@ fi
             args.issues = (6453..=6458)
                 .map(|number| format!("https://github.com/Extra-Chill/homeboy/issues/{number}"))
                 .collect();
-            args.dry_run = false;
+            args.preview = false;
             let mut plan = build_cook_batch_plan(&args).expect("fanout plan");
             let (worktrees, resolution) =
                 queue_or_reuse_worktrees_with_terminal_paths(&args, &plan, None, false)
@@ -7664,7 +7687,7 @@ fi
             homeboy::core::defaults::save_config(&config).expect("save provider config");
 
             let mut args = cook_batch_args();
-            args.dry_run = false;
+            args.preview = false;
             let plan = build_cook_batch_plan(&args).expect("immutable fanout plan");
             let original_plan = plan.clone();
             let (first_claim, retry) =
@@ -7982,7 +8005,7 @@ fi
             let sentinel = "PRIVATE_GATE_BOUND_PLAN_SENTINEL";
             let mut args = cook_batch_args();
             args.gates.private_verify = vec![sentinel.to_string()];
-            args.dry_run = false;
+            args.preview = false;
             args.run_plan = false;
 
             let (public, exit_code) = cook_batch(args).expect("prepare private batch");
@@ -8119,7 +8142,7 @@ fi
             let mut args = cook_batch_args();
             args.repo = "fixture".to_string();
             args.gates.verify = vec!["homeboy lint fixture --path .".to_string()];
-            args.dry_run = false;
+            args.preview = false;
             let error =
                 cook_batch(args).expect_err("script alias must reject before queuing worktrees");
             assert!(error.message.contains("repository script identity"));
@@ -8558,7 +8581,7 @@ fi
         let mut args = cook_batch_args();
         args.backend = Some("codebox-nonexistent".to_string());
         args.selector = None;
-        args.dry_run = false;
+        args.preview = false;
         args.run_plan = true;
 
         let error = resolve_and_validate_effective_backend(&mut args)
@@ -8582,7 +8605,7 @@ fi
         let mut args = cook_batch_args();
         args.backend = Some("opencode".to_string());
         args.selector = Some("dmc".to_string());
-        args.dry_run = false;
+        args.preview = false;
         args.run_plan = true;
         let providers = vec![serde_json::from_value(serde_json::json!({
             "id": "opencode.agent-task-executor",
@@ -8610,7 +8633,7 @@ fi
         // visible and carried consistently.
         let mut args = cook_batch_args();
         args.backend = Some("sandbox".to_string());
-        args.dry_run = true;
+        args.preview = true;
         args.run_plan = false;
 
         resolve_and_validate_effective_backend(&mut args)

--- a/crates/homeboy-cli/src/commands/contract_lab_routing.rs
+++ b/crates/homeboy-cli/src/commands/contract_lab_routing.rs
@@ -205,7 +205,7 @@ impl Commands {
                     agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
                         command: agent_task::AgentTaskFanoutCommand::CookBatch(args),
                     }),
-            }) if args.dry_run => agent_task_fanout_local_only_contract(
+            }) if args.preview => agent_task_fanout_local_only_contract(
                 AGENT_TASK_FANOUT_COOK_BATCH_LAB_LABEL,
                 AGENT_TASK_FANOUT_COOK_BATCH_DRY_RUN_CONTROLLER_REASON,
             ),

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -4205,7 +4205,7 @@ fn agent_task_local_fanout_warning(
                 AgentTaskCommand::Fanout(AgentTaskFanoutArgs {
                     command: AgentTaskFanoutCommand::CookBatch(args),
                 }),
-        }) if args.run_plan && !args.dry_run => {
+        }) if args.run_plan && !args.preview => {
             if args.issues.len() <= 1 {
                 return None;
             }

--- a/crates/homeboy-cli/src/commands/infra/route/local_detach_fanout.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach_fanout.rs
@@ -127,10 +127,10 @@ fn detachable_local_fanout(cli: &Cli) -> homeboy::core::Result<Option<Detachable
                     "Add `--run-plan` to execute the wave from this machine, which is the coordinator that can be detached.",
                 ));
             }
-            if args.dry_run {
+            if args.preview {
                 return Err(no_coordinator_error(
-                    "agent-task fanout cook-batch --dry-run",
-                    "A dry run plans without executing, so it owns no coordinator. Drop `--dry-run` to detach a real wave.",
+                    "agent-task fanout cook-batch --preview",
+                    "A preview plans without executing, so it owns no coordinator. Drop `--preview` to detach a real wave.",
                 ));
             }
             Ok(Some(match &args.fanout_id {

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
@@ -243,7 +243,7 @@ pub(super) fn is_plan_only_command(command: &Commands) -> bool {
             command: agent_task::AgentTaskCommand::Fanout(agent_task::AgentTaskFanoutArgs {
                 command: agent_task::AgentTaskFanoutCommand::CookBatch(args),
             }),
-        }) if args.dry_run
+        }) if args.preview
     )
 }
 


### PR DESCRIPTION
## Summary
- Document every visible `agent-task` argument and guard the tree against future empty clap help text.
- Make `--preview` the documented fanout planning verb while retaining `--dry-run` as a hidden compatibility alias.
- Allow `fanout plan --repo <REPO> <ISSUE_URL>...` to use the static cook-batch planner, and explain cook-batch's two-phase behavior prominently.

## Observed Cost
Coming from `cook --preview`, I guessed `--preview`, got a misleading `--private-verify` tip, tried `fanout plan` which rejected `--repo`, then ran the real command, which planned silently and reported success. Three commands were needed to discover a two-phase model that `--help` did not mention.

## Help Evidence
Before:
```text
--dry-run

--dry-run-planner-timeout-seconds <SECONDS>
    Maximum wall-clock budget for each bounded static dry-run planning phase

--run-plan
```
After `cargo run --bin homeboy -- agent-task fanout cook-batch --help`:
```text
TWO-PHASE MODEL: this command plans first and executes only when told to.
...
--preview
    Resolve and validate the batch without side effects ... `--dry-run` is accepted as the historical spelling.

--dry-run-planner-timeout-seconds <SECONDS>
    Maximum wall-clock budget for each bounded static --preview planning phase (default 10 seconds per phase).

--run-plan
    Execute the planned wave in this invocation ... Without this flag the command only plans the batch ...
```
The exact requested `cargo run --bin homeboy -- agent-task fanout cook-batch --preview` now recognizes `--preview`; it reports only the expected missing required `--repo` and issue URL inputs, rather than an unknown-argument suggestion. A fully supplied static preview with `--repo homeboy`, issue #13704, and `--verify true` completed successfully.

## Verification
- Passed: `cargo fmt --all --check`
- Passed: `cargo check --workspace --tests --locked`
- Passed: focused `homeboy-cli` tests for the help audit, preview alias, and `fanout plan --repo` issue-URL parsing.
- Attempted: `cargo test -p homeboy-cli --locked`. It did not complete locally because machine contention left the suite running past 30 minutes. Its observed failure, `agent_task_fanout_dispatch_id_matches_the_canonical_plan_identity`, reproduces unchanged in a detached `origin/main` worktree, so it is pre-existing and unrelated to this PR. CI's Test gate is authoritative.
- `cargo test --workspace` was NOT run locally due to machine contention.

## AI Assistance
- AI assistance: Yes
- Tool(s): OpenAI GPT-5.6-terra via OpenCode
- AI work: Audited the earlier WIP draft, repaired compile and routing omissions, completed the CLI help coverage, added parser/help tests, ran the targeted verification, and prepared this PR.
- An earlier partial draft was produced by GLM 5.3 and was audited before this implementation was finalized.