### PR TITLE
Remove extension merge re-export

### DIFF
--- a/crates/homeboy-cli/src/commands/extension.rs
+++ b/crates/homeboy-cli/src/commands/extension.rs
@@ -1568,7 +1568,7 @@ fn set_extension(
     json: &str,
     replace_fields: &[String],
 ) -> CmdResult<ExtensionOutput> {
-    match homeboy_core::extension::merge(extension_id, json, replace_fields)? {
+    match homeboy_core::extension_store::merge(extension_id, json, replace_fields)? {
         homeboy::core::MergeOutput::Single(result) => Ok((
             ExtensionOutput::Set {
                 extension_id: result.id,

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -64,7 +64,7 @@ pub use fingerprint::{
 };
 pub use homeboy_core::extension_store::{
     available_extension_ids, discover_extensions, find_extension_for_file_ext, is_extension_linked,
-    load_all_extensions, load_extension, merge, save_manifest, DiscoveredExtension,
+    load_all_extensions, load_extension, save_manifest, DiscoveredExtension,
 };
 pub use homeboy_extension_contract::runner_contract::{
     phase_failure_category_from_exit_code, phase_status_from_exit_code, ExtensionPhaseTiming,


### PR DESCRIPTION
Closes #13850.

## Summary
- route the CLI extension-set command directly to `homeboy_core::extension_store::merge`
- remove the parallel `homeboy_core::extension::merge` re-export
- preserve merge validation, mutation, and output behavior unchanged

## Verification
- confirmed no workspace consumers use `extension::merge`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p homeboy-cli --lib`

## AI assistance
OpenCode 1.18.23 with OpenAI GPT-5.6 Sol was used to audit the sole facade consumer, apply the namespace-only migration, and run targeted verification. Chris Huber directed the work and owns the decisions.