### PR TITLE
Remove duplicate legacy runtime path accessor

### DIFF
--- a/crates/homeboy-core/src/extension/lifecycle/install_sources.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/install_sources.rs
@@ -356,9 +356,7 @@ fn install_shared_assets_from_root(
 }
 
 fn runtime_generation_boundary_active() -> Result<bool> {
-    Ok(std::fs::read_link(paths::legacy_agent_runtimes()?)
-        .ok()
-        .as_deref()
+    Ok(std::fs::read_link(paths::agent_runtimes()?).ok().as_deref()
         == Some(std::path::Path::new(
             "runtime-generations/current/agent-runtimes",
         )))
@@ -390,7 +388,7 @@ fn installed_shared_asset_target(extension_dir: &Path, shared_dir: &str) -> Resu
         // Extension installation maintains the legacy/source layout. A runtime
         // refresh snapshots it into an immutable generation; it must not write
         // through the active generation read boundary.
-        "agent-runtimes" => paths::legacy_agent_runtimes()?,
+        "agent-runtimes" => paths::agent_runtimes()?,
         "runtime-agent-ci" | "agent-task-contracts" => paths::homeboy()?.join(shared_dir),
         // Shared extension libraries install under the extensions root so
         // installed wrappers can source `../../../scripts/lib/...`.

--- a/crates/homeboy-core/src/runtime_package.rs
+++ b/crates/homeboy-core/src/runtime_package.rs
@@ -277,7 +277,7 @@ fn seed_legacy_generation(config_root: &Path, stage: &Path) -> Result<()> {
     // The shared-asset loop below already joins `config_root`; resolving the
     // legacy runtime directory ambiently would seed a generation from one
     // installation's runtimes and another's shared assets.
-    let legacy = paths::legacy_agent_runtimes_in_root(config_root);
+    let legacy = config_root.join("agent-runtimes");
     if legacy.is_dir() {
         reject_symlink_tree_except_root(&legacy)?;
         copy_regular_tree(
@@ -674,9 +674,9 @@ fn switch_current(store: &Path, generation: &str) -> Result<()> {
 fn ensure_stable_runtime_boundary(config_root: &Path) -> Result<()> {
     // Derived from the injected root, never re-resolved: the backup and
     // temporary siblings below are already `config_root`-relative, so an
-    // ambient `legacy_agent_runtimes()` here would rename a boundary in one
+    // ambient `agent_runtimes()` here would rename a boundary in one
     // installation into a backup name recorded in another.
-    let boundary = paths::legacy_agent_runtimes_in_root(config_root);
+    let boundary = paths::agent_runtimes_in_root(config_root);
     let expected = Path::new(GENERATIONS).join(CURRENT).join("agent-runtimes");
     if fs::read_link(&boundary).ok().as_deref() == Some(expected.as_path()) {
         return Ok(());
@@ -808,7 +808,7 @@ fn recover_boundary_migration(config_root: &Path) -> Result<()> {
     // this recovery already runs against one specific installation. Resolving
     // the boundary ambiently could restore a backup recorded here over an
     // unrelated installation's live boundary.
-    let boundary = paths::legacy_agent_runtimes_in_root(config_root);
+    let boundary = paths::agent_runtimes_in_root(config_root);
     let expected = Path::new(GENERATIONS).join(CURRENT).join("agent-runtimes");
 
     if fs::read_link(&boundary).ok().as_deref() != Some(expected.as_path()) {
@@ -1062,7 +1062,7 @@ mod tests {
             let result =
                 refresh("opencode", &staged_source.path().to_string_lossy(), None).unwrap();
             fs::remove_dir_all(staged_source.path()).unwrap();
-            let documented = paths::legacy_agent_runtimes().unwrap();
+            let documented = paths::agent_runtimes().unwrap();
             assert_eq!(result.path, documented.join("opencode"));
             assert_eq!(
                 fs::read_link(&documented).unwrap(),
@@ -1093,7 +1093,7 @@ mod tests {
             CRASH_AFTER_BOUNDARY_BOOTSTRAP.store(true, Ordering::SeqCst);
             assert!(refresh("neutral", &source.path().to_string_lossy(), None).is_err());
 
-            let boundary = paths::legacy_agent_runtimes().unwrap();
+            let boundary = paths::agent_runtimes().unwrap();
             let current = active_current_generation(&root.join(GENERATIONS))
                 .unwrap()
                 .unwrap();
@@ -1125,7 +1125,7 @@ mod tests {
             CRASH_AFTER_BOUNDARY_BACKUP_RENAME.store(true, Ordering::SeqCst);
             assert!(refresh("neutral", &source.path().to_string_lossy(), None).is_err());
 
-            let boundary = paths::legacy_agent_runtimes().unwrap();
+            let boundary = paths::agent_runtimes().unwrap();
             assert!(fs::symlink_metadata(&boundary).is_err());
             let current = active_current_generation(&store).unwrap().unwrap();
             assert_eq!(
@@ -1256,7 +1256,7 @@ mod tests {
             package(linked.path(), "legacy", "linked");
             let source = tempfile::tempdir().unwrap();
             package(source.path(), "neutral", "new");
-            let legacy = paths::legacy_agent_runtimes().unwrap();
+            let legacy = paths::agent_runtimes().unwrap();
             fs::create_dir_all(legacy.parent().unwrap()).unwrap();
             symlink(linked.path().join("agent-runtimes"), &legacy).unwrap();
 

--- a/crates/homeboy-paths/src/locations.rs
+++ b/crates/homeboy-paths/src/locations.rs
@@ -96,17 +96,6 @@ pub fn agent_runtimes() -> Result<PathBuf> {
     Ok(agent_runtimes_in_root(&homeboy()?))
 }
 
-/// Legacy runtime package directory below an already-resolved config root.
-pub fn legacy_agent_runtimes_in_root(config_root: &Path) -> PathBuf {
-    config_root.join("agent-runtimes")
-}
-
-/// Legacy runtime package directory, used only while migrating it into a
-/// generation. Runtime consumers must use [`agent_runtimes`].
-pub fn legacy_agent_runtimes() -> Result<PathBuf> {
-    Ok(legacy_agent_runtimes_in_root(&homeboy()?))
-}
-
 /// Keys directory below an already-resolved config root.
 pub fn keys_in_root(config_root: &Path) -> PathBuf {
     config_root.join("keys")


### PR DESCRIPTION
## Summary

- remove the duplicate `legacy_agent_runtimes*` path API
- route stable boundary consumers through canonical `agent_runtimes*` accessors
- keep the pre-generation migration read explicit inside `seed_legacy_generation`

Closes #13751

## Verification

- `cargo test -p homeboy-paths`
- `cargo test -p homeboy-core runtime_package::tests`
- `cargo test -p homeboy-core extension::lifecycle::tests`
- `cargo fmt --check`
- `git diff --check`

The full `cargo test -p homeboy-core` run exceeded the five-minute command limit. It surfaced one unrelated temp-retention test failure during the run; that exact test passed when rerun independently.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode audited the runtime boundary call sites, implemented the focused API deletion, and ran the verification commands. Chris Huber directed the target and reviewed the delivery workflow.