### PR TITLE
Hydrate structured provider errors in diagnose (#13703)

### DIFF
--- a/crates/contracts/homeboy-lab-contract/src/agent_task_outcome.rs
+++ b/crates/contracts/homeboy-lab-contract/src/agent_task_outcome.rs
@@ -47,6 +47,10 @@ pub enum AgentTaskFailureClassification {
         alias = "rate_limit"
     )]
     RateLimited,
+    /// The provider rejected the request because its account, credentials, or
+    /// spending quota cannot serve it. Rotation policy is intentionally owned
+    /// by the caller rather than implied by this classification.
+    ProviderAccountQuotaRejected,
     PolicyDenied,
     CapabilityMissing,
     InvalidInput,

--- a/crates/homeboy-agents/src/agent_task_contract.rs
+++ b/crates/homeboy-agents/src/agent_task_contract.rs
@@ -479,6 +479,7 @@ fn agent_task_failure_classifications() -> Vec<String> {
         AgentTaskFailureClassification::Timeout,
         AgentTaskFailureClassification::Stalled,
         AgentTaskFailureClassification::RateLimited,
+        AgentTaskFailureClassification::ProviderAccountQuotaRejected,
         AgentTaskFailureClassification::PolicyDenied,
         AgentTaskFailureClassification::CapabilityMissing,
         AgentTaskFailureClassification::InvalidInput,

--- a/crates/homeboy-agents/src/agent_task_executor_evidence.rs
+++ b/crates/homeboy-agents/src/agent_task_executor_evidence.rs
@@ -25,7 +25,10 @@ use std::path::{Path, PathBuf};
 
 use serde_json::{json, Value};
 
-use crate::agent_task::{AgentTaskEvidenceRef, AgentTaskExecutorRequest, AgentTaskOutcome};
+use crate::agent_task::{
+    AgentTaskEvidenceRef, AgentTaskExecutorRequest, AgentTaskFailureClassification,
+    AgentTaskOutcome,
+};
 use homeboy_core::redaction::RedactionPolicy;
 
 /// Evidence kind for the latest raw executor request (input piped to the
@@ -124,12 +127,31 @@ fn link_runtime_evidence(
         hydrate_structured_runtime_evidence(outcome, &runtime_files, policy);
     }
     let sessions = provider_session_metadata(outcome);
+    let structured_error = runtime_files
+        .get(RUNTIME_STDOUT_EVIDENCE_KIND)
+        .and_then(|paths| {
+            structured_error_from_runtime_files(&request.request.executor.backend, paths)
+        });
+    if structured_error
+        .as_ref()
+        .and_then(|error| error.get("failure_classification"))
+        .and_then(Value::as_str)
+        == Some(crate::agent_task_provider::PROVIDER_ACCOUNT_QUOTA_REJECTED)
+    {
+        // This is a provider-side account rejection, not a code-level failure.
+        // Rotation remains an explicit scheduler policy decision (#13691).
+        outcome.failure_classification =
+            Some(AgentTaskFailureClassification::ProviderAccountQuotaRejected);
+    }
     let index = json!({
         "artifact_root": artifact_root.as_ref().map(|path| format!("file://{}", path.display())),
         "provider_runtime_identities": sessions,
         "runtime_stdout": runtime_files.get(RUNTIME_STDOUT_EVIDENCE_KIND),
         "runtime_stderr": runtime_files.get(RUNTIME_STDERR_EVIDENCE_KIND),
         "runtime_progress": runtime_files.get(RUNTIME_PROGRESS_EVIDENCE_KIND),
+        // Adapter-normalized terminal provider error, redacted. Persisted at
+        // execution time so read paths never need vendor knowledge (#13703).
+        "structured_error": structured_error,
     });
     let Some(index_uri) = persist_evidence_file(
         &evidence_dir.join(RUNTIME_EVIDENCE_FILE),
@@ -265,6 +287,29 @@ fn structured_session_id(event: &Value) -> Option<&str> {
         .and_then(Value::as_str)
         .or_else(|| event.pointer("/part/sessionID").and_then(Value::as_str))
         .filter(|id| !id.trim().is_empty())
+}
+
+/// Normalize a terminal structured provider error out of the runtime stdout
+/// capture files, backend-aware through the provider adapter registry. The
+/// latest capture file wins: it belongs to the final attempt. Only the
+/// adapter's normalized, redacted output is persisted.
+fn structured_error_from_runtime_files(backend: &str, paths: &[PathBuf]) -> Option<Value> {
+    for path in paths.iter().rev() {
+        let Some(tail) =
+            crate::agent_task_provider::structured_error::read_runtime_stream_tail(path)
+        else {
+            continue;
+        };
+        if let Some(error) =
+            crate::agent_task_provider::structured_error::normalize_runtime_stream_error(
+                Some(backend),
+                &tail.raw,
+            )
+        {
+            return Some(error);
+        }
+    }
+    None
 }
 
 fn structured_progress_event(event: &Value) -> Option<Value> {
@@ -463,8 +508,9 @@ fn push_unique_evidence_ref(outcome: &mut AgentTaskOutcome, evidence_ref: AgentT
 mod tests {
     use super::*;
     use crate::agent_task::{
-        AgentTaskComponentContract, AgentTaskExecutor, AgentTaskLimits, AgentTaskOutcomeStatus,
-        AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace, AGENT_TASK_REQUEST_SCHEMA,
+        AgentTaskComponentContract, AgentTaskExecutor, AgentTaskFailureClassification,
+        AgentTaskLimits, AgentTaskOutcomeStatus, AgentTaskPolicy, AgentTaskRequest,
+        AgentTaskWorkspace, AGENT_TASK_REQUEST_SCHEMA,
     };
     use serde_json::Map;
     use std::sync::Mutex;
@@ -734,6 +780,28 @@ mod tests {
             assert!(!fs::read_to_string(&progress_path)
                 .expect("read progress")
                 .contains("private transcript content"));
+        });
+    }
+
+    #[test]
+    fn classifies_a_structured_opencode_account_rejection() {
+        with_artifact_root(|_| {
+            let mut request = executor_test_request();
+            request.request.executor.backend = "opencode".to_string();
+            fs::write(
+                request.artifacts_path.join("provider-runtime-stdout.log"),
+                r#"{"type":"error","error":{"name":"APIError","data":{"message":"spending-limit: You have run out of credits.","statusCode":403,"isRetryable":false}}}"#,
+            )
+            .expect("write stdout");
+            let mut outcome = test_outcome();
+            outcome.failure_classification = Some(AgentTaskFailureClassification::ExecutionFailed);
+
+            link_latest_executor_evidence(&request, &mut outcome, Some("run-1"));
+
+            assert_eq!(
+                outcome.failure_classification,
+                Some(AgentTaskFailureClassification::ProviderAccountQuotaRejected)
+            );
         });
     }
 

--- a/crates/homeboy-agents/src/agent_task_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_provider.rs
@@ -57,6 +57,7 @@ mod runtime_tool_resolution;
 mod runtime_types;
 mod secret_types;
 mod secrets;
+pub mod structured_error;
 mod types;
 mod usage_cap;
 mod workspace_types;
@@ -115,9 +116,13 @@ pub use secrets::{
     provider_runner_secret_env_for_plan_with_providers,
     provider_secret_sources_for_plan_with_providers,
 };
+pub use structured_error::{
+    normalize_runtime_stream_error, normalized_structured_error,
+    structured_error_failure_classification, PROVIDER_ACCOUNT_QUOTA_REJECTED, PROVIDER_ERROR,
+    PROVIDER_RATE_LIMITED, PROVIDER_STRUCTURED_ERROR_SCHEMA,
+};
 pub(crate) use types::wildcard_match;
 pub use types::*;
-use types::{default_metadata, is_empty_metadata};
 pub use usage_cap::{
     detect_usage_cap, provider_usage_cap_key, reset_at_from_outcome, ProviderUsageCapRegistry,
     AGENT_TASK_PROVIDER_USAGE_CAP_DIAGNOSTIC_CLASS,

--- a/crates/homeboy-agents/src/agent_task_provider/structured_error.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/structured_error.rs
@@ -1,0 +1,381 @@
+//! Provider structured runtime errors (#13703).
+//!
+//! When a provider runtime dies, its CLI exit code says almost nothing: the
+//! actionable cause — an account-level 403 with a human-readable message and
+//! an explicit non-retryable flag — is emitted as a structured error event on
+//! the provider's runtime stdout stream. Diagnose used to collapse that to
+//! "OpenCode CLI exited with status 1" and leave `stdout_excerpt: null` while
+//! the actual error sat in a log file the same response already listed.
+//!
+//! This module is the provider adapter boundary for that evidence:
+//! - Vendor stream shapes (currently the OpenCode JSONL error event) are
+//!   parsed HERE and nowhere else.
+//! - Everything downstream — diagnose projection, status summaries, the
+//!   runtime evidence index — consumes only the normalized
+//!   [`PROVIDER_STRUCTURED_ERROR_SCHEMA`] shape, never a vendor payload.
+//!
+//! The normalized error also carries a projection-level
+//! `failure_classification` that separates a provider *account/quota*
+//! rejection (`provider_account_quota_rejected`) from a code-level execution
+//! failure. Rotation policy on top of that distinction is owned by #13691;
+//! this module only makes the classification observable.
+
+use serde_json::{json, Value};
+use std::fs;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::Path;
+
+use homeboy_core::redaction::RedactionPolicy;
+
+/// Schema of the normalized structured error consumed by generic diagnose and
+/// status code. Vendor payloads are always converted to this shape first.
+pub const PROVIDER_STRUCTURED_ERROR_SCHEMA: &str = "homeboy/provider-structured-error/v1";
+
+/// Byte budget hydrated from the END of a provider runtime stream. Terminal
+/// error events are appended last, so a tail — not a head — carries the
+/// cause; the budget keeps a runaway log out of every diagnose payload.
+pub const RUNTIME_STREAM_TAIL_BYTES: usize = 8 * 1024;
+
+/// The provider account or spending quota rejected the request. Permanent
+/// until the account changes: retrying the same provider cannot succeed.
+pub const PROVIDER_ACCOUNT_QUOTA_REJECTED: &str = "provider_account_quota_rejected";
+
+/// The provider throttled the request (HTTP 429 or an explicit retryable
+/// flag). Retrying — possibly on another provider route — can succeed.
+pub const PROVIDER_RATE_LIMITED: &str = "provider_rate_limited";
+
+/// Any other structured provider error (bad request, upstream 5xx surfaced as
+/// an error event, ...). No account-level conclusion can be drawn.
+pub const PROVIDER_ERROR: &str = "provider_error";
+
+/// Normalize a provider runtime stream into the normalized structured error.
+///
+/// `backend` selects the registered adapter:
+/// - `Some(backend)` uses only that backend's parser (execution time, where
+///   the executor backend is known), and returns `None` for unregistered
+///   backends so an unrelated provider's output is never misread.
+/// - `None` tries every registered adapter (read time, where only the stream
+///   text is available). Every adapter is structurally strict — it requires a
+///   terminal error event carrying a non-empty message — so cross-vendor
+///   false positives are not realistic.
+///
+/// The returned value is redacted; it is safe to persist and project.
+pub fn normalize_runtime_stream_error(backend: Option<&str>, text: &str) -> Option<Value> {
+    let normalized = match backend {
+        Some("opencode") => normalize_opencode_stream_error(text),
+        Some(_) => None,
+        None => normalize_opencode_stream_error(text),
+    }?;
+    Some(RedactionPolicy::default().redact_json(&normalized))
+}
+
+/// Recognize an already-normalized structured error so generic consumers can
+/// trust the shape without knowing any vendor. Returns the value unchanged.
+pub fn normalized_structured_error(value: &Value) -> Option<Value> {
+    let schema_matches =
+        value.get("schema").and_then(Value::as_str) == Some(PROVIDER_STRUCTURED_ERROR_SCHEMA);
+    let has_message = value
+        .get("message")
+        .and_then(Value::as_str)
+        .is_some_and(|message| !message.trim().is_empty());
+    (schema_matches && has_message).then(|| value.clone())
+}
+
+/// Projection-level failure classification for a normalized structured error.
+///
+/// An account/quota rejection requires billing vocabulary (credits, quota,
+/// spending limit, subscription, ...) — an HTTP 403 alone can also mean a
+/// forbidden resource, which is a different failure — combined with either an
+/// account-status code (401/402/403) or an explicit non-retryable flag.
+pub fn structured_error_failure_classification(
+    message: &str,
+    status_code: Option<i64>,
+    retryable: Option<bool>,
+) -> &'static str {
+    if matches!(status_code, Some(429)) || retryable == Some(true) {
+        return PROVIDER_RATE_LIMITED;
+    }
+    if account_quota_rejected(message, status_code, retryable) {
+        return PROVIDER_ACCOUNT_QUOTA_REJECTED;
+    }
+    PROVIDER_ERROR
+}
+
+fn account_quota_rejected(
+    message: &str,
+    status_code: Option<i64>,
+    retryable: Option<bool>,
+) -> bool {
+    const BILLING_VOCABULARY: [&str; 9] = [
+        "credit",
+        "quota",
+        "spending limit",
+        "spending-limit",
+        "subscription",
+        "billing",
+        "payment",
+        "insufficient",
+        "run out of",
+    ];
+    let lowered = message.to_ascii_lowercase();
+    let vocabulary_hit = BILLING_VOCABULARY
+        .iter()
+        .any(|pattern| lowered.contains(pattern));
+    let account_status = matches!(status_code, Some(401 | 402 | 403));
+    match retryable {
+        // The provider itself declared the failure permanent; billing
+        // vocabulary is then sufficient evidence of an account-level cause.
+        Some(false) => vocabulary_hit,
+        // Without an explicit flag, require both signals so a plain 403 on a
+        // forbidden resource stays a generic provider error.
+        None => account_status && vocabulary_hit,
+        Some(true) => false,
+    }
+}
+
+/// Build the normalized error from parsed fields.
+fn normalized_error(
+    message: &str,
+    status_code: Option<i64>,
+    retryable: Option<bool>,
+    error_name: Option<&str>,
+) -> Value {
+    json!({
+        "schema": PROVIDER_STRUCTURED_ERROR_SCHEMA,
+        "message": message,
+        "status_code": status_code,
+        "retryable": retryable,
+        "failure_classification": structured_error_failure_classification(
+            message,
+            status_code,
+            retryable,
+        ),
+        "error_name": error_name,
+    })
+}
+
+/// Parse the OpenCode runtime stream for its terminal error event.
+///
+/// OpenCode emits JSONL events on runtime stdout; a fatal provider/API error
+/// is `{"type":"error","error":{"name":"APIError","data":{"message":...,
+/// "statusCode":403,"isRetryable":false}}}` (observed live in #13703). The
+/// whole stream may also be a single JSON object. The LAST error event wins:
+/// it is the terminal cause.
+fn normalize_opencode_stream_error(text: &str) -> Option<Value> {
+    let mut last_error = None;
+    for line in text.lines().rev() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(event) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if let Some(error) = structured_error_from_opencode_event(&event) {
+            last_error = Some(error);
+            break;
+        }
+    }
+    if last_error.is_none() {
+        if let Ok(event) = serde_json::from_str::<Value>(text) {
+            last_error = structured_error_from_opencode_event(&event);
+        }
+    }
+    last_error
+}
+
+fn structured_error_from_opencode_event(event: &Value) -> Option<Value> {
+    if event.get("type").and_then(Value::as_str) != Some("error") {
+        return None;
+    }
+    let error = event.get("error")?;
+    // The observed shape nests the payload under `data`; accept the error
+    // object itself as a fallback for revisions that flatten it.
+    let payload = error.get("data").unwrap_or(error);
+    let message = payload
+        .get("message")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|message| !message.is_empty())?;
+    let status_code = payload
+        .get("statusCode")
+        .or_else(|| payload.get("status_code"))
+        .and_then(Value::as_i64);
+    let retryable = payload
+        .get("isRetryable")
+        .or_else(|| payload.get("retryable"))
+        .and_then(Value::as_bool);
+    Some(normalized_error(
+        message,
+        status_code,
+        retryable,
+        error.get("name").and_then(Value::as_str),
+    ))
+}
+
+/// The bounded tail of a provider runtime stream.
+pub struct RuntimeStreamTail {
+    /// Raw tail text. Only the adapter normalization consumes it, and that
+    /// normalization redacts its output, so secrets never leave this struct
+    /// unredacted.
+    pub raw: String,
+    /// Redacted tail text, used for every projected excerpt.
+    pub redacted: String,
+    pub truncated: bool,
+}
+
+/// Read the bounded tail of a provider runtime stream. Symlinks are refused:
+/// a runtime stream is a Homeboy-captured or provider-written log file, and
+/// following links here would let evidence content point anywhere.
+pub fn read_runtime_stream_tail(path: &Path) -> Option<RuntimeStreamTail> {
+    let metadata = fs::symlink_metadata(path).ok()?;
+    if !metadata.file_type().is_file() {
+        return None;
+    }
+    let len = metadata.len();
+    let mut file = fs::File::open(path).ok()?;
+    let start = len.saturating_sub(RUNTIME_STREAM_TAIL_BYTES as u64);
+    if start > 0 {
+        file.seek(SeekFrom::Start(start)).ok()?;
+    }
+    let mut bytes = Vec::with_capacity(RUNTIME_STREAM_TAIL_BYTES.min(len as usize));
+    file.take(RUNTIME_STREAM_TAIL_BYTES as u64)
+        .read_to_end(&mut bytes)
+        .ok()?;
+    let text = String::from_utf8_lossy(&bytes).into_owned();
+    // A tail can start mid-line; drop the partial first line so only whole
+    // events remain parseable.
+    let text = if start > 0 {
+        text.find('\n')
+            .map(|index| text[index + 1..].to_string())
+            .unwrap_or_default()
+    } else {
+        text
+    };
+    Some(RuntimeStreamTail {
+        redacted: RedactionPolicy::default().redact_string(&text),
+        raw: text,
+        truncated: start > 0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LIVE_STREAM: &str = concat!(
+        r#"{"type":"session.start","sessionID":"ses_fixture"}"#,
+        "\n",
+        r#"{"type":"error","error":{"name":"APIError","data":{"message":"personal-team-blocked:spending-limit: You have run out of credits or need a Grok subscription.","statusCode":403,"isRetryable":false}}}"#,
+        "\n",
+    );
+
+    #[test]
+    fn normalizes_the_live_opencode_account_rejection() {
+        let normalized =
+            normalize_runtime_stream_error(Some("opencode"), LIVE_STREAM).expect("normalized");
+
+        assert_eq!(normalized["schema"], PROVIDER_STRUCTURED_ERROR_SCHEMA);
+        assert_eq!(
+            normalized["message"],
+            "personal-team-blocked:spending-limit: You have run out of credits or need a Grok subscription."
+        );
+        assert_eq!(normalized["status_code"], 403);
+        assert_eq!(normalized["retryable"], false);
+        assert_eq!(
+            normalized["failure_classification"],
+            PROVIDER_ACCOUNT_QUOTA_REJECTED
+        );
+        assert_eq!(normalized["error_name"], "APIError");
+    }
+
+    #[test]
+    fn normalizes_without_a_backend_hint_by_trying_registered_adapters() {
+        let normalized = normalize_runtime_stream_error(None, LIVE_STREAM).expect("normalized");
+        assert_eq!(normalized["status_code"], 403);
+    }
+
+    #[test]
+    fn an_unregistered_backend_is_never_parsed() {
+        assert!(normalize_runtime_stream_error(Some("claude-cli"), LIVE_STREAM).is_none());
+    }
+
+    #[test]
+    fn the_last_error_event_wins() {
+        let stream = concat!(
+            r#"{"type":"error","error":{"data":{"message":"transient blip","statusCode":500,"isRetryable":true}}}"#,
+            "\n",
+            r#"{"type":"error","error":{"data":{"message":"final failure","statusCode":403,"isRetryable":false}}}"#,
+            "\n",
+        );
+        let normalized =
+            normalize_runtime_stream_error(Some("opencode"), stream).expect("normalized");
+        assert_eq!(normalized["message"], "final failure");
+    }
+
+    #[test]
+    fn a_retryable_error_classifies_as_rate_limited() {
+        let normalized = normalize_runtime_stream_error(
+            Some("opencode"),
+            r#"{"type":"error","error":{"data":{"message":"too many requests","statusCode":429,"isRetryable":true}}}"#,
+        )
+        .expect("normalized");
+        assert_eq!(normalized["failure_classification"], PROVIDER_RATE_LIMITED);
+    }
+
+    #[test]
+    fn a_forbidden_resource_without_billing_vocabulary_is_a_generic_provider_error() {
+        let normalized = normalize_runtime_stream_error(
+            Some("opencode"),
+            r#"{"type":"error","error":{"data":{"message":"repository not accessible","statusCode":403,"isRetryable":false}}}"#,
+        )
+        .expect("normalized");
+        assert_eq!(normalized["failure_classification"], PROVIDER_ERROR);
+    }
+
+    #[test]
+    fn non_error_streams_do_not_normalize() {
+        assert!(normalize_runtime_stream_error(
+            Some("opencode"),
+            r#"{"type":"step_start","part":{"id":"p1"}}"#
+        )
+        .is_none());
+        assert!(
+            normalize_runtime_stream_error(Some("opencode"), "unstructured output\n").is_none()
+        );
+        // An error event without a message is not actionable evidence.
+        assert!(normalize_runtime_stream_error(
+            Some("opencode"),
+            r#"{"type":"error","error":{"data":{"statusCode":500}}}"#
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn normalized_output_is_redacted() {
+        let normalized = normalize_runtime_stream_error(
+            Some("opencode"),
+            r#"{"type":"error","error":{"data":{"message":"rejected for api_key=sk-live-secret-value","statusCode":401,"isRetryable":false}}}"#,
+        )
+        .expect("normalized");
+        let serialized = normalized.to_string();
+        assert!(!serialized.contains("sk-live-secret-value"));
+        assert!(serialized.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn the_recognizer_accepts_only_the_normalized_schema_with_a_message() {
+        let normalized =
+            normalize_runtime_stream_error(Some("opencode"), LIVE_STREAM).expect("normalized");
+        assert!(normalized_structured_error(&normalized).is_some());
+        assert!(normalized_structured_error(&json!({
+            "schema": PROVIDER_STRUCTURED_ERROR_SCHEMA,
+            "message": " ",
+        }))
+        .is_none());
+        assert!(normalized_structured_error(&json!({
+            "message": "vendor payload without the normalized schema",
+        }))
+        .is_none());
+    }
+}

--- a/crates/homeboy-agents/src/agent_task_service/status_support.rs
+++ b/crates/homeboy-agents/src/agent_task_service/status_support.rs
@@ -4,6 +4,13 @@ use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
+use crate::agent_task_executor_evidence::{
+    RUNTIME_STDERR_EVIDENCE_KIND, RUNTIME_STDOUT_EVIDENCE_KIND,
+};
+use crate::agent_task_provider::structured_error::{
+    normalize_runtime_stream_error, normalized_structured_error, read_runtime_stream_tail,
+    RUNTIME_STREAM_TAIL_BYTES,
+};
 use crate::agent_task_scheduler::{AgentTaskAggregate, AgentTaskPlan};
 use crate::agent_tasks::AgentTaskEvidenceRef;
 use homeboy_core::observation::ObservationStore;
@@ -598,6 +605,9 @@ pub fn evidence_ref_task_id(evidence_ref: &AgentTaskEvidenceRef) -> Option<Strin
 }
 
 pub fn hydrate_evidence_summary(task_id: &str, evidence: &AgentTaskEvidenceRef) -> Option<Value> {
+    if let Some(summary) = runtime_stream_evidence_summary(task_id, evidence) {
+        return Some(summary);
+    }
     let path = evidence.uri.strip_prefix("file://")?;
     if !path.ends_with(".json") {
         return None;
@@ -622,6 +632,9 @@ const EVIDENCE_DIAGNOSTIC_MAX_DEPTH: usize = 16;
 /// ranking. The compact evidence summary deliberately previews only three
 /// diagnostics, so callers must use this reader before presentation bounds.
 pub fn hydrate_evidence_diagnostics(evidence: &AgentTaskEvidenceRef) -> Option<Value> {
+    if let Some(value) = runtime_stream_evidence_diagnostics(evidence) {
+        return Some(value);
+    }
     let path = evidence.uri.strip_prefix("file://")?;
     if !path.ends_with(".json") {
         return None;
@@ -648,9 +661,38 @@ pub fn hydrate_evidence_diagnostics(evidence: &AgentTaskEvidenceRef) -> Option<V
     let mut diagnostics = Vec::new();
     let mut budget = DiagnosticBudget::default();
     collect_diagnostics(&redacted, &mut diagnostics, 0, &mut budget);
+    let mut streams = process_stream_summaries(&redacted, Path::new(path).parent());
+    // The runtime evidence index embeds the adapter-normalized structured
+    // error persisted at execution time. Surface it through the same stream
+    // channel so the diagnostic chain still sees the provider's terminal
+    // error even when the raw runtime log is no longer hydratable.
+    if let Some(error) = redacted
+        .get("structured_error")
+        .and_then(normalized_structured_error)
+    {
+        let already_surfaced = streams.as_array().is_some_and(|streams| {
+            streams
+                .iter()
+                .any(|stream| stream.get("structured_error").is_some())
+        });
+        if !already_surfaced {
+            streams = match streams {
+                Value::Array(mut streams) => {
+                    streams.push(json!({
+                        "name": "stdout",
+                        "source": "runtime_evidence_index",
+                        "status": "available",
+                        "structured_error": error,
+                    }));
+                    Value::Array(streams)
+                }
+                other => other,
+            };
+        }
+    }
     Some(json!({
         "diagnostics": diagnostics,
-        "process_streams": process_stream_summaries(&redacted, Path::new(path).parent()),
+        "process_streams": streams,
         "usage": {
             "diagnostic_count": budget.count,
             "diagnostic_bytes": budget.bytes,
@@ -659,18 +701,237 @@ pub fn hydrate_evidence_diagnostics(evidence: &AgentTaskEvidenceRef) -> Option<V
     }))
 }
 
+/// Which provider runtime stream an evidence ref points at, if any. Matches
+/// Homeboy's own runtime-stream evidence kinds first, then the runtime stream
+/// file naming convention (`...runtime-stdout...` / `...runtime-stderr...`)
+/// used by provider wrappers and the executor's own capture files.
+fn runtime_stream_ref_stream_name(evidence: &AgentTaskEvidenceRef) -> Option<&'static str> {
+    match evidence.kind.as_str() {
+        kind if kind == RUNTIME_STDOUT_EVIDENCE_KIND => return Some("stdout"),
+        kind if kind == RUNTIME_STDERR_EVIDENCE_KIND => return Some("stderr"),
+        _ => {}
+    }
+    let name = Path::new(&evidence.uri)
+        .file_name()?
+        .to_string_lossy()
+        .to_ascii_lowercase();
+    if name.contains("runtime") && name.contains("stdout") {
+        Some("stdout")
+    } else if name.contains("runtime") && name.contains("stderr") {
+        Some("stderr")
+    } else {
+        None
+    }
+}
+
+fn runtime_stream_ref_path(evidence: &AgentTaskEvidenceRef) -> Option<PathBuf> {
+    let raw = evidence
+        .uri
+        .strip_prefix("file://")
+        .unwrap_or(&evidence.uri);
+    if raw.contains("://") || raw.contains('\0') || raw.trim().is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(raw);
+    path.is_absolute().then_some(path)
+}
+
+/// Hydrate a provider runtime stream evidence ref (`provider-runtime-stdout`
+/// and friends) into a bounded, redacted summary whose `message` is the
+/// normalized structured error when the stream carries one (#13703).
+fn runtime_stream_evidence_summary(
+    task_id: &str,
+    evidence: &AgentTaskEvidenceRef,
+) -> Option<Value> {
+    let stream_name = runtime_stream_ref_stream_name(evidence)?;
+    let path = runtime_stream_ref_path(evidence)?;
+    let stream = runtime_stream_file_summary(stream_name, "evidence_ref", &evidence.uri, &path);
+    let structured = stream.get("structured_error");
+    let stream_excerpt = |name: &str| {
+        (stream.get("name").and_then(Value::as_str) == Some(name))
+            .then(|| stream.get("excerpt").cloned().unwrap_or(Value::Null))
+            .unwrap_or(Value::Null)
+    };
+    Some(json!({
+        "task_id": task_id,
+        "kind": evidence.kind,
+        "label": evidence.label,
+        "uri": evidence.uri,
+        "summary": {
+            "status": stream.get("status"),
+            "failure_classification": structured
+                .and_then(|error| error.get("failure_classification").cloned())
+                .unwrap_or(Value::Null),
+            "message": structured
+                .and_then(|error| error.get("message").cloned())
+                .unwrap_or(Value::Null),
+            "command": Value::Null,
+            "exit_code": Value::Null,
+            "stderr_excerpt": stream_excerpt("stderr"),
+            "stdout_excerpt": stream_excerpt("stdout"),
+            "diagnostics": [],
+            "process_streams": [stream],
+        }
+    }))
+}
+
+/// Contribute a provider runtime stream evidence ref to the diagnostic chain.
+/// The stream summary (bounded tail, structured error) flows through the same
+/// `process_streams` channel the diagnostic ranker already consumes.
+fn runtime_stream_evidence_diagnostics(evidence: &AgentTaskEvidenceRef) -> Option<Value> {
+    let stream_name = runtime_stream_ref_stream_name(evidence)?;
+    let path = runtime_stream_ref_path(evidence)?;
+    let stream = runtime_stream_file_summary(stream_name, "evidence_ref", &evidence.uri, &path);
+    Some(json!({
+        "diagnostics": [],
+        "process_streams": [stream],
+        "usage": {
+            "diagnostic_count": 0,
+            "diagnostic_bytes": 0,
+        },
+        "truncation": {
+            "truncated": stream.get("truncated").and_then(Value::as_bool) == Some(true),
+            "reason": "runtime_stream_tail",
+            "limit_bytes": RUNTIME_STREAM_TAIL_BYTES,
+        },
+    }))
+}
+
+/// Summarize one runtime stream file: a bounded tail excerpt plus the
+/// adapter-normalized structured error when the stream carries a terminal
+/// provider error event. Vendor shapes are parsed by the provider adapter;
+/// only its normalized output is attached here.
+fn runtime_stream_file_summary(name: &str, source: &str, reference: &str, path: &Path) -> Value {
+    let unavailable = |error: &str| {
+        json!({
+            "name": name,
+            "source": source,
+            "reference": reference,
+            "status": "unavailable",
+            "error": error,
+        })
+    };
+    let Ok(metadata) = fs::symlink_metadata(path) else {
+        return unavailable("not_found");
+    };
+    if !metadata.file_type().is_file() {
+        return unavailable("not_regular_file");
+    }
+    let Some(tail) = read_runtime_stream_tail(path) else {
+        return unavailable("unreadable");
+    };
+    let mut summary = json!({
+        "name": name,
+        "source": source,
+        "reference": reference,
+        "status": "available",
+        "excerpt": tail_excerpt(&tail.redacted),
+        "truncated": tail.truncated,
+    });
+    if let Some(error) = normalize_runtime_stream_error(None, &tail.raw) {
+        summary["structured_error"] = error;
+    }
+    summary
+}
+
+/// Excerpt the END of an already-redacted runtime stream tail. Runtime logs
+/// append, so the terminal cause is the last thing written.
+fn tail_excerpt(text: &str) -> String {
+    const LIMIT: usize = 600;
+    let trimmed = text.trim();
+    if trimmed.chars().count() <= LIMIT {
+        trimmed.to_string()
+    } else {
+        let suffix: String = trimmed
+            .chars()
+            .skip(trimmed.chars().count() - LIMIT)
+            .collect();
+        format!("...{suffix}")
+    }
+}
+
+/// Find a provider runtime stream file next to the evidence file. Provider
+/// runtimes write their stdout/stderr logs into the same artifact directory
+/// as the agent result, without linking the two; discovering the sibling by
+/// Homeboy's runtime-stream naming convention closes that gap without
+/// teaching the generic layer any provider (#13703).
+fn sibling_runtime_stream_summary(name: &str, stream_root: Option<&Path>) -> Option<Value> {
+    let root = stream_root?;
+    let mut candidates: Vec<PathBuf> = fs::read_dir(root)
+        .ok()?
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_file())
+                && runtime_stream_file_name_matches(path, name)
+        })
+        .collect();
+    candidates.sort();
+    // The lexicographically last match carries the highest attempt suffix.
+    let path = candidates.pop()?;
+    let reference = format!("file://{}", path.display());
+    Some(runtime_stream_file_summary(
+        name, "sibling", &reference, &path,
+    ))
+}
+
+fn runtime_stream_file_name_matches(path: &Path, stream_name: &str) -> bool {
+    let Some(file_name) = path.file_name() else {
+        return false;
+    };
+    let file_name = file_name.to_string_lossy().to_ascii_lowercase();
+    file_name.contains("runtime") && file_name.contains(stream_name)
+}
+
 fn evidence_json_summary(value: &Value, stream_root: Option<&Path>) -> Value {
+    let streams = process_stream_summaries(value, stream_root);
     json!({
         "status": find_string_field(value, &["status", "state"]),
-        "failure_classification": find_string_field(value, &["failure_classification", "failure_class", "classification", "class", "code", "kind"]),
-        "message": find_string_field(value, &["message", "summary", "error", "detail", "reason"]),
+        "failure_classification": find_string_field(value, &["failure_classification", "failure_class", "classification", "class", "code", "kind"])
+            .or_else(|| structured_stream_field(&streams, "failure_classification")),
+        "message": find_string_field(value, &["message", "summary", "error", "detail", "reason"])
+            .or_else(|| structured_stream_field(&streams, "message")),
         "command": find_string_field(value, &["command", "cmd", "failing_command"]),
         "exit_code": find_number_field(value, &["exit_code", "exit_status", "status_code"]),
-        "stderr_excerpt": find_string_field(value, &["stderr", "stderr_excerpt"]).map(|text| excerpt(&text)),
-        "stdout_excerpt": find_string_field(value, &["stdout", "stdout_excerpt"]).map(|text| excerpt(&text)),
+        "stderr_excerpt": find_string_field(value, &["stderr", "stderr_excerpt"])
+            .map(|text| excerpt(&text))
+            .or_else(|| stream_excerpt(&streams, "stderr")),
+        "stdout_excerpt": find_string_field(value, &["stdout", "stdout_excerpt"])
+            .map(|text| excerpt(&text))
+            .or_else(|| stream_excerpt(&streams, "stdout")),
         "diagnostics": first_diagnostics(value),
-        "process_streams": process_stream_summaries(value, stream_root),
+        "process_streams": streams,
     })
+}
+
+/// A field of the normalized structured error carried by one of the hydrated
+/// streams, when the evidence JSON itself did not carry the fact.
+fn structured_stream_field(streams: &Value, field: &str) -> Option<String> {
+    streams
+        .as_array()?
+        .iter()
+        .filter_map(|stream| stream.get("structured_error"))
+        .find_map(|error| {
+            error
+                .get(field)
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .map(str::to_string)
+        })
+}
+
+/// The bounded, redacted excerpt of an available hydrated stream, when the
+/// evidence JSON itself did not carry the stream inline.
+fn stream_excerpt(streams: &Value, name: &str) -> Option<String> {
+    streams
+        .as_array()?
+        .iter()
+        .find(|stream| {
+            stream.get("name").and_then(Value::as_str) == Some(name)
+                && stream.get("status").and_then(Value::as_str) == Some("available")
+        })
+        .and_then(|stream| stream.get("excerpt").and_then(Value::as_str))
+        .map(str::to_string)
 }
 
 /// Project executor process output without requiring a provider-specific wrapper
@@ -680,6 +941,25 @@ fn process_stream_summaries(value: &Value, stream_root: Option<&Path>) -> Value 
     const LIMIT: usize = 600;
     let mut streams = Vec::new();
     collect_process_stream_summaries(value, &mut streams, LIMIT, stream_root, 0);
+    // A provider runtime writes its stdout/stderr logs next to its result
+    // artifacts without linking them. When the evidence JSON carries no
+    // pointer to its own streams, hydrate the sibling runtime stream so the
+    // actual provider failure reaches stdout_excerpt/stderr_excerpt and the
+    // diagnostic chain instead of a null placeholder (#13703).
+    for name in ["stdout", "stderr"] {
+        if streams.len() >= 2 {
+            break;
+        }
+        let already_present = streams
+            .iter()
+            .any(|stream| stream.get("name").and_then(Value::as_str) == Some(name));
+        if already_present {
+            continue;
+        }
+        if let Some(summary) = sibling_runtime_stream_summary(name, stream_root) {
+            streams.push(summary);
+        }
+    }
     Value::Array(streams)
 }
 
@@ -799,14 +1079,23 @@ fn process_stream_file_summary(
     let truncated = bytes.len() > limit;
     bytes.truncate(limit);
     let excerpt = RedactionPolicy::default().redact_string(&String::from_utf8_lossy(&bytes));
-    json!({
+    let mut summary = json!({
         "name": name,
         "source": source,
         "reference": reference,
         "status": "available",
         "excerpt": excerpt,
         "truncated": truncated,
-    })
+    });
+    // Terminal provider errors are appended at the end of a stream, past the
+    // head excerpt. Scan the bounded tail through the provider adapter so a
+    // structured error is promoted instead of collapsed to an exit code.
+    if let Some(tail) = read_runtime_stream_tail(&path) {
+        if let Some(error) = normalize_runtime_stream_error(None, &tail.raw) {
+            summary["structured_error"] = error;
+        }
+    }
+    summary
 }
 
 fn find_string_field(value: &Value, names: &[&str]) -> Option<String> {

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -11,6 +11,7 @@ use serde_json::{json, Value};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::time::{Duration, Instant};
 
+use homeboy::agents::agent_task_provider::structured_error::normalized_structured_error;
 use homeboy::agents::agent_task_service as agent_task_service_direct;
 use homeboy::agents::agent_tasks::lifecycle::{self as agent_task_lifecycle, AgentTaskRunRecord};
 use homeboy::agents::agent_tasks::scheduler::{AgentTaskAggregate, AgentTaskPlan};
@@ -3287,6 +3288,16 @@ fn classification_next_actions(
             actions.extend(retry);
             actions
         }
+        // The provider rejected this account or quota. Diagnose makes the
+        // distinction visible, but #13691 owns whether a rotation is legal.
+        AgentTaskFailureClassification::ProviderAccountQuotaRejected => vec![
+            failure_evidence,
+            CommandNextAction::new(
+                "list registered providers for a possible rotation",
+                "homeboy agent-task providers".to_string(),
+            )
+            .with_kind(CommandNextActionKind::Show),
+        ],
         // Policy refused this request. Retrying an identical request is denied
         // identically, so no retry action is emitted.
         AgentTaskFailureClassification::PolicyDenied => vec![
@@ -5683,6 +5694,10 @@ fn diagnostic_priority(item: &CollectedDiagnostic) -> (u8, u8) {
         0
     } else if is_required_output_diagnostic(&class) {
         1
+    } else if is_provider_structured_error(&class) {
+        // The provider's own terminal error event, already normalized by the
+        // provider adapter: the most specific execution-layer cause there is.
+        1
     } else if is_provider_contract_diagnostic(&class) {
         2
     } else if is_successful_process_exit(&text) {
@@ -5728,13 +5743,24 @@ fn diagnostic_priority(item: &CollectedDiagnostic) -> (u8, u8) {
 
 /// Process streams are untrusted wrapper output. When a stream is JSON, its
 /// diagnostics are the execution-layer cause and therefore rank ahead of the
-/// wrapper's outcome-normalization consequence.
+/// wrapper's outcome-normalization consequence. A stream carrying a
+/// normalized structured provider error (already converted by the provider
+/// adapter) is promoted with its message, status code, retryability, and
+/// account/quota classification instead of collapsing to an exit code
+/// (#13703).
 fn collect_process_stream_diagnostics(
     task_id: &str,
     streams: &Value,
     out: &mut Vec<CollectedDiagnostic>,
 ) {
     for stream in streams.as_array().into_iter().flatten() {
+        if let Some(error) = stream
+            .get("structured_error")
+            .and_then(normalized_structured_error)
+        {
+            out.push(structured_error_diagnostic(task_id, &error));
+            continue;
+        }
         let Some(excerpt) = stream.get("excerpt").and_then(Value::as_str) else {
             continue;
         };
@@ -5751,6 +5777,38 @@ fn collect_process_stream_diagnostics(
                 data: Value::Null,
             });
         }
+    }
+}
+
+/// Project a normalized structured provider error as a diagnostic whose
+/// message carries the provider's own answer: the human-readable message, the
+/// HTTP status, and whether the provider declared the failure retryable.
+fn structured_error_diagnostic(task_id: &str, error: &Value) -> CollectedDiagnostic {
+    let message = error
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let status_code = error.get("status_code").and_then(Value::as_i64);
+    let retryable = error.get("retryable").and_then(Value::as_bool);
+    let status_note = status_code
+        .map(|code| format!("HTTP {code}, "))
+        .unwrap_or_default();
+    let retry_note = match retryable {
+        Some(true) => "retryable",
+        Some(false) => "not retryable",
+        None => "retryability unspecified",
+    };
+    CollectedDiagnostic {
+        task_id: task_id.to_string(),
+        class: "provider.structured_error".to_string(),
+        message: format!("provider rejected the request ({status_note}{retry_note}): {message}"),
+        source: "hydrated_process_stream".to_string(),
+        data: json!({
+            "status_code": status_code,
+            "retryable": retryable,
+            "failure_classification": error.get("failure_classification"),
+            "error_name": error.get("error_name"),
+        }),
     }
 }
 
@@ -7542,6 +7600,8 @@ fn collected_diagnostic_value_with_details(
         }
     } else if let Some(details) = policy_denial_details(&item.data) {
         value["details"] = details;
+    } else if let Some(details) = structured_error_details(&item.data) {
+        value["details"] = details;
     } else if item.source == "pre_execution_failure" {
         value["details"] = bounded_diagnostic_value(&item.data).unwrap_or(Value::Null);
     } else if item.source == "lab_preacceptance_transport" {
@@ -7575,6 +7635,10 @@ fn is_required_output_diagnostic(class: &str) -> bool {
     class.contains("required_output_missing")
 }
 
+fn is_provider_structured_error(class: &str) -> bool {
+    class.contains("provider.structured_error")
+}
+
 fn is_provider_contract_diagnostic(class: &str) -> bool {
     class.contains("provider_outcome_contract_violation")
         || class.contains("outcome_contract_violation")
@@ -7595,8 +7659,28 @@ fn policy_denial_details(data: &Value) -> Option<Value> {
         "policy_mode",
         "reason",
     ];
-    let details = fields.into_iter().filter_map(|field| {
-        data.get(field)
+    structured_details(data, &fields)
+}
+
+/// Preserve the bounded, actionable facts of a normalized structured provider
+/// error — status code, retryability, and the account/quota classification
+/// (#13691 consumes this classification for provider rotation) — without
+/// forwarding arbitrary provider payload.
+fn structured_error_details(data: &Value) -> Option<Value> {
+    structured_details(
+        data,
+        &[
+            "status_code",
+            "retryable",
+            "failure_classification",
+            "error_name",
+        ],
+    )
+}
+
+fn structured_details(data: &Value, fields: &[&str]) -> Option<Value> {
+    let details = fields.iter().filter_map(|field| {
+        data.get(*field)
             .filter(|value| !value.is_null())
             .and_then(|value| {
                 bounded_diagnostic_value(value).map(|value| (field.to_string(), value))

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -3015,6 +3015,66 @@ fn diagnose_hydrates_executor_result_evidence_root_cause() {
 }
 
 #[test]
+fn diagnose_hydrates_and_redacts_structured_provider_runtime_errors() {
+    with_temp_home(|| {
+        let evidence_dir = tempfile::tempdir().expect("evidence dir");
+        let runtime_stdout = evidence_dir
+            .path()
+            .join("cook-homeboy-opencode-runtime-stdout.log");
+        std::fs::write(
+            &runtime_stdout,
+            concat!(
+                "set-cookie: session=fixture-secret\n",
+                r#"{"type":"error","error":{"name":"APIError","data":{"message":"personal-team-blocked:spending-limit: You have run out of credits or need a Grok subscription.","statusCode":403,"isRetryable":false}}}"#,
+                "\n"
+            ),
+        )
+        .expect("write runtime stdout");
+        let evidence_path = evidence_dir.path().join("executor-result.json");
+        std::fs::write(
+            &evidence_path,
+            r#"{"status":"failed","exit_code":1,"diagnostics":[{"class":"provider.process_exit","message":"OpenCode CLI exited with status 1."}]}"#,
+        )
+        .expect("write executor result");
+
+        let run_id = "run-cli-diagnose-structured-provider-error";
+        run_loaded_plan(
+            test_plan(),
+            Some(run_id),
+            Arc::new(ExecutorResultEvidenceFailureExecutor {
+                evidence_uri: format!("file://{}", evidence_path.display()),
+            }),
+        )
+        .expect("run completed with failed outcome");
+
+        let (value, exit_code) = diagnose(DiagnoseArgs {
+            run_id: run_id.to_string(),
+            full: false,
+        })
+        .expect("diagnose loaded");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(
+            value["root_cause"]["message"],
+            "provider rejected the request (HTTP 403, not retryable): personal-team-blocked:spending-limit: You have run out of credits or need a Grok subscription."
+        );
+        assert_eq!(value["root_cause"]["details"]["status_code"], 403);
+        assert_eq!(value["root_cause"]["details"]["retryable"], false);
+        assert_eq!(
+            value["root_cause"]["details"]["failure_classification"],
+            "provider_account_quota_rejected"
+        );
+        assert!(value["hydrated_evidence"][0]["summary"]["stdout_excerpt"]
+            .as_str()
+            .expect("stdout excerpt")
+            .contains("personal-team-blocked:spending-limit"));
+        let output = value.to_string();
+        assert!(!output.contains("fixture-secret"));
+        assert!(output.contains("[REDACTED]"));
+    });
+}
+
+#[test]
 fn diagnose_routes_timed_out_review_form_continuation_away_from_generic_retry() {
     with_temp_home(|| {
         let cook_id = "cook-diagnose-review-form";


### PR DESCRIPTION
## Summary
- Hydrate bounded, redacted provider runtime stdout/stderr evidence in `agent-task diagnose`.
- Normalize OpenCode structured error events into one provider-adapter error schema consumed by diagnose, execution evidence, and provider-result normalization.
- Converge on `ProviderAccountBlocked`: #13715 retains generic scheduler rotation semantics, while this branch supplies the shared normalized error that classifies the OpenCode account/quota rejection.
- Remove the parallel account/quota enum and the separate outcome-normalization vendor parser; generic layers consume the same redacted normalized error.
- Cover structured error hydration, redaction, and account-block rotation classification regressions.

## Testing
- `cargo fmt --all --check`
- `cargo check --workspace --tests --locked`
- `cargo test -p homeboy-agents --locked agent_task_provider::tests::outcome_tests::opencode_account_block_maps_to_rotatable_provider_classification -- --exact`
- `cargo test -p homeboy-agents --locked agent_task_provider::structured_error::tests::normalizes_the_live_opencode_account_rejection -- --exact`
- `cargo test -p homeboy-agents --locked agent_task_provider::structured_error::tests::normalized_output_is_redacted -- --exact`
- `target/debug/deps/homeboy_cli-221e2f6544e174e0 commands::agent_task::tests::lifecycle::diagnose_hydrates_and_redacts_structured_provider_runtime_errors --exact`

The focused `cargo test -p homeboy-cli` invocation passed the requested diagnose test, then stalled while starting a filtered integration harness; the exact test-binary invocation above passed. Full package/workspace tests were not run because the descendant-reaper harness hang is tracked in #13714; CI is authoritative.

## AI Assistance
OpenAI GPT-5.6-terra via OpenCode; earlier GLM 5.3 draft audited.