### PR TITLE
Rotate blocked provider accounts (#13691)

### DIFF
--- a/crates/contracts/homeboy-lab-contract/src/agent_task_outcome.rs
+++ b/crates/contracts/homeboy-lab-contract/src/agent_task_outcome.rs
@@ -47,6 +47,11 @@ pub enum AgentTaskFailureClassification {
         alias = "rate_limit"
     )]
     RateLimited,
+    /// The configured provider account rejected the request because its quota,
+    /// billing, credentials, or account standing needs operator attention.
+    /// Unlike a normal execution failure, another configured provider can
+    /// satisfy the request, so this classification is eligible for rotation.
+    ProviderAccountBlocked,
     PolicyDenied,
     CapabilityMissing,
     InvalidInput,

--- a/crates/homeboy-agents/src/agent_task_contract.rs
+++ b/crates/homeboy-agents/src/agent_task_contract.rs
@@ -479,6 +479,7 @@ fn agent_task_failure_classifications() -> Vec<String> {
         AgentTaskFailureClassification::Timeout,
         AgentTaskFailureClassification::Stalled,
         AgentTaskFailureClassification::RateLimited,
+        AgentTaskFailureClassification::ProviderAccountBlocked,
         AgentTaskFailureClassification::PolicyDenied,
         AgentTaskFailureClassification::CapabilityMissing,
         AgentTaskFailureClassification::InvalidInput,

--- a/crates/homeboy-agents/src/agent_task_provider/outcome_normalization.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/outcome_normalization.rs
@@ -12,6 +12,63 @@ pub(super) fn normalize_provider_outcome_roles(
     if result_contract_valid {
         surface_provider_run_result_diagnostics(outcome);
     }
+    normalize_opencode_account_block(outcome, provider);
+}
+
+/// OpenCode exposes vendor failures in its structured provider error payload.
+/// Keep its payload vocabulary at this adapter boundary; the scheduler only
+/// acts on Homeboy's generic failure classification.
+fn normalize_opencode_account_block(
+    outcome: &mut AgentTaskOutcome,
+    provider: &AgentTaskExecutorProvider,
+) {
+    if provider.backend != "opencode"
+        || outcome.failure_classification != Some(AgentTaskFailureClassification::ExecutionFailed)
+    {
+        return;
+    }
+    let Some(error) = outcome.metadata.get("provider_error") else {
+        return;
+    };
+    if !opencode_account_block(error) {
+        return;
+    }
+
+    outcome.failure_classification = Some(AgentTaskFailureClassification::ProviderAccountBlocked);
+    push_unique_diagnostic(
+        &mut outcome.diagnostics,
+        "opencode.provider_account_blocked".to_string(),
+        "OpenCode provider account rejected the request; retrying this account is disabled and the scheduler may rotate to the next configured provider."
+            .to_string(),
+        error.clone(),
+    );
+}
+
+fn opencode_account_block(value: &Value) -> bool {
+    match value {
+        Value::Object(object) => {
+            let status = object
+                .get("statusCode")
+                .or_else(|| object.get("status_code"))
+                .and_then(Value::as_u64);
+            let non_retryable = object
+                .get("isRetryable")
+                .or_else(|| object.get("is_retryable"))
+                .and_then(Value::as_bool)
+                == Some(false);
+            let account_code = object.values().filter_map(Value::as_str).any(|text| {
+                let text = text.to_ascii_lowercase();
+                text.contains("team-blocked")
+                    || text.contains("spending-limit")
+                    || text.contains("run out of credits")
+                    || text.contains("grok subscription")
+            });
+            (matches!(status, Some(402 | 403)) && non_retryable && account_code)
+                || object.values().any(opencode_account_block)
+        }
+        Value::Array(values) => values.iter().any(opencode_account_block),
+        _ => false,
+    }
 }
 
 const HOMEBOY_ARTIFACT_PROVENANCE_KEY: &str = "artifact_provenance";

--- a/crates/homeboy-agents/src/agent_task_provider/tests/outcome_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/outcome_tests.rs
@@ -682,6 +682,39 @@ fn typed_provider_quota_normalizes_to_rate_limited_and_preserves_retry_hint() {
 }
 
 #[test]
+fn opencode_account_block_maps_to_rotatable_provider_classification() {
+    let (_, mut provider) = request("quota-task", "node provider.js".to_string());
+    provider.backend = "opencode".to_string();
+    let mut outcome = AgentTaskOutcome {
+        task_id: "quota-task".to_string(),
+        status: AgentTaskOutcomeStatus::Failed,
+        failure_classification: Some(AgentTaskFailureClassification::ExecutionFailed),
+        metadata: json!({
+            "provider_error": {
+                "name": "APIError",
+                "data": {
+                    "message": "personal-team-blocked:spending-limit: You have run out of credits or need a Grok subscription.",
+                    "statusCode": 403,
+                    "isRetryable": false
+                }
+            }
+        }),
+        ..Default::default()
+    };
+
+    normalize_provider_outcome_roles(&mut outcome, &provider);
+
+    assert_eq!(
+        outcome.failure_classification,
+        Some(AgentTaskFailureClassification::ProviderAccountBlocked)
+    );
+    assert!(outcome
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.class == "opencode.provider_account_blocked"));
+}
+
+#[test]
 fn empty_failed_run_result_surfaces_explanatory_diagnostic() {
     // Mirrors the #4105 repro: a failed run-result that is an empty shell.
     let mut outcome = failed_outcome_with_run_result(json!({

--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -250,12 +250,31 @@ impl AgentTaskScheduler {
                         );
                     }
                 }
+                let rotation_index = plan_rotation
+                    .as_ref()
+                    .and_then(|policy| policy.entries.first())
+                    .is_some_and(|entry| {
+                        entry
+                            .backend
+                            .as_deref()
+                            .is_none_or(|backend| backend == request.executor.backend)
+                            && entry.selector.as_deref().is_none_or(|selector| {
+                                request.executor.selector.as_deref() == Some(selector)
+                            })
+                            && entry
+                                .model
+                                .as_deref()
+                                .is_none_or(|model| request.executor.model() == Some(model))
+                    }) as usize;
                 ScheduledTask {
                     workspace_key: AgentTaskScheduleSupport::workspace_key(&request),
                     request,
                     resource_wait: None,
                     attempt: 1,
-                    rotation_index: 0,
+                    // The first matching entry describes this initial attempt,
+                    // so a failure must advance to the next entry rather than
+                    // immediately repeat the exhausted provider route.
+                    rotation_index,
                     rotation_attempts: Vec::new(),
                     candidate_artifacts: Vec::new(),
                     retry_attempts: Vec::new(),
@@ -1327,6 +1346,10 @@ impl AgentTaskScheduler {
                             running_task.rotation_index,
                         ));
                         AgentTaskScheduleSupport::attach_rotation_evidence(
+                            &mut outcome,
+                            &rotation_attempts,
+                        );
+                        AgentTaskScheduleSupport::attach_rotation_exhaustion_diagnostic(
                             &mut outcome,
                             &rotation_attempts,
                         );

--- a/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
@@ -1237,7 +1237,8 @@ impl AgentTaskScheduleSupport {
     }
 
     /// Rotation triggers only on provider capacity failures (`provider`,
-    /// `transient`, `timeout`, `stalled`, `rate_limited` classifications).
+    /// `transient`, `timeout`, `stalled`, `rate_limited`, and
+    /// `provider_account_blocked` classifications).
     /// Task-level failures (`execution_failed`, `policy_denied`,
     /// `invalid_input`, `capability_missing`, `unknown`) never rotate so a
     /// provider swap cannot mask a real task failure or policy denial (#6978).
@@ -1268,6 +1269,7 @@ impl AgentTaskScheduleSupport {
                         | AgentTaskFailureClassification::Timeout
                         | AgentTaskFailureClassification::Stalled
                         | AgentTaskFailureClassification::RateLimited
+                        | AgentTaskFailureClassification::ProviderAccountBlocked
                 )
             )
     }
