### PR TITLE
Require live credential verification before provider dispatch

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_provider.rs
@@ -87,7 +87,7 @@ pub use dispatchability::{
     preflight_plan_provider_dispatchability_with_providers, preflight_provider_dispatchability,
     preflight_provider_dispatchability_with_config,
     preflight_provider_dispatchability_without_runtime_with_config,
-    AgentTaskProviderDispatchability,
+    AgentTaskProviderCredentialStatus, AgentTaskProviderDispatchability,
 };
 pub(crate) use fixture_gate::fixture_provider_outcome;
 pub use fixture_gate::is_fixture_backend;

--- a/crates/homeboy-agents/src/agent_task_provider/dispatchability.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/dispatchability.rs
@@ -2,8 +2,9 @@ use serde::Serialize;
 
 use super::{
     effective_provider_config, provider_credential_readiness, readiness_verdict,
-    resolve_provider_for_backend, validate_provider_immediate_failure_patterns,
-    AgentTaskProviderCatalog, ProviderResolution, ProviderRuntimeReadinessCache,
+    resolve_provider_for_backend, runtime_readiness::provider_requires_live_auth_validation,
+    validate_provider_immediate_failure_patterns, AgentTaskProviderCatalog, ProviderResolution,
+    ProviderRuntimeReadinessCache,
 };
 use crate::agent_task_scheduler::AgentTaskPlan;
 use serde_json::Value;
