### PR TITLE
Consolidate extension lifecycle source APIs

### DIFF
--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -2792,7 +2792,7 @@ fn materialize_extension_inputs(
             ));
         }
         let identity = extension_tree_identity(source)?;
-        let source_revision = homeboy_core::extension_update_check::read_source_revision_at(source);
+        let source_revision = homeboy_core::extension::lifecycle::read_source_revision_at(source);
         if input
             .identity
             .as_deref()

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -3273,7 +3273,7 @@ fn run_startup_update_checks(command: &Commands) {
         Commands::Upgrade(_) | Commands::Daemon(_) | Commands::SelfCmd(_)
     ) {
         homeboy_upgrade::upgrade::update_check::run_startup_check();
-        homeboy_core::extension::update_check::run_startup_check();
+        homeboy_upgrade::upgrade::extension_update_check::run_startup_check();
     }
 }
 

--- a/crates/homeboy-cli/src/commands/extension.rs
+++ b/crates/homeboy-cli/src/commands/extension.rs
@@ -889,7 +889,7 @@ fn read_source_url_metadata(path: &str) -> Option<String> {
     if path.is_empty() {
         return None;
     }
-    homeboy_core::extension_update_check::read_source_url(Path::new(path))
+    homeboy_core::extension::lifecycle::read_source_url(Path::new(path))
 }
 
 fn local_source_path(source: &str) -> Option<String> {
@@ -1005,7 +1005,7 @@ fn show_extension(
         components: r.components.clone(),
     });
 
