### PR TITLE
Add the control-plane identity contract (#13697 slice 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,6 +882,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "homeboy-control-plane-contract"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "homeboy-core"
 version = "0.1.0"
 dependencies = [

--- a/crates/contracts/homeboy-control-plane-contract/Cargo.toml
+++ b/crates/contracts/homeboy-control-plane-contract/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "homeboy-control-plane-contract"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Chris Huber <chubes@extrachill.com>"]
+description = "Pure serializable control-plane identity contract types for homeboy"
+repository = "https://github.com/Extra-Chill/homeboy"
+publish = false
+
+[lib]
+name = "homeboy_control_plane_contract"
+path = "src/lib.rs"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/crates/contracts/homeboy-control-plane-contract/src/capabilities.rs
+++ b/crates/contracts/homeboy-control-plane-contract/src/capabilities.rs
@@ -1,0 +1,88 @@
+//! `homeboy/control-plane-capabilities/v1` — which resources this build serves.
+
+use serde::{Deserialize, Serialize};
+
+pub const CONTROL_PLANE_CAPABILITIES_SCHEMA: &str = "homeboy/control-plane-capabilities/v1";
+pub const LEGACY_COMPATIBILITY_MINOR_VERSIONS: u32 = 1;
+
+/// Pure serializable declaration of control-plane resources and compatibility.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ControlPlaneCapabilities {
+    pub schema: String,
+    pub resources: Vec<ControlPlaneResource>,
+    pub compatibility: CompatibilityWindow,
+}
+
+/// Declared legacy-compatibility window of one minor version.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct CompatibilityWindow {
+    pub legacy_minor_versions: u32,
+}
+
+/// A resource identity this build serves.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ControlPlaneResource {
+    Mission,
+    Run,
+    Task,
+    Attempt,
+    Execution,
+    ProviderSession,
+}
+
+impl ControlPlaneCapabilities {
+    pub fn this_build() -> Self {
+        Self {
+            schema: CONTROL_PLANE_CAPABILITIES_SCHEMA.to_string(),
+            resources: vec![
+                ControlPlaneResource::Mission,
+                ControlPlaneResource::Run,
+                ControlPlaneResource::Task,
+                ControlPlaneResource::Attempt,
+                ControlPlaneResource::Execution,
+                ControlPlaneResource::ProviderSession,
+            ],
+            compatibility: CompatibilityWindow {
+                legacy_minor_versions: LEGACY_COMPATIBILITY_MINOR_VERSIONS,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ControlPlaneCapabilities, ControlPlaneResource, CONTROL_PLANE_CAPABILITIES_SCHEMA,
+        LEGACY_COMPATIBILITY_MINOR_VERSIONS,
+    };
+
+    #[test]
+    fn capabilities_document_serializes_schema_and_compatibility_window() {
+        let document = ControlPlaneCapabilities::this_build();
+        let value = serde_json::to_value(&document).expect("serialize");
+        assert_eq!(value["schema"], CONTROL_PLANE_CAPABILITIES_SCHEMA);
+        assert_eq!(value["compatibility"]["legacy_minor_versions"], 1);
+        assert_eq!(
+            document.compatibility.legacy_minor_versions,
+            LEGACY_COMPATIBILITY_MINOR_VERSIONS
+        );
+        assert_eq!(
+            value["resources"],
+            serde_json::json!([
+                "mission",
+                "run",
+                "task",
+                "attempt",
+                "execution",
+                "provider_session"
+            ])
+        );
+        let decoded: ControlPlaneCapabilities = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(decoded, document);
+        assert_eq!(decoded.resources.len(), 6);
+        assert!(decoded.resources.contains(&ControlPlaneResource::Mission));
+    }
+}

--- a/crates/contracts/homeboy-control-plane-contract/src/control_plane_ref.rs
+++ b/crates/contracts/homeboy-control-plane-contract/src/control_plane_ref.rs
@@ -1,0 +1,218 @@
+//! Tagged control-plane reference with a stable parse/render string form.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::de::Error as DeError;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::identity::{
+    AttemptId, ExecutionId, IdentityError, MissionId, ProviderSessionId, RunId, TaskId,
+};
+
+const KIND_MISSION: &str = "mission";
+const KIND_RUN: &str = "run";
+const KIND_TASK: &str = "task";
+const KIND_ATTEMPT: &str = "attempt";
+const KIND_EXECUTION: &str = "execution";
+const KIND_PROVIDER_SESSION: &str = "provider-session";
+
+/// One of the control-plane identities, tagged so the kind cannot be lost.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ControlPlaneRef {
+    Mission(MissionId),
+    Run(RunId),
+    Task(TaskId),
+    Attempt(AttemptId),
+    Execution(ExecutionId),
+    ProviderSession(ProviderSessionId),
+}
+
+impl ControlPlaneRef {
+    pub fn as_str_kind(&self) -> &'static str {
+        match self {
+            Self::Mission(_) => KIND_MISSION,
+            Self::Run(_) => KIND_RUN,
+            Self::Task(_) => KIND_TASK,
+            Self::Attempt(_) => KIND_ATTEMPT,
+            Self::Execution(_) => KIND_EXECUTION,
+            Self::ProviderSession(_) => KIND_PROVIDER_SESSION,
+        }
+    }
+
+    pub fn identity_str(&self) -> &str {
+        match self {
+            Self::Mission(id) => id.as_str(),
+            Self::Run(id) => id.as_str(),
+            Self::Task(id) => id.as_str(),
+            Self::Attempt(id) => id.as_str(),
+            Self::Execution(id) => id.as_str(),
+            Self::ProviderSession(id) => id.as_str(),
+        }
+    }
+}
+
+impl fmt::Display for ControlPlaneRef {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}/{}", self.as_str_kind(), self.identity_str())
+    }
+}
+
+impl FromStr for ControlPlaneRef {
+    type Err = ControlPlaneRefError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.is_empty() || value.trim().is_empty() {
+            return Err(ControlPlaneRefError::Empty);
+        }
+        let Some((kind, identity)) = value.split_once('/') else {
+            return Err(ControlPlaneRefError::Malformed {
+                value: value.to_string(),
+            });
+        };
+        if kind.is_empty() || identity.is_empty() {
+            return Err(ControlPlaneRefError::Malformed {
+                value: value.to_string(),
+            });
+        }
+        match kind {
+            KIND_MISSION => Ok(Self::Mission(MissionId::new(identity)?)),
+            KIND_RUN => Ok(Self::Run(RunId::new(identity)?)),
+            KIND_TASK => Ok(Self::Task(TaskId::new(identity)?)),
+            KIND_ATTEMPT => Ok(Self::Attempt(AttemptId::new(identity)?)),
+            KIND_EXECUTION => Ok(Self::Execution(ExecutionId::new(identity)?)),
+            KIND_PROVIDER_SESSION => Ok(Self::ProviderSession(ProviderSessionId::new(identity)?)),
+            _ => Err(ControlPlaneRefError::Unrecognized {
+                value: value.to_string(),
+            }),
+        }
+    }
+}
+
+impl Serialize for ControlPlaneRef {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for ControlPlaneRef {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = String::deserialize(deserializer)?;
+        value.parse().map_err(DeError::custom)
+    }
+}
+
+/// Why a [`ControlPlaneRef`] string could not be parsed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ControlPlaneRefError {
+    Empty,
+    Malformed { value: String },
+    Unrecognized { value: String },
+    InvalidIdentity(IdentityError),
+}
+
+impl fmt::Display for ControlPlaneRefError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => formatter.write_str("control-plane ref must be a nonempty string"),
+            Self::Malformed { value } => {
+                write!(
+                    formatter,
+                    "control-plane ref `{value}` is malformed; expected `<kind>/<identity>`"
+                )
+            }
+            Self::Unrecognized { value } => {
+                write!(
+                    formatter,
+                    "control-plane ref `{value}` has an unrecognized kind"
+                )
+            }
+            Self::InvalidIdentity(error) => write!(formatter, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for ControlPlaneRefError {}
+
+impl From<IdentityError> for ControlPlaneRefError {
+    fn from(error: IdentityError) -> Self {
+        Self::InvalidIdentity(error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ControlPlaneRef;
+    use crate::{
+        AttemptId, ControlPlaneRefError, ExecutionId, MissionId, ProviderSessionId, RunId, TaskId,
+    };
+
+    const AGENT_TASK_RUN: &str =
+        "agent-task-301a2b9a-a63d-446b-a918-e21b2ff6421e-attempt-1-ea6a6751";
+    const AGENT_TASK_COOK: &str = "agent-task-301a2b9a-a63d-446b-a918-e21b2ff6421e";
+    const DETACHED_RUN: &str =
+        "cook-detached-37abbb52-d638-495c-b270-46fdc965fc9c-attempt-1-fb890874-transport-retry";
+
+    fn round_trip(reference: ControlPlaneRef) {
+        let rendered = reference.to_string();
+        let parsed: ControlPlaneRef = rendered.parse().expect("parse");
+        assert_eq!(parsed, reference);
+        let json = serde_json::to_value(&reference).expect("serialize");
+        assert_eq!(json, serde_json::Value::String(rendered));
+        let decoded: ControlPlaneRef = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(decoded, reference);
+    }
+
+    #[test]
+    fn every_identity_round_trips_through_control_plane_ref() {
+        round_trip(ControlPlaneRef::Mission(
+            MissionId::new(AGENT_TASK_COOK).expect("mission"),
+        ));
+        round_trip(ControlPlaneRef::Run(
+            RunId::new(AGENT_TASK_RUN).expect("run"),
+        ));
+        round_trip(ControlPlaneRef::Run(
+            RunId::new(DETACHED_RUN).expect("detached run"),
+        ));
+        round_trip(ControlPlaneRef::Task(
+            TaskId::new("cook-static-site-importer").expect("task"),
+        ));
+        round_trip(ControlPlaneRef::Attempt(
+            AttemptId::new(AGENT_TASK_RUN).expect("attempt"),
+        ));
+        round_trip(ControlPlaneRef::Execution(
+            ExecutionId::new("accepted-daemon-job").expect("execution"),
+        ));
+        round_trip(ControlPlaneRef::ProviderSession(
+            ProviderSessionId::new("session-123").expect("session"),
+        ));
+    }
+
+    #[test]
+    fn unrecognized_and_malformed_refs_fail() {
+        assert_eq!(
+            "".parse::<ControlPlaneRef>().unwrap_err(),
+            ControlPlaneRefError::Empty
+        );
+        assert!(matches!(
+            "run".parse::<ControlPlaneRef>().unwrap_err(),
+            ControlPlaneRefError::Malformed { .. }
+        ));
+        assert!(matches!(
+            "run/".parse::<ControlPlaneRef>().unwrap_err(),
+            ControlPlaneRefError::Malformed { .. }
+        ));
+        assert!(matches!(
+            "widget/agent-task-301a2b9a-a63d-446b-a918-e21b2ff6421e"
+                .parse::<ControlPlaneRef>()
+                .unwrap_err(),
+            ControlPlaneRefError::Unrecognized { .. }
+        ));
+        assert!(matches!(
+            "provider_session/session-123"
+                .parse::<ControlPlaneRef>()
+                .unwrap_err(),
+            ControlPlaneRefError::Unrecognized { .. }
+        ));
+    }
+}

--- a/crates/contracts/homeboy-control-plane-contract/src/identity.rs
+++ b/crates/contracts/homeboy-control-plane-contract/src/identity.rs
@@ -1,0 +1,147 @@
+//! Distinct identity newtypes over the opaque strings Homeboy already persists.
+//!
+//! Each type serializes as its plain string form so existing documents remain
+//! readable. The types are not interchangeable: a [`RunId`] cannot be passed
+//! where a [`MissionId`] is expected.
+//!
+//! ```compile_fail
+//! use homeboy_control_plane_contract::{MissionId, RunId};
+//! fn takes_mission(_: MissionId) {}
+//! fn example(run: RunId) {
+//!     takes_mission(run);
+//! }
+//! ```
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+macro_rules! opaque_identity {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            /// Wrap a nonempty opaque identity string.
+            pub fn new(value: impl Into<String>) -> Result<Self, IdentityError> {
+                let value = value.into();
+                validate_opaque(&value)?;
+                Ok(Self(value))
+            }
+
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+
+            #[allow(dead_code)]
+            pub(crate) fn from_validated(value: impl Into<String>) -> Self {
+                Self(value.into())
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str(&self.0)
+            }
+        }
+    };
+}
+
+opaque_identity!(
+    /// Typed name for the existing grouping identity. A Cook id and a fanout
+    /// portfolio id both resolve to a mission; this crate does not invent a
+    /// third grouping concept.
+    MissionId
+);
+opaque_identity!(
+    /// A single Cook attempt's run identity, including any trailing qualifiers
+    /// such as `-transport-retry`.
+    RunId
+);
+opaque_identity!(
+    /// A plan-level task identity as persisted on agent-task documents.
+    TaskId
+);
+opaque_identity!(
+    /// The attempt identity encoded by a run id. The opaque string is the run
+    /// id itself; the attempt *number* lives on [`crate::ResolvedIdentities`].
+    AttemptId
+);
+opaque_identity!(
+    /// A runner-job / execution identity.
+    ExecutionId
+);
+opaque_identity!(
+    /// A provider session identity.
+    ProviderSessionId
+);
+
+/// Why an identity newtype could not be constructed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IdentityError {
+    Empty,
+}
+
+impl fmt::Display for IdentityError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => formatter.write_str("control-plane identity must be a nonempty string"),
+        }
+    }
+}
+
+impl std::error::Error for IdentityError {}
+
+pub(crate) fn validate_opaque(value: &str) -> Result<(), IdentityError> {
+    if value.is_empty() || value.trim().is_empty() {
+        Err(IdentityError::Empty)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AttemptId, ExecutionId, MissionId, ProviderSessionId, RunId, TaskId};
+    use crate::IdentityError;
+
+    #[test]
+    fn identity_types_are_not_interchangeable() {
+        let names = [
+            std::any::type_name::<MissionId>(),
+            std::any::type_name::<RunId>(),
+            std::any::type_name::<TaskId>(),
+            std::any::type_name::<AttemptId>(),
+            std::any::type_name::<ExecutionId>(),
+            std::any::type_name::<ProviderSessionId>(),
+        ];
+        for (index, name) in names.iter().enumerate() {
+            for other in names.iter().skip(index + 1) {
+                assert_ne!(name, other);
+            }
+        }
+    }
+
+    #[test]
+    fn identities_serialize_as_plain_strings() {
+        let mission =
+            MissionId::new("agent-task-301a2b9a-a63d-446b-a918-e21b2ff6421e").expect("mission");
+        let json = serde_json::to_value(&mission).expect("serialize");
+        assert_eq!(
+            json,
+            serde_json::Value::String(
+                "agent-task-301a2b9a-a63d-446b-a918-e21b2ff6421e".to_string()
+            )
+        );
+        let decoded: MissionId = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(decoded, mission);
+    }
+
+    #[test]
+    fn empty_identity_is_rejected() {
+        assert_eq!(MissionId::new("").unwrap_err(), IdentityError::Empty);
+        assert_eq!(RunId::new("   ").unwrap_err(), IdentityError::Empty);
+    }
+}

