### PR TITLE
Materialize executable generic Lab retries

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -4526,7 +4526,7 @@ fn controller_owns_agent_task_lifecycle_command(cli: &Cli) -> homeboy::core::Res
         AgentTaskCommand::Evidence(args) => Some(&args.run_id),
         AgentTaskCommand::Diagnose(args) => Some(&args.run_id),
         AgentTaskCommand::Review(args) => Some(&args.run_id),
-        AgentTaskCommand::Retry(args) => Some(&args.run_id),
+        AgentTaskCommand::Retry(args) if !args.run => Some(&args.run_id),
         AgentTaskCommand::Reconcile(args) => Some(&args.run_id),
         _ => None,
     };

--- a/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
@@ -1170,6 +1170,30 @@ fn controller_local_record_owns_lifecycle_reads_before_default_lab_selection() {
                 };
             assert_eq!(route_runner, None, "{args:?} must not use homeboy-lab");
         }
+
+        let plan_only_retry =
+            Cli::try_parse_from(["homeboy", "agent-task", "retry", OWNER_LOCAL_RUN_ID])
+                .expect("plan-only retry parses");
+        assert!(
+            controller_owns_agent_task_lifecycle_command(&plan_only_retry)
+                .expect("plan-only retry owner resolves")
+        );
+
+        let executable_retry = Cli::try_parse_from([
+            "homeboy",
+            "agent-task",
+            "retry",
+            OWNER_LOCAL_RUN_ID,
+            "--run",
+            "--runner",
+            "homeboy-lab",
+        ])
+        .expect("executable retry parses");
+        assert!(
+            !controller_owns_agent_task_lifecycle_command(&executable_retry)
+                .expect("executable retry owner resolves"),
+            "retry --run must reach controller preflight and Lab handoff materialization"
+        );
     });
 }
 


### PR DESCRIPTION
## Summary

- keep plan-only agent-task retries controller-local
- allow `retry --run` to reach the existing controller replay preflight and Lab handoff materializer
- cover both ownership paths in the lifecycle routing test

Closes #13766.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-cli controller_local_record_owns_lifecycle_reads_before_default_lab_selection`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode traced the live replay failure, identified the lifecycle-ownership early return, implemented the focused fix/test, and ran verification under human direction.