### PR TITLE
fix(agent-task): resolve catalog secret_env per requiring provider

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_provider.rs
@@ -80,8 +80,8 @@ pub(crate) use config_preflight::preflight_plan_provider_config_with_providers;
 pub use credential_readiness::{
     preflight_discovered_provider_credentials_for_backend, preflight_provider_credentials,
     preflight_provider_credentials_for_backend, provider_credential_readiness,
-    AgentTaskProviderCredentialReadiness, AgentTaskProviderCredentialRequirement,
-    AGENT_TASK_PROVIDER_CREDENTIAL_READINESS_SCHEMA,
+    provider_required_secret_env_names, AgentTaskProviderCredentialReadiness,
+    AgentTaskProviderCredentialRequirement, AGENT_TASK_PROVIDER_CREDENTIAL_READINESS_SCHEMA,
 };
 pub use dispatchability::{
     evaluate_provider_dispatchability, evaluate_provider_dispatchability_with_config,

--- a/crates/homeboy-agents/src/agent_task_provider/catalog.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/catalog.rs
@@ -645,6 +645,24 @@ pub fn provider_secret_sources_for_providers(
     sources
 }
 
+/// One secret-env scope per provider so catalog `secret_env` resolves each
+/// required name against the provider that requires it (#13629).
+pub fn provider_secret_env_scopes(
+    providers: &[AgentTaskExecutorProvider],
+) -> Vec<crate::agent_task_secrets::AgentTaskSecretEnvScope> {
+    providers
+        .iter()
+        .map(
+            |provider| crate::agent_task_secrets::AgentTaskSecretEnvScope {
+                fallback_sources: provider_declared_secret_sources(provider),
+                required_names: super::credential_readiness::provider_required_secret_env_names(
+                    provider,
+                ),
+            },
+        )
+        .collect()
+}
+
 /// Secret sources scoped to a single backend (and optional provider selector).
 ///
 /// Mirrors the backend/selector resolution `agent-task doctor` uses so auth

--- a/crates/homeboy-agents/src/agent_task_provider/credential_readiness.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/credential_readiness.rs
@@ -144,6 +144,14 @@ fn push_declared_credential(
     });
 }
 
+/// Env names this provider unconditionally requires, in declaration order.
+pub fn provider_required_secret_env_names(provider: &AgentTaskExecutorProvider) -> Vec<String> {
+    declared_credentials(provider)
+        .into_iter()
+        .map(|entry| entry.env)
+        .collect()
+}
+
 /// Every unconditionally-required credential a provider declares.
 ///
 /// Order is declaration order, deduplicated on the env name so a credential

--- a/crates/homeboy-agents/src/agent_task_secrets.rs
+++ b/crates/homeboy-agents/src/agent_task_secrets.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::env;
 use std::fs;
 use std::path::PathBuf;
@@ -71,26 +71,135 @@ pub fn secret_env_plan_status(plan: &SecretEnvPlan) -> Vec<AgentTaskSecretEnvSta
     secret_env_status(&plan.secret_env_names())
 }
 
-/// Redacted secret-env status for a scope, defaulting to every secret that
-/// scope declares a source for when the caller names none explicitly.
+/// One provider-shaped secret-env scope: that provider's sources, plus the
+/// names it unconditionally requires even when it declares no source for them.
 ///
