### PR TITLE
Persist inspectable upgrade operation progress

### DIFF
--- a/crates/homeboy-cli/src/command_contract/descriptors.rs
+++ b/crates/homeboy-cli/src/command_contract/descriptors.rs
@@ -47,7 +47,7 @@ macro_rules! builtin_json_command_descriptors {
             (SelfCmd, $crate::commands::self_cmd::run, CommandSpec { subcommand_safety: SELF_SUBCOMMAND_SAFETY, ..command_spec_with_output_notes("self", CommandJsonFamily::Ops, "inspects the active Homeboy runtime and renders built-in CLI documentation") }),
             (Stack, $crate::commands::stack::run, CommandSpec { subcommand_safety: STACK_SUBCOMMAND_SAFETY, ..command_spec("stack", CommandJsonFamily::Workspace) }),
             (Api, $crate::commands::api::run, CommandSpec { subcommand_safety: API_SUBCOMMAND_SAFETY, ..command_spec("api", CommandJsonFamily::Ops) }),
-            (Upgrade, $crate::commands::upgrade::run, command_spec_with_output_notes_and_safety("upgrade", CommandJsonFamily::Ops, "upgrades the active Homeboy binary, extensions, runners, and services unless --check or skip flags are used", operator_safety(None, UPGRADE_DANGEROUS_FLAGS))),
+            (Upgrade, $crate::commands::upgrade::run, CommandSpec { subcommand_safety: UPGRADE_SUBCOMMAND_SAFETY, ..command_spec_with_output_notes_and_safety("upgrade", CommandJsonFamily::Ops, "upgrades the active Homeboy binary, extensions, runners, and services unless --check or skip flags are used", operator_safety(None, UPGRADE_DANGEROUS_FLAGS)) }),
         }
     };
 }

--- a/crates/homeboy-cli/src/command_contract/spec.rs
+++ b/crates/homeboy-cli/src/command_contract/spec.rs
@@ -1069,6 +1069,12 @@ const CLEANUP_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[paths_safety(
     "default output is a non-mutating cleanup plan; pass --apply to remove artifacts",
 )];
 
