### PR TITLE
fix(cook): clarify explicit cwd repository inference

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -4537,9 +4537,25 @@ fn normalize_cook_repository_identity(args: &mut AgentTaskCookArgs) -> homeboy::
     }
     if identities.is_empty() {
         if args.dispatch.workspace.is_some() || args.dispatch.cwd.is_some() {
+            let supplied_workspaces = [
+                args.dispatch.workspace.as_deref(),
+                args.dispatch.cwd.as_deref(),
+            ]
+            .into_iter()
+            .flatten()
+            .map(cook_workspace_path)
+            .collect::<homeboy::core::Result<Vec<_>>>()?;
+            let supplied_git_checkout = supplied_workspaces
+                .into_iter()
+                .flatten()
+                .any(|path| homeboy::core::git::repo_root(&path).is_some());
             return require_explicit_cook_repo(
                 args,
-                "the supplied workspace is not a Git checkout with a configured repository remote",
+                if supplied_git_checkout {
+                    "the supplied Git checkout has no configured repository remote mapping"
+                } else {
+                    "the supplied workspace is not a Git checkout"
+                },
             );
         }
         return bind_cook_repository_identity_from_config(args);
@@ -4947,19 +4963,7 @@ pub(super) fn cook_repository_identities_for_workspace(
     value: &str,
     requested_repository: Option<&str>,
 ) -> homeboy::core::Result<Vec<CookRepositoryIdentity>> {
-    let path = Path::new(value);
-    let workspace_path = if path.is_dir() {
-        std::fs::canonicalize(path).map_err(|error| {
-            homeboy::core::Error::internal_io(error.to_string(), Some(path.display().to_string()))
-        })?
-    } else if let Some(target) =
-        homeboy::core::worktree_provider::resolve_native_worktree_mutation_target(
-            value,
-            homeboy::core::worktree_provider::WorktreeMutationContext::default(),
-        )?
-    {
-        target.path
-    } else {
+    let Some(workspace_path) = cook_workspace_path(value)? else {
         return Ok(Vec::new());
     };
     let Some(git_root) = homeboy::core::git::repo_root(&workspace_path) else {
@@ -5028,6 +5032,22 @@ pub(super) fn cook_repository_identities_for_workspace(
         }
     }
     Ok(identities)
+}
+
+fn cook_workspace_path(value: &str) -> homeboy::core::Result<Option<PathBuf>> {
+    let path = Path::new(value);
+    if path.is_dir() {
+        return std::fs::canonicalize(path).map(Some).map_err(|error| {
+            homeboy::core::Error::internal_io(error.to_string(), Some(path.display().to_string()))
+        });
+    }
+    Ok(
+        homeboy::core::worktree_provider::resolve_native_worktree_mutation_target(
+            value,
+            homeboy::core::worktree_provider::WorktreeMutationContext::default(),
+        )?
+        .map(|target| target.path),
+    )
 }
 
 pub(crate) fn canonical_remote_identity(remote_url: &str) -> Option<String> {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -708,7 +708,7 @@ fn cook_explicit_repo_skips_unrelated_portable_git_enrichment() {
 }
 
 #[test]
-fn cook_infers_repo_from_an_explicit_git_workspace_and_persists_its_provenance() {
+fn cook_infers_repo_from_an_explicit_linked_worktree_cwd_and_persists_its_provenance() {
     with_isolated_home(|_| {
         let source = tempfile::tempdir().expect("source checkout");
         init_runtime_component_checkout(source.path());
@@ -737,15 +737,15 @@ fn cook_infers_repo_from_an_explicit_git_workspace_and_persists_its_provenance()
             "cook".to_string(),
             "--prompt".to_string(),
             "implement the fix".to_string(),
-            "--workspace".to_string(),
-            source.path().display().to_string(),
-            "--to-worktree".to_string(),
+            "--cwd".to_string(),
             destination.display().to_string(),
+            "--task-url".to_string(),
+            "https://github.com/example/inferred/issues/13947".to_string(),
             "--backend".to_string(),
             "fixture".to_string(),
             "--no-finalize".to_string(),
         ]))
-        .expect("infer repository from workspace");
+        .expect("infer repository from linked worktree cwd");
         assert_eq!(args.dispatch.repo.as_deref(), Some("inferred"));
         assert_eq!(
             args.repository_identity.as_ref().expect("identity")["remote_identity"],
@@ -753,7 +753,7 @@ fn cook_infers_repo_from_an_explicit_git_workspace_and_persists_its_provenance()
         );
         assert_eq!(
             args.repository_identity.as_ref().expect("identity")["provenance"],
-            "--workspace:git-remote:origin"
+            "--cwd:git-remote:origin"
         );
 
         let plan = super::super::run::compile_cook_plan(&args, json!({ "path": destination }))
@@ -1611,7 +1611,39 @@ fn cook_requires_repo_for_an_explicit_non_git_workspace() {
         .expect_err("non-Git workspace cannot infer a repository");
         assert_eq!(
             error.details["args"][0],
-            "--repo <repo> is required because the supplied workspace is not a Git checkout with a configured repository remote; provide --repo <configured-component>"
+            "--repo <repo> is required because the supplied workspace is not a Git checkout; provide --repo <repository-or-configured-component>"
+        );
+    });
+}
+
+#[test]
+fn cook_requires_repo_for_an_explicit_git_workspace_without_a_configured_mapping() {
+    with_isolated_home(|_| {
+        let workspace = tempfile::tempdir().expect("workspace");
+        init_runtime_component_checkout(workspace.path());
+        add_remote(
+            workspace.path(),
+            "origin",
+            "https://github.com/example/unconfigured.git",
+        );
+
+        let error = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "implement the fix".to_string(),
+            "--cwd".to_string(),
+            workspace.path().display().to_string(),
+            "--to-worktree".to_string(),
+            workspace.path().display().to_string(),
+            "--no-finalize".to_string(),
+        ]))
+        .expect_err("unmapped Git workspace cannot infer a repository");
+
+        assert_eq!(
+            error.details["args"][0],
+            "--repo <repo> is required because the supplied Git checkout has no configured repository remote mapping; provide --repo <repository-or-configured-component>"
         );
     });
 }


### PR DESCRIPTION
## Summary

- infer configured repository identity from an explicit linked-worktree `--cwd`
- distinguish non-Git workspaces from Git checkouts without configured remote mappings
- preserve canonical remote provenance in the Cook plan

Closes #13947.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-cli linked_worktree_cwd -- --nocapture`
- `cargo test -p homeboy-cli git_workspace_without_a_configured_mapping -- --nocapture`
- `cargo test -p homeboy-cli explicit_non_git_workspace -- --nocapture`

## AI assistance

OpenAI GPT-5.6 Terra via OpenCode inspected the Cook repository-resolution contract, implemented the fix and focused tests, and ran verification. OpenAI GPT-5.6 Sol via OpenCode reviewed, rebased, and published the candidate under Chris Huber's direction.