### PR TITLE
Add native worktree handoff freshness proof

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/execution.rs
+++ b/crates/homeboy-agents/src/agent_task_service/execution.rs
@@ -2567,6 +2567,7 @@ fn prepare_component_worktree_workspace(
         task_url,
         run_id: run_id.map(str::to_string),
         cleanup_policy: cleanup_policy.clone(),
+        require_handoff_freshness: false,
     })?;
     let (root, cleanup, materialization) = match created {
         worktree_provider::WorktreeProviderCreateOutput::Native(created) => {

--- a/crates/homeboy-agents/src/agent_tool_control_plane.rs
+++ b/crates/homeboy-agents/src/agent_tool_control_plane.rs
@@ -539,6 +539,7 @@ mod tools {
             task_url: optional_string(input, &["task_url"]).map(str::to_string),
             run_id: optional_string(input, &["run_id", "task_ref"]).map(str::to_string),
             cleanup_policy: None,
+            require_handoff_freshness: false,
         })
         .map_err(|error| AgentTaskDiagnostic {
             class: "agent_tool.homeboy_error".to_string(),

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -6824,6 +6824,7 @@ mod tests {
                 task_url: plan.cooks[0].task_url.clone(),
                 run_id: Some(plan.cooks[0].run_id()),
                 cleanup_policy: Some(homeboy::core::worktree::CleanupPolicy::RemoveWhenSafe),
+                require_handoff_freshness: false,
             })
             .expect("native destination");
             let report = agent_task_service::AgentTaskCookBatchReport {

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -2781,6 +2781,7 @@ fn cook_rejects_an_inactive_managed_destination_before_provider_execution() {
                 task_url: None,
                 run_id: None,
                 cleanup_policy: None,
+                require_handoff_freshness: false,
             })
             .expect("create managed worktree");
         let cwd = created.record.worktree_path.clone();

--- a/crates/homeboy-cli/src/commands/worktree.rs
+++ b/crates/homeboy-cli/src/commands/worktree.rs
@@ -65,6 +65,9 @@ enum WorktreeCommand {
         /// Cleanup policy for lifecycle cleanup
         #[arg(long, value_enum)]
         cleanup_policy: Option<CliCleanupPolicy>,
+        /// Require bounded remote freshness proof before allocating the worktree
+        #[arg(long)]
+        require_handoff_freshness: bool,
     },
     /// Import an existing exact Git worktree into the built-in lifecycle registry
     Import {
@@ -519,6 +522,7 @@ pub fn run(args: WorktreeArgs) -> CmdResult<WorktreeOutput> {
             task_url,
             run_id,
             cleanup_policy,
+            require_handoff_freshness,
         } => WorktreeOutput::Create(
             worktree_provider::create_worktree(WorktreeCreateOptions {
                 component_id,
@@ -527,6 +531,7 @@ pub fn run(args: WorktreeArgs) -> CmdResult<WorktreeOutput> {
                 task_url,
                 run_id,
                 cleanup_policy: cleanup_policy.map(Into::into),
+                require_handoff_freshness,
             })?
             .into(),
         ),

--- a/crates/homeboy-core/src/worktree/mod.rs
+++ b/crates/homeboy-core/src/worktree/mod.rs
@@ -27,16 +27,17 @@ pub use types::{
     WorktreeBranchCleanupReport, WorktreeCleanupCandidate, WorktreeCleanupCounts,
     WorktreeCleanupOptions, WorktreeCleanupOutput, WorktreeCleanupSkipped, WorktreeCreateAction,
     WorktreeCreateEvidence, WorktreeCreateOptions, WorktreeCreateOutput,
-    WorktreeCreateReconciliation, WorktreeImportOptions, WorktreeImportOutput,
-    WorktreeInventoryApplyRefusal, WorktreeInventoryAuthorization, WorktreeInventoryCrossTab,
-    WorktreeInventoryLocalEvidence, WorktreeInventoryOptions, WorktreeInventoryOutput,
-    WorktreeInventoryRecord, WorktreeLeaseActivity, WorktreeListOutput, WorktreeLivenessAuthority,
-    WorktreeOwnershipProbe, WorktreeQueueCreateFailure, WorktreeQueueCreateOptions,
-    WorktreeQueueCreateOutput, WorktreeQueueCreateRequest, WorktreeQueueCreateRow,
-    WorktreeQueueCreateStatus, WorktreeQueueLockHolder, WorktreeReconciliationAction,
-    WorktreeReconciliationAuthority, WorktreeReconciliationResult, WorktreeRemoveOptions,
-    WorktreeRemoveOutput, WorktreeSafetyReport, WorktreeStatusOutput,
-    TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY, TERMINAL_WORKSPACE_AUTHORITY_SCHEMA,
+    WorktreeCreateReconciliation, WorktreeHandoffFreshness, WorktreeHandoffFreshnessProof,
+    WorktreeImportOptions, WorktreeImportOutput, WorktreeInventoryApplyRefusal,
+    WorktreeInventoryAuthorization, WorktreeInventoryCrossTab, WorktreeInventoryLocalEvidence,
+    WorktreeInventoryOptions, WorktreeInventoryOutput, WorktreeInventoryRecord,
+    WorktreeLeaseActivity, WorktreeListOutput, WorktreeLivenessAuthority, WorktreeOwnershipProbe,
+    WorktreeQueueCreateFailure, WorktreeQueueCreateOptions, WorktreeQueueCreateOutput,
+    WorktreeQueueCreateRequest, WorktreeQueueCreateRow, WorktreeQueueCreateStatus,
+    WorktreeQueueLockHolder, WorktreeReconciliationAction, WorktreeReconciliationAuthority,
+    WorktreeReconciliationResult, WorktreeRemoveOptions, WorktreeRemoveOutput,
+    WorktreeSafetyReport, WorktreeStatusOutput, TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY,
+    TERMINAL_WORKSPACE_AUTHORITY_SCHEMA,
 };
 
 /// The managed handle a repo and branch pair resolves to. Creation slugifies the
@@ -793,6 +794,7 @@ pub fn queue_create(options: WorktreeQueueCreateOptions) -> Result<WorktreeQueue
                 task_url: request.task_url.clone(),
                 run_id: request.run_id.clone(),
                 cleanup_policy: None,
+                require_handoff_freshness: false,
             })
             .map(|created| created.record.worktree_path)
         };

--- a/crates/homeboy-core/src/worktree/store_ops.rs
+++ b/crates/homeboy-core/src/worktree/store_ops.rs
@@ -381,6 +381,15 @@ fn create_with_store_unlocked(
     {
         return Err(branch_ownership_error(&options.branch, registration));
     }
+    let handoff_base_ref = existing
+        .as_ref()
+        .map(|record| record.base_ref.as_str())
+        .or(options.from.as_deref())
+        .unwrap_or("HEAD");
+    let handoff_observation = options
+        .require_handoff_freshness
+        .then(|| prepare_handoff_freshness(&source_checkout, handoff_base_ref))
+        .transpose()?;
     if worktree_path.exists() {
         let record = existing.ok_or_else(|| {
             Error::validation_invalid_argument(
@@ -405,6 +414,9 @@ fn create_with_store_unlocked(
             })?;
         verify_linked_worktree_identity(&source_checkout, &worktree_path, &options.branch)?;
         return Ok(WorktreeCreateOutput {
+            handoff_freshness: handoff_observation
+                .map(|observation| complete_handoff_freshness(&record, observation))
+                .transpose()?,
             record,
             reconciliation: None,
         });
@@ -463,6 +475,9 @@ fn create_with_store_unlocked(
         pin_worktree_identity(&worktree_path)?;
         let current = create_evidence(&record, "registered".to_string())?;
         return Ok(WorktreeCreateOutput {
+            handoff_freshness: handoff_observation
+                .map(|observation| complete_handoff_freshness(&record, observation))
+                .transpose()?,
             record,
             reconciliation: Some(WorktreeCreateReconciliation {
                 action: WorktreeCreateAction::Restored,
@@ -512,8 +527,123 @@ fn create_with_store_unlocked(
     record.workspace_identity = Some(record.effective_workspace_identity()?);
     write_record_unlocked(store_dir, &record)?;
     Ok(WorktreeCreateOutput {
+        handoff_freshness: handoff_observation
+            .map(|observation| complete_handoff_freshness(&record, observation))
+            .transpose()?,
         record,
         reconciliation: None,
+    })
+}
+
+#[derive(Debug)]
+struct PendingHandoffFreshness {
+    resolved_base_ref: String,
+    resolved_base_sha: String,
+    remote_default_ref: String,
+    remote_default_sha: String,
+}
+
+fn prepare_handoff_freshness(source: &Path, base_ref: &str) -> Result<PendingHandoffFreshness> {
+    const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+    git::run_git_with_env_timeout(
+        source,
+        &["fetch", "origin"],
+        "git fetch origin for worktree handoff",
+        &[],
+        TIMEOUT,
+    )?;
+    let advertised = git::run_git_with_env_timeout(
+        source,
+        &["ls-remote", "--symref", "origin", "HEAD"],
+        "git ls-remote origin HEAD for worktree handoff",
+        &[],
+        TIMEOUT,
+    )?;
+    let remote_head = advertised.lines().find_map(|line| {
+        line.strip_prefix("ref: refs/heads/")
+            .and_then(|value| value.strip_suffix("\tHEAD"))
+    });
+    let advertised_sha = advertised.lines().find_map(|line| {
+        let (sha, name) = line.split_once('\t')?;
+        (name == "HEAD"
+            && (40..=64).contains(&sha.len())
+            && sha.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        .then(|| sha.to_ascii_lowercase())
+    });
+    let (remote_head, advertised_sha) = remote_head.zip(advertised_sha).ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "handoff_freshness",
+            "Remote origin did not advertise an unambiguous default branch and commit",
+            None,
+            Some(vec![
+                "Configure origin/HEAD or provide a reachable remote.".to_string()
+            ]),
+        )
+    })?;
+    let remote_default_ref = format!("refs/remotes/origin/{remote_head}");
+    let remote_default_sha = git::run_git_with_env_timeout(
+        source,
+        &[
+            "rev-parse",
+            "--verify",
+            &format!("{remote_default_ref}^{{commit}}"),
+        ],
+        "resolve fetched remote default for worktree handoff",
+        &[],
+        TIMEOUT,
+    )?
+    .trim()
+    .to_ascii_lowercase();
+    if remote_default_sha != advertised_sha {
+        return Err(Error::validation_invalid_argument(
+            "handoff_freshness",
+            "Remote default changed during worktree handoff verification",
+            Some(remote_default_ref),
+            Some(vec!["Retry to verify one remote advertisement.".to_string()]),
+        ));
+    }
+    let resolved_base_sha = git::run_git_with_env_timeout(
+        source,
+        &["rev-parse", "--verify", &format!("{base_ref}^{{commit}}")],
+        "resolve worktree handoff base",
+        &[],
+        TIMEOUT,
+    )?
+    .trim()
+    .to_ascii_lowercase();
+    Ok(PendingHandoffFreshness {
+        resolved_base_ref: base_ref.to_string(),
+        resolved_base_sha,
+        remote_default_ref,
+        remote_default_sha,
+    })
+}
+
+fn complete_handoff_freshness(
+    record: &TaskWorktreeRecord,
+    observation: PendingHandoffFreshness,
+) -> Result<WorktreeHandoffFreshness> {
+    let worktree_sha = git::run_git(
+        Path::new(&record.worktree_path),
+        &["rev-parse", "--verify", "HEAD^{commit}"],
+        "resolve worktree handoff HEAD",
+    )?
+    .trim()
+    .to_ascii_lowercase();
+    Ok(WorktreeHandoffFreshness {
+        status: "verified".to_string(),
+        proof: WorktreeHandoffFreshnessProof {
+            schema: "homeboy/worktree-handoff-freshness/v1".to_string(),
+            proof_id: uuid::Uuid::new_v4().to_string(),
+            handle: record.id.clone(),
+            worktree_sha,
+            resolved_base_ref: observation.resolved_base_ref,
+            resolved_base_sha: observation.resolved_base_sha,
+            remote_default_ref: observation.remote_default_ref,
+            remote_default_sha: observation.remote_default_sha.clone(),
+            remote_default_advertised_sha: observation.remote_default_sha,
+            verified_at: chrono::Utc::now().to_rfc3339(),
+        },
     })
 }
 

--- a/crates/homeboy-core/src/worktree/tests.rs
+++ b/crates/homeboy-core/src/worktree/tests.rs
@@ -389,6 +389,7 @@ fn registered_create_fixture(home: &Path, id: &str) -> (PathBuf, WorktreeCreateO
             task_url: Some("https://example.com/tasks/restore".to_string()),
             run_id: None,
             cleanup_policy: None,
+            require_handoff_freshness: false,
         },
     )
 }
@@ -595,6 +596,112 @@ fn create_returns_existing_matching_task_worktree_idempotently() {
         assert_eq!(existing.record, created.record);
         assert!(created.reconciliation.is_none());
         assert!(existing.reconciliation.is_none());
+    });
+}
+
+fn add_bare_origin(home: &Path, source: &Path) -> PathBuf {
+    let remote = home.join("remote.git");
+    fs::create_dir_all(&remote).expect("remote directory");
+    run_git(&remote, &["init", "--bare", "-q"]);
+    run_git(source, &["branch", "-M", "main"]);
+    run_git(
+        source,
+        &["remote", "add", "origin", &remote.to_string_lossy()],
+    );
+    run_git(source, &["push", "-q", "-u", "origin", "main"]);
+    run_git(&remote, &["symbolic-ref", "HEAD", "refs/heads/main"]);
+    remote
+}
+
+#[test]
+fn create_can_issue_remote_verified_handoff_freshness() {
+    crate::test_support::with_isolated_home(|home| {
+        let (source, mut options) = registered_create_fixture(home.path(), "fresh-fixture");
+        add_bare_origin(home.path(), &source);
+        options.from = Some("origin/main".to_string());
+        options.require_handoff_freshness = true;
+
+        let created = create(options).expect("create with freshness proof");
+        let freshness = created.handoff_freshness.expect("freshness evidence");
+
+        assert_eq!(freshness.status, "verified");
+        assert_eq!(freshness.proof.handle, created.record.id);
+        assert_eq!(freshness.proof.resolved_base_ref, "origin/main");
+        assert_eq!(
+            freshness.proof.remote_default_sha,
+            freshness.proof.remote_default_advertised_sha
+        );
+        assert_eq!(
+            freshness.proof.worktree_sha,
+            freshness.proof.resolved_base_sha
+        );
+    });
+}
+
+#[test]
+fn freshness_required_create_fetches_an_advanced_remote_base() {
+    crate::test_support::with_isolated_home(|home| {
+        let (source, mut options) = registered_create_fixture(home.path(), "advanced-fixture");
+        let remote = add_bare_origin(home.path(), &source);
+        let updater = home.path().join("updater");
+        run_git(
+            home.path(),
+            &[
+                "clone",
+                "-q",
+                &remote.to_string_lossy(),
+                &updater.to_string_lossy(),
+            ],
+        );
+        run_git(&updater, &["config", "user.email", "homeboy@example.com"]);
+        run_git(&updater, &["config", "user.name", "Homeboy Test"]);
+        fs::write(updater.join("advanced.txt"), "advanced\n").expect("advanced file");
+        run_git(&updater, &["add", "."]);
+        run_git(&updater, &["commit", "-q", "-m", "advance remote"]);
+        run_git(&updater, &["push", "-q", "origin", "main"]);
+        let advanced_sha = git::run_git(&updater, &["rev-parse", "HEAD"], "advanced sha")
+            .unwrap()
+            .trim()
+            .to_string();
+
+        options.from = Some("origin/main".to_string());
+        options.require_handoff_freshness = true;
+        let created = create(options).expect("create from refreshed base");
+        let proof = created.handoff_freshness.expect("freshness").proof;
+
+        assert_eq!(proof.resolved_base_sha, advanced_sha);
+        assert_eq!(proof.worktree_sha, advanced_sha);
+    });
+}
+
+#[test]
+fn freshness_failure_refuses_before_worktree_allocation() {
+    crate::test_support::with_isolated_home(|home| {
+        let (source, mut options) = registered_create_fixture(home.path(), "failed-fixture");
+        let missing = home.path().join("missing-remote.git");
+        run_git(
+            &source,
+            &["remote", "add", "origin", &missing.to_string_lossy()],
+        );
+        options.from = Some("origin/main".to_string());
+        options.require_handoff_freshness = true;
+        let branch = options.branch.clone();
+        let expected_path = source.parent().unwrap().join("failed-fixture@fix-restore");
+
+        create(options).expect_err("unverifiable remote must fail closed");
+
+        assert!(!expected_path.exists());
+        assert!(git::run_git(
+            &source,
+            &[
+                "show-ref",
+                "--verify",
+                "--quiet",
+                &format!("refs/heads/{branch}")
+            ],
+            "branch absence"
+        )
+        .is_err());
     });
 }
 

--- a/crates/homeboy-core/src/worktree/types.rs
+++ b/crates/homeboy-core/src/worktree/types.rs
@@ -353,6 +353,28 @@ pub struct WorktreeCreateOutput {
     pub record: TaskWorktreeRecord,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reconciliation: Option<WorktreeCreateReconciliation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub handoff_freshness: Option<WorktreeHandoffFreshness>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct WorktreeHandoffFreshness {
+    pub status: String,
+    pub proof: WorktreeHandoffFreshnessProof,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct WorktreeHandoffFreshnessProof {
+    pub schema: String,
+    pub proof_id: String,
+    pub handle: String,
+    pub worktree_sha: String,
+    pub resolved_base_ref: String,
+    pub resolved_base_sha: String,
+    pub remote_default_ref: String,
+    pub remote_default_sha: String,
+    pub remote_default_advertised_sha: String,
+    pub verified_at: String,
 }
 
 #[derive(Debug, Clone)]
@@ -625,6 +647,7 @@ pub struct WorktreeCreateOptions {
     pub task_url: Option<String>,
     pub run_id: Option<String>,
     pub cleanup_policy: Option<CleanupPolicy>,
+    pub require_handoff_freshness: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/homeboy-core/src/worktree_provider.rs
+++ b/crates/homeboy-core/src/worktree_provider.rs
@@ -772,6 +772,7 @@ impl WorktreeProvisionProvider for NativeWorktreeProvider {
                     worktree::CleanupPolicy::PreserveOnFailure
                 }
             }),
+            require_handoff_freshness: false,
         })?;
         Ok(WorktreeProvision {
             destination: WorktreeProvisionDestination {
@@ -2591,6 +2592,7 @@ mod tests {
                     task_url: None,
                     run_id: None,
                     cleanup_policy: None,
+                    require_handoff_freshness: false,
                 },
                 &config,
             )


### PR DESCRIPTION
## Summary
- add opt-in `--require-handoff-freshness` to native worktree creation
- fetch and verify the remote default and requested base before allocation
- return exact post-allocation SHA evidence for downstream handoff validation

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p homeboy-core create_can_issue_remote_verified_handoff_freshness --lib`
- `cargo test -p homeboy-core freshness_required_create_fetches_an_advanced_remote_base --lib`
- `cargo test -p homeboy-core freshness_failure_refuses_before_worktree_allocation --lib`
- `cargo check -p homeboy-cli`
- `cargo build -p homeboy-cli`

Tracks #13940.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented and verified the bounded native freshness contract under Chris Huber's direction. Chris reviewed the runtime evidence and remains responsible for the change.