### PR TITLE
Remove the flat extension fingerprint export

### DIFF
--- a/crates/homeboy-core/src/extension/audit_fingerprint_script_provider.rs
+++ b/crates/homeboy-core/src/extension/audit_fingerprint_script_provider.rs
@@ -27,7 +27,7 @@ impl FingerprintScriptProvider for ExtensionFingerprintScriptProvider {
             file_extension,
             crate::extension::resolve::FileExtensionCapability::Fingerprint,
         )?;
-        super::run_fingerprint_script(&matched, relative_path, content)
+        super::fingerprint::run_fingerprint_script(&matched, relative_path, content)
     }
 }
 

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -7,7 +7,7 @@ pub mod build;
 pub mod catalog;
 mod compiler_warning_contract;
 pub mod component_script;
-mod fingerprint;
+pub mod fingerprint;
 pub mod invoke;
 pub mod lifecycle;
 pub mod lint;
@@ -28,7 +28,6 @@ pub use compiler_warning_contract::{
 };
 pub(crate) use homeboy_core::extension::resolve::{extension_guidance_hints, stderr_tail};
 
-pub use fingerprint::run_fingerprint_script;
 pub(crate) use invoke::build_settings_json_from_manifest;
 pub use refactor_protocol::{
     run_refactor_script, run_refactor_script_result, AdjustedItem, ParsedItem,

--- a/homeboy.json
+++ b/homeboy.json
@@ -659,6 +659,15 @@
         "forbid": {
           "glob": "crates/**",
           "patterns": [
+            "\\bextension::run_fingerprint_script\\b"
+          ]
+        },
+        "name": "extensions-use-canonical-fingerprint-api"
+      },
+      {
+        "forbid": {
+          "glob": "crates/**",
+          "patterns": [
             "\\bextension_execution\\b",
             "\\bfind_extension_for_file_ext\\b"
           ]


### PR DESCRIPTION
## Summary

- expose `extension::fingerprint` as the canonical fingerprint-script owner
- migrate the audit fingerprint provider to the owned namespace
- remove the flat fingerprint export and ratchet against its return

Closes #13942
Parent: #13882

## Verification

- `cargo check -p homeboy-core --all-targets`
- `cargo check --workspace --all-targets`
- `cargo run -q -p homeboy -- review audit --profile architecture --changed-since origin/main --placement local` (0 introduced findings)

No dedicated fingerprint-script tests exist; this namespace-only change does not add low-signal smoke coverage. The checks retain one pre-existing unused test import warning in `observation/store/artifacts.rs`.

---

AI assistance: OpenAI GPT-5.6 Sol via OpenCode exposed the canonical fingerprint owner, migrated its provider, removed the compatibility export, added the architecture ratchet, and ran verification under Chris Huber's direction.