### PR TITLE
Consolidate extension readiness ownership

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -24,9 +24,9 @@ use crate::commands::utils::{args, entity_suggest, resource_policy, response as 
 use homeboy::extension::{list_summaries_with, ExtensionSummary};
 use homeboy_agents::agent_task_service::cook_continue_command;
 use homeboy_core::extension::catalog::load_all_extensions;
-use homeboy_core::extension_readiness::ExtensionReadinessMode;
+use homeboy_core::extension::readiness::ExtensionReadinessMode;
 #[cfg(test)]
-use homeboy_core::extension_readiness::READY_CHECK_SKIPPED_REASON;
+use homeboy_core::extension::readiness::READY_CHECK_SKIPPED_REASON;
 use homeboy_extension_contract::{
     CliConfig, ExtensionCapability, ExtensionManifest as InstalledExtensionManifest,
 };
@@ -2303,7 +2303,7 @@ fn extension_command_health_from_summary(summary: &ExtensionSummary) -> Extensio
     // A command-health contract that treated an absent measurement as ready
     // would reproduce the fail-open defect class in #10685. (#10616)
     let readiness_unknown =
-        summary.readiness == homeboy_core::extension_readiness::ExtensionReadinessState::Unknown;
+        summary.readiness == homeboy_core::extension::readiness::ExtensionReadinessState::Unknown;
 
     let status = if summary.error.is_some() {
         "error"
@@ -2314,7 +2314,7 @@ fn extension_command_health_from_summary(summary: &ExtensionSummary) -> Extensio
     } else if summary.ready == Some(true) {
         "ready"
     } else if summary.readiness
-        == homeboy_core::extension_readiness::ExtensionReadinessState::TimedOut
+        == homeboy_core::extension::readiness::ExtensionReadinessState::TimedOut
     {
         "timed_out"
     } else {

--- a/crates/homeboy-cli/src/commands/extension.rs
+++ b/crates/homeboy-cli/src/commands/extension.rs
@@ -11,10 +11,10 @@ use homeboy::core::project::{self, Project};
 use homeboy::core::server::{self, SshClient};
 use homeboy::runner::runners::{self, RunnerKind};
 use homeboy_core::extension::catalog::{is_extension_linked, load_extension};
-use homeboy_core::extension::{invoke::run_setup, ExtensionSummary};
-use homeboy_core::extension_readiness::{
+use homeboy_core::extension::readiness::{
     extension_ready_status_with, ExtensionReadinessMode, ExtensionReadinessState,
 };
+use homeboy_core::extension::{invoke::run_setup, ExtensionSummary};
 use homeboy_extension_contract as extension_contract;
 use homeboy_extension_contract::update_output::UpdateEntry;
 use std::collections::BTreeMap;

--- a/crates/homeboy-cli/src/commands/fuzz/doctor.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/doctor.rs
@@ -1,5 +1,5 @@
 use homeboy_core::extension::catalog::{is_extension_linked, load_extension};
-use homeboy_core::extension_readiness::extension_ready_status;
+use homeboy_core::extension::readiness::extension_ready_status;
 use homeboy_core::extension_update_check::{check_update_available, read_source_revision};
 
 use super::types::FuzzDoctorArgs;

--- a/crates/homeboy-cli/src/commands/fuzz/types_extra.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/types_extra.rs
@@ -50,7 +50,7 @@ pub struct FuzzDoctorExtensionOutput {
     pub version: String,
     pub path: String,
     pub linked: bool,
-    pub readiness: homeboy_core::extension_readiness::ExtensionReadinessState,
+    pub readiness: homeboy_core::extension::readiness::ExtensionReadinessState,
     pub ready: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ready_reason: Option<String>,

--- a/crates/homeboy-core/src/context/report.rs
+++ b/crates/homeboy-core/src/context/report.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 
 use crate::component::{self, Component};
 use crate::extension::catalog::{is_extension_linked, load_all_extensions};
-use crate::extension_readiness::is_extension_compatible;
+use crate::extension::resolve::is_extension_compatible;
 use crate::project::{self, Project};
 use crate::release_provider::{self, ReleaseStateEntry};
 use crate::server::{self, Server};
@@ -120,7 +120,7 @@ pub struct ExtensionEntry {
     pub description: String,
     pub runtime: String,
     pub compatible: bool,
-    pub readiness: crate::extension_readiness::ExtensionReadinessState,
+    pub readiness: crate::extension::readiness::ExtensionReadinessState,
     pub ready: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ready_reason: Option<String>,
@@ -274,9 +274,9 @@ fn build_report_at(
         .iter()
         .filter(|m| show_all || linked_extension_ids.contains(&m.id) || m.executable.is_none())
         .map(|m| {
-            let ready_status = crate::extension_readiness::extension_ready_status_with(
+            let ready_status = crate::extension::readiness::extension_ready_status_with(
                 m,
-                crate::extension_readiness::ExtensionReadinessMode::Cached,
+                crate::extension::readiness::ExtensionReadinessMode::Cached,
             );
             ExtensionEntry {
                 id: m.id.clone(),

--- a/crates/homeboy-core/src/extension/invoke.rs
+++ b/crates/homeboy-core/src/extension/invoke.rs
@@ -19,7 +19,6 @@ mod action;
 mod context;
 mod environment;
 mod scope;
-// readiness relocated to homeboy_core::extension_readiness (core glue)
 mod settings;
 
 use super::env_provider;
@@ -37,7 +36,7 @@ pub(crate) use environment::prepare_capability_run;
 use environment::{
     build_action_env, build_exec_env, execute_extension_command, execute_extension_runtime,
 };
-use homeboy_core::extension_readiness::extension_ready_status;
+use homeboy_core::extension::readiness::extension_ready_status;
 use settings::serialize_settings;
 pub(crate) use settings::{build_settings_json_from_manifest, load_extension_manifest_from_dir};
 

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -16,6 +16,7 @@ pub mod lint;
 mod maintenance;
 mod manifest;
 mod manifest_sidecar;
+pub mod readiness;
 pub mod recipe_run;
 mod refactor_protocol;
 pub mod resolve;

--- a/crates/homeboy-core/src/extension/readiness.rs
+++ b/crates/homeboy-core/src/extension/readiness.rs
@@ -3,11 +3,9 @@ use std::time::{Duration, Instant};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::project::Project;
 use crate::server::execute_local_command_in_dir_with_timeout;
 use homeboy_engine_primitives::template;
 
-use crate::extension::catalog::load_extension;
 use homeboy_extension_contract::ExtensionManifest;
 
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
@@ -333,31 +331,6 @@ fn write_cached_status(
             status: status.clone(),
         },
     );
-}
-
-/// Check if a extension is compatible with a project.
-pub fn is_extension_compatible(extension: &ExtensionManifest, project: Option<&Project>) -> bool {
-    let Some(ref requires) = extension.requires else {
-        return true;
-    };
-
-    // Required extensions must be installed globally
-    for required_extension in &requires.extensions {
-        if load_extension(required_extension).is_err() {
-            return false;
-        }
-    }
-
-    // Required components must be linked to the project (if project context exists)
-    if let Some(project) = project {
-        for component in &requires.components {
-            if !crate::project::has_component(project, component) {
-                return false;
-            }
-        }
-    }
-
-    true
 }
 
 #[cfg(test)]

--- a/crates/homeboy-core/src/extension/resolve.rs
+++ b/crates/homeboy-core/src/extension/resolve.rs
@@ -2,11 +2,12 @@
 
 use crate::component::Component;
 use crate::error::{Error, ErrorCode, Result};
+use crate::project::Project;
 use std::path::{Path, PathBuf};
 
 use crate::extension::catalog::{extension_path, load_extension, load_extension_in_root};
 use crate::extension::invoke::ResolvedExtensionInvocationContext;
-use homeboy_extension_contract::ExtensionCapability;
+use homeboy_extension_contract::{ExtensionCapability, ExtensionManifest};
 
 mod surface;
 
@@ -15,6 +16,28 @@ pub use surface::{
     resolve_file_extension_in_root, FileExtensionCapability, FILE_EXTENSIONS_SURFACE,
     REMOTE_PATH_SURFACE, SINCE_TAG_SURFACE,
 };
+
+/// Whether an extension's declared dependencies are available in this context.
+pub fn is_extension_compatible(extension: &ExtensionManifest, project: Option<&Project>) -> bool {
+    let Some(requires) = extension.requires.as_ref() else {
+        return true;
+    };
+
+    if requires
+        .extensions
+        .iter()
+        .any(|extension_id| load_extension(extension_id).is_err())
+    {
+        return false;
+    }
+
+    project.is_none_or(|project| {
+        requires
+            .components
+            .iter()
+            .all(|component_id| crate::project::has_component(project, component_id))
+    })
+}
 
 pub fn stderr_tail(stderr: &str) -> String {
     const MAX_LINES: usize = 20;
@@ -896,6 +919,43 @@ mod tests {
                     .expect("installed fallback");
 
             assert_eq!(resolved.id, "alpha");
+        });
+    }
+
+    #[test]
+    fn compatibility_requires_installed_extensions_and_project_components() {
+        crate::test_support::with_isolated_home(|home| {
+            let extension: ExtensionManifest = serde_json::from_value(serde_json::json!({
+                "name": "consumer",
+                "version": "1.0.0",
+                "requires": {
+                    "extensions": ["provider"],
+                    "components": ["database"]
+                }
+            }))
+            .expect("extension manifest");
+            let project = Project {
+                id: "site".to_string(),
+                components: vec![crate::project::ProjectComponentAttachment {
+                    id: "database".to_string(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            };
+
+            assert!(!is_extension_compatible(&extension, Some(&project)));
+
+            write_extension_manifest(home.path(), "provider", "deps");
+            assert!(is_extension_compatible(&extension, Some(&project)));
+
+            let missing_component = Project {
+                id: "other".to_string(),
+                ..Default::default()
+            };
+            assert!(!is_extension_compatible(
+                &extension,
+                Some(&missing_component)
+            ));
         });
     }
 

--- a/crates/homeboy-core/src/extension/summary.rs
+++ b/crates/homeboy-core/src/extension/summary.rs
@@ -5,10 +5,10 @@ use homeboy_core::extension::catalog::{
     broken_extension_link_repair_actions, discover_extensions, is_extension_linked,
     DiscoveredExtension, ExtensionManifestFailure,
 };
-use homeboy_core::extension_readiness::{
-    extension_ready_status_with, is_extension_compatible, ExtensionReadinessMode,
-    ExtensionReadinessState,
+use homeboy_core::extension::readiness::{
+    extension_ready_status_with, ExtensionReadinessMode, ExtensionReadinessState,
 };
+use homeboy_core::extension::resolve::is_extension_compatible;
 use homeboy_extension_contract::action_types::ActionType;
 use homeboy_extension_contract::NotificationTransportDescriptor;
 use homeboy_extension_contract::{evaluate_core_compatibility, CoreCompatibilityReport};

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -103,7 +103,6 @@ pub mod execution_contract;
 pub mod expand;
 pub mod extension;
 pub mod extension_provider_discovery;
-pub mod extension_readiness;
 pub mod extension_update_check;
 // finding moved to the internal `homeboy-finding` crate. Re-exported so existing
 // `crate::finding::*` call sites keep working unchanged.

--- a/homeboy.json
+++ b/homeboy.json
@@ -655,6 +655,15 @@
           ]
         },
         "name": "extensions-use-canonical-invoke-api"
+      },
+      {
+        "forbid": {
+          "glob": "crates/**",
+          "patterns": [
+            "\\bextension_readiness\\b"
+          ]
+        },
+        "name": "extensions-use-canonical-readiness-api"
       }
     ]
   },


### PR DESCRIPTION
## Summary

- establish `homeboy_core::extension::readiness` as the single readiness owner
- move project and installed-extension compatibility checking to `extension::resolve`
- remove the top-level `extension_readiness` module without a compatibility alias
- migrate core and CLI callers and guard the retired path architecturally

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo nextest run -p homeboy-core --lib -E 'test(extension::readiness) | test(compatibility_requires_installed_extensions_and_project_components)'` (8 passed)
- `cargo run --quiet -- review audit --placement local --profile architecture --changed-since refactor-13891-extension-invoke-api` (0 introduced findings)
- `git diff refactor-13891-extension-invoke-api...HEAD --check`

Closes #13895
Part of #13882 and #8010.

Stacked on #13894; retarget to `main` after that PR lands.

## AI assistance

OpenAI gpt-5.6-sol using OpenCode consolidated readiness ownership, separated compatibility resolution, migrated callers, and ran verification under Chris Huber's direction.
