### PR TITLE
fix(agent-task): derive Cook pull request titles

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -5540,10 +5540,7 @@ pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress(
         .and_then(|task| task.workspace.root.as_ref())
         .map(std::path::PathBuf::from);
     let task_base_sha = source_worktree_path.as_deref().and_then(git_head_sha);
-    let title = args
-        .title
-        .clone()
-        .unwrap_or_else(|| default_loop_title(&args));
+    let title = default_loop_title(&args, source_worktree_path.as_deref());
     let commit_message = args
         .commit_message
         .clone()
@@ -8228,14 +8225,62 @@ fn git_head_sha(path: &Path) -> Option<String> {
         .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
-fn default_loop_title(args: &AgentTaskCookArgs) -> String {
+fn default_loop_title(args: &AgentTaskCookArgs, source_worktree_path: Option<&Path>) -> String {
+    if let Some(title) = &args.title {
+        return title.clone();
+    }
+    if let Some(title) = args.goal.as_deref().and_then(bounded_cook_title) {
+        return title;
+    }
+    if let Some(title) = source_worktree_path
+        .zip(
+            args.base_resolution
+                .as_ref()
+                .and_then(|resolution| resolution.get("sha"))
+                .and_then(Value::as_str),
+        )
+        .and_then(|(path, base_sha)| existing_candidate_title(path, base_sha))
+    {
+        return title;
+    }
     let target = args
         .dispatch
         .repo
         .as_deref()
         .or(args.dispatch.task_url.as_deref())
         .unwrap_or("agent task");
-    format!("Cook {target}")
+    bounded_cook_title(&format!("Cook {target}")).unwrap_or_else(|| "Cook agent task".to_string())
+}
+
+fn existing_candidate_title(path: &Path, base_sha: &str) -> Option<String> {
+    let head_sha = git_head_sha(path)?;
+    if head_sha == base_sha
+        || !Command::new("git")
+            .args(["merge-base", "--is-ancestor", base_sha, &head_sha])
+            .current_dir(path)
+            .status()
+            .ok()?
+            .success()
+    {
+        return None;
+    }
+    let output = Command::new("git")
+        .args(["show", "-s", "--format=%s", &head_sha])
+        .current_dir(path)
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).into_owned())
+        .and_then(|subject| bounded_cook_title(&subject))
+}
+
+fn bounded_cook_title(value: &str) -> Option<String> {
+    const MAX_PR_TITLE_CHARS: usize = 256;
+
+    let title = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    (!title.is_empty()).then(|| title.chars().take(MAX_PR_TITLE_CHARS).collect())
 }
 
 fn default_loop_commit_message(args: &AgentTaskCookArgs) -> String {
@@ -8521,13 +8566,98 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        cook_attached_local_placement_disclosure, cook_continuation_status,
+        bounded_cook_title, cook_attached_local_placement_disclosure, cook_continuation_status,
         cook_provider_timeout_disclosure, cook_report_with_continuation,
-        cook_resolved_policy_disclosure, cook_review_form_timeout_disclosure,
-        detached_cook_route_less_warning, durable_cook_identity_lines, preflight_continue_cook,
-        project_preview_dirty_admission,
+        cook_resolved_policy_disclosure, cook_review_form_timeout_disclosure, default_loop_title,
+        detached_cook_route_less_warning, durable_cook_identity_lines, existing_candidate_title,
+        preflight_continue_cook, project_preview_dirty_admission,
     };
+    use crate::cli_surface::{Cli, Commands};
     use crate::commands::agent_task::args::CookContinueArgs;
+    use crate::commands::agent_task::AgentTaskCommand;
+    use clap::Parser;
+
+    fn title_cook_args(extra: &[&str]) -> super::AgentTaskCookArgs {
+        let mut argv = vec![
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "fixture",
+            "--cwd",
+            ".",
+            "--no-finalize",
+        ];
+        argv.extend_from_slice(extra);
+        let Commands::AgentTask(command) = Cli::parse_from(argv).command else {
+            panic!("agent-task command");
+        };
+        let AgentTaskCommand::Cook(args) = command.command else {
+            panic!("cook command");
+        };
+        *args
+    }
+
+    #[test]
+    fn cook_title_precedence_keeps_explicit_goal_candidate_and_fallback_semantics() {
+        let explicit = title_cook_args(&["--title", "Explicit title", "--goal", "Goal title"]);
+        assert_eq!(default_loop_title(&explicit, None), "Explicit title");
+
+        let goal = title_cook_args(&["--goal", "  Restore\n cold\t reconstruction  "]);
+        assert_eq!(
+            default_loop_title(&goal, None),
+            "Restore cold reconstruction"
+        );
+
+        let fallback = title_cook_args(&["--repo", "fixture-repository"]);
+        assert_eq!(
+            default_loop_title(&fallback, None),
+            "Cook fixture-repository"
+        );
+    }
+
+    #[test]
+    fn cook_title_semantics_are_bounded_and_candidate_aware() {
+        assert_eq!(
+            bounded_cook_title("  Restore\n cold\t reconstruction  ").as_deref(),
+            Some("Restore cold reconstruction")
+        );
+        assert_eq!(
+            bounded_cook_title(&"x".repeat(300))
+                .expect("bounded title")
+                .chars()
+                .count(),
+            256
+        );
+
+        let workspace = tempfile::tempdir().expect("workspace");
+        let git = |args: &[&str]| {
+            assert!(std::process::Command::new("git")
+                .args(args)
+                .current_dir(workspace.path())
+                .status()
+                .expect("run git")
+                .success());
+        };
+        git(&["init", "--initial-branch=main"]);
+        git(&["config", "user.email", "agent@example.test"]);
+        git(&["config", "user.name", "Agent"]);
+        std::fs::write(workspace.path().join("candidate.txt"), "base\n").expect("write base");
+        git(&["add", "candidate.txt"]);
+        git(&["commit", "-m", "base"]);
+        let base = super::git_head_sha(workspace.path()).expect("base sha");
+        assert_eq!(existing_candidate_title(workspace.path(), &base), None);
+
+        std::fs::write(workspace.path().join("candidate.txt"), "candidate\n")
+            .expect("write candidate");
+        git(&["commit", "-am", "fix: restore schema\n\nuntrusted body"]);
+        let mut candidate = title_cook_args(&["--repo", "fixture-repository"]);
+        candidate.base_resolution = Some(serde_json::json!({ "sha": base }));
+        assert_eq!(
+            default_loop_title(&candidate, Some(workspace.path())),
+            "fix: restore schema"
+        );
+    }
 
     #[test]
     fn preview_projects_each_dirty_admission_state() {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/promotion_review.rs
@@ -797,6 +797,26 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
         homeboy::core::defaults::save_config(&config).expect("save worktree provider config");
         std::fs::write(source.join("pre-existing-candidate.txt"), "preserve me\n")
             .expect("write pre-existing candidate");
+        std::fs::write(target.join("candidate-commit.txt"), "existing candidate\n")
+            .expect("write candidate commit");
+        let status = Command::new("git")
+            .args(["add", "candidate-commit.txt"])
+            .current_dir(&target)
+            .status()
+            .expect("stage candidate commit");
+        assert!(status.success());
+        let status = Command::new("git")
+            .args([
+                "commit",
+                "-m",
+                "fix: preserve existing candidate title",
+                "-m",
+                "commit body must not become the pull request title",
+            ])
+            .current_dir(&target)
+            .status()
+            .expect("commit existing candidate");
+        assert!(status.success());
         let expected_patch = temp.path().join("expected.patch");
         let promotion_request = temp.path().join("promotion-request.json");
         std::fs::write(
@@ -923,6 +943,12 @@ fn cook_promotes_mirrored_remote_attempt_into_controller_target() {
         assert!(prepared.load(std::sync::atomic::Ordering::SeqCst));
         assert_eq!(exit_code, 0, "{value:#}");
         assert_eq!(value["status"], "green_no_finalize");
+        let recipe = homeboy::agents::agent_task_service::load_recipe("cook-committed-work")
+            .expect("load persisted Cook recipe");
+        assert_eq!(
+            recipe.finalization["title"],
+            "fix: preserve existing candidate title"
+        );
         assert_eq!(
             value["attempts"][0]["feedback"]["status"],
             "green_completed"


### PR DESCRIPTION
## Summary

- preserve explicit Cook titles and otherwise derive them from the normalized goal
- use an existing candidate commit subject when the candidate is ahead of the resolved base
- bound generated titles to 256 characters and retain the repository/task fallback
- cover title precedence and the existing-candidate promotion lifecycle

Fixes #13143

## Validation

- `cargo test -p homeboy-cli --lib cook_title`
- `cargo test -p homeboy-cli --lib cook_promotes_mirrored_remote_attempt_into_controller_target -- --nocapture`
- `cargo test -p homeboy-cli --lib commands::agent_task::run::tests`
- `cargo fmt --all -- --check`
- `git diff --check`

`cargo clippy -p homeboy-cli --lib -- -D warnings` remains blocked by pre-existing Rust 1.95 Clippy findings across `homeboy-core` and `homeboy-cli`; no finding points to the new title derivation or its tests.

## AI Assistance

OpenAI GPT-5.6-sol via OpenCode inspected the Cook lifecycle, implemented deterministic title derivation, added regression coverage, and ran the listed validation. Chris Huber directed and reviewed the work.