### PR TITLE
Canonicalize managed release staging handles

### DIFF
--- a/crates/homeboy-release/src/release/workspace.rs
+++ b/crates/homeboy-release/src/release/workspace.rs
@@ -60,12 +60,13 @@ impl ReleaseWorkspace {
             owner_run_ref: owner_run_ref.clone(),
             cleanup_policy: WorktreeProviderCleanupPolicy::RemoveOnSuccess,
         };
-        let handle = format!("release-{}-{}", component.id, &source_sha[..12]);
+        let branch = format!("release-{}-{}", component.id, &source_sha[..12]);
+        let handle = homeboy_core::worktree::handle_for_branch(&component.id, &branch);
         let mut intent = WorktreeProviderCreateIntent {
             handle: handle.clone(),
             repo: component.id.clone(),
             base: source_sha.clone(),
-            head: handle,
+            head: branch,
             task_url: owner_run_ref,
         };
         let planned =
@@ -698,6 +699,11 @@ mod tests {
 
             assert_eq!(workspace.output.kind, "provider_owned");
             assert_eq!(workspace.output.provider_id.as_deref(), Some("native"));
+            assert!(workspace
+                .output
+                .handle
+                .as_deref()
+                .is_some_and(|handle| handle.starts_with("fixture@release-fixture-")));
             assert_ne!(workspace.component.local_path, component.local_path);
             assert_eq!(
                 git::head_sha(Path::new(&workspace.component.local_path)),


### PR DESCRIPTION
## Summary

- give release staging worktrees Homeboy’s canonical `<repo>@<branch>` identity
- preserve the generated `release-<component>-<sha>` branch as the provisioned head
- assert the canonical identity at the release-workspace boundary

Fixes #13770.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-release dirty_default_checkout_stages_through_the_builtin_provider`
- full `homeboy-release` suite: 553 passed; three extension-lint tests fail unchanged on `main` in this environment
- reproduced `extension_release_lint_blocks_finding_in_file_changed_since_prior_tag` on authoritative `main`
- `git diff --check`

## AI Assistance

OpenAI GPT-5.6 Sol through OpenCode traced the DMC-backed WP Codebox release failure to Homeboy’s release workspace identity construction, implemented the canonical handle fix and regression assertion, and ran focused and package-level verification. Chris Huber directed the release and upstream-repair workflow.