### PR TITLE
Consolidate runner execution-context marker ownership

### DIFF
--- a/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
@@ -28,6 +28,11 @@ pub use execution_placement::{
     CONTROLLER_LOCAL_SUBMISSION_POLICY_ID,
 };
 /// Compatibility exports for established Lab runner consumers. Generic runner
+/// execution-context vocabulary is canonical in `homeboy-runner-contract`.
+pub use homeboy_runner_contract::{
+    is_internal_control_env, RUNNER_HOSTED_EXEC_ENV, RUNNER_ID_ENV, RUNNER_PLACEMENT_RESOLVED_ENV,
+};
+/// Compatibility exports for established Lab runner consumers. Generic runner
 /// artifact results are canonical in `homeboy-runner-contract`.
 pub use homeboy_runner_contract::{RunnerArtifactRef, RunnerMutationArtifacts};
 /// Compatibility exports for established Lab runner consumers. Generic runner
@@ -87,23 +92,6 @@ pub struct RunnerWorkspaceSyncOptions {
     /// execution supplies this token; callers that explicitly opt into a stable
     /// identity must reject an already-owned path before materialization.
     pub run_isolation_token: Option<String>,
-}
-
-/// Set while a hosted exec runs inside a runner (as opposed to the local host).
-pub const RUNNER_HOSTED_EXEC_ENV: &str = "HOMEBOY_RUNNER_HOSTED_EXEC";
-
-/// Private process marker added only while a runner exec crosses a remote
-/// runner boundary. Intentionally absent from CLI parsing and argv.
-pub const RUNNER_PLACEMENT_RESOLVED_ENV: &str = "HOMEBOY_RUNNER_PLACEMENT_RESOLVED";
-
-/// Identifies the runner an exec is bound to.
-pub const RUNNER_ID_ENV: &str = "HOMEBOY_RUNNER_ID";
-
-/// Whether an env-var name is an internal runner control marker (not a
-/// user-facing variable). Contract-level classification, so it lives here and
-/// core can call it without a core -> runner edge.
-pub fn is_internal_control_env(name: &str) -> bool {
-    name == RUNNER_PLACEMENT_RESOLVED_ENV
 }
 
 /// A lab runner capability prepared from a contract, ready to preflight.

--- a/crates/contracts/homeboy-runner-contract/src/execution_context.rs
+++ b/crates/contracts/homeboy-runner-contract/src/execution_context.rs
@@ -1,0 +1,35 @@
+//! Cross-process runner execution-context vocabulary.
+
+/// Set while a hosted exec runs inside a runner rather than the local host.
+pub const RUNNER_HOSTED_EXEC_ENV: &str = "HOMEBOY_RUNNER_HOSTED_EXEC";
+
+/// Private marker added only when an exec crosses a remote runner boundary.
+pub const RUNNER_PLACEMENT_RESOLVED_ENV: &str = "HOMEBOY_RUNNER_PLACEMENT_RESOLVED";
+
+/// Identifies the runner an exec is bound to.
+pub const RUNNER_ID_ENV: &str = "HOMEBOY_RUNNER_ID";
+
+/// Whether an environment variable is a private runner control marker.
+pub fn is_internal_control_env(name: &str) -> bool {
+    name == RUNNER_PLACEMENT_RESOLVED_ENV
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn execution_context_vocabulary_and_classification_stay_stable() {
+        assert_eq!(RUNNER_HOSTED_EXEC_ENV, "HOMEBOY_RUNNER_HOSTED_EXEC");
+        assert_eq!(
+            RUNNER_PLACEMENT_RESOLVED_ENV,
+            "HOMEBOY_RUNNER_PLACEMENT_RESOLVED"
+        );
+        assert_eq!(RUNNER_ID_ENV, "HOMEBOY_RUNNER_ID");
+
+        assert!(is_internal_control_env(RUNNER_PLACEMENT_RESOLVED_ENV));
+        assert!(!is_internal_control_env(RUNNER_HOSTED_EXEC_ENV));
+        assert!(!is_internal_control_env(RUNNER_ID_ENV));
+        assert!(!is_internal_control_env("HOMEBOY_LAB_EXECUTION_RUNNER_ID"));
+    }
+}

