### PR TITLE
Separate release lifecycle ownership from tracker URLs

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -8806,7 +8806,7 @@ fn provision_pending_cook_workspace(
         repo: required("repo")?.to_string(),
         base: required("base")?.to_string(),
         head: required("head")?.to_string(),
-        task_url: required("task_url")?.to_string(),
+        task_url: Some(required("task_url")?.to_string()),
     };
     let Some(lifecycle) = options
         .initial_plan

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -3468,10 +3468,11 @@ fn with_workspace_owner_repair_commands(
             repo: provision_repo.clone(),
             base: cook_batch_from(args).to_string(),
             head: row.branch.clone(),
-            task_url: cook
-                .task_url
-                .clone()
-                .expect("generated cooks have task URLs"),
+            task_url: Some(
+                cook.task_url
+                    .clone()
+                    .expect("generated cooks have task URLs"),
+            ),
         };
         let lifecycle = homeboy::core::worktree_provider::WorktreeProvisionLifecycle {
             purpose: "agent_task_cook".to_string(),

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -1509,7 +1509,7 @@ mod preview_tests {
                 repo: "fixture".to_string(),
                 base: "main".to_string(),
                 head: "fix/issue-12890-repo".to_string(),
-                task_url: "https://example.test/owner/repo/issues/12890".to_string(),
+                task_url: Some("https://example.test/owner/repo/issues/12890".to_string()),
             };
             let lifecycle = WorktreeProviderLifecycleIntent {
                 purpose: "agent_task_cook".to_string(),
@@ -3740,12 +3740,12 @@ fn cook_workspace_create_intent(
                     .to_string(),
             ])
         })?,
-        task_url: args.dispatch.task_url.clone().ok_or_else(|| {
+        task_url: Some(args.dispatch.task_url.clone().ok_or_else(|| {
             homeboy::core::Error::validation_missing_argument(vec![
                 "--task-url <url> is required to create a missing --to-worktree destination"
                     .to_string(),
             ])
-        })?,
+        })?),
     })
 }
 

--- a/crates/homeboy-core/src/worktree/mod.rs
+++ b/crates/homeboy-core/src/worktree/mod.rs
@@ -773,7 +773,7 @@ pub fn queue_create(options: WorktreeQueueCreateOptions) -> Result<WorktreeQueue
                     repo: options.repo.clone(),
                     base: options.from.clone(),
                     head: request.branch.clone(),
-                    task_url,
+                    task_url: Some(task_url),
                 },
                 lifecycle,
                 None,

--- a/crates/homeboy-core/src/worktree_provider.rs
+++ b/crates/homeboy-core/src/worktree_provider.rs
@@ -244,7 +244,7 @@ pub struct WorktreeProvisionIntent {
     pub repo: String,
     pub base: String,
     pub head: String,
-    pub task_url: String,
+    pub task_url: Option<String>,
 }
 
 /// Lifecycle ownership bound before a provisioning mutation is allowed.
@@ -734,7 +734,7 @@ impl WorktreeProvisionProvider for NativeWorktreeProvider {
                     path: worktree::planned_create_path(&intent.repo, &intent.head, &intent.base)?,
                     kind: WorktreeWorkspaceKind::TaskWorktree,
                     branch: Some(intent.head.clone()),
-                    task_url: Some(intent.task_url.clone()),
+                    task_url: intent.task_url.clone(),
                     provenance: None,
                 },
                 exact_identity: None,
