### PR TITLE
Define the Extension API v1 descriptor handshake

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/api/mod.rs
+++ b/crates/contracts/homeboy-extension-contract/src/api/mod.rs
@@ -1,0 +1,3 @@
+//! Stable, transport-neutral Extension API contracts.
+
+pub mod v1;

--- a/crates/contracts/homeboy-extension-contract/src/api/v1.rs
+++ b/crates/contracts/homeboy-extension-contract/src/api/v1.rs
@@ -40,7 +40,8 @@ pub struct ExtensionApiSchemaReference {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ExtensionApiCapabilityDescriptor {
     pub id: String,
-    pub contract_version: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contract_version: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub configuration_schema: Option<ExtensionApiSchemaReference>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -155,7 +156,7 @@ mod tests {
             },
             capabilities: vec![ExtensionApiCapabilityDescriptor {
                 id: "test".to_string(),
-                contract_version: 1,
+                contract_version: Some("1".to_string()),
                 configuration_schema: None,
                 input_schema: None,
                 output_schema: Some(ExtensionApiSchemaReference {
@@ -189,7 +190,7 @@ mod tests {
                 },
                 "capabilities": [{
                     "id": "test",
-                    "contract_version": 1,
+                    "contract_version": "1",
                     "output_schema": { "schema": "homeboy/test-results/v1" }
                 }],
                 "readiness": {

--- a/crates/contracts/homeboy-extension-contract/src/api/v1.rs
+++ b/crates/contracts/homeboy-extension-contract/src/api/v1.rs
@@ -1,0 +1,206 @@
+//! Version 1 Extension API discovery and compatibility contracts.
+//!
+//! This module contains serialized values only. Catalog projection and version
+//! negotiation behavior belong to the application service that serves them.
+
+use serde::{Deserialize, Serialize};
+
+pub const EXTENSION_API_DESCRIPTOR_SCHEMA: &str = "homeboy/extension-api-descriptor/v1";
+pub const EXTENSION_API_HANDSHAKE_REQUEST_SCHEMA: &str =
+    "homeboy/extension-api-handshake-request/v1";
+pub const EXTENSION_API_HANDSHAKE_RESPONSE_SCHEMA: &str =
+    "homeboy/extension-api-handshake-response/v1";
+pub const EXTENSION_API_V1: ExtensionApiVersion = ExtensionApiVersion { major: 1 };
+
+/// A transport-neutral Extension API major version.
+///
+/// The numeric shape lets an older client retain and reject a future version
+/// explicitly instead of failing to deserialize an unknown enum variant.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ExtensionApiVersion {
+    pub major: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiIdentity {
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_revision: Option<String>,
+}
+
+/// A named serialized contract consumed or produced by a capability.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiSchemaReference {
+    pub schema: String,
+}
+
+/// One extension capability projected independently of its implementation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiCapabilityDescriptor {
+    pub id: String,
+    pub contract_version: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub configuration_schema: Option<ExtensionApiSchemaReference>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_schema: Option<ExtensionApiSchemaReference>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_schema: Option<ExtensionApiSchemaReference>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_schemas: Vec<ExtensionApiSchemaReference>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiReadinessDescriptor {
+    pub runtime_probe: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub toolchain_probe_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiRuntimeRequirement {
+    pub id: String,
+    pub version: String,
+}
+
+/// Runner-neutral requirements declared by an extension.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiExecutionRequirements {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runtimes: Vec<ExtensionApiRuntimeRequirement>,
+}
+
+/// The stable catalog projection of one installed extension.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiDescriptor {
+    pub schema: String,
+    pub api_version: ExtensionApiVersion,
+    pub identity: ExtensionApiIdentity,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capabilities: Vec<ExtensionApiCapabilityDescriptor>,
+    pub readiness: ExtensionApiReadinessDescriptor,
+    pub execution_requirements: ExtensionApiExecutionRequirements,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requires_homeboy: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiHandshakeRequest {
+    pub schema: String,
+    pub supported_versions: Vec<ExtensionApiVersion>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionApiCompatibilityStatus {
+    Compatible,
+    Incompatible,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionApiCompatibilityFailureCode {
+    InvalidHandshakeSchema,
+    NoSharedApiVersion,
+    InvalidHomeboyVersionConstraint,
+    HomeboyVersionIncompatible,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiCompatibilityFailure {
+    pub code: ExtensionApiCompatibilityFailureCode,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiCompatibility {
+    pub status: ExtensionApiCompatibilityStatus,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failures: Vec<ExtensionApiCompatibilityFailure>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiHandshakeResponse {
+    pub schema: String,
+    pub supported_versions: Vec<ExtensionApiVersion>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_version: Option<ExtensionApiVersion>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub descriptor: Option<ExtensionApiDescriptor>,
+    pub compatibility: ExtensionApiCompatibility,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn future_api_versions_remain_parseable() {
+        let version: ExtensionApiVersion =
+            serde_json::from_value(serde_json::json!({ "major": 99 })).expect("api version");
+        assert_eq!(version.major, 99);
+    }
+
+    #[test]
+    fn descriptor_wire_shape_is_explicitly_versioned() {
+        let descriptor = ExtensionApiDescriptor {
+            schema: EXTENSION_API_DESCRIPTOR_SCHEMA.to_string(),
+            api_version: EXTENSION_API_V1,
+            identity: ExtensionApiIdentity {
+                id: "fixture".to_string(),
+                name: "Fixture".to_string(),
+                version: "1.2.3".to_string(),
+                source_revision: Some("abc123".to_string()),
+            },
+            capabilities: vec![ExtensionApiCapabilityDescriptor {
+                id: "test".to_string(),
+                contract_version: 1,
+                configuration_schema: None,
+                input_schema: None,
+                output_schema: Some(ExtensionApiSchemaReference {
+                    schema: "homeboy/test-results/v1".to_string(),
+                }),
+                artifact_schemas: Vec::new(),
+            }],
+            readiness: ExtensionApiReadinessDescriptor {
+                runtime_probe: true,
+                toolchain_probe_ids: vec!["runtime".to_string()],
+            },
+            execution_requirements: ExtensionApiExecutionRequirements {
+                runtimes: vec![ExtensionApiRuntimeRequirement {
+                    id: "php".to_string(),
+                    version: ">=8.0".to_string(),
+                }],
+            },
+            requires_homeboy: Some(">=0.1.0".to_string()),
+        };
+
+        assert_eq!(
+            serde_json::to_value(descriptor).expect("descriptor JSON"),
+            serde_json::json!({
+                "schema": EXTENSION_API_DESCRIPTOR_SCHEMA,
+                "api_version": { "major": 1 },
+                "identity": {
+                    "id": "fixture",
+                    "name": "Fixture",
+                    "version": "1.2.3",
+                    "source_revision": "abc123"
+                },
+                "capabilities": [{
+                    "id": "test",
+                    "contract_version": 1,
+                    "output_schema": { "schema": "homeboy/test-results/v1" }
+                }],
+                "readiness": {
+                    "runtime_probe": true,
+                    "toolchain_probe_ids": ["runtime"]
+                },
+                "execution_requirements": {
+                    "runtimes": [{ "id": "php", "version": ">=8.0" }]
+                },
+                "requires_homeboy": ">=0.1.0"
+            })
+        );
+    }
+}

--- a/crates/contracts/homeboy-extension-contract/src/lib.rs
+++ b/crates/contracts/homeboy-extension-contract/src/lib.rs
@@ -10,6 +10,7 @@
 //! workflow modules expose only the result types that are part of those workflows.
 
 pub use action_types::HttpMethod;
+pub mod api;
 pub use ci_config::{
     CiCachePath, CiCachePathRoot, CiCacheSpec, CiCapability, CiJobFidelity, CiJobMapping,
     CiJobSpec, CiLocalContext, CiProfileSpec,

--- a/crates/homeboy-core/src/extension/catalog/api.rs
+++ b/crates/homeboy-core/src/extension/catalog/api.rs
@@ -55,9 +55,12 @@ pub fn api_descriptor(extension_id: &str) -> Result<ExtensionApiDescriptor> {
             .recipe_run_providers
             .iter()
             .filter_map(|provider| {
-                provider
-                    .declared_str("id")
-                    .map(|id| capability_descriptor(&format!("recipe-run-provider.{id}")))
+                provider.declared_str("id").map(|id| {
+                    versioned_capability_descriptor(
+                        &format!("recipe-run-provider.{id}"),
+                        provider.declared_str("version"),
+                    )
+                })
             }),
     );
     if extension.env_provider.is_some() {
@@ -185,9 +188,16 @@ pub fn negotiate_api(
 }
 
 fn capability_descriptor(id: &str) -> ExtensionApiCapabilityDescriptor {
+    versioned_capability_descriptor(id, None)
+}
+
+fn versioned_capability_descriptor(
+    id: &str,
+    contract_version: Option<String>,
+) -> ExtensionApiCapabilityDescriptor {
     ExtensionApiCapabilityDescriptor {
         id: id.to_string(),
-        contract_version: 1,
+        contract_version,
         configuration_schema: None,
         input_schema: None,
         output_schema: None,
@@ -221,6 +231,12 @@ mod tests {
                     "version": "1.2.3",
                     "test": { "extension_script": "test.sh" },
                     "executable": { "runtime": { "run_command": "fixture", "ready_check": "fixture --ready" } },
+                    "recipe_run_providers": [{
+                        "id": "fixture.recipe",
+                        "version": "2",
+                        "executable": "fixture-run",
+                        "command": ["fixture-run"]
+                    }],
                     "runtime": { "runtimes": { "php": { "version": ">=8.0" }, "node": { "version": ">=20" } } },
                     "toolchain_readiness": [
                         { "id": "zeta", "program": "zeta" },
@@ -240,7 +256,11 @@ mod tests {
                     .iter()
                     .map(|capability| capability.id.as_str())
                     .collect::<Vec<_>>(),
-                vec!["execute", "test"]
+                vec!["execute", "recipe-run-provider.fixture.recipe", "test"]
+            );
+            assert_eq!(
+                descriptor.capabilities[1].contract_version.as_deref(),
+                Some("2")
             );
             assert!(descriptor.readiness.runtime_probe);
             assert_eq!(descriptor.readiness.toolchain_probe_ids, ["alpha", "zeta"]);

--- a/crates/homeboy-core/src/extension/catalog/api.rs
+++ b/crates/homeboy-core/src/extension/catalog/api.rs
@@ -1,0 +1,361 @@
+use homeboy_core::error::Result;
+use homeboy_extension_contract::api::v1::{
+    ExtensionApiCapabilityDescriptor, ExtensionApiCompatibility, ExtensionApiCompatibilityFailure,
+    ExtensionApiCompatibilityFailureCode, ExtensionApiCompatibilityStatus, ExtensionApiDescriptor,
+    ExtensionApiExecutionRequirements, ExtensionApiHandshakeRequest, ExtensionApiHandshakeResponse,
+    ExtensionApiIdentity, ExtensionApiReadinessDescriptor, ExtensionApiRuntimeRequirement,
+    ExtensionApiVersion, EXTENSION_API_DESCRIPTOR_SCHEMA, EXTENSION_API_HANDSHAKE_REQUEST_SCHEMA,
+    EXTENSION_API_HANDSHAKE_RESPONSE_SCHEMA, EXTENSION_API_V1,
+};
+use homeboy_extension_contract::{evaluate_core_compatibility, ExtensionCapability};
+
+use super::load_extension;
+
+const SUPPORTED_API_VERSIONS: &[ExtensionApiVersion] = &[EXTENSION_API_V1];
+
+/// Project an installed manifest into the stable Extension API v1 descriptor.
+pub fn api_descriptor(extension_id: &str) -> Result<ExtensionApiDescriptor> {
+    let extension = load_extension(extension_id)?;
+    let mut capabilities = [
+        ExtensionCapability::Lint,
+        ExtensionCapability::Test,
+        ExtensionCapability::Build,
+        ExtensionCapability::Bench,
+        ExtensionCapability::Fuzz,
+        ExtensionCapability::Trace,
+        ExtensionCapability::Deps,
+        ExtensionCapability::Audit,
+    ]
+    .into_iter()
+    .filter(|capability| capability.has_manifest_support(&extension))
+    .map(|capability| capability_descriptor(capability.label()))
+    .collect::<Vec<_>>();
+
+    if extension
+        .runtime()
+        .and_then(|runtime| runtime.run_command.as_ref())
+        .is_some()
+    {
+        capabilities.push(capability_descriptor("execute"));
+    }
+    capabilities.extend(
+        extension
+            .actions
+            .iter()
+            .map(|action| capability_descriptor(&format!("action.{}", action.id))),
+    );
+    capabilities.extend(
+        extension
+            .deployment_providers
+            .iter()
+            .map(|provider| capability_descriptor(&format!("deployment-provider.{}", provider.id))),
+    );
+    capabilities.extend(
+        extension
+            .recipe_run_providers
+            .iter()
+            .filter_map(|provider| {
+                provider
+                    .declared_str("id")
+                    .map(|id| capability_descriptor(&format!("recipe-run-provider.{id}")))
+            }),
+    );
+    if extension.env_provider.is_some() {
+        capabilities.push(capability_descriptor("environment"));
+    }
+    capabilities.extend(
+        extension
+            .agent_runtimes
+            .iter()
+            .map(|runtime| capability_descriptor(&format!("agent-runtime.{}", runtime.id))),
+    );
+    capabilities.sort_by(|left, right| left.id.cmp(&right.id));
+    capabilities.dedup_by(|left, right| left.id == right.id);
+
+    let mut toolchain_probe_ids = extension
+        .toolchain_readiness
+        .iter()
+        .map(|probe| probe.id.clone())
+        .collect::<Vec<_>>();
+    toolchain_probe_ids.sort();
+    toolchain_probe_ids.dedup();
+
+    let mut runtimes = extension
+        .runtime
+        .as_ref()
+        .into_iter()
+        .flat_map(|requirements| requirements.runtimes.iter())
+        .map(|(id, requirement)| ExtensionApiRuntimeRequirement {
+            id: id.clone(),
+            version: requirement.version.clone(),
+        })
+        .collect::<Vec<_>>();
+    runtimes.sort_by(|left, right| left.id.cmp(&right.id));
+
+    Ok(ExtensionApiDescriptor {
+        schema: EXTENSION_API_DESCRIPTOR_SCHEMA.to_string(),
+        api_version: EXTENSION_API_V1,
+        identity: ExtensionApiIdentity {
+            id: extension.id.clone(),
+            name: extension.name.clone(),
+            version: extension.version.clone(),
+            source_revision: crate::extension::lifecycle::read_source_revision(&extension.id),
+        },
+        capabilities,
+        readiness: ExtensionApiReadinessDescriptor {
+            runtime_probe: extension
+                .runtime()
+                .and_then(|runtime| runtime.ready_check.as_ref())
+                .is_some(),
+            toolchain_probe_ids,
+        },
+        execution_requirements: ExtensionApiExecutionRequirements { runtimes },
+        requires_homeboy: extension
+            .requires
+            .as_ref()
+            .and_then(|requirements| requirements.homeboy.clone()),
+    })
+}
+
+/// Negotiate a client's supported API versions against one installed extension.
+pub fn negotiate_api(
+    extension_id: &str,
+    request: &ExtensionApiHandshakeRequest,
+) -> Result<ExtensionApiHandshakeResponse> {
+    let descriptor = api_descriptor(extension_id)?;
+    let supported_versions = SUPPORTED_API_VERSIONS.to_vec();
+    let valid_schema = request.schema == EXTENSION_API_HANDSHAKE_REQUEST_SCHEMA;
+    let selected_version = valid_schema
+        .then(|| {
+            request
+                .supported_versions
+                .iter()
+                .filter(|version| SUPPORTED_API_VERSIONS.contains(version))
+                .max()
+                .copied()
+        })
+        .flatten();
+    let mut failures = Vec::new();
+
+    if !valid_schema {
+        failures.push(ExtensionApiCompatibilityFailure {
+            code: ExtensionApiCompatibilityFailureCode::InvalidHandshakeSchema,
+            message: format!(
+                "Unsupported Extension API handshake schema '{}'; expected '{}'",
+                request.schema, EXTENSION_API_HANDSHAKE_REQUEST_SCHEMA
+            ),
+        });
+    } else if selected_version.is_none() {
+        failures.push(ExtensionApiCompatibilityFailure {
+            code: ExtensionApiCompatibilityFailureCode::NoSharedApiVersion,
+            message: "Client and Homeboy do not share an Extension API major version".to_string(),
+        });
+    }
+
+    match evaluate_core_compatibility(descriptor.requires_homeboy.as_deref(), None) {
+        Ok(report) if report.status == "incompatible" => {
+            failures.push(ExtensionApiCompatibilityFailure {
+                code: ExtensionApiCompatibilityFailureCode::HomeboyVersionIncompatible,
+                message: format!(
+                    "Extension requires Homeboy {}, but {} is installed",
+                    report.requires_homeboy.as_deref().unwrap_or("<undeclared>"),
+                    report.installed_homeboy
+                ),
+            });
+        }
+        Err(error) => failures.push(ExtensionApiCompatibilityFailure {
+            code: ExtensionApiCompatibilityFailureCode::InvalidHomeboyVersionConstraint,
+            message: error.message,
+        }),
+        _ => {}
+    }
+
+    let status = if failures.is_empty() {
+        ExtensionApiCompatibilityStatus::Compatible
+    } else {
+        ExtensionApiCompatibilityStatus::Incompatible
+    };
+    Ok(ExtensionApiHandshakeResponse {
+        schema: EXTENSION_API_HANDSHAKE_RESPONSE_SCHEMA.to_string(),
+        supported_versions,
+        selected_version,
+        descriptor: selected_version.map(|_| descriptor),
+        compatibility: ExtensionApiCompatibility { status, failures },
+    })
+}
+
+fn capability_descriptor(id: &str) -> ExtensionApiCapabilityDescriptor {
+    ExtensionApiCapabilityDescriptor {
+        id: id.to_string(),
+        contract_version: 1,
+        configuration_schema: None,
+        input_schema: None,
+        output_schema: None,
+        artifact_schemas: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_extension(id: &str, manifest: serde_json::Value) {
+        let extension_dir = crate::paths::extensions()
+            .expect("extensions path")
+            .join(id);
+        std::fs::create_dir_all(&extension_dir).expect("extension directory");
+        std::fs::write(
+            extension_dir.join(format!("{id}.json")),
+            manifest.to_string(),
+        )
+        .expect("extension manifest");
+    }
+
+    #[test]
+    fn descriptor_normalizes_manifest_capabilities_and_requirements() {
+        crate::test_support::with_isolated_home(|_| {
+            write_extension(
+                "fixture",
+                serde_json::json!({
+                    "name": "Fixture",
+                    "version": "1.2.3",
+                    "test": { "extension_script": "test.sh" },
+                    "executable": { "runtime": { "run_command": "fixture", "ready_check": "fixture --ready" } },
+                    "runtime": { "runtimes": { "php": { "version": ">=8.0" }, "node": { "version": ">=20" } } },
+                    "toolchain_readiness": [
+                        { "id": "zeta", "program": "zeta" },
+                        { "id": "alpha", "program": "alpha" }
+                    ],
+                    "requires": { "homeboy": ">=0.1.0" }
+                }),
+            );
+
+            let descriptor = api_descriptor("fixture").expect("descriptor");
+
+            assert_eq!(descriptor.api_version, EXTENSION_API_V1);
+            assert_eq!(descriptor.identity.id, "fixture");
+            assert_eq!(
+                descriptor
+                    .capabilities
+                    .iter()
+                    .map(|capability| capability.id.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["execute", "test"]
+            );
+            assert!(descriptor.readiness.runtime_probe);
+            assert_eq!(descriptor.readiness.toolchain_probe_ids, ["alpha", "zeta"]);
+            assert_eq!(
+                descriptor
+                    .execution_requirements
+                    .runtimes
+                    .iter()
+                    .map(|runtime| runtime.id.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["node", "php"]
+            );
+        });
+    }
+
+    #[test]
+    fn handshake_selects_v1_and_returns_the_descriptor() {
+        crate::test_support::with_isolated_home(|_| {
+            write_extension(
+                "fixture",
+                serde_json::json!({ "name": "Fixture", "version": "1.0.0" }),
+            );
+            let response = negotiate_api(
+                "fixture",
+                &ExtensionApiHandshakeRequest {
+                    schema: EXTENSION_API_HANDSHAKE_REQUEST_SCHEMA.to_string(),
+                    supported_versions: vec![ExtensionApiVersion { major: 99 }, EXTENSION_API_V1],
+                },
+            )
+            .expect("handshake");
+
+            assert_eq!(response.selected_version, Some(EXTENSION_API_V1));
+            assert!(response.descriptor.is_some());
+            assert_eq!(
+                response.compatibility.status,
+                ExtensionApiCompatibilityStatus::Compatible
+            );
+        });
+    }
+
+    #[test]
+    fn handshake_reports_no_shared_version_without_losing_supported_versions() {
+        crate::test_support::with_isolated_home(|_| {
+            write_extension(
+                "fixture",
+                serde_json::json!({ "name": "Fixture", "version": "1.0.0" }),
+            );
+            let response = negotiate_api(
+                "fixture",
+                &ExtensionApiHandshakeRequest {
+                    schema: EXTENSION_API_HANDSHAKE_REQUEST_SCHEMA.to_string(),
+                    supported_versions: vec![ExtensionApiVersion { major: 99 }],
+                },
+            )
+            .expect("handshake");
+
+            assert_eq!(response.selected_version, None);
+            assert_eq!(response.supported_versions, [EXTENSION_API_V1]);
+            assert_eq!(response.descriptor, None);
+            assert_eq!(
+                response.compatibility.failures[0].code,
+                ExtensionApiCompatibilityFailureCode::NoSharedApiVersion
+            );
+        });
+    }
+
+    #[test]
+    fn handshake_reports_controller_version_incompatibility() {
+        crate::test_support::with_isolated_home(|_| {
+            write_extension(
+                "fixture",
+                serde_json::json!({
+                    "name": "Fixture",
+                    "version": "1.0.0",
+                    "requires": { "homeboy": ">=999.0.0" }
+                }),
+            );
+            let response = negotiate_api(
+                "fixture",
+                &ExtensionApiHandshakeRequest {
+                    schema: EXTENSION_API_HANDSHAKE_REQUEST_SCHEMA.to_string(),
+                    supported_versions: vec![EXTENSION_API_V1],
+                },
+            )
+            .expect("handshake");
+
+            assert_eq!(response.selected_version, Some(EXTENSION_API_V1));
+            assert_eq!(
+                response.compatibility.failures[0].code,
+                ExtensionApiCompatibilityFailureCode::HomeboyVersionIncompatible
+            );
+        });
+    }
+
+    #[test]
+    fn handshake_rejects_the_wrong_request_schema() {
+        crate::test_support::with_isolated_home(|_| {
+            write_extension(
+                "fixture",
+                serde_json::json!({ "name": "Fixture", "version": "1.0.0" }),
+            );
+            let response = negotiate_api(
+                "fixture",
+                &ExtensionApiHandshakeRequest {
+                    schema: "homeboy/extension-api-handshake-request/v2".to_string(),
+                    supported_versions: vec![EXTENSION_API_V1],
+                },
+            )
+            .expect("handshake");
+
+            assert_eq!(response.selected_version, None);
+            assert_eq!(
+                response.compatibility.failures[0].code,
+                ExtensionApiCompatibilityFailureCode::InvalidHandshakeSchema
+            );
+        });
+    }
+}

--- a/crates/homeboy-core/src/extension/catalog/mod.rs
+++ b/crates/homeboy-core/src/extension/catalog/mod.rs
@@ -9,9 +9,11 @@ use std::path::{Path, PathBuf};
 use homeboy_error::{ActionSafety, ExecutableAction};
 use homeboy_extension_contract::ExtensionManifest;
 
+mod api;
 mod manifest;
 mod summary;
 
+pub use api::{api_descriptor, negotiate_api};
 pub use manifest::{
     deployment_provider_layered_input, deployment_providers, structured_sidecar_schema_version,
     structured_sidecars,

--- a/docs/internals/development/contracts/extension-api-v1.md
+++ b/docs/internals/development/contracts/extension-api-v1.md
@@ -1,0 +1,81 @@
+# Extension API v1
+
+The Extension API is the transport-neutral contract through which Homeboy
+describes installed extensions and negotiates compatibility. Its serialized v1
+types live in `homeboy_extension_contract::api::v1`; catalog projection and
+negotiation behavior live in `homeboy_core::extension::catalog`.
+
+This boundary is independent of any extension family. A language toolchain, a
+deployment provider, and an agent runtime are all catalog entries described by
+the same identity, capability, readiness, and execution-requirement vocabulary.
+
+## Versioning
+
+API versions are numeric majors. Homeboy currently advertises major `1`.
+Clients send every major they understand in an
+`ExtensionApiHandshakeRequest`; Homeboy deterministically selects the highest
+shared major or returns a typed compatibility failure.
+
+The wire schemas are:
+
+- `homeboy/extension-api-descriptor/v1`
+- `homeboy/extension-api-handshake-request/v1`
+- `homeboy/extension-api-handshake-response/v1`
+
+Additive optional fields may be added within v1. Changes to identity,
+capability meaning, compatibility decisions, or required fields require a new
+major version. Numeric versions remain parseable by older clients so an unknown
+future major produces `no_shared_api_version` instead of a deserialization
+failure.
+
+The existing `HOMEBOY_EXEC_CONTEXT_VERSION=2` is a separate child-process
+environment protocol. It is not the Extension API version.
+
+## Descriptor
+
+`ExtensionApiDescriptor` projects an installed manifest into:
+
+- extension identity and source revision
+- open capability IDs with independent contract versions and schema references
+- runtime and toolchain readiness declarations
+- runner-neutral runtime requirements
+- the declared Homeboy version constraint
+
+Manifest command strings and local extension paths are not part of this public
+descriptor. They remain implementation details behind catalog and invocation
+services.
+
+## Handshake
+
+`extension::catalog::negotiate_api` evaluates two independent compatibility
+dimensions:
+
+1. The client and Homeboy must share an Extension API major.
+2. The installed extension's declared Homeboy version constraint must accept the
+   running controller.
+
+Failures are typed as `invalid_handshake_schema`, `no_shared_api_version`,
+`invalid_homeboy_version_constraint`, or `homeboy_version_incompatible`.
+Responses always advertise Homeboy's supported versions. A descriptor is
+returned only when an API major was selected.
+
+## Contract Classification
+
+`homeboy-extension-contract` predates the stable API and contains several kinds
+of portable data. Only `api` is a stable Extension API module in this slice.
+The rest is classified explicitly so package membership is not mistaken for API
+stability.
+
+| Classification | Modules | Direction |
+| --- | --- | --- |
+| Stable Extension API | `api` | Versioned public descriptor and handshake envelopes. |
+| Stable API candidates | `capability`, `core_compat`, `exec_context`, `runtime_helper`, `sidecar_config` | Reuse or reference from future v1 operations after their wire semantics are reviewed. |
+| Extension-owned domain contracts | `action_types`, `agent_task_executor_declaration`, `autofix_config`, `bench_artifact`, `bench_diagnostics`, `bench_distribution`, `bench_gate`, `bench_metric_preset`, `bench_responsiveness`, `bench_result`, `bench_results`, `bench_stage`, `ci_config`, `ci_context`, `external_check_detail_resolver`, `external_storage_retention`, `fuzz_config`, `lint_result`, `lint_results`, `notification_transport_config`, `source_metadata_repair`, `test_analysis`, `test_drift`, `test_duration`, `test_inventory_config`, `test_parsing`, `test_result`, `test_results`, `test_workflow`, `trace_config`, `trace_parsing`, `trace_preview`, `trace_results`, `trace_spec`, `update_output`, `worktree_retention` | Remain portable domain schemas; the Extension API references their schema IDs rather than absorbing their fields. |
+| Manifest and implementation detail | `extension_contract_producer`, `hook_event`, `manifest`, `manifest_action_config`, `manifest_artifact_cleanup`, `manifest_capabilities`, `manifest_capability_config`, `manifest_deploy_config`, `manifest_test_config`, `manifest_toolchain_config`, `runner_contract`, `version` | Inputs and helpers used to build or execute descriptors. They are not a stable service API. |
+
+## Next Operations
+
+The descriptor handshake deliberately does not define invocation lifecycle.
+Subsequent v1 slices will add typed catalog and resolve requests, followed by
+idempotent invoke, cancel, reconcile, readiness, activity, and terminal-result
+contracts anchored to canonical control-plane references from issue #13697.


### PR DESCRIPTION
## Summary

- define behavior-free `homeboy_extension_contract::api::v1` descriptor and handshake wire types
- project installed manifests into deterministic versioned descriptors through `extension::catalog`
- negotiate API majors and Homeboy compatibility with typed failure codes
- classify every existing extension-contract module and document the independent v1 versioning boundary
- preserve only capability contract versions explicitly declared by manifests

Closes #13950
Advances #13882
Dependencies: #13697, #13881

## Verification

- `cargo nextest run -p homeboy-extension-contract -E 'test(api::v1)'` (2 passed)\n- `cargo nextest run -p homeboy-core --lib -E 'test(extension::catalog::api)'` (5 passed)\n- `cargo check --workspace --all-targets`\n- `cargo run -q -p homeboy -- review audit --profile architecture --changed-since origin/main --placement local` (0 findings)\n\nThe workspace check retains one pre-existing unused test import warning in `observation/store/artifacts.rs`.\n\n---\n\nAI assistance: OpenAI GPT-5.6 Sol via OpenCode audited #13882 and existing contract conventions, designed and implemented the behavior-free v1 descriptor/handshake values, added catalog projection and negotiation, classified the legacy contract surface, corrected undeclared capability version assumptions, and ran verification under Chris Huber's direction.