### PR TITLE
Honor snapshot exclusions during Lab harvest

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
@@ -24,7 +24,7 @@ fn run_snapshot_fence_test_hook() {
 
 use super::harvest::{
     git_is_repository, git_output_raw, git_output_with_env, git_status_ignoring_runner_metadata,
-    RUNNER_METADATA_EXCLUDE_PATHSPECS,
+    git_status_ignoring_snapshot_excludes, RUNNER_METADATA_EXCLUDE_PATHSPECS,
 };
 use super::*;
 
@@ -114,6 +114,13 @@ impl HarvestExecutionContext {
 
     pub fn snapshot_signaled(&self) -> bool {
         self.source_snapshot.is_some() || self.lab_offload.is_some()
+    }
+
+    fn snapshot_sync_excludes(&self) -> &[String] {
+        self.source_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.sync_excludes.as_slice())
+            .unwrap_or(&[])
     }
 
     fn source_snapshot(
@@ -359,7 +366,7 @@ pub(super) fn prepare_committed_harvest(
             message: "Git top-level does not exactly match the managed workspace root".to_string(),
         });
     }
-    let status = git_status_ignoring_runner_metadata(root)?;
+    let status = git_status_ignoring_snapshot_excludes(root, context.snapshot_sync_excludes())?;
     let candidate_baseline = if status.trim().is_empty() {
         None
     } else if let Some(baseline) = verified_initial_cook_candidate_baseline(root, request)? {
@@ -376,7 +383,8 @@ pub(super) fn prepare_committed_harvest(
     // observation is only a candidate baseline, never authorization to create
     // the provider attempt worktree.
     let source_head = git_output(root, &["rev-parse", "HEAD"])?;
-    let snapshot_status = git_status_ignoring_runner_metadata(root)?;
+    let snapshot_status =
+        git_status_ignoring_snapshot_excludes(root, context.snapshot_sync_excludes())?;
     let base_sha =
         pinned_cook_workspace_base_snapshot(request, root, &source_head, &snapshot_status)?
             .unwrap_or(source_head);
@@ -651,7 +659,7 @@ fn validate_derived_cook_baseline(
             "derived baseline capability does not bind this workspace and task".to_string(),
         ));
     }
-    let status = git_status_ignoring_runner_metadata(root)?;
+    let status = git_status_ignoring_snapshot_excludes(root, context.snapshot_sync_excludes())?;
     if !status.is_empty() {
         return Err(HarvestError::DirtyWorkspace { status });
     }
@@ -1157,6 +1165,53 @@ mod tests {
         assert!(
             status.contains("user-output.txt"),
             "unrelated untracked files must still fail the cleanliness check: {status}"
+        );
+    }
+
+    #[test]
+    fn excluded_tracked_context_is_clean_but_real_drift_is_not() {
+        let workspace = tempfile::tempdir().expect("workspace repository");
+        git(workspace.path(), &["init", "-b", "main"]);
+        fs::write(workspace.path().join("tracked.txt"), "base").expect("base file");
+        fs::write(workspace.path().join("AGENTS.md"), "injected").expect("context file");
+        git(workspace.path(), &["add", "tracked.txt", "AGENTS.md"]);
+        git(
+            workspace.path(),
+            &[
+                "-c",
+                "user.name=Homeboy Test",
+                "-c",
+                "user.email=homeboy@example.test",
+                "commit",
+                "-m",
+                "initial",
+            ],
+        );
+        fs::remove_file(workspace.path().join("AGENTS.md")).expect("omit excluded context");
+        let excludes = vec!["AGENTS.md".to_string()];
+        assert!(
+            git_status_ignoring_snapshot_excludes(workspace.path(), &excludes)
+                .expect("excluded context status")
+                .is_empty(),
+            "omitted tracked context must not dirty an exclusion-aware snapshot"
+        );
+
+        fs::write(workspace.path().join("tracked.txt"), "changed").expect("tracked drift");
+        let status = git_status_ignoring_snapshot_excludes(workspace.path(), &excludes)
+            .expect("tracked drift status");
+        assert!(
+            status.contains("tracked.txt"),
+            "tracked source drift must still fail closed: {status}"
+        );
+        git(workspace.path(), &["checkout", "--", "tracked.txt"]);
+
+        fs::write(workspace.path().join("provider-output.txt"), "unexpected")
+            .expect("untracked drift");
+        let status = git_status_ignoring_snapshot_excludes(workspace.path(), &excludes)
+            .expect("untracked drift status");
+        assert!(
+            status.contains("provider-output.txt"),
+            "untracked source drift must still fail closed: {status}"
         );
     }
 

