### PR TITLE
Bound hermetic test execution (#13714)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,6 +4,9 @@ test-route-dispatch = "test -p homeboy-cli commands::infra::route::tests::dispat
 
 # Every test binary runs under a small supervisor. It creates a private process
 # group and reaps it when Cargo cancels the runner, so a test cannot leave a
-# daemonized fixture behind after the test binary is interrupted.
+# daemonized fixture behind after the test binary is interrupted. It also
+# enforces HOMEBOY_TEST_TIMEOUT_SECONDS (default: 1500); set
+# HOMEBOY_TEST_ALLOW_UNBOUNDED=1 with HOMEBOY_TEST_TIMEOUT_SECONDS=unbounded
+# only for interactive debugging.
 [target.'cfg(unix)']
 runner = "scripts/nextest-hermetic-test-environment.sh"

--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -1634,6 +1634,18 @@ pub(crate) fn run_gate_command_with_supervision(
     selected_environment.configure_cargo_target(cwd, gate_environment.shared_cargo_target)?;
     selected_environment.report.package_artifacts = package_artifacts;
     selected_environment.apply(&mut process);
+    // Cook's persisted gate deadline is the only deadline policy here. When a
+    // shell gate starts Cargo, propagate it into the hermetic binary runner so
+    // a hung test binary gets the same bound and process-group cleanup.
+    if let Some(supervision) = supervision {
+        let plan =
+            homeboy_engine_primitives::test_execution::TestExecutionPlan::with_suite_timeout(
+                supervision.timeout,
+            )
+            .expect("Cook gate timeout is normalized to a positive duration");
+        let (name, value) = plan.suite_timeout_env();
+        process.env(name, value);
+    }
     if supervision.is_some() && !homeboy_core::engine::command::supports_process_tree_isolation() {
         return Err(Error::validation_invalid_argument(
             "gate_supervision",

--- a/crates/homeboy-engine-primitives/src/lib.rs
+++ b/crates/homeboy-engine-primitives/src/lib.rs
@@ -29,6 +29,7 @@ pub mod phase_timing;
 pub mod provider_registry;
 pub mod shell;
 pub mod template;
+pub mod test_execution;
 pub mod test_path;
 pub mod text;
 pub mod validation;

--- a/crates/homeboy-engine-primitives/src/test_execution.rs
+++ b/crates/homeboy-engine-primitives/src/test_execution.rs
@@ -1,0 +1,69 @@
+//! Shared, bounded contract for declared test execution.
+//!
+//! This deliberately starts with the one policy every adapter can enforce: a
+//! positive suite deadline. Adapters add per-test limits, isolation, output,
+//! and concurrency only when they can enforce and report them.
+
+use std::time::Duration;
+
+/// Environment setting understood by the hermetic Cargo test runner.
+pub const SUITE_TIMEOUT_ENV: &str = "HOMEBOY_TEST_TIMEOUT_SECONDS";
+
+/// Conservative bound for direct `cargo test` calls that do not have a typed
+/// owner. Product entry points should construct a plan explicitly.
+pub const DEFAULT_SUITE_TIMEOUT_SECONDS: u64 = 25 * 60;
+
+/// The minimal product-agnostic contract shared by declared test adapters.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TestExecutionPlan {
+    suite_timeout: Duration,
+}
+
+impl TestExecutionPlan {
+    /// A suite deadline must be positive. Zero is never an implicit request for
+    /// unbounded execution.
+    pub fn with_suite_timeout(suite_timeout: Duration) -> Result<Self, &'static str> {
+        if suite_timeout.is_zero() {
+            return Err("test suite timeout must be greater than zero");
+        }
+        Ok(Self { suite_timeout })
+    }
+
+    pub fn suite_timeout(self) -> Duration {
+        self.suite_timeout
+    }
+
+    /// Pass the resolved deadline to an adapter that uses the global Cargo
+    /// runner. This prevents that runner from silently choosing a second policy.
+    pub fn suite_timeout_env(self) -> (&'static str, String) {
+        (SUITE_TIMEOUT_ENV, self.suite_timeout.as_secs().to_string())
+    }
+}
+
+/// Resolve the declared review-test deadline. Invalid and zero inherited
+/// values retain the safe default; direct runner invocation rejects them so an
+/// explicit zero cannot turn a binary into an unbounded process.
+pub fn suite_timeout_from_env() -> TestExecutionPlan {
+    let seconds = std::env::var(SUITE_TIMEOUT_ENV)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|seconds| *seconds > 0)
+        .unwrap_or(DEFAULT_SUITE_TIMEOUT_SECONDS);
+    TestExecutionPlan::with_suite_timeout(Duration::from_secs(seconds))
+        .expect("default test suite timeout is positive")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn suite_timeout_is_positive_and_exported_for_the_runner() {
+        let plan = TestExecutionPlan::with_suite_timeout(Duration::from_secs(42)).unwrap();
+        assert_eq!(
+            plan.suite_timeout_env(),
+            (SUITE_TIMEOUT_ENV, "42".to_string())
+        );
+        assert!(TestExecutionPlan::with_suite_timeout(Duration::ZERO).is_err());
+    }
+}

--- a/crates/homeboy-extension/src/test/run.rs
+++ b/crates/homeboy-extension/src/test/run.rs
@@ -75,7 +75,6 @@ const TEST_INVENTORY_FILE: &str = "test-inventory.json";
 const TEST_INVENTORY_PUBLIC_FILE: &str = "homeboy-test-inventory.json";
 #[cfg(unix)]
 const MAX_TEST_INVENTORY_BYTES: u64 = 64 * 1024 * 1024;
-const DEFAULT_TEST_TIMEOUT_SECONDS: u64 = 25 * 60;
 const MAX_CHANGED_TEST_FILES_ENV: &str = "HOMEBOY_MAX_CHANGED_TEST_FILES";
 
 #[derive(Debug, Deserialize)]
@@ -366,12 +365,7 @@ fn execution_fingerprint(
 }
 
 pub(crate) fn test_timeout() -> Duration {
-    std::env::var("HOMEBOY_TEST_TIMEOUT_SECONDS")
-        .ok()
-        .and_then(|value| value.parse::<u64>().ok())
-        .filter(|seconds| *seconds > 0)
-        .map(Duration::from_secs)
-        .unwrap_or_else(|| Duration::from_secs(DEFAULT_TEST_TIMEOUT_SECONDS))
+    homeboy_engine_primitives::test_execution::suite_timeout_from_env().suite_timeout()
 }
 
 /// Resolve the optional changed-scope selection cap.
@@ -1560,6 +1554,8 @@ fn run_main_test_workflow_inner(
     let no_tests_evidence_file = run_dir.step_file(run_dir::files::NO_TESTS_APPLICABLE);
     let no_tests_nonce = uuid::Uuid::new_v4().to_string();
     let write_results_helper = write_test_results_helper(run_dir)?;
+    let test_plan = homeboy_engine_primitives::test_execution::suite_timeout_from_env();
+    let (suite_timeout_env, suite_timeout_value) = test_plan.suite_timeout_env();
     let inventory_profile = test_context.as_ref().and_then(|_| {
         InventoryProfile::resolve(
             test_config
@@ -1618,6 +1614,7 @@ fn run_main_test_workflow_inner(
                             .iter()
                             .fold(producer, |producer, (key, value)| producer.env(key, value));
                         let output = producer
+                            .env(suite_timeout_env, &suite_timeout_value)
                             .env(TEST_INVENTORY_ONLY_ENV, "1")
                             .env(
                                 TEST_INVENTORY_FILE_ENV,
@@ -1685,6 +1682,10 @@ fn run_main_test_workflow_inner(
         .iter()
         .fold(runner, |runner, (key, value)| runner.env(key, value));
     let runner = runner
+        // Normalize inherited configuration before a Cargo adapter reaches the
+        // global runner: an explicit zero falls back to the declared default,
+        // never to the runner's debug-only unbounded mode.
+        .env(suite_timeout_env, &suite_timeout_value)
         .env(
             "HOMEBOY_TEST_RESULTS_FILE",
             results_file.to_string_lossy().as_ref(),
@@ -1738,7 +1739,7 @@ fn run_main_test_workflow_inner(
         vec![("test runner".to_string(), args.component_label.clone())],
     )?;
     progress.start(0)?;
-    let timeout = test_timeout();
+    let timeout = test_plan.suite_timeout();
     homeboy_core::log_status!(
         "test",
         "phase=child command=test runner timeout={}s; streaming bounded child supervision",

--- a/scripts/nextest-hermetic-test-environment.sh
+++ b/scripts/nextest-hermetic-test-environment.sh
@@ -98,7 +98,15 @@ export TMP TEMP
 # here would never fire, and an accumulating per-test directory under `target/`
 # would be a disk leak. Set HOMEBOY_TEST_KEEP_TMPDIR=1 to retain it for
 # debugging.
-exec perl -MPOSIX=setsid,WNOHANG -e '
+exec perl -MPOSIX=setsid,WNOHANG -MTime::HiRes=time -e '
+    my $timeout_value = $ENV{HOMEBOY_TEST_TIMEOUT_SECONDS};
+    my $unbounded = defined($timeout_value) && $timeout_value eq "unbounded"
+        && ($ENV{HOMEBOY_TEST_ALLOW_UNBOUNDED} // "") eq "1";
+    if (!$unbounded && defined($timeout_value) && $timeout_value !~ /^[1-9][0-9]*$/) {
+        print STDERR "hermetic test environment: HOMEBOY_TEST_TIMEOUT_SECONDS must be a positive integer; unbounded execution requires HOMEBOY_TEST_ALLOW_UNBOUNDED=1 and HOMEBOY_TEST_TIMEOUT_SECONDS=unbounded\n";
+        exit 2;
+    }
+    my $timeout_seconds = $unbounded ? undef : (defined($timeout_value) ? $timeout_value : 1500);
     # Adopt descendants of a completed test group long enough to reap them.
     # CI containers commonly run a PID 1 that does not reap orphaned children.
     syscall(157, 36, 1, 0, 0, 0) if $^O eq "linux";
@@ -136,8 +144,18 @@ exec perl -MPOSIX=setsid,WNOHANG -e '
         $discard_tmpdir->();
         exit 143;
     };
+    my $started = time;
     my $status;
-    while (($status = waitpid $child, WNOHANG) == 0) { select undef, undef, undef, 0.05; }
+    while (($status = waitpid $child, WNOHANG) == 0) {
+        if (defined($timeout_seconds) && time - $started >= $timeout_seconds) {
+            my $binary = $ARGV[0] // "test binary";
+            print STDERR "hermetic test environment: test binary $binary exceeded suite deadline ${timeout_seconds}s; terminating its process group\n";
+            $cleanup->();
+            $discard_tmpdir->();
+            exit 124;
+        }
+        select undef, undef, undef, 0.05;
+    }
     my $exit = $?;
     $cleanup->();
     $discard_tmpdir->();

--- a/scripts/test-hermetic-test-runner.sh
+++ b/scripts/test-hermetic-test-runner.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Focused regression tests for the globally configured Cargo test runner.
+# Each invocation has an independent external alarm: this test must remain
+# bounded even if the runner regresses.
+set -eu
+
+root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+runner="$root/scripts/nextest-hermetic-test-environment.sh"
+scratch="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-hermetic-runner-test.XXXXXX")"
+trap 'rm -rf "$scratch"' EXIT HUP INT TERM
+
+run_bounded() {
+    perl -e 'alarm shift @ARGV; exec @ARGV or die "exec: $!\n"' 8 "$runner" "$@"
+}
+
+started="$(date +%s)"
+run_bounded sh -c 'printf "%s" "$TMPDIR" > "$1"; exit 0' sh "$scratch/clean-tmp"
+elapsed=$(( $(date +%s) - started ))
+[ "$elapsed" -lt 3 ]
+clean_tmp="$(<"$scratch/clean-tmp")"
+[ ! -e "$clean_tmp" ]
+
+set +e
+HOMEBOY_TEST_TIMEOUT_SECONDS=1 run_bounded sh -c 'printf "%s" "$TMPDIR" > "$1"; trap "" TERM; (trap "" TERM; while :; do sleep 1; done) & printf "%s" "$!" > "$2"; while :; do sleep 1; done' sh "$scratch/hung-tmp" "$scratch/descendant-pid" >"$scratch/hung.stdout" 2>"$scratch/hung.stderr"
+status=$?
+set -e
+[ "$status" -eq 124 ]
+hung_tmp="$(<"$scratch/hung-tmp")"
+[ ! -e "$hung_tmp" ]
+descendant="$(<"$scratch/descendant-pid")"
+if kill -0 "$descendant" 2>/dev/null; then
+    echo "TERM-resistant descendant survived runner timeout: $descendant" >&2
+    exit 1
+fi
+if ! perl -0777 -ne 'exit(/test binary .* exceeded suite deadline 1s/ ? 0 : 1)' "$scratch/hung.stderr"; then
+    echo "timeout diagnostic did not name the binary and deadline" >&2
+    exit 1
+fi
+
+set +e
+HOMEBOY_TEST_TIMEOUT_SECONDS=0 run_bounded sh -c 'exit 0' >"$scratch/zero.stdout" 2>"$scratch/zero.stderr"
+status=$?
+set -e
+[ "$status" -eq 2 ]
+if ! perl -0777 -ne 'exit(/must be a positive integer/ ? 0 : 1)' "$scratch/zero.stderr"; then
+    echo "zero timeout was not rejected" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Add a mandatory suite deadline to the globally configured hermetic Cargo runner: default 1500 seconds, positive `HOMEBOY_TEST_TIMEOUT_SECONDS` override, explicit debug-only `HOMEBOY_TEST_ALLOW_UNBOUNDED=1` plus `HOMEBOY_TEST_TIMEOUT_SECONDS=unbounded`, timeout exit 124, binary/deadline diagnostic, TERM then KILL of the private process group, and temp-root removal.
- Add the minimal product-agnostic `TestExecutionPlan` contract at the engine-primitives boundary. `review test` normalizes and forwards its resolved deadline; Cook compiles its existing persisted gate timeout into the same plan and forwards it to Cargo. Arbitrary `--verify` shell commands remain supported.
- Add externally bounded shell regression coverage for a clean child, hung child, TERM-resistant descendant, timeout diagnostic/exit, and temp-root cleanup.

## Before / After
Before: raw `cargo test -p homeboy-cli --locked` hung for 26m12s and 27m17s; `cargo test -p homeboy-agents --locked -- --test-threads=1` hung for 21m55s. Cargo and the runner Perl supervisor were idle while a Rust test binary remained live; operator TERM was required.

After: every Unix Cargo test binary receives a 1500-second suite deadline by default (or the positive resolved override). On expiry the runner reports the binary and deadline, terminates its private process group with TERM/KILL, removes its private temp root, and exits 124.

## Timeout Precedence
Cook already owns persisted `gate_timeout_seconds`; this PR does not add a second Cook timer. Cook resolves that existing positive deadline, compiles it into `TestExecutionPlan`, and exports it as `HOMEBOY_TEST_TIMEOUT_SECONDS` for a Cargo child. `review test` resolves the same typed plan from its environment and forwards the normalized value to its adapter. Direct Cargo uses the runner default. The only unbounded mode requires both explicit debug settings; zero is rejected by the runner and never means infinite.

## Verification
- `cargo fmt --all --check`
- `cargo check --workspace --tests --locked`
- `cargo test -p homeboy-engine-primitives --lib test_execution::tests::suite_timeout_is_positive_and_exported_for_the_runner --locked`
- `scripts/test-hermetic-test-runner.sh` (strict external 8-second alarm per invocation)

Full package/workspace test suites were intentionally not run because #13714 fixes their current unbounded-hang failure mode.

## AI Disclosure
OpenAI GPT-5.6-terra via OpenCode.