### PR TITLE
Persist interrupted local Cook owner failures

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -55,6 +55,367 @@ pub fn record_pre_execution_failure_in_store(
     Ok(record)
 }
 
+/// Persist interrupted-owner evidence before a local Cook observer loss becomes
+/// terminal. Aggregate, attempt diagnostics, candidate harvest (or explicit
+/// unavailability), stop reason, and retry duplication facts are committed first
+/// so later status/diagnose reads are not an empty Failed tombstone.
+pub fn record_interrupted_local_owner_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<AgentTaskRunRecord> {
+    let run_id = sanitize_run_id(run_id);
+    let (mut record, aggregate) = lifecycle_store.with_config_lock(|| {
+        let mut record = lifecycle_store.read_record(&run_id)?;
+        if record.state.is_terminal() {
+            return Ok((record, None));
+        }
+        let decision = annotate_local_provider_ownership(&mut record);
+        record_interrupted_local_owner_locked(lifecycle_store, record, decision)
+    })?;
+    if let Some(aggregate) = aggregate {
+        record_terminal_artifact_projection_in_store(lifecycle_store, &mut record, &aggregate)?;
+        update_cook_candidate_after_completion_in_store(
+            lifecycle_store,
+            &record,
+            &aggregate,
+            None,
+        )?;
+    } else if record.state.is_terminal() {
+        lifecycle_store.project_terminal_record_after_unlock(&record.run_id)?;
+    }
+    Ok(record)
+}
+
+fn record_interrupted_local_owner_locked(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    mut record: AgentTaskRunRecord,
+    decision: LocalProviderOwnerDecision,
+) -> Result<(AgentTaskRunRecord, Option<AgentTaskAggregate>)> {
+    let plan = lifecycle_store.read_controller_plan(&record.run_id)?;
+    let now = now_timestamp();
+    let (has_succeeded, has_failed, recovery_identity) = match decision {
+        LocalProviderOwnerDecision::Interrupted {
+            has_succeeded,
+            has_failed,
+            recovery_identity,
+        } => (has_succeeded, has_failed, recovery_identity),
+        LocalProviderOwnerDecision::StayRunning | LocalProviderOwnerDecision::NotApplicable => {
+            let identity = record
+                .metadata
+                .get("provider_executions")
+                .and_then(Value::as_array)
+                .map(|executions| {
+                    executions
+                        .iter()
+                        .map(|execution| execution["owner_identity"].clone())
+                        .collect()
+                })
+                .unwrap_or_default();
+            (false, false, identity)
+        }
+    };
+    let consumed = record
+        .metadata
+        .get("provider_executions")
+        .and_then(Value::as_array)
+        .map(|executions| executions.len())
+        .unwrap_or_default();
+    let in_flight = record
+        .metadata
+        .get("provider_executions")
+        .and_then(Value::as_array)
+        .is_some_and(|executions| {
+            executions
+                .iter()
+                .any(|execution| execution["state"] == json!("running"))
+        });
+    if in_flight {
+        if let Some(executions) = record
+            .ensure_metadata_object()
+            .get_mut("provider_executions")
+            .and_then(Value::as_array_mut)
+        {
+            for execution in executions {
+                if execution["state"] == json!("running") {
+                    execution["state"] = json!("cancelled");
+                    execution["finished_at"] = json!(now.clone());
+                }
+            }
+        }
+    }
+    let stop_reason = "local Cook observer was interrupted during provider execution".to_string();
+    let outcomes = plan
+        .tasks
+        .iter()
+        .map(|task| {
+            build_interrupted_owner_outcome(
+                &record.run_id,
+                task,
+                has_succeeded,
+                has_failed,
+                consumed,
+                in_flight,
+                &stop_reason,
+            )
+        })
+        .collect::<Vec<_>>();
+    let harvested = outcomes.iter().any(|outcome| {
+        outcome.status == AgentTaskOutcomeStatus::CandidateRecoverable
+            || outcome
+                .artifacts
+                .iter()
+                .any(crate::agent_task_timeout_artifacts::is_actionable_patch_artifact)
+    });
+    let (aggregate_status, ownership_state, run_cancelled) = if has_succeeded || harvested {
+        (
+            crate::agent_task_scheduler::AgentTaskAggregateStatus::CandidateRecoverable,
+            "owner_dead",
+            false,
+        )
+    } else if has_failed {
+        (
+            crate::agent_task_scheduler::AgentTaskAggregateStatus::Failed,
+            "provider_failed",
+            false,
+        )
+    } else {
+        (
+            crate::agent_task_scheduler::AgentTaskAggregateStatus::Cancelled,
+            "owner_dead",
+            true,
+        )
+    };
+    let failed = outcomes
+        .iter()
+        .filter(|outcome| {
+            matches!(
+                outcome.status,
+                AgentTaskOutcomeStatus::Failed | AgentTaskOutcomeStatus::Cancelled
+            )
+        })
+        .count();
+    let candidate_recoverable = outcomes
+        .iter()
+        .filter(|outcome| outcome.status == AgentTaskOutcomeStatus::CandidateRecoverable)
+        .count();
+    let cancelled = outcomes
+        .iter()
+        .filter(|outcome| outcome.status == AgentTaskOutcomeStatus::Cancelled)
+        .count();
+    let aggregate = AgentTaskAggregate {
+        schema: AGENT_TASK_AGGREGATE_SCHEMA.to_string(),
+        plan_id: plan.plan_id.clone(),
+        status: aggregate_status,
+        totals: AgentTaskAggregateTotals {
+            failed,
+            cancelled,
+            candidate_recoverable,
+            recoverable_candidates: candidate_recoverable,
+            ..AgentTaskAggregateTotals::default()
+        },
+        outcomes,
+        events: plan
+            .tasks
+            .iter()
+            .map(|task| AgentTaskProgressEvent {
+                task_id: task.task_id.clone(),
+                state: if harvested || has_succeeded {
+                    AgentTaskState::CandidateRecoverable
+                } else if run_cancelled {
+                    AgentTaskState::Cancelled
+                } else {
+                    AgentTaskState::Failed
+                },
+                attempt: 1,
+                message: Some(stop_reason.clone()),
+            })
+            .collect(),
+        artifact_lineage: Vec::new(),
+        child_runs: Vec::new(),
+        artifact_bindings: Vec::new(),
+        queue: AgentTaskQueueStatus {
+            max_concurrency: plan.options.max_concurrency,
+            completed: plan.tasks.len(),
+            ..AgentTaskQueueStatus::default()
+        },
+    };
+    let aggregate_path = lifecycle_store
+        .aggregate_path(&record.run_id)
+        .display()
+        .to_string();
+    apply_aggregate_to_record(&mut record, &plan, &aggregate, aggregate_path);
+    let metadata = record.ensure_metadata_object();
+    metadata.insert(
+        "local_provider_ownership".to_string(),
+        json!({
+            "state": ownership_state,
+            "recovery_identity": recovery_identity,
+            "reconciled_at": now,
+        }),
+    );
+    metadata.insert("stop_reason".to_string(), json!(stop_reason));
+    metadata.insert(
+        "terminal_failure_classification".to_string(),
+        json!("interrupted_owner"),
+    );
+    metadata.insert("terminal_phase".to_string(), json!("interrupted_owner"));
+    metadata.insert("provider_executions_consumed".to_string(), json!(consumed));
+    metadata.insert(METADATA_KEY_RETRYABLE.to_string(), json!(true));
+    metadata.insert(
+        "interrupted_owner".to_string(),
+        json!({
+            "schema": "homeboy/agent-task-interrupted-owner/v1",
+            "cause": "observer_interrupted_during_provider_execution",
+            "stop_reason": stop_reason,
+            "provider_executions_consumed": consumed,
+            "provider_budget_consumed": consumed > 0,
+            "in_flight_work_may_be_duplicated": in_flight || consumed > 0,
+            "candidate_status": if harvested || has_succeeded {
+                "harvested_or_recoverable"
+            } else {
+                "unavailable"
+            },
+        }),
+    );
+    if run_cancelled {
+        metadata.insert(
+            "cancel_reason".to_string(),
+            json!("local provider owner process is not running"),
+        );
+    }
+    metadata.insert(
+        "cook_progress".to_string(),
+        json!({
+            "phase": "terminal",
+            "attempt": 1,
+            "detail": "interrupted_owner",
+            "terminal_success": harvested || has_succeeded,
+            "exit_code": if harvested || has_succeeded { 0 } else { 1 },
+            "updated_at": now,
+        }),
+    );
+    let record = lifecycle_store
+        .write_aggregate_and_record_locked_without_terminal_projection(&record, &aggregate)?;
+    Ok((record, Some(aggregate)))
+}
+
+fn build_interrupted_owner_outcome(
+    run_id: &str,
+    task: &AgentTaskRequest,
+    has_succeeded: bool,
+    has_failed: bool,
+    consumed: usize,
+    in_flight: bool,
+    stop_reason: &str,
+) -> AgentTaskOutcome {
+    let mut outcome = AgentTaskOutcome {
+        schema: AGENT_TASK_OUTCOME_SCHEMA.to_string(),
+        task_id: task.task_id.clone(),
+        status: if has_succeeded {
+            AgentTaskOutcomeStatus::CandidateRecoverable
+        } else if has_failed {
+            AgentTaskOutcomeStatus::Failed
+        } else {
+            AgentTaskOutcomeStatus::Cancelled
+        },
+        summary: Some(stop_reason.to_string()),
+        failure_classification: if has_succeeded {
+            None
+        } else {
+            Some(AgentTaskFailureClassification::ExecutionFailed)
+        },
+        evidence_refs: vec![AgentTaskEvidenceRef {
+            kind: "interrupted-owner".to_string(),
+            uri: format!("homeboy://agent-task/run/{run_id}/status#interrupted-owner"),
+            label: Some("Interrupted local Cook observer".to_string()),
+        }],
+        diagnostics: vec![AgentTaskDiagnostic {
+            class: "interrupted_owner".to_string(),
+            message: stop_reason.to_string(),
+            data: json!({
+                "phase": "interrupted_owner",
+                "provider_executions_consumed": consumed,
+                "provider_budget_consumed": consumed > 0,
+                "in_flight_work_may_be_duplicated": in_flight || consumed > 0,
+            }),
+        }],
+        outputs: json!({
+            "schema": "homeboy/agent-task-interrupted-owner/v1",
+            "phase": "interrupted_owner",
+            "stop_reason": stop_reason,
+            "provider_executions_consumed": consumed,
+            "provider_budget_consumed": consumed > 0,
+            "in_flight_work_may_be_duplicated": in_flight || consumed > 0,
+        }),
+        metadata: json!({
+            "kind": "interrupted_owner",
+            "phase": "interrupted_owner",
+            "provider_executions_consumed": consumed,
+            "provider_budget_consumed": consumed > 0,
+            "in_flight_work_may_be_duplicated": in_flight || consumed > 0,
+        }),
+        ..Default::default()
+    };
+    harvest_interrupted_owner_candidate(run_id, task, &mut outcome);
+    outcome
+}
+
+fn harvest_interrupted_owner_candidate(
+    run_id: &str,
+    task: &AgentTaskRequest,
+    outcome: &mut AgentTaskOutcome,
+) {
+    let discovery = crate::agent_task_timeout_artifacts::TimeoutArtifactDiscovery::discover(task);
+    crate::agent_task_timeout_artifacts::append_unique_artifacts(
+        &mut outcome.artifacts,
+        discovery.artifacts,
+    );
+    crate::agent_task_timeout_artifacts::append_unique_evidence_refs(
+        &mut outcome.evidence_refs,
+        discovery.evidence_refs,
+    );
+    outcome.diagnostics.extend(discovery.diagnostics);
+    if let Some(discovered) = discovery.outcome {
+        crate::agent_task_timeout_artifacts::append_unique_artifacts(
+            &mut outcome.artifacts,
+            discovered.artifacts,
+        );
+        crate::agent_task_timeout_artifacts::append_unique_evidence_refs(
+            &mut outcome.evidence_refs,
+            discovered.evidence_refs,
+        );
+        outcome.diagnostics.extend(discovered.diagnostics);
+    }
+    let harvested = outcome
+        .artifacts
+        .iter()
+        .any(crate::agent_task_timeout_artifacts::is_actionable_patch_artifact);
+    if harvested {
+        outcome.status = AgentTaskOutcomeStatus::CandidateRecoverable;
+        outcome.failure_classification = None;
+        outcome.summary =
+            Some("interrupted local Cook observer left a recoverable candidate".to_string());
+        outcome.metadata["candidate_status"] = json!("harvested");
+        return;
+    }
+    crate::agent_task_timeout_artifacts::append_unique_evidence_refs(
+        &mut outcome.evidence_refs,
+        vec![AgentTaskEvidenceRef {
+            kind: "interrupted-owner-candidate".to_string(),
+            uri: format!("homeboy://agent-task/run/{run_id}/status#interrupted-owner-candidate"),
+            label: Some("Candidate unavailable after interrupted owner".to_string()),
+        }],
+    );
+    outcome.diagnostics.push(AgentTaskDiagnostic {
+        class: "interrupted_owner.candidate_unavailable".to_string(),
+        message:
+            "no candidate could be harvested after the local Cook observer was interrupted during provider execution"
+                .to_string(),
+        data: json!({ "status": "unavailable" }),
+    });
+    outcome.metadata["candidate_status"] = json!("unavailable");
+}
+
 /// Replace only a scheduler-terminal snapshot fence failure with Cook's normal
 /// retryable pre-execution record. A provider ledger entry is authoritative: it
 /// permanently fences this path from rewriting real provider failures.

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -4100,19 +4100,31 @@ pub fn inject_raw_record_metadata_for_corruption_test(
     store::inject_raw_record_metadata_for_corruption_test(&sanitize_run_id(run_id), inject)
 }
 