--- a/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
@@ -488,14 +488,30 @@ pub(super) fn git_is_repository(cwd: &Path) -> Result<bool, HarvestError> {
 
 /// Report workspace changes while excluding state injected by Homeboy's runner.
 pub(super) fn git_status_ignoring_runner_metadata(cwd: &Path) -> Result<String, HarvestError> {
+    git_status_ignoring_snapshot_excludes(cwd, &[])
+}
+
+/// Same cleanliness surface as [`git_status_ignoring_runner_metadata`], plus
+/// declared snapshot excludes so omitted tracked context is not source dirt.
+pub(super) fn git_status_ignoring_snapshot_excludes(
+    cwd: &Path,
+    sync_excludes: &[String],
+) -> Result<String, HarvestError> {
+    let extra = homeboy_core::source_snapshot::git_exclude_pathspecs(sync_excludes);
     let mut args = vec![
-        "status",
-        "--porcelain=v1",
-        "--untracked-files=all",
-        "--",
-        ".",
+        "status".to_string(),
+        "--porcelain=v1".to_string(),
+        "--untracked-files=all".to_string(),
+        "--".to_string(),
+        ".".to_string(),
     ];
-    args.extend_from_slice(RUNNER_METADATA_EXCLUDE_PATHSPECS);
+    args.extend(
+        RUNNER_METADATA_EXCLUDE_PATHSPECS
+            .iter()
+            .map(|pathspec| (*pathspec).to_string()),
+    );
+    args.extend(extra);
+    let args = args.iter().map(String::as_str).collect::<Vec<_>>();
     git_output(cwd, &args)
 }
 

--- a/crates/homeboy-core/src/source_snapshot.rs
+++ b/crates/homeboy-core/src/source_snapshot.rs
@@ -137,6 +137,42 @@ pub(crate) fn existing_remote_with_policy(
     }
 }
 
