### PR TITLE
Fix Lab linked worktree materialization

### DIFF
--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -964,9 +964,11 @@ fn private_at_file_snapshot_directory() -> std::io::Result<std::path::PathBuf> {
     ))
 }
 
-/// Snapshot transport intentionally excludes `.git`. Reconstruct the verified,
-/// deterministic baseline before the nested agent-task command starts so its
-/// provider and harvest share the exact accepted workspace provenance.
+/// Snapshot transport intentionally excludes `.git`. Reconstruct or verify the
+/// Git baseline before the nested agent-task command starts so its provider and
+/// harvest share the exact accepted workspace provenance. Snapshot-git must
+/// already own a valid `.git` representation; this gate refuses a dangling
+/// linked-worktree gitfile before handoff.
 fn materialize_snapshot_git_baseline(envelope: &RunnerExecutionEnvelope) -> Result<()> {
     let Some(dispatch) = envelope.dispatch.as_ref() else {
         return Ok(());
@@ -983,7 +985,7 @@ fn materialize_snapshot_git_baseline(envelope: &RunnerExecutionEnvelope) -> Resu
     let lab = reverse_worker_lab_offload(lab)?;
     if !matches!(
         lab.get("sync_mode").and_then(serde_json::Value::as_str),
-        Some("snapshot" | "filesystem_snapshot")
+        Some("snapshot" | "filesystem_snapshot" | "snapshot-git")
     ) {
         return Ok(());
     }

--- a/crates/homeboy-lab-runner/src/workspace/git.rs
+++ b/crates/homeboy-lab-runner/src/workspace/git.rs
@@ -11,7 +11,9 @@ use super::materializer::{WorkspaceMaterializationOperation, WorkspaceMaterializ
 use super::snapshot::materialize_snapshot_overlay;
 use super::types::ControllerGitBundleProvenance;
 use super::types::GitSnapshot;
-use super::util::{git_output, run_shell_command, ssh_args, ssh_client_for_runner};
+use super::util::{
+    git_output, run_shell_command, ssh_args, ssh_client_for_runner, verify_valid_git_representation,
+};
 
 pub(super) fn git_snapshot(
     local_path: &Path,
@@ -272,7 +274,42 @@ pub(super) fn materialize_git_snapshot_from_controller_bundle(
         },
     )?;
     materialize_snapshot_overlay(runner, local_path, remote_path, excludes)?;
+    verify_materialized_snapshot_git_representation(runner, remote_path)?;
     Ok(Some(provenance))
+}
+
+fn verify_materialized_snapshot_git_representation(
+    runner: &Runner,
+    remote_path: &str,
+) -> Result<()> {
+    match runner.kind {
+        RunnerKind::Local => verify_valid_git_representation(Path::new(remote_path)),
+        RunnerKind::Ssh => {
+            let (_server, client) = ssh_client_for_runner(runner)?;
+            if client.is_local {
+                return verify_valid_git_representation(Path::new(remote_path));
+            }
+            let inside = super::snapshot::synthetic_checkout_value(
+                runner,
+                remote_path,
+                "rev-parse --is-inside-work-tree",
+            )?;
+            if inside != "true" {
+                return Err(Error::validation_invalid_argument(
+                    "workspace",
+                    "snapshot-git workspace .git representation is not a Git work tree",
+                    Some(remote_path.to_string()),
+                    None,
+                ));
+            }
+            super::snapshot::synthetic_checkout_value(
+                runner,
+                remote_path,
+                "rev-parse --verify -q HEAD",
+            )
+            .map(|_| ())
+        }
+    }
 }
 
 fn sha256_file(path: &Path) -> Result<String> {

--- a/crates/homeboy-lab-runner/src/workspace/provenance.rs
+++ b/crates/homeboy-lab-runner/src/workspace/provenance.rs
@@ -58,12 +58,30 @@ pub(crate) fn materialize_verified_lab_snapshot_git_baseline(
             "does not require a synthetic Git baseline for git materialization".to_string(),
         );
     }
-    if materialized_workspace_path.join(".git").exists() {
-        // A replay reaches the same accepted snapshot after a prior worker has
-        // already materialized its deterministic baseline. Reuse it only after
-        // validating every provenance and Git-root invariant.
-        verify_lab_workspace_git_root(materialized_workspace_path, &provenance)?;
-        return git(materialized_workspace_path, &["rev-parse", "HEAD"]);
+    let git_path = materialized_workspace_path.join(".git");
+    if git_path.exists() {
+        match super::util::verify_valid_git_representation(materialized_workspace_path) {
+            Ok(()) => {
+                // A replay reaches the same accepted snapshot after a prior worker has
+                // already materialized its deterministic baseline. Reuse it only after
+                // validating every provenance and Git-root invariant.
+                verify_lab_workspace_git_root(materialized_workspace_path, &provenance)?;
+                return git(materialized_workspace_path, &["rev-parse", "HEAD"]);
+            }
+            Err(_) if git_path.is_file() && provenance.materialization_mode != "snapshot-git" => {
+                // A leftover linked-worktree gitfile whose gitdir was not
+                // snapshotted is not a reusable baseline. Snapshot modes replace
+                // it with a verified synthetic checkout before handoff.
+                std::fs::remove_file(&git_path)
+                    .map_err(|error| format!("could not replace invalid .git pointer: {error}"))?;
+            }
+            Err(error) => {
+                return Err(format!(
+                    "workspace .git representation is not a valid Git checkout: {}",
+                    error.message
+                ))
+            }
+        }
     }
     if let Some(path) = nested_git_metadata(materialized_workspace_path, &provenance.sync_excludes)?
     {
@@ -1694,6 +1712,59 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn snapshot_baseline_replaces_dangling_linked_worktree_gitfile_before_handoff() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        std::fs::write(workspace.path().join("file.txt"), "baseline\n").expect("source file");
+        std::fs::write(
+            workspace.path().join(".git"),
+            "gitdir: /does-not-exist/gitdir\n",
+        )
+        .expect("dangling linked-worktree gitfile");
+        let snapshot = snapshot(workspace.path());
+        let lab = lab(workspace.path(), &snapshot);
+
+        let baseline = materialize_verified_lab_snapshot_git_baseline(
+            &workspace.path().display().to_string(),
+            workspace.path(),
+            snapshot,
+            lab,
+        )
+        .expect("dangling gitfile is replaced with a synthetic baseline");
+
+        assert!(!baseline.is_empty());
+        assert!(workspace.path().join(".git").is_dir());
+        super::super::util::verify_valid_git_representation(workspace.path())
+            .expect("handoff workspace has a verified valid .git representation");
+    }
+
+    #[test]
+    fn snapshot_git_baseline_rejects_dangling_linked_worktree_gitfile() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        std::fs::write(workspace.path().join("file.txt"), "baseline\n").expect("source file");
+        std::fs::write(
+            workspace.path().join(".git"),
+            "gitdir: /does-not-exist/gitdir\n",
+        )
+        .expect("dangling linked-worktree gitfile");
+        let snapshot = snapshot(workspace.path());
+        let mut lab = lab(workspace.path(), &snapshot);
+        lab["sync_mode"] = serde_json::json!("snapshot-git");
+
+        let error = materialize_verified_lab_snapshot_git_baseline(
+            &workspace.path().display().to_string(),
+            workspace.path(),
+            snapshot,
+            lab,
+        )
+        .expect_err("snapshot-git must fail closed on an invalid gitfile");
+        assert!(
+            error.contains("not a valid Git checkout"),
+            "unexpected error: {error}"
+        );
+        assert!(workspace.path().join(".git").is_file());
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::fs::OpenOptions;
 use std::hash::{Hash, Hasher};
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant, SystemTime};
 
 use base64::Engine;
@@ -2966,7 +2966,10 @@ fn human_bytes(bytes: u64) -> String {
 }
 
 fn exclude_homeboy_metadata_from_git_status(workspace_path: &Path) -> Result<()> {
-    let git_dir = workspace_path.join(".git");
+    let git_dir = match git_output(workspace_path, &["rev-parse", "--absolute-git-dir"]) {
+        Ok(dir) => PathBuf::from(dir),
+        Err(_) => return Ok(()),
+    };
     if !git_dir.is_dir() {
         return Ok(());
     }

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -306,6 +306,91 @@ fn snapshot_git_reports_checkout_provenance_for_committed_harvest() {
 }
 
 #[test]
+fn snapshot_git_materializes_linked_worktree_with_valid_git_before_handoff() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let source = tempfile::tempdir().expect("source repository");
+        let worktrees = tempfile::tempdir().expect("linked worktree root");
+        let runner_root = tempfile::tempdir().expect("runner root");
+        fs::write(source.path().join("file.txt"), "linked source\n").expect("source file");
+        git(source.path(), &["init", "--quiet", "-b", "main"]);
+        git(source.path(), &["config", "user.email", "test@example.com"]);
+        git(source.path(), &["config", "user.name", "Test User"]);
+        git(source.path(), &["add", "file.txt"]);
+        git(source.path(), &["commit", "--quiet", "-m", "source"]);
+        git(
+            source.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "file:///does-not-exist/linked-worktree.git",
+            ],
+        );
+        let linked = worktrees.path().join("task-worktree");
+        git(
+            source.path(),
+            &[
+                "worktree",
+                "add",
+                "--detach",
+                linked.to_str().expect("linked path"),
+                "HEAD",
+            ],
+        );
+        assert!(
+            linked.join(".git").is_file(),
+            "provider-managed linked task worktree uses a gitdir pointer file"
+        );
+        let source_revision = git_output(&linked, &["rev-parse", "HEAD"]).expect("linked HEAD");
+        crate::create(
+            &format!(
+                r#"{{"id":"lab-linked-snapshot-git","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+
+        let (synced, exit_code) = sync_workspace(
+            "lab-linked-snapshot-git",
+            RunnerWorkspaceSyncOptions {
+                path: linked.display().to_string(),
+                mode: RunnerWorkspaceSyncMode::SnapshotGit,
+                controller_routed_git: false,
+                changed_since_base: None,
+                git_fetch_refs: Vec::new(),
+                snapshot_includes: Vec::new(),
+                allow_dirty_lab_workspace: false,
+                run_isolation_token: None,
+            },
+        )
+        .expect("snapshot-git materializes a linked worktree");
+
+        let remote = Path::new(&synced.remote_path);
+        assert_eq!(exit_code, 0);
+        assert_eq!(synced.sync_mode, RunnerWorkspaceSyncMode::SnapshotGit);
+        assert!(
+            remote.join(".git").is_dir(),
+            "handoff workspace must own a Git directory rather than a copied gitdir pointer"
+        );
+        assert_eq!(
+            git_output(remote, &["rev-parse", "--is-inside-work-tree"]).expect("work tree"),
+            "true"
+        );
+        assert_eq!(
+            git_output(remote, &["rev-parse", "--verify", "-q", "HEAD"]).expect("HEAD"),
+            source_revision
+        );
+        assert_eq!(
+            fs::read_to_string(remote.join("file.txt")).expect("linked source content"),
+            "linked source\n"
+        );
+        super::super::util::verify_valid_git_representation(remote)
+            .expect("verified valid .git representation before handoff");
+    });
+}
+
+#[test]
 fn snapshot_git_fails_before_handoff_when_controller_closure_is_unavailable() {
     let _path_guard = PATH_LOCK
         .get_or_init(|| Mutex::new(()))

--- a/crates/homeboy-lab-runner/src/workspace/util.rs
+++ b/crates/homeboy-lab-runner/src/workspace/util.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use sha2::{Digest, Sha256};
@@ -106,6 +106,82 @@ pub(crate) fn git_output(local_path: &Path, args: &[&str]) -> Result<String> {
         )));
     }
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Confirm a materialized workspace has a Git representation Git itself can
+/// use: a `.git` directory, or a gitdir pointer file whose target exists, with
+/// a resolvable HEAD. Linked worktrees use the pointer-file form; a copied
+/// gitfile whose gitdir was not materialized is not valid.
+pub(crate) fn verify_valid_git_representation(workspace: &Path) -> Result<()> {
+    let git_path = workspace.join(".git");
+    let metadata = std::fs::symlink_metadata(&git_path).map_err(|error| {
+        Error::internal_io(
+            format!("workspace is missing a valid .git representation: {error}"),
+            Some(git_path.display().to_string()),
+        )
+    })?;
+    if metadata.file_type().is_symlink() {
+        return Err(Error::validation_invalid_argument(
+            "workspace",
+            "workspace .git must be a regular pointer file or directory",
+            Some(git_path.display().to_string()),
+            None,
+        ));
+    }
+    if metadata.file_type().is_file() {
+        let content = std::fs::read_to_string(&git_path).map_err(|error| {
+            Error::internal_io(error.to_string(), Some(git_path.display().to_string()))
+        })?;
+        let target = content
+            .strip_prefix("gitdir:")
+            .map(str::trim)
+            .filter(|target| !target.is_empty())
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "workspace",
+                    "workspace .git pointer must reference an existing Git directory",
+                    Some(git_path.display().to_string()),
+                    None,
+                )
+            })?;
+        let resolved = if Path::new(target).is_absolute() {
+            PathBuf::from(target)
+        } else {
+            workspace.join(target)
+        };
+        let canonical = std::fs::canonicalize(&resolved).map_err(|error| {
+            Error::validation_invalid_argument(
+                "workspace",
+                format!("workspace .git pointer must reference an existing Git directory: {error}"),
+                Some(git_path.display().to_string()),
+                None,
+            )
+        })?;
+        if !canonical.is_dir() {
+            return Err(Error::validation_invalid_argument(
+                "workspace",
+                "workspace .git pointer must reference an existing Git directory",
+                Some(git_path.display().to_string()),
+                None,
+            ));
+        }
+    } else if !metadata.file_type().is_dir() {
+        return Err(Error::validation_invalid_argument(
+            "workspace",
+            "workspace .git must be a regular pointer file or directory",
+            Some(git_path.display().to_string()),
+            None,
+        ));
+    }
+    if git_output(workspace, &["rev-parse", "--is-inside-work-tree"])? != "true" {
+        return Err(Error::validation_invalid_argument(
+            "workspace",
+            "workspace .git representation is not a Git work tree",
+            Some(workspace.display().to_string()),
+            None,
+        ));
+    }
+    git_output(workspace, &["rev-parse", "--verify", "-q", "HEAD"]).map(|_| ())
 }
 
 pub(super) fn owner_capture_shell(reference: &str) -> String {


### PR DESCRIPTION
## Summary

- validate snapshot-git workspaces as real Git work trees before Lab handoff
- reconstruct ordinary snapshot baselines when a copied linked-worktree gitfile dangles, while failing closed for invalid snapshot-git materialization
- resolve linked-worktree Git directories correctly when excluding Homeboy metadata
- cover linked task-worktree materialization and dangling-pointer rejection

Closes #13775

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-lab-runner snapshot_git_materializes_linked_worktree_with_valid_git_before_handoff`
- `cargo test -p homeboy-lab-runner snapshot_git_baseline_rejects_dangling_linked_worktree_gitfile`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6-sol via OpenCode diagnosed the Lab materialization failure, produced the initial candidate, and assisted with focused verification and cleanup. Chris Huber directed and reviewed the work and is responsible for this pull request.