### PR TITLE
Provision runtime settings for extension scripts

### DIFF
--- a/crates/homeboy-extension/src/runtime_helper.rs
+++ b/crates/homeboy-extension/src/runtime_helper.rs
@@ -112,6 +112,12 @@ const HELPERS: &[RuntimeHelper] = &[
         content: assets::BENCH_HELPER_JS,
         env_var: BENCH_HELPER_JS_ENV,
     },
+    RuntimeHelper {
+        id: RUNTIME_SETTINGS_HELPER_ID,
+        filename: "settings.sh",
+        content: assets::SETTINGS_SH,
+        env_var: RUNTIME_SETTINGS_HELPER_ENV,
+    },
 ];
 
 const DECLARABLE_HELPERS: &[RuntimeHelper] = &[RuntimeHelper {

--- a/crates/homeboy-extension/src/runtime_helper/tests.rs
+++ b/crates/homeboy-extension/src/runtime_helper/tests.rs
@@ -57,6 +57,10 @@ fn ensure_all_helpers_writes_all_files() {
             pairs.iter().any(|(k, _)| k == BENCH_HELPER_JS_ENV),
             "bench JS helper should be in pairs"
         );
+        assert!(
+            pairs.iter().any(|(k, _)| k == RUNTIME_SETTINGS_HELPER_ENV),
+            "runtime settings helper should be in pairs"
+        );
     });
 }
 


### PR DESCRIPTION
## Summary
- include the embedded settings helper in Homeboy's always-provisioned extension runtime helpers
- export `HOMEBOY_RUNTIME_SETTINGS_HELPER` for normal lint, test, build, bench, trace, and dependency extension scripts
- preserve the content-addressed declarable-helper path used by fuzz
- assert settings helper materialization in the existing exact-byte helper test

Closes #13740.

This restores the runtime contract relied on by Extra-Chill/homeboy-extensions#2734. Normal test and bench phase configs do not implement declarable `runtime_helpers`, so the released WordPress extension could not resolve `settings.sh` even after Extra-Chill/homeboy-extensions#2738 added phase declarations.

## Verification
- `cargo test -p homeboy-extension runtime_helper` (32 passed)
- `cargo fmt --all --check`
- `git diff --check`

## AI assistance

GPT-5.6 Sol running in OpenCode traced the released downstream failure through Homeboy's runtime-helper tables and extension manifest contracts, implemented the minimal always-provisioned helper repair, and ran the focused Rust verification under Chris Huber's direction.