### PR TITLE
Consolidate runner artifact result contract ownership

### DIFF
--- a/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
@@ -31,6 +31,9 @@ pub use execution_placement::{
 /// ownership is canonical in `homeboy-runner-contract`.
 pub use homeboy_runner_contract::RunnerLifecycleOwner;
 /// Compatibility exports for established Lab runner consumers. Generic runner
+/// artifact results are canonical in `homeboy-runner-contract`.
+pub use homeboy_runner_contract::{RunnerArtifactRef, RunnerMutationArtifacts};
+/// Compatibility exports for established Lab runner consumers. Generic runner
 /// capability and readiness requests are canonical in `homeboy-runner-contract`.
 pub use homeboy_runner_contract::{
     RunnerCapabilityPreflight, RunnerRequiredTool, RunnerToolCapabilityRequirement,
@@ -98,28 +101,6 @@ pub struct RunnerWorkspaceCurrentSummary {
     pub synthetic_checkout_ref: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub synthetic_checkout_tree: Option<String>,
-}
-
-/// A reference to an artifact produced by a runner job. Plain data describing
-/// where/how to fetch the artifact; behavior-free so core can name it without a
-/// core -> runner edge.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RunnerArtifactRef {
-    pub artifact_id: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub path: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub mime: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub size_bytes: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub sha256: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub transport: Option<String>,
 }
 
 /// How a runner workspace is synced before a job runs.
@@ -306,26 +287,6 @@ pub struct RunnerResourceGuardViolation {
     pub rss_limit_bytes: u64,
     pub process_count: u64,
     pub process_count_limit: u64,
-}
-
-/// Artifact references produced by a runner mutation (patch, file bundle,
-/// operation log). Pure serde data embedded in core job records.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RunnerMutationArtifacts {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub patch_ref: Option<RunnerArtifactRef>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub file_bundle_ref: Option<RunnerArtifactRef>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub operation_log_ref: Option<RunnerArtifactRef>,
-}
-
-impl RunnerMutationArtifacts {
-    pub fn is_empty(&self) -> bool {
-        self.patch_ref.is_none()
-            && self.file_bundle_ref.is_none()
-            && self.operation_log_ref.is_none()
-    }
 }
 
 /// How a runner session is tunneled. Pure serde data (with small label helpers)

