### PR TITLE
Fix resource lease test roots

### DIFF
--- a/crates/homeboy-cli/src/commands/trace/rig_tests.rs
+++ b/crates/homeboy-cli/src/commands/trace/rig_tests.rs
@@ -94,8 +94,9 @@ fn rig_trace_run_fails_fast_on_active_default_namespace_resource_lease() {
         set_trace_rig_resources(home, "studio-rig", resources.clone());
         set_trace_rig_resources(home, "studio-alt", resources);
 
-        let active_spec = rig::load(home.path(), "studio-rig").expect("load active rig");
-        let _lease = rig::lease::acquire_active_run_lease(home.path(), &active_spec, "trace")
+        let config_root = home.path().join(".config/homeboy");
+        let active_spec = rig::load(&config_root, "studio-rig").expect("load active rig");
+        let _lease = rig::lease::acquire_active_run_lease(&config_root, &active_spec, "trace")
             .expect("acquire active trace lease")
             .expect("resourceful trace rig leases");
 

--- a/tests/core/rig/bench_resource_lease_test.rs
+++ b/tests/core/rig/bench_resource_lease_test.rs
@@ -42,9 +42,10 @@ fn run_single_rig_bench_fails_fast_on_active_resource_lease() {
         set_rig_resources(home, "studio", resources.clone());
         set_rig_resources(home, "studio-bfb", resources);
 
-        let active_spec = crate::rig::load(home.path(), "studio").expect("load active rig");
+        let config_root = test_config_root();
+        let active_spec = crate::rig::load(&config_root, "studio").expect("load active rig");
         let _lease =
-            crate::rig::lease::acquire_active_run_lease(home.path(), &active_spec, "bench")
+            crate::rig::lease::acquire_active_run_lease(&config_root, &active_spec, "bench")
                 .expect("acquire active lease")
                 .expect("resourceful rig leases");
 
@@ -72,7 +73,7 @@ fn run_single_rig_bench_without_resources_does_not_create_lease() {
             .expect("non-resourceful rig bench should run");
 
         assert_eq!(exit_code, 0);
-        assert!(crate::rig::lease::active_run_leases(home.path())
+        assert!(crate::rig::lease::active_run_leases(&test_config_root())
             .expect("list active leases")
             .is_empty());
         assert!(!crate::core::paths::rig_leases_dir_in_root(&test_config_root()).exists());


### PR DESCRIPTION
## Summary

- load bench and trace rig fixtures from the Homeboy config root expected by the rig API
- acquire and inspect leases through that same root
- preserve the end-to-end conflict behavior instead of weakening assertions

Part of #13755.

## Baseline impact

Addresses both active resource-lease failures.

## Verification

- `cargo fmt --check`
- `git diff --check`
- bounded test fixture correction

## AI Assistance

OpenAI gpt-5.6-sol via OpenCode traced both failures to the shared config-root mismatch and corrected the fixtures. Chris Huber directed the simplification brigade.