### PR TITLE
Remove legacy daemon recovery help negotiation

### DIFF
--- a/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
@@ -612,8 +612,7 @@ pub const fn unleased_candidate_reconciliation_supported() -> bool {
 /// recovery contracts negotiated only when a controller must repair a remote
 /// daemon, not admission requirements every ordinary handoff needs. A runner
 /// that omits them can still execute work; controllers that need the recovery
-/// path fall back to scraping the long-option help text when the typed list is
-/// absent. Keep these names protocol-focused.
+/// path require the typed capability. Keep these names protocol-focused.
 pub fn daemon_recovery_capabilities() -> Vec<LabCapabilityVersion> {
     let mut capabilities = vec![
         DAEMON_RECOVERY_LEASELESS_CAPABILITY,
@@ -632,68 +631,16 @@ pub fn daemon_recovery_capabilities() -> Vec<LabCapabilityVersion> {
         .collect()
 }
 
-/// The bare long options rendered by a clap help `Options:` heading.
-///
-/// This is the last-resort contract for daemon-recovery negotiation against a
-/// remote that does not advertise the typed [`LabCapabilityVersion`] list. It
-/// only accepts an option whose trailing tokens are all value placeholders, so
-/// a `/// doc comment` rendering prose after the flag name silently removes it
-/// from the advertised contract. Kept here (rather than in the runner crate)
-/// so the CLI crate can assert the same predicate against real rendered help.
-pub fn declared_long_options(help: &str) -> std::collections::BTreeSet<&str> {
-    let mut options = std::collections::BTreeSet::new();
-    let mut in_options = false;
-    for line in help.lines() {
-        let trimmed = line.trim();
-        if line == trimmed && trimmed.ends_with(':') {
-            in_options = trimmed.eq_ignore_ascii_case("options:");
-            continue;
-        }
-        if !in_options || line == trimmed {
-            continue;
-        }
-        let mut tokens = trimmed.split_whitespace();
-        let Some(option) = tokens.next() else {
-            continue;
-        };
-        let option = option.trim_end_matches(',');
-        if option.starts_with("--") && tokens.all(is_option_value_placeholder) {
-            options.insert(option);
-        }
-    }
-    options
-}
-
-/// Whether a clap help token is a value placeholder (`<NAME>` or `[<NAME>]`).
-pub fn is_option_value_placeholder(token: &str) -> bool {
-    (token.starts_with('<') && token.ends_with('>'))
-        || (token.starts_with("[<") && token.ends_with(">]"))
-}
-
 /// Decide whether a remote daemon advertises a recovery capability.
-///
-/// `advertised` is the typed capability list parsed from the remote's
-/// self-identity report. `None` means the remote is an older binary that never
-/// advertised the field, so the caller's `scrape` (long-option help text) is
-/// consulted. `Some(list)` is authoritative: the scrape is never executed.
-///
-/// The three daemon-recovery negotiations each call this with their own
-/// capability id and their own scrape closure, so the decision is defined once
-/// instead of copied at every site.
-pub fn daemon_recovery_capability_negotiated<Scrape>(
+pub fn daemon_recovery_capability_advertised(
     advertised: Option<&[LabCapabilityVersion]>,
     capability_id: &str,
-    scrape: Scrape,
-) -> std::result::Result<bool, String>
-where
-    Scrape: FnOnce() -> std::result::Result<bool, String>,
-{
-    match advertised {
-        Some(capabilities) => Ok(capabilities
+) -> bool {
+    advertised.is_some_and(|capabilities| {
+        capabilities
             .iter()
-            .any(|capability| capability.id == capability_id)),
-        None => scrape(),
-    }
+            .any(|capability| capability.id == capability_id)
+    })
 }
 
 /// Immutable runtime provenance supplied by a controller, runner command, or
@@ -1085,84 +1032,22 @@ mod daemon_recovery_capability_tests {
     }
 
     #[test]
-    fn declared_long_options_accepts_only_bare_value_placeholders() {
-        let options = declared_long_options(
-            "OPTIONS:\n    --reconcile-leaseless-orphans\n    --confirm-no-daemon-owner\n    --replacement-operation-id <ID>\n    --addr <ADDR>\n",
-        );
-        assert!(options.contains("--confirm-no-daemon-owner"));
-        assert!(options.contains("--replacement-operation-id"));
-        assert!(options.contains("--addr"));
-
-        let prose =
-            declared_long_options("Options:\n    --confirm-no-daemon-owner after inspection\n");
-        assert!(!prose.contains("--confirm-no-daemon-owner"));
-        assert!(prose.is_empty());
-
-        let examples = declared_long_options("Examples:\n    --confirm-no-daemon-owner\n");
-        assert!(examples.is_empty());
-
-        let lowercase = declared_long_options("options:\n    --confirm-no-daemon-owner\n");
-        assert!(lowercase.contains("--confirm-no-daemon-owner"));
-    }
-
-    #[test]
-    fn is_option_value_placeholder_matches_only_value_shaped_tokens() {
-        assert!(is_option_value_placeholder("<ID>"));
-        assert!(is_option_value_placeholder("[<ID>]"));
-        assert!(!is_option_value_placeholder("ID"));
-        assert!(!is_option_value_placeholder("after inspection"));
-    }
-
-    #[test]
-    fn typed_capability_advertisement_is_authoritative_and_skips_the_scrape() {
+    fn recovery_capability_requires_typed_advertisement() {
         let advertised: [LabCapabilityVersion; 1] = [LabCapabilityVersion {
             id: DAEMON_RECOVERY_LEASELESS_CAPABILITY.to_string(),
             version: 1,
         }];
-        let mut scraped = false;
-        let negotiated = daemon_recovery_capability_negotiated(
+        assert!(daemon_recovery_capability_advertised(
             Some(advertised.as_slice()),
             DAEMON_RECOVERY_LEASELESS_CAPABILITY,
-            || {
-                scraped = true;
-                Ok(false)
-            },
-        );
-        assert_eq!(negotiated, Ok(true));
-        assert!(!scraped, "the typed list must replace the help scrape");
-    }
-
-    #[test]
-    fn typed_advertisement_missing_the_capability_is_an_authoritative_no() {
-        let advertised: [LabCapabilityVersion; 1] = [LabCapabilityVersion {
-            id: DAEMON_RECOVERY_STATE_LOSS_CAPABILITY.to_string(),
-            version: 1,
-        }];
-        let mut scraped = false;
-        let negotiated = daemon_recovery_capability_negotiated(
+        ));
+        assert!(!daemon_recovery_capability_advertised(
             Some(advertised.as_slice()),
-            DAEMON_RECOVERY_LEASELESS_CAPABILITY,
-            || {
-                scraped = true;
-                Ok(true)
-            },
-        );
-        assert_eq!(negotiated, Ok(false));
-        assert!(!scraped, "a typed no must not be overridden by the scrape");
-    }
-
-    #[test]
-    fn absent_advertisement_falls_back_to_the_scrape() {
-        let mut scraped = false;
-        let negotiated = daemon_recovery_capability_negotiated::<_>(
+            DAEMON_RECOVERY_STATE_LOSS_CAPABILITY,
+        ));
+        assert!(!daemon_recovery_capability_advertised(
             None,
             DAEMON_RECOVERY_LEASELESS_CAPABILITY,
-            || {
-                scraped = true;
-                Ok(true)
-            },
-        );
-        assert_eq!(negotiated, Ok(true));
-        assert!(scraped, "an older binary must fall back to the help scrape");
+        ));
     }
 }

--- a/crates/homeboy-cli/src/cli_surface/global_flag_surface_tests.rs
+++ b/crates/homeboy-cli/src/cli_surface/global_flag_surface_tests.rs
@@ -8,14 +8,7 @@
 use super::Cli;
 use clap::CommandFactory;
 
-/// The globally-propagated flag set is a wire protocol, not just documentation:
-/// `homeboy-lab-runner` negotiates the lease-less recovery contract by parsing
-/// a remote binary's rendered `Options:` block
-/// (`negotiate_leaseless_recovery_contract`), and every `global = true`
-/// argument is rendered into that block for every subcommand. Pin the set so
-/// any addition or removal is a deliberate, reviewed protocol change.
-///
-/// This also anchors the invariant that motivated deleting the fieldless
+/// This anchors the invariant that motivated deleting the fieldless
 /// `GlobalArgs` handler parameter: process-wide CLI state is carried by these
 /// clap arguments on `Cli`, never by a separate struct threaded through
 /// command handlers.

--- a/crates/homeboy-cli/src/cli_surface/reference_docs.rs
+++ b/crates/homeboy-cli/src/cli_surface/reference_docs.rs
@@ -1,16 +1,10 @@
 //! Generates the CLI reference under `docs/reference/cli/commands/` from the
 //! clap command tree.
 //!
-//! # Why reflective, and not `--help` scraping
+//! # Why reflective
 //!
-//! Rendered `--help` is a *wire protocol* in this repository:
-//! `homeboy-lab-runner`'s `negotiate_leaseless_recovery_contract` parses a
-//! remote binary's rendered `Options:` block to negotiate a capability
-//! handshake. Generating docs by shelling out to `--help` would couple doc
-//! generation to that rendering, and would also require a built binary. Walking
-//! `clap::Command` reflectively reads the same source of truth without touching
-//! the rendered surface at all: this module only *reads* `Command`/`Arg`
-//! accessors, so it can never change what `--help` prints.
+//! Generating docs by shelling out to `--help` would require a built binary.
+//! Walking `clap::Command` reflectively reads the source of truth directly.
 //!
 //! # Why checked in, and not generated at build time
 //!

--- a/crates/homeboy-cli/src/commands/daemon.rs
+++ b/crates/homeboy-cli/src/commands/daemon.rs
@@ -123,14 +123,8 @@ enum DaemonCommand {
         // negotiate the lease-less recovery contract from the typed capability
         // list advertised in `self identity`
         // (`homeboy_lab_runner_contract::daemon_recovery_capabilities`); older
-        // controllers still fall back to running this subcommand's `--help` on
-        // the remote and matching bare long options
-        // (`homeboy_lab_runner_contract::declared_long_options` only accepts an
-        // option whose trailing tokens are value placeholders). Rendering help
-        // text after `--confirm-no-daemon-owner` removes it from the advertised
-        // contract and makes every help-scraping controller refuse remote
-        // lease-less recovery. The deprecation is documented in
-        // `docs/commands/daemon.md` instead.
+        // controllers may still invoke this spelling. The deprecation is
+        // documented in `docs/commands/daemon.md` instead.
         #[arg(long)]
         confirm_no_daemon_owner: bool,
         #[arg(long, default_value = daemon::DEFAULT_ADDR)]
@@ -871,7 +865,7 @@ impl AnalysisJobRunner for CommandAnalysisJobRunner {
 
 #[cfg(test)]
 mod tests {
-    use clap::{CommandFactory, Parser};
+    use clap::Parser;
     use std::io::{Read, Write};
     use std::net::TcpListener;
 
@@ -1035,13 +1029,10 @@ mod tests {
     }
 
     /// The released spellings still appear in composed remote commands and in
-    /// operator runbooks. They must keep parsing for one release, and — because
-    /// controllers still negotiate the lease-less recovery contract by reading
-    /// `--confirm-no-daemon-owner` out of the remote's `--help` output when the
-    /// remote does not advertise the typed capability list — they must also
-    /// stay visible in help rather than being hidden.
+    /// operator runbooks, so they remain accepted until their callers are
+    /// removed.
     #[test]
-    fn deprecated_confirmations_remain_accepted_and_advertised() {
+    fn deprecated_confirmations_remain_accepted() {
         for args in [
             vec![
                 "homeboy",
@@ -1076,48 +1067,6 @@ mod tests {
                 "released spelling must stay accepted: {args:?}"
             );
         }
-
-        let mut command = Cli::command();
-        let daemon = command
-            .find_subcommand_mut("daemon")
-            .expect("daemon subcommand");
-        let leaseless = daemon
-            .find_subcommand_mut("reconcile-leaseless-orphans")
-            .expect("reconcile-leaseless-orphans subcommand");
-        let help = leaseless.render_help().to_string();
-        assert!(
-            help.contains("--confirm-no-daemon-owner"),
-            "controllers negotiate this contract from remote help output: {help}"
-        );
-    }
-
-    /// Controllers negotiate the lease-less recovery contract by running this
-    /// subcommand's `--help` on the remote and matching *bare* long options —
-    /// now only as the fallback for older binaries that do not advertise the
-    /// typed capability list (`self identity`). The predicate lives in
-    /// `homeboy_lab_runner_contract::declared_long_options`, which only accepts
-    /// an option whose trailing tokens are value placeholders. Adding a doc
-    /// comment to `--confirm-no-daemon-owner` makes clap render help text after
-    /// the flag name, silently removing it from the advertised contract and
-    /// making every controller refuse remote lease-less recovery. This
-    /// reproduces that predicate against the real rendered help so the coupling
-    /// cannot rot.
-    #[test]
-    fn leaseless_recovery_help_advertises_a_bare_confirmation_option() {
-        let mut command = Cli::command();
-        let daemon = command
-            .find_subcommand_mut("daemon")
-            .expect("daemon subcommand");
-        let leaseless = daemon
-            .find_subcommand_mut("reconcile-leaseless-orphans")
-            .expect("reconcile-leaseless-orphans subcommand");
-        let help = leaseless.render_help().to_string();
-
-        let declared = homeboy_lab_runner_contract::declared_long_options(&help);
-        assert!(
-            declared.contains("--confirm-no-daemon-owner"),
-            "--confirm-no-daemon-owner must render as a bare long option or controllers refuse remote lease-less recovery; declared={declared:?} help={help}"
-        );
     }
 
     /// #11105: five recovery subcommands existed and nothing chose between

--- a/crates/homeboy-cli/src/commands/self_cmd.rs
+++ b/crates/homeboy-cli/src/commands/self_cmd.rs
@@ -451,8 +451,7 @@ mod tests {
     /// #11102: controllers negotiate the daemon-recovery contract from this
     /// envelope instead of scraping `--help` text. The field name is a wire
     /// contract read by `homeboy_lab_runner::connection::remote_daemon`, so
-    /// renaming or dropping it here must fail loudly rather than silently
-    /// reverting every controller to the help scrape.
+    /// renaming or dropping it here must fail loudly.
     #[test]
     fn identity_report_advertises_the_daemon_recovery_capabilities() {
         let report = super::identity_report();

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -85,11 +85,9 @@ fn wake_unmaterialized_admission_reconciliation_with(
     true
 }
 use homeboy_core::broker_auth;
-use homeboy_lab_runner_contract::declared_long_options;
 
 const REVERSE_RUNNER_HEARTBEAT_TTL: Duration = Duration::from_secs(90);
 const REMOTE_LEASELESS_RECOVERY_TIMEOUT: Duration = Duration::from_secs(30);
-const REMOTE_LEASELESS_RECOVERY_PROBE_TIMEOUT: Duration = Duration::from_secs(15);
 const REMOTE_RUNNER_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 // A reader may wait for an in-flight reconnect, but never indefinitely behind a
 // controller-local tunnel that disappeared during a link flap.
@@ -733,21 +731,13 @@ fn connect_with_orphan_adoption_and_live_lease(
         ));
     };
     let version = identity.version.clone();
-    // The typed daemon-recovery capability list replaces the `--help` scrape
-    // for current runners. `None` (an older binary that never advertised the
-    // field) keeps the scrape fallback at every negotiation site below.
     let daemon_recovery_capabilities = identity.daemon_recovery_capabilities.as_deref();
     // Capability negotiation is a preflight, not a mutation. In particular, a
     // non-Linux runner cannot expose pidfd-safe reconciliation and must not get
     // a replay journal merely because this connect requested the action.
     if reconcile_unleased_candidates {
         if let Err(message) =
-            negotiate_unleased_candidate_reconciliation(daemon_recovery_capabilities, || {
-                client.execute_with_timeout(
-                    &remote_unleased_candidate_reconciliation_help_command(homeboy),
-                    REMOTE_LEASELESS_RECOVERY_PROBE_TIMEOUT,
-                )
-            })
+            negotiate_unleased_candidate_reconciliation(daemon_recovery_capabilities)
         {
             return Ok(failed_connect(
                 runner_id,
@@ -843,8 +833,6 @@ fn connect_with_orphan_adoption_and_live_lease(
         if let Some((kind, command)) = replay {
             let command = if kind == "ensure-running" {
                 if let Err(error) = negotiate_ensure_running_operation_id(
-                    &client,
-                    homeboy,
                     Some(&replacement_operation_id),
                     daemon_recovery_capabilities,
                 ) {
@@ -1034,35 +1022,16 @@ fn connect_with_orphan_adoption_and_live_lease(
                     None,
                 )
             })?;
-            // Negotiate the exact state-loss recovery contract from the typed
-            // capability list when the runner advertises it; otherwise scrape
-            // `daemon recover-missing-lease-state --help` on the remote.
-            if let Err(message) = homeboy_lab_runner_contract::daemon_recovery_capability_negotiated(
+            if !homeboy_lab_runner_contract::daemon_recovery_capability_advertised(
                 daemon_recovery_capabilities,
                 homeboy_lab_runner_contract::DAEMON_RECOVERY_STATE_LOSS_CAPABILITY,
-                || {
-                    let capability = format!(
-                        "{} daemon recover-missing-lease-state --help",
-                        shell::quote_arg(homeboy),
-                    );
-                    let capability =
-                        client.execute_with_timeout(&capability, REMOTE_LEASELESS_RECOVERY_TIMEOUT);
-                    if !capability.success {
-                        return Err("remote Homeboy does not support `daemon recover-missing-lease-state`; update the runner to a build with the canonical state-loss recovery contract before retrying".to_string());
-                    }
-                    if !declared_long_options(&capability.stdout)
-                        .contains("--replacement-operation-id")
-                    {
-                        return Err("remote Homeboy must be upgraded: recover-missing-lease-state does not support --replacement-operation-id".to_string());
-                    }
-                    Ok(true)
-                },
             ) {
                 return Ok(failed_connect(
                     runner_id,
                     session_path,
                     RunnerFailureKind::DaemonStartupFailure,
-                    message,
+                    "remote Homeboy must advertise the typed state-loss recovery capability"
+                        .to_string(),
                 ));
             }
             let command = remote_state_loss_recovery_command(
@@ -1132,15 +1101,8 @@ fn connect_with_orphan_adoption_and_live_lease(
             .and_then(|session| session.remote_daemon_address.as_deref())
             .filter(|address| parse_loopback_daemon_addr(address).is_ok())
             .unwrap_or("127.0.0.1:0");
-        let recovery = execute_remote_leaseless_recovery(
-            daemon_recovery_capabilities,
-            || {
-                client.execute_with_timeout(
-                    &remote_leaseless_recovery_help_command(homeboy),
-                    REMOTE_LEASELESS_RECOVERY_PROBE_TIMEOUT,
-                )
-            },
-            |contract| {
+        let recovery =
+            execute_remote_leaseless_recovery(daemon_recovery_capabilities, |contract| {
                 let command = remote_leaseless_recovery_command(
                     homeboy,
                     recovery_addr,
@@ -1174,8 +1136,7 @@ fn connect_with_orphan_adoption_and_live_lease(
                     &command,
                     REMOTE_LEASELESS_RECOVERY_TIMEOUT,
                 )
-            },
-        );
+            });
         let (contract, recovery) = match recovery {
             Ok(recovery) => recovery,
             Err(message) => {
@@ -1538,34 +1499,13 @@ fn connect_with_orphan_adoption_and_live_lease(
     ))
 }
 
-fn remote_unleased_candidate_reconciliation_help_command(homeboy: &str) -> String {
-    format!(
-        "{} daemon reconcile-unleased-candidates --help",
-        shell::quote_arg(homeboy),
-    )
-}
-
-fn negotiate_unleased_candidate_reconciliation<Probe>(
+fn negotiate_unleased_candidate_reconciliation(
     daemon_recovery_capabilities: Option<&[homeboy_lab_runner_contract::LabCapabilityVersion]>,
-    probe: Probe,
-) -> std::result::Result<(), String>
-where
-    Probe: FnOnce() -> homeboy_core::server::CommandOutput,
-{
-    let advertised = homeboy_lab_runner_contract::daemon_recovery_capability_negotiated(
+) -> std::result::Result<(), String> {
+    let advertised = homeboy_lab_runner_contract::daemon_recovery_capability_advertised(
         daemon_recovery_capabilities,
         homeboy_lab_runner_contract::DAEMON_RECOVERY_UNLEASED_CANDIDATES_CAPABILITY,
-        || {
-            let output = probe();
-            if !output.success {
-                return Err("remote Homeboy must be upgraded: unable to negotiate unleased candidate reconciliation before mutation".to_string());
-            }
-            let options = declared_long_options(&output.stdout);
-            Ok(options.contains("--apply")
-                && options.contains("--addr")
-                && options.contains("--replacement-operation-id"))
-        },
-    )?;
+    );
     if !advertised {
         return Err("remote Homeboy must be upgraded: daemon reconcile-unleased-candidates does not advertise the idempotent candidate-reconciliation capability".to_string());
     }
@@ -1699,13 +1639,6 @@ fn verify_live_lease_adoption(
     Ok(())
 }
 
-fn remote_leaseless_recovery_help_command(homeboy: &str) -> String {
-    format!(
-        "{} daemon reconcile-leaseless-orphans --help",
-        shell::quote_arg(homeboy),
-    )
-}
-
 fn remote_leaseless_recovery_command(
     homeboy: &str,
     addr: &str,
@@ -1725,9 +1658,8 @@ fn remote_leaseless_recovery_command(
     )
 }
 
-fn execute_remote_leaseless_recovery<Probe, Recover>(
+fn execute_remote_leaseless_recovery<Recover>(
     daemon_recovery_capabilities: Option<&[homeboy_lab_runner_contract::LabCapabilityVersion]>,
-    probe: Probe,
     recover: Recover,
 ) -> std::result::Result<
     (
@@ -1737,60 +1669,17 @@ fn execute_remote_leaseless_recovery<Probe, Recover>(
     String,
 >
 where
-    Probe: FnOnce() -> homeboy_core::server::CommandOutput,
     Recover: FnOnce(RunnerLeaselessRecoveryContract) -> homeboy_core::server::CommandOutput,
 {
-    // A runner that advertises the typed lease-less recovery capability skips
-    // the help scrape entirely; an older runner still negotiates from the
-    // `--help` text. Both paths resolve to the canonical one-flag contract.
-    let advertised = homeboy_lab_runner_contract::daemon_recovery_capability_negotiated(
+    let advertised = homeboy_lab_runner_contract::daemon_recovery_capability_advertised(
         daemon_recovery_capabilities,
         homeboy_lab_runner_contract::DAEMON_RECOVERY_LEASELESS_CAPABILITY,
-        || {
-            let probe = probe();
-            negotiate_leaseless_recovery_contract(&probe).map(|_| true)
-        },
-    )?;
+    );
     if !advertised {
         return Err("remote Homeboy must be upgraded: daemon reconcile-leaseless-orphans does not advertise the lease-less recovery contract".to_string());
     }
     let contract = RunnerLeaselessRecoveryContract::ConfirmNoDaemonOwner;
     Ok((contract.clone(), recover(contract)))
-}
-
-fn negotiate_leaseless_recovery_contract(
-    output: &homeboy_core::server::CommandOutput,
-) -> std::result::Result<RunnerLeaselessRecoveryContract, String> {
-    if !output.success {
-        if output.timed_out {
-            return Err(format!(
-                "lease-less recovery capability probe timed out after {}s; refusing recovery before contract negotiation",
-                REMOTE_LEASELESS_RECOVERY_PROBE_TIMEOUT.as_secs()
-            ));
-        }
-        return Err(command_failure_message(
-            "lease-less recovery capability probe failed; refusing recovery before contract negotiation",
-            output,
-        ));
-    }
-
-    let options = declared_long_options(&output.stdout);
-    let confirm_no_daemon_owner = options.contains("--confirm-no-daemon-owner");
-    let replacement_operation_id = options.contains("--replacement-operation-id");
-    if !replacement_operation_id {
-        return Err("lease-less recovery capability probe did not advertise the canonical --replacement-operation-id contract; upgrade the remote Homeboy before mutation".to_string());
-    }
-    if confirm_no_daemon_owner
-        && !options.contains("--reconcile-leaseless-orphans")
-        && !options.contains("--confirm-control-plane-lost")
-    {
-        Ok(RunnerLeaselessRecoveryContract::ConfirmNoDaemonOwner)
-    } else {
-        Err(
-            "lease-less recovery capability probe did not advertise the canonical --confirm-no-daemon-owner contract; update the runner before retrying"
-                .to_string(),
-        )
-    }
 }
 
 fn leaseless_recovery_evidence(

--- a/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
+++ b/crates/homeboy-lab-runner/src/connection/remote_daemon.rs
@@ -234,10 +234,8 @@ pub(super) fn parse_self_identity_output(output: &str) -> Option<RemoteHomeboyId
 ///
 /// `None` is returned for an absent field, a JSON `null`, a non-array value,
 /// or an array that does not deserialize as [`LabCapabilityVersion`] entries;
-/// the caller then falls back to the help scrape for those recovery contracts
-/// (older binary). Unknown ids and future versions are preserved verbatim:
-/// matching is by id, and a typed list — even an explicitly empty one — is
-/// authoritative whenever it parses.
+/// those binaries cannot perform typed remote recovery. Unknown ids and future
+/// versions are preserved verbatim: matching is by id.
 fn parse_daemon_recovery_capabilities(value: &Value) -> Option<Vec<LabCapabilityVersion>> {
     if value.is_null() {
         return None;
@@ -945,8 +943,7 @@ pub(super) struct RemoteDaemonEnsureRequest<'a> {
     pub(super) admission_fence: Option<&'a crate::generation_store::AdmissionFence>,
     pub(super) registry_lock_held: bool,
     /// The typed daemon-recovery capabilities advertised in the remote's
-    /// self-identity report. `None` (older binary) keeps the help scrape
-    /// fallback for `daemon ensure-running --replacement-operation-id`.
+    /// self-identity report.
     pub(super) daemon_recovery_capabilities: Option<&'a [LabCapabilityVersion]>,
 }
 
@@ -1036,8 +1033,6 @@ fn ensure_remote_daemon_inner(
         }
         RemoteDaemonConnectAction::Start => {
             negotiate_ensure_running_operation_id(
-                client,
-                homeboy,
                 replacement_operation_id,
                 daemon_recovery_capabilities,
             )?;
@@ -1054,8 +1049,6 @@ fn ensure_remote_daemon_inner(
             // Prove idempotent replacement support before stopping A. Otherwise
             // a controller response loss could leave no recoverable owner.
             negotiate_ensure_running_operation_id(
-                client,
-                homeboy,
                 replacement_operation_id,
                 daemon_recovery_capabilities,
             )?;
@@ -1129,32 +1122,16 @@ fn journal_ensure_running_replay(
 }
 
 pub(super) fn negotiate_ensure_running_operation_id(
-    client: &SshClient,
-    homeboy: &str,
     replacement_operation_id: Option<&str>,
     daemon_recovery_capabilities: Option<&[LabCapabilityVersion]>,
 ) -> std::result::Result<(), String> {
     let Some(_) = replacement_operation_id else {
         return Ok(());
     };
-    // A runner that advertises the typed `--replacement-operation-id`
-    // capability skips the help scrape entirely; an older runner still
-    // negotiates from `daemon ensure-running --help`.
-    let advertised = homeboy_lab_runner_contract::daemon_recovery_capability_negotiated(
+    let advertised = homeboy_lab_runner_contract::daemon_recovery_capability_advertised(
         daemon_recovery_capabilities,
         homeboy_lab_runner_contract::DAEMON_ENSURE_RUNNING_OPERATION_ID_CAPABILITY,
-        || {
-            let command = format!("{} daemon ensure-running --help", shell::quote_arg(homeboy));
-            let output = client.execute_with_timeout(&command, REMOTE_DAEMON_STATUS_TIMEOUT);
-            if !output.success {
-                return Err("remote Homeboy must be upgraded: unable to negotiate daemon ensure-running --replacement-operation-id before mutation".to_string());
-            }
-            if !declared_long_options(&output.stdout).contains("--replacement-operation-id") {
-                return Err("remote Homeboy must be upgraded: daemon ensure-running does not support --replacement-operation-id".to_string());
-            }
-            Ok(true)
-        },
-    )?;
+    );
     if !advertised {
         return Err("remote Homeboy must be upgraded: daemon ensure-running does not advertise the --replacement-operation-id capability".to_string());
     }

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -1963,118 +1963,27 @@ fn state_loss_recovery_delegation_uses_the_canonical_exact_contract() {
 }
 
 #[test]
-fn leaseless_recovery_uses_confirm_no_daemon_owner_contract() {
-    let contract = negotiate_leaseless_recovery_contract(&command_output(
-        true,
-        "OPTIONS:\n    --confirm-no-daemon-owner\n    --replacement-operation-id <ID>\n",
-        false,
-    ))
-    .expect("one-flag contract");
+fn leaseless_recovery_evidence_records_selected_contract_and_command_identity() {
+    let evidence = leaseless_recovery_evidence(
+        RunnerLeaselessRecoveryContract::ConfirmNoDaemonOwner,
+        "homeboy 0.284.1+abc123",
+        sample_leaseless_recovery(),
+    );
 
     assert_eq!(
-        contract,
+        evidence.contract,
         RunnerLeaselessRecoveryContract::ConfirmNoDaemonOwner
     );
-    let command =
-        remote_leaseless_recovery_command("/opt/homeboy", "127.0.0.1:0", contract, "operation-1");
-    assert!(command.contains("--confirm-no-daemon-owner"));
-    assert!(!command.contains("--reconcile-leaseless-orphans"));
-    assert!(!command.contains("--confirm-control-plane-lost"));
-}
-
-#[test]
-fn leaseless_recovery_rejects_legacy_two_flag_contract() {
-    let error = negotiate_leaseless_recovery_contract(&command_output(
-        true,
-        "OPTIONS:\n    --reconcile-leaseless-orphans\n    --confirm-no-daemon-owner\n",
-        false,
-    ))
-    .expect_err("legacy two-flag contract is unsupported");
-    assert!(error.contains("canonical"));
-}
-
-#[test]
-fn leaseless_recovery_rejects_control_plane_lost_contract() {
-    let error = negotiate_leaseless_recovery_contract(&command_output(
-        true,
-        "OPTIONS:\n    --confirm-control-plane-lost\n",
-        false,
-    ))
-    .expect_err("legacy control-plane-lost contract is unsupported");
-    assert!(error.contains("canonical"));
-}
-
-#[test]
-fn leaseless_recovery_refuses_unsupported_or_ambiguous_help() {
-    let unsupported = negotiate_leaseless_recovery_contract(&command_output(
-        true,
-        "OPTIONS:\n    --addr <ADDR>\n",
-        false,
-    ))
-    .expect_err("unsupported contract");
-    assert!(unsupported.contains("did not advertise"));
-
-    let ambiguous = negotiate_leaseless_recovery_contract(&command_output(
-        true,
-        "OPTIONS:\n    --reconcile-leaseless-orphans\n    --confirm-no-daemon-owner\n    --confirm-control-plane-lost\n",
-        false,
-    ))
-    .expect_err("mixed legacy flags are unsupported");
-    assert!(ambiguous.contains("canonical"));
-}
-
-#[test]
-fn leaseless_recovery_parses_only_exact_option_declarations() {
-    let options = declared_long_options(
-        "OPTIONS:\n    --reconcile-leaseless-orphans\n    --confirm-no-daemon-owner\n    --addr <ADDR>\n",
+    assert_eq!(evidence.remote_command_identity, "homeboy 0.284.1+abc123");
+    assert_eq!(
+        evidence
+            .recovery
+            .as_ref()
+            .expect("recovery result")
+            .replacement
+            .lease_id,
+        "lease-new"
     );
-    assert!(options.contains("--reconcile-leaseless-orphans"));
-    assert!(options.contains("--confirm-no-daemon-owner"));
-    assert!(options.contains("--addr"));
-
-    let prose = negotiate_leaseless_recovery_contract(&command_output(
-        true,
-        "Examples:\n    --reconcile-leaseless-orphans\n    --confirm-no-daemon-owner\n",
-        false,
-    ))
-    .expect_err("example lines must not advertise a contract");
-    assert!(prose.contains("did not advertise"));
-
-    let prose = negotiate_leaseless_recovery_contract(&command_output(
-        true,
-        "Options:\n    --reconcile-leaseless-orphans after inspection\n    --confirm-no-daemon-owner after inspection\n",
-        false,
-    ))
-    .expect_err("prose in the options section must not advertise a contract");
-    assert!(prose.contains("did not advertise"));
-}
-
-#[test]
-fn leaseless_recovery_evidence_records_selected_contract_and_command_identity() {
-    for (help, expected_contract) in [(
-        "Options:\n    --confirm-no-daemon-owner\n    --replacement-operation-id <ID>\n",
-        RunnerLeaselessRecoveryContract::ConfirmNoDaemonOwner,
-    )] {
-        let contract = negotiate_leaseless_recovery_contract(&command_output(true, help, false))
-            .expect("advertised contract");
-        let evidence = leaseless_recovery_evidence(
-            contract,
-            "homeboy 0.284.1+abc123",
-            sample_leaseless_recovery(),
-        );
-
-        assert_eq!(evidence.contract, expected_contract);
-        assert_eq!(evidence.remote_command_identity, "homeboy 0.284.1+abc123");
-        assert_eq!(
-            evidence
-                .recovery
-                .as_ref()
-                .expect("recovery result")
-                .replacement
-                .lease_id,
-            "lease-new"
-        );
-    }
 }
 
 // NOTE: the test asserting generated recovery commands parse against the real
@@ -2152,35 +2061,15 @@ fn hanging_ssh_connect_is_classified_as_a_timeout() {
 }
 
 #[test]
-fn leaseless_recovery_refuses_failed_or_timed_out_probe() {
-    let failed =
-        negotiate_leaseless_recovery_contract(&command_output(false, String::new(), false))
-            .expect_err("failed probe");
-    assert!(failed.contains("capability probe failed"));
-
-    let timed_out =
-        negotiate_leaseless_recovery_contract(&command_output(false, String::new(), true))
-            .expect_err("timed out probe");
-    assert!(timed_out.contains("timed out"));
-}
-
-#[test]
-fn leaseless_recovery_does_not_mutate_before_successful_negotiation() {
-    let events = std::cell::RefCell::new(Vec::new());
-    let result = execute_remote_leaseless_recovery(
-        None,
-        || {
-            events.borrow_mut().push("probe");
-            command_output(true, "OPTIONS:\n    --addr <ADDR>\n", false)
-        },
-        |_| {
-            events.borrow_mut().push("recover");
-            command_output(true, String::new(), false)
-        },
-    );
+fn leaseless_recovery_requires_typed_capability_before_mutation() {
+    let recovered = std::cell::Cell::new(false);
+    let result = execute_remote_leaseless_recovery(None, |_| {
+        recovered.set(true);
+        command_output(true, String::new(), false)
+    });
 
     assert!(result.is_err());
-    assert_eq!(*events.borrow(), vec!["probe"]);
+    assert!(!recovered.get());
 }
 
 #[test]
@@ -2484,23 +2373,11 @@ fn stale_replacement_force_stop_rejects_a_success_envelope_without_stop_action()
 
 #[test]
 fn unleased_candidate_reconciliation_requires_a_negotiated_contract() {
-    let output = || {
-        homeboy_core::server::CommandOutput {
-        success: true,
-        stdout: "Options:\n    --apply\n    --addr <ADDR>\n    --replacement-operation-id <REPLACEMENT_OPERATION_ID>\n".to_string(),
-        stderr: String::new(),
-        exit_code: 0,
-        timed_out: false,
-        observation: Default::default(),
-        child_resource: None,
-    }
-    };
-    negotiate_unleased_candidate_reconciliation(None, output)
-        .expect("legacy help advertises the canonical contract");
+    let error = negotiate_unleased_candidate_reconciliation(None)
+        .expect_err("remote without typed capabilities requires upgrade");
+    assert!(error.contains("must be upgraded"));
 
-    let error = negotiate_unleased_candidate_reconciliation(Some(&[]), || {
-        unreachable!("typed capability absence must not fall back to help")
-    })
-    .expect_err("current remote without capability requires upgrade");
+    let error = negotiate_unleased_candidate_reconciliation(Some(&[]))
+        .expect_err("typed capability absence requires upgrade");
     assert!(error.contains("must be upgraded"));
 }

--- a/crates/homeboy-lab-runner/src/connection/tests/session.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/session.rs
@@ -542,8 +542,7 @@ fn parses_self_identity_json_envelope() {
         identity.build_identity.as_deref(),
         Some("homeboy 0.228.13+19a41cd5102d")
     );
-    // An envelope with no capability field is an older binary: absent, not
-    // "advertises none", so the caller keeps the help-scrape fallback (#11102).
+    // An envelope with no capability field cannot perform typed recovery.
     assert_eq!(identity.daemon_recovery_capabilities, None);
 }
 
@@ -619,18 +618,16 @@ fn unknown_ids_and_future_versions_are_preserved() {
         .expect("forward-compatible list parses");
     assert_eq!(advertised.len(), 2);
     assert!(
-        homeboy_lab_runner_contract::daemon_recovery_capability_negotiated(
+        homeboy_lab_runner_contract::daemon_recovery_capability_advertised(
             Some(advertised.as_slice()),
             homeboy_lab_runner_contract::DAEMON_RECOVERY_LEASELESS_CAPABILITY,
-            || Err("the scrape must not run when a typed list is present".to_string()),
         )
-        .expect("negotiation succeeds")
     );
 }
 
 /// The drift this issue is about: the envelope and the parser are written in
 /// different crates. Bind them, so renaming the field on one side fails here
-/// rather than silently reverting every controller to scraping help text.
+/// rather than silently disabling remote daemon recovery.
 #[test]
 fn the_advertised_capability_set_round_trips_through_the_parser() {
     let advertised = homeboy_lab_runner_contract::daemon_recovery_capabilities();


### PR DESCRIPTION
## Summary
- make typed daemon recovery capabilities the single negotiation contract
- remove remote `--help` probes and long-option parsing fallbacks
- delete tests that only preserved obsolete help-output protocol shapes

## Safety
Recovery still fails closed when the remote does not advertise the required typed capability. Persisted recovery evidence and daemon ownership checks are unchanged.

## Verification
- `cargo check -p homeboy-lab-runner-contract -p homeboy-lab-runner -p homeboy-cli --tests`
- `cargo fmt --all -- --check`
- `git diff --check`

Part of #13755.

## AI assistance
OpenAI GPT-5.6 Sol was used through OpenCode to audit compatibility paths, implement the deletion, and run focused verification.