### PR TITLE
Consolidate extension provider registry

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/discovery.rs
@@ -265,7 +265,7 @@ fn expected_agent_runtime_provider_refs(
 /// Agent-task implementation of core's extension provider-discovery validator.
 struct ExtensionProviderDiscoveryValidatorImpl;
 
-impl homeboy_core::extension_provider_discovery::ExtensionProviderDiscoveryValidator
+impl homeboy_core::extension::registry::ExtensionProviderDiscoveryValidator
     for ExtensionProviderDiscoveryValidatorImpl
 {
     fn validate_installed_extension_provider_discovery(&self, extension_id: &str) -> Result<()> {
@@ -277,9 +277,9 @@ impl homeboy_core::extension_provider_discovery::ExtensionProviderDiscoveryValid
 /// install/repair can verify declared agent-runtime providers are discoverable
 /// without depending on the agent-task subsystem.
 pub fn register() {
-    homeboy_core::extension_provider_discovery::register_extension_provider_discovery_validator(
-        Box::new(ExtensionProviderDiscoveryValidatorImpl),
-    );
+    homeboy_core::extension::registry::register_extension_provider_discovery_validator(Box::new(
+        ExtensionProviderDiscoveryValidatorImpl,
+    ));
 }
 
 #[cfg(test)]

--- a/crates/homeboy-core/src/extension/lifecycle/install_sources.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/install_sources.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 
 use homeboy_core::config::{self, from_str};
 use homeboy_core::error::{Error, Result};
-use homeboy_core::extension_provider_discovery::validate_installed_extension_provider_discovery;
+use homeboy_core::extension::registry::validate_installed_extension_provider_discovery;
 use homeboy_core::git;
 use homeboy_core::paths;
 use homeboy_engine_primitives::local_files;

--- a/crates/homeboy-core/src/extension/lifecycle/repair.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/repair.rs
@@ -1,6 +1,6 @@
 use homeboy_core::config::{self, from_str};
 use homeboy_core::error::{Error, Result};
-use homeboy_core::extension_provider_discovery::validate_installed_extension_provider_discovery;
+use homeboy_core::extension::registry::validate_installed_extension_provider_discovery;
 use homeboy_core::extension_update_check::is_git_url;
 use homeboy_core::git;
 use homeboy_core::paths;

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -19,6 +19,7 @@ mod manifest_sidecar;
 pub mod readiness;
 pub mod recipe_run;
 mod refactor_protocol;
+pub mod registry;
 pub mod resolve;
 mod runner;
 mod runtime_helper;

--- a/crates/homeboy-core/src/extension/registry.rs
+++ b/crates/homeboy-core/src/extension/registry.rs
@@ -1,4 +1,4 @@
-//! Extension agent-runtime provider-discovery validation hook.
+//! Extension provider registration and discovery validation.
 //!
 //! When an extension is installed or repaired, core verifies that every
 //! agent-runtime executor provider the extension declares is actually

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -102,7 +102,6 @@ pub mod execution;
 pub mod execution_contract;
 pub mod expand;
 pub mod extension;
-pub mod extension_provider_discovery;
 pub mod extension_update_check;
 // finding moved to the internal `homeboy-finding` crate. Re-exported so existing
 // `crate::finding::*` call sites keep working unchanged.

--- a/homeboy.json
+++ b/homeboy.json
@@ -664,6 +664,15 @@
           ]
         },
         "name": "extensions-use-canonical-readiness-api"
+      },
+      {
+        "forbid": {
+          "glob": "crates/**",
+          "patterns": [
+            "\\bextension_provider_discovery\\b"
+          ]
+        },
+        "name": "extensions-use-canonical-registry-api"
       }
     ]
   },


### PR DESCRIPTION
## Summary

- establish `homeboy_core::extension::registry` as the provider-registration owner
- relocate provider discovery validation from the top-level core module
- migrate lifecycle and agent-task callers without a compatibility alias
- guard the retired top-level path architecturally

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- three focused provider-discovery install/repair tests passed
- `cargo run --quiet -- review audit --placement local --profile architecture --changed-since refactor-13895-extension-readiness-api` (0 introduced findings)
- `git diff refactor-13895-extension-readiness-api...HEAD --check`

Closes #13899
Part of #13882 and #8010.

Stacked on #13898; retarget to `main` after the preceding PRs land.

## AI assistance

OpenAI gpt-5.6-sol using OpenCode consolidated provider registry ownership, migrated callers, and ran verification under Chris Huber's direction.
