### PR TITLE
Consolidate runner lifecycle contract ownership

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ name = "homeboy-api-jobs-contract"
 version = "0.1.0"
 dependencies = [
  "homeboy-lab-contract",
- "homeboy-lab-runner-contract",
+ "homeboy-runner-contract",
  "homeboy-source-snapshot-contract",
  "serde",
  "serde_json",
@@ -1101,6 +1101,7 @@ name = "homeboy-lab-runner-contract"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "homeboy-runner-contract",
  "serde",
  "serde_json",
 ]
@@ -1239,7 +1240,6 @@ dependencies = [
 name = "homeboy-runner-contract"
 version = "0.1.0"
 dependencies = [
- "homeboy-api-jobs-contract",
  "homeboy-lab-contract",
  "homeboy-source-snapshot-contract",
  "serde",

--- a/crates/contracts/homeboy-api-jobs-contract/Cargo.toml
+++ b/crates/contracts/homeboy-api-jobs-contract/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 
 [dependencies]
 homeboy-lab-contract = { version = "0.1.0", path = "../homeboy-lab-contract" }
-homeboy-lab-runner-contract = { version = "0.1.0", path = "../homeboy-lab-runner-contract" }
+homeboy-runner-contract = { version = "0.1.0", path = "../homeboy-runner-contract" }
 homeboy-source-snapshot-contract = { version = "0.1.0", path = "../homeboy-source-snapshot-contract" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/contracts/homeboy-api-jobs-contract/src/lib.rs
+++ b/crates/contracts/homeboy-api-jobs-contract/src/lib.rs
@@ -2,9 +2,9 @@
 //!
 //! `Job`, `JobStatus`, `JobEvent`, and their runner/daemon companions describe
 //! the shape of a homeboy API job as it crosses process boundaries between the
-//! controller, daemon, and runner. These are behavior-free serde data types
-//! (plus the pure `JobArtifactMetadata` / `RunnerJobLifecycleMetadata`), so this
-//! is a leaf crate other crates can depend on without pulling in core.
+//! controller, daemon, and runner. These are behavior-free serde data types, so
+//! this crate can depend on the canonical runner contract without pulling in
+//! core. Established API-job imports for shared metadata remain re-exported.
 //!
 //! The job *store* (`api_jobs::store`, persistence, remote-runner dispatch,
 //! provider hooks) stays in `homeboy-core`.

--- a/crates/contracts/homeboy-api-jobs-contract/src/metadata.rs
+++ b/crates/contracts/homeboy-api-jobs-contract/src/metadata.rs
@@ -1,7 +1,5 @@
-//! Pure job artifact / lifecycle metadata structs shared by the job model and
-//! the runner-facing execution surface.
-
-use serde::{Deserialize, Serialize};
+//! Compatibility exports for metadata shared by the job model and runner
+//! execution contract.
 
 /// The canonical artifact pointer. Defined in `homeboy-lab-contract` because
 /// this crate already depends on it and the Lab workload types need the same
@@ -9,16 +7,6 @@ use serde::{Deserialize, Serialize};
 /// Re-exported so existing `api_jobs`-side call sites are unchanged.
 pub use homeboy_lab_contract::lab::workload::JobArtifactMetadata;
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RunnerJobLifecycleMetadata {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub source: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub kind: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub durable_run_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub active_child_count: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub active_cell_count: Option<u64>,
-}
+/// Compatibility export for API-job consumers. Runner lifecycle metadata is
+/// owned by the transport-neutral runner contract.
+pub use homeboy_runner_contract::RunnerJobLifecycleMetadata;

--- a/crates/contracts/homeboy-api-jobs-contract/src/types.rs
+++ b/crates/contracts/homeboy-api-jobs-contract/src/types.rs
@@ -5,9 +5,8 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::metadata::JobArtifactMetadata;
-use crate::metadata::RunnerJobLifecycleMetadata;
 use homeboy_lab_contract::path_materialization::PathMaterializationPlan;
-use homeboy_lab_runner_contract::RunnerLifecycleOwner;
+use homeboy_runner_contract::{RunnerJobLifecycleMetadata, RunnerLifecycleOwner};
 use homeboy_source_snapshot_contract::SourceSnapshot;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/contracts/homeboy-lab-runner-contract/Cargo.toml
+++ b/crates/contracts/homeboy-lab-runner-contract/Cargo.toml
@@ -14,5 +14,6 @@ path = "src/lib.rs"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive", "string"] }
+homeboy-runner-contract = { version = "0.1.0", path = "../homeboy-runner-contract" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
@@ -1,11 +1,11 @@
-//! Shared runner contract: behavior-free types and env-var constants that both
-//! `homeboy-core` and the optional `homeboy-runner` feature crate depend on.
+//! Lab routing, handoff, and compatibility contracts used by `homeboy-core` and
+//! the optional `homeboy-runner` feature crate.
 //!
 //! Runner is an optional Lab-offload feature; core must not depend on runner
 //! *behavior*. But some core code legitimately needs to name runner *concepts*
 //! (e.g. the runner kind, or the env-var markers used when an exec crosses a
-//! remote-runner boundary). Those plain-data contracts live here so core can
-//! reference them without a `core -> runner` edge.
+//! remote-runner boundary). Generic lifecycle data is canonical in
+//! `homeboy-runner-contract`; its established import is re-exported here.
 //!
 //! Two single-type crates were folded in here for the same reason they existed
 //! separately — both are behavior-free runner contracts below core, and both
@@ -27,6 +27,9 @@ pub use execution_placement::{
     ExecutionPlacementRequirement, ExecutionPlacementRunnerSelection, RunnerSelectionSource,
     CONTROLLER_LOCAL_SUBMISSION_POLICY_ID,
 };
+/// Compatibility export for established Lab runner consumers. Lifecycle
+/// ownership is canonical in `homeboy-runner-contract`.
+pub use homeboy_runner_contract::RunnerLifecycleOwner;
 pub use placement::Placement;
 pub use provider_source_types::AgentTaskProviderRunnerSource;
 
@@ -40,27 +43,6 @@ use serde::{Deserialize, Serialize};
 pub enum RunnerKind {
     Local,
     Ssh,
-}
-
-/// Which side of a runner exchange owns a lifecycle resource.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum RunnerLifecycleOwner {
-    Controller,
-    Runner,
-    Broker,
-    Local,
-}
-
-impl RunnerLifecycleOwner {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Controller => "controller",
-            Self::Runner => "runner",
-            Self::Broker => "broker",
-            Self::Local => "local",
-        }
-    }
 }
 
 /// File + byte counts for a workspace sync.

--- a/crates/contracts/homeboy-runner-contract/Cargo.toml
+++ b/crates/contracts/homeboy-runner-contract/Cargo.toml
@@ -8,7 +8,6 @@ repository = "https://github.com/Extra-Chill/homeboy"
 publish = false
 
 [dependencies]
-homeboy-api-jobs-contract = { version = "0.1.0", path = "../homeboy-api-jobs-contract" }
 homeboy-lab-contract = { version = "0.1.0", path = "../homeboy-lab-contract" }
 homeboy-source-snapshot-contract = { version = "0.1.0", path = "../homeboy-source-snapshot-contract" }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/contracts/homeboy-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-runner-contract/src/lib.rs
@@ -4,6 +4,10 @@
 //! boundaries. Execution behavior and service ownership remain outside this
 //! crate.
 
+mod lifecycle;
+
+pub use lifecycle::{RunnerJobLifecycleMetadata, RunnerLifecycleOwner};
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -26,7 +30,7 @@ use homeboy_source_snapshot_contract::SourceSnapshot;
 /// it as well, which removed the lossy `job_artifact_refs` rebuild that silently
 /// dropped `mime`, `size_bytes` and `sha256`. The serialized shape is unchanged
 /// in both collapses: every extra field is `Option` + `skip_serializing_if`.
-pub use homeboy_api_jobs_contract::JobArtifactMetadata;
+pub use homeboy_lab_contract::lab::workload::JobArtifactMetadata;
 
 pub const RUNNER_EXECUTION_ENVELOPE_SCHEMA: &str = "homeboy/runner-execution-envelope/v1";
 pub const RUNNER_EXECUTION_RECORD_SCHEMA: &str = "homeboy/runner-execution-record/v1";
@@ -114,11 +118,9 @@ pub struct RunnerExecutionDispatch {
 /// Lifecycle facts carried by a runner execution envelope.
 ///
 /// This was a second declaration of
-/// [`homeboy_api_jobs_contract::RunnerJobLifecycleMetadata`] -- the same five
-/// fields with byte-identical serde attributes on each. `homeboy-core` depends
-/// on `homeboy-api-jobs-contract` directly, so the envelope and the job request
-/// were always able to name one type for the same five facts.
-pub type RunnerExecutionLifecycle = homeboy_api_jobs_contract::RunnerJobLifecycleMetadata;
+/// [`RunnerJobLifecycleMetadata`] -- the same five fields with byte-identical
+/// serde attributes on each.
+pub type RunnerExecutionLifecycle = RunnerJobLifecycleMetadata;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RunnerExecutionRecord {

--- a/crates/contracts/homeboy-runner-contract/src/lifecycle.rs
+++ b/crates/contracts/homeboy-runner-contract/src/lifecycle.rs
@@ -1,0 +1,87 @@
+//! Transport-neutral runner lifecycle metadata.
+
+use serde::{Deserialize, Serialize};
+
+/// Which side of a runner exchange owns a lifecycle resource.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerLifecycleOwner {
+    Controller,
+    Runner,
+    Broker,
+    Local,
+}
+
+impl RunnerLifecycleOwner {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Controller => "controller",
+            Self::Runner => "runner",
+            Self::Broker => "broker",
+            Self::Local => "local",
+        }
+    }
+}
+
+/// Lifecycle facts carried by runner jobs and execution envelopes.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerJobLifecycleMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub durable_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_child_count: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_cell_count: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lifecycle_owner_keeps_its_wire_values() {
+        for (owner, expected) in [
+            (RunnerLifecycleOwner::Controller, "controller"),
+            (RunnerLifecycleOwner::Runner, "runner"),
+            (RunnerLifecycleOwner::Broker, "broker"),
+            (RunnerLifecycleOwner::Local, "local"),
+        ] {
+            assert_eq!(owner.as_str(), expected);
+            assert_eq!(serde_json::to_value(owner).expect("serialize"), expected);
+        }
+    }
+
+    #[test]
+    fn empty_lifecycle_metadata_keeps_its_wire_shape() {
+        assert_eq!(
+            serde_json::to_value(RunnerJobLifecycleMetadata::default()).expect("serialize"),
+            serde_json::json!({})
+        );
+    }
+
+    #[test]
+    fn lifecycle_metadata_keeps_its_complete_wire_shape() {
+        let metadata = RunnerJobLifecycleMetadata {
+            source: Some("daemon".to_string()),
+            kind: Some("agent_task".to_string()),
+            durable_run_id: Some("run-1".to_string()),
+            active_child_count: Some(2),
+            active_cell_count: Some(3),
+        };
+
+        assert_eq!(
+            serde_json::to_value(metadata).expect("serialize"),
+            serde_json::json!({
+                "source": "daemon",
+                "kind": "agent_task",
+                "durable_run_id": "run-1",
+                "active_child_count": 2,
+                "active_cell_count": 3,
+            })
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- make `homeboy-runner-contract` the canonical owner of runner lifecycle ownership and metadata
- reverse the `homeboy-runner-contract -> homeboy-api-jobs-contract -> homeboy-lab-runner-contract` dependency chain into acyclic downward dependencies
- preserve established API jobs and Lab runner imports through compatibility re-exports
- keep execution placement in the Lab routing contract and leave runtime behavior unchanged

Closes #13893.

## Dependency graph

- `homeboy-runner-contract -> homeboy-lab-contract`
- `homeboy-api-jobs-contract -> homeboy-runner-contract`
- `homeboy-lab-runner-contract -> homeboy-runner-contract`
- no `homeboy-runner-contract -> homeboy-api-jobs-contract` edge

## Verification

- `cargo test -p homeboy-runner-contract -p homeboy-api-jobs-contract -p homeboy-lab-runner-contract` (36 passed)
- `cargo check -p homeboy-core -p homeboy-lab-runner -p homeboy-agents -p homeboy-cli`
- `cargo test -p homeboy-paths workspace_membership_is_complete`
- `cargo clippy -p homeboy-runner-contract -p homeboy-api-jobs-contract -p homeboy-lab-runner-contract -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode inspected the existing contract graph, selected the bounded lifecycle ownership slice, implemented the dependency inversion and compatibility exports, and ran the verification gates. Chris Huber directed the one-Runner-API architecture and authorized the work.