### PR TITLE
Root controller runtime pins in lifecycle stores

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -3080,11 +3080,8 @@ pub fn load_plan_for_execution_in_store(
 /// Validate a queued lifecycle's pinned controller against an explicitly rooted
 /// store.
 ///
-/// The record read and the legacy-pin migration write both follow
-/// `lifecycle_store`. The immutable controller-runtime pin store that
-/// `controller_runtime::validate` consults is deliberately left process-global:
-/// it is a content-addressed executable cache shared across homes, not durable
-/// lifecycle state, so it is not one of this store's roots.
+/// The record read, legacy-pin migration, and immutable controller runtime all
+/// follow `lifecycle_store`.
 pub fn validate_controller_runtime_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
@@ -3270,11 +3267,8 @@ fn migrate_record_controller_runtime_in_store(
 /// against one home's provenance and persisting into another leaves the run this
 /// operator is trying to re-enter still holding the broken pin.
 ///
-/// The immutable controller-runtime store that `recover_pin_and_persist`
-/// republishes into is deliberately left process-global, for the same reason
-/// `validate_controller_runtime_in_store` leaves it alone: it is a
-/// content-addressed executable cache shared across homes, not durable lifecycle
-/// state, so it is not one of this store's roots.
+/// Recovery republishes the immutable pin under this lifecycle store's runtime
+/// root before persisting the repaired reference.
 pub fn recover_controller_runtime_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -895,11 +895,8 @@ fn claim_family_siblings_coordinate_only_inside_the_injected_store() {
             // Remove the admission-supplied runtime pin rather than leaving a
             // malformed one. An invalid *present* pin sends
             // `validate_controller_runtime_in_store` through
-            // `migrate_legacy_pin_and_persist`, which creates and locks the
-            // process-global controller-runtime store — the one root that is
-            // deliberately not a lifecycle root, and the one this test must not
-            // touch. With no pin at all the preflight fails on the record
-            // itself, entirely inside the injected store.
+            // `migrate_legacy_pin_and_persist`. With no pin at all the preflight
+            // fails on the record itself without materializing runtime state.
             lifecycle_store
                 .mutate_record(run_id, |record| {
                     record

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -2447,10 +2447,8 @@ fn acceptance_rejects_a_promotion_that_changes_during_authority_verification() {
 /// false, None, …)` with a stub admission. That is the exact flag pair the
 /// ambient `retry` uses (`retry_in_store` → `retry_with_force_inner_in_store`
 /// with `force: false, enforce_lineage_reservation: false`); only the
-/// controller-runtime admission is stubbed, because that queue lives under
-/// `paths::controller_runtimes_store()` and is deliberately process-global —
-/// a migrated test enqueuing against the real operator data root could block
-/// on its cross-process lock. Same substitution as
+/// controller-runtime admission is stubbed so this test controls the exact
+/// runtime metadata it exercises. Same substitution as
 /// `retry_submits_new_run_from_existing_plan`.
 ///
 /// `revalidate_durable_attestation` stays ambient: it reads no durable state at

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -1436,7 +1436,29 @@ pub fn reconcile_recipe_attempt_for_continuation(
     recipe: &AgentTaskCookRecipe,
     run_id: &str,
 ) -> Result<agent_task_lifecycle::AgentTaskRunRecord> {
-    let record = super::cook_pre_execution::recover_recipe_attempt(run_id)?.ok_or_else(|| {
+    let recipe_store = CookRecipeStore::from_current_data_root()?;
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    reconcile_recipe_attempt_for_continuation_in_stores(
+        &recipe_store,
+        &lifecycle_store,
+        recipe,
+        run_id,
+    )
+}
+
+fn reconcile_recipe_attempt_for_continuation_in_stores(
+    recipe_store: &CookRecipeStore,
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    recipe: &AgentTaskCookRecipe,
+    run_id: &str,
+) -> Result<agent_task_lifecycle::AgentTaskRunRecord> {
+    let record = super::cook_pre_execution::recover_recipe_attempt_with_stores(
+        recipe_store,
+        lifecycle_store,
+        run_id,
+    )?
+    .ok_or_else(|| {
         Error::internal_unexpected(
             "Cook recipe unexpectedly disappeared during continuation recovery",
         )
@@ -1445,15 +1467,19 @@ pub fn reconcile_recipe_attempt_for_continuation(
     // Promotion has copied and verified the selected artifact into the
     // controller-owned destination. Once its gates are green, finalization no
     // longer consumes the provider aggregate's artifact transport.
-    let finalized_candidate = super::cook_promotion::persisted_promotion_for_attempt(run_id)?
-        .is_some_and(|promotion| {
-            promotion.status == crate::agent_task_promotion::AgentTaskPromotionStatus::Applied
-                && promotion.finalization_eligible(false)
-        });
+    let finalized_candidate =
+        super::cook_promotion::persisted_promotion_for_attempt_in_store(lifecycle_store, run_id)?
+            .is_some_and(|promotion| {
+                promotion.status == crate::agent_task_promotion::AgentTaskPromotionStatus::Applied
+                    && promotion.finalization_eligible(false)
+            });
     if finalized_candidate {
         return Ok(record);
     }
-    if let Some(reason) = agent_task_lifecycle::terminal_artifact_projection_readiness(run_id)? {
+    if let Some(reason) = agent_task_lifecycle::terminal_artifact_projection_readiness_in_store(
+        lifecycle_store,
+        run_id,
+    )? {
         return Err(Error::validation_invalid_argument(
             "cook_continuation.artifact_projection",
             format!(
@@ -2183,6 +2209,8 @@ fn consume_claimed_with_dispatcher_policy(
     execute: impl FnOnce(AgentTaskCookServiceOptions) -> Result<i32>,
     allow_historical_terminal: bool,
 ) -> Result<i32> {
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_data_root(store.data_root());
     let recipe = match store.load_recipe(&claim.continuation().cook_id) {
         Ok(recipe) => recipe,
         Err(error) => {
@@ -2222,10 +2250,16 @@ fn consume_claimed_with_dispatcher_policy(
             .map(|attempt| attempt.attempt)
             .unwrap_or(0);
     }
-    if agent_task_lifecycle::run_record_exists(&claim.continuation().run_id)? {
-        if let Err(error) =
-            reconcile_recipe_attempt_for_continuation(&recipe, &claim.continuation().run_id)
-        {
+    if agent_task_lifecycle::run_record_exists_in_store(
+        &lifecycle_store,
+        &claim.continuation().run_id,
+    )? {
+        if let Err(error) = reconcile_recipe_attempt_for_continuation_in_stores(
+            store,
+            &lifecycle_store,
+            &recipe,
+            &claim.continuation().run_id,
+        ) {
             if error.retryable == Some(true) {
                 claim.retry()?;
             } else {

--- a/crates/homeboy-core/src/controller_runtime.rs
+++ b/crates/homeboy-core/src/controller_runtime.rs
@@ -24,6 +24,8 @@ pub const CONTROLLER_RUNTIME_METADATA_KEY: &str = "controller_runtime";
 #[cfg(any(test, feature = "test-support"))]
 pub(crate) const TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV: &str =
     "HOMEBOY_TEST_CONTROLLER_RUNTIME_EXECUTABLE";
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) const TEST_CONTROLLER_RUNTIME_USE_ENV: &str = "HOMEBOY_TEST_CONTROLLER_RUNTIME_USE_ENV";
 /// Names the executable [`TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV`]'s fixture is
 /// copied from.
 ///
@@ -35,8 +37,6 @@ pub(crate) const TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV: &str =
 #[cfg(any(test, feature = "test-support"))]
 pub(crate) const TEST_CONTROLLER_RUNTIME_SOURCE_ENV: &str =
     "HOMEBOY_TEST_CONTROLLER_RUNTIME_SOURCE";
-#[cfg(any(test, feature = "test-support"))]
-pub(crate) const TEST_CONTROLLER_RUNTIME_STORE_ENV: &str = "HOMEBOY_TEST_CONTROLLER_RUNTIME_STORE";
 #[cfg(any(test, feature = "test-support"))]
 pub(crate) const TEST_CONTROLLER_RUNTIME_IDENTITY_ENV: &str =
     "HOMEBOY_TEST_CONTROLLER_RUNTIME_IDENTITY";
@@ -779,13 +779,14 @@ impl Drop for AdmissionLock {
 /// `pin_current` under an already-resolved runtime root.
 pub fn pin_current_in_root(root: &Path) -> Result<Value> {
     let _lock = acquire_admission_lock(&root.join(ADMISSION_LOCK_DIR))?;
-    pin_current_unlocked()
+    pin_current_unlocked(root)
 }
 
-fn pin_current_unlocked() -> Result<Value> {
+fn pin_current_unlocked(root: &Path) -> Result<Value> {
     let identity = build_identity::current();
     let executable = current_executable()?;
-    pin_executable_with_source(
+    pin_executable_with_source_in_root(
+        root,
         &executable,
         &identity.display,
         build_source_provenance(&identity),
@@ -828,22 +829,30 @@ pub fn pin_current_queued_in_root(
             return Err(error);
         }
     };
-    let runtime = pin_current_unlocked()?;
+    let runtime = pin_current_unlocked(root)?;
     drop(lock);
     Ok(runtime)
 }
 
 fn current_executable() -> Result<PathBuf> {
-    #[cfg(any(test, feature = "test-support"))]
-    if let Some(executable) = std::env::var_os(TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV) {
-        let executable = PathBuf::from(executable);
-        // The fixture is materialized here, on first read, instead of when the
-        // hermetic home was built: only the handful of readers of this contract
-        // need its bytes, and the copy is of a multi-hundred-megabyte binary.
-        crate::test_support::ensure_test_controller_fixture(&executable);
-        return Ok(executable);
+    #[cfg(test)]
+    {
+        return Ok(crate::test_support::controller_runtime_test_executable());
     }
 
+    #[cfg(all(not(test), feature = "test-support"))]
+    {
+        if std::env::var_os(TEST_CONTROLLER_RUNTIME_USE_ENV).is_some() {
+            if let Some(executable) = std::env::var_os(TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV) {
+                let executable = PathBuf::from(executable);
+                crate::test_support::ensure_test_controller_fixture(&executable);
+                return Ok(executable);
+            }
+        }
+        return Ok(crate::test_support::controller_runtime_test_executable());
+    }
+
+    #[cfg(all(not(test), not(feature = "test-support")))]
     std::env::current_exe().map_err(|error| {
         Error::internal_io(
             error.to_string(),
@@ -855,12 +864,22 @@ fn current_executable() -> Result<PathBuf> {
 /// Seal a verified executable for a command-scoped controller continuation.
 /// The returned pin is content-addressed, executable, and self-identifying.
 pub fn pin_executable(executable: &Path, identity: &str) -> Result<Value> {
-    pin_executable_with_source(executable, identity, unavailable_source_provenance())
+    pin_executable_with_source_in_root(
+        &runtime_root()?,
+        executable,
+        identity,
+        unavailable_source_provenance(),
+    )
 }
 
-fn pin_executable_with_source(executable: &Path, identity: &str, source: Value) -> Result<Value> {
+fn pin_executable_with_source_in_root(
+    root: &Path,
+    executable: &Path,
+    identity: &str,
+    source: Value,
+) -> Result<Value> {
     let digest = controller_executable_digest(executable)?;
-    let pinned_path = pinned_path(identity, &digest)?;
+    let pinned_path = pinned_path_in_root(root, identity, &digest);
     publish_pin(executable, &pinned_path, &digest)?;
 
     let runtime = runtime_pin(identity, executable, &pinned_path, &digest, source);
@@ -932,7 +951,8 @@ pub fn materialize_source_commit(source: &str, commit: &str, identity: &str) -> 
             None,
         ));
     }
-    pin_executable_with_source(
+    pin_executable_with_source_in_root(
+        &runtime_root()?,
         &target.target_dir().join("release/homeboy"),
         identity,
         json!({
@@ -1040,7 +1060,7 @@ pub fn admit_current_for_with_cancellation_check_in_root(
             return Err(error);
         }
     };
-    let runtime = pin_current_unlocked()?;
+    let runtime = pin_current_unlocked(root)?;
     write_active_generation(&root.join(ACTIVE_GENERATION_FILE), &runtime)?;
     validate_pin(&runtime)?;
     heartbeat_admission_owner(&lock_path, request_id, Some(&runtime))?;
@@ -1064,11 +1084,7 @@ pub fn admission_status(request_id: &str) -> Result<Value> {
 /// admitting siblings do not. The projection below resolves nothing but the
 /// admission queue beneath `runtime_root`, so a rooted status can never report
 /// this installation's queue position against another installation's owner.
-/// `pin_current`, `admit_current_for`, `activate_installed_generation`,
-/// `migrate_legacy_pin`, and `recover_pin` all also publish into the
-/// content-addressed pin store, which is deliberately process-global (#7505);
-/// rooting only their queue half is exactly the split this campaign forbids.
-/// Nothing here touches that store.
+/// Unlike mutation, this projection does not publish pin bytes.
 pub fn admission_status_at(runtime_root: &Path, request_id: &str) -> Result<Value> {
     fs::create_dir_all(runtime_root).map_err(|error| {
         Error::internal_io(
@@ -1154,7 +1170,12 @@ pub fn activate_installed_generation(executable: &Path) -> Result<Value> {
 pub fn activate_installed_generation_in_root(root: &Path, executable: &Path) -> Result<Value> {
     let lock_path = root.join(ADMISSION_LOCK_DIR);
     let _lock = acquire_admission_lock(&lock_path)?;
-    let runtime = pin_executable(executable, &activated_executable_identity(executable)?)?;
+    let runtime = pin_executable_with_source_in_root(
+        root,
+        executable,
+        &activated_executable_identity(executable)?,
+        unavailable_source_provenance(),
+    )?;
     validate_pin(&runtime)?;
     write_active_generation(&root.join(ACTIVE_GENERATION_FILE), &runtime)?;
     Ok(runtime)
@@ -1238,7 +1259,7 @@ fn mutation_identity_mismatch(
 /// `migrate_legacy_pin` under an already-resolved runtime root.
 pub fn migrate_legacy_pin_in_root(root: &Path, runtime: &Value) -> Result<Value> {
     let _lock = acquire_admission_lock(&root.join(ADMISSION_LOCK_DIR))?;
-    migrate_legacy_pin_unlocked(runtime)
+    migrate_legacy_pin_unlocked(root, runtime)
 }
 
 /// [`migrate_legacy_pin_and_persist`] under an already-resolved runtime root.
@@ -1248,14 +1269,14 @@ pub fn migrate_legacy_pin_and_persist_in_root(
     persist: impl FnOnce(&Value) -> Result<()>,
 ) -> Result<Value> {
     let _lock = acquire_admission_lock(&runtime_root.join(ADMISSION_LOCK_DIR))?;
-    let migrated = migrate_legacy_pin_unlocked(runtime)?;
+    let migrated = migrate_legacy_pin_unlocked(runtime_root, runtime)?;
     if &migrated != runtime {
         persist(&migrated)?;
     }
     Ok(migrated)
 }
 
-fn migrate_legacy_pin_unlocked(runtime: &Value) -> Result<Value> {
+fn migrate_legacy_pin_unlocked(root: &Path, runtime: &Value) -> Result<Value> {
     let identity =
         required_runtime_string(runtime, "/originating/build_identity", "build identity")?;
     let current = required_runtime_string(
@@ -1271,7 +1292,7 @@ fn migrate_legacy_pin_unlocked(runtime: &Value) -> Result<Value> {
         verify_executable(current, "legacy controller runtime")?;
         verify_self_status_identity(current, identity)?;
         let digest = executable_digest(current)?;
-        let destination = pinned_path(identity, &digest)?;
+        let destination = pinned_path_in_root(root, identity, &digest);
         publish_pin(current, &destination, &digest)?;
 
         let mut migrated = runtime.clone();
@@ -1288,7 +1309,7 @@ fn migrate_legacy_pin_unlocked(runtime: &Value) -> Result<Value> {
     }
 
     let digest = required_runtime_string(runtime, "/originating/sha256", "content digest")?;
-    let destination = pinned_path(identity, digest)?;
+    let destination = pinned_path_in_root(root, identity, digest);
     if current == destination {
         validate_pin(runtime)?;
         return Ok(runtime.clone());
@@ -1316,7 +1337,7 @@ pub fn recover_pin_in_root(
     source: Option<&Path>,
 ) -> Result<Value> {
     let _lock = acquire_admission_lock(&root.join(ADMISSION_LOCK_DIR))?;
-    recover_pin_unlocked(runtime, artifact, source)
+    recover_pin_unlocked(root, runtime, artifact, source)
 }
 
 /// Publish a recovered pin and persist its durable reference under one
@@ -1339,12 +1360,13 @@ pub fn recover_pin_and_persist_in_root(
     persist: impl FnOnce(&Value) -> Result<()>,
 ) -> Result<Value> {
     let _lock = acquire_admission_lock(&runtime_root.join(ADMISSION_LOCK_DIR))?;
-    let recovered = recover_pin_unlocked(runtime, artifact, source)?;
+    let recovered = recover_pin_unlocked(runtime_root, runtime, artifact, source)?;
     persist(&recovered)?;
     Ok(recovered)
 }
 
 fn recover_pin_unlocked(
+    root: &Path,
     runtime: &Value,
     artifact: Option<&Path>,
     source: Option<&Path>,
@@ -1355,7 +1377,7 @@ fn recover_pin_unlocked(
     // Recovery never repairs an existing path in place. A corrupted canonical
     // path can still be referenced by another durable record, so this record
     // receives a distinct immutable snapshot after the artifact is verified.
-    let destination = recovered_pinned_path(identity, expected)?;
+    let destination = recovered_pinned_path_in_root(root, identity, expected);
     if let Some(artifact) = artifact {
         verify_artifact(artifact, expected, identity)?;
         publish_pin(artifact, &destination, expected)?;
@@ -2895,36 +2917,28 @@ fn is_executable(metadata: &fs::Metadata) -> bool {
     }
 }
 
+#[cfg(test)]
 fn pinned_path(identity: &str, digest: &str) -> Result<PathBuf> {
-    Ok(controller_runtime_store_root()?
-        .join("controller-runtimes")
-        .join(format!(
-            "{}-{}",
-            paths::sanitize_path_segment(identity),
-            digest
-        ))
-        .join("homeboy"))
+    Ok(pinned_path_in_root(&runtime_root()?, identity, digest))
 }
 
-fn recovered_pinned_path(identity: &str, digest: &str) -> Result<PathBuf> {
-    Ok(controller_runtime_store_root()?
-        .join("controller-runtimes")
-        .join(format!(
-            "{}-{}",
-            paths::sanitize_path_segment(identity),
-            digest
-        ))
-        .join(format!("recovery-{}", uuid::Uuid::new_v4()))
-        .join("homeboy"))
+fn pinned_path_in_root(root: &Path, identity: &str, digest: &str) -> PathBuf {
+    root.join(format!(
+        "{}-{}",
+        paths::sanitize_path_segment(identity),
+        digest
+    ))
+    .join("homeboy")
 }
 
-fn controller_runtime_store_root() -> Result<PathBuf> {
-    #[cfg(any(test, feature = "test-support"))]
-    if let Some(path) = std::env::var_os(TEST_CONTROLLER_RUNTIME_STORE_ENV) {
-        return Ok(PathBuf::from(path));
-    }
-
-    paths::homeboy_data()
+fn recovered_pinned_path_in_root(root: &Path, identity: &str, digest: &str) -> PathBuf {
+    root.join(format!(
+        "{}-{}",
+        paths::sanitize_path_segment(identity),
+        digest
+    ))
+    .join(format!("recovery-{}", uuid::Uuid::new_v4()))
+    .join("homeboy")
 }
 
 fn publish_pin(source: &Path, destination: &Path, expected_digest: &str) -> Result<()> {
@@ -4319,8 +4333,9 @@ mod tests {
     #[test]
     fn pin_current_uses_the_explicit_test_controller_fixture() {
         crate::test_support::with_isolated_home(|_| {
+            let explicit = tempfile::tempdir().expect("explicit runtime root");
             let runtime =
-                pin_current_in_root(&test_runtime_root()).expect("pin explicit controller fixture");
+                pin_current_in_root(explicit.path()).expect("pin explicit controller fixture");
             let source = runtime
                 .pointer("/originating/executable")
                 .and_then(Value::as_str)
@@ -4340,6 +4355,7 @@ mod tests {
                 source,
                 std::env::current_exe().expect("current test executable")
             );
+            assert!(pinned.starts_with(explicit.path()));
             assert_eq!(
                 executable_identity(&pinned, None).expect("fixture identity"),
                 build_identity::current().display

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -222,7 +222,6 @@ static SHARED_CONTROLLER_RUNTIME_FIXTURE: OnceLock<TempDir> = OnceLock::new();
 #[cfg(unix)]
 static SHARED_CONTROLLER_RUNTIME_VERSION_FIXTURE: OnceLock<PathBuf> = OnceLock::new();
 static SHARED_HOMEBOY_CONTROLLER_RUNTIME_FIXTURE: OnceLock<TempDir> = OnceLock::new();
-static SHARED_CONTROLLER_RUNTIME_STORE: OnceLock<TempDir> = OnceLock::new();
 /// Destinations whose controller fixture bytes this process has already
 /// published. Keeps the copy to at most once per process per fixture path —
 /// including a path inherited from a parent test process — and serializes
@@ -394,11 +393,9 @@ impl HermeticTestContext {
                 crate::controller_runtime::TEST_CONTROLLER_RUNTIME_IDENTITY_ENV,
                 crate::build_identity::current().display,
             )
-            // Runtime pins are immutable content-addressed files, so tests can
-            // share them without sharing mutable Homeboy state.
             .env(
-                crate::controller_runtime::TEST_CONTROLLER_RUNTIME_STORE_ENV,
-                shared_controller_runtime_store(),
+                crate::controller_runtime::TEST_CONTROLLER_RUNTIME_USE_ENV,
+                "1",
             );
         command
     }
@@ -1345,11 +1342,14 @@ fn test_controller_fixture_source(binary: TestBinary) -> PathBuf {
                     .get_or_init(|| {
                         let root = SHARED_CONTROLLER_RUNTIME_FIXTURE.get_or_init(exec_capable_tempdir);
                         let source = root.path().join("homeboy-controller-version-fixture");
+                        let identity = crate::build_identity::current().display.clone();
+                        let identity_json = serde_json::json!({
+                            "data": { "display": identity }
+                        });
                         fs::write(
                             &source,
                             format!(
-                                "#!/bin/sh\nif [ \"${{1:-}}\" = --version ]; then\n  printf '%s\\n' '{}'\n  exit 0\nfi\nexit 64\n",
-                                crate::build_identity::current().display
+                                "#!/bin/sh\nif [ \"${{1:-}}\" = --version ]; then\n  printf '%s\\n' '{identity}'\n  exit 0\nfi\nif [ \"${{1:-}}\" = self ] && [ \"${{2:-}}\" = identity ]; then\n  printf '%s\\n' '{identity_json}'\n  exit 0\nfi\nexit 64\n"
                             ),
                         )
                         .expect("write controller version fixture");
@@ -1479,14 +1479,6 @@ fn publish_test_controller_fixture(source: &Path, destination: &Path) {
     let _ = fs::remove_file(&staging);
 }
 
-/// Return the process-wide immutable controller-runtime pin store for tests
-/// that spawn controller subprocesses outside `controller_runtime_command`.
-pub fn shared_controller_runtime_store() -> &'static Path {
-    SHARED_CONTROLLER_RUNTIME_STORE
-        .get_or_init(exec_capable_tempdir)
-        .path()
-}
-
 fn make_test_controller_fixture_read_only(path: &Path) {
     #[cfg(unix)]
     {
@@ -1510,12 +1502,7 @@ fn make_test_controller_fixture_read_only(path: &Path) {
 /// Materializes the fixture, so callers may execute, hash, or stat the returned
 /// path exactly as they could when the copy was made eagerly.
 pub fn controller_runtime_test_executable() -> PathBuf {
-    let executable = PathBuf::from(
-        std::env::var_os(crate::controller_runtime::TEST_CONTROLLER_RUNTIME_EXECUTABLE_ENV)
-            .expect("controller runtime test executable"),
-    );
-    ensure_test_controller_fixture(&executable);
-    executable
+    test_controller_fixture_source(TestBinary::CurrentTest)
 }
 
 pub fn with_isolated_home<R>(body: impl FnOnce(&TempDir) -> R) -> R {

--- a/tests/reverse_cook_queue_acceptance.rs
+++ b/tests/reverse_cook_queue_acceptance.rs
@@ -206,11 +206,8 @@ fn explicit_lab_route_persists_the_verified_lab_outcome_through_detached_cook_li
     let runtime_identity = std::env::var("HOMEBOY_TEST_CONTROLLER_RUNTIME_IDENTITY")
         .expect("fixture controller runtime identity");
     // The daemon, submitting CLI, and detached worker all pin the same
-    // immutable controller binary while retaining independent mutable state.
-    std::env::set_var(
-        "HOMEBOY_TEST_CONTROLLER_RUNTIME_STORE",
-        homeboy_core::test_support::shared_controller_runtime_store(),
-    );
+    // immutable controller binary under this context's data root.
+    std::env::set_var("HOMEBOY_TEST_CONTROLLER_RUNTIME_USE_ENV", "1");
     ledger.mark("hermetic_context");
     let broker = ReverseBrokerFixture::start("lab");
     let (_checkout_guard, checkout) =


### PR DESCRIPTION
## Summary
- publish controller runtime pins, migrations, recovery artifacts, and active generations under the caller's explicit runtime root
- remove the process-wide test pin store and use deterministic in-process controller identity fixtures
- keep Cook continuation existence checks and recovery in the recipe store's lifecycle roots

Closes #11897

## Verification
- `cargo check -p homeboy-core --features test-support`
- `cargo check -p homeboy-agents --features test-support`
- `cargo test -p homeboy-core --lib controller_runtime::tests::pin_current_uses_the_explicit_test_controller_fixture`
- `cargo test -p homeboy-agents --lib -- --exact agent_task_service::cook_recipe::tests::recipe_only_recovery_rearms_a_failed_continuation_without_a_run_record`
- `cargo test -p homeboy-agents --lib -- --exact agent_task_service::execution::tests::local_execution_isolates_identical_run_ids_in_explicit_lifecycle_stores`
- full parallel suite before final main refresh: 2092 passed, 0 failed, 6 ignored

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to trace cross-test root leaks, implement the explicit-root refactor, run verification, and prepare this pull request. Chris Huber reviewed and directed the work.