### PR TITLE
fix(cli): promote provider failure diagnostics

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -351,6 +351,7 @@ pub(crate) fn preview_cook(
         provision["action"].as_str(),
         Some("materialization_required" | "unresolved_provider")
     ) {
+        let failure = provision.get("failure").cloned();
         return Ok((
             serde_json::json!({
                 "schema": "homeboy/agent-task-cook-preview/v1",
@@ -367,6 +368,7 @@ pub(crate) fn preview_cook(
                     "notification_resolution": notification_resolution,
                 },
                 "progress": progress,
+                "failure": failure,
                 "replay_argv": replay.argv,
                 "replay_requires": replay.requires,
             }),
@@ -4464,6 +4466,7 @@ fn unresolved_provider_preview(
         .as_str()
         .unwrap_or_default();
     let planning_timeout = preview_provider_plan_timeout(config, provider_id);
+    let failure = error.details.get("provider_failure").cloned();
     serde_json::json!({
         "action": "unresolved_provider",
         "disposition": "unresolved",
@@ -4474,6 +4477,7 @@ fn unresolved_provider_preview(
         "planning_timeout": planning_timeout,
         "reason": error.message,
         "remediation": error.details["tried"],
+        "failure": failure,
         "details": error.details,
     })
 }

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -1814,7 +1814,7 @@ fn project_operator_value(value: &mut Value, evidence_content: bool) {
                     || (evidence_content && key == "body")
                 {
                     if let Value::String(text) = item {
-                        if text.len() > COMPACT_TEXT_LIMIT {
+                        if text.len() > COMPACT_TEXT_LIMIT && !is_bounded_failure_result(text) {
                             let digest = content_hash::sha256_hex(text.as_bytes());
                             *text = format!("[omitted {} bytes; sha256={digest}]", text.len());
                         }
@@ -1828,6 +1828,61 @@ fn project_operator_value(value: &mut Value, evidence_content: bool) {
             }
         }
         _ => {}
+    }
+}
+
+fn is_bounded_failure_result(text: &str) -> bool {
+    if text.len() > 8_192 {
+        return false;
+    }
+    let Ok(Value::Object(result)) = serde_json::from_str(text) else {
+        return false;
+    };
+    let failed = result.get("success").and_then(Value::as_bool) == Some(false)
+        || result
+            .get("status")
+            .and_then(Value::as_str)
+            .is_some_and(|status| {
+                matches!(
+                    status.to_ascii_lowercase().as_str(),
+                    "blocked" | "error" | "failed" | "failure" | "timed_out" | "timeout"
+                )
+            });
+    failed
+}
+
+#[cfg(test)]
+mod bounded_failure_result_tests {
+    use super::{is_bounded_failure_result, COMPACT_TEXT_LIMIT};
+
+    #[test]
+    fn retains_code_less_payloads_for_every_liftable_failure_status() {
+        for status in [
+            "blocked",
+            "error",
+            "failed",
+            "failure",
+            "timed_out",
+            "timeout",
+        ] {
+            let payload = serde_json::json!({
+                "status": status,
+                "message": "x".repeat(COMPACT_TEXT_LIMIT),
+            })
+            .to_string();
+            assert!(payload.len() > COMPACT_TEXT_LIMIT);
+            assert!(is_bounded_failure_result(&payload), "status={status}");
+        }
+    }
+
+    #[test]
+    fn retains_success_false_without_a_code() {
+        let payload = serde_json::json!({
+            "success": false,
+            "message": "x".repeat(COMPACT_TEXT_LIMIT),
+        })
+        .to_string();
+        assert!(is_bounded_failure_result(&payload));
     }
 }
 

--- a/crates/homeboy-cli/src/commands/utils/response.rs
+++ b/crates/homeboy-cli/src/commands/utils/response.rs
@@ -729,17 +729,178 @@ fn failure_diagnostics_for_data(
     if exit_code == 0 {
         return None;
     }
+
+    let specialized_digest = release_failure_digest(data)
+        .or_else(|| cook_batch_failure_digest(data))
+        .or_else(|| formatting_failure_digest(data));
+    if let Some(failure_digest) = specialized_digest {
+        return Some(command_failed_diagnostics(exit_code, failure_digest));
+    }
+    if let Some(failure) = declared_failure(data) {
+        let mut details = failure.details;
+        details.insert("exit_code".to_string(), Value::from(exit_code));
+        details.insert(
+            "source_pointer".to_string(),
+            Value::String("/failure".to_string()),
+        );
+        let failure_digest = CommandFailureDigest {
+            summary: failure.message.clone(),
+            stdout_tail: failure.stdout_tail,
+            stderr_tail: failure.stderr_tail,
+            artifact_refs: Vec::new(),
+            next_actions: failure.next_actions,
+            retryable: failure.retryable,
+        };
+        return Some(CommandDiagnostics {
+            code: failure.code,
+            message: failure.message,
+            details: Value::Object(details),
+            hints: None,
+            retryable: failure.retryable,
+            failure_digest: Some(failure_digest),
+        });
+    }
+
     let failure_digest = failure_digest_for_data(data).or_else(|| {
         run.as_ref()
             .and_then(|run| failure_digest_for_run(&run.id, artifacts))
     });
-    failure_digest.map(|failure_digest| CommandDiagnostics {
+    failure_digest.map(|failure_digest| command_failed_diagnostics(exit_code, failure_digest))
+}
+
+fn command_failed_diagnostics(
+    exit_code: i32,
+    failure_digest: CommandFailureDigest,
+) -> CommandDiagnostics {
+    CommandDiagnostics {
         code: "command.failed".to_string(),
         message: failure_digest.summary.clone(),
         details: serde_json::json!({ "exit_code": exit_code }),
         hints: None,
         retryable: failure_digest.retryable,
         failure_digest: Some(failure_digest),
+    }
+}
+
+struct DeclaredFailure {
+    code: String,
+    message: String,
+    details: Map<String, Value>,
+    stdout_tail: Option<String>,
+    stderr_tail: Option<String>,
+    next_actions: Vec<CommandNextAction>,
+    retryable: Option<bool>,
+}
+
+/// Lift only the payload's declared current failure. Producer layers promote
+/// causal subprocess failures here; unrelated nested historical records are
+/// data and must not be attributed to this command invocation.
+fn declared_failure(data: &Value) -> Option<DeclaredFailure> {
+    let object = data.get("failure")?.as_object()?;
+    let message = ["message", "problem", "summary"]
+        .into_iter()
+        .find_map(|key| object.get(key).and_then(Value::as_str))
+        .or_else(|| object.get("error").and_then(Value::as_str))?
+        .trim();
+    if message.is_empty() {
+        return None;
+    }
+
+    let local_details = object.get("details").and_then(Value::as_object);
+    let detail_value = object
+        .get("details")
+        .cloned()
+        .unwrap_or_else(|| Value::Object(object.clone()));
+    let details = bounded_failure_detail(&detail_value)
+        .as_object()
+        .cloned()
+        .unwrap_or_default();
+    let stream_tail = |key: &str| {
+        local_details
+            .and_then(|value| value.get(key))
+            .or_else(|| object.get(key))
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .map(str::to_string)
+            .map(tail_text)
+    };
+    let retryable = object
+        .get("retryable")
+        .and_then(Value::as_bool)
+        .or_else(|| {
+            local_details
+                .and_then(|details| details.get("retryable"))
+                .and_then(Value::as_bool)
+        });
+
+    Some(DeclaredFailure {
+        code: object
+            .get("code")
+            .or_else(|| object.get("kind"))
+            .or_else(|| object.get("class"))
+            .and_then(Value::as_str)
+            .filter(|code| !code.trim().is_empty())
+            .map(|code| bounded_text(code.trim(), 128))
+            .unwrap_or_else(|| "command.failed".to_string()),
+        message: bounded_text(message, 1_000),
+        stdout_tail: stream_tail("stdout_tail").or_else(|| stream_tail("stdout")),
+        stderr_tail: stream_tail("stderr_tail").or_else(|| stream_tail("stderr")),
+        next_actions: object
+            .get("next_actions")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .take(4)
+            .filter_map(|action| serde_json::from_value(action.clone()).ok())
+            .collect::<Vec<_>>()
+            .into_iter()
+            .chain(failure_replay_action(&details))
+            .take(4)
+            .collect(),
+        details,
+        retryable,
+    })
+}
+
+fn bounded_failure_detail(value: &Value) -> Value {
+    match value {
+        Value::String(value) => Value::String(bounded_text(value, 1_000)),
+        Value::Array(items) => {
+            Value::Array(items.iter().take(4).map(bounded_failure_detail).collect())
+        }
+        Value::Object(object) => Value::Object(
+            object
+                .iter()
+                .take(8)
+                .map(|(key, value)| (key.clone(), bounded_failure_detail(value)))
+                .collect(),
+        ),
+        value => value.clone(),
+    }
+}
+
+fn failure_replay_action(details: &Map<String, Value>) -> Option<CommandNextAction> {
+    let command = details
+        .get("refresh_command")
+        .and_then(Value::as_str)
+        .or_else(|| details.get("replay_command").and_then(Value::as_str))
+        .or_else(|| details.get("recovery_command").and_then(Value::as_str))
+        .or_else(|| {
+            details
+                .get("remediation")
+                .and_then(Value::as_object)
+                .and_then(|remediation| {
+                    remediation
+                        .get("command")
+                        .or_else(|| remediation.get("replay_command"))
+                        .and_then(Value::as_str)
+                })
+        })
+        .map(str::trim)
+        .filter(|command| !command.is_empty());
+    command.map(|command| {
+        CommandNextAction::new("replay the failed operation", command)
+            .with_kind(CommandNextActionKind::Repair)
     })
 }
 
@@ -777,15 +938,6 @@ fn actions_for_error(err: &Error) -> Vec<CommandNextAction> {
 }
 
 fn failure_digest_for_data(data: &Value) -> Option<CommandFailureDigest> {
-    if let Some(digest) = release_failure_digest(data) {
-        return Some(digest);
-    }
-    if let Some(digest) = cook_batch_failure_digest(data) {
-        return Some(digest);
-    }
-    if let Some(digest) = formatting_failure_digest(data) {
-        return Some(digest);
-    }
     let failure = data.get("failure").and_then(Value::as_object);
     let summary = failure
         .and_then(|failure| string_at_object(failure, "summary"))
@@ -2011,6 +2163,160 @@ mod tests {
             value["diagnostics"]["failure_digest"]["next_actions"][0]["command"],
             "homeboy agent-task cook-continue cook-1"
         );
+    }
+
+    #[test]
+    fn cook_preview_lifts_declared_typed_provider_failure() {
+        let provider_failure = json!({
+            "schema": "fixture/worktree-provider-error/v1",
+            "status": "error",
+            "code": "freshness_refresh_required",
+            "message": "workspace freshness must be refreshed before planning",
+            "refresh_command": "workspace-provider refresh example@fix-13848",
+            "remediation": ["refresh provider state, then replay planning"],
+            "stderr": "provider freshness probe timed out",
+            "evidence": "x".repeat(600),
+        });
+        let provider_stderr = serde_json::to_string(&provider_failure).expect("provider failure");
+        let payload = json!({
+            "schema": "homeboy/agent-task-cook-preview/v1",
+            "mutates": false,
+            "failure": {
+                "code": "freshness_refresh_required",
+                "message": "workspace freshness must be refreshed before planning",
+                "details": {
+                    "refresh_command": "workspace-provider refresh example@fix-13848",
+                    "remediation": ["refresh provider state, then replay planning"],
+                },
+                "stderr_tail": "provider freshness probe timed out",
+            },
+            "resolved": {
+                "worktree": "example@fix-13848",
+                "workspace": {
+                    "action": "unresolved_provider",
+                    "disposition": "unresolved",
+                    "kind": "provider",
+                    "handle": "example@fix-13848",
+                    "provider_id": "fixture",
+                    "reason": "worktree provider plan command failed with exit code 1",
+                    "details": {
+                        "field": "to_worktree",
+                        "problem": "worktree provider plan command failed with exit code 1",
+                        "worktree_provider_phase": "worktree_provider_plan",
+                        "worktree_provider_replay_command": "workspace-provider plan example@fix-13848",
+                        "command_evidence": {
+                            "command": "workspace-provider plan example@fix-13848",
+                            "exit_code": 1,
+                            "stdout": provider_stderr,
+                            "stderr": "provider plan failed",
+                        },
+                    },
+                },
+            },
+            "replay_argv": ["homeboy", "agent-task", "cook", "--preview"],
+        });
+        assert!(provider_stderr.len() > 512, "exercise compact projection");
+        let mut compact_payload = payload.clone();
+        crate::commands::agent_task::status::project_operator_output(&mut compact_payload);
+        assert_eq!(
+            compact_payload, payload,
+            "typed failure evidence is retained"
+        );
+        let response = cli_response_for_json_result_for_identity(
+            &Ok(compact_payload),
+            1,
+            &CommandIdentity::with_operation("agent-task", "cook"),
+            None,
+        );
+        let value = serde_json::to_value(response).expect("serialize response");
+
+        assert_eq!(value["diagnostics"]["code"], "freshness_refresh_required");
+        assert_eq!(
+            value["summary"],
+            "workspace freshness must be refreshed before planning"
+        );
+        assert_eq!(
+            value["diagnostics"]["details"]["refresh_command"],
+            "workspace-provider refresh example@fix-13848"
+        );
+        assert_eq!(
+            value["diagnostics"]["details"]["remediation"],
+            json!(["refresh provider state, then replay planning"])
+        );
+        assert_eq!(
+            value["diagnostics"]["failure_digest"]["stderr_tail"],
+            "provider freshness probe timed out"
+        );
+        assert_eq!(
+            value["next_actions"][0]["command"],
+            "workspace-provider refresh example@fix-13848"
+        );
+        assert_eq!(
+            value["diagnostics"]["details"]["source_pointer"],
+            "/failure"
+        );
+        assert_eq!(
+            value["data"]["resolved"]["workspace"]["details"]["field"],
+            "to_worktree"
+        );
+        assert_eq!(
+            value["data"]["resolved"]["workspace"]["details"]["worktree_provider_phase"],
+            "worktree_provider_plan"
+        );
+        assert_eq!(
+            value["data"]["resolved"]["workspace"]["details"]["worktree_provider_replay_command"],
+            "workspace-provider plan example@fix-13848"
+        );
+        assert_eq!(value["data"], payload, "nested evidence remains lossless");
+    }
+
+    #[test]
+    fn historical_nested_errors_are_not_attributed_to_the_current_exit() {
+        let response = cli_response_for_json_result_for_identity(
+            &Ok(json!({
+                "schema": "fixture/history/v1",
+                "history": [{
+                    "status": "failed",
+                    "error": {
+                        "code": "historical.provider_failure",
+                        "message": "an earlier attempt failed",
+                    },
+                }],
+                "resolved": { "status": "blocked" },
+            })),
+            1,
+            &CommandIdentity::with_operation("agent-task", "cook"),
+            None,
+        );
+        let value = serde_json::to_value(response).expect("serialize response");
+
+        assert_eq!(value["diagnostics"]["code"], "command.failed");
+        assert!(!value["summary"]
+            .as_str()
+            .expect("summary")
+            .contains("earlier attempt"));
+    }
+
+    #[test]
+    fn truly_causeless_nonzero_result_keeps_generic_failure() {
+        let response = cli_response_for_json_result_for_identity(
+            &Ok(json!({
+                "schema": "homeboy/agent-task-cook-preview/v1",
+                "mutates": false,
+                "resolved": { "worktree": "example@fix-13848" },
+            })),
+            1,
+            &CommandIdentity::with_operation("agent-task", "cook"),
+            None,
+        );
+        let value = serde_json::to_value(response).expect("serialize response");
+
+        assert_eq!(value["diagnostics"]["code"], "command.failed");
+        assert_eq!(
+            value["summary"],
+            "agent-task cook exited 1 without reporting a failure cause"
+        );
+        assert!(value["diagnostics"].get("failure_digest").is_none());
     }
 
     /// #13702: `success: false` is never emitted without a named cause. A

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -2445,6 +2445,7 @@ fn run_provider_mutation_command(
         None,
         Some(provider_command_evidence(command, &output)),
     );
+    promote_provider_command_failure(&mut error, &output);
     annotate_provider_lookup_error(&mut error, provider_id, command, operation, "command");
     Err(error)
 }
@@ -2956,6 +2957,7 @@ fn run_provider_split_command(
             None,
             Some(provider_command_evidence(command, &output)),
         );
+        promote_provider_command_failure(&mut error, &output);
         annotate_provider_lookup_error(&mut error, provider_id, command, operation, "command");
         return Err(error);
     }
@@ -3170,6 +3172,7 @@ fn run_provider_lookup_command(
             None,
             Some(provider_command_evidence(command, &output)),
         );
+        promote_provider_command_failure(&mut error, &output);
         annotate_provider_lookup_error(&mut error, provider_id, command, operation, "command");
         return Err(error);
     }
@@ -3496,6 +3499,118 @@ fn provider_command_evidence(command: &[String], output: &std::process::Output) 
     }
 }
 
+/// Promote a provider's declared current failure beside the lossless command
+/// evidence. Stderr wins when both streams contain failure JSON because it is
+/// the command's diagnostic channel; stdout remains preserved as evidence.
+fn promote_provider_command_failure(error: &mut Error, output: &std::process::Output) {
+    let failure = [&output.stderr, &output.stdout]
+        .into_iter()
+        .filter_map(|stream| serde_json::from_slice::<Value>(stream).ok())
+        .find_map(|value| bounded_declared_provider_failure(&value));
+    if let Some(failure) = failure {
+        error.details["provider_failure"] = failure;
+    }
+}
+
+fn bounded_declared_provider_failure(value: &Value) -> Option<Value> {
+    const TEXT_LIMIT: usize = 1_000;
+    const CODE_LIMIT: usize = 128;
+    const REMEDIATION_LIMIT: usize = 4;
+
+    let object = value.as_object()?;
+    let failed = object.get("success").and_then(Value::as_bool) == Some(false)
+        || object
+            .get("status")
+            .and_then(Value::as_str)
+            .is_some_and(|status| {
+                matches!(
+                    status.to_ascii_lowercase().as_str(),
+                    "blocked" | "error" | "failed" | "failure" | "timed_out" | "timeout"
+                )
+            });
+    if !failed {
+        return None;
+    }
+    let message = ["message", "problem", "summary"]
+        .into_iter()
+        .find_map(|key| object.get(key).and_then(Value::as_str))
+        .or_else(|| object.get("error").and_then(Value::as_str))
+        .or_else(|| object.get("failure").and_then(Value::as_str))?
+        .trim();
+    if message.is_empty() {
+        return None;
+    }
+    let bounded = |text: &str, limit: usize| text.chars().take(limit).collect::<String>();
+    let bounded_detail = |text: &str, limit: usize| {
+        crate::redaction::redact_string(text)
+            .chars()
+            .take(limit)
+            .collect::<String>()
+    };
+    let mut details = serde_json::Map::new();
+    if let Some(command) = object
+        .get("refresh_command")
+        .and_then(Value::as_str)
+        .filter(|command| !command.trim().is_empty())
+    {
+        details.insert(
+            "refresh_command".to_string(),
+            Value::String(bounded_detail(command.trim(), TEXT_LIMIT)),
+        );
+    }
+    if let Some(remediation) = object.get("remediation") {
+        let remediation = match remediation {
+            Value::String(text) => Value::String(bounded_detail(text, TEXT_LIMIT)),
+            Value::Array(items) => Value::Array(
+                items
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .take(REMEDIATION_LIMIT)
+                    .map(|text| Value::String(bounded_detail(text, TEXT_LIMIT)))
+                    .collect(),
+            ),
+            Value::Object(remediation) => {
+                let mut projected = serde_json::Map::new();
+                for key in ["command", "replay_command", "message"] {
+                    if let Some(text) = remediation.get(key).and_then(Value::as_str) {
+                        projected.insert(
+                            key.to_string(),
+                            Value::String(bounded_detail(text, TEXT_LIMIT)),
+                        );
+                    }
+                }
+                Value::Object(projected)
+            }
+            _ => Value::Null,
+        };
+        if !remediation.is_null() {
+            details.insert("remediation".to_string(), remediation);
+        }
+    }
+    let mut failure = serde_json::json!({
+        "message": bounded_detail(message, TEXT_LIMIT),
+        "details": details,
+    });
+    if let Some(code) = object
+        .get("code")
+        .or_else(|| object.get("kind"))
+        .or_else(|| object.get("class"))
+        .and_then(Value::as_str)
+        .filter(|code| !code.trim().is_empty())
+    {
+        failure["code"] = Value::String(bounded(code.trim(), CODE_LIMIT));
+    }
+    for key in ["stdout", "stderr"] {
+        if let Some(text) = object.get(key).and_then(Value::as_str) {
+            failure[format!("{key}_tail")] = Value::String(bounded_detail(text, TEXT_LIMIT));
+        }
+    }
+    if let Some(retryable) = object.get("retryable").and_then(Value::as_bool) {
+        failure["retryable"] = Value::Bool(retryable);
+    }
+    Some(failure)
+}
+
 fn bounded_provider_output(output: &[u8]) -> (String, bool) {
     const MAX_OUTPUT_CHARS: usize = 8_192;
 
@@ -3506,7 +3621,7 @@ fn bounded_provider_output(output: &[u8]) -> (String, bool) {
 
 #[cfg(test)]
 mod compact_provider_failure_details_tests {
-    use super::compact_provider_failure_details;
+    use super::{bounded_declared_provider_failure, compact_provider_failure_details};
     use serde_json::json;
 
     #[test]
@@ -3599,6 +3714,49 @@ mod compact_provider_failure_details_tests {
             "Authorization: Bearer [REDACTED]"
         );
         assert!(!projection.to_string().contains("provider-secret"));
+    }
+
+    #[test]
+    fn typed_failure_keeps_code_when_error_is_a_sibling_string() {
+        let failure = bounded_declared_provider_failure(&json!({
+            "status": "error",
+            "code": "freshness_refresh_required",
+            "message": "refresh before planning",
+            "error": "generic wrapper text",
+        }))
+        .expect("declared failure");
+
+        assert_eq!(failure["code"], "freshness_refresh_required");
+        assert_eq!(failure["message"], "refresh before planning");
+    }
+
+    #[test]
+    fn declared_failure_bounds_refresh_and_remediation_deterministically() {
+        let failure = bounded_declared_provider_failure(&json!({
+            "status": "blocked",
+            "message": "refresh required",
+            "refresh_command": "r".repeat(1_200),
+            "remediation": ["one", "two", "three", "four", "five"],
+            "unrelated": "must not be promoted",
+        }))
+        .expect("declared failure");
+
+        assert_eq!(
+            failure["details"]["refresh_command"]
+                .as_str()
+                .expect("refresh command")
+                .chars()
+                .count(),
+            1_000
+        );
+        assert_eq!(
+            failure["details"]["remediation"]
+                .as_array()
+                .expect("remediation")
+                .len(),
+            4
+        );
+        assert!(failure["details"].get("unrelated").is_none());
     }
 }
 
@@ -7921,6 +8079,85 @@ mod tests {
             .details
             .to_string()
             .contains("provider-secret-must-not-persist"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn provider_failure_json_on_stderr_precedes_stdout_for_lookup_and_mutation() {
+        let dir = unique_fixture_script_dir();
+        let script = dir.join("provider");
+        fs::write(
+            &script,
+            "#!/bin/sh\nprintf '%s\\n' '{\"status\":\"failed\",\"code\":\"stdout_failure\",\"message\":\"stdout cause\"}'\nprintf '%s\\n' '{\"status\":\"error\",\"code\":\"stderr_failure\",\"message\":\"stderr cause\",\"error\":\"generic sibling\"}' >&2\nexit 1\n",
+        )
+        .expect("write provider");
+        make_executable(&script);
+        let provider = WorktreeProviderConfig {
+            enabled: true,
+            kind: WorktreeProviderKind::Command,
+            apply_enabled: true,
+            lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
+            lookup_output_limit_bytes: 64 * 1024,
+            commands: WorktreeProviderCommands::default(),
+            list_result_mapping: None,
+        };
+
+        let command = [script.to_string_lossy().to_string()];
+        let lookup = run_provider_lookup_command("fixture", &provider, &command, "resolve", &[])
+            .expect_err("lookup fails");
+        let mutation = run_provider_mutation_command("fixture", &provider, &command, "ensure")
+            .expect_err("mutation fails");
+
+        for error in [lookup, mutation] {
+            assert_eq!(error.details["provider_failure"]["code"], "stderr_failure");
+            assert_eq!(error.details["provider_failure"]["message"], "stderr cause");
+            assert!(error.details["command_evidence"]["stdout"]
+                .as_str()
+                .expect("stdout evidence")
+                .contains("stdout_failure"));
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn non_json_lookup_and_ensure_failures_keep_command_evidence() {
+        let dir = unique_fixture_script_dir();
+        let script = dir.join("provider");
+        fs::write(
+            &script,
+            "#!/bin/sh\nprintf 'plain stdout evidence\\n'\nprintf 'plain stderr evidence\\n' >&2\nexit 23\n",
+        )
+        .expect("write provider");
+        make_executable(&script);
+        let provider = WorktreeProviderConfig {
+            enabled: true,
+            kind: WorktreeProviderKind::Command,
+            apply_enabled: true,
+            lookup_timeout_ms: 10_000,
+            mutation_timeout_ms: 30_000,
+            lookup_output_limit_bytes: 64 * 1024,
+            commands: WorktreeProviderCommands::default(),
+            list_result_mapping: None,
+        };
+        let command = [script.to_string_lossy().to_string()];
+
+        let lookup = run_provider_lookup_command("fixture", &provider, &command, "resolve", &[])
+            .expect_err("lookup fails");
+        let ensure =
+            run_provider_ensure_command("fixture", &provider, &command).expect_err("ensure fails");
+        for error in [lookup, ensure] {
+            assert_eq!(error.details["command_evidence"]["exit_code"], 23);
+            assert_eq!(
+                error.details["command_evidence"]["stdout"],
+                "plain stdout evidence\n"
+            );
+            assert_eq!(
+                error.details["command_evidence"]["stderr"],
+                "plain stderr evidence\n"
+            );
+            assert!(error.details.get("provider_failure").is_none());
+        }
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
Closes #13848.

## Summary
- promote bounded typed provider failures at the producer boundary
- preserve deterministic stderr/stdout precedence and remediation
- prevent historical nested errors from replacing the current failure
- retain compact code-less failure payloads and non-JSON evidence

## Verification
- Homeboy core provider projection and precedence tests
- `cargo test -p homeboy-cli commands::utils::response::tests`
- compact failure retention and cook preview tests
- `cargo fmt --check`
- `git diff --check`

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented and reviewed the provider diagnostic promotion, added focused regression coverage, and ran the verification commands under Chris Huber's direction.