### PR TITLE
Consolidate runner resource telemetry contract ownership

### DIFF
--- a/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
@@ -37,6 +37,11 @@ pub use homeboy_runner_contract::{
     RunnerCapabilityPreflight, RunnerKind, RunnerLifecycleOwner, RunnerRequiredTool,
     RunnerToolCapabilityRequirement, RunnerToolchainReadinessProbe,
 };
+/// Compatibility exports for established Lab runner consumers. Generic runner
+/// resource telemetry is canonical in `homeboy-runner-contract`.
+pub use homeboy_runner_contract::{
+    RunnerResourceGuardLimits, RunnerResourceGuardViolation, RunnerResourceMetrics,
+};
 pub use placement::Placement;
 pub use provider_source_types::AgentTaskProviderRunnerSource;
 
@@ -219,64 +224,6 @@ pub enum LabRunnerGateDecision {
         reason: String,
         remediation: Vec<String>,
     },
-}
-
-/// Resource-usage metrics captured while a runner child process ran. Pure serde
-/// data (no runner behavior) so it can live in the contract and be embedded in
-/// core job records (`api_jobs`) without a core -> runner edge.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RunnerResourceMetrics {
-    pub duration_ms: u64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cpu_user_ms: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cpu_system_ms: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub peak_rss_bytes: Option<u64>,
-    pub sample_count: u64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub child_process_count_peak: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub resource_guard: Option<RunnerResourceGuardLimits>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub guard_violation: Option<RunnerResourceGuardViolation>,
-    pub source: String,
-}
-
-/// The resource-guard limits in force for a runner child process.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RunnerResourceGuardLimits {
-    pub rss_limit_bytes: u64,
-    pub process_count_limit: u64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub process_count_limit_source: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub requested_process_count_limit: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub process_count_limit_ceiling: Option<u64>,
-    pub concurrency: u64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub memory_capacity_bytes: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub host_headroom_bytes: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub aggregate_rss_budget_bytes: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub active_rss_bytes: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub aggregate_rss_bytes: Option<u64>,
-    pub rss_limit_source: String,
-}
-
-/// A resource-guard violation that terminated or flagged a runner child.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RunnerResourceGuardViolation {
-    pub reason: String,
-    pub message: String,
-    pub rss_bytes: u64,
-    pub rss_limit_bytes: u64,
-    pub process_count: u64,
-    pub process_count_limit: u64,
 }
 
 /// How a runner session is tunneled. Pure serde data (with small label helpers)

--- a/crates/contracts/homeboy-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-runner-contract/src/lib.rs
@@ -8,6 +8,7 @@ mod artifact;
 mod capability;
 mod discovery;
 mod lifecycle;