@@ -1483,6 +1485,34 @@ impl AgentTaskScheduleSupport {
             );
     }
 
+    /// Make an exhausted rotation actionable without requiring an operator to
+    /// decode its metadata: name every attempted route and its rejection.
+    pub(super) fn attach_rotation_exhaustion_diagnostic(
+        outcome: &mut AgentTaskOutcome,
+        attempts: &[AgentTaskProviderRotationAttempt],
+    ) {
+        if attempts.len() < 2 {
+            return;
+        }
+        let rejections = attempts
+            .iter()
+            .map(|attempt| {
+                let model = attempt.model.as_deref().unwrap_or("default model");
+                let reason = attempt
+                    .failure_classification
+                    .map(|classification| format!("{classification:?}").to_ascii_lowercase())
+                    .unwrap_or_else(|| "unclassified failure".to_string());
+                format!("{}/{}: {reason}", attempt.backend, model)
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+        outcome.diagnostics.push(AgentTaskDiagnostic {
+            class: "agent_task.provider_rotation_exhausted".to_string(),
+            message: format!("all configured provider routes were rejected: {rejections}"),
+            data: serde_json::json!({ "attempts": attempts }),
+        });
+    }
+
     /// Record the configured budget and the terminal constraint that stopped
     /// additional provider execution. This makes a timeout distinguishable from
     /// an exhausted same-provider, rotation, or total-execution budget.
@@ -1590,6 +1620,8 @@ impl AgentTaskScheduleSupport {
                 .map(|budget| retry_budget_used < budget)
                 .unwrap_or(true)
             && outcome.failure_classification != Some(AgentTaskFailureClassification::PolicyDenied)
+            && outcome.failure_classification
+                != Some(AgentTaskFailureClassification::ProviderAccountBlocked)
             && (retryable_failure_classifications.is_empty()
                 || outcome
                     .failure_classification

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/provider_rotation.rs
@@ -822,6 +822,72 @@ mod provider_rotation_tests {
     }
 
     #[test]
+    fn account_block_rotates_to_the_next_configured_entry_without_retrying_it() {
+        let executor = RotationScriptedExecutor::new(vec![
+            (
+                AgentTaskOutcomeStatus::ProviderError,
+                Some(AgentTaskFailureClassification::ProviderAccountBlocked),
+            ),
+            success(),
+        ]);
+        let observed = Arc::clone(&executor.observed);
+        let calls = Arc::clone(&executor.calls);
+        let scheduler = AgentTaskScheduler::new(Arc::new(executor));
+        let mut plan = plan_with_tasks(1);
+        plan.tasks[0].executor.backend = "opencode".to_string();
+        plan.options.rotation = Some(AgentTaskProviderRotationPolicy {
+            entries: vec![
+                AgentTaskProviderRotationEntry {
+                    backend: Some("opencode".to_string()),
+                    model: Some("xai/grok-4.6".to_string()),
+                    ..Default::default()
+                },
+                AgentTaskProviderRotationEntry {
+                    backend: Some("opencode".to_string()),
+                    model: Some("zai-coding-plan/glm-5.3".to_string()),
+                    ..Default::default()
+                },
+                AgentTaskProviderRotationEntry {
+                    backend: Some("opencode".to_string()),
+                    model: Some("opencode-go/kimi-k3".to_string()),
+                    ..Default::default()
+                },
+                AgentTaskProviderRotationEntry {
+                    backend: Some("opencode".to_string()),
+                    model: Some("anthropic/claude-sonnet-5".to_string()),
+                    ..Default::default()
+                },
+            ],
+            max_attempts: Some(4),
+            ..Default::default()
+        });
+        plan.options.execution_budget = AgentTaskExecutionBudget {
+            version: AgentTaskExecutionBudget::VERSION,
+            deadline_unix_ms: None,
+            max_provider_executions: 4,
+            max_same_provider_retries: 1,
+            max_provider_rotations: 3,
+        };
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        let observed = observed.lock().expect("observed requests");
+        assert_eq!(
+            observed
+                .iter()
+                .map(|request| request.executor.model.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("xai/grok-4.6"), Some("zai-coding-plan/glm-5.3")]
+        );
+        assert_eq!(
+            aggregate.outcomes[0].metadata["execution_budget"]["same_provider_retries_used"], 0,
+            "an explicitly non-retryable account rejection must rotate immediately"
+        );
+    }
+
+    #[test]
     fn timed_out_attempt_rotates_after_recovering_a_malformed_scratch_index() {
         struct TimeoutThenSuccessExecutor {
             calls: AtomicUsize,
@@ -992,6 +1058,15 @@ mod provider_rotation_tests {
         assert!(attempts
             .iter()
             .all(|attempt| attempt["failure_classification"] == "provider"));
+        let diagnostic = aggregate.outcomes[0]
+            .diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.class == "agent_task.provider_rotation_exhausted")
+            .expect("rotation exhaustion diagnostic");
+        assert_eq!(
+            diagnostic.message,
+            "all configured provider routes were rejected: test/default model: provider; fallback-backend-a/default model: provider; fallback-backend-b/default model: provider"
+        );
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -3287,6 +3287,17 @@ fn classification_next_actions(
             actions.extend(retry);
             actions
         }
+        // This account cannot satisfy another request until its quota, billing,
+        // or credentials are repaired. Show alternative providers rather than
+        // offering a same-provider retry.
+        AgentTaskFailureClassification::ProviderAccountBlocked => vec![
+            failure_evidence,
+            CommandNextAction::new(
+                "list registered providers to rotate to",
+                "homeboy agent-task providers".to_string(),
+            )
+            .with_kind(CommandNextActionKind::Show),
+        ],
         // Policy refused this request. Retrying an identical request is denied
         // identically, so no retry action is emitted.
         AgentTaskFailureClassification::PolicyDenied => vec![


### PR DESCRIPTION
## Summary
- Classify OpenCode non-retryable account blocks as `provider_account_blocked` and rotate instead of retrying the same account.
- Treat the first matching rotation entry as the initial attempt, so failover advances to entry 2.
- Report every rejected provider route when rotation is exhausted, and surface appropriate CLI guidance.

## Verification
- `cargo fmt --all --check`
- `cargo check --workspace --tests --locked`
- `cargo test -p homeboy-agents --lib agent_task_provider::tests::outcome_tests::opencode_account_block_maps_to_rotatable_provider_classification -- --exact`
- `cargo test -p homeboy-agents --lib agent_task_scheduler::tests::scheduling_tests::provider_rotation::provider_rotation_tests::account_block_rotates_to_the_next_configured_entry_without_retrying_it -- --exact`
- `cargo test -p homeboy-agents --lib agent_task_scheduler::tests::scheduling_tests::provider_rotation::provider_rotation_tests::rotation_exhausts_entries_and_records_attempt_sequence_in_order -- --exact`

The full `cargo test -p homeboy-agents` harness was not rerun: the prior full-package gate hung in the repository descendant-reaper for 22 minutes at 0% CPU and was terminated. CI is authoritative for the full test suite.

## AI assistance
AI assistance: Yes

Tool(s): OpenAI GPT-5.6-terra via OpenCode

OpenCode audited the earlier draft, removed unrelated reversions, completed the provider normalization and scheduler behavior, added focused regressions, and ran the listed checks. An earlier GLM 5.3 draft was audited.