### PR TITLE
Report truthful fanout command outcomes (#13702)

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -404,9 +404,13 @@ fn batch_status(args: AgentTaskFanoutBatchStatusArgs, placement: Placement) -> C
             report.status = state.outcome_status().to_string();
         }
     }
-    let exit_code = report.batch.state.exit_code();
-    // `status` is a read-only projection. Durable reconciliation and any child
-    // continuation are intentionally limited to the explicit `resume` command.
+    // `status` is a read. The operation either returned the requested batch
+    // projection (exit 0) or failed and names its cause through `Err`
+    // (#13702). The batch's own aggregate state — including `failed` — is
+    // subject state: it stays in `data.batch`, never in the transport
+    // envelope's success/exit_code.
+    // The mutating `resume` command keeps the aggregate exit policy, and
+    // durable reconciliation / child continuation stay limited to it.
     let portfolio = reconcile_portfolio(&report.batch)?;
     Ok((
         serde_json::json!({
@@ -415,7 +419,7 @@ fn batch_status(args: AgentTaskFanoutBatchStatusArgs, placement: Placement) -> C
             "portfolio": portfolio,
             "commands": batch_commands(&args.batch_id, placement),
         }),
-        exit_code,
+        0,
     ))
 }
 
@@ -9511,27 +9515,78 @@ fi
             batch::AgentTaskBatchState::Cancelled,
             batch::AgentTaskBatchState::TimedOut,
         ] {
-            let exit_code = state.exit_code();
+            // `fanout status` is a read: it exits 0 and reports `succeeded`
+            // whenever the projection returned, regardless of the batch's own
+            // terminal state (#13702). The subject state stays in `data`.
             let envelope =
-                crate::commands::utils::response::cli_response_for_json_result_for_command(
+                crate::commands::utils::response::cli_response_for_json_result_for_identity(
                     &Ok(json!({
-                        "status": state.outcome_status(),
-                        "batch": { "state": state.outcome_status() }
+                        "schema": "homeboy/agent-task-fanout-status/v2",
+                        "batch": { "status": state.outcome_status(), "batch": { "state": state.outcome_status() } }
                     })),
-                    exit_code,
-                    "agent-task fanout status",
+                    0,
+                    &crate::commands::utils::response::CommandIdentity::with_operation(
+                        "agent-task",
+                        "fanout status",
+                    ),
                     None,
                 );
 
-            assert_eq!(envelope.success, exit_code == 0, "{state:?}");
-            assert_eq!(envelope.exit_code, exit_code, "{state:?}");
-            assert_eq!(envelope.status, state.outcome_status(), "{state:?}");
+            assert!(envelope.success, "{state:?}");
+            assert_eq!(envelope.exit_code, 0, "{state:?}");
+            assert_eq!(envelope.status, "succeeded", "{state:?}");
             assert_eq!(
-                envelope.data.expect("durable status")["batch"]["state"],
+                envelope.data.expect("durable status")["batch"]["batch"]["state"],
                 state.outcome_status(),
                 "{state:?}"
             );
         }
+    }
+
+    /// #13702 direction 2 regression: reading a FAILED batch is a successful
+    /// read. The documented recovery path (`next_actions` prints exactly this
+    /// command) must survive `set -e`.
+    #[test]
+    fn batch_status_read_of_a_failed_batch_is_a_successful_operation() {
+        with_isolated_home(|_| {
+            let batch_id = "read-of-failed-batch";
+            batch::persist_fanout_run_batch(
+                batch_id,
+                batch_id,
+                &[batch::FanoutRunBatchChild {
+                    task_id: "child".to_string(),
+                    run_id: "missing-child-record".to_string(),
+                }],
+                json!({}),
+            )
+            .expect("persist fanout batch");
+            let claim_id = batch::claim_fanout_run_batch(batch_id)
+                .expect("claim batch")
+                .expect("coordinator claim");
+            batch::record_fanout_run_batch_failure(
+                batch_id,
+                &claim_id,
+                "worktree_preflight",
+                json!({ "message": "fixture failure before first child" }),
+            )
+            .expect("persist coordinator failure");
+
+            let (value, exit_code) = batch_status(
+                AgentTaskFanoutBatchStatusArgs {
+                    batch_id: batch_id.to_string(),
+                },
+                Placement::Auto,
+            )
+            .expect("reading a failed batch must still return its projection");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(value["batch"]["status"], "failed");
+            assert_eq!(value["batch"]["batch"]["state"], "failed");
+            assert_eq!(
+                value["batch"]["admission_blocker"]["stage"],
+                "worktree_preflight"
+            );
+        });
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
@@ -19,6 +19,7 @@ pub(crate) enum AgentTaskSummaryKind {
     Controller,
     Providers,
     FanoutCookBatch,
+    FanoutStatus,
 }
 
 pub(crate) fn agent_task_summary_kind(args: &AgentTaskArgs) -> Option<AgentTaskSummaryKind> {
@@ -28,11 +29,11 @@ pub(crate) fn agent_task_summary_kind(args: &AgentTaskArgs) -> Option<AgentTaskS
         AgentTaskCommand::Logs(_) => Some(AgentTaskSummaryKind::Logs),
         AgentTaskCommand::Review(_) => Some(AgentTaskSummaryKind::Review),
         AgentTaskCommand::Providers(_) => Some(AgentTaskSummaryKind::Providers),
-        AgentTaskCommand::Fanout(args)
-            if matches!(&args.command, AgentTaskFanoutCommand::CookBatch(_)) =>
-        {
-            Some(AgentTaskSummaryKind::FanoutCookBatch)
-        }
+        AgentTaskCommand::Fanout(args) => match &args.command {
+            AgentTaskFanoutCommand::CookBatch(_) => Some(AgentTaskSummaryKind::FanoutCookBatch),
+            AgentTaskFanoutCommand::Status(_) => Some(AgentTaskSummaryKind::FanoutStatus),
+            _ => None,
+        },
         AgentTaskCommand::Controller(controller_args) => match &controller_args.command {
             AgentTaskControllerCommand::Status(_)
             | AgentTaskControllerCommand::Diagnose(_)
@@ -60,7 +61,74 @@ pub(crate) fn render_agent_task_summary(
         AgentTaskSummaryKind::Controller => controller::render_controller_summary(payload),
         AgentTaskSummaryKind::Providers => render_providers_summary(payload),
         AgentTaskSummaryKind::FanoutCookBatch => render_fanout_cook_batch_summary(payload),
+        AgentTaskSummaryKind::FanoutStatus => render_fanout_status_summary(payload),
     }
+}
+
+/// `fanout status` is a read that succeeds even when the batch it inspected
+/// failed, so its human summary must render for every terminal subject state —
+/// including failures (#13702).
+fn render_fanout_status_summary(payload: &Value) -> Option<String> {
+    if payload.get("schema")?.as_str()? != "homeboy/agent-task-fanout-status/v2" {
+        return None;
+    }
+    let batch_id = payload
+        .pointer("/batch/batch/batch_id")
+        .and_then(Value::as_str)?;
+    let state = payload.pointer("/batch/status").and_then(Value::as_str)?;
+    let mut lines = vec![format!(
+        "Fanout batch {batch_id}: {state}{}",
+        fanout_totals_sentence(payload)
+            .map(|totals| format!(" ({totals})"))
+            .unwrap_or_default()
+    )];
+    if let Some(blocker) = payload.pointer("/batch/admission_blocker") {
+        let stage = blocker
+            .get("stage")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let cause = blocker
+            .pointer("/failure/message")
+            .and_then(Value::as_str)
+            .or_else(|| blocker.pointer("/failure/code").and_then(Value::as_str))
+            .unwrap_or("no reported cause");
+        lines.push(format!("Blocked before admission in {stage}: {cause}"));
+    }
+    if payload
+        .pointer("/batch/resumable")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        if let Some(resume) = payload.pointer("/commands/resume").and_then(Value::as_str) {
+            lines.push(format!("Resume unfinalized children: {resume}"));
+        }
+    }
+    Some(lines.join("\n"))
+}
+
+/// Compact "2 succeeded, 1 failed" child tally from the batch totals.
+fn fanout_totals_sentence(payload: &Value) -> Option<String> {
+    let totals = payload.pointer("/batch/totals")?;
+    let mut parts = Vec::new();
+    for key in [
+        "queued",
+        "running",
+        "succeeded",
+        "partial_failure",
+        "failed",
+        "cancelled",
+        "timed_out",
+        "unavailable",
+    ] {
+        let count = totals.get(key).and_then(Value::as_u64).unwrap_or(0);
+        if count > 0 {
+            parts.push(format!("{count} {key}"));
+        }
+    }
+    if parts.is_empty() {
+        return None;
+    }
+    Some(parts.join(", "))
 }
 
 fn render_fanout_cook_batch_summary(payload: &Value) -> Option<String> {
@@ -2172,6 +2240,55 @@ mod tests {
         ));
         assert!(summary.contains(
             "Next: homeboy agent-task controller diagnose loop-123  # inspect failed action evidence\n"
+        ));
+    }
+
+    /// #13702: a failed batch's status read still renders a human summary —
+    /// the read succeeded, and the summary is how the envelope populates
+    /// `presentation.stdout` for terminal subject states including failures.
+    #[test]
+    fn fanout_status_summary_renders_for_failed_batches() {
+        let payload = json!({
+            "schema": "homeboy/agent-task-fanout-status/v2",
+            "batch": {
+                "status": "failed",
+                "batch": { "batch_id": "cook-batch-homeboy-issue-13400-2-5665d644ed6f", "state": "failed", "task_count": 2 },
+                "totals": { "succeeded": 1, "failed": 1 },
+                "resumable": true,
+            },
+            "commands": {
+                "resume": "homeboy agent-task fanout resume cook-batch-homeboy-issue-13400-2-5665d644ed6f"
+            },
+        });
+
+        let summary =
+            render_agent_task_summary(AgentTaskSummaryKind::FanoutStatus, &payload).unwrap();
+
+        assert!(summary.contains("Fanout batch cook-batch-homeboy-issue-13400-2-5665d644ed6f: failed (1 succeeded, 1 failed)"));
+        assert!(summary.contains("Resume unfinalized children: homeboy agent-task fanout resume cook-batch-homeboy-issue-13400-2-5665d644ed6f"));
+    }
+
+    #[test]
+    fn fanout_status_summary_names_pre_admission_blockers() {
+        let payload = json!({
+            "schema": "homeboy/agent-task-fanout-status/v2",
+            "batch": {
+                "status": "failed",
+                "batch": { "batch_id": "failed-before-admission", "state": "failed", "task_count": 1 },
+                "totals": { "failed": 1 },
+                "admission_blocker": {
+                    "stage": "worktree_preflight",
+                    "failure": { "code": "worktree.creation_failed", "message": "fixture failure before first child" }
+                },
+            },
+        });
+
+        let summary =
+            render_agent_task_summary(AgentTaskSummaryKind::FanoutStatus, &payload).unwrap();
+
+        assert!(summary.contains("Fanout batch failed-before-admission: failed"));
+        assert!(summary.contains(
+            "Blocked before admission in worktree_preflight: fixture failure before first child"
         ));
     }
 

