### PR TITLE
Consolidate runner workspace transfer accounting ownership

### DIFF
--- a/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-lab-runner-contract/src/lib.rs
@@ -33,6 +33,11 @@ pub use homeboy_runner_contract::{
     is_internal_control_env, RUNNER_HOSTED_EXEC_ENV, RUNNER_ID_ENV, RUNNER_PLACEMENT_RESOLVED_ENV,
 };
 /// Compatibility exports for established Lab runner consumers. Generic runner
+/// workspace state is canonical in `homeboy-runner-contract`.
+pub use homeboy_runner_contract::{
+    ByteFileCounts, RunnerWorkspaceCurrentSummary, RunnerWorkspaceLease, RunnerWorkspaceSyncMode,
+};
+/// Compatibility exports for established Lab runner consumers. Generic runner
 /// artifact results are canonical in `homeboy-runner-contract`.
 pub use homeboy_runner_contract::{RunnerArtifactRef, RunnerMutationArtifacts};
 /// Compatibility exports for established Lab runner consumers. Generic runner
@@ -53,24 +58,12 @@ pub use homeboy_runner_contract::{
 pub use homeboy_runner_contract::{
     RunnerResourceGuardLimits, RunnerResourceGuardViolation, RunnerResourceMetrics,
 };
-/// Compatibility exports for established Lab runner consumers. Generic runner
-/// workspace state is canonical in `homeboy-runner-contract`.
-pub use homeboy_runner_contract::{
-    RunnerWorkspaceCurrentSummary, RunnerWorkspaceLease, RunnerWorkspaceSyncMode,
-};
 pub use placement::Placement;
 pub use provider_source_types::AgentTaskProviderRunnerSource;
 
 use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
-
-/// File + byte counts for a workspace sync.
-#[derive(Debug, Clone, Copy, Default, Serialize, PartialEq, Eq)]
-pub struct ByteFileCounts {
-    pub files: usize,
-    pub bytes: u64,
-}
 
 /// Options controlling how a runner workspace is synced before a job runs.
 #[derive(Debug, Clone, Default)]

--- a/crates/contracts/homeboy-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-runner-contract/src/lib.rs
@@ -34,7 +34,9 @@ pub use session::{
     RunnerProxyForward, RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerTunnelMode,
     RunnerTunnelProcessStartIdentity,
 };
-pub use workspace::{RunnerWorkspaceCurrentSummary, RunnerWorkspaceLease, RunnerWorkspaceSyncMode};
+pub use workspace::{
+    ByteFileCounts, RunnerWorkspaceCurrentSummary, RunnerWorkspaceLease, RunnerWorkspaceSyncMode,
+};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/crates/contracts/homeboy-runner-contract/src/workspace.rs
+++ b/crates/contracts/homeboy-runner-contract/src/workspace.rs
@@ -4,6 +4,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::RunnerLifecycleOwner;
 
+/// File and byte counts for a runner workspace transfer.
+#[derive(Debug, Clone, Copy, Default, Serialize, PartialEq, Eq)]
+pub struct ByteFileCounts {
+    pub files: usize,
+    pub bytes: u64,
+}
+
 /// A lease describing a runner's materialized workspace.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RunnerWorkspaceLease {
@@ -73,6 +80,22 @@ impl RunnerWorkspaceSyncMode {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn byte_file_counts_keep_their_wire_shape_and_zero_default() {
+        assert_eq!(
+            serde_json::to_value(ByteFileCounts::default()).expect("serialize"),
+            serde_json::json!({ "files": 0, "bytes": 0 })
+        );
+        assert_eq!(
+            serde_json::to_value(ByteFileCounts {
+                files: 3,
+                bytes: 1024,
+            })
+            .expect("serialize"),
+            serde_json::json!({ "files": 3, "bytes": 1024 })
+        );
+    }
 
     #[test]
     fn workspace_lease_keeps_its_minimal_wire_shape() {

--- a/crates/homeboy-lab-runner/src/workspace/types.rs
+++ b/crates/homeboy-lab-runner/src/workspace/types.rs
@@ -649,9 +649,8 @@ pub use homeboy_runner_contract::RunnerWorkspaceCurrentSummary;
 /// Shared across the workspace-sync and git-dependency materialization outputs
 /// so the `files` / `bytes` pair is declared once. Serialized flat via
 /// `#[serde(flatten)]` to preserve the historical top-level JSON keys.
-// ByteFileCounts now lives in the shared runner-contract crate (core's dev_run
-// names it). Re-exported so runner-internal call sites resolve.
-pub use homeboy_lab_runner_contract::ByteFileCounts;
+// Re-exported so runner-internal call sites resolve.
+pub use homeboy_runner_contract::ByteFileCounts;
 
 pub(super) type SnapshotStats = ByteFileCounts;
 


### PR DESCRIPTION
## Summary

- move `ByteFileCounts` into the transport-neutral runner contract
- preserve the established Lab contract import through a compatibility re-export
- migrate the Lab workspace implementation to the canonical package directly
- pin the exact `{ files, bytes }` wire shape and zero default

Closes #13956
Parent: #13881

## Verification

- `cargo test -p homeboy-runner-contract`
- `cargo test -p homeboy-lab-runner-contract`
- `cargo check -p homeboy-lab-runner`
- `cargo clippy -p homeboy-runner-contract -p homeboy-lab-runner-contract --all-targets -- -D warnings`
- `cargo test -p homeboy-paths workspace_membership_is_complete`
- `cargo fmt --all -- --check`
- `git diff --check`

A broad `cargo test -p homeboy-lab-runner workspace` run passed 350 of 352 selected tests. Two existing environment-sensitive assertions failed around ambient Git ignore configuration and installed-command rendering; this patch changes only type ownership/imports and the focused workspace consumer check passes.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode identified the bounded generic accounting record, implemented the canonical ownership move and compatibility facade, ran the verification gates, and prepared this pull request under Chris Huber’s direction.