### PR TITLE
fix(runner): reconcile terminal job observations

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
@@ -84,10 +84,13 @@ pub(crate) fn run_with_options(
         repair::apply(&target, &options, &mut report);
     }
 
-    // Doctor probes the runner directly. Its observation supersedes any
-    // process-local capability answer, so the next execution preflight probes
-    // the exact command environment rather than replaying stale remediation.
-    runner::observe_runner_capabilities(runner_id);
+    // Only general doctor observes the complete capability surface. Scoped
+    // Lab diagnostics deliberately skip CPU, tools, workspace, and artifact
+    // probes, so treating that partial report as a complete observation would
+    // evict known-good admission evidence.
+    if observes_complete_capabilities(options.scope) {
+        runner::observe_runner_capabilities(runner_id);
+    }
     if options.scope == RunnerDoctorScope::LabOffload {
         let catalog = homeboy::agents::agent_tasks::provider::AgentTaskProviderCatalog::discover();
         let eligible_provider_ids = probes::eligible_provider_ids(
@@ -285,6 +288,10 @@ pub(super) fn repair_scope(scope: RunnerDoctorScope, repair: bool) -> RunnerDoct
     } else {
         scope
     }
+}
+
+fn observes_complete_capabilities(scope: RunnerDoctorScope) -> bool {
+    scope != RunnerDoctorScope::LabOffload
 }
 
 fn runner_summary(

--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/mod.rs
@@ -6,3 +6,14 @@ mod managed_source;
 mod provider;
 mod shape;
 mod tools;
+
+use super::*;
+
+#[test]
+fn scoped_lab_doctor_does_not_replace_complete_capability_observation() {
+    assert!(observes_complete_capabilities(RunnerDoctorScope::General));
+    assert!(observes_complete_capabilities(RunnerDoctorScope::SecretEnv));
+    assert!(!observes_complete_capabilities(
+        RunnerDoctorScope::LabOffload
+    ));
+}

--- a/crates/homeboy-cli/src/commands/runs/reconcile.rs
+++ b/crates/homeboy-cli/src/commands/runs/reconcile.rs
@@ -114,10 +114,15 @@ pub(crate) fn reconcile_owned_stale_running_run(
     if run.status != RunStatus::Running.as_str() {
         return Ok(None);
     }
-    let Some(reason) = stale_running_reason(run, &pid_is_running) else {
-        return Ok(None);
-    };
-    reconcile_orphaned_running_run(store, run, reason, false).map(Some)
+    Ok(reconcile_orphaned_running_runs_with_remote_status(
+        store,
+        vec![run.clone()],
+        false,
+        pid_is_running,
+        runs_service::selected_mirrored_daemon_job_status,
+    )?
+    .into_iter()
+    .next())
 }
 
 fn reconcile_orphaned_running_runs<F>(
@@ -129,11 +134,47 @@ fn reconcile_orphaned_running_runs<F>(
 where
     F: Fn(u32) -> bool,
 {
-    Ok(running
-        .iter()
-        .filter_map(|run| stale_running_reason(run, &pid_is_alive).map(|reason| (run, reason)))
-        .map(|(run, reason)| reconcile_orphaned_running_run(store, run, reason, dry_run))
-        .collect::<homeboy::core::Result<Vec<_>>>()?)
+    reconcile_orphaned_running_runs_with_remote_status(
+        store,
+        running,
+        dry_run,
+        pid_is_alive,
+        runs_service::selected_mirrored_daemon_job_status,
+    )
+}
+
+fn reconcile_orphaned_running_runs_with_remote_status<F, R>(
+    store: &ObservationStore,
+    running: Vec<RunRecord>,
+    dry_run: bool,
+    pid_is_alive: F,
+    remote_status: R,
+) -> homeboy::core::Result<Vec<ReconciledRunSummary>>
+where
+    F: Fn(u32) -> bool,
+    R: Fn(&RunRecord) -> homeboy::core::Result<Option<String>>,
+{
+    let mut reconciled = Vec::new();
+    for run in &running {
+        // An unavailable or malformed runner answer cannot prove terminality.
+        // Leave the row running rather than falling back to daemon-PID or age
+        // heuristics that could contradict live remote work.
+        let Ok(remote_job_status) = remote_status(run) else {
+            continue;
+        };
+        let Some(reason) = reconciliation_reason(run, &pid_is_alive, remote_job_status.as_deref())
+        else {
+            continue;
+        };
+        reconciled.push(reconcile_orphaned_running_run(
+            store,
+            run,
+            reason,
+            remote_job_status,
+            dry_run,
+        )?);
+    }
+    Ok(reconciled)
 }
 
 fn running_runs(store: &ObservationStore, limit: i64) -> homeboy::core::Result<Vec<RunRecord>> {
@@ -148,42 +189,67 @@ fn reconcile_orphaned_running_run(
     store: &ObservationStore,
     run: &RunRecord,
     reason: &str,
+    remote_job_status: Option<String>,
     dry_run: bool,
 ) -> homeboy::core::Result<ReconciledRunSummary> {
     let owner_pid = run_owner_pid(run);
-    let remote_job_status = runs_service::selected_mirrored_daemon_job_status(run)?;
     if !dry_run {
         // Candidate selection is entirely local. Refresh only a selected row,
         // never the unrelated running mirrors that happen to share the store.
         runs_service::refresh_selected_mirrored_daemon_evidence(store, run);
     }
-    let reason = if remote_job_status.as_deref() == Some("not_found") {
-        "daemon_job_not_found"
-    } else {
-        reason
-    };
     let artifact_count = if dry_run {
         store.list_artifacts(&run.id)?.len()
     } else {
         reconcile_available_run_dir_artifacts(store, run)?
     };
-    let finished = if dry_run {
-        None
+    let terminal_status = remote_job_status.as_deref().and_then(terminal_run_status);
+    let (status, finished) = if dry_run {
+        (terminal_status.unwrap_or(RunStatus::Stale), None)
     } else if remote_job_status.as_deref() == Some("not_found") {
-        store.get_run(&run.id)?.and_then(|run| run.finished_at)
+        let refreshed = store.get_run(&run.id)?;
+        (
+            refreshed
+                .as_ref()
+                .and_then(|run| RunStatus::from_label(&run.status))
+                .unwrap_or(RunStatus::Stale),
+            refreshed.and_then(|run| run.finished_at),
+        )
+    } else if let Some(status) = terminal_status {
+        let metadata = with_runner_terminal_metadata(
+            run,
+            owner_pid,
+            reason,
+            remote_job_status
+                .as_deref()
+                .expect("terminal status is present"),
+        );
+        let refreshed = store
+            .finish_running_run(&run.id, status, Some(metadata))?
+            .or_else(|| store.get_run(&run.id).ok().flatten());
+        (
+            refreshed
+                .as_ref()
+                .and_then(|run| RunStatus::from_label(&run.status))
+                .unwrap_or(status),
+            refreshed.and_then(|run| run.finished_at),
+        )
     } else {
         let metadata =
             with_reconcile_metadata(run, owner_pid, reason, &reconcile_run_dir_metadata(run));
-        store
-            .finish_run(&run.id, RunStatus::Stale, Some(metadata))?
-            .finished_at
+        (
+            RunStatus::Stale,
+            store
+                .finish_run(&run.id, RunStatus::Stale, Some(metadata))?
+                .finished_at,
+        )
     };
 
     Ok(ReconciledRunSummary {
         id: run.id.clone(),
         kind: run.kind.clone(),
         previous_status: run.status.clone(),
-        status: RunStatus::Stale.as_str().to_string(),
+        status: status.as_str().to_string(),
         started_at: run.started_at.clone(),
         finished_at: finished,
         owner_pid,
@@ -191,6 +257,65 @@ fn reconcile_orphaned_running_run(
         artifact_count,
         remote_job_status,
     })
+}
+
+fn reconciliation_reason<F>(
+    run: &RunRecord,
+    pid_is_alive: &F,
+    remote_job_status: Option<&str>,
+) -> Option<&'static str>
+where
+    F: Fn(u32) -> bool,
+{
+    match remote_job_status {
+        Some("succeeded") => Some("runner_job_succeeded"),
+        Some("failed") => Some("runner_job_failed"),
+        Some("cancelled") => Some("runner_job_cancelled"),
+        Some("queued" | "running") => None,
+        Some("not_found") => {
+            stale_running_reason(run, pid_is_alive).map(|_| "daemon_job_not_found")
+        }
+        Some(_) => None,
+        None => stale_running_reason(run, pid_is_alive),
+    }
+}
+
+fn terminal_run_status(remote_job_status: &str) -> Option<RunStatus> {
+    match remote_job_status {
+        "succeeded" => Some(RunStatus::Pass),
+        "failed" | "cancelled" => Some(RunStatus::Fail),
+        _ => None,
+    }
+}
+
+fn with_runner_terminal_metadata(
+    run: &RunRecord,
+    owner_pid: Option<u32>,
+    reason: &str,
+    remote_job_status: &str,
+) -> Value {
+    let mut metadata =
+        with_reconcile_metadata(run, owner_pid, reason, &reconcile_run_dir_metadata(run));
+    let status = terminal_run_status(remote_job_status).expect("terminal status is known");
+    if let Some(marker) = metadata
+        .get_mut("homeboy_reconciled")
+        .and_then(Value::as_object_mut)
+    {
+        marker.insert(
+            "status".to_string(),
+            Value::String(status.as_str().to_string()),
+        );
+    }
+    if let Some(object) = metadata.as_object_mut() {
+        object.insert(
+            "runner_terminal_evidence".to_string(),
+            serde_json::json!({
+                "status": remote_job_status,
+                "reconciled_at": chrono::Utc::now().to_rfc3339(),
+            }),
+        );
+    }
+    metadata
 }
 
 pub(crate) fn stale_running_reason<F>(run: &RunRecord, pid_is_alive: &F) -> Option<&'static str>
@@ -565,6 +690,118 @@ mod tests {
 
             assert!(reconciled.is_empty());
             assert_eq!(unchanged.status, "running");
+        });
+    }
+
+    #[test]
+    fn authoritative_terminal_runner_job_outranks_live_daemon_owner() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let mut run = phantom_handoff_run("terminal-runner-job", minutes_ago(1));
+            run.metadata_json = serde_json::json!({
+                "homeboy_run_owner": { "pid": std::process::id() },
+                "lab": {
+                    "runner": { "id": "homeboy-lab" },
+                    "remote_job": { "id": "terminal-job" },
+                    "remote_job_status": "running"
+                }
+            });
+            store.import_run(&run).expect("import runner-backed run");
+
+            let reconciled = reconcile_orphaned_running_runs_with_remote_status(
+                &store,
+                vec![run],
+                false,
+                |_| true,
+                |_| Ok(Some("succeeded".to_string())),
+            )
+            .expect("reconcile terminal runner job");
+            let updated = store
+                .get_run("terminal-runner-job")
+                .expect("get run")
+                .expect("run exists");
+
+            assert_eq!(reconciled.len(), 1);
+            assert_eq!(reconciled[0].reason, "runner_job_succeeded");
+            assert_eq!(
+                reconciled[0].remote_job_status.as_deref(),
+                Some("succeeded")
+            );
+            assert_eq!(reconciled[0].status, RunStatus::Pass.as_str());
+            assert_eq!(updated.status, RunStatus::Pass.as_str());
+            assert_eq!(
+                updated.metadata_json["homeboy_reconciled"]["status"],
+                RunStatus::Pass.as_str()
+            );
+            assert_eq!(
+                updated.metadata_json["runner_terminal_evidence"]["status"],
+                "succeeded"
+            );
+        });
+    }
+
+    #[test]
+    fn authoritative_active_runner_job_remains_running() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let mut run = phantom_handoff_run(
+                "active-runner-job",
+                minutes_ago(RUNNER_BACKED_RUNNING_STALE_THRESHOLD_MINUTES + 60),
+            );
+            run.metadata_json["homeboy_run_owner"] = serde_json::json!({ "pid": u32::MAX });
+            store.import_run(&run).expect("import runner-backed run");
+
+            let reconciled = reconcile_orphaned_running_runs_with_remote_status(
+                &store,
+                vec![run],
+                false,
+                |_| false,
+                |_| Ok(Some("running".to_string())),
+            )
+            .expect("inspect active runner job");
+            let unchanged = store
+                .get_run("active-runner-job")
+                .expect("get run")
+                .expect("run exists");
+
+            assert!(reconciled.is_empty());
+            assert_eq!(unchanged.status, RunStatus::Running.as_str());
+        });
+    }
+
+    #[test]
+    fn unavailable_runner_job_status_remains_fail_closed() {
+        with_isolated_home(|_home| {
+            let _xdg = XdgGuard::unset();
+            let store = ObservationStore::open_initialized().expect("store");
+            let mut run = phantom_handoff_run(
+                "unavailable-runner-job",
+                minutes_ago(RUNNER_BACKED_RUNNING_STALE_THRESHOLD_MINUTES + 60),
+            );
+            run.metadata_json["homeboy_run_owner"] = serde_json::json!({ "pid": u32::MAX });
+            store.import_run(&run).expect("import runner-backed run");
+
+            let reconciled = reconcile_orphaned_running_runs_with_remote_status(
+                &store,
+                vec![run],
+                false,
+                |_| false,
+                |_| {
+                    Err(homeboy::core::Error::internal_unexpected(
+                        "runner unavailable",
+                    ))
+                },
+            )
+            .expect("unavailable runner remains fail closed");
+            let unchanged = store
+                .get_run("unavailable-runner-job")
+                .expect("get run")
+                .expect("run exists");
+
+            assert!(reconciled.is_empty());
+            assert_eq!(unchanged.status, RunStatus::Running.as_str());
         });
     }
 

