### PR TITLE
Protect live managed worktrees from foreign writes

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
@@ -1213,7 +1213,9 @@ fn store() -> Result<WorkspaceClaimStore> {
 /// Construct the controller-local claim authority below an explicit lifecycle
 /// data root. Lifecycle commits use this rather than resolving ambient paths.
 pub(crate) fn workspace_claim_store_at(data_root: std::path::PathBuf) -> WorkspaceClaimStore {
-    WorkspaceClaimStore::new(data_root.join("agent-task-workspace-claims"))
+    WorkspaceClaimStore::new(
+        data_root.join(homeboy_core::workspace_claim::LOCAL_WORKSPACE_CLAIMS_DIR),
+    )
 }
 
 /// Return the durable controller binding for a workspace-owning run. Callers

--- a/crates/homeboy-cli/src/commands/lint.rs
+++ b/crates/homeboy-cli/src/commands/lint.rs
@@ -90,7 +90,7 @@ pub struct LintArgs {
     #[arg(long)]
     pub fix: bool,
 
-    /// Allow --fix to edit the current dirty working tree for unbounded runs
+    /// Override dirty-tree and foreign live worktree-holder write protection
     #[arg(long)]
     pub force: bool,
 

--- a/crates/homeboy-cli/src/commands/refactor.rs
+++ b/crates/homeboy-cli/src/commands/refactor.rs
@@ -62,7 +62,7 @@ pub struct RefactorArgs {
     #[command(flatten)]
     baseline_args: BaselineArgs,
 
-    /// Skip the clean working tree check (for CI or when you know what you're doing)
+    /// Override dirty-tree and foreign live worktree-holder write protection
     #[arg(long)]
     force: bool,
 

--- a/crates/homeboy-cli/src/commands/worktree.rs
+++ b/crates/homeboy-cli/src/commands/worktree.rs
@@ -9,8 +9,9 @@ use homeboy::core::cleanup::{
 use homeboy::core::worktree::{
     self, CleanupPolicy, TaskWorktreeRegistryQuarantine, WorktreeAdoptOptions, WorktreeAdoptOutput,
     WorktreeCleanupOutput, WorktreeCreateOptions, WorktreeCreateOutput, WorktreeInventoryOptions,
-    WorktreeInventoryOutput, WorktreeListOutput, WorktreeQueueCreateOptions,
-    WorktreeQueueCreateOutput, WorktreeRemoveOptions, WorktreeRemoveOutput, WorktreeStatusOutput,
+    WorktreeInventoryOutput, WorktreeListOutput, WorktreeOwnershipProbe,
+    WorktreeQueueCreateOptions, WorktreeQueueCreateOutput, WorktreeRemoveOptions,
+    WorktreeRemoveOutput, WorktreeStatusOutput,
 };
 use homeboy::core::worktree_provider::{
     self, ConfiguredWorktreeCleanupOutput as WorktreeProviderCleanupOutput,
@@ -122,6 +123,11 @@ enum WorktreeCommand {
         /// Task worktree ID, e.g. component@branch-slug
         id: String,
     },
+    /// Report the session currently holding a managed checkout's write lease
+    Holder {
+        /// Managed worktree handle or any path inside the checkout
+        target: String,
+    },
     /// Remove one task worktree after safety checks
     Remove {
         /// Task worktree ID, e.g. component@branch-slug
@@ -202,6 +208,7 @@ pub enum WorktreeOutput {
     List(WorktreeListCommandOutput),
     Inventory(WorktreeInventoryOutput),
     Status(WorktreeStatusCommandOutput),
+    Holder(WorktreeOwnershipProbe),
     Remove(WorktreeRemoveOutput),
     Cleanup(WorktreeCleanupCommandOutput),
     QuarantineList(Vec<TaskWorktreeRegistryQuarantine>),
@@ -558,6 +565,22 @@ pub fn run(args: WorktreeArgs) -> CmdResult<WorktreeOutput> {
                 }
             };
             WorktreeOutput::Status(status)
+        }
+        WorktreeCommand::Holder { target } => {
+            let path = PathBuf::from(&target);
+            let path = if path.exists() {
+                path
+            } else {
+                PathBuf::from(worktree::resolve(&target)?.worktree_path)
+            };
+            WorktreeOutput::Holder(worktree::ownership_probe(&path)?.ok_or_else(|| {
+                homeboy::core::Error::validation_invalid_argument(
+                    "worktree",
+                    "path is not inside a managed task worktree",
+                    Some(target),
+                    None,
+                )
+            })?)
         }
         WorktreeCommand::Remove {
             id,
@@ -947,6 +970,18 @@ mod tests {
         assert!(cursor.is_none());
         assert!(adopted_cursor.is_none());
         assert!(!apply);
+    }
+
+    #[test]
+    fn worktree_holder_accepts_a_checkout_path() {
+        let cli = Cli::parse_from(["homeboy", "worktree", "holder", "/tmp/managed-checkout"]);
+        let Commands::Worktree(args) = cli.command else {
+            panic!("expected worktree command");
+        };
+        let WorktreeCommand::Holder { target } = args.command else {
+            panic!("expected holder command");
+        };
+        assert_eq!(target, "/tmp/managed-checkout");
     }
 
     #[test]

--- a/crates/homeboy-core/src/workspace_claim.rs
+++ b/crates/homeboy-core/src/workspace_claim.rs
@@ -21,6 +21,7 @@ pub const WORKSPACE_CLAIM_SCHEMA: &str = "homeboy/workspace-claim/v2";
 pub const WORKSPACE_OWNER_LEASE_SCHEMA: &str = "homeboy/workspace-owner-lease/v2";
 pub const WORKSPACE_OWNER_RELEASE_RECOVERY_SCHEMA: &str =
     "homeboy/workspace-owner-release-recovery/v1";
+pub const LOCAL_WORKSPACE_CLAIMS_DIR: &str = "agent-task-workspace-claims";
 const WORKSPACE_AUTHORITY_SCHEMA: &str = "homeboy/workspace-authority/v2";
 pub const MAX_WORKSPACE_CLAIM_TTL_MS: u64 = 300_000;
 
@@ -156,6 +157,15 @@ pub struct WorkspaceAuthorityStatus {
     pub live_owner_count: usize,
     pub live_owners: Vec<RedactedWorkspaceOwnerIdentity>,
     pub clear: bool,
+}
+
+/// Token-free local owner details for operator diagnostics and write admission.
+/// Unlike transport-safe authority status, this intentionally names owner IDs.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceOwnerStatus {
+    pub owner_id: String,
+    pub lifecycle_revision: u64,
+    pub expires_at_ms: u64,
 }
 
 pub const WORKSPACE_AUTHORITY_STATUS_SCHEMA: &str = "homeboy/workspace-authority-status/v2";
@@ -663,6 +673,30 @@ impl WorkspaceClaimStore {
                 clear: state.reconciliation.is_none() && live_owners.is_empty(),
                 live_owners,
             })
+        })
+    }
+    /// Return exact live owner identities after pruning expiry under the
+    /// workspace lock. This local-only probe never exposes authority tokens.
+    pub fn owner_status(
+        &self,
+        workspace: &WorkspaceIdentity,
+        now_ms: u64,
+    ) -> Result<Vec<WorkspaceOwnerStatus>> {
+        workspace.verify()?;
+        self.with_lock(workspace, || {
+            let mut state = self.read_or_empty(workspace)?;
+            if state.prune(now_ms) {
+                self.commit(&mut state)?;
+            }
+            Ok(state
+                .owners
+                .iter()
+                .map(|owner| WorkspaceOwnerStatus {
+                    owner_id: owner.owner_id.clone(),
+                    lifecycle_revision: owner.lifecycle_revision,
+                    expires_at_ms: owner.expires_at_ms,
+                })
+                .collect())
         })
     }
     /// Exact reconciliation release is idempotent; a different live token fails.

--- a/crates/homeboy-core/src/worktree/mod.rs
+++ b/crates/homeboy-core/src/worktree/mod.rs
@@ -29,12 +29,12 @@ pub use types::{
     WorktreeCreateEvidence, WorktreeCreateOptions, WorktreeCreateOutput,
     WorktreeCreateReconciliation, WorktreeInventoryApplyRefusal, WorktreeInventoryAuthorization,
     WorktreeInventoryCrossTab, WorktreeInventoryLocalEvidence, WorktreeInventoryOptions,
-    WorktreeInventoryOutput, WorktreeInventoryRecord, WorktreeListOutput,
-    WorktreeLivenessAuthority, WorktreeQueueCreateFailure, WorktreeQueueCreateOptions,
-    WorktreeQueueCreateOutput, WorktreeQueueCreateRequest, WorktreeQueueCreateRow,
-    WorktreeQueueCreateStatus, WorktreeQueueLockHolder, WorktreeReconciliationAction,
-    WorktreeReconciliationAuthority, WorktreeReconciliationResult, WorktreeRemoveOptions,
-    WorktreeRemoveOutput, WorktreeSafetyReport, WorktreeStatusOutput,
+    WorktreeInventoryOutput, WorktreeInventoryRecord, WorktreeLeaseActivity, WorktreeListOutput,
+    WorktreeLivenessAuthority, WorktreeOwnershipProbe, WorktreeQueueCreateFailure,
+    WorktreeQueueCreateOptions, WorktreeQueueCreateOutput, WorktreeQueueCreateRequest,
+    WorktreeQueueCreateRow, WorktreeQueueCreateStatus, WorktreeQueueLockHolder,
+    WorktreeReconciliationAction, WorktreeReconciliationAuthority, WorktreeReconciliationResult,
+    WorktreeRemoveOptions, WorktreeRemoveOutput, WorktreeSafetyReport, WorktreeStatusOutput,
     TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY, TERMINAL_WORKSPACE_AUTHORITY_SCHEMA,
 };
 
@@ -57,6 +57,121 @@ pub fn adopt(options: WorktreeAdoptOptions) -> Result<WorktreeAdoptOutput> {
 
 pub fn list() -> Result<WorktreeListOutput> {
     with_task_worktree_registry_read_lock(list_unlocked)
+}
+
+/// Report the live write holder for a checkout path, including component
+/// subdirectories. Unmanaged paths return `None` rather than failing closed.
+pub fn ownership_probe(path: &Path) -> Result<Option<WorktreeOwnershipProbe>> {
+    let data_root = paths::homeboy_data()?;
+    ownership_probe_in_root(path, &data_root, now_ms())
+}
+
+/// Refuse a write when a different live owner holds the managed checkout.
+/// `force` is an explicit operator override, not an authority receipt.
+pub fn enforce_write_ownership(
+    path: &Path,
+    caller_owner_id: Option<&str>,
+    force: bool,
+) -> Result<Option<WorktreeOwnershipProbe>> {
+    let probe = ownership_probe(path)?;
+    if force {
+        return Ok(probe);
+    }
+    let Some(status) = probe.as_ref() else {
+        return Ok(None);
+    };
+    let foreign = status
+        .live_holders
+        .iter()
+        .filter(|holder| Some(holder.as_str()) != caller_owner_id)
+        .cloned()
+        .collect::<Vec<_>>();
+    if !foreign.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "worktree_write_ownership",
+            format!(
+                "refusing to write managed worktree {}: held by live session(s) {}; pass --force to override",
+                status.handle,
+                foreign.join(", ")
+            ),
+            Some(status.path.clone()),
+            Some(vec!["override: --force".to_string()]),
+        ));
+    }
+    Ok(probe)
+}
+
+fn ownership_probe_in_root(
+    path: &Path,
+    data_root: &Path,
+    now_ms: u64,
+) -> Result<Option<WorktreeOwnershipProbe>> {
+    let requested = normalize_existing_path(path);
+    let record = list_with_store(&metadata_dir_in_root(data_root))?
+        .worktrees
+        .into_iter()
+        .filter(|record| {
+            let root = normalize_existing_path(Path::new(&record.worktree_path));
+            requested == root || requested.starts_with(&root)
+        })
+        .max_by_key(|record| Path::new(&record.worktree_path).components().count());
+    let Some(record) = record else {
+        return Ok(None);
+    };
+    let workspace = record.effective_workspace_identity()?;
+    let owners = crate::workspace_claim::WorkspaceClaimStore::new(
+        data_root.join(crate::workspace_claim::LOCAL_WORKSPACE_CLAIMS_DIR),
+    )
+    .owner_status(&workspace, now_ms)?;
+    let live_holders = owners
+        .iter()
+        .map(|owner| owner.owner_id.clone())
+        .collect::<Vec<_>>();
+    let live_holder = record
+        .run_id
+        .as_ref()
+        .filter(|run_id| live_holders.contains(run_id))
+        .cloned()
+        .or_else(|| live_holders.first().cloned());
+    let holder = live_holder.or_else(|| record.run_id.clone());
+    let stopped =
+        record.state == TaskWorktreeState::Removed || record.terminal_disposition.is_some();
+    let activity = if stopped {
+        WorktreeLeaseActivity::Stopped
+    } else if live_holders.is_empty() {
+        WorktreeLeaseActivity::Stale
+    } else {
+        WorktreeLeaseActivity::Live
+    };
+    let lease_expires_at_ms = holder.as_ref().and_then(|holder| {
+        owners
+            .iter()
+            .find(|owner| &owner.owner_id == holder)
+            .map(|owner| owner.expires_at_ms)
+    });
+    Ok(Some(WorktreeOwnershipProbe {
+        handle: record.id,
+        path: record.worktree_path,
+        holder,
+        lifecycle_state: record
+            .terminal_disposition
+            .unwrap_or_else(|| match record.state {
+                TaskWorktreeState::Active => "active".to_string(),
+                TaskWorktreeState::Removed => "removed".to_string(),
+            }),
+        heartbeat_fresh: !owners.is_empty(),
+        activity,
+        lease_expires_at_ms,
+        live_holders,
+    }))
+}
+
+fn normalize_existing_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn now_ms() -> u64 {
+    chrono::Utc::now().timestamp_millis().max(0) as u64
 }
 
 pub(crate) fn list_workspace_refs() -> Result<Vec<WorkspaceRefRecord>> {
@@ -538,8 +653,9 @@ pub fn cleanup(options: WorktreeCleanupOptions) -> Result<WorktreeCleanupOutput>
 /// active checkout to exercise it. Keeping the helper here means the record
 /// store layout stays owned by this module instead of being reimplemented by
 /// every caller's test fixtures.
-#[cfg(test)]
-pub(crate) fn record_active_for_test(id: &str, worktree_path: &Path) {
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
+pub fn record_active_for_test(id: &str, worktree_path: &Path) {
     record_for_test(id, worktree_path, worktree_path, TaskWorktreeState::Active);
 }
 
@@ -562,7 +678,7 @@ pub(crate) fn record_removed_for_test(id: &str, worktree_path: &Path) {
     record_for_test(id, worktree_path, worktree_path, TaskWorktreeState::Removed);
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 fn record_for_test(
     id: &str,
     source_checkout: &Path,

--- a/crates/homeboy-core/src/worktree/tests.rs
+++ b/crates/homeboy-core/src/worktree/tests.rs
@@ -277,6 +277,40 @@ fn task_worktree_identity_is_path_independent_and_rejects_conflicts() {
     assert!(conflicting.effective_workspace_identity().is_err());
 }
 
+#[test]
+fn ownership_probe_names_the_live_holder_for_a_nested_checkout_path() {
+    let data_root = tempfile::tempdir().expect("data root");
+    let checkout = tempfile::tempdir().expect("checkout");
+    let nested = checkout.path().join("crates/component");
+    fs::create_dir_all(&nested).expect("nested component");
+    let mut record = fixture_record(checkout.path(), checkout.path());
+    record.run_id = Some("ses_live_holder".to_string());
+    write_record(&metadata_dir_in_root(data_root.path()), &record).expect("record worktree");
+    let claims = crate::workspace_claim::WorkspaceClaimStore::new(
+        data_root
+            .path()
+            .join(crate::workspace_claim::LOCAL_WORKSPACE_CLAIMS_DIR),
+    );
+    claims
+        .register_owner(
+            record.effective_workspace_identity().expect("identity"),
+            "ses_live_holder",
+            10_000,
+            1_000,
+        )
+        .expect("register holder");
+
+    let probe = ownership_probe_in_root(&nested, data_root.path(), 2_000)
+        .expect("probe succeeds")
+        .expect("managed checkout");
+
+    assert_eq!(probe.holder.as_deref(), Some("ses_live_holder"));
+    assert_eq!(probe.lifecycle_state, "active");
+    assert_eq!(probe.activity, WorktreeLeaseActivity::Live);
+    assert!(probe.heartbeat_fresh);
+    assert_eq!(probe.lease_expires_at_ms, Some(11_000));
+}
+
 fn git_repo() -> tempfile::TempDir {
     let temp = tempfile::tempdir().unwrap();
     run_git(temp.path(), &["init", "-q"]);

--- a/crates/homeboy-core/src/worktree/types.rs
+++ b/crates/homeboy-core/src/worktree/types.rs
@@ -20,6 +20,30 @@ pub enum TaskWorktreeState {
     Removed,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorktreeLeaseActivity {
+    Live,
+    Stale,
+    Stopped,
+}
+
+/// Deterministic local view of the write authority protecting a managed checkout.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct WorktreeOwnershipProbe {
+    pub handle: String,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub holder: Option<String>,
+    pub lifecycle_state: String,
+    pub activity: WorktreeLeaseActivity,
+    pub heartbeat_fresh: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lease_expires_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub live_holders: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum CleanupPolicy {

--- a/crates/homeboy-refactor/src/plan/sources.rs
+++ b/crates/homeboy-refactor/src/plan/sources.rs
@@ -141,6 +141,15 @@ pub fn collect_refactor_sources(
 ) -> homeboy_core::Result<RefactorSourceRun> {
     let sources = normalize_sources(&request.sources)?;
     let root_str = request.root.to_string_lossy().to_string();
+    if request.write {
+        homeboy_core::worktree::enforce_write_ownership(
+            &request.root,
+            std::env::var(homeboy_core::observation::ACTIVE_RUN_ID_ENV)
+                .ok()
+                .as_deref(),
+            request.force,
+        )?;
+    }
     let original_changes = git::get_uncommitted_changes(&root_str).ok();
 
     // Refuse to write to a dirty working tree unless --force is set.
@@ -855,6 +864,54 @@ mod tests {
         );
 
         let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn collect_refactor_sources_refuses_a_foreign_live_worktree_holder_before_writing() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let root = tmp_dir("foreign-held-worktree");
+            init_test_repo(&root);
+            let source = root.join("README.md");
+            let original = fs::read_to_string(&source).expect("read original source");
+            homeboy_core::worktree::record_active_for_test("fixture@foreign-held", &root);
+            let record = homeboy_core::worktree::resolve("fixture@foreign-held")
+                .expect("resolve managed worktree");
+            let claims = homeboy_core::workspace_claim::WorkspaceClaimStore::new(
+                homeboy_core::paths::homeboy_data()
+                    .expect("data root")
+                    .join(homeboy_core::workspace_claim::LOCAL_WORKSPACE_CLAIMS_DIR),
+            );
+            claims
+                .register_owner(
+                    record.effective_workspace_identity().expect("identity"),
+                    "ses_foreign_13748",
+                    300_000,
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .expect("current time")
+                        .as_millis() as u64,
+                )
+                .expect("register foreign holder");
+
+            let err = collect_refactor_sources(lint_refactor_request(
+                test_component(&root),
+                root.clone(),
+                Vec::new(),
+                LintSourceOptions::default(),
+                true,
+            ))
+            .expect_err("foreign live holder must protect the checkout");
+
+            let message = err.to_string();
+            assert!(message.contains("ses_foreign_13748"), "{message}");
+            assert!(message.contains("--force"), "{message}");
+            assert_eq!(
+                fs::read_to_string(&source).expect("read protected source"),
+                original,
+                "the mutating pipeline must leave the held checkout untouched"
+            );
+            let _ = fs::remove_dir_all(&root);
+        });
     }
 
     fn init_test_repo(path: &Path) {


### PR DESCRIPTION
## Summary

- add a deterministic core ownership probe that joins managed-worktree lifecycle metadata with the existing renewable workspace-owner lease store
- expose the holder, lifecycle state, live/stale/stopped activity, and heartbeat freshness through `homeboy worktree holder <handle-or-path>`
- make the shared refactor source mutation boundary, including `homeboy review lint --fix`, refuse writes when another live session holds the checkout
- retain `--force` as the explicit operator override and document the expanded safety behavior

## Root Cause

Managed worktrees recorded an owning run and Homeboy already renewed workspace-owner leases, but mutation orchestration did not consult that authority before running fixers or formatters. The existing authority status was transport-safe and intentionally redacted owner IDs, so operators also had no cheap way to identify the holder. As a result, unrelated review/refactor processes could write directly into a checkout held by another live session.

## Design

The fix extends `WorkspaceClaimStore` rather than introducing a second lease mechanism. A local token-free owner probe exposes exact owner IDs and lease expiry while preserving opaque authority tokens. The worktree layer resolves any nested path to its managed checkout, combines the lease with lifecycle metadata, and provides one reusable write-admission function. The shared refactor source pipeline invokes that function before dirty-tree cleanup, undo snapshots, fixers, or formatters, so all callers of that pipeline receive the same protection.

## Tests

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo test -p homeboy-core ownership_probe_names_the_live_holder_for_a_nested_checkout_path`
- `cargo test -p homeboy-refactor collect_refactor_sources_refuses_a_foreign_live_worktree_holder_before_writing`
- `cargo test -p homeboy-cli --lib worktree_holder_accepts_a_checkout_path`

All passed. The workspace check emitted only the pre-existing duplicated `#[test]` warning in `crates/homeboy-cli/src/commands/runner/doctor/tests/homeboy_path.rs`.

Closes #13748

AI assistance: implemented by GPT-5.6 Sol running in OpenCode. The model investigated the ownership and heartbeat model, designed the lease enforcement, and wrote the implementation and tests.