### PR TITLE
Persist canonical fanout child lineage

### DIFF
--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -426,6 +426,43 @@ pub fn record_fanout_run_batch_failed_admissions<'a>(
         .record_fanout_run_batch_failed_admissions(batch_id, failed_run_ids)
 }
 
+/// Move a fanout child to the canonical durable run that replaced its current
+/// Cook attempt. The batch lock makes concurrent status and coordinator reads
+/// observe either complete roster identity, never a partially rewritten child.
+pub fn record_fanout_child_run_replacement_in_store(
+    store: &AgentTaskBatchStore,
+    batch_id: &str,
+    replaced_run_id: &str,
+    replacement_run_id: &str,
+) -> Result<()> {
+    store.mutate_batch(batch_id, |batch| {
+        if batch
+            .child_runs
+            .iter()
+            .any(|child| child.run_id == replacement_run_id)
+        {
+            return Ok(());
+        }
+        let child = batch
+            .child_runs
+            .iter_mut()
+            .find(|child| child.run_id == replaced_run_id)
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "run_id",
+                    "replacement Cook run is not the canonical durable fanout child",
+                    Some(replaced_run_id.to_string()),
+                    None,
+                )
+            })?;
+        child.run_id = replacement_run_id.to_string();
+        child.state = AgentTaskRunState::Queued;
+        child.placement = None;
+        batch.updated_at = Some(now_timestamp());
+        Ok(())
+    })
+}
+
 pub fn record_fanout_run_batch_failed_admissions_in_store<'a>(
     store: &AgentTaskBatchStore,
     batch_id: &str,
@@ -692,7 +729,7 @@ where
                 if error.code == ErrorCode::ObservationStoreBusy {
                     observation_fresh = false;
                 }
