### PR TITLE
Fix portable rig Lab handoff

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/activity_provider.rs
@@ -216,6 +216,7 @@ fn item_from_agent_task(record: AgentTaskRunRecord) -> ActivityItem {
                     .as_ref()
                     .is_ok_and(plan_has_retry_materialization_identity),
         ),
+        failure: None,
     }
 }
 

--- a/crates/homeboy-cli/src/commands/activity.rs
+++ b/crates/homeboy-cli/src/commands/activity.rs
@@ -208,6 +208,16 @@ pub(crate) fn render_activity_summary(payload: &serde_json::Value) -> Option<Str
             truncate(kind, 18),
             updated
         ));
+        if let Some(failure) = item.get("failure") {
+            let code = failure
+                .get("code")
+                .and_then(serde_json::Value::as_str)
+                .map(|code| format!(" [{code}]"))
+                .unwrap_or_default();
+            if let Some(message) = failure.get("message").and_then(serde_json::Value::as_str) {
+                lines.push(format!("  failure{code}: {message}"));
+            }
+        }
         if let Some(actions) = item
             .get("next_actions")
             .and_then(serde_json::Value::as_array)
@@ -706,6 +716,7 @@ mod tests {
                 label: "show".to_string(),
                 command: "homeboy activity show run-1".to_string(),
             }],
+            failure: None,
         }
     }
 
@@ -782,6 +793,36 @@ mod tests {
                 .contains("activity: total=3 executing=0 (running=0 queued=0) open_resources=3"),
             "summary line: {zero_executing}"
         );
+    }
+
+    #[test]
+    fn summary_presents_controller_job_failure_cause() {
+        let rendered = render_activity_summary(&json!({
+            "counts": {
+                "total": 1,
+                "active": 0,
+                "running": 0,
+                "queued": 0,
+                "failed": 1,
+                "stale": 0,
+                "open_resources": 0
+            },
+            "items": [{
+                "id": "job-1",
+                "state": "failed",
+                "kind": "controller.lab.staging-dispatch",
+                "created_at": "2026-08-30T00:00:00Z",
+                "failure": {
+                    "message": "runner dispatch cannot materialize the selected rig",
+                    "code": "validation.invalid_argument"
+                }
+            }]
+        }))
+        .expect("summary");
+
+        assert!(rendered.contains(
+            "failure [validation.invalid_argument]: runner dispatch cannot materialize the selected rig"
+        ));
     }
 
     #[test]

--- a/crates/homeboy-core/src/activity.rs
+++ b/crates/homeboy-core/src/activity.rs
@@ -513,6 +513,7 @@ mod tests {
             source_projections: Vec::new(),
             state_conflicts: Vec::new(),
             next_actions: vec![action("show", format!("homeboy runs show {id}"))],
+            failure: None,
         }
     }
 
@@ -537,6 +538,7 @@ mod tests {
             source_projections: Vec::new(),
             state_conflicts: Vec::new(),
             next_actions: Vec::new(),
+            failure: None,
         }
     }
 

--- a/crates/homeboy-core/src/activity/collector.rs
+++ b/crates/homeboy-core/src/activity/collector.rs
@@ -82,6 +82,9 @@ fn merge_item(existing: &mut ActivityItem, incoming: &ActivityItem) {
             &mut replacement.source_projections,
             &existing.source_projections,
         );
+        if replacement.failure.is_none() {
+            replacement.failure = existing.failure.clone();
+        }
         *existing = replacement;
         return;
     }
@@ -94,6 +97,9 @@ fn merge_item(existing: &mut ActivityItem, incoming: &ActivityItem) {
         &mut existing.source_projections,
         &incoming.source_projections,
     );
