### PR TITLE
fix(lab): validate dependency hydration outputs

### DIFF
--- a/crates/homeboy-core/src/deps.rs
+++ b/crates/homeboy-core/src/deps.rs
@@ -694,8 +694,8 @@ pub enum DependencyInstallInvocation {
 /// provide dependency support is equivalent to no provider for this optional
 /// planning surface; invalid explicit capability ownership still fails.
 /// Providers whose install cannot be expressed as a standalone shell command
-/// (component-script/extension providers) are omitted. Returns an empty vector
-/// when no provider detects the workspace.
+/// (component-script providers) are omitted. Returns an empty vector when no
+/// provider detects the workspace.
 ///
 /// The lockfile/manifest files are part of the synced snapshot (only built
 /// dependency trees like `vendor/`/`node_modules/` are excluded), so detecting
@@ -720,12 +720,11 @@ pub fn dependency_install_plan(path: &Path) -> Result<Vec<DependencyInstallPlanS
         };
     let mut steps = Vec::new();
     for provider in providers {
-        let status = provider.status(&component, &resolved_path, None)?;
-        if let Some(command) = provider.install_command(&component, &resolved_path)? {
+        if let Some(plan) = provider.hydration_plan(&component, &resolved_path)? {
             steps.push(DependencyInstallPlanStep {
-                provider_id: status.package_manager,
-                invocation: dependency_install_invocation(command.argv())?,
-                outputs: provider.install_outputs()?,
+                provider_id: plan.provider_id,
+                invocation: dependency_install_invocation(plan.install.argv())?,
+                outputs: plan.outputs,
             });
         }
     }
@@ -924,6 +923,55 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Mutex;
 
+    fn write_builtin_dependency_adapters(home: &Path) {
+        let root = home.join(".config/homeboy/extensions/dependency-adapters");
+        std::fs::create_dir_all(root.join("examples")).expect("adapter directory");
+        std::fs::write(
+            root.join("index.json"),
+            r#"{
+                "schema":"homeboy-extension/dependency-adapter-index/v1",
+                "manifests":[
+                    {"id":"nodejs-package-managers","ecosystem":"nodejs","path":"examples/nodejs.json"},
+                    {"id":"composer-package-manager","ecosystem":"php","path":"examples/composer.json"}
+                ]
+            }"#,
+        )
+        .expect("adapter index");
+        std::fs::write(
+            root.join("examples/nodejs.json"),
+            r#"{
+                "schema":"homeboy-extension/dependency-adapter-manifest/v1",
+                "id":"nodejs-package-managers",
+                "version":1,
+                "ecosystem":"nodejs",
+                "project_signals":{"root_files":["package.json"]},
+                "package_managers":[
+                    {"id":"pnpm","selection":{"priority":1,"files":["pnpm-lock.yaml"]},"commands":{"install":{"command":"pnpm install --frozen-lockfile"}},"outputs":[{"path":"node_modules","kind":"directory"}]},
+                    {"id":"yarn","selection":{"priority":2,"files":["yarn.lock"]},"commands":{"install":{"command":"yarn install --frozen-lockfile"}},"outputs":[{"path":"node_modules","kind":"directory"}]},
+                    {"id":"npm","selection":{"priority":3,"files":["package-lock.json"],"default":true},"commands":{"install":{"command":"npm ci"}},"outputs":[{"path":"node_modules","kind":"directory"}]}
+                ]
+            }"#,
+        )
+        .expect("node adapter");
+        std::fs::write(
+            root.join("examples/composer.json"),
+            r#"{
+                "schema":"homeboy-extension/dependency-adapter-manifest/v1",
+                "id":"composer-package-manager",
+                "version":1,
+                "ecosystem":"php",
+                "project_signals":{"root_files":["composer.json"]},
+                "package_managers":[{
+                    "id":"composer",
+                    "selection":{"priority":1,"default":true},
+                    "commands":{"install":{"command":"composer install"}},
+                    "outputs":[{"path":"vendor","kind":"directory"},{"path":"vendor/autoload.php","kind":"file"}]
+                }]
+            }"#,
+        )
+        .expect("composer adapter");
+    }
+
     #[test]
     fn extension_owned_install_path_becomes_portable_invocation() {
         crate::test_support::with_isolated_home(|home| {
@@ -1011,6 +1059,54 @@ mod tests {
                 .expect("unrelated linked extensions do not require dependency hydration");
 
             assert!(plan.is_empty());
+        });
+    }
+
+    #[test]
+    fn detected_builtin_adapters_declare_deterministic_outputs() {
+        crate::test_support::with_isolated_home(|home| {
+            write_builtin_dependency_adapters(home.path());
+
+            for (manager, lockfile) in [
+                ("pnpm", "pnpm-lock.yaml"),
+                ("yarn", "yarn.lock"),
+                ("npm", "package-lock.json"),
+            ] {
+                let project = tempfile::tempdir().expect("node project");
+                std::fs::write(project.path().join("package.json"), "{}").expect("package");
+                std::fs::write(project.path().join(lockfile), "").expect("lockfile");
+
+                let plan = dependency_install_plan(project.path()).expect("detected node plan");
+
+                assert_eq!(plan.len(), 1);
+                assert_eq!(plan[0].provider_id, manager);
+                assert_eq!(
+                    plan[0].outputs,
+                    vec![DependencyInstallOutput {
+                        path: "node_modules".to_string(),
+                        kind: DependencyInstallOutputKind::Directory,
+                    }]
+                );
+            }
+
+            let project = tempfile::tempdir().expect("composer project");
+            std::fs::write(project.path().join("composer.json"), "{}").expect("manifest");
+            let plan = dependency_install_plan(project.path()).expect("detected composer plan");
+            assert_eq!(plan.len(), 1);
+            assert_eq!(plan[0].provider_id, "composer");
+            assert_eq!(
+                plan[0].outputs,
+                vec![
+                    DependencyInstallOutput {
+                        path: "vendor".to_string(),
+                        kind: DependencyInstallOutputKind::Directory,
+                    },
+                    DependencyInstallOutput {
+                        path: "vendor/autoload.php".to_string(),
+                        kind: DependencyInstallOutputKind::File,
+                    },
+                ]
+            );
         });
     }
 

--- a/crates/homeboy-core/src/deps_provider.rs
+++ b/crates/homeboy-core/src/deps_provider.rs
@@ -168,30 +168,6 @@ impl DependencyProvider {
         }
     }
 
