### PR TITLE
Reconcile idle queued runner residue during upgrade

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -900,14 +900,14 @@ fn classify_live_cancellation(record: &AgentTaskRunRecord) -> Result<LiveCancell
     if record.is_runner_backed() {
         let runner_id = record.runner_id().map(str::to_string);
         let runner_job_id = record.runner_job_id().map(str::to_string);
-        if runner_id.as_deref().is_some_and(|runner_id| {
+        let runner_removed = runner_id.as_deref().is_some_and(|runner_id| {
             super::runner_continuation::with_runner_continuation(|provider| {
                 provider.runner_authority(runner_id) == RunnerAuthority::Removed
             })
-        }) {
-            // A successful registry inventory proved the original daemon
-            // authority was removed. There is no remote job left to cancel, so
-            // reclaim only the durable controller projection.
+        });
+        if runner_removed || record.is_locally_reconcilable_after_runner_idle() {
+            // Removed authority or authoritative idle evidence for exact
+            // zero-work queued residue means no remote job remains to cancel.
             return Ok(LiveCancellationOutcome::NotRunning);
         }
         if let (Some(runner_id), Some(runner_job_id)) =

--- a/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
@@ -93,8 +93,8 @@ pub use runner_continuation::{
     clear_runner_continuation_provider_for_test, RunnerContinuationTestGuard,
 };
 pub use runner_continuation::{
-    register_runner_continuation_provider, runner_authority, RunnerAuthority,
-    RunnerContinuationProvider, RunnerJobReconciliation,
+    register_runner_continuation_provider, runner_authority, runner_live_job_authority,
+    RunnerAuthority, RunnerContinuationProvider, RunnerJobReconciliation, RunnerLiveJobAuthority,
 };
 pub use runner_exec::*;
 pub use workspace_authority::*;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -522,6 +522,50 @@ impl AgentTaskRunRecord {
         !self.provider_handles.is_empty() || self.has_candidate_terminal_state()
     }
 
+    /// Whether runner placement was recorded without any execution ever taking
+    /// ownership or producing durable work. A leftover `runner_job_id` is not
+    /// ownership once the runner's live-job view is authoritatively idle.
+    pub(crate) fn is_ownerless_zero_artifact_queued_runner_record(&self) -> bool {
+        let now = chrono::Utc::now();
+        self.state == AgentTaskRunState::Queued
+            && self.runner_id().is_some()
+            && self.runner_job_id().is_some()
+            && self.lab_handoff.is_none()
+            && self.local_owner_liveness() == LocalOwnerLiveness::Absent
+            && !self.has_planned_runner_execution()
+            && !super::has_live_pending_runner_submission_intent(self, now)
+            && !self.has_live_pending_local_cook_supervisor(now)
+            && self.aggregate_path.is_none()
+            && self.totals.is_none()
+            && self.artifact_refs.is_empty()
+            && self.provider_handles.is_empty()
+            && self.latest_executor_evidence.is_none()
+            && self.candidate_adoption.is_none()
+            && self.lifecycle.external_runtime_ids.is_empty()
+            && self
+                .lifecycle
+                .provider_runtime
+                .iter()
+                .all(|runtime| runtime.external_runtime_ids.is_empty())
+            && self
+                .metadata
+                .get("provider_executions")
+                .is_none_or(|value| value.as_array().is_some_and(Vec::is_empty))
+            && self
+                .metadata
+                .get("provider_executions_consumed")
+                .is_none_or(|value| value.as_u64() == Some(0))
+    }
+
+    /// Ownerless queued runner residue whose runner has already proved zero live
+    /// jobs. Runner-generation reconcile cannot mutate this durable record.
+    pub(crate) fn is_locally_reconcilable_after_runner_idle(&self) -> bool {
+        self.is_ownerless_zero_artifact_queued_runner_record()
+            && self.runner_id().is_some_and(|runner_id| {
+                super::runner_live_job_authority(runner_id) == super::RunnerLiveJobAuthority::Idle
+            })
+    }
+
     /// A terminal state that carries a produced candidate (success or a
     /// recoverable/partial candidate), as opposed to a bare failure/cancellation
     /// that produced nothing to preserve.

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
@@ -45,6 +45,16 @@ impl RunnerAuthority {
     }
 }
 
+/// Authoritative live-job evidence for one runner after generation
+/// reconciliation. Unknown must keep runner-generation ownership: a missing
+/// probe cannot prove the daemon is idle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunnerLiveJobAuthority {
+    Idle,
+    Busy,
+    Unknown,
+}
+
 /// Runner-side operations the agent-task lifecycle needs when reconciling or
 /// resuming a run that was handed off to a remote runner.
 pub trait RunnerContinuationProvider: Send + Sync {
@@ -149,6 +159,12 @@ pub trait RunnerContinuationProvider: Send + Sync {
         } else {
             RunnerAuthority::Unknown
         }
+    }
+
+    /// Live-job evidence after runner-generation reconciliation. Default is
+    /// unknown so older providers cannot turn a missing probe into idle proof.
+    fn runner_live_job_authority(&self, _runner_id: &str) -> RunnerLiveJobAuthority {
+        RunnerLiveJobAuthority::Unknown
     }
 
     /// Execute a continuation command on the runner, returning the exit code.
