### PR TITLE
Fix publication after provider rotation

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -1429,11 +1429,26 @@ fn validate_durable_publication_eligibility(
     promotion: &AgentTaskPromotionReport,
 ) -> Result<DurablePublicationEligibility> {
     use homeboy_core::run_lifecycle_record::{ProviderRuntimeState, RunExecutionState};
-    if !lifecycle.provider_runtime.is_empty()
+    let all_provider_runtimes_succeeded = !lifecycle.provider_runtime.is_empty()
         && lifecycle
             .provider_runtime
             .iter()
-            .all(|runtime| runtime.state == ProviderRuntimeState::Succeeded)
+            .all(|runtime| runtime.state == ProviderRuntimeState::Succeeded);
+    let producing_runtime = lifecycle.provider_runtime.iter().find(|runtime| {
+        runtime.task_id == promotion.source.task_id
+            && runtime.state == ProviderRuntimeState::Succeeded
+    });
+    let fingerprinted_candidate = matches!(
+        serde_json::from_value::<crate::agent_task_promotion::AgentTaskPromotionCandidate>(
+            promotion.provenance["candidate"].clone(),
+        ),
+        Ok(crate::agent_task_promotion::AgentTaskPromotionCandidate::Git { .. })
+    );
+    let successful_fallback_produced_candidate = lifecycle.execution.state
+        == RunExecutionState::Succeeded
+        && producing_runtime.is_some()
+        && fingerprinted_candidate;
+    if (all_provider_runtimes_succeeded || successful_fallback_produced_candidate)
         && (lifecycle.execution.state == RunExecutionState::Succeeded
             // `CandidateRecoverable` and `PartialRecoverable` were folded into
             // `PartialFailure` before #6761, so they reached this check as

--- a/crates/homeboy-agents/src/agent_task_finalization/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization/tests.rs
@@ -1695,6 +1695,81 @@ fn durable_finalization_discloses_terminal_successful_model_after_cross_backend_
 }
 
 #[test]
+fn durable_finalization_accepts_fingerprinted_candidate_from_successful_fallback() {
+    let mut lifecycle = successful_lifecycle("openai/gpt-5.6-terra");
+    lifecycle.provider_runtime = vec![
+        ProviderRuntimeLifecycle {
+            task_id: "task".to_string(),
+            backend: "quota-exhausted-provider".to_string(),
+            state: ProviderRuntimeState::Failed,
+            stream_uri: None,
+            external_runtime_ids: Vec::new(),
+            metadata: json!({ "failure": "quota_exhausted", "model": "openai/gpt-5.6-sol" }),
+        },
+        ProviderRuntimeLifecycle {
+            task_id: "account-fallback".to_string(),
+            backend: "account-unavailable-provider".to_string(),
+            state: ProviderRuntimeState::Failed,
+            stream_uri: None,
+            external_runtime_ids: Vec::new(),
+            metadata: json!({ "failure": "account_unavailable", "model": "openai/gpt-5.6-sol" }),
+        },
+        ProviderRuntimeLifecycle {
+            task_id: "task".to_string(),
+            backend: "fallback-provider".to_string(),
+            state: ProviderRuntimeState::Succeeded,
+            stream_uri: None,
+            external_runtime_ids: Vec::new(),
+            metadata: json!({ "model": "openai/gpt-5.6-terra" }),
+        },
+    ];
+    let mut backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        lifecycle: Some(lifecycle.clone()),
+        gate_proof: Some(successful_gate_proof()),
+        ..Default::default()
+    };
+    let mut finalization_options = options();
+    finalization_options.manual_finalization = false;
+
+    finalize_pr_with_backend(finalization_options, &mut backend)
+        .expect("successful fallback candidate finalizes");
+    assert_eq!(lifecycle.provider_runtime.len(), 3);
+    assert_eq!(
+        lifecycle.provider_runtime[0].state,
+        ProviderRuntimeState::Failed
+    );
+    assert_eq!(
+        lifecycle.provider_runtime[1].state,
+        ProviderRuntimeState::Failed
+    );
+
+    let mut failed_only = lifecycle.clone();
+    failed_only.provider_runtime[2].state = ProviderRuntimeState::Failed;
+    let mut backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        lifecycle: Some(failed_only),
+        gate_proof: Some(successful_gate_proof()),
+        ..Default::default()
+    };
+    let mut finalization_options = options();
+    finalization_options.manual_finalization = false;
+    assert!(finalize_pr_with_backend(finalization_options, &mut backend).is_err());
+
+    let mut unbound_candidate = successful_gate_proof();
+    unbound_candidate.promotion.source.task_id = "other-task".to_string();
+    let mut backend = MockBackend {
+        changed_files: vec!["src/lib.rs".to_string()],
+        lifecycle: Some(lifecycle),
+        gate_proof: Some(unbound_candidate),
+        ..Default::default()
+    };
+    let mut finalization_options = options();
+    finalization_options.manual_finalization = false;
+    assert!(finalize_pr_with_backend(finalization_options, &mut backend).is_err());
+}
+
+#[test]
 fn finalization_keeps_internal_durable_refs_for_operators_but_not_reviewers() {
     let internal_ref = "homeboy://agent-task/run/run-9568/artifacts#task=cook&artifact=patch";
     let reviewer_ref = "https://github.com/Extra-Chill/homeboy/issues/9568";
@@ -3031,6 +3106,20 @@ fn successful_gate_proof() -> AgentTaskPrDurableGateProof {
             "to_worktree": "worktree", "target": { "worktree": "worktree", "path": "/repo" },
             "patch_artifact": { "id": "patch", "kind": "patch", "path": "patch" },
             "operator_notification": { "status": "completed", "message": "complete" },
+            "provenance": {
+                "candidate": {
+                    "kind": "git",
+                    "fingerprint": {
+                        "schema": "homeboy/agent-task-candidate-fingerprint/v1",
+                        "target_path": "/repo",
+                        "head": "7f76933ef002d195ee1cc5bf21069e0f40b1c972",
+                        "base": "6f76933ef002d195ee1cc5bf21069e0f40b1c972",
+                        "changed_files": ["src/lib.rs"],
+                        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        "tree": "5f76933ef002d195ee1cc5bf21069e0f40b1c972"
+                    }
+                }
+            },
             "gate_results": [{ "id": "gate", "name": "cargo test", "kind": "command", "status": "passed" }]
         })).expect("promotion proof"),
     }