-/// Reconcile the ownership captured at the local provider boundary. A local
-/// provider has no opaque remote handle, so its reserving process is the only
-/// durable authority that can prove the reservation is still executing.
-fn reconcile_local_provider_ownership(record: &mut AgentTaskRunRecord) -> bool {
+#[derive(Debug, Clone)]
+pub(crate) enum LocalProviderOwnerDecision {
+    StayRunning,
+    NotApplicable,
+    Interrupted {
+        has_succeeded: bool,
+        has_failed: bool,
+        recovery_identity: Vec<Value>,
+    },
+}
+
+/// Annotate persisted local-provider owner identity without terminalizing.
+/// Terminalization must persist an aggregate first.
+pub(crate) fn annotate_local_provider_ownership(
+    record: &mut AgentTaskRunRecord,
+) -> LocalProviderOwnerDecision {
     if record.state != AgentTaskRunState::Running || record.is_runner_backed() {
-        return false;
+        return LocalProviderOwnerDecision::NotApplicable;
     }
     let Some(executions) = record
         .metadata
         .get_mut("provider_executions")
         .and_then(Value::as_array_mut)
     else {
-        return false;
+        return LocalProviderOwnerDecision::NotApplicable;
     };
 
     let mut has_reconcilable_execution = false;
@@ -4164,82 +4176,34 @@ fn reconcile_local_provider_ownership(record: &mut AgentTaskRunRecord) -> bool {
             _ => {}
         }
     }
-    // Older records predate per-provider ownership, and non-Linux hosts can be
-    // unable to verify a persisted identity. Neither alone is proof that the
-    // owner died, so retain a joinable run unless its provider already recorded
-    // a terminal failure.
-    // A terminal provider failure is already conclusive evidence that this
-    // execution cannot make progress. It must not retain `Running` solely
-    // because the foreground wrapper was interrupted before aggregate harvest.
     if has_live_owner || (has_unverifiable_owner && !has_failed) {
-        return true;
+        return LocalProviderOwnerDecision::StayRunning;
     }
     if !has_reconcilable_execution {
-        return false;
+        return LocalProviderOwnerDecision::NotApplicable;
     }
+    LocalProviderOwnerDecision::Interrupted {
+        has_succeeded,
+        has_failed,
+        recovery_identity,
+    }
+}
 