--- a/crates/homeboy-core/src/observation/runs_service/run_lookup.rs
+++ b/crates/homeboy-core/src/observation/runs_service/run_lookup.rs
@@ -336,12 +336,29 @@ pub fn selected_mirrored_daemon_job_status(run: &RunRecord) -> Result<Option<Str
     match runner_evidence::with_runner_evidence(|p| {
         p.daemon_api_get(&runner_id, &format!("/jobs/{job_id}"))
     }) {
-        Ok(_) => Ok(None),
+        Ok(data) => Ok(Some(daemon_job_status(&data, &runner_id, &job_id)?)),
         Err(err) if err.details.get("http_status").and_then(Value::as_u64) == Some(404) => {
             Ok(Some("not_found".to_string()))
         }
         Err(err) => Err(err),
     }
+}
+
+fn daemon_job_status(data: &Value, runner_id: &str, job_id: &str) -> Result<String> {
+    data.pointer("/data/body")
+        .or_else(|| data.get("body"))
+        .unwrap_or(data)
+        .pointer("/job/status")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "runner_job_status",
+                format!("runner `{runner_id}` job `{job_id}` response did not include job.status"),
+                None,
+                None,
+            )
+        })
 }
 
 pub fn refresh_selected_mirrored_daemon_evidence(
@@ -447,6 +464,19 @@ fn finish_stale_runner_child_run(store: &ObservationStore, job: &StaleRunnerJobI
 #[cfg(test)]
 mod guidance_tests {
     use super::*;
+
+    #[test]
+    fn daemon_job_status_reads_the_authoritative_terminal_state() {
+        let response = serde_json::json!({
+            "data": { "body": { "job": { "status": "succeeded" } } }
+        });
+
+        assert_eq!(
+            daemon_job_status(&response, "homeboy-lab", "job-1").expect("job status"),
+            "succeeded"
+        );
+        assert!(daemon_job_status(&serde_json::json!({}), "homeboy-lab", "job-1").is_err());
+    }
 
     #[test]
     fn runner_owned_guidance_offers_non_destructive_controller_and_read_only_retrieval() {

--- a/crates/homeboy-lab-runner/src/evidence/mirror.rs
+++ b/crates/homeboy-lab-runner/src/evidence/mirror.rs
@@ -916,16 +916,30 @@ pub fn runner_job_log_snapshot_for_session_until(
 }
 
 pub fn mirrored_runner_job_identity(run: &RunRecord) -> Option<(String, String)> {
-    let lab = run.metadata_json.get("lab")?;
-    let runner_id = lab
-        .pointer("/runner/id")
-        .or_else(|| lab.get("runner_id"))
-        .and_then(Value::as_str)?;
-    let job_id = lab
-        .pointer("/remote_job/id")
-        .or_else(|| lab.get("remote_job_id"))
-        .and_then(Value::as_str)?;
-    Some((runner_id.to_string(), job_id.to_string()))
+    let lab_identity = || {
+        let lab = run.metadata_json.get("lab")?;
+        Some((
+            lab.pointer("/runner/id")
+                .or_else(|| lab.get("runner_id"))
+                .and_then(Value::as_str)?,
+            lab.pointer("/remote_job/id")
+                .or_else(|| lab.get("remote_job_id"))
+                .and_then(Value::as_str)?,
+        ))
+    };
+    let execution_identity = || {
+        let record = run.metadata_json.get("runner_execution_record")?;
+        Some((
+            record.get("runner_id").and_then(Value::as_str)?,
+            record
+                .get("job_id")
+                .or_else(|| record.get("execution_id"))
+                .and_then(Value::as_str)?,
+        ))
+    };
+    lab_identity()
+        .or_else(execution_identity)
+        .map(|(runner_id, job_id)| (runner_id.to_string(), job_id.to_string()))
 }
 
 fn fetch_daemon_job(runner_id: &str, job_id: &str) -> Result<Job> {

--- a/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
+++ b/crates/homeboy-lab-runner/src/evidence/tests/mod.rs
@@ -37,15 +37,39 @@ use super::mirror::{
     mirror_daemon_evidence, mirror_job_run, mirror_job_run_request,
     mirror_remote_observation_runs_by_id_with,
     mirror_remote_observation_runs_by_id_with_downloader, mirror_reverse_broker_evidence,
-    mirror_terminal_job_artifacts_with, mirrored_patch_result, primary_mirrored_run,
-    refresh_mirrored_daemon_evidence, refresh_mirrored_daemon_evidence_with, MirrorEvidenceRequest,
-    ReverseBrokerEvidenceContext, MIRRORED_REMOTE_EVENT_LIMIT, MIRRORED_REMOTE_EVENT_MESSAGE_LIMIT,
+    mirror_terminal_job_artifacts_with, mirrored_patch_result, mirrored_runner_job_identity,
+    primary_mirrored_run, refresh_mirrored_daemon_evidence, refresh_mirrored_daemon_evidence_with,
+    MirrorEvidenceRequest, ReverseBrokerEvidenceContext, MIRRORED_REMOTE_EVENT_LIMIT,
+    MIRRORED_REMOTE_EVENT_MESSAGE_LIMIT,
 };
+
 use super::tokens::{
     is_reportable_artifact_evidence_path, is_retrievable_runner_artifact, runner_artifact_token,
     RemoteArtifactToken,
 };
 use super::util::{fuzz_run_id_from_command, runner_exec_run_label};
+
+#[test]
+fn runner_execution_record_resolves_its_authoritative_job_identity() {
+    let run = RunRecord {
+        metadata_json: json!({
+            "runner_execution_record": {
+                "runner_id": "homeboy-lab",
+                "job_id": "c2d54086-5e83-4268-88a7-51232fa05a0c",
+                "status": "running"
+            }
+        }),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        mirrored_runner_job_identity(&run),
+        Some((
+            "homeboy-lab".to_string(),
+            "c2d54086-5e83-4268-88a7-51232fa05a0c".to_string()
+        ))
+    );
+}
 
 fn ssh_runner() -> Runner {
     Runner {


### PR DESCRIPTION
## Summary

- resolve authoritative runner job status for both mirrored Lab records and generic `runner_execution_record` observations
- converge terminal jobs to `pass`/`fail` even when the observation owner is a long-lived daemon PID
- keep queued, running, unavailable, malformed, and unresolvable runner states fail-closed
- prevent scoped Lab doctor runs from invalidating complete capability observations they did not collect

Refs #7451.

## Verification

- `cargo test -p homeboy-cli reconcile --locked` (45 passed)
- `cargo test -p homeboy-cli commands::runner::doctor::tests --locked` (77 passed)
- `cargo test -p homeboy-lab-runner runner_execution_record_resolves_its_authoritative_job_identity --locked` (1 passed)
- `cargo test -p homeboy-core activity --locked` (43 passed)
- `cargo test -p homeboy-cli activity --locked` (23 passed)
- `cargo fmt --all -- --check`

## AI Assistance

OpenAI gpt-5.6-sol was used through OpenCode to inspect the lifecycle and runner-doctor paths, implement the fixes directly in the managed worktree, add regression coverage, and run the verification commands. The final diff and test evidence were reviewed before publication.