### PR TITLE
Preserve Lab Cook ownership at provider_start

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_offload.rs
@@ -884,46 +884,50 @@ fn record_lab_offload_proxy_in_store(
     if record.state.is_terminal() {
         return Ok(record);
     }
-    let metadata = record.ensure_metadata_object();
-    metadata.insert("kind".to_string(), json!("lab_offload_controller_proxy"));
-    // This record is the controller's durable projection of a runner handoff.
-    // It remains controller-owned until a runner-local record is independently
-    // discovered, so controller-generated commands must keep resolving here.
-    metadata.insert("lifecycle_store_owner".to_string(), json!("controller"));
-    metadata.insert("runner_id".to_string(), json!(runner_id));
-    if !durable_plan
-        .map(|plan| plan.services.is_empty())
-        .unwrap_or(true)
     {
+        let metadata = record.ensure_metadata_object();
+        metadata.insert("kind".to_string(), json!("lab_offload_controller_proxy"));
+        // This record is the controller's durable projection of a runner handoff.
+        // It remains controller-owned until a runner-local record is independently
+        // discovered, so controller-generated commands must keep resolving here.
+        metadata.insert("lifecycle_store_owner".to_string(), json!("controller"));
+        metadata.insert("runner_id".to_string(), json!(runner_id));
+        if !durable_plan
+            .map(|plan| plan.services.is_empty())
+            .unwrap_or(true)
+        {
+            metadata.insert(
+                "managed_service_supervisor".to_string(),
+                json!({
+                    "runner_id": runner_id,
+                    "remote_workspace": remote_workspace,
+                    "state_ref": format!("homeboy://runner/{runner_id}/agent-task-runs/{run_id}/service-supervisor/state"),
+                    "operations": ["status", "stop", "reconcile"],
+                }),
+            );
+        }
+        if remote_workspace != "pending" {
+            metadata.insert("remote_workspace".to_string(), json!(remote_workspace));
+        }
+        if !remote_command.is_empty() {
+            metadata.insert("remote_command".to_string(), json!(remote_command));
+        }
+        metadata.insert(METADATA_KEY_RETRYABLE.to_string(), json!(true));
+        metadata.remove(METADATA_KEY_STALE_RUNNING);
+        metadata.remove(METADATA_KEY_STALE_RUNNING_REASON);
         metadata.insert(
-            "managed_service_supervisor".to_string(),
-            json!({
-                "runner_id": runner_id,
-                "remote_workspace": remote_workspace,
-                "state_ref": format!("homeboy://runner/{runner_id}/agent-task-runs/{run_id}/service-supervisor/state"),
-                "operations": ["status", "stop", "reconcile"],
-            }),
+            "runner_execution_record".to_string(),
+            serde_json::to_value(
+                homeboy_core::runner_execution_envelope::RunnerExecutionRecord::planned(
+                    &run_id, runner_id, "daemon",
+                )
+                .with_agent_task_run_id(&run_id),
+            )
+            .unwrap_or(Value::Null),
         );
     }
-    if remote_workspace != "pending" {
-        metadata.insert("remote_workspace".to_string(), json!(remote_workspace));
-    }
-    if !remote_command.is_empty() {
-        metadata.insert("remote_command".to_string(), json!(remote_command));
-    }
-    metadata.insert(METADATA_KEY_RETRYABLE.to_string(), json!(true));
-    metadata.remove(METADATA_KEY_STALE_RUNNING);
-    metadata.remove(METADATA_KEY_STALE_RUNNING_REASON);
-    metadata.insert(
-        "runner_execution_record".to_string(),
-        serde_json::to_value(
-            homeboy_core::runner_execution_envelope::RunnerExecutionRecord::planned(
-                &run_id, runner_id, "daemon",
-            )
-            .with_agent_task_run_id(&run_id),
-        )
-        .unwrap_or(Value::Null),
-    );
+    record.updated_at = Some(now_timestamp());
+    update_lifecycle_heartbeat(&mut record);
     lifecycle_store.write_record(&record)?;
     Ok(record)
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -915,7 +915,7 @@ impl AgentTaskRunRecord {
                 self.metadata
                     .pointer("/cook_progress/phase")
                     .and_then(Value::as_str),
-                Some("worktree_provider_lookup" | "worktree_provider_ensure")
+                Some("worktree_provider_lookup" | "worktree_provider_ensure" | "provider_start")
             )
     }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -2889,6 +2889,48 @@ fn status_keeps_fresh_planned_runner_submission_live() {
     });
 }
 