--- a/crates/contracts/homeboy-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-runner-contract/src/lib.rs
@@ -7,6 +7,7 @@
 mod artifact;
 mod capability;
 mod discovery;
+mod execution_context;
 mod lifecycle;
 mod resource;
 mod session;
@@ -21,6 +22,9 @@ pub use discovery::{
     RunnerCapabilities, RunnerDescriptor, RunnerInspection, RunnerKind, RunnerReadiness,
     RUNNER_CAPABILITIES_SCHEMA, RUNNER_DESCRIPTOR_SCHEMA, RUNNER_INSPECTION_SCHEMA,
     RUNNER_READINESS_SCHEMA,
+};
+pub use execution_context::{
+    is_internal_control_env, RUNNER_HOSTED_EXEC_ENV, RUNNER_ID_ENV, RUNNER_PLACEMENT_RESOLVED_ENV,
 };
 pub use lifecycle::{RunnerJobLifecycleMetadata, RunnerLifecycleOwner};
 pub use resource::{

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -23,7 +23,9 @@ use crate::runner_execution_envelope::{
 };
 use crate::secret_env_plan::SecretEnvPlan;
 use crate::source_snapshot::SourceSnapshot;
-use homeboy_runner_contract::{RunnerMutationArtifacts, RunnerResourceMetrics};
+use homeboy_runner_contract::{
+    is_internal_control_env, RunnerMutationArtifacts, RunnerResourceMetrics,
+};
 
 /// Broker metadata is durable queue input. Keep command-file payloads bounded
 /// before they can be persisted or decoded by a worker.
@@ -248,7 +250,7 @@ impl RemoteRunnerJobRequest {
             env: request
                 .env
                 .into_iter()
-                .filter(|(name, _)| !homeboy_lab_runner_contract::is_internal_control_env(name))
+                .filter(|(name, _)| !is_internal_control_env(name))
                 .collect(),
             source_snapshot: request.source_snapshot,
             require_paths: request.require_paths,
@@ -288,9 +290,7 @@ impl RemoteRunnerJobRequest {
 
     pub fn public_metadata(&self) -> Self {
         let mut public = self.clone();
-        public
-            .env
-            .retain(|name, _| !homeboy_lab_runner_contract::is_internal_control_env(name));
+        public.env.retain(|name, _| !is_internal_control_env(name));
         let mut secret_env_name_values = self.secret_env_plan.secret_env_names();
         secret_env_name_values.extend(self.secret_env_names.clone());
         let secret_env_names = secret_env_name_values

--- a/crates/homeboy-core/src/resource_policy_context.rs
+++ b/crates/homeboy-core/src/resource_policy_context.rs
@@ -12,6 +12,9 @@
 
 use std::sync::{OnceLock, RwLock};
 
+use homeboy_runner_contract::{
+    RUNNER_HOSTED_EXEC_ENV, RUNNER_ID_ENV, RUNNER_PLACEMENT_RESOLVED_ENV,
+};
 use serde::{Deserialize, Serialize};
 
 /// Structured, serde-friendly snapshot of the resource-policy decision captured
@@ -158,7 +161,7 @@ pub fn reset_captured_context_for_test() {
 }
 
 pub fn is_runner_hosted_exec() -> bool {
-    std::env::var(homeboy_lab_runner_contract::RUNNER_HOSTED_EXEC_ENV)
+    std::env::var(RUNNER_HOSTED_EXEC_ENV)
         .ok()
         .is_some_and(|value| value == "1")
 }
@@ -202,25 +205,25 @@ pub fn is_ci_execution() -> bool {
 /// and daemon job preparation rather than trusting the resolved marker alone.
 pub fn is_managed_runner_placement_context() -> bool {
     is_runner_hosted_exec()
-        && std::env::var(homeboy_lab_runner_contract::RUNNER_PLACEMENT_RESOLVED_ENV)
+        && std::env::var(RUNNER_PLACEMENT_RESOLVED_ENV)
             .ok()
             .is_some_and(|value| value == "1")
-        && std::env::var(homeboy_lab_runner_contract::RUNNER_ID_ENV)
+        && std::env::var(RUNNER_ID_ENV)
             .ok()
             .is_some_and(|value| !value.trim().is_empty())
 }
 
 pub fn clear_runner_hosted_exec() {
-    std::env::remove_var(homeboy_lab_runner_contract::RUNNER_HOSTED_EXEC_ENV);
+    std::env::remove_var(RUNNER_HOSTED_EXEC_ENV);
 }
 
 /// Remove the private runner-placement transport context after CLI routing.
 /// Child workloads and persisted artifacts must not inherit controller routing
 /// markers once their single placement decision has been consumed.
 pub fn clear_managed_runner_placement_context() {
-    std::env::remove_var(homeboy_lab_runner_contract::RUNNER_HOSTED_EXEC_ENV);
-    std::env::remove_var(homeboy_lab_runner_contract::RUNNER_PLACEMENT_RESOLVED_ENV);
-    std::env::remove_var(homeboy_lab_runner_contract::RUNNER_ID_ENV);
+    std::env::remove_var(RUNNER_HOSTED_EXEC_ENV);
+    std::env::remove_var(RUNNER_PLACEMENT_RESOLVED_ENV);
+    std::env::remove_var(RUNNER_ID_ENV);
     // This legacy value selected a controller daemon. A runner-local child must
     // not pass it into provider preflight after the Lab handoff is accepted.
     std::env::remove_var("HOMEBOY_LAB_RUNNER_ID");

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -42,14 +42,14 @@ pub(crate) const RUNNER_CANCEL_ON_WAIT_TIMEOUT_ENV: &str = "HOMEBOY_RUNNER_CANCE
 // These runner env-var markers now live in the shared runner-contract crate so
 // core can reference them without a core -> runner edge. Re-exported here so the
 // existing `runner::execution::RUNNER_*_ENV` call sites keep resolving.
-pub use homeboy_lab_runner_contract::{
+pub use homeboy_runner_contract::{
     RUNNER_HOSTED_EXEC_ENV, RUNNER_ID_ENV, RUNNER_PLACEMENT_RESOLVED_ENV,
 };
 
 // Moved to the runner-contract crate (contract-level env classification) so
 // core can call it without a core -> runner edge. Re-exported for runner-
 // internal call sites.
-pub(crate) use homeboy_lab_runner_contract::is_internal_control_env;
+pub(crate) use homeboy_runner_contract::is_internal_control_env;
 
 mod artifact_promotion;
 mod broker;


### PR DESCRIPTION
## Summary

- make `homeboy-runner-contract` the canonical owner of runner-hosted, placement-resolved, and runner-identity environment names
- move the private control-marker classifier with that vocabulary
- migrate core and Lab implementation consumers to the canonical package
- retain `homeboy-lab-runner-contract` compatibility exports
- keep the distinct Lab execution identity marker and all propagation behavior unchanged

Closes #13943
Parent: #13881

## Verification

- `cargo test -p homeboy-runner-contract`
- `cargo test -p homeboy-lab-runner-contract`
- `cargo test -p homeboy-core resource_policy_context`
- `cargo test -p homeboy-lab-runner execution::tests::prepare` (20 tests)
- `cargo check -p homeboy-lab-runner-contract -p homeboy-lab-runner -p homeboy-core -p homeboy-agents`
- `cargo check -p homeboy-agents --tests`
- `cargo clippy -p homeboy-runner-contract --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo metadata --no-deps --format-version 1`

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode mapped the remaining execution-context vocabulary, implemented canonical ownership and compatibility exports, pinned the exact marker values and narrow classifier behavior, rebased onto current main, and ran the verification commands. Chris Huber selected and authorized this bounded Runner API simplification.