### PR TITLE
Remove core extension glob re-export

### DIFF
--- a/crates/homeboy-agents/src/agent_task/bench_matrix_provider.rs
+++ b/crates/homeboy-agents/src/agent_task/bench_matrix_provider.rs
@@ -15,11 +15,11 @@ use crate::agent_task::{
     AgentTaskOutcome, AgentTaskOutcomeStatus, AgentTaskPolicy, AgentTaskRequest,
     AgentTaskWorkspace, AGENT_TASK_OUTCOME_SCHEMA, AGENT_TASK_REQUEST_SCHEMA,
 };
-use homeboy_core::bench::diagnostic::BenchDiagnostic;
-use homeboy_core::bench::report::comparison::agent_task_matrix_provider::{
+use homeboy_core::extension::bench::diagnostic::BenchDiagnostic;
+use homeboy_core::extension::bench::report::comparison::agent_task_matrix_provider::{
     register_bench_agent_task_matrix_provider, BenchAgentTaskMatrixProvider,
 };
-use homeboy_core::bench::report::comparison::RigBenchEntry;
+use homeboy_core::extension::bench::report::comparison::RigBenchEntry;
 
 struct AgentTaskBenchMatrixProvider;
 

--- a/crates/homeboy-agents/src/agent_task_provider/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/discovery.rs
@@ -17,7 +17,7 @@ use homeboy_core::agent_runtime_manifest::{
     AGENT_RUNTIME_REVISION_PROBE_TIMEOUT,
 };
 use homeboy_core::command_invocation::COMMAND_INVOCATION_SCHEMA;
-use homeboy_core::{load_extension, ExtensionManifest};
+use homeboy_core::extension::{load_extension, ExtensionManifest};
 use homeboy_core::{Error, Result};
 
 use super::AgentTaskExecutorProvider;

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -379,16 +379,16 @@ pub(crate) fn register_startup_providers_before_reconcile() {
     // behavior through the hook. Moves out with deploy/release when they
     // become the homeboy-release crate.
     crate::release::provider_impl::register();
-    homeboy_core::audit_manifest_provider::register();
-    homeboy_core::component_script::register_component_script_runner();
-    homeboy_core::build::register_component_build_runner();
+    homeboy_core::extension::audit_manifest_provider::register();
+    homeboy_core::extension::component_script::register_component_script_runner();
+    homeboy_core::extension::build::register_component_build_runner();
     homeboy_core::extension::lifecycle::register_component_install_runner();
     // Register extension-backed audit providers so code_audit can load
     // grammars, run fallback fingerprint scripts, and collect compiler
     // warnings without depending on the extension registry or script runner.
-    homeboy_core::audit_fingerprint_script_provider::register();
-    homeboy_core::audit_grammar_source_provider::register();
-    homeboy_core::audit_compiler_warning_provider::register();
+    homeboy_core::extension::audit_fingerprint_script_provider::register();
+    homeboy_core::extension::audit_grammar_source_provider::register();
+    homeboy_core::extension::audit_compiler_warning_provider::register();
     // Register the audit recorded-artifact provider so the artifact-portability
     // detector can read past runs' artifacts from the observation store without
     // code_audit depending on observation — the last seam before audit becomes
@@ -2288,7 +2288,8 @@ fn extension_command_health_from_summary(summary: &ExtensionSummary) -> Extensio
     // An extension whose `ready_check` was never run is `unknown`, not `ready`.
     // A command-health contract that treated an absent measurement as ready
     // would reproduce the fail-open defect class in #10685. (#10616)
-    let readiness_unknown = summary.readiness == homeboy_core::ExtensionReadinessState::Unknown;
+    let readiness_unknown =
+        summary.readiness == homeboy_core::extension::ExtensionReadinessState::Unknown;
 
     let status = if summary.error.is_some() {
         "error"
@@ -2298,7 +2299,7 @@ fn extension_command_health_from_summary(summary: &ExtensionSummary) -> Extensio
         "unknown"
     } else if summary.ready == Some(true) {
         "ready"
-    } else if summary.readiness == homeboy_core::ExtensionReadinessState::TimedOut {
+    } else if summary.readiness == homeboy_core::extension::ExtensionReadinessState::TimedOut {
         "timed_out"
     } else {
         "not_ready"
@@ -3129,7 +3130,7 @@ fn preflight_review_test_capability(cli: &Cli) -> homeboy::core::Result<()> {
     if args.should_use_self_check_dispatch(&passthrough_args)
         && source
             .component
-            .has_script(homeboy_core::ExtensionCapability::Test)
+            .has_script(homeboy_core::extension::ExtensionCapability::Test)
     {
         return Ok(());
     }
@@ -3138,12 +3139,12 @@ fn preflight_review_test_capability(cli: &Cli) -> homeboy::core::Result<()> {
         &args.comp,
         &args.setting_args,
         &args.extension_override,
-        Some(homeboy_core::ExtensionCapability::Test),
+        Some(homeboy_core::extension::ExtensionCapability::Test),
     )
 	.and_then(|context| {
 		homeboy::core::extension_execution::resolve_execution_context(
 			&context.component,
-			homeboy_core::ExtensionCapability::Test,
+			homeboy_core::extension::ExtensionCapability::Test,
 		)
 		.map(|_| ())
 	})
@@ -3241,7 +3242,7 @@ fn run_startup_update_checks(command: &Commands) {
         Commands::Upgrade(_) | Commands::Daemon(_) | Commands::SelfCmd(_)
     ) {
         homeboy_upgrade::upgrade::update_check::run_startup_check();
-        homeboy_core::update_check::run_startup_check();
+        homeboy_core::extension::update_check::run_startup_check();
     }
 }
 

--- a/crates/homeboy-cli/src/commands/audit.rs
+++ b/crates/homeboy-cli/src/commands/audit.rs
@@ -11,7 +11,7 @@ use homeboy::core::observation::{
     finding_records_from_audit, ActiveObservation, NewFindingRecord, NewRunRecord, RunStatus,
 };
 
-use homeboy_core::{ExtensionCapability, ExtensionRunner};
+use homeboy_core::extension::{ExtensionCapability, ExtensionRunner};
 
 use super::source_command::resolve_source_context;
 use super::utils::args::{
@@ -552,7 +552,7 @@ pub(crate) fn resolve_audit_reference_paths(
         // An unreadable sibling manifest does not get to fail audit for the
         // extensions that are readable (#11122). Only a declared-and-broken
         // setup script is an error.
-        let Ok(manifest) = homeboy_core::load_extension(ext_id) else {
+        let Ok(manifest) = homeboy_core::extension::load_extension(ext_id) else {
             continue;
         };
         if !manifest.has_audit() {

--- a/crates/homeboy-cli/src/commands/bench.rs
+++ b/crates/homeboy-cli/src/commands/bench.rs
@@ -7,13 +7,13 @@ use std::thread;
 use homeboy::core::engine::execution_context::{self, ResolveOptions};
 use homeboy::core::engine::run_dir::RunDir;
 use homeboy::rig::{self, RigSpec};
-use homeboy_core::bench as extension_bench;
-use homeboy_core::bench::{
+use homeboy_core::extension::bench as extension_bench;
+use homeboy_core::extension::bench::{
     aggregate_comparison_with_axes, BenchCommandOutput, BenchComparisonOutput,
     BenchComparisonSummaryOutput, BenchListProfile, BenchListWorkflowArgs, BenchListWorkflowResult,
     RigBenchEntry, DEFAULT_REGRESSION_THRESHOLD_PERCENT,
 };
-use homeboy_core::ExtensionCapability;
+use homeboy_core::extension::ExtensionCapability;
 
 use super::utils::args::{
     filter_passthrough_args, BaselineArgs, ExtensionOverrideArgs, PassthroughCommand,

--- a/crates/homeboy-cli/src/commands/bench/default_baseline.rs
+++ b/crates/homeboy-cli/src/commands/bench/default_baseline.rs
@@ -8,7 +8,7 @@
 //! fails.
 
 use homeboy::rig;
-use homeboy_core::bench::{BenchComparisonOutput, BenchDefaultBaselineExpansion};
+use homeboy_core::extension::bench::{BenchComparisonOutput, BenchDefaultBaselineExpansion};
 
 use super::{matrix, BenchRunArgs};
 

--- a/crates/homeboy-cli/src/commands/bench/fanout.rs
+++ b/crates/homeboy-cli/src/commands/bench/fanout.rs
@@ -12,7 +12,7 @@ use homeboy::agents::agent_tasks::{
     AGENT_TASK_REQUEST_SCHEMA,
 };
 use homeboy::rig::RigSpec;
-use homeboy_core::bench::{BenchGate, BenchGateOp, BenchGateResult};
+use homeboy_core::extension::bench::{BenchGate, BenchGateOp, BenchGateResult};
 
 use super::{matrix, BenchReportFormat, BenchRunArgs};
 
@@ -398,7 +398,7 @@ mod tests {
     use homeboy::agents::agent_tasks::{
         AgentTaskMatrixAggregateCell, AgentTaskMatrixExecutionState,
     };
-    use homeboy_core::bench::BenchGateOp;
+    use homeboy_core::extension::bench::BenchGateOp;
 
     #[derive(Parser)]
     struct TestCli {

--- a/crates/homeboy-cli/src/commands/bench/matrix.rs
+++ b/crates/homeboy-cli/src/commands/bench/matrix.rs
@@ -8,13 +8,13 @@ use homeboy::core::engine::invocation::InvocationRequirements;
 use homeboy::core::engine::run_dir::RunDir;
 use homeboy::rig::lease::ActiveRigRunLease;
 use homeboy::rig::{self, BenchPrepareReport, BenchSpec, RigSpec, RigStateSnapshot};
-use homeboy_core::bench as extension_bench;
-use homeboy_core::bench::report::collect_artifacts;
-use homeboy_core::bench::{
+use homeboy_core::extension::bench as extension_bench;
+use homeboy_core::extension::bench::report::collect_artifacts;
+use homeboy_core::extension::bench::{
     BenchCommandOutput, BenchGate, BenchGateOp, BenchResults, BenchRunExecution,
     BenchRunWorkflowArgs, BenchRunWorkflowResult,
 };
-use homeboy_core::ExtensionCapability;
+use homeboy_core::extension::ExtensionCapability;
 
 use super::observation::{self, BenchObservationStart};
 use super::{BenchRunArgs, CmdResult};
@@ -1242,19 +1242,19 @@ mod tests {
         assert_eq!(scenario_gates.len(), 2);
         assert!(scenario_gates.iter().any(|gate| {
             gate.metric == "native_block_quality_pass"
-                && gate.op == homeboy_core::bench::BenchGateOp::Eq
+                && gate.op == homeboy_core::extension::bench::BenchGateOp::Eq
                 && gate.value == 1.0
         }));
         assert!(scenario_gates.iter().any(|gate| {
             gate.metric == "tool_error_count"
-                && gate.op == homeboy_core::bench::BenchGateOp::Lte
+                && gate.op == homeboy_core::extension::bench::BenchGateOp::Lte
                 && gate.value == 0.0
         }));
         assert_eq!(gates.result_gates.len(), 1);
         assert_eq!(gates.result_gates[0].metric, "failed_fixture_count");
         assert_eq!(
             gates.result_gates[0].op,
-            homeboy_core::bench::BenchGateOp::Lte
+            homeboy_core::extension::bench::BenchGateOp::Lte
         );
         assert_eq!(gates.result_gates[0].value, 0.0);
     }
@@ -1272,7 +1272,7 @@ mod tests {
             }"#,
         )
         .expect("parse rig spec");
-        let results = homeboy_core::bench::parse_bench_results_str(
+        let results = homeboy_core::extension::bench::parse_bench_results_str(
             r#"{
                 "component_id": "static-site-importer",
                 "iterations": 1,
@@ -1317,7 +1317,7 @@ mod tests {
 
     #[test]
     fn default_result_gate_fails_discovered_but_not_run_fixtures() {
-        let results = homeboy_core::bench::parse_bench_results_str(
+        let results = homeboy_core::extension::bench::parse_bench_results_str(
             r#"{
                 "component_id": "static-site-importer",
                 "iterations": 1,
@@ -1363,7 +1363,7 @@ mod tests {
 
     #[test]
     fn default_not_run_fixture_gate_skips_explicit_planning_workload() {
-        let results = homeboy_core::bench::parse_bench_results_str(
+        let results = homeboy_core::extension::bench::parse_bench_results_str(
             r#"{
                 "component_id": "static-site-importer",
                 "iterations": 1,

--- a/crates/homeboy-cli/src/commands/bench/observation/artifacts.rs
+++ b/crates/homeboy-cli/src/commands/bench/observation/artifacts.rs
@@ -1,13 +1,13 @@
 use std::path::PathBuf;
 
 use homeboy::core::engine::run_dir::RunDir;
-use homeboy_core::bench::{self};
+use homeboy_core::extension::bench::{self};
 
 use super::lifecycle::BenchObservation;
 
 pub(super) fn record_bench_observation_artifacts(
     observation: &BenchObservation,
-    workflow: &mut homeboy_core::bench::BenchRunWorkflowResult,
+    workflow: &mut homeboy_core::extension::bench::BenchRunWorkflowResult,
     run_dir: &RunDir,
 ) -> bool {
     bench::record_bench_observation_artifacts(&observation.0, workflow, run_dir)

--- a/crates/homeboy-cli/src/commands/bench/observation/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/bench/observation/lifecycle.rs
@@ -4,8 +4,8 @@ use homeboy::core::engine::run_dir::{self, RunDir};
 use homeboy::core::git::short_head_revision_at;
 use homeboy::core::observation::{merge_metadata, ActiveObservation, NewRunRecord, RunStatus};
 use homeboy::rig::RigStateSnapshot;
-use homeboy_core::bench::run::BenchRunFailure;
-use homeboy_core::bench::BenchRunWorkflowResult;
+use homeboy_core::extension::bench::run::BenchRunFailure;
+use homeboy_core::extension::bench::BenchRunWorkflowResult;
 
 use super::artifacts::{
     record_bench_observation_artifacts, record_if_exists, record_memory_timeline_artifacts,
@@ -133,8 +133,8 @@ pub(in crate::commands::bench) fn finish_success(
 /// downstream tools can locate the full evidence (#3257, #3260).
 pub(in crate::commands::bench) fn persisted_run_pointer(
     summary: &BenchObservationSummary,
-) -> homeboy_core::bench::BenchPersistedRun {
-    homeboy_core::bench::BenchPersistedRun {
+) -> homeboy_core::extension::bench::BenchPersistedRun {
+    homeboy_core::extension::bench::BenchPersistedRun {
         run_id: summary.run_id.clone(),
         component_id: (!summary.component_id.is_empty()).then(|| summary.component_id.clone()),
         rig_id: summary.rig_id.clone(),

--- a/crates/homeboy-cli/src/commands/bench/observation/metadata.rs
+++ b/crates/homeboy-cli/src/commands/bench/observation/metadata.rs
@@ -1,7 +1,7 @@
 use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::observation::merge_metadata;
 use homeboy::rig::RigStateSnapshot;
-use homeboy_core::bench::{BenchResults, BenchRunWorkflowResult};
+use homeboy_core::extension::bench::{BenchResults, BenchRunWorkflowResult};
 
 use crate::commands::bench::BenchRunArgs;
 use crate::commands::utils::resource_policy;

--- a/crates/homeboy-cli/src/commands/bench/observation/status.rs
+++ b/crates/homeboy-cli/src/commands/bench/observation/status.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use homeboy::core::engine::run_dir::RunDir;
-use homeboy_core::bench::BenchRunWorkflowResult;
+use homeboy_core::extension::bench::BenchRunWorkflowResult;
 
 use super::lifecycle::BenchObservation;
 use crate::commands::bench::BenchRunArgs;

--- a/crates/homeboy-cli/src/commands/bench/observation/tests.rs
+++ b/crates/homeboy-cli/src/commands/bench/observation/tests.rs
@@ -4,9 +4,11 @@ use std::path::PathBuf;
 use homeboy::core::engine::run_dir::{self, RunDir};
 use homeboy::core::observation::ObservationStore;
 use homeboy::runner::runners::{LabRunnerReadiness, LabRunnerReadinessState};
-use homeboy_core::bench::artifact::BenchArtifact;
-use homeboy_core::bench::run::BenchRunFailure;
-use homeboy_core::bench::{parse_bench_results_str, BenchResults, BenchRunWorkflowResult};
+use homeboy_core::extension::bench::artifact::BenchArtifact;
+use homeboy_core::extension::bench::run::BenchRunFailure;
+use homeboy_core::extension::bench::{
+    parse_bench_results_str, BenchResults, BenchRunWorkflowResult,
+};
 
 use super::*;
 use crate::commands::bench::{BenchRigOrder, BenchRunArgs};
@@ -157,21 +159,23 @@ fn bench_observation_persists_success_with_metrics_and_artifacts() {
                 ..BenchArtifact::default()
             },
         );
-        let child_command_failures = vec![homeboy_core::bench::parsing::BenchChildCommandFailure {
-            argv: vec!["generic-child".to_string(), "run".to_string()],
-            command: None,
-            exit_status: Some(9),
-            signal: None,
-            stdout_tail: Some("child stdout tail".to_string()),
-            stderr_tail: Some("child stderr tail".to_string()),
-            scenario_id: Some("cold".to_string()),
-            iteration: Some("5/10".to_string()),
-            batch: None,
-            artifact_refs: vec![serde_json::json!({
-                "kind": "log",
-                "ref": "runner-artifact://run/child-log"
-            })],
-        }];
+        let child_command_failures = vec![
+            homeboy_core::extension::bench::parsing::BenchChildCommandFailure {
+                argv: vec!["generic-child".to_string(), "run".to_string()],
+                command: None,
+                exit_status: Some(9),
+                signal: None,
+                stdout_tail: Some("child stdout tail".to_string()),
+                stderr_tail: Some("child stderr tail".to_string()),
+                scenario_id: Some("cold".to_string()),
+                iteration: Some("5/10".to_string()),
+                batch: None,
+                artifact_refs: vec![serde_json::json!({
+                    "kind": "log",
+                    "ref": "runner-artifact://run/child-log"
+                })],
+            },
+        ];
         results.child_command_failures = child_command_failures.clone();
         let mut workflow = BenchRunWorkflowResult {
             status: "passed".to_string(),

--- a/crates/homeboy-cli/src/commands/bench/settings_matrix.rs
+++ b/crates/homeboy-cli/src/commands/bench/settings_matrix.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 
 use homeboy::agents::agent_tasks::AgentTaskMatrixExecutionState;
 use homeboy::core::matrix_artifact_summary;
-use homeboy_core::bench::{BenchCommandOutput, BenchScenario};
+use homeboy_core::extension::bench::{BenchCommandOutput, BenchScenario};
 
 use super::{filter_homeboy_flags, matrix as bench_runner, BenchRunArgs};
 

--- a/crates/homeboy-cli/src/commands/bench/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/bench/tests/mod.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::test_support::{git_fixture_output, run_git_fixture_command, with_isolated_home};
 use clap::error::ErrorKind;
 use clap::Parser;
-use homeboy_core::bench::aggregate_comparison;
+use homeboy_core::extension::bench::aggregate_comparison;
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;

--- a/crates/homeboy-cli/src/commands/bench/tests/run_list_tests.rs
+++ b/crates/homeboy-cli/src/commands/bench/tests/run_list_tests.rs
@@ -100,7 +100,7 @@ fn run_list_serializes_installed_rig_package_evidence() {
                 assert!(!evidence.freshness_verified);
                 assert_eq!(
                     evidence.freshness,
-                    homeboy_core::bench::parsing::RigPackageFreshness::Unknown
+                    homeboy_core::extension::bench::parsing::RigPackageFreshness::Unknown
                 );
                 assert!(evidence
                     .refresh_command

--- a/crates/homeboy-cli/src/commands/build.rs
+++ b/crates/homeboy-cli/src/commands/build.rs
@@ -3,8 +3,8 @@ use homeboy::core::component;
 use homeboy::core::engine::execution_context::{self, ResolveOptions};
 use homeboy::core::project;
 use homeboy::core::scope::{self, Scope};
-use homeboy_core::build;
-use homeboy_core::ExtensionCapability;
+use homeboy_core::extension::build;
+use homeboy_core::extension::ExtensionCapability;
 
 use crate::commands::utils::args::{ChangedSinceArgs, ScopeArgs};
 use crate::commands::utils::resolve::resolve_project_components;

--- a/crates/homeboy-cli/src/commands/component/env.rs
+++ b/crates/homeboy-cli/src/commands/component/env.rs
@@ -63,7 +63,7 @@ pub(super) fn env(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOu
             if let Ok(json) = serde_json::from_str::<serde_json::Value>(&raw) {
                 if let Some(ext_obj) = json.get("extensions").and_then(|e| e.get(ext_id.as_str())) {
                     if let Ok(requirements) = serde_json::from_value::<
-                        homeboy_core::RuntimeRequirementsConfig,
+                        homeboy_core::extension::RuntimeRequirementsConfig,
                     >(ext_obj.clone())
                     {
                         apply_component_runtime_requirements(
@@ -79,7 +79,7 @@ pub(super) fn env(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOu
     }
 
     let extension = if let Some(ref ext_id) = extension_id {
-        homeboy_core::load_extension(ext_id).ok()
+        homeboy_core::extension::load_extension(ext_id).ok()
     } else {
         None
     };
@@ -124,9 +124,9 @@ pub(super) fn env(id: Option<&str>, path: Option<&str>) -> CmdResult<ComponentOu
 }
 
 fn run_component_env_detector(
-    extension: &homeboy_core::ExtensionManifest,
+    extension: &homeboy_core::extension::ExtensionManifest,
     component_path: &Path,
-) -> homeboy::core::Result<Option<homeboy_core::RuntimeRequirementsConfig>> {
+) -> homeboy::core::Result<Option<homeboy_core::extension::RuntimeRequirementsConfig>> {
     let Some(component_env) = extension.component_env.as_ref() else {
         return Ok(None);
     };
@@ -175,23 +175,24 @@ fn run_component_env_detector(
         return Ok(None);
     }
 
-    let detected = serde_json::from_str::<homeboy_core::RuntimeRequirementsConfig>(trimmed)
-        .map_err(|error| {
-            homeboy::core::Error::validation_invalid_json(
-                error,
-                Some(format!(
-                    "parse component env detector output for extension '{}'",
-                    extension.id
-                )),
-                Some(trimmed.chars().take(200).collect()),
-            )
-        })?;
+    let detected =
+        serde_json::from_str::<homeboy_core::extension::RuntimeRequirementsConfig>(trimmed)
+            .map_err(|error| {
+                homeboy::core::Error::validation_invalid_json(
+                    error,
+                    Some(format!(
+                        "parse component env detector output for extension '{}'",
+                        extension.id
+                    )),
+                    Some(trimmed.chars().take(200).collect()),
+                )
+            })?;
 
     Ok(Some(detected))
 }
 
 fn apply_component_env_detector_output(
-    detected: homeboy_core::RuntimeRequirementsConfig,
+    detected: homeboy_core::extension::RuntimeRequirementsConfig,
     runtimes: &mut BTreeMap<String, ComponentRuntimeRequirement>,
 ) {
     apply_component_runtime_requirements(detected, runtimes, "component", true);
@@ -199,7 +200,7 @@ fn apply_component_env_detector_output(
 
 fn apply_extension_runtime_requirements(
     extension_id: &str,
-    runtime: &homeboy_core::RuntimeRequirementsConfig,
+    runtime: &homeboy_core::extension::RuntimeRequirementsConfig,
     runtimes: &mut BTreeMap<String, ComponentRuntimeRequirement>,
 ) {
     let source = format!("extension:{}", extension_id);
@@ -207,7 +208,7 @@ fn apply_extension_runtime_requirements(
 }
 
 fn apply_component_runtime_requirements(
-    requirements: homeboy_core::RuntimeRequirementsConfig,
+    requirements: homeboy_core::extension::RuntimeRequirementsConfig,
     runtimes: &mut BTreeMap<String, ComponentRuntimeRequirement>,
     source: &str,
     overwrite: bool,
@@ -254,7 +255,7 @@ mod tests {
 
     #[test]
     fn extension_runtime_requirements_fill_missing_component_versions() {
-        let runtime: homeboy_core::RuntimeRequirementsConfig =
+        let runtime: homeboy_core::extension::RuntimeRequirementsConfig =
             serde_json::from_value(serde_json::json!({
                 "runtimes": {
                     "node": { "version": "24" },
@@ -292,7 +293,7 @@ mod tests {
         perms.set_mode(0o755);
         fs::set_permissions(&script, perms).expect("chmod detector");
 
-        let mut extension: homeboy_core::ExtensionManifest =
+        let mut extension: homeboy_core::extension::ExtensionManifest =
             serde_json::from_value(serde_json::json!({
                 "name": "Demo",
                 "version": "1.0.0",
@@ -312,7 +313,7 @@ mod tests {
 
     #[test]
     fn runtime_requirements_accept_canonical_shape_only() {
-        let generic: homeboy_core::RuntimeRequirementsConfig =
+        let generic: homeboy_core::extension::RuntimeRequirementsConfig =
             serde_json::from_value(serde_json::json!({
                 "runtimes": {
                     "python": { "version": "3.12" },
@@ -327,7 +328,7 @@ mod tests {
 
     #[test]
     fn component_env_detector_output_overrides_component_values_before_runtime_defaults() {
-        let runtime: homeboy_core::RuntimeRequirementsConfig =
+        let runtime: homeboy_core::extension::RuntimeRequirementsConfig =
             serde_json::from_value(serde_json::json!({
                 "runtimes": {
                     "node": { "version": "24" },
@@ -369,7 +370,7 @@ mod tests {
 
     #[test]
     fn component_versions_win_over_extension_runtime_requirements() {
-        let runtime: homeboy_core::RuntimeRequirementsConfig =
+        let runtime: homeboy_core::extension::RuntimeRequirementsConfig =
             serde_json::from_value(serde_json::json!({
                 "runtimes": {
                     "node": { "version": "24" },

--- a/crates/homeboy-cli/src/commands/contract_lab_routing.rs
+++ b/crates/homeboy-cli/src/commands/contract_lab_routing.rs
@@ -15,7 +15,7 @@ use crate::command_contract::{
 };
 use crate::commands::{adapter, agent_task};
 use crate::core::engine::execution_context::{self, ResolveOptions};
-use homeboy_core::ExtensionCapability;
+use homeboy_core::extension::ExtensionCapability;
 
 use crate::command_contract::{
     CommandPortabilityContract, LabCommandContract, LabWorkspaceModePolicy,

--- a/crates/homeboy-cli/src/commands/extension.rs
+++ b/crates/homeboy-cli/src/commands/extension.rs
@@ -10,8 +10,8 @@ use homeboy::core::git;
 use homeboy::core::project::{self, Project};
 use homeboy::core::server::{self, SshClient};
 use homeboy::runner::runners::{self, RunnerKind};
-use homeboy_core::{
-    self, extension_ready_status_with, is_extension_linked, load_extension, run_setup,
+use homeboy_core::extension::{
+    extension_ready_status_with, is_extension_linked, load_extension, run_setup,
     ExtensionReadinessMode, ExtensionSummary, UpdateEntry,
 };
 use std::collections::BTreeMap;
@@ -417,13 +417,13 @@ pub enum ExtensionOutput {
         #[serde(skip_serializing_if = "Option::is_none")]
         git_root: Option<String>,
         #[serde(flatten)]
-        source_update: homeboy_core::ExtensionSourceUpdate,
+        source_update: homeboy_core::extension::ExtensionSourceUpdate,
         #[serde(skip_serializing_if = "Option::is_none")]
         old_version: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         new_version: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        repaired_source_metadata: Option<homeboy_core::SourceMetadataRepair>,
+        repaired_source_metadata: Option<homeboy_core::extension::SourceMetadataRepair>,
     },
     #[serde(rename = "extension.update_all")]
     UpdateAll {
@@ -435,7 +435,7 @@ pub enum ExtensionOutput {
         controller_version: String,
         compatibility: Vec<ExtensionConvergenceCompatibility>,
         updated: Vec<UpdateEntry>,
-        skipped: Vec<homeboy_core::UpdateSkippedEntry>,
+        skipped: Vec<homeboy_core::extension::UpdateSkippedEntry>,
         revision_evidence: Vec<ExtensionRevisionEvidence>,
         provider_catalog_before: ProviderCatalogEvidence,
         provider_catalog_after: ProviderCatalogEvidence,
@@ -476,7 +476,7 @@ pub enum ExtensionOutput {
 #[derive(Serialize)]
 pub struct ExtensionConvergenceCompatibility {
     pub extension_id: String,
-    pub core_compatibility: homeboy_core::CoreCompatibilityReport,
+    pub core_compatibility: homeboy_core::extension::CoreCompatibilityReport,
 }
 
 #[derive(Serialize)]
@@ -514,14 +514,14 @@ pub struct ExtensionDetail {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_url: Option<String>,
     pub runtime: String,
-    pub core_compatibility: homeboy_core::CoreCompatibilityReport,
+    pub core_compatibility: homeboy_core::extension::CoreCompatibilityReport,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub runtime_requirements: Option<homeboy_core::RuntimeRequirementsConfig>,
+    pub runtime_requirements: Option<homeboy_core::extension::RuntimeRequirementsConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub has_setup: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub has_ready_check: Option<bool>,
-    pub readiness: homeboy_core::ExtensionReadinessState,
+    pub readiness: homeboy_core::extension::ExtensionReadinessState,
     pub ready: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ready_reason: Option<String>,
@@ -545,19 +545,20 @@ pub struct ExtensionDetail {
     pub actions: Vec<ActionDetail>,
     /// Installed transport IDs and schemas, without executable argv.
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub notification_transports: Vec<homeboy_core::NotificationTransportDescriptor>,
+    pub notification_transports: Vec<homeboy_core::extension::NotificationTransportDescriptor>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub inputs: Vec<homeboy_core::InputConfig>,
+    pub inputs: Vec<homeboy_core::extension::InputConfig>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub settings: Vec<homeboy_core::SettingConfig>,
+    pub settings: Vec<homeboy_core::extension::SettingConfig>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub structured_sidecars: Vec<homeboy_core::StructuredSidecarDeclaration>,
+    pub structured_sidecars: Vec<homeboy_core::extension::StructuredSidecarDeclaration>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ci_cache: Option<homeboy_core::CiCacheSpec>,
+    pub ci_cache: Option<homeboy_core::extension::CiCacheSpec>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub materialization_source: Option<homeboy_core::ExtensionMaterializationSourceContract>,
+    pub materialization_source:
+        Option<homeboy_core::extension::ExtensionMaterializationSourceContract>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub contract_producers: Vec<homeboy_core::ExtensionContractProducer>,
+    pub contract_producers: Vec<homeboy_core::extension::ExtensionContractProducer>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requires: Option<RequiresDetail>,
 }
@@ -585,11 +586,11 @@ pub struct ActionDetail {
     pub id: String,
     pub label: String,
     #[serde(rename = "type")]
-    pub action_type: homeboy_core::ActionType,
+    pub action_type: homeboy_core::extension::ActionType,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub endpoint: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub method: Option<homeboy_core::HttpMethod>,
+    pub method: Option<homeboy_core::extension::HttpMethod>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
 }
@@ -992,7 +993,7 @@ fn show_extension(
     });
 
     let source_revision = homeboy_core::extension_update_check::read_source_revision(&extension.id);
-    let core_compatibility = homeboy_core::evaluate_core_compatibility(
+    let core_compatibility = homeboy_core::extension::evaluate_core_compatibility(
         extension
             .requires
             .as_ref()
@@ -1037,7 +1038,7 @@ fn show_extension(
             .collect(),
         inputs: extension.inputs().to_vec(),
         settings: extension.settings.clone(),
-        structured_sidecars: homeboy_core::structured_sidecars(&extension),
+        structured_sidecars: homeboy_core::extension::structured_sidecars(&extension),
         ci_cache: extension.ci.as_ref().and_then(|ci| ci.cache.clone()),
         materialization_source: extension.materialization_source.clone(),
         contract_producers: extension.contract_producers.clone(),
@@ -1059,7 +1060,7 @@ fn run_extension(
     step: Option<String>,
     skip: Option<String>,
 ) -> CmdResult<ExtensionOutput> {
-    use homeboy_core::{ExtensionExecutionMode, ExtensionStepFilter};
+    use homeboy_core::extension::{ExtensionExecutionMode, ExtensionStepFilter};
 
     let mode = if no_stream {
         ExtensionExecutionMode::Captured
@@ -1071,7 +1072,7 @@ fn run_extension(
 
     let filter = ExtensionStepFilter { step, skip };
 
-    let result = homeboy_core::run_extension(
+    let result = homeboy_core::extension::run_extension(
         extension_id,
         project.as_deref(),
         component.as_deref(),
@@ -1098,8 +1099,11 @@ fn install_extension(
     replace: bool,
 ) -> CmdResult<ExtensionOutput> {
     if replace {
-        let result =
-            homeboy_core::replace_with_revision(source, id.as_deref(), revision.as_deref())?;
+        let result = homeboy_core::extension::replace_with_revision(
+            source,
+            id.as_deref(),
+            revision.as_deref(),
+        )?;
         return Ok((
             ExtensionOutput::Replace {
                 extension_id: result.extension_id,
@@ -1114,7 +1118,8 @@ fn install_extension(
         ));
     }
 
-    let result = homeboy_core::install_with_revision(source, id.as_deref(), revision.as_deref())?;
+    let result =
+        homeboy_core::extension::install_with_revision(source, id.as_deref(), revision.as_deref())?;
     let linked = is_extension_linked(&result.extension_id);
 
     Ok((
@@ -1135,7 +1140,7 @@ fn refresh_extension(
     id: Option<&str>,
     revision: Option<&str>,
 ) -> CmdResult<ExtensionOutput> {
-    let result = homeboy_core::refresh(source, id, revision)?;
+    let result = homeboy_core::extension::refresh(source, id, revision)?;
     let linked = is_extension_linked(&result.extension_id);
 
     Ok((
@@ -1157,7 +1162,7 @@ fn refresh_extension(
 }
 
 fn relink_extension(extension_id: &str, source: &str) -> CmdResult<ExtensionOutput> {
-    let result = homeboy_core::relink(extension_id, source)?;
+    let result = homeboy_core::extension::relink(extension_id, source)?;
 
     Ok((
         ExtensionOutput::Replace {
@@ -1187,7 +1192,7 @@ fn dev_run_extension(
 
 fn install_for_component(source: &str, path: Option<&str>) -> CmdResult<ExtensionOutput> {
     let component = resolve_install_component(path)?;
-    let result = homeboy_core::install_for_component(&component, source)?;
+    let result = homeboy_core::extension::install_for_component(&component, source)?;
 
     let installed = result
         .installed
@@ -1410,7 +1415,7 @@ fn bounded_diagnostic(message: &str) -> String {
 
 fn uninstall_extension(extension_id: &str) -> CmdResult<ExtensionOutput> {
     let was_linked = is_extension_linked(extension_id);
-    let path = homeboy_core::uninstall(extension_id)?;
+    let path = homeboy_core::extension::uninstall(extension_id)?;
 
     Ok((
         ExtensionOutput::Uninstall {
@@ -1538,7 +1543,7 @@ fn run_action(
     project_id: Option<String>,
     data: Option<String>,
 ) -> CmdResult<ExtensionOutput> {
-    let response = homeboy_core::run_action(
+    let response = homeboy_core::extension::run_action(
         extension_id,
         action_id,
         project_id.as_deref(),
@@ -1561,7 +1566,7 @@ fn set_extension(
     json: &str,
     replace_fields: &[String],
 ) -> CmdResult<ExtensionOutput> {
-    match homeboy_core::merge(extension_id, json, replace_fields)? {
+    match homeboy_core::extension::merge(extension_id, json, replace_fields)? {
         homeboy::core::MergeOutput::Single(result) => Ok((
             ExtensionOutput::Set {
                 extension_id: result.id,
@@ -1596,7 +1601,7 @@ fn exec_extension_tool(
 mod tests {
     use super::*;
     use crate::test_support::with_isolated_home;
-    use homeboy_core::{ExtensionSourceUpdate, UpdateEntry};
+    use homeboy_core::extension::{ExtensionSourceUpdate, UpdateEntry};
     use std::fs;
     #[cfg(unix)]
     use std::os::unix::fs::symlink;
@@ -2070,7 +2075,7 @@ mod tests {
 
             assert_eq!(
                 source.source_kind,
-                homeboy_core::ExtensionMaterializationSourceKind::Git
+                homeboy_core::extension::ExtensionMaterializationSourceKind::Git
             );
             assert_eq!(source.revision.as_deref(), Some("abc1234"));
             assert_eq!(
@@ -2117,7 +2122,7 @@ mod tests {
             assert_eq!(extension.notification_transports[0].id, "example.completed");
             assert_eq!(
                 extension.notification_transports[0].schema,
-                homeboy_core::NOTIFICATION_TRANSPORT_SCHEMA
+                homeboy_core::extension::NOTIFICATION_TRANSPORT_SCHEMA
             );
             assert!(
                 serde_json::to_value(&extension)
@@ -2181,11 +2186,11 @@ mod tests {
             assert_eq!(extension.contract_producers[0].id, "handoff-envelope");
             assert_eq!(
                 extension.contract_producers[0].phase,
-                homeboy_core::ExtensionContractProducerPhase::Handoff
+                homeboy_core::extension::ExtensionContractProducerPhase::Handoff
             );
             assert_eq!(
                 extension.contract_producers[0].produces[0].kind,
-                homeboy_core::ExtensionContractProducerOutputKind::RunnerEnvelopeAddition
+                homeboy_core::extension::ExtensionContractProducerOutputKind::RunnerEnvelopeAddition
             );
         });
     }
@@ -2231,7 +2236,7 @@ mod tests {
             assert_eq!(cache.paths.len(), 3);
             assert_eq!(
                 cache.paths[1].root,
-                homeboy_core::CiCachePathRoot::HomeboyData
+                homeboy_core::extension::CiCachePathRoot::HomeboyData
             );
             assert_eq!(cache.paths[1].path, "build-targets");
             assert_eq!(cache.paths[2].env.as_deref(), Some("BUILD_TARGET_DIR"));
@@ -2307,8 +2312,8 @@ mod tests {
             description: String::new(),
             runtime: "platform".to_string(),
             compatible: true,
-            core_compatibility: homeboy_core::CoreCompatibilityReport::undeclared(None),
-            readiness: homeboy_core::ExtensionReadinessState::Ready,
+            core_compatibility: homeboy_core::extension::CoreCompatibilityReport::undeclared(None),
+            readiness: homeboy_core::extension::ExtensionReadinessState::Ready,
             ready: Some(true),
             ready_reason: None,
             ready_detail: None,
@@ -2371,8 +2376,10 @@ mod tests {
                 description: String::new(),
                 runtime: "platform".to_string(),
                 compatible: true,
-                core_compatibility: homeboy_core::CoreCompatibilityReport::undeclared(None),
-                readiness: homeboy_core::ExtensionReadinessState::Ready,
+                core_compatibility: homeboy_core::extension::CoreCompatibilityReport::undeclared(
+                    None,
+                ),
+                readiness: homeboy_core::extension::ExtensionReadinessState::Ready,
                 ready: Some(true),
                 ready_reason: None,
                 ready_detail: None,
@@ -2424,8 +2431,10 @@ mod tests {
                 description: String::new(),
                 runtime: "platform".to_string(),
                 compatible: true,
-                core_compatibility: homeboy_core::CoreCompatibilityReport::undeclared(None),
-                readiness: homeboy_core::ExtensionReadinessState::Ready,
+                core_compatibility: homeboy_core::extension::CoreCompatibilityReport::undeclared(
+                    None,
+                ),
+                readiness: homeboy_core::extension::ExtensionReadinessState::Ready,
                 ready: Some(true),
                 ready_reason: None,
                 ready_detail: None,

--- a/crates/homeboy-cli/src/commands/fuzz/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/dispatch.rs
@@ -6,7 +6,7 @@ use homeboy::fuzz::{
     fuzz_gate_profile_contract, merge_fuzz_target_inventory, parse_fuzz_target_inventory_file,
     FuzzGateProfile, FuzzProvenance, FuzzTargetInventory, FUZZ_PROVENANCE_SCHEMA,
 };
-use homeboy_core::ExtensionCapability;
+use homeboy_core::extension::ExtensionCapability;
 
 use super::super::CmdResult;
 use super::compare::run_compare;

--- a/crates/homeboy-cli/src/commands/fuzz/doctor.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/doctor.rs
@@ -1,7 +1,7 @@
-use homeboy_core::extension_update_check::read_source_revision;
-use homeboy_core::{
+use homeboy_core::extension::{
     check_update_available, extension_ready_status, is_extension_linked, load_extension,
 };
+use homeboy_core::extension_update_check::read_source_revision;
 
 use super::types::FuzzDoctorArgs;
 use super::types_extra::{FuzzDoctorExtensionOutput, FuzzDoctorHomeboyOutput, FuzzDoctorOutput};

--- a/crates/homeboy-cli/src/commands/fuzz/execution.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/execution.rs
@@ -19,7 +19,10 @@ use homeboy::fuzz::{
     FUZZ_RESULTS_FILE_PRODUCER_CONTRACT,
 };
 use homeboy::rig::{self, FuzzPrepareReport, RigSpec};
-use homeboy_core::{self, ExtensionCapability, ExtensionRunner, FuzzConfig};
+use homeboy_core::{
+    self,
+    extension::{ExtensionCapability, ExtensionRunner, FuzzConfig},
+};
 use uuid::Uuid;
 
 use super::inspect::fuzz_failure_diagnostic;
@@ -335,7 +338,7 @@ pub(super) fn run_run(mut args: FuzzRunArgs) -> homeboy::core::Result<(FuzzRunOu
 
 pub(super) fn ensure_strict_rig_source_is_clean(
     args: &FuzzRunArgs,
-    rig_package: Option<&homeboy_core::bench::parsing::RigPackageEvidence>,
+    rig_package: Option<&homeboy_core::extension::bench::parsing::RigPackageEvidence>,
 ) -> homeboy::core::Result<()> {
     if args.effective_gate_profile().as_core() == FuzzGateProfile::Strict
         && rig_package.is_some_and(|package| package.linked && package.source_dirty)
@@ -861,7 +864,7 @@ pub(super) struct FuzzRunEvidenceInput<'a> {
     pub(super) run_id: Option<&'a str>,
     pub(super) component_id: &'a str,
     pub(super) rig_id: Option<&'a str>,
-    pub(super) rig_package: Option<&'a homeboy_core::bench::parsing::RigPackageEvidence>,
+    pub(super) rig_package: Option<&'a homeboy_core::extension::bench::parsing::RigPackageEvidence>,
     pub(super) workload_id: Option<&'a str>,
     pub(super) workload_path: Option<&'a str>,
     pub(super) status: &'a str,
@@ -1429,7 +1432,7 @@ pub(super) fn fuzz_runner_contract(config: Option<&FuzzConfig>) -> FuzzRunnerCon
                 env.push(key.to_string());
             }
         }
-        for key in homeboy_core::declared_helper_env_names(&config.runtime_helpers) {
+        for key in homeboy_core::extension::declared_helper_env_names(&config.runtime_helpers) {
             if !env.iter().any(|existing| existing == &key) {
                 env.push(key);
             }
@@ -1454,8 +1457,8 @@ fn run_fuzz_extension_script(
     run_dir: &RunDir,
     execution_request_path: &Path,
     sequence_plan_path: Option<&Path>,
-    runtime_helpers: &[homeboy_core::RuntimeHelperRequirement],
-) -> homeboy::core::Result<homeboy_core::RunnerOutput> {
+    runtime_helpers: &[homeboy_core::extension::RuntimeHelperRequirement],
+) -> homeboy::core::Result<homeboy_core::extension::RunnerOutput> {
     let results_path = run_dir.step_file(homeboy::core::engine::run_dir::files::FUZZ_RESULTS);
     let env = fuzz_runner_env(
         args,
@@ -1466,7 +1469,7 @@ fn run_fuzz_extension_script(
         Some(execution_request_path),
         sequence_plan_path,
     )?;
-    let helper_provenance = homeboy_core::provision_declared_helpers(runtime_helpers)?;
+    let helper_provenance = homeboy_core::extension::provision_declared_helpers(runtime_helpers)?;
     let mut helper_env = helper_provenance
         .iter()
         .map(|helper| (helper.env_var.clone(), helper.path.clone()))
@@ -1484,7 +1487,7 @@ fn run_fuzz_extension_script(
     if ctx.component.has_script(ExtensionCapability::Fuzz) {
         let mut component_env = env;
         component_env.extend(helper_env);
-        let output = homeboy_core::component_script::run_component_scripts_with_run_dir(
+        let output = homeboy_core::extension::component_script::run_component_scripts_with_run_dir(
             &ctx.component,
             ExtensionCapability::Fuzz,
             &ctx.source_path,

--- a/crates/homeboy-cli/src/commands/fuzz/planning.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/planning.rs
@@ -24,7 +24,7 @@ use super::workloads::{
     build_target_inventory, fuzz_workloads, load_rig, resolve_component_id, resolve_fuzz_context,
     resolve_profile_workload_id, resolve_profile_workload_ids, select_workload,
 };
-use homeboy_core::ExtensionCapability;
+use homeboy_core::extension::ExtensionCapability;
 
 pub(super) fn run_plan(args: FuzzPlanArgs) -> homeboy::core::Result<FuzzPlanOutput> {
     let rig_context = load_rig(args.run.rig.as_deref(), &args.run.setting_args)?;
@@ -43,7 +43,7 @@ pub(super) fn run_plan(args: FuzzPlanArgs) -> homeboy::core::Result<FuzzPlanOutp
     let fuzz_config = ctx
         .extension_id
         .as_deref()
-        .and_then(|extension_id| homeboy_core::load_extension(extension_id).ok())
+        .and_then(|extension_id| homeboy_core::extension::load_extension(extension_id).ok())
         .and_then(|manifest| manifest.fuzz);
     let workloads = fuzz_workloads(
         &ctx.component,

--- a/crates/homeboy-cli/src/commands/fuzz/replay.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/replay.rs
@@ -10,7 +10,10 @@ use homeboy::fuzz::{
     FUZZ_RESULT_ENVELOPE_SCHEMA,
 };
 use homeboy::runner::runners::is_retrievable_runner_artifact;
-use homeboy_core::{self, ExtensionCapability, ExtensionRunner};
+use homeboy_core::{
+    self,
+    extension::{ExtensionCapability, ExtensionRunner},
+};
 
 use super::super::utils::args::PositionalComponentArgs;
 use super::types::{
@@ -307,7 +310,7 @@ impl ReplayLikeMode {
 
 #[derive(Clone)]
 struct ResolvedReplayContext {
-    execution_context: homeboy_core::ExtensionExecutionContext,
+    execution_context: homeboy_core::extension::ExtensionExecutionContext,
     component: homeboy::core::component::Component,
     command: Option<String>,
 }

--- a/crates/homeboy-cli/src/commands/fuzz/tests/execution_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/execution_tests.rs
@@ -41,7 +41,7 @@ fn install_fuzz_postprocess_helper(home: &std::path::Path) {
 fn strict_fuzz_rejects_dirty_linked_rig_packages() {
     let mut args = fuzz_run_args_with_run_id("dirty-rig");
     args.gate_profile = FuzzGateProfileArg::Strict;
-    let dirty_linked = homeboy_core::bench::parsing::RigPackageEvidence {
+    let dirty_linked = homeboy_core::extension::bench::parsing::RigPackageEvidence {
         rig_id: "rig".to_string(),
         package_root: "/tmp/rig".to_string(),
         source: "/tmp/rig".to_string(),
@@ -55,7 +55,7 @@ fn strict_fuzz_rejects_dirty_linked_rig_packages() {
         source_dirty: true,
         linked: true,
         materialized: false,
-        freshness: homeboy_core::bench::parsing::RigPackageFreshness::Stale,
+        freshness: homeboy_core::extension::bench::parsing::RigPackageFreshness::Stale,
         freshness_verified: false,
         freshness_message: Some("content changed".to_string()),
         refresh_command: None,
@@ -114,8 +114,8 @@ fn auto_run_ids_scope_identical_payloads_while_explicit_ids_remain_stable() {
 #[test]
 fn fuzz_contract_exposes_only_declared_core_helper_environment() {
     let config = FuzzConfig {
-        runtime_helpers: vec![homeboy_core::RuntimeHelperRequirement {
-            id: homeboy_core::RUNTIME_SETTINGS_HELPER_ID.to_string(),
+        runtime_helpers: vec![homeboy_core::extension::RuntimeHelperRequirement {
+            id: homeboy_core::extension::RUNTIME_SETTINGS_HELPER_ID.to_string(),
             revision: None,
         }],
         ..Default::default()
@@ -124,7 +124,7 @@ fn fuzz_contract_exposes_only_declared_core_helper_environment() {
 
     assert!(contract
         .env
-        .contains(&homeboy_core::RUNTIME_SETTINGS_HELPER_ENV.to_string()));
+        .contains(&homeboy_core::extension::RUNTIME_SETTINGS_HELPER_ENV.to_string()));
     assert!(!contract
         .env
         .contains(&"HOMEBOY_RUNTIME_HELPERS_PROVENANCE".to_string()));

--- a/crates/homeboy-cli/src/commands/fuzz/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/mod.rs
@@ -46,7 +46,7 @@ use homeboy::fuzz::{
 };
 use homeboy::rig::RigSpec;
 use homeboy::test_support::with_isolated_home;
-use homeboy_core::FuzzConfig;
+use homeboy_core::extension::FuzzConfig;
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/crates/homeboy-cli/src/commands/fuzz/tests/workload_tests.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/tests/workload_tests.rs
@@ -154,7 +154,7 @@ fn resolve_fuzz_context_preserves_rig_extensions_with_explicit_path_when_registr
             &comp,
             &SettingArgs::default(),
             &ExtensionOverrideArgs::default(),
-            homeboy_core::ExtensionCapability::Fuzz,
+            homeboy_core::extension::ExtensionCapability::Fuzz,
             Some(&context),
         )
         .expect("resolve fuzz context");
@@ -217,7 +217,7 @@ fn resolve_fuzz_context_infers_single_rig_fuzz_workload_extension() {
             &comp,
             &SettingArgs::default(),
             &ExtensionOverrideArgs::default(),
-            homeboy_core::ExtensionCapability::Fuzz,
+            homeboy_core::extension::ExtensionCapability::Fuzz,
             Some(&context),
         )
         .expect("resolve fuzz context");
@@ -272,7 +272,7 @@ fn resolve_fuzz_context_reports_explicit_extension_without_fuzz_capability() {
             &comp,
             &SettingArgs::default(),
             &extension_override,
-            homeboy_core::ExtensionCapability::Fuzz,
+            homeboy_core::extension::ExtensionCapability::Fuzz,
             Some(&context),
         )
         .expect_err("old extension manifest should fail explicitly");

--- a/crates/homeboy-cli/src/commands/fuzz/types_extra.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/types_extra.rs
@@ -50,7 +50,7 @@ pub struct FuzzDoctorExtensionOutput {
     pub version: String,
     pub path: String,
     pub linked: bool,
-    pub readiness: homeboy_core::ExtensionReadinessState,
+    pub readiness: homeboy_core::extension::ExtensionReadinessState,
     pub ready: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ready_reason: Option<String>,
@@ -196,7 +196,7 @@ pub struct FuzzListOutput {
     pub command: String,
     pub component: String,
     pub rig_id: Option<String>,
-    pub rig_package: Option<homeboy_core::bench::parsing::RigPackageEvidence>,
+    pub rig_package: Option<homeboy_core::extension::bench::parsing::RigPackageEvidence>,
     pub component_mapping: FuzzListComponentMapping,
     pub extension_provider: Option<String>,
     pub workloads: Vec<FuzzWorkloadOutput>,

--- a/crates/homeboy-cli/src/commands/fuzz/workloads.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/workloads.rs
@@ -10,7 +10,7 @@ use homeboy::fuzz::{
     FUZZ_CONTRACT_VERSION, FUZZ_TARGET_INVENTORY_SCHEMA,
 };
 use homeboy::rig::{self, RigSpec};
-use homeboy_core::{self, ExtensionCapability};
+use homeboy_core::{self, extension::ExtensionCapability};
 
 use super::super::utils::args::{ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs};
 use super::report::fuzz_provenance;

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -4129,15 +4129,17 @@ fn lab_job_overrides(cli: &Cli) -> homeboy::core::Result<runners::LabJobOverride
 
 /// The test manifest, not the ambient controller, owns portable environment.
 /// This runs before direct Lab dispatch and deferred-plan persistence.
-fn portable_test_env(cli: &Cli) -> homeboy::core::Result<homeboy_core::test::PortableTestEnv> {
+fn portable_test_env(
+    cli: &Cli,
+) -> homeboy::core::Result<homeboy_core::extension::test::PortableTestEnv> {
     let Commands::Review(review) = &cli.command else {
-        return Ok(homeboy_core::test::PortableTestEnv {
+        return Ok(homeboy_core::extension::test::PortableTestEnv {
             public_env: Vec::new(),
             secret_env: Default::default(),
         });
     };
     let Some(crate::commands::review::ReviewCommand::Test(args)) = review.command.as_ref() else {
-        return Ok(homeboy_core::test::PortableTestEnv {
+        return Ok(homeboy_core::extension::test::PortableTestEnv {
             public_env: Vec::new(),
             secret_env: Default::default(),
         });
@@ -4146,9 +4148,9 @@ fn portable_test_env(cli: &Cli) -> homeboy::core::Result<homeboy_core::test::Por
         &args.comp,
         &args.setting_args,
         &args.extension_override,
-        Some(homeboy_core::ExtensionCapability::Test),
+        Some(homeboy_core::extension::ExtensionCapability::Test),
     )?;
-    homeboy_core::test::portable_env(&context.component)
+    homeboy_core::extension::test::portable_env(&context.component)
 }
 
 fn parse_lab_env_pair(source: &str, raw: &str) -> homeboy::core::Result<(String, String)> {

--- a/crates/homeboy-cli/src/commands/infra/runtime.rs
+++ b/crates/homeboy-cli/src/commands/infra/runtime.rs
@@ -189,7 +189,7 @@ pub(crate) fn run_plain_text(args: RuntimeArgs) -> homeboy::core::Result<(String
     match args.command {
         RuntimeCommand::Helper { command } => match command {
             RuntimeHelperCommand::Path { helper, .. } => {
-                let path = homeboy_core::helper_path(&helper)?;
+                let path = homeboy_core::extension::helper_path(&helper)?;
                 Ok((format!("{}\n", path.to_string_lossy()), 0))
             }
         },
@@ -313,7 +313,7 @@ fn promotion_takeover() -> CmdResult<RuntimeOutput> {
 }
 
 fn helper_path(helper: &str) -> CmdResult<RuntimeOutput> {
-    let path = homeboy_core::helper_path(helper)?;
+    let path = homeboy_core::extension::helper_path(helper)?;
 
     Ok((
         RuntimeOutput::HelperPath(RuntimeHelperPathOutput {

--- a/crates/homeboy-cli/src/commands/infra/source_command.rs
+++ b/crates/homeboy-cli/src/commands/infra/source_command.rs
@@ -1,7 +1,7 @@
 use homeboy::core::ci_profile::{self, CiResolvedJob};
 use homeboy::core::component::Component;
 use homeboy::core::engine::execution_context::{self, ExecutionContext, ResolveOptions};
-use homeboy_core::ExtensionCapability;
+use homeboy_core::extension::ExtensionCapability;
 
 use crate::commands::utils::args::{ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs};
 

--- a/crates/homeboy-cli/src/commands/lint.rs
+++ b/crates/homeboy-cli/src/commands/lint.rs
@@ -2,11 +2,11 @@ use clap::Args;
 
 use homeboy::core::ci_profile;
 use homeboy::core::git;
-use homeboy_core::lint::{
+use homeboy_core::extension::lint::{
     report, run_main_lint_workflow, run_self_check_lint_workflow_with_progress, LintCommandOutput,
     LintRunWorkflowArgs,
 };
-use homeboy_core::ExtensionCapability;
+use homeboy_core::extension::ExtensionCapability;
 
 /// Build the slim `LintFixInput` the core lint report consumes from a full
 /// refactor source-run, so core does not depend on the refactor engine's
@@ -363,7 +363,7 @@ impl LintObservationAdapter {
     }
 }
 
-impl WorkflowObservationAdapter<homeboy_core::lint::LintRunWorkflowResult>
+impl WorkflowObservationAdapter<homeboy_core::extension::lint::LintRunWorkflowResult>
     for LintObservationAdapter
 {
     fn start_record(&self) -> NewRunRecord {
@@ -378,7 +378,10 @@ impl WorkflowObservationAdapter<homeboy_core::lint::LintRunWorkflowResult>
             .build()
     }
 
-    fn success_status(&self, workflow: &homeboy_core::lint::LintRunWorkflowResult) -> RunStatus {
+    fn success_status(
+        &self,
+        workflow: &homeboy_core::extension::lint::LintRunWorkflowResult,
+    ) -> RunStatus {
         if workflow.status == "passed" {
             RunStatus::Pass
         } else {
@@ -388,7 +391,7 @@ impl WorkflowObservationAdapter<homeboy_core::lint::LintRunWorkflowResult>
 
     fn success_metadata(
         &self,
-        workflow: &homeboy_core::lint::LintRunWorkflowResult,
+        workflow: &homeboy_core::extension::lint::LintRunWorkflowResult,
     ) -> serde_json::Value {
         serde_json::json!({
             "exit_code": workflow.exit_code,
@@ -400,7 +403,7 @@ impl WorkflowObservationAdapter<homeboy_core::lint::LintRunWorkflowResult>
     fn success_findings(
         &self,
         run_id: &str,
-        workflow: &homeboy_core::lint::LintRunWorkflowResult,
+        workflow: &homeboy_core::extension::lint::LintRunWorkflowResult,
     ) -> Vec<NewFindingRecord> {
         workflow
             .findings
@@ -413,7 +416,7 @@ impl WorkflowObservationAdapter<homeboy_core::lint::LintRunWorkflowResult>
 fn finish_lint_observation(
     active: ActiveObservation,
     adapter: &LintObservationAdapter,
-    workflow: &homeboy_core::lint::LintRunWorkflowResult,
+    workflow: &homeboy_core::extension::lint::LintRunWorkflowResult,
 ) {
     let mut metadata = merge_metadata(
         active.initial_metadata().clone(),
@@ -533,8 +536,8 @@ mod tests {
     use homeboy::refactor::{
         lint_refactor_request, LintSourceOptions, RefactorSourceRun, SourceTotals,
     };
-    use homeboy_core::lint as extension_lint;
-    use homeboy_core::lint::report;
+    use homeboy_core::extension::lint as extension_lint;
+    use homeboy_core::extension::lint::report;
 
     #[derive(Parser)]
     struct TestCli {
@@ -740,7 +743,7 @@ mod tests {
                 summary: false,
                 file: None,
                 glob: Some("/tmp/demo/src/lib.rs".to_string()),
-                sniff_filters: homeboy_core::lint::LintSniffFilters {
+                sniff_filters: homeboy_core::extension::lint::LintSniffFilters {
                     errors_only: true,
                     sniffs: Some("Generic.Security".to_string()),
                     exclude_sniffs: Some("Generic.WhiteSpace".to_string()),

--- a/crates/homeboy-cli/src/commands/review/mod.rs
+++ b/crates/homeboy-cli/src/commands/review/mod.rs
@@ -20,8 +20,8 @@ use homeboy::core::git;
 use homeboy::core::observation::ObservationStore;
 use homeboy::core::plan::PlanStep;
 use homeboy::core::quality::{build_quality_plan, QualityPlanOptions};
-use homeboy_core::lint::LintCommandOutput;
-use homeboy_core::test::TestCommandOutput;
+use homeboy_core::extension::lint::LintCommandOutput;
+use homeboy_core::extension::test::TestCommandOutput;
 use homeboy_release::release::{changelog, version};
 use homeboy_review::review::{
     self, ReviewArtifactFindings, ReviewCommandOutput, ReviewOutputInput, ReviewService,

--- a/crates/homeboy-cli/src/commands/review/observation.rs
+++ b/crates/homeboy-cli/src/commands/review/observation.rs
@@ -362,8 +362,8 @@ mod tests {
     #[test]
     fn finish_metadata_captures_aggregate_and_linkable_stages() {
         use homeboy::core::code_audit::AuditCommandOutput;
-        use homeboy_core::lint::LintCommandOutput;
-        use homeboy_core::test::TestCommandOutput;
+        use homeboy_core::extension::lint::LintCommandOutput;
+        use homeboy_core::extension::test::TestCommandOutput;
 
         let initial = serde_json::json!({
             "schema": "homeboy/review-observation/v1",

--- a/crates/homeboy-cli/src/commands/runner/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/runner/dispatch.rs
@@ -321,7 +321,7 @@ pub fn run(args: RunnerArgs) -> CmdResult<RunnerCommandOutput> {
             RunnerCommandOutput::RecipeRunProviders(Box::new(RecipeRunProvidersOutput {
                 variant: "recipe_run_providers",
                 command: "list",
-                providers: homeboy_core::recipe_run_provider_inventory(),
+                providers: homeboy_core::extension::recipe_run_provider_inventory(),
             })),
             0,
         )),

--- a/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/probes.rs
@@ -1,7 +1,7 @@
 use super::*;
 use homeboy::core::agent_runtime_manifest::{self, AgentRuntimeManifest};
 use homeboy_core::extension;
-use homeboy_core::{self, ExtensionManifest};
+use homeboy_core::{self, extension::ExtensionManifest};
 use types::{DiskProbe, HomeboyProbe, MemoryProbe, RunnerCapabilities, RunnerCheck, ToolProbe};
 
 pub(crate) fn tool_specs(runner: &Runner) -> Vec<RunnerToolSpec> {

--- a/crates/homeboy-cli/src/commands/runner/recipe_run.rs
+++ b/crates/homeboy-cli/src/commands/runner/recipe_run.rs
@@ -24,10 +24,10 @@ pub(super) fn recipe_run(
             None,
         ));
     }
-    let descriptor = homeboy_core::resolve_recipe_run_provider(provider_id)?;
-    let command = homeboy_core::render_recipe_run_command(
+    let descriptor = homeboy_core::extension::resolve_recipe_run_provider(provider_id)?;
+    let command = homeboy_core::extension::render_recipe_run_command(
         &descriptor,
-        &homeboy_core::RecipeRunRequest {
+        &homeboy_core::extension::RecipeRunRequest {
             recipe_path: recipe,
             artifact_path: artifacts.clone(),
         },
@@ -109,7 +109,7 @@ mod tests {
             .to_string(),
         )
         .expect("manifest");
-        homeboy_core::install(&source.path().display().to_string(), Some(id))
+        homeboy_core::extension::install(&source.path().display().to_string(), Some(id))
             .expect("install extension");
         // Installed extensions are linked to their source. Keep the fixture
         // alive until discovery and execution complete.

--- a/crates/homeboy-cli/src/commands/runner/tests/exec.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/exec.rs
@@ -113,7 +113,7 @@ fn synced_node_workload_receives_runner_extension_environment() {
             )
             .expect("provider executable");
         }
-        homeboy_core::install(&extension.path().display().to_string(), Some("fixture"))
+        homeboy_core::extension::install(&extension.path().display().to_string(), Some("fixture"))
             .expect("install fixture extension");
         runner::create(
             &format!(

--- a/crates/homeboy-cli/src/commands/runner/types.rs
+++ b/crates/homeboy-cli/src/commands/runner/types.rs
@@ -522,7 +522,7 @@ pub enum RunnerCommandOutput {
 pub struct RecipeRunProvidersOutput {
     pub variant: &'static str,
     pub command: &'static str,
-    pub providers: Vec<homeboy_core::RecipeRunProviderInventoryEntry>,
+    pub providers: Vec<homeboy_core::extension::RecipeRunProviderInventoryEntry>,
 }
 
 /// An authoritative job observation or a retained generation ownership record.

--- a/crates/homeboy-cli/src/commands/runs/report/bench_coverage.rs
+++ b/crates/homeboy-cli/src/commands/runs/report/bench_coverage.rs
@@ -4,10 +4,10 @@ use serde::Serialize;
 use homeboy::core::component::{self, Component};
 use homeboy::core::engine::execution_context::{self, ResolveOptions};
 use homeboy::core::engine::run_dir::RunDir;
-use homeboy_core::bench::{
+use homeboy_core::extension::bench::{
     run_bench_list_workflow, BenchListWorkflowArgs, BenchListWorkflowResult, BenchScenario,
 };
-use homeboy_core::{resolve_extension_for_capability, ExtensionCapability};
+use homeboy_core::extension::{resolve_extension_for_capability, ExtensionCapability};
 
 use crate::commands::escape_markdown_table_cell;
 use crate::commands::utils::args::{ExtensionOverrideArgs, PositionalComponentArgs, SettingArgs};
@@ -376,7 +376,7 @@ pub fn render_markdown(report: &BenchCoverageReport) -> String {
 mod tests {
     use std::collections::BTreeMap;
 
-    use homeboy_core::bench::{BenchMetrics, BenchScenario};
+    use homeboy_core::extension::bench::{BenchMetrics, BenchScenario};
 
     use super::*;
 

--- a/crates/homeboy-cli/src/commands/runs/report/browser_evidence_compare/implementation/parse.rs
+++ b/crates/homeboy-cli/src/commands/runs/report/browser_evidence_compare/implementation/parse.rs
@@ -3,8 +3,10 @@ use std::path::Path;
 
 use serde_json::{Map, Value};
 
-use homeboy_core::trace::{trace_browser_artifact_map_fields, trace_browser_summary_extract};
-use homeboy_core::TraceBrowserEvidenceAdapterConfig;
+use homeboy_core::extension::trace::{
+    trace_browser_artifact_map_fields, trace_browser_summary_extract,
+};
+use homeboy_core::extension::TraceBrowserEvidenceAdapterConfig;
 
 use super::super::types::{AssertionFailure, AssertionStats, BrowserEvidenceArtifactLink};
 use super::BrowserEvidenceSample;

--- a/crates/homeboy-cli/src/commands/runs/report/browser_evidence_compare/implementation/reader.rs
+++ b/crates/homeboy-cli/src/commands/runs/report/browser_evidence_compare/implementation/reader.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 
 use serde_json::{Map, Value};
 
-use homeboy_core::trace::trace_browser_summary_has_signal;
-use homeboy_core::TraceBrowserEvidenceAdapterConfig;
+use homeboy_core::extension::trace::trace_browser_summary_has_signal;
+use homeboy_core::extension::TraceBrowserEvidenceAdapterConfig;
 
 use super::super::types::BrowserEvidenceArtifactLink;
 use super::parse::{

--- a/crates/homeboy-cli/src/commands/runs/report/browser_evidence_compare/mod.rs
+++ b/crates/homeboy-cli/src/commands/runs/report/browser_evidence_compare/mod.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
-use homeboy_core::trace::trace_browser_evidence_adapters;
-use homeboy_core::TraceBrowserEvidenceAdapterConfig;
+use homeboy_core::extension::trace::trace_browser_evidence_adapters;
+use homeboy_core::extension::TraceBrowserEvidenceAdapterConfig;
 
 mod implementation;
 mod types;

--- a/crates/homeboy-cli/src/commands/test.rs
+++ b/crates/homeboy-cli/src/commands/test.rs
@@ -7,14 +7,14 @@ use homeboy::core::observation::{
     finding_records_from_failure_clusters, finding_records_from_test_analysis_input,
     merge_metadata, ActiveObservation, NewRunRecord, RunStatus,
 };
-use homeboy_core::test as extension_test;
-use homeboy_core::test::{
+use homeboy_core::extension::test as extension_test;
+use homeboy_core::extension::test::{
     build_test_summary, detect_test_drift, parse_test_failures_from_text,
     parse_test_results_failures_file, parse_test_results_file, parse_test_results_text, report,
     run_self_check_test_workflow_with_progress, test_failure_summary_items, TestAnalysisInput,
     TestCommandOutput, TestFailure, TestRunWorkflowArgs,
 };
-use homeboy_core::ExtensionCapability;
+use homeboy_core::extension::ExtensionCapability;
 #[cfg(test)]
 use homeboy_extension_contract::test_results::TestInventoryRejection;
 use serde_json::Value;
@@ -1527,7 +1527,7 @@ mod tests {
     use homeboy::core::component::Component;
     use homeboy::core::observation::{FindingListFilter, ObservationStore};
     use homeboy::refactor::{build_test_refactor_request, TestSourceOptions};
-    use homeboy_core::test::{TestAnalysisInput, TestCounts, TestFailure};
+    use homeboy_core::extension::test::{TestAnalysisInput, TestCounts, TestFailure};
     use std::fs;
     use std::path::PathBuf;
 
@@ -2042,7 +2042,7 @@ mod tests {
                 test_scope: None,
                 summary: None,
                 raw_output: None,
-                extension_phase_timings: vec![homeboy_core::ExtensionPhaseTiming {
+                extension_phase_timings: vec![homeboy_core::extension::ExtensionPhaseTiming {
                     name: "provider-test".to_string(),
                     duration_ms: 1,
                     status: Some("failed".to_string()),
@@ -2282,7 +2282,7 @@ mod tests {
                 start_test_observation("homeboy", home.path(), &args, "test", Some(&run_dir))
                     .expect("observation");
             let run_id = observation.active.run_id().to_string();
-            let timing = homeboy_core::ExtensionPhaseTiming {
+            let timing = homeboy_core::extension::ExtensionPhaseTiming {
                 name: "provider-test".to_string(),
                 duration_ms: 1,
                 status: Some("failed".to_string()),
@@ -2469,7 +2469,7 @@ mod tests {
                     test_scope: None,
                     summary: None,
                     raw_output: None,
-                    extension_phase_timings: vec![homeboy_core::ExtensionPhaseTiming {
+                    extension_phase_timings: vec![homeboy_core::extension::ExtensionPhaseTiming {
                         name: "provider-test".to_string(),
                         duration_ms: 1,
                         status: Some("completed".to_string()),
@@ -2550,7 +2550,7 @@ mod tests {
                 stdout_limit_bytes: 0,
                 stderr_limit_bytes: 0,
             }),
-            extension_phase_timings: vec![homeboy_core::ExtensionPhaseTiming {
+            extension_phase_timings: vec![homeboy_core::extension::ExtensionPhaseTiming {
                 name: "provider".to_string(),
                 duration_ms: 0,
                 status: None,

--- a/crates/homeboy-cli/src/commands/trace.rs
+++ b/crates/homeboy-cli/src/commands/trace.rs
@@ -10,13 +10,13 @@ use homeboy::core::engine::invocation::InvocationRequirements;
 use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::observation::{ActiveObservation, NewRunRecord};
 use homeboy::rig::{self, RigSpec};
-use homeboy_core::trace as extension_trace;
-use homeboy_core::trace::{
+use homeboy_core::extension::trace as extension_trace;
+use homeboy_core::extension::trace::{
     TraceAttachment, TraceCanonicalPolicy, TraceCheckoutProvenance, TraceCommandOutput,
     TraceListWorkflowArgs, TraceOverlayRequest, TraceRunWorkflowArgs, TraceRunnerInputs,
     TraceSpanDefinition,
 };
-use homeboy_core::ExtensionCapability;
+use homeboy_core::extension::ExtensionCapability;
 
 use super::utils::args::{BaselineArgs, PositionalComponentArgs, SettingArgs};
 use super::CmdResult;

--- a/crates/homeboy-cli/src/commands/trace/aggregate.rs
+++ b/crates/homeboy-cli/src/commands/trace/aggregate.rs
@@ -1,4 +1,4 @@
-use homeboy_core::trace as extension_trace;
+use homeboy_core::extension::trace as extension_trace;
 
 #[derive(Clone)]
 pub(super) struct TraceAggregateSpanSample {

--- a/crates/homeboy-cli/src/commands/trace/aggregate_tests.rs
+++ b/crates/homeboy-cli/src/commands/trace/aggregate_tests.rs
@@ -1,4 +1,4 @@
-use homeboy_core::trace as extension_trace;
+use homeboy_core::extension::trace as extension_trace;
 
 use super::aggregate::aggregate_span;
 use super::aggregate_test_support::aggregate_samples;

--- a/crates/homeboy-cli/src/commands/trace/bundle.rs
+++ b/crates/homeboy-cli/src/commands/trace/bundle.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use serde::Serialize;
 
 use homeboy::rig::trace_experiment;
-use homeboy_core::trace as extension_trace;
+use homeboy_core::extension::trace as extension_trace;
 
 use super::output::{
     fmt_delta_avg_ms, fmt_delta_ms, fmt_ms, render_compare_markdown, TraceAggregateInput,

--- a/crates/homeboy-cli/src/commands/trace/compare_bundle.rs
+++ b/crates/homeboy-cli/src/commands/trace/compare_bundle.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use homeboy_core::trace::{self as extension_trace, TraceCommandOutput};
+use homeboy_core::extension::trace::{self as extension_trace, TraceCommandOutput};
 use serde::Serialize;
 
 use super::compare_targets::run_compare_targets;

--- a/crates/homeboy-cli/src/commands/trace/compare_targets.rs
+++ b/crates/homeboy-cli/src/commands/trace/compare_targets.rs
@@ -5,8 +5,8 @@ use crate::commands::trace::compare_artifacts::{self, CompareArtifactSet, Compar
 use homeboy::core::component;
 use homeboy::core::git;
 use homeboy::core::observation::{NewRunRecord, RunStatus};
-use homeboy_core::trace as extension_trace;
-use homeboy_core::trace::{TraceCheckoutProvenance, TraceCommandOutput};
+use homeboy_core::extension::trace as extension_trace;
+use homeboy_core::extension::trace::{TraceCheckoutProvenance, TraceCommandOutput};
 
 use super::aggregate::{
     aggregate_metric, aggregate_span, TraceAggregateMetricSample, TraceAggregateSpanSample,

--- a/crates/homeboy-cli/src/commands/trace/compare_variant.rs
+++ b/crates/homeboy-cli/src/commands/trace/compare_variant.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 
 use crate::commands::trace::compare_artifacts;
 use homeboy::rig;
-use homeboy_core::trace as extension_trace;
-use homeboy_core::trace::TraceCommandOutput;
+use homeboy_core::extension::trace as extension_trace;
+use homeboy_core::extension::trace::TraceCommandOutput;
 
 use super::aggregate::{
     aggregate_metric, aggregate_span, TraceAggregateMetricSample, TraceAggregateSpanSample,

--- a/crates/homeboy-cli/src/commands/trace/compare_variant_tests.rs
+++ b/crates/homeboy-cli/src/commands/trace/compare_variant_tests.rs
@@ -5,8 +5,8 @@ use crate::test_support::with_isolated_home;
 
 use super::test_fixture::TRACE_FIXTURE_EXTENSION_ID;
 
-use homeboy_core::trace as extension_trace;
-use homeboy_core::trace::TraceCommandOutput;
+use homeboy_core::extension::trace as extension_trace;
+use homeboy_core::extension::trace::TraceCommandOutput;
 
 use super::test_fixture::{init_overlay_component, write_trace_extension};
 use super::{run, TraceArgs, TraceSchedule, TraceVariantMatrixMode};

--- a/crates/homeboy-cli/src/commands/trace/experiment.rs
+++ b/crates/homeboy-cli/src/commands/trace/experiment.rs
@@ -2,7 +2,7 @@ use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanValues};
 use homeboy::rig;
 use homeboy::rig::trace_experiment::{self, TraceExperimentContext};
-use homeboy_core::trace as extension_trace;
+use homeboy_core::extension::trace as extension_trace;
 
 use super::{TraceArgs, TraceRigContext};
 

--- a/crates/homeboy-cli/src/commands/trace/experiment_tests.rs
+++ b/crates/homeboy-cli/src/commands/trace/experiment_tests.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use crate::commands::utils::args::{BaselineArgs, PositionalComponentArgs, SettingArgs};
 use crate::test_support::with_isolated_home;
 
-use homeboy_core::trace as extension_trace;
+use homeboy_core::extension::trace as extension_trace;
 
 use super::test_fixture::TRACE_FIXTURE_EXTENSION_ID;
 use super::{execute_trace_run, TraceArgs, TraceSchedule, TraceVariantMatrixMode};

--- a/crates/homeboy-cli/src/commands/trace/guardrails.rs
+++ b/crates/homeboy-cli/src/commands/trace/guardrails.rs
@@ -1,5 +1,5 @@
 use homeboy::rig;
-use homeboy_core::trace as extension_trace;
+use homeboy_core::extension::trace as extension_trace;
 
 use super::{
     load_rig_context, required_trace_scenario, resolve_component_id, trace_variants_for_args,

--- a/crates/homeboy-cli/src/commands/trace/matrix.rs
+++ b/crates/homeboy-cli/src/commands/trace/matrix.rs
@@ -5,8 +5,8 @@ use crate::commands::trace::compare_artifacts::{
     prepare_matrix_cell_dir, prepare_matrix_output_dir, prepare_variant_matrix_output_dir,
     write_json_artifact, write_matrix_summary, write_variant_matrix_summary,
 };
-use homeboy_core::trace as extension_trace;
-use homeboy_core::trace::TraceCommandOutput;
+use homeboy_core::extension::trace as extension_trace;
+use homeboy_core::extension::trace::TraceCommandOutput;
 
 use super::output::{
     compare_trace_aggregates_with_focus, render_matrix_markdown, TraceAggregateIdentity,

--- a/crates/homeboy-cli/src/commands/trace/observation_lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/trace/observation_lifecycle.rs
@@ -16,7 +16,7 @@ use homeboy::core::observation::{
     ObservationStore, RunStatus,
 };
 use homeboy::rig;
-use homeboy_core::trace as extension_trace;
+use homeboy_core::extension::trace as extension_trace;
 
 use super::observations::{self, record_trace_artifacts};
 use super::{

--- a/crates/homeboy-cli/src/commands/trace/observations.rs
+++ b/crates/homeboy-cli/src/commands/trace/observations.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use homeboy::core::engine::run_dir::RunDir;
 use homeboy::core::observation::{NewFindingRecord, ObservationStore};
-use homeboy_core::trace as extension_trace;
+use homeboy_core::extension::trace as extension_trace;
 
 use extension_trace::resolve_declared_trace_artifact_path;
 
@@ -326,7 +326,7 @@ mod tests {
     use super::*;
     use homeboy::core::engine::run_dir::RunDir;
     use homeboy::core::observation::{NewRunRecord, ObservationStore};
-    use homeboy_core::trace::parsing::{TraceArtifact, TraceResults, TraceStatus};
+    use homeboy_core::extension::trace::parsing::{TraceArtifact, TraceResults, TraceStatus};
 
     fn sample_results(artifacts: Vec<TraceArtifact>) -> TraceResults {
         TraceResults {

--- a/crates/homeboy-cli/src/commands/trace/output.rs
+++ b/crates/homeboy-cli/src/commands/trace/output.rs
@@ -5,8 +5,8 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 use serde_json::Value;
 
-use homeboy_core::trace as extension_trace;
-use homeboy_core::trace::TraceCommandOutput;
+use homeboy_core::extension::trace as extension_trace;
+use homeboy_core::extension::trace::TraceCommandOutput;
 
 use super::bundle::{write_trace_experiment_bundle, TraceExperimentBundleRequest};
 use super::TraceArgs;

--- a/crates/homeboy-cli/src/commands/trace/output/markdown.rs
+++ b/crates/homeboy-cli/src/commands/trace/output/markdown.rs
@@ -9,7 +9,7 @@
 use std::fmt::Write as _;
 use std::path::Path;
 
-use homeboy_core::trace as extension_trace;
+use homeboy_core::extension::trace as extension_trace;
 
 #[cfg(test)]
 pub(crate) fn render_aggregate_markdown(

--- a/crates/homeboy-cli/src/commands/trace/output_tests.rs
+++ b/crates/homeboy-cli/src/commands/trace/output_tests.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::Path;
 
-use homeboy_core::trace as extension_trace;
+use homeboy_core::extension::trace as extension_trace;
 
 use super::bundle::{write_trace_experiment_bundle, TraceExperimentBundleRequest};
 use super::output::{

--- a/crates/homeboy-cli/src/commands/trace/overlay_locks.rs
+++ b/crates/homeboy-cli/src/commands/trace/overlay_locks.rs
@@ -1,5 +1,5 @@
-use homeboy_core::trace as extension_trace;
-use homeboy_core::trace::TraceCommandOutput;
+use homeboy_core::extension::trace as extension_trace;
+use homeboy_core::extension::trace::TraceCommandOutput;
 
 use super::TraceArgs;
 use crate::commands::CmdResult;

--- a/crates/homeboy-cli/src/commands/trace/passive.rs
+++ b/crates/homeboy-cli/src/commands/trace/passive.rs
@@ -7,7 +7,7 @@ use homeboy::core::git::short_head_revision_at;
 use homeboy::core::io::{write_output_file_atomically, OutputWriteOptions};
 use homeboy::core::observation::{ActiveObservation, NewRunRecord, RunStatus};
 use homeboy::core::Error;
-use homeboy_core::trace::{
+use homeboy_core::extension::trace::{
     PassiveTraceCapture, TraceArtifact, TraceCommandOutput, TracePassiveOutput, TraceProbeConfig,
     TraceResults,
 };
@@ -139,7 +139,7 @@ fn error_results(component_id: String, failure: String) -> TraceResults {
     TraceResults {
         component_id,
         scenario_id: "observe".to_string(),
-        status: homeboy_core::trace::TraceStatus::Error,
+        status: homeboy_core::extension::trace::TraceStatus::Error,
         summary: Some("Passive trace timeline".to_string()),
         failure: Some(failure),
         rig: None,

--- a/crates/homeboy-cli/src/commands/trace/phase_args.rs
+++ b/crates/homeboy-cli/src/commands/trace/phase_args.rs
@@ -1,5 +1,5 @@
-use homeboy_core::trace as extension_trace;
-use homeboy_core::trace::TraceSpanDefinition;
+use homeboy_core::extension::trace as extension_trace;
+use homeboy_core::extension::trace::TraceSpanDefinition;
 
 use super::workload::trace_workload_scenario_id;
 use super::{trace_scenario, TraceArgs, TraceRigContext};

--- a/crates/homeboy-cli/src/commands/trace/probes.rs
+++ b/crates/homeboy-cli/src/commands/trace/probes.rs
@@ -1,5 +1,5 @@
 use homeboy::rig;
-use homeboy_core::trace as extension_trace;
+use homeboy_core::extension::trace as extension_trace;
 
 use super::{trace_scenario, trace_workload_scenario_id, TraceArgs, TraceRigContext};
 

--- a/crates/homeboy-cli/src/commands/trace/repeat.rs
+++ b/crates/homeboy-cli/src/commands/trace/repeat.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use homeboy_core::trace as extension_trace;
-use homeboy_core::trace::TraceCommandOutput;
+use homeboy_core::extension::trace as extension_trace;
+use homeboy_core::extension::trace::TraceCommandOutput;
 
 use super::aggregate::{
     aggregate_metric, aggregate_span, TraceAggregateMetricSample, TraceAggregateSpanSample,

--- a/crates/homeboy-cli/src/commands/trace/run_service.rs
+++ b/crates/homeboy-cli/src/commands/trace/run_service.rs
@@ -1,6 +1,6 @@
 use homeboy::core::engine::run_dir::RunDir;
 use homeboy::rig;
-use homeboy_core::trace as extension_trace;
+use homeboy_core::extension::trace as extension_trace;
 
 use super::{execute_trace_run_impl, TraceArgs};
 

--- a/crates/homeboy-cli/src/commands/utils/args.rs
+++ b/crates/homeboy-cli/src/commands/utils/args.rs
@@ -1295,7 +1295,7 @@ mod changed_scope_tests {
 /// The `[errors_only, sniffs, exclude_sniffs]` triplet used to be re-declared
 /// field-by-field on `LintArgs` (CLI), `LintRunWorkflowArgs` (workflow), and
 /// `LintSourceOptions` (refactor). Owning the group here — and mapping it to
-/// the core [`homeboy_core::lint::LintSniffFilters`] contract —
+/// the core [`homeboy_core::extension::lint::LintSniffFilters`] contract —
 /// keeps the shape defined once instead of being repeated across layers (#5576).
 #[derive(Args, Debug, Clone, Default)]
 pub struct LintSniffArgs {
@@ -1314,8 +1314,8 @@ pub struct LintSniffArgs {
 
 impl LintSniffArgs {
     /// Project the CLI flags onto the shared core sniff-filter contract.
-    pub(crate) fn to_lint_sniff_filters(&self) -> homeboy_core::lint::LintSniffFilters {
-        homeboy_core::lint::LintSniffFilters {
+    pub(crate) fn to_lint_sniff_filters(&self) -> homeboy_core::extension::lint::LintSniffFilters {
+        homeboy_core::extension::lint::LintSniffFilters {
             errors_only: self.errors_only,
             sniffs: self.sniffs.clone(),
             exclude_sniffs: self.exclude_sniffs.clone(),

--- a/crates/homeboy-code-audit/src/grammar_source_provider.rs
+++ b/crates/homeboy-code-audit/src/grammar_source_provider.rs
@@ -4,7 +4,7 @@
 //! The core grammar engine fingerprints a file by loading a grammar
 //! (`grammar.toml`/`grammar.json`) shipped by the extension that handles the
 //! file's extension. Audit used to resolve that by calling
-//! `homeboy_core::find_extension_for_file_ext` directly and reading the
+//! `homeboy_core::extension::find_extension_for_file_ext` directly and reading the
 //! matched manifest's `extension_path`, coupling `code_audit` to the extension
 //! registry.
 //!

--- a/crates/homeboy-code-audit/src/lib.rs
+++ b/crates/homeboy-code-audit/src/lib.rs
@@ -125,7 +125,9 @@ mod tests {
     /// portability test double). Mirrors `audit_manifest_provider`'s `project`.
     struct StoreManifestProvider;
 
-    fn project_manifest(manifest: &homeboy_core::ExtensionManifest) -> AuditExtensionManifest {
+    fn project_manifest(
+        manifest: &homeboy_core::extension::ExtensionManifest,
+    ) -> AuditExtensionManifest {
         AuditExtensionManifest {
             id: manifest.id.clone(),
             extension_path: manifest.extension_path.clone(),
@@ -138,7 +140,7 @@ mod tests {
 
     impl AuditExtensionManifestProvider for StoreManifestProvider {
         fn load_all(&self) -> Vec<AuditExtensionManifest> {
-            homeboy_core::load_all_extensions()
+            homeboy_core::extension::load_all_extensions()
                 .unwrap_or_default()
                 .iter()
                 .map(project_manifest)
@@ -146,7 +148,7 @@ mod tests {
         }
 
         fn load(&self, id: &str) -> Option<AuditExtensionManifest> {
-            homeboy_core::load_extension(id)
+            homeboy_core::extension::load_extension(id)
                 .ok()
                 .map(|m| project_manifest(&m))
         }
@@ -241,7 +243,7 @@ mod tests {
         // no-op provider is used and no saved manifest is ever seen.
         register_store_manifest_provider();
         homeboy_core::test_support::with_isolated_home(|home| {
-            let mut manifest: homeboy_core::ExtensionManifest =
+            let mut manifest: homeboy_core::extension::ExtensionManifest =
                 serde_json::from_value(serde_json::json!({
                     "name": "Fixture",
                     "version": "0.0.0",
@@ -253,7 +255,7 @@ mod tests {
                 }))
                 .expect("manifest");
             manifest.id = "fixture".to_string();
-            homeboy_core::save_manifest(&manifest).expect("save fixture extension");
+            homeboy_core::extension::save_manifest(&manifest).expect("save fixture extension");
 
             let config = audit_config_for(
                 "component-without-extension",

--- a/crates/homeboy-core/src/extension/bench/aggregation.rs
+++ b/crates/homeboy-core/src/extension/bench/aggregation.rs
@@ -1,7 +1,9 @@
 use std::collections::BTreeMap;
 
-use crate::bench::distribution::{distribution, percentile};
-use crate::bench::parsing::{BenchMetrics, BenchResults, BenchRunSnapshot, BenchScenario};
+use crate::extension::bench::distribution::{distribution, percentile};
+use crate::extension::bench::parsing::{
+    BenchMetrics, BenchResults, BenchRunSnapshot, BenchScenario,
+};
 use homeboy_core::error::{Error, Result};
 use homeboy_core::observation::timeline::{ObservationSpanResult, ObservationSpanStatus};
 

--- a/crates/homeboy-core/src/extension/bench/artifact_persistence.rs
+++ b/crates/homeboy-core/src/extension/bench/artifact_persistence.rs
@@ -11,7 +11,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 
-use crate::bench::{
+use crate::extension::bench::{
     BenchArtifact, BenchDiagnostic, BenchDiagnosticSource, BenchResults, BenchRunWorkflowResult,
 };
 use homeboy_core::artifacts as artifact_links;

--- a/crates/homeboy-core/src/extension/bench/artifact_validation.rs
+++ b/crates/homeboy-core/src/extension/bench/artifact_validation.rs
@@ -134,7 +134,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use super::*;
-    use crate::bench::parsing::{BenchMetrics, BenchRunSnapshot};
+    use crate::extension::bench::parsing::{BenchMetrics, BenchRunSnapshot};
 
     #[test]
     fn test_validate_artifact_paths() {

--- a/crates/homeboy-core/src/extension/bench/diagnostic.rs
+++ b/crates/homeboy-core/src/extension/bench/diagnostic.rs
@@ -58,7 +58,7 @@ fn with_default_source(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bench::parsing::{BenchMetrics, BenchRunSnapshot, BenchScenario};
+    use crate::extension::bench::parsing::{BenchMetrics, BenchRunSnapshot, BenchScenario};
     use std::collections::BTreeMap;
 
     #[test]

--- a/crates/homeboy-core/src/extension/bench/failure_diagnostic.rs
+++ b/crates/homeboy-core/src/extension/bench/failure_diagnostic.rs
@@ -1,6 +1,6 @@
 //! Bench runner failure diagnostic enrichment.
 
-use crate::stderr_tail;
+use crate::extension::stderr_tail;
 
 use super::run::BenchRunWorkflowArgs;
 
@@ -85,7 +85,7 @@ fn text_after<'a>(text: &'a str, start: &str) -> Option<&'a str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bench::parsing::BenchRunExecution;
+    use crate::extension::bench::parsing::BenchRunExecution;
     use homeboy_engine_primitives::baseline::BaselineFlags;
 
     #[test]

--- a/crates/homeboy-core/src/extension/bench/gate.rs
+++ b/crates/homeboy-core/src/extension/bench/gate.rs
@@ -130,7 +130,7 @@ mod normalization_tests {
 
     #[test]
     fn normalized_gate_results_are_scenario_scoped_and_agent_actionable() {
-        let mut results = crate::bench::parsing::parse_bench_results_str(
+        let mut results = crate::extension::bench::parsing::parse_bench_results_str(
             r#"{
                 "component_id": "homeboy",
                 "iterations": 1,

--- a/crates/homeboy-core/src/extension/bench/mod.rs
+++ b/crates/homeboy-core/src/extension/bench/mod.rs
@@ -42,7 +42,7 @@ pub(crate) mod side_by_side;
 #[cfg(test)]
 pub(crate) mod test_support;
 
-use crate::{ExtensionCapability, ExtensionExecutionContext};
+use crate::extension::{ExtensionCapability, ExtensionExecutionContext};
 use homeboy_core::component::Component;
 
 pub use aggregation::aggregate_runs;
@@ -85,5 +85,5 @@ pub use run::{
 pub fn resolve_bench_command(
     component: &Component,
 ) -> homeboy_core::error::Result<ExtensionExecutionContext> {
-    crate::resolve_execution_context(component, ExtensionCapability::Bench)
+    crate::extension_execution::resolve_execution_context(component, ExtensionCapability::Bench)
 }

--- a/crates/homeboy-core/src/extension/bench/report/comparison.rs
+++ b/crates/homeboy-core/src/extension/bench/report/comparison.rs
@@ -11,10 +11,10 @@ pub use types::{
     RigBenchEntry,
 };
 
-use crate::bench::diagnostic::BenchDiagnostic;
-use crate::bench::distribution::BenchRunDistribution;
-use crate::bench::parsing::{BenchResults, BenchScenario};
-use crate::bench::side_by_side::build_side_by_side_report;
+use crate::extension::bench::diagnostic::BenchDiagnostic;
+use crate::extension::bench::distribution::BenchRunDistribution;
+use crate::extension::bench::parsing::{BenchResults, BenchScenario};
+use crate::extension::bench::side_by_side::build_side_by_side_report;
 
 impl BenchComparisonDiff {
     /// Build the diff table from a reference rig's results plus zero or

--- a/crates/homeboy-core/src/extension/bench/report/comparison/types.rs
+++ b/crates/homeboy-core/src/extension/bench/report/comparison/types.rs
@@ -5,10 +5,10 @@ use serde::Serialize;
 use serde_json::Value;
 
 use super::super::BenchArtifactRef;
-use crate::bench::diagnostic::BenchDiagnostic;
-use crate::bench::parsing::{BenchMetricPhase, BenchMetricPolicy, BenchResults};
-use crate::bench::run::BenchRunFailure;
-use crate::bench::side_by_side::BenchSideBySideReport;
+use crate::extension::bench::diagnostic::BenchDiagnostic;
+use crate::extension::bench::parsing::{BenchMetricPhase, BenchMetricPolicy, BenchResults};
+use crate::extension::bench::run::BenchRunFailure;
+use crate::extension::bench::side_by_side::BenchSideBySideReport;
 use homeboy_lifecycle_contract::RigStateSnapshot;
 
 /// Cross-rig comparison envelope.

--- a/crates/homeboy-core/src/extension/bench/run/failure.rs
+++ b/crates/homeboy-core/src/extension/bench/run/failure.rs
@@ -1,7 +1,7 @@
 //! Bench failure classification.
 
-use crate::bench::phase_events::BenchPhaseFailureClassification;
-use crate::bench::responsiveness::BenchResponsivenessSummary;
+use crate::extension::bench::phase_events::BenchPhaseFailureClassification;
+use crate::extension::bench::responsiveness::BenchResponsivenessSummary;
 
 pub(crate) fn classify_bench_failure(
     success: bool,

--- a/crates/homeboy-core/src/extension/bench/run/list.rs
+++ b/crates/homeboy-core/src/extension/bench/run/list.rs
@@ -2,8 +2,8 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::bench::parsing::{self, BenchRunExecution};
-use crate::{resolve_execution_context, ExtensionCapability};
+use crate::extension::bench::parsing::{self, BenchRunExecution};
+use crate::extension::{resolve_execution_context, ExtensionCapability};
 use homeboy_core::component::Component;
 use homeboy_core::engine::invocation::InvocationRequirements;
 use homeboy_core::engine::run_dir::{self, RunDir};
@@ -24,9 +24,11 @@ pub fn run_bench_list_workflow(
         preferred_workspace_path(component, &args).map(Path::to_path_buf);
     if component.has_script(ExtensionCapability::Bench) && args.extra_workloads.is_empty() {
         let list_env = bench_component_script_list_env(&args)?;
-        let source_path =
-            crate::component_script::source_path(component, args.path_override.as_deref());
-        let output = crate::component_script::run_component_scripts_with_run_dir(
+        let source_path = crate::extension::component_script::source_path(
+            component,
+            args.path_override.as_deref(),
+        );
+        let output = crate::extension::component_script::run_component_scripts_with_run_dir(
             component,
             ExtensionCapability::Bench,
             &source_path,
@@ -130,7 +132,7 @@ pub(crate) fn bench_list_result(
     results_file: PathBuf,
     scenario_ids: &[String],
     preferred_workspace_path: Option<&Path>,
-    rig_package: Option<crate::bench::parsing::RigPackageEvidence>,
+    rig_package: Option<crate::extension::bench::parsing::RigPackageEvidence>,
     profiles: Vec<super::types::BenchListProfile>,
 ) -> Result<BenchListWorkflowResult> {
     let mut parsed =
@@ -180,7 +182,7 @@ pub(crate) fn bench_component_script_list_env(
     ));
     env.push((
         "HOMEBOY_SETTINGS_JSON".to_string(),
-        crate::build_settings_json_from_manifest(
+        crate::extension::build_settings_json_from_manifest(
             &serde_json::json!({}),
             &[],
             &args.settings,

--- a/crates/homeboy-core/src/extension/bench/run/memory_timeline.rs
+++ b/crates/homeboy-core/src/extension/bench/run/memory_timeline.rs
@@ -3,8 +3,8 @@
 use std::collections::BTreeMap;
 use std::fs;
 
-use crate::bench::artifact::BenchArtifact;
-use crate::bench::parsing::BenchResults;
+use crate::extension::bench::artifact::BenchArtifact;
+use crate::extension::bench::parsing::BenchResults;
 use homeboy_core::engine::resource::{self, ExtensionChildResourceSummary};
 use homeboy_core::engine::run_dir::RunDir;
 use homeboy_core::error::{Error, Result};

--- a/crates/homeboy-core/src/extension/bench/run/mod.rs
+++ b/crates/homeboy-core/src/extension/bench/run/mod.rs
@@ -30,10 +30,10 @@ mod tests {
     };
     use super::types::{BenchListWorkflowArgs, BenchListWorkflowResult, BenchRunWorkflowArgs};
     use super::workflow::bench_component_script_env;
-    use crate::bench::parsing::{self, BenchResults, BenchRunExecution, BenchScenario};
-    use crate::bench::responsiveness::BenchResponsivenessSummary;
-    use crate::bench::test_support::{results_with_scenarios, scenario_with_iterations};
-    use crate::path_list_env_value;
+    use crate::extension::bench::parsing::{self, BenchResults, BenchRunExecution, BenchScenario};
+    use crate::extension::bench::responsiveness::BenchResponsivenessSummary;
+    use crate::extension::bench::test_support::{results_with_scenarios, scenario_with_iterations};
+    use crate::extension::path_list_env_value;
     use homeboy_core::component::Component;
     use homeboy_core::engine::invocation::InvocationRequirements;
     use homeboy_core::engine::resource::{

--- a/crates/homeboy-core/src/extension/bench/run/results.rs
+++ b/crates/homeboy-core/src/extension/bench/run/results.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use crate::bench::parsing::{self, BenchResults, BenchScenario};
+use crate::extension::bench::parsing::{self, BenchResults, BenchScenario};
 use homeboy_core::error::Result;
 
 use super::scenario::{apply_scenario_filter, normalize_workload_json_scenario_ids};

--- a/crates/homeboy-core/src/extension/bench/run/runner.rs
+++ b/crates/homeboy-core/src/extension/bench/run/runner.rs
@@ -4,11 +4,11 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::thread;
 
-use crate::bench::aggregate_runs;
-use crate::bench::failure_diagnostic::bench_failure_stderr_tail;
-use crate::bench::parsing::{self, BenchResults, BenchScenario};
-use crate::bench::responsiveness::{memory_sample, BenchFailureMemorySample};
-use crate::{
+use crate::extension::bench::aggregate_runs;
+use crate::extension::bench::failure_diagnostic::bench_failure_stderr_tail;
+use crate::extension::bench::parsing::{self, BenchResults, BenchScenario};
+use crate::extension::bench::responsiveness::{memory_sample, BenchFailureMemorySample};
+use crate::extension::{
     build_scenario_runner, ExtensionExecutionContext, ExtensionRunner, ScenarioRunnerOptions,
 };
 use homeboy_core::component::Component;
@@ -187,7 +187,7 @@ pub(crate) fn build_runner(
     .env("HOMEBOY_BENCH_ITERATIONS", &args.iterations.to_string())
     .env(
         "HOMEBOY_BENCH_RESPONSIVENESS_MISSED_MS",
-        &crate::bench::responsiveness::missed_ping_window_ms().to_string(),
+        &crate::extension::bench::responsiveness::missed_ping_window_ms().to_string(),
     )
     .env("HOMEBOY_BENCH_PROGRESS", bench_progress_env_value())
     .env("HOMEBOY_BENCH_PROGRESS_STREAM", "stderr")
@@ -372,7 +372,7 @@ pub(crate) fn run_concurrent_instances(
         }));
     }
 
-    let mut per_instance: Vec<(u32, crate::RunnerOutput)> =
+    let mut per_instance: Vec<(u32, crate::extension::RunnerOutput)> =
         Vec::with_capacity(concurrency as usize);
     for h in handles {
         match h.join() {

--- a/crates/homeboy-core/src/extension/bench/run/scenario.rs
+++ b/crates/homeboy-core/src/extension/bench/run/scenario.rs
@@ -2,8 +2,8 @@
 
 use std::path::PathBuf;
 
-use crate::bench::parsing::{self, BenchResults};
-use crate::ExtensionExecutionContext;
+use crate::extension::bench::parsing::{self, BenchResults};
+use crate::extension_execution::ExtensionExecutionContext;
 use homeboy_core::component::Component;
 use homeboy_core::engine::run_dir::{self, RunDir};
 use homeboy_core::error::{Error, Result};

--- a/crates/homeboy-core/src/extension/bench/run/types.rs
+++ b/crates/homeboy-core/src/extension/bench/run/types.rs
@@ -4,12 +4,14 @@ use std::path::PathBuf;
 
 use serde::Serialize;
 
-use crate::bench::baseline::BenchBaselineComparison;
-use crate::bench::diagnostic::BenchDiagnostic;
-use crate::bench::parsing::RigPackageEvidence;
-use crate::bench::parsing::{BenchResults, BenchRunExecution, BenchScenario};
-use crate::bench::phase_events::BenchPhaseFailureClassification;
-use crate::bench::responsiveness::{BenchFailureMemorySample, BenchResponsivenessSummary};
+use crate::extension::bench::baseline::BenchBaselineComparison;
+use crate::extension::bench::diagnostic::BenchDiagnostic;
+use crate::extension::bench::parsing::RigPackageEvidence;
+use crate::extension::bench::parsing::{BenchResults, BenchRunExecution, BenchScenario};
+use crate::extension::bench::phase_events::BenchPhaseFailureClassification;
+use crate::extension::bench::responsiveness::{
+    BenchFailureMemorySample, BenchResponsivenessSummary,
+};
 use homeboy_core::engine::invocation::InvocationRequirements;
 use homeboy_core::gate::HomeboyGateResult;
 use homeboy_engine_primitives::baseline::BaselineFlags;

--- a/crates/homeboy-core/src/extension/bench/run/workflow.rs
+++ b/crates/homeboy-core/src/extension/bench/run/workflow.rs
@@ -3,13 +3,13 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use crate::bench::baseline;
-use crate::bench::diagnostic::{self, BenchDiagnostic};
-use crate::bench::failure_diagnostic::bench_failure_stderr_tail;
-use crate::bench::parsing::{BenchRunMetadata, BenchRunnerMetadata};
-use crate::bench::responsiveness::{memory_sample, read_responsiveness_summary};
-use crate::bench::run_metadata::stamp_run_metadata;
-use crate::{resolve_execution_context, ExtensionCapability};
+use crate::extension::bench::baseline;
+use crate::extension::bench::diagnostic::{self, BenchDiagnostic};
+use crate::extension::bench::failure_diagnostic::bench_failure_stderr_tail;
+use crate::extension::bench::parsing::{BenchRunMetadata, BenchRunnerMetadata};
+use crate::extension::bench::responsiveness::{memory_sample, read_responsiveness_summary};
+use crate::extension::bench::run_metadata::stamp_run_metadata;
+use crate::extension::{resolve_execution_context, ExtensionCapability};
 use homeboy_core::component::Component;
 use homeboy_core::engine::run_dir::{self, RunDir};
 use homeboy_core::error::{Error, Result};
@@ -106,7 +106,7 @@ pub fn run_main_bench_workflow(
     if component.has_script(ExtensionCapability::Bench) && args.extra_workloads.is_empty() {
         clear_responsiveness_file(run_dir)?;
         let component_env = bench_component_script_env(&args, run_dir)?;
-        let script_output = crate::component_script::run_component_scripts_with_run_dir(
+        let script_output = crate::extension::component_script::run_component_scripts_with_run_dir(
             component,
             ExtensionCapability::Bench,
             source_path,
@@ -172,14 +172,14 @@ pub fn run_main_bench_workflow(
         }
         let mut gate_failures = parsed
             .as_mut()
-            .map(crate::bench::gate::evaluate_gates)
+            .map(crate::extension::bench::gate::evaluate_gates)
             .unwrap_or_default();
         if let Some(results) = parsed.as_ref() {
             gate_failures.extend(workload_status_failures(results));
         }
         let gate_results = parsed
             .as_ref()
-            .map(crate::bench::gate::normalized_gate_results)
+            .map(crate::extension::bench::gate::normalized_gate_results)
             .unwrap_or_default();
         let gates_passed = gate_failures.is_empty();
         let status = if script_output.success && gates_passed {
@@ -324,14 +324,14 @@ pub fn run_main_bench_workflow(
     }
     let mut gate_failures = parsed
         .as_mut()
-        .map(crate::bench::gate::evaluate_gates)
+        .map(crate::extension::bench::gate::evaluate_gates)
         .unwrap_or_default();
     if let Some(results) = parsed.as_ref() {
         gate_failures.extend(workload_status_failures(results));
     }
     let gate_results = parsed
         .as_ref()
-        .map(crate::bench::gate::normalized_gate_results)
+        .map(crate::extension::bench::gate::normalized_gate_results)
         .unwrap_or_default();
     let gates_passed = gate_failures.is_empty();
     let diagnostics = diagnostic::collect_diagnostics(parsed.as_ref());
@@ -494,7 +494,7 @@ pub(crate) fn bench_component_script_env(
         ),
         (
             "HOMEBOY_BENCH_RESPONSIVENESS_MISSED_MS".to_string(),
-            crate::bench::responsiveness::missed_ping_window_ms().to_string(),
+            crate::extension::bench::responsiveness::missed_ping_window_ms().to_string(),
         ),
         (
             "HOMEBOY_BENCH_SCENARIOS".to_string(),
@@ -511,7 +511,7 @@ pub(crate) fn bench_component_script_env(
         ),
         (
             "HOMEBOY_SETTINGS_JSON".to_string(),
-            crate::build_settings_json_from_manifest(
+            crate::extension::build_settings_json_from_manifest(
                 &serde_json::json!({}),
                 &[],
                 &args.settings,

--- a/crates/homeboy-core/src/extension/bench/run_metadata.rs
+++ b/crates/homeboy-core/src/extension/bench/run_metadata.rs
@@ -3,11 +3,11 @@ use std::path::{Path, PathBuf};
 
 use homeboy_engine_primitives::content_hash;
 
-use crate::bench::parsing::{
+use crate::extension::bench::parsing::{
     BenchResults, BenchRunMetadata, BenchRunnerMetadata, BenchScenario, BenchWorkloadMetadata,
 };
-use crate::bench::run::BenchRunWorkflowArgs;
-use crate::ExtensionExecutionContext;
+use crate::extension::bench::run::BenchRunWorkflowArgs;
+use crate::extension_execution::ExtensionExecutionContext;
 use homeboy_core::component::Component;
 
 pub(crate) fn stamp_run_metadata(
@@ -169,8 +169,8 @@ fn source_revision_at(path: &Path) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bench::parsing::{self, BenchRunExecution};
-    use crate::ExtensionCapability;
+    use crate::extension::bench::parsing::{self, BenchRunExecution};
+    use crate::extension::ExtensionCapability;
     use homeboy_core::engine::invocation::InvocationRequirements;
     use homeboy_engine_primitives::baseline::BaselineFlags;
 

--- a/crates/homeboy-core/src/extension/bench/test_support.rs
+++ b/crates/homeboy-core/src/extension/bench/test_support.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use crate::bench::parsing::{BenchMetrics, BenchResults, BenchScenario};
+use crate::extension::bench::parsing::{BenchMetrics, BenchResults, BenchScenario};
 
 pub(crate) fn scenario_with_iterations(
     id: &str,

--- a/crates/homeboy-core/src/extension/build/mod.rs
+++ b/crates/homeboy-core/src/extension/build/mod.rs
@@ -1,10 +1,12 @@
-use crate as extension;
+use crate::extension;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use std::time::Instant;
 
-use crate::{exec_context, ExtensionCapability, ExtensionExecutionContext, ExtensionPhaseTiming};
+use crate::extension::{
+    exec_context, ExtensionCapability, ExtensionExecutionContext, ExtensionPhaseTiming,
+};
 use homeboy_core::artifact_inputs::{self, ResolvedArtifactInput};
 use homeboy_core::component::{self, Component};
 use homeboy_core::config::{is_json_input, parse_bulk_ids};
@@ -560,9 +562,9 @@ fn execute_build_component(
         build_timeout.as_secs()
     );
     let runner_output = if let ResolvedBuildCommand::ComponentScript { .. } = &resolved {
-        crate::component_script::run_component_scripts_with_run_dir_and_timeout(
+        crate::extension::component_script::run_component_scripts_with_run_dir_and_timeout(
             comp,
-            crate::component_script::ComponentScriptRunRequest {
+            crate::extension::component_script::ComponentScriptRunRequest {
                 capability: extension::ExtensionCapability::Build,
                 source_path: &validated_path,
                 run_dir: &run_dir,
@@ -883,7 +885,7 @@ fn run_pre_build_scripts(
             build_context.component.local_path.clone(),
         ),
     ];
-    env.extend(crate::component_script::component_env_vars(
+    env.extend(crate::extension::component_script::component_env_vars(
         &build_context.component,
     ));
     let env_refs: Vec<(&str, &str)> = env

--- a/crates/homeboy-core/src/extension/compiler_warning_contract.rs
+++ b/crates/homeboy-core/src/extension/compiler_warning_contract.rs
@@ -29,7 +29,7 @@ pub fn extensions_for_compiler_warning_contract(
     if let Some(component) = homeboy_core::component::discover_from_portable(root) {
         if let Some(component_extensions) = component.extensions.as_ref() {
             for extension_id in component_extensions.keys() {
-                let Ok(extension) = crate::load_extension(extension_id) else {
+                let Ok(extension) = crate::extension_store::load_extension(extension_id) else {
                     continue;
                 };
                 if contract.script_path(&extension).is_some() && seen.insert(extension.id.clone()) {
@@ -41,7 +41,7 @@ pub fn extensions_for_compiler_warning_contract(
 
     if extensions.is_empty() {
         extensions.extend(
-            crate::load_all_extensions()
+            crate::extension_store::load_all_extensions()
                 .unwrap_or_default()
                 .into_iter()
                 .filter(|extension| contract.script_path(extension).is_some()),
@@ -168,7 +168,7 @@ mod tests {
         .unwrap();
         extension.id = "example".to_string();
         extension.extension_path = Some(dir.path().to_string_lossy().to_string());
-        extension.scripts = Some(crate::ScriptsConfig {
+        extension.scripts = Some(crate::extension::ScriptsConfig {
             compiler_warnings: Some("warnings.sh".to_string()),
             ..Default::default()
         });

--- a/crates/homeboy-core/src/extension/component_script.rs
+++ b/crates/homeboy-core/src/extension/component_script.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use super::runner::ExtensionRunner;
 use crate::extension::env_provider;
-use crate::{exec_context, load_extension, ExtensionCapability, RunnerOutput};
+use crate::extension::{exec_context, load_extension, ExtensionCapability, RunnerOutput};
 use homeboy_core::component::Component;
 pub use homeboy_core::component_script_provider::ComponentScriptOutput;
 use homeboy_core::engine::invocation::{InvocationGuard, InvocationRequirements};

--- a/crates/homeboy-core/src/extension/env_provider.rs
+++ b/crates/homeboy-core/src/extension/env_provider.rs
@@ -279,7 +279,8 @@ mod tests {
             .expect("provider script");
         std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
             .expect("provider executable");
-        crate::install(&source.display().to_string(), Some(id)).expect("install provider fixture");
+        crate::extension::install(&source.display().to_string(), Some(id))
+            .expect("install provider fixture");
     }
 
     #[test]

--- a/crates/homeboy-core/src/extension/execution.rs
+++ b/crates/homeboy-core/src/extension/execution.rs
@@ -943,7 +943,7 @@ fn build_exec_env(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::extract_component_extension_settings;
+    use crate::extension::extract_component_extension_settings;
     use homeboy_core::component::Component;
 
     fn make_executable(path: &Path) {
@@ -1681,15 +1681,15 @@ mod tests {
         assert_eq!(output.stderr, "");
     }
 
-    fn lint_execution_context() -> crate::ExtensionExecutionContext {
-        crate::ExtensionExecutionContext {
+    fn lint_execution_context() -> crate::extension_execution::ExtensionExecutionContext {
+        crate::extension_execution::ExtensionExecutionContext {
             component: Component::new(
                 "fixture".to_string(),
                 "/configured/path".to_string(),
                 "fixture-extension".to_string(),
                 None,
             ),
-            capability: crate::ExtensionCapability::Lint,
+            capability: crate::extension::ExtensionCapability::Lint,
             extension_id: "fixture-extension".to_string(),
             extension_path: std::path::PathBuf::from("/tmp/fixture-extension"),
             script_path: "lint.sh".to_string(),

--- a/crates/homeboy-core/src/extension/execution/action.rs
+++ b/crates/homeboy-core/src/extension/execution/action.rs
@@ -7,7 +7,7 @@ use homeboy_engine_primitives::validation;
 
 use super::{build_action_env, execute_extension_command, load_extension, ExtensionExecutionMode};
 use crate::extension::manifest::{ActionConfig, ActionType, HttpMethod};
-use crate::ExtensionScope;
+use crate::extension_scope::ExtensionScope;
 
 pub fn execute_action(
     extension_id: &str,
@@ -17,7 +17,7 @@ pub fn execute_action(
     payload: Option<&serde_json::Value>,
 ) -> Result<serde_json::Value> {
     let extension = load_extension(extension_id)?;
-    crate::validate_core_compatibility(
+    crate::extension::validate_core_compatibility(
         "extension",
         extension_id,
         extension

--- a/crates/homeboy-core/src/extension/lifecycle/mod.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/mod.rs
@@ -373,7 +373,7 @@ mod tests {
         load_extension, refresh, register_component_install_runner,
         shared_assets_for_extension_source, source_metadata, uninstall, update,
     };
-    use crate::update_all;
+    use crate::extension::update_all;
     use homeboy_core::component;
     use homeboy_core::test_support::with_isolated_home;
     use std::fs;

--- a/crates/homeboy-core/src/extension/lifecycle/source_metadata.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/source_metadata.rs
@@ -74,7 +74,7 @@ pub fn resolve_source_url(extension_id: &str) -> Result<SourceMetadataResolution
     ))
 }
 
-fn manifest_source_url(extension: &crate::ExtensionManifest) -> Option<String> {
+fn manifest_source_url(extension: &crate::extension::ExtensionManifest) -> Option<String> {
     extension
         .source_url
         .clone()

--- a/crates/homeboy-core/src/extension/lint/mod.rs
+++ b/crates/homeboy-core/src/extension/lint/mod.rs
@@ -2,7 +2,7 @@ pub mod baseline;
 pub mod report;
 pub mod run;
 
-use crate::{ExtensionCapability, ExtensionExecutionContext, ExtensionRunner};
+use crate::extension::{ExtensionCapability, ExtensionExecutionContext, ExtensionRunner};
 use homeboy_core::component::Component;
 
 pub use baseline::{BaselineComparison, LintBaseline, LintBaselineMetadata};
@@ -37,7 +37,7 @@ pub struct LintRunnerRequest<'a> {
 pub fn resolve_lint_command(
     component: &Component,
 ) -> homeboy_core::error::Result<ExtensionExecutionContext> {
-    crate::resolve_execution_context(component, ExtensionCapability::Lint)
+    crate::extension_execution::resolve_execution_context(component, ExtensionCapability::Lint)
 }
 
 /// The manifest key for the lint findings structured sidecar.
@@ -65,10 +65,10 @@ pub fn declares_lint_findings_sidecar(component: &Component) -> bool {
     let Ok(context) = resolve_lint_command(component) else {
         return false;
     };
-    let Ok(manifest) = crate::load_extension(&context.extension_id) else {
+    let Ok(manifest) = crate::extension_store::load_extension(&context.extension_id) else {
         return false;
     };
-    crate::structured_sidecars(&manifest)
+    crate::extension::structured_sidecars(&manifest)
         .iter()
         .any(|declaration| declaration.name == LINT_FINDINGS_SIDECAR)
 }

--- a/crates/homeboy-core/src/extension/lint/report.rs
+++ b/crates/homeboy-core/src/extension/lint/report.rs
@@ -3,7 +3,7 @@
 //! Mirrors `core/extension/test/report.rs` — the command layer calls a single
 //! builder function to convert a workflow result into the command output tuple.
 
-use crate::{
+use crate::extension::{
     phase_failure_category_from_exit_code, phase_status_from_exit_code, PhaseFailure,
     PhaseFailureCategory, PhaseReport, VerificationPhase,
 };
@@ -96,7 +96,7 @@ fn lint_phase_report(
     PhaseReport {
         phase: VerificationPhase::Lint,
         status: if infrastructure_failure {
-            crate::PhaseStatus::Error
+            crate::extension::PhaseStatus::Error
         } else {
             phase_status_from_exit_code(exit_code)
         },
@@ -347,7 +347,7 @@ mod tests {
         let (output, exit_code) = from_main_workflow(result);
 
         assert_eq!(exit_code, 0);
-        assert_eq!(output.phase.status, crate::PhaseStatus::Passed);
+        assert_eq!(output.phase.status, crate::extension::PhaseStatus::Passed);
         assert_eq!(
             output.phase.summary,
             "lint phase passed with 1 advisory finding(s) across phpcs passed: 1"
@@ -449,7 +449,7 @@ mod tests {
 
         assert_eq!(exit_code, 1);
         assert_eq!(output.status, "error");
-        assert_eq!(output.phase.status, crate::PhaseStatus::Error);
+        assert_eq!(output.phase.status, crate::extension::PhaseStatus::Error);
         assert_eq!(
             output.phase.summary,
             "lint phase infrastructure failure (exit 1)"

--- a/crates/homeboy-core/src/extension/lint/run/formatting.rs
+++ b/crates/homeboy-core/src/extension/lint/run/formatting.rs
@@ -1,7 +1,7 @@
 //! Formatting-finding extraction and harness-failure classification.
 
 use super::types::FormattingFindings;
-use crate as extension;
+use crate::extension;
 use std::collections::BTreeSet;
 use std::path::Path;
 

--- a/crates/homeboy-core/src/extension/lint/run/scoping.rs
+++ b/crates/homeboy-core/src/extension/lint/run/scoping.rs
@@ -2,8 +2,8 @@
 //! flags into runner-compatible globbed lint runs via extension routes.
 
 use super::types::{LintRunWorkflowArgs, ScopedLintPlan, ScopedLintRun};
-use crate as extension;
-use crate::LintChangedFileRoute;
+use crate::extension;
+use crate::extension::LintChangedFileRoute;
 use homeboy_core::component::Component;
 use homeboy_core::git;
 use std::path::Path;

--- a/crates/homeboy-core/src/extension/lint/run/tests/mod.rs
+++ b/crates/homeboy-core/src/extension/lint/run/tests/mod.rs
@@ -1,7 +1,7 @@
 //! Tests for the lint run workflow, grouped by concern.
 
 use super::types::{LintRunWorkflowArgs, LintSniffFilters};
-use crate::LintChangedFileRoute;
+use crate::extension::LintChangedFileRoute;
 use homeboy_core::component::Component;
 use homeboy_core::finding::HomeboyFinding;
 use homeboy_engine_primitives::baseline::BaselineFlags;

--- a/crates/homeboy-core/src/extension/lint/run/tests/scoping.rs
+++ b/crates/homeboy-core/src/extension/lint/run/tests/scoping.rs
@@ -4,7 +4,7 @@ use super::super::scoping::{
 };
 use super::super::types::ScopedLintRun;
 use super::{component, split_lint_routes};
-use crate::LintChangedFileRoute;
+use crate::extension::LintChangedFileRoute;
 use homeboy_core::component::Component;
 
 #[test]

--- a/crates/homeboy-core/src/extension/lint/run/tests/workflow.rs
+++ b/crates/homeboy-core/src/extension/lint/run/tests/workflow.rs
@@ -168,7 +168,7 @@ fn full_scope_legacy_baseline_is_compared_with_legacy_provenance() {
         let finding = homeboy_core::finding::HomeboyFinding::builder("eslint", "known finding")
             .fingerprint("known")
             .build();
-        crate::lint::baseline::save_baseline(source.path(), "legacy", &[finding])
+        crate::extension::lint::baseline::save_baseline(source.path(), "legacy", &[finding])
             .expect("save legacy baseline");
         let component = routed_lint_component(
             home.path(),
@@ -196,7 +196,7 @@ exit 1
         assert!(provenance.compared);
         assert_eq!(
             provenance.resolution,
-            crate::lint::baseline::LintBaselineResolution::LegacyFull
+            crate::extension::lint::baseline::LintBaselineResolution::LegacyFull
         );
         assert_eq!(provenance.baseline_key, "lint");
     });
@@ -206,7 +206,7 @@ exit 1
 fn empty_legacy_full_baseline_is_incomparable_instead_of_new_drift() {
     homeboy_core::test_support::with_isolated_home(|home| {
         let source = tempfile::tempdir().expect("source dir");
-        crate::lint::baseline::save_baseline(source.path(), "legacy", &[])
+        crate::extension::lint::baseline::save_baseline(source.path(), "legacy", &[])
             .expect("save empty legacy baseline");
         let component = routed_lint_component(
             home.path(),
@@ -237,7 +237,7 @@ exit 1
         assert_eq!(provenance.baseline_key, "lint");
         assert_eq!(
             provenance.resolution,
-            crate::lint::baseline::LintBaselineResolution::LegacyEmptyIncomparable
+            crate::extension::lint::baseline::LintBaselineResolution::LegacyEmptyIncomparable
         );
     });
 }
@@ -246,7 +246,7 @@ exit 1
 fn scoped_empty_full_baseline_still_blocks_a_genuine_increase() {
     homeboy_core::test_support::with_isolated_home(|home| {
         let source = tempfile::tempdir().expect("source dir");
-        let provenance = crate::lint::baseline::LintBaselineProvenance::new(
+        let provenance = crate::extension::lint::baseline::LintBaselineProvenance::new(
             Vec::new(),
             vec!["phpcs".to_string()],
             "full",
@@ -255,7 +255,7 @@ fn scoped_empty_full_baseline_still_blocks_a_genuine_increase() {
             None,
             None,
         );
-        crate::lint::baseline::save_baseline_for_scope(
+        crate::extension::lint::baseline::save_baseline_for_scope(
             source.path(),
             "scoped",
             &[],
@@ -291,7 +291,7 @@ exit 1
                 .baseline_provenance
                 .as_ref()
                 .map(|provenance| &provenance.resolution),
-            Some(&crate::lint::baseline::LintBaselineResolution::Scoped)
+            Some(&crate::extension::lint::baseline::LintBaselineResolution::Scoped)
         );
     });
 }
@@ -331,7 +331,7 @@ fn accepted_pr_finding_stays_accepted_on_full_default_branch_run() {
         .expect("candidate source");
         run_git(&["add", "."]);
         run_git(&["commit", "-q", "-m", "candidate"]);
-        crate::lint::baseline::save_baseline(source.path(), "legacy", &[])
+        crate::extension::lint::baseline::save_baseline(source.path(), "legacy", &[])
             .expect("save empty legacy baseline");
         let component = routed_lint_component(
             home.path(),
@@ -367,13 +367,15 @@ exit 1
             pr.baseline_provenance
                 .as_ref()
                 .map(|provenance| &provenance.resolution),
-            Some(&crate::lint::baseline::LintBaselineResolution::GitBase)
+            Some(&crate::extension::lint::baseline::LintBaselineResolution::GitBase)
         );
         assert_eq!(
             push.baseline_provenance
                 .as_ref()
                 .map(|provenance| &provenance.resolution),
-            Some(&crate::lint::baseline::LintBaselineResolution::LegacyEmptyIncomparable)
+            Some(
+                &crate::extension::lint::baseline::LintBaselineResolution::LegacyEmptyIncomparable
+            )
         );
     });
 }
@@ -503,7 +505,7 @@ exit 1
             .baseline_provenance
             .as_ref()
             .expect("stored baseline provenance");
-        crate::lint::baseline::save_baseline_for_scope(
+        crate::extension::lint::baseline::save_baseline_for_scope(
             source.path(),
             "fixture",
             seed.findings.as_deref().expect("seed findings"),
@@ -697,7 +699,7 @@ fn accepted_baseline_does_not_hide_later_route_producer_error() {
             .fingerprint("known")
             .build();
         known.location.file = Some("assets/app.js".to_string());
-        crate::lint::baseline::save_baseline(source.path(), "fixture", &[known])
+        crate::extension::lint::baseline::save_baseline(source.path(), "fixture", &[known])
             .expect("save baseline");
         let component = routed_lint_component(
             home.path(),
@@ -735,7 +737,7 @@ exit 0
 
 #[test]
 fn lint_config_deserializes_changed_file_routes() {
-    let config: crate::LintConfig = serde_json::from_str(
+    let config: crate::extension::LintConfig = serde_json::from_str(
         r#"{
                 "extension_script": "scripts/lint.sh",
                 "changed_file_routes": [

--- a/crates/homeboy-core/src/extension/lint/run/types.rs
+++ b/crates/homeboy-core/src/extension/lint/run/types.rs
@@ -1,8 +1,8 @@
 //! Shared workflow types — args, results, and summary structures.
 
-use crate::lint::baseline as lint_baseline;
-use crate::self_check::SelfCheckCaptureMetadata;
-use crate::ExtensionPhaseTiming;
+use crate::extension::lint::baseline as lint_baseline;
+use crate::extension::self_check::SelfCheckCaptureMetadata;
+use crate::extension::ExtensionPhaseTiming;
 use homeboy_core::finding::{FindingProducerSummary, HomeboyFinding};
 use homeboy_engine_primitives::baseline::BaselineFlags;
 pub use homeboy_extension_contract::FormattingFindings;

--- a/crates/homeboy-core/src/extension/lint/run/workflow.rs
+++ b/crates/homeboy-core/src/extension/lint/run/workflow.rs
@@ -12,10 +12,10 @@ use super::formatting::{extract_formatting_findings, self_check_output_is_harnes
 use super::hints::build_autofix_hint;
 use super::scoping::resolve_scoped_lint_runs;
 use super::types::{LintRunWorkflowArgs, LintRunWorkflowResult, ScopedLintPlan, ScopedLintRun};
-use crate as extension;
-use crate::lint::baseline as lint_baseline;
-use crate::lint::build_lint_runner;
-use crate::ExtensionCapability;
+use crate::extension;
+use crate::extension::lint::baseline as lint_baseline;
+use crate::extension::lint::build_lint_runner;
+use crate::extension::ExtensionCapability;
 use homeboy_core::component::Component;
 use homeboy_core::engine::run_dir::{self, RunDir};
 use homeboy_core::finding::HomeboyFinding;
@@ -127,7 +127,7 @@ pub fn run_main_lint_workflow(
             None,
             vec![("lint runner".to_string(), args.component_label.clone())],
         )?;
-        let runner = build_lint_runner(crate::lint::LintRunnerRequest {
+        let runner = build_lint_runner(crate::extension::lint::LintRunnerRequest {
             component,
             path_override: args.path_override.clone(),
             settings: &args.settings,
@@ -158,7 +158,9 @@ pub fn run_main_lint_workflow(
         let stderr_artifact = write_command_artifact(run_dir, 0, "stderr", &output.stderr)?;
         progress.finish(0, output.exit_code, stdout_artifact, stderr_artifact)?;
         let lint_findings_file = run_dir.step_file(run_dir::files::LINT_FINDINGS);
-        if crate::lint::declares_lint_findings_sidecar(component) && !lint_findings_file.is_file() {
+        if crate::extension::lint::declares_lint_findings_sidecar(component)
+            && !lint_findings_file.is_file()
+        {
             return Err(missing_findings_evidence_error(&lint_findings_file));
         }
         let lint_producers_file = run_dir.step_file(run_dir::files::LINT_PRODUCERS);
@@ -402,7 +404,8 @@ fn run_scoped_lint_runs(
     // Read the declaration once, not once per scoped run: it is a property of
     // the component's lint extension, and every run in this loop is that same
     // extension.
-    let requires_findings_evidence = crate::lint::declares_lint_findings_sidecar(component);
+    let requires_findings_evidence =
+        crate::extension::lint::declares_lint_findings_sidecar(component);
     let mut progress = ValidationProgressRecorder::new(
         run_dir,
         None,
@@ -423,7 +426,7 @@ fn run_scoped_lint_runs(
         let scoped_run_dir = (index > 0).then(RunDir::create).transpose()?;
         let active_run_dir = scoped_run_dir.as_ref().unwrap_or(run_dir);
 
-        let runner = build_lint_runner(crate::lint::LintRunnerRequest {
+        let runner = build_lint_runner(crate::extension::lint::LintRunnerRequest {
             component,
             path_override: args.path_override.clone(),
             settings: &args.settings,
@@ -523,13 +526,13 @@ fn finish_scoped_lint_run_dirs(run_dirs: &[RunDir], success: bool) {
 
 /// Reported only when the extension *declared* `lint.findings` and then did not
 /// write it — i.e. it broke a contract it opted into. See
-/// [`crate::lint::declares_lint_findings_sidecar`] for why the declaration
+/// [`crate::extension::lint::declares_lint_findings_sidecar`] for why the declaration
 /// gates this at all.
 fn missing_findings_evidence_error(path: &Path) -> homeboy_core::Error {
     homeboy_core::Error::internal_io(
         format!(
             "Lint runner declares the `{}` structured sidecar but did not produce it at {}",
-            crate::lint::LINT_FINDINGS_SIDECAR,
+            crate::extension::lint::LINT_FINDINGS_SIDECAR,
             path.display()
         ),
         Some("lint.findings.evidence".to_string()),
@@ -537,7 +540,7 @@ fn missing_findings_evidence_error(path: &Path) -> homeboy_core::Error {
     .with_hint(format!(
         "Either write the sidecar on every exit path (seed it empty for a clean pass) or drop \
          `\"{}\"` from the extension manifest's `structured_sidecars`.",
-        crate::lint::LINT_FINDINGS_SIDECAR
+        crate::extension::lint::LINT_FINDINGS_SIDECAR
     ))
 }
 

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -14,10 +14,8 @@ mod env_provider;
 mod execution;
 mod fingerprint;
 // invocation_context relocated to homeboy_core::extension_invocation_context
-// The grammar parsing engine is a language-agnostic primitive; it now lives in
-// homeboy-engine-primitives. Re-exported here so existing
-// `crate::grammar` / `crate::grammar_items` paths keep
-// resolving. (grammar_items is now the `items` submodule of grammar.)
+// The grammar parsing engine is a language-agnostic primitive; expose it through
+// the extension API while its implementation remains in homeboy-engine-primitives.
 pub use homeboy_engine_primitives::grammar;
 pub use homeboy_engine_primitives::grammar::items as grammar_items;
 pub mod lifecycle;

--- a/crates/homeboy-core/src/extension/recipe_run.rs
+++ b/crates/homeboy-core/src/extension/recipe_run.rs
@@ -3,7 +3,7 @@
 use homeboy_core::error::{Error, Result};
 
 use crate::extension::manifest::ExtensionManifest;
-use crate::DiscoveredExtension;
+use crate::extension_store::DiscoveredExtension;
 
 const AVAILABLE_ID_LIMIT: usize = 20;
 
@@ -135,7 +135,7 @@ impl RecipeRunProviderInventoryEntry {
 }
 
 fn discover_recipe_run_providers() -> Vec<DiscoveredProvider> {
-    let mut providers = crate::discover_extensions()
+    let mut providers = crate::extension_store::discover_extensions()
         .into_iter()
         .flat_map(|extension| match extension {
             DiscoveredExtension::Valid(manifest) => declarations_from_manifest(&manifest),
@@ -296,7 +296,7 @@ mod tests {
                 .to_string(),
             )
             .expect("manifest");
-            crate::install(&source.path().display().to_string(), Some("fixture"))
+            crate::extension::install(&source.path().display().to_string(), Some("fixture"))
                 .expect("install extension");
 
             let provider = resolve_recipe_run_provider("fixture.recipe-run").expect("discover");
@@ -347,7 +347,7 @@ mod tests {
                 .to_string(),
             )
             .expect("manifest");
-            crate::install(&source.path().display().to_string(), Some("fixture"))
+            crate::extension::install(&source.path().display().to_string(), Some("fixture"))
                 .expect("a malformed provider must not make the manifest unreadable");
 
             let inventory = recipe_run_provider_inventory();
@@ -392,7 +392,8 @@ mod tests {
                 .to_string(),
             )
             .expect("manifest");
-            crate::install(&source.path().display().to_string(), Some("fixture")).expect("install");
+            crate::extension::install(&source.path().display().to_string(), Some("fixture"))
+                .expect("install");
             let duplicate_source = tempfile::tempdir().expect("duplicate extension source");
             std::fs::write(
                 duplicate_source.path().join("duplicate.json"),
@@ -403,7 +404,7 @@ mod tests {
                 .to_string(),
             )
             .expect("duplicate manifest");
-            crate::install(
+            crate::extension::install(
                 &duplicate_source.path().display().to_string(),
                 Some("duplicate"),
             )

--- a/crates/homeboy-core/src/extension/refactor_protocol.rs
+++ b/crates/homeboy-core/src/extension/refactor_protocol.rs
@@ -165,14 +165,14 @@ impl RefactorScriptFailure {
 /// Output from a `parse_items` refactor command: the protocol name for a parsed
 /// top-level item.
 ///
-/// This was a second declaration of [`crate::grammar_items::GrammarItem`] --
+/// This was a second declaration of [`crate::extension::grammar_items::GrammarItem`] --
 /// same six fields, same order, same serde, and the same doc comment on every
 /// field -- plus a `From` impl that moved them across one at a time.
 /// `GrammarItem`'s own doc already described it as "the core equivalent of
 /// `extension::ParsedItem`", and this crate re-exports the core module as
 /// `grammar_items`, so the two names always resolved through the same crate with
 /// no dependency boundary between them to justify a copy.
-pub type ParsedItem = crate::grammar_items::GrammarItem;
+pub type ParsedItem = crate::extension::grammar_items::GrammarItem;
 
 /// Output from a `resolve_imports` refactor command.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -234,7 +234,7 @@ mod tests {
 
     #[test]
     fn test_parsed_item_from_grammar_item() {
-        let item = crate::grammar_items::GrammarItem {
+        let item = crate::extension::grammar_items::GrammarItem {
             name: "run".to_string(),
             kind: "function".to_string(),
             start_line: 3,

--- a/crates/homeboy-core/src/extension/repair.rs
+++ b/crates/homeboy-core/src/extension/repair.rs
@@ -440,7 +440,7 @@ mod tests {
         clean_stale_replace_clone_temps, relink, replace, replace_with_revision,
         unique_replace_clone_temp,
     };
-    use crate::{install, load_extension};
+    use crate::extension::{install, load_extension};
     use homeboy_core::test_support::with_isolated_home;
     use std::fs;
     use std::path::Path;

--- a/crates/homeboy-core/src/extension/runner.rs
+++ b/crates/homeboy-core/src/extension/runner.rs
@@ -2,7 +2,7 @@ use std::io;
 use std::path::{Component as PathComponent, Path, PathBuf};
 use std::time::Duration;
 
-use crate::{ExtensionCapability, ExtensionPhaseTiming, TestSecretEnvProjection};
+use crate::extension::{ExtensionCapability, ExtensionPhaseTiming, TestSecretEnvProjection};
 use homeboy_core::component::Component;
 use homeboy_core::engine::invocation::{InvocationGuard, InvocationRequirements};
 use homeboy_core::engine::resource::{self, ExtensionChildResourceSummary};
@@ -298,7 +298,7 @@ impl ExtensionRunner {
 
         let project_path = PathBuf::from(&prepared.execution.component.local_path);
         let invocation = self.acquire_invocation_guard()?;
-        let secret_env_names = crate::test::effective_secret_env_names(
+        let secret_env_names = crate::extension::test::effective_secret_env_names(
             &self.secret_env_names,
             &self.test_secret_env_projections,
             &prepared.settings_json,
@@ -455,9 +455,9 @@ impl ExtensionRunner {
     /// loading that manifest, so a failure here means it became unreadable
     /// mid-run, and losing the seed is a strictly better outcome than failing
     /// the run inside sidecar bookkeeping.
-    fn declared_structured_sidecars(&self) -> Vec<crate::StructuredSidecarDeclaration> {
-        crate::load_extension(&self.execution_context.extension_id)
-            .map(|manifest| crate::structured_sidecars(&manifest))
+    fn declared_structured_sidecars(&self) -> Vec<crate::extension::StructuredSidecarDeclaration> {
+        crate::extension_store::load_extension(&self.execution_context.extension_id)
+            .map(|manifest| crate::extension::structured_sidecars(&manifest))
             .unwrap_or_default()
     }
 
@@ -756,7 +756,7 @@ fn write_structured_failure_sidecar(
 /// `seed_on_start` are written here.
 fn initialize_structured_sidecars(
     run_dir_path: &Path,
-    declared: &[crate::StructuredSidecarDeclaration],
+    declared: &[crate::extension::StructuredSidecarDeclaration],
 ) -> Result<()> {
     for declaration in declared {
         if !homeboy_core::structured_sidecar::seeds_on_start(&declaration.name) {
@@ -778,7 +778,7 @@ fn initialize_structured_sidecars(
 /// captured output; this sidecar contains only individual failure records.
 fn normalize_declared_test_failures(
     run_dir_path: &Path,
-    declared: &[crate::StructuredSidecarDeclaration],
+    declared: &[crate::extension::StructuredSidecarDeclaration],
 ) -> Result<()> {
     let Some(declaration) = declared
         .iter()
@@ -823,7 +823,7 @@ fn normalize_declared_test_failures(
 ///   failure sidecars written over it and a real failure to report.
 fn validate_declared_structured_sidecars(
     run_dir_path: &Path,
-    declared: &[crate::StructuredSidecarDeclaration],
+    declared: &[crate::extension::StructuredSidecarDeclaration],
 ) -> Result<()> {
     for declaration in declared {
         let Some(path) = run_dir_relative_sidecar_path(run_dir_path, &declaration.path) else {
@@ -1033,7 +1033,7 @@ fn stale_validation_dependency_message(stdout: &str, stderr: &str) -> Option<Str
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ExtensionCapability;
+    use crate::extension::ExtensionCapability;
     use homeboy_core::component::Component;
     use homeboy_core::engine::run_dir::RunDir;
     use homeboy_core::server::CommandObservation;
@@ -1233,8 +1233,8 @@ mod tests {
         run_dir.cleanup();
     }
 
-    fn declaration(name: &str) -> crate::StructuredSidecarDeclaration {
-        crate::StructuredSidecarDeclaration {
+    fn declaration(name: &str) -> crate::extension::StructuredSidecarDeclaration {
+        crate::extension::StructuredSidecarDeclaration {
             name: name.to_string(),
             path: homeboy_core::structured_sidecar::default_path(name)
                 .unwrap_or(name)

--- a/crates/homeboy-core/src/extension/self_check.rs
+++ b/crates/homeboy-core/src/extension/self_check.rs
@@ -1,4 +1,4 @@
-use crate::ExtensionCapability;
+use crate::extension::ExtensionCapability;
 use homeboy_core::component::Component;
 use homeboy_core::engine::run_dir::RunDir;
 use homeboy_core::error::{Error, Result};

--- a/crates/homeboy-core/src/extension/test/differential/mod.rs
+++ b/crates/homeboy-core/src/extension/test/differential/mod.rs
@@ -553,7 +553,7 @@ impl DifferentialReport {
 }
 
 /// Exit status assigned to a child terminated for exhausting its execution
-/// budget. Duplicated from `crate::test::report` deliberately: this module must
+/// budget. Duplicated from `crate::extension::test::report` deliberately: this module must
 /// be usable without pulling in the report envelope.
 pub const TIMEOUT_EXIT_CODE: i32 = 124;
 

--- a/crates/homeboy-core/src/extension/test/drift.rs
+++ b/crates/homeboy-core/src/extension/test/drift.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::TestDriftConfig;
+use crate::extension::TestDriftConfig;
 use homeboy_core::error::{Error, Result};
 use homeboy_core::git;
 use homeboy_engine_primitives::test_path::is_test_path;
@@ -1609,7 +1609,7 @@ class FooTest extends TestCase {
 #[cfg(test)]
 mod workspace_layout_tests {
     use super::*;
-    use crate::TestDriftConfig;
+    use crate::extension::TestDriftConfig;
 
     fn run_git(root: &Path, args: &[&str]) {
         let output = std::process::Command::new("git")

--- a/crates/homeboy-core/src/extension/test/mod.rs
+++ b/crates/homeboy-core/src/extension/test/mod.rs
@@ -10,8 +10,8 @@ pub mod report;
 pub mod run;
 pub mod workflow;
 
-use crate::test::drift::DriftOptions;
-use crate::{
+use crate::extension::test::drift::DriftOptions;
+use crate::extension::{
     ExtensionCapability, ExtensionExecutionContext, ExtensionRunner, TestChangedFileExclusiveEnv,
     TestChangedFileRouting, TestChangedFileRoutingStrategy, TestPassthroughFilter,
     TestPassthroughFilterStrategy, TestSecretEnvProjection,
@@ -59,7 +59,7 @@ pub use workflow::{
 pub fn resolve_test_command(
     component: &Component,
 ) -> homeboy_core::error::Result<ExtensionExecutionContext> {
-    crate::resolve_execution_context(component, ExtensionCapability::Test)
+    crate::extension_execution::resolve_execution_context(component, ExtensionCapability::Test)
 }
 
 /// Resolve only the process environment explicitly declared portable by the
@@ -73,7 +73,7 @@ pub struct PortableTestEnv {
 /// explicitly declared by the selected test extension.
 pub fn portable_env(component: &Component) -> homeboy_core::Result<PortableTestEnv> {
     let context = resolve_test_command(component)?;
-    let manifest = crate::load_extension(&context.extension_id)?;
+    let manifest = crate::extension_store::load_extension(&context.extension_id)?;
     let Some(test) = manifest.test else {
         return Ok(PortableTestEnv {
             public_env: Vec::new(),
@@ -146,7 +146,7 @@ pub fn declared_secret_env_names(component: &Component) -> homeboy_core::Result<
     let Ok(context) = resolve_test_command(component) else {
         return Ok(Vec::new());
     };
-    let Some(test) = crate::load_extension(&context.extension_id)?.test else {
+    let Some(test) = crate::extension_store::load_extension(&context.extension_id)?.test else {
         return Ok(Vec::new());
     };
 
@@ -182,7 +182,7 @@ pub fn build_test_runner(
 ) -> homeboy_core::Result<ExtensionRunner> {
     let resolved = resolve_test_command(component)?;
     let extension_id = resolved.extension_id.clone();
-    let test_config = crate::load_extension(&extension_id)?.test;
+    let test_config = crate::extension_store::load_extension(&extension_id)?.test;
     let (secret_env_names, secret_env_projections) = test_config
         .map(|test| {
             (
@@ -380,7 +380,7 @@ fn test_passthrough_filter(
     component: &Component,
 ) -> homeboy_core::error::Result<Option<TestPassthroughFilter>> {
     let context = resolve_test_command(component)?;
-    let manifest = crate::load_extension(&context.extension_id)?;
+    let manifest = crate::extension_store::load_extension(&context.extension_id)?;
     Ok(manifest
         .test
         .and_then(|test| test.passthrough_filter.clone()))
@@ -423,7 +423,7 @@ fn positional_filter_args(args: &[String]) -> Vec<String> {
 fn test_changed_file_routing(
     extension_id: &str,
 ) -> homeboy_core::error::Result<Option<TestChangedFileRouting>> {
-    let manifest = crate::load_extension(extension_id)?;
+    let manifest = crate::extension_store::load_extension(extension_id)?;
     Ok(manifest
         .test
         .and_then(|test| test.changed_file_routing.clone()))
@@ -988,7 +988,7 @@ pub fn resolve_drift_options(
 
     if let Some(extensions) = &component.extensions {
         for extension_id in extensions.keys() {
-            let manifest = crate::load_extension(extension_id)?;
+            let manifest = crate::extension_store::load_extension(extension_id)?;
             if let Some(config) = manifest.test_drift() {
                 return Ok(DriftOptions::from_config(
                     &source_path,
@@ -1235,7 +1235,7 @@ fn is_direct_changed_test_path(file: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{TestDriftConfig, TestSettingStringPredicate};
+    use crate::extension::{TestDriftConfig, TestSettingStringPredicate};
     use std::fs;
     use std::process::Command;
     use tempfile::TempDir;

--- a/crates/homeboy-core/src/extension/test/parsing.rs
+++ b/crates/homeboy-core/src/extension/test/parsing.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 
-use crate::test::analyze::{TestAnalysis, TestAnalysisInput, TestFailure};
-use crate::test::TestCounts;
+use crate::extension::test::analyze::{TestAnalysis, TestAnalysisInput, TestFailure};
+use crate::extension::test::TestCounts;
 use homeboy_core::error::Result;
 use homeboy_core::structured_sidecar;
 use homeboy_engine_primitives::local_files;

--- a/crates/homeboy-core/src/extension/test/report.rs
+++ b/crates/homeboy-core/src/extension/test/report.rs
@@ -4,8 +4,8 @@
 //! produce domain-specific result types. This module provides the unified output
 //! envelope and builder functions that assemble results into command-ready output.
 
-use crate::test::TestCounts;
-use crate::{
+use crate::extension::test::TestCounts;
+use crate::extension::{
     phase_failure_category_from_exit_code, phase_status_from_exit_code, PhaseFailure,
     PhaseFailureCategory, PhaseReport, PhaseStatus, VerificationPhase,
 };
@@ -589,7 +589,7 @@ mod tests {
     #[test]
     fn serializes_extension_phase_timings_as_opaque_metadata() {
         let mut result = workflow_result(None);
-        result.extension_phase_timings = vec![crate::ExtensionPhaseTiming {
+        result.extension_phase_timings = vec![crate::extension::ExtensionPhaseTiming {
             name: "opaque-provider-phase".to_string(),
             duration_ms: 4321,
             status: Some("waiting".to_string()),

--- a/crates/homeboy-core/src/extension/test/run.rs
+++ b/crates/homeboy-core/src/extension/test/run.rs
@@ -1,17 +1,17 @@
-use crate as extension;
+use crate::extension;
 use crate::extension::runner::tail_lines;
-use crate::test::analyze::{analyze, TestAnalysisInput};
-use crate::test::baseline::{self, TestCounts};
-use crate::test::durations::{
+use crate::extension::test::analyze::{analyze, TestAnalysisInput};
+use crate::extension::test::baseline::{self, TestCounts};
+use crate::extension::test::durations::{
     build_test_durations, parse_duration_samples, parse_test_durations_file, SlowTestPolicy,
     TestDurations,
 };
-use crate::test::{
+use crate::extension::test::{
     build_test_runner, build_test_summary, compute_changed_test_scope,
     normalize_test_passthrough_args, parse_coverage_file, parse_failures_file,
     parse_test_results_file_with_spec, parse_test_results_text, parse_test_results_text_with_spec,
 };
-use crate::{ExtensionCapability, ExtensionPhaseTiming};
+use crate::extension::{ExtensionCapability, ExtensionPhaseTiming};
 use homeboy_core::component::Component;
 use homeboy_core::engine::run_dir::{self, RunDir};
 use homeboy_core::error::{Error, ErrorCode};
@@ -469,7 +469,7 @@ impl InventoryProfile {
     /// A declared config that selects no fingerprint files, or names no usable
     /// runner, is refused rather than silently degraded: an inventory bound to
     /// a constant fingerprint would compare equal across unrelated workspaces.
-    fn resolve(config: Option<&crate::TestInventoryConfig>) -> Option<Self> {
+    fn resolve(config: Option<&crate::extension::TestInventoryConfig>) -> Option<Self> {
         let Some(config) = config else {
             return Some(Self::cargo());
         };
@@ -1297,7 +1297,7 @@ fn run_main_test_workflow_inner(
 ) -> homeboy_core::Result<TestRunWorkflowResult> {
     let changed_scope = if let Some(ref git_ref) = args.changed_since {
         Some(match args.precomputed_changed_files.as_ref() {
-            Some(changed_files) => crate::test::compute_changed_test_scope_for_files(
+            Some(changed_files) => crate::extension::test::compute_changed_test_scope_for_files(
                 component,
                 git_ref,
                 changed_files,
@@ -1539,10 +1539,10 @@ fn run_main_test_workflow_inner(
         }
     }
 
-    let test_context = crate::test::resolve_test_command(component).ok();
+    let test_context = crate::extension::test::resolve_test_command(component).ok();
     let test_config = test_context
         .as_ref()
-        .and_then(|context| crate::load_extension(&context.extension_id).ok())
+        .and_then(|context| crate::extension_store::load_extension(&context.extension_id).ok())
         .and_then(|extension| extension.test);
     let result_parse = test_config
         .as_ref()
@@ -2185,7 +2185,7 @@ fn parse_compiler_failures(stdout: &str, stderr: &str) -> Option<TestAnalysisInp
             .captures(&message)
             .map(|captures| captures[1].to_string())
             .unwrap_or_else(|| message.clone());
-        failures.push(crate::test::TestFailure {
+        failures.push(crate::extension::test::TestFailure {
             test_name: format!("{code}: {symbol}"),
             test_file: String::new(),
             error_type: format!("compiler_error:{code}"),
@@ -2345,7 +2345,7 @@ fn failed_test_workflow(
 
 fn run_declared_result_parser(
     component: &Component,
-    context: &crate::ExtensionExecutionContext,
+    context: &crate::extension_execution::ExtensionExecutionContext,
     spec: &ParseSpec,
     stdout: &str,
     run_dir: &RunDir,
@@ -2737,7 +2737,7 @@ fn merge_reported_test_artifact_locators(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::TestFailure;
+    use crate::extension::test::TestFailure;
     use homeboy_core::component::{ComponentScriptsConfig, ScopedExtensionConfig};
     use std::collections::HashMap;
     use std::sync::{Mutex, OnceLock};
@@ -3150,12 +3150,13 @@ mod tests {
             .expect("marker script");
 
             assert_eq!(
-                crate::test::declared_secret_env_names(&matching).expect("matching declaration"),
+                crate::extension::test::declared_secret_env_names(&matching)
+                    .expect("matching declaration"),
                 vec!["FIRST_PROJECTED_SECRET", "SECOND_PROJECTED_SECRET"]
             );
 
             let local = conditional_test_component(home.path(), source.path(), "local");
-            assert!(crate::test::declared_secret_env_names(&local)
+            assert!(crate::extension::test::declared_secret_env_names(&local)
                 .expect("non-matching declaration")
                 .is_empty());
 
@@ -5570,7 +5571,7 @@ printf '{"total":%s,"passed":%s,"failed":%s,"skipped":%s}\n' "$total" "$passed" 
                 "fixture-extension".to_string(),
                 None,
             );
-            let context = crate::ExtensionExecutionContext {
+            let context = crate::extension_execution::ExtensionExecutionContext {
                 component: component.clone(),
                 capability: ExtensionCapability::Test,
                 extension_id: "fixture-extension".to_string(),
@@ -5631,7 +5632,7 @@ printf '{"total":%s,"passed":%s,"failed":%s,"skipped":%s}\n' "$total" "$passed" 
             "fixture-extension".to_string(),
             None,
         );
-        let context = crate::ExtensionExecutionContext {
+        let context = crate::extension_execution::ExtensionExecutionContext {
             component: component.clone(),
             capability: ExtensionCapability::Test,
             extension_id: "fixture-extension".to_string(),
@@ -5706,7 +5707,7 @@ exit 23
                 "fixture-extension".to_string(),
                 None,
             );
-            let context = crate::ExtensionExecutionContext {
+            let context = crate::extension_execution::ExtensionExecutionContext {
                 component: component.clone(),
                 capability: ExtensionCapability::Test,
                 extension_id: "fixture-extension".to_string(),
@@ -5778,7 +5779,7 @@ printf '{"total":5,"passed":3,"failed":1,"skipped":1}\n'
                 "fixture-extension".to_string(),
                 None,
             );
-            let context = crate::ExtensionExecutionContext {
+            let context = crate::extension_execution::ExtensionExecutionContext {
                 component: component.clone(),
                 capability: ExtensionCapability::Test,
                 extension_id: "fixture-extension".to_string(),
@@ -5845,7 +5846,7 @@ printf 'not json\n'
             "fixture-extension".to_string(),
             None,
         );
-        let context = crate::ExtensionExecutionContext {
+        let context = crate::extension_execution::ExtensionExecutionContext {
             component: component.clone(),
             capability: ExtensionCapability::Test,
             extension_id: "fixture-extension".to_string(),
@@ -5909,7 +5910,7 @@ printf 'not json\n'
 #[cfg(all(test, unix))]
 mod inventory_profile_tests {
     use super::*;
-    use crate::{TestInventoryConfig, TestInventoryRunner};
+    use crate::extension::{TestInventoryConfig, TestInventoryRunner};
 
     fn wordpress_config() -> TestInventoryConfig {
         TestInventoryConfig {

--- a/crates/homeboy-core/src/extension/test/workflow.rs
+++ b/crates/homeboy-core/src/extension/test/workflow.rs
@@ -1,6 +1,6 @@
-use crate::test::drift::{detect_drift, generate_transform_rules};
-use crate::test::resolve_drift_options;
-use crate::test::ChangeType;
+use crate::extension::test::drift::{detect_drift, generate_transform_rules};
+use crate::extension::test::resolve_drift_options;
+use crate::extension::test::ChangeType;
 use homeboy_core::component::Component;
 pub use homeboy_extension_contract::test_results::{
     AutoFixDriftWorkflowResult, DriftWorkflowResult, MainTestWorkflowResult,

--- a/crates/homeboy-core/src/extension/trace/assertions.rs
+++ b/crates/homeboy-core/src/extension/trace/assertions.rs
@@ -1,6 +1,6 @@
 //! Temporal trace assertion evaluation over timeline events.
 
-use crate::bench::distribution::percentile;
+use crate::extension::bench::distribution::percentile;
 use serde_json::json;
 
 use super::parsing::{
@@ -610,7 +610,7 @@ fn event_details(events: &[&super::parsing::TraceEvent]) -> Vec<serde_json::Valu
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::trace::parsing::TraceEvent;
+    use crate::extension::trace::parsing::TraceEvent;
     use std::collections::BTreeMap;
 
     fn event(t_ms: u64, source: &str, event: &str) -> TraceEvent {

--- a/crates/homeboy-core/src/extension/trace/baseline.rs
+++ b/crates/homeboy-core/src/extension/trace/baseline.rs
@@ -367,7 +367,9 @@ impl generic::Fingerprintable for TraceBaselineItem<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::trace::parsing::{TraceAssertion, TraceSpanResult, TraceSpanStatus, TraceStatus};
+    use crate::extension::trace::parsing::{
+        TraceAssertion, TraceSpanResult, TraceSpanStatus, TraceStatus,
+    };
 
     fn results(duration_ms: u64) -> TraceResults {
         TraceResults {

--- a/crates/homeboy-core/src/extension/trace/browser_evidence.rs
+++ b/crates/homeboy-core/src/extension/trace/browser_evidence.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use serde_json::{Map, Value};
 
-use crate::{
+use crate::extension::{
     load_all_extensions, TraceBrowserArtifactMapConfig, TraceBrowserEvidenceAdapterConfig,
     TraceBrowserSummaryAliasConfig,
 };

--- a/crates/homeboy-core/src/extension/trace/canonicality.rs
+++ b/crates/homeboy-core/src/extension/trace/canonicality.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::process::Command;
 
 use crate::extension::manifest_config::TraceToolchainProvenanceConfig;
-use crate::ExtensionExecutionContext;
+use crate::extension_execution::ExtensionExecutionContext;
 use homeboy_core::component::Component;
 use homeboy_core::error::Result;
 use homeboy_core::lab_workspace_provenance::{
@@ -596,8 +596,8 @@ fn parse_ahead_behind(value: &str) -> Option<(Option<u32>, Option<u32>)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::trace::run::{run_trace_workflow, TraceRunnerInputs};
-    use crate::ExtensionCapability;
+    use crate::extension::trace::run::{run_trace_workflow, TraceRunnerInputs};
+    use crate::extension::ExtensionCapability;
     use homeboy_core::engine::run_dir::RunDir;
     use homeboy_engine_primitives::baseline::BaselineFlags;
     use std::path::Path;
@@ -1145,8 +1145,9 @@ mod tests {
                 ratchet: false,
             },
             regression_threshold_percent:
-                crate::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
-            regression_min_delta_ms: crate::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+                crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+            regression_min_delta_ms:
+                crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
             canonical_policy: TraceCanonicalPolicy::Development,
             checkout_provenance: None,
         }

--- a/crates/homeboy-core/src/extension/trace/generic_runner.rs
+++ b/crates/homeboy-core/src/extension/trace/generic_runner.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::{path_list_env_value, RunnerOutput};
+use crate::extension::{path_list_env_value, RunnerOutput};
 use homeboy_core::component::Component;
 use homeboy_core::engine::run_dir::{self, RunDir};
 use homeboy_core::error::{Error, Result};

--- a/crates/homeboy-core/src/extension/trace/mod.rs
+++ b/crates/homeboy-core/src/extension/trace/mod.rs
@@ -27,7 +27,7 @@ pub mod run;
 mod span_summary;
 pub mod spans;
 
-use crate::{ExtensionCapability, ExtensionExecutionContext};
+use crate::extension::{ExtensionCapability, ExtensionExecutionContext};
 use homeboy_core::component::Component;
 
 pub use aggregate_report::TraceAggregateSpanSampleOutput;
@@ -80,5 +80,5 @@ pub use span_summary::{
 pub fn resolve_trace_command(
     component: &Component,
 ) -> homeboy_core::error::Result<ExtensionExecutionContext> {
-    crate::resolve_execution_context(component, ExtensionCapability::Trace)
+    crate::extension_execution::resolve_execution_context(component, ExtensionCapability::Trace)
 }

--- a/crates/homeboy-core/src/extension/trace/preflight.rs
+++ b/crates/homeboy-core/src/extension/trace/preflight.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use std::path::Path;
 
-use crate::ExtensionExecutionContext;
+use crate::extension_execution::ExtensionExecutionContext;
 use homeboy_core::error::{Error, Result};
 use homeboy_extension_contract::TraceDependencySpec;
 
@@ -182,7 +182,7 @@ fn trace_runner_capabilities(
         capabilities.extend(parsed);
     }
     if let Some(context) = execution_context {
-        let manifest = crate::load_extension(&context.extension_id)?;
+        let manifest = crate::extension_store::load_extension(&context.extension_id)?;
         capabilities.extend(manifest.trace_runner_capabilities().iter().cloned());
     }
     Ok(capabilities)

--- a/crates/homeboy-core/src/extension/trace/report.rs
+++ b/crates/homeboy-core/src/extension/trace/report.rs
@@ -926,7 +926,7 @@ mod markdown {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::trace::parsing::{
+    use crate::extension::trace::parsing::{
         TraceComponentsProvenance, TraceGitProvenance, TraceScenario, TraceStatus,
         TraceToolchainProvenance,
     };
@@ -1036,18 +1036,18 @@ mod tests {
                 failure: None,
                 rig: None,
                 evidence: None,
-                timeline: vec![crate::trace::parsing::TraceEvent {
+                timeline: vec![crate::extension::trace::parsing::TraceEvent {
                     t_ms: 10,
                     source: "ui".to_string(),
                     event: "submit".to_string(),
                     data: std::collections::BTreeMap::new(),
                 }],
                 span_definitions: Vec::new(),
-                span_results: vec![crate::trace::parsing::TraceSpanResult {
+                span_results: vec![crate::extension::trace::parsing::TraceSpanResult {
                     id: "submit_to_cli".to_string(),
                     from: "ui.submit".to_string(),
                     to: "cli.start".to_string(),
-                    status: crate::trace::parsing::TraceSpanStatus::Ok,
+                    status: crate::extension::trace::parsing::TraceSpanStatus::Ok,
                     duration_ms: Some(42),
                     from_t_ms: Some(10),
                     to_t_ms: Some(52),
@@ -1168,11 +1168,11 @@ mod tests {
             evidence: None,
             timeline: Vec::new(),
             span_definitions: Vec::new(),
-            span_results: vec![crate::trace::parsing::TraceSpanResult {
+            span_results: vec![crate::extension::trace::parsing::TraceSpanResult {
                 id: "submit_to_cli".to_string(),
                 from: "ui.submit".to_string(),
                 to: "cli.start".to_string(),
-                status: crate::trace::parsing::TraceSpanStatus::Ok,
+                status: crate::extension::trace::parsing::TraceSpanStatus::Ok,
                 duration_ms: Some(42),
                 from_t_ms: Some(10),
                 to_t_ms: Some(52),

--- a/crates/homeboy-core/src/extension/trace/run/list.rs
+++ b/crates/homeboy-core/src/extension/trace/run/list.rs
@@ -1,6 +1,6 @@
 //! Trace scenario discovery (list-only) workflow.
 
-use crate::{resolve_execution_context, ExtensionCapability, RunnerOutput};
+use crate::extension::{resolve_execution_context, ExtensionCapability, RunnerOutput};
 use homeboy_core::component::Component;
 use homeboy_core::engine::run_dir::{self, RunDir};
 use homeboy_core::error::{Error, Result};
@@ -17,9 +17,11 @@ pub fn run_trace_list_workflow(
     run_dir: &RunDir,
 ) -> Result<TraceList> {
     if component.has_script(ExtensionCapability::Trace) {
-        let source_path =
-            crate::component_script::source_path(component, args.path_override.as_deref());
-        let output = crate::component_script::run_component_scripts_with_run_dir(
+        let source_path = crate::extension::component_script::source_path(
+            component,
+            args.path_override.as_deref(),
+        );
+        let output = crate::extension::component_script::run_component_scripts_with_run_dir(
             component,
             ExtensionCapability::Trace,
             &source_path,
@@ -75,8 +77,8 @@ struct TraceListOutput {
     stderr: String,
 }
 
-impl From<crate::component_script::ComponentScriptOutput> for TraceListOutput {
-    fn from(output: crate::component_script::ComponentScriptOutput) -> Self {
+impl From<crate::extension::component_script::ComponentScriptOutput> for TraceListOutput {
+    fn from(output: crate::extension::component_script::ComponentScriptOutput) -> Self {
         Self {
             exit_code: output.exit_code,
             success: output.success,

--- a/crates/homeboy-core/src/extension/trace/run/provenance.rs
+++ b/crates/homeboy-core/src/extension/trace/run/provenance.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::ExtensionExecutionContext;
+use crate::extension_execution::ExtensionExecutionContext;
 use homeboy_core::error::Result;
 
 use super::super::canonicality::trace_toolchain_provenance_requirements;

--- a/crates/homeboy-core/src/extension/trace/run/runner.rs
+++ b/crates/homeboy-core/src/extension/trace/run/runner.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::{
+use crate::extension::{
     build_scenario_runner, stderr_tail, ExtensionExecutionContext, RunnerOutput,
     ScenarioRunnerOptions,
 };

--- a/crates/homeboy-core/src/extension/trace/run/tests/extension.rs
+++ b/crates/homeboy-core/src/extension/trace/run/tests/extension.rs
@@ -5,12 +5,14 @@ use std::fs;
 use std::process::Command;
 use std::sync::{Mutex, OnceLock};
 
-use crate::trace::attach::TraceAttachment;
-use crate::trace::canonicality::TraceCanonicalPolicy;
-use crate::trace::generic_runner::{discover_generic_trace_workloads, trace_workload_scenario_id};
-use crate::trace::overlay::{apply_trace_overlays, TraceOverlayRequest};
-use crate::trace::probes::TraceProbeConfig;
-use crate::{ExtensionCapability, ExtensionExecutionContext, RunnerOutput};
+use crate::extension::trace::attach::TraceAttachment;
+use crate::extension::trace::canonicality::TraceCanonicalPolicy;
+use crate::extension::trace::generic_runner::{
+    discover_generic_trace_workloads, trace_workload_scenario_id,
+};
+use crate::extension::trace::overlay::{apply_trace_overlays, TraceOverlayRequest};
+use crate::extension::trace::probes::TraceProbeConfig;
+use crate::extension::{ExtensionCapability, ExtensionExecutionContext, RunnerOutput};
 use homeboy_core::component::{Component, ScopedExtensionConfig};
 use homeboy_core::engine::invocation::InvocationRequirements;
 use homeboy_core::engine::run_dir::RunDir;
@@ -111,8 +113,9 @@ JSON
             ignore_baseline: true,
             ratchet: false,
         },
-        regression_threshold_percent: crate::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
-        regression_min_delta_ms: crate::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+        regression_threshold_percent:
+            crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+        regression_min_delta_ms: crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
         canonical_policy: TraceCanonicalPolicy::Development,
         checkout_provenance: None,
     };
@@ -183,8 +186,9 @@ JSON
             ignore_baseline: true,
             ratchet: false,
         },
-        regression_threshold_percent: crate::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
-        regression_min_delta_ms: crate::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+        regression_threshold_percent:
+            crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+        regression_min_delta_ms: crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
         canonical_policy: TraceCanonicalPolicy::Development,
         checkout_provenance: None,
     };
@@ -276,8 +280,9 @@ fn test_run_trace_workflow() {
             ignore_baseline: true,
             ratchet: false,
         },
-        regression_threshold_percent: crate::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
-        regression_min_delta_ms: crate::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+        regression_threshold_percent:
+            crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+        regression_min_delta_ms: crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
         canonical_policy: TraceCanonicalPolicy::Development,
         checkout_provenance: None,
     };
@@ -365,8 +370,9 @@ JSON
             ignore_baseline: true,
             ratchet: false,
         },
-        regression_threshold_percent: crate::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
-        regression_min_delta_ms: crate::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+        regression_threshold_percent:
+            crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+        regression_min_delta_ms: crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
         canonical_policy: TraceCanonicalPolicy::Development,
         checkout_provenance: None,
     };
@@ -430,8 +436,9 @@ exit 1
             ignore_baseline: true,
             ratchet: false,
         },
-        regression_threshold_percent: crate::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
-        regression_min_delta_ms: crate::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+        regression_threshold_percent:
+            crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+        regression_min_delta_ms: crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
         canonical_policy: TraceCanonicalPolicy::Development,
         checkout_provenance: None,
     };
@@ -524,8 +531,9 @@ JSON
                 ratchet: false,
             },
             regression_threshold_percent:
-                crate::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
-            regression_min_delta_ms: crate::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+                crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+            regression_min_delta_ms:
+                crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
             canonical_policy: TraceCanonicalPolicy::Development,
             checkout_provenance: None,
         },
@@ -656,7 +664,9 @@ fn trace_overlay_run_failure_reverts_patch_and_releases_lock() {
             fs::read_to_string(fixture.component_dir.join("scenario.txt")).unwrap(),
             "base\n"
         );
-        assert!(crate::trace::list_trace_overlay_locks().unwrap().is_empty());
+        assert!(crate::extension::trace::list_trace_overlay_locks()
+            .unwrap()
+            .is_empty());
         run_dir.cleanup();
     });
 }
@@ -714,8 +724,9 @@ fn overlay_fixture(keep_overlay: bool) -> OverlayFixture {
             ignore_baseline: true,
             ratchet: false,
         },
-        regression_threshold_percent: crate::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
-        regression_min_delta_ms: crate::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+        regression_threshold_percent:
+            crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+        regression_min_delta_ms: crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
         canonical_policy: TraceCanonicalPolicy::Development,
         checkout_provenance: None,
     };

--- a/crates/homeboy-core/src/extension/trace/run/tests/workflow.rs
+++ b/crates/homeboy-core/src/extension/trace/run/tests/workflow.rs
@@ -4,11 +4,11 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::process::Command;
 
-use crate::trace::attach::TraceAttachment;
-use crate::trace::canonicality::TraceCanonicalPolicy;
-use crate::trace::parsing::{TraceGitProvenance, TraceResults, TraceStatus};
-use crate::trace::probes::TraceProbeConfig;
-use crate::{ExtensionCapability, ExtensionExecutionContext, RunnerOutput};
+use crate::extension::trace::attach::TraceAttachment;
+use crate::extension::trace::canonicality::TraceCanonicalPolicy;
+use crate::extension::trace::parsing::{TraceGitProvenance, TraceResults, TraceStatus};
+use crate::extension::trace::probes::TraceProbeConfig;
+use crate::extension::{ExtensionCapability, ExtensionExecutionContext, RunnerOutput};
 use homeboy_core::component::Component;
 use homeboy_core::engine::run_dir::RunDir;
 use homeboy_core::error::{Error, ErrorCode};
@@ -235,8 +235,10 @@ fn resolve_trace_baseline_root_with_rig_uses_rig_state_dir_and_skips_component_p
 
 #[test]
 fn rig_save_baseline_does_not_write_component_homeboy_json() {
-    use crate::trace::baseline;
-    use crate::trace::parsing::{TraceResults, TraceSpanResult, TraceSpanStatus, TraceStatus};
+    use crate::extension::trace::baseline;
+    use crate::extension::trace::parsing::{
+        TraceResults, TraceSpanResult, TraceSpanStatus, TraceStatus,
+    };
 
     let temp = tempfile::tempdir().unwrap();
     let component_path = temp.path().to_string_lossy().to_string();
@@ -535,8 +537,9 @@ fn test_run_args(path: &std::path::Path) -> TraceRunWorkflowArgs {
             ignore_baseline: true,
             ratchet: false,
         },
-        regression_threshold_percent: crate::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
-        regression_min_delta_ms: crate::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
+        regression_threshold_percent:
+            crate::extension::trace::baseline::DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+        regression_min_delta_ms: crate::extension::trace::baseline::DEFAULT_REGRESSION_MIN_DELTA_MS,
         canonical_policy: TraceCanonicalPolicy::Development,
         checkout_provenance: None,
     }

--- a/crates/homeboy-core/src/extension/trace/run/types.rs
+++ b/crates/homeboy-core/src/extension/trace/run/types.rs
@@ -3,7 +3,7 @@
 use serde::Serialize;
 use std::path::PathBuf;
 
-use crate::trace::baseline::TraceBaselineComparison;
+use crate::extension::trace::baseline::TraceBaselineComparison;
 use homeboy_core::engine::invocation::InvocationRequirements;
 use homeboy_engine_primitives::baseline::BaselineFlags;
 use homeboy_extension_contract::TraceDependencySpec;

--- a/crates/homeboy-core/src/extension/trace/run/workflow.rs
+++ b/crates/homeboy-core/src/extension/trace/run/workflow.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 use std::time::Instant;
 
-use crate::{
+use crate::extension::{
     resolve_execution_context, stderr_tail, ExtensionCapability, ExtensionExecutionContext,
 };
 use homeboy_core::component::Component;
@@ -97,7 +97,7 @@ fn run_trace_workflow_with_component_script(
         ("HOMEBOY_TRACE_LIST_ONLY".to_string(), "0".to_string()),
     ];
     script_env.extend(args.runner_inputs.env.clone());
-    let script_output = crate::component_script::run_component_scripts_with_run_dir(
+    let script_output = crate::extension::component_script::run_component_scripts_with_run_dir(
         component,
         ExtensionCapability::Trace,
         source_path,

--- a/crates/homeboy-core/src/extension/trace/spans.rs
+++ b/crates/homeboy-core/src/extension/trace/spans.rs
@@ -50,7 +50,7 @@ pub(crate) fn event_matches_key(event: &TraceEvent, key: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::trace::parsing::{TraceAssertion, TraceSpanStatus, TraceStatus};
+    use crate::extension::trace::parsing::{TraceAssertion, TraceSpanStatus, TraceStatus};
 
     fn event(t_ms: u64, source: &str, event: &str) -> TraceEvent {
         TraceEvent {

--- a/crates/homeboy-core/src/extension/update_check.rs
+++ b/crates/homeboy-core/src/extension/update_check.rs
@@ -13,7 +13,7 @@
 //! [`homeboy_core::update_check_cache`]. The on-disk filename and JSON
 //! schema live here and are unchanged.
 
-use crate as extension;
+use crate::extension;
 use homeboy_core::update_check_cache;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/crates/homeboy-core/src/extension/validation.rs
+++ b/crates/homeboy-core/src/extension/validation.rs
@@ -280,7 +280,7 @@ mod tests {
             // requirement because dev iteration may lag the published constraint.
             let source = home.join("source/wordpress");
             write_extension_manifest(&source, "wordpress", "1.0.0");
-            crate::install(&source.to_string_lossy(), Some("wordpress"))
+            crate::extension::install(&source.to_string_lossy(), Some("wordpress"))
                 .expect("install linked extension");
             assert!(super::is_extension_linked("wordpress"));
 

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -102,7 +102,6 @@ pub mod execution;
 pub mod execution_contract;
 pub mod expand;
 pub mod extension;
-pub use extension::*;
 pub mod extension_execution;
 pub mod extension_invocation_context;
 pub mod extension_provider_discovery;

--- a/crates/homeboy-deploy/src/execution/preflight.rs
+++ b/crates/homeboy-deploy/src/execution/preflight.rs
@@ -1,8 +1,8 @@
 use std::path::{Path, PathBuf};
 
-use homeboy_core::build::resolve_artifact_path_from_root;
 use homeboy_core::component::Component;
 use homeboy_core::engine::command;
+use homeboy_core::extension::build::resolve_artifact_path_from_root;
 use homeboy_version::version;
 
 use super::super::types::{ComponentDeployResult, DeployConfig};

--- a/crates/homeboy-deploy/src/execution/prepare.rs
+++ b/crates/homeboy-deploy/src/execution/prepare.rs
@@ -1,8 +1,8 @@
 use std::path::{Path, PathBuf};
 
-use homeboy_core::build;
 use homeboy_core::component::Component;
 use homeboy_core::context::RemoteProjectContext;
+use homeboy_core::extension::build;
 use homeboy_core::project::Project;
 
 use super::super::generated_artifacts::GeneratedBuildArtifactCleanupGuard;

--- a/crates/homeboy-deploy/src/execution/strategies.rs
+++ b/crates/homeboy-deploy/src/execution/strategies.rs
@@ -561,7 +561,7 @@ fn cleanup_build_dependencies(
     let mut cleanup_paths = Vec::new();
     if let Some(ref extensions) = component.extensions {
         for extension_id in extensions.keys() {
-            if let Ok(manifest) = homeboy_core::load_extension(extension_id) {
+            if let Ok(manifest) = homeboy_core::extension::load_extension(extension_id) {
                 if let Some(ref build) = manifest.build {
                     cleanup_paths.extend(build.cleanup_paths.iter().cloned());
                 }

--- a/crates/homeboy-deploy/src/lib.rs
+++ b/crates/homeboy-deploy/src/lib.rs
@@ -799,10 +799,10 @@ pub fn resolve_shared_targets(component_ids: &[String]) -> Result<Vec<String>> {
 mod tests {
     use super::*;
     use homeboy_core::component::{Component, ScopedExtensionConfig};
+    use homeboy_core::extension::{DeployCapability, ExtensionManifest, RemotePathRootRule};
     use homeboy_core::project::{Project, ProjectComponentAttachment};
     use homeboy_core::server::{self, Server};
     use homeboy_core::test_support::with_isolated_home;
-    use homeboy_core::{DeployCapability, ExtensionManifest, RemotePathRootRule};
     use std::collections::{BTreeMap, HashMap};
     use std::path::Path;
 
@@ -963,7 +963,7 @@ mod tests {
             let base_path = home.path().join("runtime");
             std::fs::create_dir_all(&base_path).expect("runtime root");
             let managed_root = base_path.join("wp-content");
-            homeboy_core::save_manifest(&ExtensionManifest {
+            homeboy_core::extension::save_manifest(&ExtensionManifest {
                 id: "managed-paths".to_string(),
                 name: "Managed Paths".to_string(),
                 version: "1.0.0".to_string(),

--- a/crates/homeboy-deploy/src/orchestration/mod.rs
+++ b/crates/homeboy-deploy/src/orchestration/mod.rs
@@ -2817,7 +2817,8 @@ mod tests {
             config.force = true;
             config.head = true;
 
-            let (build_exit_code, build_error) = homeboy_core::build::build_component(&component);
+            let (build_exit_code, build_error) =
+                homeboy_core::extension::build::build_component(&component);
             assert_eq!(build_exit_code, Some(42));
             assert!(
                 build_error.is_some(),

--- a/crates/homeboy-deploy/src/policy.rs
+++ b/crates/homeboy-deploy/src/policy.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use homeboy_core::component::Component;
 use homeboy_core::error::{Error, Result};
-use homeboy_core::{DeployCapability, ExtensionManifest};
+use homeboy_core::extension::{DeployCapability, ExtensionManifest};
 
 /// Framework-neutral shared directory names that typically contain sibling components.
 const GENERIC_PROTECTED_PATH_SUFFIXES: &[&str] =

--- a/crates/homeboy-deploy/src/preparation.rs
+++ b/crates/homeboy-deploy/src/preparation.rs
@@ -404,7 +404,8 @@ fn prepare_payload(
     let mut generated_source_artifact = None;
     if release_artifact.is_none() && !request.config.skip_build {
         let cleanup = GeneratedSourceArtifactCleanup::new(&component)?;
-        let (build_exit_code, build_error) = homeboy_core::build::build_component(&component);
+        let (build_exit_code, build_error) =
+            homeboy_core::extension::build::build_component(&component);
         if let Some(message) = build_error {
             let mut error = Error::validation_invalid_argument(
                 "build",
@@ -549,7 +550,7 @@ fn copy_prepared_artifact(source: &Path) -> Result<(PathBuf, PreparedArtifactCle
 
 fn artifact_path(component: &Component) -> Result<PathBuf> {
     let artifact = artifact_pattern(component)?;
-    homeboy_core::build::resolve_artifact_path_from_root(
+    homeboy_core::extension::build::resolve_artifact_path_from_root(
         &artifact,
         Some(Path::new(&component.local_path)),
     )

--- a/crates/homeboy-deploy/src/provider.rs
+++ b/crates/homeboy-deploy/src/provider.rs
@@ -194,13 +194,15 @@ fn run_component(
             }),
         )
     })?;
-    let layered = homeboy_core::deployment_provider_layered_input(
+    let layered = homeboy_core::extension::deployment_provider_layered_input(
         &attachment.extension,
         &attachment.provider,
     )?;
     let target_input = project_attachment.deployment_provider_input.as_ref();
     let layered = match layered {
-        Some(layered) if layered.schema == homeboy_core::DEPLOYMENT_PROVIDER_PAYLOAD_SCHEMA => {
+        Some(layered)
+            if layered.schema == homeboy_core::extension::DEPLOYMENT_PROVIDER_PAYLOAD_SCHEMA =>
+        {
             Some(layered)
         }
         Some(_) => {
@@ -272,7 +274,7 @@ fn run_component(
             attachment.policy.as_ref().expect("validated inline policy"),
             target_input,
         )?;
-        homeboy_core::run_deployment_provider(
+        homeboy_core::extension::run_deployment_provider(
             &attachment.extension,
             &attachment.provider,
             project_id,
@@ -289,7 +291,7 @@ fn run_component(
                 .as_deref()
                 .expect("validated legacy contract"),
         )?;
-        homeboy_core::run_deployment_provider(
+        homeboy_core::extension::run_deployment_provider(
             &attachment.extension,
             &attachment.provider,
             project_id,
@@ -387,7 +389,7 @@ fn layered_payload(
         .map_err(|error| Error::from_json_error(&error, Some(ENCODE_POLICY_CONTEXT.to_string())))?;
     let revision = clean_head_revision(component)?;
     let payload = serde_json::json!({
-        "schema": homeboy_core::DEPLOYMENT_PROVIDER_PAYLOAD_SCHEMA,
+        "schema": homeboy_core::extension::DEPLOYMENT_PROVIDER_PAYLOAD_SCHEMA,
         "policy": {
             "value": policy,
             "reference": {

--- a/crates/homeboy-deploy/src/safety_and_artifact.rs
+++ b/crates/homeboy-deploy/src/safety_and_artifact.rs
@@ -8,8 +8,8 @@ use homeboy_core::defaults;
 use homeboy_core::engine::shell;
 use homeboy_core::engine::template::{render_map, TemplateVars};
 use homeboy_core::error::{Error, Result};
+use homeboy_core::extension::DeployVerification;
 use homeboy_core::server::SshClient;
-use homeboy_core::DeployVerification;
 
 use super::transfer::{upload_directory, upload_file};
 use super::types::{DeployEffect, DeployResult};
@@ -492,9 +492,9 @@ mod tests {
         remote_basename, render_extract_command, DANGEROUS_PATH_SUFFIXES,
     };
     use crate::lifecycle::DeployObservation;
+    use homeboy_core::extension::DeployVerification;
     use homeboy_core::observation::ObservationStore;
     use homeboy_core::server::SshClient;
-    use homeboy_core::DeployVerification;
     use std::collections::HashMap;
     use std::collections::HashSet;
     use std::fs;

--- a/crates/homeboy-deploy/src/types.rs
+++ b/crates/homeboy-deploy/src/types.rs
@@ -861,9 +861,9 @@ mod tests {
         DeploymentProvenanceEvidence, PreparedDeployArtifact, ReleaseState, ReleaseStateStatus,
     };
     use homeboy_core::component::{Component, ScopedExtensionConfig};
+    use homeboy_core::extension::{DeployCapability, ExtensionManifest, RemotePathRootRule};
     use homeboy_core::project::Project;
     use homeboy_core::test_support::with_isolated_home;
-    use homeboy_core::{DeployCapability, ExtensionManifest, RemotePathRootRule};
     use std::collections::HashMap;
 
     fn component() -> Component {
@@ -885,7 +885,7 @@ mod tests {
     }
 
     fn install_wordpress_extension() {
-        homeboy_core::save_manifest(&ExtensionManifest {
+        homeboy_core::extension::save_manifest(&ExtensionManifest {
             id: "wordpress".to_string(),
             name: "WordPress".to_string(),
             version: "1.0.0".to_string(),

--- a/crates/homeboy-deploy/src/version_overrides.rs
+++ b/crates/homeboy-deploy/src/version_overrides.rs
@@ -9,13 +9,13 @@ use homeboy_core::engine::hooks::{self, HookFailureMode};
 use homeboy_core::engine::shell;
 use homeboy_core::engine::template::{render_map, TemplateVars};
 use homeboy_core::error::{Error, Result};
-use homeboy_core::paths as base_path;
-use homeboy_core::project::Project;
-use homeboy_core::server::SshClient;
-use homeboy_core::{
+use homeboy_core::extension::{
     load_all_extensions, DeployArchiveInstallPolicy, DeployOverride, DeployVerification,
     ExtensionManifest,
 };
+use homeboy_core::paths as base_path;
+use homeboy_core::project::Project;
+use homeboy_core::server::SshClient;
 use homeboy_extension_contract::HookEvent;
 use homeboy_version::version;
 
@@ -841,11 +841,11 @@ pub(super) fn run_post_deploy_hooks(
 mod tests {
     use super::*;
     use homeboy_core::component::VersionTarget;
-    use homeboy_core::server::SshClient;
-    use homeboy_core::{
+    use homeboy_core::extension::{
         DeployArchiveInstallPolicy, DeployOverride, DeployRequiredHeader, DeployVerification,
         ExtensionManifest,
     };
+    use homeboy_core::server::SshClient;
     use std::collections::HashMap;
     use std::fs;
     use std::io::Write;

--- a/crates/homeboy-lab-runner/src/daemon_exec_driver.rs
+++ b/crates/homeboy-lab-runner/src/daemon_exec_driver.rs
@@ -60,7 +60,7 @@ impl RunnerExecDriver for RunnerDaemonExecDriver {
         let provider_secret_names = request
             .extension_env_providers
             .iter()
-            .map(|id| homeboy_core::env_provider_secret_names(id))
+            .map(|id| homeboy_core::extension::env_provider_secret_names(id))
             .collect::<Result<Vec<_>>>()?
             .into_iter()
             .flatten()

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -201,9 +201,14 @@ pub(crate) fn resolve_provider_env_with_execution_context(
     cwd: &std::path::Path,
     env: &HashMap<String, String>,
     explicit_run_id: Option<&str>,
-) -> Result<Vec<homeboy_core::EnvProviderContribution>> {
+) -> Result<Vec<homeboy_core::extension::EnvProviderContribution>> {
     let env = provider_resolution_env(env, explicit_run_id);
-    homeboy_core::resolve_installed_env_providers(execution_context, provider_ids, cwd, &env)
+    homeboy_core::extension::resolve_installed_env_providers(
+        execution_context,
+        provider_ids,
+        cwd,
+        &env,
+    )
 }
 
 /// Environment visible to extension providers before they contribute their
@@ -566,7 +571,7 @@ fn extension_provenance(required_extensions: &[String]) -> Vec<ExtensionProvenan
     let mut extensions = required_extensions
         .iter()
         .filter_map(|extension_id| {
-            let manifest = homeboy_core::load_extension(extension_id).ok()?;
+            let manifest = homeboy_core::extension::load_extension(extension_id).ok()?;
             let path = manifest.extension_path.clone().unwrap_or_else(|| {
                 homeboy_core::paths::extension(extension_id)
                     .map(|path| path.display().to_string())
@@ -579,7 +584,7 @@ fn extension_provenance(required_extensions: &[String]) -> Vec<ExtensionProvenan
             Some(ExtensionProvenance {
                 extension_id: extension_id.clone(),
                 path,
-                install_mode: if homeboy_core::is_extension_linked(extension_id) {
+                install_mode: if homeboy_core::extension::is_extension_linked(extension_id) {
                     "linked".to_string()
                 } else {
                     "copied".to_string()
@@ -972,7 +977,7 @@ fn exec_with_status_snapshot_attempt(
         let provider_secret_names = options
             .extension_env_providers
             .iter()
-            .map(|id| homeboy_core::env_provider_secret_names(id))
+            .map(|id| homeboy_core::extension::env_provider_secret_names(id))
             .collect::<Result<Vec<_>>>()?
             .into_iter()
             .flatten()

--- a/crates/homeboy-lab-runner/src/execution/tests/daemon_exec.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/daemon_exec.rs
@@ -188,7 +188,7 @@ fn daemon_exec_injects_extension_env_and_redacts_provider_secret() {
         )
         .expect("provider executable");
     }
-    homeboy_core::install(&extension.path().display().to_string(), Some("fixture"))
+    homeboy_core::extension::install(&extension.path().display().to_string(), Some("fixture"))
         .expect("install fixture extension");
     let store = JobStore::default();
     let response = route_with_body(

--- a/crates/homeboy-lab-runner/src/execution/tests/exec.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/exec.rs
@@ -1289,7 +1289,7 @@ fn runner_exec_explicit_run_id_overrides_conflicting_run_id_env() {
             std::fs::set_permissions(&provider, std::fs::Permissions::from_mode(0o755))
                 .expect("provider executable");
         }
-        homeboy_core::install(&extension.path().display().to_string(), Some("fixture"))
+        homeboy_core::extension::install(&extension.path().display().to_string(), Some("fixture"))
             .expect("install provider fixture");
 
         let (output, exit_code) = exec(

--- a/crates/homeboy-lab-runner/src/execution/worker.rs
+++ b/crates/homeboy-lab-runner/src/execution/worker.rs
@@ -62,7 +62,7 @@ pub(super) fn exec_worker_local_with_process_output(
     let provider_secret_names = options
         .extension_env_providers
         .iter()
-        .map(|id| homeboy_core::env_provider_secret_names(id))
+        .map(|id| homeboy_core::extension::env_provider_secret_names(id))
         .collect::<Result<Vec<_>>>()?
         .into_iter()
         .flatten()

--- a/crates/homeboy-lab-runner/src/extension_materialization.rs
+++ b/crates/homeboy-lab-runner/src/extension_materialization.rs
@@ -1275,7 +1275,7 @@ mod tests {
                 "#!/bin/sh\nset -eu\nexec node --test \"$1\"\n",
             )
             .expect("shared node runner");
-            homeboy_core::install(&nodejs.display().to_string(), Some("nodejs"))
+            homeboy_core::extension::install(&nodejs.display().to_string(), Some("nodejs"))
                 .expect("install linked nodejs extension");
 
             let runner_root = tempfile::tempdir().expect("runner root");

--- a/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
@@ -135,7 +135,7 @@ fn runner_manifest_preflight_with_executor(
         let Some(requires_homeboy) = requires_homeboy else {
             continue;
         };
-        match homeboy_core::evaluate_core_compatibility_for_version(
+        match homeboy_core::extension::evaluate_core_compatibility_for_version(
             Some(&requires_homeboy),
             None,
             candidate_version,

--- a/crates/homeboy-lab-runner/src/validation_dependencies.rs
+++ b/crates/homeboy-lab-runner/src/validation_dependencies.rs
@@ -472,8 +472,8 @@ mod tests {
             // extension subsystem, which registers its runners at binary startup.
             // Register them explicitly here so this test does not depend on a
             // sibling test having populated the process-global runner slots.
-            homeboy_core::component_script::register_component_script_runner();
-            homeboy_core::build::register_component_build_runner();
+            homeboy_core::extension::component_script::register_component_script_runner();
+            homeboy_core::extension::build::register_component_build_runner();
             let workspace_parent = tempfile::tempdir().expect("workspace parent");
             let source = workspace_parent.path().join("host-app");
             let dependency = workspace_parent.path().join("shared-runtime");
@@ -556,8 +556,8 @@ mod tests {
         homeboy_core::test_support::with_isolated_home(|_| {
             // Register the extension runners this dependency lifecycle needs (see
             // the sibling test above) rather than relying on cross-test global state.
-            homeboy_core::component_script::register_component_script_runner();
-            homeboy_core::build::register_component_build_runner();
+            homeboy_core::extension::component_script::register_component_script_runner();
+            homeboy_core::extension::build::register_component_build_runner();
             let workspace_parent = tempfile::tempdir().expect("workspace parent");
             let source = workspace_parent.path().join("host-app");
             let dependency = workspace_parent.path().join("shared-runtime");

--- a/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
@@ -814,7 +814,7 @@ fn reverse_worker_injects_lifecycle_run_id_into_claimed_job_env() {
             std::fs::set_permissions(&provider, std::fs::Permissions::from_mode(0o755))
                 .expect("provider executable");
         }
-        homeboy_core::install(&extension.path().display().to_string(), Some("fixture"))
+        homeboy_core::extension::install(&extension.path().display().to_string(), Some("fixture"))
             .expect("install provider fixture");
         let store = JobStore::default();
         let mut request = run_id_echo_request();

--- a/crates/homeboy-lab-runner/src/workspace/tests/git.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/git.rs
@@ -764,7 +764,7 @@ fn git_sync_of_detached_extension_source_preserves_source_revision() {
             "HEAD"
         );
 
-        let install = homeboy_core::install(
+        let install = homeboy_core::extension::install(
             &remote.join("wordpress").display().to_string(),
             Some("wordpress"),
         )

--- a/crates/homeboy-refactor/src/auto/apply.rs
+++ b/crates/homeboy-refactor/src/auto/apply.rs
@@ -3,7 +3,7 @@ use crate::plan::verify::rewrite_callers_after_dedup;
 use crate::auto::verify::{applied_files_from_chunks, capture_pre_apply_snapshot, run_verify_gate};
 use crate::auto::{ApplyChunkResult, ChunkStatus, Fix, NewFile};
 use homeboy_core::engine::undo::InMemoryRollback;
-use homeboy_core::AutofixVerifyConfig;
+use homeboy_core::extension::AutofixVerifyConfig;
 use std::path::Path;
 
 // ============================================================================

--- a/crates/homeboy-refactor/src/auto/verify.rs
+++ b/crates/homeboy-refactor/src/auto/verify.rs
@@ -34,7 +34,7 @@
 
 use crate::auto::{ApplyChunkResult, ChunkStatus};
 use homeboy_core::engine::undo::InMemoryRollback;
-use homeboy_core::AutofixVerifyConfig;
+use homeboy_core::extension::AutofixVerifyConfig;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};

--- a/crates/homeboy-refactor/src/decompose.rs
+++ b/crates/homeboy-refactor/src/decompose.rs
@@ -6,7 +6,10 @@ use serde::{Deserialize, Serialize};
 
 use homeboy_core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanValues};
 use homeboy_core::Result;
-use homeboy_core::{self, grammar, grammar_items, ParsedItem};
+use homeboy_core::{
+    self,
+    extension::{grammar, grammar_items, ParsedItem},
+};
 
 use super::move_items::{MoveOptions, MoveResult};
 
@@ -550,7 +553,7 @@ fn public_items_for_group(plan: &DecomposePlan, group: &DecomposeGroup) -> Vec<S
 }
 
 fn parse_items_for_group_export(ext: &str, content: &str, file: &str) -> Option<Vec<ParsedItem>> {
-    let manifest = homeboy_core::find_extension_for_file_ext(ext, "refactor")?;
+    let manifest = homeboy_core::extension::find_extension_for_file_ext(ext, "refactor")?;
     crate::move_items::ext_parse_items(&manifest, content, file)
         .or_else(|| crate::move_items::core_parse_items(&manifest, content))
 }

--- a/crates/homeboy-refactor/src/decompose/grouping.rs
+++ b/crates/homeboy-refactor/src/decompose/grouping.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use homeboy_core::ParsedItem;
+use homeboy_core::extension::ParsedItem;
 
 use super::DecomposeGroup;
 

--- a/crates/homeboy-refactor/src/move_items.rs
+++ b/crates/homeboy-refactor/src/move_items.rs
@@ -31,7 +31,8 @@ use homeboy_core::engine::codebase_scan::{self, ExtensionFilter, ScanConfig};
 use homeboy_core::engine::symbol_graph::module_path_from_file;
 use homeboy_core::Result;
 use homeboy_core::{
-    self, AdjustedItem, ExtensionManifest, ParsedItem, RelatedTests, ResolvedImports,
+    self,
+    extension::{AdjustedItem, ExtensionManifest, ParsedItem, RelatedTests, ResolvedImports},
 };
 
 impl ItemKind {

--- a/crates/homeboy-refactor/src/move_items/extension_integration.rs
+++ b/crates/homeboy-refactor/src/move_items/extension_integration.rs
@@ -3,7 +3,10 @@
 use homeboy_core::extension;
 use std::path::Path;
 
-use homeboy_core::{self, grammar, grammar_items, ExtensionManifest, ParsedItem};
+use homeboy_core::{
+    self,
+    extension::{grammar, grammar_items, ExtensionManifest, ParsedItem},
+};
 
 /// Find a refactor-capable extension for a file based on its extension.
 pub(crate) fn find_refactor_extension(file_path: &str) -> Option<ExtensionManifest> {

--- a/crates/homeboy-refactor/src/plan/generate/compiler_warning_fixes.rs
+++ b/crates/homeboy-refactor/src/plan/generate/compiler_warning_fixes.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use super::{tagged_line_replacement, tagged_range_removal};
 use crate::auto::{Fix, RefactorPrimitive, SkippedFile};
 use homeboy_code_audit::{AuditFinding, CodeAuditResult};
-use homeboy_core::{
+use homeboy_core::extension::{
     extensions_for_compiler_warning_contract, run_compiler_warning_contract_script,
     CompilerWarningContract, ExtensionManifest,
 };

--- a/crates/homeboy-refactor/src/plan/generate/duplicate_fixes.rs
+++ b/crates/homeboy-refactor/src/plan/generate/duplicate_fixes.rs
@@ -341,7 +341,7 @@ pub(crate) fn generate_duplicate_function_fixes(
         };
 
         let manifest = if use_extract_shared {
-            homeboy_core::find_extension_for_file_ext(ext, "refactor")
+            homeboy_core::extension::find_extension_for_file_ext(ext, "refactor")
         } else {
             None
         };
@@ -391,7 +391,9 @@ pub(crate) fn generate_duplicate_function_fixes(
             "project_root": root.to_string_lossy(),
         });
 
-        let Some(result_val) = homeboy_core::run_refactor_script(&manifest, &extract_cmd) else {
+        let Some(result_val) =
+            homeboy_core::extension::run_refactor_script(&manifest, &extract_cmd)
+        else {
             generate_simple_duplicate_fixes(group, root, module_surfaces, fixes, skipped);
             continue;
         };

--- a/crates/homeboy-refactor/src/plan/generate/orphaned_test_fixes.rs
+++ b/crates/homeboy-refactor/src/plan/generate/orphaned_test_fixes.rs
@@ -128,7 +128,9 @@ fn lines_inside_string_literals(lines: &[&str]) -> Vec<bool> {
         let line = lines[i];
 
         // Check for raw string opening: r#"  r##"  r###" etc.
-        if let Some(close_pattern) = homeboy_core::grammar::find_unclosed_raw_string_on_line(line) {
+        if let Some(close_pattern) =
+            homeboy_core::extension::grammar::find_unclosed_raw_string_on_line(line)
+        {
             // Mark subsequent lines as inside the string until we find the close.
             let mut j = i + 1;
             while j < lines.len() {
@@ -228,7 +230,9 @@ fn find_test_function_range(content: &str, fn_name: &str) -> Option<(usize, usiz
         }
 
         // Check if this line opens a raw string that isn't closed on the same line.
-        if let Some(close_pattern) = homeboy_core::grammar::find_unclosed_raw_string_on_line(line) {
+        if let Some(close_pattern) =
+            homeboy_core::extension::grammar::find_unclosed_raw_string_on_line(line)
+        {
             raw_string_close = Some(close_pattern);
             // Still count braces on this line BEFORE the raw string opens.
             // The opening line may have `let x = r#"` preceded by real braces.

--- a/crates/homeboy-refactor/src/plan/generate/signatures.rs
+++ b/crates/homeboy-refactor/src/plan/generate/signatures.rs
@@ -79,9 +79,9 @@ fn normalize_item_name(name: &str) -> String {
 }
 
 pub(crate) fn find_parsed_item_by_name<'a>(
-    items: &'a [homeboy_core::ParsedItem],
+    items: &'a [homeboy_core::extension::ParsedItem],
     requested_name: &str,
-) -> Option<&'a homeboy_core::ParsedItem> {
+) -> Option<&'a homeboy_core::extension::ParsedItem> {
     if let Some(exact) = items.iter().find(|item| item.name == requested_name) {
         return Some(exact);
     }
@@ -122,20 +122,20 @@ pub(crate) fn parse_items_for_dedup(
     file_ext: &str,
     content: &str,
     file_path: &str,
-) -> Option<Vec<homeboy_core::ParsedItem>> {
+) -> Option<Vec<homeboy_core::extension::ParsedItem>> {
     if let Some(grammar) = homeboy_code_audit::core_fingerprint::load_grammar_for_ext(file_ext) {
-        let items = homeboy_core::grammar_items::parse_items(content, &grammar);
+        let items = homeboy_core::extension::grammar_items::parse_items(content, &grammar);
         if !items.is_empty() {
             return Some(
                 items
                     .into_iter()
-                    .map(homeboy_core::ParsedItem::from)
+                    .map(homeboy_core::extension::ParsedItem::from)
                     .collect(),
             );
         }
     }
 
-    let manifest = homeboy_core::find_extension_for_file_ext(file_ext, "refactor")?;
+    let manifest = homeboy_core::extension::find_extension_for_file_ext(file_ext, "refactor")?;
     let parse_cmd = serde_json::json!({
         "command": "parse_items",
         "file_path": file_path,
@@ -143,7 +143,7 @@ pub(crate) fn parse_items_for_dedup(
         "items": [],
     });
 
-    homeboy_core::run_refactor_script(&manifest, &parse_cmd)
+    homeboy_core::extension::run_refactor_script(&manifest, &parse_cmd)
         .and_then(|value| value.get("items").cloned())
         .and_then(|value| serde_json::from_value(value).ok())
 }

--- a/crates/homeboy-refactor/src/plan/sources.rs
+++ b/crates/homeboy-refactor/src/plan/sources.rs
@@ -2,8 +2,8 @@ use crate::auto::FixResultsSummary;
 use homeboy_core::component::Component;
 use homeboy_core::engine::run_dir::RunDir;
 use homeboy_core::engine::undo::UndoSnapshot;
+use homeboy_core::extension::test::compute_changed_test_files;
 use homeboy_core::git;
-use homeboy_core::test::compute_changed_test_files;
 use homeboy_core::Error;
 use serde::Serialize;
 use std::collections::HashSet;
@@ -101,7 +101,7 @@ pub struct LintSourceOptions {
     pub summary: bool,
     pub file: Option<String>,
     pub glob: Option<String>,
-    pub sniff_filters: homeboy_core::lint::LintSniffFilters,
+    pub sniff_filters: homeboy_core::extension::lint::LintSniffFilters,
     pub category: Option<String>,
 }
 

--- a/crates/homeboy-refactor/src/plan/sources/stages.rs
+++ b/crates/homeboy-refactor/src/plan/sources/stages.rs
@@ -396,7 +396,8 @@ pub(super) fn run_lint_stage(
             runner.run()?;
         }
 
-        homeboy_core::lint::baseline::parse_findings_file(&findings_file).unwrap_or_default()
+        homeboy_core::extension::lint::baseline::parse_findings_file(&findings_file)
+            .unwrap_or_default()
     };
 
     let lint_source_result = serde_json::json!({
@@ -524,7 +525,8 @@ pub(super) fn run_lint_stage(
         } else {
             runner.run()?;
         }
-        let remaining_findings = homeboy_core::lint::baseline::parse_findings_file(&findings_file)?;
+        let remaining_findings =
+            homeboy_core::extension::lint::baseline::parse_findings_file(&findings_file)?;
         reject_remaining_lint_fix_findings(&remaining_findings)?;
 
         let fix_results = fix_sidecars.consume_fix_results();

--- a/crates/homeboy-refactor/src/plan/verify.rs
+++ b/crates/homeboy-refactor/src/plan/verify.rs
@@ -134,7 +134,9 @@ pub(crate) fn run_audit_refactor(
     })
 }
 
-fn resolve_verify_config(component_id: &str) -> Option<homeboy_core::AutofixVerifyConfig> {
+fn resolve_verify_config(
+    component_id: &str,
+) -> Option<homeboy_core::extension::AutofixVerifyConfig> {
     use homeboy_core::component;
 
     let comp = component::load(component_id).ok()?;

--- a/crates/homeboy-release/src/release/context.rs
+++ b/crates/homeboy-release/src/release/context.rs
@@ -1,7 +1,7 @@
 use homeboy_core::component::{self, Component};
 use homeboy_core::error::{Error, ErrorCode, Result};
 use homeboy_core::extension;
-use homeboy_core::{self, ExtensionManifest};
+use homeboy_core::{self, extension::ExtensionManifest};
 
 use super::types::{ReleaseOptions, ReleaseReadinessProvenance};
 

--- a/crates/homeboy-release/src/release/execution_dispatch.rs
+++ b/crates/homeboy-release/src/release/execution_dispatch.rs
@@ -2,9 +2,9 @@ use crate::release::executor;
 use crate::release::types::{ReleaseOptions, ReleaseState, ReleaseStepResult, ReleaseStepStatus};
 use homeboy_core::component::Component;
 use homeboy_core::error::{Error, Result};
+use homeboy_core::extension::ExtensionManifest;
 use homeboy_core::git;
 use homeboy_core::plan::{PlanStep, PlanStepStatus};
-use homeboy_core::ExtensionManifest;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 use std::process::Command;
@@ -1051,8 +1051,8 @@ mod tests {
     };
     use homeboy_core::component::{Component, ComponentScriptsConfig, VersionTarget};
     use homeboy_core::deps::{DependencyCommandResult, DependencyInstallResult};
+    use homeboy_core::extension::ExtensionManifest;
     use homeboy_core::plan::PlanStep;
-    use homeboy_core::ExtensionManifest;
 
     #[test]
     fn test_release_step_is_plan_only() {
@@ -1114,7 +1114,7 @@ mod tests {
             }))
             .expect("extension manifest");
             extension.id = "registry".to_string();
-            homeboy_core::save_manifest(&extension).expect("save extension manifest");
+            homeboy_core::extension::save_manifest(&extension).expect("save extension manifest");
             let component = Component {
                 id: "fixture".to_string(),
                 local_path: component_path.path().to_string_lossy().to_string(),
@@ -1166,7 +1166,7 @@ mod tests {
                  printf '[{{\"path\":\"build/fixture.zip\",\"type\":\"archive\"}}]'",
                 counter = counter.display(),
             ));
-            homeboy_core::save_manifest(&package).expect("save package extension");
+            homeboy_core::extension::save_manifest(&package).expect("save package extension");
 
             let component = Component {
                 id: "fixture".to_string(),
@@ -1230,7 +1230,7 @@ mod tests {
                 "printf '9.9.9\n' > VERSION; printf artifact > fixture.zip; \
                  printf '[{\"path\":\"fixture.zip\",\"type\":\"archive\"}]'",
             );
-            homeboy_core::save_manifest(&package).expect("save package extension");
+            homeboy_core::extension::save_manifest(&package).expect("save package extension");
             let component = Component {
                 id: "fixture".to_string(),
                 local_path: repo.path().to_string_lossy().to_string(),
@@ -1292,7 +1292,7 @@ mod tests {
                  printf package > fixture-1.2.3.tgz; \
                  printf '[{\"path\":\"fixture-1.2.3.tgz\",\"type\":\"archive\"}]'",
             );
-            homeboy_core::save_manifest(&package).expect("save package extension");
+            homeboy_core::extension::save_manifest(&package).expect("save package extension");
             let component = Component {
                 id: "fixture".to_string(),
                 local_path: repo.path().to_string_lossy().to_string(),
@@ -1357,7 +1357,7 @@ mod tests {
                 "mkdir -p build; printf diagnostic > build/output; \
                  printf partial > fixture-1.2.3.tgz; printf failed >&2; exit 1",
             );
-            homeboy_core::save_manifest(&package).expect("save package extension");
+            homeboy_core::extension::save_manifest(&package).expect("save package extension");
             let component = Component {
                 id: "fixture".to_string(),
                 local_path: repo.path().to_string_lossy().to_string(),
@@ -1397,7 +1397,7 @@ mod tests {
                  printf partial > fixture-1.2.3.tgz; \
                  printf '[{\"path\":\"fixture-1.2.3.tgz\",\"type\":\"archive\"}]'",
             );
-            homeboy_core::save_manifest(&package).expect("replace package extension");
+            homeboy_core::extension::save_manifest(&package).expect("replace package extension");
             let recovery_extensions = vec![package];
             let mut recovery = ReleaseExecutionContext {
                 component: &component,
@@ -1447,7 +1447,7 @@ mod tests {
             let package = package_extension(
                 "mkdir -p build/stage; cp plugin.php build/stage/plugin.php; (cd build && zip -q fixture.zip stage/plugin.php); printf '[{\"path\":\"build/fixture.zip\",\"type\":\"archive\"}]'",
             );
-            homeboy_core::save_manifest(&package).expect("save package extension");
+            homeboy_core::extension::save_manifest(&package).expect("save package extension");
 
             let component = Component {
                 id: "fixture".to_string(),
@@ -1983,7 +1983,7 @@ mod tests {
     fn extension_declared_release_preflight_executes_action() {
         homeboy_core::test_support::with_isolated_home(|_| {
             let temp = tempfile::tempdir().expect("tempdir");
-            let mut extension: homeboy_core::ExtensionManifest =
+            let mut extension: homeboy_core::extension::ExtensionManifest =
                 serde_json::from_value(serde_json::json!({
                     "name": "Registry",
                     "version": "1.0.0",
@@ -2002,7 +2002,7 @@ mod tests {
                 }))
                 .expect("extension manifest");
             extension.id = "registry".to_string();
-            homeboy_core::save_manifest(&extension).expect("save extension");
+            homeboy_core::extension::save_manifest(&extension).expect("save extension");
 
             let component = Component {
                 id: "fixture".to_string(),

--- a/crates/homeboy-release/src/release/executor.rs
+++ b/crates/homeboy-release/src/release/executor.rs
@@ -556,8 +556,8 @@ mod tests {
     use crate::release::types::ReleaseState;
     use crate::release::types::{ReleaseArtifact, ReleaseStepStatus};
     use homeboy_core::component::{Component, ScopedExtensionConfig};
+    use homeboy_core::extension::ExtensionManifest;
     use homeboy_core::git::release_download::GitHubRepo;
-    use homeboy_core::ExtensionManifest;
     fn test_repo() -> GitHubRepo {
         GitHubRepo {
             host: "github.com".to_string(),
@@ -931,7 +931,7 @@ mod tests {
                 "wordpress",
                 "mkdir -p build; printf artifact > build/fixture.zip; printf '[{\"path\":\"build/fixture.zip\",\"type\":\"archive\"}]'",
             );
-            homeboy_core::save_manifest(&package).expect("save package extension");
+            homeboy_core::extension::save_manifest(&package).expect("save package extension");
             let component_config = Component {
                 id: "fixture".to_string(),
                 local_path: component.path().to_string_lossy().to_string(),
@@ -999,7 +999,7 @@ mod tests {
                 "rm -f packages/plugin/dist/plugin.zip; mkdir -p target; printf npm > target/plugin-1.2.3.tgz; \
                  printf '[{\"path\":\"target/plugin-1.2.3.tgz\",\"type\":\"npm\"}]'",
             );
-            homeboy_core::save_manifest(&package).expect("save package extension");
+            homeboy_core::extension::save_manifest(&package).expect("save package extension");
             let component = Component {
                 id: "plugin".to_string(),
                 local_path: component_dir.path().to_string_lossy().to_string(),
@@ -1144,7 +1144,7 @@ mod tests {
                 "mkdir -p target; printf npm > target/plugin-1.2.3.tgz; \
                  printf '[{\"path\":\"target/plugin-1.2.3.tgz\",\"type\":\"npm\"}]'",
             );
-            homeboy_core::save_manifest(&package).expect("save package extension");
+            homeboy_core::extension::save_manifest(&package).expect("save package extension");
 
             let error = run_package(
                 &test_roots(),
@@ -1311,8 +1311,8 @@ mod tests {
                 "package-b",
                 "printf '[{\"path\":\"target/package-b.zip\",\"type\":\"archive\"}]'",
             );
-            homeboy_core::save_manifest(&package_a).expect("save package A extension");
-            homeboy_core::save_manifest(&package_b).expect("save package B extension");
+            homeboy_core::extension::save_manifest(&package_a).expect("save package A extension");
+            homeboy_core::extension::save_manifest(&package_b).expect("save package B extension");
 
             let mut state = crate::release::types::ReleaseState::default();
             let result = run_package(
@@ -1351,7 +1351,7 @@ mod tests {
                 "wordpress",
                 "printf '[{\"path\":\"build/%s.zip\",\"type\":\"wordpress\"}]' \"$HOMEBOY_COMPONENT_ID\"",
             );
-            homeboy_core::save_manifest(&package).expect("save package extension");
+            homeboy_core::extension::save_manifest(&package).expect("save package extension");
 
             let mut state = crate::release::types::ReleaseState::default();
             let result = run_package(
@@ -1392,7 +1392,7 @@ mod tests {
                     payload_out.display()
                 ),
             );
-            homeboy_core::save_manifest(&package).expect("save package extension");
+            homeboy_core::extension::save_manifest(&package).expect("save package extension");
 
             let mut component = Component::default();
             component.extensions = Some(std::collections::HashMap::from([
@@ -1481,7 +1481,7 @@ mod tests {
                     component_env_out.display()
                 ),
             );
-            homeboy_core::save_manifest(&package).expect("save package extension");
+            homeboy_core::extension::save_manifest(&package).expect("save package extension");
 
             package_preflight::run_package_preflight(&component.path().to_string_lossy())
                 .expect("package guards");
@@ -1520,7 +1520,7 @@ mod tests {
                  cp ../../build-input.txt build/root-input.txt; \
                  printf '[{\"path\":\"build/root-input.txt\",\"type\":\"archive\"}]'",
             );
-            homeboy_core::save_manifest(&package).expect("save package extension");
+            homeboy_core::extension::save_manifest(&package).expect("save package extension");
 
             package_preflight::run_package_preflight(&component.to_string_lossy())
                 .expect("package guards");
@@ -1536,7 +1536,7 @@ mod tests {
                 "wordpress",
                 "printf 'building package\n'; printf 'error: missing tsconfig.base.json\n' >&2; exit 9",
             );
-            homeboy_core::save_manifest(&package).expect("save package extension");
+            homeboy_core::extension::save_manifest(&package).expect("save package extension");
 
             let mut state = ReleaseState::default();
             let err = run_package(
@@ -1571,8 +1571,8 @@ mod tests {
                 "package-b",
                 "printf 'archive command failed' >&2; exit 7",
             );
-            homeboy_core::save_manifest(&package_a).expect("save package A extension");
-            homeboy_core::save_manifest(&package_b).expect("save package B extension");
+            homeboy_core::extension::save_manifest(&package_a).expect("save package A extension");
+            homeboy_core::extension::save_manifest(&package_b).expect("save package B extension");
 
             let mut state = crate::release::types::ReleaseState::default();
             let err = run_package(
@@ -1614,7 +1614,7 @@ mod tests {
                 "printf '[BUILD] Installing npm dependencies...\\n'; \
                  printf 'npm error: ERESOLVE\\n' >&2; exit 1",
             );
-            homeboy_core::save_manifest(&package).expect("save package extension");
+            homeboy_core::extension::save_manifest(&package).expect("save package extension");
 
             let mut state = crate::release::types::ReleaseState::default();
             let err = run_package(
@@ -1670,7 +1670,7 @@ mod tests {
                 marker = marker.display()
             );
             let package = release_package_extension("wordpress", &script);
-            homeboy_core::save_manifest(&package).expect("save package extension");
+            homeboy_core::extension::save_manifest(&package).expect("save package extension");
 
             let mut state = crate::release::types::ReleaseState::default();
             let result = run_package(

--- a/crates/homeboy-release/src/release/executor/package.rs
+++ b/crates/homeboy-release/src/release/executor/package.rs
@@ -7,8 +7,8 @@
 use homeboy_core::component::Component;
 use homeboy_core::error::{Error, Result};
 use homeboy_core::extension;
-use homeboy_core::ExtensionCapability;
-use homeboy_core::{self, ExtensionManifest};
+use homeboy_core::extension::ExtensionCapability;
+use homeboy_core::{self, extension::ExtensionManifest};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::fs;
@@ -439,15 +439,15 @@ fn record_existing_cleanup_path(component_path: &Path, path: &str, paths: &mut B
 fn build_declared_component_artifact(
     component: &Component,
     declared_build_artifact: Option<&str>,
-) -> Result<Option<homeboy_core::build::BuildOutput>> {
+) -> Result<Option<homeboy_core::extension::build::BuildOutput>> {
     if declared_build_artifact.is_none_or(|path| path.trim().is_empty())
         || !component.has_script(ExtensionCapability::Build)
     {
         return Ok(None);
     }
 
-    let (build, exit_code) =
-        homeboy_core::build::build_component_with_output(component).map_err(|error| {
+    let (build, exit_code) = homeboy_core::extension::build::build_component_with_output(component)
+        .map_err(|error| {
             Error::validation_invalid_argument(
                 "scripts.build",
                 error.message,
@@ -475,7 +475,7 @@ fn build_declared_component_artifact(
 }
 
 fn format_build_failure(
-    build: &homeboy_core::build::BuildOutput,
+    build: &homeboy_core::extension::build::BuildOutput,
     working_dir: &str,
     exit_code: i32,
 ) -> String {
@@ -518,7 +518,7 @@ mod build_failure_tests {
 
     #[test]
     fn timed_out_build_error_is_reproducible_and_bounded() {
-        let build = homeboy_core::build::BuildOutput {
+        let build = homeboy_core::extension::build::BuildOutput {
             command: "build.run".to_string(),
             component_id: "example".to_string(),
             build_command: "make release".to_string(),

--- a/crates/homeboy-release/src/release/executor/prepare.rs
+++ b/crates/homeboy-release/src/release/executor/prepare.rs
@@ -1,6 +1,6 @@
 use homeboy_core::error::{Error, Result};
 use homeboy_core::extension;
-use homeboy_core::{self, ExtensionManifest};
+use homeboy_core::{self, extension::ExtensionManifest};
 
 use super::{build_release_payload, publish_response_output, step_failed, step_success};
 use crate::release::types::{ReleaseState, ReleaseStepResult};

--- a/crates/homeboy-release/src/release/executor/publish.rs
+++ b/crates/homeboy-release/src/release/executor/publish.rs
@@ -4,7 +4,7 @@ use std::fmt::Write;
 use crate::release::types::{ReleaseState, ReleaseStepResult};
 use homeboy_core::component::GithubConfig;
 use homeboy_core::error::{Error, Result};
-use homeboy_core::{self, ExtensionManifest};
+use homeboy_core::{self, extension::ExtensionManifest};
 
 use super::{build_release_payload, step_failed, step_skipped, step_success};
 
@@ -430,7 +430,7 @@ mod tests {
     use crate::release::types::ReleaseState;
     use crate::release::types::ReleaseStepStatus;
     use homeboy_core::component::{GithubConfig, GithubHostConfig};
-    use homeboy_core::ExtensionManifest;
+    use homeboy_core::extension::ExtensionManifest;
     use std::collections::HashMap;
     use std::io::{Read, Write};
     use std::net::TcpListener;
@@ -495,7 +495,7 @@ mod tests {
                 "registry",
                 "printf '{\"component_id\":\"%s\",\"component_path\":\"%s\"}' \"$HOMEBOY_COMPONENT_ID\" \"$HOMEBOY_COMPONENT_PATH\"",
             );
-            homeboy_core::save_manifest(&publish).expect("save publish extension");
+            homeboy_core::extension::save_manifest(&publish).expect("save publish extension");
 
             let result = run_publish(
                 &[publish],
@@ -529,7 +529,7 @@ mod tests {
             let component = tempfile::tempdir_in(std::env::temp_dir()).expect("component tempdir");
             let publish =
                 release_publish_extension("registry", "printf '%s' \"$HOMEBOY_SETTINGS_JSON\"");
-            homeboy_core::save_manifest(&publish).expect("save publish extension");
+            homeboy_core::extension::save_manifest(&publish).expect("save publish extension");
             let github = GithubConfig {
                 hosts: HashMap::from([(
                     "github.enterprise.test".to_string(),

--- a/crates/homeboy-release/src/release/pipeline_capabilities.rs
+++ b/crates/homeboy-release/src/release/pipeline_capabilities.rs
@@ -1,4 +1,4 @@
-use homeboy_core::ExtensionManifest;
+use homeboy_core::extension::ExtensionManifest;
 
 /// Derive publish targets from extensions that have `release.publish` action.
 pub(super) fn get_publish_targets(extensions: &[ExtensionManifest]) -> Vec<String> {
@@ -26,7 +26,7 @@ pub(super) fn has_prepare_capability(extensions: &[ExtensionManifest]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{get_publish_targets, has_package_capability, has_prepare_capability};
-    use homeboy_core::ExtensionManifest;
+    use homeboy_core::extension::ExtensionManifest;
 
     fn extension(id: &str, actions: &[&str]) -> ExtensionManifest {
         let mut manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({

--- a/crates/homeboy-release/src/release/plan_steps/preflight.rs
+++ b/crates/homeboy-release/src/release/plan_steps/preflight.rs
@@ -1,10 +1,10 @@
 use super::builders::{disabled_step, ready_step, string_config, StepConfig};
 use crate::release::types::{ReleaseOptions, ReleaseSemverRecommendation};
+use homeboy_core::extension::ExtensionManifest;
 use homeboy_core::plan::PlanStep;
 use homeboy_core::quality::{
     build_quality_steps as build_shared_quality_steps, QualityPlanOptions,
 };
-use homeboy_core::ExtensionManifest;
 
 pub(in crate::release) fn build_preflight_steps(
     options: &ReleaseOptions,

--- a/crates/homeboy-release/src/release/plan_steps/release.rs
+++ b/crates/homeboy-release/src/release/plan_steps/release.rs
@@ -7,9 +7,9 @@ use crate::release::pipeline_capabilities::{
 use crate::release::scope::ReleaseScope;
 use crate::release::types::{ReleaseChangelogPlan, ReleaseOptions};
 use homeboy_core::component::Component;
+use homeboy_core::extension::{ExtensionCapability, ExtensionManifest};
 use homeboy_core::plan::PlanStep;
 use homeboy_core::Result;
-use homeboy_core::{ExtensionCapability, ExtensionManifest};
 
 pub(in crate::release) fn build_release_steps_with_reconciliation(
     component: &Component,

--- a/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
+++ b/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
@@ -7,8 +7,8 @@ use crate::release::types::{
     ReleaseSemverRecommendation,
 };
 use homeboy_core::component::{Component, ComponentScriptsConfig, ScopedExtensionConfig};
+use homeboy_core::extension::ExtensionManifest;
 use homeboy_core::plan::{PlanStep, PlanStepStatus};
-use homeboy_core::ExtensionManifest;
 use homeboy_core::Result;
 
 /// Test-local shim: production callers pass their own reconciliation input,
@@ -604,7 +604,7 @@ fn release_plan_runs_package_preflight_before_mutating_release_steps() {
         }))
         .expect("extension manifest");
         extension.id = "fixture-packager".to_string();
-        homeboy_core::save_manifest(&extension).expect("save extension manifest");
+        homeboy_core::extension::save_manifest(&extension).expect("save extension manifest");
         let mut warnings = Vec::new();
         let mut hints = Vec::new();
         let release_scope =
@@ -1230,7 +1230,7 @@ fn release_plan_warns_when_configured_extensions_have_no_publish_action() {
             ScopedExtensionConfig::default(),
         )]));
         let extension = release_extension("wordpress", &["release.package"]);
-        homeboy_core::save_manifest(&extension).expect("install extension manifest");
+        homeboy_core::extension::save_manifest(&extension).expect("install extension manifest");
         let mut warnings = Vec::new();
         let mut hints = Vec::new();
         let release_scope =

--- a/crates/homeboy-release/src/release/planning_quality.rs
+++ b/crates/homeboy-release/src/release/planning_quality.rs
@@ -2,7 +2,7 @@ use homeboy_core::component::Component;
 use homeboy_core::engine::run_dir::RunDir;
 use homeboy_core::error::{ActionSafety, CommandEvidence, Error, ExecutableAction, Result};
 use homeboy_core::extension;
-use homeboy_core::{self, ExtensionCapability};
+use homeboy_core::{self, extension::ExtensionCapability};
 use std::path::Path;
 
 use super::scope::ReleaseScope;
@@ -501,7 +501,7 @@ mod tests {
     };
     use homeboy_core::component::{Component, ComponentScriptsConfig, ScopedExtensionConfig};
     use homeboy_core::error::Error;
-    use homeboy_core::RunnerOutput;
+    use homeboy_core::extension::RunnerOutput;
     use std::collections::HashMap;
     use std::fs;
     use std::path::Path;
@@ -907,7 +907,7 @@ mod tests {
             std::env::set_var("DECLARED_RELEASE_SECRET", "static-release-secret");
             std::env::set_var("PROJECTED_RELEASE_SECRET", "projected-release-secret");
 
-            homeboy_core::test::resolve_test_command(&component)
+            homeboy_core::extension::test::resolve_test_command(&component)
                 .expect("conditional release test extension resolves");
 
             let error = validate_test_quality(&component)

--- a/crates/homeboy-review/src/review/artifact_findings.rs
+++ b/crates/homeboy-review/src/review/artifact_findings.rs
@@ -2,8 +2,8 @@ use serde_json::Value;
 
 use homeboy_code_audit::{homeboy_finding_from_audit, AuditCommandOutput};
 use homeboy_core::ci_profile::CiRunOutput;
-use homeboy_core::lint::LintCommandOutput;
-use homeboy_core::test::TestCommandOutput;
+use homeboy_core::extension::lint::LintCommandOutput;
+use homeboy_core::extension::test::TestCommandOutput;
 use homeboy_finding::HomeboyFinding;
 
 pub trait ReviewArtifactFindings {

--- a/crates/homeboy-review/src/review/mod.rs
+++ b/crates/homeboy-review/src/review/mod.rs
@@ -7,9 +7,9 @@ use serde_json::Value;
 use homeboy_code_audit::AuditCommandOutput;
 use homeboy_core::ci_profile::CiRunOutput;
 use homeboy_core::execution::{self, PlanExecutionRun};
-use homeboy_core::lint::LintCommandOutput;
+use homeboy_core::extension::lint::LintCommandOutput;
+use homeboy_core::extension::test::TestCommandOutput;
 use homeboy_core::plan::{HomeboyPlan, PlanStep};
-use homeboy_core::test::TestCommandOutput;
 use homeboy_core::ObservationOutputMetadata;
 use homeboy_finding::HomeboyFinding;
 
@@ -345,7 +345,7 @@ fn generated_at_now() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use homeboy_core::{test::TestCommandOutput, ExtensionPhaseTiming};
+    use homeboy_core::extension::{test::TestCommandOutput, ExtensionPhaseTiming};
 
     #[test]
     fn stage_skipped_helper_marks_not_ran() {

--- a/crates/homeboy-review/src/review/render.rs
+++ b/crates/homeboy-review/src/review/render.rs
@@ -20,11 +20,11 @@ use std::fmt::Write as _;
 use super::top_n::top_n_by;
 use homeboy_code_audit::AuditCommandOutput;
 use homeboy_core::ci_profile::CiRunOutput;
-use homeboy_core::lint::LintCommandOutput;
-use homeboy_core::test::{
+use homeboy_core::extension::lint::LintCommandOutput;
+use homeboy_core::extension::test::{
     TestCommandOutput, TestDurations, TestUnitDuration, SLOWEST_UNITS_REPORTED,
 };
-use homeboy_core::ExtensionPhaseTiming;
+use homeboy_core::extension::ExtensionPhaseTiming;
 use homeboy_finding::HomeboyFinding;
 
 use super::{ReviewCommandOutput, ReviewStage};
@@ -479,13 +479,13 @@ mod tests {
         AuditCommandOutput, AuditFinding, CodeAuditResult, Finding, Severity,
     };
     use homeboy_core::ci_profile::{CiContext, CiJobRunOutput, CiRunOutput, CiRunSelection};
-    use homeboy_core::lint::LintCommandOutput;
-    use homeboy_core::quality::{build_quality_plan, QualityPlanOptions};
-    use homeboy_core::test::{
+    use homeboy_core::extension::lint::LintCommandOutput;
+    use homeboy_core::extension::test::{
         SlowTestFinding, TestCommandOutput, TestCounts, TestDurations, TestUnitDuration,
     };
-    use homeboy_core::CiJobMapping;
-    use homeboy_core::{PhaseReport, PhaseStatus, VerificationPhase};
+    use homeboy_core::extension::CiJobMapping;
+    use homeboy_core::extension::{PhaseReport, PhaseStatus, VerificationPhase};
+    use homeboy_core::quality::{build_quality_plan, QualityPlanOptions};
     use homeboy_finding::HomeboyFinding;
 
     // ── Builders for fixture envelopes ──────────────────────────────────

--- a/crates/homeboy-rig/src/lib.rs
+++ b/crates/homeboy-rig/src/lib.rs
@@ -149,8 +149,8 @@ pub use workloads::{
 };
 
 use discovery::discover_rigs_for_install;
-use homeboy_core::bench::parsing::{RigPackageEvidence, RigPackageFreshness};
 use homeboy_core::error::{Error, Result};
+use homeboy_core::extension::bench::parsing::{RigPackageEvidence, RigPackageFreshness};
 use homeboy_core::{git, paths};
 use std::collections::HashMap;
 use std::fs;
@@ -407,7 +407,7 @@ fn read_spec_from_path(
     if spec.id.is_empty() {
         spec.id = id_hint.unwrap_or_default().to_string();
     }
-    spec.id = homeboy_core::slugify_id(&spec.id)?;
+    spec.id = homeboy_core::extension::slugify_id(&spec.id)?;
     remember_local_package_root(&spec.id, package_root);
     apply_trace_workload_defaults(&mut spec)?;
     validate_rig_spec(&spec)?;
@@ -575,7 +575,7 @@ pub fn load_local_source(source: &str, id: Option<&str>) -> Result<RigSpec> {
         discover_rigs(&path)?
     };
     if let Some(id) = id {
-        let id = homeboy_core::slugify_id(id)?;
+        let id = homeboy_core::extension::slugify_id(id)?;
         if rigs.is_empty() {
             return Err(Error::validation_invalid_argument(
                 "id",

--- a/crates/homeboy-rig/src/pipeline/component.rs
+++ b/crates/homeboy-rig/src/pipeline/component.rs
@@ -29,11 +29,11 @@ fn resolve_rig_component(rig: &RigSpec, component_id: &str) -> Result<Component>
 
 pub(super) fn run_build_step(rig: &RigSpec, component_id: &str) -> Result<()> {
     let component = resolve_rig_component(rig, component_id)?;
-    let (result, exit_code) = homeboy_core::build::run_component(&component)?;
+    let (result, exit_code) = homeboy_core::extension::build::run_component(&component)?;
 
     if exit_code != 0 {
         let detail = match &result {
-            homeboy_core::build::BuildResult::Single(output) => {
+            homeboy_core::extension::build::BuildResult::Single(output) => {
                 let tail = output
                     .output
                     .stderr
@@ -51,7 +51,7 @@ pub(super) fn run_build_step(rig: &RigSpec, component_id: &str) -> Result<()> {
                     format!("exit {} — {}", exit_code, tail)
                 }
             }
-            homeboy_core::build::BuildResult::Bulk(_) => format!("exit {}", exit_code),
+            homeboy_core::extension::build::BuildResult::Bulk(_) => format!("exit {}", exit_code),
         };
         return Err(Error::rig_pipeline_failed(
             &rig.id,

--- a/crates/homeboy-rig/src/pipeline/lifecycle_step.rs
+++ b/crates/homeboy-rig/src/pipeline/lifecycle_step.rs
@@ -377,7 +377,7 @@ fn run_extension_hook(
         "env": env_map,
     });
 
-    let value = homeboy_core::execute_action(
+    let value = homeboy_core::extension::execute_action(
         extension_id.trim(),
         action_id.trim(),
         None,

--- a/crates/homeboy-rig/src/spec.rs
+++ b/crates/homeboy-rig/src/spec.rs
@@ -2,15 +2,15 @@
 
 use serde::{Deserialize, Serialize};
 
+use homeboy_core::extension::trace::TraceProbeConfig;
+use homeboy_core::extension::trace::TraceSpanMetadata;
 use homeboy_core::resource_cleanup_intent::ResourceCleanupIntent;
 use homeboy_core::resource_lifecycle_index::ResourceCleanupPolicy;
-use homeboy_core::trace::TraceProbeConfig;
-use homeboy_core::trace::TraceSpanMetadata;
 use std::collections::{BTreeMap, HashMap};
 
 pub use homeboy_core::artifact_postprocess::ArtifactPostprocessAction as ArtifactPostprocessSpec;
-use homeboy_core::bench::{BenchGate, BenchGateOp};
 use homeboy_core::component::ScopedExtensionConfig;
+use homeboy_core::extension::bench::{BenchGate, BenchGateOp};
 pub use homeboy_core::lifecycle::{
     LifecycleContract, LifecyclePhaseContract, LifecyclePhaseKind, LifecyclePhaseResult,
     LifecyclePhaseStatus, LifecycleResultMetadata, LifecycleSnapshotRef,

--- a/crates/homeboy-rig/src/spec/workload.rs
+++ b/crates/homeboy-rig/src/spec/workload.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use homeboy_core::trace::{TraceProbeConfig, TraceSpanMetadata};
+use homeboy_core::extension::trace::{TraceProbeConfig, TraceSpanMetadata};
 
 use super::{
     ArtifactPostprocessSpec, LifecycleContract, TraceDependencySpec, TraceGuardrailSpec,

--- a/crates/homeboy-rig/src/trace_experiment.rs
+++ b/crates/homeboy-rig/src/trace_experiment.rs
@@ -13,7 +13,7 @@ use std::process::Command;
 use serde::Serialize;
 
 use homeboy_core::engine::run_dir::RunDir;
-use homeboy_core::trace as extension_trace;
+use homeboy_core::extension::trace as extension_trace;
 
 /// Context required to resolve rig variables when orchestrating a trace
 /// experiment. Owns only the data the orchestration needs, decoupled from the

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -881,7 +881,7 @@ fn preflight_extensions_for_upgrade(candidate_version: &str) -> Vec<ExtensionPre
                     .requires
                     .as_ref()
                     .and_then(|requirements| requirements.homeboy.as_deref());
-                match homeboy_core::evaluate_core_compatibility_for_version(
+                match homeboy_core::extension::evaluate_core_compatibility_for_version(
                     requires,
                     homeboy_core::extension_update_check::read_source_revision(&extension_id),
                     candidate_version,
@@ -1493,7 +1493,7 @@ fn installed_extension_catalog_for(extension_ids: &[String]) -> Vec<ExtensionUpg
                         git_root: None,
                         source_url,
                         source_revision: homeboy_core::extension_update_check::read_source_revision(&extension_id),
-                        source_update: homeboy_core::ExtensionSourceUpdate {
+                        source_update: homeboy_core::extension::ExtensionSourceUpdate {
                             update_note,
                             ..Default::default()
                         },
@@ -1508,7 +1508,7 @@ fn installed_extension_catalog_for(extension_ids: &[String]) -> Vec<ExtensionUpg
                     git_root: None,
                     source_url: None,
                     source_revision: None,
-                    source_update: homeboy_core::ExtensionSourceUpdate {
+                    source_update: homeboy_core::extension::ExtensionSourceUpdate {
                         update_note: Some(format!(
                             "unrefreshable extension manifest: {}",
                             err.message
@@ -2034,7 +2034,7 @@ fn git_commits_behind_upstream(git_root: &Path) -> Option<u32> {
     count.trim().parse::<u32>().ok()
 }
 
-fn portable_extension_source_url(result: &homeboy_core::UpdateResult) -> Option<String> {
+fn portable_extension_source_url(result: &homeboy_core::extension::UpdateResult) -> Option<String> {
     if let Some(git_root) = result.git_root.as_ref() {
         return git::remote_origin_url(git_root);
     }
@@ -2299,7 +2299,7 @@ mod runner_source_upgrade_tests {
             Vec::new(),
             || {
                 events.borrow_mut().push("runner manifest revalidation");
-                let compatible = homeboy_core::evaluate_core_compatibility_for_version(
+                let compatible = homeboy_core::extension::evaluate_core_compatibility_for_version(
                     Some(changed_manifest_requires_homeboy),
                     None,
                     "2.1.0",

--- a/crates/homeboy-upgrade/src/upgrade/types.rs
+++ b/crates/homeboy-upgrade/src/upgrade/types.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use homeboy_core::ExtensionSourceUpdate;
+use homeboy_core::extension::ExtensionSourceUpdate;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InstallMethod {

--- a/crates/homeboy-version/src/version.rs
+++ b/crates/homeboy-version/src/version.rs
@@ -32,7 +32,7 @@ use homeboy_core::config::{from_str, set_json_pointer, to_string_pretty};
 use homeboy_core::engine::hooks::{self, HookFailureMode};
 use homeboy_core::engine::local_files;
 use homeboy_core::engine::text;
-use homeboy_core::ExtensionManifest;
+use homeboy_core::extension::ExtensionManifest;
 use homeboy_extension_contract::HookEvent;
 use serde_json::Value;
 use std::path::Path;

--- a/crates/homeboy-version/src/version/default_pattern_for_file.rs
+++ b/crates/homeboy-version/src/version/default_pattern_for_file.rs
@@ -9,8 +9,8 @@ use homeboy_core::component::{self, Component, VersionTarget};
 use homeboy_core::engine::codebase_scan;
 use homeboy_core::engine::text;
 use homeboy_core::error::{Error, Result};
+use homeboy_core::extension::load_all_extensions;
 use homeboy_core::extension_execution::{resolve_owner, SINCE_TAG_SURFACE};
-use homeboy_core::load_all_extensions;
 use homeboy_core::paths::resolve_path_string;
 use regex::Regex;
 use std::collections::{BTreeMap, BTreeSet};
@@ -238,14 +238,16 @@ pub(crate) fn detect_unconfigured_patterns(component: &Component) -> Vec<Unconfi
 ///   it (agreeing extensions are not ambiguous)
 /// - conflicting configs → [`resolve_owner`] on the `since_tag` surface, then a
 ///   hard error with a runnable fix command
-fn resolve_since_tag_config(component: &Component) -> Result<Option<homeboy_core::SinceTagConfig>> {
-    use homeboy_core::load_extension;
+fn resolve_since_tag_config(
+    component: &Component,
+) -> Result<Option<homeboy_core::extension::SinceTagConfig>> {
+    use homeboy_core::extension::load_extension;
 
     let Some(extensions) = component.extensions.as_ref() else {
         return Ok(None);
     };
 
-    let mut providers: BTreeMap<String, homeboy_core::SinceTagConfig> = BTreeMap::new();
+    let mut providers: BTreeMap<String, homeboy_core::extension::SinceTagConfig> = BTreeMap::new();
     for extension_id in extensions.keys() {
         let Ok(manifest) = load_extension(extension_id) else {
             continue;

--- a/tests/commands/bench/observation_artifact_test.rs
+++ b/tests/commands/bench/observation_artifact_test.rs
@@ -1,9 +1,9 @@
 use std::fs;
 
 use homeboy::core::engine::run_dir::{self, RunDir};
-use homeboy_core::bench::artifact::BenchArtifact;
-use homeboy_core::bench::result_types::BenchRunMetadata;
-use homeboy_core::bench::{BenchRunExecution, BenchRunWorkflowResult};
+use homeboy_core::extension::bench::artifact::BenchArtifact;
+use homeboy_core::extension::bench::result_types::BenchRunMetadata;
+use homeboy_core::extension::bench::{BenchRunExecution, BenchRunWorkflowResult};
 
 use super::tests::{bench_args, bench_results, XdgGuard};
 use super::{finish_success, start, BenchObservationStart};

--- a/tests/core/extension/bench/aggregation_test.rs
+++ b/tests/core/extension/bench/aggregation_test.rs
@@ -1,4 +1,4 @@
-use crate::bench::test_support::{results_with_scenarios, scenario_with_iterations};
+use crate::extension::bench::test_support::{results_with_scenarios, scenario_with_iterations};
 use homeboy_core::observation::timeline::{
     ObservationEvent, ObservationSpanDefinition, ObservationSpanResult, ObservationSpanStatus,
 };

--- a/tests/core/extension/bench/phase_tag_test.rs
+++ b/tests/core/extension/bench/phase_tag_test.rs
@@ -25,12 +25,12 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::bench::parsing::{
+use crate::extension::bench::parsing::{
     parse_bench_results_str, BenchMetricDirection, BenchMetricPhase, BenchMetricPolicy,
     BenchResults, BenchScenario,
 };
-use crate::bench::report::{BenchComparisonDiff, BenchPhaseGroups};
-use crate::bench::test_support::scenario_with_iterations;
+use crate::extension::bench::report::{BenchComparisonDiff, BenchPhaseGroups};
+use crate::extension::bench::test_support::scenario_with_iterations;
 
 fn policy(direction: BenchMetricDirection, phase: Option<BenchMetricPhase>) -> BenchMetricPolicy {
     BenchMetricPolicy {

--- a/tests/core/extension/bench/report_comparison_test.rs
+++ b/tests/core/extension/bench/report_comparison_test.rs
@@ -5,15 +5,17 @@ use super::{
     aggregate_comparison, aggregate_comparison_with_axes, BenchComparisonDiff, BenchPhaseGroups,
     RigBenchEntry,
 };
-use crate::bench::artifact::{BenchArtifact, BenchArtifactViewer, BenchPreviewLifecycleMetadata};
-use crate::bench::diagnostic::{BenchDiagnostic, BenchDiagnosticSource};
-use crate::bench::distribution::BenchRunDistribution;
-use crate::bench::parsing::{
+use crate::extension::bench::artifact::{
+    BenchArtifact, BenchArtifactViewer, BenchPreviewLifecycleMetadata,
+};
+use crate::extension::bench::diagnostic::{BenchDiagnostic, BenchDiagnosticSource};
+use crate::extension::bench::distribution::BenchRunDistribution;
+use crate::extension::bench::parsing::{
     BenchMetricDirection, BenchMetricPhase, BenchMetricPolicy, BenchMetrics, BenchResults,
     BenchRunSnapshot, BenchScenario,
 };
-use crate::bench::run::{BenchRunFailure, BenchRunWorkflowResult};
-use crate::bench::side_by_side::BenchSideBySideMetric;
+use crate::extension::bench::run::{BenchRunFailure, BenchRunWorkflowResult};
+use crate::extension::bench::side_by_side::BenchSideBySideMetric;
 
 mod fixtures {
     use super::*;

--- a/tests/core/extension/bench/runs_flag_test.rs
+++ b/tests/core/extension/bench/runs_flag_test.rs
@@ -9,10 +9,10 @@
 //! 4. Scenarios missing from some runs aggregate from the runs that emitted
 //!    them instead of failing the whole bench.
 
-use crate::bench::aggregation::aggregate_runs;
-use crate::bench::artifact::BenchArtifact;
-use crate::bench::parsing::{BenchResults, BenchScenario};
-use crate::bench::test_support::{results_with_scenarios, scenario_with_iterations};
+use crate::extension::bench::aggregation::aggregate_runs;
+use crate::extension::bench::artifact::BenchArtifact;
+use crate::extension::bench::parsing::{BenchResults, BenchScenario};
+use crate::extension::bench::test_support::{results_with_scenarios, scenario_with_iterations};
 
 fn scenario(id: &str, metrics: &[(&str, f64)]) -> BenchScenario {
     scenario_with_iterations(id, metrics, 1)

--- a/tests/core/extension/component_script_test.rs
+++ b/tests/core/extension/component_script_test.rs
@@ -6,13 +6,13 @@ use std::process::Command;
 
 use crate::commands::test::{run as run_test, TestArgs};
 use homeboy_core::component::{Component, ComponentScriptsConfig, ScopedExtensionConfig};
-use homeboy_core::component_script::{
+use homeboy_core::engine::run_dir::RunDir;
+use homeboy_core::extension::component_script::{
     run_component_scripts, run_component_scripts_with_env, run_component_scripts_with_run_dir,
     source_path,
 };
-use homeboy_core::engine::run_dir::RunDir;
+use homeboy_core::extension::ExtensionCapability;
 use homeboy_core::test_support::with_isolated_home;
-use homeboy_core::ExtensionCapability;
 
 fn test_command_args(root: &Path) -> TestArgs {
     TestArgs::for_test("fixture", root)
@@ -926,7 +926,7 @@ fn extension_policy_with_evidence_allows_a_neutral_no_test_scope() {
         assert_eq!(output.status, "skipped");
         assert_eq!(
             output.phase.expect("phase").status,
-            homeboy_core::PhaseStatus::Skipped
+            homeboy_core::extension::PhaseStatus::Skipped
         );
     });
 }

--- a/tests/core/lint_baseline_test.rs
+++ b/tests/core/lint_baseline_test.rs
@@ -1,4 +1,4 @@
-use crate::lint::baseline as lint_baseline;
+use crate::extension::lint::baseline as lint_baseline;
 use homeboy_core::finding::HomeboyFinding;
 use std::path::Path;
 

--- a/tests/core/project/path_resolution_test.rs
+++ b/tests/core/project/path_resolution_test.rs
@@ -8,11 +8,11 @@ use super::*;
 
 use crate::component::ScopedExtensionConfig;
 use crate::test_support::with_isolated_home;
-use homeboy_core::{DeployCapability, ExtensionManifest};
+use homeboy_core::extension::{DeployCapability, ExtensionManifest};
 use std::collections::HashMap;
 
 fn install_wordpress_extension() {
-    homeboy_core::save_manifest(&ExtensionManifest {
+    homeboy_core::extension::save_manifest(&ExtensionManifest {
         id: "wordpress".to_string(),
         name: "WordPress".to_string(),
         version: "1.0.0".to_string(),

--- a/tests/core/rig/bench_default_baseline_output_test.rs
+++ b/tests/core/rig/bench_default_baseline_output_test.rs
@@ -1,5 +1,5 @@
 use super::*;
-use homeboy_core::bench::BenchDefaultBaselineExpansion;
+use homeboy_core::extension::bench::BenchDefaultBaselineExpansion;
 
 fn write_rig_with_default_baseline(
     home: &TempDir,
@@ -165,7 +165,7 @@ fn default_baseline_failure_summary_marks_implicit_baseline() {
             artifacts: Vec::new(),
             results: None,
             rig_state: None,
-            failure: Some(homeboy_core::bench::run::BenchRunFailure {
+            failure: Some(homeboy_core::extension::bench::run::BenchRunFailure {
                 component_id: "studio".to_string(),
                 component_path: None,
                 scenario_id: None,

--- a/tests/core/rig/bench_default_baseline_spec_test.rs
+++ b/tests/core/rig/bench_default_baseline_spec_test.rs
@@ -5,7 +5,7 @@
 //! tooling) read this directly off disk.
 
 use crate::spec::{BenchMetricGateCondition, BenchSpec, RigSpec, WorkloadSpec};
-use homeboy_core::bench::BenchGateOp;
+use homeboy_core::extension::bench::BenchGateOp;
 
 /// Parses a minimal RigSpec JSON via serde and returns the embedded
 /// `BenchSpec` (or panics).

--- a/tests/deps_test.rs
+++ b/tests/deps_test.rs
@@ -16,8 +16,8 @@ use tempfile::tempdir;
 // test run that excludes a registering sibling, these tests failed with "no
 // component-script runner registered" (#8964).
 fn register_component_script_runner() {
-    homeboy_core::component_script::register_component_script_runner();
-    homeboy_core::build::register_component_build_runner();
+    homeboy_core::extension::component_script::register_component_script_runner();
+    homeboy_core::extension::build::register_component_build_runner();
 }
 
 fn write_file(path: &std::path::Path, contents: &str) {

--- a/tests/report_browser_evidence_compare_test.rs
+++ b/tests/report_browser_evidence_compare_test.rs
@@ -6,7 +6,7 @@ use homeboy::commands::runs::report::{
     browser_evidence_compare_from_dirs_with_visual_and_adapters, BrowserEvidenceCompareArgs,
     VisualCompareOptions,
 };
-use homeboy_core::{
+use homeboy_core::extension::{
     TraceBrowserArtifactMapConfig, TraceBrowserEvidenceAdapterConfig,
     TraceBrowserMetricAliasConfig, TraceBrowserSummaryAliasConfig,
 };


### PR DESCRIPTION
## Summary

- remove the `pub use extension::*` compatibility facade from `homeboy-core`
- migrate product consumers to the canonical `homeboy_core::extension` API
- keep unrelated core modules at their existing root ownership

Closes #13790

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo nextest run --profile ci -p homeboy-core --lib extension` (927 passed)
- `cargo test --test report_browser_evidence_compare_test` (8 passed)
- `git diff --check origin/main...HEAD`

`cargo test --test deps_test` reached 9 passed and 1 ignored; `update_runs_component_provider_install_and_optional_rebuild` was blocked by local capacity admission (99.1 GB available versus the 150 GB reconstructable-artifact reserve). A broader core run also exposed the untouched controller-runtime cache assertion `test_fixture_identity_cache_reuses_sealed_candidates_and_invalidates_changes`; the extension-focused suite is green.

## AI assistance

OpenAI GPT-5.6 Sol in OpenCode 1.18.23 migrated the extension API paths, reviewed the namespace-only diff, and ran the verification commands under Chris Huber direction. Chris Huber owns the architecture and final decisions.