### PR TITLE
Remove extension grammar re-exports

### DIFF
--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -14,10 +14,6 @@ mod env_provider;
 mod execution;
 mod fingerprint;
 // invocation_context relocated to homeboy_core::extension_invocation_context
-// The grammar parsing engine is a language-agnostic primitive; expose it through
-// the extension API while its implementation remains in homeboy-engine-primitives.
-pub use homeboy_engine_primitives::grammar;
-pub use homeboy_engine_primitives::grammar::items as grammar_items;
 pub mod lifecycle;
 pub mod lint;
 mod maintenance;

--- a/crates/homeboy-core/src/extension/refactor_protocol.rs
+++ b/crates/homeboy-core/src/extension/refactor_protocol.rs
@@ -165,14 +165,13 @@ impl RefactorScriptFailure {
 /// Output from a `parse_items` refactor command: the protocol name for a parsed
 /// top-level item.
 ///
-/// This was a second declaration of [`crate::extension::grammar_items::GrammarItem`] --
+/// This was a second declaration of [`homeboy_engine_primitives::grammar::items::GrammarItem`] --
 /// same six fields, same order, same serde, and the same doc comment on every
 /// field -- plus a `From` impl that moved them across one at a time.
 /// `GrammarItem`'s own doc already described it as "the core equivalent of
-/// `extension::ParsedItem`", and this crate re-exports the core module as
-/// `grammar_items`, so the two names always resolved through the same crate with
-/// no dependency boundary between them to justify a copy.
-pub type ParsedItem = crate::extension::grammar_items::GrammarItem;
+/// `extension::ParsedItem`", and core already depends directly on the grammar
+/// primitives, so there is no dependency boundary to justify a copy.
+pub type ParsedItem = homeboy_engine_primitives::grammar::items::GrammarItem;
 
 /// Output from a `resolve_imports` refactor command.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -234,7 +233,7 @@ mod tests {
 
     #[test]
     fn test_parsed_item_from_grammar_item() {
-        let item = crate::extension::grammar_items::GrammarItem {
+        let item = homeboy_engine_primitives::grammar::items::GrammarItem {
             name: "run".to_string(),
             kind: "function".to_string(),
             start_line: 3,

--- a/crates/homeboy-refactor/src/decompose.rs
+++ b/crates/homeboy-refactor/src/decompose.rs
@@ -6,10 +6,8 @@ use serde::{Deserialize, Serialize};
 
 use homeboy_core::plan::{HomeboyPlan, PlanKind, PlanStep, PlanValues};
 use homeboy_core::Result;
-use homeboy_core::{
-    self,
-    extension::{grammar, grammar_items, ParsedItem},
-};
+use homeboy_core::{self, extension::ParsedItem};
+use homeboy_engine_primitives::grammar::{self, items as grammar_items};
 
 use super::move_items::{MoveOptions, MoveResult};
 

--- a/crates/homeboy-refactor/src/move_items/extension_integration.rs
+++ b/crates/homeboy-refactor/src/move_items/extension_integration.rs
@@ -5,8 +5,9 @@ use std::path::Path;
 
 use homeboy_core::{
     self,
-    extension::{grammar, grammar_items, ExtensionManifest, ParsedItem},
+    extension::{ExtensionManifest, ParsedItem},
 };
+use homeboy_engine_primitives::grammar::{self, items as grammar_items};
 
 /// Find a refactor-capable extension for a file based on its extension.
 pub(crate) fn find_refactor_extension(file_path: &str) -> Option<ExtensionManifest> {

--- a/crates/homeboy-refactor/src/plan/generate/orphaned_test_fixes.rs
+++ b/crates/homeboy-refactor/src/plan/generate/orphaned_test_fixes.rs
@@ -129,7 +129,7 @@ fn lines_inside_string_literals(lines: &[&str]) -> Vec<bool> {
 
         // Check for raw string opening: r#"  r##"  r###" etc.
         if let Some(close_pattern) =
-            homeboy_core::extension::grammar::find_unclosed_raw_string_on_line(line)
+            homeboy_engine_primitives::grammar::find_unclosed_raw_string_on_line(line)
         {
             // Mark subsequent lines as inside the string until we find the close.
             let mut j = i + 1;
@@ -231,7 +231,7 @@ fn find_test_function_range(content: &str, fn_name: &str) -> Option<(usize, usiz
 
         // Check if this line opens a raw string that isn't closed on the same line.
         if let Some(close_pattern) =
-            homeboy_core::extension::grammar::find_unclosed_raw_string_on_line(line)
+            homeboy_engine_primitives::grammar::find_unclosed_raw_string_on_line(line)
         {
             raw_string_close = Some(close_pattern);
             // Still count braces on this line BEFORE the raw string opens.

--- a/crates/homeboy-refactor/src/plan/generate/signatures.rs
+++ b/crates/homeboy-refactor/src/plan/generate/signatures.rs
@@ -124,7 +124,7 @@ pub(crate) fn parse_items_for_dedup(
     file_path: &str,
 ) -> Option<Vec<homeboy_core::extension::ParsedItem>> {
     if let Some(grammar) = homeboy_code_audit::core_fingerprint::load_grammar_for_ext(file_ext) {
-        let items = homeboy_core::extension::grammar_items::parse_items(content, &grammar);
+        let items = homeboy_engine_primitives::grammar::items::parse_items(content, &grammar);
         if !items.is_empty() {
             return Some(
                 items


### PR DESCRIPTION
## Summary

- remove the language-agnostic grammar and grammar-items re-exports from `homeboy_core::extension`
- import those primitives directly from `homeboy-engine-primitives`
- retain `extension::ParsedItem` as the product-level refactor protocol type

Closes #13833

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p homeboy-core -p homeboy-refactor --all-targets`
- `cargo nextest run -p homeboy-core --lib extension` (927 passed)
- `cargo nextest run -p homeboy-refactor` (347 passed)
- `git diff --check origin/main...HEAD`

## AI Assistance

OpenCode 1.18.23 with OpenAI GPT-5.6 Sol audited the post-#13828 extension surface, made the six-file ownership cleanup, and ran the verification under Chris Huber's direction. Chris owns the architecture and implementation decisions.