### PR TITLE
Type recipe_run_providers and empty the extra buffer (#13724)

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/lib.rs
+++ b/crates/contracts/homeboy-extension-contract/src/lib.rs
@@ -15,7 +15,9 @@ pub use ci_config::{
     CiJobSpec, CiLocalContext, CiProfileSpec,
 };
 pub use manifest_capability_config::AgentRuntimeManifestConfig;
-pub use manifest_capability_config::{DiscoveryMarkerConfig, ScriptsConfig};
+pub use manifest_capability_config::{
+    DiscoveryMarkerConfig, RecipeRunProviderDeclaration, RecipeRunProviderDescriptor, ScriptsConfig,
+};
 pub use manifest_toolchain_config::{
     CliAutoFlag, CliAutoFlagCondition, CliHelpConfig, DatabaseCliConfig, DeployVerification,
     LintChangedFileRoute, RemotePathRootRule, RequirementsConfig, TestSecretEnvProjection,

--- a/crates/contracts/homeboy-extension-contract/src/manifest.rs
+++ b/crates/contracts/homeboy-extension-contract/src/manifest.rs
@@ -61,6 +61,13 @@ pub struct ExtensionManifest {
     // Capability groups
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deploy: Option<DeployCapability>,
+    /// Recipe-run providers this extension publishes.
+    ///
+    /// Typed since #13724. Malformed entries are retained rather than rejected
+    /// so `runner recipe-providers` can name the broken declaration instead of
+    /// reporting the whole manifest as unreadable.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub recipe_run_providers: Vec<RecipeRunProviderDeclaration>,
     /// Deployment providers this extension publishes.
     ///
     /// Typed since #13723. While this rode in `extra`, a malformed descriptor
@@ -192,11 +199,13 @@ pub struct ExtensionManifest {
     /// extension published against a newer or older core still deserializes.
     ///
     /// This is a *forward-compatibility buffer*, not an extension point. Core
-    /// reads exactly two keys out of it — the legacy camelCase `sourceUrl`
-    /// (`lifecycle::source_metadata`) and `recipe_run_providers`
-    /// (`recipe_run::recipe_run_providers`, tracked for promotion in #13724) —
-    /// and nothing else in here has a reader. `deployment_providers` was the
-    /// third and became a typed field in #13723.
+    /// reads exactly one key out of it — the legacy camelCase `sourceUrl`
+    /// (`lifecycle::source_metadata`) — and nothing else in here has a reader.
+    /// `deployment_providers` (#13723) and `recipe_run_providers` (#13724) were
+    /// the other two and are now typed fields.
+    ///
+    /// With only a legacy alias left, a key appearing here is a key nothing
+    /// will ever act on.
     ///
     /// Landing anything else here makes it inert *silently*, which is how
     /// shipped manifests accumulated `required_output_declarations` (26 lines),

--- a/crates/contracts/homeboy-extension-contract/src/manifest_capability_config.rs
+++ b/crates/contracts/homeboy-extension-contract/src/manifest_capability_config.rs
@@ -187,3 +187,51 @@ pub struct RuntimeRequirementsConfig {
 pub struct RuntimeRequirementConfig {
     pub version: String,
 }
+
+/// Extension-owned remote recipe execution descriptor.
+///
+/// Typed since #13724. While this rode in `ExtensionManifest::extra` it had two
+/// readers that disagreed: one `.ok()`-discarded malformed entries, the other
+/// retained them so `runner recipe-providers` could report which declaration was
+/// broken and why.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RecipeRunProviderDescriptor {
+    pub id: String,
+    pub version: String,
+    pub executable: String,
+    pub command: Vec<String>,
+}
+
+/// One declared recipe-run provider, retaining entries that do not satisfy the
+/// descriptor shape.
+///
+/// Rejecting a malformed entry at manifest load would fail the whole manifest
+/// and collapse a precise per-provider diagnostic ("requires id, version,
+/// executable, and argv beginning with executable") into "this extension's
+/// manifest is invalid". The malformed value is preserved so inventory can name
+/// the offending declaration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum RecipeRunProviderDeclaration {
+    Descriptor(Box<RecipeRunProviderDescriptor>),
+    Malformed(serde_json::Value),
+}
+
+impl RecipeRunProviderDeclaration {
+    /// Best-effort string field read that works for both variants, so
+    /// diagnostics can name a provider that failed to satisfy the shape.
+    pub fn declared_str(&self, field: &str) -> Option<String> {
+        match self {
+            RecipeRunProviderDeclaration::Descriptor(descriptor) => match field {
+                "id" => Some(descriptor.id.clone()),
+                "version" => Some(descriptor.version.clone()),
+                "executable" => Some(descriptor.executable.clone()),
+                _ => None,
+            },
+            RecipeRunProviderDeclaration::Malformed(value) => value
+                .get(field)
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string),
+        }
+    }
+}

--- a/crates/homeboy-cli/src/commands/runner/recipe_run.rs
+++ b/crates/homeboy-cli/src/commands/runner/recipe_run.rs
@@ -25,10 +25,13 @@ pub(super) fn recipe_run(
         ));
     }
     let descriptor = homeboy_extension::resolve_recipe_run_provider(provider_id)?;
