### PR TITLE
fix(agent-task): resolve catalog secret_env per provider

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_provider.rs
@@ -80,8 +80,8 @@ pub(crate) use config_preflight::preflight_plan_provider_config_with_providers;
 pub use credential_readiness::{
     preflight_discovered_provider_credentials_for_backend, preflight_provider_credentials,
     preflight_provider_credentials_for_backend, provider_credential_readiness,
-    AgentTaskProviderCredentialReadiness, AgentTaskProviderCredentialRequirement,
-    AGENT_TASK_PROVIDER_CREDENTIAL_READINESS_SCHEMA,
+    secret_env_status_for_providers, AgentTaskProviderCredentialReadiness,
+    AgentTaskProviderCredentialRequirement, AGENT_TASK_PROVIDER_CREDENTIAL_READINESS_SCHEMA,
 };
 pub use dispatchability::{
     evaluate_provider_dispatchability, evaluate_provider_dispatchability_with_config,

--- a/crates/homeboy-agents/src/agent_task_provider/credential_readiness.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/credential_readiness.rs
@@ -41,6 +41,9 @@
 
 use super::secrets::provider_declared_secret_sources;
 use super::*;
+use crate::agent_task_secrets::{
+    secret_env_status_for_scopes, AgentTaskSecretEnvScope, AgentTaskSecretEnvStatus,
+};
 
 pub const AGENT_TASK_PROVIDER_CREDENTIAL_READINESS_SCHEMA: &str =
     "homeboy/agent-task-provider-credential-readiness/v1";
@@ -247,6 +250,29 @@ fn sole_provider_default_required_secret_env(provider: &AgentTaskExecutorProvide
         }
     }
     Vec::new()
+}
+
+/// Redacted secret-env status for the shown providers, resolved per provider.
+///
+/// This is the single catalog answer shared by `agent-task providers` and
+/// `agent-task auth status`. Merging every provider's sources before resolving
+/// made a required credential look configured from another backend's json-file
+/// while that requiring provider still reported it missing (#13629).
+pub fn secret_env_status_for_providers(
+    explicit_names: &[String],
+    providers: &[AgentTaskExecutorProvider],
+) -> Vec<AgentTaskSecretEnvStatus> {
+    let scopes = providers
+        .iter()
+        .map(|provider| AgentTaskSecretEnvScope {
+            fallback_sources: provider_declared_secret_sources(provider),
+            required_names: declared_credentials(provider)
+                .into_iter()
+                .map(|entry| entry.env)
+                .collect(),
+        })
+        .collect::<Vec<_>>();
+    secret_env_status_for_scopes(explicit_names, &scopes)
 }
 
 /// Resolve a provider's declared credentials against the observed scope.
@@ -591,6 +617,70 @@ mod tests {
             structured.contains("\"failure_classification\":\"configuration\""),
             "a credential gap is configuration, not a spent provider execution: {structured}"
         );
