### PR TITLE
refactor(runs): root artifact handlers at dispatch

### DIFF
--- a/crates/homeboy-cli/src/commands/runs/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/runs/dispatch.rs
@@ -4,6 +4,7 @@
 //! `--runner` guidance surfaced when operators misuse the top-level flag.
 
 use homeboy::core::observation::ObservationStore;
+use homeboy::core::paths::PathRoots;
 use homeboy::core::Error;
 
 use super::types::{
@@ -183,7 +184,8 @@ pub fn run(args: RunsArgs) -> CmdResult<RunsOutput> {
     // observation store is opened exactly once here and handed to the handlers
     // below. Each of those used to open its own, which made a single command
     // several independently-resolved stores (#7505).
-    let store = ObservationStore::open_initialized()?;
+    let roots = PathRoots::from_environment()?;
+    let store = ObservationStore::open_initialized_in_roots(&roots)?;
     match args.command {
         RunsCommand::List(args) => handlers::list_runs(&store, args, "runs.list"),
         RunsCommand::Distribution(args) => {
@@ -235,7 +237,7 @@ pub fn run(args: RunsArgs) -> CmdResult<RunsOutput> {
         }
         RunsCommand::Env { run_id } => handlers::env(&store, &run_id),
         RunsCommand::Artifacts(args) => handlers::artifacts_from_args(&store, args),
-        RunsCommand::Artifact(args) => handlers::artifact_command(args),
+        RunsCommand::Artifact(args) => handlers::artifact_command(&store, args),
         RunsCommand::Findings(args) => findings::findings(&store, args),
         RunsCommand::Finding { finding_id } => findings::finding(&store, &finding_id),
         RunsCommand::LatestFinding(args) => findings::latest_finding(args),
@@ -243,7 +245,9 @@ pub fn run(args: RunsArgs) -> CmdResult<RunsOutput> {
         RunsCommand::Import(args) => super::bundle::import_runs(&store, args),
         RunsCommand::Query(args) => query::runs_query(&store, args),
         RunsCommand::Refs(args) => refs::runs_refs(&store, args),
-        RunsCommand::Resources(args) => resources::runs_resources(args),
+        RunsCommand::Resources(args) => {
+            resources::runs_resources_in_store(&store, roots.config(), args)
+        }
         RunsCommand::Drift(args) => drift::runs_drift(&store, args),
         RunsCommand::LoopSync(args) => loop_sync::loop_sync(args),
         RunsCommand::Report(args) => {
@@ -259,7 +263,8 @@ pub(crate) fn global_runner_error(args: &RunsArgs, runner_id: &str) -> Error {
 
 pub(crate) fn run_markdown(args: RunsArgs) -> CmdResult<String> {
     // Same boundary rule as `run`: one invocation, one store (#7505).
-    let store = ObservationStore::open_initialized()?;
+    let roots = PathRoots::from_environment()?;
+    let store = ObservationStore::open_initialized_in_roots(&roots)?;
     match args.command {
         RunsCommand::Compare(args) => compare::run_markdown(&store, args),
         RunsCommand::Report(args) => report::run_markdown(args),

--- a/crates/homeboy-cli/src/commands/runs/evidence.rs
+++ b/crates/homeboy-cli/src/commands/runs/evidence.rs
@@ -953,12 +953,15 @@ mod tests {
 
             assert_eq!(artifact.artifact_type, "directory");
 
-            let (preview, _) = artifact_command(RunsArtifactArgs {
-                command: RunsArtifactCommand::PreviewHandle(RunsArtifactPreviewHandleArgs {
-                    handle: handle.to_string(),
-                    port: None,
-                }),
-            })
+            let (preview, _) = artifact_command(
+                &test_store(),
+                RunsArtifactArgs {
+                    command: RunsArtifactCommand::PreviewHandle(RunsArtifactPreviewHandleArgs {
+                        handle: handle.to_string(),
+                        port: None,
+                    }),
+                },
+            )
             .expect("preview selected directory diagnostic by handle");
             let RunsOutput::ArtifactPreview(preview) = preview else {
                 panic!("expected directory preview output");

--- a/crates/homeboy-cli/src/commands/runs/handlers.rs
+++ b/crates/homeboy-cli/src/commands/runs/handlers.rs
@@ -1313,14 +1313,14 @@ fn env_source_layer_output(value: &Value) -> Option<RunsEnvSourceLayerOutput> {
     })
 }
 
-pub fn artifact_command(args: RunsArtifactArgs) -> CmdResult<RunsOutput> {
+pub fn artifact_command(store: &ObservationStore, args: RunsArtifactArgs) -> CmdResult<RunsOutput> {
     match args.command {
-        RunsArtifactCommand::Attach(args) => remote_artifact::attach(args),
-        RunsArtifactCommand::Get(args) => artifact_get(args),
-        RunsArtifactCommand::GetHandle(args) => artifact_get_handle(args),
-        RunsArtifactCommand::Preview(args) => remote_artifact::preview(args),
-        RunsArtifactCommand::PreviewHandle(args) => artifact_preview_handle(args),
-        RunsArtifactCommand::Capture(args) => remote_artifact::capture(args),
+        RunsArtifactCommand::Attach(args) => remote_artifact::attach(store, args),
+        RunsArtifactCommand::Get(args) => artifact_get(store, args),
+        RunsArtifactCommand::GetHandle(args) => artifact_get_handle(store, args),
+        RunsArtifactCommand::Preview(args) => remote_artifact::preview(store, args),
+        RunsArtifactCommand::PreviewHandle(args) => artifact_preview_handle(store, args),
+        RunsArtifactCommand::Capture(args) => remote_artifact::capture(store, args),
         RunsArtifactCommand::CleanupDownloads(args) => remote_artifact::cleanup_downloads(args),
         RunsArtifactCommand::CleanupPersisted(args) => remote_artifact::cleanup_persisted(args),
         RunsArtifactCommand::Postprocess(args) => {
@@ -1331,9 +1331,9 @@ pub fn artifact_command(args: RunsArtifactArgs) -> CmdResult<RunsOutput> {
 }
 
 pub(crate) fn artifact_preview_handle(
+    store: &ObservationStore,
     args: RunsArtifactPreviewHandleArgs,
 ) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
     let artifact = store
         .get_artifact_for_handle(&args.handle)?
         .ok_or_else(|| {
@@ -1347,31 +1347,38 @@ pub(crate) fn artifact_preview_handle(
     remote_artifact::preview_artifact(artifact, args.port)
 }
 
-pub(crate) fn artifact_get(args: RunsArtifactGetArgs) -> CmdResult<RunsOutput> {
+pub(crate) fn artifact_get(
+    store: &ObservationStore,
+    args: RunsArtifactGetArgs,
+) -> CmdResult<RunsOutput> {
     let fields = args.field.clone();
-    let (output, exit_code) = artifact_get_inner(args)?;
+    let (output, exit_code) = artifact_get_inner(store, args)?;
     if fields.is_empty() {
         return Ok((output, exit_code));
     }
     apply_field_selection(output, &fields)
 }
 
-fn artifact_get_inner(args: RunsArtifactGetArgs) -> CmdResult<RunsOutput> {
+fn artifact_get_inner(
+    store: &ObservationStore,
+    args: RunsArtifactGetArgs,
+) -> CmdResult<RunsOutput> {
     if let Some(runner_id) = args.runner.clone() {
         return remote::runner_artifact_get(&runner_id, args);
     }
 
-    let store = ObservationStore::open_initialized()?;
-    let artifact = runs_service::resolve_artifact_for_run(&store, &args.run_id, &args.artifact_id)?;
+    let artifact = runs_service::resolve_artifact_for_run(store, &args.run_id, &args.artifact_id)?;
     artifact_get_resolved(artifact, args.output)
 }
 
 /// Handle lookup is deliberately exact: it has no run-id, name, ordinal, or
 /// fuzzy token fallback. The unique handle index scopes the resolved artifact
 /// to its durable owner before any byte access happens.
-fn artifact_get_handle(args: RunsArtifactGetHandleArgs) -> CmdResult<RunsOutput> {
+fn artifact_get_handle(
+    store: &ObservationStore,
+    args: RunsArtifactGetHandleArgs,
+) -> CmdResult<RunsOutput> {
     let fields = args.field.clone();
-    let store = ObservationStore::open_initialized()?;
     let artifact = store
         .get_artifact_for_handle(&args.handle)?
         .ok_or_else(|| {

--- a/crates/homeboy-cli/src/commands/runs/mod.rs
+++ b/crates/homeboy-cli/src/commands/runs/mod.rs
@@ -57,12 +57,17 @@ pub(crate) fn attach_runner_artifact(
     path: String,
     name: String,
 ) -> homeboy::core::Result<serde_json::Value> {
-    let (output, _) = remote_artifact::attach(types::RunsArtifactAttachArgs {
-        run_id,
-        runner,
-        path,
-        name,
-    })?;
+    let roots = homeboy::core::paths::PathRoots::from_environment()?;
+    let store = homeboy::core::observation::ObservationStore::open_initialized_in_roots(&roots)?;
+    let (output, _) = remote_artifact::attach(
+        &store,
+        types::RunsArtifactAttachArgs {
+            run_id,
+            runner,
+            path,
+            name,
+        },
+    )?;
     serde_json::to_value(output)
         .map_err(|error| homeboy::core::Error::internal_json(error.to_string(), None))
 }

--- a/crates/homeboy-cli/src/commands/runs/remote_artifact.rs
+++ b/crates/homeboy-cli/src/commands/runs/remote_artifact.rs
@@ -65,9 +65,8 @@ fn runner_id_from_artifact_ref(path: &str) -> Option<&str> {
     path.split('/').next()
 }
 
-pub fn attach(args: RunsArtifactAttachArgs) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
-    runs_service::require_run(&store, &args.run_id)?;
+pub fn attach(store: &ObservationStore, args: RunsArtifactAttachArgs) -> CmdResult<RunsOutput> {
+    runs_service::require_run(store, &args.run_id)?;
     validate_artifact_name(&args.name)?;
     let runner = runner::load(&args.runner)?;
     // The root that authorizes the path and the root the bytes are copied under
@@ -141,9 +140,8 @@ fn metadata_with_resource_lifecycle(
     metadata
 }
 
-pub fn preview(args: RunsArtifactPreviewArgs) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
-    let artifact = runs_service::resolve_artifact_for_run(&store, &args.run_id, &args.artifact_id)?;
+pub fn preview(store: &ObservationStore, args: RunsArtifactPreviewArgs) -> CmdResult<RunsOutput> {
+    let artifact = runs_service::resolve_artifact_for_run(store, &args.run_id, &args.artifact_id)?;
     preview_artifact(artifact, args.port)
 }
 
@@ -212,9 +210,8 @@ pub fn preview_artifact(artifact: ArtifactRecord, port: Option<u16>) -> CmdResul
     ))
 }
 
-pub fn capture(args: RunsArtifactCaptureArgs) -> CmdResult<RunsOutput> {
-    let store = ObservationStore::open_initialized()?;
-    let artifact = runs_service::resolve_artifact_for_run(&store, &args.run_id, &args.artifact_id)?;
+pub fn capture(store: &ObservationStore, args: RunsArtifactCaptureArgs) -> CmdResult<RunsOutput> {
+    let artifact = runs_service::resolve_artifact_for_run(store, &args.run_id, &args.artifact_id)?;
     if artifact.artifact_type != "directory" {
         return Err(Error::validation_invalid_argument(
             "artifact_id",
@@ -582,12 +579,15 @@ mod tests {
                 )
                 .expect("run");
 
-            let output = attach(RunsArtifactAttachArgs {
-                run_id: run.id.clone(),
-                runner: "issue-6403-local".to_string(),
-                path: source.display().to_string(),
-                name: "runner-report".to_string(),
-            })
+            let output = attach(
+                &store,
+                RunsArtifactAttachArgs {
+                    run_id: run.id.clone(),
+                    runner: "issue-6403-local".to_string(),
+                    path: source.display().to_string(),
+                    name: "runner-report".to_string(),
+                },
+            )
             .expect("attach")
             .0;
             let RunsOutput::ArtifactAttach(output) = output else {
@@ -654,12 +654,15 @@ mod tests {
                 )
                 .expect("run");
 
-            let output = attach(RunsArtifactAttachArgs {
-                run_id: run.id.clone(),
-                runner: "issue-6462-local".to_string(),
-                path: site.display().to_string(),
-                name: "generated-site".to_string(),
-            })
+            let output = attach(
+                &store,
+                RunsArtifactAttachArgs {
+                    run_id: run.id.clone(),
+                    runner: "issue-6462-local".to_string(),
+                    path: site.display().to_string(),
+                    name: "generated-site".to_string(),
+                },
+            )
             .expect("attach")
             .0;
             let RunsOutput::ArtifactAttach(output) = output else {
@@ -726,12 +729,15 @@ mod tests {
                 .start_run(NewRunRecord::builder("runner-exec").build())
                 .expect("run");
 
-            let result = attach(RunsArtifactAttachArgs {
-                run_id: run.id,
-                runner: "issue-6403-guard".to_string(),
-                path: outside.display().to_string(),
-                name: "outside".to_string(),
-            });
+            let result = attach(
+                &store,
+                RunsArtifactAttachArgs {
+                    run_id: run.id,
+                    runner: "issue-6403-guard".to_string(),
+                    path: outside.display().to_string(),
+                    name: "outside".to_string(),
+                },
+            );
             let Err(err) = result else {
                 panic!("outside path should fail");
             };
@@ -763,12 +769,15 @@ mod tests {
                 .start_run(NewRunRecord::builder("runner-exec").build())
                 .expect("run");
 
-            let result = attach(RunsArtifactAttachArgs {
-                run_id: run.id,
-                runner: "issue-6403-parent".to_string(),
-                path: workspace.join("../outside.txt").display().to_string(),
-                name: "outside".to_string(),
-            });
+            let result = attach(
+                &store,
+                RunsArtifactAttachArgs {
+                    run_id: run.id,
+                    runner: "issue-6403-parent".to_string(),
+                    path: workspace.join("../outside.txt").display().to_string(),
+                    name: "outside".to_string(),
+                },
+            );
             let Err(err) = result else {
                 panic!("parent-dir path should fail");
             };
@@ -810,11 +819,14 @@ mod tests {
                 )
                 .expect("artifact");
 
-            let output = preview(RunsArtifactPreviewArgs {
-                run_id: run.id.clone(),
-                artifact_id: artifact.id.clone(),
-                port: None,
-            })
+            let output = preview(
+                &store,
+                RunsArtifactPreviewArgs {
+                    run_id: run.id.clone(),
+                    artifact_id: artifact.id.clone(),
+                    port: None,
+                },
+            )
             .expect("preview")
             .0;
             let RunsOutput::ArtifactPreview(output) = output else {
@@ -858,11 +870,14 @@ mod tests {
                 .record_artifact(&run.id, "summary", &file)
                 .expect("artifact");
 
-            let result = preview(RunsArtifactPreviewArgs {
-                run_id: run.id,
-                artifact_id: artifact.id,
-                port: None,
-            });
+            let result = preview(
+                &store,
+                RunsArtifactPreviewArgs {
+                    run_id: run.id,
+                    artifact_id: artifact.id,
+                    port: None,
+                },
+            );
             let Err(err) = result else {
                 panic!("file artifact should fail");
             };
@@ -912,15 +927,18 @@ mod tests {
                 .expect("artifact");
             let output_dir = home.path().join("captures");
 
-            let result = capture(RunsArtifactCaptureArgs {
-                run_id: run.id.clone(),
-                artifact_id: artifact.id.clone(),
-                entrypoints: vec!["fse-pilot-build-theme/index.html".to_string()],
-                output_dir: output_dir.clone(),
-                port: None,
-                viewport_width: 390,
-                viewport_height: 844,
-            })
+            let result = capture(
+                &store,
+                RunsArtifactCaptureArgs {
+                    run_id: run.id.clone(),
+                    artifact_id: artifact.id.clone(),
+                    entrypoints: vec!["fse-pilot-build-theme/index.html".to_string()],
+                    output_dir: output_dir.clone(),
+                    port: None,
+                    viewport_width: 390,
+                    viewport_height: 844,
+                },
+            )
             .expect("capture");
             match old_provider {
                 Some(value) => env::set_var("HOMEBOY_ARTIFACT_CAPTURE_COMMAND", value),
@@ -966,15 +984,18 @@ mod tests {
                 .record_directory_artifact(&run.id, "generated_site", &site)
                 .expect("artifact");
 
-            let result = capture(RunsArtifactCaptureArgs {
-                run_id: run.id,
-                artifact_id: artifact.id,
-                entrypoints: vec!["index.html".to_string()],
-                output_dir: home.path().join("captures"),
-                port: None,
-                viewport_width: 390,
-                viewport_height: 844,
-            })
+            let result = capture(
+                &store,
+                RunsArtifactCaptureArgs {
+                    run_id: run.id,
+                    artifact_id: artifact.id,
+                    entrypoints: vec!["index.html".to_string()],
+                    output_dir: home.path().join("captures"),
+                    port: None,
+                    viewport_width: 390,
+                    viewport_height: 844,
+                },
+            )
             .expect("capture manifest");
             match old_provider {
                 Some(value) => env::set_var("HOMEBOY_ARTIFACT_CAPTURE_COMMAND", value),

--- a/crates/homeboy-cli/src/commands/runs/resources.rs
+++ b/crates/homeboy-cli/src/commands/runs/resources.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use clap::Args;
 use homeboy::core::observation::{ObservationStore, RunListFilter, RunStatus};
+use homeboy::core::paths::PathRoots;
 use homeboy::core::resource_cleanup_intent::ResourceCleanupIntent;
 use homeboy::core::resource_lifecycle_index::{
     resource_lifecycle_index_from_artifacts, resource_lifecycle_record_is_actionable,
@@ -188,9 +189,19 @@ pub struct RunsResourcesDiagnosticOutput {
 }
 
 pub(crate) fn runs_resources(args: RunsResourcesArgs) -> CmdResult<RunsOutput> {
+    let roots = PathRoots::from_environment()?;
+    let store = ObservationStore::open_initialized_in_roots(&roots)?;
+    runs_resources_in_store(&store, roots.config(), args)
+}
+
+pub(crate) fn runs_resources_in_store(
+    store: &ObservationStore,
+    config_root: &Path,
+    args: RunsResourcesArgs,
+) -> CmdResult<RunsOutput> {
     validate_cleanup_args(&args)?;
 
-    let loaded = load_indexes(&args)?;
+    let loaded = load_indexes(store, config_root, &args)?;
     let source_count = loaded.len();
     let mut sources = Vec::with_capacity(source_count);
     let mut all_resources = Vec::new();
@@ -221,7 +232,7 @@ pub(crate) fn runs_resources(args: RunsResourcesArgs) -> CmdResult<RunsOutput> {
     } else {
         None
     };
-    let diagnostics = load_runtime_diagnostics(&args)?;
+    let diagnostics = load_runtime_diagnostics(store, config_root, &args)?;
     let mode = if args.apply {
         ResourceCleanupMode::Apply
     } else if args.cleanup_plan {
@@ -461,7 +472,11 @@ struct LoadedResourceIndex {
     index: ResourceLifecycleIndex,
 }
 
-fn load_indexes(args: &RunsResourcesArgs) -> Result<Vec<LoadedResourceIndex>> {
+fn load_indexes(
+    store: &ObservationStore,
+    config_root: &Path,
+    args: &RunsResourcesArgs,
+) -> Result<Vec<LoadedResourceIndex>> {
     if args.sample {
         return Ok(vec![LoadedResourceIndex {
             source: "sample".to_string(),
@@ -473,10 +488,7 @@ fn load_indexes(args: &RunsResourcesArgs) -> Result<Vec<LoadedResourceIndex>> {
         return args.file.iter().map(|path| load_index_file(path)).collect();
     }
 
-    let store = ObservationStore::open_initialized()?;
-    // Boundary: one `runs resources` load is one unit of work (#7505).
-    let roots = homeboy::core::paths::PathRoots::from_environment()?;
-    load_observation_store_index(roots.config(), &store, args.run_id.as_deref())
+    load_observation_store_index(config_root, store, args.run_id.as_deref())
 }
 
 fn load_observation_store_index(
@@ -610,17 +622,16 @@ fn rig_lease_resource_record(
 }
 
 fn load_runtime_diagnostics(
+    store: &ObservationStore,
+    config_root: &Path,
     args: &RunsResourcesArgs,
 ) -> Result<Vec<RunsResourcesDiagnosticOutput>> {
     if args.sample || !args.file.is_empty() {
         return Ok(Vec::new());
     }
 
-    let store = ObservationStore::open_initialized()?;
     let mut outputs = Vec::new();
-    // Boundary: one resource-lifecycle report is one unit of work (#7505).
-    let roots = homeboy::core::paths::PathRoots::from_environment()?;
-    for diagnostic in homeboy::rig::lease::run_lease_diagnostics(roots.config())? {
+    for diagnostic in homeboy::rig::lease::run_lease_diagnostics(config_root)? {
         if args
             .run_id
             .as_deref()
@@ -628,7 +639,7 @@ fn load_runtime_diagnostics(
         {
             continue;
         }
-        outputs.push(rig_lease_diagnostic_output(&store, diagnostic)?);
+        outputs.push(rig_lease_diagnostic_output(store, diagnostic)?);
     }
     Ok(outputs)
 }

--- a/crates/homeboy-cli/src/commands/runs/tests/mod.rs
+++ b/crates/homeboy-cli/src/commands/runs/tests/mod.rs
@@ -1513,13 +1513,16 @@ fn artifacts_command_lists_copy_paste_get_commands_with_names() {
         );
 
         let downloaded = home.path().join("downloaded-named.json");
-        let (output, _) = artifact_get(RunsArtifactGetArgs {
-            run_id: run.id.clone(),
-            artifact_id: "readable-report".to_string(),
-            runner: None,
-            output: Some(downloaded.clone()),
-            field: Vec::new(),
-        })
+        let (output, _) = artifact_get(
+            &store,
+            RunsArtifactGetArgs {
+                run_id: run.id.clone(),
+                artifact_id: "readable-report".to_string(),
+                runner: None,
+                output: Some(downloaded.clone()),
+                field: Vec::new(),
+            },
+        )
         .expect("get by readable name");
         let RunsOutput::ArtifactGet(output) = output else {
             panic!("expected artifact get output");
@@ -1547,13 +1550,16 @@ fn artifact_get_copies_registered_file_without_raw_path_lookup() {
             .expect("record artifact");
         let output_path = home.path().join("downloaded.json");
 
-        let (output, _) = artifact_get(RunsArtifactGetArgs {
-            run_id: run.id.clone(),
-            artifact_id: artifact.id.clone(),
-            runner: None,
-            output: Some(output_path.clone()),
-            field: Vec::new(),
-        })
+        let (output, _) = artifact_get(
+            &store,
+            RunsArtifactGetArgs {
+                run_id: run.id.clone(),
+                artifact_id: artifact.id.clone(),
+                runner: None,
+                output: Some(output_path.clone()),
+                field: Vec::new(),
+            },
+        )
         .expect("get artifact");
 
         let RunsOutput::ArtifactGet(output) = output else {
@@ -1566,13 +1572,16 @@ fn artifact_get_copies_registered_file_without_raw_path_lookup() {
             br#"{"ok":true}"#
         );
 
-        let err = match artifact_get(RunsArtifactGetArgs {
-            run_id: run.id,
-            artifact_id: artifact_path.display().to_string(),
-            runner: None,
-            output: Some(home.path().join("bad.json")),
-            field: Vec::new(),
-        }) {
+        let err = match artifact_get(
+            &store,
+            RunsArtifactGetArgs {
+                run_id: run.id,
+                artifact_id: artifact_path.display().to_string(),
+                runner: None,
+                output: Some(home.path().join("bad.json")),
+                field: Vec::new(),
+            },
+        ) {
             Ok(_) => panic!("raw paths are not accepted as artifact ids"),
             Err(err) => err,
         };
@@ -1595,13 +1604,16 @@ fn artifact_get_field_selector_projects_only_requested_fields() {
             .expect("record artifact");
         let output_path = home.path().join("downloaded.json");
 
-        let (output, _) = artifact_get(RunsArtifactGetArgs {
-            run_id: run.id.clone(),
-            artifact_id: artifact.id.clone(),
-            runner: None,
-            output: Some(output_path.clone()),
-            field: vec!["$.output_path".to_string(), "$.artifact_id".to_string()],
-        })
+        let (output, _) = artifact_get(
+            &store,
+            RunsArtifactGetArgs {
+                run_id: run.id.clone(),
+                artifact_id: artifact.id.clone(),
+                runner: None,
+                output: Some(output_path.clone()),
+                field: vec!["$.output_path".to_string(), "$.artifact_id".to_string()],
+            },
+        )
         .expect("get artifact with field selector");
 
         // The artifact bytes are still written even when fields are projected.
@@ -1700,13 +1712,16 @@ fn artifact_get_fetches_nested_publication_artifact_store_ref() {
         assert_eq!(nested.path, materialized.to_string_lossy());
 
         let output_path = home.path().join("downloaded-nested.json");
-        let (output, _) = artifact_get(RunsArtifactGetArgs {
-            run_id: run.id.clone(),
-            artifact_id: "nested-result".to_string(),
-            runner: None,
-            output: Some(output_path.clone()),
-            field: Vec::new(),
-        })
+        let (output, _) = artifact_get(
+            &store,
+            RunsArtifactGetArgs {
+                run_id: run.id.clone(),
+                artifact_id: "nested-result".to_string(),
+                runner: None,
+                output: Some(output_path.clone()),
+                field: Vec::new(),
+            },
+        )
         .expect("get nested artifact");
 
         let RunsOutput::ArtifactGet(output) = output else {
@@ -1779,13 +1794,16 @@ fn artifacts_index_and_fetch_nested_visual_summary_refs_from_public_urls() {
         }
 
         let output_path = home.path().join("visual-source.png");
-        let (fetched, _) = artifact_get(RunsArtifactGetArgs {
-            run_id: run.id.clone(),
-            artifact_id: "visual_compare_15-saas_source".to_string(),
-            runner: None,
-            output: Some(output_path.clone()),
-            field: Vec::new(),
-        })
+        let (fetched, _) = artifact_get(
+            &store,
+            RunsArtifactGetArgs {
+                run_id: run.id.clone(),
+                artifact_id: "visual_compare_15-saas_source".to_string(),
+                runner: None,
+                output: Some(output_path.clone()),
+                field: Vec::new(),
+            },
+        )
         .expect("fetch public fallback");
         let RunsOutput::ArtifactGet(fetched) = fetched else {
             panic!("expected artifact get")

--- a/tests/runs_dispatch_boundary_rooting_test.rs
+++ b/tests/runs_dispatch_boundary_rooting_test.rs
@@ -18,12 +18,12 @@
 //! declared and not enforced, and every handler that keeps its own open is one
 //! more place that has to be revisited before the ambient entry point can go.
 //!
-//! `resume_plan`, `env`, and `artifacts_from_args` now take the store the
-//! dispatcher already holds.
+//! Run detail, artifact, and resource handlers now take the store the dispatcher
+//! already holds.
 //!
 //! ## What this test pins
 //!
-//! That those three keep taking an injected store. It deliberately does not
+//! That those handlers keep taking an injected store. It deliberately does not
 //! assert a total count for the module: `show_run` uses `open_readonly`, which
 //! is a different mode chosen so a read cannot create or migrate a database,
 //! and several sibling commands are still their own boundaries.
@@ -40,24 +40,41 @@ fn source(relative: &str) -> String {
 
 #[test]
 fn dispatched_handlers_do_not_reopen_the_store_they_were_given() {
-    let handlers = source("handlers.rs");
-    for name in ["resume_plan", "artifacts_from_args", "env"] {
-        let start = handlers
-            .find(&format!("fn {name}("))
-            .unwrap_or_else(|| panic!("`{name}` still exists in handlers.rs"));
-        let rest = &handlers[start..];
-        let end = rest.find("\n}\n").expect("terminated body");
-        let body = &rest[..end];
-        assert!(
-            body.contains("store: &ObservationStore"),
-            "`{name}` stopped taking the dispatcher's store (#7505)."
-        );
-        assert!(
-            !body.contains("ObservationStore::open_initialized()"),
-            "`{name}` takes an injected store and then opens another one. That \
+    for (relative, names) in [
+        (
+            "handlers.rs",
+            &[
+                "resume_plan",
+                "artifacts_from_args",
+                "env",
+                "artifact_command",
+                "artifact_preview_handle",
+                "artifact_get_inner",
+                "artifact_get_handle",
+            ][..],
+        ),
+        ("remote_artifact.rs", &["attach", "preview", "capture"]),
+        ("resources.rs", &["runs_resources_in_store"]),
+    ] {
+        let source = source(relative);
+        for name in names {
+            let start = source
+                .find(&format!("fn {name}("))
+                .unwrap_or_else(|| panic!("`{name}` still exists in {relative}"));
+            let rest = &source[start..];
+            let end = rest.find("\n}\n").expect("terminated body");
+            let body = &rest[..end];
+            assert!(
+                body.contains("store: &ObservationStore"),
+                "`{name}` stopped taking the dispatcher's store (#7505)."
+            );
+            assert!(
+                !body.contains("ObservationStore::open_initialized()"),
+                "`{name}` takes an injected store and then opens another one. That \
              is the shape the compiler cannot catch: the signature looks rooted \
              while the body still resolves the environment for itself (#7505)."
-        );
+            );
+        }
     }
 }
 
@@ -68,6 +85,8 @@ fn the_dispatcher_hands_its_store_to_those_handlers() {
         "handlers::resume_plan(&store, &run_id)",
         "handlers::env(&store, &run_id)",
         "handlers::artifacts_from_args(&store, args)",
+        "handlers::artifact_command(&store, args)",
+        "resources::runs_resources_in_store(&store, roots.config(), args)",
     ] {
         assert!(
             dispatch.contains(call),


### PR DESCRIPTION
## Summary
- resolve `PathRoots` and one `ObservationStore` at each `runs` command boundary
- pass that store through artifact attach, get, handle lookup, preview, capture, and resource reporting
- pass the same config root into resource indexes and rig diagnostics
- remove eight nested production `ObservationStore::open_initialized()` sites
- extend the existing boundary guard across the newly rooted handlers

## Verification
- `cargo check --workspace --all-targets -j2`
- `cargo check -p homeboy-cli --all-targets -j2` after rebasing onto current `main`
- `cargo test --test runs_dispatch_boundary_rooting_test`
- 12 remote-artifact tests
- 21 runs-resource tests
- 3 artifact-get tests
- focused `rustfmt --check` and `git diff --check`

Pre-existing warnings remain in runner doctor/external resolver test fixtures and the removed lifecycle-lock fixture import.

Tracks #13226 and #13755.

## AI assistance
OpenAI gpt-5.6-sol via OpenCode traced the `runs` dispatcher and nested artifact/resource handlers, threaded the existing rooted store and config root through the complete call chain, updated focused tests, and ran the listed verification.