### PR TITLE
Remove flat extension recipe-run exports

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/runner/dispatch.rs
@@ -317,7 +317,7 @@ pub fn run(args: RunnerArgs) -> CmdResult<RunnerCommandOutput> {
             RunnerCommandOutput::RecipeRunProviders(Box::new(RecipeRunProvidersOutput {
                 variant: "recipe_run_providers",
                 command: "list",
-                providers: homeboy_core::extension::recipe_run_provider_inventory(),
+                providers: homeboy_core::extension::recipe_run::recipe_run_provider_inventory(),
             })),
             0,
         )),

--- a/crates/homeboy-cli/src/commands/runner/recipe_run.rs
+++ b/crates/homeboy-cli/src/commands/runner/recipe_run.rs
@@ -24,10 +24,10 @@ pub(super) fn recipe_run(
             None,
         ));
     }
-    let descriptor = homeboy_core::extension::resolve_recipe_run_provider(provider_id)?;
-    let command = homeboy_core::extension::render_recipe_run_command(
+    let descriptor = homeboy_core::extension::recipe_run::resolve_recipe_run_provider(provider_id)?;
+    let command = homeboy_core::extension::recipe_run::render_recipe_run_command(
         &descriptor,
-        &homeboy_core::extension::RecipeRunRequest {
+        &homeboy_core::extension::recipe_run::RecipeRunRequest {
             recipe_path: recipe,
             artifact_path: artifacts.clone(),
         },

--- a/crates/homeboy-cli/src/commands/runner/types.rs
+++ b/crates/homeboy-cli/src/commands/runner/types.rs
@@ -522,7 +522,7 @@ pub enum RunnerCommandOutput {
 pub struct RecipeRunProvidersOutput {
     pub variant: &'static str,
     pub command: &'static str,
-    pub providers: Vec<homeboy_core::extension::RecipeRunProviderInventoryEntry>,
+    pub providers: Vec<homeboy_core::extension::recipe_run::RecipeRunProviderInventoryEntry>,
 }
 
 /// An authoritative job observation or a retained generation ownership record.

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -30,10 +30,6 @@ pub(crate) use homeboy_core::extension::resolve::{extension_guidance_hints, stde
 
 pub use fingerprint::run_fingerprint_script;
 pub(crate) use invoke::build_settings_json_from_manifest;
-pub use recipe_run::{
-    recipe_run_provider_inventory, render_recipe_run_command, resolve_recipe_run_provider,
-    RecipeRunProviderInventoryEntry, RecipeRunProviderValidation, RecipeRunRequest,
-};
 pub use refactor_protocol::{
     run_refactor_script, run_refactor_script_result, AdjustedItem, ParsedItem,
     RefactorScriptFailure, RefactorScriptFailureKind, RelatedTests, ResolvedImports,

--- a/homeboy.json
+++ b/homeboy.json
@@ -650,6 +650,15 @@
         "forbid": {
           "glob": "crates/**",
           "patterns": [
+            "\\bextension::(?:recipe_run_provider_inventory|render_recipe_run_command|resolve_recipe_run_provider|RecipeRunProviderInventoryEntry|RecipeRunProviderValidation|RecipeRunRequest)\\b"
+          ]
+        },
+        "name": "extensions-use-canonical-recipe-run-api"
+      },
+      {
+        "forbid": {
+          "glob": "crates/**",
+          "patterns": [
             "\\bextension_execution\\b",
             "\\bfind_extension_for_file_ext\\b"
           ]


### PR DESCRIPTION
## Summary

- migrate runner CLI consumers to the canonical `extension::recipe_run` namespace
- remove the flat recipe-run exports from `extension/mod.rs`
- ratchet against legacy flat recipe-run paths

Closes #13938
Parent: #13882

## Verification

- `cargo nextest run -p homeboy-core --lib -E 'test(extension::recipe_run)'` (5 passed)\n- `cargo check --workspace --all-targets`\n- `cargo run -q -p homeboy -- review audit --profile architecture --changed-since origin/main --placement local` (0 introduced findings)\n\nThe workspace check retains one pre-existing unused test import warning in `observation/store/artifacts.rs`.\n\n---\n\nAI assistance: OpenAI GPT-5.6 Sol via OpenCode migrated consumers to the canonical recipe-run namespace, removed the compatibility exports, added the architecture ratchet, and ran verification under Chris Huber's direction.