-/// `agent-task auth status` and `agent-task providers --secret-env` both
-/// answer "what is this scope's secret-env readiness" and must agree: a
-/// secret that reads as configured from one must read as configured from the
-/// other, since they are the same question about the same underlying state
-/// (#13629). Routing both through this one function, rather than each
-/// assembling its own default name list, makes that agreement structural
-/// instead of something each call site has to maintain by hand.
+/// Catalog `secret_env` used to merge every shown provider's sources into one
+/// map and resolve once. A backend that required a name without declaring a
+/// source then reported it missing while the flattened catalog reported the
+/// same name configured from a different provider's json-file (#13629).
+#[derive(Debug, Clone, Default)]
+pub struct AgentTaskSecretEnvScope {
+    pub fallback_sources: HashMap<String, AgentTaskSecretSource>,
+    pub required_names: Vec<String>,
+}
+
+/// Redacted secret-env status for a single source map.
+///
+/// Prefer [`secret_env_status_for_scopes`] when more than one provider is in
+/// view: a required name must resolve against the provider that requires it,
+/// not against a merged map of unrelated sources (#13629).
 pub fn secret_env_status_for_scope(
     explicit_names: &[String],
     fallback_sources: &HashMap<String, AgentTaskSecretSource>,
 ) -> Vec<AgentTaskSecretEnvStatus> {
+    secret_env_status_for_scopes(
+        explicit_names,
+        &[AgentTaskSecretEnvScope {
+            fallback_sources: fallback_sources.clone(),
+            required_names: Vec::new(),
+        }],
+    )
+}
+
+/// Resolve each scope against its own sources, then flatten to one row per name.
+///
+/// A name a scope requires and cannot resolve vetoes `configured=true` from any
+/// other scope. That is the single catalog answer: another provider's json-file
+/// must not make a requiring backend look configured (#13629).
+pub fn secret_env_status_for_scopes(
+    explicit_names: &[String],
+    scopes: &[AgentTaskSecretEnvScope],
+) -> Vec<AgentTaskSecretEnvStatus> {
+    let names = secret_env_names_for_scopes(explicit_names, scopes);
+    names
+        .into_iter()
+        .map(|name| secret_env_status_for_name(&name, scopes))
+        .collect()
+}
+
+fn secret_env_names_for_scopes(
+    explicit_names: &[String],
+    scopes: &[AgentTaskSecretEnvScope],
+) -> Vec<String> {
     if !explicit_names.is_empty() {
-        return secret_env_status_with_fallbacks(explicit_names, fallback_sources);
+        return explicit_names.to_vec();
     }
-    let mut names: Vec<String> = fallback_sources.keys().cloned().collect();
-    names.sort();
-    secret_env_status_with_fallbacks(&names, fallback_sources)
+    let mut names = BTreeSet::new();
+    for scope in scopes {
+        names.extend(scope.fallback_sources.keys().cloned());
+        names.extend(scope.required_names.iter().cloned());
+    }
+    names.into_iter().collect()
+}
+
+fn secret_env_status_for_name(
+    name: &str,
+    scopes: &[AgentTaskSecretEnvScope],
+) -> AgentTaskSecretEnvStatus {
+    if scopes.is_empty() {
+        return secret_env_status_with_fallbacks(
+            std::slice::from_ref(&name.to_string()),
+            &HashMap::new(),
+        )
+        .into_iter()
+        .next()
+        .expect("status for one name");
+    }
+
+    let per_scope = scopes
+        .iter()
+        .map(|scope| {
+            secret_env_status_with_fallbacks(
+                std::slice::from_ref(&name.to_string()),
+                &scope.fallback_sources,
+            )
+            .into_iter()
+            .next()
+            .expect("status for one name")
+        })
+        .collect::<Vec<_>>();
+
+    let required_missing = scopes.iter().zip(&per_scope).any(|(scope, status)| {
+        scope.required_names.iter().any(|required| required == name) && !status.configured
+    });
+    if required_missing {
+        let mut alternatives = Vec::new();
+        for status in &per_scope {
+            if !status.configured {
+                continue;
+            }
+            if alternatives
+                .iter()
+                .any(|entry: &AgentTaskSecretEnvSourceStatus| {
+                    entry.source == status.source && entry.configured
+                })
+            {
+                continue;
+            }
+            alternatives.push(AgentTaskSecretEnvSourceStatus {
+                origin: "provider-default".to_string(),
+                source: status.source.clone(),
+                configured: true,
+            });
+        }
+        return AgentTaskSecretEnvStatus {
+            name: name.to_string(),
+            configured: false,
+            source: "missing".to_string(),
+            alternatives,
+        };
+    }
+
+    per_scope
+        .into_iter()
+        .find(|status| status.configured)
+        .unwrap_or(AgentTaskSecretEnvStatus {
+            name: name.to_string(),
+            configured: false,
+            source: "missing".to_string(),
+            alternatives: Vec::new(),
+        })
 }
 
 pub fn map_secret_to_env(
@@ -704,6 +813,75 @@ mod tests {
         );
 
         std::env::remove_var(configured);
+    }
+
+    #[test]
+    fn secret_env_status_for_scopes_does_not_let_another_scope_mark_a_required_secret_configured() {
+        let required = unique_env("SCOPE_REQUIRED");
+        let present = unique_env("SCOPE_PRESENT");
+        std::env::remove_var(&required);
+        std::env::set_var(&present, "present-value");
+        let source = |env_var: &str| AgentTaskSecretSource {
+            source: "env".to_string(),
+            env_var: Some(env_var.to_string()),
+            path: None,
+            scope: None,
+            name: None,
+            field: None,
+            value: None,
+        };
+        let requiring = AgentTaskSecretEnvScope {
+            fallback_sources: HashMap::new(),
+            required_names: vec![required.clone()],
+        };
+        let mut other_sources = HashMap::new();
+        other_sources.insert(required.clone(), source(&present));
+        let other = AgentTaskSecretEnvScope {
+            fallback_sources: other_sources,
+            required_names: Vec::new(),
+        };
+
+        let status = secret_env_status_for_scopes(&[], &[requiring, other]);
+        let entry = status
+            .iter()
+            .find(|entry| entry.name == required)
+            .expect("required name is reported even without a local source");
+        assert!(
+            !entry.configured,
+            "a required name missing from its own scope must not read as configured from another scope"
+        );
+        assert_eq!(entry.source, "missing");
+        assert!(
+            entry
+                .alternatives
+                .iter()
+                .any(|alternative| alternative.configured && alternative.source == "env"),
+            "the other scope's present source stays visible as an alternative: {:?}",
+            entry.alternatives
+        );
+
+        let explicit = secret_env_status_for_scopes(
+            std::slice::from_ref(&required),
+            &[
+                AgentTaskSecretEnvScope {
+                    fallback_sources: HashMap::new(),
+                    required_names: vec![required.clone()],
+                },
+                AgentTaskSecretEnvScope {
+                    fallback_sources: {
+                        let mut sources = HashMap::new();
+                        sources.insert(required.clone(), source(&present));
+                        sources
+                    },
+                    required_names: Vec::new(),
+                },
+            ],
+        );
+        assert_eq!(explicit.len(), 1);
+        assert!(!explicit[0].configured);
+        assert_eq!(explicit[0].source, "missing");
+
+        std::env::remove_var(present);
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -429,10 +429,10 @@ pub mod provider {
         default_backend, default_backend_for_component, dependency_failure_patterns,
         provider_capability_contract, provider_requires_cwd_git_checkout,
         provider_runner_readiness_contracts, provider_runner_secret_env_for_plan,
-        provider_runner_source_contracts, provider_secret_sources_for_backend,
-        provider_secret_sources_for_plan, provider_secret_sources_for_providers,
-        required_extension_ids_for_plan, resolve_provider_for_backend,
-        validate_provider_runner_readiness_for_backend,
+        provider_runner_source_contracts, provider_secret_env_scopes,
+        provider_secret_sources_for_backend, provider_secret_sources_for_plan,
+        provider_secret_sources_for_providers, required_extension_ids_for_plan,
+        resolve_provider_for_backend, validate_provider_runner_readiness_for_backend,
         validate_provider_runner_readiness_for_backend_with_catalog, AgentTaskExecutorProvider,
         AgentTaskProviderCapabilityContract, AgentTaskProviderCatalog,
         AgentTaskProviderDependencyFailurePattern, AgentTaskProviderEnvPathReadiness,
@@ -493,8 +493,9 @@ pub mod secrets {
     pub use super::super::agent_task_secrets::{
         legacy_secrets_file, map_secret_to_env, map_secret_to_keychain_bundle,
         remove_secret_mapping, resolve_secret_env, resolve_secret_env_with_fallbacks,
-        secret_env_status, secret_env_status_for_scope, secret_env_status_with_fallbacks,
-        set_config_secret, set_keychain_bundle, set_keychain_secret, validate_secret_env,
+        secret_env_status, secret_env_status_for_scope, secret_env_status_for_scopes,
+        secret_env_status_with_fallbacks, set_config_secret, set_keychain_bundle,
+        set_keychain_secret, validate_secret_env, AgentTaskSecretEnvScope,
         AgentTaskSecretEnvStatus, AgentTaskSecretResolutionError,
     };
 }

--- a/crates/homeboy-cli/src/commands/agent_task/auth.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/auth.rs
@@ -126,23 +126,30 @@ fn auth_status(status_args: AgentTaskAuthStatusArgs) -> Value {
         .clone()
         .or_else(|| default_backend.clone());
 
-    // Scope provider secret sources to the selected backend (and optional
-    // selector). Falling back to all-provider sources keeps status useful when
-    // no backend can be resolved.
-    let fallback_sources = match selected_backend.as_deref() {
-        Some(backend) => agent_task_provider::provider_secret_sources_for_backend(
-            providers,
-            backend,
-            status_args.selector.as_deref(),
-        ),
-        None => agent_task_provider::provider_secret_sources_for_providers(providers),
+    // Scope each provider independently so a required name cannot read as
+    // configured from a different provider's json-file (#13629).
+    let scoped_providers: Vec<_> = match selected_backend.as_deref() {
+        Some(backend) => providers
+            .iter()
+            .filter(|provider| provider.backend == backend)
+            .filter(|provider| {
+                status_args
+                    .selector
+                    .as_deref()
+                    .is_none_or(|selector| provider.id == selector)
+            })
+            .cloned()
+            .collect(),
+        None => providers.to_vec(),
     };
 
     // Explicit operator-supplied names win; otherwise report every secret the
     // selected backend declares. Shared with `agent-task providers
     // --secret-env` so the two commands agree about the same secrets (#13629).
-    let secret_env =
-        agent_task_secrets::secret_env_status_for_scope(&status_args.secret_env, &fallback_sources);
+    let secret_env = agent_task_secrets::secret_env_status_for_scopes(
+        &status_args.secret_env,
+        &agent_task_provider::provider_secret_env_scopes(&scoped_providers),
+    );
 
     serde_json::json!({
         "schema": "homeboy/agent-task-auth-status/v1",

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -2038,8 +2038,8 @@ fn providers_with_catalog(
                 _ => None,
             })
         });
-    let fallback_sources =
-        homeboy::agents::agent_tasks::provider::provider_secret_sources_for_providers(providers);
+    let secret_env_scopes =
+        homeboy::agents::agent_tasks::provider::provider_secret_env_scopes(providers);
 
     let full_command = provider_full_command(&args);
     let shown_providers = if args.full {
@@ -2119,9 +2119,9 @@ fn providers_with_catalog(
             ),
             "diagnostics": shown_diagnostics,
             // Explicit `--secret-env` names win; otherwise report every secret
-            // the shown providers declare, so this agrees with `agent-task
-            // auth status` about the same secrets by construction (#13629).
-            "secret_env": homeboy::agents::agent_tasks::secrets::secret_env_status_for_scope(&args.secret_env, &fallback_sources),
+            // the shown providers declare, resolved per provider so this agrees
+            // with credential readiness about the same secrets (#13629).
+            "secret_env": homeboy::agents::agent_tasks::secrets::secret_env_status_for_scopes(&args.secret_env, &secret_env_scopes),
         }),
         0,
     ))
