### PR TITLE
Preserve Git worktrees across Lab extra-workspace materialization

### DIFF
--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -908,16 +908,21 @@ fn declared_agent_task_evidence_inputs(
 pub(crate) fn workspace_path_materialization_plan(
     workspace_mapping: &[LabWorkspaceMappingEntry],
     owner: &str,
-    materialization_mode: impl Into<String>,
+    primary_materialization_mode: impl Into<String>,
 ) -> PathMaterializationPlan {
-    let materialization_mode = materialization_mode.into();
+    let primary_materialization_mode = primary_materialization_mode.into();
     PathMaterializationPlan::new(workspace_mapping.iter().map(|entry| {
+        let materialization_mode = if entry.role() == "primary" {
+            primary_materialization_mode.as_str()
+        } else {
+            entry.sync_mode()
+        };
         PathMaterializationEntry::new(
             entry.role(),
             owner,
             (!entry.local_path().trim().is_empty()).then(|| entry.local_path().to_string()),
             entry.remote_path(),
-            &materialization_mode,
+            materialization_mode,
             PATH_MATERIALIZATION_STATUS_MATERIALIZED,
         )
     }))
@@ -2723,6 +2728,33 @@ mod tests {
         assert_eq!(plan.entries[0].remote_path, "/runner/workspaces/homeboy");
         assert_eq!(plan.entries[0].materialization_mode, "snapshot");
         assert_eq!(plan.entries[0].validation_status, "materialized");
+    }
+
+    #[test]
+    fn workspace_path_materialization_plan_preserves_each_extra_workspace_mode() {
+        let primary = test_synced_workspace(
+            "/controller/workspaces/primary",
+            "/runner/workspaces/primary",
+        );
+        let mut provider = test_synced_workspace(
+            "/controller/workspaces/provider@issue",
+            "/runner/workspaces/provider@issue",
+        );
+        provider.sync_mode = RunnerWorkspaceSyncMode::SnapshotGit;
+        let workspace_mapping = vec![
+            workspace_mapping_entry("primary", &primary),
+            workspace_mapping_entry("agent_task_plan_config", &provider),
+        ];
+
+        let plan = workspace_path_materialization_plan(
+            &workspace_mapping,
+            PATH_MATERIALIZATION_OWNER_LAB_EXECUTION_CONTEXT,
+            RunnerWorkspaceSyncMode::Git.as_str(),
+        );
+
+        assert_eq!(plan.entries[0].materialization_mode, "git");
+        assert_eq!(plan.entries[1].role, "agent_task_plan_config");
+        assert_eq!(plan.entries[1].materialization_mode, "snapshot-git");
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/lab_workspaces/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces/mod.rs
@@ -19,6 +19,7 @@ use super::{
     RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions, RunnerWorkspaceSyncOutput,
 };
 use crate::rig_materialization::LabStackComponentMaterialization;
+use crate::workspace::git_output;
 
 pub(super) const LAB_EXTRA_WORKSPACES_ENV: &str = "HOMEBOY_LAB_EXTRA_WORKSPACES";
 pub(super) const LAB_EXTRA_WORKSPACES_JSON_ENV: &str = "HOMEBOY_LAB_EXTRA_WORKSPACES_JSON";
@@ -63,6 +64,10 @@ impl LabWorkspaceMappingEntry {
 
     pub(super) fn dependency_freshness(&self) -> Option<&serde_json::Value> {
         self.dependency_freshness.as_ref()
+    }
+
+    pub(super) fn sync_mode(&self) -> &str {
+        &self.sync_mode
     }
 }
 
@@ -176,7 +181,7 @@ pub(super) fn sync_extra_lab_workspaces(
             runner_id,
             RunnerWorkspaceSyncOptions {
                 path: local_path.display().to_string(),
-                mode: RunnerWorkspaceSyncMode::Snapshot,
+                mode: extra_workspace_sync_mode(&local_path),
                 controller_routed_git: false,
                 changed_since_base: None,
                 git_fetch_refs: Vec::new(),
@@ -193,6 +198,17 @@ pub(super) fn sync_extra_lab_workspaces(
     }
 
     Ok(synced_entries)
+}
+
+fn extra_workspace_sync_mode(path: &Path) -> RunnerWorkspaceSyncMode {
+    if matches!(
+        git_output(path, &["rev-parse", "--is-inside-work-tree"]).as_deref(),
+        Ok("true")
+    ) {
+        RunnerWorkspaceSyncMode::SnapshotGit
+    } else {
+        RunnerWorkspaceSyncMode::Snapshot
+    }
 }
 
 pub(super) fn workspace_mapping_entry(

--- a/crates/homeboy-lab-runner/src/lab_workspaces/tests/provider_config.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces/tests/provider_config.rs
@@ -10,10 +10,14 @@ use super::super::{
     provider_config_candidate_paths, provider_config_extra_workspaces,
     resolve_path_setting_workspace_refs_in_args,
     rig_component_path_env_extra_workspaces_from_entries, runtime_refresh_source_extra_workspaces,
-    workspace_mapping_entries_for_git_dependency, workspace_ref_extra_workspaces,
-    ExtraLabWorkspace,
+    sync_extra_lab_workspaces, workspace_mapping_entries_for_git_dependency,
+    workspace_mapping_entry, workspace_ref_extra_workspaces, ExtraLabWorkspace,
 };
-use crate::{ByteFileCounts, RunnerGitDependencyMaterializationOutput, RunnerWorkspaceSyncMode};
+use crate::workspace::git_output;
+use crate::{
+    sync_workspace, ByteFileCounts, RunnerGitDependencyMaterializationOutput,
+    RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions,
+};
 use homeboy_core::worktree;
 
 fn git(path: &Path, args: &[&str]) {
@@ -356,6 +360,141 @@ fn agent_task_run_plan_file_path_syncs_containing_checkout() {
     assert!(workspaces[1]
         .snapshot_includes
         .contains(&"packages/cli/dist/**".to_string()));
+}
+
+#[test]
+fn agent_task_plan_config_linked_worktree_remains_git_backed_for_provider_start() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        use std::os::unix::fs::PermissionsExt;
+
+        let controller = tempfile::tempdir().expect("controller");
+        let runner_root = tempfile::tempdir().expect("runner root");
+        let primary = controller.path().join("primary");
+        let provider_source = controller.path().join("provider-source");
+        let provider_worktree = controller.path().join("provider@issue");
+        init_task_worktree(&provider_source, &provider_worktree, "issue-worktree");
+        let provider = provider_worktree.join("bin/provider");
+        std::fs::create_dir_all(provider.parent().expect("provider parent")).expect("provider dir");
+        std::fs::write(&provider, "#!/bin/sh\nprintf started > \"$1\"\n")
+            .expect("provider executable");
+        let mut permissions = std::fs::metadata(&provider)
+            .expect("provider metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&provider, permissions).expect("executable provider");
+        git(&provider_worktree, &["add", "."]);
+        git(&provider_worktree, &["commit", "-m", "provider executable"]);
+        assert!(
+            provider_worktree.join(".git").is_file(),
+            "issue-owned destination must model linked-worktree gitdir indirection"
+        );
+
+        let plan = primary.join(".ci/agent-task-plan.json");
+        std::fs::create_dir_all(plan.parent().expect("plan parent")).expect("plan dir");
+        std::fs::write(
+            &plan,
+            serde_json::json!({
+                "schema": "homeboy/agent-task-plan/v1",
+                "plan_id": "linked-provider-boundary",
+                "tasks": [{
+                    "task_id": "task-1",
+                    "instructions": "start provider",
+                    "executor": {
+                        "backend": "external-provider",
+                        "config": { "command": provider }
+                    }
+                }]
+            })
+            .to_string(),
+        )
+        .expect("plan file");
+        git(&primary, &["init", "-b", "main"]);
+        git(&primary, &["config", "user.email", "homeboy@example.test"]);
+        git(&primary, &["config", "user.name", "Homeboy Test"]);
+        git(&primary, &["add", "."]);
+        git(&primary, &["commit", "-m", "agent task plan"]);
+
+        crate::create(
+            &format!(
+                r#"{{"id":"lab-plan-config-boundary","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+        let args = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "run-plan".to_string(),
+            "--plan".to_string(),
+            format!("@{}", plan.display()),
+        ];
+        let extra_workspaces =
+            agent_task_plan_extra_workspaces(&args, &primary).expect("planned extra workspaces");
+        assert_eq!(extra_workspaces.len(), 1);
+        assert_eq!(extra_workspaces[0].role, "agent_task_plan_config");
+        assert_eq!(
+            extra_workspaces[0].path,
+            provider_worktree.canonicalize().expect("provider worktree")
+        );
+
+        let (primary_synced, _) = sync_workspace(
+            "lab-plan-config-boundary",
+            RunnerWorkspaceSyncOptions {
+                path: primary.display().to_string(),
+                mode: RunnerWorkspaceSyncMode::SnapshotGit,
+                controller_routed_git: false,
+                changed_since_base: None,
+                git_fetch_refs: Vec::new(),
+                snapshot_includes: Vec::new(),
+                allow_dirty_lab_workspace: false,
+                run_isolation_token: None,
+            },
+        )
+        .expect("materialize primary workspace");
+        let mut workspace_mapping = vec![workspace_mapping_entry("primary", &primary_synced)];
+        sync_extra_lab_workspaces(
+            "lab-plan-config-boundary",
+            &primary_synced.local_path,
+            extra_workspaces,
+            &mut workspace_mapping,
+        )
+        .expect("materialize planned extra workspaces");
+
+        assert_eq!(workspace_mapping.len(), 2);
+        for entry in &workspace_mapping {
+            assert_eq!(
+                git_output(
+                    Path::new(entry.remote_path()),
+                    &["rev-parse", "--is-inside-work-tree"]
+                )
+                .expect("materialized Git worktree"),
+                "true",
+                "planned source path with role {} lost its Git representation",
+                entry.role()
+            );
+        }
+        let provider_entry = workspace_mapping
+            .iter()
+            .find(|entry| entry.role() == "agent_task_plan_config")
+            .expect("provider workspace mapping");
+        assert_eq!(provider_entry.sync_mode(), "snapshot-git");
+        let remote_provider = Path::new(provider_entry.remote_path()).join(
+            provider
+                .strip_prefix(&provider_worktree)
+                .expect("provider path relative to worktree"),
+        );
+        let provider_started = runner_root.path().join("provider-started");
+        let status = Command::new(&remote_provider)
+            .arg(&provider_started)
+            .status()
+            .expect("start materialized provider");
+        assert!(status.success());
+        assert_eq!(
+            std::fs::read_to_string(provider_started).expect("provider start marker"),
+            "started"
+        );
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- detect Git-backed extra workspaces and materialize them with `snapshot-git` instead of plain snapshots
- preserve each workspace mapping's actual sync mode in the path materialization plan
- reproduce the `agent_task_plan_config` linked-worktree boundary with a real provider executable
- prove every planned source remains a valid Git worktree and provider execution can begin

Closes #13864.

## Verification

- `cargo fmt --all --check`
- `cargo test -p homeboy-lab-runner agent_task_plan_config_linked_worktree_remains_git_backed_for_provider_start`
- `cargo test -p homeboy-lab-runner workspace_path_materialization_plan_preserves_each_extra_workspace_mode`
- tests rerun after rebase onto current `origin/main`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode traced Lab path materialization, implemented the owning-layer repair and behavioral fixture, and reran focused verification. OpenAI GPT-5.6 Sol via OpenCode independently reviewed and rebased the candidate under Chris Huber's direction.