### PR TITLE
Pin canonical enum wire labels (#13400)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,6 +815,7 @@ dependencies = [
  "homeboy-release",
  "homeboy-review",
  "homeboy-rig",
+ "homeboy-serde-pin",
  "homeboy-stack",
  "homeboy-tunnel",
  "homeboy-upgrade",
@@ -913,6 +914,7 @@ dependencies = [
  "homeboy-redaction",
  "homeboy-refactor-contract",
  "homeboy-release-contract",
+ "homeboy-serde-pin",
  "homeboy-source-snapshot-contract",
  "keyring",
  "libc",
@@ -1244,6 +1246,14 @@ dependencies = [
  "sha2",
  "shellexpand",
  "tempfile",
+]
+
+[[package]]
+name = "homeboy-serde-pin"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/homeboy-cli/Cargo.toml
+++ b/crates/homeboy-cli/Cargo.toml
@@ -65,6 +65,7 @@ shlex = "1.3"
 windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
 
 [dev-dependencies]
+homeboy-serde-pin = { version = "0.1.0", path = "../homeboy-serde-pin" }
 # Enable homeboy-core's shared hermetic test fixtures for this crate's test build.
 homeboy-core = { version = "0.1.0", path = "../homeboy-core", features = ["test-support"] }
 homeboy-extension = { version = "0.1.0", path = "../homeboy-extension" }

--- a/crates/homeboy-cli/src/commands/ci/scope.rs
+++ b/crates/homeboy-cli/src/commands/ci/scope.rs
@@ -45,17 +45,6 @@ pub enum ScopeContext {
     Manual,
 }
 
-impl ScopeContext {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            ScopeContext::PullRequest => "pr",
-            ScopeContext::Push => "push",
-            ScopeContext::Cron => "cron",
-            ScopeContext::Manual => "manual",
-        }
-    }
-}
-
 /// Whether the run should be scoped to changed files or run fully.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -64,15 +53,6 @@ pub enum ScopeMode {
     Changed,
     /// The whole component.
     Full,
-}
-
-impl ScopeMode {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            ScopeMode::Changed => "changed",
-            ScopeMode::Full => "full",
-        }
-    }
 }
 
 /// Provider-agnostic description of a CI event, normalized from whatever the

--- a/crates/homeboy-cli/src/commands/trace/schedule.rs
+++ b/crates/homeboy-cli/src/commands/trace/schedule.rs
@@ -107,6 +107,7 @@ fn plan_str_input<'a>(plan: &'a HomeboyPlan, key: &str) -> &'a str {
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, ValueEnum)]
+#[serde(rename_all = "snake_case")]
 pub enum TraceVariantMatrixMode {
     #[default]
     None,
@@ -115,11 +116,30 @@ pub enum TraceVariantMatrixMode {
 }
 
 impl TraceVariantMatrixMode {
+    /// This mode as its canonical wire string. Serde and this allocation-free
+    /// output helper are pinned together below (#13400).
     pub(super) fn as_str(self) -> &'static str {
         match self {
             Self::None => "none",
             Self::Single => "single",
             Self::Cumulative => "cumulative",
         }
+    }
+}
+
+#[cfg(test)]
+mod serde_label_pins {
+    use super::TraceVariantMatrixMode;
+
+    #[test]
+    fn trace_variant_matrix_mode_matches_its_serialized_form() {
+        homeboy_serde_pin::assert_label_matches_serde!(
+            as_str,
+            [
+                TraceVariantMatrixMode::None,
+                TraceVariantMatrixMode::Single,
+                TraceVariantMatrixMode::Cumulative,
+            ]
+        );
     }
 }

--- a/crates/homeboy-core/Cargo.toml
+++ b/crates/homeboy-core/Cargo.toml
@@ -73,5 +73,6 @@ sha2 = "0.10.9"
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Pipes", "Win32_System_Threading"] }
 
 [dev-dependencies]
+homeboy-serde-pin = { version = "0.1.0", path = "../homeboy-serde-pin" }
 homeboy-code-audit = { version = "0.1.0", path = "../homeboy-code-audit", features = ["test-support"] }
 homeboy-extension = { version = "0.1.0", path = "../homeboy-extension" }