--- a/crates/homeboy-cli/src/commands/utils/response.rs
+++ b/crates/homeboy-cli/src/commands/utils/response.rs
@@ -623,7 +623,9 @@ fn envelope_for_data(
         }
     }
 
-    let diagnostics = failure_diagnostics_for_data(exit_code, &run, &artifacts, &data);
+    let subject_state = subject_state_for_identity(identity, &data);
+    let diagnostics = failure_diagnostics_for_data(exit_code, &run, &artifacts, &data)
+        .or_else(|| unnamed_failure_diagnostics(identity, exit_code, &subject_state, &data));
     let failure_next_actions = diagnostics
         .as_ref()
         .and_then(|diagnostics| diagnostics.failure_digest.as_ref())
@@ -646,14 +648,7 @@ fn envelope_for_data(
         success,
         exit_code,
         status: status_for_result(Some(&data), exit_code),
-        subject_state: (identity.command == "agent-task"
-            && identity.operation.as_deref() == Some("status"))
-        .then(|| {
-            data.get("state")
-                .and_then(Value::as_str)
-                .map(str::to_string)
-        })
-        .flatten(),
+        subject_state,
         run,
         refs,
         summary,
@@ -665,6 +660,64 @@ fn envelope_for_data(
         presentation,
         contract_warnings,
     }
+}
+
+/// Lifecycle state of the inspected subject for read-only status operations.
+///
+/// These commands describe their *operation* through `success` / `exit_code` /
+/// `status`: a read that returns the requested projection succeeded, whatever
+/// state the subject is in (#13702). The subject's own state travels in
+/// `subject_state` and `data` so machine consumers never have to conflate the
+/// two.
+fn subject_state_for_identity(identity: &CommandIdentity, data: &Value) -> Option<String> {
+    match (identity.command.as_str(), identity.operation.as_deref()) {
+        ("agent-task", Some("status")) => data
+            .get("state")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        _ => None,
+    }
+}
+
+/// A failed operation must name its cause (#13702).
+///
+/// A nonzero exit arriving with a payload that carries no failure digest used
+/// to serialize `success: false` with no error and no summary — the exact
+/// "failed with error: null" shape callers cannot branch on. Keep a named, if
+/// generic, cause so `success: false` is always explained.
+fn unnamed_failure_diagnostics(
+    identity: &CommandIdentity,
+    exit_code: i32,
+    subject_state: &Option<String>,
+    data: &Value,
+) -> Option<CommandDiagnostics> {
+    if exit_code == 0 {
+        return None;
+    }
+    let mut operation = identity.command.clone();
+    if let Some(operation_name) = identity.operation.as_deref() {
+        operation.push(' ');
+        operation.push_str(operation_name);
+    }
+    let subject = subject_state.as_deref().map(str::to_string).or_else(|| {
+        data.get("status")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+    });
+    let message = match subject {
+        Some(subject) => {
+            format!("{operation} exited {exit_code} without reporting a failure cause; subject state: {subject}")
+        }
+        None => format!("{operation} exited {exit_code} without reporting a failure cause"),
+    };
+    Some(CommandDiagnostics {
+        code: "command.failed".to_string(),
+        message,
+        details: serde_json::json!({ "exit_code": exit_code }),
+        hints: None,
+        retryable: None,
+        failure_digest: None,
+    })
 }
 
 fn failure_diagnostics_for_data(
@@ -727,6 +780,9 @@ fn failure_digest_for_data(data: &Value) -> Option<CommandFailureDigest> {
     if let Some(digest) = release_failure_digest(data) {
         return Some(digest);
     }
+    if let Some(digest) = cook_batch_failure_digest(data) {
+        return Some(digest);
+    }
     if let Some(digest) = formatting_failure_digest(data) {
         return Some(digest);
     }
@@ -750,6 +806,56 @@ fn failure_digest_for_data(data: &Value) -> Option<CommandFailureDigest> {
         stderr_tail: raw_output_tail(data, "stderr_tail"),
         artifact_refs: Vec::new(),
         next_actions: Vec::new(),
+        retryable: None,
+    })
+}
+
+/// Lift the first blocked worktree row of a cook-batch preflight into the
+/// bounded command envelope. The blocked batch exits nonzero while the
+/// complete per-row evidence stays under `data.worktrees.rows` (#13702).
+fn cook_batch_failure_digest(data: &Value) -> Option<CommandFailureDigest> {
+    if data.get("schema").and_then(Value::as_str) != Some("homeboy/agent-task-cook-batch/v1") {
+        return None;
+    }
+    if data.get("status").and_then(Value::as_str) != Some("blocked") {
+        return None;
+    }
+    let primary = data.get("primary_failure")?;
+    let phase = primary
+        .get("phase")
+        .and_then(Value::as_str)
+        .unwrap_or("worktree_preflight");
+    let handle = primary
+        .get("handle")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let cause = primary
+        .get("reason")
+        .and_then(Value::as_str)
+        .unwrap_or("worktree preflight blocked without a reported reason");
+    let blocked_rows = data
+        .pointer("/causal_failures/total")
+        .and_then(Value::as_u64)
+        .unwrap_or(1);
+    let next_actions = primary
+        .get("next_action")
+        .and_then(Value::as_str)
+        .map(|command| {
+            vec![
+                CommandNextAction::new("create the blocked worktree", command)
+                    .with_kind(CommandNextActionKind::Repair),
+            ]
+        })
+        .unwrap_or_default();
+    Some(CommandFailureDigest {
+        summary: format!(
+            "cook-batch blocked in {phase} on worktree {handle} ({blocked_rows} blocked row(s)): {}",
+            bounded_text(cause, 1000)
+        ),
+        stdout_tail: None,
+        stderr_tail: None,
+        artifact_refs: Vec::new(),
+        next_actions,
         retryable: None,
     })
 }