+const UPGRADE_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[paths_safety(
+    &["status"],
+    CommandSafetySpec::read_only(),
+    "inspects a persisted upgrade operation without mutating the controller",
+)];
+
 const SELF_SUBCOMMAND_SAFETY: &[CommandPathSafetySpec] = &[
     paths_safety(
         &["docs map"],

--- a/crates/homeboy-cli/src/commands/upgrade.rs
+++ b/crates/homeboy-cli/src/commands/upgrade.rs
@@ -1,4 +1,4 @@
-use clap::Args;
+use clap::{Args, Subcommand};
 use homeboy_upgrade::upgrade;
 use serde_json::Value;
 use std::path::PathBuf;
@@ -68,9 +68,28 @@ pub struct UpgradeArgs {
     /// Pin the published release tag to install instead of the newest installable release
     #[arg(long = "version", value_name = "TAG", conflicts_with = "check")]
     pub pin_version: Option<String>,
+
+    #[command(subcommand)]
+    pub command: Option<UpgradeCommand>,
+}
+
+#[derive(Subcommand)]
+pub enum UpgradeCommand {
+    /// Inspect a persisted upgrade operation
+    Status {
+        /// Operation id from a previous `homeboy upgrade`. Defaults to the latest upgrade run.
+        id: Option<String>,
+    },
 }
 
 pub fn run(args: UpgradeArgs) -> CmdResult<Value> {
+    if let Some(UpgradeCommand::Status { id }) = args.command {
+        let result = upgrade::load_upgrade_operation_status(id.as_deref())?;
+        let json = serde_json::to_value(result)
+            .map_err(|e| homeboy::core::Error::internal_json(e.to_string(), None))?;
+        return Ok((json, 0));
+    }
+
     if args.check {
         let result = upgrade::check_for_updates()?;
         // A check that quietly withholds an update because the newest release
@@ -382,6 +401,7 @@ mod tests {
             extensions_unrefreshed: Vec::new(),
             services_restarted: Vec::new(),
             services_pending_restart: Vec::new(),
+            operation_id: None,
         }
     }
 }

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -5,11 +5,16 @@ use homeboy_extension as extension;
 use semver::Version;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 
 use super::constants::{GITHUB_RELEASES_API, VERSION};
 use super::execution::{
     execute_upgrade, installed_target_build_identity, prepare_source_workspace_for_upgrade,
     resolve_source_workspace,
+};
+use super::operation::{
+    persist_extension_progress, run_with_upgrade_heartbeats, UpgradeOperation,
+    UPGRADE_PROGRESS_HEARTBEAT_INTERVAL,
 };
 use super::release_catalog::{self, InstallableSelection, ReleaseEntry, SelectedRelease};
 use super::services;
@@ -381,10 +386,13 @@ pub fn run_upgrade_with_method(
             check.update_available,
         ) {
             // Even when no binary update is needed, still run extension updates.
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
             let (extensions_updated, extension_skips) = if skip_extensions {
+                operation.mark_extensions("skipped", "extension refresh skipped");
                 (vec![], vec![])
             } else {
-                update_all_extensions()
+                operation.set_phase("refreshing installed extensions");
+                update_all_extensions(operation.id())
             };
             let promotion_lease = homeboy_core::runtime_promotion::acquire(
                 "controller upgrade completion",
@@ -423,7 +431,7 @@ pub fn run_upgrade_with_method(
                 &extensions_updated,
                 &extension_skips,
             );
-            return Ok(UpgradeResult {
+            let result = UpgradeResult {
                 command: "upgrade".to_string(),
                 install_method,
                 previous_version: previous_version.clone(),
@@ -477,7 +485,9 @@ pub fn run_upgrade_with_method(
                 // current binary and need no restart.
                 services_restarted: Vec::new(),
                 services_pending_restart: Vec::new(),
-            });
+                operation_id: None,
+            };
+            return Ok(complete_upgrade_operation(operation, result));
         }
     }
 
@@ -499,6 +509,8 @@ pub fn run_upgrade_with_method(
             extension_revalidation,
         ));
     }
+    let mut operation = UpgradeOperation::start("homeboy upgrade");
+    operation.set_phase("mutating controller");
     let controller_upgrade = run_controller_mutation_after_runner_preflight(
         runner_preflight,
         || {
@@ -547,15 +559,29 @@ pub fn run_upgrade_with_method(
         // before it retain their immutable runtime pin and remain executable.
         let installed_executable = super::execution::active_binary_path()?;
         homeboy_core::controller_runtime::activate_installed_generation(&installed_executable)?;
+        if success {
+            operation.mark_controller_promoted("controller installation completed");
+        }
+    } else if superseded {
+        operation.mark_controller(
+            "superseded",
+            "controller promotion was superseded by the active build",
+        );
+    } else {
+        operation.mark_controller("failed", "controller installation did not complete");
     }
 
     // Auto-update all installed extensions after the upgrade command completes.
     // This prevents CI/local extension version drift that causes baseline
     // mismatches and inconsistent audit findings.
     let (extensions_updated, extension_skips) = if upgrade_completed && !skip_extensions {
-        upgrade_phase("refreshing installed extensions");
-        update_all_extensions()
+        operation.set_phase("refreshing installed extensions");
+        update_all_extensions(operation.id())
+    } else if skip_extensions {
+        operation.mark_extensions("skipped", "extension refresh skipped");
+        (vec![], vec![])
     } else {
+        operation.mark_extensions("not_run", "extension refresh was not attempted");
         (vec![], vec![])
     };
 
@@ -565,7 +591,7 @@ pub fn run_upgrade_with_method(
     )?;
     promotion_lease.assert_generation()?;
     let (runners_updated, runners_skipped) = if upgrade_completed && !skip_runners {
-        upgrade_phase("refreshing configured runners");
+        operation.set_phase("refreshing configured runners");
         super::with_runner_upgrade(|p| {
             p.upgrade_configured_runners_with_explicit_source_path(
                 force,
@@ -603,7 +629,7 @@ pub fn run_upgrade_with_method(
         &extension_skips,
     );
 
-    Ok(UpgradeResult {
+    let result = UpgradeResult {
         command: "upgrade".to_string(),
         install_method,
         previous_version,
@@ -671,7 +697,9 @@ pub fn run_upgrade_with_method(
         runners_skipped,
         services_restarted,
         services_pending_restart,
-    })
+        operation_id: None,
+    };
+    Ok(complete_upgrade_operation(operation, result))
 }
 
 fn source_upgrade_noop_result(
@@ -710,6 +738,7 @@ fn source_upgrade_noop_result(
         extensions_unrefreshed: Vec::new(),
         services_restarted: Vec::new(),
         services_pending_restart: Vec::new(),
+        operation_id: None,
     }
 }
 
@@ -769,6 +798,7 @@ fn runner_preflight_failure_result(
         extensions_unrefreshed: Vec::new(),
         services_restarted: Vec::new(),
         services_pending_restart: Vec::new(),
+        operation_id: None,
     }
 }
 
@@ -817,6 +847,7 @@ fn extension_preflight_failure_result(
         extensions_unrefreshed: Vec::new(),
         services_restarted: Vec::new(),
         services_pending_restart: Vec::new(),
+        operation_id: None,
     }
 }
 
@@ -1228,6 +1259,7 @@ fn run_targeted_runner_upgrade(
         extensions_unrefreshed: Vec::new(),
         services_restarted: Vec::new(),
         services_pending_restart: Vec::new(),
+        operation_id: None,
     })
 }
 
@@ -1642,10 +1674,21 @@ pub(crate) fn should_sync_after_upgrade(new_version: Option<&str>) -> bool {
     new_version.is_some()
 }
 
+fn complete_upgrade_operation(
+    mut operation: UpgradeOperation,
+    mut result: UpgradeResult,
+) -> UpgradeResult {
+    operation.finish_completed(&result);
+    result.operation_id = operation.id().map(str::to_string);
+    result
+}
+
 /// Update all installed extensions. Best-effort — failures are logged, and the
 /// extension is added to the skipped list carrying its error reason so the
 /// structured result can say *why* it was skipped (#12181).
-fn update_all_extensions() -> (Vec<ExtensionUpgradeEntry>, Vec<ExtensionUpgradeSkip>) {
+fn update_all_extensions(
+    operation_id: Option<&str>,
+) -> (Vec<ExtensionUpgradeEntry>, Vec<ExtensionUpgradeSkip>) {
     let extension_ids = extension::available_extension_ids();
     if extension_ids.is_empty() {
         return (vec![], vec![]);
@@ -1660,13 +1703,22 @@ fn update_all_extensions() -> (Vec<ExtensionUpgradeEntry>, Vec<ExtensionUpgradeS
     let mut updated = Vec::new();
     let mut skipped = Vec::new();
 
-    for id in &extension_ids {
+    for (index, id) in extension_ids.iter().enumerate() {
         let old_version = extension::load_extension(id)
             .ok()
             .map(|m| m.version.clone())
             .unwrap_or_default();
 
-        match extension::update(id, false) {
+        let current = index + 1;
+        let total = extension_ids.len();
+        report_extension_progress(operation_id, id, current, total, Duration::ZERO);
+        let update_result = run_with_upgrade_heartbeats(
+            UPGRADE_PROGRESS_HEARTBEAT_INTERVAL,
+            |elapsed| report_extension_progress(operation_id, id, current, total, elapsed),
+            || extension::update(id, false),
+        );
+
+        match update_result {
             Ok(result) => {
                 let new_version = extension::load_extension(id)
                     .ok()
@@ -1735,6 +1787,25 @@ fn update_all_extensions() -> (Vec<ExtensionUpgradeEntry>, Vec<ExtensionUpgradeS
     }
 
     (updated, skipped)
+}
+
+fn report_extension_progress(
+    operation_id: Option<&str>,
+    extension_id: &str,
+    current: usize,
+    total: usize,
+    elapsed: Duration,
+) {
+    if let Some(run_id) = operation_id {
+        persist_extension_progress(run_id, extension_id, current, total, elapsed);
+        return;
+    }
+    upgrade_phase(&super::operation::upgrade_extension_progress_message(
+        extension_id,
+        current,
+        total,
+        elapsed,
+    ));
 }
 
 /// Detect unrefreshed symlinked extension clones and log a loud, actionable

--- a/crates/homeboy-upgrade/src/upgrade/mod.rs
+++ b/crates/homeboy-upgrade/src/upgrade/mod.rs
@@ -2,6 +2,7 @@ mod admission;
 mod constants;
 mod execution;
 mod helpers;
+mod operation;
 mod planning;
 pub mod release_catalog;
 mod runner_upgrade_provider;
@@ -20,6 +21,7 @@ pub use helpers::{
     current_build_version, current_version, detect_install_method, fetch_latest_version,
     run_upgrade_with_method, version_is_newer,
 };
+pub use operation::{load_upgrade_operation_status, UpgradeOperationStatus};
 pub use planning::resolve_binary_on_path;
 pub use release_catalog::{
     running_target_triple, InstallableSelection, ReleaseRef, SelectedRelease,

--- a/crates/homeboy-upgrade/src/upgrade/operation.rs
+++ b/crates/homeboy-upgrade/src/upgrade/operation.rs
@@ -1,0 +1,594 @@
+//! Durable upgrade operation identity on the existing observation run store.
+//!
+//! Binary promotion and optional post-install refresh are independent phases.
+//! Persisting them before mutation lets a timed-out client inspect whether the
+//! controller actually promoted, instead of guessing from a silent hang.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use homeboy_core::error::{Error, Result};
+use homeboy_core::observation::{
+    run_owner_pid, running_status_note, ActiveObservation, NewRunRecord, ObservationStore,
+    RunListFilter, RunRecord, RunStatus,
+};
+
+use super::types::{UpgradeComponentStatus, UpgradeResult};
+
+pub const UPGRADE_OPERATION_KIND: &str = "upgrade";
+pub const UPGRADE_OPERATION_SCHEMA: &str = "homeboy/upgrade-operation/v1";
+pub const UPGRADE_PROGRESS_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UpgradeOperationStatus {
+    pub command: String,
+    pub operation_id: String,
+    pub status: String,
+    pub phase: String,
+    pub elapsed_seconds: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub controller: Option<UpgradeComponentStatus>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<UpgradeComponentStatus>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runners: Option<UpgradeComponentStatus>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_pid: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inspect_command: Option<String>,
+}
+
+pub struct UpgradeOperation {
+    observation: Option<ActiveObservation>,
+    metadata: Value,
+    started: Instant,
+    finished: bool,
+    controller_promoted: bool,
+}
+
+impl UpgradeOperation {
+    pub fn start(command: impl Into<String>) -> Self {
+        let metadata = json!({
+            "schema": UPGRADE_OPERATION_SCHEMA,
+            "phase": "admitted",
+            "elapsed_seconds": 0,
+            "controller": component("pending", "controller mutation has not started"),
+            "extensions": component("pending", "extension refresh has not started"),
+            "runners": component("pending", "runner refresh has not started"),
+            "homeboy_run_owner": { "pid": std::process::id() },
+        });
+        let observation = ActiveObservation::start_best_effort(
+            NewRunRecord::builder(UPGRADE_OPERATION_KIND)
+                .component_id("homeboy")
+                .command(command.into())
+                .current_homeboy_version()
+                .metadata(metadata.clone())
+                .build(),
+        );
+        let operation = Self {
+            observation,
+            metadata,
+            started: Instant::now(),
+            finished: false,
+            controller_promoted: false,
+        };
+        if let Some(id) = operation.id() {
+            emit_upgrade_phase(&format!("operation={id}"));
+        }
+        operation
+    }
+
+    pub fn id(&self) -> Option<&str> {
+        self.observation.as_ref().map(ActiveObservation::run_id)
+    }
+
+    pub fn set_phase(&mut self, phase: &str) {
+        emit_upgrade_phase(phase);
+        self.metadata["phase"] = json!(phase);
+        self.metadata["elapsed_seconds"] = json!(self.started.elapsed().as_secs());
+        self.persist();
+    }
+
+    pub fn mark_controller_promoted(&mut self, summary: &str) {
+        self.controller_promoted = true;
+        self.metadata["controller"] = component("updated", summary);
+        self.set_phase(
+            "controller installation verified; continuing with optional post-install refresh",
+        );
+    }
+
+    pub fn mark_controller(&mut self, status: &str, summary: &str) {
+        if status == "updated" {
+            self.controller_promoted = true;
+        }
+        self.metadata["controller"] = component(status, summary);
+        self.persist();
+    }
+
+    pub fn mark_extensions(&mut self, status: &str, summary: &str) {
+        self.metadata["extensions"] = component(status, summary);
+        self.persist();
+    }
+
+    pub fn finish_completed(&mut self, result: &UpgradeResult) {
+        if let Some(status) = &result.controller {
+            self.metadata["controller"] = json!(status);
+            if status.status == "updated" {
+                self.controller_promoted = true;
+            }
+        }
+        if let Some(status) = &result.extensions {
+            self.metadata["extensions"] = json!(status);
+        }
+        if let Some(status) = &result.runners {
+            self.metadata["runners"] = json!(status);
+        }
+        self.metadata["phase"] = json!("completed");
+        self.metadata["elapsed_seconds"] = json!(self.started.elapsed().as_secs());
+        let status = if result
+            .controller
+            .as_ref()
+            .is_some_and(|controller| controller.status == "failed")
+        {
+            RunStatus::Fail
+        } else {
+            RunStatus::Pass
+        };
+        self.finish(status);
+    }
+
+    fn persist(&mut self) {
+        let Some(observation) = &self.observation else {
+            return;
+        };
+        self.metadata["elapsed_seconds"] = json!(self.started.elapsed().as_secs());
+        let _ = observation
+            .store()
+            .update_run_metadata(observation.run_id(), self.metadata.clone());
+    }
+
+    fn finish(&mut self, status: RunStatus) {
+        if self.finished {
+            return;
+        }
+        self.finished = true;
+        let Some(observation) = &self.observation else {
+            return;
+        };
+        if let Ok(Some(run)) = observation.store().get_run(observation.run_id()) {
+            merge_component_fields(&mut self.metadata, &run.metadata_json);
+            if let Some(elapsed) = run.metadata_json.get("elapsed_seconds") {
+                self.metadata["elapsed_seconds"] = elapsed.clone();
+            }
+        }
+        self.metadata["elapsed_seconds"] = json!(self.started.elapsed().as_secs());
+        let _ = observation.store().finish_running_run(
+            observation.run_id(),
+            status,
+            Some(self.metadata.clone()),
+        );
+    }
+}
+
+impl Drop for UpgradeOperation {
+    fn drop(&mut self) {
+        if self.finished {
+            return;
+        }
+        if self.controller_promoted {
+            self.metadata["phase"] = json!("interrupted_after_controller");
+            if self.metadata["extensions"]["status"] == "pending"
+                || self.metadata["extensions"]["status"] == "running"
+            {
+                self.metadata["extensions"] = component(
+                    "interrupted",
+                    "optional refresh did not finish after controller promotion",
+                );
+            }
+            self.finish(RunStatus::Pass);
+            return;
+        }
+        self.metadata["phase"] = json!("interrupted");
+        self.finish(RunStatus::Error);
+    }
+}
+
+pub fn load_upgrade_operation_status(id: Option<&str>) -> Result<UpgradeOperationStatus> {
+    let store = ObservationStore::open_initialized()?;
+    let run = match id {
+        Some(id) => store.get_run(id)?.ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "id",
+                format!("upgrade operation not found: {id}"),
+                Some(id.to_string()),
+                None,
+            )
+        })?,
+        None => store
+            .latest_run(RunListFilter {
+                kind: Some(UPGRADE_OPERATION_KIND.to_string()),
+                limit: Some(1),
+                ..RunListFilter::default()
+            })?
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "id",
+                    "no upgrade operation has been recorded",
+                    None,
+                    None,
+                )
+            })?,
+    };
+    status_from_run(&run)
+}
+
+pub fn persist_extension_progress(
+    run_id: &str,
+    extension_id: &str,
+    current: usize,
+    total: usize,
+    elapsed: Duration,
+) {
+    emit_upgrade_phase(&upgrade_extension_progress_message(
+        extension_id,
+        current,
+        total,
+        elapsed,
+    ));
+    patch_metadata(run_id, |metadata| {
+        metadata["phase"] = json!("refreshing_installed_extensions");
+        metadata["elapsed_seconds"] = json!(elapsed.as_secs());
+        metadata["extensions"] = component(
+            "running",
+            format!("refreshing {extension_id} ({current}/{total})"),
+        );
+    });
+}
+
+pub fn run_with_upgrade_heartbeats<T>(
+    interval: Duration,
+    heartbeat: impl Fn(Duration) + Send + Sync,
+    operation: impl FnOnce() -> T,
+) -> T {
+    let finished = AtomicBool::new(false);
+    let started = Instant::now();
+    std::thread::scope(|scope| {
+        let finished = &finished;
+        let heartbeat = &heartbeat;
+        let monitor = scope.spawn(move || {
+            while !finished.load(Ordering::Acquire) {
+                std::thread::park_timeout(interval);
+                if !finished.load(Ordering::Acquire) {
+                    heartbeat(started.elapsed());
+                }
+            }
+        });
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(operation));
+        finished.store(true, Ordering::Release);
+        monitor.thread().unpark();
+        monitor.join().expect("upgrade heartbeat monitor panicked");
+        match result {
+            Ok(result) => result,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
+    })
+}
+
+pub(crate) fn emit_upgrade_phase(phase: &str) {
+    eprintln!("[upgrade] {phase}");
+}
+
+pub(crate) fn upgrade_extension_progress_message(
+    id: &str,
+    current: usize,
+    total: usize,
+    elapsed: Duration,
+) -> String {
+    format!(
+        "phase=refreshing_installed_extensions extension={id} item={current}/{total} elapsed={}s",
+        elapsed.as_secs()
+    )
+}
+
+fn component(status: impl Into<String>, summary: impl Into<String>) -> Value {
+    json!({
+        "status": status.into(),
+        "summary": summary.into(),
+    })
+}
+
+fn patch_metadata(run_id: &str, patch: impl FnOnce(&mut Value)) {
+    let Ok(store) = ObservationStore::open_initialized() else {
+        return;
+    };
+    let Ok(Some(run)) = store.get_run(run_id) else {
+        return;
+    };
+    if run.kind != UPGRADE_OPERATION_KIND {
+        return;
+    }
+    let mut metadata = run.metadata_json;
+    patch(&mut metadata);
+    let _ = store.update_run_metadata(run_id, metadata);
+}
+
+fn merge_component_fields(target: &mut Value, source: &Value) {
+    for key in ["controller", "extensions", "runners", "phase"] {
+        if let Some(value) = source.get(key) {
+            if target.get(key).is_none() {
+                target[key] = value.clone();
+            }
+        }
+    }
+}
+
+fn status_from_run(run: &RunRecord) -> Result<UpgradeOperationStatus> {
+    if run.kind != UPGRADE_OPERATION_KIND {
+        return Err(Error::validation_invalid_argument(
+            "id",
+            format!("run {} is not an upgrade operation", run.id),
+            Some(run.id.clone()),
+            None,
+        ));
+    }
+    let schema = run
+        .metadata_json
+        .get("schema")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if !schema.is_empty() && schema != UPGRADE_OPERATION_SCHEMA {
+        return Err(Error::validation_invalid_argument(
+            "id",
+            format!(
+                "upgrade operation {} uses unsupported schema {schema}",
+                run.id
+            ),
+            Some(run.id.clone()),
+            None,
+        ));
+    }
+    Ok(UpgradeOperationStatus {
+        command: "upgrade.status".to_string(),
+        operation_id: run.id.clone(),
+        status: run.status.clone(),
+        phase: run
+            .metadata_json
+            .get("phase")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string(),
+        elapsed_seconds: run
+            .metadata_json
+            .get("elapsed_seconds")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        controller: component_from_metadata(&run.metadata_json, "controller"),
+        extensions: component_from_metadata(&run.metadata_json, "extensions"),
+        runners: component_from_metadata(&run.metadata_json, "runners"),
+        owner_pid: run_owner_pid(run),
+        note: running_status_note(run),
+        inspect_command: Some(format!("homeboy upgrade status {}", run.id)),
+    })
+}
+
+fn component_from_metadata(metadata: &Value, key: &str) -> Option<UpgradeComponentStatus> {
+    let value = metadata.get(key)?;
+    Some(UpgradeComponentStatus {
+        status: value.get("status")?.as_str()?.to_string(),
+        summary: value.get("summary")?.as_str()?.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+
+    #[test]
+    fn extension_progress_identifies_the_blocked_item_and_elapsed_time() {
+        assert_eq!(
+            upgrade_extension_progress_message("wordpress", 2, 3, Duration::from_secs(45)),
+            "phase=refreshing_installed_extensions extension=wordpress item=2/3 elapsed=45s"
+        );
+    }
+
+    #[test]
+    fn blocked_upgrade_work_emits_a_heartbeat_before_it_completes() {
+        let (heartbeat_tx, heartbeat_rx) = mpsc::channel();
+        let result = run_with_upgrade_heartbeats(
+            Duration::from_millis(1),
+            move |elapsed| heartbeat_tx.send(elapsed).expect("record heartbeat"),
+            || {
+                heartbeat_rx
+                    .recv_timeout(Duration::from_secs(1))
+                    .expect("heartbeat while operation remains blocked");
+                42
+            },
+        );
+
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn completed_upgrade_work_does_not_emit_a_late_heartbeat() {
+        let (heartbeat_tx, heartbeat_rx) = mpsc::channel();
+        run_with_upgrade_heartbeats(
+            Duration::from_secs(1),
+            move |elapsed| heartbeat_tx.send(elapsed).expect("record heartbeat"),
+            || (),
+        );
+
+        assert!(heartbeat_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn start_persists_a_running_operation_before_mutation() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let operation = UpgradeOperation::start("homeboy upgrade");
+            let id = operation.id().expect("persisted operation").to_string();
+
+            let status = load_upgrade_operation_status(Some(&id)).expect("load status");
+            assert_eq!(status.operation_id, id);
+            assert_eq!(status.status, RunStatus::Running.as_str());
+            assert_eq!(status.phase, "admitted");
+            assert_eq!(
+                status
+                    .controller
+                    .as_ref()
+                    .map(|component| component.status.as_str()),
+                Some("pending")
+            );
+        });
+    }
+
+    #[test]
+    fn controller_promotion_stays_inspectable_while_extension_refresh_runs() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
+            let id = operation.id().expect("persisted operation").to_string();
+            operation.mark_controller_promoted("controller installation completed");
+            persist_extension_progress(&id, "wordpress", 2, 3, Duration::from_secs(45));
+
+            let status = load_upgrade_operation_status(Some(&id)).expect("load status");
+            assert_eq!(status.status, RunStatus::Running.as_str());
+            assert_eq!(
+                status
+                    .controller
+                    .as_ref()
+                    .map(|component| component.status.as_str()),
+                Some("updated")
+            );
+            assert_eq!(
+                status
+                    .extensions
+                    .as_ref()
+                    .map(|component| component.status.as_str()),
+                Some("running")
+            );
+            assert!(status
+                .extensions
+                .as_ref()
+                .map(|component| component.summary.as_str())
+                .unwrap_or_default()
+                .contains("wordpress"));
+            assert_eq!(status.elapsed_seconds, 45);
+        });
+    }
+
+    #[test]
+    fn interrupting_after_controller_promotion_is_not_a_failed_install() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let id = {
+                let mut operation = UpgradeOperation::start("homeboy upgrade");
+                let id = operation.id().expect("persisted operation").to_string();
+                operation.mark_controller_promoted("controller installation completed");
+                persist_extension_progress(&id, "wordpress", 1, 2, Duration::from_secs(12));
+                id
+            };
+
+            let status = load_upgrade_operation_status(Some(&id)).expect("load status");
+            assert_eq!(status.status, RunStatus::Pass.as_str());
+            assert_eq!(status.phase, "interrupted_after_controller");
+            assert_eq!(
+                status
+                    .controller
+                    .as_ref()
+                    .map(|component| component.status.as_str()),
+                Some("updated")
+            );
+            assert_eq!(
+                status
+                    .extensions
+                    .as_ref()
+                    .map(|component| component.status.as_str()),
+                Some("interrupted")
+            );
+        });
+    }
+
+    #[test]
+    fn latest_status_reports_the_most_recent_upgrade_operation() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let first = UpgradeOperation::start("homeboy upgrade");
+            let first_id = first.id().expect("first").to_string();
+            drop(first);
+            let second = UpgradeOperation::start("homeboy upgrade");
+            let second_id = second.id().expect("second").to_string();
+            drop(second);
+
+            let status = load_upgrade_operation_status(None).expect("latest");
+            assert_eq!(status.operation_id, second_id);
+            assert_ne!(status.operation_id, first_id);
+        });
+    }
+
+    #[test]
+    fn completed_result_is_terminal_pass_with_independent_component_statuses() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
+            let id = operation.id().expect("persisted operation").to_string();
+            let result = UpgradeResult {
+                command: "upgrade".to_string(),
+                install_method: super::super::types::InstallMethod::Binary,
+                previous_version: "0.1.0".to_string(),
+                new_version: Some("0.2.0".to_string()),
+                previous_build_identity: None,
+                new_build_identity: None,
+                source_revision: None,
+                upgraded: true,
+                outcome: Some("controller_updated".to_string()),
+                preflight: None,
+                controller: Some(UpgradeComponentStatus {
+                    status: "updated".to_string(),
+                    summary: "controller installation completed".to_string(),
+                }),
+                extensions: Some(UpgradeComponentStatus {
+                    status: "completed".to_string(),
+                    summary: "1 updated, 0 skipped".to_string(),
+                }),
+                runners: Some(UpgradeComponentStatus {
+                    status: "skipped".to_string(),
+                    summary: "runner convergence skipped".to_string(),
+                }),
+                partial: false,
+                runner_convergence: None,
+                message: "Upgraded".to_string(),
+                restart_required: false,
+                extensions_updated: Vec::new(),
+                extensions_skipped: Vec::new(),
+                extension_skips: Vec::new(),
+                runners_updated: Vec::new(),
+                runners_skipped: Vec::new(),
+                extensions_unrefreshed: Vec::new(),
+                services_restarted: Vec::new(),
+                services_pending_restart: Vec::new(),
+                operation_id: None,
+            };
+            operation.finish_completed(&result);
+
+            let status = load_upgrade_operation_status(Some(&id)).expect("load status");
+            assert_eq!(status.status, RunStatus::Pass.as_str());
+            assert_eq!(status.phase, "completed");
+            assert_eq!(
+                status
+                    .controller
+                    .as_ref()
+                    .map(|component| component.status.as_str()),
+                Some("updated")
+            );
+            assert_eq!(
+                status
+                    .extensions
+                    .as_ref()
+                    .map(|component| component.status.as_str()),
+                Some("completed")
+            );
+        });
+    }
+}

