### PR TITLE
Keep one owner for generated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,10 @@ jobs:
   # Fast exit if nothing to release (e.g. chore-only commits).
   check:
     name: Check for releasable commits
+    # The originating run owns publication of the release commit it creates.
+    # A later ordinary push can still recover a stranded tag, and explicit tag
+    # recovery remains available through workflow_dispatch.
+    if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'release: v') }}"
     runs-on: ubuntu-latest
     # Coalesce only the read-only planning phase. A new main push interrupts an
     # in-flight dry run before gates or mutation begin; the latest push retains

--- a/tests/release_workflow_test.rs
+++ b/tests/release_workflow_test.rs
@@ -344,6 +344,23 @@ fn release_concurrency_scopes_recovery_runs_to_the_requested_tag() {
     ));
 }
 
+#[test]
+fn generated_release_commit_does_not_start_a_competing_release() {
+    let workflow = release_workflow();
+    let check = job_section(workflow, "check");
+
+    assert!(
+        check.contains(
+            "if: \"${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'release: v') }}\""
+        ),
+        "the run that creates a canonical release commit must remain the sole publisher"
+    );
+    assert!(
+        workflow.contains("workflow_dispatch:"),
+        "explicit recovery must remain available"
+    );
+}
+
 /// Three rapid main pushes must collapse their expensive read-only planning to
 /// the latest SHA without allowing a workflow-level cancellation to interrupt
 /// a release that has already entered mutation or publication (#12504, #10645).


### PR DESCRIPTION
## Summary

- stop the Release workflow before planning when a push is Homeboy's canonical generated `release: vX.Y.Z` commit
- keep ordinary `main` pushes eligible to recover a stranded tag
- keep explicit `workflow_dispatch` tag recovery unchanged
- pin the single-owner contract in the release workflow test suite

This prevents the duplicate behavior observed for `v0.366.0`, where the originating run `33334165637` was still publishing while generated-commit run `33335513706` started another full Build for the same tag.

Closes #13905.

## Verification

- `cargo test --test release_workflow_test` (70 passed)
- `actionlint -shellcheck= .github/workflows/release.yml`
- `cargo fmt --all -- --check`
- `git diff --check`

Full `actionlint` additionally reports existing ShellCheck findings in unchanged release scripts; workflow syntax and expressions pass with ShellCheck integration disabled.

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode traced the overlapping `v0.366.0` release runs, separated required safety stages from duplicate generated-commit recovery, implemented the single-owner workflow guard and regression coverage, and ran verification under Chris Huber's direction.