### PR TITLE
Remove the extension validation facade

### DIFF
--- a/crates/homeboy-core/src/extension/build/mod.rs
+++ b/crates/homeboy-core/src/extension/build/mod.rs
@@ -59,6 +59,15 @@ impl ResolvedBuildCommand {
     }
 }
 
+fn extension_provides_build(component: &Component) -> bool {
+    component.extensions.as_ref().is_some_and(|extensions| {
+        extensions.keys().any(|extension_id| {
+            crate::extension::catalog::load_extension(extension_id)
+                .is_ok_and(|extension| extension.has_build())
+        })
+    })
+}
+
 /// Resolve build command for a component using extension-managed build configuration.
 ///
 /// Priority:
@@ -126,7 +135,7 @@ pub(crate) fn resolve_build_command(component: &Component) -> Result<ResolvedBui
         }
     }
 
-    if extension::extension_provides_build(component) {
+    if extension_provides_build(component) {
         Err(Error::validation_invalid_argument(
             "buildCommand",
             format!(
@@ -462,7 +471,7 @@ fn execute_build_component(
 
     // Validate required extensions are installed before resolving build commands.
     // Without this, missing extensions cause vague "no build command" errors.
-    extension::validate_required_extensions(comp)?;
+    extension::resolve::validate_required_extensions(comp)?;
 
     // Validate local_path before attempting build
     let validated_path = component::validate_local_path(comp)?;
@@ -913,6 +922,11 @@ fn run_pre_build_scripts(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn component_without_extensions_has_no_extension_build() {
+        assert!(!extension_provides_build(&Component::default()));
+    }
 
     #[test]
     fn build_timeout_preserves_long_default_and_accepts_override() {

--- a/crates/homeboy-core/src/extension/build/mod.rs
+++ b/crates/homeboy-core/src/extension/build/mod.rs
@@ -924,11 +924,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn component_without_extensions_has_no_extension_build() {
-        assert!(!extension_provides_build(&Component::default()));
-    }
-
-    #[test]
     fn build_timeout_preserves_long_default_and_accepts_override() {
         assert_eq!(build_timeout_from(None), Duration::from_secs(30 * 60));
         assert_eq!(build_timeout_from(Some("7200")), Duration::from_secs(7200));

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -21,7 +21,6 @@ pub mod self_check;
 mod setup_env;
 pub mod test;
 pub mod trace;
-mod validation;
 
 pub use compiler_warning_contract::{
     extensions_for_compiler_warning_contract, run_compiler_warning_contract_script,
@@ -39,9 +38,6 @@ pub use refactor_protocol::{
     run_refactor_script, run_refactor_script_result, AdjustedItem, ParsedItem,
     RefactorScriptFailure, RefactorScriptFailureKind, RelatedTests, ResolvedImports,
     RewrittenImport,
-};
-pub use validation::{
-    extension_provides_build, validate_extension_requirements, validate_required_extensions,
 };
 
 #[cfg(test)]

--- a/crates/homeboy-core/src/extension/resolve/mod.rs
+++ b/crates/homeboy-core/src/extension/resolve/mod.rs
@@ -9,8 +9,10 @@ use crate::extension::catalog::{extension_path, load_extension, load_extension_i
 use crate::extension::invoke::ResolvedExtensionInvocationContext;
 use homeboy_extension_contract::{ExtensionCapability, ExtensionManifest};
 
+mod requirements;
 mod surface;
 
+pub use requirements::{validate_extension_requirements, validate_required_extensions};
 pub use surface::{
     find_installed_file_extension, find_installed_file_extension_in_root, resolve_file_extension,
     resolve_file_extension_in_root, FileExtensionCapability, FILE_EXTENSIONS_SURFACE,

--- a/crates/homeboy-core/src/extension/resolve/requirements.rs
+++ b/crates/homeboy-core/src/extension/resolve/requirements.rs
@@ -193,23 +193,6 @@ fn extension_source(ext_config: &homeboy_core::component::ScopedExtensionConfig)
         .filter(|value| !value.trim().is_empty())
 }
 
-/// Check if any of the component's linked extensions provide build configuration.
-pub fn extension_provides_build(component: &homeboy_core::component::Component) -> bool {
-    let extensions = match &component.extensions {
-        Some(m) => m,
-        None => return false,
-    };
-
-    for extension_id in extensions.keys() {
-        if let Ok(extension) = load_extension(extension_id) {
-            if extension.has_build() {
-                return true;
-            }
-        }
-    }
-    false
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -233,16 +216,6 @@ mod tests {
         };
 
         assert!(validate_extension_requirements(&component).is_ok());
-    }
-
-    #[test]
-    fn test_extension_provides_build() {
-        let component = Component {
-            id: "plain".to_string(),
-            ..Default::default()
-        };
-
-        assert!(!extension_provides_build(&component));
     }
 
     fn component_requiring(extension_id: &str, version: &str) -> Component {

--- a/crates/homeboy-core/src/extension/tests.rs
+++ b/crates/homeboy-core/src/extension/tests.rs
@@ -785,7 +785,7 @@ fn validate_required_extensions_passes_with_no_modules() {
         id: "test-component".to_string(),
         ..Default::default()
     };
-    assert!(validate_required_extensions(&comp).is_ok());
+    assert!(resolve::validate_required_extensions(&comp).is_ok());
 }
 
 #[test]
@@ -795,7 +795,7 @@ fn validate_required_extensions_passes_with_empty_modules() {
         extensions: Some(HashMap::new()),
         ..Default::default()
     };
-    assert!(validate_required_extensions(&comp).is_ok());
+    assert!(resolve::validate_required_extensions(&comp).is_ok());
 }
 
 #[test]
@@ -810,7 +810,7 @@ fn validate_required_extensions_fails_with_missing_module() {
         extensions: Some(extensions),
         ..Default::default()
     };
-    let err = validate_required_extensions(&comp).unwrap_err();
+    let err = resolve::validate_required_extensions(&comp).unwrap_err();
     assert_eq!(err.code, homeboy_core::error::ErrorCode::ExtensionNotFound);
     assert!(err.message.contains("nonexistent-extension-abc123"));
     assert!(err.message.contains("test-component"));
@@ -846,7 +846,7 @@ fn validate_required_extensions_uses_declared_extension_source_hint() {
         ..Default::default()
     };
 
-    let err = validate_required_extensions(&comp).unwrap_err();
+    let err = resolve::validate_required_extensions(&comp).unwrap_err();
     let hints = err
         .hints
         .iter()
@@ -876,7 +876,7 @@ fn validate_required_extensions_reports_all_missing() {
         extensions: Some(extensions),
         ..Default::default()
     };
-    let err = validate_required_extensions(&comp).unwrap_err();
+    let err = resolve::validate_required_extensions(&comp).unwrap_err();
     // Error should mention both missing extensions
     assert!(err.message.contains("missing-mod-a"));
     assert!(err.message.contains("missing-mod-b"));
@@ -890,7 +890,7 @@ fn test_validate_extension_requirements() {
         id: "test-component".to_string(),
         ..Default::default()
     };
-    assert!(validate_extension_requirements(&comp).is_ok());
+    assert!(resolve::validate_extension_requirements(&comp).is_ok());
 }
 
 #[test]

--- a/crates/homeboy-deploy/src/planning.rs
+++ b/crates/homeboy-deploy/src/planning.rs
@@ -812,7 +812,7 @@ pub(super) fn load_project_components_with_projection(
         // Validate required extensions are installed before attempting artifact resolution.
         // Without this check, missing extensions cause resolve_artifact() to silently
         // return None, and the component gets skipped with a vague "no artifact" message.
-        if let Err(err) = extension::validate_required_extensions(&loaded) {
+        if let Err(err) = extension::resolve::validate_required_extensions(&loaded) {
             if check {
                 // Read-only diff: a missing extension must not poison the whole pass.
                 // Skip-and-warn so operators still see the diff for the components they

--- a/homeboy.json
+++ b/homeboy.json
@@ -640,6 +640,16 @@
         "forbid": {
           "glob": "crates/**",
           "patterns": [
+            "\\bextension::validation::",
+            "\\bextension::(?:extension_provides_build|validate_extension_requirements|validate_required_extensions)\\b"
+          ]
+        },
+        "name": "extensions-use-owned-validation-api"
+      },
+      {
+        "forbid": {
+          "glob": "crates/**",
+          "patterns": [
             "\\bextension_execution\\b",
             "\\bfind_extension_for_file_ext\\b"
           ]


### PR DESCRIPTION
## Summary

- move component extension requirement checks under `extension::resolve`
- move build-capability detection into `extension::build`
- remove the mixed validation module and flat facade exports
- ratchet against legacy validation paths

Closes #13931
Parent: #13882

## Verification

- `cargo nextest run -p homeboy-core --lib -E 'test(extension::resolve::requirements) | test(extension::tests::test_validate_)'` (5 passed)\n- `cargo check --workspace --all-targets`\n- `cargo run -q -p homeboy -- review audit --profile architecture --changed-since origin/main --placement local` (0 introduced findings)\n\nThe workspace check retains one pre-existing unused test import warning in `observation/store/artifacts.rs`.\n\n---\n\nAI assistance: OpenAI GPT-5.6 Sol via OpenCode audited the mixed facade, split behavior into canonical owners, migrated consumers, and ran verification under Chris Huber's direction.