+    }
+
+    #[test]
+    fn catalog_secret_env_does_not_inherit_another_provider_source_for_a_required_credential() {
+        let required = format!("HOMEBOY_TEST_CREDENTIAL_{}", uuid::Uuid::new_v4());
+        let auth = tempfile::NamedTempFile::new().expect("auth file");
+        std::fs::write(auth.path(), r#"{"token":"refresh-token-value"}"#).expect("write auth");
+        let requiring = provider(serde_json::json!({
+            "id": "claude-code.agent-task-executor",
+            "backend": "claude-code",
+            "provider_defaults": {
+                "claude-code": {
+                    "secret_env": [required.clone()],
+                    "required_secret_env": [required.clone()]
+                }
+            }
+        }));
+        let other = provider(serde_json::json!({
+            "id": "wordpress.codebox-agent-task-executor",
+            "backend": "wp-codebox",
+            "provider_defaults": {
+                "claude-code": {
+                    "secret_env": [required.clone()],
+                    "secret_env_sources": {
+                        required.clone(): {
+                            "source": "json-file",
+                            "path": auth.path().display().to_string(),
+                            "field": "token"
+                        }
+                    }
+                }
+            }
+        }));
+
+        let readiness = provider_credential_readiness(&requiring);
+        assert!(
+            !readiness.dispatchable,
+            "the requiring provider still cannot resolve the credential from its own sources"
+        );
+        assert_eq!(readiness.missing, vec![required.clone()]);
+
+        let catalog = secret_env_status_for_providers(&[], &[requiring.clone(), other.clone()]);
+        let entry = catalog
+            .iter()
+            .find(|entry| entry.name == required)
+            .expect("required name is reported");
+        assert!(
+            !entry.configured,
+            "catalog secret_env must not report configured=true from the other provider: {entry:?}"
+        );
+        assert_eq!(
+            entry.configured,
+            readiness
+                .requirements
+                .iter()
+                .find(|requirement| requirement.env == required)
+                .expect("requirement row")
+                .configured
+        );
+
+        let explicit =
+            secret_env_status_for_providers(std::slice::from_ref(&required), &[requiring, other]);
+        assert_eq!(explicit.len(), 1);
+        assert!(!explicit[0].configured);
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_secrets.rs
+++ b/crates/homeboy-agents/src/agent_task_secrets.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::env;
 use std::fs;
 use std::path::PathBuf;
@@ -71,6 +71,19 @@ pub fn secret_env_plan_status(plan: &SecretEnvPlan) -> Vec<AgentTaskSecretEnvSta
     secret_env_status(&plan.secret_env_names())
 }
 
+/// One provider-shaped secret-env scope: that provider's sources, plus the
+/// names it unconditionally requires even when it declares no source for them.
+///
+/// Catalog `secret_env` used to merge every shown provider's sources into one
+/// map and resolve once. A backend that required a name without declaring a
+/// source then reported it missing while the flattened catalog reported the
+/// same name configured from a *different* provider's json-file (#13629).
+#[derive(Debug, Clone, Default)]
+pub struct AgentTaskSecretEnvScope {
+    pub fallback_sources: HashMap<String, AgentTaskSecretSource>,
+    pub required_names: Vec<String>,
+}
+
 /// Redacted secret-env status for a scope, defaulting to every secret that
 /// scope declares a source for when the caller names none explicitly.
 ///
@@ -85,12 +98,145 @@ pub fn secret_env_status_for_scope(
     explicit_names: &[String],
     fallback_sources: &HashMap<String, AgentTaskSecretSource>,
 ) -> Vec<AgentTaskSecretEnvStatus> {
-    if !explicit_names.is_empty() {
-        return secret_env_status_with_fallbacks(explicit_names, fallback_sources);
+    secret_env_status_for_scopes(
+        explicit_names,
+        &[AgentTaskSecretEnvScope {
+            fallback_sources: fallback_sources.clone(),
+            required_names: Vec::new(),
+        }],
+    )
+}
+
+/// Resolve each scope against its own sources, then flatten.
+///
+/// A name a scope *requires* and cannot resolve vetoes `configured=true` from
+/// any other scope. That is the single catalog answer: another provider's
+/// json-file must not make a requiring backend look configured (#13629).
+pub fn secret_env_status_for_scopes(
+    explicit_names: &[String],
+    scopes: &[AgentTaskSecretEnvScope],
+) -> Vec<AgentTaskSecretEnvStatus> {
+    if scopes.is_empty() {
+        if explicit_names.is_empty() {
+            return Vec::new();
+        }
+        return secret_env_status_with_fallbacks(explicit_names, &HashMap::new());
     }
-    let mut names: Vec<String> = fallback_sources.keys().cloned().collect();
-    names.sort();
-    secret_env_status_with_fallbacks(&names, fallback_sources)
+
+    let mut merged: BTreeMap<String, AgentTaskSecretEnvStatus> = BTreeMap::new();
+    let mut required_unconfigured: BTreeSet<String> = BTreeSet::new();
+
+    for scope in scopes {
+        let names = scope_secret_env_names(explicit_names, scope);
+        let status = secret_env_status_with_fallbacks(&names, &scope.fallback_sources);
+        for required in &scope.required_names {
+            if !explicit_names.is_empty() && !explicit_names.iter().any(|name| name == required) {
+                continue;
+            }
+            let configured = status
+                .iter()
+                .find(|entry| &entry.name == required)
+                .is_some_and(|entry| entry.configured);
+            if !configured {
+                required_unconfigured.insert(required.clone());
+            }
+        }
+        for entry in status {
+            merged
+                .entry(entry.name.clone())
+                .and_modify(|existing| merge_scope_status(existing, &entry))
+                .or_insert(entry);
+        }
+    }
+
+    for name in required_unconfigured {
+        match merged.get_mut(&name) {
+            Some(entry) if entry.configured => {
+                if !entry
+                    .alternatives
+                    .iter()
+                    .any(|alternative| alternative.source == entry.source && alternative.configured)
+                {
+                    entry.alternatives.push(AgentTaskSecretEnvSourceStatus {
+                        origin: "provider-default".to_string(),
+                        source: entry.source.clone(),
+                        configured: true,
+                    });
+                }
+                entry.configured = false;
+                entry.source = "missing".to_string();
+            }
+            Some(_) => {}
+            None => {
+                merged.insert(
+                    name.clone(),
+                    AgentTaskSecretEnvStatus {
+                        name,
+                        configured: false,
+                        source: "missing".to_string(),
+                        alternatives: Vec::new(),
+                    },
+                );
+            }
+        }
+    }
+
+    merged.into_values().collect()
+}
+
+fn scope_secret_env_names(
+    explicit_names: &[String],
+    scope: &AgentTaskSecretEnvScope,
+) -> Vec<String> {
+    if !explicit_names.is_empty() {
+        return explicit_names.to_vec();
+    }
+    let mut names: BTreeSet<String> = scope.fallback_sources.keys().cloned().collect();
+    names.extend(scope.required_names.iter().cloned());
+    names.into_iter().collect()
+}
+
+fn merge_scope_status(
+    existing: &mut AgentTaskSecretEnvStatus,
+    incoming: &AgentTaskSecretEnvStatus,
+) {
+    if existing.configured || !incoming.configured {
+        for alternative in &incoming.alternatives {
+            if !existing.alternatives.iter().any(|entry| {
+                entry.origin == alternative.origin && entry.source == alternative.source
+            }) {
+                existing.alternatives.push(alternative.clone());
+            }
+        }
+        if incoming.configured == existing.configured
+            && incoming.source != existing.source
+            && !existing
+                .alternatives
+                .iter()
+                .any(|entry| entry.source == incoming.source)
+        {
+            existing.alternatives.push(AgentTaskSecretEnvSourceStatus {
+                origin: "provider-default".to_string(),
+                source: incoming.source.clone(),
+                configured: incoming.configured,
+            });
+        }
+        return;
+    }
+    let previous = existing.clone();
+    *existing = incoming.clone();
+    if previous.source != existing.source
+        && !existing
+            .alternatives
+            .iter()
+            .any(|entry| entry.source == previous.source && entry.configured == previous.configured)
+    {
+        existing.alternatives.push(AgentTaskSecretEnvSourceStatus {
+            origin: "provider-default".to_string(),
+            source: previous.source,
+            configured: previous.configured,
+        });
+    }
 }
 
 pub fn map_secret_to_env(
@@ -704,6 +850,83 @@ mod tests {
         );
 
         std::env::remove_var(configured);
+    }
+
+    #[test]
+    fn secret_env_status_for_scopes_does_not_let_another_scope_mark_a_required_secret_configured() {
+        let required = unique_env("SCOPE_REQUIRED");
+        let present = unique_env("SCOPE_PRESENT");
+        std::env::remove_var(&required);
+        std::env::set_var(&present, "present-value");
+        let source = |env_var: &str| AgentTaskSecretSource {
+            source: "env".to_string(),
+            env_var: Some(env_var.to_string()),
+            path: None,
+            scope: None,
+            name: None,
+            field: None,
+            value: None,
+        };
+        let requiring = AgentTaskSecretEnvScope {
+            fallback_sources: HashMap::new(),
+            required_names: vec![required.clone()],
+        };
+        let mut other_sources = HashMap::new();
+        other_sources.insert(required.clone(), source(&present));
+        let other = AgentTaskSecretEnvScope {
+            fallback_sources: other_sources,
+            required_names: Vec::new(),
+        };
+
+        let merged = secret_env_status_for_scopes(&[], &[requiring, other]);
+        let entry = merged
+            .iter()
+            .find(|entry| entry.name == required)
+            .expect("required name is still reported");
+        assert!(
+            !entry.configured,
+            "a requiring scope that cannot resolve the name vetoes another scope's configured source: {entry:?}"
+        );
+        assert_eq!(entry.source, "missing");
+
+        let explicit = secret_env_status_for_scopes(
+            std::slice::from_ref(&required),
+            &[
+                AgentTaskSecretEnvScope {
+                    fallback_sources: HashMap::new(),
+                    required_names: vec![required.clone()],
+                },
+                AgentTaskSecretEnvScope {
+                    fallback_sources: HashMap::from([(required.clone(), source(&present))]),
+                    required_names: Vec::new(),
+                },
+            ],
+        );
+        assert_eq!(explicit.len(), 1);
+        assert_eq!(explicit[0].name, required);
+        assert!(
+            !explicit[0].configured,
+            "explicit lookup must use the same veto, not the merged-source shortcut"
+        );
+
+        std::env::remove_var(present);
+    }
+
+    #[test]
+    fn secret_env_status_for_scopes_lists_a_required_name_with_no_declared_source() {
+        let required = unique_env("SCOPE_REQUIRED_ONLY");
+        std::env::remove_var(&required);
+        let status = secret_env_status_for_scopes(
+            &[],
+            &[AgentTaskSecretEnvScope {
+                fallback_sources: HashMap::new(),
+                required_names: vec![required.clone()],
+            }],
+        );
+        assert_eq!(status.len(), 1);
+        assert_eq!(status[0].name, required);
+        assert!(!status[0].configured);
+        assert_eq!(status[0].source, "missing");
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -455,9 +455,9 @@ pub mod provider {
         preflight_provider_credentials_for_backend, preflight_provider_dispatchability,
         preflight_provider_dispatchability_with_config,
         preflight_provider_dispatchability_without_runtime_with_config,
-        provider_credential_readiness, AgentTaskProviderCredentialReadiness,
-        AgentTaskProviderCredentialRequirement, AgentTaskProviderDispatchability,
-        AGENT_TASK_PROVIDER_CREDENTIAL_READINESS_SCHEMA,
+        provider_credential_readiness, secret_env_status_for_providers,
+        AgentTaskProviderCredentialReadiness, AgentTaskProviderCredentialRequirement,
+        AgentTaskProviderDispatchability, AGENT_TASK_PROVIDER_CREDENTIAL_READINESS_SCHEMA,
     };
     pub use crate::agent_task_provider::{
         probe_provider_executor_resolves, provider_runner_secret_env_for_plan_with_providers,
@@ -493,8 +493,9 @@ pub mod secrets {
     pub use super::super::agent_task_secrets::{
         legacy_secrets_file, map_secret_to_env, map_secret_to_keychain_bundle,
         remove_secret_mapping, resolve_secret_env, resolve_secret_env_with_fallbacks,
-        secret_env_status, secret_env_status_for_scope, secret_env_status_with_fallbacks,
-        set_config_secret, set_keychain_bundle, set_keychain_secret, validate_secret_env,
+        secret_env_status, secret_env_status_for_scope, secret_env_status_for_scopes,
+        secret_env_status_with_fallbacks, set_config_secret, set_keychain_bundle,
+        set_keychain_secret, validate_secret_env, AgentTaskSecretEnvScope,
         AgentTaskSecretEnvStatus, AgentTaskSecretResolutionError,
     };
 }

--- a/crates/homeboy-cli/src/commands/agent_task/auth.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/auth.rs
@@ -126,23 +126,28 @@ fn auth_status(status_args: AgentTaskAuthStatusArgs) -> Value {
         .clone()
         .or_else(|| default_backend.clone());
 
-    // Scope provider secret sources to the selected backend (and optional
-    // selector). Falling back to all-provider sources keeps status useful when
-    // no backend can be resolved.
-    let fallback_sources = match selected_backend.as_deref() {
-        Some(backend) => agent_task_provider::provider_secret_sources_for_backend(
-            providers,
-            backend,
-            status_args.selector.as_deref(),
-        ),
-        None => agent_task_provider::provider_secret_sources_for_providers(providers),
+    // Scope status to the selected backend (and optional selector). Falling
+    // back to every discovered provider keeps status useful when no backend
+    // can be resolved. Shared with `agent-task providers --secret-env` so
+    // the two commands agree about the same secrets (#13629).
+    let scoped_providers: Vec<_> = match selected_backend.as_deref() {
+        Some(backend) => providers
+            .iter()
+            .filter(|provider| provider.backend == backend)
+            .filter(|provider| {
+                status_args
+                    .selector
+                    .as_deref()
+                    .is_none_or(|selector| provider.id == selector)
+            })
+            .cloned()
+            .collect(),
+        None => providers.to_vec(),
     };
-
-    // Explicit operator-supplied names win; otherwise report every secret the
-    // selected backend declares. Shared with `agent-task providers
-    // --secret-env` so the two commands agree about the same secrets (#13629).
-    let secret_env =
-        agent_task_secrets::secret_env_status_for_scope(&status_args.secret_env, &fallback_sources);
+    let secret_env = agent_task_provider::secret_env_status_for_providers(
+        &status_args.secret_env,
+        &scoped_providers,
+    );
 
     serde_json::json!({
         "schema": "homeboy/agent-task-auth-status/v1",

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -2038,8 +2038,6 @@ fn providers_with_catalog(
                 _ => None,
             })
         });
-    let fallback_sources =
-        homeboy::agents::agent_tasks::provider::provider_secret_sources_for_providers(providers);
 
     let full_command = provider_full_command(&args);
     let shown_providers = if args.full {
@@ -2119,9 +2117,10 @@ fn providers_with_catalog(
             ),
             "diagnostics": shown_diagnostics,
             // Explicit `--secret-env` names win; otherwise report every secret
-            // the shown providers declare, so this agrees with `agent-task
-            // auth status` about the same secrets by construction (#13629).
-            "secret_env": homeboy::agents::agent_tasks::secrets::secret_env_status_for_scope(&args.secret_env, &fallback_sources),
+            // the shown providers declare. Resolved per provider so another
+            // backend's json-file cannot mark a requiring backend configured
+            // (#13629).
+            "secret_env": homeboy::agents::agent_tasks::provider::secret_env_status_for_providers(&args.secret_env, providers),
         }),
         0,
     ))
@@ -3928,6 +3927,97 @@ mod tests {
                     .expect("declared credential entry")["configured"],
                 false,
                 "unconfigured in this hermetic test environment, matching auth status"
+            );
+        });
+    }
+
+    /// #13629: a catalog that mixes a requiring backend with no sources and
+    /// another backend that can resolve the same name from a json-file must
+    /// not report `secret_env.configured=true` while `credential_readiness`
+    /// lists that name as missing.
+    #[test]
+    fn providers_catalog_secret_env_agrees_with_credential_readiness_across_backends() {
+        crate::test_support::with_isolated_home(|_| {
+            save_provider_policy(None, None);
+            let auth = tempfile::NamedTempFile::new().expect("auth file");
+            std::fs::write(auth.path(), r#"{"token":"refresh-token-value"}"#).expect("write auth");
+            let requiring = credential_declaring_provider();
+            let other: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
+                "id": "wordpress.codebox-agent-task-executor",
+                "backend": "wp-codebox",
+                "provider_defaults": {
+                    "claude-code": {
+                        "secret_env": ["AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"],
+                        "secret_env_sources": {
+                            "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN": {
+                                "source": "json-file",
+                                "path": auth.path().display().to_string(),
+                                "field": "token"
+                            }
+                        }
+                    }
+                }
+            }))
+            .expect("other provider fixture");
+            let output =
+                providers_with_catalog(providers_args(), provider_catalog(vec![requiring, other]))
+                    .expect("provider report")
+                    .0;
+
+            let missing = output["credential_readiness"]
+                .as_array()
+                .expect("credential_readiness")
+                .iter()
+                .find(|entry| entry["backend"] == "claude-code")
+                .expect("claude-code readiness")["missing"]
+                .as_array()
+                .expect("missing names")
+                .iter()
+                .any(|name| name == "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN");
+            assert!(
+                missing,
+                "claude-code still cannot resolve the required credential from its own sources"
+            );
+
+            let secret_env = output["secret_env"]
+                .as_array()
+                .expect("secret_env is an array");
+            let token = secret_env
+                .iter()
+                .find(|entry| entry["name"] == "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN")
+                .expect("catalog still names the required credential");
+            assert_eq!(
+                token["configured"], false,
+                "catalog secret_env must not contradict credential_readiness: {token:?}"
+            );
+        });
+    }
+
+    #[test]
+    fn providers_scoped_secret_env_lists_a_required_credential_with_no_declared_source() {
+        crate::test_support::with_isolated_home(|_| {
+            save_provider_policy(None, None);
+            let mut args = providers_args();
+            args.backend = Some("claude-code".to_string());
+            let output = providers_with_catalog(
+                args,
+                provider_catalog(vec![credential_declaring_provider()]),
+            )
+            .expect("provider report")
+            .0;
+
+            let secret_env = output["secret_env"]
+                .as_array()
+                .expect("secret_env is an array");
+            let token = secret_env
+                .iter()
+                .find(|entry| entry["name"] == "AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN")
+                .expect("required credential is listed even without a declared source");
+            assert_eq!(token["configured"], false);
+            assert_eq!(token["source"], "missing");
+            assert_eq!(
+                output["credential_readiness"][0]["requirements"][0]["configured"],
+                false
             );
         });
     }


