### PR TITLE
Fix dirty-destination Cook adoption recovery

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -1468,7 +1468,9 @@ fn validate_durable_publication_eligibility(
         && candidate_ref.is_some_and(is_git_commit_identity)
         && candidate_ref == candidate_head
         && adoption_model.is_some_and(is_concrete_model)
-        && recovery.is_some_and(crate::agent_task_lifecycle::is_pre_provider_transport_recovery)
+        && recovery.is_some_and(|recovery| {
+            crate::agent_task_lifecycle::candidate_adoption_recovery_eligibility(recovery).is_some()
+        })
         && !promotion.gate_results.is_empty()
         && promotion
             .gate_results

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -498,7 +498,7 @@ fn record_pre_execution_failure_locked(
     let failed = task_count;
     let retryable = error.retryable == Some(true);
     let failure_classification = pre_execution_failure_classification(error);
-    let candidate_adoption_recovery = candidate_adoption_recovery(phase);
+    let candidate_adoption_recovery = candidate_adoption_recovery(phase, error);
     let error_code = reported_error_code(error);
     let outcomes = plan
         .tasks
@@ -771,7 +771,7 @@ pub(crate) fn build_pre_execution_failure_outcome(
 ) -> AgentTaskOutcome {
     let retryable = error.retryable == Some(true);
     let failure_classification = pre_execution_failure_classification(error);
-    let candidate_adoption_recovery = candidate_adoption_recovery(phase);
+    let candidate_adoption_recovery = candidate_adoption_recovery(phase, error);
     let error_code = reported_error_code(error);
     let diagnostic = AgentTaskDiagnostic {
         class: "pre_execution_failure".to_string(),
@@ -844,18 +844,22 @@ fn reported_error_code(error: &Error) -> &str {
         .unwrap_or_else(|| error.code.as_str())
 }
 
-fn candidate_adoption_recovery(phase: &str) -> Option<serde_json::Value> {
-    matches!(
+fn candidate_adoption_recovery(phase: &str, error: &Error) -> Option<serde_json::Value> {
+    let reason = if matches!(
         phase,
         "lab_handoff_preacceptance" | "transport_dispatcher_prepare"
-    )
-    .then(|| {
-        json!({
-            "schema": super::CANDIDATE_ADOPTION_RECOVERY_SCHEMA,
-            "reason": "pre_provider_transport_failure",
-            "provider_executions_consumed": 0,
-        })
-    })
+    ) {
+        "pre_provider_transport_failure"
+    } else if error.details["dirty_candidate_adoption"]["reason"] == "first_provider_admission" {
+        "dirty_destination_first_provider_admission"
+    } else {
+        return None;
+    };
+    Some(json!({
+        "schema": super::CANDIDATE_ADOPTION_RECOVERY_SCHEMA,
+        "reason": reason,
+        "provider_executions_consumed": 0,
+    }))
 }
 
 fn pre_execution_failure_classification(error: &Error) -> AgentTaskFailureClassification {

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
@@ -499,8 +499,20 @@ pub fn candidate_adoption_recovery_outcome(
             && record.metadata["handoff_acceptance"]["state"] == "expired"
             && record.metadata["handoff_acceptance"]["reason"] == EXPIRED_LAB_HANDOFF_REASON
     });
-    let failed_preacceptance = record.state == AgentTaskRunState::Failed
-        && record.metadata["phase"] == "lab_handoff_preacceptance"
+    let failure = &record.metadata["pre_execution_failure"];
+    let recovery_matches_failure =
+        match candidate_adoption_recovery_eligibility(&failure["candidate_adoption_recovery"]) {
+            Some(CandidateAdoptionRecoveryEligibility::PreProviderTransportFailure) => matches!(
+                failure["phase"].as_str(),
+                Some("lab_handoff_preacceptance" | "transport_dispatcher_prepare")
+            ),
+            Some(CandidateAdoptionRecoveryEligibility::DirtyDestinationFirstProviderAdmission) => {
+                failure["details"]["dirty_candidate_adoption"]["reason"]
+                    == "first_provider_admission"
+            }
+            None => false,
+        };
+    let eligible_failed_preexecution = record.state == AgentTaskRunState::Failed
         && record.metadata["provider_executions_consumed"] == 0
         && record.provider_handles.is_empty()
         && no_runner_job_recorded(record)
@@ -509,17 +521,22 @@ pub fn candidate_adoption_recovery_outcome(
             runtime.external_runtime_ids.is_empty()
                 && runtime.metadata["evidence_source"] == "canonical_executor_outcome"
         })
-        && record.metadata["pre_execution_failure"]["phase"] == "lab_handoff_preacceptance"
-        && is_pre_provider_transport_recovery(
-            &record.metadata["pre_execution_failure"]["candidate_adoption_recovery"],
-        );
-    (expired_handoff || failed_preacceptance).then(|| {
-        build_pre_execution_failure_outcome(
+        && recovery_matches_failure;
+    (expired_handoff || eligible_failed_preexecution).then(|| {
+        let phase = failure["phase"]
+            .as_str()
+            .unwrap_or("lab_handoff_preacceptance");
+        let mut outcome = build_pre_execution_failure_outcome(
             &record.run_id,
             task,
-            "lab_handoff_preacceptance",
+            phase,
             &Error::internal_unexpected(EXPIRED_LAB_HANDOFF_REASON.to_string()),
-        )
+        );
+        if eligible_failed_preexecution {
+            outcome.metadata["candidate_adoption_recovery"] =
+                failure["candidate_adoption_recovery"].clone();
+        }
+        outcome
     })
 }
 
@@ -534,23 +551,42 @@ fn no_runner_job_recorded(record: &AgentTaskRunRecord) -> bool {
 }
 
 /// Schema tag stamped on the pre-provider candidate-adoption recovery marker
-/// produced when a Lab handoff fails before any provider executes. It is the
+/// produced when an adoptable Cook admission fails before any provider executes. It is the
 /// single source of truth for that marker's identity across the adoption
 /// pipeline (recording, promotion eligibility, publication eligibility).
 pub(crate) const CANDIDATE_ADOPTION_RECOVERY_SCHEMA: &str =
     "homeboy/agent-task-candidate-adoption-recovery/v1";
 
-/// True when `recovery` is an authenticated pre-provider transport-failure
-/// recovery marker: the exact shape that authorizes adopting an externally
-/// prepared candidate whose original attempt never ran a provider.
+/// Parse the authenticated pre-provider recovery marker that authorizes
+/// adopting an externally prepared candidate whose original attempt never ran
+/// a provider.
 ///
 /// This is the *one* definition of that check. The adoption recovery pipeline
 /// validates the same marker at several independent boundaries (candidate
 /// source resolution, promotion eligibility, publication eligibility); routing
 /// them all through here keeps those boundaries from drifting apart — the drift
 /// that made this path regress repeatedly (issue #8983).
-pub(crate) fn is_pre_provider_transport_recovery(recovery: &Value) -> bool {
-    recovery["schema"] == CANDIDATE_ADOPTION_RECOVERY_SCHEMA
-        && recovery["reason"] == "pre_provider_transport_failure"
-        && recovery["provider_executions_consumed"] == 0
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CandidateAdoptionRecoveryEligibility {
+    PreProviderTransportFailure,
+    DirtyDestinationFirstProviderAdmission,
+}
+
+pub(crate) fn candidate_adoption_recovery_eligibility(
+    recovery: &Value,
+) -> Option<CandidateAdoptionRecoveryEligibility> {
+    if recovery["schema"] != CANDIDATE_ADOPTION_RECOVERY_SCHEMA
+        || recovery["provider_executions_consumed"] != 0
+    {
+        return None;
+    }
+    match recovery["reason"].as_str()? {
+        "pre_provider_transport_failure" => {
+            Some(CandidateAdoptionRecoveryEligibility::PreProviderTransportFailure)
+        }
+        "dirty_destination_first_provider_admission" => {
+            Some(CandidateAdoptionRecoveryEligibility::DirtyDestinationFirstProviderAdmission)
+        }
+        _ => None,
+    }
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -684,7 +684,7 @@ fn failed_lab_preacceptance_reconstructs_only_authenticated_zero_execution_recov
     assert!(candidate_adoption_recovery_outcome(&record, &plan.tasks[0]).is_some());
 
     let mut wrong_phase = record.clone();
-    wrong_phase.metadata["phase"] = json!("provider_dispatch");
+    wrong_phase.metadata["pre_execution_failure"]["phase"] = json!("provider_dispatch");
     assert!(candidate_adoption_recovery_outcome(&wrong_phase, &plan.tasks[0]).is_none());
 
     let mut consumed_execution = record.clone();

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -707,7 +707,7 @@ fn promote_with_provider_and_checkpoint_internal(
 
     let failed_candidate_adoption = options.candidate_ref.is_some()
         && outcome.status == AgentTaskOutcomeStatus::Failed
-        && has_pre_provider_transport_recovery_eligibility(&outcome);
+        && has_candidate_adoption_recovery_eligibility(&outcome);
     if !matches!(
         outcome.status,
         AgentTaskOutcomeStatus::Succeeded
@@ -718,7 +718,7 @@ fn promote_with_provider_and_checkpoint_internal(
         let problem = if options.candidate_ref.is_some()
             && outcome.status == AgentTaskOutcomeStatus::Failed
         {
-            "immutable candidate adoption requires explicit durable pre-provider transport recovery eligibility; legacy or provider/test failures remain ineligible. Retry the cook or record a new transport failure through Homeboy."
+            "immutable candidate adoption requires explicit durable pre-provider recovery eligibility; legacy or provider/test failures remain ineligible. Retry the cook or record a new eligible pre-provider failure through Homeboy."
                 .to_string()
         } else {
             format!(
@@ -1184,13 +1184,15 @@ fn valid_git_object_id(value: &str) -> bool {
     matches!(value.len(), 40 | 64) && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
-fn has_pre_provider_transport_recovery_eligibility(outcome: &AgentTaskOutcome) -> bool {
+fn has_candidate_adoption_recovery_eligibility(outcome: &AgentTaskOutcome) -> bool {
     let eligibility = outcome
         .metadata
         .get("candidate_adoption_recovery")
         .or_else(|| outcome.outputs.get("candidate_adoption_recovery"));
     eligibility
-        .filter(|value| crate::agent_task_lifecycle::is_pre_provider_transport_recovery(value))
+        .filter(|value| {
+            crate::agent_task_lifecycle::candidate_adoption_recovery_eligibility(value).is_some()
+        })
         .is_some()
 }
 

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_c.rs
@@ -1088,7 +1088,7 @@ fn explicit_candidate_adopts_only_durable_pre_provider_transport_failures() {
         assert!(
             error
                 .message
-                .contains("explicit durable pre-provider transport recovery eligibility"),
+                .contains("explicit durable pre-provider recovery eligibility"),
             "{}",
             error.message
         );

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -5587,6 +5587,13 @@ fn dirty_candidate_adoption_recovery_actions(
     run_id: &str,
 ) -> Option<CookRecoveryActions> {
     let record = record?;
+    let task = recipe
+        .attempts
+        .iter()
+        .find(|attempt| attempt.run_id == run_id)?
+        .plan
+        .tasks
+        .first()?;
     if record.metadata["provider_executions_consumed"]
         .as_u64()
         .unwrap_or_default()
@@ -5594,6 +5601,9 @@ fn dirty_candidate_adoption_recovery_actions(
         || record.metadata["pre_execution_failure"]["details"]["dirty_candidate_adoption"]["reason"]
             != "first_provider_admission"
     {
+        return None;
+    }
+    if agent_task_lifecycle::candidate_adoption_recovery_outcome(record, task).is_none() {
         return None;
     }
     let workspace = record.metadata["pre_execution_failure"]["details"]["dirty_candidate_adoption"]

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -5565,6 +5565,119 @@ fn dirty_explicit_cwd_blocks_detached_provider_dispatch() {
 }
 
 #[test]
+fn dirty_destination_recovery_actions_commit_review_and_adopt_through_publication() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let mut fixture = CandidateAdoptionFixture::new_without_recovery(
+            "cook-13976-dirty-adopt",
+            2,
+            1,
+            false,
+            None,
+        );
+        std::fs::write(fixture.source.join("recovered.txt"), "operator candidate\n")
+            .expect("write dirty candidate");
+        let mut invalid_input = Error::validation_invalid_argument(
+            "to_worktree",
+            "explicit Cook checkout must be clean before its first provider execution",
+            Some(fixture.source.display().to_string()),
+            None,
+        );
+        invalid_input.details["dirty_candidate_adoption"] = serde_json::json!({
+            "workspace": fixture.source,
+            "reason": "first_provider_admission",
+        });
+        super::super::materialize_initial_cook_attempt(&fixture.options)
+            .expect("materialize dirty-destination Cook attempt");
+        agent_task_lifecycle::record_pre_execution_failure(
+            &fixture.run_id,
+            &fixture.options.identity.initial_plan,
+            "cook_pre_execution",
+            &invalid_input,
+        )
+        .expect("persist dirty-destination invalid_input failure");
+
+        let record = agent_task_lifecycle::reconcile_status(&fixture.run_id)
+            .expect("read dirty-destination failure");
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["failure_classification"],
+            "invalid_input"
+        );
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["candidate_adoption_recovery"]["reason"],
+            "dirty_destination_first_provider_admission"
+        );
+        let context = cook_report(CookReportInput {
+            cook_id: fixture.cook_id.clone(),
+            status: "pre_execution_failure",
+            disposition: CookDisposition::Terminal,
+            attempts: Vec::new(),
+            finalization: None,
+            stop_reason: None,
+            exit_code: 1,
+            invocation_latest_run_id: Some(&fixture.run_id),
+        })
+        .value
+        .failure_context
+        .expect("dirty recovery actions");
+        assert_eq!(
+            context
+                .legal_actions
+                .iter()
+                .map(|action| action.action.as_str())
+                .collect::<Vec<_>>(),
+            vec!["commit_candidate", "review_candidate", "adopt_candidate"]
+        );
+
+        let git = |args: &[&str]| {
+            let output = Command::new("git")
+                .args(args)
+                .current_dir(&fixture.source)
+                .output()
+                .expect("run generated commit step");
+            assert!(
+                output.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        git(&["add", "-A"]);
+        git(&["commit", "-m", "test"]);
+        fixture.candidate = git_output(&fixture.source, &["rev-parse", "HEAD"])
+            .expect("resolve committed candidate");
+        std::fs::write(
+            &fixture.provider,
+            format!(
+                "#!/bin/sh\ncat >/dev/null\ngit -C {target} fetch origin {candidate}\ngit -C {target} reset --hard --quiet FETCH_HEAD\nprintf '{{\"schema\":\"homeboy/agent-task-promotion-apply-response/v1\",\"workspace_path\":\"{target}\",\"command_evidence\":[]}}'\n",
+                target = fixture.target.display(),
+                candidate = fixture.candidate,
+            ),
+        )
+        .expect("bind promotion provider to committed candidate");
+
+        let review = agent_task_lifecycle::durable_local_read(&fixture.run_id)
+            .expect("generated review action reads the durable failure");
+        assert!(review.aggregate.is_some());
+
+        let mut backend = CaptureBackend {
+            hydrate_run_id: Some(fixture.run_id.clone()),
+            ..Default::default()
+        };
+        let adopted = fixture
+            .adopt(|_| Ok(None), Arc::new(ReviewFormOnlyExecutor), &mut backend)
+            .expect("generated adopt action accepts the advertised recovery");
+
+        assert_eq!(adopted.exit_code, 0, "{:#?}", adopted.value);
+        assert_eq!(adopted.value.status, "review_ready");
+        assert!(adopted.value.attempts[0]
+            .promotion
+            .as_ref()
+            .is_some_and(|promotion| promotion.finalization_eligible(false)));
+        assert!(backend.committed && backend.pushed && backend.created);
+    });
+}
+
+#[test]
 fn reconstructed_cook_rejects_a_removed_managed_workspace_before_provider_execution() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let primary = tempfile::tempdir().expect("primary repository");
@@ -5913,6 +6026,44 @@ impl CandidateAdoptionFixture {
         no_finalize: bool,
         dispatcher: Option<Arc<dyn AgentTaskCookAttemptDispatcher>>,
     ) -> Self {
+        Self::new_with_execution_budget_and_recovery(
+            cook_id,
+            max_attempts,
+            max_provider_executions,
+            max_same_provider_retries,
+            no_finalize,
+            dispatcher,
+            true,
+        )
+    }
+
+    fn new_without_recovery(
+        cook_id: &str,
+        max_attempts: u32,
+        max_same_provider_retries: u32,
+        no_finalize: bool,
+        dispatcher: Option<Arc<dyn AgentTaskCookAttemptDispatcher>>,
+    ) -> Self {
+        Self::new_with_execution_budget_and_recovery(
+            cook_id,
+            max_attempts,
+            max_attempts,
+            max_same_provider_retries,
+            no_finalize,
+            dispatcher,
+            false,
+        )
+    }
+
+    fn new_with_execution_budget_and_recovery(
+        cook_id: &str,
+        max_attempts: u32,
+        max_provider_executions: u32,
+        max_same_provider_retries: u32,
+        no_finalize: bool,
+        dispatcher: Option<Arc<dyn AgentTaskCookAttemptDispatcher>>,
+        authenticate_recovery: bool,
+    ) -> Self {
         let temp = tempfile::tempdir().expect("temporary adoption repositories");
         let source = temp.path().join("source");
         let target = temp.path().join("target");
@@ -6024,7 +6175,9 @@ impl CandidateAdoptionFixture {
             run_id,
             options,
         };
-        fixture.authenticate_pre_provider_recovery();
+        if authenticate_recovery {
+            fixture.authenticate_pre_provider_recovery();
+        }
         fixture
     }
 


### PR DESCRIPTION
## Summary
- persist dirty first-provider admission as typed candidate-adoption recovery eligibility
- share that eligibility across legal-action projection, adoption source reconstruction, promotion, and publication validation
- add deterministic lifecycle coverage that executes commit, review, gates, and publication intent from the observed `pre_execution_failure` / `invalid_input` path

## Tests
- `cargo test -p homeboy-agents dirty_destination_recovery_actions_commit_review_and_adopt_through_publication --lib`
- `cargo test -p homeboy-agents candidate_adoption --lib`
- `cargo test -p homeboy-agents failed_lab_preacceptance_reconstructs_only_authenticated_zero_execution_recovery --lib`
- `cargo test -p homeboy-agents dirty_explicit_cwd_blocks_detached_provider_dispatch --lib`
- `cargo test -p homeboy-agents explicit_candidate_adoption_ignores_recoverable_provider_patch_selection --lib`
- `cargo fmt --all --check`

Closes #13976

AI assistance disclosure: OpenAI GPT-5.6 Sol via OpenCode implemented and verified the durable dirty-destination recovery fix under Chris Huber's orchestration.