### PR TITLE
Preserve excluded roots in Lab snapshot staging

### DIFF
--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -2271,7 +2271,30 @@ pub(super) fn materialize_snapshot_stage(
     })?;
     for entry in &manifest.entries {
         let output = stage.path().join(&entry.staging_output);
-        if !output.exists() && !entry.source.exists() {
+        if output.exists() {
+            continue;
+        }
+        let metadata = fs::metadata(&entry.source).map_err(|error| {
+            snapshot_construction_failure(
+                &entry.declaration_id,
+                &entry.source,
+                Some(&output),
+                &error.to_string(),
+            )
+        })?;
+        if metadata.is_dir() {
+            // Tar may omit an admitted root directory when every child is
+            // excluded. Preserve the empty directory represented by the source
+            // manifest so pre-transport stability compares equivalent trees.
+            fs::create_dir_all(&output).map_err(|error| {
+                snapshot_construction_failure(
+                    &entry.declaration_id,
+                    &entry.source,
+                    Some(&output),
+                    &error.to_string(),
+                )
+            })?;
+        } else {
             return Err(snapshot_construction_failure(
                 &entry.declaration_id,
                 &entry.source,

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -1976,6 +1976,28 @@ fn snapshot_stability_rejects_a_mixed_staged_tree_even_if_source_is_restored() {
 }
 
 #[test]
+fn snapshot_staging_preserves_an_admitted_root_when_every_child_is_excluded() {
+    let source = tempfile::tempdir().expect("source");
+    let overlays = source.path().join("runtime-overlays/php-wasm");
+    fs::create_dir_all(&overlays).expect("runtime overlay directory");
+    fs::write(overlays.join("runtime.wasm"), b"\0asm").expect("runtime artifact");
+    let excludes = vec!["runtime-overlays/*".to_string()];
+
+    let before = snapshot_stable_manifest(source.path(), &excludes).expect("source manifest");
+    let manifest = snapshot_input_manifest(source.path(), &excludes).expect("input manifest");
+    let stage = materialize_snapshot_stage(source.path(), &excludes, &manifest, None)
+        .expect("snapshot stage");
+    let staged_source = stage.path().join("source");
+    let staged = snapshot_stable_manifest(&staged_source, &excludes).expect("staged manifest");
+    let after = snapshot_stable_manifest(source.path(), &excludes).expect("current manifest");
+
+    validate_snapshot_stability(&before, &staged, &after, source.path(), &staged_source)
+        .expect("the excluded children retain their admitted empty root");
+    assert!(staged_source.join("runtime-overlays").is_dir());
+    assert!(!staged_source.join("runtime-overlays/php-wasm").exists());
+}
+
+#[test]
 fn snapshot_staging_is_stable_with_sibling_worktrees_and_ignored_outputs() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let workspace_root = tempfile::tempdir().expect("workspace root");


### PR DESCRIPTION
## Summary

- preserve admitted root directories when tar elides them because every child is excluded
- fail closed when any omitted staging input is not a directory
- retain the existing source/stage/current manifest comparison as the authority for actual drift

## Root cause

A policy such as `runtime-overlays/*` retains the root directory in Homeboy's source manifest while excluding every child. Controller-side tar staging omits that empty root header, so the staged manifest alone lacks `runtime-overlays` and the pre-transport stability check rejects a clean workspace as mixed.

The fix recreates only a manifest-admitted directory root after tar staging. File bytes, executable capabilities, symlink behavior, child exclusions, and post-stage source stability remain covered by the unchanged manifest comparison.

## Verification

- `cargo test -p homeboy-lab-runner workspace::tests::snapshot --lib` (81 passed)
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

The regression fixture uses `runtime-overlays/*` with a nested binary artifact and proves the empty admitted root survives while excluded children do not.

Closes #13749

## AI assistance

Implemented with OpenCode using OpenAI GPT-5.6 Sol. The model traced the failed Lab staging evidence to the exclude-policy/tar representation mismatch, reproduced it against the downstream clean checkout, implemented the bounded directory-root repair, and ran the focused and full snapshot-module gates.