--- a/crates/homeboy-upgrade/src/upgrade/types.rs
+++ b/crates/homeboy-upgrade/src/upgrade/types.rs
@@ -167,6 +167,10 @@ pub struct UpgradeResult {
     /// exact recovery command so the operator can restart it manually.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub services_pending_restart: Vec<ServiceRestartEntry>,
+    /// Durable observation-run id for this upgrade. Inspect with
+    /// `homeboy upgrade status <id>` after a client timeout.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operation_id: Option<String>,
 }
 
 /// Compact named outcome for one upgrade dimension. Detailed build output stays
@@ -376,6 +380,7 @@ mod tests {
             extensions_unrefreshed: Vec::new(),
             services_restarted: Vec::new(),
             services_pending_restart: Vec::new(),
+            operation_id: None,
         };
 
         let json = serde_json::to_value(&result).expect("upgrade result serializes");

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -22,6 +22,7 @@ Runner sync uses this contract:
 
 ## Options
 
+- `status [ID]`: Inspect a persisted upgrade operation. Reports whether binary promotion and optional extension/runner refresh completed. Omit `ID` to read the latest upgrade run. Also available as `homeboy runs show <id>`.
 - `--check`: Check for updates without installing. Returns version information without making changes.
 - `--force`: Force upgrade even if already at the latest version.
 - `--skip-extensions`: Skip automatic extension updates.