--- a/crates/contracts/homeboy-control-plane-contract/src/lib.rs
+++ b/crates/contracts/homeboy-control-plane-contract/src/lib.rs
@@ -1,0 +1,25 @@
+//! Pure serializable control-plane identity contract types.
+//!
+//! These behavior-free data structures name the resource identities Homeboy
+//! already persists as untyped strings — mission (Cook / fanout portfolio),
+//! run, task, attempt, execution (runner job), and provider session — and
+//! resolve those strings deterministically. They depend only on serde, which
+//! keeps this a leaf crate other crates can depend on without pulling in core.
+//!
+//! This crate does not serve endpoints, migrate call sites, or change any
+//! existing serialized document. Later slices consume these types.
+
+pub mod capabilities;
+pub mod control_plane_ref;
+pub mod identity;
+pub mod resolve;
+
+pub use capabilities::{
+    CompatibilityWindow, ControlPlaneCapabilities, ControlPlaneResource,
+    CONTROL_PLANE_CAPABILITIES_SCHEMA, LEGACY_COMPATIBILITY_MINOR_VERSIONS,
+};
+pub use control_plane_ref::{ControlPlaneRef, ControlPlaneRefError};
+pub use identity::{
+    AttemptId, ExecutionId, IdentityError, MissionId, ProviderSessionId, RunId, TaskId,
+};
+pub use resolve::{resolve, IdentityKind, ResolveError, ResolvedIdentities};

