### PR TITLE
Define Extension API v1 catalog and resolve operations

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/api/v1.rs
+++ b/crates/contracts/homeboy-extension-contract/src/api/v1.rs
@@ -5,6 +5,10 @@
 
 use serde::{Deserialize, Serialize};
 
+mod operations;
+
+pub use operations::*;
+
 pub const EXTENSION_API_DESCRIPTOR_SCHEMA: &str = "homeboy/extension-api-descriptor/v1";
 pub const EXTENSION_API_HANDSHAKE_REQUEST_SCHEMA: &str =
     "homeboy/extension-api-handshake-request/v1";
@@ -201,6 +205,33 @@ mod tests {
                     "runtimes": [{ "id": "php", "version": ">=8.0" }]
                 },
                 "requires_homeboy": ">=0.1.0"
+            })
+        );
+    }
+
+    #[test]
+    fn resolve_failure_wire_shape_is_typed() {
+        let response = ExtensionApiResolveResponse {
+            schema: EXTENSION_API_RESOLVE_RESPONSE_SCHEMA.to_string(),
+            api_version: EXTENSION_API_V1,
+            descriptor: None,
+            capability: None,
+            compatibility: None,
+            failure: Some(ExtensionApiOperationFailure {
+                code: ExtensionApiOperationFailureCode::CapabilityNotProvided,
+                message: "Extension 'fixture' does not provide 'deploy'".to_string(),
+            }),
+        };
+
+        assert_eq!(
+            serde_json::to_value(response).expect("resolve response JSON"),
+            serde_json::json!({
+                "schema": EXTENSION_API_RESOLVE_RESPONSE_SCHEMA,
+                "api_version": { "major": 1 },
+                "failure": {
+                    "code": "capability_not_provided",
+                    "message": "Extension 'fixture' does not provide 'deploy'"
+                }
             })
         );
     }