-    let now = now_timestamp();
-    let metadata = record.ensure_metadata_object();
-    metadata.insert(
-        "local_provider_ownership".to_string(),
-        json!({
-            "state": "owner_dead",
-            "recovery_identity": recovery_identity,
-            "reconciled_at": now,
-        }),
-    );
-    if has_succeeded {
-        // The provider reported completion before the foreground owner died,
-        // but the aggregate was not yet persisted. Preserve that fact and the
-        // workspace as a recoverable candidate instead of erasing it.
-        record.updated_at = Some(now);
-        set_run_state(record, AgentTaskRunState::CandidateRecoverable);
-        for task in &mut record.tasks {
-            if task.state == AgentTaskState::Running {
-                task.state = AgentTaskState::CandidateRecoverable;
-            }
+/// Reconcile the ownership captured at the local provider boundary. A local
+/// provider has no opaque remote handle, so its reserving process is the only
+/// durable authority that can prove the reservation is still executing.
+fn reconcile_local_provider_ownership(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    record: &mut AgentTaskRunRecord,
+) -> Result<bool> {
+    match annotate_local_provider_ownership(record) {
+        LocalProviderOwnerDecision::StayRunning => Ok(true),
+        LocalProviderOwnerDecision::NotApplicable => Ok(false),
+        LocalProviderOwnerDecision::Interrupted { .. } => {
+            *record = record_interrupted_local_owner_in_store(lifecycle_store, &record.run_id)?;
+            Ok(false)
         }
-    } else if has_failed {
-        record.updated_at = Some(now.clone());
-        set_run_state(record, AgentTaskRunState::Failed);
-        for task in &mut record.tasks {
-            if matches!(task.state, AgentTaskState::Queued | AgentTaskState::Running) {
-                task.state = AgentTaskState::Failed;
-            }
-        }
-        record.ensure_metadata_object().insert(
-            "local_provider_ownership".to_string(),
-            json!({
-                "state": "provider_failed",
-                "recovery_identity": recovery_identity,
-                "reconciled_at": now,
-            }),
-        );
-    } else {
-        let executions = record
-            .ensure_metadata_object()
-            .get_mut("provider_executions")
-            .and_then(Value::as_array_mut)
-            .expect("provider executions were checked above");
-        for execution in executions.iter_mut() {
-            if execution["state"] == json!("running") {
-                execution["state"] = json!("cancelled");
-                execution["finished_at"] = json!(now.clone());
-            }
-        }
-        record.updated_at = Some(now.clone());
-        set_run_state(record, AgentTaskRunState::Cancelled);
-        for task in &mut record.tasks {
-            if matches!(task.state, AgentTaskState::Queued | AgentTaskState::Running) {
-                task.state = AgentTaskState::Cancelled;
-            }
-        }
-        record.ensure_metadata_object().insert(
-            "cancel_reason".to_string(),
-            json!("local provider owner process is not running"),
-        );
     }
-    true
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -5076,7 +5040,7 @@ pub fn status_in_store(
             }
         }
     }
-    if reconcile_local_provider_ownership(&mut record) {
+    if reconcile_local_provider_ownership(lifecycle_store, &mut record)? {
         lifecycle_store.write_record(&record)?;
     }
     // The only genuinely-remote step in this read. Skipping it for a

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -3457,6 +3457,34 @@ fn dead_local_provider_owner_terminalizes_running_reservation_once() {
             replay.metadata["local_provider_ownership"]["state"],
             json!("owner_dead")
         );
+        assert_eq!(
+            replay.metadata["stop_reason"],
+            json!("local Cook observer was interrupted during provider execution")
+        );
+        assert_eq!(
+            replay.metadata["terminal_failure_classification"],
+            json!("interrupted_owner")
+        );
+        assert_eq!(replay.metadata["provider_executions_consumed"], json!(1));
+        assert_eq!(
+            replay.metadata["interrupted_owner"]["provider_budget_consumed"],
+            json!(true)
+        );
+        assert_eq!(
+            replay.metadata["interrupted_owner"]["in_flight_work_may_be_duplicated"],
+            json!(true)
+        );
+        let aggregate = test_lifecycle_store()
+            .read_aggregate("owner-dead")
+            .expect("interrupted-owner aggregate");
+        assert_eq!(
+            aggregate.outcomes[0].diagnostics[0].class,
+            "interrupted_owner"
+        );
+        assert!(aggregate.outcomes[0]
+            .evidence_refs
+            .iter()
+            .any(|reference| { reference.kind == "interrupted-owner-candidate" }));
     });
 }
 