--- a/crates/contracts/homeboy-control-plane-contract/src/resolve.rs
+++ b/crates/contracts/homeboy-control-plane-contract/src/resolve.rs
@@ -1,0 +1,341 @@
+//! Deterministic resolution of persisted identity strings.
+//!
+//! Resolution is pure and total: every input yields a resolved identity set or
+//! a typed explanation of why it could not be resolved. It never guesses a
+//! kind from an untagged string.
+
+use std::fmt;
+
+use crate::identity::{validate_opaque, AttemptId, ExecutionId, MissionId, RunId, TaskId};
+
+/// Which persisted identity string is being resolved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IdentityKind {
+    CookId,
+    RunId,
+    TaskId,
+    RunnerJobId,
+    FanoutPortfolioId,
+}
+
+impl IdentityKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::CookId => "cook id",
+            Self::RunId => "run id",
+            Self::TaskId => "task id",
+            Self::RunnerJobId => "runner job id",
+            Self::FanoutPortfolioId => "fanout portfolio id",
+        }
+    }
+}
+
+impl fmt::Display for IdentityKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Canonical identities denoted by a persisted identity string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedIdentities {
+    pub mission: Option<MissionId>,
+    pub run: Option<RunId>,
+    pub attempt: Option<AttemptId>,
+    pub attempt_number: Option<u32>,
+    pub task: Option<TaskId>,
+    pub execution: Option<ExecutionId>,
+}
+
+/// Why resolution refused to produce an identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolveError {
+    Empty { kind: IdentityKind },
+    MalformedRun { value: String },
+    GroupingIdEncodesRun { kind: IdentityKind, value: String },
+}
+
+impl fmt::Display for ResolveError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty { kind } => write!(formatter, "{kind} must be a nonempty string"),
+            Self::MalformedRun { value } => write!(
+                formatter,
+                "run id `{value}` does not match the `-attempt-<n>-<suffix>` convention"
+            ),
+            Self::GroupingIdEncodesRun { kind, value } => write!(
+                formatter,
+                "{kind} `{value}` encodes a run, not a grouping identity"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ResolveError {}
+
+/// Resolve a persisted identity string of a declared kind.
+///
+/// The kind is part of the input so this function never classifies an
+/// untagged string as a cook, run, task, runner job, or fanout portfolio.
+pub fn resolve(kind: IdentityKind, value: &str) -> Result<ResolvedIdentities, ResolveError> {
+    match kind {
+        IdentityKind::CookId | IdentityKind::FanoutPortfolioId => resolve_grouping(kind, value),
+        IdentityKind::RunId => resolve_run(value),
+        IdentityKind::TaskId => resolve_task(value),
+        IdentityKind::RunnerJobId => resolve_execution(value),
+    }
+}
+
+fn resolve_grouping(kind: IdentityKind, value: &str) -> Result<ResolvedIdentities, ResolveError> {
+    require_opaque(kind, value)?;
+    if run_parts(value).is_some() {
+        return Err(ResolveError::GroupingIdEncodesRun {
+            kind,
+            value: value.to_string(),
+        });
+    }
+    Ok(ResolvedIdentities {
+        mission: Some(MissionId::from_validated(value)),
+        run: None,
+        attempt: None,
+        attempt_number: None,
+        task: None,
+        execution: None,
+    })
+}
+
+fn resolve_run(value: &str) -> Result<ResolvedIdentities, ResolveError> {
+    require_opaque(IdentityKind::RunId, value)?;
+    let Some(parts) = run_parts(value) else {
+        return Err(ResolveError::MalformedRun {
+            value: value.to_string(),
+        });
+    };
+    Ok(ResolvedIdentities {
+        mission: Some(MissionId::from_validated(parts.mission)),
+        run: Some(RunId::from_validated(value)),
+        attempt: Some(AttemptId::from_validated(value)),
+        attempt_number: Some(parts.attempt_number),
+        task: None,
+        execution: None,
+    })
+}
+
+fn resolve_task(value: &str) -> Result<ResolvedIdentities, ResolveError> {
+    require_opaque(IdentityKind::TaskId, value)?;
+    Ok(ResolvedIdentities {
+        mission: None,
+        run: None,
+        attempt: None,
+        attempt_number: None,
+        task: Some(TaskId::from_validated(value)),
+        execution: None,
+    })
+}
+
+fn resolve_execution(value: &str) -> Result<ResolvedIdentities, ResolveError> {
+    require_opaque(IdentityKind::RunnerJobId, value)?;
+    Ok(ResolvedIdentities {
+        mission: None,
+        run: None,
+        attempt: None,
+        attempt_number: None,
+        task: None,
+        execution: Some(ExecutionId::from_validated(value)),
+    })
+}
+
+fn require_opaque(kind: IdentityKind, value: &str) -> Result<(), ResolveError> {
+    validate_opaque(value).map_err(|_| ResolveError::Empty { kind })
+}
+
+struct RunParts<'a> {
+    mission: &'a str,
+    attempt_number: u32,
+}
+
+/// Split a run id minted as `{cook_id}-attempt-{n}-{suffix}[qualifiers]`.
+///
+/// Takes the last well-formed `-attempt-<n>-` marker so the mission is the
+/// cook id the run was minted from, and trailing qualifiers such as
+/// `-transport-retry` stay on the run string rather than being dropped.
+fn run_parts(value: &str) -> Option<RunParts<'_>> {
+    const MARKER: &str = "-attempt-";
+    let mut last = None;
+    let mut from = 0;
+    while from < value.len() {
+        let rest = &value[from..];
+        let Some(relative) = rest.find(MARKER) else {
+            break;
+        };
+        let marker_at = from + relative;
+        let after = &value[marker_at + MARKER.len()..];
+        let digits = after.bytes().take_while(u8::is_ascii_digit).count();
+        let number = after.get(..digits).and_then(|raw| {
+            if raw.is_empty() || raw.starts_with('0') {
+                return None;
+            }
+            raw.parse::<u32>().ok().filter(|number| *number >= 1)
+        });
+        let has_suffix = after.len() > digits + 1 && after[digits..].starts_with('-');
+        if let Some(attempt_number) = number {
+            if has_suffix && marker_at > 0 {
+                last = Some(RunParts {
+                    mission: &value[..marker_at],
+                    attempt_number,
+                });
+            }
+        }
+        from = marker_at + 1;
+    }
+    last
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve, run_parts, IdentityKind, ResolveError};
+
+    const AGENT_TASK_COOK: &str = "agent-task-301a2b9a-a63d-446b-a918-e21b2ff6421e";
+    const AGENT_TASK_RUN: &str =
+        "agent-task-301a2b9a-a63d-446b-a918-e21b2ff6421e-attempt-1-ea6a6751";
+    const DETACHED_COOK: &str = "cook-detached-37abbb52-d638-495c-b270-46fdc965fc9c";
+    const DETACHED_RUN: &str =
+        "cook-detached-37abbb52-d638-495c-b270-46fdc965fc9c-attempt-1-fb890874-transport-retry";
+
+    #[test]
+    fn agent_task_run_id_resolves_mission_run_and_attempt_number() {
+        let resolved = resolve(IdentityKind::RunId, AGENT_TASK_RUN).expect("run");
+        assert_eq!(
+            resolved.mission.as_ref().map(|id| id.as_str()),
+            Some(AGENT_TASK_COOK)
+        );
+        assert_eq!(
+            resolved.run.as_ref().map(|id| id.as_str()),
+            Some(AGENT_TASK_RUN)
+        );
+        assert_eq!(
+            resolved.attempt.as_ref().map(|id| id.as_str()),
+            Some(AGENT_TASK_RUN)
+        );
+        assert_eq!(resolved.attempt_number, Some(1));
+        assert!(resolved.task.is_none());
+        assert!(resolved.execution.is_none());
+    }
+
+    #[test]
+    fn detached_transport_retry_run_id_preserves_trailing_qualifiers() {
+        let resolved = resolve(IdentityKind::RunId, DETACHED_RUN).expect("detached run");
+        assert_eq!(
+            resolved.mission.as_ref().map(|id| id.as_str()),
+            Some(DETACHED_COOK)
+        );
+        assert_eq!(
+            resolved.run.as_ref().map(|id| id.as_str()),
+            Some(DETACHED_RUN)
+        );
+        assert!(DETACHED_RUN.ends_with("-transport-retry"));
+        assert_eq!(resolved.attempt_number, Some(1));
+        assert_eq!(
+            run_parts(DETACHED_RUN).map(|parts| parts.mission),
+            Some(DETACHED_COOK)
+        );
+    }
+
+    #[test]
+    fn bare_cook_id_resolves_to_a_mission_with_no_attempt() {
+        for cook_id in [AGENT_TASK_COOK, DETACHED_COOK] {
+            let resolved = resolve(IdentityKind::CookId, cook_id).expect("cook");
+            assert_eq!(
+                resolved.mission.as_ref().map(|id| id.as_str()),
+                Some(cook_id)
+            );
+            assert!(resolved.run.is_none());
+            assert!(resolved.attempt.is_none());
+            assert!(resolved.attempt_number.is_none());
+        }
+    }
+
+    #[test]
+    fn fanout_portfolio_id_resolves_to_a_mission() {
+        let resolved =
+            resolve(IdentityKind::FanoutPortfolioId, "production-interface").expect("fanout");
+        assert_eq!(
+            resolved.mission.as_ref().map(|id| id.as_str()),
+            Some("production-interface")
+        );
+        assert!(resolved.attempt_number.is_none());
+    }
+
+    #[test]
+    fn task_and_runner_job_ids_resolve_to_their_own_identities() {
+        let task = resolve(IdentityKind::TaskId, "cook-static-site-importer").expect("task");
+        assert_eq!(
+            task.task.as_ref().map(|id| id.as_str()),
+            Some("cook-static-site-importer")
+        );
+        assert!(task.mission.is_none());
+        let job = resolve(IdentityKind::RunnerJobId, "accepted-daemon-job").expect("job");
+        assert_eq!(
+            job.execution.as_ref().map(|id| id.as_str()),
+            Some("accepted-daemon-job")
+        );
+        assert!(job.mission.is_none());
+    }
+
+    #[test]
+    fn malformed_and_unrecognized_inputs_return_typed_explanations() {
+        assert_eq!(
+            resolve(IdentityKind::RunId, "").unwrap_err(),
+            ResolveError::Empty {
+                kind: IdentityKind::RunId
+            }
+        );
+        assert_eq!(
+            resolve(IdentityKind::RunId, AGENT_TASK_COOK).unwrap_err(),
+            ResolveError::MalformedRun {
+                value: AGENT_TASK_COOK.to_string()
+            }
+        );
+        assert_eq!(
+            resolve(IdentityKind::RunId, "attempt-1-ea6a6751").unwrap_err(),
+            ResolveError::MalformedRun {
+                value: "attempt-1-ea6a6751".to_string()
+            }
+        );
+        assert_eq!(
+            resolve(
+                IdentityKind::RunId,
+                "agent-task-301a2b9a-a63d-446b-a918-e21b2ff6421e-attempt-1"
+            )
+            .unwrap_err(),
+            ResolveError::MalformedRun {
+                value: "agent-task-301a2b9a-a63d-446b-a918-e21b2ff6421e-attempt-1".to_string()
+            }
+        );
+        assert_eq!(
+            resolve(
+                IdentityKind::RunId,
+                "agent-task-301a2b9a-a63d-446b-a918-e21b2ff6421e-attempt-01-ea6a6751"
+            )
+            .unwrap_err(),
+            ResolveError::MalformedRun {
+                value: "agent-task-301a2b9a-a63d-446b-a918-e21b2ff6421e-attempt-01-ea6a6751"
+                    .to_string()
+            }
+        );
+        assert_eq!(
+            resolve(IdentityKind::CookId, AGENT_TASK_RUN).unwrap_err(),
+            ResolveError::GroupingIdEncodesRun {
+                kind: IdentityKind::CookId,
+                value: AGENT_TASK_RUN.to_string()
+            }
+        );
+        assert_eq!(
+            resolve(IdentityKind::FanoutPortfolioId, DETACHED_RUN).unwrap_err(),
+            ResolveError::GroupingIdEncodesRun {
+                kind: IdentityKind::FanoutPortfolioId,
+                value: DETACHED_RUN.to_string()
+            }
+        );
+    }
+}


