### PR TITLE
Expose worktree import and terminal finalization primitives

### DIFF
--- a/crates/homeboy-cli/src/commands/worktree.rs
+++ b/crates/homeboy-cli/src/commands/worktree.rs
@@ -8,16 +8,17 @@ use homeboy::core::cleanup::{
 };
 use homeboy::core::worktree::{
     self, CleanupPolicy, TaskWorktreeRegistryQuarantine, WorktreeAdoptOptions, WorktreeAdoptOutput,
-    WorktreeCleanupOutput, WorktreeCreateOptions, WorktreeCreateOutput, WorktreeInventoryOptions,
-    WorktreeInventoryOutput, WorktreeListOutput, WorktreeOwnershipProbe,
-    WorktreeQueueCreateOptions, WorktreeQueueCreateOutput, WorktreeRemoveOptions,
-    WorktreeRemoveOutput, WorktreeStatusOutput,
+    WorktreeCleanupOutput, WorktreeCreateOptions, WorktreeCreateOutput, WorktreeImportOptions,
+    WorktreeImportOutput, WorktreeInventoryOptions, WorktreeInventoryOutput, WorktreeListOutput,
+    WorktreeOwnershipProbe, WorktreeQueueCreateOptions, WorktreeQueueCreateOutput,
+    WorktreeRemoveOptions, WorktreeRemoveOutput, WorktreeStatusOutput,
 };
 use homeboy::core::worktree_provider::{
     self, ConfiguredWorktreeCleanupOutput as WorktreeProviderCleanupOutput,
     ConfiguredWorktreeCreateEvidence, WorktreeCleanupRequest, WorktreeCleanupScope,
-    WorktreeProviderCreateOutput, WorktreeProviderIdentity, WorktreeProviderSafety,
-    WorktreeProviderWorkspace, WorktreeStatusEvidence,
+    WorktreeFinalization, WorktreeFinalizationLookup, WorktreeProviderCreateOutput,
+    WorktreeProviderIdentity, WorktreeProviderSafety, WorktreeProviderWorkspace,
+    WorktreeProvisionLifecycle, WorktreeStatusEvidence, WorktreeTerminalDisposition,
 };
 
 use crate::command_contract::{LabCommandContract, WORKTREE_CLEANUP_LAB_LABEL};