--- a/crates/homeboy-core/src/observation/records/run_status.rs
+++ b/crates/homeboy-core/src/observation/records/run_status.rs
@@ -41,6 +41,7 @@ pub const RUNNING_HEARTBEAT_STALE_MINUTES: i64 = 30;
 pub const OWNERLESS_RUNNING_STALE_THRESHOLD_MINUTES: i64 = 30;
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum RunStatus {
     Running,
     Pass,
@@ -65,6 +66,8 @@ pub enum RunStatus {
 }
 
 impl RunStatus {
+    /// This status as its canonical wire string. Serde and this allocation-free
+    /// storage/query form are pinned together below (#13400).
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Running => "running",
@@ -192,5 +195,26 @@ mod tests {
                 "{status:?} owns its own outcome"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod serde_label_pins {
+    use super::RunStatus;
+
+    #[test]
+    fn run_status_matches_its_serialized_form() {
+        homeboy_serde_pin::assert_label_matches_serde!(
+            as_str,
+            [
+                RunStatus::Running,
+                RunStatus::Pass,
+                RunStatus::Fail,
+                RunStatus::Error,
+                RunStatus::Skipped,
+                RunStatus::Stale,
+                RunStatus::HandedOff,
+            ]
+        );
     }
 }

--- a/crates/homeboy-serde-pin/Cargo.toml
+++ b/crates/homeboy-serde-pin/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "homeboy-serde-pin"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Chris Huber <chubes@extrachill.com>"]
+description = "Test macro pinning enum labels to their serde wire form"
+repository = "https://github.com/Extra-Chill/homeboy"
+publish = false
+
+[lib]
+name = "homeboy_serde_pin"
+path = "src/lib.rs"
+
+[dev-dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/crates/homeboy-serde-pin/src/lib.rs
+++ b/crates/homeboy-serde-pin/src/lib.rs
@@ -1,0 +1,47 @@
+//! Test support for enum labels that restate their serde wire form.
+
+/// Assert that every listed enum value's label equals its serialized JSON string.
+///
+/// The caller must depend on `serde_json`; this crate deliberately has no
+/// production dependencies.
+#[macro_export]
+macro_rules! assert_label_matches_serde {
+    ($label:ident, [$($value:expr),+ $(,)?]) => {
+        $(
+            assert_eq!(
+                ::serde_json::to_value($value).expect("serialize enum"),
+                ::serde_json::Value::String(($value).$label().to_owned()),
+                concat!(
+                    stringify!($value),
+                    ": label drifted from the serde wire form",
+                ),
+            );
+        )+
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Serialize;
+
+    #[derive(Clone, Copy, Serialize)]
+    #[serde(rename_all = "snake_case")]
+    enum Sample {
+        FirstCase,
+        SecondCase,
+    }
+
+    impl Sample {
+        fn as_str(self) -> &'static str {
+            match self {
+                Self::FirstCase => "first_case",
+                Self::SecondCase => "second_case",
+            }
+        }
+    }
+
+    #[test]
+    fn pins_matching_labels() {
+        crate::assert_label_matches_serde!(as_str, [Sample::FirstCase, Sample::SecondCase]);
+    }
+}


### PR DESCRIPTION
## Summary
- Align `RunStatus` and `TraceVariantMatrixMode` serde wire values with their existing canonical string helpers.
- Add a small test-only `homeboy-serde-pin` macro and pin both verified same-vocabulary enums.
- Remove unused CI scope label helpers; preserve the documented and tested `JobStatus::run_status_label` cross-vocabulary projection.

## Scope reduction
- Audited prior WIP: 48 files changed, 955 additions, 20 deletions.
- Final slice: 8 files changed, 120 additions, 20 deletions.
- No `serde_json` dependency was added to contract crates.

## Validation
- `cargo fmt --all --check`
- `cargo check --workspace --tests --locked`
- Exact tests for the macro, `RunStatus`, `TraceVariantMatrixMode`, and `JobStatus::run_status_label`.
- Full package test suites intentionally not run due to #13714.

## AI disclosure
Implemented with OpenAI GPT-5.6-terra via OpenCode. An earlier GLM draft/WIP was audited and replaced.