### PR DESCRIPTION
Slice 1 of #13697. Types only — **no endpoints, no migrated call sites, and no change to any existing serialized document.**

## Why

Homeboy has 575 distinct `"homeboy/<name>/vN"` schema strings, 209 of them `agent-task-*`. Cook alone minted 53 and loop 37. Eleven separate schemas describe *admission*, 17 describe *gate*, 14 *recovery*, 10 *promotion*, 8 *candidate*, 8 *replay*. Serialization discipline is not the gap; the missing piece is the resource model those documents should have referenced.

The identity graph already exists in the data, untyped:

- `AgentTaskCookIndex { cook_id, latest_run_id, attempts: [{ attempt, run_id }] }` (`records.rs:414-452`) is already mission → run → attempt as bare `String`s.
- Run ids encode their own lineage by string convention: `agent-task-<uuid>-attempt-1-<suffix>`, and `cook-detached-<uuid>-attempt-1-<suffix>-transport-retry`.
- `ActivityCrossRefs` (`activity/model.rs:73-80`) carries `run_id`, `agent_task_run_id`, and `runner_job_id` side by side with nothing declaring which is authoritative.
- `ActivityContext.task_url` (`:85-88`) is documented in-source as a "legacy single-task identity."
- `DeferredControllerReceipt.mission_id` (`controller_fallback_projection.rs:31`) is the only `mission_id` in the codebase — an untyped `String` whose fixture sets it to `"run-1"`, a run id already wearing the mission identity.

