### PR TITLE
Fix native Cook workspace readmission

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -7150,12 +7150,15 @@ fn validate_cook_workspace_with_adopted_candidate(
     let continuation = tracked_promotion_continuation(options)?;
     let source = options.workspace.source_worktree_path.as_deref();
     let target = if let Some(source) = source {
-        homeboy_core::worktree_provider::resolve_native_worktree_mutation_target(
-            &options.workspace.to_worktree,
-            homeboy_core::worktree_provider::WorktreeMutationContext::default(),
-        )?;
+        let native_target =
+            homeboy_core::worktree_provider::resolve_native_worktree_mutation_target(
+                &options.workspace.to_worktree,
+                homeboy_core::worktree_provider::WorktreeMutationContext::default(),
+            )?;
         if cook_uses_explicit_cwd_workspace(options) {
             source.to_path_buf()
+        } else if let Some(target) = native_target {
+            target.path
         } else {
             trusted_initial_cook_workspace(options, source)?.unwrap_or_else(|| source.to_path_buf())
         }

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -5741,7 +5741,7 @@ fn cook_recovery_actions(
     let mut actions = vec![
         super::AgentTaskCookRecoveryAction {
             action: "status".to_string(),
-            command: super::cook_recovery_command(run_id, &["status", run_id, "--full"]),
+            command: super::cook_recovery_command(run_id, &["status", run_id]),
         },
         super::AgentTaskCookRecoveryAction {
             action: "diagnose".to_string(),
@@ -5873,6 +5873,11 @@ mod recovery_action_tests {
                 .map(|action| action.action.as_str())
                 .collect::<Vec<_>>();
             assert_eq!(actions, expected, "{status}");
+            assert_eq!(
+                recovery.legal_actions[0].command,
+                "homeboy agent-task status cook-state-matrix-attempt-1",
+                "status recovery must contain only supported CLI arguments"
+            );
             assert_eq!(
                 recovery.reason,
                 format!(

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -7406,6 +7406,17 @@ fn pending_cook_ensures_native_destination_after_durable_admission_idempotently(
             .status()
             .expect("git commit")
             .success());
+        let base_sha = String::from_utf8(
+            Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .current_dir(&source)
+                .output()
+                .expect("git rev-parse runs")
+                .stdout,
+        )
+        .expect("base SHA is UTF-8")
+        .trim()
+        .to_string();
         let components = home.path().join(".config/homeboy/components");
         std::fs::create_dir_all(&components).expect("component registry");
         std::fs::write(
@@ -7423,7 +7434,7 @@ fn pending_cook_ensures_native_destination_after_durable_admission_idempotently(
         let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
         options.identity.initial_run_id = run_id.to_string();
         options.workspace.to_worktree = "fixture@native-provision".to_string();
-        options.workspace.task_base_sha = Some("fixture-base".to_string());
+        options.workspace.task_base_sha = Some(base_sha);
         options.identity.initial_plan.metadata["cook_provision"] = serde_json::json!({
             "action": "lookup_pending",
             "kind": "provider",
@@ -7460,6 +7471,8 @@ fn pending_cook_ensures_native_destination_after_durable_admission_idempotently(
             .expect("bound native destination");
         materialize_pending_cook_workspace(&lifecycle_store, &mut options, None)
             .expect("re-admit native Cook destination");
+        validate_cook_workspace(&options)
+            .expect("invocation-created native destination remains valid for provider dispatch");
 
         let record = homeboy_core::worktree::resolve_if_present(&options.workspace.to_worktree)
             .expect("native lookup")


### PR DESCRIPTION
## Summary

- preserve a successfully resolved native mutation target during Cook workspace validation instead of falling through to configured-provider-only adoption
- extend the native provisioning regression through same-invocation readmission and provider-dispatch validation with a real base commit
- remove the unsupported `--full` argument from generated `agent-task status` recovery commands

Closes #13904.

## Verification

- `cargo test -p homeboy-agents pending_cook_ensures_native_destination_after_durable_admission_idempotently`
- `cargo test -p homeboy-agents recovery_actions_follow_the_cook_state_matrix`
- `cargo check -p homeboy-agents`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode traced the native/configured-provider resolution handoff, implemented the scoped fix and regression coverage, and ran the verification commands under Chris Huber's direction.