-    pub(crate) fn install_command(
-        &self,
-        component: &Component,
-        path: &Path,
-    ) -> Result<Option<DependencyProviderCommand>> {
-        let context = DependencyProviderContext { component, path };
-        match self {
-            DependencyProvider::Manifest(provider) => provider.install_command(context),
-            DependencyProvider::Adapter(provider) => provider.install_command(context),
-            DependencyProvider::ComponentScript(provider) => provider.install_command(context),
-            DependencyProvider::Extension(provider) => provider.install_command(context),
-        }
-    }
-
-    pub(crate) fn install_outputs(&self) -> Result<Vec<DependencyInstallOutput>> {
-        match self {
-            DependencyProvider::Manifest(provider) => provider.install_outputs(),
-            DependencyProvider::Adapter(provider) => provider.install_outputs(),
-            DependencyProvider::Extension(_) | DependencyProvider::ComponentScript(_) => {
-                Ok(Vec::new())
-            }
-        }
-    }
-
     pub(crate) fn hydration_plan(
         &self,
         component: &Component,
@@ -340,25 +316,33 @@ impl AdapterDependencyProvider {
 
     fn load(path: &Path) -> Result<Vec<Self>> {
         let extensions_dir = paths::extensions()?;
-        let Ok(entries) = fs::read_dir(extensions_dir) else {
+        let Ok(entries) = fs::read_dir(&extensions_dir) else {
             return Ok(Vec::new());
         };
 
+        let mut index_paths = vec![extensions_dir.join(DEPENDENCY_ADAPTER_INDEX)];
+        index_paths.extend(
+            entries
+                .flatten()
+                .map(|entry| entry.path().join(DEPENDENCY_ADAPTER_INDEX)),
+        );
+        index_paths.sort();
+        index_paths.dedup();
+
         let mut adapters = Vec::new();
-        let mut seen_manifests = HashSet::new();
-        for entry in entries.flatten() {
-            let index_path = entry.path().join(DEPENDENCY_ADAPTER_INDEX);
+        let mut seen_adapter_ids = HashSet::new();
+        for index_path in index_paths {
             if !index_path.is_file() {
                 continue;
             }
             for manifest in read_dependency_adapter_index(&index_path)? {
+                if !seen_adapter_ids.insert(manifest.id.clone()) {
+                    continue;
+                }
                 let manifest_path = index_path
                     .parent()
                     .expect("dependency adapter index has a parent")
                     .join(&manifest.path);
-                if !seen_manifests.insert(manifest_path.clone()) {
-                    continue;
-                }
                 let adapter = read_installed_dependency_adapter(&manifest_path)?;
                 if adapter.id != manifest.id || adapter.ecosystem != manifest.ecosystem {
                     return Err(Error::validation_invalid_argument(
@@ -530,19 +514,6 @@ impl AdapterDependencyProvider {
             return Ok(None);
         };
         Ok(Some(self.run(command, "install")?))
-    }
-
-    fn install_command(
-        &self,
-        _context: DependencyProviderContext<'_>,
-    ) -> Result<Option<DependencyProviderCommand>> {
-        Ok(self
-            .adapter
-            .package_manager()
-            .commands
-            .install
-            .as_ref()
-            .map(|command| self.command(command)))
     }
 }
 
@@ -1023,18 +994,6 @@ impl ManifestDependencyProvider {
         let command = self.command(command, context, None, None);
         Ok(Some(run_dependency_provider_command(&command, "install")?))
     }
-
-    fn install_command(
-        &self,
-        context: DependencyProviderContext<'_>,
-    ) -> Result<Option<DependencyProviderCommand>> {
-        Ok(self
-            .manifest
-            .commands
-            .install
-            .as_ref()
-            .map(|command| self.command(command, context, None, None)))
-    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1221,13 +1180,6 @@ impl ComponentScriptDependencyProvider {
             stderr: output.stderr,
         }))
     }
-
-    fn install_command(
-        &self,
-        _context: DependencyProviderContext<'_>,
-    ) -> Result<Option<DependencyProviderCommand>> {
-        Ok(None)
-    }
 }
 
 pub(crate) struct ExtensionDependencyProvider {
@@ -1295,29 +1247,6 @@ impl ExtensionDependencyProvider {
             stdout: output.stdout,
             stderr: output.stderr,
         }))
-    }
-
-    fn install_command(
-        &self,
-        context: DependencyProviderContext<'_>,
-    ) -> Result<Option<DependencyProviderCommand>> {
-        let args = vec!["install-command".to_string()];
-        let output = self.run(context.component, context.path, &args)?;
-        let plan: ExtensionInstallCommandOutput =
-            parse_extension_output(&output.stdout, "deps install-command")?;
-        if plan.command.is_empty() {
-            return Err(Error::validation_invalid_argument(
-                "dependency_provider",
-                "Dependency provider install-command returned an empty command".to_string(),
-                None,
-                None,
-            ));
-        }
-        Ok(Some(DependencyProviderCommand::new(
-            plan.command.first().cloned().unwrap_or_default(),
-            plan.command.into_iter().skip(1).collect(),
-            context.path,
-        )))
     }
 
     fn hydration_plan(
@@ -1660,7 +1589,7 @@ mod tests {
                     "{\"package_manager\":\"fixture\",\"packages\":[]}\n"
                 }
                 [action] if action == "install-command" => {
-                    "{\"command\":[\"fixture-pm\",\"install\",\"--locked\"]}\n"
+                    "{\"command\":[\"fixture-pm\",\"install\",\"--locked\"],\"outputs\":[{\"path\":\"deps\",\"kind\":\"directory\"}]}\n"
                 }
                 _ => unreachable!("unexpected fixture command: {script_args:?}"),
             };
@@ -1736,15 +1665,25 @@ esac
             .unwrap();
         assert_eq!(status.package_manager, "fixture");
 
-        let command = provider
-            .install_command(DependencyProviderContext {
+        let plan = provider
+            .hydration_plan(DependencyProviderContext {
                 component: &component,
                 path: &component_path,
             })
             .unwrap()
             .unwrap();
-        assert_eq!(command.argv(), vec!["fixture-pm", "install", "--locked"]);
-        assert_eq!(command.cwd, component_path);
+        assert_eq!(
+            plan.install.argv(),
+            vec!["fixture-pm", "install", "--locked"]
+        );
+        assert_eq!(plan.install.cwd, component_path);
+        assert_eq!(
+            plan.outputs,
+            vec![DependencyInstallOutput {
+                path: "deps".to_string(),
+                kind: DependencyInstallOutputKind::Directory,
+            }]
+        );
     }
 
     #[test]
@@ -1873,6 +1812,51 @@ esac
                 providers.as_slice(),
                 [DependencyProvider::Manifest(_)]
             ));
+        });
+    }
+
+    #[test]
+    fn global_and_extension_indexes_do_not_duplicate_adapter_ids() {
+        crate::test_support::with_isolated_home(|_| {
+            let project = tempdir().unwrap();
+            fs::write(project.path().join("fixture.json"), "{}").unwrap();
+            let extensions = paths::extensions().unwrap();
+            for root in [
+                extensions.join("dependency-adapters"),
+                extensions.join("fixture-extension/dependency-adapters"),
+            ] {
+                fs::create_dir_all(&root).unwrap();
+                fs::write(
+                    root.join("index.json"),
+                    r#"{
+                        "schema": "homeboy-extension/dependency-adapter-index/v1",
+                        "manifests": [{ "id": "fixture", "ecosystem": "fixture", "path": "fixture.json" }]
+                    }"#,
+                )
+                .unwrap();
+                fs::write(
+                    root.join("fixture.json"),
+                    r#"{
+                        "schema": "homeboy-extension/dependency-adapter-manifest/v1",
+                        "id": "fixture",
+                        "version": 1,
+                        "ecosystem": "fixture",
+                        "project_signals": { "root_files": ["fixture.json"] },
+                        "package_managers": [{
+                            "id": "fixture-pm",
+                            "selection": { "priority": 1, "default": true },
+                            "commands": { "install": { "command": "true" } },
+                            "outputs": [{ "kind": "directory", "path": "deps" }]
+                        }]
+                    }"#,
+                )
+                .unwrap();
+            }
+
+            let providers = AdapterDependencyProvider::load(project.path()).unwrap();
+
+            assert_eq!(providers.len(), 1);
+            assert_eq!(providers[0].adapter.id, "fixture");
         });
     }
 