## What this adds

A leaf contract crate, `crates/contracts/homeboy-control-plane-contract`, following the existing pattern of the other 13 contract crates. Serde only; no dependency on `homeboy-core` or `homeboy-agents`.

- **`identity`** — `MissionId`, `RunId`, `TaskId`, `AttemptId`, `ExecutionId`, `ProviderSessionId` as distinct `#[serde(transparent)]` newtypes. Each serializes as its plain string so existing persisted documents stay readable, and they are not interchangeable — enforced by a `compile_fail` doctest, not a convention.
- **`control_plane_ref`** — one `ControlPlaneRef` over those identities with a round-trippable string form. Unrecognized or malformed input returns a typed error instead of silently producing an identity.
- **`resolve`** — pure, total resolution from the identity strings persisted today (cook id, run id including the `-attempt-N-<suffix>` convention, task id, runner job id, fanout portfolio id) to the canonical identities they denote. Every input yields either a `ResolvedIdentities` or a typed `ResolveError`. It never guesses a kind from an untagged string.
- **`capabilities`** — `homeboy/control-plane-capabilities/v1` declaring served resources and a one-minor legacy compatibility window. A pure type here; nothing serves it yet.

**Mission naming:** `MissionId` types the grouping identity that already exists rather than inventing a third one. A Cook id resolves to a mission; a fanout portfolio id resolves to a mission.