@@ -262,6 +278,12 @@ pub fn runner_authority(runner_id: &str) -> RunnerAuthority {
     with_runner_continuation(|provider| provider.runner_authority(runner_id))
 }
 
+/// Resolve whether a runner currently has zero live jobs and a resolved
+/// generation projection. A missing provider remains unknown, not idle.
+pub fn runner_live_job_authority(runner_id: &str) -> RunnerLiveJobAuthority {
+    with_runner_continuation(|provider| provider.runner_live_job_authority(runner_id))
+}
+
 /// Clear any registered runner-continuation provider so a fresh test starts from
 /// the no-op default. The provider slot is a process-global; without this reset a
 /// provider registered by one test would leak into every later test in the same
@@ -363,6 +385,17 @@ mod tests {
         ) -> Result<Job> {
             Err(Error::internal_unexpected("unused in fixture"))
         }
+    }
+
+    #[test]
+    fn default_live_job_authority_is_unknown() {
+        assert_eq!(
+            LegacyProvider {
+                runner_exists: true,
+            }
+            .runner_live_job_authority("legacy-runner"),
+            RunnerLiveJobAuthority::Unknown
+        );
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -30,6 +30,48 @@ struct ServiceRunnerFixture {
     commands: Arc<Mutex<Vec<Vec<String>>>>,
 }
 
+struct IdleRunnerFixture;
+
+impl RunnerContinuationProvider for IdleRunnerFixture {
+    fn runner_job_log_snapshot(
+        &self,
+        _runner_id: &str,
+        _job_id: &str,
+    ) -> Result<homeboy_core::api_jobs::RunnerJobLogSnapshot> {
+        Err(Error::internal_unexpected("not used by idle fixture"))
+    }
+
+    fn is_runner_connected(&self, _runner_id: &str) -> bool {
+        true
+    }
+
+    fn runner_authority(&self, _runner_id: &str) -> RunnerAuthority {
+        RunnerAuthority::Configured
+    }
+
+    fn runner_live_job_authority(&self, _runner_id: &str) -> RunnerLiveJobAuthority {
+        RunnerLiveJobAuthority::Idle
+    }
+
+    fn run_continuation_exec(
+        &self,
+        _runner_id: &str,
+        _cwd: &str,
+        _command: &[String],
+        _run_id: &str,
+    ) -> Result<i32> {
+        Err(Error::internal_unexpected("not used by idle fixture"))
+    }
+
+    fn submit_reverse_broker_job(
+        &self,
+        _runner_id: &str,
+        _request: RemoteRunnerJobRequest,
+    ) -> Result<Job> {
+        Err(Error::internal_unexpected("not used by idle fixture"))
+    }
+}
+
 static CONFIG_LOCK_STRICT_TEST: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 fn with_strict_config_lock(test: impl FnOnce()) {
@@ -1516,6 +1558,8 @@ fn accepted_runner_cancellation_fails_closed_when_daemon_cannot_be_reached() {
         },
     )
     .expect("accepted runner handoff");
+
+    let _runner = RunnerContinuationTestGuard::install(Box::new(IdleRunnerFixture));
 
     let _cancel = super::cancellation::test_cancel_hook::install(Box::new(
         |_runner_id, _runner_job_id, _durable_run_id| {

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -530,8 +530,14 @@ pub(crate) fn controller_upgrade_admission_for_records(
                     .get(record.run_id.as_str())
                     .copied()
                     .unwrap_or(&record.run_id);
+                let locally_reconcilable_after_runner_idle =
+                    record.is_locally_reconcilable_after_runner_idle();
                 let recovery_command = if invalid_handoff_parents.contains(record.run_id.as_str()) {
                     "homeboy agent-task reconcile-records --dry-run".to_string()
+                } else if locally_reconcilable_after_runner_idle {
+                    format!(
+                        "homeboy --placement local agent-task reconcile {group_run_id} --apply"
+                    )
                 } else {
                     match record.runner_id() {
                         Some(runner)
@@ -587,7 +593,9 @@ pub(crate) fn controller_upgrade_admission_for_records(
                     scope,
                     postcondition: postcondition.to_string(),
                     liveness: liveness.as_str(),
-                    reason: if runner_unverified {
+                    reason: if locally_reconcilable_after_runner_idle {
+                        "ownerless_queued_after_runner_reconciliation".to_string()
+                    } else if runner_unverified {
                         "runner_job_unverified_after_daemon_restart".to_string()
                     } else {
                         stale_reason_for_record(record)

--- a/crates/homeboy-agents/src/agent_task_service/reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_service/reconcile.rs
@@ -328,6 +328,8 @@ pub fn reconcile_run(run_id: &str, dry_run: bool) -> Result<AgentTaskReconcileRe
                 // Re-read immediately before apply. A newly-live runner or a changed
                 // owner is authoritative and turns this scoped request into a no-op.
                 let refreshed = rooted_exact_status(&lifecycle_store, resolved_run_id)?;
+                let locally_reconcilable_after_runner_idle =
+                    refreshed.is_locally_reconcilable_after_runner_idle();
                 let still_reconcilable = discover_runs(AgentTaskDiscoveryFilter::Active)?
                     .runs
                     .into_iter()
@@ -346,6 +348,7 @@ pub fn reconcile_run(run_id: &str, dry_run: bool) -> Result<AgentTaskReconcileRe
                     });
                 } else if refreshed.runner_id().is_some()
                     && refreshed.runner_job_id().is_some()
+                    && !locally_reconcilable_after_runner_idle
                     && refreshed.runner_id().is_some_and(|runner_id| {
                         agent_task_lifecycle::runner_authority(runner_id)
                             != agent_task_lifecycle::RunnerAuthority::Removed
@@ -376,6 +379,7 @@ pub fn reconcile_run(run_id: &str, dry_run: bool) -> Result<AgentTaskReconcileRe
                     if let Some(runner_id) = refreshed.runner_id() {
                         if agent_task_lifecycle::runner_authority(runner_id)
                             != agent_task_lifecycle::RunnerAuthority::Removed
+                            && !locally_reconcilable_after_runner_idle
                         {
                             failed += 1;
                             runs.push(AgentTaskReconcileRun {

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -1939,6 +1939,160 @@ fn upgrade_admission_keeps_configured_disconnected_runner_ownership() {
 }
 
 #[test]
+fn upgrade_admission_repairs_ownerless_queued_runner_record_after_zero_live_reconciliation() {
+    with_isolated_home(|_| {
+        let cook_id = "cook-queued-after-runner-reconcile";
+        let run_id = agent_task_lifecycle::cook_attempt_run_id(cook_id, 1);
+        let _runner = agent_task_lifecycle::RunnerContinuationTestGuard::install(Box::new(
+            RunnerAuthorityFixture::configured_idle(),
+        ));
+        agent_task_lifecycle::submit_plan(&discovery_plan(), Some(&run_id)).expect("submitted");
+        agent_task_lifecycle::rewrite_record_for_test(&run_id, |record| {
+            record.metadata["cook_id"] = serde_json::json!(cook_id);
+            record.metadata["runner_id"] = serde_json::json!("homeboy-lab");
+            record.metadata["runner_job_id"] = serde_json::json!("stale-zero-live-job");
+            record.metadata["provider_executions_consumed"] = serde_json::json!(0);
+            record
+                .metadata
+                .as_object_mut()
+                .expect("metadata")
+                .remove("runner_pid");
+        })
+        .expect("record ownerless queued runner child");
+
+        let queued = agent_task_lifecycle::exact_record(&run_id).expect("queued record");
+        assert!(queued.is_ownerless_zero_artifact_queued_runner_record());
+        assert!(queued.is_locally_reconcilable_after_runner_idle());
+        let (records, health) = agent_task_lifecycle::read_records_with_health().expect("records");
+        let blocked =
+            controller_upgrade_admission_for_records(&records, health, chrono::Utc::now());
+        assert_eq!(blocked.blockers.len(), 1);
+        assert_eq!(blocked.blockers[0].run_id, run_id);
+        assert_eq!(blocked.blockers[0].owner, "durable_agent_tasks");
+        assert_eq!(
+            blocked.blockers[0].reason,
+            "ownerless_queued_after_runner_reconciliation"
+        );
+        assert_eq!(
+            blocked.blockers[0].recovery_command,
+            format!("homeboy --placement local agent-task reconcile {run_id} --apply")
+        );
+        assert!(!blocked.blockers[0]
+            .recovery_command
+            .contains("runner reconcile"));
+
+        let repaired = reconcile_run(&run_id, false).expect("bounded agent-task repair");
+        assert_eq!(repaired.reconciled, 1, "{repaired:?}");
+        assert_eq!(repaired.runs[0].action, "reconciled");
+        assert_eq!(
+            agent_task_lifecycle::exact_record(&run_id)
+                .expect("terminal repaired record")
+                .state,
+            AgentTaskRunState::Cancelled
+        );
+
+        let (records, health) = agent_task_lifecycle::read_records_with_health().expect("records");
+        let admitted =
+            controller_upgrade_admission_for_records(&records, health, chrono::Utc::now());
+        assert!(admitted.allows_controller_replacement(), "{admitted:?}");
+        assert!(admitted.blockers.is_empty());
+    });
+}
+
+#[test]
+fn upgrade_admission_keeps_ownerless_queued_runner_record_on_runner_plane_without_idle_evidence() {
+    with_isolated_home(|_| {
+        let run_id = "queued-without-idle-runner-evidence";
+        let _runner = agent_task_lifecycle::RunnerContinuationTestGuard::install(Box::new(
+            RunnerAuthorityFixture::configured_disconnected(),
+        ));
+        agent_task_lifecycle::submit_plan(&discovery_plan(), Some(run_id)).expect("submitted");
+        agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+            record.metadata["runner_id"] = serde_json::json!("homeboy-lab");
+            record.metadata["runner_job_id"] = serde_json::json!("unverified-job");
+            record.metadata["provider_executions_consumed"] = serde_json::json!(0);
+            record
+                .metadata
+                .as_object_mut()
+                .expect("metadata")
+                .remove("runner_pid");
+        })
+        .expect("record ownerless queued runner child");
+
+        let (records, health) = agent_task_lifecycle::read_records_with_health().expect("records");
+        let admission =
+            controller_upgrade_admission_for_records(&records, health, chrono::Utc::now());
+        assert_eq!(admission.blockers.len(), 1);
+        assert_eq!(admission.blockers[0].owner, "runner_generations");
+        assert_eq!(
+            admission.blockers[0].recovery_command,
+            "homeboy runner reconcile homeboy-lab"
+        );
+        let report = reconcile_run(run_id, false).expect("runner plane remains fail-closed");
+        assert_eq!(report.reconciled, 0);
+        assert_eq!(report.runs[0].action, "no-op");
+    });
+}
+
+#[test]
+fn idle_runner_evidence_does_not_reclaim_live_or_ambiguous_queued_records() {
+    with_isolated_home(|_| {
+        let _runner = agent_task_lifecycle::RunnerContinuationTestGuard::install(Box::new(
+            RunnerAuthorityFixture::configured_idle(),
+        ));
+        let now = chrono::Utc::now();
+        for run_id in ["queued-without-job", "queued-planned", "queued-supervised"] {
+            agent_task_lifecycle::submit_plan(&discovery_plan(), Some(run_id)).expect("submitted");
+            agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+                record.metadata["runner_id"] = serde_json::json!("homeboy-lab");
+                record.metadata["runner_job_id"] = serde_json::json!("stale-job");
+                match run_id {
+                    "queued-without-job" => {
+                        record
+                            .metadata
+                            .as_object_mut()
+                            .expect("metadata")
+                            .remove("runner_job_id");
+                    }
+                    "queued-planned" => {
+                        record.metadata["runner_execution_record"] = serde_json::json!({
+                            "status": "planned",
+                            "agent_task_run_id": run_id,
+                            "runner_id": "homeboy-lab",
+                        });
+                    }
+                    "queued-supervised" => {
+                        record.metadata["cook_id"] = serde_json::json!("supervised-cook");
+                        record.metadata["local_cook_supervisor"] = serde_json::json!({
+                            "state": "supervising",
+                            "pinned_run_id": run_id,
+                            "lease_started_at": now.to_rfc3339(),
+                            "lease_expires_at": (now
+                                + chrono::Duration::seconds(
+                                    agent_task_lifecycle::LOCAL_COOK_SUPERVISOR_LEASE_SECONDS
+                                ))
+                            .to_rfc3339(),
+                        });
+                    }
+                    _ => unreachable!(),
+                }
+            })
+            .expect("record queued runner state");
+
+            let record = agent_task_lifecycle::exact_record(run_id).expect("queued record");
+            assert!(!record.is_ownerless_zero_artifact_queued_runner_record());
+            assert!(!record.is_locally_reconcilable_after_runner_idle());
+        }
+
+        record_stale_accepted_lab_handoff("accepted-idle-runner", "homeboy-lab");
+        let accepted = agent_task_lifecycle::exact_record("accepted-idle-runner")
+            .expect("accepted runner record");
+        assert!(!accepted.is_ownerless_zero_artifact_queued_runner_record());
+        assert!(!accepted.is_locally_reconcilable_after_runner_idle());
+    });
+}
+
+#[test]
 fn upgrade_admission_keeps_provider_unavailable_runner_ownership() {
     with_isolated_home(|_| {
         let cook_id = "unknown-offline-cook-run";
@@ -3077,6 +3231,7 @@ fn record_stale_accepted_lab_handoff(run_id: &str, runner_id: &str) {
 struct RunnerAuthorityFixture {
     authority: agent_task_lifecycle::RunnerAuthority,
     connected: bool,
+    live_job_authority: agent_task_lifecycle::RunnerLiveJobAuthority,
 }
 
 impl RunnerAuthorityFixture {
@@ -3084,6 +3239,15 @@ impl RunnerAuthorityFixture {
         Self {
             authority: agent_task_lifecycle::RunnerAuthority::Configured,
             connected: false,
+            live_job_authority: agent_task_lifecycle::RunnerLiveJobAuthority::Unknown,
+        }
+    }
+
+    fn configured_idle() -> Self {
+        Self {
+            authority: agent_task_lifecycle::RunnerAuthority::Configured,
+            connected: true,
+            live_job_authority: agent_task_lifecycle::RunnerLiveJobAuthority::Idle,
         }
     }
 
@@ -3091,6 +3255,7 @@ impl RunnerAuthorityFixture {
         Self {
             authority: agent_task_lifecycle::RunnerAuthority::Removed,
             connected: false,
+            live_job_authority: agent_task_lifecycle::RunnerLiveJobAuthority::Unknown,
         }
     }
 
@@ -3098,6 +3263,7 @@ impl RunnerAuthorityFixture {
         Self {
             authority: agent_task_lifecycle::RunnerAuthority::Unknown,
             connected: false,
+            live_job_authority: agent_task_lifecycle::RunnerLiveJobAuthority::Unknown,
         }
     }
 }
@@ -3119,6 +3285,13 @@ impl agent_task_lifecycle::RunnerContinuationProvider for RunnerAuthorityFixture
 
     fn runner_authority(&self, _runner_id: &str) -> agent_task_lifecycle::RunnerAuthority {
         self.authority
+    }
+
+    fn runner_live_job_authority(
+        &self,
+        _runner_id: &str,
+    ) -> agent_task_lifecycle::RunnerLiveJobAuthority {
+        self.live_job_authority
     }
 
     fn run_continuation_exec(

--- a/crates/homeboy-lab-runner/src/continuation_provider.rs
+++ b/crates/homeboy-lab-runner/src/continuation_provider.rs
@@ -6,7 +6,7 @@
 //! execution, and evidence functions.
 
 use homeboy_agents::agent_task_lifecycle::{
-    RunnerAuthority, RunnerContinuationProvider, RunnerJobReconciliation,
+    RunnerAuthority, RunnerContinuationProvider, RunnerJobReconciliation, RunnerLiveJobAuthority,
 };
 use homeboy_core::api_jobs::{Job, RemoteRunnerJobRequest, RunnerJobLogSnapshot};
 use std::time::Duration;
@@ -202,6 +202,17 @@ impl RunnerContinuationProvider for RunnerContinuation {
         runner_authority_from_inventory(runner_id, super::list(), || super::load(runner_id).is_ok())
     }
 
+    fn runner_live_job_authority(&self, runner_id: &str) -> RunnerLiveJobAuthority {
+        match super::runner_admission_snapshot(runner_id) {
+            Ok(snapshot) => runner_live_job_authority_from_admission(
+                snapshot.summary.active_job_count,
+                snapshot.summary.safe_to_rotate,
+                snapshot.summary.unresolved_retained_projection_count,
+            ),
+            Err(_) => RunnerLiveJobAuthority::Unknown,
+        }
+    }
+
     fn run_continuation_exec(
         &self,
         runner_id: &str,
@@ -236,6 +247,20 @@ impl RunnerContinuationProvider for RunnerContinuation {
     ) -> Result<homeboy_core::api_jobs::RemoteRunnerSubmissionLookup> {
         super::connection::lookup_reverse_broker_submission(runner_id, submission_key)
     }
+}
+
+fn runner_live_job_authority_from_admission(
+    active_job_count: usize,
+    safe_to_rotate: bool,
+    unresolved_retained_projection_count: usize,
+) -> RunnerLiveJobAuthority {
+    if active_job_count > 0 {
+        return RunnerLiveJobAuthority::Busy;
+    }
+    if safe_to_rotate && unresolved_retained_projection_count == 0 {
+        return RunnerLiveJobAuthority::Idle;
+    }
+    RunnerLiveJobAuthority::Unknown
 }
 
 fn runner_authority_from_inventory(
@@ -478,6 +503,26 @@ mod tests {
         let mut runner = super::super::load("local").expect("built-in local runner");
         runner.id = id.to_string();
         runner
+    }
+
+    #[test]
+    fn live_job_authority_maps_reconciled_idle_busy_and_unknown_admission() {
+        assert_eq!(
+            runner_live_job_authority_from_admission(0, true, 0),
+            RunnerLiveJobAuthority::Idle
+        );
+        assert_eq!(
+            runner_live_job_authority_from_admission(2, false, 0),
+            RunnerLiveJobAuthority::Busy
+        );
+        assert_eq!(
+            runner_live_job_authority_from_admission(0, true, 1),
+            RunnerLiveJobAuthority::Unknown
+        );
+        assert_eq!(
+            runner_live_job_authority_from_admission(0, false, 0),
+            RunnerLiveJobAuthority::Unknown
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- distinguish authoritative zero-live-job runner evidence from unknown or busy runner ownership
- route only ownerless, zero-artifact queued residue to bounded local agent-task reconciliation
- keep accepted handoffs, planned execution, live supervisors, malformed evidence, and unavailable runner probes fail-closed
- make upgrade admission prescribe the reconciliation plane that can actually clear the blocker

Closes #13798

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p homeboy-agents -p homeboy-lab-runner`
- `cargo test -p homeboy-agents upgrade_admission_`
- `cargo test -p homeboy-agents idle_runner_evidence_does_not_reclaim_live_or_ambiguous_queued_records`
- `cargo test -p homeboy-agents accepted_runner_cancellation_fails_closed_when_daemon_cannot_be_reached`
- `cargo test -p homeboy-agents reconcile_`
- `cargo test -p homeboy-lab-runner continuation_provider::tests::`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol through OpenCode traced the contradictory runner and durable-record projections, reviewed and narrowed the existing candidate, implemented fail-closed ownership guards, and ran focused regression verification under Chris Huber’s direction.