### PR TITLE
Promote audit to a first-class extension capability (#13723)

### DIFF
--- a/crates/contracts/homeboy-component-contract/src/model.rs
+++ b/crates/contracts/homeboy-component-contract/src/model.rs
@@ -397,6 +397,13 @@ impl Component {
         &self,
         capability: homeboy_extension_contract::ExtensionCapability,
     ) -> &[String] {
+        // Audit reference setup is extension-owned: it resolves the extension's
+        // own dependency directories, so there is no component-level
+        // `scripts.audit` override to fall back to.
+        if capability == homeboy_extension_contract::ExtensionCapability::Audit {
+            return &[];
+        }
+
         if let Some(scripts) = self.scripts.as_ref() {
             let commands = match capability {
                 homeboy_extension_contract::ExtensionCapability::Lint => &scripts.lint,
@@ -406,6 +413,9 @@ impl Component {
                 homeboy_extension_contract::ExtensionCapability::Fuzz => &scripts.fuzz,
                 homeboy_extension_contract::ExtensionCapability::Trace => &scripts.trace,
                 homeboy_extension_contract::ExtensionCapability::Deps => &scripts.deps,
+                homeboy_extension_contract::ExtensionCapability::Audit => unreachable!(
+                    "Audit returns early: no component-level scripts.audit override exists"
+                ),
             };
             if !commands.is_empty() {
                 return commands;

--- a/crates/contracts/homeboy-extension-contract/src/capability.rs
+++ b/crates/contracts/homeboy-extension-contract/src/capability.rs
@@ -15,6 +15,16 @@ pub enum ExtensionCapability {
     Fuzz,
     Trace,
     Deps,
+    /// Audit reference setup: resolves the reference dependency paths that
+    /// cross-reference analysis fingerprints but excludes from convention and
+    /// duplication detection.
+    ///
+    /// Unlike the capabilities above, Audit is *aggregating*: a component's
+    /// reference paths are the union of every linked extension's contribution,
+    /// so callers resolve one context per linked extension through
+    /// `resolve_execution_context_for_extension` rather than electing a single
+    /// owner.
+    Audit,
 }
 
 /// Static metadata for an [`ExtensionCapability`] variant.
@@ -66,6 +76,11 @@ impl ExtensionCapability {
                 label: "deps",
                 has_manifest_support: ExtensionManifest::has_deps,
                 script_path: ExtensionManifest::deps_script,
+            },
+            ExtensionCapability::Audit => ExtensionCapabilityDescriptor {
+                label: "audit",
+                has_manifest_support: ExtensionManifest::has_audit,
+                script_path: ExtensionManifest::audit_script,
             },
         }
     }

--- a/crates/contracts/homeboy-extension-contract/src/lib.rs
+++ b/crates/contracts/homeboy-extension-contract/src/lib.rs
@@ -156,7 +156,10 @@ pub use core_compat::{
     installed_homeboy_version, validate_core_compatibility, CoreCompatibilityReport,
     CORE_COMPAT_REMEDIATION_COMMAND, CORE_INCOMPATIBLE_DIAGNOSTIC,
 };
-pub use manifest_deploy_config::{DeployArchiveInstallPolicy, DeployRequiredHeader};
+pub use manifest_deploy_config::{
+    DeployArchiveInstallPolicy, DeployRequiredHeader, DeploymentProviderLayeredInputManifest,
+    DeploymentProviderManifest, DEPLOYMENT_PROVIDER_PAYLOAD_SCHEMA,
+};
 pub use manifest_test_config::{TestPassthroughFilter, TestPassthroughFilterStrategy};
 pub use runner_contract::{
     phase_failure_category_from_exit_code, phase_status_from_exit_code, ExtensionPhaseTiming,

--- a/crates/contracts/homeboy-extension-contract/src/manifest.rs
+++ b/crates/contracts/homeboy-extension-contract/src/manifest.rs
@@ -61,6 +61,13 @@ pub struct ExtensionManifest {
     // Capability groups
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deploy: Option<DeployCapability>,
+    /// Deployment providers this extension publishes.
+    ///
+    /// Typed since #13723. While this rode in `extra`, a malformed descriptor
+    /// was `.ok()`-discarded and surfaced as "extension declares no providers",
+    /// which is indistinguishable from a correct manifest that declares none.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub deployment_providers: Vec<DeploymentProviderManifest>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub audit: Option<AuditCapability>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -185,9 +192,11 @@ pub struct ExtensionManifest {
     /// extension published against a newer or older core still deserializes.
     ///
     /// This is a *forward-compatibility buffer*, not an extension point. Core
-    /// reads exactly two keys out of it — `deployment_providers`
-    /// (`manifest::deployment_providers`) and the legacy camelCase `sourceUrl`
-    /// (`lifecycle::source_metadata`) — and nothing else in here has a reader.
+    /// reads exactly two keys out of it — the legacy camelCase `sourceUrl`
+    /// (`lifecycle::source_metadata`) and `recipe_run_providers`
+    /// (`recipe_run::recipe_run_providers`, tracked for promotion in #13724) —
+    /// and nothing else in here has a reader. `deployment_providers` was the
+    /// third and became a typed field in #13723.
     ///
     /// Landing anything else here makes it inert *silently*, which is how
     /// shipped manifests accumulated `required_output_declarations` (26 lines),
@@ -333,6 +342,18 @@ impl ExtensionManifest {
             .is_some()
     }
 
+    /// Whether this extension contributes audit reference paths.
+    ///
+    /// An `audit` block that only carries detector rules, ignore patterns, or
+    /// doc targets is not an executable audit capability — only
+    /// `setup_references` is.
+    pub fn has_audit(&self) -> bool {
+        self.audit
+            .as_ref()
+            .and_then(|c| c.setup_references.as_ref())
+            .is_some()
+    }
+
     pub fn lint_script(&self) -> Option<&str> {
         self.lint
             .as_ref()
@@ -380,6 +401,12 @@ impl ExtensionManifest {
         self.trace
             .as_ref()
             .and_then(|c| c.extension_script.as_deref())
+    }
+
+    pub fn audit_script(&self) -> Option<&str> {
+        self.audit
+            .as_ref()
+            .and_then(|c| c.setup_references.as_deref())
     }
 
     pub fn trace_runner_capabilities(&self) -> &[String] {
@@ -493,13 +520,6 @@ impl ExtensionManifest {
             .as_ref()
             .map(|e| e.inputs.as_slice())
             .unwrap_or(&[])
-    }
-
-    /// Convenience: get audit reference setup script path (relative to extension dir).
-    pub fn audit_setup_references(&self) -> Option<&str> {
-        self.audit
-            .as_ref()
-            .and_then(|a| a.setup_references.as_deref())
     }
 
     /// Convenience: get audit ignore claim patterns (empty if no audit capability).

--- a/crates/contracts/homeboy-extension-contract/src/manifest_deploy_config.rs
+++ b/crates/contracts/homeboy-extension-contract/src/manifest_deploy_config.rs
@@ -54,3 +54,33 @@ impl TryFrom<DeployRequiredHeaderConfig> for DeployRequiredHeader {
 fn default_staging_path() -> String {
     "/tmp/homeboy-staging".to_string()
 }
+
+/// Generic deployment provider descriptor owned by an extension manifest.
+///
+/// This was carried in `ExtensionManifest::extra` until #13723. A malformed
+/// descriptor there deserialized to `None`, was discarded, and presented as
+/// zero declared providers with no diagnostic; as a typed field it is a named
+/// deserialization error instead.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeploymentProviderManifest {
+    pub id: String,
+    pub command: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dry_run_command: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub layered_input: Option<DeploymentProviderLayeredInputManifest>,
+}
+
+/// Opt-in capability for providers that receive a versioned layered payload.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeploymentProviderLayeredInputManifest {
+    pub schema: String,
+    #[serde(default)]
+    pub target_required: bool,
+    /// Schema for provider-produced structured evidence. Providers declaring this
+    /// contract are responsible for emitting already-redacted JSON.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result_schema: Option<String>,
+}
+
+pub const DEPLOYMENT_PROVIDER_PAYLOAD_SCHEMA: &str = "homeboy/deployment-provider-payload/v1";

--- a/crates/homeboy-cli/src/commands/audit.rs
+++ b/crates/homeboy-cli/src/commands/audit.rs
@@ -11,6 +11,8 @@ use homeboy::core::observation::{
     finding_records_from_audit, ActiveObservation, NewFindingRecord, NewRunRecord, RunStatus,
 };
 
+use homeboy_extension::{ExtensionCapability, ExtensionRunner};
+
 use super::source_command::resolve_source_context;
 use super::utils::args::{
     BaselineArgs, ChangedSinceArgs, ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs,
@@ -142,7 +144,7 @@ pub fn run(args: AuditArgs) -> CmdResult<AuditCommandOutput> {
         &args.extension_override,
         None,
     )?;
-    let reference_paths = resolve_audit_reference_paths(&source_ctx);
+    let reference_paths = resolve_audit_reference_paths(&source_ctx)?;
     let resolved_id = source_ctx.component_id.clone();
     let resolved_path = source_ctx.source_path.to_string_lossy().to_string();
 
@@ -514,69 +516,100 @@ fn code_audit_result_observation_summary(
     summary
 }
 
-/// Run configured extension audit reference setup scripts for the resolved audit target.
+/// Wall-clock budget for a single extension's audit reference setup.
 ///
-/// Setup still speaks the legacy shell boundary (`--export` stdout), but the command
-/// converts that output into typed workflow input instead of process-global state.
-pub(crate) fn resolve_audit_reference_paths(source_ctx: &ExecutionContext) -> Vec<String> {
-    let extensions = match &source_ctx.component.extensions {
-        Some(ext) => ext,
-        None => return Vec::new(),
+/// Reference setup resolves dependency directories; it is not a build. Before
+/// this ran through [`ExtensionRunner`] it had no budget at all, so a setup
+/// script that hung wedged the audit indefinitely.
+const AUDIT_REFERENCE_SETUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// Run configured extension audit reference setup for the resolved audit target.
+///
+/// Audit is an *aggregating* capability: reference paths are the union of every
+/// linked extension's contribution, so this resolves one execution context per
+/// linked extension rather than electing a single owner the way Lint or Test do.
+///
+/// Setup still speaks the legacy shell boundary (`--export` stdout), but it now
+/// runs through [`ExtensionRunner`], which supplies resolved settings, the
+/// component environment, the env-provider chain, and a wall-clock budget. A
+/// declared setup script that fails is an error rather than an empty result:
+/// reference paths feed cross-reference analysis, so silently dropping them
+/// degrades findings instead of reporting a problem.
+pub(crate) fn resolve_audit_reference_paths(
+    source_ctx: &ExecutionContext,
+) -> homeboy::core::Result<Vec<String>> {
+    let Some(extensions) = &source_ctx.component.extensions else {
+        return Ok(Vec::new());
     };
 
+    // Deterministic order: `extensions` is a HashMap, and which extension's
+    // failure surfaces first should not depend on hash iteration order.
+    let mut extension_ids: Vec<&String> = extensions.keys().collect();
+    extension_ids.sort();
+
     let mut reference_paths = Vec::new();
-    for ext_id in extensions.keys() {
-        let ext_manifest = match homeboy_extension::load_extension(ext_id) {
-            Ok(m) => m,
-            Err(_) => continue,
-        };
-
-        let setup_script = match ext_manifest.audit_setup_references() {
-            Some(s) => s,
-            None => continue,
-        };
-
-        // Resolve script path relative to extension directory
-        let ext_path = homeboy_extension::extension_path(ext_id);
-        if !ext_path.is_dir() {
+    for ext_id in extension_ids {
+        // An unreadable sibling manifest does not get to fail audit for the
+        // extensions that are readable (#11122). Only a declared-and-broken
+        // setup script is an error.
+        let Ok(manifest) = homeboy_extension::load_extension(ext_id) else {
             continue;
-        }
-        let script_path = ext_path.join(setup_script);
-        if !script_path.is_file() {
+        };
+        if !manifest.has_audit() {
             continue;
         }
 
-        homeboy::log_status!(
-            "audit",
-            "Running reference setup: {}",
-            script_path.display()
-        );
+        let execution_context = homeboy::core::extension_execution::
+            resolve_execution_context_for_extension(
+                &source_ctx.component,
+                ExtensionCapability::Audit,
+                ext_id,
+            )?;
 
-        // Run the script with --export flag and capture stdout.
-        let output = std::process::Command::new("bash")
-            .arg(script_path.to_str().unwrap_or(""))
-            .arg("--export")
-            .env("HOMEBOY_COMPONENT_PATH", &source_ctx.component.local_path)
-            .current_dir(&source_ctx.source_path)
-            .output();
+        homeboy::log_status!("audit", "Running reference setup: {}", ext_id);
 
-        if let Ok(output) = output {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            reference_paths.extend(parse_audit_reference_paths_export(&stdout));
+        let output = ExtensionRunner::for_context(execution_context)
+            .path_override(Some(source_ctx.source_path.to_string_lossy().to_string()))
+            .script_args(&["--export".to_string()])
+            .passthrough(false)
+            .timeout(Some(AUDIT_REFERENCE_SETUP_TIMEOUT))
+            .run()?;
 
-            // Log stderr (the script's informational output)
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            for line in stderr.lines() {
-                if !line.is_empty() {
-                    homeboy::log_status!("audit", "{}", line);
-                }
-            }
+        // Setup scripts report progress on stderr; keep surfacing it.
+        for line in output.stderr.lines().filter(|line| !line.is_empty()) {
+            homeboy::log_status!("audit", "{}", line);
         }
+
+        if !output.success {
+            return Err(homeboy::core::Error::validation_invalid_argument(
+                "audit.setup_references",
+                format!(
+                    "Extension '{}' audit reference setup failed with exit code {}{}",
+                    ext_id,
+                    output.exit_code,
+                    if output.timed_out {
+                        format!(
+                            " (timed out after {}s)",
+                            AUDIT_REFERENCE_SETUP_TIMEOUT.as_secs()
+                        )
+                    } else {
+                        String::new()
+                    }
+                ),
+                Some(ext_id.clone()),
+                Some(vec![
+                    homeboy::core::extension_execution::stderr_tail(&output.stderr),
+                    "Reference paths feed cross-reference analysis; running audit without them would change findings.".to_string(),
+                ]),
+            ));
+        }
+
+        reference_paths.extend(parse_audit_reference_paths_export(&output.stdout));
     }
 
     reference_paths.sort();
     reference_paths.dedup();
-    reference_paths
+    Ok(reference_paths)
 }
 
 fn parse_audit_reference_paths_export(stdout: &str) -> Vec<String> {
@@ -766,14 +799,44 @@ mod tests {
             .to_string(),
         )
         .expect("extension manifest");
-        fs::write(
-            extension_dir.join("setup.sh"),
-            format!(
-                "printf '%s\\n' \"export HOMEBOY_AUDIT_REFERENCE_PATHS='{}'\"\n",
+        write_executable_script(
+            &extension_dir.join("setup.sh"),
+            &format!(
+                "#!/bin/sh\nprintf '%s\\n' \"export HOMEBOY_AUDIT_REFERENCE_PATHS='{}'\"\n",
                 reference_path.display()
             ),
+        );
+    }
+
+    /// Extension whose declared reference setup exists but exits non-zero.
+    fn write_failing_reference_extension(home: &std::path::Path, id: &str) {
+        let extension_dir = home.join(".config/homeboy/extensions").join(id);
+        fs::create_dir_all(&extension_dir).expect("extension dir");
+        fs::write(
+            extension_dir.join(format!("{id}.json")),
+            serde_json::json!({
+                "name": id,
+                "version": "0.0.0",
+                "audit": { "setup_references": "setup.sh" }
+            })
+            .to_string(),
         )
-        .expect("setup script");
+        .expect("extension manifest");
+        write_executable_script(
+            &extension_dir.join("setup.sh"),
+            "#!/bin/sh\necho 'dependency resolution failed' >&2\nexit 3\n",
+        );
+    }
+
+    fn write_executable_script(path: &std::path::Path, body: &str) {
+        fs::write(path, body).expect("setup script");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = fs::metadata(path).expect("script metadata").permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(path, permissions).expect("make script executable");
+        }
     }
 
     fn write_extension_without_reference_setup(home: &std::path::Path, id: &str) {
@@ -889,7 +952,8 @@ mod tests {
             write_standalone_component(home.path(), "demo", &component_dir, "fixture");
 
             let source_ctx = source_context_for(Some("demo".to_string()), None, vec![]);
-            let reference_paths = resolve_audit_reference_paths(&source_ctx);
+            let reference_paths =
+                resolve_audit_reference_paths(&source_ctx).expect("reference setup succeeds");
 
             assert_eq!(
                 reference_paths,
@@ -924,7 +988,8 @@ mod tests {
                 Some(component_dir.to_string_lossy().to_string()),
                 vec![],
             );
-            let reference_paths = resolve_audit_reference_paths(&source_ctx);
+            let reference_paths =
+                resolve_audit_reference_paths(&source_ctx).expect("reference setup succeeds");
 
             assert_eq!(source_ctx.component_id, "portable-demo");
             assert_eq!(
@@ -960,7 +1025,8 @@ mod tests {
                 Some(component_dir.to_string_lossy().to_string()),
                 vec!["override".to_string()],
             );
-            let reference_paths = resolve_audit_reference_paths(&source_ctx);
+            let reference_paths =
+                resolve_audit_reference_paths(&source_ctx).expect("reference setup succeeds");
 
             assert_eq!(
                 reference_paths,
@@ -993,7 +1059,50 @@ mod tests {
                 vec![],
             );
 
-            assert!(resolve_audit_reference_paths(&source_ctx).is_empty());
+            assert!(resolve_audit_reference_paths(&source_ctx)
+                .expect("no declared setup is not a failure")
+                .is_empty());
+            let _ = fs::remove_dir_all(component_dir);
+        });
+    }
+
+    /// Before #13723 this resolved to an empty path list, so audit ran without
+    /// the extension's reference dependencies and silently produced different
+    /// cross-reference findings. A declared setup script that fails is now an
+    /// error carrying the script's own stderr.
+    #[test]
+    fn audit_reference_setup_reports_failing_setup_script() {
+        with_isolated_home(|home| {
+            let component_dir = tmp_dir("failing-reference-component");
+            fs::create_dir_all(&component_dir).expect("component dir");
+            fs::write(
+                component_dir.join("homeboy.json"),
+                serde_json::json!({
+                    "id": "failing-demo",
+                    "extensions": { "fixture": {} }
+                })
+                .to_string(),
+            )
+            .expect("portable config");
+            write_failing_reference_extension(home.path(), "fixture");
+
+            let source_ctx = source_context_for(
+                None,
+                Some(component_dir.to_string_lossy().to_string()),
+                vec![],
+            );
+
+            let error = resolve_audit_reference_paths(&source_ctx)
+                .expect_err("a failing reference setup must not resolve to an empty path list");
+            let rendered = error.to_string();
+            assert!(
+                rendered.contains("fixture"),
+                "error should name the extension: {rendered}"
+            );
+            assert!(
+                rendered.contains("reference setup failed"),
+                "error should name the failure: {rendered}"
+            );
             let _ = fs::remove_dir_all(component_dir);
         });
     }

--- a/crates/homeboy-cli/src/commands/audit.rs
+++ b/crates/homeboy-cli/src/commands/audit.rs
@@ -559,8 +559,8 @@ pub(crate) fn resolve_audit_reference_paths(
             continue;
         }
 
-        let execution_context = homeboy::core::extension_execution::
-            resolve_execution_context_for_extension(
+        let execution_context =
+            homeboy::core::extension_execution::resolve_execution_context_for_extension(
                 &source_ctx.component,
                 ExtensionCapability::Audit,
                 ext_id,

--- a/crates/homeboy-cli/src/commands/audit_baseline.rs
+++ b/crates/homeboy-cli/src/commands/audit_baseline.rs
@@ -207,7 +207,7 @@ fn refresh(args: AuditBaselineRefreshArgs) -> CmdResult<AuditBaselineRefreshOutp
         &args.extension_override,
         None,
     )?;
-    let reference_paths = super::audit::resolve_audit_reference_paths(&source_ctx);
+    let reference_paths = super::audit::resolve_audit_reference_paths(&source_ctx)?;
     let source_path = source_ctx.source_path.to_string_lossy().to_string();
     let source = Path::new(&source_path);
 

--- a/crates/homeboy-core/src/extension_execution.rs
+++ b/crates/homeboy-core/src/extension_execution.rs
@@ -629,6 +629,55 @@ pub fn resolve_execution_context_if_available(
     execution_context_for_extension(component, None, capability, extension_id).map(Some)
 }
 
+/// Resolve an execution context for one named linked extension.
+///
+/// Owner-elected capabilities (Lint, Test, Bench, Trace, Deps, Build, Fuzz)
+/// resolve exactly one provider and should use [`resolve_execution_context`].
+/// Aggregating capabilities compose a result from every linked extension that
+/// advertises them — audit reference paths are the union of each extension's
+/// contribution, not one extension's answer — so they need a context bound to a
+/// specific extension rather than an elected owner.
+///
+/// The extension must be linked to the component and must advertise
+/// `capability`; both are validation errors rather than silent skips.
+pub fn resolve_execution_context_for_extension(
+    component: &Component,
+    capability: ExtensionCapability,
+    extension_id: &str,
+) -> Result<ExtensionExecutionContext> {
+    let linked = component
+        .extensions
+        .as_ref()
+        .is_some_and(|extensions| extensions.contains_key(extension_id));
+    if !linked {
+        return Err(Error::validation_invalid_argument(
+            "extension",
+            format!(
+                "Component '{}' does not link extension '{}'",
+                component.id, extension_id
+            ),
+            Some(extension_id.to_string()),
+            None,
+        ));
+    }
+
+    let manifest = load_extension(extension_id)?;
+    if !capability.has_manifest_support(&manifest) {
+        return Err(Error::validation_invalid_argument(
+            "extension",
+            format!(
+                "Extension '{}' does not provide {} support",
+                extension_id,
+                capability.label()
+            ),
+            Some(extension_id.to_string()),
+            None,
+        ));
+    }
+
+    execution_context_for_extension(component, None, capability, extension_id.to_string())
+}
+
 /// Resolve a capability against a project attachment, retaining the project
 /// settings and attachment path for the runner environment.
 pub fn resolve_execution_context_for_project(

--- a/crates/homeboy-extension/src/manifest.rs
+++ b/crates/homeboy-extension/src/manifest.rs
@@ -72,40 +72,14 @@ pub use homeboy_extension_contract::notification_transport_config::{
 
 pub use homeboy_extension_contract::ExtensionManifest;
 
-/// Generic provider metadata owned by an extension manifest.
-#[derive(Debug, Clone, serde::Deserialize)]
-pub struct DeploymentProviderManifest {
-    pub id: String,
-    pub command: String,
-    #[serde(default)]
-    pub dry_run_command: Option<String>,
-    #[serde(default)]
-    pub layered_input: Option<DeploymentProviderLayeredInputManifest>,
-}
+pub use homeboy_extension_contract::{
+    DeploymentProviderLayeredInputManifest, DeploymentProviderManifest,
+    DEPLOYMENT_PROVIDER_PAYLOAD_SCHEMA,
+};
 
-/// Opt-in capability for providers that receive a versioned layered payload.
-#[derive(Debug, Clone, serde::Deserialize)]
-pub struct DeploymentProviderLayeredInputManifest {
-    pub schema: String,
-    #[serde(default)]
-    pub target_required: bool,
-    /// Schema for provider-produced structured evidence. Providers declaring this
-    /// contract are responsible for emitting already-redacted JSON.
-    #[serde(default)]
-    pub result_schema: Option<String>,
-}
-
-pub const DEPLOYMENT_PROVIDER_PAYLOAD_SCHEMA: &str = "homeboy/deployment-provider-payload/v1";
-
-/// Extension manifests retain provider descriptors as extension-owned data until
-/// the shared manifest contract publishes this capability.
-pub fn deployment_providers(manifest: &ExtensionManifest) -> Vec<DeploymentProviderManifest> {
-    manifest
-        .extra
-        .get("deployment_providers")
-        .cloned()
-        .and_then(|value| serde_json::from_value(value).ok())
-        .unwrap_or_default()
+/// Deployment providers declared by an extension manifest.
+pub fn deployment_providers(manifest: &ExtensionManifest) -> &[DeploymentProviderManifest] {
+    &manifest.deployment_providers
 }
 
 pub fn deployment_provider_layered_input(
@@ -114,7 +88,7 @@ pub fn deployment_provider_layered_input(
 ) -> Result<Option<DeploymentProviderLayeredInputManifest>> {
     let extension = super::load_extension(extension_id)?;
     let provider = deployment_providers(&extension)
-        .into_iter()
+        .iter()
         .find(|provider| provider.id == provider_id)
         .ok_or_else(|| Error::validation_invalid_argument(
             "deployment_provider.provider",
@@ -122,7 +96,7 @@ pub fn deployment_provider_layered_input(
             None,
             None,
         ))?;
-    Ok(provider.layered_input)
+    Ok(provider.layered_input.clone())
 }
 
 #[cfg(test)]
@@ -163,6 +137,27 @@ mod deployment_provider_tests {
                 .as_ref()
                 .expect("layered input")
                 .target_required
+        );
+    }
+
+    /// While `deployment_providers` rode in `ExtensionManifest::extra`, a
+    /// malformed descriptor was `.ok()`-discarded and reported as "extension
+    /// declares no providers" — indistinguishable from a correct manifest that
+    /// declares none. As a typed field it is a named deserialization error.
+    #[test]
+    fn malformed_provider_descriptor_is_an_error_not_an_empty_list() {
+        let result: std::result::Result<ExtensionManifest, _> =
+            serde_json::from_value(serde_json::json!({
+                "name": "fixture", "version": "1.0.0",
+                "deployment_providers": [
+                    { "id": "fixture.alpha" }
+                ]
+            }));
+
+        let error = result.expect_err("a provider missing `command` must not deserialize");
+        assert!(
+            error.to_string().contains("command"),
+            "error should name the missing field: {error}"
         );
     }
 }


### PR DESCRIPTION
Closes #13723.

## What changed

`ExtensionCapability` had seven variants; audit and deploy consumed extension-declared behavior without one, so each built a private path around `ExtensionRunner`.

**Audit is now a capability.** `ExtensionCapability::Audit` plus `has_audit` / `audit_script` accessors, and reference setup runs through `ExtensionRunner` instead of `std::process::Command::new("bash")` in the CLI command layer.

**Audit is aggregating, not owner-elected.** Reference paths are the union of every linked extension's contribution, so the existing resolvers — which all elect exactly one owner — are the wrong shape. This adds `resolve_execution_context_for_extension(component, capability, extension_id)`, a thin public binding over the already-private `execution_context_for_extension`, and documents the distinction on the `Audit` variant.

**Deploy does not get a variant.** See the scope note below.

**Deploy providers are typed.** `deployment_providers` moves from `ExtensionManifest::extra` to a typed manifest field.

## Why the audit boundary mattered

`crates/homeboy-cli/src/commands/audit.rs` was the only `Command::new("bash")` outside test code in the workspace; every other match is in a `#[cfg(test)]` module or `tests/`. It passed one environment variable, had no resolved settings, no run dir, and no timeout, and it swallowed both extension load failure (`Err(_) => continue`) and execution failure (`if let Ok(output)`).

That last part is the real defect. Reference paths feed cross-reference/dead-code analysis, so a setup script that failed produced a *quieter* audit rather than a failing one — fewer reference directories, different findings, no diagnostic. Audit findings gate CI.

Now: linked extensions are visited in sorted order so which failure surfaces first does not depend on `HashMap` iteration; a declared setup script that fails is a named error carrying the script's own stderr tail; and setup runs under a 300s wall-clock budget where it previously had none. An unreadable *sibling* manifest still does not fail audit for the extensions that are readable, consistent with the precedent already documented at `extension_execution.rs:600-606` (#11122).

## Scope correction against the issue

#13723 proposed five items. Reading the code before implementing showed two of them were wrong, and I did not build them:

**No `ExtensionCapability::Deploy`.** Components declare the owning extension explicitly via `component.deployment_provider` (`{ extension, provider }`), consumed at `homeboy-deploy/src/provider.rs:197`. There is no owner to elect. Deploy also has no entrypoint script — it runs provider command templates. A variant would have bought a permanently-`None` `deploy_script` and a `has_script(Deploy)` that is always false. That is ceremony, not a contract. Deploy's actual defect was descriptor storage, which this PR fixes.

**No owner resolution for audit.** `resolve_extension_for_capability` elects one provider. Forcing audit through it would drop every non-elected extension's reference paths — a behavior regression, and the opposite of what audit needs. Hence the aggregating primitive instead.

The remaining three items are implemented.

## Verification

- `cargo check --workspace --all-targets` clean.
- New: `audit_reference_setup_reports_failing_setup_script` — a declared setup script exiting 3 now returns an error naming the extension and the failure, where it previously resolved to an empty path list.
- New: `malformed_provider_descriptor_is_an_error_not_an_empty_list` — a provider missing `command` now fails deserialization naming the field, where it was previously `.ok()`-discarded.
- Unchanged behavior for well-formed manifests proven by the four pre-existing reference-setup tests, which pass untouched: registered component context, path-portable config, extension override, and no-setup-contract. Fixture scripts gained `#!/bin/sh` and mode `0755`, since the runner executes the script rather than passing it to `bash`.
- `homeboy-extension` lib: 817 passed, 0 failed. `homeboy-extension-contract` + `homeboy-component-contract`: 80 passed, 0 failed. `homeboy-core` `extension_execution`: 9 passed, 0 failed. `homeboy-cli` reference-setup: 5 passed, 0 failed.
- `homeboy-deploy` lib: 319 passed, 4 failed — `safety_and_artifact::*`, failing on `chmod` under `/private/tmp`. **Pre-existing.** I stashed this branch, ran the same tests on an unmodified `4560bcaaf`, and reproduced the identical four failures. Related to #13273.
- `cargo clippy --workspace --all-targets` introduces no new warnings; the workspace's 362 existing warnings are unchanged, and none point at changed lines.

## Follow-up

`recipe_run_providers` is now the last non-legacy tenant of `ExtensionManifest::extra`, tracked in #13724. The `extra` doc comment is updated here to record the tenancy accurately, since it claimed two readers while there were three.

## AI assistance

OpenCode 1.18.23 running Anthropic `claude-opus-5` investigated the extension capability boundary, wrote this change, and verified it — including reproducing the `homeboy-deploy` failures on the unmodified base commit to establish they are pre-existing. It also identified that two of the issue's own proposals were unsound and left them unimplemented. Chris Huber directed the investigation, chose the scope, and owns the review.
