### PR TITLE
Preserve detached Lab staging ownership

### DIFF
--- a/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/classification.rs
@@ -236,6 +236,17 @@ pub(super) fn is_lab_offloadable_fanout_coordinator(command: &Commands) -> bool 
     )
 }
 
+/// Executable retries use the generic Lab route, which first materializes the
+/// persisted controller plan and then hands that replay to the selected runner.
+pub(super) fn is_executable_agent_task_retry(command: &Commands) -> bool {
+    matches!(
+        command,
+        Commands::AgentTask(agent_task::AgentTaskArgs {
+            command: agent_task::AgentTaskCommand::Retry(retry),
+        }) if retry.run
+    )
+}
+
 pub(super) fn is_plan_only_command(command: &Commands) -> bool {
     matches!(
         command,

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
@@ -12,7 +12,8 @@ use serde::Serialize;
 
 use classification::{
     is_bounded_agent_task_metadata_read, is_controller_owned_fanout_coordination,
-    is_lab_offloadable_fanout_coordinator, is_local_registry_management, is_plan_only_command,
+    is_executable_agent_task_retry, is_lab_offloadable_fanout_coordinator,
+    is_local_registry_management, is_plan_only_command,
 };
 use messages::{
     append_local_placement, lab_routed_controller_notice, primary_action, severity_str,
@@ -67,8 +68,8 @@ pub(crate) fn parsed_command_preflight_input(
         || is_local_registry_management(&cli.command)
     {
         ControllerExecution::ControllerOnly
-    } else if hot_command(&cli.command)
-        .is_some_and(|command| command.allows_warm_runner_coordination)
+    } else if !is_executable_agent_task_retry(&cli.command)
+        && hot_command(&cli.command).is_some_and(|command| command.allows_warm_runner_coordination)
     {
         ControllerExecution::SplitPlacementCoordinator
     } else {
@@ -894,6 +895,31 @@ mod tests {
     use crate::commands::resources::{LoadSummary, MemorySummary, ProcessSummary, RigLeaseSummary};
     use crate::test_support::with_isolated_home;
     use clap::Parser;
+
+    #[test]
+    fn executable_agent_task_retry_uses_generic_lab_routing() {
+        use crate::core::parsed_command_preflight::ControllerExecution;
+
+        let args = [
+            "homeboy",
+            "agent-task",
+            "retry",
+            "persisted-lab-run",
+            "--run",
+            "--runner",
+            "homeboy-lab",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+        let cli = Cli::parse_from(&args);
+
+        assert_eq!(
+            parsed_command_preflight_input(&cli, &args).controller_execution,
+            ControllerExecution::Ordinary
+        );
+    }
+
     fn resources(recommendation: ResourceRecommendation) -> DoctorOutput {
         DoctorOutput {
             command: "self.resources",

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -1070,6 +1070,20 @@ where
             None,
         ));
     }
+    if let Some(durable_plan) = request.durable_agent_task_plan {
+        homeboy_agents::agent_task_lifecycle::record_lab_offload_phase_in_store(
+            &lab_lifecycle_store,
+            homeboy_agents::agent_task_lifecycle::LabOffloadPhaseRecord {
+                requested_run_id: run_id,
+                runner_id,
+                phase: "materializing",
+                remote_workspace: None,
+                source_checkout: None,
+                provider_rotation: None,
+                durable_plan: Some(durable_plan),
+            },
+        )?;
+    }
     let daemon = match ensure_daemon() {
         Ok(daemon) => daemon,
         Err(daemon_error) => {
@@ -4544,6 +4558,55 @@ mod tests {
             Some(run_id),
         )
         .expect("submit durable attempt");
+    }
+
+    #[test]
+    fn detached_staging_publishes_planned_ownership_before_daemon_convergence() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let _adapter_guard = global_state_lock().lock().expect("adapter lock");
+            clear_installed_adapter();
+            register();
+            enable_production_routing();
+
+            let run_id = "detached-staging-daemon-convergence";
+            let plan = homeboy_agents::agent_task_scheduler::AgentTaskPlan::new(
+                "detached-staging-daemon-convergence",
+                Vec::new(),
+            );
+            submit_recipe_run(run_id);
+            let args = vec!["agent-task".to_string(), "run-plan".to_string()];
+            let mut request = recipe_request(Some(recipe_command()), &args, HashMap::new());
+            request.durable_agent_task_plan = Some(&plan);
+
+            let result = submit_detached_staging_with_daemon_ensure(
+                run_id,
+                "lab-1",
+                crate::RunnerTunnelMode::DirectSsh,
+                &request,
+                || {
+                    let report =
+                        homeboy_agents::agent_task_service::reconcile_stale_active_runs(false)
+                            .expect("reconcile during daemon convergence");
+                    assert_eq!(report.reconciled, 0, "{report:#?}");
+
+                    let record = homeboy_agents::agent_task_lifecycle::exact_record(run_id)
+                        .expect("planned Lab proxy");
+                    assert!(!record.state.is_terminal(), "{record:#?}");
+                    assert_eq!(
+                        record.metadata["runner_execution_record"]["status"],
+                        "planned"
+                    );
+                    assert_eq!(record.metadata["phase"], "materializing");
+                    Err(Error::internal_unexpected("stop after ownership assertion"))
+                },
+            );
+            let error = match result {
+                Err(error) => error,
+                Ok(_) => panic!("fixture must stop before controller daemon submission"),
+            };
+
+            assert_ne!(error.message, "missing_runner_pid");
+        });
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
Closes #13758.

## Summary

- publish the existing planned Lab proxy before controller-daemon convergence
- prevent startup reconciliation from cancelling detached portable workloads during staging admission
- cover the production staging path by reconciling inside daemon convergence

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-lab-runner detached_staging_publishes_planned_ownership_before_daemon_convergence`
- `cargo test -p homeboy-lab-runner detached_staging_falls_back_through_authenticated_reverse_broker_and_projects_terminal_result_once`
- `cargo test -p homeboy-agents concurrent_planned_submissions_survive_delayed_runner_identity_publication`

Live detached Lab Bench acceptance is in progress against this immutable branch commit.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced and traced the lifecycle race, implemented the pre-daemon ownership publication and regression fixture, and ran the focused verification suite. Chris Huber directed the repair and remains responsible.