### PR TITLE
fix: preserve upgrade failure streams

### DIFF
--- a/crates/homeboy-upgrade/src/upgrade/execution.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution.rs
@@ -115,6 +115,22 @@ pub(crate) fn annotate_truncation(detail: &str, capture: &StreamCaptureMetadata)
     }
 }
 
+fn upgrade_failure_detail(stderr: &[u8], stdout: &[u8]) -> Option<String> {
+    let (stderr, stderr_capture) = bound_captured_stream(stderr, UPGRADE_CAPTURE_LIMIT_BYTES);
+    let (stdout, stdout_capture) = bound_captured_stream(stdout, UPGRADE_CAPTURE_LIMIT_BYTES);
+    let stderr =
+        (!stderr.trim().is_empty()).then(|| annotate_truncation(stderr.trim(), &stderr_capture));
+    let stdout =
+        (!stdout.trim().is_empty()).then(|| annotate_truncation(stdout.trim(), &stdout_capture));
+
+    match (stderr, stdout) {
+        (Some(stderr), Some(stdout)) => Some(format!("stderr:\n{stderr}\nstdout:\n{stdout}")),
+        (Some(stderr), None) => Some(stderr),
+        (None, Some(stdout)) => Some(stdout),
+        (None, None) => None,
+    }
+}
+
 pub(crate) fn execute_upgrade(
     method: InstallMethod,
     source_path: Option<&Path>,
@@ -227,21 +243,10 @@ pub(crate) fn execute_upgrade(
     };
 
     if !output.status.success() {
-        // The upgrade command's stdout/stderr are unbounded; bound the retained
-        // bytes (keeping the trailing tail) with truncation metadata so a
-        // pathological command cannot force an arbitrarily large failure string
-        // into memory or logs (#5297).
-        let (stderr, stderr_capture) =
-            bound_captured_stream(&output.stderr, UPGRADE_CAPTURE_LIMIT_BYTES);
-        let (stdout, stdout_capture) =
-            bound_captured_stream(&output.stdout, UPGRADE_CAPTURE_LIMIT_BYTES);
-        let error_detail = if !stderr.trim().is_empty() {
-            annotate_truncation(stderr.trim(), &stderr_capture)
-        } else if !stdout.trim().is_empty() {
-            annotate_truncation(stdout.trim(), &stdout_capture)
-        } else {
-            format!("exit code {}", output.status.code().unwrap_or(1))
-        };
+        // Keep both bounded streams: installers may log progress to stderr while
+        // a staged candidate returns the actionable failure contract on stdout.
+        let error_detail = upgrade_failure_detail(&output.stderr, &output.stdout)
+            .unwrap_or_else(|| format!("exit code {}", output.status.code().unwrap_or(1)));
         return Err(upgrade_failure_error(
             method,
             &error_detail,

--- a/crates/homeboy-upgrade/src/upgrade/execution/tests/part_a.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution/tests/part_a.rs
@@ -63,6 +63,19 @@ fn annotate_truncation_leaves_untruncated_detail_unchanged() {
 }
 
 #[test]
+fn upgrade_failure_detail_preserves_stderr_and_structured_stdout() {
+    let detail = upgrade_failure_detail(
+        b"homeboy upgrade: target darwin-arm64, asset homeboy.tar.xz",
+        br#"{"status":"failed","recovery_command":"homeboy agent-task reconcile run-id --apply"}"#,
+    )
+    .expect("failure detail");
+
+    assert!(detail.contains("stderr:\nhomeboy upgrade: target darwin-arm64"));
+    assert!(detail.contains("stdout:\n{\"status\":\"failed\""));
+    assert!(detail.contains("homeboy agent-task reconcile run-id --apply"));
+}
+
+#[test]
 fn parses_homeboy_version_output() {
     assert_eq!(
         parse_cli_version_output("homeboy 0.158.0").as_deref(),


### PR DESCRIPTION
## Summary

- retain bounded stderr and stdout when an upgrade subprocess fails
- label both streams when both contain evidence while preserving the existing single-stream message shape
- prove an installer progress line cannot hide a staged candidate recovery command

Closes #13872.

## Verification

- `cargo fmt --all --check`
- `cargo test -p homeboy-upgrade` (223 passed)
- `git diff --check origin/main...HEAD`

## AI assistance

OpenAI GPT-5.6-sol via OpenCode reproduced the upgrade failure, verified release assets and host prerequisites, identified the stderr-exclusive diagnostic selection, implemented the bounded dual-stream contract, and ran the verification above. Chris Huber directed and reviewed the work.