@@ -3504,15 +3532,22 @@ fn dead_owner_preserves_late_provider_success_as_recoverable_candidate() {
             recovered.metadata["provider_executions"][0]["state"],
             json!("succeeded")
         );
+        assert_eq!(
+            recovered.metadata["terminal_failure_classification"],
+            json!("interrupted_owner")
+        );
+        test_lifecycle_store()
+            .read_aggregate("owner-late-success")
+            .expect("interrupted-owner aggregate");
     });
 }
 
 /// A foreground controller can be interrupted after the provider's terminal
 /// result was persisted but before aggregate harvesting starts. The failed
-/// provider result is sufficient to converge without an aggregate, handle, or
-/// surviving owner process.
+/// provider result still converges, and the interrupted-owner path persists the
+/// aggregate before that terminal transition.
 #[test]
-fn terminal_provider_failure_without_owner_or_aggregate_converges_to_failed() {
+fn terminal_provider_failure_without_owner_persists_interrupted_owner_aggregate() {
     with_isolated_home(|_| {
         let plan = test_plan();
         submit_plan(&plan, Some("provider-failed-no-owner")).expect("submitted");
@@ -3547,11 +3582,22 @@ fn terminal_provider_failure_without_owner_or_aggregate_converges_to_failed() {
         assert_eq!(terminal.state, AgentTaskRunState::Failed);
         assert_eq!(replay.state, AgentTaskRunState::Failed);
         assert!(replay.provider_handles.is_empty());
-        assert!(replay.aggregate_path.is_none());
+        assert!(replay.aggregate_path.is_some());
         assert_eq!(replay.tasks[0].state, AgentTaskState::Failed);
         assert_eq!(
             replay.metadata["local_provider_ownership"]["state"],
             json!("provider_failed")
+        );
+        assert_eq!(
+            replay.metadata["stop_reason"],
+            json!("local Cook observer was interrupted during provider execution")
+        );
+        let aggregate = test_lifecycle_store()
+            .read_aggregate("provider-failed-no-owner")
+            .expect("interrupted-owner aggregate");
+        assert_eq!(
+            aggregate.outcomes[0].diagnostics[0].class,
+            "interrupted_owner"
         );
     });
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_job.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_job.rs
@@ -520,16 +520,17 @@ impl AgentTaskCookJob {
                 &self.request.cook_id,
                 "detached Cook exited before materializing its first attempt",
             )?;
-        }
-        // A retry supervisor is attached to an existing queued attempt rather
-        // than an initial handoff parent. If its launcher exits before provider
-        // execution, retain the normal zero-provider terminal outcome.
-        if self.request.supervisor_id.is_some() {
-            if let Some(run_id) = run_id.as_deref() {
-                let lifecycle_store =
-                    agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
-                let record = lifecycle_store.read_record(run_id)?;
-                if !record.state.is_terminal() {
+        } else if let Some(run_id) = run_id.as_deref() {
+            let lifecycle_store =
+                agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+            let record = lifecycle_store.read_record(run_id)?;
+            if !record.state.is_terminal() {
+                let provider_started = record
+                    .metadata
+                    .get("provider_executions")
+                    .and_then(Value::as_array)
+                    .is_some_and(|executions| !executions.is_empty());
+                if self.request.supervisor_id.is_some() && !provider_started {
                     let plan = lifecycle_store.read_controller_plan(run_id)?;
                     let error = retry_child_failure(&self.request);
                     agent_task_lifecycle::record_pre_execution_failure_in_store(
@@ -538,6 +539,11 @@ impl AgentTaskCookJob {
                         &plan,
                         "local_retry_supervisor",
                         &error,
+                    )?;
+                } else {
+                    agent_task_lifecycle::record_interrupted_local_owner_in_store(
+                        &lifecycle_store,
+                        run_id,
                     )?;
                 }
             }
@@ -1422,6 +1428,109 @@ mod tests {
                     && reference.uri
                         == format!("homeboy://agent-task/run/{run_id}/status#detached-child-command-result")
             }));
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn observe_terminal_persists_interrupted_owner_aggregate_during_provider_execution() {
+        with_isolated_home(|_| {
+            let cook_id = "cook-interrupted-observer";
+            let run_id = "cook-interrupted-observer-attempt-1";
+            let plan = crate::agent_task_scheduler::AgentTaskPlan::new(
+                "interrupted-observer",
+                vec![AgentTaskRequest {
+                    schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+                    task_id: "task-a".to_string(),
+                    group_key: None,
+                    parent_plan_id: None,
+                    executor: AgentTaskExecutor {
+                        backend: "test".to_string(),
+                        selector: Some("fixture".to_string()),
+                        runtime_selection: None,
+                        required_capabilities: Vec::new(),
+                        secret_env: Vec::new(),
+                        model: None,
+                        config: Value::Null,
+                    },
+                    instructions: "run".to_string(),
+                    inputs: Value::Null,
+                    source_refs: Vec::new(),
+                    workspace: AgentTaskWorkspace::default(),
+                    component_contracts: Vec::new(),
+                    policy: AgentTaskPolicy::default(),
+                    limits: AgentTaskLimits::default(),
+                    expected_artifacts: Vec::new(),
+                    artifact_declarations: Vec::new(),
+                    output_declarations: Vec::new(),
+                    runtime_tools: Vec::new(),
+                    metadata: Value::Null,
+                }],
+            );
+            agent_task_lifecycle::record_detached_cook_handoff_parent_in_store(
+                &test_lifecycle_store(),
+                cook_id,
+            )
+            .expect("persist handoff parent");
+            agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("persist attempt");
+            agent_task_lifecycle::record_cook_attempt_in_store(
+                &test_lifecycle_store(),
+                cook_id,
+                1,
+                run_id,
+            )
+            .expect("index attempt");
+            agent_task_lifecycle::mark_running(run_id).expect("running");
+            agent_task_lifecycle::reserve_provider_execution_in_store(
+                &test_lifecycle_store(),
+                run_id,
+                &plan.tasks[0],
+                1,
+            )
+            .expect("reserved");
+            let mut owner = std::process::Command::new("sleep")
+                .arg("60")
+                .spawn()
+                .expect("start cook observer");
+            agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+                record.metadata["provider_executions"][0]["owner_pid"] = json!(owner.id());
+                record.metadata["provider_executions"][0]["owner_linux_starttime_ticks"] =
+                    Value::Null;
+            })
+            .expect("observer fixture");
+            owner.kill().expect("kill cook observer");
+            owner.wait().expect("reap cook observer");
+
+            let mut job =
+                AgentTaskCookJob::parse(request_of(cook_id, u32::MAX)).expect("parse request");
+            job.phase = AgentTaskCookJobPhase::Supervising;
+            job.observe_terminal(Some(run_id.to_string()))
+                .expect("observe interrupted observer");
+
+            let record = agent_task_lifecycle::exact_record(run_id).expect("read interrupted run");
+            assert_eq!(
+                record.state,
+                agent_task_lifecycle::AgentTaskRunState::Cancelled
+            );
+            assert_eq!(
+                record.metadata["stop_reason"],
+                json!("local Cook observer was interrupted during provider execution")
+            );
+            assert_eq!(
+                record.metadata["terminal_failure_classification"],
+                json!("interrupted_owner")
+            );
+            assert_eq!(
+                record.metadata["interrupted_owner"]["provider_budget_consumed"],
+                true
+            );
+            let aggregate = test_lifecycle_store()
+                .read_aggregate(run_id)
+                .expect("read interrupted-owner aggregate");
+            assert_eq!(
+                aggregate.outcomes[0].diagnostics[0].class,
+                "interrupted_owner"
+            );
         });
     }
 

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -3035,6 +3035,7 @@ struct DiagnosedFailure {
     phase: Option<String>,
     provider_boundary_exists: bool,
     controller_runtime_recovery_available: bool,
+    provider_budget_consumed: bool,
 }
 
 /// Collect the distinct failure classifications a run actually recorded, first
@@ -3074,6 +3075,7 @@ fn diagnosed_failures(
                 .iter()
                 .any(|evidence| evidence.kind == "executor-input"),
             controller_runtime_recovery_available: controller_runtime_recovery_available(record),
+            provider_budget_consumed: outcome.metadata["provider_budget_consumed"] == true,
         });
     }
     failures