+/// Git exclusion pathspecs with the same root and glob semantics as snapshot
+/// traversal. A malformed Git pathspec is left for Git to reject so callers
+/// that validate provenance fail closed.
+pub fn git_exclude_pathspecs(excludes: &[String]) -> Vec<String> {
+    let mut pathspecs = Vec::new();
+    for exclude in excludes {
+        let root_anchored = exclude.starts_with("./");
+        let pattern = exclude
+            .trim_start_matches("./")
+            .trim_end_matches('/')
+            .trim();
+        if pattern.is_empty() {
+            continue;
+        }
+        let pattern = if root_anchored || pattern.contains('/') {
+            pattern.to_string()
+        } else {
+            format!("**/{pattern}")
+        };
+        let pathspec = format!(":(exclude,top,glob){pattern}");
+        if !pathspecs.contains(&pathspec) {
+            pathspecs.push(pathspec);
+        }
+        // Snapshot traversal skips an excluded directory before visiting its
+        // children. Add its descendants explicitly because Git status reports
+        // files rather than the excluded directory entry itself.
+        if !pattern.contains('*') {
+            let descendants = format!(":(exclude,top,glob){pattern}/**");
+            if !pathspecs.contains(&descendants) {
+                pathspecs.push(descendants);
+            }
+        }
+    }
+    pathspecs
+}
+
 pub fn declared_sync_excludes_for_path(path: &Path) -> Vec<String> {
     let mut excludes = Vec::new();
     append_unique(&mut excludes, component_extension_sync_excludes(path));
@@ -297,6 +333,21 @@ mod tests {
     use super::*;
     use std::io::Write;
     use std::process::Command;
+
+    #[test]
+    fn git_exclude_pathspecs_match_root_files_and_directory_trees() {
+        let pathspecs = git_exclude_pathspecs(&[
+            "AGENTS.md".to_string(),
+            ".claude".to_string(),
+            ".claude/**".to_string(),
+            "./.datamachine".to_string(),
+        ]);
+        assert!(pathspecs.contains(&":(exclude,top,glob)**/AGENTS.md".to_string()));
+        assert!(pathspecs.contains(&":(exclude,top,glob)**/.claude".to_string()));
+        assert!(pathspecs.contains(&":(exclude,top,glob).claude/**".to_string()));
+        assert!(pathspecs.contains(&":(exclude,top,glob).datamachine".to_string()));
+        assert!(pathspecs.contains(&":(exclude,top,glob).datamachine/**".to_string()));
+    }
 
     #[test]
     fn test_default_sync_excludes() {

--- a/crates/homeboy-lab-runner/src/workspace/provenance.rs
+++ b/crates/homeboy-lab-runner/src/workspace/provenance.rs
@@ -1768,6 +1768,162 @@ mod tests {
     }
 
     #[test]
+    fn snapshot_git_cook_harvest_ignores_excluded_tracked_context_but_fails_closed_on_drift() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            crate::register_lab_workspace_provenance_provider();
+            let source = tempfile::tempdir().expect("source");
+            let runner_root = tempfile::tempdir().expect("runner root");
+            std::fs::write(source.path().join("file.txt"), "baseline\n").expect("source file");
+            std::fs::write(source.path().join("AGENTS.md"), "injected context\n")
+                .expect("tracked context file");
+            std::fs::create_dir_all(source.path().join(".claude")).expect("claude dir");
+            std::fs::write(source.path().join(".claude/settings.json"), "{}\n")
+                .expect("claude context");
+            std::fs::create_dir_all(source.path().join(".datamachine")).expect("datamachine dir");
+            std::fs::write(source.path().join(".datamachine/context.json"), "{}\n")
+                .expect("datamachine context");
+            git(source.path(), &["init", "--quiet", "-b", "main"]).expect("init");
+            git(
+                source.path(),
+                &["config", "user.email", "test@homeboy.invalid"],
+            )
+            .expect("email");
+            git(source.path(), &["config", "user.name", "Homeboy Test"]).expect("name");
+            git(source.path(), &["add", "."]).expect("stage");
+            git(source.path(), &["commit", "--quiet", "-m", "baseline"]).expect("commit");
+            assert!(
+                git(source.path(), &["status", "--porcelain"])
+                    .expect("source status")
+                    .is_empty(),
+                "controller source must be clean"
+            );
+
+            crate::create(
+                &format!(
+                    r#"{{"id":"lab-excluded-context","kind":"local","workspace_root":"{}","policy":{{"snapshot_excludes":["AGENTS.md",".claude",".claude/**",".datamachine",".datamachine/**"]}}}}"#,
+                    runner_root.path().display()
+                ),
+                false,
+            )
+            .expect("create runner");
+            let (synced, _) = crate::workspace::sync_workspace(
+                "lab-excluded-context",
+                crate::workspace::RunnerWorkspaceSyncOptions {
+                    path: source.path().display().to_string(),
+                    mode: crate::workspace::RunnerWorkspaceSyncMode::SnapshotGit,
+                    ..Default::default()
+                },
+            )
+            .expect("materialize exclusion-aware snapshot-git");
+            let remote = PathBuf::from(&synced.remote_path);
+            assert!(remote.join("file.txt").is_file());
+            assert!(!remote.join("AGENTS.md").exists());
+            assert!(!remote.join(".claude").exists());
+            assert!(!remote.join(".datamachine").exists());
+
+            let mut snapshot = homeboy_core::source_snapshot::collect_local(
+                "lab-excluded-context",
+                source.path(),
+                Some(&synced.remote_path),
+                LAB_SOURCE_SNAPSHOT_SYNC_MODE,
+            );
+            assert!(!snapshot.dirty, "controller records the source as clean");
+            snapshot.sync_excludes = synced.excludes.clone();
+            snapshot.workspace_snapshot_identity = Some(synced.snapshot_identity.clone());
+            let content_hash = super::super::snapshot::workspace_content_hash(
+                source.path(),
+                &snapshot.sync_excludes,
+            )
+            .expect("source content hash");
+            let lab = serde_json::json!({
+                "runner_id": "lab-excluded-context",
+                "remote_workspace": synced.remote_path.clone(),
+                "sync_mode": synced.materialization_plan.actual_materialization_mode,
+                "status": "offloaded",
+                "source_snapshot": snapshot,
+                "workspace_cleanliness": { "allow_dirty_lab_workspace": false },
+                "workspace_verification": {
+                    "schema": "homeboy/lab-workspace-verification/v2",
+                    "identity": synced.snapshot_identity.clone(),
+                    "content_hash_algorithm": super::super::snapshot::workspace_content_hash_algorithm(
+                        WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
+                    ).expect("content hash algorithm"),
+                    "permission_policy": WORKSPACE_CONTENT_DEFAULT_PERMISSION_POLICY,
+                    "content_hash": content_hash,
+                    "sync_excludes": snapshot.sync_excludes,
+                    "source_snapshot": snapshot.clone(),
+                    "primary_workspace": {
+                        "identity": synced.snapshot_identity.clone(),
+                        "remote_path": synced.remote_path.clone(),
+                    },
+                },
+            });
+            assert_eq!(
+                snapshot.workspace_snapshot_identity.as_deref(),
+                Some(synced.snapshot_identity.as_str()),
+                "controller and runner must report one snapshot identity"
+            );
+
+            let dispatched = Arc::new(AtomicBool::new(false));
+            let scheduler = AgentTaskScheduler::new(Arc::new(FilesystemSnapshotProvider {
+                change_workspace: true,
+                dispatched: Arc::clone(&dispatched),
+            }))
+            .with_harvest_context(
+                HarvestExecutionContext::from_lab_transport(snapshot.clone(), lab.clone())
+                    .expect("paired Lab transport"),
+            );
+            let aggregate = scheduler.run(AgentTaskPlan::new(
+                "excluded-context-cook",
+                vec![filesystem_snapshot_request(&remote)],
+            ));
+            assert!(
+                dispatched.load(Ordering::SeqCst),
+                "clean exclusion-aware Lab snapshot must reach the provider: {aggregate:?}"
+            );
+            assert_eq!(aggregate.totals.succeeded, 1, "{aggregate:?}");
+            assert_eq!(
+                aggregate.outcomes[0]
+                    .artifacts
+                    .iter()
+                    .find(|artifact| artifact.kind == "patch")
+                    .expect("harvested patch")
+                    .metadata["source_provenance"]["workspace_snapshot_identity"],
+                synced.snapshot_identity,
+            );
+
+            std::fs::write(remote.join("file.txt"), "drift\n").expect("tracked drift");
+            let drifted = Arc::new(AtomicBool::new(false));
+            let failed = AgentTaskScheduler::new(Arc::new(FilesystemSnapshotProvider {
+                change_workspace: true,
+                dispatched: Arc::clone(&drifted),
+            }))
+            .with_harvest_context(
+                HarvestExecutionContext::from_lab_transport(snapshot, lab)
+                    .expect("paired Lab transport"),
+            )
+            .run(AgentTaskPlan::new(
+                "excluded-context-drift",
+                vec![filesystem_snapshot_request(&remote)],
+            ));
+            assert!(
+                !drifted.load(Ordering::SeqCst),
+                "real tracked drift must fail before provider execution"
+            );
+            assert_eq!(failed.totals.failed, 1, "{failed:?}");
+            assert!(
+                failed.outcomes[0].diagnostics.iter().any(|diagnostic| {
+                    diagnostic.class == "agent_task.committed_harvest_git_failed"
+                        || diagnostic.class == "agent_task.committed_harvest_dirty_workspace"
+                        || diagnostic.class == "agent_task.workspace_snapshot_invalidated"
+                }),
+                "real drift must fail closed: {:?}",
+                failed.outcomes[0].diagnostics
+            );
+        });
+    }
+
+    #[test]
     fn verified_snapshot_baseline_replay_reuses_only_the_matching_baseline() {
         let workspace = tempfile::tempdir().expect("workspace");
         std::fs::write(workspace.path().join("file.txt"), "baseline\n").expect("source file");

--- a/crates/homeboy-lab-runner/src/workspace/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/snapshot.rs
@@ -159,36 +159,7 @@ pub(crate) fn snapshot_identity(
 /// snapshot traversal. A malformed Git pathspec is deliberately left to Git to
 /// reject so callers that validate provenance fail closed.
 pub(crate) fn snapshot_git_exclude_pathspecs(excludes: &[String]) -> Vec<String> {
-    let mut pathspecs = Vec::new();
-    for exclude in excludes {
-        let root_anchored = exclude.starts_with("./");
-        let pattern = exclude
-            .trim_start_matches("./")
-            .trim_end_matches('/')
-            .trim();
-        if pattern.is_empty() {
-            continue;
-        }
-        let pattern = if root_anchored || pattern.contains('/') {
-            pattern.to_string()
-        } else {
-            format!("**/{pattern}")
-        };
-        let pathspec = format!(":(exclude,top,glob){pattern}");
-        if !pathspecs.contains(&pathspec) {
-            pathspecs.push(pathspec);
-        }
-        // Snapshot traversal skips an excluded directory before visiting its
-        // children. Add its descendants explicitly because Git status reports
-        // files rather than the excluded directory entry itself.
-        if !pattern.contains('*') {
-            let descendants = format!(":(exclude,top,glob){pattern}/**");
-            if !pathspecs.contains(&descendants) {
-                pathspecs.push(descendants);
-            }
-        }
-    }
-    pathspecs
+    homeboy_core::source_snapshot::git_exclude_pathspecs(excludes)
 }
 
 pub(crate) fn snapshot_git_output(


### PR DESCRIPTION
## Summary

- project declared snapshot exclusions into committed-harvest Git cleanliness checks
- share one pathspec implementation between controller and runner snapshot verification
- prove excluded tracked context is ignored while real tracked and untracked drift still fails closed

Closes #13523

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-lab-runner snapshot_git_cook_harvest_ignores_excluded_tracked_context_but_fails_closed_on_drift`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol through OpenCode traced the exclusion-aware snapshot identity mismatch, implemented the shared pathspec projection, and ran focused regression verification under Chris Huber’s direction.