### PR TITLE
Remove extension update-check re-exports

### DIFF
--- a/crates/homeboy-cli/src/commands/fuzz/doctor.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/doctor.rs
@@ -1,6 +1,6 @@
-use homeboy_core::extension::{check_update_available, is_extension_linked, load_extension};
+use homeboy_core::extension::{is_extension_linked, load_extension};
 use homeboy_core::extension_readiness::extension_ready_status;
-use homeboy_core::extension_update_check::read_source_revision;
+use homeboy_core::extension_update_check::{check_update_available, read_source_revision};
 
 use super::types::FuzzDoctorArgs;
 use super::types_extra::{FuzzDoctorExtensionOutput, FuzzDoctorHomeboyOutput, FuzzDoctorOutput};

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -1,6 +1,3 @@
-pub use homeboy_core::extension_update_check::{
-    check_update_available, is_git_url, UpdateAvailable,
-};
 pub mod audit_compiler_warning_provider;
 pub mod audit_fingerprint_script_provider;
 pub mod audit_grammar_source_provider;

--- a/crates/homeboy-rig/src/install.rs
+++ b/crates/homeboy-rig/src/install.rs
@@ -7,6 +7,7 @@
 
 use homeboy_core::error::{Error, Result};
 use homeboy_core::extension;
+use homeboy_core::extension_update_check::is_git_url;
 use homeboy_core::{git, paths};
 use homeboy_stack::stack;
 use serde::{Deserialize, Serialize};
@@ -1124,7 +1125,7 @@ pub fn read_stack_source_metadata_in_root(
 }
 
 pub(crate) fn prepare_source(config_root: &Path, source: &str) -> Result<PreparedSource> {
-    if extension::is_git_url(source) || source.contains(".git//") {
+    if is_git_url(source) || source.contains(".git//") {
         prepare_git_source(config_root, source)
     } else {
         prepare_local_source(source)

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -1,6 +1,7 @@
 use homeboy_core::defaults;
 use homeboy_core::error::{Error, Result};
 use homeboy_core::extension;
+use homeboy_core::extension_update_check::is_git_url;
 use homeboy_core::{build_identity, git};
 use semver::Version;
 use std::path::{Path, PathBuf};
@@ -1467,7 +1468,7 @@ fn installed_extension_catalog_for(extension_ids: &[String]) -> Vec<ExtensionUpg
                 Ok(manifest) => {
                     let (source_url, update_note) =
                         match extension::resolve_source_url_read_only(&extension_id) {
-                            Ok(source_url) if extension::is_git_url(&source_url) => {
+                            Ok(source_url) if is_git_url(&source_url) => {
                                 (Some(source_url), None)
                             }
                             Ok(source_url) => (
@@ -2039,7 +2040,7 @@ fn portable_extension_source_url(result: &homeboy_core::extension::UpdateResult)
         return git::remote_origin_url(git_root);
     }
 
-    if extension::is_git_url(&result.url) {
+    if is_git_url(&result.url) {
         Some(result.url.clone())
     } else {
         None


### PR DESCRIPTION
## Summary

- make `homeboy_core::extension_update_check` the single public owner of update-check APIs
- remove update-check functions and types from the extension barrel
- move CLI, rig, and upgrade consumers to the canonical module

Closes #13839

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p homeboy-core -p homeboy-cli -p homeboy-rig -p homeboy-upgrade --all-targets`
- `cargo nextest run -p homeboy-core extension_update_check` (12 passed)
- `cargo nextest run -p homeboy-rig -p homeboy-upgrade` (707 passed)
- `cargo nextest run -p homeboy-cli fuzz_doctor` (2 passed)
- `git diff --check origin/main...HEAD`

## AI Assistance

OpenCode 1.18.23 with OpenAI GPT-5.6 Sol audited update-check alias usage, implemented the four-file migration, and ran the verification under Chris Huber's direction. Chris owns the architecture and implementation decisions.