### PR TITLE
Fix intentional no-change Cook outcomes

### DIFF
--- a/crates/contracts/homeboy-lifecycle-contract/src/cook_status.rs
+++ b/crates/contracts/homeboy-lifecycle-contract/src/cook_status.rs
@@ -89,6 +89,8 @@ pub enum CookStatus {
     GreenNoFinalize,
     /// A verified provider review intentionally produced no candidate patch.
     IntentionalNoChange,
+    /// Verified no-change evidence cannot satisfy a task that requires a patch.
+    NoCandidate,
     /// Finalization ran and found no changed files.
     NoChanges,
     /// A no-op candidate failed its gates.
@@ -148,6 +150,7 @@ impl CookStatus {
             "draft_published" => Self::DraftPublished,
             "green_no_finalize" => Self::GreenNoFinalize,
             "intentional_no_change" => Self::IntentionalNoChange,
+            "no_candidate" => Self::NoCandidate,
             "no_changes" => Self::NoChanges,
             "no_op_gate_failed" => Self::NoOpGateFailed,
             "gate_failed" => Self::GateFailed,
@@ -182,6 +185,7 @@ impl CookStatus {
             Self::DraftPublished => "draft_published",
             Self::GreenNoFinalize => "green_no_finalize",
             Self::IntentionalNoChange => "intentional_no_change",
+            Self::NoCandidate => "no_candidate",
             Self::NoChanges => "no_changes",
             Self::NoOpGateFailed => "no_op_gate_failed",
             Self::GateFailed => "gate_failed",
@@ -317,6 +321,7 @@ mod tests {
             "draft_published",
             "green_no_finalize",
             "intentional_no_change",
+            "no_candidate",
             "no_changes",
             "gate_failed",
             "awaiting_acceptance",
@@ -386,6 +391,7 @@ mod tests {
             CookStatus::DraftPublished,
             CookStatus::GreenNoFinalize,
             CookStatus::IntentionalNoChange,
+            CookStatus::NoCandidate,
             CookStatus::NoChanges,
             CookStatus::NoOpGateFailed,
             CookStatus::GateFailed,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -3886,6 +3886,7 @@ pub fn record_cook_supervision_stop_in_store(
 pub fn record_cook_terminal_result_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
+    terminal_status: &str,
     terminal_success: bool,
     exit_code: i32,
 ) -> Result<AgentTaskRunRecord> {
@@ -3901,8 +3902,12 @@ pub fn record_cook_terminal_result_in_store(
         if progress.get("phase").and_then(Value::as_str) != Some("terminal") {
             return false;
         }
+        progress.insert("terminal_status".to_string(), json!(terminal_status));
         progress.insert("terminal_success".to_string(), json!(terminal_success));
         progress.insert("exit_code".to_string(), json!(exit_code));
+        if terminal_status == "no_candidate" {
+            set_run_state(record, AgentTaskRunState::PartialFailure);
+        }
         true
     })?;
     record.ok_or_else(|| Error::internal_unexpected("Cook terminal result was unchanged"))

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -3717,6 +3717,14 @@ pub fn record_cook_progress_with_activity_in_store(
         {
             let metadata = record.ensure_metadata_object();
             let previous = metadata.get("cook_progress").cloned();
+            if previous
+                .as_ref()
+                .and_then(|progress| progress.get("terminal_status"))
+                .and_then(Value::as_str)
+                .is_some()
+            {
+                return true;
+            }
             let mut progress = json!({
                 "phase": phase,
                 "attempt": attempt,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -735,6 +735,19 @@ fn cook_progress_is_durable_across_active_and_terminal_lifecycle_states() {
         false
     );
     assert_eq!(terminal.metadata["cook_progress"]["exit_code"], 1);
+
+    let repeated = record_cook_progress_in_store(
+        &lifecycle_store,
+        run_id,
+        "durable_identity",
+        1,
+        Some("restarted Cook"),
+    )
+    .expect("retain exact terminal result after restart");
+    assert_eq!(
+        repeated.metadata["cook_progress"],
+        terminal.metadata["cook_progress"]
+    );
 }
 
 /// Rooted in an explicit store rather than a mutated process environment

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -727,8 +727,9 @@ fn cook_progress_is_durable_across_active_and_terminal_lifecycle_states() {
             .expect("retain terminal progress");
     assert_eq!(terminal.state, AgentTaskRunState::Cancelled);
     assert_eq!(terminal.metadata["cook_progress"]["phase"], "terminal");
-    let terminal = record_cook_terminal_result_in_store(&lifecycle_store, run_id, false, 1)
-        .expect("record terminal Cook result");
+    let terminal =
+        record_cook_terminal_result_in_store(&lifecycle_store, run_id, "no_candidate", false, 1)
+            .expect("record terminal Cook result");
     assert_eq!(
         terminal.metadata["cook_progress"]["terminal_success"],
         false
@@ -859,8 +860,9 @@ fn cook_write_siblings_persist_into_the_injected_store_and_not_a_second_root() {
     let progress = record_cook_progress_in_store(&seeded, run_id, "terminal", 1, Some("rooted"))
         .expect("record Cook progress into the injected store");
     assert_eq!(progress.metadata["cook_progress"]["phase"], "terminal");
-    let terminal = record_cook_terminal_result_in_store(&seeded, run_id, true, 0)
-        .expect("record the terminal Cook result into the injected store");
+    let terminal =
+        record_cook_terminal_result_in_store(&seeded, run_id, "intentional_no_change", true, 0)
+            .expect("record the terminal Cook result into the injected store");
     assert_eq!(terminal.metadata["cook_progress"]["terminal_success"], true);
     record_cook_controller_failure_in_store(&seeded, run_id, &json!({ "reason": "rooted" }))
         .expect("record a controller failure into the injected store");

--- a/crates/homeboy-agents/src/agent_task_notify_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_notify_tests.rs
@@ -91,6 +91,19 @@ fn successful_cook_carries_the_pull_request_link() {
 }
 
 #[test]
+fn intentional_no_change_terminal_notifications_match_policy_outcome() {
+    let accepted = terminal_payload(&report("intentional_no_change", None), None, 0);
+    assert_eq!(accepted.kind, NotifyEventKind::Completed);
+    assert!(accepted
+        .render_body()
+        .contains("Status: intentional_no_change"));
+
+    let refused = terminal_payload(&report("no_candidate", None), None, 1);
+    assert_eq!(refused.kind, NotifyEventKind::NeedsAttention);
+    assert!(refused.render_body().contains("Status: no_candidate"));
+}
+
+#[test]
 fn failed_cook_forwards_its_own_legal_recovery_commands() {
     let mut failed = report("durable_failure", None);
     failed.failure_context = Some(failure_context());

--- a/crates/homeboy-agents/src/agent_task_provider/outcome_normalization.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/outcome_normalization.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::agent_task_cook_loop::AgentTaskIntentionalNoChange;
 
 pub(super) fn normalize_provider_outcome_roles(
     outcome: &mut AgentTaskOutcome,
@@ -8,7 +9,7 @@ pub(super) fn normalize_provider_outcome_roles(
     normalize_provider_run_result_output(outcome, &provider.role_aliases);
     let result_contract_valid = normalize_provider_result_contract(outcome, provider);
     normalize_provider_runtime_contract(outcome, provider);
-    strip_reserved_artifact_metadata(outcome);
+    strip_reserved_provider_metadata(outcome);
     if result_contract_valid {
         surface_provider_run_result_diagnostics(outcome);
     }
@@ -45,10 +46,14 @@ fn normalize_provider_account_block(
 }
 
 const HOMEBOY_ARTIFACT_PROVENANCE_KEY: &str = "artifact_provenance";
+const HOMEBOY_INTENTIONAL_NO_CHANGE_VERIFIED_KEY: &str = "intentional_no_change_verified";
 
-/// Provider payloads cannot assert Homeboy-internal artifact provenance. The
-/// scheduler adds this key only after it writes a generated patch itself.
-fn strip_reserved_artifact_metadata(outcome: &mut AgentTaskOutcome) {
+/// Provider payloads cannot assert Homeboy-owned verification or artifact
+/// provenance. Those fields are added only after local validation.
+fn strip_reserved_provider_metadata(outcome: &mut AgentTaskOutcome) {
+    if let Some(metadata) = outcome.metadata.as_object_mut() {
+        metadata.remove(HOMEBOY_INTENTIONAL_NO_CHANGE_VERIFIED_KEY);
+    }
     for artifact in &mut outcome.artifacts {
         if let Some(metadata) = artifact.metadata.as_object_mut() {
             metadata.remove(HOMEBOY_ARTIFACT_PROVENANCE_KEY);
@@ -75,6 +80,10 @@ pub(super) fn normalize_homeboy_local_artifact_sizes(
         return;
     }
 
+    if let Some(metadata) = outcome.metadata.as_object_mut() {
+        metadata.remove(HOMEBOY_INTENTIONAL_NO_CHANGE_VERIFIED_KEY);
+    }
+
     let Ok(artifact_root) = artifact_root.canonicalize() else {
         return;
     };
@@ -93,22 +102,28 @@ pub(super) fn normalize_homeboy_local_artifact_sizes(
         }
     }
 
-    if outcome.status == AgentTaskOutcomeStatus::Succeeded && has_known_empty_change_set(outcome) {
+    if outcome.status == AgentTaskOutcomeStatus::Succeeded {
         match intentional_no_change_verdict(outcome, workspace_root) {
-            IntentionalNoChangeVerdict::Verified => {
-                // Preserve Succeeded so promotion follows the empty-patch gate
-                // path and records a verified no-op rather than attempting a
-                // candidate recovery.
+            IntentionalNoChangeValidation::Verified => {
+                // Preserve Succeeded. Cook applies task policy before deciding
+                // whether this evidence-only result may terminalize.
+                if !outcome.metadata.is_object() {
+                    outcome.metadata = json!({});
+                }
+                outcome.metadata[HOMEBOY_INTENTIONAL_NO_CHANGE_VERIFIED_KEY] = Value::Bool(true);
                 outcome.summary = Some(
                     "provider declared an intentional no-change review verdict bound to the verified workspace revision"
                         .to_string(),
                 );
             }
-            IntentionalNoChangeVerdict::Invalid(message) => {
+            IntentionalNoChangeValidation::Invalid(message) => {
                 outcome.status = AgentTaskOutcomeStatus::CandidateRecoverable;
                 outcome.summary = Some(message);
             }
-            IntentionalNoChangeVerdict::Absent if has_substantive_non_change_evidence(outcome) => {
+            IntentionalNoChangeValidation::Absent
+                if has_known_empty_change_set(outcome)
+                    && has_substantive_non_change_evidence(outcome) =>
+            {
                 // An empty change artifact next to substantive work evidence
                 // (a transcript, report, log, or other content-bearing artifact)
                 // is not a clean "nothing happened" — it is a patch-capture
@@ -121,37 +136,21 @@ pub(super) fn normalize_homeboy_local_artifact_sizes(
                     .to_string(),
             );
             }
-            IntentionalNoChangeVerdict::Absent => {
+            IntentionalNoChangeValidation::Absent if has_known_empty_change_set(outcome) => {
                 outcome.status = AgentTaskOutcomeStatus::NoOp;
                 outcome.summary = Some("provider produced an empty change artifact".to_string());
             }
+            IntentionalNoChangeValidation::Absent => {}
         }
     }
 }
 
 const INTENTIONAL_NO_CHANGE_SCHEMA: &str = "homeboy/intentional-no-change/v1";
 
-enum IntentionalNoChangeVerdict {
+enum IntentionalNoChangeValidation {
     Absent,
     Verified,
     Invalid(String),
-}
-
-#[derive(serde::Deserialize)]
-struct IntentionalNoChangeDeclaration {
-    schema: String,
-    #[serde(rename = "verdict")]
-    _verdict: IntentionalNoChangeDisposition,
-    inspected_revision: String,
-}
-
-#[derive(serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-enum IntentionalNoChangeDisposition {
-    Blocked,
-    AlreadySatisfied,
-    #[serde(alias = "no_change")]
-    InvestigationOnly,
 }
 
 /// A provider may declare a no-change review only through this versioned result
@@ -161,17 +160,17 @@ enum IntentionalNoChangeDisposition {
 fn intentional_no_change_verdict(
     outcome: &AgentTaskOutcome,
     workspace_root: Option<&std::path::Path>,
-) -> IntentionalNoChangeVerdict {
+) -> IntentionalNoChangeValidation {
     let Some(verdict) = outcome
         .outputs
         .get("provider_run_result")
         .and_then(|result| result.get("intentional_no_change"))
     else {
-        return IntentionalNoChangeVerdict::Absent;
+        return IntentionalNoChangeValidation::Absent;
     };
-    let Ok(declaration) = serde_json::from_value::<IntentionalNoChangeDeclaration>(verdict.clone())
+    let Ok(declaration) = serde_json::from_value::<AgentTaskIntentionalNoChange>(verdict.clone())
     else {
-        return IntentionalNoChangeVerdict::Invalid(
+        return IntentionalNoChangeValidation::Invalid(
             "provider declared an intentional no-change verdict without a valid schema, supported disposition, and inspected workspace revision; changes require recovery review"
                 .to_string(),
         );
@@ -179,20 +178,20 @@ fn intentional_no_change_verdict(
     if declaration.schema != INTENTIONAL_NO_CHANGE_SCHEMA
         || declaration.inspected_revision.trim().is_empty()
     {
-        return IntentionalNoChangeVerdict::Invalid(
+        return IntentionalNoChangeValidation::Invalid(
             "provider declared an invalid intentional no-change verdict; changes require recovery review"
                 .to_string(),
         );
     }
     let Some(workspace_root) = workspace_root else {
-        return IntentionalNoChangeVerdict::Invalid(
+        return IntentionalNoChangeValidation::Invalid(
             "provider declared an intentional no-change verdict but Homeboy has no workspace checkout to verify; changes require recovery review"
                 .to_string(),
         );
     };
     let head = git_output(workspace_root, &["rev-parse", "HEAD"]);
     if head.as_deref() != Some(declaration.inspected_revision.as_str()) {
-        return IntentionalNoChangeVerdict::Invalid(
+        return IntentionalNoChangeValidation::Invalid(
             "provider declared an intentional no-change verdict for a revision that does not match the workspace checkout; changes require recovery review"
                 .to_string(),
         );
@@ -203,12 +202,12 @@ fn intentional_no_change_verdict(
     )
     .is_none_or(|status| !status.is_empty())
     {
-        return IntentionalNoChangeVerdict::Invalid(
+        return IntentionalNoChangeValidation::Invalid(
             "provider declared an intentional no-change verdict but the workspace checkout changed; changes require recovery review"
                 .to_string(),
         );
     }
-    IntentionalNoChangeVerdict::Verified
+    IntentionalNoChangeValidation::Verified
 }
 
 fn git_output(workspace_root: &std::path::Path, args: &[&str]) -> Option<String> {

--- a/crates/homeboy-agents/src/agent_task_provider/tests/outcome_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/outcome_tests.rs
@@ -431,7 +431,7 @@ fn empty_patch_with_substantive_evidence_is_flagged_for_review_not_noop() {
 }
 
 #[test]
-fn revision_bound_no_change_verdict_accepts_substantive_review_only_for_clean_checkout() {
+fn revision_bound_no_change_verdict_without_patch_accepts_review_only_for_clean_checkout() {
     let workspace = tempfile::tempdir().expect("workspace");
     let artifacts = tempfile::tempdir().expect("artifact root");
     for args in [
@@ -470,9 +470,7 @@ fn revision_bound_no_change_verdict_accepts_substantive_review_only_for_clean_ch
     .expect("UTF-8 revision")
     .trim()
     .to_string();
-    let empty_patch_path = artifacts.path().join("review.patch");
     let transcript_path = artifacts.path().join("review.md");
-    fs::write(&empty_patch_path, "").expect("empty patch");
     fs::write(&transcript_path, "No findings.\n".repeat(1024)).expect("large transcript");
     let provenance = AgentTaskArtifactsPathProvenance {
         owner: "homeboy".to_string(),
@@ -482,8 +480,6 @@ fn revision_bound_no_change_verdict_accepts_substantive_review_only_for_clean_ch
         task_id: "review".to_string(),
         attempt: 1,
     };
-    let mut patch = fixture_artifact("patch", "patch", &empty_patch_path, Some("text/x-patch"));
-    patch.size_bytes = None;
     let mut transcript = fixture_artifact(
         "transcript",
         "transcript",
@@ -503,7 +499,7 @@ fn revision_bound_no_change_verdict_accepts_substantive_review_only_for_clean_ch
     }));
     outcome.status = AgentTaskOutcomeStatus::Succeeded;
     outcome.failure_classification = None;
-    outcome.artifacts = vec![patch, transcript];
+    outcome.artifacts = vec![transcript];
 
     normalize_homeboy_local_artifact_sizes(
         &mut outcome,
@@ -513,6 +509,7 @@ fn revision_bound_no_change_verdict_accepts_substantive_review_only_for_clean_ch
     );
 
     assert_eq!(outcome.status, AgentTaskOutcomeStatus::Succeeded);
+    assert_eq!(outcome.metadata["intentional_no_change_verified"], true);
     assert!(outcome
         .summary
         .as_deref()
@@ -527,6 +524,10 @@ fn revision_bound_no_change_verdict_accepts_substantive_review_only_for_clean_ch
         Some(workspace.path()),
     );
     assert_eq!(outcome.status, AgentTaskOutcomeStatus::CandidateRecoverable);
+    assert!(outcome
+        .metadata
+        .get("intentional_no_change_verified")
+        .is_none());
     assert!(outcome
         .summary
         .as_deref()

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -2958,9 +2958,9 @@ fn claim_disposition(
     control: AgentTaskCookBatchControl,
 ) -> ClaimDisposition {
     if control.skip_durably_terminal_children {
-        if let Some(state) = durably_terminal_child_state(&cook.identity.cook_id) {
+        if let Some(record) = durably_terminal_child_record(&cook.identity.cook_id) {
             if matches!(
-                state,
+                record.state,
                 agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable
                     | agent_task_lifecycle::AgentTaskRunState::PartialRecoverable
             ) {
@@ -2969,7 +2969,7 @@ fn claim_disposition(
                 // and finalization without redispatching the provider.
                 return ClaimDisposition::Run;
             }
-            return ClaimDisposition::AlreadyTerminal(observed_child_cell(cook, state));
+            return ClaimDisposition::AlreadyTerminal(observed_child_cell(cook, &record));
         }
     }
     if control.honour_durable_cancellation
@@ -3000,9 +3000,19 @@ fn claim_disposition(
 /// lifecycle record, so a fresh batch reads `None` here for every child. An
 /// unreadable record is also `None` — the coordinator's job is to run work, and
 /// a transient read failure must not be turned into a silent skip.
-fn durably_terminal_child_state(cook_id: &str) -> Option<agent_task_lifecycle::AgentTaskRunState> {
+fn durably_terminal_child_record(
+    cook_id: &str,
+) -> Option<agent_task_lifecycle::AgentTaskRunRecord> {
     let record = agent_task_lifecycle::reconcile_status(cook_id).ok()?;
-    record.state.is_terminal().then_some(record.state)
+    record.state.is_terminal().then_some(record)
+}
+
+fn persisted_terminal_cook_status(
+    record: &agent_task_lifecycle::AgentTaskRunRecord,
+) -> Option<CookStatus> {
+    record.metadata["cook_progress"]["terminal_status"]
+        .as_str()
+        .map(CookStatus::from_status)
 }
 
 /// Report a child from the durable state a previous coordinator left, without
@@ -3010,22 +3020,25 @@ fn durably_terminal_child_state(cook_id: &str) -> Option<agent_task_lifecycle::A
 /// successful run is a zero exit.
 fn observed_child_cell(
     cook: &CookRequest,
-    state: agent_task_lifecycle::AgentTaskRunState,
+    record: &agent_task_lifecycle::AgentTaskRunRecord,
 ) -> AgentTaskCookBatchCellReport {
-    let status = match state {
-        // A terminal, successful durable run is a completed Cook. `Completed`
-        // rather than a synthesized string so `cook_batch_result`'s
-        // `CookStatus::from_status` classification is the same one the live
-        // path produces.
-        agent_task_lifecycle::AgentTaskRunState::Succeeded => CookStatus::Completed,
-        agent_task_lifecycle::AgentTaskRunState::Cancelled => CookStatus::Cancelled,
-        _ => CookStatus::Failed,
-    };
+    let status = persisted_terminal_cook_status(record).unwrap_or_else(|| {
+        match record.state {
+            // A terminal, successful durable run is a completed Cook. `Completed`
+            // rather than a synthesized string so `cook_batch_result`'s
+            // `CookStatus::from_status` classification is the same one the live
+            // path produces.
+            agent_task_lifecycle::AgentTaskRunState::Succeeded => CookStatus::Completed,
+            agent_task_lifecycle::AgentTaskRunState::Cancelled => CookStatus::Cancelled,
+            _ => CookStatus::Failed,
+        }
+    });
+    let exit_code = i32::from(!status.is_success_exit());
     AgentTaskCookBatchCellReport {
         cook_id: cook.identity.cook_id.clone(),
         initial_run_id: cook.identity.initial_run_id.clone(),
         status: status.as_str().to_string(),
-        exit_code: i32::from(state != agent_task_lifecycle::AgentTaskRunState::Succeeded),
+        exit_code,
         result: None,
         error: None,
     }
@@ -6341,6 +6354,51 @@ fn run_cook_spine(
         let review_form_continuation = mode.allows_historical_terminal()
             && review_form_attempt_is_ready_for_cook_continuation(&plan, &record)?
             && retryable_review_form_terminal_failure(&record, &aggregate);
+        let persisted_terminal_status = record.metadata["cook_progress"]["terminal_status"]
+            .as_str()
+            .map(str::to_string);
+        if let Some(status @ ("intentional_no_change" | "no_candidate")) =
+            persisted_terminal_status.as_deref()
+        {
+            let declaration =
+                intentional_no_change_from_aggregate(&aggregate).ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                    "intentional_no_change",
+                    "persisted no-change terminal status requires its durable provider declaration",
+                    Some(run_id.clone()),
+                    None,
+                )
+                })?;
+            let review_form = review_form_from_aggregate(&aggregate)?;
+            attempts.push(AgentTaskCookAttemptReport {
+                attempt,
+                run_id: run_id.clone(),
+                run_state: format!("{:?}", record.state),
+                aggregate_path: record.aggregate_path,
+                promotion: None,
+                feedback: None,
+            });
+            let is_refusal = status == "no_candidate";
+            let mut report = cook_report(CookReportInput {
+                cook_id,
+                status,
+                disposition: CookDisposition::Terminal,
+                attempts,
+                finalization: None,
+                stop_reason: Some("Cook restored its exact verified intentional no-change terminal result from durable state".to_string()),
+                exit_code: i32::from(is_refusal),
+                invocation_latest_run_id: Some(&run_id),
+            });
+            report.value.intentional_no_change = Some(AgentTaskCookIntentionalNoChangeReport {
+                declaration,
+                review_form,
+            });
+            if is_refusal {
+                report.value.terminal_phase = Some("candidate_selection".to_string());
+                report.value.terminal_failure_classification = Some("no_candidate".to_string());
+            }
+            return Ok(report);
+        }
         if !matches!(
             record.state,
             agent_task_lifecycle::AgentTaskRunState::Succeeded
@@ -6448,7 +6506,10 @@ fn run_cook_spine(
                         && selection.selected_task_id.is_some()
                         && selection.selected_artifact_id.is_some()
                 });
-        if let Some(declaration) = intentional_no_change.filter(|_| !has_substantive_candidate) {
+        if let Some(declaration) = intentional_no_change.filter(|declaration| {
+            !has_substantive_candidate
+                || declaration.verdict == AgentTaskIntentionalNoChangeVerdict::Blocked
+        }) {
             let review_form = review_form_from_aggregate(&aggregate)?;
             let requires_candidate =
                 no_change_requires_substantive_candidate(&declaration, &source_request);
@@ -6470,17 +6531,28 @@ fn run_cook_spine(
                 disposition: CookDisposition::Terminal,
                 attempts,
                 finalization: None,
-                stop_reason: Some(if requires_candidate {
-                    format!(
+                stop_reason: Some(
+                    if declaration.verdict == AgentTaskIntentionalNoChangeVerdict::Blocked {
+                        format!(
+                        "provider returned a verified blocked verdict; promotion and publication were skipped{}",
+                        declaration
+                            .next_action
+                            .is_empty()
+                            .then(String::new)
+                            .unwrap_or_else(|| format!("; next action: {}", declaration.next_action))
+                    )
+                    } else if requires_candidate {
+                        format!(
                         "provider completed a verified {} review, but task policy requires a substantive candidate patch",
                         declaration.verdict
                     )
-                } else {
-                    format!(
+                    } else {
+                        format!(
                         "provider completed a verified {} evidence-only review without a candidate patch; promotion and publication were skipped",
                         declaration.verdict
                     )
-                }),
+                    },
+                ),
                 exit_code: i32::from(requires_candidate),
                 invocation_latest_run_id: Some(&run_id),
             });

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -14,6 +14,7 @@ use std::time::{Duration, Instant};
 use crate::agent_task_cook_loop::{
     evaluate_cook_loop, request_is_review_form_only, AgentTaskCookLoopOptions,
     AgentTaskCookLoopReport, AgentTaskCookLoopStatus, AgentTaskIntentionalNoChange,
+    AgentTaskIntentionalNoChangeVerdict,
 };
 
 pub use crate::agent_task_cook_loop::{
@@ -330,6 +331,19 @@ fn request_requires_substantive_candidate(request: &crate::agent_task::AgentTask
                         .as_deref()
                         .is_some_and(is_change_artifact))
         })
+}
+
+fn no_change_requires_substantive_candidate(
+    declaration: &AgentTaskIntentionalNoChange,
+    request: &crate::agent_task::AgentTaskRequest,
+) -> bool {
+    match declaration.verdict {
+        AgentTaskIntentionalNoChangeVerdict::AlreadySatisfied => false,
+        AgentTaskIntentionalNoChangeVerdict::Blocked => true,
+        AgentTaskIntentionalNoChangeVerdict::InvestigationOnly => {
+            request_requires_substantive_candidate(request)
+        }
+    }
 }
 
 fn pre_artifact_execution_count(record: &agent_task_lifecycle::AgentTaskRunRecord) -> u32 {
@@ -4787,6 +4801,7 @@ fn run_cook_reported(
             if let Err(error) = agent_task_lifecycle::record_cook_terminal_result_in_store(
                 lifecycle_store,
                 run_id,
+                &result.value.status,
                 result.exit_code == 0,
                 result.exit_code,
             ) {
@@ -6435,7 +6450,8 @@ fn run_cook_spine(
                 });
         if let Some(declaration) = intentional_no_change.filter(|_| !has_substantive_candidate) {
             let review_form = review_form_from_aggregate(&aggregate)?;
-            let requires_candidate = request_requires_substantive_candidate(&source_request);
+            let requires_candidate =
+                no_change_requires_substantive_candidate(&declaration, &source_request);
             attempts.push(AgentTaskCookAttemptReport {
                 attempt,
                 run_id: run_id.clone(),

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -292,14 +292,44 @@ fn pre_artifact_interruption_phase(
 pub(crate) fn intentional_no_change_from_aggregate(
     aggregate: &crate::agent_task_scheduler::AgentTaskAggregate,
 ) -> Option<AgentTaskIntentionalNoChange> {
-    aggregate.outcomes.iter().find_map(|outcome| {
-        let declaration = outcome
-            .outputs
-            .get("provider_run_result")?
-            .get("intentional_no_change")?
-            .clone();
-        serde_json::from_value::<AgentTaskIntentionalNoChange>(declaration).ok()
-    })
+    let outcome = aggregate.selected_outcome().or_else(|| {
+        (aggregate.outcomes.len() == 1)
+            .then(|| aggregate.outcomes.first())
+            .flatten()
+    })?;
+    (outcome.status == crate::agent_task::AgentTaskOutcomeStatus::Succeeded).then_some(())?;
+    (outcome.metadata["intentional_no_change_verified"] == Value::Bool(true)).then_some(())?;
+    let declaration = outcome
+        .outputs
+        .get("provider_run_result")?
+        .get("intentional_no_change")?
+        .clone();
+    serde_json::from_value::<AgentTaskIntentionalNoChange>(declaration)
+        .ok()
+        .filter(|declaration| declaration.schema == "homeboy/intentional-no-change/v1")
+}
+
+fn request_requires_substantive_candidate(request: &crate::agent_task::AgentTaskRequest) -> bool {
+    fn is_change_artifact(value: &str) -> bool {
+        matches!(
+            value,
+            "patch" | "diff" | "change_artifact" | "workspace_patch" | "artifact"
+        )
+    }
+
+    request.policy.write == "patch"
+        || request
+            .expected_artifacts
+            .iter()
+            .any(|artifact| is_change_artifact(artifact))
+        || request.artifact_declarations.iter().any(|artifact| {
+            artifact.required
+                && (is_change_artifact(&artifact.name)
+                    || artifact
+                        .artifact_type
+                        .as_deref()
+                        .is_some_and(is_change_artifact))
+        })
 }
 
 fn pre_artifact_execution_count(record: &agent_task_lifecycle::AgentTaskRunRecord) -> u32 {
@@ -6393,6 +6423,60 @@ fn run_cook_spine(
                 exit_code,
                 invocation_latest_run_id: Some(&run_id),
             }));
+        }
+
+        let intentional_no_change = intentional_no_change_from_aggregate(&aggregate);
+        let has_substantive_candidate =
+            agent_task_lifecycle::select_cook_candidate_in_store(lifecycle_store, &cook_id)
+                .is_ok_and(|selection| {
+                    !selection.incomplete
+                        && selection.selected_task_id.is_some()
+                        && selection.selected_artifact_id.is_some()
+                });
+        if let Some(declaration) = intentional_no_change.filter(|_| !has_substantive_candidate) {
+            let review_form = review_form_from_aggregate(&aggregate)?;
+            let requires_candidate = request_requires_substantive_candidate(&source_request);
+            attempts.push(AgentTaskCookAttemptReport {
+                attempt,
+                run_id: run_id.clone(),
+                run_state: format!("{:?}", record.state),
+                aggregate_path: record.aggregate_path,
+                promotion: None,
+                feedback: None,
+            });
+            let mut report = cook_report(CookReportInput {
+                cook_id,
+                status: if requires_candidate {
+                    "no_candidate"
+                } else {
+                    "intentional_no_change"
+                },
+                disposition: CookDisposition::Terminal,
+                attempts,
+                finalization: None,
+                stop_reason: Some(if requires_candidate {
+                    format!(
+                        "provider completed a verified {} review, but task policy requires a substantive candidate patch",
+                        declaration.verdict
+                    )
+                } else {
+                    format!(
+                        "provider completed a verified {} evidence-only review without a candidate patch; promotion and publication were skipped",
+                        declaration.verdict
+                    )
+                }),
+                exit_code: i32::from(requires_candidate),
+                invocation_latest_run_id: Some(&run_id),
+            });
+            report.value.intentional_no_change = Some(AgentTaskCookIntentionalNoChangeReport {
+                declaration,
+                review_form,
+            });
+            if requires_candidate {
+                report.value.terminal_phase = Some("candidate_selection".to_string());
+                report.value.terminal_failure_classification = Some("no_candidate".to_string());
+            }
+            return Ok(report);
         }
 
         // Gate dispatch boundary. Promotion is where the deterministic gates

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -5470,7 +5470,16 @@ pub fn cook_failure_context(
                     .flat_map(|outcome| &outcome.diagnostics),
             )
         });
-    let (phase, reason_code, diagnostic) = if blocking_claim.is_some() {
+    let (phase, reason_code, diagnostic) = if status == "no_candidate" {
+        (
+            "candidate_selection".to_string(),
+            "no_candidate".to_string(),
+            Some(serde_json::json!({
+                "class": "agent_task.no_candidate",
+                "message": "verified intentional no-change evidence exists, but task policy requires a substantive candidate patch",
+            })),
+        )
+    } else if blocking_claim.is_some() {
         (
             "promotion".to_string(),
             "operation_in_progress".to_string(),
@@ -5782,6 +5791,7 @@ fn cook_recovery_actions(
         | "review_ready"
         | "green_no_finalize"
         | "intentional_no_change"
+        | "no_candidate"
         | "execution_budget_exhausted"
         | "retries_exhausted"
         | "pre_execution_failure" => false,

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -1931,7 +1931,8 @@ impl CookSideEffectService for NoChangeSideEffects {
 fn run_intentional_no_change_cook(
     evidence_policy: bool,
     verdict: &str,
-) -> (AgentTaskRunResult<AgentTaskCookReport>, String) {
+    with_candidate: bool,
+) -> (AgentTaskRunResult<AgentTaskCookReport>, String, CookRequest) {
     let policy = if evidence_policy {
         "evidence"
     } else {
@@ -1974,6 +1975,31 @@ fn run_intentional_no_change_cook(
         }
     });
     aggregate.outcomes[0].metadata["intentional_no_change_verified"] = Value::Bool(true);
+    let _candidate_patch = if with_candidate {
+        let patch = "diff --git a/a b/a\n--- a/a\n+++ b/a\n@@ -1 +1 @@\n-old\n+new\n";
+        let file = tempfile::NamedTempFile::new().expect("candidate patch file");
+        std::fs::write(file.path(), patch).expect("write candidate patch");
+        aggregate.outcomes[0]
+            .artifacts
+            .push(crate::agent_task::AgentTaskArtifact {
+                id: "patch".to_string(),
+                kind: "patch".to_string(),
+                path: Some(file.path().display().to_string()),
+                size_bytes: Some(patch.len() as u64),
+                sha256: Some(homeboy_engine_primitives::content_hash::sha256_hex(
+                    patch.as_bytes(),
+                )),
+                metadata: serde_json::json!({
+                    "producer_attempt": 1,
+                    "base_ref": "main",
+                    "provider_backend": "fixture",
+                }),
+                ..Default::default()
+            });
+        Some(file)
+    } else {
+        None
+    };
     aggregate.outcomes[0].evidence_refs = vec![crate::agent_task::AgentTaskEvidenceRef {
         kind: "transcript".to_string(),
         uri: "provider://review/transcript".to_string(),
@@ -1984,6 +2010,7 @@ fn run_intentional_no_change_cook(
 
     let promotions = Arc::new(AtomicUsize::new(0));
     let finalizations = Arc::new(AtomicUsize::new(0));
+    let resume_options = options.clone();
     let result = run_cook(CookContext {
         side_effects: Some(Box::new(NoChangeSideEffects {
             promotions: Arc::clone(&promotions),
@@ -1996,13 +2023,13 @@ fn run_intentional_no_change_cook(
     assert_eq!(finalizations.load(Ordering::SeqCst), 0);
     assert_eq!(result.value.attempts.len(), 1);
     assert!(result.value.attempts[0].promotion.is_none());
-    (result, run_id)
+    (result, run_id, resume_options)
 }
 
 #[test]
 fn finalizing_cook_accepts_patch_absent_intentional_no_change_for_evidence_policy() {
     homeboy_core::test_support::with_isolated_home(|_| {
-        let (result, run_id) = run_intentional_no_change_cook(true, "no_change");
+        let (result, run_id, _) = run_intentional_no_change_cook(true, "no_change", false);
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.value.status, "intentional_no_change");
         assert_eq!(
@@ -2035,7 +2062,7 @@ fn finalizing_cook_accepts_patch_absent_intentional_no_change_for_evidence_polic
 #[test]
 fn finalizing_cook_refuses_patch_absent_intentional_no_change_for_change_policy() {
     homeboy_core::test_support::with_isolated_home(|_| {
-        let (result, run_id) = run_intentional_no_change_cook(false, "no_change");
+        let (result, run_id, options) = run_intentional_no_change_cook(false, "no_change", false);
         assert_eq!(result.exit_code, 1);
         assert_eq!(result.value.status, "no_candidate");
         assert_eq!(
@@ -2074,13 +2101,36 @@ fn finalizing_cook_refuses_patch_absent_intentional_no_change_for_change_policy(
             persisted.metadata["cook_progress"]["terminal_status"],
             "no_candidate"
         );
+
+        let restarted = run_cook(CookContext::new(options.clone(), Arc::new(UnusedExecutor)))
+            .expect("restore terminal no-candidate report");
+        assert_eq!(restarted.exit_code, 1);
+        assert_eq!(restarted.value.status, "no_candidate");
+        assert_eq!(
+            agent_task_lifecycle::exact_record(&run_id)
+                .unwrap()
+                .metadata["cook_progress"]["terminal_status"],
+            "no_candidate"
+        );
+
+        let observed = match claim_disposition(
+            "batch-13966",
+            &options,
+            AgentTaskCookBatchControl::daemon_owned(),
+        ) {
+            ClaimDisposition::AlreadyTerminal(cell) => cell,
+            disposition => panic!("expected terminal batch observation, got {disposition:?}"),
+        };
+        assert_eq!(observed.status, "no_candidate");
+        assert_eq!(observed.exit_code, 1);
     });
 }
 
 #[test]
 fn finalizing_patch_cook_accepts_verified_already_satisfied_verdict() {
     homeboy_core::test_support::with_isolated_home(|_| {
-        let (result, run_id) = run_intentional_no_change_cook(false, "already_satisfied");
+        let (result, run_id, options) =
+            run_intentional_no_change_cook(false, "already_satisfied", false);
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.value.status, "intentional_no_change");
         let persisted = agent_task_lifecycle::exact_record(&run_id).expect("persisted terminal");
@@ -2092,13 +2142,29 @@ fn finalizing_patch_cook_accepts_verified_already_satisfied_verdict() {
             persisted.metadata["cook_progress"]["terminal_status"],
             "intentional_no_change"
         );
+
+        let restarted = run_cook(CookContext::new(options.clone(), Arc::new(UnusedExecutor)))
+            .expect("restore terminal intentional-no-change report");
+        assert_eq!(restarted.exit_code, 0);
+        assert_eq!(restarted.value.status, "intentional_no_change");
+
+        let observed = match claim_disposition(
+            "batch-13966",
+            &options,
+            AgentTaskCookBatchControl::daemon_owned(),
+        ) {
+            ClaimDisposition::AlreadyTerminal(cell) => cell,
+            disposition => panic!("expected terminal batch observation, got {disposition:?}"),
+        };
+        assert_eq!(observed.status, "intentional_no_change");
+        assert_eq!(observed.exit_code, 0);
     });
 }
 
 #[test]
-fn finalizing_patch_cook_refuses_verified_blocked_verdict() {
+fn finalizing_patch_cook_refuses_verified_blocked_verdict_with_selectable_candidate() {
     homeboy_core::test_support::with_isolated_home(|_| {
-        let (result, run_id) = run_intentional_no_change_cook(false, "blocked");
+        let (result, run_id, _) = run_intentional_no_change_cook(false, "blocked", true);
         assert_eq!(result.exit_code, 1);
         assert_eq!(result.value.status, "no_candidate");
         let persisted = agent_task_lifecycle::exact_record(&run_id).expect("persisted terminal");

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -1890,6 +1890,170 @@ impl CookSideEffectService for SelectionRequiredSideEffects {
     }
 }
 
+#[derive(Clone)]
+struct NoChangeSideEffects {
+    promotions: Arc<AtomicUsize>,
+    finalizations: Arc<AtomicUsize>,
+}
+
+impl CookSideEffectService for NoChangeSideEffects {
+    fn promote(
+        &mut self,
+        _lifecycle_store: &AgentTaskLifecycleStore,
+        _options: &CookRequest,
+        _run_id: &str,
+    ) -> Result<AgentTaskPromotionReport> {
+        self.promotions.fetch_add(1, Ordering::SeqCst);
+        unreachable!("intentional no-change without a candidate must not promote")
+    }
+
+    fn recover_moving_base(
+        &mut self,
+        _lifecycle_store: &AgentTaskLifecycleStore,
+        _options: &CookRequest,
+        _recovery: &MovingBaseCookRecovery,
+    ) -> Result<AgentTaskPromotionReport> {
+        unreachable!("intentional no-change cannot enter moving-base recovery")
+    }
+
+    fn finalize(
+        &mut self,
+        _lifecycle_store: &AgentTaskLifecycleStore,
+        _options: &CookRequest,
+        _run_id: &str,
+        _promotion: &AgentTaskPromotionReport,
+    ) -> Result<Value> {
+        self.finalizations.fetch_add(1, Ordering::SeqCst);
+        unreachable!("intentional no-change without a candidate must not finalize")
+    }
+}
+
+fn run_intentional_no_change_cook(
+    requires_candidate: bool,
+) -> AgentTaskRunResult<AgentTaskCookReport> {
+    let policy = if requires_candidate {
+        "change"
+    } else {
+        "evidence"
+    };
+    let cook_id = format!("cook-13966-{policy}");
+    let run_id = format!("{cook_id}-attempt-1");
+    let mut options = batch_cook_options(&cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
+    options.identity.initial_run_id = run_id.clone();
+    options.finalization.no_finalize = false;
+    options.identity.initial_plan.tasks[0].policy.write = "patch".to_string();
+    options.identity.initial_plan.tasks[0].policy.apply = "manual".to_string();
+    options.identity.initial_plan.tasks[0].expected_artifacts = vec!["patch".to_string()];
+    if !requires_candidate {
+        let request = &mut options.identity.initial_plan.tasks[0];
+        request.policy.write = "none".to_string();
+        request.policy.apply = "none".to_string();
+        request.expected_artifacts.clear();
+        request.artifact_declarations.clear();
+    }
+    persist_initial_recipe(&options).expect("persist Cook recipe");
+    agent_task_lifecycle::submit_plan(&options.identity.initial_plan, Some(&run_id))
+        .expect("submit Cook attempt");
+    agent_task_lifecycle::record_cook_attempt_in_store(
+        &test_lifecycle_store(),
+        &cook_id,
+        1,
+        &run_id,
+    )
+    .expect("record Cook attempt");
+    let mut aggregate = review_form_aggregate(&options.identity.initial_plan);
+    aggregate.outcomes[0].outputs["provider_run_result"] = serde_json::json!({
+        "status": "succeeded",
+        "intentional_no_change": {
+            "schema": "homeboy/intentional-no-change/v1",
+            "verdict": "no_change",
+            "inspected_revision": "0123456789abcdef",
+            "next_action": "Retain the review evidence.",
+            "source_evidence": ["provider://review/transcript"]
+        }
+    });
+    aggregate.outcomes[0].metadata["intentional_no_change_verified"] = Value::Bool(true);
+    aggregate.outcomes[0].evidence_refs = vec![crate::agent_task::AgentTaskEvidenceRef {
+        kind: "transcript".to_string(),
+        uri: "provider://review/transcript".to_string(),
+        label: Some("provider review transcript".to_string()),
+    }];
+    agent_task_lifecycle::record_run_aggregate(&run_id, &options.identity.initial_plan, &aggregate)
+        .expect("persist intentional no-change aggregate");
+
+    let promotions = Arc::new(AtomicUsize::new(0));
+    let finalizations = Arc::new(AtomicUsize::new(0));
+    let result = run_cook(CookContext {
+        side_effects: Some(Box::new(NoChangeSideEffects {
+            promotions: Arc::clone(&promotions),
+            finalizations: Arc::clone(&finalizations),
+        })),
+        ..CookContext::new(options, Arc::new(UnusedExecutor))
+    })
+    .expect("finalize intentional no-change Cook");
+    assert_eq!(promotions.load(Ordering::SeqCst), 0);
+    assert_eq!(finalizations.load(Ordering::SeqCst), 0);
+    assert_eq!(result.value.attempts.len(), 1);
+    assert!(result.value.attempts[0].promotion.is_none());
+    result
+}
+
+#[test]
+fn finalizing_cook_accepts_patch_absent_intentional_no_change_for_evidence_policy() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let result = run_intentional_no_change_cook(false);
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.value.status, "intentional_no_change");
+        assert_eq!(
+            result.value.lifecycle().lifecycle_status,
+            RunLifecycleStatus::Succeeded
+        );
+        assert!(result.value.failure_context.is_none());
+        let evidence = result
+            .value
+            .intentional_no_change
+            .expect("durable no-change evidence");
+        assert_eq!(evidence.declaration.inspected_revision, "0123456789abcdef");
+        assert_eq!(
+            evidence.declaration.source_evidence,
+            ["provider://review/transcript"]
+        );
+        assert!(evidence.review_form.is_some());
+    });
+}
+
+#[test]
+fn finalizing_cook_refuses_patch_absent_intentional_no_change_for_change_policy() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let result = run_intentional_no_change_cook(true);
+        assert_eq!(result.exit_code, 1);
+        assert_eq!(result.value.status, "no_candidate");
+        assert_eq!(
+            result.value.lifecycle().lifecycle_status,
+            RunLifecycleStatus::PartialFailure
+        );
+        assert_eq!(
+            result.value.terminal_failure_classification.as_deref(),
+            Some("no_candidate")
+        );
+        let context = result
+            .value
+            .failure_context
+            .as_ref()
+            .expect("typed refusal diagnosis");
+        assert_eq!(context.phase, "candidate_selection");
+        assert_eq!(context.reason_code, "no_candidate");
+        assert!(!context
+            .next_actions
+            .iter()
+            .any(|action| action.action == "resume"));
+        let encoded = serde_json::to_string(&result.value).expect("serialize refusal");
+        assert!(!encoded.contains("InternalIoError"));
+        assert!(encoded.contains("0123456789abcdef"));
+        assert!(encoded.contains("provider://review/transcript"));
+    });
+}
+
 #[test]
 fn cook_promotes_the_rotated_success_after_a_retained_timeout_with_aliases_collapsed() {
     homeboy_core::test_support::with_isolated_home(|_| {

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -1929,14 +1929,15 @@ impl CookSideEffectService for NoChangeSideEffects {
 }
 
 fn run_intentional_no_change_cook(
-    requires_candidate: bool,
-) -> AgentTaskRunResult<AgentTaskCookReport> {
-    let policy = if requires_candidate {
-        "change"
-    } else {
+    evidence_policy: bool,
+    verdict: &str,
+) -> (AgentTaskRunResult<AgentTaskCookReport>, String) {
+    let policy = if evidence_policy {
         "evidence"
+    } else {
+        "change"
     };
-    let cook_id = format!("cook-13966-{policy}");
+    let cook_id = format!("cook-13966-{policy}-{verdict}");
     let run_id = format!("{cook_id}-attempt-1");
     let mut options = batch_cook_options(&cook_id, Arc::new(AcceptedDetachedAttemptDispatcher));
     options.identity.initial_run_id = run_id.clone();
@@ -1944,7 +1945,7 @@ fn run_intentional_no_change_cook(
     options.identity.initial_plan.tasks[0].policy.write = "patch".to_string();
     options.identity.initial_plan.tasks[0].policy.apply = "manual".to_string();
     options.identity.initial_plan.tasks[0].expected_artifacts = vec!["patch".to_string()];
-    if !requires_candidate {
+    if evidence_policy {
         let request = &mut options.identity.initial_plan.tasks[0];
         request.policy.write = "none".to_string();
         request.policy.apply = "none".to_string();
@@ -1966,7 +1967,7 @@ fn run_intentional_no_change_cook(
         "status": "succeeded",
         "intentional_no_change": {
             "schema": "homeboy/intentional-no-change/v1",
-            "verdict": "no_change",
+            "verdict": verdict,
             "inspected_revision": "0123456789abcdef",
             "next_action": "Retain the review evidence.",
             "source_evidence": ["provider://review/transcript"]
@@ -1995,13 +1996,13 @@ fn run_intentional_no_change_cook(
     assert_eq!(finalizations.load(Ordering::SeqCst), 0);
     assert_eq!(result.value.attempts.len(), 1);
     assert!(result.value.attempts[0].promotion.is_none());
-    result
+    (result, run_id)
 }
 
 #[test]
 fn finalizing_cook_accepts_patch_absent_intentional_no_change_for_evidence_policy() {
     homeboy_core::test_support::with_isolated_home(|_| {
-        let result = run_intentional_no_change_cook(false);
+        let (result, run_id) = run_intentional_no_change_cook(true, "no_change");
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.value.status, "intentional_no_change");
         assert_eq!(
@@ -2019,13 +2020,22 @@ fn finalizing_cook_accepts_patch_absent_intentional_no_change_for_evidence_polic
             ["provider://review/transcript"]
         );
         assert!(evidence.review_form.is_some());
+        let persisted = agent_task_lifecycle::exact_record(&run_id).expect("persisted terminal");
+        assert_eq!(
+            persisted.state,
+            agent_task_lifecycle::AgentTaskRunState::Succeeded
+        );
+        assert_eq!(
+            persisted.metadata["cook_progress"]["terminal_status"],
+            "intentional_no_change"
+        );
     });
 }
 
 #[test]
 fn finalizing_cook_refuses_patch_absent_intentional_no_change_for_change_policy() {
     homeboy_core::test_support::with_isolated_home(|_| {
-        let result = run_intentional_no_change_cook(true);
+        let (result, run_id) = run_intentional_no_change_cook(false, "no_change");
         assert_eq!(result.exit_code, 1);
         assert_eq!(result.value.status, "no_candidate");
         assert_eq!(
@@ -2051,6 +2061,51 @@ fn finalizing_cook_refuses_patch_absent_intentional_no_change_for_change_policy(
         assert!(!encoded.contains("InternalIoError"));
         assert!(encoded.contains("0123456789abcdef"));
         assert!(encoded.contains("provider://review/transcript"));
+        let persisted = agent_task_lifecycle::exact_record(&run_id).expect("persisted terminal");
+        assert_eq!(
+            persisted.state,
+            agent_task_lifecycle::AgentTaskRunState::PartialFailure
+        );
+        assert_eq!(
+            persisted.lifecycle.execution.state,
+            RunExecutionState::PartialFailure
+        );
+        assert_eq!(
+            persisted.metadata["cook_progress"]["terminal_status"],
+            "no_candidate"
+        );
+    });
+}
+
+#[test]
+fn finalizing_patch_cook_accepts_verified_already_satisfied_verdict() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let (result, run_id) = run_intentional_no_change_cook(false, "already_satisfied");
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.value.status, "intentional_no_change");
+        let persisted = agent_task_lifecycle::exact_record(&run_id).expect("persisted terminal");
+        assert_eq!(
+            persisted.state,
+            agent_task_lifecycle::AgentTaskRunState::Succeeded
+        );
+        assert_eq!(
+            persisted.metadata["cook_progress"]["terminal_status"],
+            "intentional_no_change"
+        );
+    });
+}
+
+#[test]
+fn finalizing_patch_cook_refuses_verified_blocked_verdict() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let (result, run_id) = run_intentional_no_change_cook(false, "blocked");
+        assert_eq!(result.exit_code, 1);
+        assert_eq!(result.value.status, "no_candidate");
+        let persisted = agent_task_lifecycle::exact_record(&run_id).expect("persisted terminal");
+        assert_eq!(
+            persisted.state,
+            agent_task_lifecycle::AgentTaskRunState::PartialFailure
+        );
     });
 }
 

--- a/crates/homeboy-core/src/run_lifecycle_status.rs
+++ b/crates/homeboy-core/src/run_lifecycle_status.rs
@@ -159,7 +159,7 @@ impl From<&CookStatus> for RunLifecycleStatus {
             // --- terminal, unsuccessful, not an invitation to retry ---
             // Finalization ran and produced nothing. Nothing failed, but the
             // Cook did not succeed either, and re-running it changes nothing.
-            CookStatus::NoChanges => Self::PartialFailure,
+            CookStatus::NoChanges | CookStatus::NoCandidate => Self::PartialFailure,
             // A candidate exists and can still be recovered. This matches the
             // `AgentTaskRunState::CandidateRecoverable ->
             // RunExecutionState::CandidateRecoverable` projection rather than
@@ -287,6 +287,7 @@ mod tests {
             CookStatus::DraftPublished,
             CookStatus::GreenNoFinalize,
             CookStatus::IntentionalNoChange,
+            CookStatus::NoCandidate,
             CookStatus::NoChanges,
             CookStatus::NoOpGateFailed,
             CookStatus::GateFailed,
@@ -320,6 +321,7 @@ mod tests {
                 CookStatus::DraftPublished => RunLifecycleStatus::Succeeded,
                 CookStatus::GreenNoFinalize => RunLifecycleStatus::Succeeded,
                 CookStatus::IntentionalNoChange => RunLifecycleStatus::Succeeded,
+                CookStatus::NoCandidate => RunLifecycleStatus::PartialFailure,
                 CookStatus::NoChanges => RunLifecycleStatus::PartialFailure,
                 CookStatus::NoOpGateFailed => RunLifecycleStatus::Failed,
                 CookStatus::GateFailed => RunLifecycleStatus::Failed,
@@ -406,6 +408,7 @@ mod tests {
             CookStatus::Blocked,
             CookStatus::Cancelled,
             CookStatus::NoChanges,
+            CookStatus::NoCandidate,
         ] {
             let projected = RunLifecycleStatus::from(&status);
             assert!(projected.is_terminal(), "{status} must be terminal");


### PR DESCRIPTION
Closes #13966

## Summary
- handle verified intentional no-change outcomes before candidate promotion
- distinguish accepted evidence-only completion from typed `no_candidate` refusal
- preserve exact terminal Cook outcomes across restart and batch observation
- refuse verified blocked verdicts even when a patch artifact is present

## Verification
- `cargo test -p homeboy-agents cook_progress_is_durable_across_active_and_terminal_lifecycle_states`
- `cargo test -p homeboy-agents finalizing_cook_`
- `cargo test -p homeboy-agents finalizing_patch_cook_`
- `cargo test -p homeboy-agents revision_bound_no_change_verdict_without_patch_accepts_review_only_for_clean_checkout`
- `cargo test -p homeboy-agents intentional_no_change_terminal_notifications_match_policy_outcome`
- `cargo fmt --all --check`
- `git diff --check`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode implemented and tested the lifecycle, Cook policy, restart, batch-observation, and notification changes under Chris Huber’s direction.