+    if existing.failure.is_none() {
+        existing.failure = incoming.failure.clone();
+    }
 }
 
 fn source_precedence(item: &ActivityItem) -> u8 {

--- a/crates/homeboy-core/src/activity/daemon_jobs.rs
+++ b/crates/homeboy-core/src/activity/daemon_jobs.rs
@@ -1,9 +1,9 @@
 use super::{
     action, is_active, ms_to_rfc3339, ActivityCollector, ActivityContext, ActivityCrossRefs,
-    ActivityEvidenceRef, ActivityFilter, ActivityItem, ActivityNextAction, ActivityRunnerRefs,
-    ActivityState,
+    ActivityEvidenceRef, ActivityFailure, ActivityFilter, ActivityItem, ActivityNextAction,
+    ActivityRunnerRefs, ActivityState,
 };
-use crate::api_jobs::{self, Job, JobEvent};
+use crate::api_jobs::{self, Job, JobEvent, JobEventKind};
 use crate::{paths, Result};
 
 /// Resolve a single daemon-job activity item by id without listing every
@@ -43,7 +43,9 @@ pub(super) fn collect(collector: &mut ActivityCollector, filter: &ActivityFilter
 pub(super) fn item_from_job(store: &api_jobs::JobStore, job: Job) -> Result<ActivityItem> {
     let state = ActivityState::from(job.status);
     let job_id = job.id.to_string();
-    let durable_run_id = job_run_id(store, &job);
+    let events = store.events(job.id).unwrap_or_default();
+    let durable_run_id = job_run_id(&events);
+    let failure = job_failure(&events);
     Ok(ActivityItem {
         id: job_id.clone(),
         kind: job.operation.clone(),
@@ -83,19 +85,36 @@ pub(super) fn item_from_job(store: &api_jobs::JobStore, job: Job) -> Result<Acti
         source_projections: Vec::new(),
         state_conflicts: Vec::new(),
         next_actions: actions_for_job(None, &job_id, state),
+        failure,
     })
 }
 
-fn job_run_id(store: &api_jobs::JobStore, job: &Job) -> Option<String> {
-    store
-        .events(job.id)
-        .unwrap_or_default()
-        .iter()
-        .fold(None, |durable, event| {
-            durable.or_else(|| {
-                event_metadata_string(event, &["durable_run_id", "run_id", "agent_task_run_id"])
-            })
+fn job_run_id(events: &[JobEvent]) -> Option<String> {
+    events.iter().fold(None, |durable, event| {
+        durable.or_else(|| {
+            event_metadata_string(event, &["durable_run_id", "run_id", "agent_task_run_id"])
         })
+    })
+}
+
+fn job_failure(events: &[JobEvent]) -> Option<ActivityFailure> {
+    let event = events
+        .iter()
+        .rev()
+        .find(|event| event.kind == JobEventKind::Error)?;
+    let details = event.data.clone();
+    Some(ActivityFailure {
+        message: event
+            .message
+            .clone()
+            .unwrap_or_else(|| "job failed".to_string()),
+        code: details
+            .as_ref()
+            .and_then(|value| value.get("code"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string),
+        details,
+    })
 }
 
 fn event_metadata_string(event: &JobEvent, keys: &[&str]) -> Option<String> {
@@ -126,4 +145,33 @@ pub(super) fn actions_for_job(
         actions.push(action("daemon status", "homeboy daemon status"));
     }
     actions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn controller_error_event_projects_typed_activity_failure() {
+        let event = JobEvent {
+            sequence: 1,
+            job_id: uuid::Uuid::new_v4(),
+            kind: JobEventKind::Error,
+            timestamp_ms: 1,
+            message: Some("Lab staging failed to resolve a rig package".to_string()),
+            data: Some(serde_json::json!({
+                "classification": "lab_staging",
+                "code": "validation.invalid_argument",
+                "details": { "field": "rig" }
+            })),
+        };
+
+        let failure = job_failure(&[event]).expect("failure projection");
+        assert_eq!(
+            failure.message,
+            "Lab staging failed to resolve a rig package"
+        );
+        assert_eq!(failure.code.as_deref(), Some("validation.invalid_argument"));
+        assert_eq!(failure.details.expect("details")["details"]["field"], "rig");
+    }
 }

--- a/crates/homeboy-core/src/activity/model.rs
+++ b/crates/homeboy-core/src/activity/model.rs
@@ -151,6 +151,15 @@ pub struct ActivityEvidenceRef {
     pub uri: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActivityFailure {
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
+}
+
 /// A store-specific view retained with the canonical activity item so state
 /// reconciliation remains inspectable without returning duplicate work items.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -204,6 +213,8 @@ pub struct ActivityItem {
     pub state_conflicts: Vec<ActivityStateConflict>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub next_actions: Vec<ActivityNextAction>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<ActivityFailure>,
 }
 
 /// The `source_store` of the worktree provider projection. Items from this

--- a/crates/homeboy-core/src/activity/observation.rs
+++ b/crates/homeboy-core/src/activity/observation.rs
@@ -105,6 +105,7 @@ fn item_from_run(store: &ObservationStore, run: RunRecord) -> Result<ActivityIte
         source_projections: Vec::new(),
         state_conflicts: Vec::new(),
         next_actions: actions_for_observation_run(&run.id, state_from_run_status(&run.status)),
+        failure: None,
     })
 }
 

--- a/crates/homeboy-core/src/activity/runner_sessions.rs
+++ b/crates/homeboy-core/src/activity/runner_sessions.rs
@@ -156,6 +156,7 @@ fn item_from_active_runner_job(job: ActiveRunnerJobSummary) -> ActivityItem {
         source_projections: Vec::new(),
         state_conflicts: Vec::new(),
         next_actions: actions_for_runner_job(&job.runner_id, &job.job_id, state),
+        failure: None,
     }
 }
 

--- a/crates/homeboy-core/src/activity/worktrees.rs
+++ b/crates/homeboy-core/src/activity/worktrees.rs
@@ -72,6 +72,7 @@ fn item_from_workspace(workspace: WorktreeProviderWorkspace) -> ActivityItem {
         source_projections: Vec::new(),
         state_conflicts: Vec::new(),
         next_actions: Vec::new(),
+        failure: None,
     }
 }
 

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -3584,6 +3584,7 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
         let mut public_env = request.recipe.job_override_env.clone();
         public_env.extend(runtime_env);
         public_env.extend(crate::lab_env::build_lab_offload_env(&lab_metadata));
+        public_env.extend(durable_runtime_rig_registry_env(&runtime.payload.output));
         let mut secret_handoff = crate::lab::secrets::build_lab_secret_env_handoff_plan(
             &request.recipe.command.secret_env_sources,
             &request.recipe.normalized_args,
@@ -3909,6 +3910,14 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
         }
         Ok(())
     }
