### PR TITLE
Fix manual-finalization intent recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,6 +747,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_path",
+ "serde_path_to_error",
  "sha2",
  "shellexpand",
  "tempfile",

--- a/crates/homeboy-agents/Cargo.toml
+++ b/crates/homeboy-agents/Cargo.toml
@@ -21,6 +21,7 @@ homeboy-lab-runner-contract = { version = "0.1.0", path = "../contracts/homeboy-
 homeboy-extension-contract = { version = "0.1.0", path = "../contracts/homeboy-extension-contract" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_path_to_error = "0.1"
 serde_json_path = "0.7"
 chrono = "0.4"
 uuid = { version = "1.11", features = ["v4", "v5", "serde"] }

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -2914,7 +2914,7 @@ pub fn persist_manual_finalization_intent(
     validate_manual_preflight_report(&report, run_id, false)?;
     agent_task_lifecycle::record_manual_finalization_intent(
         run_id,
-        serde_json::to_value(&report).expect("finalization report serializes"),
+        manual_finalization_report_value(&report, run_id, "manual_finalization_intent")?,
     )
 }
 
@@ -2927,7 +2927,7 @@ pub fn persist_manual_finalization_retry_intent(
     validate_manual_preflight_report(report, run_id, true)?;
     let record = agent_task_lifecycle::record_manual_finalization_intent(
         run_id,
-        serde_json::to_value(report).expect("finalization report serializes"),
+        manual_finalization_report_value(report, run_id, "manual_finalization_intent")?,
     )?;
     agent_task_lifecycle::record_manual_finalization_retry(run_id)?;
     let candidate = crate::agent_task_promotion::candidate_fingerprint(&report.path)?;
@@ -3139,7 +3139,7 @@ pub fn persist_manual_finalization_receipt(
     }
     agent_task_lifecycle::record_manual_finalization_receipt(
         run_id,
-        serde_json::to_value(report).expect("finalization report serializes"),
+        manual_finalization_report_value(report, run_id, "cook_finalization")?,
     )
 }
 
@@ -3766,15 +3766,8 @@ fn manual_finalization_receipt_for_run(
     {
         return Ok(None);
     }
-    let report: AgentTaskPrFinalizationReport =
-        serde_json::from_value(value.clone()).map_err(|_| {
-            Error::validation_invalid_argument(
-                "cook_finalization",
-                "persisted manual finalization receipt is invalid",
-                Some(run_id.to_string()),
-                None,
-            )
-        })?;
+    let report =
+        manual_finalization_report_from_value(value, run_id, "cook_finalization", "receipt")?;
     let intent = manual_finalization_intent_for_run(record, run_id)?;
     if !valid_manual_finalization_receipt(&report, &intent, record, run_id, true) {
         return Err(Error::validation_invalid_argument(
@@ -3839,15 +3832,12 @@ fn manual_finalization_intent_for_run(
             None,
         ));
     }
-    let report: AgentTaskPrFinalizationReport =
-        serde_json::from_value(value.clone()).map_err(|_| {
-            Error::validation_invalid_argument(
-                "manual_finalization_intent",
-                "persisted manual finalization intent is invalid",
-                Some(run_id.to_string()),
-                None,
-            )
-        })?;
+    let report = manual_finalization_report_from_value(
+        value,
+        run_id,
+        "manual_finalization_intent",
+        "intent",
+    )?;
     if report.run_id != run_id {
         return Err(Error::validation_invalid_argument(
             "manual_finalization_intent.run_id",
@@ -3880,6 +3870,41 @@ fn manual_finalization_intent_for_run(
         }
     }
     Ok(report)
+}
+
+fn manual_finalization_report_value(
+    report: &AgentTaskPrFinalizationReport,
+    run_id: &str,
+    field: &str,
+) -> Result<Value> {
+    let value = serde_json::to_value(report).expect("finalization report serializes");
+    manual_finalization_report_from_value(&value, run_id, field, "report")?;
+    Ok(value)
+}
+
+fn manual_finalization_report_from_value(
+    value: &Value,
+    run_id: &str,
+    field: &str,
+    kind: &str,
+) -> Result<AgentTaskPrFinalizationReport> {
+    serde_path_to_error::deserialize(value.clone()).map_err(|error| {
+        let path = error.path().to_string();
+        let field = if path.is_empty() || path == "." {
+            field.to_string()
+        } else {
+            format!("{field}.{path}")
+        };
+        Error::validation_invalid_argument(
+            field,
+            format!(
+                "persisted manual finalization {kind} is invalid: {}",
+                error.inner()
+            ),
+            Some(run_id.to_string()),
+            None,
+        )
+    })
 }
 
 fn valid_manual_finalization_receipt(

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -19527,6 +19527,91 @@ fn manual_preflight_intent_does_not_block_normal_cook_finalization() {
 }
 
 #[test]
+fn failed_attempt_manual_preflight_hydrates_serialized_intent_and_publishes() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let cook_id = "cook-13977";
+        let run_id = "cook-13977-attempt-1";
+        let target = tempfile::tempdir().expect("fixture target");
+        let mut options = batch_cook_options(cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+        options.identity.initial_run_id = run_id.to_string();
+        options.finalization.head = Some("fix/8058".to_string());
+        options.identity.initial_plan.tasks[0].executor.model = Some("fixture-model".to_string());
+        persist_initial_recipe(&options).expect("persist recipe");
+        agent_task_lifecycle::submit_plan(&options.identity.initial_plan, Some(run_id))
+            .expect("submit attempt");
+        agent_task_lifecycle::record_pre_execution_failure(
+            run_id,
+            &options.identity.initial_plan,
+            "test",
+            &homeboy_core::Error::invalid_argument("test", "failed Cook attempt"),
+        )
+        .expect("fail attempt");
+        assert_eq!(
+            prepare_manual_finalization_identity(cook_id).expect("resolve failed attempt"),
+            run_id
+        );
+        seed_review_form_aggregate(run_id, &options.identity.initial_plan);
+
+        let promotion = promotion_with_existing_path(run_id, target.path());
+        let mut finalization = cook_finalization_options(&options, run_id, &promotion, Vec::new())
+            .expect("manual finalization options");
+        finalization.manual_finalization = true;
+        finalization
+            .evidence
+            .verification
+            .dependency_hydration
+            .push(homeboy_core::deps::DependencyHydrationOutcome {
+                schema: "homeboy/dependency-hydration-outcome/v1".to_string(),
+                workspace: "manual_finalization_checkout".to_string(),
+                package_root: ".".to_string(),
+                provider_id: "fixture".to_string(),
+                command: vec!["fixture-install".to_string()],
+                reason: "deterministic fixture".to_string(),
+                duration_ms: 17,
+                termination: homeboy_core::deps::DependencyHydrationTermination::Completed,
+                status: homeboy_core::deps::DependencyHydrationStatus::Succeeded,
+                exit_code: Some(0),
+            });
+        let candidate = crate::agent_task_finalization::AgentTaskPrCandidateState::Committed {
+            changed_files: vec!["src/lib.rs".to_string()],
+            push_required: false,
+        };
+        let preflight = crate::agent_task_finalization::preflight_pr_with_backend(
+            finalization,
+            &mut CaptureBackend {
+                candidate_state: Some(candidate.clone()),
+                ..Default::default()
+            },
+        )
+        .expect("manual preflight");
+        assert_eq!(preflight.status, "validated");
+        persist_manual_finalization_intent(run_id, &preflight)
+            .expect("persist recoverable serialized intent");
+        let record = agent_task_lifecycle::reconcile_status(run_id).expect("read intent");
+        assert_eq!(
+            record.metadata["manual_finalization_intent"]["verification"]["dependency_hydration"]
+                [0]["duration_ms"],
+            17
+        );
+
+        let continuation = format!("homeboy agent-task finalize-pr --recover {run_id}");
+        assert_eq!(
+            continuation,
+            "homeboy agent-task finalize-pr --recover cook-13977-attempt-1"
+        );
+        let mut backend = CaptureBackend {
+            candidate_state: Some(candidate),
+            ..Default::default()
+        };
+        let published = recover_cook_pr_with_backend(run_id, Vec::new(), false, &mut backend)
+            .expect("hydrate the exact intent and publish");
+        assert_eq!(published["status"], "review_ready");
+        assert!(backend.created);
+        assert!(!backend.committed && !backend.pushed);
+    });
+}
+
+#[test]
 fn candidate_recoverable_manual_preflight_binds_canonical_candidate_and_recovers_once() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let cook_id = "cook-13060";

--- a/crates/homeboy-core/src/deps.rs
+++ b/crates/homeboy-core/src/deps.rs
@@ -107,7 +107,7 @@ pub struct DependencyHydrationOutcome {
     pub provider_id: String,
     pub command: Vec<String>,
     pub reason: String,
-    pub duration_ms: u128,
+    pub duration_ms: u64,
     pub termination: DependencyHydrationTermination,
     pub status: DependencyHydrationStatus,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -418,7 +418,7 @@ fn hydration_outcome(
         provider_id,
         command,
         reason: crate::redaction::redact_string(&reason),
-        duration_ms: duration.as_millis(),
+        duration_ms: u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
         termination,
         status,
         exit_code,


### PR DESCRIPTION
Closes #13977

## Summary
- store dependency-hydration durations as JSON-compatible `u64` values
- round-trip validate manual-finalization intents and receipts with field-aware diagnostics before persistence and during recovery
- cover failed-attempt manual preflight, persisted hydration evidence, generated recovery, and PR publication end to end

## Verification
- `cargo test -p homeboy-agents failed_attempt_manual_preflight_hydrates_serialized_intent_and_publishes`
- `cargo test -p homeboy-agents manual_preflight`
- `cargo test -p homeboy-agents manual_finalization`
- `cargo fmt --all --check`
- `cargo test -p homeboy-core deps::tests::` (9 passed; unrelated `stale_state_runs_exact_declared_command_and_reports_progress` failed in shell fixture execution, alternating between no-progress and missing fixture output)

## AI assistance
AI assistance disclosure: OpenAI GPT-5.6 Sol via OpenCode implemented and verified the manual-finalization recovery fix under Chris Huber's orchestration.