## Deliberately not in this slice

Endpoints, daemon routes, reads, writes, and consumer migration. Slice 2 makes `agent-task status` speak these identities and retires the `task_url` / `agent_task_run_id` aliases. Slice 3 adds the read-only endpoints of #8286 and #10307. Slice 4 is the payoff: retiring the prefixed duplicates of admission, candidate, recovery, replay, gate, and promotion across Cook, loop, worktree, and retention.

## Verification

| gate | result |
|---|---|
| `cargo fmt --check` | pass |
| `cargo check --workspace --tests --locked` | clean |
| `cargo test -p homeboy-control-plane-contract` | 12 passed, 0 failed |
| compile-fail doctest (identity non-interchangeability) | pass |

Tests are anchored to the real identity string shapes above rather than invented placeholders:

- `bare_cook_id_resolves_to_a_mission_with_no_attempt`
- `detached_transport_retry_run_id_preserves_trailing_qualifiers`
- `fanout_portfolio_id_resolves_to_a_mission`
- `task_and_runner_job_ids_resolve_to_their_own_identities`
- `malformed_and_unrecognized_inputs_return_typed_explanations`

The one `duplicate_macro_attributes` warning in a workspace check comes from `crates/homeboy-cli/src/commands/runner/doctor/tests/homeboy_path.rs:242`, which this branch does not touch.

## Provenance

The candidate was produced by a Homeboy Cook that stopped at finalization when `main` advanced to `ac74a2910 release: v0.364.11` mid-run and the base could not be merged automatically. The divergence was a clean one-commit rebase, resolved in the worktree, after which the gates above were run directly.

## AI Assistance

Claude (Sonnet 4.5) via OpenCode audited the schema surface, traced the existing untyped identities and their aliases, and wrote the slice specification. The implementation was produced by xai/grok-4.6 via OpenCode through `homeboy agent-task cook`. Claude then rebased the diverged base, ran the gates, and authored this description. All work was directed by Chris Huber.