-    let source_revision = homeboy_core::extension_update_check::read_source_revision(&extension.id);
+    let source_revision = homeboy_core::extension::lifecycle::read_source_revision(&extension.id);
     let core_compatibility = extension_contract::core_compat::evaluate_core_compatibility(
         extension
             .requires
@@ -1320,7 +1320,7 @@ fn converge_extensions() -> CmdResult<ExtensionOutput> {
         .iter()
         .map(|id| {
             let manifest = homeboy_core::extension::catalog::load_extension(id)?;
-            let source_revision = homeboy_core::extension_update_check::read_source_revision(id);
+            let source_revision = homeboy_core::extension::lifecycle::read_source_revision(id);
             let report = extension_contract::core_compat::evaluate_core_compatibility(
                 manifest
                     .requires
@@ -1472,7 +1472,7 @@ fn extension_runtime_diagnostics(
         .and_then(|extension| extension.extension_path.clone())
         .unwrap_or_default();
     let source_revision = source_revision
-        .or_else(|| homeboy_core::extension_update_check::read_source_revision(extension_id));
+        .or_else(|| homeboy_core::extension::lifecycle::read_source_revision(extension_id));
     let matching_manifests = discover_agent_runtime_catalog()
         .manifests
         .into_iter()
@@ -1767,7 +1767,7 @@ mod tests {
             assert!(sentinel.exists(), "configured extension service restarted");
 
             let before_rollback =
-                homeboy_core::extension_update_check::read_source_revision("fixture")
+                homeboy_core::extension::lifecycle::read_source_revision("fixture")
                     .expect("current revision");
             write_convergence_manifest(&seed, ">=999.0.0");
             commit_and_push(&seed, "incompatible refresh");
@@ -1784,7 +1784,7 @@ mod tests {
             assert_eq!(skipped.len(), 1);
             assert!(skipped[0].reason.contains("requires homeboy"));
             assert_eq!(
-                homeboy_core::extension_update_check::read_source_revision("fixture").as_deref(),
+                homeboy_core::extension::lifecycle::read_source_revision("fixture").as_deref(),
                 Some(before_rollback.as_str())
             );
             assert!(

--- a/crates/homeboy-cli/src/commands/fuzz/doctor.rs
+++ b/crates/homeboy-cli/src/commands/fuzz/doctor.rs
@@ -1,6 +1,6 @@
 use homeboy_core::extension::catalog::{is_extension_linked, load_extension};
+use homeboy_core::extension::lifecycle::{check_update_available, read_source_revision};
 use homeboy_core::extension::readiness::extension_ready_status;
-use homeboy_core::extension_update_check::{check_update_available, read_source_revision};
 
 use super::types::FuzzDoctorArgs;
 use super::types_extra::{FuzzDoctorExtensionOutput, FuzzDoctorHomeboyOutput, FuzzDoctorOutput};

--- a/crates/homeboy-core/src/agent_runtime_manifest.rs
+++ b/crates/homeboy-core/src/agent_runtime_manifest.rs
@@ -844,7 +844,7 @@ pub(crate) fn discover_agent_runtime_catalog_from_extensions(
                 Some(&extension.id),
                 extension.extension_path.as_deref(),
                 runtime_core_constraint(runtime, extension),
-                crate::extension_update_check::read_source_revision(&extension.id),
+                crate::extension::lifecycle::read_source_revision(&extension.id),
             ) {
                 diagnostics.push(diagnostic);
                 continue;
@@ -884,7 +884,7 @@ pub(crate) fn discover_agent_runtime_catalog_from_extensions(
                 requires: runtime_requires(runtime, extension),
                 extension_path: extension.extension_path.clone(),
                 runtime_path: extension.extension_path.clone(),
-                source_revision: crate::extension_update_check::read_source_revision(&extension.id)
+                source_revision: crate::extension::lifecycle::read_source_revision(&extension.id)
                     .filter(|revision| is_immutable_revision(revision)),
                 extra: runtime
                     .extra

--- a/crates/homeboy-core/src/context/report.rs
+++ b/crates/homeboy-core/src/context/report.rs
@@ -648,7 +648,7 @@ fn build_actionable_next_steps(
 
     let mut outdated_extensions = Vec::new();
     for extension in all_extensions {
-        if let Some(update) = crate::extension_update_check::check_update_available(&extension.id) {
+        if let Some(update) = crate::extension::lifecycle::check_update_available(&extension.id) {
             outdated_extensions.push(update);
         }
     }

--- a/crates/homeboy-core/src/extension/invoke/action.rs
+++ b/crates/homeboy-core/src/extension/invoke/action.rs
@@ -26,7 +26,7 @@ pub fn execute_action(
             .requires
             .as_ref()
             .and_then(|requires| requires.homeboy.as_deref()),
-        homeboy_core::extension_update_check::read_source_revision(extension_id),
+        homeboy_core::extension::lifecycle::read_source_revision(extension_id),
     )?;
 
     if extension.actions.is_empty() {

--- a/crates/homeboy-core/src/extension/invoke/environment.rs
+++ b/crates/homeboy-core/src/extension/invoke/environment.rs
@@ -30,7 +30,7 @@ pub(crate) fn prepare_capability_run(
             .get("requires")
             .and_then(|requires| requires.get("homeboy"))
             .and_then(serde_json::Value::as_str),
-        homeboy_core::extension_update_check::read_source_revision(&execution.extension_id),
+        homeboy_core::extension::lifecycle::read_source_revision(&execution.extension_id),
     )?;
     let settings_json = build_settings_json_from_manifest(
         &manifest,
@@ -207,7 +207,7 @@ pub(super) fn execute_extension_runtime(
             .requires
             .as_ref()
             .and_then(|requires| requires.homeboy.as_deref()),
-        homeboy_core::extension_update_check::read_source_revision(extension_id),
+        homeboy_core::extension::lifecycle::read_source_revision(extension_id),
     )?;
     let runtime = extension_runtime(&extension)?;
     let run_command = runtime.run_command.as_ref().ok_or_else(|| {

--- a/crates/homeboy-core/src/extension/lifecycle/install_sources.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/install_sources.rs
@@ -106,7 +106,7 @@ pub(super) fn install_configured_extension(
     source: &str,
     extension_id: &str,
 ) -> Result<InstallResult> {
-    if homeboy_core::extension_update_check::is_git_url(source) {
+    if super::is_git_url(source) {
         return super::install(source, Some(extension_id));
     }
 

--- a/crates/homeboy-core/src/extension/lifecycle/mod.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/mod.rs
@@ -40,9 +40,16 @@ pub struct UpdateResult {
 }
 
 mod repair;
+mod source;
 pub mod source_metadata;
 
 pub use repair::{relink, replace, replace_with_revision, ReplaceResult};
+pub use source::{
+    check_update_available, check_update_available_until, is_git_url, read_source_cleanliness,
+    read_source_revision, read_source_revision_at, read_source_url, ExtensionSourceCleanliness,
+    UpdateAvailable,
+};
+use source::{read_source_metadata_value, source_metadata_dir};
 
 pub fn slugify_id(value: &str) -> Result<String> {
     identifier::slugify_id(value, "extension_id")
@@ -78,7 +85,7 @@ pub fn install_with_revision(
     id_override: Option<&str>,
     revision: Option<&str>,
 ) -> Result<InstallResult> {
-    if homeboy_core::extension_update_check::is_git_url(source) {
+    if is_git_url(source) {
         install_from_url(source, id_override, revision)
     } else {
         install_from_path(source, id_override, None, revision)
@@ -160,7 +167,7 @@ pub fn refresh(
         None => derive_id_from_url(source)?,
     };
 
-    let local_source_revision = if homeboy_core::extension_update_check::is_git_url(source) {
+    let local_source_revision = if is_git_url(source) {
         None
     } else {
         git::short_head_revision(&absolute_source_path(source)?)
@@ -198,7 +205,7 @@ pub fn refresh(
 }
 
 fn durable_refresh_source(source: &str, extension_id: &str) -> Result<String> {
-    if homeboy_core::extension_update_check::is_git_url(source) {
+    if is_git_url(source) {
         return Ok(source.to_string());
     }
 
@@ -334,7 +341,6 @@ pub(crate) use install_sources::{
 };
 
 mod update;
-pub use homeboy_core::extension_update_check::{read_source_revision, read_source_url};
 #[cfg(test)]
 use update::is_extension_update_workdir_clean;
 pub(crate) use update::write_requested_source_ref;
@@ -374,8 +380,9 @@ pub fn uninstall(extension_id: &str) -> Result<PathBuf> {
 mod tests {
     use super::{
         install, install_for_component, install_with_revision, is_extension_update_workdir_clean,
-        load_extension, refresh, register_component_install_runner,
-        shared_assets_for_extension_source, source_metadata, uninstall, update,
+        load_extension, read_source_revision, read_source_url, refresh,
+        register_component_install_runner, shared_assets_for_extension_source, source_metadata,
+        uninstall, update,
     };
     use crate::extension::update_all;
     use homeboy_core::component;
@@ -977,7 +984,7 @@ exec '{}' "$@"
                 Some(source_revision.as_str())
             );
             assert_eq!(
-                homeboy_core::extension_update_check::read_source_revision("nodejs").as_deref(),
+                read_source_revision("nodejs").as_deref(),
                 Some(source_revision.as_str())
             );
             assert_eq!(
@@ -1022,8 +1029,7 @@ exec '{}' "$@"
             install(&extension_source.to_string_lossy(), Some("wordpress"))
                 .expect("install linked extension");
 
-            let before = homeboy_core::extension_update_check::read_source_revision("wordpress")
-                .expect("linked git revision");
+            let before = read_source_revision("wordpress").expect("linked git revision");
             assert!(!extension_source.join(".source-revision").exists());
 
             update("wordpress", false).expect("update linked extension");
@@ -1033,7 +1039,7 @@ exec '{}' "$@"
                 "linked update must not write metadata into the source checkout"
             );
             assert_eq!(
-                homeboy_core::extension_update_check::read_source_revision("wordpress"),
+                read_source_revision("wordpress"),
                 Some(before),
                 "linked extensions should resolve revisions through git discovery"
             );
@@ -1060,11 +1066,11 @@ exec '{}' "$@"
                 "linked install metadata should not dirty the source checkout"
             );
             assert_eq!(
-                homeboy_core::extension_update_check::read_source_revision("wordpress").as_deref(),
+                read_source_revision("wordpress").as_deref(),
                 Some("abc1234")
             );
             assert_eq!(
-                homeboy_core::extension_update_check::read_source_url(&result.path).as_deref(),
+                read_source_url(&result.path).as_deref(),
                 Some(source.join("wordpress").to_string_lossy().as_ref())
             );
 
@@ -1150,7 +1156,7 @@ exec '{}' "$@"
                 remote_url.to_string_lossy()
             );
             assert_eq!(
-                homeboy_core::extension_update_check::read_source_revision("wordpress"),
+                read_source_revision("wordpress"),
                 result.source_revision,
                 "monorepo installs keep the stored source revision after .git is discarded"
             );
@@ -1594,7 +1600,7 @@ exec '{}' "$@"
                 Some(pinned_revision.as_str())
             );
             assert_eq!(
-                homeboy_core::extension_update_check::read_source_revision("wordpress").as_deref(),
+                read_source_revision("wordpress").as_deref(),
                 Some(pinned_revision.as_str())
             );
         });

--- a/crates/homeboy-core/src/extension/lifecycle/repair.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/repair.rs
@@ -1,7 +1,7 @@
+use super::is_git_url;
 use homeboy_core::config::{self, from_str};
 use homeboy_core::error::{Error, Result};
 use homeboy_core::extension::registry::validate_installed_extension_provider_discovery;
-use homeboy_core::extension_update_check::is_git_url;
 use homeboy_core::git;
 use homeboy_core::paths;
 use homeboy_engine_primitives::local_files;

--- a/crates/homeboy-core/src/extension/lifecycle/source.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/source.rs
@@ -1,6 +1,4 @@
-//! Extension update-check + source-URL utilities (core glue over an extension's
-//! git checkout). Relocated from the extension lifecycle module - depends only on
-//! core paths/git/error + the core extension store, no extension behavior.
+//! Extension source provenance and remote update probes.
 
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
@@ -28,9 +26,9 @@ pub fn check_update_available(extension_id: &str) -> Option<UpdateAvailable> {
 /// The startup update check is advisory, but it runs before every normal CLI
 /// command. Keep each extension probe bounded so an unreachable Git transport
 /// or credential helper cannot withhold unrelated command output.
-pub const EXTENSION_UPDATE_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+const EXTENSION_UPDATE_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
-pub fn check_update_available_with_timeout(
+fn check_update_available_with_timeout(
     extension_id: &str,
     timeout: Duration,
 ) -> Option<UpdateAvailable> {
@@ -226,7 +224,7 @@ pub fn read_source_cleanliness(extension_id: &str) -> ExtensionSourceCleanliness
 ///
 /// Scoped to the extension directory itself: a monorepo of extensions must not
 /// report `rust` as dirty because `nodejs` was edited.
-pub fn read_source_cleanliness_at(extension_dir: &Path) -> ExtensionSourceCleanliness {
+fn read_source_cleanliness_at(extension_dir: &Path) -> ExtensionSourceCleanliness {
     if !extension_dir.exists() {
         return ExtensionSourceCleanliness::Unknown;
     }
@@ -277,7 +275,7 @@ fn is_generated_source_metadata_path(path: &str) -> bool {
     GENERATED_SOURCE_METADATA.contains(&name)
 }
 
-pub fn read_source_metadata_value(extension_dir: &Path, kind: &str) -> Option<String> {
+pub(super) fn read_source_metadata_value(extension_dir: &Path, kind: &str) -> Option<String> {
     let sidecar =
         source_metadata_dir(extension_dir).join(source_metadata_file(extension_dir, kind));
     let embedded = extension_dir.join(format!(".source-{kind}"));
@@ -304,7 +302,7 @@ pub fn read_source_url(extension_dir: &Path) -> Option<String> {
     read_source_metadata_value(extension_dir, "url")
 }
 
-pub fn source_metadata_dir(extension_dir: &Path) -> PathBuf {
+pub(super) fn source_metadata_dir(extension_dir: &Path) -> PathBuf {
     if extension_dir.is_symlink() {
         return extension_dir
             .parent()

--- a/crates/homeboy-core/src/extension/lifecycle/source_metadata.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/source_metadata.rs
@@ -1,7 +1,7 @@
 use super::write_source_metadata;
+use super::{read_source_revision, read_source_url};
 use homeboy_core::error::{Error, Result};
 use homeboy_core::extension::catalog::{is_extension_linked, load_extension};
-use homeboy_core::extension_update_check::read_source_url;
 use homeboy_core::git;
 use homeboy_core::paths;
 
@@ -35,7 +35,7 @@ pub fn resolve_source_url_read_only(extension_id: &str) -> Result<String> {
 pub fn resolve_source_url(extension_id: &str) -> Result<SourceMetadataResolution> {
     let extension = load_extension(extension_id)?;
     let extension_dir = paths::extension(extension_id)?;
-    let metadata_url = homeboy_core::extension_update_check::read_source_url(&extension_dir);
+    let metadata_url = read_source_url(&extension_dir);
 
     let manifest_source_url = manifest_source_url(&extension);
 
@@ -44,7 +44,7 @@ pub fn resolve_source_url(extension_id: &str) -> Result<SourceMetadataResolution
             write_source_metadata(
                 &extension_dir,
                 &source_url,
-                homeboy_core::extension_update_check::read_source_revision(extension_id),
+                read_source_revision(extension_id),
             );
             Some(SourceMetadataRepair {
                 source_url: source_url.clone(),

--- a/crates/homeboy-core/src/extension/lifecycle/update.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/update.rs
@@ -290,7 +290,7 @@ pub(crate) fn write_source_metadata(
     source_url: &str,
     source_revision: Option<String>,
 ) {
-    let metadata_dir = homeboy_core::extension_update_check::source_metadata_dir(extension_dir);
+    let metadata_dir = super::source_metadata_dir(extension_dir);
     let revision_path = metadata_dir.join(source_metadata_file(extension_dir, "revision"));
     if let Some(rev) = source_revision {
         let _ = std::fs::write(revision_path, rev);
@@ -307,7 +307,7 @@ pub(crate) fn write_source_metadata(
 /// Extracted monorepo installs discard `.git`, so this is the only durable
 /// input that lets a later update preserve a branch, tag, or commit pin.
 pub(crate) fn write_requested_source_ref(extension_dir: &Path, requested_ref: Option<&str>) {
-    let path = homeboy_core::extension_update_check::source_metadata_dir(extension_dir)
+    let path = super::source_metadata_dir(extension_dir)
         .join(source_metadata_file(extension_dir, "requested-ref"));
     match requested_ref.filter(|value| !value.trim().is_empty()) {
         Some(value) => {
@@ -320,7 +320,7 @@ pub(crate) fn write_requested_source_ref(extension_dir: &Path, requested_ref: Op
 }
 
 pub(crate) fn read_source_requested_ref(extension_dir: &Path) -> Option<String> {
-    homeboy_core::extension_update_check::read_source_metadata_value(extension_dir, "requested-ref")
+    super::read_source_metadata_value(extension_dir, "requested-ref")
 }
 
 /// The extension update gate. `Ok(())` when the worktree holds nothing an

--- a/crates/homeboy-core/src/extension/maintenance.rs
+++ b/crates/homeboy-core/src/extension/maintenance.rs
@@ -41,7 +41,7 @@ pub fn update_all(force: bool) -> UpdateAllResult {
 
     for id in &extension_ids {
         let old_version = load_extension(id).ok().map(|m| m.version.clone());
-        let old_source_revision = homeboy_core::extension_update_check::read_source_revision(id);
+        let old_source_revision = homeboy_core::extension::lifecycle::read_source_revision(id);
 
         let update_result = linked_group_result(id, force, &linked_groups, &mut grouped_results);
         match update_result.unwrap_or_else(|| update(id, force)) {
@@ -59,7 +59,7 @@ pub fn update_all(force: bool) -> UpdateAllResult {
                 }
                 if result.source_update.new_source_revision.is_none() {
                     result.source_update.new_source_revision =
-                        homeboy_core::extension_update_check::read_source_revision(id);
+                        homeboy_core::extension::lifecycle::read_source_revision(id);
                 }
 
                 if let Some(repair) = repaired.clone() {

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -28,7 +28,6 @@ mod setup_env;
 mod summary;
 pub mod test;
 pub mod trace;
-pub mod update_check;
 mod validation;
 
 pub use capability::{build_scenario_runner, ScenarioRunnerOptions};

--- a/crates/homeboy-core/src/extension/readiness.rs
+++ b/crates/homeboy-core/src/extension/readiness.rs
@@ -286,7 +286,7 @@ fn readiness_identity(
     if let Some(revision) = extension
         .extension_path
         .as_deref()
-        .and_then(|path| crate::extension_update_check::read_source_revision_at(path.as_ref()))
+        .and_then(|path| crate::extension::lifecycle::read_source_revision_at(path.as_ref()))
     {
         hasher.update(revision.as_bytes());
     }

--- a/crates/homeboy-core/src/extension/summary.rs
+++ b/crates/homeboy-core/src/extension/summary.rs
@@ -157,8 +157,7 @@ fn summary_for_extension(
                 .and_then(|r| r.ready_check.as_ref())
                 .map(|_| true);
 
-            let source_revision =
-                homeboy_core::extension_update_check::read_source_revision(&ext.id);
+            let source_revision = homeboy_core::extension::lifecycle::read_source_revision(&ext.id);
             let core_compatibility = evaluate_core_compatibility(
                 ext.requires
                     .as_ref()

--- a/crates/homeboy-core/src/lib.rs
+++ b/crates/homeboy-core/src/lib.rs
@@ -102,7 +102,6 @@ pub mod execution;
 pub mod execution_contract;
 pub mod expand;
 pub mod extension;
-pub mod extension_update_check;
 // finding moved to the internal `homeboy-finding` crate. Re-exported so existing
 // `crate::finding::*` call sites keep working unchanged.
 pub use homeboy_finding as finding;

--- a/crates/homeboy-core/src/runtime_package.rs
+++ b/crates/homeboy-core/src/runtime_package.rs
@@ -121,7 +121,7 @@ fn refresh_locked_in_root(
 
     let source_stage = store.join(format!("source-{}-{}", runtime_id, nonce()));
     remove_if_exists(&source_stage, "clean runtime refresh source")?;
-    let (source_root, source_revision) = if crate::extension_update_check::is_git_url(source) {
+    let (source_root, source_revision) = if crate::extension::lifecycle::is_git_url(source) {
         git::clone_repo_at_ref(source, &source_stage, revision)?;
         (
             source_stage.as_path(),

--- a/crates/homeboy-lab-runner/src/execution/extension_parity.rs
+++ b/crates/homeboy-lab-runner/src/execution/extension_parity.rs
@@ -561,7 +561,7 @@ fn runner_extension_materialization_request(
     extension_id: &str,
     parity_error: Error,
 ) -> Result<RunnerExtensionMaterializationRequest> {
-    let local_revision = homeboy_core::extension_update_check::read_source_revision(extension_id)
+    let local_revision = homeboy_core::extension::lifecycle::read_source_revision(extension_id)
         .filter(|revision| !revision.trim().is_empty())
         .ok_or_else(|| parity_error.clone())?;
     let source =
@@ -890,7 +890,7 @@ fn validate_runner_extension_revision(
         );
     }
 
-    let local_revision = homeboy_core::extension_update_check::read_source_revision(extension_id)
+    let local_revision = homeboy_core::extension::lifecycle::read_source_revision(extension_id)
         .filter(|revision| !revision.trim().is_empty());
     let remote_revision = remote_extension_source_revision(remote_stdout)
         .filter(|revision| !revision.trim().is_empty());
@@ -903,10 +903,9 @@ fn validate_runner_extension_revision(
     // silently ran the *committed* code instead of the edited code. A dirty
     // controller checkout is therefore stale parity by definition, whatever the
     // revisions say.
-    let cleanliness = homeboy_core::extension_update_check::read_source_cleanliness(extension_id);
-    if let homeboy_core::extension_update_check::ExtensionSourceCleanliness::Dirty {
-        changed_paths,
-    } = &cleanliness
+    let cleanliness = homeboy_core::extension::lifecycle::read_source_cleanliness(extension_id);
+    if let homeboy_core::extension::lifecycle::ExtensionSourceCleanliness::Dirty { changed_paths } =
+        &cleanliness
     {
         return Err(uncommitted_controller_extension_source_error(
             runner_id,
@@ -969,11 +968,11 @@ fn warn_revision_only_extension_parity(
     runner_id: &str,
     extension_id: &str,
     local_revision: &str,
-    cleanliness: &homeboy_core::extension_update_check::ExtensionSourceCleanliness,
+    cleanliness: &homeboy_core::extension::lifecycle::ExtensionSourceCleanliness,
 ) {
     if !matches!(
         cleanliness,
-        homeboy_core::extension_update_check::ExtensionSourceCleanliness::Unknown
+        homeboy_core::extension::lifecycle::ExtensionSourceCleanliness::Unknown
     ) {
         return;
     }

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -592,7 +592,7 @@ fn extension_provenance(required_extensions: &[String]) -> Vec<ExtensionProvenan
                 },
                 manifest_path,
                 version: Some(manifest.version),
-                source_revision: homeboy_core::extension_update_check::read_source_revision(
+                source_revision: homeboy_core::extension::lifecycle::read_source_revision(
                     extension_id,
                 ),
             })

--- a/crates/homeboy-lab-runner/src/workload.rs
+++ b/crates/homeboy-lab-runner/src/workload.rs
@@ -243,7 +243,7 @@ fn required_extension_revisions(
 ) -> Vec<LabRunnerWorkloadExtensionRevision> {
     required_extension_revisions_with(
         required_extensions,
-        homeboy_core::extension_update_check::read_source_revision,
+        homeboy_core::extension::lifecycle::read_source_revision,
     )
 }
 

--- a/crates/homeboy-lab-runner/src/workspace/tests/git.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/git.rs
@@ -775,7 +775,7 @@ fn git_sync_of_detached_extension_source_preserves_source_revision() {
             Some(detached_short.as_str())
         );
         assert_eq!(
-            homeboy_core::extension_update_check::read_source_revision("wordpress").as_deref(),
+            homeboy_core::extension::lifecycle::read_source_revision("wordpress").as_deref(),
             Some(detached_full.as_str())
         );
     });

--- a/crates/homeboy-rig/src/install.rs
+++ b/crates/homeboy-rig/src/install.rs
@@ -7,7 +7,7 @@
 
 use homeboy_core::error::{Error, Result};
 use homeboy_core::extension::lifecycle;
-use homeboy_core::extension_update_check::is_git_url;
+use homeboy_core::extension::lifecycle::is_git_url;
 use homeboy_core::{git, paths};
 use homeboy_stack::stack;
 use serde::{Deserialize, Serialize};

--- a/crates/homeboy-upgrade/src/upgrade/extension_update_check.rs
+++ b/crates/homeboy-upgrade/src/upgrade/extension_update_check.rs
@@ -13,7 +13,7 @@
 //! [`homeboy_core::update_check_cache`]. The on-disk filename and JSON
 //! schema live here and are unchanged.
 
-use crate::extension::catalog;
+use homeboy_core::extension::catalog;
 use homeboy_core::update_check_cache;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -100,7 +100,7 @@ pub fn run_startup_check() {
     let extensions_behind = collect_updates_with_budget(
         &extension_ids,
         STARTUP_UPDATE_CHECK_BUDGET,
-        homeboy_core::extension_update_check::check_update_available_until,
+        homeboy_core::extension::lifecycle::check_update_available_until,
     );
 
     write_cache(&ExtensionUpdateCache {
@@ -119,7 +119,7 @@ fn collect_updates_with_budget<F>(
     mut check: F,
 ) -> HashMap<String, usize>
 where
-    F: FnMut(&str, Instant) -> Option<homeboy_core::extension_update_check::UpdateAvailable>,
+    F: FnMut(&str, Instant) -> Option<homeboy_core::extension::lifecycle::UpdateAvailable>,
 {
     let deadline = Instant::now() + budget;
     let mut extensions_behind = HashMap::new();

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -2,7 +2,7 @@ use homeboy_core::defaults;
 use homeboy_core::error::{Error, Result};
 use homeboy_core::extension::catalog::{discover_extensions, DiscoveredExtension};
 use homeboy_core::extension::lifecycle;
-use homeboy_core::extension_update_check::is_git_url;
+use homeboy_core::extension::lifecycle::is_git_url;
 use homeboy_core::{build_identity, git};
 use semver::Version;
 use std::path::{Path, PathBuf};
@@ -890,7 +890,7 @@ fn preflight_extensions_for_upgrade(candidate_version: &str) -> Vec<ExtensionPre
                     .and_then(|requirements| requirements.homeboy.as_deref());
                 match homeboy_extension_contract::evaluate_core_compatibility_for_version(
                     requires,
-                    homeboy_core::extension_update_check::read_source_revision(&extension_id),
+                    homeboy_core::extension::lifecycle::read_source_revision(&extension_id),
                     candidate_version,
                 ) {
                     Ok(report) if report.status != "incompatible" => None,
@@ -939,7 +939,7 @@ fn linked_extension_source_blocker(
         (Some(root), Some(source)) if source.starts_with(root)
     );
     if is_registered_source
-        && homeboy_core::extension_update_check::read_source_revision(extension_id).is_some()
+        && homeboy_core::extension::lifecycle::read_source_revision(extension_id).is_some()
     {
         return None;
     }
@@ -1518,7 +1518,7 @@ fn installed_extension_catalog_for(extension_ids: &[String]) -> Vec<ExtensionUpg
                         source_path: manifest.extension_path,
                         git_root: None,
                         source_url,
-                        source_revision: homeboy_core::extension_update_check::read_source_revision(&extension_id),
+                        source_revision: homeboy_core::extension::lifecycle::read_source_revision(&extension_id),
                         source_update: homeboy_extension_contract::update_output::ExtensionSourceUpdate {
                             update_note,
                             ..Default::default()
@@ -1755,7 +1755,7 @@ fn update_all_extensions(
                     .source_update
                     .new_source_revision
                     .clone()
-                    .or_else(|| homeboy_core::extension_update_check::read_source_revision(id));
+                    .or_else(|| homeboy_core::extension::lifecycle::read_source_revision(id));
 
                 if result.linked {
                     let branch_detail = match (

--- a/crates/homeboy-upgrade/src/upgrade/mod.rs
+++ b/crates/homeboy-upgrade/src/upgrade/mod.rs
@@ -1,6 +1,7 @@
 mod admission;
 mod constants;
 mod execution;
+pub mod extension_update_check;
 mod helpers;
 mod operation;
 mod planning;

--- a/homeboy.json
+++ b/homeboy.json
@@ -673,6 +673,16 @@
           ]
         },
         "name": "extensions-use-canonical-registry-api"
+      },
+      {
+        "forbid": {
+          "glob": "crates/**",
+          "patterns": [
+            "\\b(?:homeboy_core|crate)::extension_update_check::",
+            "\\bextension::update_check\\b"
+          ]
+        },
+        "name": "extensions-use-canonical-lifecycle-source-api"
       }
     ]
   },


### PR DESCRIPTION
## Summary

- move extension source provenance and remote update probes behind `homeboy_core::extension::lifecycle`
- move extension startup update scheduling, caching, and notices into `homeboy-upgrade`
- remove the final top-level `homeboy_core::extension_update_check` module and migrate all consumers
- guard the canonical ownership boundary in the architecture audit

## Verification

- `cargo nextest run -p homeboy-core --lib -E 'test(extension::lifecycle::source)'` (12 passed)\n- `cargo nextest run -p homeboy-upgrade -E 'test(upgrade::extension_update_check)'` (6 passed)\n- `cargo check --workspace --all-targets`\n- `cargo run -q -p homeboy -- review audit --profile architecture --changed-since origin/main --placement local` (0 introduced findings)\n\nCloses #13903\nParent: #13882\n\n---\n\nAI assistance: OpenAI GPT-5.6 Sol via OpenCode audited the extension and Upgrade ownership boundaries, implemented the namespace migration, and ran focused and workspace verification; Chris Huber directed the architecture and scope.