### PR TITLE
Complete worktree import provenance and lifecycle coverage

### DIFF
--- a/crates/homeboy-cli/src/commands/worktree.rs
+++ b/crates/homeboy-cli/src/commands/worktree.rs
@@ -78,9 +78,11 @@ enum WorktreeCommand {
         #[arg(long)]
         task_url: Option<String>,
         #[arg(long)]
-        run_id: Option<String>,
+        owner_run_ref: Option<String>,
         #[arg(long, value_enum)]
         cleanup_policy: CliCleanupPolicy,
+        #[arg(long)]
+        created_at: Option<String>,
     },
     /// Record a terminal worktree disposition without performing cleanup
     Finalize {
@@ -535,8 +537,9 @@ pub fn run(args: WorktreeArgs) -> CmdResult<WorktreeOutput> {
             branch,
             base_ref,
             task_url,
-            run_id,
+            owner_run_ref,
             cleanup_policy,
+            created_at,
         } => WorktreeOutput::Import(worktree::import(WorktreeImportOptions {
             component_id,
             handle,
@@ -544,8 +547,9 @@ pub fn run(args: WorktreeArgs) -> CmdResult<WorktreeOutput> {
             branch,
             base_ref,
             task_url,
-            run_id,
+            owner_run_ref,
             cleanup_policy: cleanup_policy.into(),
+            created_at,
         })?),
         WorktreeCommand::Finalize {
             handle,
@@ -812,7 +816,7 @@ mod tests {
     use homeboy::core::worktree::{
         CleanupPolicy, TaskWorktreeRecord, TaskWorktreeState, WorktreeCreateAction,
         WorktreeCreateEvidence, WorktreeCreateOutput, WorktreeCreateReconciliation,
-        WorktreeListOutput,
+        WorktreeImportOutput, WorktreeListOutput,
     };
 
     use crate::cli_surface::{Cli, Commands};
@@ -894,6 +898,65 @@ mod tests {
         assert!(existing.get("reconciliation").is_none());
         assert_eq!(restored["action"], "create");
         assert_eq!(restored["reconciliation"]["action"], "restored");
+    }
+
+    #[test]
+    fn worktree_import_and_finalize_are_public_typed_cli_commands() {
+        let cli = Cli::parse_from([
+            "homeboy",
+            "worktree",
+            "import",
+            "fixture",
+            "fixture@branch",
+            "/tmp/fixture@branch",
+            "--branch",
+            "branch",
+            "--base-ref",
+            "main",
+            "--owner-run-ref",
+            "run-1",
+            "--cleanup-policy",
+            "preserve-on-failure",
+            "--created-at",
+            "2026-01-02T03:04:05Z",
+        ]);
+        let Commands::Worktree(args) = cli.command else {
+            panic!("expected worktree command");
+        };
+        let WorktreeCommand::Import {
+            owner_run_ref,
+            created_at,
+            ..
+        } = args.command
+        else {
+            panic!("expected import command");
+        };
+        assert_eq!(owner_run_ref.as_deref(), Some("run-1"));
+        assert_eq!(created_at.as_deref(), Some("2026-01-02T03:04:05Z"));
+
+        let record = create_output(None).record;
+        let imported = serde_json::to_value(WorktreeOutput::Import(WorktreeImportOutput {
+            record,
+            imported: true,
+        }))
+        .expect("serialize import");
+        let finalized = serde_json::to_value(WorktreeOutput::Finalize(
+            homeboy::core::worktree_provider::WorktreeFinalization {
+                provider_id: "builtin".to_string(),
+                handle: "fixture@branch".to_string(),
+                disposition:
+                    homeboy::core::worktree_provider::WorktreeTerminalDisposition::Succeeded,
+                owner_outcome: "success".to_string(),
+                lifecycle_state: "completed".to_string(),
+                inspection_path: "/tmp/fixture@branch".to_string(),
+            },
+        ))
+        .expect("serialize finalization");
+
+        assert_eq!(imported["action"], "import");
+        assert_eq!(imported["imported"], true);
+        assert_eq!(finalized["action"], "finalize");
+        assert_eq!(finalized["disposition"], "succeeded");
     }
 
     #[test]

--- a/crates/homeboy-core/src/worktree/store_ops.rs
+++ b/crates/homeboy-core/src/worktree/store_ops.rs
@@ -47,6 +47,32 @@ pub(super) fn import_with_store(
     store_dir: &Path,
 ) -> Result<WorktreeImportOutput> {
     with_task_worktree_registry_write_lock(|| {
+        if options.branch.trim().is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "branch",
+                "Imported worktree branch must not be empty",
+                None,
+                None,
+            ));
+        }
+        if options.base_ref.trim().is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "base_ref",
+                "Imported worktree base ref must not be empty",
+                None,
+                None,
+            ));
+        }
+        if let Some(created_at) = &options.created_at {
+            chrono::DateTime::parse_from_rfc3339(created_at).map_err(|error| {
+                Error::validation_invalid_argument(
+                    "created_at",
+                    "Imported worktree creation timestamp must be RFC 3339",
+                    Some(format!("{created_at} ({error})")),
+                    None,
+                )
+            })?;
+        }
         let target = component::resolve_target(TargetSpec {
             component_id: Some(&options.component_id),
             path_override: None,

--- a/crates/homeboy-core/src/worktree/store_ops.rs
+++ b/crates/homeboy-core/src/worktree/store_ops.rs
@@ -110,8 +110,12 @@ pub(super) fn import_with_store(
                 && record.branch == options.branch
                 && record.base_ref == options.base_ref
                 && record.task_url == options.task_url
-                && record.run_id == options.run_id
+                && record.run_id == options.owner_run_ref
                 && record.cleanup_policy == options.cleanup_policy
+                && options
+                    .created_at
+                    .as_ref()
+                    .is_none_or(|created_at| &record.created_at == created_at)
                 && record.state == TaskWorktreeState::Active
                 && record.terminal_disposition.is_none()
                 && record.effective_workspace_identity()? == identity;
@@ -138,11 +142,13 @@ pub(super) fn import_with_store(
             base_ref: options.base_ref,
             workspace_identity: Some(identity),
             task_url: options.task_url,
-            run_id: options.run_id,
+            run_id: options.owner_run_ref,
             cleanup_policy: options.cleanup_policy,
             terminal_disposition: None,
             branch_cleanup_intent: BranchCleanupIntent::DeleteWhenMerged,
-            created_at: chrono::Utc::now().to_rfc3339(),
+            created_at: options
+                .created_at
+                .unwrap_or_else(|| chrono::Utc::now().to_rfc3339()),
             state: TaskWorktreeState::Active,
             lifecycle_revision: 0,
             terminal_workspace_authority: None,

--- a/crates/homeboy-core/src/worktree/tests.rs
+++ b/crates/homeboy-core/src/worktree/tests.rs
@@ -394,6 +394,141 @@ fn registered_create_fixture(home: &Path, id: &str) -> (PathBuf, WorktreeCreateO
 }
 
 #[test]
+fn import_records_an_exact_existing_worktree_without_changing_git_and_replays_idempotently() {
+    crate::test_support::with_isolated_home(|home| {
+        let (source, _) = registered_create_fixture(home.path(), "import-fixture");
+        let branch = "fix/import";
+        let handle = "import-fixture@fix-import";
+        let path = source.parent().expect("source parent").join(handle);
+        run_git(
+            &source,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                &path.to_string_lossy(),
+                "HEAD",
+            ],
+        );
+        let head_before = git::run_git(&path, &["rev-parse", "HEAD"], "git head").unwrap();
+        let status_before = git::run_git(&path, &["status", "--porcelain"], "git status").unwrap();
+        let options = WorktreeImportOptions {
+            component_id: "import-fixture".to_string(),
+            handle: handle.to_string(),
+            path: path.display().to_string(),
+            branch: branch.to_string(),
+            base_ref: "origin/main".to_string(),
+            task_url: Some("https://example.com/tasks/import".to_string()),
+            owner_run_ref: Some("run-import".to_string()),
+            cleanup_policy: CleanupPolicy::PreserveOnFailure,
+            created_at: Some("2026-01-02T03:04:05Z".to_string()),
+        };
+
+        let imported = import(options.clone()).expect("import exact worktree");
+        let replay = import(options).expect("replay exact import");
+
+        assert!(imported.imported);
+        assert!(!replay.imported);
+        assert_eq!(replay.record, imported.record);
+        assert_eq!(imported.record.created_at, "2026-01-02T03:04:05Z");
+        assert_eq!(imported.record.run_id.as_deref(), Some("run-import"));
+        assert_eq!(
+            git::run_git(&path, &["rev-parse", "HEAD"], "git head").unwrap(),
+            head_before
+        );
+        assert_eq!(
+            git::run_git(&path, &["status", "--porcelain"], "git status").unwrap(),
+            status_before
+        );
+    });
+}
+
+#[test]
+fn import_refuses_primary_mismatched_handle_and_conflicting_replay() {
+    crate::test_support::with_isolated_home(|home| {
+        let (source, _) = registered_create_fixture(home.path(), "import-conflict");
+        let branch = "fix/import";
+        let handle = "import-conflict@fix-import";
+        let path = source.parent().expect("source parent").join(handle);
+        run_git(
+            &source,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                &path.to_string_lossy(),
+                "HEAD",
+            ],
+        );
+        let options = WorktreeImportOptions {
+            component_id: "import-conflict".to_string(),
+            handle: handle.to_string(),
+            path: path.display().to_string(),
+            branch: branch.to_string(),
+            base_ref: "HEAD".to_string(),
+            task_url: None,
+            owner_run_ref: Some("run-import".to_string()),
+            cleanup_policy: CleanupPolicy::RemoveWhenSafe,
+            created_at: None,
+        };
+
+        let mut primary = options.clone();
+        primary.path = source.display().to_string();
+        assert!(import(primary).is_err());
+        let mut wrong_handle = options.clone();
+        wrong_handle.handle = "import-conflict@wrong".to_string();
+        assert!(import(wrong_handle).is_err());
+        import(options.clone()).expect("initial import");
+        let mut conflicting = options;
+        conflicting.base_ref = "origin/main".to_string();
+        assert!(import(conflicting).is_err());
+    });
+}
+
+#[test]
+fn finalization_is_owner_bound_idempotent_conflict_safe_and_never_cleans_up() {
+    crate::test_support::with_isolated_home(|home| {
+        let (_, mut options) = registered_create_fixture(home.path(), "finalize-fixture");
+        options.run_id = Some("run-finalize".to_string());
+        let created = create(options).expect("create task worktree");
+        let path = PathBuf::from(&created.record.worktree_path);
+
+        assert!(finalize_provider_lifecycle(
+            &created.record.id,
+            "wrong-owner",
+            crate::worktree_provider::WorktreeTerminalDisposition::Failed,
+        )
+        .is_err());
+        let finalized = finalize_provider_lifecycle(
+            &created.record.id,
+            "run-finalize",
+            crate::worktree_provider::WorktreeTerminalDisposition::Failed,
+        )
+        .expect("finalize worktree");
+        let replay = finalize_provider_lifecycle(
+            &created.record.id,
+            "run-finalize",
+            crate::worktree_provider::WorktreeTerminalDisposition::Failed,
+        )
+        .expect("replay finalization");
+
+        assert_eq!(replay, finalized);
+        assert_eq!(finalized.lifecycle_revision, 1);
+        assert_eq!(finalized.terminal_disposition.as_deref(), Some("failed"));
+        assert_eq!(finalized.cleanup_policy, CleanupPolicy::PreserveOnFailure);
+        assert!(path.exists(), "finalization must not clean up the worktree");
+        assert!(finalize_provider_lifecycle(
+            &created.record.id,
+            "run-finalize",
+            crate::worktree_provider::WorktreeTerminalDisposition::Succeeded,
+        )
+        .is_err());
+    });
+}
+
+#[test]
 fn create_restores_missing_active_record_from_an_unclaimed_existing_branch() {
     crate::test_support::with_isolated_home(|home| {
         let (source, options) = registered_create_fixture(home.path(), "restore-fixture");

--- a/crates/homeboy-core/src/worktree/tests.rs
+++ b/crates/homeboy-core/src/worktree/tests.rs
@@ -418,7 +418,7 @@ fn import_records_an_exact_existing_worktree_without_changing_git_and_replays_id
             handle: handle.to_string(),
             path: path.display().to_string(),
             branch: branch.to_string(),
-            base_ref: "origin/main".to_string(),
+            base_ref: "HEAD~0".to_string(),
             task_url: Some("https://example.com/tasks/import".to_string()),
             owner_run_ref: Some("run-import".to_string()),
             cleanup_policy: CleanupPolicy::PreserveOnFailure,
@@ -434,6 +434,19 @@ fn import_records_an_exact_existing_worktree_without_changing_git_and_replays_id
         assert_eq!(imported.record.created_at, "2026-01-02T03:04:05Z");
         assert_eq!(imported.record.run_id.as_deref(), Some("run-import"));
         assert_eq!(
+            list()
+                .expect("list imported worktree")
+                .worktrees
+                .into_iter()
+                .find(|record| record.id == handle)
+                .expect("imported record is listed"),
+            imported.record
+        );
+        assert_eq!(
+            status(handle).expect("status imported worktree").record,
+            imported.record
+        );
+        assert_eq!(
             git::run_git(&path, &["rev-parse", "HEAD"], "git head").unwrap(),
             head_before
         );
@@ -441,6 +454,23 @@ fn import_records_an_exact_existing_worktree_without_changing_git_and_replays_id
             git::run_git(&path, &["status", "--porcelain"], "git status").unwrap(),
             status_before
         );
+
+        let finalized = finalize_provider_lifecycle(
+            handle,
+            "run-import",
+            crate::worktree_provider::WorktreeTerminalDisposition::Failed,
+        )
+        .expect("finalize imported worktree");
+        assert_eq!(finalized.terminal_disposition.as_deref(), Some("failed"));
+        let cleanup = cleanup(WorktreeCleanupOptions {
+            force: false,
+            dry_run: true,
+            cleanup_branches: false,
+            allow_unmerged_branches: false,
+        })
+        .expect("preview imported worktree cleanup");
+        assert!(cleanup.dry_run);
+        assert!(path.exists(), "cleanup preview must preserve the worktree");
     });
 }
 
@@ -480,6 +510,9 @@ fn import_refuses_primary_mismatched_handle_and_conflicting_replay() {
         let mut wrong_handle = options.clone();
         wrong_handle.handle = "import-conflict@wrong".to_string();
         assert!(import(wrong_handle).is_err());
+        let mut malformed = options.clone();
+        malformed.created_at = Some("not-a-timestamp".to_string());
+        assert!(import(malformed).is_err());
         import(options.clone()).expect("initial import");
         let mut conflicting = options;
         conflicting.base_ref = "origin/main".to_string();

--- a/crates/homeboy-core/src/worktree/types.rs
+++ b/crates/homeboy-core/src/worktree/types.rs
@@ -363,8 +363,9 @@ pub struct WorktreeImportOptions {
     pub branch: String,
     pub base_ref: String,
     pub task_url: Option<String>,
-    pub run_id: Option<String>,
+    pub owner_run_ref: Option<String>,
     pub cleanup_policy: CleanupPolicy,
+    pub created_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
## Summary
- preserve explicit owner-run and RFC 3339 creation provenance during native worktree import
- reject malformed creation provenance while retaining exact, conflict-safe replay semantics
- add focused import/finalization CLI and core lifecycle tests
- prove imported worktrees continue through native list, status, finalization, and cleanup preview

## Context

Follow-up to #13853, which merged while these acceptance tests and provenance corrections were still being pushed. Completes the remaining acceptance scope from #13593.

## Verification
- `cargo fmt --all -- --check`
- `cargo check -p homeboy-cli`
- `cargo test -p homeboy-core worktree::tests::import_`
- `cargo test -p homeboy-core worktree::tests::finalization_is_owner_bound_idempotent_conflict_safe_and_never_cleans_up`
- `cargo test -p homeboy-cli worktree_import_and_finalize_are_public_typed_cli_commands`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode inspected the merged lifecycle primitives, implemented the remaining provenance contract and focused lifecycle coverage under Chris Huber's direction, and ran the listed verification.