@@ -3278,6 +3280,34 @@ fn classification_next_actions(
             )
             .with_kind(CommandNextActionKind::Show),
         );
+        return actions;
+    }
+
+    if failure.phase.as_deref() == Some("interrupted_owner") {
+        let budget_label = if failure.provider_budget_consumed {
+            "provider budget was consumed and in-flight work may be duplicated"
+        } else {
+            "provider budget was not consumed"
+        };
+        let mut actions = vec![
+            failure_evidence,
+            CommandNextAction::new(
+                format!(
+                    "show the interrupted-owner stop reason and candidate harvest evidence; {budget_label}"
+                ),
+                format!("homeboy agent-task status {run} --full"),
+            )
+            .with_kind(CommandNextActionKind::Show),
+        ];
+        if let Some(retry) = retry {
+            actions.push(
+                CommandNextAction::new(
+                    format!("retry this Cook; {budget_label}"),
+                    retry.command.clone(),
+                )
+                .with_kind(CommandNextActionKind::Repair),
+            );
+        }
         return actions;
     }
 
@@ -4113,6 +4143,7 @@ mod diagnose_actionable_tests {
             phase: None,
             provider_boundary_exists: true,
             controller_runtime_recovery_available: false,
+            provider_budget_consumed: false,
         }
     }
 