@@ -37,6 +38,7 @@ pub struct AgentTaskProviderDispatchabilityCheck {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct AgentTaskProviderDispatchabilityCredentialCheck {
+    pub status: AgentTaskProviderCredentialStatus,
     pub ready: bool,
     pub missing: Vec<String>,
     /// `true` only when a provider-declared live readiness probe
@@ -48,6 +50,24 @@ pub struct AgentTaskProviderDispatchabilityCredentialCheck {
     /// provider-owned auth must not treat presence-only readiness as
     /// equivalent to a live-verified one.
     pub verified: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub remediation: Vec<String>,
+}
+
+/// Credential evidence is deliberately more precise than a boolean. In
+/// particular, readable provider-owned auth is only `Present` until a bounded
+/// provider-declared readiness invocation proves it usable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTaskProviderCredentialStatus {
+    NotRequired,
+    Missing,
+    Present,
+    Unverified,
+    Verified,
+    Unusable,
 }
 
 pub fn evaluate_provider_dispatchability(
@@ -109,11 +129,18 @@ pub fn evaluate_provider_dispatchability_with_config(
                     reason: None,
                 },
                 credentials: AgentTaskProviderDispatchabilityCredentialCheck {
+                    status: if credentials_ready {
+                        AgentTaskProviderCredentialStatus::Unverified
+                    } else {
+                        AgentTaskProviderCredentialStatus::Missing
+                    },
                     ready: credentials_ready,
                     missing: Vec::new(),
                     // A route that never resolved to one provider was never
                     // probed, so nothing here was live-verified.
                     verified: false,
+                    reason: Some("the provider route did not resolve, so credentials were not live-validated".to_string()),
+                    remediation: Vec::new(),
                 },
                 configuration: AgentTaskProviderDispatchabilityCheck {
                     ready: configuration_ready,
@@ -171,6 +198,7 @@ pub fn evaluate_provider_dispatchability_with_config(
             reason: Some(reason),
         },
     };
+    let mut runtime_remediation = Vec::new();
     let runtime = if probe_runtime && model_ready && credentials.dispatchable && configuration.ready
     {
         let config = effective_provider_config(config, model);
@@ -179,10 +207,29 @@ pub fn evaluate_provider_dispatchability_with_config(
                 ready: true,
                 reason: None,
             },
-            Ok(verdict) => AgentTaskProviderDispatchabilityCheck {
-                ready: false,
-                reason: Some(homeboy_core::redaction::redact_string(&verdict.reason)),
-            },
+            Ok(verdict) => {
+                if !verdict.remediation.trim().is_empty() {
+                    runtime_remediation
+                        .push(homeboy_core::redaction::redact_string(&verdict.remediation));
+                }
+                let classification = if verdict.classification.trim().is_empty() {
+                    "unknown"
+                } else {
+                    verdict.classification.trim()
+                };
+                let reason = if verdict.reason.trim().is_empty() {
+                    classification.to_string()
+                } else {
+                    format!(
+                        "{classification}: {}",
+                        homeboy_core::redaction::redact_string(&verdict.reason)
+                    )
+                };
+                AgentTaskProviderDispatchabilityCheck {
+                    ready: false,
+                    reason: Some(reason),
+                }
+            }
             Err(reason) => AgentTaskProviderDispatchabilityCheck {
                 ready: false,
                 reason: Some(homeboy_core::redaction::redact_string(&reason.message)),
@@ -203,6 +250,54 @@ pub fn evaluate_provider_dispatchability_with_config(
     // credential gets reported dispatchable (#13628).
     let credentials_verified =
         probe_runtime && provider.readiness_invocation.is_some() && runtime.ready;
+    let provider_owned_auth = provider_requires_live_auth_validation(provider);
+    let (credential_status, credential_reason) = if !credentials.dispatchable {
+        (AgentTaskProviderCredentialStatus::Missing, None)
+    } else if credentials_verified {
+        (AgentTaskProviderCredentialStatus::Verified, None)
+    } else if probe_runtime
+        && provider.readiness_invocation.is_some()
+        && !runtime.ready
+        && (!credentials.requirements.is_empty() || provider_owned_auth)
+    {
+        (
+            AgentTaskProviderCredentialStatus::Unusable,
+            runtime.reason.clone(),
+        )
+    } else if !provider_owned_auth && credentials.requirements.is_empty() {
+        (AgentTaskProviderCredentialStatus::NotRequired, None)
+    } else if !provider_owned_auth {
+        (
+            AgentTaskProviderCredentialStatus::Present,
+            Some("declared credential material is present".to_string()),
+        )
+    } else if !probe_runtime && credentials.requirements.is_empty() {
+        (
+            AgentTaskProviderCredentialStatus::Unverified,
+            Some(
+                "the provider owns authentication but declares no credential presence contract; live validation was not requested"
+                    .to_string(),
+            ),
+        )
+    } else if !probe_runtime {
+        (
+            AgentTaskProviderCredentialStatus::Present,
+            Some(
+                "provider-owned credential material is present; live validation was not requested"
+                    .to_string(),
+            ),
+        )
+    } else if provider.readiness_invocation.is_none() {
+        (
+            AgentTaskProviderCredentialStatus::Unverified,
+            Some(
+                "the provider declares provider-owned authentication but no live readiness invocation"
+                    .to_string(),
+            ),
+        )
+    } else {
+        (AgentTaskProviderCredentialStatus::Unverified, None)
+    };
     let (state, ready, reason) = if !model_ready {
         (
             "model_unavailable",
@@ -221,6 +316,28 @@ pub fn evaluate_provider_dispatchability_with_config(
             false,
             "required provider credentials are not configured",
         )
+    } else if provider_owned_auth && !probe_runtime {
+        (
+            if credentials.requirements.is_empty() {
+                "credentials_unverified"
+            } else {
+                "credentials_present"
+            },
+            false,
+            "provider-owned authentication must be live-validated before dispatch",
+        )
+    } else if provider_owned_auth && provider.readiness_invocation.is_none() {
+        (
+            "credentials_unverified",
+            false,
+            "provider-owned authentication has no live validation route",
+        )
+    } else if provider_owned_auth && !runtime.ready {
+        (
+            "credentials_unusable",
+            false,
+            "provider-owned authentication or its runtime is revoked or unusable",
+        )
     } else if probe_runtime && !runtime.ready {
         (
             "runtime_unavailable",
@@ -229,16 +346,10 @@ pub fn evaluate_provider_dispatchability_with_config(
         )
     } else if !probe_runtime {
         ("ready", true, "live runtime readiness was not requested")
-    } else if credentials_verified {
+    } else if !provider_owned_auth || credentials_verified {
         ("ready", true, "all dispatchability checks passed")
     } else {
-        (
-            "ready",
-            true,
-            "credentials and configuration are present, but the provider declares no live \
-             readiness probe to confirm them; presence is not proof a provider-owned credential \
-             is still valid",
-        )
+        unreachable!("provider-owned auth without verification is rejected above")
     };
     AgentTaskProviderDispatchability {
         state,
@@ -254,9 +365,22 @@ pub fn evaluate_provider_dispatchability_with_config(
                 reason: (!model_ready).then_some("unsupported selected model".to_string()),
             },
             credentials: AgentTaskProviderDispatchabilityCredentialCheck {
+                status: credential_status,
                 ready: credentials.dispatchable,
                 missing: credentials.missing,
                 verified: credentials_verified,
+                reason: credential_reason,
+                remediation: if provider_owned_auth
+                    && probe_runtime
+                    && provider.readiness_invocation.is_none()
+                {
+                    vec![format!(
+                        "Update provider '{}' to declare a bounded readiness_invocation that validates its provider-owned authentication, or select a verified backend.",
+                        provider.id
+                    )]
+                } else {
+                    runtime_remediation
+                },
             },
             configuration,
             runtime,
@@ -328,22 +452,36 @@ fn preflight_provider_dispatchability_with_config_and_probe(
         probe_runtime,
         cache,
     );
-    if verdict.ready {
+    if verdict.ready
+        || (!probe_runtime
+            && matches!(
+                verdict.state,
+                "credentials_present" | "credentials_unverified"
+            ))
+    {
         return Ok(verdict);
     }
     let detail = verdict
         .checks
-        .runtime
+        .credentials
         .reason
         .as_deref()
+        .or(verdict.checks.runtime.reason.as_deref())
         .filter(|reason| *reason != "not requested")
         .map(|reason| format!(": {reason}"))
+        .unwrap_or_default();
+    let remediation = verdict
+        .checks
+        .credentials
+        .remediation
+        .first()
+        .map(|remediation| format!(" Remediation: {remediation}"))
         .unwrap_or_default();
     Err(homeboy_core::Error::validation_invalid_argument(
         "provider_dispatchability",
         format!(
-            "agent-task backend `{backend}` is not dispatchable: {}{detail}",
-            verdict.reason,
+            "agent-task backend `{backend}` is not dispatchable: {}{detail}.{remediation}",
+            verdict.reason.trim_end_matches('.'),
         ),
         Some(backend.to_string()),
         Some(vec![serde_json::to_string(&verdict).unwrap_or_default()]),
@@ -435,7 +573,7 @@ mod tests {
     }
 
     #[test]
-    fn presence_only_credentials_report_ready_but_not_verified() {
+    fn present_credentials_are_not_admitted_when_live_validation_is_unavailable() {
         let auth = tempfile::NamedTempFile::new().expect("auth file");
         // The credential material is present, exactly like a revoked-but-still-
         // on-disk refresh token (#13628): Homeboy can read it, but reading it
@@ -447,25 +585,44 @@ mod tests {
 
         let verdict = evaluate_provider_dispatchability(&catalog, "revocable", None, None, true);
 
-        assert_eq!(verdict.state, "ready");
+        assert_eq!(verdict.state, "credentials_unverified");
         assert!(
-            verdict.ready,
-            "Homeboy has no contrary evidence, so dispatch must not be blocked"
+            !verdict.ready,
+            "unverified provider-owned auth must fail closed"
         );
         assert!(
             verdict.checks.credentials.ready,
             "the declared credential is present"
+        );
+        assert_eq!(
+            verdict.checks.credentials.status,
+            AgentTaskProviderCredentialStatus::Unverified
         );
         assert!(
             !verdict.checks.credentials.verified,
             "no provider-declared readiness probe ran, so this is presence only, not a live \
              verification — reporting it as verified is exactly the #13628 defect"
         );
-        assert!(
-            !verdict.reason.contains("all dispatchability checks passed"),
-            "the reason must not claim full validation when only presence was checked: {}",
-            verdict.reason
+        assert!(verdict.checks.credentials.remediation[0].contains("readiness_invocation"));
+    }
+
+    #[test]
+    fn static_status_distinguishes_present_provider_owned_credentials() {
+        let auth = tempfile::NamedTempFile::new().expect("auth file");
+        std::fs::write(auth.path(), r#"{"token":"present-token"}"#).expect("write auth");
+        let catalog = catalog(provider_with_present_but_unverifiable_credential(
+            auth.path(),
+        ));
+
+        let verdict = evaluate_provider_dispatchability(&catalog, "revocable", None, None, false);
+
+        assert_eq!(verdict.state, "credentials_present");
+        assert!(!verdict.ready);
+        assert_eq!(
+            verdict.checks.credentials.status,
+            AgentTaskProviderCredentialStatus::Present
         );
+        assert!(!verdict.checks.credentials.verified);
     }
 
     #[test]
@@ -500,6 +657,50 @@ mod tests {
              verification"
         );
         assert_eq!(verdict.reason, "all dispatchability checks passed");
+    }
+
+    #[test]
+    fn revoked_or_unusable_credentials_preserve_provider_remediation() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let auth = root.path().join("auth.json");
+        let script = root.path().join("readiness.js");
+        std::fs::write(&auth, r#"{"token":"revoked-but-present-token"}"#).expect("write auth");
+        std::fs::write(
+            &script,
+            "process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-provider-readiness-result/v1',ready:false,classification:'auth_failure',retryable:false,remediation:'Log out and sign in again.',reason:'refresh token revoked',cache_key:'k',identity:{}}));",
+        )
+        .expect("readiness script");
+        let mut provider = provider_with_present_but_unverifiable_credential(&auth);
+        provider.readiness_invocation = Some(CommandInvocation {
+            argv: vec!["node".to_string(), script.display().to_string()],
+            ..CommandInvocation::default()
+        });
+        let catalog = catalog(provider);
+
+        let verdict = evaluate_provider_dispatchability(&catalog, "revocable", None, None, true);
+
+        assert_eq!(verdict.state, "credentials_unusable");
+        assert!(!verdict.ready);
+        assert_eq!(
+            verdict.checks.credentials.status,
+            AgentTaskProviderCredentialStatus::Unusable
+        );
+        assert_eq!(
+            verdict.checks.credentials.reason.as_deref(),
+            Some("auth_failure: refresh token revoked")
+        );
+        assert_eq!(
+            verdict.checks.credentials.remediation,
+            vec!["Log out and sign in again."]
+        );
+
+        let error = preflight_provider_dispatchability(&catalog, "revocable", None, None)
+            .expect_err("revoked credential must fail before dispatch");
+        assert!(error.message.contains("refresh token revoked"), "{error}");
+        assert!(
+            error.message.contains("Log out and sign in again"),
+            "{error}"
+        );
     }
 
     #[test]
@@ -609,7 +810,7 @@ mod tests {
         assert_eq!(blocked.state, "runtime_unavailable");
         assert_eq!(
             blocked.checks.runtime.reason.as_deref(),
-            Some("token=[REDACTED]")
+            Some("configuration: token=[REDACTED]")
         );
 
         let ready = evaluate_provider_dispatchability_with_config(

--- a/crates/homeboy-agents/src/agent_task_provider/runtime_readiness.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/runtime_readiness.rs
@@ -31,6 +31,9 @@ pub fn preflight_plan_provider_runtime_readiness_with_providers(
             continue;
         };
         if provider.readiness_invocation.is_none() {
+            if provider_requires_live_auth_validation(provider) {
+                return Err(unverified_provider_auth_error(provider));
+            }
             validate_provider_immediate_failure_patterns(provider).map_err(|message| {
                 Error::validation_invalid_argument(
                     "immediate_failure_patterns",
@@ -62,6 +65,28 @@ pub fn preflight_plan_provider_runtime_readiness_with_providers(
         }
     }
     Ok(())
+}
+
+pub(crate) fn provider_requires_live_auth_validation(provider: &AgentTaskExecutorProvider) -> bool {
+    provider
+        .capabilities
+        .iter()
+        .any(|capability| capability == "provider_owned_auth")
+}
+
+pub(crate) fn unverified_provider_auth_error(provider: &AgentTaskExecutorProvider) -> Error {
+    Error::validation_invalid_argument(
+        "provider_runtime_readiness",
+        format!(
+            "agent-task backend '{}' is not dispatchable: provider-owned authentication has no live validation route. Update provider '{}' to declare a bounded readiness_invocation that validates its provider-owned authentication, or select a verified backend",
+            provider.backend, provider.id
+        ),
+        Some(provider.backend.clone()),
+        Some(vec![format!(
+            "Update provider '{}' to declare a bounded readiness_invocation that validates its provider-owned authentication, or select a verified backend.",
+            provider.id
+        )]),
+    )
 }
 
 pub(crate) fn readiness_verdict(
@@ -178,6 +203,10 @@ fn readiness_error(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent_task::{
+        AgentTaskExecutor, AgentTaskLimits, AgentTaskPolicy, AgentTaskRequest, AgentTaskWorkspace,
+        AGENT_TASK_REQUEST_SCHEMA,
+    };
     use homeboy_core::command_invocation::CommandInvocation;
 
     fn provider(script: &std::path::Path, count: &std::path::Path) -> AgentTaskExecutorProvider {
@@ -259,5 +288,58 @@ mod tests {
 
         assert_eq!(first.cache_key, second.cache_key);
         assert_eq!(std::fs::read_to_string(count).expect("probe count"), "1");
+    }
+
+    #[test]
+    fn provider_owned_auth_without_a_probe_fails_plan_admission() {
+        let provider: AgentTaskExecutorProvider = serde_json::from_value(json!({
+            "id": "unverified.provider",
+            "backend": "unverified",
+            "capabilities": ["cli_runtime", "provider_owned_auth"]
+        }))
+        .expect("provider fixture");
+        let plan = AgentTaskPlan::new(
+            "unverified-plan",
+            vec![AgentTaskRequest {
+                schema: AGENT_TASK_REQUEST_SCHEMA.to_string(),
+                task_id: "task".to_string(),
+                group_key: None,
+                parent_plan_id: None,
+                executor: AgentTaskExecutor {
+                    backend: "unverified".to_string(),
+                    selector: None,
+                    runtime_selection: None,
+                    required_capabilities: Vec::new(),
+                    secret_env: Vec::new(),
+                    model: None,
+                    config: Value::Null,
+                },
+                instructions: "test".to_string(),
+                inputs: Value::Null,
+                source_refs: Vec::new(),
+                workspace: AgentTaskWorkspace::default(),
+                component_contracts: Vec::new(),
+                policy: AgentTaskPolicy::default(),
+                limits: AgentTaskLimits::default(),
+                expected_artifacts: Vec::new(),
+                artifact_declarations: Vec::new(),
+                output_declarations: Vec::new(),
+                runtime_tools: Vec::new(),
+                metadata: Value::Null,
+            }],
+        );
+
+        let error = preflight_plan_provider_runtime_readiness_with_providers(
+            &plan,
+            &[provider],
+            &mut ProviderRuntimeReadinessCache::default(),
+        )
+        .expect_err("provider-owned auth requires a live probe");
+
+        assert!(
+            error.message.contains("no live validation route"),
+            "{error}"
+        );
+        assert!(error.message.contains("readiness_invocation"), "{error}");
     }
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -4693,6 +4693,19 @@ fn compile_cook_with_injected_catalog_rejects_each_unavailable_dimension_before_
                 compile_command("runtime", None, None),
                 "runtime readiness validation failed",
             ),
+            (
+                "unverified-provider-auth",
+                crate::agent_task_provider::AgentTaskProviderCatalog {
+                    providers: vec![serde_json::from_value(serde_json::json!({
+                        "id": "unverified.provider",
+                        "backend": "unverified",
+                        "capabilities": ["cli_runtime", "provider_owned_auth"]
+                    })).expect("unverified provider")],
+                    ..Default::default()
+                },
+                compile_command("unverified", None, None),
+                "no live validation route",
+            ),
         ];
 
         for (dimension, catalog, command, reason) in cases {
@@ -4729,6 +4742,33 @@ fn compile_cook_with_injected_catalog_proceeds_only_when_every_check_is_ready() 
             options.identity.initial_plan.tasks[0].executor.backend,
             "ready"
         );
+    });
+}
+
+#[test]
+fn compile_cook_admits_provider_owned_auth_only_after_live_verification() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let mut provider = compile_provider("verified.provider", "verified");
+        provider.capabilities = vec!["cli_runtime".to_string(), "provider_owned_auth".to_string()];
+        provider.readiness_invocation = Some(
+            serde_json::from_value(serde_json::json!({
+                "argv": ["sh", "-c", "cat >/dev/null; printf '%s' '{\"schema\":\"homeboy/agent-task-provider-readiness-result/v1\",\"ready\":true,\"classification\":\"ready\",\"retryable\":false,\"remediation\":\"\",\"reason\":\"\",\"cache_key\":\"verified\",\"identity\":{}}'"]
+            }))
+            .expect("readiness invocation"),
+        );
+
+        let options = compile_cook_attempt_with_catalog_and_readiness_cache(
+            compile_options("verified-cook"),
+            compile_command("verified", None, None),
+            &crate::agent_task_provider::AgentTaskProviderCatalog {
+                providers: vec![provider],
+                ..Default::default()
+            },
+            &mut crate::agent_task_provider::ProviderRuntimeReadinessCache::default(),
+        )
+        .expect("verified provider-owned auth is admitted before scheduler reservation");
+
+        assert_eq!(options.identity.initial_plan.tasks.len(), 1);
     });
 }
 

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -455,8 +455,8 @@ pub mod provider {
         preflight_provider_dispatchability_with_config,
         preflight_provider_dispatchability_without_runtime_with_config,
         provider_credential_readiness, AgentTaskProviderCredentialReadiness,
-        AgentTaskProviderCredentialRequirement, AgentTaskProviderDispatchability,
-        AGENT_TASK_PROVIDER_CREDENTIAL_READINESS_SCHEMA,
+        AgentTaskProviderCredentialRequirement, AgentTaskProviderCredentialStatus,
+        AgentTaskProviderDispatchability, AGENT_TASK_PROVIDER_CREDENTIAL_READINESS_SCHEMA,
     };
     pub use crate::agent_task_provider::{
         probe_provider_executor_resolves, provider_runner_secret_env_for_plan_with_providers,

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -2067,17 +2067,14 @@ fn providers_with_catalog(
                     .as_deref()
                     .is_none_or(|runtime| provider.runtime_id.as_deref() == Some(runtime))
                 && args.status.as_deref().is_none_or(|status| {
-                    provider_status(
-                        provider,
-                        &evaluate_provider_dispatchability(
-                            &catalog,
-                            &provider.backend,
-                            Some(&provider.id),
-                            None,
-                            false,
-                        ),
-                    )
-                    .eq_ignore_ascii_case(status)
+                    let dispatchability = evaluate_provider_dispatchability(
+                        &catalog,
+                        &provider.backend,
+                        Some(&provider.id),
+                        None,
+                        args.validate_readiness,
+                    );
+                    provider_matches_status(provider, &dispatchability, status)
                 })
         })
         .cloned()
@@ -2166,7 +2163,7 @@ fn providers_with_catalog(
             // catalog look empty even while it listed selectable executors.
             "provider_identity_catalog": provider_identity_catalog(&shown_providers),
             "capability_contract": homeboy::agents::agent_tasks::provider::provider_capability_contract(),
-            "providers": if args.full { serde_json::to_value(shown_providers.clone()).unwrap_or(Value::Null) } else { Value::Array(shown_providers.iter().map(|provider| compact_provider(provider, &evaluate_provider_dispatchability(&catalog, &provider.backend, Some(&provider.id), None, false))).collect()) },
+            "providers": if args.full { serde_json::to_value(shown_providers.clone()).unwrap_or(Value::Null) } else { Value::Array(shown_providers.iter().map(|provider| compact_provider(provider, &evaluate_provider_dispatchability(&catalog, &provider.backend, Some(&provider.id), None, args.validate_readiness))).collect()) },
             // Availability means dispatchable. Anything that is declared but
             // not dispatchable reports the credential it is missing here so the
             // remediation survives the `--full` serde presentation too (#11479).
@@ -2204,13 +2201,29 @@ fn provider_status(
     dispatchability: &homeboy::agents::agent_tasks::provider::AgentTaskProviderDispatchability,
 ) -> &'static str {
     if !dispatchability.ready {
-        return "unavailable";
+        return match dispatchability.state {
+            "credentials_present" => "present",
+            "credentials_unverified" => "unverified",
+            "credentials_unusable" => "unusable",
+            _ => "unavailable",
+        };
     }
     if provider.default_backend {
         "default"
     } else {
         "available"
     }
+}
+
+fn provider_matches_status(
+    provider: &AgentTaskExecutorProvider,
+    dispatchability: &homeboy::agents::agent_tasks::provider::AgentTaskProviderDispatchability,
+    status: &str,
+) -> bool {
+    if status.eq_ignore_ascii_case("unavailable") {
+        return !dispatchability.ready;
+    }
+    provider_status(provider, dispatchability).eq_ignore_ascii_case(status)
 }
 
 /// Per-provider credential readiness for every provider that is not
@@ -2257,7 +2270,9 @@ fn compact_provider(
         "runtime_id": provider.runtime_id.as_deref().map(|value| bounded_text(value, 160)),
         "extension_id": provider.extension_id.as_deref().map(|value| bounded_text(value, 160)),
         "status": provider_status(provider, dispatchability),
-        "reason": readiness.reason().map(|value| bounded_text(&value, 128)).or_else(|| (!dispatchability.ready).then(|| bounded_text(&dispatchability.reason, 128))),
+        "reason": readiness.reason().map(|value| bounded_text(&value, 128))
+            .or_else(|| dispatchability.checks.credentials.reason.as_deref().map(|value| bounded_text(value, 128)))
+            .or_else(|| (!dispatchability.ready).then(|| bounded_text(&dispatchability.reason, 128))),
         "dispatchability": {
             "state": dispatchability.state,
             "ready": dispatchability.ready,
@@ -2266,9 +2281,12 @@ fn compact_provider(
                 "route": compact_check(dispatchability.checks.route.ready, dispatchability.checks.route.reason.as_deref()),
                 "model": compact_check(dispatchability.checks.model.ready, dispatchability.checks.model.reason.as_deref()),
                 "credentials": {
+                    "status": dispatchability.checks.credentials.status,
                     "ready": dispatchability.checks.credentials.ready,
                     "missing": dispatchability.checks.credentials.missing.iter().take(8).map(|value| bounded_text(value, 96)).collect::<Vec<_>>(),
                     "verified": dispatchability.checks.credentials.verified,
+                    "reason": dispatchability.checks.credentials.reason.as_deref().map(|value| bounded_text(value, 128)),
+                    "remediation": dispatchability.checks.credentials.remediation.iter().take(4).map(|value| bounded_text(value, 256)).collect::<Vec<_>>(),
                 },
                 "configuration": compact_check(dispatchability.checks.configuration.ready, dispatchability.checks.configuration.reason.as_deref()),
                 "runtime": compact_check(dispatchability.checks.runtime.ready, dispatchability.checks.runtime.reason.as_deref()),
@@ -4250,6 +4268,57 @@ mod tests {
             assert_eq!(provider_status(&provider, &dispatchability), "available");
             assert!(compact_provider(&provider, &dispatchability)["reason"].is_null());
         });
+    }
+
+    #[test]
+    fn provider_status_distinguishes_present_and_unverified_provider_owned_auth() {
+        let auth = tempfile::NamedTempFile::new().expect("auth file");
+        std::fs::write(auth.path(), r#"{"token":"present-token"}"#).expect("write auth");
+        let provider: AgentTaskExecutorProvider = serde_json::from_value(serde_json::json!({
+            "id": "owned-auth.provider",
+            "backend": "owned-auth",
+            "capabilities": ["cli_runtime", "provider_owned_auth"],
+            "provider_defaults": {
+                "owned-auth": {
+                    "required_secret_env": ["HOMEBOY_TEST_OWNED_AUTH_TOKEN"],
+                    "secret_env_sources": {
+                        "HOMEBOY_TEST_OWNED_AUTH_TOKEN": {
+                            "source": "json-file",
+                            "path": auth.path(),
+                            "field": "token"
+                        }
+                    }
+                }
+            }
+        }))
+        .expect("provider fixture");
+        let catalog = provider_catalog(vec![provider.clone()]);
+
+        let present = evaluate_provider_dispatchability(
+            &catalog,
+            &provider.backend,
+            Some(&provider.id),
+            None,
+            false,
+        );
+        assert_eq!(provider_status(&provider, &present), "present");
+        assert!(provider_matches_status(&provider, &present, "unavailable"));
+        assert_eq!(compact_provider(&provider, &present)["status"], "present");
+        assert_eq!(
+            compact_provider(&provider, &present)["dispatchability"]["checks"]["credentials"]
+                ["status"],
+            "present"
+        );
+
+        let unverified = evaluate_provider_dispatchability(
+            &catalog,
+            &provider.backend,
+            Some(&provider.id),
+            None,
+            true,
+        );
+        assert_eq!(provider_status(&provider, &unverified), "unverified");
+        assert_eq!(unverified.state, "credentials_unverified");
     }
 
     #[test]

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -1107,15 +1107,16 @@ missing-`--backend` error instead of failing with the same precondition (#12569)
 A supplied `--backend` still fails fast: that query names one backend and has no
 fuller picture to report.
 
-A `ready` verdict means "no reason found to block dispatch," not "confirmed to
-work." `dispatchability.checks.credentials.verified` distinguishes the two: it
-is `true` only when the routed provider declared its own live readiness probe
-(`readiness_invocation`) and that probe ran and passed. When it is `false`,
-`ready: true` reflects presence only — the declared credential material is
-readable somewhere, which is not proof it is still valid. A revoked or expired
-provider-owned credential (e.g. an OAuth refresh token) stays present on disk
-after revocation, so presence-only readiness must not be read as a live
-go/no-go signal for that class of credential (#13628).
+`dispatchability.checks.credentials.status` distinguishes `missing`, `present`,
+`unverified`, `verified`, `unusable`, and `not_required`. Readable credential
+material is only `present`: a revoked or expired provider-owned credential stays
+on disk after revocation. A provider that declares the `provider_owned_auth`
+capability is dispatchable only after its bounded `readiness_invocation` runs
+and passes, producing `verified`. A failed probe reports `unusable` and preserves
+the provider-owned reason and remediation; an absent probe reports `unverified`
+and tells the operator to update the provider or select a verified backend.
+Cook performs this live admission against the final provider configuration
+before scheduler reservation can consume provider-execution budget (#13628).
 
 ## Repo-Local Gate Tasks
 


### PR DESCRIPTION
Closes #13628

## Summary
- distinguish missing, present, unverified, verified, unusable, and not-required credential evidence
- require provider-owned authentication to pass a bounded provider readiness invocation before dispatch
- preserve redacted provider reason and remediation when live validation fails
- expose credential status without breaking the documented unavailable provider filter

## Verification
- `cargo test -p homeboy-cli provider_status_distinguishes_present_and_unverified_provider_owned_auth`
- `cargo test -p homeboy-agents agent_task_provider::dispatchability::tests`
- `cargo test -p homeboy-agents provider_owned_auth_without_a_probe_fails_plan_admission`
- `cargo test -p homeboy-agents compile_cook_admits_provider_owned_auth_only_after_live_verification`
- `cargo fmt --all --check`
- `git diff --check`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode implemented and reviewed the credential admission states, live-readiness enforcement, CLI projection, remediation handling, and focused tests under Chris Huber’s direction.