### PR TITLE
Fix Cook isolated snapshot promotion base

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -5100,7 +5100,7 @@ fn run_cook_spine(
         && (options.provider_transport.attempt_dispatcher.is_none()
             || options.workspace.source_worktree_path.is_some())
     {
-        validate_cook_workspace_with_adopted_candidate(
+        let workspace_base = validate_cook_workspace_with_adopted_candidate(
             &options,
             options.workspace.source_worktree_path.is_some()
                 && !cook_uses_explicit_cwd_workspace(&options),
@@ -5109,6 +5109,12 @@ fn run_cook_spine(
             error.details["cook_materialized_by_invocation"] = materialized_by_invocation.into();
             error
         })?;
+        if let Some(CookWorkspaceBaseValidation::Snapshot(snapshot)) = workspace_base {
+            if let Some(resolved_base) = snapshot.get("resolved_base").and_then(Value::as_str) {
+                options.workspace.task_base_sha = Some(resolved_base.to_string());
+                options.identity.initial_plan.metadata["cook_workspace_base_snapshot"] = snapshot;
+            }
+        }
     }
     // Base resolution reaches origin. Keep its transport failure behind the
     // recipe/run saga so retry and replay have durable zero-provider evidence.

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -348,6 +348,21 @@ fn missing_promotion_source_error(
     )
 }
 
+pub(super) fn cook_candidate_base_sha(options: &CookRequest) -> Option<String> {
+    options
+        .identity
+        .initial_plan
+        .metadata
+        .get("cook_workspace_base_snapshot")
+        .filter(|snapshot| {
+            snapshot.get("mode").and_then(Value::as_str) == Some("isolated_attempt_snapshot")
+        })
+        .and_then(|snapshot| snapshot.get("resolved_base"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| options.workspace.task_base_sha.clone())
+}
+
 pub(crate) fn promote_attempt_in_store(
     lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
     options: &CookRequest,
@@ -368,7 +383,7 @@ pub(crate) fn promote_attempt_in_store(
             source_worktree_path: component_workspace_path(options)?
                 .or_else(|| options.workspace.source_worktree_path.clone()),
             base_ref: Some(options.finalization.base.clone()),
-            task_base_sha: options.workspace.task_base_sha.clone(),
+            task_base_sha: cook_candidate_base_sha(options),
             candidate_ref: None,
             to_worktree: options.workspace.to_worktree.clone(),
             task_id: selected_task_id,
@@ -416,7 +431,7 @@ pub(crate) fn canonical_cook_patch_artifact_id_in_store(
         source_worktree_path: component_workspace_path(options)?
             .or_else(|| options.workspace.source_worktree_path.clone()),
         base_ref: Some(options.finalization.base.clone()),
-        task_base_sha: options.workspace.task_base_sha.clone(),
+        task_base_sha: cook_candidate_base_sha(options),
         candidate_ref: None,
         to_worktree: options.workspace.to_worktree.clone(),
         task_id,
@@ -842,7 +857,7 @@ pub(crate) fn promote_or_load_attempt_in_store(
                     source_worktree_path: component_workspace_path(options)?
                         .or_else(|| options.workspace.source_worktree_path.clone()),
                     base_ref: Some(options.finalization.base.clone()),
-                    task_base_sha: options.workspace.task_base_sha.clone(),
+                    task_base_sha: cook_candidate_base_sha(options),
                     candidate_ref: None,
                     to_worktree: options.workspace.to_worktree.clone(),
                     // A resumed verification must retain the scheduler-selected

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -11,21 +11,22 @@ use super::super::cook_baseline::git_output;
 use super::super::cook_pre_execution::recover_recipe_attempt_with_stores;
 use super::super::cook_promotion::{
     canonical_cook_patch_artifact_id_in_store, canonical_cook_recovery_run_id,
-    cook_finalization_options, cook_finalization_options_with_stores, cook_promotion_argv,
-    cook_report, finalize_cook_pr_with_backend, finalize_cook_pr_with_backend_with_stores,
-    finalize_or_load_cook_pr_with_backend, finalize_or_load_cook_pr_with_backend_with_stores,
-    mark_replacement_gate_execution_started, moving_base_recovery_for_run,
-    moving_base_recovery_for_run_with_stores, moving_base_recovery_from_promotion,
-    moving_base_recovery_report, next_moving_base_recovery, persist_manual_finalization_intent,
-    persist_manual_finalization_receipt, persisted_promotion_for_attempt,
-    persisted_promotion_for_attempt_in_store, prepare_manual_finalization_identity,
-    record_replacement_gate_proof, recover_cook_pr_with_backend,
-    recover_moving_base_cook_candidate_in_store, refreshed_moving_base_recovery,
-    replacement_gate_execution_started, selected_candidate_task_id_in_store,
-    verify_replacement_gates, CookReportInput, MovingBaseCookRecovery,
+    cook_candidate_base_sha, cook_finalization_options, cook_finalization_options_with_stores,
+    cook_promotion_argv, cook_report, finalize_cook_pr_with_backend,
+    finalize_cook_pr_with_backend_with_stores, finalize_or_load_cook_pr_with_backend,
+    finalize_or_load_cook_pr_with_backend_with_stores, mark_replacement_gate_execution_started,
+    moving_base_recovery_for_run, moving_base_recovery_for_run_with_stores,
+    moving_base_recovery_from_promotion, moving_base_recovery_report, next_moving_base_recovery,
+    persist_manual_finalization_intent, persist_manual_finalization_receipt,
+    persisted_promotion_for_attempt, persisted_promotion_for_attempt_in_store,
+    prepare_manual_finalization_identity, record_replacement_gate_proof,
+    recover_cook_pr_with_backend, recover_moving_base_cook_candidate_in_store,
+    refreshed_moving_base_recovery, replacement_gate_execution_started,
+    selected_candidate_task_id_in_store, verify_replacement_gates, CookReportInput,
+    MovingBaseCookRecovery,
 };
 use super::super::cook_recipe::{
-    persist_initial_recipe, set_initial_recipe_creation_barrier_for_test,
+    load_recipe, persist_initial_recipe, set_initial_recipe_creation_barrier_for_test,
 };
 use super::*;
 use crate::agent_task::{
@@ -4557,6 +4558,11 @@ fn workspace_base_ancestry_preflight_converges_clean_behind_destination_at_pinne
             Some(observed_base.as_str()),
             "provider runs from the pinned base even after main advances"
         );
+        let recipe = load_recipe("cook-stale-origin-base").expect("persisted Cook recipe");
+        assert_eq!(
+            recipe.finalization["task_base_sha"], observed_base,
+            "the durable candidate base matches the isolated attempt snapshot"
+        );
 
         std::fs::write(destination.join("uncommitted.txt"), "user drift\n").unwrap();
         let dirty = preflight_cook_workspace_base_ancestry(&destination, "main", &[], false)
@@ -4613,6 +4619,25 @@ fn workspace_base_ancestry_preflight_converges_clean_behind_destination_at_pinne
             1
         );
     });
+}
+
+#[test]
+fn cook_promotion_recovers_legacy_stale_base_from_attempt_snapshot() {
+    let mut options = batch_cook_options(
+        "cook-legacy-stale-base",
+        Arc::new(AcceptedDetachedAttemptDispatcher),
+    );
+    options.workspace.task_base_sha = Some("stale-destination-head".to_string());
+    options.identity.initial_plan.metadata["cook_workspace_base_snapshot"] = serde_json::json!({
+        "schema": "homeboy/cook-workspace-base-snapshot/v1",
+        "mode": "isolated_attempt_snapshot",
+        "resolved_base": "candidate-base",
+    });
+
+    assert_eq!(
+        cook_candidate_base_sha(&options).as_deref(),
+        Some("candidate-base")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- persist the resolved isolated-attempt snapshot as the durable Cook candidate base
- prefer that immutable snapshot during promotion for legacy recipes that recorded the stale destination HEAD
- cover both new recipe persistence and retained-candidate recovery

This is a bounded repair within #13940. It restores promotion for a candidate produced from current `main` while an explicit clean destination was behind at Cook admission.

## Reproduction evidence

- Cook: `agent-task-9de1206b-8897-49ec-8b15-2aeb2a1d1076`
- Attempt: `agent-task-9de1206b-8897-49ec-8b15-2aeb2a1d1076-attempt-1-e84f6441`
- Candidate artifact base: `d3fac4ad4e4bbf6dd457ea2cd46aeb1a081b217b`
- Legacy recipe base: `0e1972b49e3e43061eabe9ffba522f61fe290394`
- Observed failure: recoverable promotion rejected the otherwise fingerprinted artifact because the recipe compared it to the stale destination base

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p homeboy-agents`
- `cargo test -p homeboy-agents workspace_base_ancestry_preflight_converges_clean_behind_destination_at_pinned_moving_main`
- `cargo test -p homeboy-agents cook_promotion_recovers_legacy_stale_base_from_attempt_snapshot`
- Broader Cook module: 256 passed, 1 pre-existing unrelated redaction assertion failed (`run_next_redacts_poisoned_recipe_dispatcher_kind`), 6 ignored

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed the durable Cook evidence, isolated the snapshot/base mismatch, implemented the bounded repair, and ran the verification under Chris Huber's direction.