@@ -1180,6 +1286,12 @@ fn normalize_status(status: &str) -> Option<&'static str> {
         "queued" => Some("queued"),
         "running" | "in_progress" | "active" => Some("running"),
         "succeeded" | "success" | "passed" | "pass" | "complete" | "completed" => Some("succeeded"),
+        // A payload that self-describes as `ready` planned work without
+        // executing it (cook-batch without `--run-plan`, or `--dry-run`).
+        // Reporting `succeeded` told orchestrators the wave shipped when no
+        // agent ran (#13702); `planned` matches the vocabulary already used by
+        // fuzz planning and refactor operations.
+        "ready" => Some("planned"),
         "partial_failure" | "partial-failure" | "partial" => Some("partial_failure"),
         "failed" | "failure" | "error" => Some("failed"),
         "cancelled" | "canceled" => Some("cancelled"),
@@ -1706,6 +1818,146 @@ mod tests {
             assert_eq!(value["status"], "succeeded", "{subject_state}");
             assert_eq!(value["subject_state"], subject_state, "{subject_state}");
             assert_eq!(value["data"]["state"], subject_state, "{subject_state}");
+        }
+    }
+
+    /// #13702 direction 2: reading a failed fanout batch is a successful
+    /// operation. The envelope reports the read; the batch's own state stays
+    /// in `data`.
+    #[test]
+    fn fanout_status_read_of_a_failed_batch_is_a_successful_envelope() {
+        let response = cli_response_for_json_result_for_identity(
+            &Ok(json!({
+                "schema": "homeboy/agent-task-fanout-status/v2",
+                "batch": {
+                    "status": "failed",
+                    "batch": {
+                        "batch_id": "cook-batch-homeboy-issue-13400-2-5665d644ed6f",
+                        "state": "failed",
+                    },
+                },
+            })),
+            0,
+            &CommandIdentity::with_operation("agent-task", "fanout status"),
+            Some(CommandPresentationEnvelope {
+                stdout: Some(
+                    "Fanout batch cook-batch-homeboy-issue-13400-2: failed (1 failed)\n"
+                        .to_string(),
+                ),
+                stderr: None,
+            }),
+        );
+        let value = serde_json::to_value(response).expect("serialize response");
+
+        assert_eq!(value["success"], true);
+        assert_eq!(value["exit_code"], 0);
+        assert_eq!(value["status"], "succeeded");
+        assert!(value.get("subject_state").is_none());
+        assert_eq!(value["data"]["batch"]["batch"]["state"], "failed");
+        assert_eq!(
+            value["presentation"]["stdout"],
+            "Fanout batch cook-batch-homeboy-issue-13400-2: failed (1 failed)\n"
+        );
+    }
+
+    /// #13702 direction 1: a cook-batch that only provisioned and planned —
+    /// no agent ran, no PR opened — must not report `succeeded`. The
+    /// plan-ready payload maps to the distinct `planned` status.
+    #[test]
+    fn plan_only_cook_batch_reports_planned_not_succeeded() {
+        for dry_run in [false, true] {
+            let response = cli_response_for_json_result_for_identity(
+                &Ok(json!({
+                    "schema": "homeboy/agent-task-cook-batch/v1",
+                    "fanout_id": "cook-batch-homeboy-issue-13400-2-5665d644ed6f",
+                    "status": "ready",
+                    "dry_run": dry_run,
+                    "run_result": null,
+                })),
+                0,
+                &CommandIdentity::with_operation("agent-task", "fanout cook-batch"),
+                None,
+            );
+            let value = serde_json::to_value(response).expect("serialize response");
+
+            assert_eq!(value["success"], true, "planning itself succeeded");
+            assert_eq!(value["exit_code"], 0);
+            assert_eq!(value["status"], "planned", "dry_run: {dry_run}");
+            assert_ne!(value["status"], "succeeded");
+        }
+    }
+
+    /// A blocked cook-batch preflight is a failed operation and must lift the
+    /// primary worktree blocker into the envelope instead of failing silently.
+    #[test]
+    fn blocked_cook_batch_names_its_primary_worktree_failure() {
+        let response = cli_response_for_json_result_for_identity(
+            &Ok(json!({
+                "schema": "homeboy/agent-task-cook-batch/v1",
+                "fanout_id": "issue-wave",
+                "status": "blocked",
+                "primary_failure": {
+                    "phase": "worktree_preflight",
+                    "handle": "homeboy@fix-a",
+                    "reason": "worktree creation failed: branch already exists",
+                    "next_action": "homeboy workspace worktrees add homeboy@fix-a",
+                },
+                "causal_failures": { "total": 1, "returned": 1, "omitted": 0 },
+            })),
+            1,
+            &CommandIdentity::with_operation("agent-task", "fanout cook-batch"),
+            None,
+        );
+        let value = serde_json::to_value(response).expect("serialize response");
+
+        assert_eq!(value["success"], false);
+        let summary = value["summary"].as_str().expect("named cause");
+        assert!(summary.contains("worktree_preflight"), "got: {summary}");
+        assert!(summary.contains("homeboy@fix-a"), "got: {summary}");
+        assert_eq!(
+            value["diagnostics"]["failure_digest"]["next_actions"][0]["command"],
+            "homeboy workspace worktrees add homeboy@fix-a"
+        );
+    }
+
+    /// #13702: `success: false` is never emitted without a named cause. A
+    /// nonzero exit whose payload carries no digest anywhere still gets
+    /// diagnostics and a summary; the typed-error path always did.
+    #[test]
+    fn failed_results_always_name_their_cause() {
+        let causeless = json!({
+            "schema": "homeboy/agent-task-status-summary/v1",
+            "run_id": "run-1",
+            "state": "succeeded",
+        });
+        for (label, result, exit_code) in [
+            ("payload without a digest", Ok(causeless.clone()), 1),
+            (
+                "typed error",
+                Err(Error::validation_invalid_argument(
+                    "runner",
+                    "stale daemon",
+                    None,
+                    None,
+                )),
+                2,
+            ),
+        ] {
+            let response = cli_response_for_json_result_for_identity(
+                &result,
+                exit_code,
+                &CommandIdentity::with_operation("agent-task", "status"),
+                None,
+            );
+            let value = serde_json::to_value(response).expect("serialize response");
+
+            assert_eq!(value["success"], false, "{label}");
+            let message = value["diagnostics"]["message"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string();
+            assert!(!message.trim().is_empty(), "{label} must name its cause");
+            assert_eq!(value["summary"].as_str(), Some(message.as_str()));
         }
     }
 

--- a/docs/architecture/output-system.md
+++ b/docs/architecture/output-system.md
@@ -74,7 +74,9 @@ For `homeboy agent-task status`, `status` and `success` describe whether the
 read completed. The inspected run's lifecycle value is exposed separately as
 `subject_state` (for example `queued`, `running`, `failed`, or `succeeded`).
 Status reads exit zero even when the subject needs action; use
-`--strict-subject-exit` to preserve the legacy nonzero exit behavior.
+`--strict-subject-exit` to preserve the legacy nonzero exit behavior. A payload
+that planned work without executing it (cook-batch without `--run-plan`, or
+`--dry-run`) reports envelope status `planned` rather than `succeeded`.
 
 Failure:
 

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -550,16 +550,32 @@ lists the exact worktree rows and retry commands, and exits non-zero before any
 provider process starts.
 
 Completed cook batches use one aggregate outcome across the result payload, the
-`homeboy/command-result/v3` envelope, and the shell exit code: `succeeded` exits
-zero; `partial_failure` means at least one child succeeded and at least one failed,
-and exits non-zero; `failed` means every child failed and exits non-zero. Child
-results and durable evidence remain available for `fanout status`, `artifacts`,
-and `resume`. This changes prior behavior where a failed `cook-batch --run-plan`
-could report a zero exit code; callers must treat nonzero as an unsuccessful batch.
-`fanout status` and `fanout resume` use the same aggregate state and exit policy.
-Active child cooks remain `queued` or `running` (including detached `in_flight`
-handoffs) with exit zero; a resume retains active children until their durable
-lifecycle reaches a terminal state.
+`homeboy/command-result/v3` envelope, and the shell exit code for the
+*executing* commands (`cook-batch --run-plan`, `fanout run-plan`, `fanout
+resume`): `succeeded` exits zero; `partial_failure` means at least one child
+succeeded and at least one failed, and exits non-zero; `failed` means every
+child failed and exits non-zero. Child results and durable evidence remain
+available for `fanout status`, `artifacts`, and `resume`. This changes prior
+behavior where a failed `cook-batch --run-plan` could report a zero exit code;
+callers must treat nonzero as an unsuccessful batch. Active child cooks remain
+`queued` or `running` (including detached `in_flight` handoffs) with exit zero;
+a resume retains active children until their durable lifecycle reaches a
+terminal state.
+
+`fanout status` is a read (#13702): it exits zero and reports
+`success: true` / `status: "succeeded"` whenever it returns the requested
+batch projection, regardless of the batch's own state. The batch's aggregate
+state — including `failed` — lives in `data.batch`, and failed batches still
+get a human summary in `presentation.stdout`. Previously the status command exited non-zero for
+failed batches, which broke the documented recovery path under `set -e`;
+scripts that branched on that exit code must branch on `subject_state` or
+`data.batch.status` instead.
+
+Planning-only cook-batch invocations (`cook-batch` without `--run-plan`, and
+`--dry-run`) report envelope status `planned`, not `succeeded` (#13702): no
+agent ran and no PR opened, even though worktrees may have been provisioned.
+A blocked worktree preflight remains a failed operation: it exits non-zero and
+lifts the primary blocked row into the envelope's failure summary.
 
 The generated plan uses the existing
 `homeboy/agent-task-batch-cook-fanout-plan/v1` contract. That means operators can

--- a/tests/cli_binary/fanout_supervisor_cli.rs
+++ b/tests/cli_binary/fanout_supervisor_cli.rs
@@ -122,6 +122,10 @@ fn fanout_resume_runs_and_persists_the_production_supervisor_across_restart() {
     });
 }
 
+/// #13702: reading a batch that failed before admission is a *successful
+/// read*. The command exits zero so the recovery path Homeboy itself prints
+/// survives `set -e`; the failed subject state stays in `data`, and the
+/// envelope carries a human summary.
 #[test]
 fn fanout_status_reports_a_pre_child_coordinator_failure() {
     homeboy_core::test_support::with_isolated_home(|_| {
@@ -152,11 +156,17 @@ fn fanout_status_reports_a_pre_child_coordinator_failure() {
             .output()
             .expect("run Homeboy fanout status");
         assert!(
-            !output.status.success(),
-            "terminal coordinator failure exits nonzero"
+            output.status.success(),
+            "the read itself succeeded; stdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
         );
         let output: serde_json::Value =
             serde_json::from_slice(&output.stdout).expect("fanout status JSON output");
+        assert_eq!(output["success"], true);
+        assert_eq!(output["exit_code"], 0);
+        assert_eq!(output["status"], "succeeded");
+        assert!(output.get("subject_state").is_none());
         assert_eq!(output["data"]["batch"]["status"], "failed");
         assert_eq!(
             output["data"]["batch"]["admission_blocker"]["stage"],
@@ -170,6 +180,14 @@ fn fanout_status_reports_a_pre_child_coordinator_failure() {
                 "rejected": 1,
                 "absent": 0,
             })
+        );
+        let summary = output["presentation"]["stdout"]
+            .as_str()
+            .expect("failed subject states still get a human summary");
+        assert!(summary.contains("failed"), "summary: {summary}");
+        assert!(
+            summary.contains("worktree_preflight"),
+            "summary names the blocker: {summary}"
         );
     });
 }


### PR DESCRIPTION
## Summary
- Make `agent-task fanout status` report the successful read operation: a failed batch now returns `success: true`, `exit_code: 0`, and envelope status `succeeded`; the batch state remains under `data.batch`.
- Render a terminal fanout-status summary in `presentation.stdout`, including pre-admission blockers.
- Map plan-only `fanout cook-batch` results from `ready` to envelope status `planned`, and ensure nonzero payload results always include named diagnostics.

## Reproduction
Direction 1 observed envelope:
```json
{ "success": true, "status": "succeeded", "exit_code": 0, "data": { "status": "ready", "run_result": null, "dry_run": false } }
```

Direction 2 observed envelope:
```json
{ "success": false, "status": "failed", "exit_code": 1, "error": null, "presentation": { "stdout": null }, "data": { "batch": { "batch": { "state": "failed", "child_runs": ["..."] } } } }
```

## Scope
Fixed:
- `agent-task fanout status` terminal reads.
- Plan-only `agent-task fanout cook-batch` envelope status.
- Missing-cause nonzero payload envelopes.

Already correct and retained:
- Ordinary `agent-task status` reads exit zero unless `--strict-subject-exit` is requested.
- Ordinary `runs` reads return their projections successfully.

Deferred:
- `runs watch` deliberately exits with the watched subject outcome; it is an established wait-and-outcome contract, not changed here.
- Existing `agent-task status` `subject_state` compatibility behavior is retained; no v3-to-v4 schema rename is proposed in this focused fix.

## Verification
Passed:
- `cargo fmt --all --check`
- `cargo check --workspace --tests --locked`
- Focused `homeboy-cli` regressions for failed fanout reads, planned cook-batches, named nonzero diagnostics, handler status reads, and terminal summaries.
- `cargo test -p homeboy --locked --test cli_binary fanout_supervisor_cli::fanout_status_reports_a_pre_child_coordinator_failure -- --exact`

`cargo test --workspace` was NOT run locally because of machine contention; CI's Test gate is the authority. `cargo test -p homeboy-cli --locked` was attempted three times but did not complete within 10, 20, and 30 minute limits under that contention; an unrelated parallel dispatch test flaked but passed when isolated.

## AI assistance
AI assistance: Yes
Tool(s): OpenAI GPT-5.6-terra via OpenCode
OpenAI GPT-5.6-terra audited the pushed WIP, corrected its schema/transport-state mistakes, added and ran focused regressions, and prepared this PR. An earlier partial draft was produced by GLM 5.3 and was audited before completion.