-                if !child.state.is_terminal() {
+                if batch.state != AgentTaskBatchState::Admitting && !child.state.is_terminal() {
                     unavailable_child_runs.push(child_issue(
                         child,
                         format!("unable to read child run status: {}", error.message),
@@ -710,12 +747,21 @@ where
         }
     }
     totals.unavailable = unavailable_child_runs.len();
-    let mut state = aggregate_state(&totals);
+    let expected = batch.child_runs.len();
+    let admission_pending = batch.state == AgentTaskBatchState::Admitting && admitted < expected;
+    let mut state = if admission_pending {
+        AgentTaskBatchState::Admitting
+    } else {
+        aggregate_state(&totals)
+    };
     if batch.state != state {
         batch.state = state;
     }
-    let dependency_graph =
-        refresh_dependency_graph_with_finalization_statuses(&mut batch, None, &mut child_status)?;
+    let dependency_graph = if admission_pending {
+        batch.metadata.get("dependency_graph").cloned()
+    } else {
+        refresh_dependency_graph_with_finalization_statuses(&mut batch, None, &mut child_status)?
+    };
     if let Some(graph) = &dependency_graph {
         state = aggregate_state_after_graph_refresh(&totals, graph, state);
         if batch.state != state {
@@ -741,7 +787,6 @@ where
     next_actions.truncate(8);
     let resumable = !resumable_child_runs.is_empty();
     let commands = commands(&batch.batch_id);
-    let expected = batch.child_runs.len();
     Ok(AgentTaskBatchStatusReport {
         schema: AGENT_TASK_BATCH_STATUS_SCHEMA,
         status: state.outcome_status().to_string(),
@@ -2631,6 +2676,88 @@ mod tests {
         let error = submit_plan_batch(&plan, Some("workflow")).expect_err("workflow rejected");
 
         assert!(error.message.contains("independent tasks"));
+    }
+
+    #[test]
+    fn fanout_status_reports_admitting_when_child_records_are_absent() {
+        let (_temp, store) = batch_store();
+        store
+            .persist_fanout_run_batch(
+                "admission-wave",
+                "admission-wave",
+                &[FanoutRunBatchChild {
+                    task_id: "issue-1419".to_string(),
+                    run_id: "cook-issue-1419".to_string(),
+                }],
+                json!({}),
+            )
+            .expect("persist planned roster");
+        store
+            .claim_fanout_run_batch("admission-wave")
+            .expect("claim")
+            .expect("claim id");
+
+        let report = store
+            .status_with(
+                "admission-wave",
+                |_| {
+                    Err(Error::validation_invalid_argument(
+                        "run_id",
+                        "agent-task run record not found: cook-issue-1419",
+                        Some("cook-issue-1419".to_string()),
+                        None,
+                    ))
+                },
+                |_| Ok(None),
+                |_| Ok(false),
+            )
+            .expect("admission window remains readable");
+
+        assert_eq!(report.status, "admitting");
+        assert_eq!(report.batch.state, AgentTaskBatchState::Admitting);
+        assert_eq!(report.admission.expected, 1);
+        assert_eq!(report.admission.admitted, 0);
+        assert_eq!(report.admission.absent, 1);
+        assert!(report.unavailable_child_runs.is_empty());
+    }
+
+    #[test]
+    fn fanout_child_run_replacement_updates_canonical_lineage() {
+        let (_temp, store) = batch_store();
+        store
+            .persist_fanout_run_batch(
+                "retry-wave",
+                "retry-wave",
+                &[FanoutRunBatchChild {
+                    task_id: "issue-1419".to_string(),
+                    run_id: "cook-issue-1419".to_string(),
+                }],
+                json!({}),
+            )
+            .expect("persist planned roster");
+
+        record_fanout_child_run_replacement_in_store(
+            &store,
+            "retry-wave",
+            "cook-issue-1419",
+            "cook-issue-1419-transport-retry",
+        )
+        .expect("replace canonical child run");
+        record_fanout_child_run_replacement_in_store(
+            &store,
+            "retry-wave",
+            "cook-issue-1419",
+            "cook-issue-1419-transport-retry",
+        )
+        .expect("replacement is idempotent");
+
+        let batch = store.read_batch("retry-wave").expect("updated roster");
+        assert_eq!(batch.child_runs[0].task_id, "issue-1419");
+        assert_eq!(
+            batch.child_runs[0].run_id,
+            "cook-issue-1419-transport-retry"
+        );
+        assert_eq!(batch.child_runs[0].state, AgentTaskRunState::Queued);
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -3064,10 +3064,12 @@ where
             });
             continue;
         }
-        // The persisted batch child `run_id` is the cook id (`cook-<id>`), which
-        // is exactly the durable recipe key. Reconstruct from that recipe so the
-        // resumed cook re-runs its own gates and finalization contract.
-        let cook_id = child.run_id.clone();
+        // Roster `run_id` is the canonical durable attempt, including transport
+        // replacements. Resolve the recipe from that attempt so resume still
+        // finds the cook after lineage moves off the synthesized cook id.
+        let cook_id = super::load_recipe_for_attempt(&child.run_id)?
+            .map(|recipe| recipe.cook_id)
+            .unwrap_or_else(|| child.run_id.clone());
         let cell = match resume_batch_child(
             batch_id,
             &cook_id,
@@ -3079,7 +3081,7 @@ where
                 let exit_code = cook_report_exit_code(&report);
                 AgentTaskCookBatchCellReport {
                     cook_id: report.cook_id.clone(),
-                    initial_run_id: cook_id,
+                    initial_run_id: child.run_id.clone(),
                     status: report.status.clone(),
                     exit_code,
                     result: Some(report),
@@ -3088,7 +3090,7 @@ where
             }
             Err(error) => AgentTaskCookBatchCellReport {
                 cook_id: child.task_id.clone(),
-                initial_run_id: cook_id,
+                initial_run_id: child.run_id.clone(),
                 status: "failed".to_string(),
                 exit_code: 1,
                 result: None,
@@ -3099,7 +3101,7 @@ where
         // repeated resume (or a crash mid-batch) converges idempotently.
         crate::agent_task_batch::record_child_finalization(
             batch_id,
-            &cell.initial_run_id,
+            &child.run_id,
             child_finalization_value(&cell),
         )?;
         cells.push(cell);

--- a/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_recipe.rs
@@ -216,12 +216,14 @@ impl CookRecipeStore {
         replaced_run_id: &str,
         replacement_run_id: &str,
     ) -> Result<AgentTaskCookRecipe> {
-        record_recipe_attempt_replacement_in_store(
+        let recipe = record_recipe_attempt_replacement_in_store(
             self,
             cook_id,
             replaced_run_id,
             replacement_run_id,
-        )
+        )?;
+        sync_fanout_replacement(self, &recipe, replaced_run_id, replacement_run_id)?;
+        Ok(recipe)
     }
 
     pub fn enqueue_continuation(
@@ -294,6 +296,32 @@ impl CookRecipeStore {
         }
         consume_claimed_with_dispatcher_policy(self, claim, dispatcher, execute, CookMode::Resume)
     }
+}
+
+fn sync_fanout_replacement(
+    store: &CookRecipeStore,
+    recipe: &AgentTaskCookRecipe,
+    replaced_run_id: &str,
+    replacement_run_id: &str,
+) -> Result<()> {
+    let Some(attempt) = recipe
+        .attempts
+        .iter()
+        .find(|attempt| attempt.run_id == replacement_run_id)
+    else {
+        return Ok(());
+    };
+    let Some(batch_id) = attempt.plan.metadata["batch_id"].as_str() else {
+        return Ok(());
+    };
+    let batch_store =
+        crate::agent_task_batch::AgentTaskBatchStore::from_data_root(store.data_root());
+    crate::agent_task_batch::record_fanout_child_run_replacement_in_store(
+        &batch_store,
+        batch_id,
+        replaced_run_id,
+        replacement_run_id,
+    )
 }
 
 fn lock_workspace_base_capture(lock: &File, lock_path: &Path, timeout: Duration) -> Result<()> {

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -471,7 +471,9 @@ fn batch_status(args: AgentTaskFanoutBatchStatusArgs, placement: Placement) -> C
     // A terminal coordinator failure is the authoritative outcome even when it
     // happened before the first child record existed. Reconciling children first
     // would turn that diagnostic into a misleading "run record not found".
-    let observations = if report.admission_blocker.is_some() {
+    let admission_pending =
+        report.batch.state == batch::AgentTaskBatchState::Admitting && report.admission.absent > 0;
+    let observations = if report.admission_blocker.is_some() || admission_pending {
         BTreeMap::new()
     } else {
         reconcile_fanout_pr_states(&args.batch_id, false)?
@@ -494,7 +496,11 @@ fn batch_status(args: AgentTaskFanoutBatchStatusArgs, placement: Placement) -> C
     // envelope's success/exit_code.
     // The mutating `resume` command keeps the aggregate exit policy, and
     // durable reconciliation / child continuation stay limited to it.
-    let portfolio = reconcile_portfolio(&report.batch)?;
+    let portfolio = if admission_pending {
+        load_portfolio(&report.batch)?.status(&BTreeMap::new())
+    } else {
+        reconcile_portfolio(&report.batch)?
+    };
     Ok((
         serde_json::json!({
             "schema": "homeboy/agent-task-fanout-status/v2",
@@ -1976,6 +1982,8 @@ fn compile_batch_cooks(
                 options.identity.initial_plan.metadata["cook_repository_identity"] =
                     cook.repository_identity.clone();
             }
+            options.identity.initial_plan.metadata["batch_id"] =
+                Value::String(plan.fanout_id.clone());
             if let (Some(workspace), Some(component_id)) = (
                 options.workspace.source_worktree_path.as_deref(),
                 cook.component_id.as_deref(),
@@ -10977,6 +10985,112 @@ fi
                     .metadata["coordinator"]["admission_deadline_at"],
                 before
             );
+        });
+    }
+
+    #[test]
+    fn public_status_reports_admitting_before_the_first_child_exists() {
+        with_isolated_home(|_| {
+            let batch_id = "status-during-admission";
+            batch::persist_fanout_run_batch(
+                batch_id,
+                batch_id,
+                &[batch::FanoutRunBatchChild {
+                    task_id: "child".to_string(),
+                    run_id: "synthesized-child-run".to_string(),
+                }],
+                json!({}),
+            )
+            .expect("persist batch before child admission");
+            batch::claim_fanout_run_batch(batch_id)
+                .expect("claim batch")
+                .expect("coordinator claim");
+
+            let (value, exit_code) = batch_status(
+                AgentTaskFanoutBatchStatusArgs {
+                    batch_id: batch_id.to_string(),
+                },
+                Placement::Lab,
+            )
+            .expect("admission window remains a readable fanout status");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(value["batch"]["status"], "admitting");
+            assert_eq!(value["batch"]["batch"]["state"], "admitting");
+            assert_eq!(value["batch"]["admission"]["admitted"], 0);
+            assert_eq!(value["batch"]["admission"]["absent"], 1);
+            assert!(value["batch"]["unavailable_child_runs"]
+                .as_array()
+                .is_none_or(Vec::is_empty));
+        });
+    }
+
+    #[test]
+    fn detached_lab_transport_retry_replaces_the_canonical_fanout_child() {
+        with_isolated_home(|_| {
+            let mut plan = test_batch_plan();
+            plan.cooks.truncate(1);
+            plan.rekey("detached-lab-transport-retry".to_string());
+            let cook = &plan.cooks[0];
+            let task_id = cook.cook_id.clone();
+            let mut options = cook
+                .to_cook_invocation(&plan)
+                .expect("compile child invocation")
+                .options;
+            materialize_test_child(&mut options);
+            options.identity.initial_plan.metadata["batch_id"] = json!(plan.fanout_id);
+            options.provider_transport.attempt_dispatcher = Some(Arc::new(LabRecipeDispatcher));
+            agent_task_service::persist_initial_recipe(&options)
+                .expect("persist detached Lab recipe");
+            let initial_run_id = options.identity.initial_run_id.clone();
+            batch::persist_fanout_run_batch(
+                &plan.fanout_id,
+                &plan.fanout_id,
+                &[batch::FanoutRunBatchChild {
+                    task_id,
+                    run_id: initial_run_id.clone(),
+                }],
+                json!({}),
+            )
+            .expect("persist fanout roster");
+
+            let retry_run_id = format!("{initial_run_id}-transport-retry");
+            let recipe_store = agent_task_service::CookRecipeStore::from_current_data_root()
+                .expect("recipe store");
+            let recipe = recipe_store
+                .record_recipe_attempt_replacement(
+                    &options.identity.cook_id,
+                    &initial_run_id,
+                    &retry_run_id,
+                )
+                .expect("record transport replacement");
+            assert_eq!(
+                recipe.promotion_transport["attempt_dispatch"]["kind"],
+                "lab"
+            );
+            agent_task_lifecycle::submit_plan(
+                &recipe.attempts.last().expect("replacement attempt").plan,
+                Some(&retry_run_id),
+            )
+            .expect("materialize replacement child");
+
+            let (value, exit_code) = batch_status(
+                AgentTaskFanoutBatchStatusArgs {
+                    batch_id: plan.fanout_id.clone(),
+                },
+                Placement::Lab,
+            )
+            .expect("original fanout id resolves replacement child");
+
+            assert_eq!(exit_code, 0);
+            assert_eq!(
+                value["batch"]["batch"]["child_runs"][0]["run_id"],
+                retry_run_id
+            );
+            assert_eq!(value["batch"]["admission"]["admitted"], 1);
+            assert!(value["batch"]["unavailable_child_runs"]
+                .as_array()
+                .is_none_or(Vec::is_empty));
         });
     }
 


### PR DESCRIPTION
## Summary

- keep fanout status readable as `admitting` before child records materialize
- update the durable batch roster when transport replacement creates a new child run ID
- resolve resume and finalization through canonical retry lineage instead of synthesized IDs

Closes #13799

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-agents agent_task_batch`
- `cargo test -p homeboy-cli public_status_reports_admitting_before_the_first_child_exists`
- `cargo test -p homeboy-cli detached_lab_transport_retry_replaces_the_canonical_fanout_child`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol through OpenCode traced synthesized and replacement child identities, implemented durable roster convergence, and ran focused regression verification under Chris Huber’s direction.