### PR TITLE
Prepare deploys once and apply targets concurrently

### DIFF
--- a/crates/homeboy-cli/src/commands/deploy.rs
+++ b/crates/homeboy-cli/src/commands/deploy.rs
@@ -148,6 +148,14 @@ pub struct DeployArgs {
     /// Resume a prior multi-project deploy run after exact identity validation
     #[arg(long, value_name = "RUN_ID")]
     pub resume: Option<String>,
+    /// Maximum number of project targets applied concurrently
+    #[arg(
+        long,
+        default_value_t = 4,
+        value_name = "COUNT",
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    pub max_concurrency: u32,
     // Populated only by a validated release-set manifest.
     #[arg(skip)]
     exact_refs: BTreeMap<String, String>,
@@ -617,6 +625,7 @@ fn build_config(args: &DeployArgs, skip_build: bool) -> DeployConfig {
         prepared_artifact: None,
         prepared_projection: None,
         resume_run_id: args.resume.clone(),
+        max_concurrency: args.max_concurrency as usize,
         target: args.target.map(DeployTarget::from),
     }
 }

--- a/crates/homeboy-deploy/src/execution/mod.rs
+++ b/crates/homeboy-deploy/src/execution/mod.rs
@@ -168,6 +168,7 @@ mod tests {
                 source_commit: "0123456789abcdef".to_string(),
             }),
             resume_run_id: None,
+            max_concurrency: 1,
             target: None,
         };
 
@@ -837,6 +838,7 @@ mod tests {
             tagged,
             prepared_artifact: None,
             resume_run_id: None,
+            max_concurrency: 1,
             target: None,
         }
     }

--- a/crates/homeboy-deploy/src/lib.rs
+++ b/crates/homeboy-deploy/src/lib.rs
@@ -124,19 +124,18 @@ use uuid::Uuid;
 /// This is the preferred entry point for callers - it handles project loading
 /// and SSH context resolution, keeping those details encapsulated.
 pub fn run(project_id: &str, config: &DeployConfig) -> Result<DeployOrchestrationResult> {
-    let mut release_artifacts =
-        homeboy_core::git::release_download::ReleaseArtifactStore::default();
+    let mut artifacts = preparation::DeploymentArtifactStore::default();
     // Single-project deploy is its own unit of work: resolve once here so the
     // receipt read, write, and invalidation below all address one home (#7505).
     let roots = homeboy_core::paths::PathRoots::from_environment()?;
-    run_with_release_artifacts(roots.data(), project_id, config, &mut release_artifacts)
+    run_with_artifact_store(roots.data(), project_id, config, &mut artifacts)
 }
 