@@ -64,6 +65,30 @@ enum WorktreeCommand {
         /// Cleanup policy for lifecycle cleanup
         #[arg(long, value_enum)]
         cleanup_policy: Option<CliCleanupPolicy>,
+    },
+    /// Import an existing exact Git worktree into the built-in lifecycle registry
+    Import {
+        component_id: String,
+        handle: String,
+        path: String,
+        #[arg(long)]
+        branch: String,
+        #[arg(long)]
+        base_ref: String,
+        #[arg(long)]
+        task_url: Option<String>,
+        #[arg(long)]
+        run_id: Option<String>,
+        #[arg(long, value_enum)]
+        cleanup_policy: CliCleanupPolicy,
+    },
+    /// Record a terminal worktree disposition without performing cleanup
+    Finalize {
+        handle: String,
+        #[arg(long)]
+        owner_run_ref: String,
+        #[arg(long, value_enum)]
+        disposition: CliTerminalDisposition,
     },
     /// Adopt an existing local workspace path for @workspace:<handle> refs
     Adopt {
@@ -190,6 +215,27 @@ enum CliCleanupPolicy {
     PreserveOnFailure,
 }
 
+#[derive(Debug, Clone, ValueEnum)]
+enum CliTerminalDisposition {
+    Succeeded,
+    Failed,
+    Cancelled,
+    TimedOut,
+    Interrupted,
+}
+
+impl From<CliTerminalDisposition> for WorktreeTerminalDisposition {
+    fn from(value: CliTerminalDisposition) -> Self {
+        match value {
+            CliTerminalDisposition::Succeeded => Self::Succeeded,
+            CliTerminalDisposition::Failed => Self::Failed,
+            CliTerminalDisposition::Cancelled => Self::Cancelled,
+            CliTerminalDisposition::TimedOut => Self::TimedOut,
+            CliTerminalDisposition::Interrupted => Self::Interrupted,
+        }
+    }
+}
+
 impl From<CliCleanupPolicy> for CleanupPolicy {
     fn from(value: CliCleanupPolicy) -> Self {
         match value {
@@ -203,6 +249,8 @@ impl From<CliCleanupPolicy> for CleanupPolicy {
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum WorktreeOutput {
     Create(WorktreeCreateCommandOutput),
+    Import(WorktreeImportOutput),
+    Finalize(WorktreeFinalization),
     Adopt(WorktreeAdoptOutput),
     QueueCreate(WorktreeQueueCreateOutput),
     List(WorktreeListCommandOutput),
@@ -480,6 +528,61 @@ pub fn run(args: WorktreeArgs) -> CmdResult<WorktreeOutput> {
             })?
             .into(),
         ),
+        WorktreeCommand::Import {
+            component_id,
+            handle,
+            path,
+            branch,
+            base_ref,
+            task_url,
+            run_id,
+            cleanup_policy,
+        } => WorktreeOutput::Import(worktree::import(WorktreeImportOptions {
+            component_id,
+            handle,
+            path,
+            branch,
+            base_ref,
+            task_url,
+            run_id,
+            cleanup_policy: cleanup_policy.into(),
+        })?),
+        WorktreeCommand::Finalize {
+            handle,
+            owner_run_ref,
+            disposition,
+        } => {
+            let lifecycle = WorktreeProvisionLifecycle {
+                purpose: "operator_terminal_finalization".to_string(),
+                owner_run_ref,
+                cleanup_policy:
+                    homeboy::core::worktree_provider::WorktreeCleanupPolicy::PreserveOnFailure,
+            };
+            match worktree_provider::finalize_worktree_from_config(
+                &handle,
+                &lifecycle,
+                disposition.into(),
+                &homeboy::core::defaults::load_config(),
+            )? {
+                WorktreeFinalizationLookup::Finalized(output) => WorktreeOutput::Finalize(output),
+                WorktreeFinalizationLookup::Unsupported => {
+                    return Err(homeboy::core::Error::validation_invalid_argument(
+                        "handle",
+                        "selected worktree provider does not support terminal finalization",
+                        Some(handle),
+                        None,
+                    ));
+                }
+                WorktreeFinalizationLookup::NotFound => {
+                    return Err(homeboy::core::Error::validation_invalid_argument(
+                        "handle",
+                        "worktree handle was not found",
+                        Some(handle),
+                        None,
+                    ));
+                }
+            }
+        }
         WorktreeCommand::Adopt {
             handle,
             path,

--- a/crates/homeboy-core/src/worktree/mod.rs
+++ b/crates/homeboy-core/src/worktree/mod.rs
@@ -27,14 +27,15 @@ pub use types::{
     WorktreeBranchCleanupReport, WorktreeCleanupCandidate, WorktreeCleanupCounts,
     WorktreeCleanupOptions, WorktreeCleanupOutput, WorktreeCleanupSkipped, WorktreeCreateAction,
     WorktreeCreateEvidence, WorktreeCreateOptions, WorktreeCreateOutput,
-    WorktreeCreateReconciliation, WorktreeInventoryApplyRefusal, WorktreeInventoryAuthorization,
-    WorktreeInventoryCrossTab, WorktreeInventoryLocalEvidence, WorktreeInventoryOptions,
-    WorktreeInventoryOutput, WorktreeInventoryRecord, WorktreeLeaseActivity, WorktreeListOutput,
-    WorktreeLivenessAuthority, WorktreeOwnershipProbe, WorktreeQueueCreateFailure,
-    WorktreeQueueCreateOptions, WorktreeQueueCreateOutput, WorktreeQueueCreateRequest,
-    WorktreeQueueCreateRow, WorktreeQueueCreateStatus, WorktreeQueueLockHolder,
-    WorktreeReconciliationAction, WorktreeReconciliationAuthority, WorktreeReconciliationResult,
-    WorktreeRemoveOptions, WorktreeRemoveOutput, WorktreeSafetyReport, WorktreeStatusOutput,
+    WorktreeCreateReconciliation, WorktreeImportOptions, WorktreeImportOutput,
+    WorktreeInventoryApplyRefusal, WorktreeInventoryAuthorization, WorktreeInventoryCrossTab,
+    WorktreeInventoryLocalEvidence, WorktreeInventoryOptions, WorktreeInventoryOutput,
+    WorktreeInventoryRecord, WorktreeLeaseActivity, WorktreeListOutput, WorktreeLivenessAuthority,
+    WorktreeOwnershipProbe, WorktreeQueueCreateFailure, WorktreeQueueCreateOptions,
+    WorktreeQueueCreateOutput, WorktreeQueueCreateRequest, WorktreeQueueCreateRow,
+    WorktreeQueueCreateStatus, WorktreeQueueLockHolder, WorktreeReconciliationAction,
+    WorktreeReconciliationAuthority, WorktreeReconciliationResult, WorktreeRemoveOptions,
+    WorktreeRemoveOutput, WorktreeSafetyReport, WorktreeStatusOutput,
     TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY, TERMINAL_WORKSPACE_AUTHORITY_SCHEMA,
 };
 
@@ -53,6 +54,10 @@ pub fn create(options: WorktreeCreateOptions) -> Result<WorktreeCreateOutput> {
 
 pub fn adopt(options: WorktreeAdoptOptions) -> Result<WorktreeAdoptOutput> {
     adopt_with_store(options, &adopted_metadata_dir()?)
+}
+
+pub fn import(options: WorktreeImportOptions) -> Result<WorktreeImportOutput> {
+    import_with_store(options, &metadata_dir()?)
 }
 
 pub fn list() -> Result<WorktreeListOutput> {

--- a/crates/homeboy-core/src/worktree/store_ops.rs
+++ b/crates/homeboy-core/src/worktree/store_ops.rs
@@ -42,6 +42,120 @@ pub(super) fn adopt_with_store(
     Ok(WorktreeAdoptOutput { record })
 }
 
+pub(super) fn import_with_store(
+    options: WorktreeImportOptions,
+    store_dir: &Path,
+) -> Result<WorktreeImportOutput> {
+    with_task_worktree_registry_write_lock(|| {
+        let target = component::resolve_target(TargetSpec {
+            component_id: Some(&options.component_id),
+            path_override: None,
+            project: None,
+            capability: None,
+            allow_synthetic: false,
+            accept_bare_directory: false,
+            ..TargetSpec::default()
+        })?;
+        let source_checkout = source_checkout_for_worktree(&target)?;
+        let path = PathBuf::from(&options.path)
+            .canonicalize()
+            .map_err(|error| {
+                Error::validation_invalid_argument(
+                    "path",
+                    "Imported worktree path must exist on the controller",
+                    Some(format!("{} ({error})", options.path)),
+                    None,
+                )
+            })?;
+        let expected_handle = format!("{}@{}", target.component_id, branch_slug(&options.branch));
+        if options.handle != expected_handle {
+            return Err(Error::validation_invalid_argument(
+                "handle",
+                "Imported worktree handle must exactly match its component and branch",
+                Some(options.handle),
+                Some(vec![format!("expected: {expected_handle}")]),
+            ));
+        }
+        let expected_path = source_checkout
+            .parent()
+            .ok_or_else(|| Error::internal_unexpected("source checkout has no parent"))?
+            .join(&expected_handle);
+        if path == source_checkout || path != normalize_missing_path(&expected_path) {
+            return Err(Error::validation_invalid_argument(
+                "path",
+                "Imported worktree must be the exact non-primary path for its native handle",
+                Some(path.display().to_string()),
+                Some(vec![format!("expected: {}", expected_path.display())]),
+            ));
+        }
+        let registration = branch_worktree_registrations(&source_checkout, &options.branch)?
+            .into_iter()
+            .find(|registration| registration.path == path && !registration.prunable)
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "path",
+                    "Imported path is not the live exact Git worktree registration for its branch",
+                    Some(path.display().to_string()),
+                    None,
+                )
+            })?;
+        verify_linked_worktree_identity(&source_checkout, &path, &options.branch)?;
+
+        let identity = task_worktree_workspace_identity(&target.component_id, &expected_handle)?;
+        if record_path(store_dir, &expected_handle).exists() {
+            let record = read_record(store_dir, &expected_handle)?;
+            let exact_replay = record.component_id == target.component_id
+                && normalize_missing_path(Path::new(&record.source_checkout)) == source_checkout
+                && normalize_missing_path(Path::new(&record.worktree_path)) == path
+                && record.branch == options.branch
+                && record.base_ref == options.base_ref
+                && record.task_url == options.task_url
+                && record.run_id == options.run_id
+                && record.cleanup_policy == options.cleanup_policy
+                && record.state == TaskWorktreeState::Active
+                && record.terminal_disposition.is_none()
+                && record.effective_workspace_identity()? == identity;
+            if !exact_replay {
+                return Err(Error::validation_invalid_argument(
+                    "handle",
+                    "Imported worktree conflicts with the existing native lifecycle record",
+                    Some(expected_handle),
+                    None,
+                ));
+            }
+            return Ok(WorktreeImportOutput {
+                record,
+                imported: false,
+            });
+        }
+
+        let record = TaskWorktreeRecord {
+            id: expected_handle,
+            component_id: target.component_id,
+            source_checkout: source_checkout.display().to_string(),
+            worktree_path: path.display().to_string(),
+            branch: options.branch,
+            base_ref: options.base_ref,
+            workspace_identity: Some(identity),
+            task_url: options.task_url,
+            run_id: options.run_id,
+            cleanup_policy: options.cleanup_policy,
+            terminal_disposition: None,
+            branch_cleanup_intent: BranchCleanupIntent::DeleteWhenMerged,
+            created_at: chrono::Utc::now().to_rfc3339(),
+            state: TaskWorktreeState::Active,
+            lifecycle_revision: 0,
+            terminal_workspace_authority: None,
+        };
+        let _ = registration;
+        write_record_unlocked(store_dir, &record)?;
+        Ok(WorktreeImportOutput {
+            record,
+            imported: true,
+        })
+    })
+}
+
 pub(super) fn cleanup_with_store(
     options: WorktreeCleanupOptions,
     store: &Path,

--- a/crates/homeboy-core/src/worktree/types.rs
+++ b/crates/homeboy-core/src/worktree/types.rs
@@ -355,6 +355,24 @@ pub struct WorktreeCreateOutput {
     pub reconciliation: Option<WorktreeCreateReconciliation>,
 }
 
+#[derive(Debug, Clone)]
+pub struct WorktreeImportOptions {
+    pub component_id: String,
+    pub handle: String,
+    pub path: String,
+    pub branch: String,
+    pub base_ref: String,
+    pub task_url: Option<String>,
+    pub run_id: Option<String>,
+    pub cleanup_policy: CleanupPolicy,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorktreeImportOutput {
+    pub record: TaskWorktreeRecord,
+    pub imported: bool,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct WorktreeAdoptOutput {
     pub record: AdoptedWorkspaceRecord,

--- a/crates/homeboy-core/src/worktree_provider.rs
+++ b/crates/homeboy-core/src/worktree_provider.rs
@@ -274,7 +274,8 @@ impl WorktreeCleanupPolicy {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum WorktreeTerminalDisposition {
     Succeeded,
     Failed,
@@ -312,7 +313,7 @@ impl WorktreeTerminalDisposition {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct WorktreeFinalization {
     pub provider_id: String,
     pub handle: String,


### PR DESCRIPTION
## Summary
- add a mutation-free built-in worktree import primitive with exact handle, path, branch, repository, and registry validation
- preserve task, owner-run, cleanup policy, and RFC 3339 creation provenance while making exact replay idempotent
- expose provider-neutral terminal finalization through the public `homeboy worktree` CLI without performing cleanup
- serialize typed import and finalization command results
- prove imported worktrees continue through native list, status, finalization, and cleanup preview

## Verification
- `cargo fmt --all -- --check`
- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-core worktree::tests::import_`
- `cargo test -p homeboy-core worktree::tests::finalization_is_owner_bound_idempotent_conflict_safe_and_never_cleans_up`
- `cargo test -p homeboy-cli worktree_import_and_finalize_are_public_typed_cli_commands`

Closes #13593

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode inspected the existing worktree lifecycle contracts, implemented the import and finalization primitives under Chris Huber's direction, and ran the listed verification.