### PR TITLE
Scope release staging handles to owners

### DIFF
--- a/crates/homeboy-release/src/release/workspace.rs
+++ b/crates/homeboy-release/src/release/workspace.rs
@@ -54,13 +54,19 @@ impl ReleaseWorkspace {
 
         let config = defaults::load_config();
         let source_sha = verified_remote_default_sha(component)?;
-        let owner_run_ref = format!("release/{}", Uuid::new_v4());
+        let owner_id = Uuid::new_v4();
+        let owner_run_ref = format!("release/{owner_id}");
         let lifecycle = WorktreeProviderLifecycleIntent {
             purpose: "release_staging".to_string(),
             owner_run_ref: owner_run_ref.clone(),
             cleanup_policy: WorktreeProviderCleanupPolicy::RemoveOnSuccess,
         };
-        let branch = format!("release-{}-{}", component.id, &source_sha[..12]);
+        let branch = format!(
+            "release-{}-{}-{}",
+            component.id,
+            &source_sha[..12],
+            &owner_id.simple().to_string()[..12]
+        );
         let handle = homeboy_core::worktree::handle_for_branch(&component.id, &branch);
         let mut intent = WorktreeProviderCreateIntent {
             handle: handle.clone(),
@@ -724,6 +730,9 @@ mod tests {
                 .handle
                 .as_deref()
                 .is_some_and(|handle| handle.starts_with("fixture@release-fixture-")));
+            let second = ReleaseWorkspace::select(&test_roots(), &component, false)
+                .expect("independent staging from the same source");
+            assert_ne!(workspace.output.handle, second.output.handle);
             assert_ne!(workspace.component.local_path, component.local_path);
             assert_eq!(
                 git::head_sha(Path::new(&workspace.component.local_path)),


### PR DESCRIPTION
## Summary

- retain component and source SHA in release staging branch names
- append the release owner UUID so independent runs cannot collide
- keep recovery deterministic through the persisted provision intent
- prove two runs from the same source produce distinct staging handles

Closes #13810.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-release dirty_default_checkout_stages_through_the_builtin_provider`
- `git diff --check`
- `cargo clippy -p homeboy-release -- -D warnings` reaches pre-existing `homeboy-core` Rust 1.95 lint failures unrelated to this file

## AI assistance

GPT-5.6 Sol via OpenCode traced the preserved-failure collision, implemented the owner-scoped identity change, and ran focused verification.