### PR TITLE
Consolidate persisted runner session contract ownership

### DIFF
--- a/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
@@ -37,6 +37,12 @@ pub use homeboy_runner_contract::{
     RunnerCapabilityPreflight, RunnerKind, RunnerLifecycleOwner, RunnerRequiredTool,
     RunnerToolCapabilityRequirement, RunnerToolchainReadinessProbe,
 };
+/// Compatibility exports for established Lab runner consumers. Persisted
+/// session and tunnel records are canonical in `homeboy-runner-contract`.
+pub use homeboy_runner_contract::{
+    RunnerProxyForward, RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerTunnelMode,
+    RunnerTunnelProcessStartIdentity,
+};
 /// Compatibility exports for established Lab runner consumers. Generic runner
 /// resource telemetry is canonical in `homeboy-runner-contract`.
 pub use homeboy_runner_contract::{
@@ -154,153 +160,6 @@ pub enum LabRunnerGateDecision {
         reason: String,
         remediation: Vec<String>,
     },
-}
-
-/// How a runner session is tunneled. Pure serde data (with small label helpers)
-/// so the core daemon can build/persist sessions without a core -> runner edge.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum RunnerTunnelMode {
-    DirectSsh,
-    Reverse,
-}
-
-impl RunnerTunnelMode {
-    /// This mode rendered for humans — `direct SSH`, `reverse-connected`.
-    ///
-    /// A different vocabulary, not a different format of
-    /// [`RunnerTunnelMode::metadata_value`]: this is prose for operator-facing
-    /// output, and it is deliberately not the wire string. Merging the two
-    /// would put a space and a hyphen into persisted metadata that
-    /// `#[serde(rename_all = "snake_case")]` spells `direct_ssh`, with no
-    /// compile error to catch it.
-    pub fn label(&self) -> &'static str {
-        self.labels().0
-    }
-
-    /// This mode as its own canonical wire string — the value `serde` already
-    /// produces, pinned to it by
-    /// `runner_tunnel_mode_metadata_value_matches_its_serialized_form`.
-    ///
-    /// Unlike [`RunnerTunnelMode::label`], this is a hand-written restatement
-    /// of the derived form, so it can drift silently on a variant rename or a
-    /// serde attribute change (#13400). The pin is what stops that.
-    pub fn metadata_value(&self) -> &'static str {
-        self.labels().1
-    }
-
-    fn labels(&self) -> (&'static str, &'static str) {
-        match self {
-            RunnerTunnelMode::DirectSsh => ("direct SSH", "direct_ssh"),
-            RunnerTunnelMode::Reverse => ("reverse-connected", "reverse"),
-        }
-    }
-}
-
-fn default_tunnel_mode() -> RunnerTunnelMode {
-    RunnerTunnelMode::DirectSsh
-}
-
-/// Which side owns a runner session.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum RunnerSessionRole {
-    Controller,
-    Runner,
-}
-
-fn default_session_role() -> RunnerSessionRole {
-    RunnerSessionRole::Controller
-}
-
-/// The connectivity state of a runner session.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum RunnerSessionState {
-    Connected,
-    Disconnected,
-    Recorded,
-}
-
-/// Kernel-derived identity for one local tunnel process instance. This survives
-/// controller restart so a recycled PID is never signaled from durable state.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "platform", rename_all = "snake_case")]
-pub enum RunnerTunnelProcessStartIdentity {
-    Linux {
-        starttime_ticks: u64,
-    },
-    Macos {
-        start_seconds: u64,
-        start_microseconds: u64,
-    },
-}
-
-/// A controller-owned reverse forward that exposes a controller-local proxy to
-/// a direct SSH runner. The URL is safe to pass to a runner process: it points
-/// at the runner loopback listener and never carries controller credentials.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RunnerProxyForward {
-    pub runner_url: String,
-    pub tunnel_pid: u32,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tunnel_process_start_identity: Option<RunnerTunnelProcessStartIdentity>,
-}
-
-/// A persisted runner session record. Pure serde data so the core daemon's
-/// `/runner/sessions` endpoints can build and persist sessions without a
-/// core -> runner edge. `leaseless_recovery_evidence` is carried as opaque JSON
-/// (the runner layer owns its typed `RunnerLeaselessRecoveryEvidence`); the
-/// daemon never populates it, so the JSON roundtrips identically.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RunnerSession {
-    pub runner_id: String,
-    #[serde(default = "default_tunnel_mode")]
-    pub mode: RunnerTunnelMode,
-    #[serde(default = "default_session_role")]
-    pub role: RunnerSessionRole,
-    pub server_id: Option<String>,
-    #[serde(default)]
-    pub controller_id: Option<String>,
-    #[serde(default)]
-    pub broker_url: Option<String>,
-    #[serde(default)]
-    pub remote_daemon_address: Option<String>,
-    #[serde(default)]
-    pub local_port: Option<u16>,
-    #[serde(default)]
-    pub local_url: Option<String>,
-    pub tunnel_pid: Option<u32>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tunnel_process_start_identity: Option<RunnerTunnelProcessStartIdentity>,
-    /// Optional controller proxy exposure owned with this direct SSH session.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub proxy_forward: Option<RunnerProxyForward>,
-    pub remote_daemon_pid: Option<u32>,
-    #[serde(default)]
-    pub remote_daemon_lease_id: Option<String>,
-    pub homeboy_version: String,
-    #[serde(default)]
-    pub homeboy_build_identity: Option<String>,
-    pub connected_at: String,
-    #[serde(default)]
-    pub worker_identity: Option<String>,
-    #[serde(default)]
-    pub worker_pid: Option<u32>,
-    #[serde(default)]
-    pub last_seen_at: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub leaseless_recovery_evidence: Option<serde_json::Value>,
-}
-
-impl RunnerSession {
-    /// Which side owns this session's lifecycle, derived from its role.
-    pub fn lifecycle_owner(&self) -> RunnerLifecycleOwner {
-        match self.role {
-            RunnerSessionRole::Controller => RunnerLifecycleOwner::Controller,
-            RunnerSessionRole::Runner => RunnerLifecycleOwner::Runner,
-        }
-    }
 }
 
 /// A versioned Lab contract required by a controller or advertised by an
