### PR TITLE
test(cli): stop compiling unused fixtures

### DIFF
--- a/crates/homeboy-cli/src/commands/ci/external_check_detail_resolver.rs
+++ b/crates/homeboy-cli/src/commands/ci/external_check_detail_resolver.rs
@@ -561,7 +561,7 @@ fn bound(value: &str, limit: usize) -> String {
     value.chars().take(limit).collect()
 }
 
-#[cfg(any(test, feature = "test-support"))]
+#[cfg(feature = "test-support")]
 pub(super) fn test_cross_platform_fixture() {
     const FIXTURE_MODE_ENV: &str = "HOMEBOY_EXTERNAL_CHECK_FIXTURE_MODE";
 
@@ -673,7 +673,7 @@ pub(super) fn test_cross_platform_fixture() {
     });
 }
 
-#[cfg(any(test, feature = "test-support"))]
+#[cfg(feature = "test-support")]
 fn install_fixture_extension(mode: &str, fixture_mode_env: &str) {
     let root = homeboy::core::paths::homeboy().unwrap();
     let extension = root.join("extensions").join("fixture-external-check");
@@ -703,7 +703,7 @@ fn install_fixture_extension(mode: &str, fixture_mode_env: &str) {
     std::env::set_var(fixture_mode_env, mode);
 }
 
-#[cfg(any(test, feature = "test-support"))]
+#[cfg(feature = "test-support")]
 fn timeout_fixture_command(extension: &Path) -> Vec<String> {
     let name = if cfg!(windows) {
         "fixture-resolver.exe"
@@ -723,7 +723,7 @@ fn timeout_fixture_command(extension: &Path) -> Vec<String> {
     ]
 }
 
-#[cfg(all(any(test, feature = "test-support"), unix))]
+#[cfg(all(feature = "test-support", unix))]
 fn fixture_program(extension: &Path, fixture_mode_env: &str) -> String {
     use std::os::unix::fs::PermissionsExt;
 
@@ -740,7 +740,7 @@ fn fixture_program(extension: &Path, fixture_mode_env: &str) -> String {
     name.into()
 }
 
-#[cfg(all(any(test, feature = "test-support"), windows))]
+#[cfg(all(feature = "test-support", windows))]
 fn fixture_program(extension: &Path, fixture_mode_env: &str) -> String {
     let name = "fixture-resolver.cmd";
     let path = extension.join(name);

--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/homeboy_path.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/homeboy_path.rs
@@ -231,7 +231,6 @@ fn homeboy_version_skew_check_is_absent_for_matching_build_identities() {
     .is_none());
 }
 
-#[test]
 /// The prose and the typed action must name the same ref.
 ///
 /// They are two vocabularies of one fix -- a sentence an operator reads and


### PR DESCRIPTION
## Summary
- remove a duplicated `#[test]` attribute that ran one runner-doctor test twice
- compile external-resolver integration fixtures only for their actual `test-support` consumer
- eliminate the associated dead-code and duplicate-attribute warnings from ordinary CLI test builds

Part of #10325 and #13755.

## Verification
- focused `rustfmt --check`
- `git diff --check`
- Cargo was intentionally not rerun locally; asynchronous CI owns compile verification while the simplification brigade continues

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode traced compiler warnings to their actual consumers, narrowed fixture compilation, removed duplicate test execution, and ran fast static gates. Chris Huber directed and owns the change.