@@ -3928,6 +3928,88 @@ mod tests {
                     .expect("declared credential entry")["configured"],
                 false,
                 "unconfigured in this hermetic test environment, matching auth status"
+            );
+        });
+    }
+
+    /// #13629: a second provider's json-file source for the same env name must
+    /// not make catalog `secret_env` say configured while the requiring
+    /// provider's credential readiness reports it missing.
+    #[test]
+    fn providers_secret_env_does_not_mark_a_required_credential_configured_from_another_provider() {
+        crate::test_support::with_isolated_home(|_| {
+            save_provider_policy(None, None);
+            let auth = tempfile::NamedTempFile::new().expect("auth file");
+            std::fs::write(auth.path(), r#"{"refresh":"present-refresh-token"}"#)
+                .expect("write auth");
+            let auth_path = auth.path().to_string_lossy().to_string();
+            let requiring: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
+                "id": "claude-code.agent-task-executor",
+                "backend": "claude-code",
+                "provider_defaults": {
+                    "claude-code": {
+                        "secret_env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"],
+                        "required_secret_env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"]
+                    }
+                }
+            }))
+            .expect("requiring provider");
+            let sourced: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
+                "id": "wordpress.codebox-agent-task-executor",
+                "backend": "wp-codebox",
+                "provider_defaults": {
+                    "openai": { "required_secret_env": ["OPENAI_API_KEY"] },
+                    "claude-code": {
+                        "secret_env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"],
+                        "secret_env_sources": {
+                            "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN": {
+                                "source": "json-file",
+                                "path": auth_path,
+                                "field": "refresh"
+                            }
+                        }
+                    }
+                }
+            }))
+            .expect("sourced provider");
+            let mut args = providers_args();
+            args.secret_env = vec!["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN".to_string()];
+            let output = providers_with_catalog(args, provider_catalog(vec![requiring, sourced]))
+                .expect("provider report")
+                .0;
+
+            let secret_env = output["secret_env"]
+                .as_array()
+                .expect("secret_env is an array");
+            let claude = secret_env
+                .iter()
+                .find(|entry| entry["name"] == "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN")
+                .expect("declared credential entry");
+            assert_eq!(
+                claude["configured"], false,
+                "another provider's json-file must not mark the requiring backend configured: {claude}"
+            );
+            assert_eq!(claude["source"], "missing");
+
+            let readiness = output["credential_readiness"]
+                .as_array()
+                .expect("credential_readiness is an array");
+            assert!(
+                readiness.iter().any(|entry| {
+                    entry["provider_id"] == "claude-code.agent-task-executor"
+                        && entry["missing"].as_array().is_some_and(|missing| {
+                            missing
+                                .iter()
+                                .any(|name| name == "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN")
+                        })
+                }),
+                "credential readiness still names the missing required token: {readiness:?}"
+            );
+            assert!(
+                !serde_json::to_string(&output)
+                    .expect("json")
+                    .contains("present-refresh-token"),
+                "secret values must stay out of the report"
             );
         });
     }


