### PR TITLE
Fix Cook continuation remediation

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -495,7 +495,13 @@ fn run_next_skips_persisted_test_detached_recipe_and_executes_eligible_work() {
             "cook_continuation_preflight_failed"
         );
         assert_eq!(result.skipped[0].error_code, "validation.invalid_argument");
-        assert!(result.skipped[0].remediation.contains("agent-task status"));
+        assert_eq!(
+            result.skipped[0].remediation,
+            format!(
+                "inspect retained diagnostics with: homeboy agent-task diagnose {} --full",
+                options.identity.initial_run_id
+            )
+        );
     });
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -984,7 +984,7 @@ fn continuation_skip(
     });
     AgentTaskRunNextSkip {
         remediation: format!(
-            "inspect retained diagnostics with: homeboy agent-task diagnose <run-id> --full"
+            "inspect retained diagnostics with: homeboy agent-task diagnose {run_id} --full"
         ),
         run_id,
         submitted_at,


### PR DESCRIPTION
## Summary

- emit the exact skipped Cook run ID in continuation diagnostic guidance
- update the stale release-blocking assertion from the former status command to the canonical diagnose command
- preserve `--full` on diagnose, where it is supported

This fixes the `run_next_skips_persisted_test_detached_recipe_and_executes_eligible_work` failure reconciled into #13297 by release run https://github.com/Extra-Chill/homeboy/actions/runs/33336459904.

## Verification

- `cargo test -p homeboy-agents run_next_skips_persisted_test_detached_recipe_and_executes_eligible_work`
- `cargo check -p homeboy-agents`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode inspected the release evidence, reproduced the failing test, corrected the executable remediation contract, and ran the focused verification under Chris Huber's direction.