### PR TITLE
Dissolve mixed extension maintenance ownership

### DIFF
--- a/crates/homeboy-cli/src/commands/extension.rs
+++ b/crates/homeboy-cli/src/commands/extension.rs
@@ -1301,7 +1301,7 @@ fn update_extension(
 }
 
 fn update_all_extensions(force: bool) -> CmdResult<ExtensionOutput> {
-    let result = extension::update_all(force);
+    let result = extension::lifecycle::update_all(force);
 
     Ok((
         ExtensionOutput::UpdateAll {
@@ -1343,7 +1343,7 @@ fn converge_extensions() -> CmdResult<ExtensionOutput> {
         .collect::<homeboy::core::Result<Vec<_>>>()?;
 
     let provider_catalog_before = provider_catalog_evidence(AgentTaskProviderCatalog::discover());
-    let result = extension::update_all(false);
+    let result = extension::lifecycle::update_all(false);
     let changed_extension_ids = changed_extension_ids(&result.updated);
     let provider_catalog_after = provider_catalog_evidence(AgentTaskProviderCatalog::refresh());
     let (services_restarted, services_pending_restart) =
@@ -1608,7 +1608,7 @@ fn exec_extension_tool(
     component: Option<String>,
     args: Vec<String>,
 ) -> CmdResult<ExtensionOutput> {
-    let exit_code = extension::exec_tool(extension_id, component.as_deref(), &args)?;
+    let exit_code = extension::invoke::exec_tool(extension_id, component.as_deref(), &args)?;
 
     Ok((
         ExtensionOutput::Exec {

--- a/crates/homeboy-core/src/extension/invoke.rs
+++ b/crates/homeboy-core/src/extension/invoke.rs
@@ -22,6 +22,7 @@ mod runner;
 mod runtime_helper;
 mod scope;
 mod settings;
+mod tool;
 
 use super::env_provider;
 use crate::extension::catalog::load_extension;
@@ -48,6 +49,7 @@ pub use runtime_helper::{
 };
 use settings::serialize_settings;
 pub(crate) use settings::{build_settings_json_from_manifest, load_extension_manifest_from_dir};
+pub use tool::exec_tool;
 
 /// Result of executing a extension.
 pub struct ExtensionRunResult {

--- a/crates/homeboy-core/src/extension/invoke/tool.rs
+++ b/crates/homeboy-core/src/extension/invoke/tool.rs
@@ -1,0 +1,39 @@
+use homeboy_core::error::{Error, Result};
+use homeboy_extension_contract::exec_context;
+
+use crate::extension::catalog::load_extension;
+
+/// Execute a tool from an extension's vendor directory.
+pub fn exec_tool(extension_id: &str, component_id: Option<&str>, args: &[String]) -> Result<i32> {
+    let extension = load_extension(extension_id)?;
+    let extension_path = extension
+        .extension_path
+        .as_deref()
+        .ok_or_else(|| Error::config_missing_key("extension_path", Some(extension_id.into())))?;
+
+    let working_dir = if let Some(component_id) = component_id {
+        homeboy_core::component::load(component_id)?.local_path
+    } else {
+        std::env::current_dir()
+            .map(|path| path.to_string_lossy().to_string())
+            .unwrap_or_else(|_| ".".to_string())
+    };
+
+    let path = format!(
+        "{}/vendor/bin:{}/node_modules/.bin:{}",
+        extension_path,
+        extension_path,
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let env = [
+        ("PATH", path.as_str()),
+        (exec_context::EXTENSION_PATH, extension_path),
+        (exec_context::EXTENSION_ID, extension_id),
+    ];
+
+    Ok(homeboy_core::server::execute_local_command_interactive(
+        &args.join(" "),
+        Some(&working_dir),
+        Some(&env),
+    ))
+}

--- a/crates/homeboy-core/src/extension/lifecycle/maintenance.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/maintenance.rs
@@ -1,9 +1,8 @@
-use homeboy_core::error::{Error, Result};
+use homeboy_core::error::Result;
 use std::collections::HashMap;
 
-use super::lifecycle::{update, update_linked_group};
+use super::{update, update_linked_group, UpdateResult};
 use homeboy_core::extension::catalog::{available_extension_ids, load_extension};
-use homeboy_extension_contract::exec_context;
 use homeboy_extension_contract::update_output::{
     SourceMetadataRepairEntry, UpdateAllResult, UpdateEntry, UpdateSkippedEntry,
 };
@@ -36,8 +35,7 @@ pub fn update_all(force: bool) -> UpdateAllResult {
             }
         }
     }
-    let mut grouped_results: HashMap<String, Result<super::lifecycle::UpdateResult>> =
-        HashMap::new();
+    let mut grouped_results: HashMap<String, Result<UpdateResult>> = HashMap::new();
 
     for id in &extension_ids {
         let old_version = load_extension(id).ok().map(|m| m.version.clone());
@@ -111,8 +109,8 @@ fn linked_group_result(
     id: &str,
     force: bool,
     groups: &HashMap<String, Vec<String>>,
-    results: &mut HashMap<String, Result<super::lifecycle::UpdateResult>>,
-) -> Option<Result<super::lifecycle::UpdateResult>> {
+    results: &mut HashMap<String, Result<UpdateResult>>,
+) -> Option<Result<UpdateResult>> {
     let path = homeboy_core::paths::extension(id).ok()?;
     let source = std::fs::canonicalize(path).ok()?;
     let root = homeboy_core::git::get_git_root(&source.to_string_lossy()).ok()?;
@@ -132,50 +130,6 @@ fn linked_group_result(
         }
     }
     results.get(id).cloned()
-}
-
-/// Execute a tool from an extension's vendor directory.
-///
-/// Sets up PATH with the extension's vendor/bin and node_modules/.bin,
-/// resolves the working directory from an optional component, and runs
-/// the command interactively.
-pub fn exec_tool(extension_id: &str, component_id: Option<&str>, args: &[String]) -> Result<i32> {
-    use homeboy_core::server::execute_local_command_interactive;
-
-    let extension = load_extension(extension_id)?;
-    let ext_path = extension
-        .extension_path
-        .as_deref()
-        .ok_or_else(|| Error::config_missing_key("extension_path", Some(extension_id.into())))?;
-
-    // Resolve working directory
-    let working_dir = if let Some(cid) = component_id {
-        let comp = homeboy_core::component::load(cid)?;
-        comp.local_path.clone()
-    } else {
-        std::env::current_dir()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_else(|_| ".".to_string())
-    };
-
-    // Build PATH with extension vendor directories prepended
-    let vendor_bin = format!("{}/vendor/bin", ext_path);
-    let node_bin = format!("{}/node_modules/.bin", ext_path);
-    let current_path = std::env::var("PATH").unwrap_or_default();
-    let enriched_path = format!("{}:{}:{}", vendor_bin, node_bin, current_path);
-
-    let env = vec![
-        ("PATH", enriched_path.as_str()),
-        (exec_context::EXTENSION_PATH, ext_path),
-        (exec_context::EXTENSION_ID, extension_id),
-    ];
-
-    let command = args.join(" ");
-    Ok(execute_local_command_interactive(
-        &command,
-        Some(&working_dir),
-        Some(&env),
-    ))
 }
 
 #[cfg(test)]

--- a/crates/homeboy-core/src/extension/lifecycle/mod.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/mod.rs
@@ -39,10 +39,12 @@ pub struct UpdateResult {
         Option<homeboy_extension_contract::source_metadata_repair::SourceMetadataRepair>,
 }
 
+mod maintenance;
 mod repair;
 mod source;
 pub mod source_metadata;
 
+pub use maintenance::update_all;
 pub use repair::{relink, replace, replace_with_revision, ReplaceResult};
 pub use source::{
     check_update_available, check_update_available_until, is_git_url, read_source_cleanliness,
@@ -378,13 +380,13 @@ pub fn uninstall(extension_id: &str) -> Result<PathBuf> {
 
 #[cfg(test)]
 mod tests {
+    use super::update_all;
     use super::{
         install, install_for_component, install_with_revision, is_extension_update_workdir_clean,
         load_extension, read_source_revision, read_source_url, refresh,
         register_component_install_runner, shared_assets_for_extension_source, source_metadata,
         uninstall, update,
     };
-    use crate::extension::update_all;
     use homeboy_core::component;
     use homeboy_core::test_support::with_isolated_home;
     use std::fs;

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -13,7 +13,6 @@ mod fingerprint;
 pub mod invoke;
 pub mod lifecycle;
 pub mod lint;
-mod maintenance;
 mod manifest;
 mod manifest_sidecar;
 pub mod readiness;
@@ -43,7 +42,6 @@ pub use env_provider::{
 };
 pub use fingerprint::run_fingerprint_script;
 pub(crate) use invoke::build_settings_json_from_manifest;
-pub use maintenance::{exec_tool, update_all};
 pub use manifest::{
     deployment_provider_layered_input, deployment_providers, structured_sidecar_schema_version,
     structured_sidecars,

--- a/homeboy.json
+++ b/homeboy.json
@@ -652,7 +652,7 @@
             "\\bextension_scope\\b",
             "\\bextension::execution\\b",
             "\\bextension::(?:runner|runtime_helper)::",
-            "\\bextension::(?:ExtensionRunner|RunnerOutput|STRICT_VALIDATION_DEPENDENCIES_ENV|declared_helper_env_names|helper_path|provision_declared_helpers|RuntimeHelperProvision|BASH_PREFLIGHT_ENV|COMMAND_CAPTURE_ENV|RUNNER_PRELUDE_ENV|RUNNER_STEPS_ENV|RUNTIME_SETTINGS_HELPER_ENV|RUNTIME_SETTINGS_HELPER_ID)\\b",
+            "\\bextension::(?:exec_tool|ExtensionRunner|RunnerOutput|STRICT_VALIDATION_DEPENDENCIES_ENV|declared_helper_env_names|helper_path|provision_declared_helpers|RuntimeHelperProvision|BASH_PREFLIGHT_ENV|COMMAND_CAPTURE_ENV|RUNNER_PRELUDE_ENV|RUNNER_STEPS_ENV|RUNTIME_SETTINGS_HELPER_ENV|RUNTIME_SETTINGS_HELPER_ID)\\b",
             "\\bextension::(execute_action|run_action|run_deployment_provider|run_extension|run_setup|ExtensionExecutionMode|ExtensionRunResult|ExtensionSetupResult|ExtensionStepFilter)\\b"
           ]
         },
@@ -681,7 +681,7 @@
           "glob": "crates/**",
           "patterns": [
             "\\b(?:homeboy_core|crate)::extension_update_check::",
-            "\\bextension::update_check\\b"
+            "\\bextension::(?:maintenance|update_all|update_check)\\b"
           ]
         },
         "name": "extensions-use-canonical-lifecycle-source-api"


### PR DESCRIPTION
## Summary

- move bulk extension update coordination under `homeboy_core::extension::lifecycle`
- move interactive extension tool execution under `homeboy_core::extension::invoke`
- remove the mixed `extension::maintenance` module and its flat exports
- migrate CLI and lifecycle consumers to explicit owner namespaces
- extend architecture guards against the legacy paths

## Verification

- `cargo nextest run -p homeboy-core --lib -E 'test(extension::lifecycle::maintenance) | test(extension::lifecycle::tests)'` (45 passed)\n- `cargo check --workspace --all-targets`\n- `cargo run -q -p homeboy -- review audit --profile architecture --changed-since origin/main --placement local` (0 introduced findings)\n\nCloses #13914\nParent: #13882\n\n---\n\nAI assistance: OpenAI GPT-5.6 Sol via OpenCode identified the mixed maintenance ownership, split it across lifecycle and invocation, migrated callers, and ran focused and workspace verification; Chris Huber directed the simplification program.