### PR TITLE
Derive controller-runtime pin retention from lifecycle mutability

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/action_eligibility.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/action_eligibility.rs
@@ -16,6 +16,14 @@ pub enum AgentTaskLifecycleAction {
     Reconcile,
 }
 
+impl AgentTaskLifecycleAction {
+    /// Review is a non-mutating read. Every other lifecycle action mutates the
+    /// durable run or a related resource.
+    pub const fn is_mutating(self) -> bool {
+        !matches!(self, Self::Review)
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentTaskActionConfirmation {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/controller_pin_reference_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/controller_pin_reference_provider.rs
@@ -1,19 +1,25 @@
 //! Agent-task implementation of the controller pin-reference hook.
 //!
 //! Core's controller-runtime retention logic asks which pinned executables are
-//! still referenced by a nonterminal durable agent-task record. That query is
-//! agent-task behavior — it reads the lifecycle store and inspects each record's
-//! state and metadata — so it is provided to core through the
-//! `ControllerPinReferenceProvider` hook instead of core calling the agent-task
-//! subsystem directly.
+//! still referenced by a durable agent-task record. That query is agent-task
+//! behavior — it reads the lifecycle store and inspects each record's
+//! canonical lifecycle-action eligibility and age — so it is provided to core
+//! through the `ControllerPinReferenceProvider` hook instead of core calling
+//! the agent-task subsystem directly.
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use serde_json::Value;
 
-use crate::agent_task_lifecycle::AgentTaskRunState;
+use crate::agent_task_lifecycle::{lifecycle_action_eligibility, AgentTaskActionAvailability};
 use homeboy_core::controller_pin_reference::{
-    register_controller_pin_reference_provider, ControllerPinReferenceProvider,
+    register_controller_pin_reference_provider, ControllerPinProtectionReason,
+    ControllerPinReferenceProvider, ReferencedControllerPin,
+};
+use homeboy_core::controller_runtime::{
+    resolve_cleanup_options, ControllerRuntimeRetentionOverrides,
 };
 use homeboy_core::Result;
 
@@ -25,16 +31,18 @@ const PINNED_EXECUTABLE_POINTER: &str = "/controller_runtime/originating/pinned_
 struct AgentTaskControllerPinReferenceProvider;
 
 impl ControllerPinReferenceProvider for AgentTaskControllerPinReferenceProvider {
-    fn referenced_controller_pins(&self) -> Result<Vec<PathBuf>> {
+    fn referenced_controller_pins(&self) -> Result<Vec<ReferencedControllerPin>> {
         // Pins are retained against the records read here, so both halves must
         // name one installation (#7505).
         let lifecycle_store = super::AgentTaskLifecycleStore::from_current_environment()?;
         let (records, _) = super::list_records_with_health_in_store(&lifecycle_store)?;
-        let mut referenced = Vec::new();
+        let min_age =
+            resolve_cleanup_options(false, ControllerRuntimeRetentionOverrides::default()).min_age;
+        let mut referenced = BTreeMap::new();
         for record in records {
-            if !state_retains_pin(&record) {
+            let Some(reason) = state_retains_pin(&record, min_age) else {
                 continue;
-            }
+            };
             for pointer in [ORIGINATING_EXECUTABLE_POINTER, PINNED_EXECUTABLE_POINTER] {
                 if let Some(path) = record
                     .metadata
@@ -42,31 +50,65 @@ impl ControllerPinReferenceProvider for AgentTaskControllerPinReferenceProvider 
                     .and_then(Value::as_str)
                     .map(PathBuf::from)
                 {
-                    referenced.push(path);
+                    referenced
+                        .entry(path)
+                        .and_modify(|existing: &mut ControllerPinProtectionReason| {
+                            *existing = (*existing).max(reason);
+                        })
+                        .or_insert(reason);
                 }
             }
         }
-        Ok(referenced)
+        Ok(referenced
+            .into_iter()
+            .map(|(path, reason)| ReferencedControllerPin { path, reason })
+            .collect())
     }
 }
 
-/// A record whose state can still operate on its pin retains it: queued,
-/// running, and recoverable-partial records may be re-run by lifecycle
-/// recovery, so their originating pinned executable must survive pruning.
-fn state_retains_pin(record: &crate::agent_task_lifecycle::AgentTaskRunRecord) -> bool {
-    if record.lifecycle.artifact_retention.status
-        == homeboy_core::run_lifecycle_record::ArtifactRetentionStatus::Retained
-    {
-        return true;
+/// A record retains its pin while a mutating lifecycle action remains
+/// available or indeterminate and the record is still inside the configured
+/// retention window. In-flight records keep the pin regardless of age.
+fn state_retains_pin(
+    record: &crate::agent_task_lifecycle::AgentTaskRunRecord,
+    min_age: Duration,
+) -> Option<ControllerPinProtectionReason> {
+    if !record.state.is_terminal() {
+        return Some(ControllerPinProtectionReason::ProtectedInFlight);
     }
-    matches!(
-        record.state,
-        AgentTaskRunState::Queued
-            | AgentTaskRunState::Running
-            | AgentTaskRunState::CandidateRecoverable
-            | AgentTaskRunState::PartialRecoverable
-            | AgentTaskRunState::PartialFailure
-    )
+    if !mutating_lifecycle_action_remains_open(record) {
+        return None;
+    }
+    if record_age_seconds(record).is_some_and(|age| age >= min_age.as_secs()) {
+        return None;
+    }
+    Some(ControllerPinProtectionReason::ProtectedByPendingMutation)
+}
+
+fn mutating_lifecycle_action_remains_open(
+    record: &crate::agent_task_lifecycle::AgentTaskRunRecord,
+) -> bool {
+    lifecycle_action_eligibility(record, None)
+        .actions
+        .iter()
+        .any(|eligibility| {
+            eligibility.action.is_mutating()
+                && matches!(
+                    eligibility.availability,
+                    AgentTaskActionAvailability::Available
+                        | AgentTaskActionAvailability::Indeterminate
+                )
+        })
+}
+
+fn record_age_seconds(record: &crate::agent_task_lifecycle::AgentTaskRunRecord) -> Option<u64> {
+    chrono::DateTime::parse_from_rfc3339(&record.submitted_at)
+        .ok()
+        .map(|submitted| {
+            (chrono::Utc::now() - submitted.with_timezone(&chrono::Utc))
+                .num_seconds()
+                .max(0) as u64
+        })
 }
 
 /// Register the agent-task controller pin-reference provider. Called once at
@@ -74,4 +116,84 @@ fn state_retains_pin(record: &crate::agent_task_lifecycle::AgentTaskRunRecord) -
 /// still-referenced pins without depending on the agent-task subsystem.
 pub fn register() {
     register_controller_pin_reference_provider(Box::new(AgentTaskControllerPinReferenceProvider));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_task_lifecycle::{
+        AgentTaskAcceptanceVerdict, AgentTaskRunRecord, AgentTaskRunState,
+    };
+    use homeboy_core::run_lifecycle_record::ArtifactRetentionStatus;
+
+    fn record(state: AgentTaskRunState, submitted_at: &str) -> AgentTaskRunRecord {
+        serde_json::from_value(serde_json::json!({
+            "schema": "homeboy/agent-task-run/v1",
+            "run_id": "run",
+            "plan_id": "plan",
+            "state": state,
+            "submitted_at": submitted_at,
+            "plan_path": "/plan"
+        }))
+        .expect("record")
+    }
+
+    fn exhaust_repair_budget(record: &mut AgentTaskRunRecord) {
+        record.acceptance = serde_json::from_value(serde_json::json!({
+            "requirement": { "authority": "test", "policy": "test" },
+            "verdict": AgentTaskAcceptanceVerdict::Accepted,
+            "candidate": {
+                "schema": "homeboy/agent-task-candidate-fingerprint/v1",
+                "target_path": "/tmp",
+                "head": "0",
+                "base": "0",
+                "changed_files": [],
+                "sha256": "0"
+            },
+            "base_sha": "0",
+            "repair_attempts": 2
+        }))
+        .expect("acceptance");
+    }
+
+    #[test]
+    fn controller_pin_in_flight_records_retain_regardless_of_age() {
+        let min_age = Duration::ZERO;
+        for state in [AgentTaskRunState::Queued, AgentTaskRunState::Running] {
+            assert_eq!(
+                state_retains_pin(&record(state, "2020-01-01T00:00:00Z"), min_age),
+                Some(ControllerPinProtectionReason::ProtectedInFlight)
+            );
+        }
+    }
+
+    #[test]
+    fn controller_pin_pending_mutation_inside_the_window_retains() {
+        let min_age = Duration::from_secs(86_400);
+        let now = chrono::Utc::now().to_rfc3339();
+        assert_eq!(
+            state_retains_pin(&record(AgentTaskRunState::Succeeded, &now), min_age),
+            Some(ControllerPinProtectionReason::ProtectedByPendingMutation)
+        );
+        assert_eq!(
+            state_retains_pin(&record(AgentTaskRunState::Failed, &now), min_age),
+            Some(ControllerPinProtectionReason::ProtectedByPendingMutation)
+        );
+    }
+
+    #[test]
+    fn controller_pin_terminal_outside_the_window_does_not_retain_artifact_retention() {
+        let min_age = Duration::from_secs(86_400);
+        let mut retained = record(AgentTaskRunState::Succeeded, "2020-01-01T00:00:00Z");
+        retained.lifecycle.artifact_retention.status = ArtifactRetentionStatus::Retained;
+        assert_eq!(state_retains_pin(&retained, min_age), None);
+    }
+
+    #[test]
+    fn controller_pin_read_only_actions_do_not_retain() {
+        let min_age = Duration::from_secs(u64::MAX);
+        let mut failed = record(AgentTaskRunState::Failed, "2026-01-01T00:00:00Z");
+        exhaust_repair_budget(&mut failed);
+        assert_eq!(state_retains_pin(&failed, min_age), None);
+    }
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -3218,7 +3218,8 @@ pub fn pin_current_controller_runtime(
 }
 
 /// Prune immutable controller pins through the durable lifecycle ownership
-/// boundary so nonterminal records remain authoritative retention roots.
+/// boundary so in-flight and pending-mutation records remain authoritative
+/// retention roots.
 ///
 /// Retention policy is resolved by core from the operator's configuration; this
 /// boundary only forwards the overrides an operator typed.

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -337,13 +337,59 @@ fn submit_plan_persists_safe_route_resolution_without_a_destination() {
 }
 
 #[cfg(unix)]
+fn pin_record_from_artifact(
+    run_id: &str,
+    artifact: &std::path::Path,
+    digest: &str,
+    identity: &str,
+) {
+    let temporary_legacy = artifact
+        .parent()
+        .expect("artifact parent")
+        .join(format!("{run_id}-legacy"));
+    std::fs::write(&temporary_legacy, b"corrupted legacy bytes").expect("write legacy pin");
+    rewrite_record_for_test(run_id, |record| {
+        record.metadata[homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] = json!({
+            "originating": {
+                "build_identity": identity,
+                "pinned_executable": temporary_legacy,
+                "sha256": digest,
+            }
+        });
+    })
+    .expect("project legacy pin");
+    recover_controller_runtime_in_store(&test_lifecycle_store(), run_id, Some(artifact), None)
+        .expect("recover pin");
+}
+
+#[cfg(unix)]
+fn record_pin(run_id: &str) -> std::path::PathBuf {
+    std::path::PathBuf::from(
+        status(run_id).expect("record").metadata
+            [homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]["originating"]
+            ["pinned_executable"]
+            .as_str()
+            .expect("pin"),
+    )
+}
+
+#[cfg(unix)]
+fn snapshot_reasons_for(
+    snapshots: &[homeboy_core::controller_runtime::ControllerRuntimeSnapshot],
+    pin: &std::path::Path,
+) -> Vec<String> {
+    snapshots
+        .iter()
+        .find(|snapshot| snapshot.pins.iter().any(|candidate| candidate == pin))
+        .map(|snapshot| snapshot.retention_reasons.clone())
+        .expect("snapshot")
+}
+
+#[cfg(unix)]
 #[test]
-fn controller_runtime_retention_keeps_mutable_and_retained_terminal_runs() {
+fn controller_pin_retention_keeps_in_flight_and_pending_mutation_inside_the_window() {
     super::ensure_runner_continuation_provider_reset_hook();
     with_isolated_home(|_| {
-        // Controller-runtime retention discovers referenced pins through the
-        // agent-task pin-reference provider hook; register it so the report can
-        // see this test's durable records.
         super::controller_pin_reference_provider::register();
         let temporary = tempfile::tempdir().expect("temporary fake controller directory");
         let identity = homeboy_core::build_identity::current().display;
@@ -357,75 +403,138 @@ fn controller_runtime_retention_keeps_mutable_and_retained_terminal_runs() {
         let active = submit_plan(&test_plan(), Some("retention-active")).expect("submit active");
         let terminal =
             submit_plan(&test_plan(), Some("retention-terminal")).expect("submit terminal");
-        for (record, artifact, digest) in [
-            (&active, &active_artifact, &active_digest),
-            (&terminal, &terminal_artifact, &terminal_digest),
-        ] {
-            let legacy = temporary.path().join(format!("{}-legacy", record.run_id));
-            std::fs::write(&legacy, b"corrupted legacy bytes").expect("write legacy pin");
-            rewrite_record_for_test(&record.run_id, |record| {
-                record.metadata
-                    [homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY] = json!({
-                    "originating": {
-                        "build_identity": identity,
-                        "pinned_executable": legacy,
-                        "sha256": digest,
-                    }
-                });
-            })
-            .expect("project legacy pin");
-            recover_controller_runtime_in_store(
-                &test_lifecycle_store(),
-                &record.run_id,
-                Some(artifact),
-                None,
-            )
-            .expect("recover pin");
-        }
+        pin_record_from_artifact(&active.run_id, &active_artifact, &active_digest, &identity);
+        pin_record_from_artifact(
+            &terminal.run_id,
+            &terminal_artifact,
+            &terminal_digest,
+            &identity,
+        );
         rewrite_record_for_test(&terminal.run_id, |record| {
-            // Use `set_run_state` so the run state and its lifecycle execution
-            // projection stay consistent. A raw `record.state = Succeeded` write
-            // left `lifecycle.execution.state` unchanged, so `diagnose_run`
-            // flagged the record `ConflictingProjections` and dropped it from
-            // `list_records_with_health` — the source the retention report reads —
-            // making the terminal pin silently unreferenced (#8964).
             set_run_state(record, AgentTaskRunState::Succeeded);
-            record.lifecycle.artifact_retention.status = ArtifactRetentionStatus::Retained;
         })
         .expect("make terminal");
 
-        let active_pin = std::path::PathBuf::from(
-            status(&active.run_id).expect("active record").metadata
-                [homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]["originating"]
-                ["pinned_executable"]
-                .as_str()
-                .expect("active pin"),
-        );
-        let terminal_pin = std::path::PathBuf::from(
-            status(&terminal.run_id).expect("terminal record").metadata
-                [homeboy_core::controller_runtime::CONTROLLER_RUNTIME_METADATA_KEY]["originating"]
-                ["pinned_executable"]
-                .as_str()
-                .expect("terminal pin"),
-        );
+        let active_pin = record_pin(&active.run_id);
+        let terminal_pin = record_pin(&terminal.run_id);
         let report =
             homeboy_core::controller_runtime::retention_report().expect("retention report");
         assert!(report.retained.contains(&active_pin));
         assert!(report.retained.contains(&terminal_pin));
-        // Opt out of the configured age/size window so this asserts reference
-        // retention specifically, not "nothing was old enough to delete".
+        assert!(snapshot_reasons_for(&report.snapshots, &active_pin)
+            .iter()
+            .any(|reason| reason == "protected_in_flight"));
+        assert!(snapshot_reasons_for(&report.snapshots, &terminal_pin)
+            .iter()
+            .any(|reason| reason == "protected_by_pending_mutation"));
         let purge = homeboy_core::controller_runtime::ControllerRuntimeRetentionOverrides {
             limit: None,
             ignore_retention: true,
         };
-        let dry_run = prune_controller_runtime_pins(false, purge).expect("plan pin pruning");
-        assert!(dry_run.retained.contains(&active_pin));
-        assert!(dry_run.retained.contains(&terminal_pin));
-        assert!(dry_run.removed.is_empty());
         let applied = prune_controller_runtime_pins(true, purge).expect("prune unreferenced pins");
         assert!(!applied.removed.contains(&terminal_pin));
         assert!(active_pin.exists());
         assert!(terminal_pin.exists());
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn controller_pin_retention_reclaims_old_terminal_retained_artifacts_under_pressure() {
+    super::ensure_runner_continuation_provider_reset_hook();
+    with_isolated_home(|_| {
+        super::controller_pin_reference_provider::register();
+        homeboy_core::defaults::save_config(&homeboy_core::defaults::HomeboyConfig {
+            retention: homeboy_core::defaults::RetentionConfig {
+                controller_runtime_days: 14,
+                controller_runtime_max_bytes: 0,
+                limit: 10,
+                ..homeboy_core::defaults::RetentionConfig::default()
+            },
+            ..homeboy_core::defaults::HomeboyConfig::default()
+        })
+        .expect("save retention config");
+        let temporary = tempfile::tempdir().expect("temporary fake controller directory");
+        let identity = homeboy_core::build_identity::current().display;
+        let terminal_artifact = temporary.path().join("terminal-homeboy");
+        let terminal_digest =
+            fake_controller_artifact(&terminal_artifact, &identity, "terminal artifact");
+        let terminal =
+            submit_plan(&test_plan(), Some("retention-old-terminal")).expect("submit terminal");
+        pin_record_from_artifact(
+            &terminal.run_id,
+            &terminal_artifact,
+            &terminal_digest,
+            &identity,
+        );
+        rewrite_record_for_test(&terminal.run_id, |record| {
+            set_run_state(record, AgentTaskRunState::Succeeded);
+            record.lifecycle.artifact_retention.status = ArtifactRetentionStatus::Retained;
+            record.submitted_at = "2020-01-01T00:00:00Z".to_string();
+        })
+        .expect("age terminal retained record");
+
+        let terminal_pin = record_pin(&terminal.run_id);
+        let applied = prune_controller_runtime_pins(
+            true,
+            homeboy_core::controller_runtime::ControllerRuntimeRetentionOverrides::default(),
+        )
+        .expect("reclaim under pressure");
+        assert!(applied.removed.contains(&terminal_pin));
+        assert!(!terminal_pin.exists());
+        assert!(applied.snapshots.iter().any(|snapshot| {
+            snapshot.pins.contains(&terminal_pin)
+                && snapshot
+                    .retention_reasons
+                    .iter()
+                    .any(|reason| reason == "reclaimable")
+        }));
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn controller_pin_retention_keeps_queued_runs_outside_the_age_window() {
+    super::ensure_runner_continuation_provider_reset_hook();
+    with_isolated_home(|_| {
+        super::controller_pin_reference_provider::register();
+        homeboy_core::defaults::save_config(&homeboy_core::defaults::HomeboyConfig {
+            retention: homeboy_core::defaults::RetentionConfig {
+                controller_runtime_days: 0,
+                controller_runtime_max_bytes: 0,
+                limit: 10,
+                ..homeboy_core::defaults::RetentionConfig::default()
+            },
+            ..homeboy_core::defaults::HomeboyConfig::default()
+        })
+        .expect("save retention config");
+        let temporary = tempfile::tempdir().expect("temporary fake controller directory");
+        let identity = homeboy_core::build_identity::current().display;
+        let queued_artifact = temporary.path().join("queued-homeboy");
+        let queued_digest =
+            fake_controller_artifact(&queued_artifact, &identity, "queued artifact");
+        let queued =
+            submit_plan(&test_plan(), Some("retention-old-queued")).expect("submit queued");
+        pin_record_from_artifact(&queued.run_id, &queued_artifact, &queued_digest, &identity);
+        rewrite_record_for_test(&queued.run_id, |record| {
+            record.submitted_at = "2020-01-01T00:00:00Z".to_string();
+        })
+        .expect("age queued record");
+
+        let queued_pin = record_pin(&queued.run_id);
+        let report =
+            homeboy_core::controller_runtime::retention_report().expect("retention report");
+        assert!(report.retained.contains(&queued_pin));
+        assert!(snapshot_reasons_for(&report.snapshots, &queued_pin)
+            .iter()
+            .any(|reason| reason == "protected_in_flight"));
+        let applied = prune_controller_runtime_pins(
+            true,
+            homeboy_core::controller_runtime::ControllerRuntimeRetentionOverrides::default(),
+        )
+        .expect("prune");
+        assert!(!applied.removed.contains(&queued_pin));
+        assert!(queued_pin.exists());
     });
 }
 

--- a/crates/homeboy-core/src/controller_pin_reference.rs
+++ b/crates/homeboy-core/src/controller_pin_reference.rs
@@ -1,15 +1,17 @@
 //! Controller-runtime pin-reference hook.
 //!
 //! Controller runtime pins (immutable homeboy executables) are retained while a
-//! durable agent-task record can still operate on them — a queued, running, or
-//! recoverable-partial record keeps its originating pinned executable alive so
-//! lifecycle recovery does not lose the binary it must re-run.
+//! durable agent-task record can still mutate them and remains inside the
+//! configured retention window. In-flight (`Queued` / `Running`) records keep
+//! their pin regardless of age so an executing run cannot lose its binary.
+//! Outside that window the pin is reclaimable; `recover_pin` can republish it
+//! from a verified artifact or the recorded source revision.
 //!
 //! Discovering which pins are still referenced requires reading the agent-task
-//! lifecycle store and inspecting each record's state and metadata, which is
-//! agent-task behavior. It is inverted behind this provider so the controller
-//! runtime's retention logic (pin classification, disk scan, pruning) stays in
-//! core without core depending on the agent-task subsystem.
+//! lifecycle store and inspecting each record's lifecycle-action eligibility
+//! and age, which is agent-task behavior. It is inverted behind this provider
+//! so the controller runtime's retention logic (pin classification, disk scan,
+//! pruning) stays in core without core depending on the agent-task subsystem.
 //!
 //! With no provider registered (no agent-task subsystem present) the no-op
 //! provider reports zero referenced pins. That is safe for the read-only
@@ -19,20 +21,49 @@ use std::path::PathBuf;
 
 use crate::Result;
 
+/// Why a durable record still protects a controller-runtime pin.
+///
+/// Discriminant order is weakest-to-strongest so [`Ord`] picks the constraint
+/// that must win when several records name the same path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ControllerPinProtectionReason {
+    /// A mutating lifecycle action remains available or indeterminate and the
+    /// record is still inside the configured retention window.
+    ProtectedByPendingMutation,
+    /// The record is genuinely in flight (`Queued` or `Running`).
+    ProtectedInFlight,
+}
+
+impl ControllerPinProtectionReason {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ProtectedByPendingMutation => "protected_by_pending_mutation",
+            Self::ProtectedInFlight => "protected_in_flight",
+        }
+    }
+}
+
+/// One originating or pinned executable still protected by a durable record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReferencedControllerPin {
+    pub path: PathBuf,
+    pub reason: ControllerPinProtectionReason,
+}
+
 /// Supplies the controller-runtime executable paths still referenced by
-/// nonterminal durable agent-task records.
+/// durable agent-task records that retain their pin.
 pub trait ControllerPinReferenceProvider: Send + Sync {
     /// Return every originating and pinned executable path referenced by an
-    /// agent-task record whose state still retains its runtime (queued, running,
-    /// or recoverable). Returned paths are raw record references; callers
-    /// select the paths they own or need to protect.
-    fn referenced_controller_pins(&self) -> Result<Vec<PathBuf>>;
+    /// agent-task record whose lifecycle still retains its runtime. Returned
+    /// paths are raw record references; callers select the paths they own or
+    /// need to protect.
+    fn referenced_controller_pins(&self) -> Result<Vec<ReferencedControllerPin>>;
 }
 
 struct NoopProvider;
 
 impl ControllerPinReferenceProvider for NoopProvider {
-    fn referenced_controller_pins(&self) -> Result<Vec<PathBuf>> {
+    fn referenced_controller_pins(&self) -> Result<Vec<ReferencedControllerPin>> {
         Ok(Vec::new())
     }
 }
@@ -48,9 +79,9 @@ homeboy_engine_primitives::provider_registry! {
     with: fn with_provider,
 }
 
-/// The controller-runtime executables still referenced by nonterminal
-/// agent-task records, via the registered provider (or an empty set when the
-/// agent-task subsystem is absent).
-pub(crate) fn referenced_controller_pins() -> Result<Vec<PathBuf>> {
+/// The controller-runtime executables still referenced by agent-task records
+/// that retain their pin, via the registered provider (or an empty set when
+/// the agent-task subsystem is absent).
+pub(crate) fn referenced_controller_pins() -> Result<Vec<ReferencedControllerPin>> {
     with_provider(|p| p.referenced_controller_pins())
 }

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -13,7 +13,12 @@ use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::time::{Duration, SystemTime};
 use uuid::Uuid;
 
+use crate::controller_pin_reference::{ControllerPinProtectionReason, ReferencedControllerPin};
 use crate::{build_identity, paths, Error, Result};
+
+const RETENTION_REASON_ACTIVE_GENERATION: &str = "protected_by_active_generation";
+const RETENTION_REASON_WITHIN_AGE_WINDOW: &str = "within_age_window";
+const RETENTION_REASON_RECLAIMABLE: &str = "reclaimable";
 
 pub const CONTROLLER_RUNTIME_METADATA_KEY: &str = "controller_runtime";
 #[cfg(any(test, feature = "test-support"))]
@@ -350,9 +355,10 @@ pub struct ControllerRuntimePruneResult {
 }
 
 /// Discover pin references through the durable lifecycle store and classify the
-/// content-addressed pins currently present on disk. Queued, running, and
-/// recoverable partial records retain their pins because lifecycle recovery can
-/// still operate on them. The active admission generation is retained as well.
+/// content-addressed pins currently present on disk. Records that still have a
+/// mutating lifecycle action inside the retention window, and in-flight runs,
+/// retain their pins. The active admission generation is retained separately
+/// and unconditionally.
 pub fn retention_report() -> Result<ControllerRuntimeRetentionReport> {
     let referenced = crate::controller_pin_reference::referenced_controller_pins()?;
     retention_report_with_references_at(&runtime_root()?, &referenced, SystemTime::now())
@@ -365,6 +371,7 @@ pub fn retention_report() -> Result<ControllerRuntimeRetentionReport> {
 pub fn protected_executables() -> Result<Vec<PathBuf>> {
     let mut protected: BTreeSet<_> = crate::controller_pin_reference::referenced_controller_pins()?
         .into_iter()
+        .map(|pin| pin.path)
         .collect();
     let active = runtime_root()?.join(ACTIVE_GENERATION_FILE);
     if active.exists() {
@@ -392,17 +399,24 @@ pub fn protected_executables() -> Result<Vec<PathBuf>> {
 
 fn retention_report_with_references_at(
     root: &Path,
-    referenced: &[PathBuf],
+    referenced: &[ReferencedControllerPin],
     now: SystemTime,
 ) -> Result<ControllerRuntimeRetentionReport> {
     let mut retained = BTreeSet::new();
-
-    for path in referenced {
-        if content_addressed_pin_path(&root, path) {
-            retained.insert(path.clone());
+    let mut referenced_reasons = BTreeMap::new();
+    for pin in referenced {
+        if content_addressed_pin_path(root, &pin.path) {
+            retained.insert(pin.path.clone());
+            referenced_reasons
+                .entry(pin.path.clone())
+                .and_modify(|existing: &mut ControllerPinProtectionReason| {
+                    *existing = (*existing).max(pin.reason);
+                })
+                .or_insert(pin.reason);
         }
     }
 
+    let mut active_generation_pins = BTreeSet::new();
     let active = root.join(ACTIVE_GENERATION_FILE);
     if active.exists() {
         let value = fs::read_to_string(&active).map_err(|error| {
@@ -422,16 +436,17 @@ fn retention_report_with_references_at(
             .pointer("/originating/pinned_executable")
             .and_then(Value::as_str)
             .map(PathBuf::from)
-            .filter(|path| content_addressed_pin_path(&root, path))
+            .filter(|path| content_addressed_pin_path(root, path))
         {
-            retained.insert(path);
+            retained.insert(path.clone());
+            active_generation_pins.insert(path);
         }
     }
 
-    let pins = discover_pin_paths(&root)?;
+    let pins = discover_pin_paths(root)?;
     let eligible = pins.difference(&retained).cloned().collect();
     let mut snapshots = Vec::new();
-    for entry in fs::read_dir(&root).map_err(|error| {
+    for entry in fs::read_dir(root).map_err(|error| {
         Error::internal_io(
             error.to_string(),
             Some("list controller runtime identities".to_string()),
@@ -460,8 +475,20 @@ fn retention_report_with_references_at(
             continue;
         }
         let mut reasons = Vec::new();
-        if identity_pins.iter().any(|pin| retained.contains(pin)) {
-            reasons.push("pinned_by_active_or_resumable_run_or_current_generation".to_string());
+        if identity_pins
+            .iter()
+            .any(|pin| active_generation_pins.contains(pin))
+        {
+            reasons.push(RETENTION_REASON_ACTIVE_GENERATION.to_string());
+        }
+        let mut pin_reasons = BTreeSet::new();
+        for pin in &identity_pins {
+            if let Some(reason) = referenced_reasons.get(pin) {
+                pin_reasons.insert(*reason);
+            }
+        }
+        for reason in pin_reasons.iter().rev() {
+            reasons.push(reason.as_str().to_string());
         }
         let modified = fs::metadata(&path)
             .and_then(|metadata| metadata.modified())
@@ -489,10 +516,10 @@ fn retention_report_with_references_at(
     })
 }
 
-/// Remove only content-addressed pins not referenced by a nonterminal durable
-/// record or the active generation, and only those the configured retention
-/// window no longer protects. The caller chooses mutation explicitly, and may
-/// opt out of the window explicitly through the overrides.
+/// Remove only content-addressed pins not protected by an in-flight or
+/// pending-mutation record or the active generation, and only those the
+/// configured retention window no longer protects. The caller chooses mutation
+/// explicitly, and may opt out of the window explicitly through the overrides.
 pub fn prune_pins(
     apply: bool,
     overrides: ControllerRuntimeRetentionOverrides,
@@ -544,7 +571,7 @@ pub fn cleanup_in_root(
         if !(expired || pressured) {
             snapshot
                 .retention_reasons
-                .push("within_age_and_size_budget".to_string());
+                .push(RETENTION_REASON_WITHIN_AGE_WINDOW.to_string());
             continue;
         }
         if removed.len() >= options.limit {
@@ -553,6 +580,9 @@ pub fn cleanup_in_root(
                 .push("cleanup_limit_reached".to_string());
             continue;
         }
+        snapshot
+            .retention_reasons
+            .push(RETENTION_REASON_RECLAIMABLE.to_string());
         if options.apply {
             // Rename first: an interrupted cleanup leaves a non-discoverable
             // tombstone rather than a partially materialized identity.
@@ -1153,25 +1183,56 @@ pub fn pinned_executable_for_mutation(
 }
 
 pub fn validate_for_mutation(metadata: &Value, current_identity: &str) -> Result<()> {
+    let Some(runtime) = metadata.get(CONTROLLER_RUNTIME_METADATA_KEY) else {
+        return Ok(());
+    };
+    let originating = runtime
+        .pointer("/originating/build_identity")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if originating.is_empty() || originating == current_identity {
+        return pinned_executable_for_mutation(metadata, current_identity).map(|_| ());
+    }
+    let pinned = runtime
+        .pointer("/originating/pinned_executable")
+        .and_then(Value::as_str)
+        .unwrap_or("<pinned-controller-runtime>");
+    if !Path::new(pinned).exists() {
+        return Err(mutation_identity_mismatch(
+            originating,
+            current_identity,
+            vec![
+                "Republish the reclaimed pin from a verified artifact or the recorded source revision (`homeboy agent-task runtime-recover --artifact` or `--source`) before mutating this run"
+                    .to_string(),
+            ],
+        ));
+    }
     let Some(pinned) = pinned_executable_for_mutation(metadata, current_identity)? else {
         return Ok(());
     };
-    let originating = metadata
-        .get(CONTROLLER_RUNTIME_METADATA_KEY)
-        .and_then(|runtime| runtime.pointer("/originating/build_identity"))
-        .and_then(Value::as_str)
-        .unwrap_or_default();
-    Err(Error::validation_invalid_argument(
+    Err(mutation_identity_mismatch(
+        originating,
+        current_identity,
+        vec![format!(
+            "Run the lifecycle mutation through the pinned compatible runtime: {} <original homeboy arguments>",
+            pinned.display()
+        )],
+    ))
+}
+
+fn mutation_identity_mismatch(
+    originating: &str,
+    current_identity: &str,
+    tried: Vec<String>,
+) -> Error {
+    Error::validation_invalid_argument(
         "controller_runtime",
         format!(
             "durable run was created by controller runtime `{originating}`, but this command is `{current_identity}`"
         ),
         Some(current_identity.to_string()),
-        Some(vec![format!(
-            "Run the lifecycle mutation through the pinned compatible runtime: {} <original homeboy arguments>",
-            pinned.display()
-        )]),
-    ))
+        Some(tried),
+    )
 }
 
 /// `migrate_legacy_pin` under an already-resolved runtime root.
@@ -4087,6 +4148,29 @@ mod tests {
     }
 
     #[test]
+    fn identity_mismatch_against_a_reclaimed_pin_names_the_recovery_route() {
+        let metadata = json!({
+            "controller_runtime": {
+                "originating": {
+                    "build_identity": "homeboy 1.0.0+origin",
+                    "pinned_executable": "/missing/reclaimed-homeboy",
+                    "sha256": "00",
+                }
+            }
+        });
+
+        let error = validate_for_mutation(&metadata, "homeboy 1.0.0+replacement")
+            .expect_err("replacement runtime must not mutate the originating lifecycle");
+
+        assert!(error.message.contains("homeboy 1.0.0+origin"));
+        assert!(error.message.contains("homeboy 1.0.0+replacement"));
+        let hint = error.details["tried"][0].as_str().expect("recovery hint");
+        assert!(hint.contains("verified artifact") || hint.contains("recorded source revision"));
+        assert!(hint.contains("runtime-recover"));
+        assert!(!hint.contains("Run the lifecycle mutation through the pinned compatible runtime"));
+    }
+
+    #[test]
     #[cfg(unix)]
     fn identity_mismatch_resolves_the_verified_pinned_executable() {
         let temporary = tempfile::tempdir().expect("temporary runtime directory");
@@ -4865,14 +4949,23 @@ mod tests {
                 limit: 10,
             })
             .expect("inventory");
+            assert!(inventory.snapshots.iter().any(|snapshot| snapshot
+                .pins
+                .contains(&current_pin)
+                && !snapshot.eligible
+                && snapshot
+                    .retention_reasons
+                    .iter()
+                    .any(|reason| reason == RETENTION_REASON_ACTIVE_GENERATION)));
             assert!(inventory
                 .snapshots
                 .iter()
-                .any(|snapshot| snapshot.pins.contains(&current_pin) && !snapshot.eligible));
-            assert!(inventory
-                .snapshots
-                .iter()
-                .any(|snapshot| snapshot.pins.contains(&stale_pin) && snapshot.eligible));
+                .any(|snapshot| snapshot.pins.contains(&stale_pin)
+                    && snapshot.eligible
+                    && snapshot
+                        .retention_reasons
+                        .iter()
+                        .any(|reason| reason == RETENTION_REASON_RECLAIMABLE)));
             let applied = cleanup(ControllerRuntimeCleanupOptions {
                 apply: true,
                 min_age: Duration::from_secs(u64::MAX),
@@ -4883,6 +4976,78 @@ mod tests {
             assert!(applied.removed.contains(&stale_pin));
             assert!(current_pin.exists());
             assert!(!stale_pin.exists());
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn retention_report_names_in_flight_pending_mutation_and_active_generation() {
+        crate::test_support::with_isolated_home(|_| {
+            let temporary = tempfile::tempdir().expect("temporary controller directory");
+            let current = temporary.path().join("current");
+            let in_flight = temporary.path().join("in-flight");
+            let pending = temporary.path().join("pending");
+            let current_digest = fake_controller(&current, "homeboy test+current", "current");
+            let in_flight_digest =
+                fake_controller(&in_flight, "homeboy test+in-flight", "in-flight");
+            let pending_digest = fake_controller(&pending, "homeboy test+pending", "pending");
+            let current_pin =
+                pinned_path("homeboy test+current", &current_digest).expect("current path");
+            let in_flight_pin =
+                pinned_path("homeboy test+in-flight", &in_flight_digest).expect("in-flight path");
+            let pending_pin =
+                pinned_path("homeboy test+pending", &pending_digest).expect("pending path");
+            publish_pin(&current, &current_pin, &current_digest).expect("publish current");
+            publish_pin(&in_flight, &in_flight_pin, &in_flight_digest).expect("publish in-flight");
+            publish_pin(&pending, &pending_pin, &pending_digest).expect("publish pending");
+            write_active_generation(
+                &runtime_root().expect("root").join(ACTIVE_GENERATION_FILE),
+                &json!({ "originating": { "pinned_executable": current_pin } }),
+            )
+            .expect("activate current");
+
+            let report = retention_report_with_references_at(
+                &runtime_root().expect("root"),
+                &[
+                    ReferencedControllerPin {
+                        path: in_flight_pin.clone(),
+                        reason: ControllerPinProtectionReason::ProtectedInFlight,
+                    },
+                    ReferencedControllerPin {
+                        path: pending_pin.clone(),
+                        reason: ControllerPinProtectionReason::ProtectedByPendingMutation,
+                    },
+                ],
+                SystemTime::now(),
+            )
+            .expect("report");
+
+            let snapshot_for = |pin: &PathBuf| {
+                report
+                    .snapshots
+                    .iter()
+                    .find(|snapshot| snapshot.pins.contains(pin))
+                    .expect("snapshot")
+            };
+            assert_eq!(
+                snapshot_for(&current_pin).retention_reasons,
+                vec![RETENTION_REASON_ACTIVE_GENERATION.to_string()]
+            );
+            assert!(!snapshot_for(&current_pin).eligible);
+            assert_eq!(
+                snapshot_for(&in_flight_pin).retention_reasons,
+                vec![ControllerPinProtectionReason::ProtectedInFlight
+                    .as_str()
+                    .to_string()]
+            );
+            assert!(!snapshot_for(&in_flight_pin).eligible);
+            assert_eq!(
+                snapshot_for(&pending_pin).retention_reasons,
+                vec![ControllerPinProtectionReason::ProtectedByPendingMutation
+                    .as_str()
+                    .to_string()]
+            );
+            assert!(!snapshot_for(&pending_pin).eligible);
         });
     }
 
@@ -4969,6 +5134,13 @@ mod tests {
             let planned = prune_pins(false, ControllerRuntimeRetentionOverrides::default())
                 .expect("plan inside configured window");
             assert!(planned.eligible.contains(&pin));
+            assert!(planned.snapshots.iter().any(|snapshot| {
+                snapshot.pins.contains(&pin)
+                    && snapshot
+                        .retention_reasons
+                        .iter()
+                        .any(|reason| reason == RETENTION_REASON_WITHIN_AGE_WINDOW)
+            }));
             let applied = prune_pins(true, ControllerRuntimeRetentionOverrides::default())
                 .expect("apply inside configured window");
             assert!(applied.removed.is_empty());


### PR DESCRIPTION
Fixes #13641.

## Problem

`homeboy runtime controller-prune` reported `eligible: 0` against a 7.1 GB store with a 1.0 GiB declared cap. The issue originally attributed this to `max_total_bytes` being declared but never enforced. It is enforced — `controller_runtime.rs:543` computes byte pressure and evicts oldest-first, and that has been correct since #8866. The cap simply never had a candidate to consider.

Candidates are filtered to `snapshot.eligible` before pressure is evaluated, and eligibility is pure reachability. Everything was reachable because `state_retains_pin` opened with:

```rust
if record.lifecycle.artifact_retention.status == ArtifactRetentionStatus::Retained {
    return true;
}
```

That clause is state-blind and undocumented — the doc comment above it describes only the queued/running/recoverable state list that follows. So **artifact retention (keep this run's output) was acting as executable retention (keep this run's binary)**. On the reporting host, 295 terminal records carried `retained`, which protected every pin on disk.

Terminality alone is not the right correction either: `retry` is offered on `Failed`/`Cancelled`/`PartialFailure` and `promote` on `Succeeded`/`CandidateRecoverable`/`PartialRecoverable`, and `validate_for_mutation` makes the pinned executable the only binary permitted to perform those mutations. Dropping pins on terminal records would delete binaries the CLI is still telling operators to run.

## Change

Retention now derives from remaining **mutability**, bounded by the retention window:

- `state_retains_pin` consumes the canonical `lifecycle_action_eligibility` policy instead of maintaining a second predicate. Read-only actions such as `Review` do not retain a pin.
- A record retains its pin while a mutating action remains available or indeterminate **and** it is inside the configured `min_age_seconds` window. Outside the window the pin is reclaimable, because `recover_pin` can republish it from a verified artifact or the recorded source revision.
- In-flight records (`Queued`, `Running`) retain unconditionally, regardless of age.
- The prune report replaces the single opaque `pinned_by_active_or_resumable_run_or_current_generation` string with typed reasons naming which constraint applied.
- A mutation refused against a reclaimed pin now names the recovery route instead of instructing the operator to run a binary that no longer exists. The identity check itself is unchanged.

This removes policy rather than adding it: the duplicated state list and the artifact-retention clause are both gone, with one canonical policy consumed in their place.

## Out of scope

The prune plan is also unbounded — `referenced_controller_pins` runs a reconciling `status_in_store` per record over up to 1000 records and then walks the full store, taking 2m21s on the reporting host. That starves the 25s cleanup category budget and is tracked with #12727. This change does not address it and does not add per-record work to the pin-reference read.

## Verification

| gate | result |
|---|---|
| `cargo fmt --check` | pass |
| `cargo test -p homeboy-core controller_runtime` | 66 passed, 0 failed (`--test-threads=1`) |
| `cargo test -p homeboy-agents controller_pin` | 8 passed, 0 failed |
| `cargo check -p homeboy-core -p homeboy-agents --tests` | clean |

New tests, one per acceptance criterion:

- `controller_pin_retention_reclaims_old_terminal_retained_artifacts_under_pressure`
- `controller_pin_pending_mutation_inside_the_window_retains`
- `controller_pin_in_flight_records_retain_regardless_of_age`
- `controller_pin_retention_keeps_queued_runs_outside_the_age_window`
- `controller_pin_read_only_actions_do_not_retain`
- `controller_pin_terminal_outside_the_window_does_not_retain_artifact_retention`
- `retention_report_names_in_flight_pending_mutation_and_active_generation`
- `identity_mismatch_against_a_reclaimed_pin_names_the_recovery_route`

### Note on the parallel run

Under the default parallel runner, `controller_runtime::tests::admission_guard_releases_after_post_acquisition_failure` and `admission_refuses_a_changed_owner_during_reclaim_compare_and_swap` fail. Both pass serially (21/21 for the `admission` filter, 66/66 for the full filter), and neither touches pin retention — they collide on a shared admission lock path. That is the #11897 flake family, not a regression from this change.

## Provenance

The candidate was produced by a Homeboy Cook that hit the 1200s OpenCode provider timeout mid-run. The edits survived; the declared `patch`/`agent_result`/`transcript` artifacts did not, so the deterministic gate went red on the parallel admission flake with no transcript evidence. `agent-task finalize-pr --recover` correctly refused a `gate_failed` promotion, and `agent-task adopt` refused the commit on a source-worktree provenance check, so the gates above were run directly against the worktree and the branch was published manually. Recovering verified work after a provider timeout is currently harder than it should be, which is relevant evidence for the control-plane contract work in #13697.

## AI Assistance

Claude (Sonnet 4.5) via OpenCode investigated the retention path, established the root cause, and wrote the task specification. The implementation was produced by xai/grok-4.6 via OpenCode through `homeboy agent-task cook`. Claude then verified the candidate — running the gates, isolating the parallel admission flake, and confirming each acceptance criterion — and authored this description. All work was directed by Chris Huber.
