### PR TITLE
Remove unused extension-store re-exports

### DIFF
--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -63,9 +63,8 @@ pub use fingerprint::{
     ProjectionFieldFact, UnusedParam,
 };
 pub use homeboy_core::extension_store::{
-    available_extension_ids, discover_extensions, extension_path, find_extension_by_tool,
-    find_extension_for_file_ext, is_extension_linked, load_all_extensions, load_extension, merge,
-    save_manifest, DiscoveredExtension, ExtensionManifestFailure,
+    available_extension_ids, discover_extensions, find_extension_for_file_ext, is_extension_linked,
+    load_all_extensions, load_extension, merge, save_manifest, DiscoveredExtension,
 };
 pub use homeboy_extension_contract::runner_contract::{
     phase_failure_category_from_exit_code, phase_status_from_exit_code, ExtensionPhaseTiming,


### PR DESCRIPTION
Closes #13846.

## Summary
- remove dead `extension_path` and `find_extension_by_tool` re-exports
- remove the dead `ExtensionManifestFailure` facade type re-export
- keep canonical implementations in `homeboy_core::extension_store` unchanged

## Verification
- confirmed no workspace consumers use the removed facade paths
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p homeboy-core --lib`

## AI assistance
OpenCode 1.18.23 with OpenAI GPT-5.6 Sol was used to audit facade consumers, apply the deletion-only cleanup, and run targeted verification. Chris Huber directed the work and owns the decisions.