@@ -593,36 +452,6 @@ fn advertised_capability_versions(
             .insert(capability.version);
     }
     versions
-}
-
-#[cfg(test)]
-mod runner_tunnel_mode_label_tests {
-    use super::RunnerTunnelMode;
-
-    /// `metadata_value` restates what `#[serde(rename_all = "snake_case")]`
-    /// already produces. It agrees today, which is exactly the state
-    /// `RunnerWorkspaceSyncMode` was in before it drifted — nothing tied the
-    /// copy to its source. This is that tie (#13400).
-    #[test]
-    fn runner_tunnel_mode_metadata_value_matches_its_serialized_form() {
-        for mode in [RunnerTunnelMode::DirectSsh, RunnerTunnelMode::Reverse] {
-            assert_eq!(
-                serde_json::to_value(&mode).expect("serialize"),
-                serde_json::json!(mode.metadata_value()),
-                "{mode:?}"
-            );
-        }
-    }
-
-    /// `label` is a different vocabulary, not a different format, and merging
-    /// it into `metadata_value` would push prose into persisted metadata
-    /// through a string assignment with no compile error. It fails here
-    /// instead.
-    #[test]
-    fn the_operator_facing_vocabulary_stays_prose() {
-        assert_eq!(RunnerTunnelMode::DirectSsh.label(), "direct SSH");
-        assert_eq!(RunnerTunnelMode::Reverse.label(), "reverse-connected");
-    }
 }
 
 #[cfg(test)]

--- a/crates/contracts/homeboy-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-runner-contract/src/lib.rs
@@ -9,6 +9,7 @@ mod capability;
 mod discovery;
 mod lifecycle;
 mod resource;
+mod session;
 mod workspace;
 
 pub use artifact::{RunnerArtifactRef, RunnerMutationArtifacts};