@@ -4299,6 +4330,7 @@ mod diagnose_actionable_tests {
             phase: None,
             provider_boundary_exists: false,
             controller_runtime_recovery_available: false,
+            provider_budget_consumed: false,
         };
 
         let (actions, basis) =
@@ -4319,6 +4351,7 @@ mod diagnose_actionable_tests {
             phase: Some("controller_admission".to_string()),
             provider_boundary_exists: false,
             controller_runtime_recovery_available: true,
+            provider_budget_consumed: false,
         };
 
         let (actions, basis) = diagnose_next_actions("run-1", &[failure], &[], None, None, false);
@@ -4441,6 +4474,7 @@ mod diagnose_actionable_tests {
                 phase: None,
                 provider_boundary_exists: true,
                 controller_runtime_recovery_available: false,
+                provider_budget_consumed: false,
             }],
             &[],
             None,
@@ -5625,6 +5659,7 @@ fn aggregate_failure_diagnostics(aggregate: &AgentTaskAggregate) -> Vec<Collecte
                 | AgentTaskOutcomeStatus::ProviderError
                 | AgentTaskOutcomeStatus::Timeout
                 | AgentTaskOutcomeStatus::UnableToRemediate
+                | AgentTaskOutcomeStatus::Cancelled
         )
     });
     let scan: Vec<&homeboy::agents::agent_tasks::AgentTaskOutcome> = failed_first.collect();
