### PR TITLE
Delete duplicate executor artifact roots

### DIFF
--- a/crates/homeboy-agents/src/agent_task/request.rs
+++ b/crates/homeboy-agents/src/agent_task/request.rs
@@ -179,6 +179,7 @@ pub struct AgentTaskRequest {
 pub struct AgentTaskExecutorRequest {
     pub request: AgentTaskRequest,
     pub artifacts_path: PathBuf,
+    pub(crate) artifact_store_root: PathBuf,
     pub artifacts_path_provenance: AgentTaskArtifactsPathProvenance,
     /// Host-resolved runtime attachments for the provider adapter. This is
     /// distinct from the caller declaration carried in the flattened request.

--- a/crates/homeboy-agents/src/agent_task_executor_evidence.rs
+++ b/crates/homeboy-agents/src/agent_task_executor_evidence.rs
@@ -70,7 +70,7 @@ pub(crate) fn link_latest_executor_evidence(
     run_id: Option<&str>,
 ) {
     let policy = RedactionPolicy::default();
-    let dir = executor_evidence_dir(run_id, &request.task_id);
+    let dir = executor_evidence_dir(&request.artifact_store_root, run_id, &request.task_id);
     if fs::create_dir_all(&dir).is_err() {
         return;
     }
@@ -350,21 +350,16 @@ fn discover_runtime_files(root: &Path) -> BTreeMap<String, Vec<PathBuf>> {
     files
 }
 
-fn executor_evidence_dir(run_id: Option<&str>, task_id: &str) -> PathBuf {
-    durable_executor_evidence_root()
-        .join(sanitize_task_id(run_id.unwrap_or("unrecorded-run")))
-        .join(sanitize_task_id(task_id))
-}
-
-fn durable_executor_evidence_root() -> PathBuf {
-    homeboy_core::artifacts::root()
-        .unwrap_or_else(|_| {
-            std::env::current_dir()
-                .unwrap_or_else(|_| PathBuf::from("."))
-                .join(".homeboy-artifacts")
-        })
+fn executor_evidence_dir(
+    artifact_store_root: &Path,
+    run_id: Option<&str>,
+    task_id: &str,
+) -> PathBuf {
+    artifact_store_root
         .join("agent-task")
         .join("executor-evidence")
+        .join(sanitize_task_id(run_id.unwrap_or("unrecorded-run")))
+        .join(sanitize_task_id(task_id))
 }
 
 fn sanitize_task_id(task_id: &str) -> String {
@@ -467,9 +462,6 @@ mod tests {
         AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace, AGENT_TASK_REQUEST_SCHEMA,
     };
     use serde_json::Map;
-    use std::sync::Mutex;
-
-    static ARTIFACT_ROOT_LOCK: Mutex<()> = Mutex::new(());
 
     fn test_request() -> AgentTaskRequest {
         AgentTaskRequest {
@@ -517,38 +509,8 @@ mod tests {
         }
     }
 
-    /// Scopes the process-global artifact-root override to one test.
-    ///
-    /// Two properties matter, and both exist so that a panicking `#[test]`
-    /// cannot fail an unrelated later test on something other than its own
-    /// merits:
-    ///
-    /// 1. The lock is poison-tolerant. A panic inside `test` poisons
-    ///    `ARTIFACT_ROOT_LOCK`, and a plain `.expect(...)` then reports every
-    ///    subsequent test in this module as a `PoisonError` rather than its
-    ///    real result. `homeboy_core::test_support::env_lock` already ignores
-    ///    poison for exactly this reason; match it here.
-    /// 2. The override is cleared from `Drop`, not on the straight-line return
-    ///    path. A panic used to skip the reset and leave the override pointing
-    ///    at an already-deleted `TempDir`, so the next test resolved artifacts
-    ///    under a missing directory.
     fn with_artifact_root<R>(test: impl FnOnce(&Path) -> R) -> R {
-        struct ClearArtifactRootOverride;
-
-        impl Drop for ClearArtifactRootOverride {
-            fn drop(&mut self) {
-                homeboy_core::set_artifact_root_override(None);
-            }
-        }
-
-        let _lock = ARTIFACT_ROOT_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let guard = tempfile::tempdir().expect("artifact root");
-        homeboy_core::set_artifact_root_override(Some(guard.path().to_path_buf()));
-        // Declared after `guard` so the override is cleared before the
-        // directory it points at is removed, and before the lock is released.
-        let _clear_override = ClearArtifactRootOverride;
         test(guard.path())
     }
 
@@ -594,8 +556,9 @@ mod tests {
         let artifacts_path = root.join("runner").join("artifacts").join("task");
         std::fs::create_dir_all(&artifacts_path).expect("create isolated artifacts path");
         AgentTaskExecutorRequest {
-            artifacts_root_identity: crate::agent_task_provider::artifact_finalization::ExecutorArtifactRootIdentity::capture(&artifacts_path).expect("artifact root identity"),
+            artifacts_root_identity: crate::agent_task_provider::artifact_finalization::ExecutorArtifactRootIdentity::capture_with_finalized_root(&artifacts_path, root.join("executor-finalized")).expect("artifact root identity"),
             artifacts_path,
+            artifact_store_root: root,
             artifacts_path_provenance: crate::agent_task::AgentTaskArtifactsPathProvenance {
                 owner: "homeboy".to_string(),
                 locality: "runner".to_string(),
@@ -884,9 +847,10 @@ mod tests {
 
     #[test]
     fn evidence_dir_is_stable_for_a_run_and_task_id() {
-        with_artifact_root(|_| {
-            let first = executor_evidence_dir(Some("run/attempt:1"), "task/with weird:chars");
-            let second = executor_evidence_dir(Some("run/attempt:1"), "task/with weird:chars");
+        with_artifact_root(|root| {
+            let first = executor_evidence_dir(root, Some("run/attempt:1"), "task/with weird:chars");
+            let second =
+                executor_evidence_dir(root, Some("run/attempt:1"), "task/with weird:chars");
             assert_eq!(first, second);
             assert!(first
                 .to_string_lossy()
@@ -897,7 +861,7 @@ mod tests {
     #[test]
     fn evidence_dir_is_under_durable_artifact_root() {
         with_artifact_root(|artifact_root| {
-            let path = executor_evidence_dir(Some("run-1"), "task-1");
+            let path = executor_evidence_dir(artifact_root, Some("run-1"), "task-1");
             assert!(path.starts_with(artifact_root));
             assert!(!path
                 .to_string_lossy()

--- a/crates/homeboy-agents/src/agent_task_provider/artifact_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/artifact_finalization.rs
@@ -29,15 +29,7 @@ pub(crate) struct ExecutorArtifactRootIdentity {
 }
 
 impl ExecutorArtifactRootIdentity {
-    #[cfg(test)]
-    // Convenience entry point used only by the provider test fixtures; production
-    // resolves the finalized root explicitly through capture_with_finalized_root.
-    pub(crate) fn capture(path: &Path) -> Result<Self> {
-        let finalized_root = homeboy_core::paths::artifact_root()?.join("executor-finalized");
-        Self::capture_with_finalized_root(path, finalized_root)
-    }
-
-    pub(super) fn capture_with_finalized_root(
+    pub(crate) fn capture_with_finalized_root(
         path: &Path,
         finalized_root: PathBuf,
     ) -> Result<Self> {

--- a/crates/homeboy-agents/src/agent_task_provider/catalog.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/catalog.rs
@@ -19,8 +19,6 @@ static PROVIDER_CATALOG: OnceLock<RwLock<AgentTaskProviderCatalog>> = OnceLock::
 pub struct ExtensionProviderAgentTaskExecutor {
     providers: Vec<AgentTaskExecutorProvider>,
     diagnostics: Vec<AgentRuntimeDiscoveryDiagnostic>,
-    #[cfg(test)]
-    pub(super) path_roots: Option<homeboy_core::paths::PathRoots>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -249,8 +247,6 @@ impl ExtensionProviderAgentTaskExecutor {
         Self {
             providers: catalog.providers,
             diagnostics: catalog.diagnostics,
-            #[cfg(test)]
-            path_roots: None,
         }
     }
 
@@ -259,14 +255,7 @@ impl ExtensionProviderAgentTaskExecutor {
         Self {
             providers,
             diagnostics: Vec::new(),
-            path_roots: None,
         }
-    }
-
-    #[cfg(test)]
-    pub(super) fn with_path_roots(mut self, path_roots: homeboy_core::paths::PathRoots) -> Self {
-        self.path_roots = Some(path_roots);
-        self
     }
 
     pub fn providers(&self) -> &[AgentTaskExecutorProvider] {

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -1693,15 +1693,20 @@ fn test_execution_context(run_id: Option<&str>) -> AgentTaskExecutionContext {
 
 #[cfg(test)]
 fn test_executor_request(request: &AgentTaskRequest) -> AgentTaskExecutorRequest {
-    let artifacts_path = std::env::temp_dir()
-        .join("homeboy-agent-task-provider-tests")
+    let artifact_store_root = tempfile::Builder::new()
+        .prefix("homeboy-agent-task-provider-test-")
+        .tempdir()
+        .expect("test artifact store")
+        .keep();
+    let artifacts_path = artifact_store_root
         .join(homeboy_core::paths::sanitize_path_segment(&request.task_id))
         .join(uuid::Uuid::new_v4().to_string());
     std::fs::create_dir_all(&artifacts_path).expect("test executor artifact root");
     AgentTaskExecutorRequest {
         request: request.clone(),
-        artifacts_root_identity: crate::agent_task_provider::artifact_finalization::ExecutorArtifactRootIdentity::capture(&artifacts_path).expect("test artifact identity"),
+        artifacts_root_identity: crate::agent_task_provider::artifact_finalization::ExecutorArtifactRootIdentity::capture_with_finalized_root(&artifacts_path, artifact_store_root.join("executor-finalized")).expect("test artifact identity"),
         artifacts_path,
+        artifact_store_root,
         artifacts_path_provenance: AgentTaskArtifactsPathProvenance {
             owner: "homeboy".to_string(),
             locality: "runner".to_string(),

--- a/crates/homeboy-agents/src/agent_task_provider/executor.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/executor.rs
@@ -7,17 +7,12 @@ impl AgentTaskExecutorAdapter for ExtensionProviderAgentTaskExecutor {
         request: AgentTaskRequest,
         context: AgentTaskExecutionContext,
     ) -> AgentTaskOutcome {
-        #[cfg(test)]
-        let materialized = match self.path_roots.as_ref() {
-            Some(roots) => materialize_executor_request_at_root(
-                request,
-                &context,
-                roots.artifacts().to_path_buf(),
-            ),
+        let materialized = match context.lifecycle_store.as_ref() {
+            Some(store) => {
+                materialize_executor_request_at_root(request, &context, store.artifact_root())
+            }
             None => materialize_executor_request(request, &context),
         };
-        #[cfg(not(test))]
-        let materialized = materialize_executor_request(request, &context);
         let mut request = match materialized {
             Ok(request) => request,
             Err((request, path, error)) => {
@@ -367,6 +362,7 @@ fn materialize_executor_request_at_root(
     Ok(AgentTaskExecutorRequest {
         request,
         artifacts_path: path,
+        artifact_store_root: root,
         artifacts_path_provenance: provenance,
         resolved_runtime_tools: Vec::new(),
         artifacts_root_identity,

--- a/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
@@ -447,6 +447,9 @@ fn runtime_tool_cannot_claim_capability_without_a_probe() {
 
 #[test]
 fn runtime_tool_without_capabilities_is_usable_without_a_probe() {
+    let test_context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store =
+        crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(test_context.path_roots());
     let provider_script = script(
         r#"process.stdin.once('data', input => {
   const tool = JSON.parse(input).resolved_runtime_tools[0];
@@ -479,7 +482,7 @@ fn runtime_tool_without_capabilities_is_usable_without_a_probe() {
             run_id: None,
             attempt: 1,
             cancellation: Default::default(),
-            lifecycle_store: None,
+            lifecycle_store: Some(lifecycle_store),
         },
     );
 

--- a/crates/homeboy-agents/src/agent_task_provider/tests/outcome_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/outcome_tests.rs
@@ -5,9 +5,13 @@ use super::*;
 fn controller_owned_publication_is_reported_as_not_attempted() {
     let (mut request, _) = request("controller-publication", "node provider.js".to_string());
     request.controller_owns_publication();
+    let artifact_store_root = tempfile::tempdir().expect("artifacts").keep();
+    let artifacts_path = artifact_store_root.join("task");
+    std::fs::create_dir_all(&artifacts_path).expect("artifact path");
     let executor_request = AgentTaskExecutorRequest {
         request,
-        artifacts_path: tempfile::tempdir().expect("artifacts").keep(),
+        artifacts_path: artifacts_path.clone(),
+        artifact_store_root: artifact_store_root.clone(),
         artifacts_path_provenance: AgentTaskArtifactsPathProvenance {
             owner: "homeboy".to_string(),
             locality: "runner".to_string(),
@@ -17,7 +21,7 @@ fn controller_owned_publication_is_reported_as_not_attempted() {
             attempt: 1,
         },
         resolved_runtime_tools: Vec::new(),
-        artifacts_root_identity: crate::agent_task_provider::artifact_finalization::ExecutorArtifactRootIdentity::capture(&tempfile::tempdir().expect("identity artifacts").keep()).expect("artifact identity"),
+        artifacts_root_identity: crate::agent_task_provider::artifact_finalization::ExecutorArtifactRootIdentity::capture_with_finalized_root(&artifacts_path, artifact_store_root.join("executor-finalized")).expect("artifact identity"),
     };
     let mut outcome = AgentTaskOutcome {
         task_id: "controller-publication".to_string(),

--- a/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/scheduler_tests.rs
@@ -255,6 +255,7 @@ fn scheduler_dispatches_extension_provider_command() {
 fn executor_materializes_runner_local_artifacts_for_no_op_and_editing_requests() {
     let context = homeboy_core::test_support::HermeticTestContext::new();
     let roots = context.path_roots();
+    let lifecycle_store = crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(roots.clone());
     let runner_root = roots.artifacts().to_path_buf();
     let controller_root = tempfile::tempdir().expect("controller root");
     let command = format!(
@@ -270,10 +271,9 @@ fn executor_materializes_runner_local_artifacts_for_no_op_and_editing_requests()
     editing.task_id = "task-editing".to_string();
     editing.executor.config["no_op"] = json!(false);
     let scheduler = AgentTaskScheduler::new(Arc::new(
-        ExtensionProviderAgentTaskExecutor::with_providers(vec![provider])
-            .with_path_roots(roots.clone()),
+        ExtensionProviderAgentTaskExecutor::with_providers(vec![provider]),
     ))
-    .with_scratch_root(roots.data().to_path_buf());
+    .with_lifecycle_store(lifecycle_store);
 
     let aggregate = scheduler.run(AgentTaskPlan::new(
         "runner-local-artifact-plan",
@@ -593,10 +593,9 @@ fn provider_empty_stdout_records_failed_run_with_executor_evidence() {
     let plan = AgentTaskPlan::new("plan-empty-stdout-recorded", vec![request]);
     let run_id = "run-empty-provider-output";
     let scheduler = AgentTaskScheduler::new(Arc::new(
-        ExtensionProviderAgentTaskExecutor::with_providers(vec![provider])
-            .with_path_roots(roots.clone()),
+        ExtensionProviderAgentTaskExecutor::with_providers(vec![provider]),
     ))
-    .with_scratch_root(roots.data().to_path_buf());
+    .with_lifecycle_store(lifecycle_store.clone());
 
     lifecycle_store
         .submit_plan_with_runtime_admission(&plan, run_id, |_| Ok(json!({})))
@@ -1145,6 +1144,7 @@ fn provider_command_receives_executor_config_env() {
 fn provider_attempts_receive_distinct_allocated_runtime_tmpdirs() {
     let context = homeboy_core::test_support::HermeticTestContext::new();
     let roots = context.path_roots();
+    let lifecycle_store = crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(roots.clone());
     let state = unique_state_path("scratch-attempts");
     let state_path = state.to_string_lossy().replace('\\', "\\\\");
     let command = format!(
@@ -1161,10 +1161,9 @@ fn provider_attempts_receive_distinct_allocated_runtime_tmpdirs() {
         vec![AgentTaskFailureClassification::ExecutionFailed];
 
     let aggregate = AgentTaskScheduler::new(Arc::new(
-        ExtensionProviderAgentTaskExecutor::with_providers(vec![provider])
-            .with_path_roots(roots.clone()),
+        ExtensionProviderAgentTaskExecutor::with_providers(vec![provider]),
     ))
-    .with_scratch_root(roots.data().to_path_buf())
+    .with_lifecycle_store(lifecycle_store)
     .run(plan);
 
     assert_eq!(aggregate.totals.succeeded, 1);
@@ -1182,22 +1181,12 @@ fn provider_attempts_receive_distinct_allocated_runtime_tmpdirs() {
     let first_tmpdir = PathBuf::from(attempts[0]["tmp"].as_str().expect("TMPDIR"));
     let scratch_root =
         fs::canonicalize(roots.data().join("controller-scratch/attempts")).expect("scratch root");
-    let scratch_run_id = first_tmpdir
+    first_tmpdir
         .strip_prefix(scratch_root)
-        .expect("scratch root")
-        .components()
-        .next()
-        .expect("scratch run id")
-        .as_os_str();
+        .expect("scratch root");
     let index: Value = serde_json::from_str(
-        &fs::read_to_string(
-            roots
-                .data()
-                .join("controller-scratch/test-indexes")
-                .join(scratch_run_id)
-                .join("resources.json"),
-        )
-        .expect("scratch index"),
+        &fs::read_to_string(roots.data().join("controller-scratch/resources.json"))
+            .expect("scratch index"),
     )
     .expect("scratch index JSON");
     let resources = index["resources"].as_array().expect("scratch resources");

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -51,8 +51,6 @@ pub struct AgentTaskScheduler {
     /// that the reservation, the terminal record, and the cleanup record are
     /// guaranteed to name the same installation (#7505).
     resolved_lifecycle_store: OnceLock<crate::agent_task_lifecycle::AgentTaskLifecycleStore>,
-    #[cfg(test)]
-    scratch_root: Option<std::path::PathBuf>,
 }
 
 impl AgentTaskScheduler {
@@ -69,8 +67,6 @@ impl AgentTaskScheduler {
             harvest_context: HarvestExecutionContext::default(),
             lifecycle_store: None,
             resolved_lifecycle_store: OnceLock::new(),
-            #[cfg(test)]
-            scratch_root: None,
         }
     }
 
@@ -109,15 +105,23 @@ impl AgentTaskScheduler {
         if let Some(store) = self.resolved_lifecycle_store.get() {
             return Ok(store);
         }
+        #[cfg(test)]
+        let store = match self.run_id.as_ref() {
+            Some(_) => {
+                crate::agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?
+            }
+            None => crate::agent_task_lifecycle::AgentTaskLifecycleStore::from_data_root(
+                tempfile::Builder::new()
+                    .prefix("homeboy-scheduler-test-")
+                    .tempdir()
+                    .map_err(|error| homeboy_core::Error::internal_io(error.to_string(), None))?
+                    .keep(),
+            ),
+        };
+        #[cfg(not(test))]
         let store =
             crate::agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
         Ok(self.resolved_lifecycle_store.get_or_init(|| store))
-    }
-
-    #[cfg(test)]
-    pub(crate) fn with_scratch_root(mut self, data_root: std::path::PathBuf) -> Self {
-        self.scratch_root = Some(data_root);
-        self
     }
 
     pub fn run(&self, plan: AgentTaskPlan) -> AgentTaskAggregate {
@@ -621,7 +625,7 @@ impl AgentTaskScheduler {
                     .or(harvest_preflight.base_sha.clone());
                 let source_workspace_root = request.workspace.root.clone();
                 let source_provenance = harvest_preflight.source_provenance;
-                let scratch = if let Some(lifecycle_store) = self.lifecycle_store.as_ref() {
+                let scratch = self.durable_lifecycle_store().and_then(|lifecycle_store| {
                     crate::controller_scratch::allocate_attempt_at(
                         &lifecycle_store.data_root(),
                         &scratch_run_id,
@@ -629,43 +633,7 @@ impl AgentTaskScheduler {
                         &request.task_id,
                         scheduled.attempt,
                     )
-                } else {
-                    #[cfg(test)]
-                    {
-                        match self.scratch_root.as_ref() {
-                            Some(data_root) => crate::controller_scratch::allocate_test_attempt_at(
-                                data_root,
-                                &scratch_run_id,
-                                &plan.plan_id,
-                                &request.task_id,
-                                scheduled.attempt,
-                            ),
-                            None => crate::controller_scratch::allocate_test_attempt(
-                                &scratch_run_id,
-                                &plan.plan_id,
-                                &request.task_id,
-                                scheduled.attempt,
-                            ),
-                        }
-                    }
-                    #[cfg(not(test))]
-                    {
-                        // The scratch directory holds the working files of the
-                        // very attempt whose reservation was taken through the
-                        // accessor. Allocating it from the environment instead
-                        // would let an attempt's scratch and its durable records
-                        // live in different installations (#7505).
-                        self.durable_lifecycle_store().and_then(|lifecycle_store| {
-                            crate::controller_scratch::allocate_attempt_at(
-                                &lifecycle_store.data_root(),
-                                &scratch_run_id,
-                                &plan.plan_id,
-                                &request.task_id,
-                                scheduled.attempt,
-                            )
-                        })
-                    }
-                };
+                });
                 let scratch = match scratch {
                     Ok(scratch) => scratch,
                     Err(error) => {
@@ -759,10 +727,7 @@ impl AgentTaskScheduler {
                     run_id: self.run_id.clone(),
                     attempt,
                     cancellation: cancellation.clone(),
-                    lifecycle_store: self
-                        .run_id
-                        .as_ref()
-                        .and_then(|_| self.durable_lifecycle_store().ok().cloned()),
+                    lifecycle_store: self.durable_lifecycle_store().ok().cloned(),
                 };
 
                 if let Some(run_id) = self.run_id.as_deref() {

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/concurrency.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/concurrency.rs
@@ -334,12 +334,16 @@ pub(super) mod concurrency_tests {
 
     #[test]
     fn serializes_tasks_that_share_a_mutable_workspace() {
+        let context = homeboy_core::test_support::HermeticTestContext::new();
+        let lifecycle_store =
+            crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
         let temp = tempfile::tempdir().expect("tempdir");
         let workspace = temp.path().join("workspace");
         init_git_workspace(&workspace);
         let executor = RecordingExecutor::new(HashMap::new(), Duration::from_millis(25));
         let max_seen = Arc::clone(&executor.max_seen);
-        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
+        let scheduler =
+            AgentTaskScheduler::new(Arc::new(executor)).with_lifecycle_store(lifecycle_store);
         let mut plan = plan_with_tasks(2);
         plan.options.max_concurrency = 2;
         for task in &mut plan.tasks {
@@ -582,17 +586,10 @@ pub(super) mod concurrency_tests {
                     .expect("scratch roots")
                     .push(scratch_root.clone());
                 std::thread::sleep(Duration::from_millis(3_000));
-                let run_id = scratch_root
-                    .ancestors()
-                    .nth(4)
-                    .and_then(std::path::Path::file_name)
-                    .expect("scheduler scratch run id");
                 let scratch_index = scratch_root
                     .ancestors()
                     .nth(6)
                     .expect("controller scratch root")
-                    .join("test-indexes")
-                    .join(run_id)
                     .join("resources.json");
                 let active = serde_json::from_str::<Value>(
                     &fs::read_to_string(scratch_index).expect("scratch index"),
@@ -686,17 +683,10 @@ pub(super) mod concurrency_tests {
             finished.load(Ordering::SeqCst)
         });
         let scratch_root = scratch_roots.lock().expect("scratch roots")[0].clone();
-        let scratch_run_id = scratch_root
-            .ancestors()
-            .nth(4)
-            .and_then(std::path::Path::file_name)
-            .expect("scheduler scratch run id");
         let scratch_index = scratch_root
             .ancestors()
             .nth(6)
             .expect("controller scratch root")
-            .join("test-indexes")
-            .join(scratch_run_id)
             .join("resources.json");
         assert!(scratch_active_while_running.load(Ordering::SeqCst));
         let cleanup_action = aggregate

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
@@ -866,9 +866,7 @@ mod provider_rotation_tests {
         let run_id = "timeout-rotation-scratch-recovery";
         let scratch_index = homeboy_core::paths::homeboy_data()
             .expect("homeboy data")
-            .join("controller-scratch/test-indexes")
-            .join(run_id)
-            .join("resources.json");
+            .join("controller-scratch/resources.json");
         let scratch_roots = Arc::new(Mutex::new(Vec::new()));
         let (cancellation, cancellation_receiver) = std::sync::mpsc::channel();
         let cancel_calls = Arc::new(AtomicUsize::new(0));

--- a/crates/homeboy-agents/src/controller_scratch.rs
+++ b/crates/homeboy-agents/src/controller_scratch.rs
@@ -118,38 +118,6 @@ pub(crate) fn allocate_attempt_at(
     )
 }
 
-#[cfg(test)]
-pub fn allocate_test_attempt(
-    run_id: &str,
-    plan_id: &str,
-    task_id: &str,
-    attempt: u32,
-) -> Result<ControllerScratchAllocation> {
-    allocate_test_attempt_at(&paths::homeboy_data()?, run_id, plan_id, task_id, attempt)
-}
-
-#[cfg(test)]
-pub fn allocate_test_attempt_at(
-    data_root: &Path,
-    run_id: &str,
-    plan_id: &str,
-    task_id: &str,
-    attempt: u32,
-) -> Result<ControllerScratchAllocation> {
-    let index_path = data_root.join(format!(
-        "controller-scratch/test-indexes/{}/resources.json",
-        paths::sanitize_path_segment(run_id)
-    ));
-    allocate_attempt_at_roots(
-        run_id,
-        plan_id,
-        task_id,
-        attempt,
-        data_root.join("controller-scratch/attempts"),
-        index_path,
-    )
-}
-
 fn allocate_attempt_at_roots(
     run_id: &str,
     plan_id: &str,


### PR DESCRIPTION
## Summary
- make the materialized executor request carry the one artifact-store root used for artifacts and evidence
- delete the provider executor's test-only path-roots field and the scheduler's test-only scratch-root field
- delete the separate test scratch allocator and `test-indexes` persistence format
- pass the scheduler's resolved lifecycle store to every executor attempt

Net change: 76 additions, 212 deletions.

## Evidence
- executor evidence: 12 passed, 0 failed
- provider tests: 137 passed, 0 failed
- scheduler concurrency: 19 passed, 0 failed
- `cargo check -p homeboy-agents --features test-support`: passed
- full lib suite: 2086 passed, 6 failed, 6 ignored; remaining failures now resolve to ambient controller-runtime and observation-store state outside this slice

Refs #11897.

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to trace duplicate root ownership, remove the redundant test-only paths, and run verification. I reviewed and directed the resulting changes and evidence.