@@ -125,9 +126,20 @@ homeboy upgrade --skip-runners
 - `uninstallable_versions`: Releases newer than `latest_version` passed over for want of a `target` asset, newest first
 - `notice`: Plain-language explanation when `latest_version` is not the newest release, when nothing installable was found, or when the target could not be determined
 
+`homeboy upgrade status [ID]` data payload:
+
+- `command`: `upgrade.status`
+- `operation_id`: Persisted observation-run id
+- `status`: Observation run status (`running`, `pass`, `error`, ...)
+- `phase`: Current or terminal upgrade phase
+- `elapsed_seconds`: Bounded elapsed time for the recorded phase
+- `controller` / `extensions` / `runners`: Independent component statuses
+- `note`: Present when a running record's owner process is no longer alive
+
 `homeboy upgrade` data payload:
 
 - `command`: `upgrade`
+- `operation_id`: Durable observation-run id persisted before mutation. Inspect later with `homeboy upgrade status <id>`
 - `install_method`: Installation method used for upgrade
 - `previous_version`: Version before upgrade
 - `new_version`: Version after upgrade (may be null)
@@ -152,6 +164,7 @@ Runner upgrade entries include the configured `homeboy_path`, observed configure
 
 - Version checking queries the GitHub Releases API. Network failures are handled gracefully.
 - On Unix platforms, successful source installs automatically restart into the new binary. Binary and package-manager installs do not require a restart.
+- Upgrade persists a durable operation before controller mutation. Long extension refresh emits bounded `[upgrade] phase=... elapsed=Ns` heartbeats. If the client times out, `homeboy upgrade status` still reports whether binary promotion completed; optional refresh may continue or show as interrupted.
 
 ## Related
 


### PR DESCRIPTION
## Summary

- persist an upgrade operation identity before controller mutation
- record independent controller, extension, and runner phase status with bounded extension-refresh heartbeats
- add read-only `homeboy upgrade status [ID]` inspection and preserve successful controller promotion across client interruption

Closes #13797

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-upgrade upgrade::operation`
- `cargo check -p homeboy-cli`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol through OpenCode traced the ambiguous post-promotion timeout, implemented durable operation progress and status inspection, and ran focused regression verification under Chris Huber’s direction.