+#[test]
+fn planned_lab_proxy_stamps_heartbeat_without_a_runner_pid() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        let run_id = "run-planned-lab-proxy-heartbeat";
+        submit_plan(&plan, Some(run_id)).expect("submitted");
+        record_cook_progress_in_store(&test_lifecycle_store(), run_id, "provider_start", 1, None)
+            .expect("provider_start");
+        let remote_command = ["homeboy".to_string(), "agent-task".to_string()];
+        let recorded = record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id,
+            runner_id: "homeboy-lab",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &remote_command,
+            durable_plan: Some(&plan),
+        })
+        .expect("planned Lab proxy");
+        rewrite_record_for_test(run_id, |record| {
+            record
+                .metadata
+                .as_object_mut()
+                .expect("metadata object")
+                .remove("runner_pid");
+        })
+        .expect("initiating client ended");
+
+        assert!(recorded.updated_at.is_some(), "{recorded:?}");
+        assert!(recorded.has_planned_runner_execution(), "{recorded:?}");
+        assert!(recorded.is_controller_pre_provider_phase(), "{recorded:?}");
+
+        let loaded = status(run_id).expect("status loaded");
+        assert!(loaded.has_fresh_update(), "{loaded:?}");
+        assert!(loaded.has_fresh_controller_pre_provider_heartbeat());
+        assert!(loaded.metadata.get("stale_running").is_none());
+        assert_eq!(
+            loaded.metadata["runner_execution_record"]["status"],
+            "planned"
+        );
+        assert_eq!(loaded.metadata["cook_progress"]["phase"], "provider_start");
+    });
+}
+
 /// Rooted in an explicit store rather than a mutated process environment
 /// (#7505). Cancellation resolves the alias, mutates the record and then reads
 /// it back; all three name `lifecycle_store`, so the durable cancellation

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -720,6 +720,9 @@ fn classify_liveness(
     if agent_task_lifecycle::has_live_pending_runner_submission_intent(record, now) {
         return AgentTaskLiveness::Active;
     }
+    if record.has_planned_runner_execution() && record.has_fresh_update() {
+        return AgentTaskLiveness::Active;
+    }
 
     match record.local_owner_liveness() {
         // Heartbeats are a projection, while a verified owner is authoritative.

--- a/crates/homeboy-agents/src/agent_task_service/reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_service/reconcile.rs
@@ -1244,6 +1244,78 @@ mod tests {
     }
 
     #[test]
+    fn planned_lab_proxy_at_provider_start_survives_initiating_client_exit() {
+        with_isolated_home(|_| {
+            register_orchestration_driver();
+            let run_id = "reconcile-lab-planned-provider-start";
+            let plan = AgentTaskPlan::new("reconcile-tick-plan", Vec::new());
+            agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("submitted");
+            agent_task_lifecycle::record_cook_progress_in_store(
+                &test_lifecycle_store(),
+                run_id,
+                "provider_start",
+                1,
+                None,
+            )
+            .expect("provider_start");
+            let remote_command = [
+                "homeboy".to_string(),
+                "--placement".to_string(),
+                "local".to_string(),
+                "agent-task".to_string(),
+                "run-plan".to_string(),
+            ];
+            agent_task_lifecycle::record_lab_offload_planned(
+                agent_task_lifecycle::LabOffloadProxyPlan {
+                    run_id,
+                    runner_id: "homeboy-lab",
+                    remote_workspace: "/runner/workspace/homeboy",
+                    remote_command: &remote_command,
+                    durable_plan: Some(&plan),
+                },
+            )
+            .expect("planned Lab proxy");
+            agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+                record
+                    .metadata
+                    .as_object_mut()
+                    .expect("metadata object")
+                    .remove("runner_pid");
+            })
+            .expect("initiating client ended");
+
+            let live = agent_task_lifecycle::status(run_id).expect("planned proxy");
+            assert!(
+                live.has_fresh_controller_pre_provider_heartbeat()
+                    || (live.has_planned_runner_execution() && live.has_fresh_update()),
+                "{live:?}"
+            );
+            assert!(
+                live.updated_at.is_some(),
+                "planned proxy must stamp a heartbeat"
+            );
+            assert_eq!(
+                live.metadata["runner_execution_record"]["status"],
+                "planned"
+            );
+            assert!(live.metadata.get("stale_running").is_none());
+
+            let report = homeboy_core::daemon::orchestration::reconcile_stale_active_runs()
+                .expect("tick after initiating client exit");
+            assert_eq!(report["reconciled"], 0, "{report}");
+            let retained = agent_task_lifecycle::status(run_id).expect("retained run");
+            assert!(
+                !retained.state.is_terminal(),
+                "Lab proxy must survive initiating-client exit: {:?}",
+                retained.state
+            );
+            assert!(retained.metadata.get("cancel_reason").is_none());
+            assert_eq!(retained.runner_id(), Some("homeboy-lab"));
+            assert!(retained.runner_job_id().is_none());
+        });
+    }
+
+    #[test]
     fn controller_heartbeat_keeps_queued_pre_provider_materialization_out_of_runner_pid_watchdog() {
         with_isolated_home(|_| {
             register_orchestration_driver();


### PR DESCRIPTION
Closes #13776.

## Summary

- stamp `updated_at` when recording a planned Lab offload proxy so liveness predicates see a fresh heartbeat
- treat `provider_start` as a controller-owned pre-provider phase until a runner job exists
- classify a fresh planned runner execution as live before a dead observing client can cancel it
- cover the production `record_lab_offload_planned` path, which existing materializing-phase tests did not exercise

## Why

Auto-selected Lab Cook reached `provider_start`, printed one heartbeat, then the initiating client ended. Daemon reconciliation cancelled the durable run as `missing_runner_pid` with no runner job, no provider attempt, and no candidate. That is a regression of #10419: caller interruption after durable Lab submission must not cancel the Lab-owned job.

`record_lab_offload_planned` wrote `runner_execution_record.status: planned` without a heartbeat, and `provider_start` was not in the controller pre-provider allowlist. A true ownerless post-submission run still cancels as `missing_runner_pid`.

## Verification

- `cargo test -p homeboy-agents --lib planned_lab_proxy`
- `cargo test -p homeboy-agents --lib missing_runner_pid`
- `cargo test -p homeboy-agents --lib status_keeps_fresh_planned`
- `cargo test -p homeboy-agents --lib controller_heartbeat_keeps_queued`
- `cargo test -p homeboy-agents --lib the_daemon_tick_preserves_a_fresh_planned`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode general subagent investigated the cancelled Lab Cook run, searched existing GitHub issues, implemented the lifecycle fix, and ran the focused tests under human direction. Chris Huber directed the work and remains responsible.