### PR TITLE
test(rig): remove real-time check waits

### DIFF
--- a/crates/homeboy-rig/src/check.rs
+++ b/crates/homeboy-rig/src/check.rs
@@ -18,6 +18,14 @@ use homeboy_core::http_probe;
 
 /// Run a check against the current rig state. Err on fail.
 pub fn evaluate(rig: &RigSpec, check: &CheckSpec) -> Result<()> {
+    evaluate_with_http_wait_ready_budget(rig, check, HTTP_WAIT_READY_BUDGET)
+}
+
+pub(crate) fn evaluate_with_http_wait_ready_budget(
+    rig: &RigSpec,
+    check: &CheckSpec,
+    http_wait_ready_budget: Duration,
+) -> Result<()> {
     let mut set = 0;
     if check.http.is_some() {
         set += 1;
@@ -53,7 +61,12 @@ pub fn evaluate(rig: &RigSpec, check: &CheckSpec) -> Result<()> {
     }
 
     if let Some(url) = &check.http {
-        return http_check(rig, url, check.expect_status.unwrap_or(200));
+        return http_check(
+            rig,
+            url,
+            check.expect_status.unwrap_or(200),
+            http_wait_ready_budget,
+        );
     }
     if let Some(path) = &check.file {
         return file_check(rig, path, check.contains.as_deref());
@@ -88,9 +101,14 @@ const HTTP_WAIT_READY_BUDGET: Duration = Duration::from_secs(10);
 /// that we don't spin the CPU against a slow-starting daemon.
 const HTTP_RETRY_INTERVAL: Duration = Duration::from_millis(200);
 
-fn http_check(rig: &RigSpec, url: &str, expect_status: u16) -> Result<()> {
+fn http_check(
+    rig: &RigSpec,
+    url: &str,
+    expect_status: u16,
+    wait_ready_budget: Duration,
+) -> Result<()> {
     let resolved = expand_vars(rig, url);
-    let deadline = std::time::Instant::now() + HTTP_WAIT_READY_BUDGET;
+    let deadline = std::time::Instant::now() + wait_ready_budget;
 
     loop {
         match http_probe::get_status(&resolved, Duration::from_secs(5)) {

--- a/tests/core/rig/check_test.rs
+++ b/tests/core/rig/check_test.rs
@@ -4,8 +4,19 @@
 //! `file` and `command` probes exercise the full one-of-three logic,
 //! short-circuit on validation errors, and cover substring matching.
 
-use crate::check::evaluate;
+use crate::check::{evaluate, evaluate_with_http_wait_ready_budget};
 use crate::spec::{CheckSpec, RigSpec};
+
+fn set_modified(path: &std::path::Path, seconds_since_epoch: u64) {
+    std::fs::File::options()
+        .write(true)
+        .open(path)
+        .expect("open file for mtime update")
+        .set_times(std::fs::FileTimes::new().set_modified(
+            std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(seconds_since_epoch),
+        ))
+        .expect("set file mtime");
+}
 
 fn minimal_rig() -> RigSpec {
     RigSpec {
@@ -164,9 +175,9 @@ fn test_evaluate_newer_than_left_newer_passes() {
     let older = tmp_dir.path().join("older.txt");
     let newer = tmp_dir.path().join("newer.txt");
     std::fs::write(&older, "x").expect("write");
-    // Sleep a beat so mtimes are distinguishable at second granularity.
-    std::thread::sleep(std::time::Duration::from_millis(1100));
     std::fs::write(&newer, "x").expect("write");
+    set_modified(&older, 1);
+    set_modified(&newer, 2);
 
     let rig = minimal_rig();
     let spec = CheckSpec {
@@ -192,8 +203,9 @@ fn test_evaluate_newer_than_left_older_fails() {
     let older = tmp_dir.path().join("older.txt");
     let newer = tmp_dir.path().join("newer.txt");
     std::fs::write(&older, "x").expect("write");
-    std::thread::sleep(std::time::Duration::from_millis(1100));
     std::fs::write(&newer, "x").expect("write");
+    set_modified(&older, 1);
+    set_modified(&newer, 2);
 
     let rig = minimal_rig();
     // left = older, right = newer ⇒ check fails.
@@ -383,18 +395,20 @@ fn test_http_check_exhausts_budget_when_nothing_ever_listens() {
         ..Default::default()
     };
     let start = std::time::Instant::now();
-    let err = evaluate(&rig, &spec).expect_err("no listener => fail");
+    let err =
+        evaluate_with_http_wait_ready_budget(&rig, &spec, std::time::Duration::from_millis(200))
+            .expect_err("no listener => fail");
     let elapsed = start.elapsed();
 
-    // Budget is 10s; allow generous slack for slow CI but cap below a
-    // pathological hang.
+    // The injected budget preserves the production retry path without making
+    // this test wait out the production ten-second ceiling.
     assert!(
-        elapsed >= std::time::Duration::from_secs(9),
+        elapsed >= std::time::Duration::from_millis(180),
         "must exhaust the wait-ready budget; elapsed = {:?}",
         elapsed
     );
     assert!(
-        elapsed < std::time::Duration::from_secs(20),
+        elapsed < std::time::Duration::from_secs(2),
         "must not hang past the budget; elapsed = {:?}",
         elapsed
     );


### PR DESCRIPTION
## Summary
- preserve the production HTTP readiness budget while allowing focused tests to inject a bounded budget
- replace two filesystem-granularity sleeps with explicit file modification times
- reduce the focused rig check suite from roughly 12.7 seconds of required sleeps to 0.55 seconds total

Part of #10325.

## Verification
- `cargo test -p homeboy-rig check_test -j2` (18 passed; 0 failed; 0.55s)
- focused `rustfmt --check`
- `git diff --check`

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode inspected the slow tests, implemented the crate-private test timing seam and deterministic mtimes, and ran the focused verification. Chris Huber directed and owns the change.