@@ -24,6 +25,10 @@ pub use discovery::{
 pub use lifecycle::{RunnerJobLifecycleMetadata, RunnerLifecycleOwner};
 pub use resource::{
     RunnerResourceGuardLimits, RunnerResourceGuardViolation, RunnerResourceMetrics,
+};
+pub use session::{
+    RunnerProxyForward, RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerTunnelMode,
+    RunnerTunnelProcessStartIdentity,
 };
 pub use workspace::{RunnerWorkspaceCurrentSummary, RunnerWorkspaceLease, RunnerWorkspaceSyncMode};
 

--- a/crates/contracts/homeboy-runner-contract/src/session.rs
+++ b/crates/contracts/homeboy-runner-contract/src/session.rs
@@ -1,0 +1,247 @@
+//! Transport-neutral persisted runner session contracts.
+
+use serde::{Deserialize, Serialize};
+
+use crate::RunnerLifecycleOwner;
+
+/// How a runner session is tunneled.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerTunnelMode {
+    DirectSsh,
+    Reverse,
+}
+
+impl RunnerTunnelMode {
+    /// This mode rendered for humans: `direct SSH`, `reverse-connected`.
+    ///
+    /// This deliberately differs from the persisted metadata vocabulary.
+    pub fn label(&self) -> &'static str {
+        self.labels().0
+    }
+
+    /// This mode as its canonical wire string. Tests pin this hand-written
+    /// restatement to the derived serde representation.
+    pub fn metadata_value(&self) -> &'static str {
+        self.labels().1
+    }
+
+    fn labels(&self) -> (&'static str, &'static str) {
+        match self {
+            RunnerTunnelMode::DirectSsh => ("direct SSH", "direct_ssh"),
+            RunnerTunnelMode::Reverse => ("reverse-connected", "reverse"),
+        }
+    }
+}
+
+fn default_tunnel_mode() -> RunnerTunnelMode {
+    RunnerTunnelMode::DirectSsh
+}
+
+/// Which side owns a runner session.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerSessionRole {
+    Controller,
+    Runner,
+}
+
+fn default_session_role() -> RunnerSessionRole {
+    RunnerSessionRole::Controller
+}
+
+/// The connectivity state of a runner session.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerSessionState {
+    Connected,
+    Disconnected,
+    Recorded,
+}
+
+/// Kernel-derived identity for one local tunnel process instance. This survives
+/// controller restart so a recycled PID is never signaled from durable state.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "platform", rename_all = "snake_case")]
+pub enum RunnerTunnelProcessStartIdentity {
+    Linux {
+        starttime_ticks: u64,
+    },
+    Macos {
+        start_seconds: u64,
+        start_microseconds: u64,
+    },
+}
+
+/// A controller-owned reverse forward that exposes a controller-local proxy to
+/// a direct SSH runner. The URL points at the runner loopback listener and
+/// carries no controller credentials.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerProxyForward {
+    pub runner_url: String,
+    pub tunnel_pid: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tunnel_process_start_identity: Option<RunnerTunnelProcessStartIdentity>,
+}
+
+/// A persisted runner session record. `leaseless_recovery_evidence` remains
+/// opaque JSON because the runner implementation owns its typed representation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunnerSession {
+    pub runner_id: String,
+    #[serde(default = "default_tunnel_mode")]
+    pub mode: RunnerTunnelMode,
+    #[serde(default = "default_session_role")]
+    pub role: RunnerSessionRole,
+    pub server_id: Option<String>,
+    #[serde(default)]
+    pub controller_id: Option<String>,
+    #[serde(default)]
+    pub broker_url: Option<String>,
+    #[serde(default)]
+    pub remote_daemon_address: Option<String>,
+    #[serde(default)]
+    pub local_port: Option<u16>,
+    #[serde(default)]
+    pub local_url: Option<String>,
+    pub tunnel_pid: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tunnel_process_start_identity: Option<RunnerTunnelProcessStartIdentity>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proxy_forward: Option<RunnerProxyForward>,
+    pub remote_daemon_pid: Option<u32>,
+    #[serde(default)]
+    pub remote_daemon_lease_id: Option<String>,
+    pub homeboy_version: String,
+    #[serde(default)]
+    pub homeboy_build_identity: Option<String>,
+    pub connected_at: String,
+    #[serde(default)]
+    pub worker_identity: Option<String>,
+    #[serde(default)]
+    pub worker_pid: Option<u32>,
+    #[serde(default)]
+    pub last_seen_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub leaseless_recovery_evidence: Option<serde_json::Value>,
+}
+
+impl RunnerSession {
+    /// Which side owns this session's lifecycle, derived from its role.
+    pub fn lifecycle_owner(&self) -> RunnerLifecycleOwner {
+        match self.role {
+            RunnerSessionRole::Controller => RunnerLifecycleOwner::Controller,
+            RunnerSessionRole::Runner => RunnerLifecycleOwner::Runner,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minimal_session() -> RunnerSession {
+        serde_json::from_value(serde_json::json!({
+            "runner_id": "runner-1",
+            "server_id": null,
+            "tunnel_pid": null,
+            "remote_daemon_pid": null,
+            "homeboy_version": "1.0.0",
+            "connected_at": "2026-08-30T00:00:00Z"
+        }))
+        .expect("deserialize")
+    }
+
+    #[test]
+    fn session_defaults_and_optional_fields_keep_their_wire_shape() {
+        let session = minimal_session();
+        assert_eq!(session.mode, RunnerTunnelMode::DirectSsh);
+        assert_eq!(session.role, RunnerSessionRole::Controller);
+        assert_eq!(session.lifecycle_owner(), RunnerLifecycleOwner::Controller);
+        assert_eq!(
+            serde_json::to_value(session).expect("serialize"),
+            serde_json::json!({
+                "runner_id": "runner-1",
+                "mode": "direct_ssh",
+                "role": "controller",
+                "server_id": null,
+                "controller_id": null,
+                "broker_url": null,
+                "remote_daemon_address": null,
+                "local_port": null,
+                "local_url": null,
+                "tunnel_pid": null,
+                "remote_daemon_pid": null,
+                "remote_daemon_lease_id": null,
+                "homeboy_version": "1.0.0",
+                "homeboy_build_identity": null,
+                "connected_at": "2026-08-30T00:00:00Z",
+                "worker_identity": null,
+                "worker_pid": null,
+                "last_seen_at": null
+            })
+        );
+    }
+
+    #[test]
+    fn complete_session_keeps_nested_identity_and_recovery_data() {
+        let value = serde_json::json!({
+            "runner_id": "runner-1",
+            "mode": "reverse",
+            "role": "runner",
+            "server_id": "server-1",
+            "controller_id": "controller-1",
+            "broker_url": "https://broker.example.test",
+            "remote_daemon_address": "127.0.0.1:9000",
+            "local_port": 9001,
+            "local_url": "http://127.0.0.1:9001",
+            "tunnel_pid": 101,
+            "tunnel_process_start_identity": {
+                "platform": "linux",
+                "starttime_ticks": 200
+            },
+            "proxy_forward": {
+                "runner_url": "http://127.0.0.1:9002",
+                "tunnel_pid": 102,
+                "tunnel_process_start_identity": {
+                    "platform": "macos",
+                    "start_seconds": 300,
+                    "start_microseconds": 400
+                }
+            },
+            "remote_daemon_pid": 103,
+            "remote_daemon_lease_id": "lease-1",
+            "homeboy_version": "1.0.0",
+            "homeboy_build_identity": "build-1",
+            "connected_at": "2026-08-30T00:00:00Z",
+            "worker_identity": "worker-1",
+            "worker_pid": 104,
+            "last_seen_at": "2026-08-30T00:01:00Z",
+            "leaseless_recovery_evidence": { "reason": "state-loss" }
+        });
+
+        let session = serde_json::from_value::<RunnerSession>(value.clone()).expect("deserialize");
+        assert_eq!(session.lifecycle_owner(), RunnerLifecycleOwner::Runner);
+        assert_eq!(serde_json::to_value(session).expect("serialize"), value);
+    }
+
+    #[test]
+    fn session_enum_vocabulary_stays_canonical() {
+        for (mode, wire, label) in [
+            (RunnerTunnelMode::DirectSsh, "direct_ssh", "direct SSH"),
+            (RunnerTunnelMode::Reverse, "reverse", "reverse-connected"),
+        ] {
+            assert_eq!(serde_json::to_value(&mode).expect("serialize"), wire);
+            assert_eq!(mode.metadata_value(), wire);
+            assert_eq!(mode.label(), label);
+        }
+
+        for (state, wire) in [
+            (RunnerSessionState::Connected, "connected"),
+            (RunnerSessionState::Disconnected, "disconnected"),
+            (RunnerSessionState::Recorded, "recorded"),
+        ] {
+            assert_eq!(serde_json::to_value(state).expect("serialize"), wire);
+        }
+    }
+}

--- a/crates/homeboy-core/src/daemon/remote_runner.rs
+++ b/crates/homeboy-core/src/daemon/remote_runner.rs
@@ -9,7 +9,7 @@ use crate::api_jobs::{
 use crate::broker_auth::{BrokerAuthStore, BrokerScope};
 use crate::error::{Error, Result};
 use crate::paths;
-use homeboy_lab_runner_contract::{RunnerSession, RunnerSessionRole, RunnerTunnelMode};
+use homeboy_runner_contract::{RunnerSession, RunnerSessionRole, RunnerTunnelMode};
 
 /// Per-request broker authentication context extracted from the network layer.
 ///

--- a/crates/homeboy-lab-runner/src/session.rs
+++ b/crates/homeboy-lab-runner/src/session.rs
@@ -20,13 +20,13 @@ mod session_enums {
     // (dev_run, run_outcome_envelope, and the types that reference it) can name it
     // without a core -> runner edge. Re-exported so runner-internal call sites
     // resolve unchanged.
-    pub use homeboy_lab_runner_contract::RunnerLifecycleOwner;
+    pub use homeboy_runner_contract::RunnerLifecycleOwner;
 
     // Session data types (RunnerTunnelMode, RunnerSessionRole, RunnerSessionState,
     // RunnerSession) now live in homeboy-runner-contract so the core daemon can
     // build/persist sessions without a core -> runner edge. Re-exported so
     // runner-internal call sites resolve unchanged.
-    pub use homeboy_lab_runner_contract::{
+    pub use homeboy_runner_contract::{
         RunnerProxyForward, RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerTunnelMode,
         RunnerTunnelProcessStartIdentity,
     };


### PR DESCRIPTION
## Summary

- make `homeboy-runner-contract` the canonical owner of persisted runner sessions, tunnel modes, roles, states, process identities, and proxy forwards
- migrate core and Lab implementation consumers to the canonical package
- retain `homeboy-lab-runner-contract` compatibility exports
- pin defaults, wire vocabularies, complete nested identities, opaque recovery JSON, and lifecycle-owner derivation
- leave tunnel, process, networking, recovery, persistence I/O, and cleanup behavior in the existing implementation layers

Closes #13935
Parent: #13881

## Verification

- `cargo test -p homeboy-runner-contract`
- `cargo test -p homeboy-lab-runner-contract`
- `cargo test -p homeboy-core daemon::remote_runner`
- `cargo test -p homeboy-lab-runner session::` (106 tests)
- `cargo check -p homeboy-core -p homeboy-lab-runner -p homeboy-agents --tests`
- `cargo clippy -p homeboy-runner-contract --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo metadata --no-deps --format-version 1`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode mapped the persisted session boundary, implemented the canonical ownership move and compatibility exports, added wire-shape regression coverage, rebased and resolved export-only overlap with the concurrently merged workspace-state contract, and ran the verification commands. Chris Huber selected and authorized this bounded Runner API simplification.