### PR TITLE
Unify control-plane event streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,7 @@ dependencies = [
  "glob",
  "homeboy-agents",
  "homeboy-command-contract",
+ "homeboy-control-plane-contract",
  "homeboy-core",
  "homeboy-deploy",
  "homeboy-engine-primitives",

--- a/crates/contracts/homeboy-control-plane-contract/Cargo.toml
+++ b/crates/contracts/homeboy-control-plane-contract/Cargo.toml
@@ -14,6 +14,4 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-
-[dev-dependencies]
 serde_json = "1.0"

--- a/crates/contracts/homeboy-control-plane-contract/src/capabilities.rs
+++ b/crates/contracts/homeboy-control-plane-contract/src/capabilities.rs
@@ -22,6 +22,7 @@ pub struct ControlPlaneCapabilities {
 pub enum ControlPlaneOperation {
     GetCapabilities,
     GetRun,
+    GetRunEvents,
 }
 
 /// A resource identity this build serves.
@@ -34,6 +35,7 @@ pub enum ControlPlaneResource {
     Attempt,
     Execution,
     ProviderSession,
+    Event,
 }
 
 impl ControlPlaneCapabilities {
@@ -77,7 +79,9 @@ mod tests {
         assert!(
             !document.operations.iter().any(|operation| !matches!(
                 operation,
-                ControlPlaneOperation::GetCapabilities | ControlPlaneOperation::GetRun
+                ControlPlaneOperation::GetCapabilities
+                    | ControlPlaneOperation::GetRun
+                    | ControlPlaneOperation::GetRunEvents
             )),
             "capabilities must not advertise unwired mutations"
         );

--- a/crates/contracts/homeboy-control-plane-contract/src/event.rs
+++ b/crates/contracts/homeboy-control-plane-contract/src/event.rs
@@ -1,0 +1,111 @@
+//! Versioned, runtime-neutral control-plane events and cursor pages.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::resource::ControlPlaneEvidenceRef;
+use crate::{AttemptId, EventCursor, EventId, ExecutionId, MissionId, RunId, TaskId};
+
+pub const CONTROL_PLANE_EVENT_SCHEMA: &str = "homeboy/control-plane-event/v1";
+pub const CONTROL_PLANE_EVENT_PAGE_SCHEMA: &str = "homeboy/control-plane-event-page/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ControlPlaneEvent {
+    pub schema: String,
+    pub event: EventId,
+    pub sequence: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub occurred_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mission: Option<MissionId>,
+    pub run: RunId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task: Option<TaskId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attempt: Option<AttemptId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution: Option<ExecutionId>,
+    pub kind: String,
+    pub source: ControlPlaneEventSource,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub data: Value,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<ControlPlaneEvidenceRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence: Vec<ControlPlaneEvidenceRef>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ControlPlaneEventSource {
+    pub component: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instance: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ControlPlaneEventPage {
+    pub schema: String,
+    pub run: RunId,
+    pub events: Vec<ControlPlaneEvent>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<EventCursor>,
+    pub has_more: bool,
+}
+
+impl ControlPlaneEventPage {
+    pub fn empty(run: RunId) -> Self {
+        Self {
+            schema: CONTROL_PLANE_EVENT_PAGE_SCHEMA.to_string(),
+            run,
+            events: Vec::new(),
+            next_cursor: None,
+            has_more: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_page_round_trips_with_typed_cursor_and_identities() {
+        let run = RunId::new("run-1").expect("run");
+        let page = ControlPlaneEventPage {
+            schema: CONTROL_PLANE_EVENT_PAGE_SCHEMA.to_string(),
+            run: run.clone(),
+            events: vec![ControlPlaneEvent {
+                schema: CONTROL_PLANE_EVENT_SCHEMA.to_string(),
+                event: EventId::new("run-1:event:1").expect("event"),
+                sequence: 1,
+                occurred_at: Some("2026-01-01T00:00:00Z".to_string()),
+                mission: None,
+                run,
+                task: Some(TaskId::new("task-1").expect("task")),
+                attempt: None,
+                execution: None,
+                kind: "task.state_changed".to_string(),
+                source: ControlPlaneEventSource {
+                    component: "agent-task".to_string(),
+                    instance: None,
+                },
+                data: serde_json::json!({ "state": "succeeded" }),
+                artifacts: Vec::new(),
+                evidence: Vec::new(),
+            }],
+            next_cursor: Some(EventCursor::new("1").expect("cursor")),
+            has_more: false,
+        };
+
+        let value = serde_json::to_value(&page).expect("serialize");
+        assert_eq!(value["schema"], CONTROL_PLANE_EVENT_PAGE_SCHEMA);
+        assert_eq!(value["events"][0]["schema"], CONTROL_PLANE_EVENT_SCHEMA);
+        assert_eq!(value["events"][0]["event"], "run-1:event:1");
+        assert_eq!(value["next_cursor"], "1");
+        let decoded: ControlPlaneEventPage = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(decoded, page);
+    }
+}

--- a/crates/contracts/homeboy-control-plane-contract/src/identity.rs
+++ b/crates/contracts/homeboy-control-plane-contract/src/identity.rs
@@ -77,6 +77,14 @@ opaque_identity!(
     /// A provider session identity.
     ProviderSessionId
 );
+opaque_identity!(
+    /// Stable identity of one event in a run stream.
+    EventId
+);
+opaque_identity!(
+    /// Opaque resume cursor returned by an event page.
+    EventCursor
+);
 
 /// Why an identity newtype could not be constructed.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/contracts/homeboy-control-plane-contract/src/lib.rs
+++ b/crates/contracts/homeboy-control-plane-contract/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod capabilities;
 pub mod control_plane_ref;
+pub mod event;
 pub mod identity;
 pub mod resolve;
 pub mod resource;
@@ -18,8 +19,13 @@ pub use capabilities::{
     CONTROL_PLANE_CAPABILITIES_SCHEMA,
 };
 pub use control_plane_ref::{ControlPlaneRef, ControlPlaneRefError};
+pub use event::{
+    ControlPlaneEvent, ControlPlaneEventPage, ControlPlaneEventSource,
+    CONTROL_PLANE_EVENT_PAGE_SCHEMA, CONTROL_PLANE_EVENT_SCHEMA,
+};
 pub use identity::{
-    AttemptId, ExecutionId, IdentityError, MissionId, ProviderSessionId, RunId, TaskId,
+    AttemptId, EventCursor, EventId, ExecutionId, IdentityError, MissionId, ProviderSessionId,
+    RunId, TaskId,
 };
 pub use resolve::{resolve, IdentityKind, ResolveError, ResolvedIdentities};
 pub use resource::{

--- a/crates/homeboy-agents/src/agent_task_lifecycle/conversion.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/conversion.rs
@@ -317,38 +317,150 @@ pub(crate) fn totals_for_tasks(tasks: &[AgentTaskRunTask]) -> AgentTaskAggregate
 }
 
 pub(crate) fn normalize_progress_events(
-    run_id: &str,
+    record: &AgentTaskRunRecord,
     events: &[AgentTaskProgressEvent],
     artifact_refs: &[AgentTaskArtifactRef],
-) -> Vec<AgentTaskEventEnvelope> {
+) -> Result<Vec<homeboy_control_plane_contract::ControlPlaneEvent>> {
     events
         .iter()
         .enumerate()
-        .map(|(index, event)| AgentTaskEventEnvelope {
-            schema: schemas::EVENT.to_string(),
-            run_id: run_id.to_string(),
-            task_id: event.task_id.clone(),
-            sequence: (index + 1) as u64,
-            event_type: "agent_task.state_changed".to_string(),
-            status: event.state,
-            message: event.message.clone(),
-            provider: None,
-            phase: None,
-            activity: None,
-            heartbeat_at_ms: None,
-            progress: json!({
-                "attempt": event.attempt,
-            }),
-            artifact_refs: artifact_refs
-                .iter()
-                .filter(|artifact_ref| artifact_ref.task_id == event.task_id)
-                .cloned()
-                .collect(),
-            metadata: json!({
-                "source_schema": AGENT_TASK_AGGREGATE_SCHEMA,
-            }),
+        .map(|(index, event)| {
+            control_plane_event(
+                record,
+                (index + 1) as u64,
+                &event.task_id,
+                "task.state_changed",
+                None,
+                "agent-task",
+                json!({
+                    "state": event.state,
+                    "message": event.message,
+                    "progress": { "attempt": event.attempt },
+                    "source_schema": AGENT_TASK_AGGREGATE_SCHEMA,
+                }),
+                artifact_refs
+                    .iter()
+                    .filter(|artifact_ref| artifact_ref.task_id == event.task_id),
+            )
         })
         .collect()
+}
+
+pub(crate) fn control_plane_event<'a>(
+    record: &AgentTaskRunRecord,
+    sequence: u64,
+    task_id: &str,
+    kind: &str,
+    occurred_at: Option<String>,
+    source: &str,
+    data: Value,
+    artifact_refs: impl Iterator<Item = &'a AgentTaskArtifactRef>,
+) -> Result<homeboy_control_plane_contract::ControlPlaneEvent> {
+    use homeboy_control_plane_contract::{
+        ControlPlaneEvent, ControlPlaneEventSource, ControlPlaneEvidenceRef, EventId, RunId,
+        TaskId, CONTROL_PLANE_EVENT_SCHEMA,
+    };
+
+    let run = RunId::new(&record.run_id).map_err(|error| {
+        Error::validation_invalid_argument(
+            "run_id",
+            error.to_string(),
+            Some(record.run_id.clone()),
+            None,
+        )
+    })?;
+    let task = TaskId::new(task_id).map_err(|error| {
+        Error::validation_invalid_argument(
+            "task_id",
+            error.to_string(),
+            Some(task_id.to_string()),
+            None,
+        )
+    })?;
+    let identities = canonical_control_plane_identities(record)?;
+    let artifacts = artifact_refs
+        .enumerate()
+        .take(crate::orchestration::REF_BOUND)
+        .map(|(index, reference)| ControlPlaneEvidenceRef {
+            id: crate::orchestration::redacted_bounded(
+                &reference
+                    .label
+                    .clone()
+                    .unwrap_or_else(|| format!("{}-artifact-{}", task_id, index + 1)),
+                128,
+            ),
+            kind: crate::orchestration::redacted_bounded(&reference.kind, 64),
+            uri: crate::orchestration::redacted_bounded(&reference.uri, 512),
+        })
+        .collect();
+
+    Ok(ControlPlaneEvent {
+        schema: CONTROL_PLANE_EVENT_SCHEMA.to_string(),
+        event: EventId::new(format!("{}:event:{sequence}", record.run_id))
+            .expect("validated run identity produces a nonempty event id"),
+        sequence,
+        occurred_at,
+        mission: identities.as_ref().map(|value| value.mission.clone()),
+        run,
+        task: Some(task),
+        attempt: identities.map(|value| value.attempt),
+        execution: record
+            .runner_job_id()
+            .and_then(|value| homeboy_control_plane_contract::ExecutionId::new(value).ok()),
+        kind: kind.to_string(),
+        source: ControlPlaneEventSource {
+            component: source.to_string(),
+            instance: None,
+        },
+        data: bounded_event_data(homeboy_core::redaction::redact_json(&data), 0),
+        artifacts,
+        evidence: Vec::new(),
+    })
+}
+
+fn bounded_event_data(value: Value, depth: usize) -> Value {
+    const MAX_DEPTH: usize = 8;
+    const MAX_ITEMS: usize = 32;
+    const MAX_STRING_CHARS: usize = 2_048;
+
+    if depth >= MAX_DEPTH {
+        return Value::String("[truncated]".to_string());
+    }
+    match value {
+        Value::String(value) => Value::String(value.chars().take(MAX_STRING_CHARS).collect()),
+        Value::Array(values) => Value::Array(
+            values
+                .into_iter()
+                .take(MAX_ITEMS)
+                .map(|value| bounded_event_data(value, depth + 1))
+                .collect(),
+        ),
+        Value::Object(values) => Value::Object(
+            values
+                .into_iter()
+                .take(MAX_ITEMS)
+                .map(|(key, value)| (key, bounded_event_data(value, depth + 1)))
+                .collect(),
+        ),
+        value => value,
+    }
+}
+
+pub(crate) fn control_plane_event_page(
+    record: &AgentTaskRunRecord,
+    events: Vec<homeboy_control_plane_contract::ControlPlaneEvent>,
+    cursor: Option<&homeboy_control_plane_contract::EventCursor>,
+) -> Result<homeboy_control_plane_contract::ControlPlaneEventPage> {
+    let run = homeboy_control_plane_contract::RunId::new(&record.run_id).map_err(|error| {
+        Error::validation_invalid_argument(
+            "run_id",
+            error.to_string(),
+            Some(record.run_id.clone()),
+            None,
+        )
+    })?;
+    crate::orchestration::event_page(run, events, cursor)
+        .map_err(|error| Error::validation_invalid_argument("cursor", error.message, None, None))
 }
 
 pub(crate) fn artifact_refs_for_outcomes(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -5317,9 +5317,12 @@ pub fn persisted_status_in_store(
 /// a read model (such as activity) projects lifecycle state. A controller wait
 /// expiry is not terminal after a runner job is recorded: the runner daemon
 /// remains the authority until it reports a terminal job result.
-pub fn run_status(run_id: &str, since_cursor: Option<u64>) -> Result<AgentTaskRunStatus> {
+pub fn run_status(
+    run_id: &str,
+    cursor: Option<homeboy_control_plane_contract::EventCursor>,
+) -> Result<AgentTaskRunStatus> {
     let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    run_status_in_store(&lifecycle_store, run_id, since_cursor)
+    run_status_in_store(&lifecycle_store, run_id, cursor)
 }
 
 /// [`run_status`] against explicitly injected durable lifecycle roots.
@@ -5332,7 +5335,7 @@ pub fn run_status(run_id: &str, since_cursor: Option<u64>) -> Result<AgentTaskRu
 pub fn run_status_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
-    since_cursor: Option<u64>,
+    cursor: Option<homeboy_control_plane_contract::EventCursor>,
 ) -> Result<AgentTaskRunStatus> {
     let record = status_in_store(
         lifecycle_store,
@@ -5382,16 +5385,8 @@ pub fn run_status_in_store(
             }
         })
     });
-    let normalized_events = normalize_progress_events(&record.run_id, &events, &artifact_refs);
-    let latest_event_cursor = normalized_events
-        .last()
-        .map(|event| event.sequence)
-        .unwrap_or(0);
-    let cursor = since_cursor.unwrap_or(0);
-    let normalized_events = normalized_events
-        .into_iter()
-        .filter(|event| event.sequence > cursor)
-        .collect();
+    let events = normalize_progress_events(&record, &events, &artifact_refs)?;
+    let events = control_plane_event_page(&record, events, cursor.as_ref())?;
     let control_plane_run =
         crate::orchestration::project_record(&record, plan.as_ref()).map_err(|error| {
             Error::validation_invalid_argument(
@@ -5409,8 +5404,7 @@ pub fn run_status_in_store(
         totals: record
             .totals
             .unwrap_or_else(|| totals_for_tasks(&record.tasks)),
-        latest_event_cursor,
-        normalized_events,
+        events,
         candidate,
     })
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/logs_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/logs_projection.rs
@@ -12,17 +12,26 @@ pub fn logs(run_id: &str) -> Result<AgentTaskRunLog> {
     logs_in_store(&lifecycle_store, run_id)
 }
 
+pub fn logs_from_cursor(
+    run_id: &str,
+    cursor: Option<&homeboy_control_plane_contract::EventCursor>,
+    include_raw: bool,
+) -> Result<AgentTaskRunLog> {
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    event_log_in_store(&lifecycle_store, run_id, include_raw, cursor)
+}
+
 /// [`logs`] against explicitly injected durable lifecycle roots.
 pub fn logs_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
 ) -> Result<AgentTaskRunLog> {
-    logs_with_raw_in_store(lifecycle_store, run_id, false)
+    event_log_in_store(lifecycle_store, run_id, false, None)
 }
 
 pub(crate) fn logs_with_raw(run_id: &str, include_raw: bool) -> Result<AgentTaskRunLog> {
     let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    logs_with_raw_in_store(&lifecycle_store, run_id, include_raw)
+    event_log_in_store(&lifecycle_store, run_id, include_raw, None)
 }
 
 /// [`logs_with_raw`] against explicitly injected durable lifecycle roots.
@@ -37,6 +46,23 @@ pub fn logs_with_raw_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     include_raw: bool,
+) -> Result<AgentTaskRunLog> {
+    event_log_in_store(lifecycle_store, run_id, include_raw, None)
+}
+
+pub fn control_plane_events_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    cursor: Option<&homeboy_control_plane_contract::EventCursor>,
+) -> Result<homeboy_control_plane_contract::ControlPlaneEventPage> {
+    Ok(event_log_in_store(lifecycle_store, run_id, false, cursor)?.events)
+}
+
+fn event_log_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+    include_raw: bool,
+    cursor: Option<&homeboy_control_plane_contract::EventCursor>,
 ) -> Result<AgentTaskRunLog> {
     // Logs are terminal inspection, not runner reconciliation. The durable
     // record remains readable when a runner is unavailable or wedged.
@@ -66,13 +92,13 @@ pub fn logs_with_raw_in_store(
         }
     };
     let events = if raw_events.is_empty() {
-        normalize_progress_events(&run_id, &events, &artifact_refs)
+        normalize_progress_events(&record, &events, &artifact_refs)?
     } else {
-        normalize_runner_job_events(&run_id, &raw_events, &record, &artifact_refs)
+        normalize_runner_job_events(&raw_events, &record, &artifact_refs)?
     };
+    let events = control_plane_event_page(&record, events, cursor)?;
     Ok(AgentTaskRunLog {
         schema: schemas::RUN_LOG.to_string(),
-        run_id,
         events,
         raw_events: if include_raw {
             raw_events
@@ -219,11 +245,10 @@ fn runner_job_raw_events(record: &AgentTaskRunRecord) -> Vec<Value> {
 }
 
 fn normalize_runner_job_events(
-    run_id: &str,
     raw_events: &[Value],
     record: &AgentTaskRunRecord,
     artifact_refs: &[AgentTaskArtifactRef],
-) -> Vec<AgentTaskEventEnvelope> {
+) -> Result<Vec<homeboy_control_plane_contract::ControlPlaneEvent>> {
     let task_id = record
         .tasks
         .first()
@@ -248,35 +273,37 @@ fn normalize_runner_job_events(
             let activity = string_field(&data, "activity")
                 .or_else(|| string_field(&data, "status_note"))
                 .or_else(|| string_field(&data, "progress"));
-            AgentTaskEventEnvelope {
-                schema: schemas::EVENT.to_string(),
-                run_id: run_id.to_string(),
-                task_id: task_id.clone(),
-                // The lifecycle cursor is positional and has always been one-based.
-                sequence: (index + 1) as u64,
-                event_type: format!("agent_task.runner_{kind}"),
-                status: AgentTaskState::Running,
-                message: raw
-                    .get("message")
-                    .and_then(Value::as_str)
-                    .map(str::to_string)
-                    .or_else(|| string_field(&data, "message")),
-                provider: string_field(&data, "provider")
-                    .or_else(|| string_field(&data, "backend"))
-                    .or_else(|| provider.clone()),
-                phase,
-                activity,
-                heartbeat_at_ms: matches!(kind, "progress" | "status")
-                    .then(|| raw.get("timestamp_ms").and_then(Value::as_u64))
-                    .flatten(),
-                progress: json!({ "attempt": 0 }),
-                artifact_refs: artifact_refs
+            let timestamp_ms = raw.get("timestamp_ms").and_then(Value::as_i64);
+            let occurred_at = timestamp_ms
+                .and_then(chrono::DateTime::from_timestamp_millis)
+                .map(|value| value.to_rfc3339());
+            control_plane_event(
+                record,
+                (index + 1) as u64,
+                &task_id,
+                &format!("runner.{kind}"),
+                occurred_at,
+                "lab-runner",
+                json!({
+                    "state": AgentTaskState::Running,
+                    "message": raw
+                        .get("message")
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                        .or_else(|| string_field(&data, "message")),
+                    "provider": string_field(&data, "provider")
+                        .or_else(|| string_field(&data, "backend"))
+                        .or_else(|| provider.clone()),
+                    "phase": phase,
+                    "activity": activity,
+                    "heartbeat_at_ms": matches!(kind, "progress" | "status").then_some(timestamp_ms).flatten(),
+                    "progress": { "attempt": 0 },
+                    "transport": data,
+                }),
+                artifact_refs
                     .iter()
-                    .filter(|reference| reference.task_id == task_id)
-                    .cloned()
-                    .collect(),
-                metadata: data,
-            }
+                    .filter(|reference| reference.task_id == task_id),
+            )
         })
         .collect()
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/records.rs
@@ -4,9 +4,8 @@ use homeboy_core::run_lifecycle_status::RunLifecycleStatus;
 
 pub(crate) mod schemas {
     pub(crate) const RUN: &str = "homeboy/agent-task-run/v1";
-    pub(crate) const RUN_LOG: &str = "homeboy/agent-task-run-log/v2";
-    pub(crate) const EVENT: &str = "homeboy/agent-task-event/v1";
-    pub(crate) const RUN_STATUS: &str = "homeboy/agent-task-run-status/v2";
+    pub(crate) const RUN_LOG: &str = "homeboy/agent-task-run-log/v3";
+    pub(crate) const RUN_STATUS: &str = "homeboy/agent-task-run-status/v3";
     pub(crate) const RUN_ARTIFACTS: &str = "homeboy/agent-task-run-artifacts/v1";
     pub(crate) const COOK_INDEX: &str = "homeboy/agent-task-cook-index/v1";
 }
@@ -1699,39 +1698,9 @@ pub struct AgentTaskRunProviderHandle {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentTaskRunLog {
     pub schema: String,
-    pub run_id: String,
-    /// The canonical consumer event stream. v1 exposed the same information
-    /// twice as `events` and `normalized_events`.
-    pub events: Vec<AgentTaskEventEnvelope>,
+    pub events: homeboy_control_plane_contract::ControlPlaneEventPage,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub raw_events: Vec<Value>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct AgentTaskEventEnvelope {
-    pub schema: String,
-    pub run_id: String,
-    pub task_id: String,
-    pub sequence: u64,
-    #[serde(rename = "type")]
-    pub event_type: String,
-    pub status: AgentTaskState,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub message: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub provider: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub phase: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub activity: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub heartbeat_at_ms: Option<u64>,
-    #[serde(default, skip_serializing_if = "Value::is_null")]
-    pub progress: Value,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub artifact_refs: Vec<AgentTaskArtifactRef>,
-    #[serde(default, skip_serializing_if = "Value::is_null")]
-    pub metadata: Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1740,9 +1709,7 @@ pub struct AgentTaskRunStatus {
     pub control_plane_run: homeboy_control_plane_contract::ControlPlaneRun,
     pub plan_id: String,
     pub totals: AgentTaskAggregateTotals,
-    pub latest_event_cursor: u64,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub normalized_events: Vec<AgentTaskEventEnvelope>,
+    pub events: homeboy_control_plane_contract::ControlPlaneEventPage,
     /// Candidate detail for multi-candidate Cook runs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub candidate: Option<AgentTaskCandidateStatus>,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -800,6 +800,7 @@ fn controller_proxy_is_queued_before_handoff_then_binds_runner_child() {
         logs_in_store(&lifecycle_store, "agent-task-controller-proxy")
             .expect("logs resolve")
             .events
+            .events
             .len(),
         1
     );
@@ -1850,7 +1851,9 @@ fn cook_lab_handoff_controller_reads_ignore_runner_plan_projection() {
     assert_eq!(
         logs_in_store(&lifecycle_store, &record.run_id)
             .expect("controller logs")
-            .run_id,
+            .events
+            .run
+            .as_str(),
         record.run_id
     );
     assert_eq!(
@@ -2048,10 +2051,9 @@ fn running_child_snapshot_persists_provider_handle_and_live_log_progress() {
         "provider-run-live"
     );
     let log = logs_in_store(&lifecycle_store, &record.run_id).expect("live logs");
-    assert_eq!(log.events.len(), 1);
-    assert!(log.events[0]
-        .message
-        .as_deref()
+    assert_eq!(log.events.events.len(), 1);
+    assert!(log.events.events[0].data["message"]
+        .as_str()
         .is_some_and(|message| message.contains("provider dispatch accepted")));
 }
 
@@ -2504,7 +2506,7 @@ fn remote_dispatch_failure_preserves_structured_outcome_details() {
             "/runner/workspace/repo"
         );
         assert_eq!(
-            log.events[0].message.as_deref(),
+            log.events.events[0].data["message"].as_str(),
             Some("Remote provider agent task failed.")
         );
         assert_eq!(artifacts.evidence_refs[0].kind, "logs");

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -1075,7 +1075,7 @@ fn detached_lab_handoff_persists_inspectable_running_record() {
                     .map(|heartbeat| heartbeat.last_seen_at.as_str()),
                 loaded.updated_at.as_deref()
             );
-            assert_eq!(log.events.len(), 1);
+            assert_eq!(log.events.events.len(), 1);
             assert!(artifacts.evidence_refs.is_empty());
         }
     });
@@ -1736,27 +1736,26 @@ fn logs_expose_mirrored_live_runner_events_before_terminal_aggregate() {
 
     let log = logs_in_store(&lifecycle_store, "live-runner-events").expect("live logs resolve");
 
-    assert_eq!(log.events.len(), 1);
-    assert!(log.events[0]
-        .message
-        .as_deref()
+    assert_eq!(log.events.events.len(), 1);
+    assert!(log.events.events[0].data["message"]
+        .as_str()
         .is_some_and(|message| message.contains("provider started")));
     assert_eq!(
-        log.events[0].provider.as_deref(),
+        log.events.events[0].data["provider"].as_str(),
         Some("openai/gpt-5.6-terra")
     );
-    assert_eq!(log.events[0].phase.as_deref(), Some("implementing"));
+    assert_eq!(log.events.events[0].data["phase"], "implementing");
     assert_eq!(
-        log.events[0].activity.as_deref(),
+        log.events.events[0].data["activity"].as_str(),
         Some("editing lifecycle projection")
     );
-    assert_eq!(log.events[0].heartbeat_at_ms, Some(42));
+    assert_eq!(log.events.events[0].data["heartbeat_at_ms"], 42);
     assert!(log.raw_events.is_empty(), "raw transport is opt-in");
 
     let raw_log = logs_with_raw_in_store(&lifecycle_store, "live-runner-events", true)
         .expect("raw logs resolve");
     assert_eq!(
-        raw_log.events[0].metadata["provider"],
+        raw_log.events.events[0].data["transport"]["provider"],
         "openai/gpt-5.6-terra"
     );
     assert_eq!(raw_log.raw_events.len(), 1);
@@ -2674,7 +2673,7 @@ fn lifecycle_store_round_trips_record_log_artifacts_and_lifecycle_contract() {
         ArtifactRetentionStatus::Retained
     );
     assert_eq!(log.schema, schemas::RUN_LOG);
-    assert_eq!(log.events[0].status, AgentTaskState::Succeeded);
+    assert_eq!(log.events.events[0].data["state"], "succeeded");
     assert_eq!(artifact_report.schema, schemas::RUN_ARTIFACTS);
     assert_eq!(artifact_report.artifacts[0].id, "patch");
     assert_eq!(artifact_report.evidence_refs[0].kind, "transcript");
@@ -3030,15 +3029,21 @@ fn logs_include_normalized_event_envelopes() {
 
     let log = logs_in_store(&lifecycle_store, "run-event-envelope").expect("logs");
 
-    assert_eq!(log.schema, "homeboy/agent-task-run-log/v2");
-    assert_eq!(log.events.len(), 2);
-    assert_eq!(log.events[0].schema, schemas::EVENT);
-    assert_eq!(log.events[0].run_id, "run-event-envelope");
-    assert_eq!(log.events[0].task_id, "task-a");
-    assert_eq!(log.events[0].sequence, 1);
-    assert_eq!(log.events[0].status, AgentTaskState::Running);
-    assert_eq!(log.events[1].message.as_deref(), Some("ok"));
-    assert_eq!(log.events[1].artifact_refs.len(), 1);
+    assert_eq!(log.schema, "homeboy/agent-task-run-log/v3");
+    assert_eq!(log.events.events.len(), 2);
+    assert_eq!(
+        log.events.events[0].schema,
+        homeboy_control_plane_contract::CONTROL_PLANE_EVENT_SCHEMA
+    );
+    assert_eq!(log.events.events[0].run.as_str(), "run-event-envelope");
+    assert_eq!(
+        log.events.events[0].task.as_ref().map(|id| id.as_str()),
+        Some("task-a")
+    );
+    assert_eq!(log.events.events[0].sequence, 1);
+    assert_eq!(log.events.events[0].data["state"], "running");
+    assert_eq!(log.events.events[1].data["message"], "ok");
+    assert_eq!(log.events.events[1].artifacts.len(), 1);
     assert!(log.raw_events.is_empty());
 }
 
@@ -3365,7 +3370,7 @@ fn runner_backed_logs_read_persisted_events_without_a_runner_probe() {
 
         let log = logs("runner-backed-logs-local-only").expect("durable logs resolve");
 
-        assert_eq!(log.run_id, "runner-backed-logs-local-only");
+        assert_eq!(log.events.run.as_str(), "runner-backed-logs-local-only");
         assert_eq!(
             interactions.load(std::sync::atomic::Ordering::SeqCst),
             0,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -2726,8 +2726,9 @@ fn local_cook_logs_surface_running_provider_execution_before_aggregate() {
         logs_in_store(&lifecycle_store, run_id).expect("logs resolve for a running local cook");
     let messages: Vec<&str> = log
         .events
+        .events
         .iter()
-        .filter_map(|event| event.message.as_deref())
+        .filter_map(|event| event.data["message"].as_str())
         .collect();
     assert!(
         messages
@@ -2778,17 +2779,19 @@ fn cancelled_local_provider_retains_runtime_evidence_in_terminal_logs() {
     let log = logs_in_store(&lifecycle_store, run_id).expect("terminal logs");
     let terminal = log
         .events
+        .events
         .iter()
         .find(|event| {
-            event.status == AgentTaskState::Cancelled
+            event.data["state"] == "cancelled"
                 && event
-                    .message
-                    .as_deref()
+                    .data
+                    .get("message")
+                    .and_then(serde_json::Value::as_str)
                     .is_some_and(|message| message.contains("provider execution cancelled"))
         })
         .expect("cancelled provider event");
     let stdout_ref = terminal
-        .artifact_refs
+        .artifacts
         .iter()
         .find(|reference| reference.kind == "provider-runtime-stdout")
         .expect("bounded stdout reference");
@@ -2945,7 +2948,7 @@ fn detached_lab_run_plan_uses_one_identity_for_status_logs_artifacts_and_cancell
         .expect("controller identity resolves artifacts");
     assert_eq!(status.run_id, run_id);
     assert_eq!(status.metadata["runner_job_id"], "job-8341");
-    assert!(!logs.events.is_empty());
+    assert!(!logs.events.events.is_empty());
     assert!(artifacts.artifacts.is_empty());
 
     let _cancel = super::cancellation::test_cancel_hook::install(Box::new(
@@ -3913,7 +3916,7 @@ fn terminal_projection_is_reader_complete_when_interrupted_after_commit_and_retr
             )
         });
         assert_eq!(status_record.state, AgentTaskRunState::Succeeded);
-        assert_eq!(log.events[0].status, AgentTaskState::Succeeded);
+        assert_eq!(log.events.events[0].data["state"], "succeeded");
         assert!(artifacts.artifacts.is_empty());
 
         reconcile_runner_job_snapshot(&mut record, &snapshot).expect("idempotent retry");
@@ -4378,8 +4381,8 @@ fn pre_dispatch_failure_persists_failed_run_without_provider_handle() {
         assert_eq!(loaded.state, AgentTaskRunState::Failed);
         assert_eq!(loaded.tasks[0].state, AgentTaskState::Failed);
         assert!(loaded.provider_handles.is_empty());
-        assert_eq!(log.events[1].status, AgentTaskState::Failed);
-        assert_eq!(mirrored_log.events[1].status, AgentTaskState::Failed);
+        assert_eq!(log.events.events[1].data["state"], "failed");
+        assert_eq!(mirrored_log.events.events[1].data["state"], "failed");
         assert_eq!(loaded.metadata["provider_run_ids"], serde_json::json!([]));
         assert_eq!(
             loaded.artifact_refs[0].kind,
@@ -4470,7 +4473,7 @@ fn record_completed_run_exposes_logs_and_artifacts() {
         let artifacts = artifacts_in_store(&lifecycle_store, &record.run_id).expect("artifacts");
 
         assert_eq!(record.state, AgentTaskRunState::Succeeded);
-        assert_eq!(log.events[0].status, AgentTaskState::Succeeded);
+        assert_eq!(log.events.events[0].data["state"], "succeeded");
         assert_eq!(artifacts.artifacts[0].id, "patch");
         assert_eq!(artifacts.evidence_refs[0].kind, "transcript");
     }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -2770,7 +2770,7 @@ fn aggregate_only_remote_dispatch_failure_preserves_lab_outcome_details() {
         assert_eq!(loaded.metadata["remote_run_id"], "remote-run");
         assert_eq!(loaded.metadata["remote_plan_path"], "remote-plan");
         assert_eq!(
-            log.events[0].message.as_deref(),
+            log.events.events[0].data["message"].as_str(),
             Some("Remote provider agent task failed.")
         );
         assert_eq!(artifacts.evidence_refs[0].kind, "provider-run");
@@ -3884,23 +3884,31 @@ fn run_status_reports_bridge_envelope_and_cursor_filtered_events() {
     )
     .expect("recorded");
 
-    let status =
-        run_status_in_store(&lifecycle_store, "run-status-bridge", Some(1)).expect("bridge status");
+    let cursor = homeboy_control_plane_contract::EventCursor::new("1").expect("cursor");
+    let status = run_status_in_store(&lifecycle_store, "run-status-bridge", Some(cursor))
+        .expect("bridge status");
 
     assert_eq!(status.schema, schemas::RUN_STATUS);
     assert_eq!(
         status.control_plane_run.state,
         homeboy_control_plane_contract::ControlPlaneRunState::Succeeded
     );
-    assert_eq!(status.latest_event_cursor, 2);
-    assert_eq!(status.normalized_events.len(), 1);
-    assert_eq!(status.normalized_events[0].sequence, 2);
-    assert_eq!(status.normalized_events[0].schema, schemas::EVENT);
     assert_eq!(
-        status.normalized_events[0].event_type,
-        "agent_task.state_changed"
+        status
+            .events
+            .next_cursor
+            .as_ref()
+            .map(|cursor| cursor.as_str()),
+        Some("2")
     );
-    assert_eq!(status.normalized_events[0].artifact_refs.len(), 1);
+    assert_eq!(status.events.events.len(), 1);
+    assert_eq!(status.events.events[0].sequence, 2);
+    assert_eq!(
+        status.events.events[0].schema,
+        homeboy_control_plane_contract::CONTROL_PLANE_EVENT_SCHEMA
+    );
+    assert_eq!(status.events.events[0].kind, "task.state_changed");
+    assert_eq!(status.events.events[0].artifacts.len(), 1);
     assert_eq!(
         status.control_plane_run.artifacts[0].kind,
         "artifact-bundle"

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -6741,8 +6741,11 @@ fn cook_persists_controller_admission_timeout_before_provider_execution() {
             0
         );
         assert_eq!(
-            logs.events.last().map(|event| event.status),
-            Some(AgentTaskState::Failed)
+            logs.events
+                .events
+                .last()
+                .and_then(|event| event.data["state"].as_str()),
+            Some("failed")
         );
         assert_eq!(retry.metadata["retry_of"], run_id);
         assert_eq!(
@@ -10114,7 +10117,7 @@ fn cook_repairs_initial_alias_after_submit_before_index_interruption() {
                 let logs =
                     agent_task_lifecycle::logs(cook).expect("Cook alias logs resolve in observer");
                 assert_eq!(status.run_id, run);
-                assert!(!logs.events.is_empty());
+                assert!(!logs.events.events.is_empty());
                 observer_records
                     .lock()
                     .expect("observer records lock")

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -2301,8 +2301,11 @@ pub fn select_cook_candidate(
     agent_task_lifecycle::select_cook_candidate(cook_id)
 }
 
-pub fn run_status(run_id: &str, since_cursor: Option<u64>) -> Result<AgentTaskRunStatus> {
-    agent_task_lifecycle::run_status(run_id, since_cursor)
+pub fn run_status(
+    run_id: &str,
+    cursor: Option<homeboy_control_plane_contract::EventCursor>,
+) -> Result<AgentTaskRunStatus> {
+    agent_task_lifecycle::run_status(run_id, cursor)
 }
 
 pub fn logs(run_id: &str) -> Result<AgentTaskRunLog> {
@@ -2311,6 +2314,14 @@ pub fn logs(run_id: &str) -> Result<AgentTaskRunLog> {
 
 pub fn logs_with_raw(run_id: &str) -> Result<AgentTaskRunLog> {
     agent_task_lifecycle::logs_with_raw(run_id, true)
+}
+
+pub fn logs_from_cursor(
+    run_id: &str,
+    cursor: Option<&homeboy_control_plane_contract::EventCursor>,
+    include_raw: bool,
+) -> Result<AgentTaskRunLog> {
+    agent_task_lifecycle::logs_from_cursor(run_id, cursor, include_raw)
 }
 
 pub fn artifacts(run_id: &str) -> Result<AgentTaskRunArtifacts> {

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -616,7 +616,7 @@ fn lab_runner_handoff_materializes_the_run_before_preparation_failure() {
         assert_eq!(error.code.as_str(), "validation.invalid_argument");
         assert_eq!(record.state, AgentTaskRunState::Failed);
         assert_eq!(record.tasks[0].state, AgentTaskState::Failed);
-        assert!(!log.events.is_empty());
+        assert!(!log.events.events.is_empty());
         assert_eq!(recovery.exit_code, 1);
         assert_eq!(
             record.metadata["pre_execution_failure"]["phase"],

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -346,8 +346,8 @@ pub mod lifecycle {
         AgentTaskAcceptanceVerificationRequest, AgentTaskAcceptanceVerifier,
         AgentTaskAcceptanceVerifierProvenance, AgentTaskArtifactRef, AgentTaskCookIndex,
         AgentTaskCookIndexAttempt, AgentTaskDurableLocalRead, AgentTaskDurableReadUnavailable,
-        AgentTaskEventEnvelope, AgentTaskLifecycleStore, AgentTaskPreDispatchFailure,
-        AgentTaskRecordHealthItem, AgentTaskRecordHealthReason, AgentTaskRecordHealthSummary,
+        AgentTaskLifecycleStore, AgentTaskPreDispatchFailure, AgentTaskRecordHealthItem,
+        AgentTaskRecordHealthReason, AgentTaskRecordHealthSummary,
         AgentTaskRecordReconciliationItem, AgentTaskRecordReconciliationReport,
         AgentTaskRemoteDispatchFailure, AgentTaskRunArtifacts, AgentTaskRunLog,
         AgentTaskRunProviderHandle, AgentTaskRunRecord, AgentTaskRunState, AgentTaskRunStatus,
@@ -355,9 +355,8 @@ pub mod lifecycle {
         AgentTaskRunnerProbePlan, AgentTaskStatusOptions, AgentTaskStatusOutcome,
         CanonicalControlPlaneIdentities, ClaimOutcome, ControllerRuntimePruneResult,
         DetachedCookMaterializingAttempt, DetachedLabRunRecord, LabOffloadProxyPlan,
-        LocalCookRetryLaunchClaim, RunnerPinnedRuntime,
-        RUNNER_PROBE_SKIPPED_CALLER_OPTED_OUT, RUNNER_PROBE_SKIPPED_CONTROLLER_LOCAL,
-        RUNNER_PROBE_SKIPPED_NOT_RUNNING,
+        LocalCookRetryLaunchClaim, RunnerPinnedRuntime, RUNNER_PROBE_SKIPPED_CALLER_OPTED_OUT,
+        RUNNER_PROBE_SKIPPED_CONTROLLER_LOCAL, RUNNER_PROBE_SKIPPED_NOT_RUNNING,
     };
     pub use super::super::agent_task_lifecycle::{
         cook_index_exists, mark_running, record_run_aggregate, record_runner_job_identity,

--- a/crates/homeboy-agents/src/orchestration.rs
+++ b/crates/homeboy-agents/src/orchestration.rs
@@ -23,8 +23,9 @@ const ID_BOUND: usize = 128;
 const STATE_BOUND: usize = 64;
 const MESSAGE_BOUND: usize = 256;
 const GATE_BOUND: usize = 12;
-const REF_BOUND: usize = 32;
+pub(crate) const REF_BOUND: usize = 32;
 const URI_BOUND: usize = 512;
+const EVENT_PAGE_BOUND: usize = 100;
 
 /// One bounded non-reconciling read of the durable record and optional plan.
 #[derive(Debug, Clone)]
@@ -37,6 +38,14 @@ pub struct RunSnapshot {
 /// doubles; the service never opens an environment-rooted store itself.
 pub trait RunLookup {
     fn get(&self, id: &RunId) -> Result<Option<RunSnapshot>, ControlPlaneError>;
+}
+
+pub trait EventLookup {
+    fn events(
+        &self,
+        id: &RunId,
+        cursor: Option<&homeboy_control_plane_contract::EventCursor>,
+    ) -> Result<Option<homeboy_control_plane_contract::ControlPlaneEventPage>, ControlPlaneError>;
 }
 
 /// Durable lifecycle-store lookup. Bounded, non-reconciling, non-writing.
@@ -73,6 +82,25 @@ impl RunLookup for LifecycleStoreLookup {
     }
 }
 
+impl EventLookup for LifecycleStoreLookup {
+    fn events(
+        &self,
+        id: &RunId,
+        cursor: Option<&homeboy_control_plane_contract::EventCursor>,
+    ) -> Result<Option<homeboy_control_plane_contract::ControlPlaneEventPage>, ControlPlaneError>
+    {
+        match crate::agent_task_lifecycle::control_plane_events_in_store(
+            &self.store,
+            id.as_str(),
+            cursor,
+        ) {
+            Ok(events) => Ok(Some(events)),
+            Err(error) if is_run_not_found(&error) => Ok(None),
+            Err(error) => Err(ControlPlaneError::unavailable(error.message)),
+        }
+    }
+}
+
 /// Public typed orchestration facade.
 pub struct OrchestrationService<L> {
     lookup: L,
@@ -86,10 +114,11 @@ impl<L: RunLookup> OrchestrationService<L> {
     /// Operations actually wired in this build. Mutations are not advertised.
     pub fn capabilities() -> ControlPlaneCapabilities {
         ControlPlaneCapabilities::new(
-            vec![ControlPlaneResource::Run],
+            vec![ControlPlaneResource::Run, ControlPlaneResource::Event],
             vec![
                 ControlPlaneOperation::GetCapabilities,
                 ControlPlaneOperation::GetRun,
+                ControlPlaneOperation::GetRunEvents,
             ],
         )
     }
@@ -100,6 +129,23 @@ impl<L: RunLookup> OrchestrationService<L> {
             ControlPlaneError::not_found(format!("agent-task run not found: {requested_id}"))
         })?;
         project_record(&snapshot.record, snapshot.plan.as_ref())
+    }
+}
+
+impl<L: EventLookup> OrchestrationService<L> {
+    pub fn events(
+        &self,
+        requested_id: &RunId,
+        cursor: Option<&homeboy_control_plane_contract::EventCursor>,
+    ) -> Result<homeboy_control_plane_contract::ControlPlaneEventPage, ControlPlaneError> {
+        if cursor.is_some_and(|cursor| cursor.as_str().parse::<u64>().is_err()) {
+            return Err(ControlPlaneError::invalid_argument(
+                "control-plane event cursor is invalid",
+            ));
+        }
+        self.lookup.events(requested_id, cursor)?.ok_or_else(|| {
+            ControlPlaneError::not_found(format!("agent-task run not found: {requested_id}"))
+        })
     }
 }
 
@@ -138,6 +184,44 @@ pub fn project_record(
     resource.evidence = evidence_refs(record);
     resource.artifacts = artifact_refs(record);
     Ok(resource)
+}
+
+/// Apply one opaque resume cursor and a fixed page bound to an ordered stream.
+pub fn event_page(
+    run: RunId,
+    events: Vec<homeboy_control_plane_contract::ControlPlaneEvent>,
+    cursor: Option<&homeboy_control_plane_contract::EventCursor>,
+) -> Result<homeboy_control_plane_contract::ControlPlaneEventPage, ControlPlaneError> {
+    use homeboy_control_plane_contract::{
+        ControlPlaneEventPage, EventCursor, CONTROL_PLANE_EVENT_PAGE_SCHEMA,
+    };
+
+    let after = cursor
+        .map(|cursor| {
+            cursor.as_str().parse::<u64>().map_err(|_| {
+                ControlPlaneError::invalid_argument("control-plane event cursor is invalid")
+            })
+        })
+        .transpose()?
+        .unwrap_or(0);
+    let mut remaining = events.into_iter().filter(|event| event.sequence > after);
+    let page_events: Vec<_> = remaining.by_ref().take(EVENT_PAGE_BOUND).collect();
+    let has_more = remaining.next().is_some();
+    let next_cursor = page_events
+        .last()
+        .map(|event| event.sequence.to_string())
+        .or_else(|| cursor.map(|cursor| cursor.as_str().to_string()))
+        .map(EventCursor::new)
+        .transpose()
+        .map_err(|error| ControlPlaneError::invalid_argument(error.to_string()))?;
+
+    Ok(ControlPlaneEventPage {
+        schema: CONTROL_PLANE_EVENT_PAGE_SCHEMA.to_string(),
+        run,
+        events: page_events,
+        next_cursor,
+        has_more,
+    })
 }
 
 fn identities_for_record(
@@ -475,7 +559,7 @@ fn nonempty_bounded(value: &str, max: usize) -> Option<String> {
     (!trimmed.is_empty()).then(|| bounded(trimmed, max))
 }
 
-fn redacted_bounded(value: &str, max: usize) -> String {
+pub(crate) fn redacted_bounded(value: &str, max: usize) -> String {
     bounded(&homeboy_core::redaction::redact_string(value), max)
 }
 
@@ -500,6 +584,16 @@ impl ControlPlaneProvider for RegisteredProvider {
             .map_err(|error| ControlPlaneError::unavailable(error.message))?;
         OrchestrationService::new(LifecycleStoreLookup::new(store)).run(requested_id)
     }
+
+    fn events(
+        &self,
+        requested_id: &RunId,
+        cursor: Option<&homeboy_control_plane_contract::EventCursor>,
+    ) -> Result<homeboy_control_plane_contract::ControlPlaneEventPage, ControlPlaneError> {
+        let store = AgentTaskLifecycleStore::from_environment()
+            .map_err(|error| ControlPlaneError::unavailable(error.message))?;
+        OrchestrationService::new(LifecycleStoreLookup::new(store)).events(requested_id, cursor)
+    }
 }
 
 /// Register the orchestration service as the HTTP control-plane provider.
@@ -509,13 +603,14 @@ pub fn register() {
 
 #[cfg(test)]
 mod tests {
-    use super::{project_record, OrchestrationService, RunLookup, RunSnapshot};
+    use super::{event_page, project_record, OrchestrationService, RunLookup, RunSnapshot};
     use crate::agent_task_lifecycle::AgentTaskRunRecord;
     use crate::agent_task_schedule::AgentTaskPlan;
     use homeboy_control_plane_contract::{
         ControlPlaneAction, ControlPlaneActionAvailability, ControlPlaneErrorClass,
-        ControlPlaneOperation, ControlPlaneRunState, RunId,
-        CONTROL_PLANE_ACTION_ELIGIBILITY_SCHEMA, CONTROL_PLANE_RUN_SCHEMA,
+        ControlPlaneEvent, ControlPlaneEventSource, ControlPlaneOperation, ControlPlaneRunState,
+        EventCursor, EventId, RunId, CONTROL_PLANE_ACTION_ELIGIBILITY_SCHEMA,
+        CONTROL_PLANE_EVENT_SCHEMA, CONTROL_PLANE_RUN_SCHEMA,
     };
     use homeboy_core::run_lifecycle_record::RunHeartbeat;
     use serde_json::json;
@@ -591,6 +686,59 @@ mod tests {
         record
     }
 
+    fn event(run: &RunId, sequence: u64) -> ControlPlaneEvent {
+        ControlPlaneEvent {
+            schema: CONTROL_PLANE_EVENT_SCHEMA.to_string(),
+            event: EventId::new(format!("{}:event:{sequence}", run.as_str())).expect("event"),
+            sequence,
+            occurred_at: None,
+            mission: None,
+            run: run.clone(),
+            task: None,
+            attempt: None,
+            execution: None,
+            kind: "run.progress".to_string(),
+            source: ControlPlaneEventSource {
+                component: "test".to_string(),
+                instance: None,
+            },
+            data: json!({ "sequence": sequence }),
+            artifacts: Vec::new(),
+            evidence: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn event_pages_are_bounded_and_resume_after_the_opaque_cursor() {
+        let run = RunId::new("run-events").expect("run");
+        let events = (1..=101).map(|sequence| event(&run, sequence)).collect();
+        let first = event_page(run.clone(), events, None).expect("first page");
+        assert_eq!(first.events.len(), 100);
+        assert!(first.has_more);
+        assert_eq!(
+            first.next_cursor.as_ref().map(EventCursor::as_str),
+            Some("100")
+        );
+
+        let second = event_page(
+            run,
+            vec![event(&RunId::new("run-events").unwrap(), 101)],
+            first.next_cursor.as_ref(),
+        )
+        .expect("second page");
+        assert_eq!(second.events.len(), 1);
+        assert_eq!(second.events[0].sequence, 101);
+        assert!(!second.has_more);
+    }
+
+    #[test]
+    fn event_pages_reject_unknown_cursor_encodings() {
+        let run = RunId::new("run-events").expect("run");
+        let cursor = EventCursor::new("not-a-provider-cursor").expect("typed opaque cursor");
+        let error = event_page(run, Vec::new(), Some(&cursor)).expect_err("invalid cursor");
+        assert_eq!(error.class, ControlPlaneErrorClass::InvalidArgument);
+    }
+
     fn snapshot(run_id: &str, plan: Option<AgentTaskPlan>) -> RunSnapshot {
         RunSnapshot {
             record: record(run_id),
@@ -626,7 +774,8 @@ mod tests {
             capabilities.operations,
             vec![
                 ControlPlaneOperation::GetCapabilities,
-                ControlPlaneOperation::GetRun
+                ControlPlaneOperation::GetRun,
+                ControlPlaneOperation::GetRunEvents,
             ]
         );
         assert!(!capabilities.operations.is_empty());

--- a/crates/homeboy-cli/Cargo.toml
+++ b/crates/homeboy-cli/Cargo.toml
@@ -22,6 +22,7 @@ test-support = ["homeboy-core/test-support", "homeboy-agents/test-support"]
 [dependencies]
 homeboy-core = { version = "0.1.0", path = "../homeboy-core" }
 homeboy-command-contract = { version = "0.1.0", path = "../contracts/homeboy-command-contract" }
+homeboy-control-plane-contract = { version = "0.1.0", path = "../contracts/homeboy-control-plane-contract" }
 homeboy-engine-primitives = { version = "0.1.0", path = "../homeboy-engine-primitives" }
 homeboy-extension-contract = { version = "0.1.0", path = "../contracts/homeboy-extension-contract" }
 homeboy-release = { version = "0.1.0", path = "../homeboy-release" }

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/lifecycle.rs
@@ -59,7 +59,7 @@ pub struct LifecycleReadArgs {
     pub bridge: bool,
     /// Resume bridged events after this cursor.
     #[arg(long, value_name = "CURSOR", requires = "bridge")]
-    pub since_cursor: Option<u64>,
+    pub since_cursor: Option<String>,
     /// Return complete lifecycle details instead of the bounded summary.
     #[arg(long, conflicts_with = "bridge")]
     pub full: bool,
@@ -86,7 +86,7 @@ pub struct StatusArgs {
     pub bridge: bool,
     /// Resume bridged status events after this cursor.
     #[arg(long, value_name = "CURSOR", requires = "bridge")]
-    pub since_cursor: Option<u64>,
+    pub since_cursor: Option<String>,
     /// Return complete status details instead of the bounded summary.
     #[arg(long, conflicts_with = "bridge")]
     pub full: bool,
@@ -140,6 +140,9 @@ impl From<StatusArgs> for LifecycleReadArgs {
 pub struct LogsArgs {
     /// Durable run or Cook ID whose logs to retrieve.
     pub run_id: String,
+    /// Resume events after this opaque cursor.
+    #[arg(long, value_name = "CURSOR")]
+    pub cursor: Option<String>,
     /// Include unprojected runner transport frames under `raw_events` for diagnostics.
     #[arg(long)]
     pub raw: bool,

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -8441,7 +8441,7 @@ pub(super) fn resume(args: impl Into<LifecycleReadArgs>) -> CmdResult<Value> {
 pub(super) fn run_resume_with_executor_and_bridge(
     run_id: String,
     bridge: bool,
-    since_cursor: Option<u64>,
+    since_cursor: Option<String>,
     full: bool,
     executor: SharedAgentTaskExecutor,
 ) -> CmdResult<Value> {
@@ -8458,7 +8458,8 @@ pub(super) fn run_resume_with_executor_and_bridge(
         // local aggregate is absent. Reproject only after that shared recovery
         // contract has persisted the aggregate and identity.
         agent_task_service::reconcile_terminal_artifact_projection(&run_id)?;
-        let status = agent_task_service::run_status(&run_id, since_cursor)?;
+        let cursor = super::status::parse_event_cursor(since_cursor.as_deref(), "since_cursor")?;
+        let status = agent_task_service::run_status(&run_id, cursor)?;
         return Ok((
             serde_json::to_value(status).unwrap_or(Value::Null),
             result.exit_code,

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -307,7 +307,8 @@ fn status_once(args: StatusArgs) -> CmdResult<Value> {
         // expires unbound controller handoffs, and persists the result. So this
         // answer is not merely a different view from `activity show <id>` — it
         // can also change what a later `activity show` returns. Say so (#W3-15).
-        let bridge_status = agent_task_service::run_status(&target.run_id, args.since_cursor)?;
+        let cursor = parse_event_cursor(args.since_cursor.as_deref(), "since_cursor")?;
+        let bridge_status = agent_task_service::run_status(&target.run_id, cursor)?;
         let mut value = serde_json::to_value(bridge_status).unwrap_or(Value::Null);
         attach_reconciled(&mut value, true);
         if let Some(selection) = target.selection {
@@ -666,7 +667,7 @@ fn status_change_projection(status: &Value) -> Value {
         "task_state_digest": task_state_digest,
         "progress": bounded_value(status.get("progress").unwrap_or(&Value::Null)),
         "liveness": compact_fields(status.get("liveness").unwrap_or(&Value::Null), &["state", "status", "reason"]),
-        "normalized_event_count": status.get("normalized_events").and_then(Value::as_array).map(Vec::len),
+        "event_count": status.pointer("/events/events").and_then(Value::as_array).map(Vec::len),
     })
 }
 
@@ -679,7 +680,7 @@ fn status_change_digest_projection(status: &Value) -> Value {
         "totals": basis.get("totals"),
         "task_count": status.get("tasks").and_then(Value::as_array).map(Vec::len),
         "task_state_digest": basis.get("task_state_digest"),
-        "normalized_event_count": basis.get("normalized_event_count"),
+        "event_count": basis.get("event_count"),
     })
 }
 
@@ -869,6 +870,23 @@ fn status_run_state(status: &Value) -> Option<&Value> {
     status
         .get("state")
         .or_else(|| status.pointer("/control_plane_run/state"))
+}
+
+pub(super) fn parse_event_cursor(
+    cursor: Option<&str>,
+    field: &'static str,
+) -> homeboy::core::Result<Option<homeboy_control_plane_contract::EventCursor>> {
+    cursor
+        .map(homeboy_control_plane_contract::EventCursor::new)
+        .transpose()
+        .map_err(|error| {
+            homeboy::core::Error::validation_invalid_argument(
+                field,
+                error.to_string(),
+                cursor.map(str::to_string),
+                None,
+            )
+        })
 }
 
 /// Status is a read-only diagnostic. A recipe-only Cook is recoverable through
@@ -2474,11 +2492,8 @@ fn preserve_controller_owner_placement_with_prefix(
 }
 
 pub(super) fn logs(args: LogsArgs) -> CmdResult<Value> {
-    let log = if args.raw {
-        agent_task_service_direct::logs_with_raw(&args.run_id)?
-    } else {
-        agent_task_service_direct::logs(&args.run_id)?
-    };
+    let cursor = parse_event_cursor(args.cursor.as_deref(), "cursor")?;
+    let log = agent_task_service_direct::logs_from_cursor(&args.run_id, cursor.as_ref(), args.raw)?;
     let mut value = serde_json::to_value(log).unwrap_or(Value::Null);
     enrich_with_diagnostic_summary(&mut value, &args.run_id)?;
     Ok((value, 0))
@@ -4015,13 +4030,15 @@ mod watch_tests {
     #[test]
     fn bridge_snapshot_is_retained_without_projection_loss() {
         let bridge = json!({
-            "schema": "homeboy/agent-task-run-status/v2",
+            "schema": "homeboy/agent-task-run-status/v3",
             "control_plane_run": {
                 "run": "run-1",
                 "state": "succeeded"
             },
             "reconciled": true,
-            "normalized_events": [{ "type": "agent_task.state_changed" }]
+            "events": {
+                "events": [{ "kind": "task.state_changed" }]
+            }
         });
         let mut full_args = args();
         full_args.full = true;

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -2420,6 +2420,7 @@ fn controller_proxy_status_and_logs_resolve_before_runner_child_is_known() {
         .expect("controller status resolves");
         let (logs_value, logs_exit) = logs(LogsArgs {
             run_id: "run-cli-controller-proxy".to_string(),
+            cursor: None,
             raw: false,
         })
         .expect("controller logs resolve");
@@ -2427,7 +2428,7 @@ fn controller_proxy_status_and_logs_resolve_before_runner_child_is_known() {
         assert_eq!(status_exit, 0);
         assert_eq!(logs_exit, 0);
         assert_eq!(status_value["outcome"]["state"], "queued");
-        assert_eq!(logs_value["run_id"], "run-cli-controller-proxy");
+        assert_eq!(logs_value["events"]["run"], "run-cli-controller-proxy");
     });
 }
 
@@ -2695,7 +2696,7 @@ fn submit_run_status_reports_terminal_state() {
         let (bridge_status_json, bridge_status_exit_code) = status(StatusArgs {
             run_id: "run-cli-terminal".to_string(),
             bridge: true,
-            since_cursor: Some(0),
+            since_cursor: Some("0".to_string()),
             interval: "5s".to_string(),
             timeout: "30m".to_string(),
             ..Default::default()
@@ -2710,9 +2711,9 @@ fn submit_run_status_reports_terminal_state() {
         assert_eq!(bridge_status_exit_code, 0);
         assert_eq!(
             bridge_status_json["schema"],
-            "homeboy/agent-task-run-status/v2"
+            "homeboy/agent-task-run-status/v3"
         );
-        assert!(bridge_status_json["normalized_events"].is_array());
+        assert!(bridge_status_json["events"]["events"].is_array());
         assert_eq!(
             bridge_status_json["control_plane_run"]["action_eligibility"]["schema"],
             "homeboy/control-plane-action-eligibility/v1"
@@ -2741,6 +2742,7 @@ fn failed_run_status_logs_and_review_include_outcome_diagnostic_summary() {
         .expect("status loaded");
         let (logs_value, _) = logs(LogsArgs {
             run_id: run_id.to_string(),
+            cursor: None,
             raw: false,
         })
         .expect("logs loaded");
@@ -4968,7 +4970,7 @@ fn bridge_resume_reprojects_historical_lab_artifacts_and_preserves_status_cursor
         let (value, exit_code) = resume(StatusArgs {
             run_id: run_id.to_string(),
             bridge: true,
-            since_cursor: Some(1),
+            since_cursor: Some("1".to_string()),
             interval: "5s".to_string(),
             timeout: "30m".to_string(),
             ..Default::default()
@@ -4976,16 +4978,13 @@ fn bridge_resume_reprojects_historical_lab_artifacts_and_preserves_status_cursor
         .expect("bridge resume reconciles terminal projection");
 
         assert_eq!(exit_code, 0);
-        assert_eq!(value["schema"], "homeboy/agent-task-run-status/v2");
+        assert_eq!(value["schema"], "homeboy/agent-task-run-status/v3");
         assert_eq!(value["control_plane_run"]["run"], run_id);
         assert_eq!(value["control_plane_run"]["state"], "succeeded");
-        assert_eq!(value["latest_event_cursor"], 2);
-        assert_eq!(value["normalized_events"].as_array().map(Vec::len), Some(1));
-        assert_eq!(
-            value["normalized_events"][0]["type"],
-            "agent_task.state_changed"
-        );
-        assert_eq!(value["normalized_events"][0]["status"], "succeeded");
+        assert_eq!(value["events"]["next_cursor"], "2");
+        assert_eq!(value["events"]["events"].as_array().map(Vec::len), Some(1));
+        assert_eq!(value["events"]["events"][0]["kind"], "task.state_changed");
+        assert_eq!(value["events"]["events"][0]["data"]["state"], "succeeded");
         let artifacts = store.list_artifacts(run_id).expect("projected artifacts");
         assert_eq!(artifacts.len(), 1);
         assert_eq!(artifacts[0].artifact_type, "file");
@@ -5002,7 +5001,7 @@ fn bridge_resume_reprojects_historical_lab_artifacts_and_preserves_status_cursor
         resume(StatusArgs {
             run_id: run_id.to_string(),
             bridge: true,
-            since_cursor: Some(1),
+            since_cursor: Some("1".to_string()),
             interval: "5s".to_string(),
             timeout: "30m".to_string(),
             ..Default::default()

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -532,13 +532,13 @@ fn cook_readers_keep_the_substantive_candidate_after_a_no_change_retry() {
         let (bridge_value, _) = status(StatusArgs {
             run_id: cook_id.to_string(),
             bridge: true,
-            since_cursor: Some(0),
+            since_cursor: Some("0".to_string()),
             interval: "5s".to_string(),
             timeout: "30m".to_string(),
             ..Default::default()
         })
         .expect("Cook bridge status selects the candidate");
-        assert_eq!(bridge_value["schema"], "homeboy/agent-task-run-status/v2");
+        assert_eq!(bridge_value["schema"], "homeboy/agent-task-run-status/v3");
         assert_eq!(bridge_value["control_plane_run"]["run"], candidate_run_id);
         assert_eq!(
             bridge_value["candidate_selection"]["run_id"],

--- a/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/local_detach.rs
@@ -2209,7 +2209,7 @@ mod tests {
 
             assert_eq!(status.run_id, "cook-pending");
             assert_eq!(status.metadata["detached_cook_handoff"]["state"], "pending");
-            assert_eq!(logs.run_id, "cook-pending");
+            assert_eq!(logs.events.run.as_str(), "cook-pending");
             assert_eq!(
                 agent_task_lifecycle::cancel_run("cook-pending", None)
                     .expect("pending handoff cancel command resolves")
@@ -2560,7 +2560,9 @@ mod tests {
             assert_eq!(
                 agent_task_lifecycle::logs(cook_id)
                     .expect("pending logs command resolves")
-                    .run_id,
+                    .events
+                    .run
+                    .as_str(),
                 cook_id
             );
             assert_eq!(

--- a/crates/homeboy-core/src/control_plane.rs
+++ b/crates/homeboy-core/src/control_plane.rs
@@ -5,10 +5,11 @@
 //! here so core stays agent-task-agnostic.
 
 use homeboy_control_plane_contract::{
-    ControlPlaneCapabilities, ControlPlaneError, ControlPlaneOperation, ControlPlaneRun, RunId,
+    ControlPlaneCapabilities, ControlPlaneError, ControlPlaneEventPage, ControlPlaneOperation,
+    ControlPlaneRun, EventCursor, RunId,
 };
 
-/// Supplies control-plane capabilities and run reads to the HTTP adapter.
+/// Supplies control-plane capabilities and resource reads to the HTTP adapter.
 pub trait ControlPlaneProvider: Send + Sync {
     fn capabilities(&self) -> ControlPlaneCapabilities {
         ControlPlaneCapabilities::new(Vec::new(), vec![ControlPlaneOperation::GetCapabilities])
@@ -16,7 +17,17 @@ pub trait ControlPlaneProvider: Send + Sync {
 
     fn run(&self, requested_id: &RunId) -> Result<ControlPlaneRun, ControlPlaneError> {
         Err(ControlPlaneError::not_found(format!(
-            "agent-task run not found: {requested_id}"
+            "control-plane run not found: {requested_id}"
+        )))
+    }
+
+    fn events(
+        &self,
+        requested_id: &RunId,
+        _cursor: Option<&EventCursor>,
+    ) -> Result<ControlPlaneEventPage, ControlPlaneError> {
+        Err(ControlPlaneError::not_found(format!(
+            "control-plane run not found: {requested_id}"
         )))
     }
 }
@@ -42,6 +53,13 @@ pub fn capabilities() -> ControlPlaneCapabilities {
 
 pub fn run(requested_id: &RunId) -> Result<ControlPlaneRun, ControlPlaneError> {
     with_provider(|provider| provider.run(requested_id))
+}
+
+pub fn events(
+    requested_id: &RunId,
+    cursor: Option<&EventCursor>,
+) -> Result<ControlPlaneEventPage, ControlPlaneError> {
+    with_provider(|provider| provider.events(requested_id, cursor))
 }
 
 #[cfg(test)]

--- a/crates/homeboy-core/src/http_api.rs
+++ b/crates/homeboy-core/src/http_api.rs
@@ -95,6 +95,18 @@ pub fn route(method: HttpMethod, path: &str) -> Result<HttpEndpoint> {
                 id: (*id).to_string(),
             })
         }
+        (HttpMethod::Get, ["v1", "control-plane", "runs", id, "events"]) => {
+            let cursor = query_value(path, "cursor")
+                .map(homeboy_control_plane_contract::EventCursor::new)
+                .transpose()
+                .map_err(|error| {
+                    Error::validation_invalid_argument("cursor", error.to_string(), None, None)
+                })?;
+            Ok(HttpEndpoint::ControlPlaneRunEvents {
+                id: (*id).to_string(),
+                cursor,
+            })
+        }
         (HttpMethod::Get, ["jobs"]) => Ok(HttpEndpoint::Jobs),
         (HttpMethod::Get, ["jobs", id]) => Ok(HttpEndpoint::Job {
             id: (*id).to_string(),
@@ -156,6 +168,7 @@ pub fn route(method: HttpMethod, path: &str) -> Result<HttpEndpoint> {
                 "GET /activity/:id".to_string(),
                 "GET /v1/control-plane/capabilities".to_string(),
                 "GET /v1/control-plane/runs/:id".to_string(),
+                "GET /v1/control-plane/runs/:id/events".to_string(),
                 "GET /jobs".to_string(),
                 "GET /jobs/:id".to_string(),
                 "GET /jobs/:id/events".to_string(),
@@ -191,6 +204,9 @@ where
     match &endpoint {
         HttpEndpoint::ControlPlaneRun { id } => {
             return control_plane_run_response(endpoint.clone(), id);
+        }
+        HttpEndpoint::ControlPlaneRunEvents { id, cursor } => {
+            return control_plane_events_response(endpoint.clone(), id, cursor.as_ref());
         }
         HttpEndpoint::ControlPlaneCapabilities => {
             return control_plane_capabilities_response();
@@ -354,7 +370,9 @@ where
                 },
             )?,
         }),
-        HttpEndpoint::ControlPlaneRun { .. } | HttpEndpoint::ControlPlaneCapabilities => {
+        HttpEndpoint::ControlPlaneRun { .. }
+        | HttpEndpoint::ControlPlaneRunEvents { .. }
+        | HttpEndpoint::ControlPlaneCapabilities => {
             unreachable!("returned before store open")
         }
         HttpEndpoint::Jobs => {
@@ -437,7 +455,7 @@ where
 /// `daemon_endpoint_identity` applies to its nonce.
 const MAX_AGENT_TASK_RUN_ID_LEN: usize = 256;
 
-/// `GET /v1/control-plane/capabilities` and `GET /v1/control-plane/runs/:id`.
+/// Versioned control-plane capability, run, and event reads.
 ///
 /// Route handlers only parse HTTP, call the registered orchestration provider,
 /// and serialize the contract.
@@ -461,10 +479,31 @@ fn control_plane_run_response(endpoint: HttpEndpoint, run_id: &str) -> Result<Ht
     }
 }
 
+fn control_plane_events_response(
+    endpoint: HttpEndpoint,
+    run_id: &str,
+    cursor: Option<&homeboy_control_plane_contract::EventCursor>,
+) -> Result<HttpApiResponse> {
+    match control_plane_events(run_id, cursor) {
+        Ok(events) => control_plane_ok(endpoint, events),
+        Err(error) => control_plane_err(endpoint, error),
+    }
+}
+
 fn control_plane_run(
     run_id: &str,
 ) -> std::result::Result<
     homeboy_control_plane_contract::ControlPlaneRun,
+    homeboy_control_plane_contract::ControlPlaneError,
+> {
+    let run_id = control_plane_run_id(run_id)?;
+    crate::control_plane::run(&run_id)
+}
+
+fn control_plane_run_id(
+    run_id: &str,
+) -> std::result::Result<
+    homeboy_control_plane_contract::RunId,
     homeboy_control_plane_contract::ControlPlaneError,
 > {
     if run_id.len() > MAX_AGENT_TASK_RUN_ID_LEN {
@@ -474,17 +513,20 @@ fn control_plane_run(
             )),
         );
     }
-    let run_id = match homeboy_control_plane_contract::RunId::new(run_id) {
-        Ok(run_id) => run_id,
-        Err(error) => {
-            return Err(
-                homeboy_control_plane_contract::ControlPlaneError::invalid_argument(
-                    error.to_string(),
-                ),
-            )
-        }
-    };
-    crate::control_plane::run(&run_id)
+    homeboy_control_plane_contract::RunId::new(run_id).map_err(|error| {
+        homeboy_control_plane_contract::ControlPlaneError::invalid_argument(error.to_string())
+    })
+}
+
+fn control_plane_events(
+    run_id: &str,
+    cursor: Option<&homeboy_control_plane_contract::EventCursor>,
+) -> std::result::Result<
+    homeboy_control_plane_contract::ControlPlaneEventPage,
+    homeboy_control_plane_contract::ControlPlaneError,
+> {
+    let requested_id = control_plane_run_id(run_id)?;
+    crate::control_plane::events(&requested_id, cursor)
 }
 
 fn control_plane_ok<T: serde::Serialize>(

--- a/crates/homeboy-core/src/http_api/types.rs
+++ b/crates/homeboy-core/src/http_api/types.rs
@@ -28,35 +28,80 @@ pub struct HttpApiResponse {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HttpEndpoint {
     Components,
-    Component { id: String },
-    ComponentStatus { id: String },
-    ComponentChanges { id: String },
+    Component {
+        id: String,
+    },
+    ComponentStatus {
+        id: String,
+    },
+    ComponentChanges {
+        id: String,
+    },
     Rigs,
-    Rig { id: String },
-    RigCheck { id: String },
+    Rig {
+        id: String,
+    },
+    RigCheck {
+        id: String,
+    },
     Stacks,
-    Stack { id: String },
-    StackStatus { id: String },
+    Stack {
+        id: String,
+    },
+    StackStatus {
+        id: String,
+    },
     Runs,
-    Run { id: String },
-    RunArtifacts { id: String },
-    RunArtifactContent { id: String, artifact_id: String },
-    RunFindings { id: String },
+    Run {
+        id: String,
+    },
+    RunArtifacts {
+        id: String,
+    },
+    RunArtifactContent {
+        id: String,
+        artifact_id: String,
+    },
+    RunFindings {
+        id: String,
+    },
     AuditRuns,
     BenchRuns,
     Activity,
-    ActivityItem { id: String },
+    ActivityItem {
+        id: String,
+    },
     ControlPlaneCapabilities,
-    ControlPlaneRun { id: String },
+    ControlPlaneRun {
+        id: String,
+    },
+    ControlPlaneRunEvents {
+        id: String,
+        cursor: Option<homeboy_control_plane_contract::EventCursor>,
+    },
     Jobs,
-    Job { id: String },
-    JobEvents { id: String },
-    JobCancel { id: String },
-    JobProjectionCancel { id: String },
-    JobReadyRun { kind: JobReadyRunKind },
+    Job {
+        id: String,
+    },
+    JobEvents {
+        id: String,
+    },
+    JobCancel {
+        id: String,
+    },
+    JobProjectionCancel {
+        id: String,
+    },
+    JobReadyRun {
+        kind: JobReadyRunKind,
+    },
     SandboxTools,
-    SandboxTool { id: String },
-    SandboxToolRun { id: String },
+    SandboxTool {
+        id: String,
+    },
+    SandboxToolRun {
+        id: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -119,6 +164,7 @@ impl HttpEndpoint {
             Self::ActivityItem { .. } => "activity.show",
             Self::ControlPlaneCapabilities => "control_plane.capabilities",
             Self::ControlPlaneRun { .. } => "control_plane.runs.show",
+            Self::ControlPlaneRunEvents { .. } => "control_plane.runs.events",
             Self::Jobs => "jobs.list",
             Self::Job { .. } => "jobs.show",
             Self::JobEvents { .. } => "jobs.events",

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -8,9 +8,11 @@ use crate::observation::{
     ArtifactRecord, NewFindingRecord, NewRunRecord, ObservationStore, RunRecord, RunStatus,
 };
 use homeboy_control_plane_contract::{
-    ControlPlaneCapabilities, ControlPlaneError, ControlPlaneErrorClass, ControlPlaneOperation,
-    ControlPlaneResource, ControlPlaneResult, ControlPlaneRun, ControlPlaneRunState, MissionId,
-    RunId, CONTROL_PLANE_RESULT_SCHEMA, CONTROL_PLANE_RUN_SCHEMA,
+    ControlPlaneCapabilities, ControlPlaneError, ControlPlaneErrorClass, ControlPlaneEvent,
+    ControlPlaneEventPage, ControlPlaneEventSource, ControlPlaneOperation, ControlPlaneResource,
+    ControlPlaneResult, ControlPlaneRun, ControlPlaneRunState, EventCursor, EventId, MissionId,
+    RunId, TaskId, CONTROL_PLANE_EVENT_PAGE_SCHEMA, CONTROL_PLANE_EVENT_SCHEMA,
+    CONTROL_PLANE_RESULT_SCHEMA, CONTROL_PLANE_RUN_SCHEMA,
 };
 
 use crate::test_support::with_isolated_home;
@@ -255,15 +257,62 @@ fn fixture_control_plane_run() -> ControlPlaneRun {
     resource
 }
 
+fn fixture_control_plane_events(cursor: Option<&EventCursor>) -> ControlPlaneEventPage {
+    let run = RunId::new(CONTROL_PLANE_FIXTURE_RUN).expect("run");
+    let after = cursor
+        .map(|cursor| cursor.as_str().parse::<u64>().expect("fixture cursor"))
+        .unwrap_or(0);
+    let events = ["running", "succeeded"]
+        .into_iter()
+        .enumerate()
+        .map(|(index, state)| {
+            let sequence = (index + 1) as u64;
+            ControlPlaneEvent {
+                schema: CONTROL_PLANE_EVENT_SCHEMA.to_string(),
+                event: EventId::new(format!("{CONTROL_PLANE_FIXTURE_RUN}:event:{sequence}"))
+                    .expect("event"),
+                sequence,
+                occurred_at: Some(format!("2026-01-01T00:00:0{sequence}Z")),
+                mission: Some(MissionId::new(CONTROL_PLANE_FIXTURE_COOK).expect("mission")),
+                run: run.clone(),
+                task: Some(TaskId::new("task-a").expect("task")),
+                attempt: None,
+                execution: None,
+                kind: "task.state_changed".to_string(),
+                source: ControlPlaneEventSource {
+                    component: "fixture".to_string(),
+                    instance: None,
+                },
+                data: serde_json::json!({ "state": state }),
+                artifacts: Vec::new(),
+                evidence: Vec::new(),
+            }
+        })
+        .filter(|event| event.sequence > after)
+        .collect::<Vec<_>>();
+    let next_cursor = events
+        .last()
+        .map(|event| EventCursor::new(event.sequence.to_string()).expect("cursor"))
+        .or_else(|| cursor.cloned());
+    ControlPlaneEventPage {
+        schema: CONTROL_PLANE_EVENT_PAGE_SCHEMA.to_string(),
+        run,
+        events,
+        next_cursor,
+        has_more: false,
+    }
+}
+
 struct FixtureControlPlaneProvider;
 
 impl ControlPlaneProvider for FixtureControlPlaneProvider {
     fn capabilities(&self) -> ControlPlaneCapabilities {
         ControlPlaneCapabilities::new(
-            vec![ControlPlaneResource::Run],
+            vec![ControlPlaneResource::Run, ControlPlaneResource::Event],
             vec![
                 ControlPlaneOperation::GetCapabilities,
                 ControlPlaneOperation::GetRun,
+                ControlPlaneOperation::GetRunEvents,
             ],
         )
     }
@@ -276,6 +325,24 @@ impl ControlPlaneProvider for FixtureControlPlaneProvider {
                 "agent-task run not found: {requested_id}"
             )))
         }
+    }
+
+    fn events(
+        &self,
+        requested_id: &RunId,
+        cursor: Option<&EventCursor>,
+    ) -> Result<ControlPlaneEventPage, ControlPlaneError> {
+        if requested_id.as_str() != CONTROL_PLANE_FIXTURE_RUN {
+            return Err(ControlPlaneError::not_found(format!(
+                "agent-task run not found: {requested_id}"
+            )));
+        }
+        if cursor.is_some_and(|cursor| cursor.as_str().parse::<u64>().is_err()) {
+            return Err(ControlPlaneError::invalid_argument(
+                "control-plane event cursor is invalid",
+            ));
+        }
+        Ok(fixture_control_plane_events(cursor))
     }
 }
 
@@ -293,6 +360,17 @@ fn routes_versioned_control_plane_endpoints() {
         http_api::route(HttpMethod::Get, "/v1/control-plane/runs/run-abc").expect("route"),
         HttpEndpoint::ControlPlaneRun {
             id: "run-abc".to_string()
+        }
+    );
+    assert_eq!(
+        http_api::route(
+            HttpMethod::Get,
+            "/v1/control-plane/runs/run-abc/events?cursor=event-page-2",
+        )
+        .expect("route"),
+        HttpEndpoint::ControlPlaneRunEvents {
+            id: "run-abc".to_string(),
+            cursor: Some(EventCursor::new("event-page-2").expect("cursor")),
         }
     );
     http_api::route(HttpMethod::Post, "/v1/control-plane/runs/run-abc")
@@ -323,7 +401,8 @@ fn control_plane_capabilities_advertise_only_wired_operations() {
         capabilities.operations,
         vec![
             ControlPlaneOperation::GetCapabilities,
-            ControlPlaneOperation::GetRun
+            ControlPlaneOperation::GetRun,
+            ControlPlaneOperation::GetRunEvents,
         ]
     );
 }
@@ -364,6 +443,59 @@ fn control_plane_run_lookup_miss_is_a_structured_not_found() {
     assert_eq!(error.class, ControlPlaneErrorClass::NotFound);
     assert!(!error.retryable);
     assert!(error.message.contains("no-such-agent-task-run"));
+}
+
+#[test]
+fn control_plane_http_events_resume_from_an_opaque_typed_cursor() {
+    register_fixture_control_plane_provider();
+    let response = http_api::handle(HttpApiRequest {
+        method: HttpMethod::Get,
+        path: format!("/v1/control-plane/runs/{CONTROL_PLANE_FIXTURE_RUN}/events?cursor=1"),
+        body: None,
+    })
+    .expect("events");
+    assert_eq!(response.status, 200);
+    assert_eq!(response.endpoint, "control_plane.runs.events");
+    let result: ControlPlaneResult<ControlPlaneEventPage> =
+        serde_json::from_value(response.body).expect("result");
+    let page = result.resource.expect("resource");
+    assert_eq!(page.schema, CONTROL_PLANE_EVENT_PAGE_SCHEMA);
+    assert_eq!(page.run.as_str(), CONTROL_PLANE_FIXTURE_RUN);
+    assert_eq!(page.events.len(), 1);
+    assert_eq!(page.events[0].sequence, 2);
+    assert_eq!(page.events[0].data["state"], "succeeded");
+    assert_eq!(
+        page.next_cursor.as_ref().map(EventCursor::as_str),
+        Some("2")
+    );
+}
+
+#[test]
+fn control_plane_event_errors_are_typed() {
+    register_fixture_control_plane_provider();
+    for (path, status, class) in [
+        (
+            "/v1/control-plane/runs/no-such-agent-task-run/events",
+            404,
+            ControlPlaneErrorClass::NotFound,
+        ),
+        (
+            "/v1/control-plane/runs/agent-task-301a2b9a-a63d-446b-a918-e21b2ff6421e-attempt-1-ea6a6751/events?cursor=invalid",
+            400,
+            ControlPlaneErrorClass::InvalidArgument,
+        ),
+    ] {
+        let response = http_api::handle(HttpApiRequest {
+            method: HttpMethod::Get,
+            path: path.to_string(),
+            body: None,
+        })
+        .expect("typed error");
+        assert_eq!(response.status, status);
+        let result: ControlPlaneResult<ControlPlaneEventPage> =
+            serde_json::from_value(response.body).expect("result");
+        assert_eq!(result.error.expect("error").class, class);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add contract-owned control-plane events, typed identities, opaque cursors, bounded pages, and advertised event-read capabilities
- expose `GET /v1/control-plane/runs/:id/events` through the generic provider and HTTP adapter with redaction, bounds, pagination, and typed errors
- migrate bridge status and logs to the canonical page, add `agent-task logs --cursor`, bump schemas to v3, and delete the duplicate agent-task event envelope

Part of #13697.

## Verification
- `cargo check -p homeboy-control-plane-contract -p homeboy-core -p homeboy-agents -p homeboy-cli --tests`
- `cargo test -p homeboy-control-plane-contract event_page_round_trips_with_typed_cursor_and_identities --lib`
- `cargo test -p homeboy-core control_plane_ --lib`
- `cargo test -p homeboy-agents orchestration::tests:: --lib`
- `cargo test -p homeboy-agents run_status_reports_bridge_envelope_and_cursor_filtered_events --lib`
- `cargo test -p homeboy-agents logs_include_normalized_event_envelopes --lib`
- `cargo test -p homeboy-agents logs_expose_mirrored_live_runner_events_before_terminal_aggregate --lib`
- `cargo test -p homeboy-cli bridge_resume_reprojects_historical_lab_artifacts_and_preserves_status_cursor_shape --lib`
- `cargo test -p homeboy-cli controller_proxy_status_and_logs_resolve_before_runner_child_is_known --lib`
- `git diff --check`

## AI Assistance
OpenAI gpt-5.6-sol via OpenCode was used to inspect the existing contracts, implement the migration, and run the focused verification. The resulting diff and test evidence were reviewed before publication.