-fn run_with_release_artifacts(
+fn run_with_artifact_store(
     data_root: &std::path::Path,
     project_id: &str,
     config: &DeployConfig,
-    release_artifacts: &mut homeboy_core::git::release_download::ReleaseArtifactStore,
+    artifacts: &mut preparation::DeploymentArtifactStore,
 ) -> Result<DeployOrchestrationResult> {
     let project = project::load(project_id)?;
     let source =
@@ -189,7 +188,7 @@ fn run_with_release_artifacts(
         &project,
         &ctx,
         &base_path,
-        release_artifacts,
+        artifacts,
         observation.as_mut(),
     )
     .map_err(|error| attach_admitted_run_id(error, admitted_run_id.as_deref()))?;
@@ -462,8 +461,10 @@ pub fn run_multi(
     let mut failed: u32 = 0;
     let mut skipped: u32 = unknown_projects.len() as u32;
     let mut planned: u32 = 0;
-    let mut release_artifacts =
-        homeboy_core::git::release_download::ReleaseArtifactStore::default();
+    // Payload ownership spans the complete fanout. Equal target-independent
+    // preparation requests therefore build or download once, while requests
+    // with genuinely different source inputs retain separate payloads.
+    let mut artifacts = preparation::DeploymentArtifactStore::default();
     // Record skipped results for unknown projects
     for pid in &unknown_projects {
         project_results.push(ProjectDeployResult {
@@ -545,12 +546,7 @@ pub fn run_multi(
         }
         let mut timer = PhaseTimer::new();
         let result = timer.time("resolve_source", || {
-            run_with_release_artifacts(
-                roots.data(),
-                project_id,
-                &project_config,
-                &mut release_artifacts,
-            )
+            run_with_artifact_store(roots.data(), project_id, &project_config, &mut artifacts)
         });
         let timings = timer.into_report();
 

--- a/crates/homeboy-deploy/src/lib.rs
+++ b/crates/homeboy-deploy/src/lib.rs
@@ -7,6 +7,7 @@ mod lifecycle;
 mod orchestration;
 mod orchestration_ref_checkout;
 mod orchestration_tag_checkout;
+mod parallel;
 mod path_roots;
 pub(crate) mod permissions;
 mod planning;
@@ -128,15 +129,32 @@ pub fn run(project_id: &str, config: &DeployConfig) -> Result<DeployOrchestratio
     // Single-project deploy is its own unit of work: resolve once here so the
     // receipt read, write, and invalidation below all address one home (#7505).
     let roots = homeboy_core::paths::PathRoots::from_environment()?;
-    run_with_artifact_store(roots.data(), project_id, config, &mut artifacts)
+    let prepared = prepare_project_deployment(roots.data(), project_id, config, &mut artifacts)?;
+    apply_project_deployment(roots.data(), prepared)
 }
 
-fn run_with_artifact_store(
+enum PreparedProjectKind {
+    Provider(provider::PreparedProviderDeployment),
+    Server {
+        ctx: Box<homeboy_core::context::RemoteProjectContext>,
+        base_path: String,
+        deployment: orchestration::PreparedDeployment,
+    },
+}
+
+struct PreparedProjectDeployment {
+    project: project::Project,
+    config: DeployConfig,
+    observation: Option<lifecycle::DeployObservation>,
+    kind: PreparedProjectKind,
+}
+
+fn prepare_project_deployment(
     data_root: &std::path::Path,
     project_id: &str,
     config: &DeployConfig,
     artifacts: &mut preparation::DeploymentArtifactStore,
-) -> Result<DeployOrchestrationResult> {
+) -> Result<PreparedProjectDeployment> {
     let project = project::load(project_id)?;
     let source =
         lifecycle_identity(&[project_id.to_string()], &config.component_ids, config).source;
@@ -144,23 +162,15 @@ fn run_with_artifact_store(
         .then(|| lifecycle::DeployObservation::start(project_id, &source))
         .transpose()?;
     let admitted_run_id = observation.as_ref().map(|run| run.run_id().to_string());
-    if let Some(mut result) =
-        provider::run_if_configured(project_id, &project, config, observation.as_mut())
-            .map_err(|error| attach_admitted_run_id(error, admitted_run_id.as_deref()))?
+    if let Some(provider) = provider::prepare_if_configured(project_id, &project, config)
+        .map_err(|error| attach_admitted_run_id(error, admitted_run_id.as_deref()))?
     {
-        if let Some(observation) = observation.as_mut() {
-            observation.finish(
-                if result.summary.failed == 0 {
-                    homeboy_core::observation::RunStatus::Pass
-                } else {
-                    homeboy_core::observation::RunStatus::Fail
-                },
-                (result.summary.failed > 0)
-                    .then_some("deployment provider reported failure".to_string()),
-            );
-            result.deploy_run_id = Some(observation.run_id().to_string());
-        }
-        return Ok(result);
+        return Ok(PreparedProjectDeployment {
+            project,
+            config: config.clone(),
+            observation,
+            kind: PreparedProjectKind::Provider(provider),
+        });
     }
     // A version-pinned release asset is resolved remotely before orchestration;
     // requiring its configured checkout to exist would reintroduce a mutable
@@ -182,7 +192,7 @@ fn run_with_artifact_store(
         .map_err(|error| attach_admitted_run_id(error, admitted_run_id.as_deref()))?;
     let (ctx, base_path) = resolve_project_ssh_with_base_path(project_id)
         .map_err(|error| attach_admitted_run_id(error, admitted_run_id.as_deref()))?;
-    let mut result = orchestration::deploy_components(
+    let deployment = orchestration::prepare_components(
         data_root,
         config,
         &project,
@@ -192,7 +202,59 @@ fn run_with_artifact_store(
         observation.as_mut(),
     )
     .map_err(|error| attach_admitted_run_id(error, admitted_run_id.as_deref()))?;
-    disclose_server_routes(&project, config, &mut result);
+    Ok(PreparedProjectDeployment {
+        project,
+        config: config.clone(),
+        observation,
+        kind: PreparedProjectKind::Server {
+            ctx: Box::new(ctx),
+            base_path,
+            deployment,
+        },
+    })
+}
+
+fn apply_project_deployment(
+    data_root: &std::path::Path,
+    prepared: PreparedProjectDeployment,
+) -> Result<DeployOrchestrationResult> {
+    let PreparedProjectDeployment {
+        project,
+        config,
+        mut observation,
+        kind,
+    } = prepared;
+    let admitted_run_id = observation.as_ref().map(|run| run.run_id().to_string());
+    let (mut result, server_route) = match kind {
+        PreparedProjectKind::Provider(prepared) => (
+            provider::apply_prepared(prepared, observation.as_mut())
+                .map_err(|error| attach_admitted_run_id(error, admitted_run_id.as_deref()))?,
+            false,
+        ),
+        PreparedProjectKind::Server {
+            ctx,
+            base_path,
+            deployment,
+        } => {
+            let result = match deployment {
+                orchestration::PreparedDeployment::Complete(result) => result,
+                orchestration::PreparedDeployment::Apply(plan) => {
+                    orchestration::apply_prepared_components(
+                        data_root,
+                        *plan,
+                        &ctx,
+                        &base_path,
+                        observation.as_mut(),
+                    )
+                    .map_err(|error| attach_admitted_run_id(error, admitted_run_id.as_deref()))?
+                }
+            };
+            (result, true)
+        }
+    };
+    if server_route {
+        disclose_server_routes(&project, &config, &mut result);
+    }
     if let Some(observation) = observation.as_mut() {
         observation.finish(
             if result.summary.failed == 0 {
@@ -206,6 +268,120 @@ fn run_with_artifact_store(
         result.deploy_run_id = Some(observation.run_id().to_string());
     }
     Ok(result)
+}
+
+fn project_preflight_failed(prepared: &PreparedProjectDeployment) -> bool {
+    match &prepared.kind {
+        PreparedProjectKind::Provider(_) => false,
+        PreparedProjectKind::Server {
+            deployment: orchestration::PreparedDeployment::Complete(result),
+            ..
+        } => result.summary.failed > 0,
+        PreparedProjectKind::Server {
+            deployment: orchestration::PreparedDeployment::Apply(_),
+            ..
+        } => false,
+    }
+}
+
+fn project_requires_apply(prepared: &PreparedProjectDeployment) -> bool {
+    match &prepared.kind {
+        PreparedProjectKind::Provider(_) => !prepared.config.dry_run && !prepared.config.check,
+        PreparedProjectKind::Server {
+            deployment: orchestration::PreparedDeployment::Apply(_),
+            ..
+        } => true,
+        PreparedProjectKind::Server {
+            deployment: orchestration::PreparedDeployment::Complete(_),
+            ..
+        } => false,
+    }
+}
+
+fn abort_project_before_apply(
+    mut prepared: PreparedProjectDeployment,
+    reason: &str,
+) -> Result<DeployOrchestrationResult> {
+    let run_id = prepared
+        .observation
+        .as_ref()
+        .map(|observation| observation.run_id().to_string());
+    if let Some(observation) = prepared.observation.as_mut() {
+        observation.finish(
+            homeboy_core::observation::RunStatus::Fail,
+            Some(reason.to_string()),
+        );
+    }
+    Err(attach_admitted_run_id(
+        Error::validation_invalid_argument(
+            "projects",
+            reason,
+            Some(prepared.project.id),
+            Some(vec![
+                "Resolve every reported target preflight failure, then rerun the complete deployment"
+                    .to_string(),
+            ]),
+        ),
+        run_id.as_deref(),
+    ))
+}
+
+struct PreparedTargetJob {
+    project_id: String,
+    timer: PhaseTimer,
+    preparation: Result<PreparedProjectDeployment>,
+}
+
+struct TargetOutcome {
+    project_id: String,
+    result: Result<DeployOrchestrationResult>,
+    timings: homeboy_core::phase_timing::PhaseTimingReport,
+}
+
+fn persist_target_outcome(
+    data_root: &std::path::Path,
+    lifecycle_run: &std::sync::Mutex<Option<lifecycle::DeployLifecycleRun>>,
+    project_id: &str,
+    result: &Result<DeployOrchestrationResult>,
+    timings: &homeboy_core::phase_timing::PhaseTimingReport,
+) -> Result<()> {
+    let mut lifecycle_run = lifecycle_run
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let Some(run) = lifecycle_run.as_mut() else {
+        return Ok(());
+    };
+    let (status, error) = match result {
+        Ok(result) if result.summary.failed == 0 => {
+            (lifecycle::DeployTargetStatus::Succeeded, None)
+        }
+        Ok(result) => {
+            let applied_unverified_only = result
+                .results
+                .iter()
+                .any(|row| row.status == "applied_unverified")
+                && result.results.iter().all(|row| row.status != "failed");
+            let error = result
+                .results
+                .iter()
+                .find_map(|row| row.error.clone())
+                .unwrap_or_else(|| "Deployment failed".to_string());
+            (
+                if applied_unverified_only {
+                    lifecycle::DeployTargetStatus::AppliedUnverified
+                } else {
+                    lifecycle::DeployTargetStatus::Failed
+                },
+                Some(error),
+            )
+        }
+        Err(error) => (
+            lifecycle::DeployTargetStatus::Failed,
+            Some(error.to_string()),
+        ),
+    };
+    run.update_target(project_id, status, error, Some(timings.clone()));
+    lifecycle::save_in_roots(data_root, run)
 }
 
 /// Record which deliverable each dual-deliverable component actually deployed.
@@ -354,7 +530,6 @@ pub fn run_multi(
             None,
         ));
     }
-
     // Validate project IDs, skip unknown ones
     let known_projects = project::list_ids().unwrap_or_default();
     let mut unknown_projects = Vec::new();
@@ -399,6 +574,7 @@ pub fn run_multi(
 
     // Every supplied payload must bind safely before this multi-target run
     // creates lifecycle state or resolves an SSH context for any project.
+    let mut target_jobs = Vec::with_capacity(valid_project_ids.len());
     for project_id in &valid_project_ids {
         let project = project::load(project_id)?;
         preflight_prepared_payload_binding(&project, project_id, config)?;
@@ -545,11 +721,62 @@ pub fn run_multi(
             lifecycle::save_in_roots(roots.data(), run)?;
         }
         let mut timer = PhaseTimer::new();
-        let result = timer.time("resolve_source", || {
-            run_with_artifact_store(roots.data(), project_id, &project_config, &mut artifacts)
+        let preparation = timer.time("prepare", || {
+            prepare_project_deployment(roots.data(), project_id, &project_config, &mut artifacts)
         });
-        let timings = timer.into_report();
+        target_jobs.push(PreparedTargetJob {
+            project_id: project_id.to_string(),
+            timer,
+            preparation,
+        });
+    }
 
+    let preflight_failed = !config.dry_run
+        && !config.check
+        && target_jobs.iter().any(|job| match &job.preparation {
+            Ok(prepared) => project_preflight_failed(prepared),
+            Err(_) => true,
+        });
+    let lifecycle_run = std::sync::Mutex::new(lifecycle_run);
+    let target_outcomes = parallel::map_bounded(target_jobs, config.max_concurrency, |job| {
+        let PreparedTargetJob {
+            project_id,
+            mut timer,
+            preparation,
+        } = job;
+        let mut result = match preparation {
+            Ok(prepared) if preflight_failed && project_requires_apply(&prepared) => {
+                timer.time("apply", || {
+                    abort_project_before_apply(
+                        prepared,
+                        "Multi-target preflight failed; no target application was started",
+                    )
+                })
+            }
+            Ok(prepared) => {
+                timer.time("apply", || apply_project_deployment(roots.data(), prepared))
+            }
+            Err(error) => Err(error),
+        };
+        let timings = timer.into_report();
+        if let Err(error) =
+            persist_target_outcome(roots.data(), &lifecycle_run, &project_id, &result, &timings)
+        {
+            result = Err(error);
+        }
+        TargetOutcome {
+            project_id,
+            result,
+            timings,
+        }
+    });
+
+    for outcome in target_outcomes {
+        let TargetOutcome {
+            project_id,
+            result,
+            timings,
+        } = outcome;
         match result {
             Ok(result) => {
                 let observation_run_id = result.deploy_run_id.clone();
@@ -557,7 +784,7 @@ pub fn run_multi(
                     aggregate_observation.as_mut(),
                     observation_run_id.as_deref(),
                 ) {
-                    aggregate.link_target(project_id, target_run_id)?;
+                    aggregate.link_target(&project_id, target_run_id)?;
                 }
                 let deploy_failed = result.summary.failed > 0;
                 let is_planned = config.dry_run || config.check;
@@ -575,7 +802,7 @@ pub fn run_multi(
                         && result.results.iter().all(|row| row.status != "failed");
 
                     project_results.push(ProjectDeployResult {
-                        project_id: project_id.to_string(),
+                        project_id: project_id.clone(),
                         status: if applied_unverified_only {
                             "applied_unverified".to_string()
                         } else {
@@ -587,23 +814,10 @@ pub fn run_multi(
                         phase_timings: Some(timings.clone()),
                         observation_run_id,
                     });
-                    if let Some(run) = lifecycle_run.as_mut() {
-                        run.update_target(
-                            project_id,
-                            if applied_unverified_only {
-                                lifecycle::DeployTargetStatus::AppliedUnverified
-                            } else {
-                                lifecycle::DeployTargetStatus::Failed
-                            },
-                            project_results.last().and_then(|entry| entry.error.clone()),
-                            Some(timings.clone()),
-                        );
-                        lifecycle::save_in_roots(roots.data(), run)?;
-                    }
                     failed += 1;
                 } else if is_planned {
                     project_results.push(ProjectDeployResult {
-                        project_id: project_id.to_string(),
+                        project_id: project_id.clone(),
                         status: "planned".to_string(),
                         error: None,
                         results: result.results,
@@ -614,7 +828,7 @@ pub fn run_multi(
                     planned += 1;
                 } else {
                     project_results.push(ProjectDeployResult {
-                        project_id: project_id.to_string(),
+                        project_id: project_id.clone(),
                         status: "deployed".to_string(),
                         error: None,
                         results: result.results,
@@ -622,15 +836,6 @@ pub fn run_multi(
                         phase_timings: Some(timings.clone()),
                         observation_run_id,
                     });
-                    if let Some(run) = lifecycle_run.as_mut() {
-                        run.update_target(
-                            project_id,
-                            lifecycle::DeployTargetStatus::Succeeded,
-                            None,
-                            Some(timings.clone()),
-                        );
-                        lifecycle::save_in_roots(roots.data(), run)?;
-                    }
                     succeeded += 1;
                 }
             }
@@ -644,10 +849,10 @@ pub fn run_multi(
                     aggregate_observation.as_mut(),
                     observation_run_id.as_deref(),
                 ) {
-                    aggregate.link_target(project_id, target_run_id)?;
+                    aggregate.link_target(&project_id, target_run_id)?;
                 }
                 project_results.push(ProjectDeployResult {
-                    project_id: project_id.to_string(),
+                    project_id: project_id.clone(),
                     status: "failed".to_string(),
                     error: Some(e.to_string()),
                     results: vec![],
@@ -660,15 +865,6 @@ pub fn run_multi(
                     phase_timings: Some(timings.clone()),
                     observation_run_id,
                 });
-                if let Some(run) = lifecycle_run.as_mut() {
-                    run.update_target(
-                        project_id,
-                        lifecycle::DeployTargetStatus::Failed,
-                        Some(e.to_string()),
-                        Some(timings),
-                    );
-                    lifecycle::save_in_roots(roots.data(), run)?;
-                }
                 failed += 1;
             }
         }
@@ -794,7 +990,7 @@ pub fn resolve_shared_targets(component_ids: &[String]) -> Result<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use homeboy_core::component::{Component, ScopedExtensionConfig};
+    use homeboy_core::component::{Component, ScopedExtensionConfig, VersionTarget};
     use homeboy_core::extension::{DeployCapability, ExtensionManifest, RemotePathRootRule};
     use homeboy_core::project::{Project, ProjectComponentAttachment};
     use homeboy_core::server::{self, Server};
@@ -1042,6 +1238,119 @@ mod tests {
 
             preflight_prepared_payload_binding(&project, "site", &config)
                 .expect("detector-backed managed path binds before lifecycle creation");
+        });
+    }
+
+    #[test]
+    fn later_target_preflight_failure_prevents_every_target_write() {
+        with_isolated_home(|home| {
+            server::save(&Server {
+                id: "local".to_string(),
+                host: "localhost".to_string(),
+                user: "test".to_string(),
+                port: 22,
+                identity_file: None,
+                aliases: vec![],
+                kind: None,
+                auth: None,
+                env: Default::default(),
+                runner: None,
+            })
+            .expect("save local server");
+
+            let first_base = home.path().join("first");
+            let second_base = home.path().join("second");
+            std::fs::create_dir_all(&first_base).expect("first base");
+            std::fs::create_dir_all(&second_base).expect("second base");
+            for (id, base_path) in [("first", &first_base), ("second", &second_base)] {
+                project::save(&Project {
+                    id: id.to_string(),
+                    server_id: Some("local".to_string()),
+                    base_path: Some(base_path.display().to_string()),
+                    components: vec![ProjectComponentAttachment {
+                        id: "plugin".to_string(),
+                        remote_path: Some("plugin".to_string()),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                })
+                .expect("save project");
+            }
+
+            let first_source = home.path().join("first-source");
+            let second_source = home.path().join("second-source");
+            std::fs::create_dir_all(&first_source).expect("first source");
+            std::fs::create_dir_all(&second_source).expect("second source");
+            std::fs::write(first_source.join("plugin.php"), "Version: 1.2.3\n")
+                .expect("first version");
+            std::fs::write(second_source.join("plugin.php"), "Version: 9.9.9\n")
+                .expect("second version");
+
+            let archive = home.path().join("plugin.zip");
+            let file = std::fs::File::create(&archive).expect("archive");
+            let mut zip = zip::ZipWriter::new(file);
+            zip.start_file("plugin.php", zip::write::FileOptions::default())
+                .expect("archive entry");
+            std::io::Write::write_all(&mut zip, b"Version: 1.2.3\n").expect("archive contents");
+            zip.finish().expect("finish archive");
+
+            let component = |local_path: &Path| Component {
+                id: "plugin".to_string(),
+                local_path: local_path.display().to_string(),
+                remote_path: "plugin".to_string(),
+                build_artifact: Some("plugin.zip".to_string()),
+                extract_command: Some("unzip -q {{artifact}} -d {{targetDir}}".to_string()),
+                version_targets: Some(vec![VersionTarget {
+                    file: "plugin.php".to_string(),
+                    pattern: Some(r"Version:\s*([0-9.]+)".to_string()),
+                    artifact_path: Some("plugin.php".to_string()),
+                }]),
+                ..Default::default()
+            };
+            let config = DeployConfig {
+                component_ids: vec!["plugin".to_string()],
+                expected_version: Some("1.2.3".to_string()),
+                force: true,
+                skip_build: true,
+                no_pull: true,
+                prepared_projection: Some(PreparedDeployProjection {
+                    components: BTreeMap::from([
+                        ("first:plugin".to_string(), component(&first_source)),
+                        ("second:plugin".to_string(), component(&second_source)),
+                    ]),
+                }),
+                prepared_artifact: Some(PreparedDeployArtifact {
+                    component_id: "plugin".to_string(),
+                    path: archive.display().to_string(),
+                    durable_path: archive.display().to_string(),
+                    size_bytes: std::fs::metadata(&archive).expect("archive metadata").len(),
+                    sha256: sha256_file(&archive).expect("archive sha"),
+                    version: "1.2.3".to_string(),
+                    tag: "v1.2.3".to_string(),
+                    source_commit: "0123456789abcdef".to_string(),
+                }),
+                max_concurrency: 2,
+                ..Default::default()
+            };
+
+            let result = run_multi(
+                &["first".to_string(), "second".to_string()],
+                &["plugin".to_string()],
+                &config,
+            )
+            .expect("preflight failures are reported per target");
+
+            assert_eq!(result.summary.failed, 2);
+            assert!(
+                result.projects[0]
+                    .error
+                    .as_deref()
+                    .is_some_and(|error| error.contains("no target application was started")),
+                "unexpected target outcomes: {:?}",
+                result.projects
+            );
+            assert!(!first_base.join("plugin").exists());
+            assert!(!second_base.join("plugin").exists());
         });
     }
 }

--- a/crates/homeboy-deploy/src/orchestration/mod.rs
+++ b/crates/homeboy-deploy/src/orchestration/mod.rs
@@ -36,7 +36,9 @@ use preflight::{
     guard_local_build_downgrades, guard_local_build_source_freshness, local_build_components,
     sync_components, verify_expected_version, warn_non_default_branch,
 };
+#[cfg(test)]
 use prepared_payloads::prepare_component_deployments;
+use prepared_payloads::{prepare_component_deployments_with_payloads, PrepareDeploymentsInput};
 use smoke_check::run_post_deploy_smoke;
 
 /// Main deploy orchestration entry point.
@@ -47,7 +49,7 @@ pub(super) fn deploy_components(
     project: &Project,
     ctx: &RemoteProjectContext,
     base_path: &str,
-    release_artifacts: &mut ReleaseArtifactStore,
+    artifacts: &mut super::preparation::DeploymentArtifactStore,
     mut observation: Option<&mut DeployObservation>,
 ) -> Result<DeployOrchestrationResult> {
     if let Some(observation) = observation.as_deref_mut() {
@@ -154,7 +156,11 @@ pub(super) fn deploy_components(
     }
 
     let (resolved_release_artifacts, unavailable_canonical_packages) =
-        resolve_release_artifacts_for_deploy(&components, config, release_artifacts)?;
+        resolve_release_artifacts_for_deploy(
+            &components,
+            config,
+            &mut artifacts.release_artifacts,
+        )?;
 
     // Resolve first, then materialize immutable detached worktrees for real deploys.
     // Dry-run resolves in `run_dry_run_mode` and never creates a worktree.
@@ -401,14 +407,17 @@ pub(super) fn deploy_components(
         // completed package work that was still in progress.
         observation.phase("package", false)?;
     }
-    let prepared_deployments = match prepare_component_deployments(
-        &components,
-        config,
-        &project,
-        base_path,
-        &local_versions,
-        &remote_versions,
-        &resolved_release_artifacts,
+    let prepared_deployments = match prepare_component_deployments_with_payloads(
+        PrepareDeploymentsInput {
+            components: &components,
+            config,
+            project: &project,
+            base_path,
+            local_versions: &local_versions,
+            remote_versions: &remote_versions,
+            release_artifacts: &resolved_release_artifacts,
+        },
+        artifacts,
     ) {
         Ok(prepared) => prepared,
         Err(failures) => {

--- a/crates/homeboy-deploy/src/orchestration/mod.rs
+++ b/crates/homeboy-deploy/src/orchestration/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use homeboy_core::component::{resolve_component_scope, Component, ScopeCommand};
 use homeboy_core::context::RemoteProjectContext;
@@ -19,8 +19,8 @@ use super::orchestration_tag_checkout::{
 use super::path_roots::{project_with_detected_path_roots, resolve_effective_remote_path};
 use super::planning::{load_project_components_with_projection, plan_components};
 use super::types::{
-    ComponentDeployResult, DeployConfig, DeployOrchestrationResult, DeploySummary, VersionSource,
-    VersionSources,
+    ComponentDeployResult, DeployConfig, DeployOrchestrationResult, DeploySummary,
+    DeploymentProvenanceEvidence, VersionSource, VersionSources,
 };
 use super::version_overrides::fetch_remote_versions_for_project;
 use homeboy_core::git::release_download::{ReleaseArtifactLease, ReleaseArtifactStore};
@@ -41,9 +41,25 @@ use prepared_payloads::prepare_component_deployments;
 use prepared_payloads::{prepare_component_deployments_with_payloads, PrepareDeploymentsInput};
 use smoke_check::run_post_deploy_smoke;
 
-/// Main deploy orchestration entry point.
-/// Handles component selection, building, and deployment.
-pub(super) fn deploy_components(
+pub(super) enum PreparedDeployment {
+    Complete(DeployOrchestrationResult),
+    Apply(Box<PreparedDeploymentPlan>),
+}
+
+pub(super) struct PreparedDeploymentPlan {
+    project: Project,
+    components: Vec<Component>,
+    config: DeployConfig,
+    prepared_deployments: prepared_payloads::PreparedDeployments,
+    deployment_provenance: BTreeMap<String, DeploymentProvenanceEvidence>,
+    exact_ref_identities: HashMap<String, ExactRefIdentity>,
+    deployed_refs: HashMap<String, String>,
+    built_from_commits: HashMap<String, String>,
+    _exact_ref_checkouts: Vec<ExactRefCheckout>,
+    _tag_ref_checkouts: Vec<ExactRefCheckout>,
+}
+
+pub(super) fn prepare_components(
     data_root: &std::path::Path,
     config: &DeployConfig,
     project: &Project,
@@ -51,7 +67,7 @@ pub(super) fn deploy_components(
     base_path: &str,
     artifacts: &mut super::preparation::DeploymentArtifactStore,
     mut observation: Option<&mut DeployObservation>,
-) -> Result<DeployOrchestrationResult> {
+) -> Result<PreparedDeployment> {
     if let Some(observation) = observation.as_deref_mut() {
         observation.phase("source_resolution", false)?;
     }
@@ -72,7 +88,7 @@ pub(super) fn deploy_components(
     if config.check && loaded.deployable.is_empty() && !loaded.extension_skipped.is_empty() {
         let results = extension_skipped_results(&loaded.extension_skipped, project, base_path);
         let skipped = results.len() as u32;
-        return Ok(DeployOrchestrationResult {
+        return Ok(PreparedDeployment::Complete(DeployOrchestrationResult {
             results,
             summary: DeploySummary {
                 total: skipped,
@@ -81,7 +97,7 @@ pub(super) fn deploy_components(
                 skipped,
             },
             deploy_run_id: None,
-        });
+        }));
     }
 
     if loaded.deployable.is_empty() {
@@ -125,7 +141,7 @@ pub(super) fn deploy_components(
     )?;
 
     if components.is_empty() {
-        return Ok(DeployOrchestrationResult {
+        return Ok(PreparedDeployment::Complete(DeployOrchestrationResult {
             results: vec![],
             summary: DeploySummary {
                 total: 0,
@@ -134,7 +150,7 @@ pub(super) fn deploy_components(
                 skipped: 0,
             },
             deploy_run_id: None,
-        });
+        }));
     }
 
     // This must precede artifact resolution and every source operation below.
@@ -256,7 +272,7 @@ pub(super) fn deploy_components(
             unavailable_canonical_packages: &unavailable_canonical_packages,
         });
         attach_version_sources(&mut result, &components);
-        return Ok(result);
+        return Ok(PreparedDeployment::Complete(result));
     }
     if config.dry_run {
         let mut result = run_dry_run_mode(
@@ -268,7 +284,7 @@ pub(super) fn deploy_components(
             config,
         )?;
         attach_version_sources(&mut result, &components);
-        return Ok(result);
+        return Ok(PreparedDeployment::Complete(result));
     }
 
     // Only local builds require mutable checkout safety checks. Release assets are
@@ -398,10 +414,8 @@ pub(super) fn deploy_components(
     )?;
 
     // Build and validate every local artifact before the first remote write.
-    if let Some(observation) = observation.as_deref_mut() {
+    if let Some(observation) = observation {
         observation.phase("build", false)?;
-    }
-    if let Some(observation) = observation.as_deref_mut() {
         // Payload preparation owns package construction and validation. Persist
         // its checkpoint before that work begins so interruption never reports
         // completed package work that was still in progress.
@@ -436,7 +450,7 @@ pub(super) fn deploy_components(
                 deploy_run_id: None,
             };
             attach_version_sources(&mut result, &components);
-            return Ok(result);
+            return Ok(PreparedDeployment::Complete(result));
         }
     };
 
@@ -488,6 +502,108 @@ pub(super) fn deploy_components(
         }
     }
 
+    let mut deployed_refs = HashMap::new();
+    let mut built_from_commits = HashMap::new();
+    for prepared in prepared_deployments.iter() {
+        let component = &prepared.component;
+        let exact_ref_identity = exact_ref_identities.get(&component.id);
+        let deployed_ref = if let Some(identity) = exact_ref_identity {
+            Some(identity.requested_ref.clone())
+        } else if let Some(artifact) = resolved_release_artifacts.get(&component.id) {
+            Some(match artifact.commit.as_deref() {
+                Some(commit) => format!("{} ({commit})", artifact.tag),
+                None => artifact.tag.clone(),
+            })
+        } else if let Some(checkout) = tag_checkouts
+            .iter()
+            .find(|checkout| checkout.component_id == component.id)
+        {
+            Some(checkout.provenance_ref())
+        } else if let Some(tag_ref) = materialized_tag_refs.get(&component.id) {
+            Some(tag_ref.clone())
+        } else if config.head {
+            homeboy_core::engine::command::run_in_optional(
+                &component.local_path,
+                "git",
+                &["rev-parse", "--abbrev-ref", "HEAD"],
+            )
+            .map(|branch| format!("{} (HEAD)", branch))
+        } else {
+            config
+                .prepared_artifact
+                .as_ref()
+                .map(|prepared_artifact| prepared_artifact.tag.clone())
+        };
+        if let Some(deployed_ref) = deployed_ref {
+            deployed_refs.insert(component.id.clone(), deployed_ref);
+        }
+
+        let built_from_commit = exact_ref_identity
+            .map(|identity| identity.resolved_sha.clone())
+            .or_else(|| {
+                resolved_release_artifacts
+                    .get(&component.id)
+                    .and_then(|artifact| artifact.commit.clone())
+            })
+            .or_else(|| {
+                tag_ref_checkouts
+                    .iter()
+                    .find(|checkout| checkout.component.id == component.id)
+                    .map(|checkout| checkout.identity.resolved_sha.clone())
+            })
+            .or_else(|| {
+                config
+                    .prepared_artifact
+                    .as_ref()
+                    .map(|artifact| artifact.source_commit.clone())
+            });
+        if let Some(commit) = built_from_commit {
+            built_from_commits.insert(component.id.clone(), commit);
+        }
+    }
+
+    // In-place tag checkouts contend across project preparation. Payload bytes
+    // are durable now, so restore the source before preparing the next target.
+    if !tag_checkouts.is_empty() {
+        restore_branches(&tag_checkouts);
+    }
+
+    Ok(PreparedDeployment::Apply(Box::new(
+        PreparedDeploymentPlan {
+            project,
+            components,
+            config: config.clone(),
+            prepared_deployments,
+            deployment_provenance,
+            exact_ref_identities,
+            deployed_refs,
+            built_from_commits,
+            _exact_ref_checkouts: exact_ref_checkouts,
+            _tag_ref_checkouts: tag_ref_checkouts,
+        },
+    )))
+}
+
+pub(super) fn apply_prepared_components(
+    data_root: &std::path::Path,
+    plan: PreparedDeploymentPlan,
+    ctx: &RemoteProjectContext,
+    base_path: &str,
+    mut observation: Option<&mut DeployObservation>,
+) -> Result<DeployOrchestrationResult> {
+    let PreparedDeploymentPlan {
+        project,
+        components,
+        config,
+        prepared_deployments,
+        deployment_provenance,
+        exact_ref_identities,
+        deployed_refs,
+        built_from_commits,
+        _exact_ref_checkouts,
+        _tag_ref_checkouts,
+    } = plan;
+
     // Execute deployments only after every component passed the local preflight.
     let mut results: Vec<ComponentDeployResult> = vec![];
     let mut succeeded: u32 = 0;
@@ -527,37 +643,8 @@ pub(super) fn deploy_components(
             observation.as_deref_mut(),
         );
 
-        // Record which git ref was deployed. The same label feeds build provenance
-        // so `deployed_ref` and `build_provenance.built_from_ref` never disagree.
         let exact_ref_identity = exact_ref_identities.get(&component.id);
-        let deployed_ref = if let Some(identity) = exact_ref_identity {
-            Some(identity.requested_ref.clone())
-        } else if let Some(artifact) = resolved_release_artifacts.get(&component.id) {
-            Some(match artifact.commit.as_deref() {
-                Some(commit) => format!("{} ({commit})", artifact.tag),
-                None => artifact.tag.clone(),
-            })
-        } else if let Some(checkout) = tag_checkouts
-            .iter()
-            .find(|c| c.component_id == component.id)
-        {
-            Some(checkout.provenance_ref())
-        } else if let Some(tag_ref) = materialized_tag_refs.get(&component.id) {
-            Some(tag_ref.clone())
-        } else if config.head {
-            // Deploying from HEAD — record the current branch
-            homeboy_core::engine::command::run_in_optional(
-                &component.local_path,
-                "git",
-                &["rev-parse", "--abbrev-ref", "HEAD"],
-            )
-            .map(|branch| format!("{} (HEAD)", branch))
-        } else {
-            config
-                .prepared_artifact
-                .as_ref()
-                .map(|prepared_artifact| prepared_artifact.tag.clone())
-        };
+        let deployed_ref = deployed_refs.get(&component.id).cloned();
 
         if let Some(ref git_ref) = deployed_ref {
             result = result.with_deployed_ref(git_ref.clone());
@@ -580,18 +667,7 @@ pub(super) fn deploy_components(
         // Attach explicit build provenance to every result, regardless of strategy.
         let mut build_provenance = prepared.build_provenance.clone();
         build_provenance.built_from_ref = deployed_ref;
-        if let Some(identity) = exact_ref_identity {
-            build_provenance.built_from_commit = Some(identity.resolved_sha.clone());
-        } else if let Some(artifact) = resolved_release_artifacts.get(&component.id) {
-            build_provenance.built_from_commit = artifact.commit.clone();
-        } else if let Some(checkout) = tag_ref_checkouts
-            .iter()
-            .find(|checkout| checkout.component.id == component.id)
-        {
-            build_provenance.built_from_commit = Some(checkout.identity.resolved_sha.clone());
-        } else if let Some(prepared_artifact) = config.prepared_artifact.as_ref() {
-            build_provenance.built_from_commit = Some(prepared_artifact.source_commit.clone());
-        }
+        build_provenance.built_from_commit = built_from_commits.get(&component.id).cloned();
         result = result.with_build_provenance(build_provenance.clone());
 
         if result.status == "deployed" {
@@ -631,11 +707,6 @@ pub(super) fn deploy_components(
         results.push(result);
     }
 
-    // Restore original branches after deployment
-    if !tag_checkouts.is_empty() {
-        restore_branches(&tag_checkouts);
-    }
-
     // Post-deploy front-end smoke check (opt-in, project-scoped). Runs only when
     // something actually deployed — a runtime-fataling release that returns 500
     // to fresh visitors should fail the deploy here so it gets rolled back
@@ -660,10 +731,6 @@ pub(super) fn deploy_components(
             }
         }
     }
-
-    // Isolated tag worktrees delete themselves on drop. Hold them until every
-    // payload has been built, transferred, and smoke-checked.
-    drop(tag_ref_checkouts);
 
     let mut result = DeployOrchestrationResult {
         results,

--- a/crates/homeboy-deploy/src/orchestration/modes.rs
+++ b/crates/homeboy-deploy/src/orchestration/modes.rs
@@ -641,6 +641,7 @@ mod tests {
             tagged: false,
             prepared_artifact: None,
             resume_run_id: None,
+            max_concurrency: 1,
             target: None,
         };
 

--- a/crates/homeboy-deploy/src/orchestration/prepared_payloads.rs
+++ b/crates/homeboy-deploy/src/orchestration/prepared_payloads.rs
@@ -6,15 +6,15 @@ use homeboy_core::project::Project;
 
 use super::super::binding::bind_project_payloads;
 use super::super::execution::{prepare_component_deploy, PreparedComponentDeploy};
-use super::super::preparation::{ComponentPayloadPreparationRequest, PreparedPayloadCollection};
+use super::super::preparation::{ComponentPayloadPreparationRequest, DeploymentArtifactStore};
 use super::super::provenance::record_payload_preparation_build;
 use super::super::types::{ComponentDeployResult, DeployConfig};
-use homeboy_core::git::release_download::{ReleaseArtifactLease, ReleaseArtifactStore};
+use homeboy_core::git::release_download::ReleaseArtifactLease;
 
 pub(super) struct PreparedDeployments {
     deployments: Vec<PreparedComponentDeploy>,
-    // Retains payload copies and release leases through every transfer.
-    _payloads: PreparedPayloadCollection,
+    #[cfg(test)]
+    _payloads: Option<super::super::preparation::PreparedPayloadCollection>,
 }
 
 impl std::ops::Deref for PreparedDeployments {
@@ -25,19 +25,31 @@ impl std::ops::Deref for PreparedDeployments {
     }
 }
 
-pub(super) fn prepare_component_deployments(
-    components: &[Component],
-    config: &DeployConfig,
-    project: &Project,
-    base_path: &str,
-    local_versions: &HashMap<String, String>,
-    remote_versions: &HashMap<String, String>,
-    release_artifacts: &HashMap<String, ReleaseArtifactLease>,
+pub(super) struct PrepareDeploymentsInput<'a> {
+    pub(super) components: &'a [Component],
+    pub(super) config: &'a DeployConfig,
+    pub(super) project: &'a Project,
+    pub(super) base_path: &'a str,
+    pub(super) local_versions: &'a HashMap<String, String>,
+    pub(super) remote_versions: &'a HashMap<String, String>,
+    pub(super) release_artifacts: &'a HashMap<String, ReleaseArtifactLease>,
+}
+
+pub(super) fn prepare_component_deployments_with_payloads(
+    input: PrepareDeploymentsInput<'_>,
+    artifacts: &mut DeploymentArtifactStore,
 ) -> std::result::Result<PreparedDeployments, Vec<ComponentDeployResult>> {
+    let PrepareDeploymentsInput {
+        components,
+        config,
+        project,
+        base_path,
+        local_versions,
+        remote_versions,
+        release_artifacts,
+    } = input;
     let mut prepared_deployments = Vec::new();
     let mut failures = Vec::new();
-    let mut payloads = PreparedPayloadCollection::default();
-    let mut release_artifact_store = ReleaseArtifactStore::default();
 
     let mut binding_payloads = config
         .prepared_artifact
@@ -66,7 +78,10 @@ pub(super) fn prepare_component_deployments(
                 ComponentPayloadPreparationRequest::new(&component, &preparation_config);
             request.config.exact_ref_materialized =
                 config.requested_ref_for(&component.id).is_some();
-            match payloads.prepare(request, &mut release_artifact_store) {
+            match artifacts
+                .payloads
+                .prepare(request, &mut artifacts.release_artifacts)
+            {
                 Ok(payload) => {
                     binding_payloads.insert(component.id.clone(), payload.artifact.clone());
                     let payload_build_ran = payload.build_ran;
@@ -142,11 +157,39 @@ pub(super) fn prepare_component_deployments(
     if failures.is_empty() {
         Ok(PreparedDeployments {
             deployments: prepared_deployments,
-            _payloads: payloads,
+            #[cfg(test)]
+            _payloads: None,
         })
     } else {
         Err(failures)
     }
+}
+
+#[cfg(test)]
+pub(super) fn prepare_component_deployments(
+    components: &[Component],
+    config: &DeployConfig,
+    project: &Project,
+    base_path: &str,
+    local_versions: &HashMap<String, String>,
+    remote_versions: &HashMap<String, String>,
+    release_artifacts: &HashMap<String, ReleaseArtifactLease>,
+) -> std::result::Result<PreparedDeployments, Vec<ComponentDeployResult>> {
+    let mut artifacts = DeploymentArtifactStore::default();
+    let mut prepared = prepare_component_deployments_with_payloads(
+        PrepareDeploymentsInput {
+            components,
+            config,
+            project,
+            base_path,
+            local_versions,
+            remote_versions,
+            release_artifacts,
+        },
+        &mut artifacts,
+    )?;
+    prepared._payloads = Some(artifacts.payloads);
+    Ok(prepared)
 }
 
 /// Read the build exit code the preparation step recorded on the structured
@@ -163,6 +206,85 @@ fn preparation_build_exit_code(error: &Error) -> Option<i32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn two_projects_share_one_prepared_payload() {
+        let source = tempfile::tempdir().expect("source");
+        let build_count = source.path().join("build-count");
+        let mut component = Component::new(
+            "fixture".to_string(),
+            source.path().display().to_string(),
+            "plugins/fixture".to_string(),
+            Some("build/fixture.bin".to_string()),
+        );
+        component.scripts = Some(homeboy_core::component::ComponentScriptsConfig {
+            build: vec![format!(
+                "mkdir -p build && printf payload > build/fixture.bin && printf build >> {}",
+                build_count.display()
+            )],
+            ..Default::default()
+        });
+        let config = DeployConfig {
+            component_ids: vec![component.id.clone()],
+            head: true,
+            ..Default::default()
+        };
+        let mut artifacts = DeploymentArtifactStore::default();
+        let versions = HashMap::new();
+        let canonical_artifacts = HashMap::new();
+
+        let first = prepare_component_deployments_with_payloads(
+            PrepareDeploymentsInput {
+                components: std::slice::from_ref(&component),
+                config: &config,
+                project: &Project {
+                    id: "first".to_string(),
+                    ..Default::default()
+                },
+                base_path: "/srv/first",
+                local_versions: &versions,
+                remote_versions: &versions,
+                release_artifacts: &canonical_artifacts,
+            },
+            &mut artifacts,
+        )
+        .expect("first target preparation");
+        let first_artifact = first[0]
+            .config
+            .prepared_artifact
+            .clone()
+            .expect("first prepared artifact");
+        drop(first);
+
+        let second = prepare_component_deployments_with_payloads(
+            PrepareDeploymentsInput {
+                components: &[component],
+                config: &config,
+                project: &Project {
+                    id: "second".to_string(),
+                    ..Default::default()
+                },
+                base_path: "/srv/second",
+                local_versions: &versions,
+                remote_versions: &versions,
+                release_artifacts: &canonical_artifacts,
+            },
+            &mut artifacts,
+        )
+        .expect("second target preparation");
+        let second_artifact = second[0]
+            .config
+            .prepared_artifact
+            .as_ref()
+            .expect("second prepared artifact");
+
+        assert_eq!(
+            std::fs::read_to_string(build_count).expect("build count"),
+            "build"
+        );
+        assert_eq!(first_artifact.sha256, second_artifact.sha256);
+        assert_eq!(first_artifact.durable_path, second_artifact.durable_path);
+    }
 
     /// Mirrors what the preparation build-failure producer records, without
     /// depending on the wording of the failure message.

--- a/crates/homeboy-deploy/src/parallel.rs
+++ b/crates/homeboy-deploy/src/parallel.rs
@@ -1,0 +1,125 @@
+use std::collections::VecDeque;
+use std::sync::{Mutex, MutexGuard};
+
+/// Apply owned jobs with bounded concurrency and return results in input order.
+pub(crate) fn map_bounded<J, R, F>(jobs: Vec<J>, max_concurrency: usize, apply: F) -> Vec<R>
+where
+    J: Send,
+    R: Send,
+    F: Fn(J) -> R + Sync,
+{
+    let worker_count = max_concurrency.max(1).min(jobs.len());
+    if worker_count <= 1 {
+        return jobs.into_iter().map(apply).collect();
+    }
+
+    let pending = Mutex::new(jobs.into_iter().enumerate().collect::<VecDeque<_>>());
+    let completed = Mutex::new(Vec::new());
+    std::thread::scope(|scope| {
+        let helpers: Vec<_> = (1..worker_count)
+            .map(|_| scope.spawn(|| drain(&pending, &completed, &apply)))
+            .collect();
+        drain(&pending, &completed, &apply);
+        for helper in helpers {
+            match helper.join() {
+                Ok(()) => {}
+                Err(payload) => std::panic::resume_unwind(payload),
+            }
+        }
+    });
+
+    let mut completed = into_inner(completed);
+    completed.sort_by_key(|(index, _)| *index);
+    completed.into_iter().map(|(_, result)| result).collect()
+}
+
+fn drain<J, R, F>(
+    pending: &Mutex<VecDeque<(usize, J)>>,
+    completed: &Mutex<Vec<(usize, R)>>,
+    apply: &F,
+) where
+    J: Send,
+    R: Send,
+    F: Fn(J) -> R + Sync,
+{
+    loop {
+        let Some((index, job)) = lock(pending).pop_front() else {
+            return;
+        };
+        let result = apply(job);
+        lock(completed).push((index, result));
+    }
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn into_inner<T>(mutex: Mutex<T>) -> T {
+    mutex
+        .into_inner()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn completion_order_does_not_change_output_order() {
+        let jobs = (0..8).collect::<Vec<u64>>();
+        let results = map_bounded(jobs, 4, |job| {
+            std::thread::sleep(Duration::from_millis(8 - job));
+            job
+        });
+
+        assert_eq!(results, (0..8).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn concurrency_never_exceeds_the_requested_bound() {
+        let active = AtomicUsize::new(0);
+        let peak = AtomicUsize::new(0);
+        map_bounded((0..12).collect::<Vec<_>>(), 3, |_| {
+            let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+            peak.fetch_max(current, Ordering::SeqCst);
+            std::thread::sleep(Duration::from_millis(5));
+            active.fetch_sub(1, Ordering::SeqCst);
+        });
+
+        assert!(peak.load(Ordering::SeqCst) > 1);
+        assert!(peak.load(Ordering::SeqCst) <= 3);
+    }
+
+    #[test]
+    fn one_job_failure_does_not_cancel_other_jobs() {
+        let completed = AtomicUsize::new(0);
+        let results = map_bounded((0..6).collect::<Vec<_>>(), 2, |job| {
+            completed.fetch_add(1, Ordering::SeqCst);
+            if job == 2 {
+                Err(job)
+            } else {
+                Ok(job)
+            }
+        });
+
+        assert_eq!(completed.load(Ordering::SeqCst), 6);
+        assert_eq!(results[2], Err(2));
+        assert_eq!(results.len(), 6);
+    }
+
+    #[test]
+    fn zero_or_one_worker_runs_serially() {
+        let thread = std::thread::current().id();
+        let zero = map_bounded(vec![1, 2], 0, |_| std::thread::current().id());
+        let one = map_bounded(vec![1, 2], 1, |_| std::thread::current().id());
+
+        assert!(zero.iter().all(|worker| *worker == thread));
+        assert!(one.iter().all(|worker| *worker == thread));
+    }
+}

--- a/crates/homeboy-deploy/src/preparation.rs
+++ b/crates/homeboy-deploy/src/preparation.rs
@@ -315,6 +315,13 @@ pub(crate) struct PreparedPayloadCollection {
     entries: HashMap<String, PreparedPayloadEntry>,
 }
 
+/// Owns reusable artifacts for the complete deployment fanout.
+#[derive(Default)]
+pub(crate) struct DeploymentArtifactStore {
+    pub(crate) payloads: PreparedPayloadCollection,
+    pub(crate) release_artifacts: ReleaseArtifactStore,
+}
+
 struct PreparedPayloadEntry {
     payload: PreparedComponentPayload,
 }

--- a/crates/homeboy-deploy/src/preparation.rs
+++ b/crates/homeboy-deploy/src/preparation.rs
@@ -683,6 +683,7 @@ impl DeployConfig {
             tagged: request.config.tagged,
             prepared_artifact: None,
             resume_run_id: None,
+            max_concurrency: 1,
             target: None,
         }
     }

--- a/crates/homeboy-deploy/src/provider.rs
+++ b/crates/homeboy-deploy/src/provider.rs
@@ -9,12 +9,44 @@ use super::lifecycle::DeployObservation;
 use super::route::DeployTarget;
 use super::types::{ComponentDeployResult, DeployConfig, DeployOrchestrationResult, DeploySummary};
 
+pub(super) struct PreparedProviderDeployment {
+    components: Vec<PreparedProviderComponent>,
+    unresolvable: Vec<UnresolvableComponent>,
+}
+
+struct PreparedProviderComponent {
+    project_id: String,
+    component: Component,
+    extension: String,
+    provider: String,
+    input: PreparedProviderInput,
+    result_schema: Option<String>,
+    explicit_route: bool,
+    dry_run: bool,
+}
+
+enum PreparedProviderInput {
+    Layered(tempfile::NamedTempFile),
+    Repository(PathBuf),
+}
+
+#[cfg(test)]
 pub(super) fn run_if_configured(
     project_id: &str,
     project: &Project,
     config: &DeployConfig,
-    mut observation: Option<&mut DeployObservation>,
+    observation: Option<&mut DeployObservation>,
 ) -> Result<Option<DeployOrchestrationResult>> {
+    prepare_if_configured(project_id, project, config)?
+        .map(|prepared| apply_prepared(prepared, observation))
+        .transpose()
+}
+
+pub(super) fn prepare_if_configured(
+    project_id: &str,
+    project: &Project,
+    config: &DeployConfig,
+) -> Result<Option<PreparedProviderDeployment>> {
     let component_ids = if config.component_ids.is_empty() && config.check {
         project
             .components
@@ -68,32 +100,13 @@ pub(super) fn run_if_configured(
         ));
     }
     if provider_count == components.len() {
-        let mut results = Vec::with_capacity(components.len() + unresolvable.len());
-        for component in &components {
-            results.push(run_component(
-                project_id,
-                project,
-                component,
-                config,
-                observation.as_deref_mut(),
-            )?);
-        }
-        results.extend(unresolvable_results(&unresolvable));
-        let failed = results
+        let components = components
             .iter()
-            .filter(|result| result.status == "failed")
-            .count() as u32;
-        let skipped = unresolvable.len() as u32;
-        let total = results.len() as u32;
-        return Ok(Some(DeployOrchestrationResult {
-            results,
-            summary: DeploySummary {
-                total,
-                succeeded: total - failed - skipped,
-                failed,
-                skipped,
-            },
-            deploy_run_id: None,
+            .map(|component| prepare_component(project_id, project, component, config))
+            .collect::<Result<Vec<_>>>()?;
+        return Ok(Some(PreparedProviderDeployment {
+            components,
+            unresolvable,
         }));
     }
     Ok(None)
@@ -158,13 +171,12 @@ fn unresolvable_results(unresolvable: &[UnresolvableComponent]) -> Vec<Component
         .collect()
 }
 
-fn run_component(
+fn prepare_component(
     project_id: &str,
     project: &Project,
     component: &Component,
     config: &DeployConfig,
-    mut observation: Option<&mut DeployObservation>,
-) -> Result<ComponentDeployResult> {
+) -> Result<PreparedProviderComponent> {
     let project_attachment = project
         .components
         .iter()
@@ -256,51 +268,96 @@ fn run_component(
 
     validate_repository_policy(component, layered.is_some(), attachment)?;
 
-    let is_layered = layered.is_some();
-    let layered_result_schema = layered
+    let result_schema = layered
         .as_ref()
-        .and_then(|layered| layered.result_schema.as_deref());
+        .and_then(|layered| layered.result_schema.clone());
     let dry_run = config.dry_run || config.check;
-    if !dry_run {
-        // Provider execution is the generic contract's first operation that may
-        // mutate a provider-owned target; provider internals remain opaque.
-        if let Some(observation) = observation.as_deref_mut() {
-            observation.phase("provider_execute", true)?;
-        }
-    }
-    let run = if layered.is_some() {
-        let payload = layered_payload(
+    let input = if layered.is_some() {
+        PreparedProviderInput::Layered(layered_payload(
             component,
             attachment.policy.as_ref().expect("validated inline policy"),
             target_input,
-        )?;
-        homeboy_core::extension::run_deployment_provider(
-            &attachment.extension,
-            &attachment.provider,
-            project_id,
-            &component.id,
-            &component.local_path,
-            payload.path(),
-            dry_run,
-        )
+        )?)
     } else {
-        let contract = repository_contract(
+        PreparedProviderInput::Repository(repository_contract(
             component,
             attachment
                 .contract
                 .as_deref()
                 .expect("validated legacy contract"),
-        )?;
-        homeboy_core::extension::run_deployment_provider(
-            &attachment.extension,
-            &attachment.provider,
-            project_id,
-            &component.id,
-            &component.local_path,
-            &contract,
-            dry_run,
-        )
-    }?;
+        )?)
+    };
+    Ok(PreparedProviderComponent {
+        project_id: project_id.to_string(),
+        component: component.clone(),
+        extension: attachment.extension.clone(),
+        provider: attachment.provider.clone(),
+        input,
+        result_schema,
+        explicit_route: config.target == Some(DeployTarget::Provider),
+        dry_run,
+    })
+}
+
+pub(super) fn apply_prepared(
+    prepared: PreparedProviderDeployment,
+    mut observation: Option<&mut DeployObservation>,
+) -> Result<DeployOrchestrationResult> {
+    let skipped = prepared.unresolvable.len() as u32;
+    let mut results = Vec::with_capacity(prepared.components.len() + prepared.unresolvable.len());
+    for component in prepared.components {
+        results.push(apply_component(component, observation.as_deref_mut())?);
+    }
+    results.extend(unresolvable_results(&prepared.unresolvable));
+    let failed = results
+        .iter()
+        .filter(|result| result.status == "failed")
+        .count() as u32;
+    let total = results.len() as u32;
+    Ok(DeployOrchestrationResult {
+        results,
+        summary: DeploySummary {
+            total,
+            succeeded: total - failed - skipped,
+            failed,
+            skipped,
+        },
+        deploy_run_id: None,
+    })
+}
+
+fn apply_component(
+    prepared: PreparedProviderComponent,
+    mut observation: Option<&mut DeployObservation>,
+) -> Result<ComponentDeployResult> {
+    let PreparedProviderComponent {
+        project_id,
+        component,
+        extension,
+        provider,
+        input,
+        result_schema,
+        explicit_route,
+        dry_run,
+    } = prepared;
+    if !dry_run {
+        if let Some(observation) = observation.as_deref_mut() {
+            observation.phase("provider_execute", true)?;
+        }
+    }
+    let (input, is_layered) = match &input {
+        PreparedProviderInput::Layered(payload) => (payload.path(), true),
+        PreparedProviderInput::Repository(contract) => (contract.as_path(), false),
+    };
+    let run = homeboy_core::extension::run_deployment_provider(
+        &extension,
+        &provider,
+        &project_id,
+        &component.id,
+        &component.local_path,
+        input,
+        dry_run,
+    )?;
     if !dry_run {
         if let Some(observation) = observation {
             observation.phase("verify", true)?;
@@ -310,14 +367,14 @@ fn run_component(
     let output = format!("{}{}", evidence.stdout, evidence.stderr);
     // Layered input can contain target secrets. Provider output is therefore not
     // promoted into deploy evidence or errors on that path.
-    let provider_result = match (is_layered, layered_result_schema) {
+    let provider_result = match (is_layered, result_schema.as_deref()) {
         (true, Some(schema)) => layered_provider_evidence(&evidence.stdout, schema),
         (true, None) => serde_json::json!({ "status": "opaque" }),
         (false, _) => serde_json::from_str::<serde_json::Value>(&evidence.stdout)
             .unwrap_or_else(|_| serde_json::json!({ "status": "unstructured", "output": output })),
     };
     let status = if run.exit_code == 0 {
-        if config.dry_run || config.check {
+        if dry_run {
             "validated"
         } else {
             "deployed"
@@ -325,12 +382,10 @@ fn run_component(
     } else {
         "failed"
     };
-    let mut result = ComponentDeployResult::new(component, "").with_status(status);
+    let mut result = ComponentDeployResult::new(&component, "").with_status(status);
     result.warnings.push(
-        match config.target {
-            Some(DeployTarget::Provider) => {
-                "deployment route: provider (selected by --target provider)"
-            }
+        match explicit_route {
+            true => "deployment route: provider (selected by --target provider)",
             _ => "deployment route: provider (selected by project deployment provider target)",
         }
         .to_string(),

--- a/crates/homeboy-deploy/src/types.rs
+++ b/crates/homeboy-deploy/src/types.rs
@@ -113,6 +113,8 @@ pub struct DeployConfig {
     pub prepared_artifact: Option<PreparedDeployArtifact>,
     /// Resume a durable multi-target deploy run after exact identity validation.
     pub resume_run_id: Option<String>,
+    /// Maximum number of project targets applied concurrently.
+    pub max_concurrency: usize,
     /// Explicitly select which deliverable a dual-deliverable component deploys.
     ///
     /// `None` infers the route from project target configuration. An explicit
@@ -149,6 +151,7 @@ impl DeployConfig {
             tagged: false,
             prepared_artifact: None,
             resume_run_id: None,
+            max_concurrency: 1,
             target: None,
         }
     }

--- a/crates/homeboy-release/src/release/deployment.rs
+++ b/crates/homeboy-release/src/release/deployment.rs
@@ -401,6 +401,7 @@ fn release_deployment_config(
         tagged: false,
         prepared_artifact: Some(prepared_artifact),
         resume_run_id: None,
+        max_concurrency: 4,
         target: None,
     })
 }

--- a/tests/commands/deploy_test.rs
+++ b/tests/commands/deploy_test.rs
@@ -329,6 +329,20 @@ fn deploy_rejects_old_apply_spelling() {
 }
 
 #[test]
+fn deploy_rejects_zero_max_concurrency() {
+    let result = Cli::try_parse_from([
+        "homeboy",
+        "deploy",
+        "project-a",
+        "component-a",
+        "--max-concurrency",
+        "0",
+    ]);
+
+    assert!(result.is_err(), "zero concurrency must be rejected");
+}
+
+#[test]
 fn deploy_parser_accepts_explicit_source_safety_overrides() {
     let cli = Cli::try_parse_from([
         "homeboy",
@@ -495,6 +509,7 @@ fn deploy_args(mut customize: impl FnMut(&mut DeployArgs)) -> DeployArgs {
         tagged: false,
         target: None,
         resume: None,
+        max_concurrency: 4,
         exact_refs: BTreeMap::new(),
         resolved_refs: BTreeMap::new(),
         preflighted_source_paths: BTreeMap::new(),


### PR DESCRIPTION
## Summary

- own prepared payloads and release artifacts for the complete multi-project deploy run
- split server and provider deployment into explicit prepare and apply phases
- prepare every target before any target mutation and abort all pending application on preflight failure
- apply independent targets with configurable bounded concurrency while preserving deterministic result order and durable per-target lifecycle checkpoints
- expose `--max-concurrency` with a default of 4 and reject zero at the CLI boundary

Closes #8112.

## Verification

- `cargo fmt --check`
- `cargo check --workspace --all-targets`
- `cargo clippy -p homeboy-deploy --no-deps -- -D warnings`
- `cargo nextest run -p homeboy-deploy parallel::tests later_target_preflight_failure_prevents_every_target_write provider::tests`: 21 passed
- `cargo nextest run -p homeboy-deploy --lib --no-fail-fast`: 325 passed; 4 inherited chmod fixture failures tracked by #13273
- `cargo nextest run -p homeboy-cli commands::deploy::deploy_test::deploy_rejects_zero_max_concurrency`: 1 passed
- `git diff --check`

A broader `homeboy-cli` library run reached an unrelated fanout worktree fixture failure before completion; the deploy parser test was rerun independently and passed.

## AI Assistance

Implemented and verified with OpenAI GPT-5.6 Sol through OpenCode. The assistant inspected the deploy lifecycle, split preparation from application for server and provider routes, implemented bounded deterministic fanout and lifecycle persistence, added acceptance coverage, and ran the listed validation commands.