-    let command = descriptor.render(&homeboy_extension::RecipeRunRequest {
-        recipe_path: recipe,
-        artifact_path: artifacts.clone(),
-    })?;
+    let command = homeboy_extension::render_recipe_run_command(
+        &descriptor,
+        &homeboy_extension::RecipeRunRequest {
+            recipe_path: recipe,
+            artifact_path: artifacts.clone(),
+        },
+    )?;
     let (output, exit_code) = exec_with_hydration(
         runner_id,
         None,

--- a/crates/homeboy-extension/src/lib.rs
+++ b/crates/homeboy-extension/src/lib.rs
@@ -138,7 +138,7 @@ pub use manifest::{
     NOTIFICATION_TRANSPORT_SCHEMA,
 };
 pub use recipe_run::{
-    recipe_run_provider_inventory, recipe_run_providers, resolve_recipe_run_provider,
+    recipe_run_provider_inventory, render_recipe_run_command, resolve_recipe_run_provider,
     RecipeRunProviderDescriptor, RecipeRunProviderInventoryEntry, RecipeRunProviderValidation,
     RecipeRunRequest,
 };

--- a/crates/homeboy-extension/src/recipe_run.rs
+++ b/crates/homeboy-extension/src/recipe_run.rs
@@ -7,13 +7,7 @@ use crate::DiscoveredExtension;
 
 const AVAILABLE_ID_LIMIT: usize = 20;
 
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
-pub struct RecipeRunProviderDescriptor {
-    pub id: String,
-    pub version: String,
-    pub executable: String,
-    pub command: Vec<String>,
-}
+pub use homeboy_extension_contract::{RecipeRunProviderDeclaration, RecipeRunProviderDescriptor};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RecipeRunRequest {
@@ -53,16 +47,6 @@ pub enum RecipeRunProviderValidation {
 struct DiscoveredProvider {
     entry: RecipeRunProviderInventoryEntry,
     descriptor: Option<RecipeRunProviderDescriptor>,
-}
-
-/// Read recipe-run descriptors from an installed extension manifest.
-pub fn recipe_run_providers(manifest: &ExtensionManifest) -> Vec<RecipeRunProviderDescriptor> {
-    manifest
-        .extra
-        .get("recipe_run_providers")
-        .cloned()
-        .and_then(|value| serde_json::from_value(value).ok())
-        .unwrap_or_default()
 }
 
 /// List every installed recipe-run declaration, including malformed entries.
@@ -166,25 +150,21 @@ fn discover_recipe_run_providers() -> Vec<DiscoveredProvider> {
 }
 
 fn declarations_from_manifest(manifest: &ExtensionManifest) -> Vec<DiscoveredProvider> {
-    let Some(value) = manifest.extra.get("recipe_run_providers") else {
-        return Vec::new();
-    };
     let source_ref = manifest.extension_path.clone();
-    let declarations = value
-        .as_array()
-        .cloned()
-        .unwrap_or_else(|| vec![value.clone()]);
-    declarations
-        .into_iter()
-        .map(|value| {
-            let id = value.get("id").and_then(serde_json::Value::as_str).map(str::to_string);
-            let version = value.get("version").and_then(serde_json::Value::as_str).map(str::to_string);
-            let executable = value.get("executable").and_then(serde_json::Value::as_str).map(str::to_string);
-            let descriptor = serde_json::from_value::<RecipeRunProviderDescriptor>(value);
-            match descriptor
-                .ok()
-                .and_then(|descriptor| validate_descriptor(descriptor).ok())
-            {
+    manifest
+        .recipe_run_providers
+        .iter()
+        .map(|declaration| {
+            let id = declaration.declared_str("id");
+            let version = declaration.declared_str("version");
+            let executable = declaration.declared_str("executable");
+            let descriptor = match declaration {
+                RecipeRunProviderDeclaration::Descriptor(descriptor) => {
+                    Some((**descriptor).clone())
+                }
+                RecipeRunProviderDeclaration::Malformed(_) => None,
+            };
+            match descriptor.and_then(|descriptor| validate_descriptor(descriptor).ok()) {
                 Some(descriptor) => DiscoveredProvider {
                     entry: RecipeRunProviderInventoryEntry { id, version, owning_extension: manifest.id.clone(), source_ref: source_ref.clone(), executable, resolvable: true, validation: RecipeRunProviderValidation::Valid, diagnostic: None },
                     descriptor: Some(descriptor),
@@ -222,20 +202,25 @@ fn unknown_provider_hints(inventory: &[RecipeRunProviderInventoryEntry]) -> Vec<
     hints
 }
 
-impl RecipeRunProviderDescriptor {
-    /// Render the extension-declared argv without introducing shell parsing.
-    pub fn render(&self, request: &RecipeRunRequest) -> Result<Vec<String>> {
-        validate_descriptor(self.clone())?;
-        Ok(self
-            .command
-            .iter()
-            .map(|argument| {
-                argument
-                    .replace("{recipe}", &request.recipe_path)
-                    .replace("{artifacts}", &request.artifact_path)
-            })
-            .collect())
-    }
+/// Render an extension-declared argv without introducing shell parsing.
+///
+/// A free function rather than an inherent method: the descriptor is owned by
+/// `homeboy-extension-contract` (#13724) while validation and the request type
+/// stay here, and the orphan rule forbids the method form.
+pub fn render_recipe_run_command(
+    descriptor: &RecipeRunProviderDescriptor,
+    request: &RecipeRunRequest,
+) -> Result<Vec<String>> {
+    validate_descriptor(descriptor.clone())?;
+    Ok(descriptor
+        .command
+        .iter()
+        .map(|argument| {
+            argument
+                .replace("{recipe}", &request.recipe_path)
+                .replace("{artifacts}", &request.artifact_path)
+        })
+        .collect())
 }
 
 fn validate_descriptor(
@@ -275,12 +260,14 @@ mod tests {
             ],
         };
         assert_eq!(
-            provider
-                .render(&RecipeRunRequest {
+            render_recipe_run_command(
+                &provider,
+                &RecipeRunRequest {
                     recipe_path: "recipe.json".to_string(),
                     artifact_path: "artifacts".to_string(),
-                })
-                .expect("render"),
+                }
+            )
+            .expect("render"),
             vec![
                 "fixture-run",
                 "--recipe",
@@ -315,12 +302,14 @@ mod tests {
             let provider = resolve_recipe_run_provider("fixture.recipe-run").expect("discover");
             assert_eq!(provider.version, "1.0.0");
             assert_eq!(
-                provider
-                    .render(&RecipeRunRequest {
+                render_recipe_run_command(
+                    &provider,
+                    &RecipeRunRequest {
                         recipe_path: "recipe.json".to_string(),
                         artifact_path: "artifacts".to_string(),
-                    })
-                    .expect("render"),
+                    }
+                )
+                .expect("render"),
                 vec![
                     "fixture-run",
                     "--recipe",
@@ -329,6 +318,59 @@ mod tests {
                     "artifacts"
                 ]
             );
+        });
+    }
+
+    /// The existing inventory test covers a *shape-valid* entry that fails
+    /// semantic validation. This covers the case typing the field could have
+    /// regressed: an entry that does not satisfy the descriptor shape at all.
+    ///
+    /// Rejecting it at deserialization would fail the whole manifest, turning a
+    /// precise per-provider diagnostic into "this extension is unreadable" and
+    /// hiding every sibling provider the extension declares. The manifest must
+    /// still load, the valid sibling must remain resolvable, and the broken
+    /// entry must still be named.
+    #[test]
+    fn structurally_malformed_declaration_stays_reportable() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let source = tempfile::tempdir().expect("extension source");
+            std::fs::write(
+                source.path().join("fixture.json"),
+                serde_json::json!({
+                    "name": "Recipe fixture",
+                    "version": "1.0.0",
+                    "recipe_run_providers": [
+                        { "id": "fixture.valid", "version": "1.0.0", "executable": "fixture-run", "command": ["fixture-run"] },
+                        { "id": "fixture.no-version", "executable": "fixture-run", "command": ["fixture-run"] }
+                    ]
+                })
+                .to_string(),
+            )
+            .expect("manifest");
+            crate::install(&source.path().display().to_string(), Some("fixture"))
+                .expect("a malformed provider must not make the manifest unreadable");
+
+            let inventory = recipe_run_provider_inventory();
+            assert_eq!(inventory.len(), 2, "both declarations must be surfaced");
+
+            assert!(
+                inventory
+                    .iter()
+                    .any(|provider| provider.id.as_deref() == Some("fixture.valid")
+                        && provider.resolvable),
+                "a sibling of a malformed entry must stay resolvable"
+            );
+
+            let malformed = inventory
+                .iter()
+                .find(|provider| provider.id.as_deref() == Some("fixture.no-version"))
+                .expect("the malformed declaration must be named, not dropped");
+            assert_eq!(malformed.validation, RecipeRunProviderValidation::Invalid);
+            assert!(!malformed.resolvable);
+            assert!(malformed.diagnostic.is_some(), "must carry a diagnostic");
+
+            assert!(resolve_recipe_run_provider("fixture.no-version").is_err());
+            assert!(resolve_recipe_run_provider("fixture.valid").is_ok());
         });
     }
 


### PR DESCRIPTION
Closes #13724.

## What changed

`recipe_run_providers` moves from `ExtensionManifest::extra` to a typed field. **`extra` now has exactly one reader: the legacy camelCase `sourceUrl`.**

## The disagreement resolved itself

The issue asked to reconcile two readers that disagreed about malformed entries — `recipe_run_providers()` used `.ok()` to discard them, while `declarations_from_manifest` retained them so inventory could report which declaration was broken.

`recipe_run_providers()` has **no caller anywhere in the workspace**. It was a dead `pub` export, re-exported from `lib.rs` and never invoked. So the disagreement is resolved by deleting the permissive reader rather than reconciling it, and there is now exactly one parse path.

## Why elements are tolerant, unlike #13723

`deployment_providers` got strict typing in #13723: a malformed descriptor is a named deserialization error. Applying that here would have been a **regression**, and this is the part worth reviewing.

Recipe-run declarations already have a per-provider diagnostic surface — `homeboy runner recipe-providers` reports each declaration as `valid` / `invalid` / `duplicate` with a reason. If a malformed entry failed deserialization, the whole manifest would fail to load, `discover_recipe_run_providers` would see `DiscoveredExtension::Invalid` and return nothing, and a precise "provider requires id, version, executable, and argv beginning with executable" would collapse into "this extension is unreadable" — hiding every *valid* sibling provider that extension declares.

So the field is typed while elements use `RecipeRunProviderDeclaration`, an untagged enum that keeps the raw value for entries that do not satisfy the shape. The field is typed and compile-time visible; the diagnostic is preserved.

The distinction is intentional: `deployment_providers` has no per-provider diagnostic surface, so failing loudly at load is the best available signal. `recipe_run_providers` has one, so failing loudly would destroy a better signal.

## Verification

New test `structurally_malformed_declaration_stays_reportable` covers precisely the regression risk — an entry missing `version`, which the old code path never had to survive because the field was untyped. It asserts the manifest still installs, the malformed entry is still named with a diagnostic, the valid sibling stays resolvable, and resolution errors for the broken id while succeeding for the good one.

The four pre-existing `recipe_run` tests pass unchanged, including the inventory test covering valid / semantically-invalid / duplicate declarations.

- `homeboy-extension` lib: **818 passed, 0 failed**
- `homeboy-extension-contract`: **80 passed, 0 failed**
- `cargo fmt --all --check` clean, `cargo check --workspace --all-targets` clean
- `cargo clippy` introduces no warnings in the touched files

## Incidental

`RecipeRunProviderDescriptor::render` becomes the free function `render_recipe_run_command`. Once the descriptor is owned by `homeboy-extension-contract`, the orphan rule forbids an inherent `impl` in `homeboy-extension`, and validation plus `RecipeRunRequest` sensibly stay where they are.

## AI assistance

OpenCode 1.18.23 running Anthropic `claude-opus-5` traced the readers, found the permissive one was dead, identified that strict typing would regress the inventory diagnostic, and implemented the tolerant-element design. Chris Huber directed the work and owns the review.