+mod resource;
 
 pub use artifact::{RunnerArtifactRef, RunnerMutationArtifacts};
 pub use capability::{
@@ -20,6 +21,9 @@ pub use discovery::{
     RUNNER_READINESS_SCHEMA,
 };
 pub use lifecycle::{RunnerJobLifecycleMetadata, RunnerLifecycleOwner};
+pub use resource::{
+    RunnerResourceGuardLimits, RunnerResourceGuardViolation, RunnerResourceMetrics,
+};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/crates/contracts/homeboy-runner-contract/src/resource.rs
+++ b/crates/contracts/homeboy-runner-contract/src/resource.rs
@@ -1,0 +1,129 @@
+//! Transport-neutral runner resource telemetry contracts.
+
+use serde::{Deserialize, Serialize};
+
+/// Resource-usage metrics captured while a runner child process ran.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerResourceMetrics {
+    pub duration_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu_user_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu_system_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub peak_rss_bytes: Option<u64>,
+    pub sample_count: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_process_count_peak: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource_guard: Option<RunnerResourceGuardLimits>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub guard_violation: Option<RunnerResourceGuardViolation>,
+    pub source: String,
+}
+
+/// The resource-guard limits in force for a runner child process.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerResourceGuardLimits {
+    pub rss_limit_bytes: u64,
+    pub process_count_limit: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub process_count_limit_source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_process_count_limit: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub process_count_limit_ceiling: Option<u64>,
+    pub concurrency: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_capacity_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host_headroom_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aggregate_rss_budget_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_rss_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aggregate_rss_bytes: Option<u64>,
+    pub rss_limit_source: String,
+}
+
+/// A resource-guard violation that terminated or flagged a runner child.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerResourceGuardViolation {
+    pub reason: String,
+    pub message: String,
+    pub rss_bytes: u64,
+    pub rss_limit_bytes: u64,
+    pub process_count: u64,
+    pub process_count_limit: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resource_metrics_keep_their_minimal_wire_shape() {
+        let value = serde_json::json!({
+            "duration_ms": 25,
+            "sample_count": 2,
+            "source": "process-tree",
+        });
+        let metrics = RunnerResourceMetrics {
+            duration_ms: 25,
+            cpu_user_ms: None,
+            cpu_system_ms: None,
+            peak_rss_bytes: None,
+            sample_count: 2,
+            child_process_count_peak: None,
+            resource_guard: None,
+            guard_violation: None,
+            source: "process-tree".to_string(),
+        };
+
+        assert_eq!(serde_json::to_value(&metrics).expect("serialize"), value);
+        assert_eq!(
+            serde_json::from_value::<RunnerResourceMetrics>(value).expect("deserialize"),
+            metrics
+        );
+    }
+
+    #[test]
+    fn resource_metrics_keep_their_complete_wire_shape() {
+        let value = serde_json::json!({
+            "duration_ms": 25,
+            "cpu_user_ms": 11,
+            "cpu_system_ms": 7,
+            "peak_rss_bytes": 512,
+            "sample_count": 2,
+            "child_process_count_peak": 3,
+            "resource_guard": {
+                "rss_limit_bytes": 1024,
+                "process_count_limit": 8,
+                "process_count_limit_source": "configured",
+                "requested_process_count_limit": 10,
+                "process_count_limit_ceiling": 8,
+                "concurrency": 2,
+                "memory_capacity_bytes": 4096,
+                "host_headroom_bytes": 512,
+                "aggregate_rss_budget_bytes": 2048,
+                "active_rss_bytes": 256,
+                "aggregate_rss_bytes": 768,
+                "rss_limit_source": "host-capacity",
+            },
+            "guard_violation": {
+                "reason": "rss_limit_exceeded",
+                "message": "runner child exceeded its RSS limit",
+                "rss_bytes": 1536,
+                "rss_limit_bytes": 1024,
+                "process_count": 3,
+                "process_count_limit": 8,
+            },
+            "source": "process-tree",
+        });
+
+        let metrics =
+            serde_json::from_value::<RunnerResourceMetrics>(value.clone()).expect("deserialize");
+        assert_eq!(serde_json::to_value(metrics).expect("serialize"), value);
+    }
+}

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -23,8 +23,7 @@ use crate::runner_execution_envelope::{
 };
 use crate::secret_env_plan::SecretEnvPlan;
 use crate::source_snapshot::SourceSnapshot;
-use homeboy_lab_runner_contract::RunnerResourceMetrics;
-use homeboy_runner_contract::RunnerMutationArtifacts;
+use homeboy_runner_contract::{RunnerMutationArtifacts, RunnerResourceMetrics};
 
 /// Broker metadata is durable queue input. Keep command-file payloads bounded
 /// before they can be persisted or decoded by a worker.

--- a/crates/homeboy-lab-runner/src/resource_metrics.rs
+++ b/crates/homeboy-lab-runner/src/resource_metrics.rs
@@ -55,7 +55,7 @@ fn require_process_tree_isolation() -> Result<()> {
 // Resource-metrics data types now live in homeboy-runner-contract (pure serde,
 // embedded in core api_jobs records) so core has no core -> runner edge.
 // Re-exported so runner-internal call sites resolve unchanged.
-pub use homeboy_lab_runner_contract::{
+pub use homeboy_runner_contract::{
     RunnerResourceGuardLimits, RunnerResourceGuardViolation, RunnerResourceMetrics,
 };
 


### PR DESCRIPTION
## Summary

- make `homeboy-runner-contract` the canonical owner of runner resource metrics, guard limits, and guard violations
- migrate core and Lab implementation consumers to the canonical package
- retain `homeboy-lab-runner-contract` compatibility exports
- pin minimal and complete serialized forms while leaving sampling and enforcement behavior in Lab

Closes #13932
Parent: #13881

## Verification

- `cargo test -p homeboy-runner-contract`
- `cargo test -p homeboy-lab-runner-contract`
- `cargo test -p homeboy-lab-runner resource_metrics`
- `cargo test -p homeboy-lab-runner worker::tests::result_tests`
- `cargo check -p homeboy-lab-runner-contract -p homeboy-lab-runner -p homeboy-core -p homeboy-agents`
- `cargo clippy -p homeboy-runner-contract --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo metadata --no-deps --format-version 1`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode inspected the telemetry ownership and dependency graph, implemented the contract move and compatibility exports, added wire-shape regression coverage, rebased onto the concurrently merged Runner discovery API, and ran the verification commands. Chris Huber selected and authorized this bounded Runner API simplification.