### PR DESCRIPTION
## Summary

Allow a Cook candidate produced by a successful fallback provider to finalize even when earlier configured rotation attempts failed.

Closes #13981.

## What changed

- Preserve the existing all-runtimes-succeeded publication path unchanged.
- Add a narrow rotated-provider path requiring successful overall execution, a successful runtime matching the promotion source task, and a Git-fingerprinted promoted candidate.
- Keep failed-only and candidate-unbound runtime histories ineligible.
- Add regression coverage for quota/account failures followed by a successful fallback while retaining predecessor attempts as audit evidence.

## Verification

- `cargo test -p homeboy-agents agent_task_finalization`: 77 passed, 0 failed, 0 ignored.
- `cargo fmt --check`: passed.
- Source relationship: reproduced by Cook `agent-task-21e6d7a1-ec7d-4a1e-a755-911a45aa05c3`, where configured rotation reached a successful OpenAI fallback, promoted a fingerprinted candidate, and passed its gate before publication rejected failed predecessor runtimes.
- Evidence boundary: focused finalization tests cover normal and recovery eligibility predicates; no release or deployment was performed.

## AI assistance

OpenAI GPT-5.6 Terra and GPT-5.6 Sol via OpenCode were used to reproduce the rotated-provider failure, trace the publication invariant, generate the initial patch, refine compatibility after focused test failures, and verify the final change. Chris Huber reviewed the diff and remains responsible for the change.