### PR TITLE
Treat projected capacity reserves as advisory

### DIFF
--- a/crates/homeboy-core/src/capacity.rs
+++ b/crates/homeboy-core/src/capacity.rs
@@ -175,9 +175,10 @@ struct CapacityReservationInput<'a> {
 /// Reserve projected materialization demand before the first large write.
 ///
 /// Capacity is compared after subtracting already-reserved capacity and this
-/// request, then against the configured floor. The reservation is intentionally
-/// process-local: it closes concurrent Cook overcommit while the durable
-/// lifecycle remains the authority for recovering interrupted work.
+/// request. Configured reserve floors are advisory; a reservation blocks only
+/// when its measured projected capacity is exhausted. The reservation is
+/// intentionally process-local: it closes concurrent Cook overcommit while the
+/// durable lifecycle remains the authority for recovering interrupted work.
 pub fn reserve_projected_capacity(
     path: &Path,
     subject: &str,
@@ -229,12 +230,12 @@ fn reserve_projected_capacity_in(
             .saturating_sub(held.inodes)
             .saturating_sub(input.demand.inodes)
     });
-    let bytes_ok = projected_bytes.is_some_and(|available| available >= input.reserve.bytes);
-    let inodes_ok = projected_inodes.is_some_and(|available| available >= input.reserve.inodes);
-    if !bytes_ok || !inodes_ok {
+    let bytes_exhausted = projected_bytes == Some(0);
+    let inodes_exhausted = projected_inodes == Some(0);
+    if bytes_exhausted || inodes_exhausted {
         let mut error = Error::storage_exhausted_detailed(StorageExhaustedDetails {
             error: format!(
-                "{} projected materialization would breach configured capacity floors",
+                "{} projected materialization would exhaust available capacity",
                 input.subject
             ),
             context: Some(format!("admission before {}", input.subject)),
@@ -800,34 +801,25 @@ mod tests {
     }
 
     #[test]
-    fn large_dependency_tree_near_the_floor_is_rejected_before_materialization() {
+    fn reserve_breached_but_projected_demand_fits_acquires_a_reservation() {
         let dir = tempfile::tempdir().expect("capacity fixture");
         let demand = CapacityDemand {
-            bytes: 4 * 1024 * 1024 * 1024,
-            inodes: 250_000,
+            bytes: 53 * 1024 * 1024,
+            inodes: 1,
         };
-        let error = reserve_projected_capacity_from_budget(
+        let reservation = reserve_projected_capacity_from_budget(
             dir.path(),
             "Cook workspace materialization",
-            budget(Some(8 * 1024 * 1024 * 1024), Some(500_000)),
+            budget(Some(144 * 1024 * 1024 * 1024), Some(990_000)),
             demand,
-            reserve(),
+            CapacityReserve {
+                bytes: 150 * 1024 * 1024 * 1024,
+                inodes: 1_000_000,
+            },
         )
-        .expect_err("node_modules/vendor-sized demand must not cross the floor");
+        .expect("configured reserve breaches are advisory when demand fits");
 
-        assert_eq!(error.details["demand_bytes"], demand.bytes);
-        assert_eq!(error.details["demand_inodes"], demand.inodes);
-        assert_eq!(
-            error.details["dominant_reclaimable_categories"][0],
-            "build_output"
-        );
-        assert_eq!(
-            error.details["cleanup_commands"][0],
-            format!(
-                "homeboy cleanup artifacts --path {} --sort size --limit 100 --apply",
-                crate::engine::shell::quote_arg(&dir.path().display().to_string())
-            )
-        );
+        drop(reservation);
     }
 
     #[test]
@@ -848,29 +840,36 @@ mod tests {
     }
 
     #[test]
-    fn projected_inode_exhaustion_blocks_even_when_bytes_are_sufficient() {
+    fn projected_inode_exhaustion_blocks_with_bytes_remaining() {
         let dir = tempfile::tempdir().expect("capacity fixture");
         let error = reserve_projected_capacity_from_budget(
             dir.path(),
             "Cook workspace materialization",
-            budget(Some(100 * 1024 * 1024 * 1024), Some(150_000)),
+            budget(Some(100 * 1024 * 1024 * 1024), Some(500_000)),
             CapacityDemand {
                 bytes: 1,
-                inodes: 60_000,
+                inodes: 500_000,
             },
             reserve(),
         )
-        .expect_err("inode floor must be enforced independently");
+        .expect_err("a demand that consumes measured inodes must block");
 
-        assert_eq!(error.details["projected_inodes"], 90_000);
-        assert_eq!(error.details["reserve_inodes"], 100_000);
+        assert_eq!(
+            error.details["projected_bytes"],
+            100_u64 * 1024 * 1024 * 1024 - 1
+        );
+        assert_eq!(error.details["projected_inodes"], 0);
+        assert!(error.details["error"]
+            .as_str()
+            .expect("message")
+            .contains("would exhaust available capacity"));
     }
 
     #[test]
     fn dropping_a_reservation_releases_capacity_for_the_next_cook() {
         let dir = tempfile::tempdir().expect("capacity fixture");
         let demand = CapacityDemand {
-            bytes: 4 * 1024 * 1024 * 1024,
+            bytes: 6 * 1024 * 1024 * 1024,
             inodes: 1,
         };
         let reservation = reserve_projected_capacity_from_budget(
@@ -881,14 +880,15 @@ mod tests {
             reserve(),
         )
         .expect("first Cook reserves capacity");
-        let blocked = reserve_projected_capacity_from_budget(
+        let error = reserve_projected_capacity_from_budget(
             dir.path(),
             "second Cook",
             budget(Some(10 * 1024 * 1024 * 1024), Some(500_000)),
             demand,
             reserve(),
-        );
-        assert!(blocked.is_err(), "live reservation prevents overcommit");
+        )
+        .expect_err("live reservation prevents projected byte exhaustion");
+        assert_eq!(error.details["projected_bytes"], 0);
 
         drop(reservation);
         reserve_projected_capacity_from_budget(
@@ -905,7 +905,7 @@ mod tests {
     fn independently_opened_ledgers_cannot_overcommit_a_live_filesystem_claim() {
         let dir = tempfile::tempdir().expect("capacity fixture");
         let demand = CapacityDemand {
-            bytes: 4 * 1024 * 1024 * 1024,
+            bytes: 6 * 1024 * 1024 * 1024,
             inodes: 1,
         };
         let first = reserve_projected_capacity_from_budget(


### PR DESCRIPTION
## Summary
- keep configured byte and inode reserves advisory during projected materialization admission
- block only measured projected exhaustion while retaining the cross-process reservation ledger
- cover reserve breaches that fit, inode exhaustion, and concurrent reservation overcommit

Fixes #13683.

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-core capacity::tests --lib`
- `cargo check -p homeboy-core`

## AI assistance
OpenAI `gpt-5.6-terra` was used through OpenCode to trace projected-capacity semantics, implement the generic Rust fix, and update focused tests. The changes and verification output were reviewed before submission.