### PR DESCRIPTION
Fixes #13629

`homeboy agent-task providers --catalog` still contradicted itself after #13652: `secret_env` reported `AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN` `configured=true` `source=json-file` while `credential_readiness` for `claude-code` listed that same name as missing.

#13652 shared the resolver function, but the catalog still merged every shown provider's `secret_env_sources` into one map before resolving. `wp-codebox` declares the json-file source; `claude-code` requires the name and declares none. Flattened catalog status then inherited the other backend's source.

This keeps a single resolution path: each provider is resolved against its own sources, required names are always listed, and a required-but-unresolved name vetoes `configured=true` in the flattened catalog. Dispatchability stays per-provider, so a backend cannot look ready from another backend's mapping.

Verified:
- `cargo test -p homeboy-agents --lib -- secret_env_status_for_scopes catalog_secret_env_does_not_inherit secret_env_status_for_scope_defaults`
- `cargo test -p homeboy-cli --lib -- providers_catalog_secret_env_agrees providers_scoped_secret_env_lists providers_secret_env_defaults`

Do not release or merge from this PR.

---

*AI assistance: OpenAI gpt-5.6-sol via OpenCode general coding subagent. The agent reproduced the live catalog contradiction without reading secret values, implemented the per-provider resolution and regression tests, and ran the focused Rust tests above. I directed the investigation against Extra-Chill/homeboy#13629 and current origin/main.*