--- a/crates/contracts/homeboy-extension-contract/src/api/v1/operations.rs
+++ b/crates/contracts/homeboy-extension-contract/src/api/v1/operations.rs
@@ -1,0 +1,102 @@
+//! Catalog and explicit capability-resolution operation envelopes.
+
+use serde::{Deserialize, Serialize};
+
+use super::{
+    ExtensionApiCapabilityDescriptor, ExtensionApiCompatibility, ExtensionApiDescriptor,
+    ExtensionApiVersion,
+};
+
+pub const EXTENSION_API_CATALOG_REQUEST_SCHEMA: &str = "homeboy/extension-api-catalog-request/v1";
+pub const EXTENSION_API_CATALOG_RESPONSE_SCHEMA: &str = "homeboy/extension-api-catalog-response/v1";
+pub const EXTENSION_API_RESOLVE_REQUEST_SCHEMA: &str = "homeboy/extension-api-resolve-request/v1";
+pub const EXTENSION_API_RESOLVE_RESPONSE_SCHEMA: &str = "homeboy/extension-api-resolve-response/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiCatalogRequest {
+    pub schema: String,
+    pub api_version: ExtensionApiVersion,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionApiCatalogEntryStatus {
+    Available,
+    Incompatible,
+    Invalid,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionApiCatalogDiagnosticCode {
+    InvalidManifest,
+    BrokenInstallation,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiCatalogDiagnostic {
+    pub code: ExtensionApiCatalogDiagnosticCode,
+    pub category: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiCatalogEntry {
+    pub id: String,
+    pub status: ExtensionApiCatalogEntryStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub descriptor: Option<ExtensionApiDescriptor>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compatibility: Option<ExtensionApiCompatibility>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diagnostic: Option<ExtensionApiCatalogDiagnostic>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionApiOperationFailureCode {
+    InvalidRequestSchema,
+    UnsupportedApiVersion,
+    ExtensionNotFound,
+    ExtensionInvalid,
+    ExtensionIncompatible,
+    CapabilityNotProvided,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiOperationFailure {
+    pub code: ExtensionApiOperationFailureCode,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiCatalogResponse {
+    pub schema: String,
+    pub api_version: ExtensionApiVersion,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub entries: Vec<ExtensionApiCatalogEntry>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<ExtensionApiOperationFailure>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiResolveRequest {
+    pub schema: String,
+    pub api_version: ExtensionApiVersion,
+    pub extension_id: String,
+    pub capability_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiResolveResponse {
+    pub schema: String,
+    pub api_version: ExtensionApiVersion,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub descriptor: Option<ExtensionApiDescriptor>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capability: Option<ExtensionApiCapabilityDescriptor>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compatibility: Option<ExtensionApiCompatibility>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<ExtensionApiOperationFailure>,
+}

--- a/crates/homeboy-core/src/extension/catalog/api.rs
+++ b/crates/homeboy-core/src/extension/catalog/api.rs
@@ -1,15 +1,21 @@
 use homeboy_core::error::Result;
 use homeboy_extension_contract::api::v1::{
-    ExtensionApiCapabilityDescriptor, ExtensionApiCompatibility, ExtensionApiCompatibilityFailure,
-    ExtensionApiCompatibilityFailureCode, ExtensionApiCompatibilityStatus, ExtensionApiDescriptor,
-    ExtensionApiExecutionRequirements, ExtensionApiHandshakeRequest, ExtensionApiHandshakeResponse,
-    ExtensionApiIdentity, ExtensionApiReadinessDescriptor, ExtensionApiRuntimeRequirement,
-    ExtensionApiVersion, EXTENSION_API_DESCRIPTOR_SCHEMA, EXTENSION_API_HANDSHAKE_REQUEST_SCHEMA,
-    EXTENSION_API_HANDSHAKE_RESPONSE_SCHEMA, EXTENSION_API_V1,
+    ExtensionApiCapabilityDescriptor, ExtensionApiCatalogDiagnostic,
+    ExtensionApiCatalogDiagnosticCode, ExtensionApiCatalogEntry, ExtensionApiCatalogEntryStatus,
+    ExtensionApiCatalogRequest, ExtensionApiCatalogResponse, ExtensionApiCompatibility,
+    ExtensionApiCompatibilityFailure, ExtensionApiCompatibilityFailureCode,
+    ExtensionApiCompatibilityStatus, ExtensionApiDescriptor, ExtensionApiExecutionRequirements,
+    ExtensionApiHandshakeRequest, ExtensionApiHandshakeResponse, ExtensionApiIdentity,
+    ExtensionApiOperationFailure, ExtensionApiOperationFailureCode,
+    ExtensionApiReadinessDescriptor, ExtensionApiResolveRequest, ExtensionApiResolveResponse,
+    ExtensionApiRuntimeRequirement, ExtensionApiVersion, EXTENSION_API_CATALOG_REQUEST_SCHEMA,
+    EXTENSION_API_CATALOG_RESPONSE_SCHEMA, EXTENSION_API_DESCRIPTOR_SCHEMA,
+    EXTENSION_API_HANDSHAKE_REQUEST_SCHEMA, EXTENSION_API_HANDSHAKE_RESPONSE_SCHEMA,
+    EXTENSION_API_RESOLVE_REQUEST_SCHEMA, EXTENSION_API_RESOLVE_RESPONSE_SCHEMA, EXTENSION_API_V1,
 };
 use homeboy_extension_contract::{evaluate_core_compatibility, ExtensionCapability};
 
-use super::load_extension;
+use super::{discover_extensions, load_extension, DiscoveredExtension};
 
 const SUPPORTED_API_VERSIONS: &[ExtensionApiVersion] = &[EXTENSION_API_V1];
 
@@ -187,6 +193,229 @@ pub fn negotiate_api(
     })
 }
 
+/// List every installed extension through the stable v1 catalog contract.
+pub fn list_api(request: &ExtensionApiCatalogRequest) -> ExtensionApiCatalogResponse {
+    if let Some(failure) = validate_operation_request(
+        &request.schema,
+        EXTENSION_API_CATALOG_REQUEST_SCHEMA,
+        request.api_version,
+    ) {
+        return ExtensionApiCatalogResponse {
+            schema: EXTENSION_API_CATALOG_RESPONSE_SCHEMA.to_string(),
+            api_version: EXTENSION_API_V1,
+            entries: Vec::new(),
+            failure: Some(failure),
+        };
+    }
+
+    let entries = discover_extensions()
+        .into_iter()
+        .map(|extension| match extension {
+            DiscoveredExtension::Valid(extension) => {
+                let id = extension.id.clone();
+                match negotiate_api(
+                    &id,
+                    &ExtensionApiHandshakeRequest {
+                        schema: EXTENSION_API_HANDSHAKE_REQUEST_SCHEMA.to_string(),
+                        supported_versions: vec![request.api_version],
+                    },
+                ) {
+                    Ok(handshake) => {
+                        let status = if handshake.compatibility.status
+                            == ExtensionApiCompatibilityStatus::Compatible
+                        {
+                            ExtensionApiCatalogEntryStatus::Available
+                        } else {
+                            ExtensionApiCatalogEntryStatus::Incompatible
+                        };
+                        ExtensionApiCatalogEntry {
+                            id,
+                            status,
+                            descriptor: handshake.descriptor,
+                            compatibility: Some(handshake.compatibility),
+                            diagnostic: None,
+                        }
+                    }
+                    Err(error) => {
+                        invalid_catalog_entry(id, "catalog_projection_failed", error.message)
+                    }
+                }
+            }
+            DiscoveredExtension::Invalid(failure) => {
+                invalid_catalog_entry(failure.id, failure.category, failure.diagnostic.to_string())
+            }
+        })
+        .collect();
+
+    ExtensionApiCatalogResponse {
+        schema: EXTENSION_API_CATALOG_RESPONSE_SCHEMA.to_string(),
+        api_version: EXTENSION_API_V1,
+        entries,
+        failure: None,
+    }
+}
+
+/// Resolve one explicitly named installed extension capability through v1.
+pub fn resolve_api(request: &ExtensionApiResolveRequest) -> ExtensionApiResolveResponse {
+    if let Some(failure) = validate_operation_request(
+        &request.schema,
+        EXTENSION_API_RESOLVE_REQUEST_SCHEMA,
+        request.api_version,
+    ) {
+        return resolve_failure(None, None, failure);
+    }
+
+    let catalog = list_api(&ExtensionApiCatalogRequest {
+        schema: EXTENSION_API_CATALOG_REQUEST_SCHEMA.to_string(),
+        api_version: request.api_version,
+    });
+    let Some(entry) = catalog
+        .entries
+        .into_iter()
+        .find(|entry| entry.id == request.extension_id)
+    else {
+        return resolve_failure(
+            None,
+            None,
+            operation_failure(
+                ExtensionApiOperationFailureCode::ExtensionNotFound,
+                format!("Extension '{}' is not installed", request.extension_id),
+            ),
+        );
+    };
+
+    if entry.status == ExtensionApiCatalogEntryStatus::Invalid {
+        return resolve_failure(
+            None,
+            None,
+            operation_failure(
+                ExtensionApiOperationFailureCode::ExtensionInvalid,
+                format!(
+                    "Extension '{}' has an invalid installation",
+                    request.extension_id
+                ),
+            ),
+        );
+    }
+
+    let (Some(descriptor), Some(compatibility)) = (entry.descriptor, entry.compatibility) else {
+        return resolve_failure(
+            None,
+            None,
+            operation_failure(
+                ExtensionApiOperationFailureCode::ExtensionInvalid,
+                format!(
+                    "Extension '{}' has an incomplete catalog projection",
+                    request.extension_id
+                ),
+            ),
+        );
+    };
+    if entry.status == ExtensionApiCatalogEntryStatus::Incompatible {
+        return resolve_failure(
+            Some(descriptor),
+            Some(compatibility),
+            operation_failure(
+                ExtensionApiOperationFailureCode::ExtensionIncompatible,
+                format!(
+                    "Extension '{}' is incompatible with this Homeboy runtime",
+                    request.extension_id
+                ),
+            ),
+        );
+    }
+
+    let Some(capability) = descriptor
+        .capabilities
+        .iter()
+        .find(|capability| capability.id == request.capability_id)
+        .cloned()
+    else {
+        return resolve_failure(
+            Some(descriptor),
+            Some(compatibility),
+            operation_failure(
+                ExtensionApiOperationFailureCode::CapabilityNotProvided,
+                format!(
+                    "Extension '{}' does not provide capability '{}'",
+                    request.extension_id, request.capability_id
+                ),
+            ),
+        );
+    };
+
+    ExtensionApiResolveResponse {
+        schema: EXTENSION_API_RESOLVE_RESPONSE_SCHEMA.to_string(),
+        api_version: EXTENSION_API_V1,
+        descriptor: Some(descriptor),
+        capability: Some(capability),
+        compatibility: Some(compatibility),
+        failure: None,
+    }
+}
+
+fn validate_operation_request(
+    actual_schema: &str,
+    expected_schema: &str,
+    api_version: ExtensionApiVersion,
+) -> Option<ExtensionApiOperationFailure> {
+    if actual_schema != expected_schema {
+        return Some(operation_failure(
+            ExtensionApiOperationFailureCode::InvalidRequestSchema,
+            format!("Unsupported request schema '{actual_schema}'; expected '{expected_schema}'"),
+        ));
+    }
+    (api_version != EXTENSION_API_V1).then(|| {
+        operation_failure(
+            ExtensionApiOperationFailureCode::UnsupportedApiVersion,
+            format!(
+                "Extension API major {} is not supported; Homeboy supports major {}",
+                api_version.major, EXTENSION_API_V1.major
+            ),
+        )
+    })
+}
+
+fn invalid_catalog_entry(id: String, category: &str, message: String) -> ExtensionApiCatalogEntry {
+    ExtensionApiCatalogEntry {
+        id,
+        status: ExtensionApiCatalogEntryStatus::Invalid,
+        descriptor: None,
+        compatibility: None,
+        diagnostic: Some(ExtensionApiCatalogDiagnostic {
+            code: if category == "target_missing" {
+                ExtensionApiCatalogDiagnosticCode::BrokenInstallation
+            } else {
+                ExtensionApiCatalogDiagnosticCode::InvalidManifest
+            },
+            category: category.to_string(),
+            message,
+        }),
+    }
+}
+
+fn resolve_failure(
+    descriptor: Option<ExtensionApiDescriptor>,
+    compatibility: Option<ExtensionApiCompatibility>,
+    failure: ExtensionApiOperationFailure,
+) -> ExtensionApiResolveResponse {
+    ExtensionApiResolveResponse {
+        schema: EXTENSION_API_RESOLVE_RESPONSE_SCHEMA.to_string(),
+        api_version: EXTENSION_API_V1,
+        descriptor,
+        capability: None,
+        compatibility,
+        failure: Some(failure),
+    }
+}
+
+fn operation_failure(
+    code: ExtensionApiOperationFailureCode,
+    message: String,
+) -> ExtensionApiOperationFailure {
+    ExtensionApiOperationFailure { code, message }
+}
+
 fn capability_descriptor(id: &str) -> ExtensionApiCapabilityDescriptor {
     versioned_capability_descriptor(id, None)
 }
@@ -219,6 +448,22 @@ mod tests {
             manifest.to_string(),
         )
         .expect("extension manifest");
+    }
+
+    fn catalog_request() -> ExtensionApiCatalogRequest {
+        ExtensionApiCatalogRequest {
+            schema: EXTENSION_API_CATALOG_REQUEST_SCHEMA.to_string(),
+            api_version: EXTENSION_API_V1,
+        }
+    }
+
+    fn resolve_request(extension_id: &str, capability_id: &str) -> ExtensionApiResolveRequest {
+        ExtensionApiResolveRequest {
+            schema: EXTENSION_API_RESOLVE_REQUEST_SCHEMA.to_string(),
+            api_version: EXTENSION_API_V1,
+            extension_id: extension_id.to_string(),
+            capability_id: capability_id.to_string(),
+        }
     }
 
     #[test]
@@ -376,6 +621,117 @@ mod tests {
                 response.compatibility.failures[0].code,
                 ExtensionApiCompatibilityFailureCode::InvalidHandshakeSchema
             );
+        });
+    }
+
+    #[test]
+    fn catalog_is_sorted_and_retains_invalid_installs() {
+        crate::test_support::with_isolated_home(|_| {
+            write_extension(
+                "zeta",
+                serde_json::json!({ "name": "Zeta", "version": "1.0.0" }),
+            );
+            let broken_dir = crate::paths::extensions()
+                .expect("extensions path")
+                .join("alpha");
+            std::fs::create_dir_all(&broken_dir).expect("broken extension directory");
+            std::fs::write(broken_dir.join("alpha.json"), "{").expect("broken manifest");
+
+            let response = list_api(&catalog_request());
+
+            assert!(response.failure.is_none());
+            assert_eq!(
+                response
+                    .entries
+                    .iter()
+                    .map(|entry| entry.id.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["alpha", "zeta"]
+            );
+            assert_eq!(
+                response.entries[0].status,
+                ExtensionApiCatalogEntryStatus::Invalid
+            );
+            assert_eq!(
+                response.entries[0]
+                    .diagnostic
+                    .as_ref()
+                    .expect("diagnostic")
+                    .category,
+                "manifest_json_malformed"
+            );
+            assert_eq!(
+                response.entries[1].status,
+                ExtensionApiCatalogEntryStatus::Available
+            );
+        });
+    }
+
+    #[test]
+    fn resolve_returns_the_named_capability() {
+        crate::test_support::with_isolated_home(|_| {
+            write_extension(
+                "fixture",
+                serde_json::json!({
+                    "name": "Fixture",
+                    "version": "1.0.0",
+                    "test": { "extension_script": "test.sh" }
+                }),
+            );
+
+            let response = resolve_api(&resolve_request("fixture", "test"));
+
+            assert!(response.failure.is_none());
+            assert_eq!(response.capability.expect("capability").id, "test");
+            assert_eq!(
+                response.descriptor.expect("descriptor").identity.id,
+                "fixture"
+            );
+        });
+    }
+
+    #[test]
+    fn resolve_reports_missing_capability_without_dropping_descriptor() {
+        crate::test_support::with_isolated_home(|_| {
+            write_extension(
+                "fixture",
+                serde_json::json!({ "name": "Fixture", "version": "1.0.0" }),
+            );
+
+            let response = resolve_api(&resolve_request("fixture", "test"));
+
+            assert_eq!(
+                response.failure.expect("failure").code,
+                ExtensionApiOperationFailureCode::CapabilityNotProvided
+            );
+            assert!(response.descriptor.is_some());
+        });
+    }
+
+    #[test]
+    fn resolve_reports_incompatible_extension_before_capability_selection() {
+        crate::test_support::with_isolated_home(|_| {
+            write_extension(
+                "fixture",
+                serde_json::json!({
+                    "name": "Fixture",
+                    "version": "1.0.0",
+                    "test": { "extension_script": "test.sh" },
+                    "requires": { "homeboy": ">=999.0.0" }
+                }),
+            );
+
+            let response = resolve_api(&resolve_request("fixture", "test"));
+
+            assert_eq!(
+                response.failure.expect("failure").code,
+                ExtensionApiOperationFailureCode::ExtensionIncompatible
+            );
+            assert_eq!(
+                response.compatibility.expect("compatibility").status,
+                ExtensionApiCompatibilityStatus::Incompatible
+            );
+            assert!(response.capability.is_none());
         });
     }
 }

--- a/crates/homeboy-core/src/extension/catalog/mod.rs
+++ b/crates/homeboy-core/src/extension/catalog/mod.rs
@@ -13,7 +13,7 @@ mod api;
 mod manifest;
 mod summary;
 
-pub use api::{api_descriptor, negotiate_api};
+pub use api::{api_descriptor, list_api, negotiate_api, resolve_api};
 pub use manifest::{
     deployment_provider_layered_input, deployment_providers, structured_sidecar_schema_version,
     structured_sidecars,

--- a/docs/internals/development/contracts/extension-api-v1.md
+++ b/docs/internals/development/contracts/extension-api-v1.md
@@ -21,6 +21,10 @@ The wire schemas are:
 - `homeboy/extension-api-descriptor/v1`
 - `homeboy/extension-api-handshake-request/v1`
 - `homeboy/extension-api-handshake-response/v1`
+- `homeboy/extension-api-catalog-request/v1`
+- `homeboy/extension-api-catalog-response/v1`
+- `homeboy/extension-api-resolve-request/v1`
+- `homeboy/extension-api-resolve-response/v1`
 
 Additive optional fields may be added within v1. Changes to identity,
 capability meaning, compatibility decisions, or required fields require a new
@@ -59,6 +63,25 @@ Failures are typed as `invalid_handshake_schema`, `no_shared_api_version`,
 Responses always advertise Homeboy's supported versions. A descriptor is
 returned only when an API major was selected.
 
+## Catalog And Resolve
+
+`extension::catalog::list_api` lists every installed extension in ascending ID
+order. Valid entries carry their v1 descriptor and compatibility result.
+Malformed manifests and broken installations remain in the catalog as `invalid`
+entries with safe typed diagnostics; catalog projection never silently drops
+them.
+
+`extension::catalog::resolve_api` resolves one explicit extension ID and open
+capability ID. It returns the same descriptor and compatibility values exposed
+by catalog, plus the selected capability descriptor. Failure codes distinguish
+invalid request schemas, unsupported API majors, missing or invalid extensions,
+incompatible extensions, and capabilities the selected extension does not
+provide.
+
+Component-aware owner election remains application policy over this primitive.
+The v1 wire contract does not serialize Homeboy's internal `Component` or
+`Project` models.
+
 ## Contract Classification
 
 `homeboy-extension-contract` predates the stable API and contains several kinds
@@ -76,6 +99,6 @@ stability.
 ## Next Operations
 
 The descriptor handshake deliberately does not define invocation lifecycle.
-Subsequent v1 slices will add typed catalog and resolve requests, followed by
-idempotent invoke, cancel, reconcile, readiness, activity, and terminal-result
-contracts anchored to canonical control-plane references from issue #13697.
+Subsequent v1 slices will add idempotent invoke, cancel, reconcile, readiness,
+activity, and terminal-result contracts anchored to canonical control-plane
+references from issue #13697.


### PR DESCRIPTION
## Summary

- add schema-versioned v1 catalog and explicit capability-resolution envelopes
- list installed extensions deterministically while retaining malformed and broken installs as typed entries
- resolve one named extension/capability with explicit version, manifest, compatibility, and capability failures
- preserve descriptor and compatibility evidence on resolution failures where available
- keep component owner election above the transport contract rather than serializing internal workflow models
- split operation values into a focused contract module after the architecture ratchet identified mixed file responsibility

Closes #13953
Advances #13882
Depends on #13950

## Verification

- `cargo nextest run -p homeboy-extension-contract -E 'test(api::v1)'` (3 passed)\n- `cargo nextest run -p homeboy-core --lib -E 'test(extension::catalog::api)'` (9 passed)\n- `cargo check --workspace --all-targets`\n- `cargo run -q -p homeboy -- review audit --profile architecture --changed-since origin/main --placement local` (0 findings)\n\nThe workspace check retains one pre-existing unused test import warning in `observation/store/artifacts.rs`.\n\n---\n\nAI assistance: OpenAI GPT-5.6 Sol via OpenCode designed and implemented the behavior-free v1 catalog/resolve envelopes and service operations, retained invalid and incompatible extension evidence, responded to the architecture ratchet by extracting focused operation contracts, hardened resolution against incomplete projections, and ran verification under Chris Huber's direction.