### PR TITLE
Define Runner API v1 handshake

### DIFF
--- a/crates/contracts/homeboy-runner-contract/src/discovery.rs
+++ b/crates/contracts/homeboy-runner-contract/src/discovery.rs
@@ -1,4 +1,8 @@
-//! Transport-neutral runner discovery and readiness resources.
+//! Transport-neutral runner discovery, readiness, and API handshake resources.
+//!
+//! Runner API negotiation covers the serialized service contract only. Homeboy
+//! binary provenance, daemon freshness, source ancestry, and Lab capability
+//! admission remain independently evaluated implementation concerns.
 
 use std::collections::BTreeSet;
 
@@ -8,6 +12,66 @@ pub const RUNNER_DESCRIPTOR_SCHEMA: &str = "homeboy/runner-descriptor/v1";
 pub const RUNNER_CAPABILITIES_SCHEMA: &str = "homeboy/runner-capabilities/v1";
 pub const RUNNER_READINESS_SCHEMA: &str = "homeboy/runner-readiness/v1";
 pub const RUNNER_INSPECTION_SCHEMA: &str = "homeboy/runner-inspection/v1";
+pub const RUNNER_API_HANDSHAKE_REQUEST_SCHEMA: &str = "homeboy/runner-api-handshake-request/v1";
+pub const RUNNER_API_HANDSHAKE_RESPONSE_SCHEMA: &str = "homeboy/runner-api-handshake-response/v1";
+pub const RUNNER_API_V1: RunnerApiVersion = RunnerApiVersion { major: 1 };
+
+/// A transport-neutral Runner API major version.
+///
+/// The numeric shape lets an older client parse and explicitly reject a future
+/// version instead of failing to deserialize an unknown enum variant.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RunnerApiVersion {
+    pub major: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerApiHandshakeRequest {
+    pub schema: String,
+    pub supported_versions: Vec<RunnerApiVersion>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerApiCompatibilityStatus {
+    Compatible,
+    Incompatible,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerApiCompatibilityFailureCode {
+    InvalidHandshakeSchema,
+    NoSharedApiVersion,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerApiCompatibilityFailure {
+    pub code: RunnerApiCompatibilityFailureCode,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerApiCompatibility {
+    pub status: RunnerApiCompatibilityStatus,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failures: Vec<RunnerApiCompatibilityFailure>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerApiHandshakeResponse {
+    pub schema: String,
+    pub supported_versions: Vec<RunnerApiVersion>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_version: Option<RunnerApiVersion>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inspection: Option<RunnerInspection>,
+    pub compatibility: RunnerApiCompatibility,
+}
 
 /// The implementation kind backing a runner definition.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -96,5 +160,45 @@ mod tests {
         assert_eq!(value["kind"], "local");
         assert!(value.get("server_id").is_none());
         assert!(value.get("concurrency_limit").is_none());
+    }
+
+    #[test]
+    fn future_api_versions_remain_parseable() {
+        let version: RunnerApiVersion =
+            serde_json::from_value(serde_json::json!({ "major": 99 })).expect("api version");
+
+        assert_eq!(version.major, 99);
+    }
+
+    #[test]
+    fn incompatible_handshake_response_has_an_explicit_wire_shape() {
+        let response = RunnerApiHandshakeResponse {
+            schema: RUNNER_API_HANDSHAKE_RESPONSE_SCHEMA.to_string(),
+            supported_versions: vec![RUNNER_API_V1],
+            selected_version: None,
+            inspection: None,
+            compatibility: RunnerApiCompatibility {
+                status: RunnerApiCompatibilityStatus::Incompatible,
+                failures: vec![RunnerApiCompatibilityFailure {
+                    code: RunnerApiCompatibilityFailureCode::NoSharedApiVersion,
+                    message: "no shared version".to_string(),
+                }],
+            },
+        };
+
+        assert_eq!(
+            serde_json::to_value(response).expect("handshake response JSON"),
+            serde_json::json!({
+                "schema": RUNNER_API_HANDSHAKE_RESPONSE_SCHEMA,
+                "supported_versions": [{ "major": 1 }],
+                "compatibility": {
+                    "status": "incompatible",
+                    "failures": [{
+                        "code": "no_shared_api_version",
+                        "message": "no shared version"
+                    }]
+                }
+            })
+        );
     }
 }

--- a/crates/contracts/homeboy-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-runner-contract/src/lib.rs
@@ -19,8 +19,11 @@ pub use capability::{
     RunnerToolchainReadinessProbe,
 };
 pub use discovery::{
-    RunnerCapabilities, RunnerDescriptor, RunnerInspection, RunnerKind, RunnerReadiness,
-    RUNNER_CAPABILITIES_SCHEMA, RUNNER_DESCRIPTOR_SCHEMA, RUNNER_INSPECTION_SCHEMA,
+    RunnerApiCompatibility, RunnerApiCompatibilityFailure, RunnerApiCompatibilityFailureCode,
+    RunnerApiCompatibilityStatus, RunnerApiHandshakeRequest, RunnerApiHandshakeResponse,
+    RunnerApiVersion, RunnerCapabilities, RunnerDescriptor, RunnerInspection, RunnerKind,
+    RunnerReadiness, RUNNER_API_HANDSHAKE_REQUEST_SCHEMA, RUNNER_API_HANDSHAKE_RESPONSE_SCHEMA,
+    RUNNER_API_V1, RUNNER_CAPABILITIES_SCHEMA, RUNNER_DESCRIPTOR_SCHEMA, RUNNER_INSPECTION_SCHEMA,
     RUNNER_READINESS_SCHEMA,
 };
 pub use execution_context::{

--- a/crates/homeboy-lab-runner/src/discovery.rs
+++ b/crates/homeboy-lab-runner/src/discovery.rs
@@ -2,14 +2,19 @@
 
 use homeboy_core::Result;
 use homeboy_runner_contract::{
-    RunnerCapabilities, RunnerDescriptor, RunnerInspection, RunnerKind, RunnerReadiness,
-    RUNNER_CAPABILITIES_SCHEMA, RUNNER_DESCRIPTOR_SCHEMA, RUNNER_INSPECTION_SCHEMA,
+    RunnerApiCompatibility, RunnerApiCompatibilityFailure, RunnerApiCompatibilityFailureCode,
+    RunnerApiCompatibilityStatus, RunnerApiHandshakeRequest, RunnerApiHandshakeResponse,
+    RunnerApiVersion, RunnerCapabilities, RunnerDescriptor, RunnerInspection, RunnerKind,
+    RunnerReadiness, RUNNER_API_HANDSHAKE_REQUEST_SCHEMA, RUNNER_API_HANDSHAKE_RESPONSE_SCHEMA,
+    RUNNER_API_V1, RUNNER_CAPABILITIES_SCHEMA, RUNNER_DESCRIPTOR_SCHEMA, RUNNER_INSPECTION_SCHEMA,
     RUNNER_READINESS_SCHEMA,
 };
 
 use crate::{Runner, RunnerAdmissionSnapshot};
 
 pub struct RunnerDiscoveryService;
+
+const SUPPORTED_RUNNER_API_VERSIONS: &[RunnerApiVersion] = &[RUNNER_API_V1];
 
 impl RunnerDiscoveryService {
     pub fn list() -> Result<Vec<RunnerDescriptor>> {
@@ -55,6 +60,62 @@ impl RunnerDiscoveryService {
             runner_id: runner_id.to_string(),
             runtime_ids: inventory.runtime_ids,
             capabilities: inventory.capabilities,
+        })
+    }
+
+    /// Negotiate the transport-neutral Runner API before serving inspection data.
+    pub fn negotiate(
+        runner_id: &str,
+        request: &RunnerApiHandshakeRequest,
+    ) -> Result<RunnerApiHandshakeResponse> {
+        let supported_versions = SUPPORTED_RUNNER_API_VERSIONS.to_vec();
+        let valid_schema = request.schema == RUNNER_API_HANDSHAKE_REQUEST_SCHEMA;
+        let selected_version = valid_schema
+            .then(|| {
+                request
+                    .supported_versions
+                    .iter()
+                    .filter(|version| SUPPORTED_RUNNER_API_VERSIONS.contains(version))
+                    .max()
+                    .copied()
+            })
+            .flatten();
+        let failures = if !valid_schema {
+            vec![RunnerApiCompatibilityFailure {
+                code: RunnerApiCompatibilityFailureCode::InvalidHandshakeSchema,
+                message: format!(
+                    "Unsupported Runner API handshake schema '{}'; expected '{}'",
+                    request.schema, RUNNER_API_HANDSHAKE_REQUEST_SCHEMA
+                ),
+            }]
+        } else if selected_version.is_none() {
+            vec![RunnerApiCompatibilityFailure {
+                code: RunnerApiCompatibilityFailureCode::NoSharedApiVersion,
+                message: "Client and runner do not share a Runner API major version".to_string(),
+            }]
+        } else {
+            Vec::new()
+        };
+        let compatibility = RunnerApiCompatibility {
+            status: if failures.is_empty() {
+                RunnerApiCompatibilityStatus::Compatible
+            } else {
+                RunnerApiCompatibilityStatus::Incompatible
+            },
+            failures,
+        };
+        let inspection = if selected_version.is_some() {
+            Some(Self::inspect(runner_id)?)
+        } else {
+            None
+        };
+
+        Ok(RunnerApiHandshakeResponse {
+            schema: RUNNER_API_HANDSHAKE_RESPONSE_SCHEMA.to_string(),
+            supported_versions,
+            selected_version,
+            inspection,
+            compatibility,
         })
     }
 }
@@ -116,5 +177,66 @@ mod tests {
         assert_eq!(descriptor.schema, RUNNER_DESCRIPTOR_SCHEMA);
         assert_eq!(descriptor.runner_id, "local");
         assert_eq!(descriptor.kind, RunnerKind::Local);
+    }
+
+    #[test]
+    fn handshake_selects_the_highest_shared_version_and_returns_inspection() {
+        let response = RunnerDiscoveryService::negotiate(
+            "local",
+            &RunnerApiHandshakeRequest {
+                schema: RUNNER_API_HANDSHAKE_REQUEST_SCHEMA.to_string(),
+                supported_versions: vec![RunnerApiVersion { major: 0 }, RUNNER_API_V1],
+            },
+        )
+        .expect("negotiate Runner API");
+
+        assert_eq!(response.selected_version, Some(RUNNER_API_V1));
+        assert_eq!(
+            response.compatibility.status,
+            RunnerApiCompatibilityStatus::Compatible
+        );
+        assert_eq!(
+            response
+                .inspection
+                .expect("compatible inspection")
+                .descriptor
+                .runner_id,
+            "local"
+        );
+    }
+
+    #[test]
+    fn invalid_or_disjoint_handshakes_fail_before_runner_lookup() {
+        let fixtures = [
+            (
+                "homeboy/runner-api-handshake-request/v99",
+                vec![RUNNER_API_V1],
+                RunnerApiCompatibilityFailureCode::InvalidHandshakeSchema,
+            ),
+            (
+                RUNNER_API_HANDSHAKE_REQUEST_SCHEMA,
+                vec![RunnerApiVersion { major: 99 }],
+                RunnerApiCompatibilityFailureCode::NoSharedApiVersion,
+            ),
+        ];
+
+        for (schema, supported_versions, expected_failure) in fixtures {
+            let response = RunnerDiscoveryService::negotiate(
+                "runner-that-does-not-exist",
+                &RunnerApiHandshakeRequest {
+                    schema: schema.to_string(),
+                    supported_versions,
+                },
+            )
+            .expect("incompatibility response");
+
+            assert_eq!(response.selected_version, None);
+            assert_eq!(response.inspection, None);
+            assert_eq!(
+                response.compatibility.status,
+                RunnerApiCompatibilityStatus::Incompatible
+            );
+            assert_eq!(response.compatibility.failures[0].code, expected_failure);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- define numeric Runner API v1 and versioned handshake resources in the canonical runner contract
- negotiate the highest shared API version through `RunnerDiscoveryService`
- return typed invalid-schema and no-shared-version incompatibilities before runner lookup
- keep Runner API negotiation independent of Homeboy semver, daemon freshness, source ancestry, and Lab capability admission

Closes #13991
Parent: #13881

## Verification

- `cargo test -p homeboy-runner-contract -p homeboy-lab-runner discovery --locked`
- `cargo check --workspace --tests --locked`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

`homeboy review audit` was attempted but resource admission refused local execution while the machine load exceeded 40 and Lab remained pinned to Homeboy 0.367.1 against the 0.367.2 source build. CI remains the authoritative audit gate.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode inspected the existing Runner and Extension API contracts, implemented the bounded transport-neutral handshake, wrote the focused compatibility tests, and ran the available verification. Chris Huber directed the architecture and continuation.