@@ -759,7 +759,7 @@ impl WorktreeProvisionProvider for NativeWorktreeProvider {
             component_id: intent.repo.clone(),
             branch: intent.head.clone(),
             from: Some(intent.base.clone()),
-            task_url: Some(intent.task_url.clone()),
+            task_url: intent.task_url.clone(),
             run_id: Some(lifecycle.owner_run_ref.clone()),
             cleanup_policy: Some(match lifecycle.cleanup_policy {
                 WorktreeCleanupPolicy::RemoveOnSuccess => worktree::CleanupPolicy::RemoveWhenSafe,
@@ -1481,10 +1481,15 @@ impl<'a> WorktreeProviderRegistry<'a> {
             repo: options.component_id.clone(),
             base: options.from.clone().unwrap_or_else(|| "HEAD".to_string()),
             head: options.branch.clone(),
-            task_url: options.task_url.clone().unwrap_or_default(),
+            task_url: options.task_url.clone(),
         };
         let configured_creation = configured_provisioning_declared(self.config);
-        if configured_creation && intent.task_url.trim().is_empty() {
+        if configured_creation
+            && intent
+                .task_url
+                .as_deref()
+                .is_none_or(|task_url| task_url.trim().is_empty())
+        {
             return Err(Error::validation_missing_argument(vec![
                 "--task-url is required for configured-provider worktree creation".to_string(),
             ]));
@@ -2164,7 +2169,7 @@ mod tests {
                 repo: "fixture".to_string(),
                 base: "main".to_string(),
                 head: "planned".to_string(),
-                task_url: "https://example.test/issues/8017".to_string(),
+                task_url: Some("https://example.test/issues/8017".to_string()),
             };
             let lifecycle = WorktreeProvisionLifecycle {
                 purpose: "agent_task_cook".to_string(),
@@ -2520,7 +2525,7 @@ mod tests {
                 repo: "fixture".to_string(),
                 base: "main".to_string(),
                 head: "command-lifecycle".to_string(),
-                task_url: "https://example.test/issues/8017".to_string(),
+                task_url: Some("https://example.test/issues/8017".to_string()),
             };
             let lifecycle = WorktreeProvisionLifecycle {
                 purpose: "contract_test".to_string(),
@@ -2590,7 +2595,7 @@ mod tests {
                 repo: "fixture".to_string(),
                 base: "main".to_string(),
                 head: "planned".to_string(),
-                task_url: "https://example.test/issues/8017".to_string(),
+                task_url: Some("https://example.test/issues/8017".to_string()),
             };
             let lifecycle = WorktreeProvisionLifecycle {
                 purpose: "agent_task_cook".to_string(),

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -1855,10 +1855,15 @@ fn plan_apply_enabled_worktree_provider_from_config_with_id(
 /// remediation leads with the command that creates the destination now and
 /// follows with the command that enables auto-creation for later runs.
 fn missing_ensure_provider_remediation(intent: &WorktreeProviderCreateIntent) -> Vec<String> {
+    let task_argument = intent
+        .task_url
+        .as_deref()
+        .map(|task_url| format!(" --task-url {task_url}"))
+        .unwrap_or_default();
     let mut actions = vec![
         format!(
-            "Create it now with: homeboy worktree create {} --branch {} --from {} --task-url {}",
-            intent.repo, intent.head, intent.base, intent.task_url
+            "Create it now with: homeboy worktree create {} --branch {} --from {}{}",
+            intent.repo, intent.head, intent.base, task_argument
         ),
         format!(
             "Then rerun with: --to-worktree {}",
@@ -2139,6 +2144,21 @@ fn provision_apply_enabled_worktree_provider_from_config_with_lifecycle(
     let resolution =
         resolve_apply_enabled_worktree_provider_from_config(&intent.handle, config, None)
             .map_err(mark_bootstrap_postcondition_failure)?;
+    if intent.task_url.as_deref().is_some_and(|expected| {
+        resolution
+            .worktree
+            .task_url
+            .as_deref()
+            .map(normalize_task_url)
+            != Some(normalize_task_url(expected))
+    }) {
+        return Err(Error::validation_invalid_argument(
+            "worktree_provider",
+            "provider postcondition did not preserve tracker ownership",
+            Some(intent.handle.clone()),
+            None,
+        ));
+    }
     if lifecycle_provider.as_deref() != Some(resolution.provider_id.as_str())
         && lifecycle_provider.is_some()
     {
@@ -2292,7 +2312,7 @@ fn expand_ensure_command(
                 .replace("{repo}", &intent.repo)
                 .replace("{base}", &intent.base)
                 .replace("{head}", &intent.head)
-                .replace("{task_url}", &intent.task_url)
+                .replace("{task_url}", intent.task_url.as_deref().unwrap_or_default())
                 .replace("{idempotency_key}", idempotency_key)
         })
         .collect()
@@ -4762,7 +4782,7 @@ mod tests {
             repo: "blocks-engine".to_string(),
             base: "origin/trunk".to_string(),
             head: "fix/12252".to_string(),
-            task_url: "https://example.test/issues/12252".to_string(),
+            task_url: Some("https://example.test/issues/12252".to_string()),
         };
         let lifecycle = WorktreeProviderLifecycleIntent {
             purpose: "agent_task_cook".to_string(),
@@ -4853,7 +4873,7 @@ mod tests {
             repo: "fixture".to_string(),
             base: "main".to_string(),
             head: head.to_string(),
-            task_url: "https://example.test/issues/1".to_string(),
+            task_url: Some("https://example.test/issues/1".to_string()),
         };
 
         let existing = plan_apply_enabled_worktree_provider_from_config(
@@ -4934,7 +4954,7 @@ mod tests {
             repo: "fixture".to_string(),
             base: "main".to_string(),
             head: "fix/placeholder".to_string(),
-            task_url: "https://example.test/issues/13349".to_string(),
+            task_url: Some("https://example.test/issues/13349".to_string()),
         };
 
         let error = plan_apply_enabled_worktree_provider_from_config(&intent, &config)
@@ -4959,7 +4979,7 @@ mod tests {
             repo: "https://example.invalid/repo.git".to_string(),
             base: "main".to_string(),
             head: "0123456789abcdef".to_string(),
-            task_url: "release/run-1".to_string(),
+            task_url: None,
         };
         let lifecycle = WorktreeProviderLifecycleIntent {
             purpose: "release_staging".to_string(),
@@ -4973,6 +4993,7 @@ mod tests {
                 "{purpose}".to_string(),
                 "{owner_run_ref}".to_string(),
                 "{cleanup_policy}".to_string(),
+                "{task_url}".to_string(),
             ],
             &intent,
             &lifecycle,
@@ -4985,7 +5006,8 @@ mod tests {
                 "fixture@release",
                 "release_staging",
                 "release/run-1",
-                "remove_on_success"
+                "remove_on_success",
+                ""
             ]
         );
 
@@ -5051,7 +5073,7 @@ mod tests {
                 repo: "repo".to_string(),
                 base: "main".to_string(),
                 head: "abc".to_string(),
-                task_url: "task".to_string(),
+                task_url: Some("task".to_string()),
             },
             &config_with_provider(provider),
         )
@@ -5126,7 +5148,7 @@ mod tests {
             repo: "homeboy".to_string(),
             base: "main".to_string(),
             head: "fix/12124".to_string(),
-            task_url: "https://github.com/Extra-Chill/homeboy/issues/12124".to_string(),
+            task_url: Some("https://github.com/Extra-Chill/homeboy/issues/12124".to_string()),
         };
         let lifecycle = WorktreeProviderLifecycleIntent {
             purpose: "agent_task_cook".to_string(),
@@ -5301,7 +5323,7 @@ mod tests {
                 repo: "homeboy".to_string(),
                 base: "main".to_string(),
                 head: "fix/11168-wire-compiler-warning-provider".to_string(),
-                task_url: "https://github.com/Extra-Chill/homeboy/issues/11168".to_string(),
+                task_url: Some("https://github.com/Extra-Chill/homeboy/issues/11168".to_string()),
             },
             &config,
         )
@@ -5346,7 +5368,7 @@ mod tests {
                 repo: "homeboy".to_string(),
                 base: "main".to_string(),
                 head: "fix/11168-wire-compiler-warning-provider".to_string(),
-                task_url: "https://github.com/Extra-Chill/homeboy/issues/11168".to_string(),
+                task_url: Some("https://github.com/Extra-Chill/homeboy/issues/11168".to_string()),
             },
             &config,
         )
@@ -5378,7 +5400,7 @@ mod tests {
                 repo: "homeboy".to_string(),
                 base: "main".to_string(),
                 head: "fix/11168".to_string(),
-                task_url: "https://github.com/Extra-Chill/homeboy/issues/11168".to_string(),
+                task_url: Some("https://github.com/Extra-Chill/homeboy/issues/11168".to_string()),
             },
             &config,
         )
@@ -5416,7 +5438,7 @@ mod tests {
         fs::write(
             &script,
             format!(
-                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  if [ -f '{}' ]; then\n    printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"homeboy@fix-9908\",\"path\":\"{}\",\"branch\":\"fix/9908\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'\n  else\n    exit 1\n  fi\nelse\n  sleep 2\n  git init -b fix/9908 '{}' >/dev/null\n  printf '%s|%s|%s|%s|%s|%s' \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" \"$7\" > '{}'\nfi\n",
+                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  if [ -f '{}' ]; then\n    printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"homeboy@fix-9908\",\"path\":\"{}\",\"branch\":\"fix/9908\",\"task_url\":\"https://github.com/Extra-Chill/homeboy/issues/9908\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'\n  else\n    exit 1\n  fi\nelse\n  sleep 2\n  git init -b fix/9908 '{}' >/dev/null\n  printf '%s|%s|%s|%s|%s|%s' \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" \"$7\" > '{}'\nfi\n",
                 state.display(),
                 workspace.display(),
                 workspace.display(),
@@ -5464,7 +5486,7 @@ mod tests {
                     dirty: "$.safety.dirty".to_string(),
                     unpushed: "$.safety.unpushed".to_string(),
                     primary: "$.safety.primary".to_string(),
-                    task_url: None,
+                    task_url: Some("$.task_url".to_string()),
                 }),
             },
         );
@@ -5475,7 +5497,7 @@ mod tests {
                 repo: "homeboy".to_string(),
                 base: "main".to_string(),
                 head: "fix/9908".to_string(),
-                task_url: "https://github.com/Extra-Chill/homeboy/issues/9908".to_string(),
+                task_url: Some("https://github.com/Extra-Chill/homeboy/issues/9908".to_string()),
             },
             &config,
         )
@@ -5488,6 +5510,160 @@ mod tests {
             fs::read_to_string(state).expect("creation intent"),
             "homeboy@fix-9908|homeboy|main|fix/9908|https://github.com/Extra-Chill/homeboy/issues/9908|homeboy@fix-9908:homeboy:main:fix/9908"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn optional_tracker_survives_provider_ensure_and_resolve() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("destination");
+        let state = temp.path().join("state");
+        let script = temp.path().join("provider");
+        fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  if [ -f '{state}' ]; then\n    printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"homeboy@release-staging\",\"path\":\"{workspace}\",\"branch\":\"release-staging\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'\n  else\n    exit 1\n  fi\nelse\n  git init -b release-staging '{workspace}' >/dev/null\n  printf '%s' \"$6\" > '{state}'\nfi\n",
+                state = state.display(),
+                workspace = workspace.display(),
+            ),
+        )
+        .expect("write provider");
+        let mut permissions = fs::metadata(&script).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script, permissions).expect("executable");
+        let mut config = HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            WorktreeProviderConfig {
+                enabled: true,
+                kind: WorktreeProviderKind::Command,
+                apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: WorktreeProviderCommands {
+                    resolve: Some(vec![
+                        script.display().to_string(),
+                        "resolve".to_string(),
+                        "{handle}".to_string(),
+                    ]),
+                    resolve_not_found_exit_codes: vec![1],
+                    ensure: Some(vec![
+                        script.display().to_string(),
+                        "create".to_string(),
+                        "{handle}".to_string(),
+                        "{repo}".to_string(),
+                        "{base}".to_string(),
+                        "{head}".to_string(),
+                        "{task_url}".to_string(),
+                        "{idempotency_key}".to_string(),
+                    ]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(worktrees_mapping()),
+            },
+        );
+
+        let provision = provision_apply_enabled_worktree_provider_from_config(
+            &WorktreeProviderCreateIntent {
+                handle: "homeboy@release-staging".to_string(),
+                repo: "homeboy".to_string(),
+                base: "main".to_string(),
+                head: "release-staging".to_string(),
+                task_url: None,
+            },
+            &config,
+        )
+        .expect("ensure without a tracker remains valid");
+
+        assert_eq!(provision.action, "ensured");
+        assert!(provision.resolution.worktree.task_url.is_none());
+        assert_eq!(fs::read_to_string(state).expect("expanded task_url"), "");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reported_tracker_url_is_verified_and_mismatches_fail_closed() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("destination");
+        let state = temp.path().join("state");
+        let script = temp.path().join("provider");
+        fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  if [ -f '{state}' ]; then\n    printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"homeboy@fix-13788\",\"path\":\"{workspace}\",\"branch\":\"fix/13788\",\"task_url\":\"https://example.test/issues/13788\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'\n  else\n    exit 1\n  fi\nelse\n  git init -b fix/13788 '{workspace}' >/dev/null\n  touch '{state}'\nfi\n",
+                state = state.display(),
+                workspace = workspace.display(),
+            ),
+        )
+        .expect("write provider");
+        let mut permissions = fs::metadata(&script).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script, permissions).expect("executable");
+        let mapping = WorktreeProviderListResultMapping {
+            task_url: Some("$.task_url".to_string()),
+            ..worktrees_mapping()
+        };
+        let mut config = HomeboyConfig::default();
+        config.worktree_providers.insert(
+            "fixture".to_string(),
+            WorktreeProviderConfig {
+                enabled: true,
+                kind: WorktreeProviderKind::Command,
+                apply_enabled: true,
+                lookup_timeout_ms: 10_000,
+                mutation_timeout_ms: 30_000,
+                lookup_output_limit_bytes: 64 * 1024,
+                commands: WorktreeProviderCommands {
+                    resolve: Some(vec![
+                        script.display().to_string(),
+                        "resolve".to_string(),
+                        "{handle}".to_string(),
+                    ]),
+                    resolve_not_found_exit_codes: vec![1],
+                    ensure: Some(vec![script.display().to_string(), "create".to_string()]),
+                    ..Default::default()
+                },
+                list_result_mapping: Some(mapping),
+            },
+        );
+
+        let matched = provision_apply_enabled_worktree_provider_from_config(
+            &WorktreeProviderCreateIntent {
+                handle: "homeboy@fix-13788".to_string(),
+                repo: "homeboy".to_string(),
+                base: "main".to_string(),
+                head: "fix/13788".to_string(),
+                task_url: Some("https://example.test/issues/13788".to_string()),
+            },
+            &config,
+        )
+        .expect("matching tracker remains verified");
+        assert_eq!(
+            matched.resolution.worktree.task_url.as_deref(),
+            Some("https://example.test/issues/13788")
+        );
+
+        fs::remove_file(&state).expect("reset destination");
+        fs::remove_dir_all(&workspace).expect("reset workspace");
+        let error = provision_apply_enabled_worktree_provider_from_config(
+            &WorktreeProviderCreateIntent {
+                handle: "homeboy@fix-13788".to_string(),
+                repo: "homeboy".to_string(),
+                base: "main".to_string(),
+                head: "fix/13788".to_string(),
+                task_url: Some("https://example.test/issues/other".to_string()),
+            },
+            &config,
+        )
+        .expect_err("mismatched tracker must fail closed");
+        assert!(error
+            .message
+            .contains("provider postcondition did not preserve tracker ownership"));
     }
 
     #[cfg(unix)]
@@ -5564,7 +5740,7 @@ mod tests {
             repo: "homeboy".to_string(),
             base: "main".to_string(),
             head: "fix/9908".to_string(),
-            task_url: "https://github.com/Extra-Chill/homeboy/issues/9908".to_string(),
+            task_url: Some("https://github.com/Extra-Chill/homeboy/issues/9908".to_string()),
         };
         let barrier = Arc::new(Barrier::new(2));
         let mut joins = Vec::new();
@@ -5643,7 +5819,7 @@ mod tests {
                     repo: "homeboy".to_string(),
                     base: "main".to_string(),
                     head: "fix/9908".to_string(),
-                    task_url: "https://example.test/9908".to_string(),
+                    task_url: Some("https://example.test/9908".to_string()),
                 },
                 &config,
             )
@@ -7242,7 +7418,7 @@ mod tests {
                 repo: "homeboy".to_string(),
                 base: "main".to_string(),
                 head: "fix/9908".to_string(),
-                task_url: "https://example.test/9908".to_string(),
+                task_url: Some("https://example.test/9908".to_string()),
             },
             &config,
         )

--- a/crates/homeboy-release/src/release/workspace.rs
+++ b/crates/homeboy-release/src/release/workspace.rs
@@ -67,7 +67,7 @@ impl ReleaseWorkspace {
             repo: component.id.clone(),
             base: source_sha.clone(),
             head: branch,
-            task_url: owner_run_ref,
+            task_url: None,
         };
         let planned =
             worktree_provider::plan_worktree_provision_from_config(&intent, &lifecycle, &config)?;
@@ -424,7 +424,7 @@ struct PersistedProvisionIntent {
     repo: String,
     base: String,
     head: String,
-    task_url: String,
+    task_url: Option<String>,
     #[allow(dead_code)]
     idempotency_key: String,
 }
@@ -696,6 +696,26 @@ mod tests {
 
             let workspace = ReleaseWorkspace::select(&test_roots(), &component, false)
                 .expect("built-in provider staging");
+
+            let owner = workspace
+                .output
+                .owner_run_ref
+                .as_deref()
+                .expect("release owner");
+            assert!(owner.starts_with("release/"));
+            assert_eq!(
+                test_store()
+                    .load(owner)
+                    .expect("load")
+                    .expect("record")
+                    .attributes["provision_intent"]["task_url"],
+                serde_json::Value::Null
+            );
+            let handle = workspace.output.handle.as_deref().expect("handle");
+            let record = homeboy_core::worktree::resolve_if_present(handle)
+                .expect("native lookup")
+                .expect("native record");
+            assert!(record.task_url.is_none());
 
             assert_eq!(workspace.output.kind, "provider_owned");
             assert_eq!(workspace.output.provider_id.as_deref(), Some("native"));
@@ -1021,7 +1041,7 @@ mod tests {
             let owner = "release/pre-ensure";
             test_store().create(&OperationRecord {
                 owner_run_ref: owner.to_string(), operation: "provider_workspace".to_string(), subject: "component".to_string(), provider: "fixture".to_string(), handle: "release-fixture".to_string(), path: None, source_sha: "abc".to_string(), cleanup_policy: "remove_on_success".to_string(), lifecycle_state: "provisioning".to_string(), terminal_disposition: None, finalization_status: "pending".to_string(), finalization_lease: None, finalization_lease_started_ms: None, attempt_count: 0, continuation_evidence: Vec::new(),
-                attributes: serde_json::Map::from_iter([("provision_intent".to_string(), serde_json::json!({ "repo": "repo", "base": "main", "head": "abc", "task_url": "release/pre-ensure", "idempotency_key": "release-fixture:repo:main:abc" }))]),
+                attributes: serde_json::Map::from_iter([("provision_intent".to_string(), serde_json::json!({ "repo": "repo", "base": "main", "head": "abc", "task_url": null, "idempotency_key": "release-fixture:repo:main:abc" }))]),
             }).expect("persist pre-ensure record");
 
             let completed = reconcile_pending(&test_roots(), "component", Some(owner))


### PR DESCRIPTION
## Summary

- make worktree provisioning tracker identity optional
- stage releases with lifecycle ownership instead of a synthetic `release/<uuid>` tracker URL
- preserve strict real-tracker requirements for Cook, CLI, queue, and fanout workflows
- verify configured providers preserve supplied tracker ownership after ensure
- persist and recover trackerless release provisioning intent

Fixes #13788. Companion adapter repair: Extra-Chill/wp-coding-agents#501.

## Verification

- `cargo check -p homeboy-core -p homeboy-release -p homeboy-cli -p homeboy-agents`
- `cargo test -p homeboy-core optional_tracker_survives_provider_ensure_and_resolve`
- `cargo test -p homeboy-core reported_tracker_url_is_verified_and_mismatches_fail_closed`
- `cargo test -p homeboy-core provision_creates_missing_destination_from_explicit_generic_intent`
- `cargo test -p homeboy-release dirty_default_checkout_stages_through_the_builtin_provider`
- `cargo test -p homeboy-release recovery_ensures_a_pre_ensure_record_then_finalizes_and_closes_it`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI Assistance

OpenAI GPT-5.6 Sol through OpenCode reproduced the DMC-backed release failure, traced lifecycle and tracker identity through the provider contract, implemented the optional tracker model and strict postcondition, and added focused recovery and provisioning tests under Chris Huber’s direction.