--- a/crates/contracts/homeboy-runner-contract/src/artifact.rs
+++ b/crates/contracts/homeboy-runner-contract/src/artifact.rs
@@ -1,0 +1,123 @@
+//! Transport-neutral runner artifact and mutation-result contracts.
+
+use serde::{Deserialize, Serialize};
+
+/// A reference to an artifact produced by a runner job.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerArtifactRef {
+    pub artifact_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mime: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transport: Option<String>,
+}
+
+/// Artifact references produced by a runner mutation.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerMutationArtifacts {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub patch_ref: Option<RunnerArtifactRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_bundle_ref: Option<RunnerArtifactRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operation_log_ref: Option<RunnerArtifactRef>,
+}
+
+impl RunnerMutationArtifacts {
+    pub fn is_empty(&self) -> bool {
+        self.patch_ref.is_none()
+            && self.file_bundle_ref.is_none()
+            && self.operation_log_ref.is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn artifact() -> RunnerArtifactRef {
+        RunnerArtifactRef {
+            artifact_id: "patch".to_string(),
+            name: Some("changes.patch".to_string()),
+            path: Some("artifacts/changes.patch".to_string()),
+            url: Some("https://example.test/changes.patch".to_string()),
+            mime: Some("text/x-diff".to_string()),
+            size_bytes: Some(42),
+            sha256: Some("abc123".to_string()),
+            transport: Some("runner-artifact".to_string()),
+        }
+    }
+
+    #[test]
+    fn artifact_ref_keeps_its_minimal_wire_shape() {
+        let value = serde_json::json!({ "artifact_id": "patch" });
+        let minimal = RunnerArtifactRef {
+            artifact_id: "patch".to_string(),
+            name: None,
+            path: None,
+            url: None,
+            mime: None,
+            size_bytes: None,
+            sha256: None,
+            transport: None,
+        };
+
+        assert_eq!(serde_json::to_value(&minimal).expect("serialize"), value);
+        assert_eq!(
+            serde_json::from_value::<RunnerArtifactRef>(value).expect("deserialize"),
+            minimal
+        );
+    }
+
+    #[test]
+    fn artifact_ref_keeps_its_complete_wire_shape() {
+        assert_eq!(
+            serde_json::to_value(artifact()).expect("serialize"),
+            serde_json::json!({
+                "artifact_id": "patch",
+                "name": "changes.patch",
+                "path": "artifacts/changes.patch",
+                "url": "https://example.test/changes.patch",
+                "mime": "text/x-diff",
+                "size_bytes": 42,
+                "sha256": "abc123",
+                "transport": "runner-artifact",
+            })
+        );
+    }
+
+    #[test]
+    fn mutation_artifacts_omit_absent_refs() {
+        let empty = RunnerMutationArtifacts::default();
+        assert!(empty.is_empty());
+        assert_eq!(
+            serde_json::to_value(&empty).expect("serialize"),
+            serde_json::json!({})
+        );
+        assert_eq!(
+            serde_json::from_value::<RunnerMutationArtifacts>(serde_json::json!({}))
+                .expect("deserialize"),
+            empty
+        );
+
+        let mutation = RunnerMutationArtifacts {
+            patch_ref: Some(artifact()),
+            ..Default::default()
+        };
+        assert!(!mutation.is_empty());
+        let value = serde_json::to_value(mutation).expect("serialize");
+        assert_eq!(value["patch_ref"]["artifact_id"], "patch");
+        assert!(value.get("file_bundle_ref").is_none());
+        assert!(value.get("operation_log_ref").is_none());
+    }
+}

--- a/crates/contracts/homeboy-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-runner-contract/src/lib.rs
@@ -4,9 +4,11 @@
 //! boundaries. Execution behavior and service ownership remain outside this
 //! crate.
 
+mod artifact;
 mod capability;
 mod lifecycle;
 
+pub use artifact::{RunnerArtifactRef, RunnerMutationArtifacts};
 pub use capability::{
     RunnerCapabilityPreflight, RunnerRequiredTool, RunnerToolCapabilityRequirement,
     RunnerToolchainReadinessProbe,

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -23,7 +23,8 @@ use crate::runner_execution_envelope::{
 };
 use crate::secret_env_plan::SecretEnvPlan;
 use crate::source_snapshot::SourceSnapshot;
-use homeboy_lab_runner_contract::{RunnerMutationArtifacts, RunnerResourceMetrics};
+use homeboy_lab_runner_contract::RunnerResourceMetrics;
+use homeboy_runner_contract::RunnerMutationArtifacts;
 
 /// Broker metadata is durable queue input. Keep command-file payloads bounded
 /// before they can be persisted or decoded by a worker.

--- a/crates/homeboy-core/src/observation/runs_service/mod.rs
+++ b/crates/homeboy-core/src/observation/runs_service/mod.rs
@@ -33,7 +33,7 @@ use crate::engine::temp::CleanupSizeTotals;
 use crate::execution_contract::EXECUTION_CONTRACT;
 use crate::Error;
 use crate::Result;
-use homeboy_lab_runner_contract::RunnerArtifactRef;
+use homeboy_runner_contract::RunnerArtifactRef;
 
 /// Output of a successful artifact byte retrieval (whether the bytes came
 /// from a locally-recorded file or from a remote runner).

--- a/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
+++ b/crates/homeboy-core/src/observation/runs_service/runner_evidence.rs
@@ -11,7 +11,7 @@
 
 use std::path::PathBuf;
 
-use homeboy_lab_runner_contract::RunnerArtifactRef;
+use homeboy_runner_contract::RunnerArtifactRef;
 use serde_json::Value;
 
 use crate::error::{Error, Result};

--- a/crates/homeboy-core/src/run_outcome_envelope.rs
+++ b/crates/homeboy-core/src/run_outcome_envelope.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 use crate::artifact_ref::{artifact_uri, ArtifactRef, EvidenceRef, ARTIFACT_REF_SCHEMA};
 use crate::lab_contract::JobArtifactMetadata;
 use crate::runner_execution_envelope::RunnerExecutionRecord;
-use homeboy_lab_runner_contract::RunnerArtifactRef;
+use homeboy_runner_contract::RunnerArtifactRef;
 
 pub const RUN_OUTCOME_ENVELOPE_SCHEMA: &str = "homeboy/run-outcome-envelope/v1";
 pub const RUN_OUTCOME_ENVELOPE_FILE: &str = "run-outcome-envelope.json";

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -175,7 +175,7 @@ pub struct RunnerLeaselessRecoveryEvidence {
 // Re-exported so internal/CLI call sites resolve unchanged. The
 // From<&JobArtifactMetadata> impl stays below (orphan rule: JobArtifactMetadata
 // is core-owned).
-pub use homeboy_lab_runner_contract::RunnerArtifactRef;
+pub use homeboy_runner_contract::RunnerArtifactRef;
 
 /// Build a `RunnerArtifactRef` from a core job artifact. A free function rather
 /// than a `From` impl because both types are foreign to this crate (orphan rule).
@@ -372,7 +372,7 @@ pub struct RunnerWorkspaceLeaseSet {
     pub leases: Vec<RunnerNamedWorkspaceLease>,
 }
 
-pub use homeboy_lab_runner_contract::RunnerMutationArtifacts;
+pub use homeboy_runner_contract::RunnerMutationArtifacts;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RunnerResult {


### PR DESCRIPTION
## Summary

- make `homeboy-runner-contract` the canonical owner of `RunnerArtifactRef` and `RunnerMutationArtifacts`
- migrate core and Lab implementation consumers to the canonical package
- retain `homeboy-lab-runner-contract` compatibility exports
- pin minimal and complete serialized forms without merging distinct artifact contracts

Closes #13926
Parent: #13881

## Verification

- `cargo test -p homeboy-runner-contract`
- `cargo test -p homeboy-lab-runner-contract`
- `cargo test -p homeboy-core run_outcome_envelope`
- `cargo check -p homeboy-lab-runner-contract -p homeboy-lab-runner -p homeboy-core -p homeboy-agents`
- `cargo check -p homeboy-agents --tests`
- `cargo clippy -p homeboy-runner-contract --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo metadata --no-deps --format-version 1`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode inspected the contract boundaries and dependency graph, implemented the ownership move and compatibility exports, added wire-shape regression coverage, and ran the verification commands. Chris Huber selected and authorized this bounded Runner API simplification.