--- a/crates/homeboy-lab-runner/src/lab/offload/dependency_package.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/dependency_package.rs
@@ -34,10 +34,24 @@ pub(super) fn prepare_in_roots(
     workspace: &Path,
     plan: &[homeboy_core::deps::DependencyInstallPlanStep],
 ) -> Result<Option<DependencyPackage>> {
-    let outputs = output_paths(plan);
-    if outputs.is_empty() || outputs.iter().any(|path| !workspace.join(path).exists()) {
+    if plan.is_empty()
+        || plan.iter().any(|step| {
+            step.outputs.is_empty()
+                || step.outputs.iter().any(|output| {
+                    let path = workspace.join(&output.path);
+                    match output.kind {
+                        homeboy_core::deps::DependencyInstallOutputKind::Path => !path.exists(),
+                        homeboy_core::deps::DependencyInstallOutputKind::File => !path.is_file(),
+                        homeboy_core::deps::DependencyInstallOutputKind::Directory => {
+                            !path.is_dir()
+                        }
+                    }
+                })
+        })
+    {
         return Ok(None);
     }
+    let outputs = output_paths(plan);
     let lockfiles = lockfile_identity(workspace)?;
     let outputs_identity = output_identity(workspace, &outputs)?;
     let key = content_hash::sha256_hex(&serde_json::to_vec(&(SCHEMA, plan, lockfiles)).map_err(
@@ -331,6 +345,37 @@ mod tests {
     fn reports_missing_outputs_without_a_package() {
         let data_root = tempfile::tempdir().unwrap();
         let root = tempfile::tempdir().unwrap();
+        assert!(prepare_in_roots(data_root.path(), root.path(), &plan())
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn refuses_partial_packages_when_any_provider_omits_outputs() {
+        let data_root = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        fs::create_dir(root.path().join("deps")).unwrap();
+        fs::write(root.path().join("deps/a"), "ok").unwrap();
+        let mut plan = plan();
+        plan.push(DependencyInstallPlanStep {
+            provider_id: "outputless".to_string(),
+            invocation: DependencyInstallInvocation::Argv {
+                argv: vec!["test".to_string()],
+            },
+            outputs: Vec::new(),
+        });
+
+        assert!(prepare_in_roots(data_root.path(), root.path(), &plan)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn validates_declared_output_kind_before_packaging() {
+        let data_root = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join("deps"), "not a directory").unwrap();
+
         assert!(prepare_in_roots(data_root.path(), root.path(), &plan())
             .unwrap()
             .is_none());

--- a/crates/homeboy-lab-runner/src/lab/offload/hydration.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/hydration.rs
@@ -192,7 +192,7 @@ fn hydrate_lab_workspace_dependencies_with_policy(
             std::path::Path::new(local_path),
             &plan,
         )? {
-            restore_controller_dependency_package(runner_id, remote_path, &package)?;
+            restore_controller_dependency_package(runner_id, remote_path, &package, &plan)?;
             return Ok(LabWorkspaceHydrationOutput {
                 schema: HYDRATION_SCHEMA,
                 status: "restored_controller_cache",
@@ -216,7 +216,7 @@ fn hydrate_lab_workspace_dependencies_with_policy(
     }
 
     let mut steps = Vec::new();
-    for (index, plan_step) in plan.into_iter().enumerate() {
+    for (index, plan_step) in plan.iter().enumerate() {
         let command = runner_hydration_command(&plan_step.invocation)?;
         let started = std::time::Instant::now();
         let options =
@@ -244,6 +244,14 @@ fn hydrate_lab_workspace_dependencies_with_policy(
         }
         steps.push(step);
     }
+    if !declared_outputs_are_ready(runner_id, remote_path, &plan)? {
+        return Err(Error::validation_invalid_argument(
+            "workspace_setup",
+            "dependency hydration completed without producing its declared outputs",
+            Some(remote_path.to_string()),
+            None,
+        ));
+    }
 
     Ok(LabWorkspaceHydrationOutput {
         schema: HYDRATION_SCHEMA,
@@ -259,6 +267,30 @@ fn restore_controller_dependency_package(
     runner_id: &str,
     remote_path: &str,
     package: &super::dependency_package::DependencyPackage,
+    plan: &[deps::DependencyInstallPlanStep],
+) -> Result<()> {
+    restore_controller_dependency_package_with_transfer(
+        runner_id,
+        remote_path,
+        package,
+        plan,
+        |runner, cache_dir, archive| {
+            let transfer = crate::RunnerFileTransfer::for_runner(
+                runner,
+                crate::status(runner_id).ok().as_ref(),
+            )?;
+            transfer.ensure_directory(cache_dir)?;
+            transfer.upload_file(&package.path.display().to_string(), archive)
+        },
+    )
+}
+
+fn restore_controller_dependency_package_with_transfer(
+    runner_id: &str,
+    remote_path: &str,
+    package: &super::dependency_package::DependencyPackage,
+    plan: &[deps::DependencyInstallPlanStep],
+    transfer_package: impl FnOnce(&crate::Runner, &str, &str) -> Result<()>,
 ) -> Result<()> {
     super::dependency_package::verify(&package.path, &package.sha256)?;
     let runner = crate::load(runner_id)?;
@@ -276,12 +308,10 @@ fn restore_controller_dependency_package(
         package.key
     );
     let archive = format!("{cache_dir}/package.zip");
-    let transfer =
-        crate::RunnerFileTransfer::for_runner(&runner, crate::status(runner_id).ok().as_ref())?;
-    transfer.ensure_directory(&cache_dir)?;
-    transfer.upload_file(&package.path.display().to_string(), &archive)?;
+    transfer_package(&runner, &cache_dir, &archive)?;
+    let output_checks = declared_output_checks(remote_path, plan).join(" && ");
     let verify_and_restore = format!(
-        "test \"$(wc -c < {archive})\" -le {max} && test \"$(shasum -a 256 {archive} | awk '{{print $1}}')\" = {sha} && unzip -oq {archive} -d {workspace}",
+        "test \"$(wc -c < {archive})\" -le {max} && test \"$(shasum -a 256 {archive} | awk '{{print $1}}')\" = {sha} && unzip -oq {archive} -d {workspace} && {output_checks}",
         archive = shell::quote_arg(&archive), max = super::dependency_package::MAX_PACKAGE_BYTES,
         sha = shell::quote_arg(&package.sha256), workspace = shell::quote_arg(remote_path),
     );
@@ -311,8 +341,44 @@ fn prepared_source_view_is_ready(
     remote_path: &str,
     plan: &[deps::DependencyInstallPlanStep],
 ) -> Result<bool> {
-    let output_tests = plan
-        .iter()
+    let Some(output_tests) = declared_output_checks_for_complete_plan(remote_path, plan) else {
+        return Ok(false);
+    };
+    let mut checks = vec![format!(
+        "test -f {}/.homeboy/prepared-source-ready",
+        shell::quote_arg(remote_path)
+    )];
+    checks.extend(output_tests);
+    remote_checks_succeed(runner_id, remote_path, checks)
+}
+
+fn declared_outputs_are_ready(
+    runner_id: &str,
+    remote_path: &str,
+    plan: &[deps::DependencyInstallPlanStep],
+) -> Result<bool> {
+    let checks = declared_output_checks(remote_path, plan);
+    if checks.is_empty() {
+        return Ok(true);
+    }
+    remote_checks_succeed(runner_id, remote_path, checks)
+}
+
+fn declared_output_checks_for_complete_plan(
+    remote_path: &str,
+    plan: &[deps::DependencyInstallPlanStep],
+) -> Option<Vec<String>> {
+    if plan.iter().any(|step| step.outputs.is_empty()) {
+        return None;
+    }
+    Some(declared_output_checks(remote_path, plan))
+}
+
+fn declared_output_checks(
+    remote_path: &str,
+    plan: &[deps::DependencyInstallPlanStep],
+) -> Vec<String> {
+    plan.iter()
         .flat_map(|step| &step.outputs)
         .map(|output| {
             let path = format!("{}/{}", remote_path.trim_end_matches('/'), output.path);
@@ -323,12 +389,10 @@ fn prepared_source_view_is_ready(
             };
             format!("test {predicate} {}", shell::quote_arg(&path))
         })
-        .collect::<Vec<_>>();
-    let mut checks = vec![format!(
-        "test -f {}/.homeboy/prepared-source-ready",
-        shell::quote_arg(remote_path)
-    )];
-    checks.extend(output_tests);
+        .collect()
+}
+
+fn remote_checks_succeed(runner_id: &str, remote_path: &str, checks: Vec<String>) -> Result<bool> {
     let (output, exit_code) = exec(
         runner_id,
         RunnerExecOptions::raw_command(vec![
@@ -666,6 +730,37 @@ mod tests {
         }
     }
 
+    fn write_detected_node_adapter(home: &std::path::Path) {
+        let root = home.join(".config/homeboy/extensions/dependency-adapters");
+        std::fs::create_dir_all(root.join("examples")).expect("adapter directory");
+        std::fs::write(
+            root.join("index.json"),
+            r#"{
+                "schema":"homeboy-extension/dependency-adapter-index/v1",
+                "manifests":[{"id":"nodejs-package-managers","ecosystem":"nodejs","path":"examples/nodejs.json"}]
+            }"#,
+        )
+        .expect("adapter index");
+        std::fs::write(
+            root.join("examples/nodejs.json"),
+            r#"{
+                "schema":"homeboy-extension/dependency-adapter-manifest/v1",
+                "id":"nodejs-package-managers",
+                "version":1,
+                "ecosystem":"nodejs",
+                "project_signals":{"root_files":["package.json"]},
+                "lockfile_priority":["package-lock.json"],
+                "package_managers":[{
+                    "id":"npm",
+                    "selection":{"priority":1,"files":["package-lock.json"],"default":true},
+                    "commands":{"install":{"command":"npm ci","requires_lockfile":true}},
+                    "outputs":[{"path":"node_modules","kind":"directory"}]
+                }]
+            }"#,
+        )
+        .expect("node adapter");
+    }
+
     /// `hydration_failure_error` classifies the failure as workspace setup and
     /// records the provider id, command, duration, and exit status so operators
     /// can distinguish a hydration (workspace setup) failure from a later
@@ -878,6 +973,113 @@ mod tests {
     }
 
     #[test]
+    fn detected_npm_hydrates_stale_marker_then_reuses_validated_outputs() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            write_detected_node_adapter(home.path());
+            let path_guard = FakeBinGuard::install(
+                "npm",
+                "#!/bin/sh\nmkdir -p node_modules\nprintf x >> npm-runs\n",
+            );
+            crate::create(&path_guard.local_runner_spec("lab-detected-npm"), false)
+                .expect("create local runner");
+            let project = tempfile::tempdir().expect("controller project");
+            std::fs::write(project.path().join("package.json"), "{}").expect("package manifest");
+            std::fs::write(project.path().join("package-lock.json"), "{}").expect("lockfile");
+            let remote = tempfile::tempdir().expect("runner workspace");
+            std::fs::create_dir_all(remote.path().join(".homeboy")).expect("marker directory");
+            std::fs::write(remote.path().join(".homeboy/prepared-source-ready"), "")
+                .expect("stale marker");
+
+            let first = hydrate_lab_workspace_dependencies(
+                "lab-detected-npm",
+                &project.path().display().to_string(),
+                &remote.path().display().to_string(),
+            )
+            .expect("missing node_modules triggers detected npm hydration");
+            assert_eq!(first.status, "hydrated");
+            assert_eq!(first.steps[0].provider_id, "npm");
+            assert_eq!(first.steps[0].command, ["sh", "-c", "npm ci"]);
+            assert!(remote.path().join("node_modules").is_dir());
+            assert_eq!(
+                std::fs::read_to_string(remote.path().join("npm-runs")).expect("npm ran"),
+                "x"
+            );
+
+            let second = hydrate_lab_workspace_dependencies(
+                "lab-detected-npm",
+                &project.path().display().to_string(),
+                &remote.path().display().to_string(),
+            )
+            .expect("validated node_modules is reusable");
+            assert_eq!(second.status, "reused_prepared_cache");
+            assert_eq!(
+                std::fs::read_to_string(remote.path().join("npm-runs")).expect("npm run count"),
+                "x"
+            );
+        });
+    }
+
+    #[test]
+    fn successful_live_hydration_requires_declared_output_kind() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let path_guard = FakeBinGuard::install(
+                "fixture-tool",
+                "#!/bin/sh\nprintf not-a-directory > node_modules\n",
+            );
+            crate::create(
+                &path_guard.local_runner_spec("lab-wrong-output-kind"),
+                false,
+            )
+            .expect("create local runner");
+            let project = tempfile::tempdir().expect("project");
+            let manifest = r#"{"provider":"fixture","commands":{"install":{"argv":["fixture-tool","install"]}},"outputs":[{"path":"node_modules","kind":"directory"}]}"#;
+            std::fs::write(project.path().join("homeboy-deps.json"), manifest).expect("manifest");
+            let remote = tempfile::tempdir().expect("remote");
+
+            let error = hydrate_lab_workspace_dependencies(
+                "lab-wrong-output-kind",
+                &project.path().display().to_string(),
+                &remote.path().display().to_string(),
+            )
+            .expect_err("a zero exit without the declared directory must fail");
+
+            assert_eq!(error.code, ErrorCode::ValidationInvalidArgument);
+            assert!(error.message.contains("declared outputs"));
+        });
+    }
+
+    #[test]
+    fn prepared_marker_cannot_reuse_an_outputless_provider_plan() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let path_guard = FakeBinGuard::install(
+                "fixture-tool",
+                "#!/bin/sh\nprintf hydrated > hydration-ran\n",
+            );
+            crate::create(&path_guard.local_runner_spec("lab-outputless"), false)
+                .expect("create local runner");
+            let project = tempfile::tempdir().expect("project");
+            let manifest = r#"{"provider":"fixture","commands":{"install":{"argv":["fixture-tool","install"]}}}"#;
+            std::fs::write(project.path().join("homeboy-deps.json"), manifest).expect("manifest");
+            let remote = tempfile::tempdir().expect("remote");
+            std::fs::write(remote.path().join("homeboy-deps.json"), manifest)
+                .expect("remote manifest");
+            std::fs::create_dir_all(remote.path().join(".homeboy")).expect("marker directory");
+            std::fs::write(remote.path().join(".homeboy/prepared-source-ready"), "")
+                .expect("marker");
+
+            let output = hydrate_lab_workspace_dependencies(
+                "lab-outputless",
+                &project.path().display().to_string(),
+                &remote.path().display().to_string(),
+            )
+            .expect("outputless plan hydrates instead of reusing marker");
+
+            assert_eq!(output.status, "hydrated");
+            assert!(remote.path().join("hydration-ran").is_file());
+        });
+    }
+
+    #[test]
     fn prepared_marker_missing_declared_build_output_hydrates() {
         homeboy_core::test_support::with_isolated_home(|_| {
             let path_guard = FakeBinGuard::install(
@@ -938,6 +1140,67 @@ mod tests {
             .expect("validated cache avoids install");
 
             assert_eq!(output.status, "reused_prepared_cache");
+        });
+    }
+
+    #[test]
+    fn detected_controller_dependencies_restore_through_restore_path() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            write_detected_node_adapter(home.path());
+            let project = tempfile::tempdir().expect("controller project");
+            std::fs::write(project.path().join("package.json"), "{}").expect("package manifest");
+            std::fs::write(project.path().join("package-lock.json"), "{}").expect("lockfile");
+            std::fs::create_dir_all(project.path().join("node_modules/tar")).expect("dependencies");
+            std::fs::write(
+                project.path().join("node_modules/tar/index.js"),
+                "module.exports = {};",
+            )
+            .expect("dependency file");
+
+            let remote = tempfile::tempdir().expect("restored workspace");
+            let runner_root = tempfile::tempdir().expect("runner root");
+            crate::create(
+                &serde_json::json!({
+                    "id": "lab-offline-restore",
+                    "kind": "local",
+                    "workspace_root": runner_root.path()
+                })
+                .to_string(),
+                false,
+            )
+            .expect("create local runner");
+            let plan = deps::dependency_install_plan(project.path()).expect("detected npm plan");
+            let data_root = tempfile::tempdir().expect("package data root");
+            let package = super::super::dependency_package::prepare_in_roots(
+                data_root.path(),
+                project.path(),
+                &plan,
+            )
+            .expect("seal dependencies")
+            .expect("declared dependencies are packageable");
+
+            restore_controller_dependency_package_with_transfer(
+                "lab-offline-restore",
+                &remote.path().display().to_string(),
+                &package,
+                &plan,
+                |_, cache_dir, archive| {
+                    std::fs::create_dir_all(cache_dir).map_err(|error| {
+                        Error::internal_io(error.to_string(), Some(cache_dir.to_string()))
+                    })?;
+                    std::fs::copy(&package.path, archive).map_err(|error| {
+                        Error::internal_io(error.to_string(), Some(archive.to_string()))
+                    })?;
+                    Ok(())
+                },
+            )
+            .expect("restore path installs the controller package");
+
+            assert_eq!(
+                std::fs::read_to_string(remote.path().join("node_modules/tar/index.js"))
+                    .expect("restored dependency"),
+                "module.exports = {};"
+            );
         });
     }
 


### PR DESCRIPTION
Closes #10453.

## Summary
- derive deterministic provider outputs for detected dependency adapters
- reject stale prepared markers and partial controller packages
- validate output kinds after live hydration and cache restore
- deduplicate adapters exposed through multiple indexes

## Verification
- `cargo test -p homeboy-lab-runner hydration --lib`
- `cargo test -p homeboy-lab-runner dependency_package --lib`
- focused Homeboy core dependency-plan tests
- `cargo fmt --all -- --check`
- `git diff --check`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented and reviewed the dependency hydration repair, added focused regression coverage, and ran the verification commands under Chris Huber's direction.