### PR TITLE
Fix interrupted release asset recovery

### DIFF
--- a/crates/homeboy-release/src/release/executor/github_release/run.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/run.rs
@@ -6,10 +6,13 @@ use homeboy_core::error::{Error, Result};
 
 use super::super::step_success;
 use super::delivery::{existing_release_action, ExistingReleaseAction};
-use super::gh_cli::manifest_declared_asset_names;
 use super::gh_cli::{
     gh_command, gh_is_authenticated, gh_is_available, gh_release_exists,
     github_release_publications,
+};
+use super::gh_cli::{
+    manifest_declared_asset_names, GhCommandOutput, GitHubReleaseMetadata,
+    GitHubReleaseMetadataError, ReleaseAssetPublication,
 };
 use super::notes::{
     build_github_release_body, github_changelog_url, github_release_notes_start_tag,
@@ -26,6 +29,92 @@ use super::{
     github_release_upload_timeout, reconcile_release_publications, run_gh_command,
     validate_draft_adoption, verify_release_publications,
 };
+
+#[derive(Debug)]
+pub(super) enum PublicationUploadError {
+    Upload {
+        output: GhCommandOutput,
+        readback_error: Option<GitHubReleaseMetadataError>,
+    },
+    Verification(GitHubReleaseMetadataError),
+}
+
+/// Upload one canonical asset at a time and read it back before continuing.
+///
+/// `gh release upload` uploads multiple positional files concurrently. A killed
+/// process can therefore leave an arbitrary subset on the draft release, while
+/// its exit status describes the batch rather than any one asset. Serial
+/// readback makes every completed asset an idempotent checkpoint. A failed
+/// command counts as success only when the exact remote bytes are verified.
+pub(super) fn upload_publications_with<M>(
+    publications: &[ReleaseAssetPublication],
+    mut upload: impl FnMut(&ReleaseAssetPublication) -> GhCommandOutput,
+    mut read_metadata: impl FnMut() -> std::result::Result<M, GitHubReleaseMetadataError>,
+    mut verify: impl FnMut(
+        &ReleaseAssetPublication,
+        &M,
+    ) -> std::result::Result<(), GitHubReleaseMetadataError>,
+) -> std::result::Result<Option<M>, PublicationUploadError> {
+    let mut latest = None;
+    for publication in publications {
+        let output = upload(publication);
+        let command_failed = output.timed_out || output.exit_code != Some(0);
+        let metadata = match read_metadata() {
+            Ok(metadata) => metadata,
+            Err(error) if command_failed => {
+                return Err(PublicationUploadError::Upload {
+                    output,
+                    readback_error: Some(error),
+                })
+            }
+            Err(error) => return Err(PublicationUploadError::Verification(error)),
+        };
+        match verify(publication, &metadata) {
+            Ok(()) => latest = Some(metadata),
+            Err(error) if command_failed => {
+                return Err(PublicationUploadError::Upload {
+                    output,
+                    readback_error: Some(error),
+                })
+            }
+            Err(error) => return Err(PublicationUploadError::Verification(error)),
+        }
+    }
+    Ok(latest)
+}
+
+fn upload_release_publications(
+    publications: &[ReleaseAssetPublication],
+    github: &homeboy_core::git::release_download::GitHubRepo,
+    config: &homeboy_core::component::GithubConfig,
+    tag: &str,
+    repo_flag: &str,
+) -> std::result::Result<Option<GitHubReleaseMetadata>, PublicationUploadError> {
+    upload_publications_with(
+        publications,
+        |publication| {
+            let upload_spec = publication.upload_spec();
+            run_gh_command(
+                gh_command(
+                    github,
+                    config,
+                    &["release", "upload", tag, &upload_spec, "-R", repo_flag],
+                ),
+                github_release_upload_timeout(),
+            )
+        },
+        || gh_release_metadata(github, config, tag, repo_flag, false),
+        |publication, metadata| {
+            verify_release_publications(
+                std::slice::from_ref(publication),
+                &metadata.assets,
+                github,
+                config,
+                repo_flag,
+            )
+        },
+    )
+}
 
 /// Create a GitHub Release for the just-pushed tag.
 ///
@@ -437,72 +526,66 @@ pub(crate) fn run_github_release(
             existing.len()
         );
 
-        let upload_specs = uploads
-            .iter()
-            .map(|publication| publication.upload_spec())
-            .collect::<Vec<_>>();
-        let upload_output = if upload_specs.is_empty() {
-            None
-        } else {
-            let mut upload_args: Vec<&str> = vec!["release", "upload", &tag];
-            for path in &upload_specs {
-                upload_args.push(path);
-            }
-            upload_args.extend_from_slice(&["-R", &repo_flag]);
-            Some(run_gh_command(
-                gh_command(&github, &component.github, &upload_args),
-                github_release_upload_timeout(),
-            ))
-        };
-
-        if upload_output
-            .as_ref()
-            .is_some_and(|output| output.timed_out || output.exit_code != Some(0))
-        {
-            let upload_output = upload_output.expect("checked upload output");
-            let diagnostic = gh_failure_diagnostic(
-                "gh release upload",
-                &format!("repos/{repo_flag}/releases/{tag}/assets"),
-                &upload_output,
-            );
-            let repair = repair_commands(None, None);
-            homeboy_core::log_status!("release", "✗ {}", diagnostic.summary);
-            log_repair_commands(&repair);
-            return Ok(upload_failed_result(
-                &tag,
-                &github,
-                UploadFailedResultRequest {
-                    stdout: upload_output.stdout,
-                    stderr: upload_output.stderr,
-                    exit_code: upload_output.exit_code,
-                    timed_out: upload_output.timed_out,
-                    artifact_count: artifact_paths.len(),
-                    repair,
-                    diagnostics: &[diagnostic],
-                },
-            ));
-        }
-
-        let metadata =
-            match gh_release_metadata(&github, &component.github, &tag, &repo_flag, false) {
-                Ok(metadata) => metadata,
-                Err(error) => {
-                    let diagnostics = error.diagnostics;
-                    return Ok(upload_failed_result(
-                        &tag,
-                        &github,
-                        UploadFailedResultRequest {
-                            stdout: String::new(),
-                            stderr: error.message,
-                            exit_code: None,
-                            timed_out: false,
-                            artifact_count: artifact_paths.len(),
-                            repair: repair_commands(None, None),
-                            diagnostics: &diagnostics,
-                        },
-                    ));
+        let metadata = match upload_release_publications(
+            &uploads,
+            &github,
+            &component.github,
+            &tag,
+            &repo_flag,
+        ) {
+            Ok(Some(metadata)) => metadata,
+            Ok(None) => metadata,
+            Err(PublicationUploadError::Upload {
+                output,
+                readback_error,
+            }) => {
+                let mut diagnostics = vec![gh_failure_diagnostic(
+                    "gh release upload",
+                    &format!("repos/{repo_flag}/releases/{tag}/assets"),
+                    &output,
+                )];
+                let mut stderr = output.stderr;
+                if let Some(error) = readback_error {
+                    if !stderr.trim().is_empty() {
+                        stderr.push_str("; ");
+                    }
+                    stderr.push_str(&error.message);
+                    diagnostics.extend(error.diagnostics);
                 }
-            };
+                let repair = repair_commands(None, None);
+                homeboy_core::log_status!("release", "✗ {}", diagnostics[0].summary);
+                log_repair_commands(&repair);
+                return Ok(upload_failed_result(
+                    &tag,
+                    &github,
+                    UploadFailedResultRequest {
+                        stdout: output.stdout,
+                        stderr,
+                        exit_code: output.exit_code,
+                        timed_out: output.timed_out,
+                        artifact_count: artifact_paths.len(),
+                        repair,
+                        diagnostics: &diagnostics,
+                    },
+                ));
+            }
+            Err(PublicationUploadError::Verification(error)) => {
+                let diagnostics = error.diagnostics;
+                return Ok(upload_failed_result(
+                    &tag,
+                    &github,
+                    UploadFailedResultRequest {
+                        stdout: String::new(),
+                        stderr: error.message,
+                        exit_code: None,
+                        timed_out: false,
+                        artifact_count: artifact_paths.len(),
+                        repair: repair_commands(None, None),
+                        diagnostics: &diagnostics,
+                    },
+                ));
+            }
+        };
         if let Err(error) = verify_release_publications(
             &publications,
             &metadata.assets,

--- a/crates/homeboy-release/src/release/executor/github_release/tests/mod.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/tests/mod.rs
@@ -14,6 +14,7 @@ mod notes_tests;
 mod repair_tests;
 mod result_builders;
 mod start_tag_tests;
+mod upload_recovery_tests;
 
 pub(super) fn test_repo() -> GitHubRepo {
     GitHubRepo {

--- a/crates/homeboy-release/src/release/executor/github_release/tests/upload_recovery_tests.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/tests/upload_recovery_tests.rs
@@ -1,0 +1,108 @@
+use std::cell::RefCell;
+
+use super::super::gh_cli::{GhCommandOutput, GitHubReleaseMetadataError, ReleaseAssetPublication};
+use super::super::run::{upload_publications_with, PublicationUploadError};
+
+fn publication(name: &str) -> ReleaseAssetPublication {
+    ReleaseAssetPublication {
+        target_name: name.to_string(),
+        sha256: format!("digest-{name}"),
+        size: 1,
+        source_path: format!("/artifacts/{name}"),
+    }
+}
+
+fn command(exit_code: i32, stderr: &str) -> GhCommandOutput {
+    GhCommandOutput {
+        stdout: String::new(),
+        stderr: stderr.to_string(),
+        exit_code: Some(exit_code),
+        timed_out: false,
+    }
+}
+
+#[test]
+fn uploads_are_serial_checkpoints() {
+    let events = RefCell::new(Vec::new());
+    let publications = [publication("first.zip"), publication("second.zip")];
+
+    let result = upload_publications_with(
+        &publications,
+        |publication| {
+            events
+                .borrow_mut()
+                .push(format!("upload:{}", publication.target_name));
+            command(0, "")
+        },
+        || {
+            events.borrow_mut().push("readback".to_string());
+            Ok(())
+        },
+        |publication, _| {
+            events
+                .borrow_mut()
+                .push(format!("verify:{}", publication.target_name));
+            Ok(())
+        },
+    );
+
+    assert!(result.is_ok());
+    assert_eq!(
+        events.into_inner(),
+        vec![
+            "upload:first.zip",
+            "readback",
+            "verify:first.zip",
+            "upload:second.zip",
+            "readback",
+            "verify:second.zip",
+        ]
+    );
+}
+
+#[test]
+fn failed_upload_is_recovered_only_when_readback_verifies_exact_bytes() {
+    let publication = publication("large.tar.gz");
+    let recovered = upload_publications_with(
+        std::slice::from_ref(&publication),
+        |_| command(1, "HTTP 404: Not Found"),
+        || Ok(()),
+        |_, _| Ok(()),
+    );
+    assert!(recovered.is_ok());
+
+    let rejected = upload_publications_with(
+        &[publication],
+        |_| command(1, "HTTP 404: Not Found"),
+        || Ok(()),
+        |_, _| Err(GitHubReleaseMetadataError::message("asset is missing")),
+    );
+    assert!(matches!(
+        rejected,
+        Err(PublicationUploadError::Upload {
+            readback_error: Some(_),
+            ..
+        })
+    ));
+}
+
+#[test]
+fn successful_upload_stops_when_readback_cannot_verify_it() {
+    let publications = [publication("first.zip"), publication("second.zip")];
+    let uploads = RefCell::new(Vec::new());
+    let result = upload_publications_with(
+        &publications,
+        |publication| {
+            uploads.borrow_mut().push(publication.target_name.clone());
+            command(0, "")
+        },
+        || Ok(()),
+        |_, _| Err(GitHubReleaseMetadataError::message("digest mismatch")),
+    );
+
+    assert!(matches!(
+        result,
+        Err(PublicationUploadError::Verification(_))
+    ));
+    assert_eq!(uploads.into_inner(), vec!["first.zip"]);
+}


### PR DESCRIPTION
## Summary
- upload missing release assets one at a time
- verify each remote digest before continuing
- recover an upload command failure only when exact remote bytes are present
- add regression coverage for partial and ambiguous upload outcomes

Closes #12064

## Verification
- `cargo test -p homeboy-release` (556 passed)
- `cargo fmt --check`
- `git diff --check`
- package Clippy reaches only pre-existing warnings outside this change
- live recovery validation against an interrupted draft release is in progress

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented and tested the change under human direction.