+}
+
+fn durable_runtime_rig_registry_env(output: &Value) -> HashMap<String, String> {
+    let root = output
+        .get("rig_registry_root")
+        .and_then(Value::as_str)
+        .filter(|root| !root.trim().is_empty());
+    crate::lab::offload::lab_rig_registry_env(root)
 }
 
 /// Executes the durable phase machine. It owns lifecycle mechanics only: the
@@ -4401,8 +4410,12 @@ impl ControllerJobDriver for LabStagingDispatchDriver {
     }
     fn public_error(&self, error: &Error) -> ControllerJobPublicError {
         ControllerJobPublicError {
-            message: "Lab staging and dispatch failed".to_string(),
-            data: json!({ "classification": "lab_staging", "code": format!("{:?}", error.code) }),
+            message: error.message.clone(),
+            data: json!({
+                "classification": "lab_staging",
+                "code": error.code.as_str(),
+                "details": error.details,
+            }),
         }
     }
     fn validate_secret_references(&self, request: &Value) -> Result<()> {
@@ -7845,6 +7858,40 @@ mod tests {
             assert_eq!(recipe.secret_env_names, ["AGENT_TOKEN"]);
             assert!(!routing_ready());
         });
+    }
+
+    #[test]
+    fn durable_dispatch_reasserts_materialized_rig_registry() {
+        let env = durable_runtime_rig_registry_env(&json!({
+            "rig_registry_root": "/runner/job-artifacts/rig-registry"
+        }));
+
+        assert_eq!(
+            env.get(homeboy_core::paths::RIG_REGISTRY_ROOT_ENV),
+            Some(&"/runner/job-artifacts/rig-registry".to_string())
+        );
+        assert!(durable_runtime_rig_registry_env(&json!({
+            "rig_registry_root": null
+        }))
+        .is_empty());
+    }
+
+    #[test]
+    fn staging_public_error_preserves_safe_typed_cause() {
+        let error = Error::validation_invalid_argument(
+            "rig",
+            "runner dispatch cannot materialize selected rig package",
+            Some("fixture-rig".to_string()),
+            None,
+        );
+        let projected = LabStagingDispatchDriver.public_error(&error);
+
+        assert_eq!(
+            projected.message,
+            "Invalid argument 'rig': runner dispatch cannot materialize selected rig package"
+        );
+        assert_eq!(projected.data["code"], "validation.invalid_argument");
+        assert_eq!(projected.data["details"]["field"], "rig");
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
+++ b/crates/homeboy-lab-runner/src/rig_materialization/mod.rs
@@ -1429,8 +1429,26 @@ fn lab_offload_rig_ids(args: &[String]) -> Vec<String> {
         }
         if arg == "rig" && iter.peek().map(|value| value.as_str()) == Some("check") {
             iter.next();
-            if let Some(rig_id) = iter.next().filter(|value| !value.starts_with('-')) {
-                push_unique(&mut rig_ids, rig_id.to_string());
+            let target = iter.next().filter(|value| !value.starts_with('-'));
+            let mut remaining = iter.clone();
+            let mut selected_id = None;
+            while let Some(value) = remaining.next() {
+                if value == "--" {
+                    break;
+                }
+                if value == "--id" {
+                    selected_id = remaining.next().cloned();
+                    break;
+                }
+                if let Some(value) = value.strip_prefix("--id=") {
+                    if !value.is_empty() {
+                        selected_id = Some(value.to_string());
+                    }
+                    break;
+                }
+            }
+            if let Some(rig_id) = selected_id.or_else(|| target.cloned()) {
+                push_unique(&mut rig_ids, rig_id);
             }
             continue;
         }
@@ -2989,6 +3007,34 @@ mod tests {
         assert_eq!(
             lab_offload_rig_ids(&args),
             vec!["static-site-fixture-matrix".to_string()]
+        );
+    }
+
+    #[test]
+    fn lab_offload_rig_ids_uses_selected_id_for_rig_check_package_target() {
+        let args = vec![
+            "homeboy".to_string(),
+            "rig".to_string(),
+            "check".to_string(),
+            "/controller/source-package".to_string(),
+            "--id".to_string(),
+            "mdi-native".to_string(),
+            "--path".to_string(),
+            "/controller/checkout".to_string(),
+        ];
+
+        assert_eq!(lab_offload_rig_ids(&args), vec!["mdi-native".to_string()]);
+
+        let equals_args = vec![
+            "homeboy".to_string(),
+            "rig".to_string(),
+            "check".to_string(),
+            "/controller/source-package".to_string(),
+            "--id=mdi-sqlite".to_string(),
+        ];
+        assert_eq!(
+            lab_offload_rig_ids(&equals_args),
+            vec!["mdi-sqlite".to_string()]
         );
     }
 


### PR DESCRIPTION
## Summary

- resolve `rig check <package> --id <rig>` as the selected rig during Lab staging instead of treating the package path as a registry ID
- preserve the job-scoped rig registry when durable staging rebuilds the final runner environment
- project typed controller-job failure causes through `activity show` and compact activity output

Closes #13920.

## Verification

- `cargo test -p homeboy-lab-runner rig_materialization::tests:: --lib` (47 passed)
- focused durable registry and typed staging error regressions passed
- `cargo test -p homeboy-core activity:: --lib` (42 passed)
- `cargo test -p homeboy-cli commands::activity::tests:: --lib` (19 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the Lab failures, traced the durable staging and activity projection paths, implemented the repair and regression coverage, and ran focused verification under Chris Huber's direction.