@@ -6581,6 +6616,19 @@ fn persisted_cook_failure_diagnostic(record: &AgentTaskRunRecord) -> Option<Coll
                     "field": cause.get("field"),
                 })
             }),
+        });
+    }
+    if let Some(failure) = record.metadata.get("interrupted_owner") {
+        return Some(CollectedDiagnostic {
+            task_id: "controller".to_string(),
+            class: "interrupted_owner".to_string(),
+            message: failure
+                .get("stop_reason")
+                .and_then(Value::as_str)
+                .unwrap_or("local Cook observer was interrupted during provider execution")
+                .to_string(),
+            source: "interrupted_owner".to_string(),
+            data: failure.clone(),
         });
     }
     if let Some(failure) = record.metadata.get("pre_execution_failure") {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -3491,6 +3491,68 @@ fn diagnose_derives_next_actions_from_the_failure_classification() {
 }
 
 #[test]
+#[cfg(unix)]
+fn diagnose_interrupted_local_owner_names_budget_and_duplication_instead_of_generic_retry() {
+    with_temp_home(|| {
+        let run_id = "run-cli-diagnose-interrupted-owner";
+        let plan = test_plan();
+        agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("submitted");
+        agent_task_lifecycle::mark_running(run_id).expect("running");
+        let mut owner = Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("start cook observer");
+        agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+            record.metadata["provider_executions"] = json!([{
+                "key": "task-a:1",
+                "task_id": "task-a",
+                "attempt": 1,
+                "backend": "test",
+                "state": "running",
+                "owner_pid": owner.id(),
+                "owner_linux_starttime_ticks": null,
+                "owner_identity": format!("{run_id}:task-a:1"),
+            }]);
+            record.metadata["provider_executions_consumed"] = json!(1);
+        })
+        .expect("observer fixture");
+        owner.kill().expect("kill cook observer");
+        owner.wait().expect("reap cook observer");
+
+        let record = lifecycle_status(run_id).expect("reconcile interrupted owner");
+        assert_eq!(record.state, AgentTaskRunState::Cancelled);
+        assert_eq!(
+            record.metadata["stop_reason"],
+            "local Cook observer was interrupted during provider execution"
+        );
+
+        let (value, exit_code) = diagnose(DiagnoseArgs {
+            run_id: run_id.to_string(),
+            full: false,
+        })
+        .expect("diagnose interrupted owner");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(value["root_cause"]["class"], "interrupted_owner");
+        assert_eq!(value["next_action_basis"], "diagnosis");
+        assert_ne!(value["next_action_basis"], "generic_fallback");
+        let commands: Vec<&str> = value["_homeboy_actionable"]["next_actions"]
+            .as_array()
+            .expect("next actions")
+            .iter()
+            .map(|action| action["label"].as_str().unwrap_or_default())
+            .collect();
+        assert!(
+            commands.iter().any(|label| {
+                label.contains("provider budget was consumed")
+                    && label.contains("may be duplicated")
+            }),
+            "{commands:?}"
+        );
+    });
+}
+
+#[test]
 fn diagnose_falls_back_to_the_generic_set_for_an_unclassified_failure() {
     with_temp_home(|| {
         let run_id = "run-cli-diagnose-actionable-unknown";


### PR DESCRIPTION
## Summary

- persist an aggregate, stop reason, diagnostics, and provider-budget facts before interrupted local ownership becomes terminal
- harvest recoverable candidate evidence or record explicit candidate unavailability
- make diagnosis name duplication risk instead of falling back to a generic retry

Closes #13794

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-agents interrupted_owner`
- `cargo test -p homeboy-cli diagnose_interrupted_local_owner_names_budget_and_duplication_instead_of_generic_retry`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol through OpenCode traced the empty terminal tombstone, implemented durable interrupted-owner aggregation and diagnosis, and ran focused regression verification under Chris Huber’s direction.