### PR TITLE
Terminalize Cook from durable runner failure evidence

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_runner_projection.rs
@@ -80,6 +80,27 @@ pub(crate) fn reconcile_runner_job_snapshot_in_store(
     validate_runner_job_snapshot(record, snapshot)?;
     let mut reconciled = record.clone();
     reconciled.record_runner_reachable();
+    // Typed terminal evidence is authoritative even when a daemon restart left
+    // the denormalized job row queued/running. Consume it before that stale row
+    // can refresh the controller heartbeat and resurrect the Cook.
+    if let Some(event) = terminal_runner_lifecycle_event(&reconciled, snapshot)? {
+        project_terminal_runner_lifecycle_event_in_store(
+            lifecycle_store,
+            &mut reconciled,
+            snapshot,
+            &event,
+        )?;
+        *record = reconciled;
+        return Ok(());
+    }
+    if project_terminal_runner_pre_provider_failure_in_store(
+        lifecycle_store,
+        &mut reconciled,
+        &snapshot.events,
+    )? {
+        *record = reconciled;
+        return Ok(());
+    }
     match snapshot.job.status {
         homeboy_core::api_jobs::JobStatus::Queued | homeboy_core::api_jobs::JobStatus::Running => {
             reconciled.updated_at = Some(now_timestamp());
@@ -133,17 +154,8 @@ pub(crate) fn reconcile_runner_job_snapshot_in_store(
         homeboy_core::api_jobs::JobStatus::Succeeded
         | homeboy_core::api_jobs::JobStatus::Failed
         | homeboy_core::api_jobs::JobStatus::Cancelled => {
-            if let Some(event) = terminal_runner_lifecycle_event(&reconciled, snapshot)? {
-                project_terminal_runner_lifecycle_event_in_store(
-                    lifecycle_store,
-                    &mut reconciled,
-                    snapshot,
-                    &event,
-                )?;
-            } else {
-                record_pending_runner_synchronization(&mut reconciled, snapshot);
-                lifecycle_store.write_record(&reconciled)?;
-            }
+            record_pending_runner_synchronization(&mut reconciled, snapshot);
+            lifecycle_store.write_record(&reconciled)?;
         }
     }
     *record = reconciled;
@@ -412,14 +424,6 @@ pub(crate) fn project_persisted_terminal_runner_events_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     record: &mut AgentTaskRunRecord,
 ) -> Result<bool> {
-    let terminal_status = record
-        .metadata
-        .get("runner_job_status")
-        .and_then(Value::as_str)
-        .is_some_and(|status| matches!(status, "succeeded" | "failed" | "cancelled"));
-    if !terminal_status {
-        return Ok(false);
-    }
     let Some(runner_job_id) = record.runner_job_id() else {
         return Ok(false);
     };
@@ -448,31 +452,160 @@ pub(crate) fn project_persisted_terminal_runner_events_in_store(
     .or_else(|| {
         crate::agent_task_lifecycle::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_job_events(Some(&events))
     });
-    let Some(event) = event else {
-        return Ok(false);
-    };
-    validate_terminal_child_event_identity(record, &event)?;
-    let aggregate = projected_runner_aggregate(record, &event.aggregate);
-    if lifecycle_store.read_aggregate(&record.run_id).ok().as_ref() == Some(&aggregate) {
+    if let Some(event) = event {
+        validate_terminal_child_event_identity(record, &event)?;
+        let aggregate = projected_runner_aggregate(record, &event.aggregate);
+        if lifecycle_store.read_aggregate(&record.run_id).ok().as_ref() == Some(&aggregate) {
+            return Ok(false);
+        }
+        let projection_plan = aggregate_projection_plan_from_outcomes(&aggregate);
+        let aggregate_path = lifecycle_store
+            .aggregate_path(&record.run_id)
+            .display()
+            .to_string();
+        apply_aggregate_to_record(record, &projection_plan, &aggregate, aggregate_path);
+        record_verified_lab_placement_outcome(record)?;
+        record.ensure_metadata_object().insert(
+            "terminal_transport_recovery".to_string(),
+            json!("persisted_runner_job_events"),
+        );
+        lifecycle_store.write_aggregate_and_record(record, &aggregate)?;
+        crate::agent_task_lifecycle::record_terminal_artifact_projection_in_store(
+            lifecycle_store,
+            record,
+            &aggregate,
+        )?;
+        return Ok(true);
+    }
+
+    project_terminal_runner_pre_provider_failure_in_store(lifecycle_store, record, &events)
+}
+
+const RUNNER_PRE_PROVIDER_FAILURE_PHASE: &str = "lab_runner_job_pre_provider";
+
+fn project_terminal_runner_pre_provider_failure_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    record: &mut AgentTaskRunRecord,
+    events: &[homeboy_core::api_jobs::JobEvent],
+) -> Result<bool> {
+    if record.state.is_terminal() {
         return Ok(false);
     }
-    let projection_plan = aggregate_projection_plan_from_outcomes(&aggregate);
-    let aggregate_path = lifecycle_store
-        .aggregate_path(&record.run_id)
-        .display()
-        .to_string();
-    apply_aggregate_to_record(record, &projection_plan, &aggregate, aggregate_path);
-    record_verified_lab_placement_outcome(record)?;
-    record.ensure_metadata_object().insert(
-        "terminal_transport_recovery".to_string(),
-        json!("persisted_runner_job_events"),
-    );
-    lifecycle_store.write_aggregate_and_record(record, &aggregate)?;
-    crate::agent_task_lifecycle::record_terminal_artifact_projection_in_store(
+    let Some(event) = events.iter().rev().find(|event| {
+        event.kind == homeboy_core::api_jobs::JobEventKind::Error
+            && event
+                .data
+                .as_ref()
+                .and_then(|data| data.get("phase"))
+                .and_then(Value::as_str)
+                == Some("local_child_worker_failed_before_child_identity")
+            && event.job_id.to_string() == record.runner_job_id().unwrap_or_default()
+    }) else {
+        return Ok(false);
+    };
+    if record
+        .metadata
+        .pointer("/runner_result_synchronization/source")
+        .and_then(Value::as_str)
+        == Some("typed_runner_job_error")
+        && record
+            .metadata
+            .pointer("/runner_result_synchronization/event_sequence")
+            .and_then(Value::as_u64)
+            == Some(event.sequence)
+    {
+        // The event has already been consumed. Report it handled so the caller
+        // does not fall through and re-project the stale queued/running row.
+        return Ok(true);
+    }
+    let data = event.data.as_ref().expect("typed runner error has data");
+    let reported_code = data
+        .get("error_code")
+        .or_else(|| data.get("code"))
+        .and_then(Value::as_str)
+        .filter(|code| !code.trim().is_empty())
+        .unwrap_or("internal.unexpected");
+    let message = data
+        .get("error")
+        .and_then(Value::as_str)
+        .or(event.message.as_deref())
+        .unwrap_or("Lab runner job failed before provider execution");
+    let mut error = Error::new(
+        ErrorCode::InternalUnexpected,
+        homeboy_core::redaction::redact_string(message),
+        json!({
+            "field": reported_code,
+            "child_reported_error_code": reported_code,
+            "child_command_result": {
+                "schema": "homeboy/runner-job-terminal-error/v1",
+                "runner_job_event_sequence": event.sequence,
+                "runner_job_error": homeboy_core::redaction::redact_json(data),
+            },
+        }),
+    )
+    .with_retryable(true)
+    .with_hint(format!(
+        "Retry safely: homeboy agent-task retry {} --run",
+        record.run_id
+    ));
+    error.details["pre_execution_phase"] = json!(RUNNER_PRE_PROVIDER_FAILURE_PHASE);
+
+    let plan = lifecycle_store.read_controller_plan(&record.run_id)?;
+    let mut failed = crate::agent_task_lifecycle::record_pre_execution_failure_in_store(
         lifecycle_store,
-        record,
-        &aggregate,
+        &record.run_id,
+        &plan,
+        RUNNER_PRE_PROVIDER_FAILURE_PHASE,
+        &error,
     )?;
+    record_runner_job_terminal_metadata(
+        &mut failed,
+        homeboy_core::api_jobs::JobStatus::Failed,
+        events,
+    );
+    let terminalized = failed.state.is_terminal();
+    let run_id = failed.run_id.clone();
+    let metadata = failed.ensure_metadata_object();
+    metadata.insert(
+        "runner_result_synchronization".to_string(),
+        json!({
+            "state": if terminalized { "projected" } else { "candidate_preserved" },
+            "runner_job_status": "failed",
+            "source": "typed_runner_job_error",
+            "event_sequence": event.sequence,
+        }),
+    );
+    if !terminalized {
+        lifecycle_store.write_record(&failed)?;
+        *record = failed;
+        return Ok(true);
+    }
+    metadata.insert(
+        "phase".to_string(),
+        json!(RUNNER_PRE_PROVIDER_FAILURE_PHASE),
+    );
+    metadata.insert(
+        "phase_activity".to_string(),
+        json!("runner job failed before provider execution"),
+    );
+    metadata.insert("provider_state".to_string(), json!("failed"));
+    metadata.insert(
+        "terminal_transport_recovery".to_string(),
+        json!("persisted_runner_job_error"),
+    );
+    metadata.insert(
+        "managed_recovery".to_string(),
+        json!({
+            "action": "agent_task_retry",
+            "command": format!("homeboy agent-task retry {run_id} --run"),
+            "reason": RUNNER_PRE_PROVIDER_FAILURE_PHASE,
+        }),
+    );
+    if let Some(handoff) = metadata.get_mut("runner_handoff") {
+        handoff["state"] = json!("terminal");
+    }
+    lifecycle_store.write_record(&failed)?;
+    *record = failed;
     Ok(true)
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -1444,6 +1444,220 @@ fn status_recovers_evicted_terminal_runner_job_from_durable_observation_once() {
     });
 }
 
+fn typed_pre_provider_runner_failure_snapshot(
+    status: homeboy_core::api_jobs::JobStatus,
+) -> homeboy_core::api_jobs::RunnerJobLogSnapshot {
+    let mut snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+    snapshot.job.status = status;
+    snapshot.job.finished_at_ms = None;
+    snapshot.events = vec![homeboy_core::api_jobs::JobEvent {
+        sequence: 7,
+        job_id: snapshot.job.id,
+        kind: JobEventKind::Error,
+        timestamp_ms: 2,
+        message: Some("failed to materialize runner workspace".to_string()),
+        data: Some(json!({
+            "phase": "local_child_worker_failed_before_child_identity",
+            "error": "IO error: failed to materialize runner workspace",
+            "error_code": "internal.io_error",
+            "error_details": {
+                "context": "persist runner execution context",
+            },
+        })),
+    }];
+    snapshot
+}
+
+#[test]
+fn typed_pre_provider_failure_outranks_stale_runner_status_and_terminalizes_once() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store = AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+
+    for (run_id, stale_status) in [
+        (
+            "cook-13965-attempt-queued",
+            homeboy_core::api_jobs::JobStatus::Queued,
+        ),
+        (
+            "cook-13965-attempt-running",
+            homeboy_core::api_jobs::JobStatus::Running,
+        ),
+    ] {
+        let mut record = record_detached_lab_run_in_store(
+            &lifecycle_store,
+            DetachedLabRunRecord {
+                run_id,
+                runner_id: "homeboy-lab",
+                runner_job_id: "00000000-0000-0000-0000-000000000123",
+                remote_workspace: "/runner/workspace/homeboy",
+                remote_command: &command,
+            },
+        )
+        .expect("accepted detached handoff");
+        let snapshot = typed_pre_provider_runner_failure_snapshot(stale_status);
+
+        reconcile_runner_job_snapshot_in_store(&lifecycle_store, &mut record, &snapshot)
+            .expect("typed terminal failure outranks stale status");
+        let aggregate = lifecycle_store
+            .read_aggregate(run_id)
+            .expect("failed aggregate is durable");
+
+        assert_eq!(record.state, AgentTaskRunState::Failed);
+        assert_eq!(record.tasks[0].state, AgentTaskState::Failed);
+        assert_eq!(record.metadata["phase"], "lab_runner_job_pre_provider");
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["error_code"],
+            "internal.io_error"
+        );
+        assert_eq!(record.metadata["provider_executions_consumed"], 0);
+        assert_eq!(record.metadata["runner_job_status"], "failed");
+        assert_eq!(
+            record.metadata["runner_result_synchronization"]["source"],
+            "typed_runner_job_error"
+        );
+        assert_eq!(
+            record.metadata["managed_recovery"]["command"],
+            format!("homeboy agent-task retry {run_id} --run")
+        );
+
+        reconcile_runner_job_snapshot_in_store(&lifecycle_store, &mut record, &snapshot)
+            .expect("repeated terminal snapshot is a no-op");
+        assert_eq!(
+            lifecycle_store
+                .read_aggregate(run_id)
+                .expect("aggregate remains durable"),
+            aggregate
+        );
+        assert_eq!(
+            record.metadata["runner_job_events"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+}
+
+#[test]
+fn typed_runner_failure_preserves_existing_provider_progress() {
+    let context = homeboy_core::test_support::HermeticTestContext::new();
+    let lifecycle_store = AgentTaskLifecycleStore::new(context.path_roots());
+    let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+    let run_id = "cook-13965-attempt-provider-progress";
+    let mut record = record_detached_lab_run_in_store(
+        &lifecycle_store,
+        DetachedLabRunRecord {
+            run_id,
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &command,
+        },
+    )
+    .expect("accepted detached handoff");
+    record.provider_handles.push(AgentTaskRunProviderHandle {
+        kind: Default::default(),
+        task_id: "task-a".to_string(),
+        backend: "test".to_string(),
+        provider_run_id: "provider-already-started".to_string(),
+        stream_uri: None,
+        state: Some(AgentTaskState::Running),
+        metadata: Value::Null,
+    });
+    lifecycle_store
+        .write_record(&record)
+        .expect("provider progress is durable");
+    let snapshot =
+        typed_pre_provider_runner_failure_snapshot(homeboy_core::api_jobs::JobStatus::Running);
+
+    reconcile_runner_job_snapshot_in_store(&lifecycle_store, &mut record, &snapshot)
+        .expect("late transport failure preserves provider work");
+
+    assert_eq!(record.state, AgentTaskRunState::Running);
+    assert_eq!(
+        record.provider_handles[0].provider_run_id,
+        "provider-already-started"
+    );
+    assert_eq!(record.metadata["candidate_preserved"], true);
+    assert_eq!(
+        record.metadata["runner_result_synchronization"]["state"],
+        "candidate_preserved"
+    );
+    assert_ne!(record.metadata["phase"], "lab_runner_job_pre_provider");
+    assert!(lifecycle_store.read_aggregate(run_id).is_err());
+
+    reconcile_runner_job_snapshot_in_store(&lifecycle_store, &mut record, &snapshot)
+        .expect("repeated transport failure is a no-op");
+    assert_eq!(record.state, AgentTaskRunState::Running);
+    assert_eq!(
+        record.provider_handles[0].provider_run_id,
+        "provider-already-started"
+    );
+    assert_eq!(record.metadata["candidate_preserved"], true);
+    assert_eq!(
+        record.metadata["runner_result_synchronization"]["event_sequence"],
+        7
+    );
+    assert!(lifecycle_store.read_aggregate(run_id).is_err());
+}
+
+#[test]
+fn restart_recovers_persisted_typed_runner_failure_before_live_reconciliation() {
+    with_isolated_home(|_| {
+        let run_id = "cook-13965-attempt-restart";
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        record_detached_lab_run(DetachedLabRunRecord {
+            run_id,
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/homeboy",
+            remote_command: &command,
+        })
+        .expect("accepted detached handoff");
+        let snapshot =
+            typed_pre_provider_runner_failure_snapshot(homeboy_core::api_jobs::JobStatus::Queued);
+        rewrite_record_for_test(run_id, |record| {
+            record.metadata["runner_job_status"] = json!(snapshot.job.status);
+            record.metadata["runner_job_events"] = json!(snapshot.events);
+            record.metadata["phase"] = json!("provider_start");
+        })
+        .expect("persist contradictory pre-restart observation");
+
+        let outcome = reconcile_status_in_store(
+            &test_lifecycle_store(),
+            run_id,
+            AgentTaskStatusOptions::default(),
+            false,
+        )
+        .expect("restart consumes durable terminal event");
+        assert_eq!(outcome.record.state, AgentTaskRunState::Failed);
+        assert!(!outcome.runner_probe.performed);
+        assert_eq!(
+            outcome.record.metadata["terminal_transport_recovery"],
+            "persisted_runner_job_error"
+        );
+        assert_eq!(
+            outcome.record.metadata["pre_execution_failure"]["phase"],
+            outcome.record.metadata["phase"]
+        );
+        assert_eq!(
+            outcome.record.metadata["pre_execution_failure"]["retryable"],
+            true
+        );
+
+        for dry_run in [true, false] {
+            let report = reconcile_run(run_id, dry_run).expect("terminal reconcile is a no-op");
+            assert_eq!(report.considered, 0);
+            assert_eq!(report.reconciled, 0);
+            assert_eq!(report.failed, 0);
+        }
+        let repeated = reconcile_status(run_id).expect("terminal status remains stable");
+        assert_eq!(repeated.state, AgentTaskRunState::Failed);
+        assert_eq!(repeated.metadata["phase"], "lab_runner_job_pre_provider");
+    });
+}
+
 #[test]
 fn stale_reconcile_keeps_an_accepted_runner_job_active_after_controller_owner_exit() {
     with_isolated_home(|_| {


### PR DESCRIPTION
## Summary

- project persisted typed pre-provider runner failures before stale queued/running job rows
- terminalize failed Cooks exactly once while preserving provider progress when execution already began
- recover the same terminal state after daemon restart without a live runner probe
- align durable aggregate, phase, provider budget, runner metadata, and legal retry action

Closes #13965.

## Verification

- `cargo fmt --all --check`
- `cargo test -p homeboy-agents typed_pre_provider_failure_outranks_stale_runner_status_and_terminalizes_once`
- `cargo test -p homeboy-agents typed_runner_failure_preserves_existing_provider_progress`
- `cargo test -p homeboy-agents restart_recovers_persisted_typed_runner_failure_before_live_reconciliation`
- tests rerun after rebase onto current `origin/main`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode traced runner events through durable lifecycle projection and reconciliation, implemented the typed terminal projection and regression coverage, and reran focused verification. OpenAI GPT-5.6 Sol via OpenCode independently reviewed and rebased the candidate under Chris Huber's direction.