### PR TITLE
Fix nested Lab command placement

### DIFF
--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -552,6 +552,7 @@ pub(crate) fn rotate_daemon_generation(
         );
         return Err(error);
     }
+    super::runner_probe_gate::invalidate_runner_probes(runner_id);
     Ok(())
 }
 
@@ -1468,6 +1469,7 @@ fn connect_with_orphan_adoption_and_live_lease(
     // registered orchestration driver belongs to the controller process; builds
     // without agent-task support resolve this as an inert no-op.
     drop(promotion_lease);
+    super::runner_probe_gate::invalidate_runner_probes(runner_id);
     wake_unmaterialized_admission_reconciliation();
     Ok((
         RunnerConnectReport {

--- a/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
+++ b/crates/homeboy-lab-runner/src/connection/tests/recovery.rs
@@ -1243,12 +1243,40 @@ esac
         )
         .expect("enable local runner");
 
+        crate::runner_probe_gate::invalidate_runner_probes("local-runner");
+        let probes = Arc::new(AtomicUsize::new(0));
+        let stale_probes = Arc::clone(&probes);
+        let cached: String = crate::runner_probe_gate::deduplicated_probe(
+            "local-runner",
+            "connect-invalidation",
+            "same-runtime-probe",
+            move || {
+                stale_probes.fetch_add(1, Ordering::SeqCst);
+                Ok("missing".to_string())
+            },
+        )
+        .expect("cache pre-connect capability answer");
+        assert_eq!(cached, "missing");
+
         let (report, exit_code) =
             connect_with_orphan_adoption("local-runner", None, &[], true, None, None, None)
                 .expect("connect result");
 
         assert_eq!(exit_code, 0);
         assert!(report.connected);
+        let fresh_probes = Arc::clone(&probes);
+        let refreshed: String = crate::runner_probe_gate::deduplicated_probe(
+            "local-runner",
+            "connect-invalidation",
+            "same-runtime-probe",
+            move || {
+                fresh_probes.fetch_add(1, Ordering::SeqCst);
+                Ok("present".to_string())
+            },
+        )
+        .expect("probe post-connect capability answer");
+        assert_eq!(refreshed, "present");
+        assert_eq!(probes.load(Ordering::SeqCst), 2);
         assert_eq!(
             report.remote_daemon_address.as_deref(),
             Some(expected_address.as_str())

--- a/crates/homeboy-lab-runner/src/homeboy_refresh.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh.rs
@@ -773,6 +773,7 @@ pub fn refresh_homeboy_binary(
     phase_summary.push(refresh_phase("identity_verification", true, 0));
     phase_summary.push(refresh_phase("bootstrap_promotion", true, 0));
     phase_summary.push(refresh_phase("configuration_promotion", true, 0));
+    super::runner_probe_gate::invalidate_runner_probes(&plan.runner_id);
     let identity = bootstrap.identity.clone();
     let updated_fields = bootstrap.updated_fields.clone();
     let rollback = bootstrap.rollback.clone();

--- a/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
+++ b/crates/homeboy-lab-runner/src/homeboy_refresh/tests/part_b.rs
@@ -749,6 +749,20 @@ fn strict_ancestor_refresh_candidate_is_rejected_while_owner_keeps_selection() {
 #[test]
 fn verified_selection_persists_on_controller_and_reports_reconnect_required() {
     test_support::with_isolated_home(|_| {
+        let probes = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let stale_probes = std::sync::Arc::clone(&probes);
+        let cached: String = crate::runner_probe_gate::deduplicated_probe(
+            "lab-local",
+            "refresh-invalidation",
+            "same-runtime-probe",
+            move || {
+                stale_probes.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok("missing".to_string())
+            },
+        )
+        .expect("cache pre-refresh capability answer");
+        assert_eq!(cached, "missing");
+
         let fixture = tempfile::tempdir().expect("fixture");
         let binary = fixture.path().join("homeboy");
         let commit = homeboy_product_identity::build_identity()
@@ -800,6 +814,19 @@ fn verified_selection_persists_on_controller_and_reports_reconnect_required() {
                 .as_deref(),
             binary.to_str()
         );
+        let fresh_probes = std::sync::Arc::clone(&probes);
+        let refreshed: String = crate::runner_probe_gate::deduplicated_probe(
+            "lab-local",
+            "refresh-invalidation",
+            "same-runtime-probe",
+            move || {
+                fresh_probes.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok("present".to_string())
+            },
+        )
+        .expect("probe refreshed capability answer");
+        assert_eq!(refreshed, "present");
+        assert_eq!(probes.load(std::sync::atomic::Ordering::SeqCst), 2);
 
         let (repeated, exit_code) = refresh_homeboy_binary(options).expect("repeat selection");
         assert_eq!(exit_code, 0);

--- a/crates/homeboy-lab-runner/src/lab/offload/resident.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/resident.rs
@@ -78,7 +78,8 @@ pub(crate) fn run_runner_resident_lab_offload(
         None,
     )
     .map_or((remapped_args, None), |(args, run_id)| (args, Some(run_id)));
-    let mut command = vec![homeboy_path.to_string()];
+    let mut command =
+        lab_offload_command_prefix(std::path::Path::new(runner_workspace_root), homeboy_path).argv;
     if remote_output_file.is_some() && !args_contain_output_file(request.normalized_args) {
         command.push("--output".to_string());
         command.push(remote_output_file.clone().expect("remote output path"));

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -1569,8 +1569,12 @@ mod tests {
             "wordpress-fixture".to_string(),
         ];
 
+        let command_prefix = lab_offload_command_prefix(
+            Path::new("/runner/workspaces/node-project"),
+            "/runner/bin/homeboy",
+        );
         let command = build_lab_offload_remote_command(
-            &["/runner/bin/homeboy".to_string()],
+            &command_prefix.argv,
             &args,
             "/runner/workspaces/node-project",
             &[],
@@ -1582,6 +1586,8 @@ mod tests {
             command,
             vec![
                 "/runner/bin/homeboy".to_string(),
+                "--placement".to_string(),
+                "local".to_string(),
                 "bench".to_string(),
                 "--extension".to_string(),
                 "wordpress".to_string(),

--- a/crates/homeboy-lab-runner/src/lab_command.rs
+++ b/crates/homeboy-lab-runner/src/lab_command.rs
@@ -12,7 +12,13 @@ pub(crate) fn lab_offload_command_prefix(
     _source_path: &Path,
     homeboy_path: &str,
 ) -> LabOffloadCommandPrefix {
-    let argv = vec![homeboy_path.to_string()];
+    // The runner already owns this execution. Keep nested agent-task and other
+    // hot commands from applying controller resource policy and offloading again.
+    let argv = vec![
+        homeboy_path.to_string(),
+        "--placement".to_string(),
+        "local".to_string(),
+    ];
     let required_tools = required_tools_for_command_prefix(&argv);
 
     LabOffloadCommandPrefix {
@@ -49,7 +55,14 @@ mod tests {
 
         let prefix = lab_offload_command_prefix(dir.path(), "/usr/local/bin/homeboy");
 
-        assert_eq!(prefix.argv, vec!["/usr/local/bin/homeboy".to_string()]);
+        assert_eq!(
+            prefix.argv,
+            vec![
+                "/usr/local/bin/homeboy".to_string(),
+                "--placement".to_string(),
+                "local".to_string(),
+            ]
+        );
         assert_eq!(prefix.required_tools, vec![RunnerRequiredTool::homeboy()]);
     }
 
@@ -59,7 +72,14 @@ mod tests {
 
         let prefix = lab_offload_command_prefix(dir.path(), "homeboy");
 
-        assert_eq!(prefix.argv, vec!["homeboy".to_string()]);
+        assert_eq!(
+            prefix.argv,
+            vec![
+                "homeboy".to_string(),
+                "--placement".to_string(),
+                "local".to_string(),
+            ]
+        );
         assert_eq!(prefix.required_tools, vec![RunnerRequiredTool::homeboy()]);
     }
 }


### PR DESCRIPTION
## Summary

- force runner-side Homeboy commands to retain explicit local placement after controller routing flags are stripped
- invalidate cached runner capabilities after binary promotion, daemon generation rotation, and authenticated reconnect
- cover final remote argv plus refresh/connect cache invalidation with deterministic tests

Closes #13892.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-lab-runner lab_command::tests`
- `cargo test -p homeboy-lab-runner final_remote_command_forwards_required_bench_extension`
- `cargo test -p homeboy-lab-runner verified_selection_persists_on_controller_and_reports_reconnect_required`
- `cargo test -p homeboy-lab-runner runner_connect_persists_recovery_evidence_after_daemon_failure`
- `cargo test -p homeboy-lab-runner runner_probe_gate::tests`

The full `homeboy-lab-runner` suite ran for 20 minutes without an observed failure before the command timeout while existing long-running staging tests remained active. Strict clippy is currently blocked by pre-existing `homeboy-core` warnings under the installed Rust lint set; no diagnostic referenced a changed file.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode assisted with root-cause analysis, implementation, tests, and verification. Chris Huber directed the work and is responsible for the change.