### PR DESCRIPTION
Fixes #13629

`auth status`, `providers --secret-env`, and `credential_readiness` still disagreed on current `origin/main` after #13652. The installed command (`homeboy 0.364.10`) and current main both reported, without reading secret values:

```
homeboy agent-task providers --secret-env AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN --placement local
```

- `secret_env`: `AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN` `configured=true` `source=json-file`
- `credential_readiness` for `claude-code.agent-task-executor`: missing that same name

Root cause: catalog `secret_env` merged every shown provider's sources into one map (wp-codebox's json-file last-write-wins) while `credential_readiness` resolved the name against only the requiring provider's sources (claude-code declares none). #13652 shared the resolver function; the inputs were still different.

## Changes

- Resolve secret-env per provider scope (`sources` + unconditional `required_names`)
- Flatten with a veto: a required name that does not resolve in its own scope cannot read as `configured=true` from another provider
- Route `agent-task auth status` and `agent-task providers` through that one path

## Verification

```
cargo test --locked -p homeboy-agents --lib secret_env_status_for -- --test-threads=1
cargo test --locked -p homeboy-agents --lib credential_readiness -- --test-threads=1
cargo test --locked -p homeboy-cli --lib providers_secret_env -- --test-threads=1
cargo fmt --all --check
```

All passed in this worktree.

## Remediation after merge

Upgrade Homeboy past the release that contains this commit (`homeboy upgrade` / the next `v0.364.x`). Installed `0.364.10` still has the disagreement.

Do not merge or release from this PR unless an operator asks.

---

*AI assistance: OpenAI gpt-5.6-sol via OpenCode general coding subagent. The agent investigated closed #13629 against origin/main in an isolated non-primary worktree, reproduced the remaining secret_env vs credential_readiness disagreement without reading secret values, implemented one per-provider resolution path with regression tests, ran focused Rust gates, and opened this PR.*