### PR TITLE
Remove extension readiness re-exports

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -23,9 +23,10 @@ use crate::commands::output_runtime;
 use crate::commands::utils::{args, entity_suggest, resource_policy, response as output};
 use homeboy::extension::{
     list_summaries_with, load_all_extensions, CliConfig,
-    ExtensionManifest as InstalledExtensionManifest, ExtensionReadinessMode, ExtensionSummary,
+    ExtensionManifest as InstalledExtensionManifest, ExtensionSummary,
 };
 use homeboy_agents::agent_task_service::cook_continue_command;
+use homeboy_core::extension_readiness::ExtensionReadinessMode;
 #[cfg(test)]
 use homeboy_core::extension_readiness::READY_CHECK_SKIPPED_REASON;
 use homeboy_upgrade::upgrade;
@@ -2289,7 +2290,7 @@ fn extension_command_health_from_summary(summary: &ExtensionSummary) -> Extensio
     // A command-health contract that treated an absent measurement as ready
     // would reproduce the fail-open defect class in #10685. (#10616)
     let readiness_unknown =
-        summary.readiness == homeboy_core::extension::ExtensionReadinessState::Unknown;
+        summary.readiness == homeboy_core::extension_readiness::ExtensionReadinessState::Unknown;
 
     let status = if summary.error.is_some() {
         "error"
@@ -2299,7 +2300,9 @@ fn extension_command_health_from_summary(summary: &ExtensionSummary) -> Extensio
         "unknown"
     } else if summary.ready == Some(true) {
         "ready"
-    } else if summary.readiness == homeboy_core::extension::ExtensionReadinessState::TimedOut {
+    } else if summary.readiness
+        == homeboy_core::extension_readiness::ExtensionReadinessState::TimedOut
+    {
         "timed_out"
     } else {
         "not_ready"

--- a/crates/homeboy-cli/src/commands/extension.rs
+++ b/crates/homeboy-cli/src/commands/extension.rs
@@ -11,8 +11,10 @@ use homeboy::core::project::{self, Project};
 use homeboy::core::server::{self, SshClient};
 use homeboy::runner::runners::{self, RunnerKind};
 use homeboy_core::extension::{
-    extension_ready_status_with, is_extension_linked, load_extension, run_setup,
-    ExtensionReadinessMode, ExtensionSummary, UpdateEntry,
+    is_extension_linked, load_extension, run_setup, ExtensionSummary, UpdateEntry,
+};
+use homeboy_core::extension_readiness::{
+    extension_ready_status_with, ExtensionReadinessMode, ExtensionReadinessState,
 };
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -521,7 +523,7 @@ pub struct ExtensionDetail {
     pub has_setup: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub has_ready_check: Option<bool>,
-    pub readiness: homeboy_core::extension::ExtensionReadinessState,
+    pub readiness: ExtensionReadinessState,
     pub ready: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ready_reason: Option<String>,
@@ -2313,7 +2315,7 @@ mod tests {
             runtime: "platform".to_string(),
             compatible: true,
             core_compatibility: homeboy_core::extension::CoreCompatibilityReport::undeclared(None),
-            readiness: homeboy_core::extension::ExtensionReadinessState::Ready,
+            readiness: ExtensionReadinessState::Ready,
             ready: Some(true),
             ready_reason: None,
             ready_detail: None,
@@ -2379,7 +2381,7 @@ mod tests {
                 core_compatibility: homeboy_core::extension::CoreCompatibilityReport::undeclared(
                     None,
                 ),
-                readiness: homeboy_core::extension::ExtensionReadinessState::Ready,
+                readiness: ExtensionReadinessState::Ready,
                 ready: Some(true),
                 ready_reason: None,
                 ready_detail: None,
@@ -2434,7 +2436,7 @@ mod tests {
                 core_compatibility: homeboy_core::extension::CoreCompatibilityReport::undeclared(
                     None,
                 ),
-                readiness: homeboy_core::extension::ExtensionReadinessState::Ready,
+                readiness: ExtensionReadinessState::Ready,
                 ready: Some(true),
                 ready_reason: None,
                 ready_detail: None,

--- a/crates/homeboy-cli/src/commands/fuzz/doctor.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/doctor.rs
@@ -1,6 +1,5 @@
-use homeboy_core::extension::{
-    check_update_available, extension_ready_status, is_extension_linked, load_extension,
-};
+use homeboy_core::extension::{check_update_available, is_extension_linked, load_extension};
+use homeboy_core::extension_readiness::extension_ready_status;
 use homeboy_core::extension_update_check::read_source_revision;
 
 use super::types::FuzzDoctorArgs;

--- a/crates/homeboy-cli/src/commands/fuzz/types_extra.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/types_extra.rs
@@ -50,7 +50,7 @@ pub struct FuzzDoctorExtensionOutput {
     pub version: String,
     pub path: String,
     pub linked: bool,
-    pub readiness: homeboy_core::extension::ExtensionReadinessState,
+    pub readiness: homeboy_core::extension_readiness::ExtensionReadinessState,
     pub ready: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ready_reason: Option<String>,

--- a/crates/homeboy-core/src/extension/execution.rs
+++ b/crates/homeboy-core/src/extension/execution.rs
@@ -28,10 +28,7 @@ use super::runtime_helper;
 use homeboy_core::extension_invocation_context::ResolvedExtensionInvocationContext;
 
 pub use action::execute_action;
-pub use homeboy_core::extension_readiness::{
-    extension_ready_status, extension_ready_status_with, is_extension_compatible,
-    ExtensionReadinessMode, ExtensionReadinessState, ExtensionReadyStatus,
-};
+use homeboy_core::extension_readiness::extension_ready_status;
 use settings::serialize_settings;
 pub(crate) use settings::{build_settings_json_from_manifest, load_extension_manifest_from_dir};
 

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -62,10 +62,8 @@ pub use env_provider::{
 pub(crate) use execution::build_settings_json_from_manifest;
 pub use execution::execute_action;
 pub use execution::{
-    extension_ready_status, extension_ready_status_with, is_extension_compatible, run_action,
-    run_deployment_provider, run_extension, run_setup, ExtensionExecutionMode,
-    ExtensionReadinessMode, ExtensionReadinessState, ExtensionReadyStatus, ExtensionRunResult,
-    ExtensionSetupResult, ExtensionStepFilter,
+    run_action, run_deployment_provider, run_extension, run_setup, ExtensionExecutionMode,
+    ExtensionRunResult, ExtensionSetupResult, ExtensionStepFilter,
 };
 pub use fingerprint::{
     run_fingerprint_script, AggregateConstructionSeam, AggregateDefinitionFact, AggregateFieldFact,

--- a/crates/homeboy-core/src/extension/summary.rs
+++ b/crates/homeboy-core/src/extension/summary.rs
@@ -1,12 +1,12 @@
 use serde::Serialize;
 
-use super::execution::{
-    extension_ready_status_with, is_extension_compatible, ExtensionReadinessMode,
-    ExtensionReadinessState,
-};
 use super::manifest::ActionType;
 use super::{evaluate_core_compatibility, CoreCompatibilityReport};
 use homeboy_core::error::ExecutableAction;
+use homeboy_core::extension_readiness::{
+    extension_ready_status_with, is_extension_compatible, ExtensionReadinessMode,
+    ExtensionReadinessState,
+};
 use homeboy_core::extension_store::{
     broken_extension_link_repair_actions, discover_extensions, is_extension_linked,
     DiscoveredExtension, ExtensionManifestFailure,


### PR DESCRIPTION
## Summary

- make `homeboy_core::extension_readiness` the single public owner of readiness APIs
- stop re-exporting readiness through extension execution and the extension barrel
- move core and CLI consumers to the canonical module without changing behavior

Closes #13835

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p homeboy-core -p homeboy-cli --all-targets`
- `cargo nextest run -p homeboy-core --lib extension` (927 passed)
- `cargo nextest run -p homeboy-cli extension` (80 passed)
- `git diff --check origin/main...HEAD`

## AI Assistance

OpenCode 1.18.23 with OpenAI GPT-5.6 Sol audited readiness ownership, implemented the seven-file path cleanup, and ran the verification under Chris Huber's direction. Chris owns the architecture and implementation decisions.