### PR TITLE
Define Runner API v1 discovery operations

### DIFF
--- a/crates/contracts/homeboy-runner-contract/src/discovery.rs
+++ b/crates/contracts/homeboy-runner-contract/src/discovery.rs
@@ -14,6 +14,10 @@ pub const RUNNER_READINESS_SCHEMA: &str = "homeboy/runner-readiness/v1";
 pub const RUNNER_INSPECTION_SCHEMA: &str = "homeboy/runner-inspection/v1";
 pub const RUNNER_API_HANDSHAKE_REQUEST_SCHEMA: &str = "homeboy/runner-api-handshake-request/v1";
 pub const RUNNER_API_HANDSHAKE_RESPONSE_SCHEMA: &str = "homeboy/runner-api-handshake-response/v1";
+pub const RUNNER_API_LIST_REQUEST_SCHEMA: &str = "homeboy/runner-api-list-request/v1";
+pub const RUNNER_API_LIST_RESPONSE_SCHEMA: &str = "homeboy/runner-api-list-response/v1";
+pub const RUNNER_API_INSPECT_REQUEST_SCHEMA: &str = "homeboy/runner-api-inspect-request/v1";
+pub const RUNNER_API_INSPECT_RESPONSE_SCHEMA: &str = "homeboy/runner-api-inspect-response/v1";
 pub const RUNNER_API_V1: RunnerApiVersion = RunnerApiVersion { major: 1 };
 
 /// A transport-neutral Runner API major version.
@@ -71,6 +75,59 @@ pub struct RunnerApiHandshakeResponse {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inspection: Option<RunnerInspection>,
     pub compatibility: RunnerApiCompatibility,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerApiOperationFailureCode {
+    InvalidRequestSchema,
+    UnsupportedApiVersion,
+    RunnerNotFound,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerApiOperationFailure {
+    pub code: RunnerApiOperationFailureCode,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerApiListRequest {
+    pub schema: String,
+    pub api_version: RunnerApiVersion,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerApiListResponse {
+    pub schema: String,
+    pub api_version: RunnerApiVersion,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub descriptors: Vec<RunnerDescriptor>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<RunnerApiOperationFailure>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerApiInspectRequest {
+    pub schema: String,
+    pub api_version: RunnerApiVersion,
+    pub runner_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerApiInspectResponse {
+    pub schema: String,
+    pub api_version: RunnerApiVersion,
+    pub runner_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inspection: Option<RunnerInspection>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<RunnerApiOperationFailure>,
 }
 
 /// The implementation kind backing a runner definition.
@@ -197,6 +254,63 @@ mod tests {
                         "code": "no_shared_api_version",
                         "message": "no shared version"
                     }]
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn list_success_wire_shape_is_explicitly_versioned() {
+        let response = RunnerApiListResponse {
+            schema: RUNNER_API_LIST_RESPONSE_SCHEMA.to_string(),
+            api_version: RUNNER_API_V1,
+            descriptors: vec![RunnerDescriptor {
+                schema: RUNNER_DESCRIPTOR_SCHEMA.to_string(),
+                runner_id: "local".to_string(),
+                kind: RunnerKind::Local,
+                server_id: None,
+                workspace_root: None,
+                concurrency_limit: None,
+            }],
+            failure: None,
+        };
+
+        assert_eq!(
+            serde_json::to_value(response).expect("list response JSON"),
+            serde_json::json!({
+                "schema": RUNNER_API_LIST_RESPONSE_SCHEMA,
+                "api_version": { "major": 1 },
+                "descriptors": [{
+                    "schema": RUNNER_DESCRIPTOR_SCHEMA,
+                    "runner_id": "local",
+                    "kind": "local"
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn inspect_failure_wire_shape_omits_inspection() {
+        let response = RunnerApiInspectResponse {
+            schema: RUNNER_API_INSPECT_RESPONSE_SCHEMA.to_string(),
+            api_version: RUNNER_API_V1,
+            runner_id: "missing".to_string(),
+            inspection: None,
+            failure: Some(RunnerApiOperationFailure {
+                code: RunnerApiOperationFailureCode::RunnerNotFound,
+                message: "Runner 'missing' was not found".to_string(),
+            }),
+        };
+
+        assert_eq!(
+            serde_json::to_value(response).expect("inspect response JSON"),
+            serde_json::json!({
+                "schema": RUNNER_API_INSPECT_RESPONSE_SCHEMA,
+                "api_version": { "major": 1 },
+                "runner_id": "missing",
+                "failure": {
+                    "code": "runner_not_found",
+                    "message": "Runner 'missing' was not found"
                 }
             })
         );

--- a/crates/contracts/homeboy-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-runner-contract/src/lib.rs
@@ -21,9 +21,13 @@ pub use capability::{
 pub use discovery::{
     RunnerApiCompatibility, RunnerApiCompatibilityFailure, RunnerApiCompatibilityFailureCode,
     RunnerApiCompatibilityStatus, RunnerApiHandshakeRequest, RunnerApiHandshakeResponse,
-    RunnerApiVersion, RunnerCapabilities, RunnerDescriptor, RunnerInspection, RunnerKind,
-    RunnerReadiness, RUNNER_API_HANDSHAKE_REQUEST_SCHEMA, RUNNER_API_HANDSHAKE_RESPONSE_SCHEMA,
-    RUNNER_API_V1, RUNNER_CAPABILITIES_SCHEMA, RUNNER_DESCRIPTOR_SCHEMA, RUNNER_INSPECTION_SCHEMA,
+    RunnerApiInspectRequest, RunnerApiInspectResponse, RunnerApiListRequest, RunnerApiListResponse,
+    RunnerApiOperationFailure, RunnerApiOperationFailureCode, RunnerApiVersion, RunnerCapabilities,
+    RunnerDescriptor, RunnerInspection, RunnerKind, RunnerReadiness,
+    RUNNER_API_HANDSHAKE_REQUEST_SCHEMA, RUNNER_API_HANDSHAKE_RESPONSE_SCHEMA,
+    RUNNER_API_INSPECT_REQUEST_SCHEMA, RUNNER_API_INSPECT_RESPONSE_SCHEMA,
+    RUNNER_API_LIST_REQUEST_SCHEMA, RUNNER_API_LIST_RESPONSE_SCHEMA, RUNNER_API_V1,
+    RUNNER_CAPABILITIES_SCHEMA, RUNNER_DESCRIPTOR_SCHEMA, RUNNER_INSPECTION_SCHEMA,
     RUNNER_READINESS_SCHEMA,
 };
 pub use execution_context::{

--- a/crates/homeboy-lab-runner/src/discovery.rs
+++ b/crates/homeboy-lab-runner/src/discovery.rs
@@ -1,12 +1,16 @@
 //! Canonical read-only Runner API service.
 
-use homeboy_core::Result;
+use homeboy_core::{error::ErrorCode, Result};
 use homeboy_runner_contract::{
     RunnerApiCompatibility, RunnerApiCompatibilityFailure, RunnerApiCompatibilityFailureCode,
     RunnerApiCompatibilityStatus, RunnerApiHandshakeRequest, RunnerApiHandshakeResponse,
-    RunnerApiVersion, RunnerCapabilities, RunnerDescriptor, RunnerInspection, RunnerKind,
-    RunnerReadiness, RUNNER_API_HANDSHAKE_REQUEST_SCHEMA, RUNNER_API_HANDSHAKE_RESPONSE_SCHEMA,
-    RUNNER_API_V1, RUNNER_CAPABILITIES_SCHEMA, RUNNER_DESCRIPTOR_SCHEMA, RUNNER_INSPECTION_SCHEMA,
+    RunnerApiInspectRequest, RunnerApiInspectResponse, RunnerApiListRequest, RunnerApiListResponse,
+    RunnerApiOperationFailure, RunnerApiOperationFailureCode, RunnerApiVersion, RunnerCapabilities,
+    RunnerDescriptor, RunnerInspection, RunnerKind, RunnerReadiness,
+    RUNNER_API_HANDSHAKE_REQUEST_SCHEMA, RUNNER_API_HANDSHAKE_RESPONSE_SCHEMA,
+    RUNNER_API_INSPECT_REQUEST_SCHEMA, RUNNER_API_INSPECT_RESPONSE_SCHEMA,
+    RUNNER_API_LIST_REQUEST_SCHEMA, RUNNER_API_LIST_RESPONSE_SCHEMA, RUNNER_API_V1,
+    RUNNER_CAPABILITIES_SCHEMA, RUNNER_DESCRIPTOR_SCHEMA, RUNNER_INSPECTION_SCHEMA,
     RUNNER_READINESS_SCHEMA,
 };
 
@@ -118,6 +122,99 @@ impl RunnerDiscoveryService {
             compatibility,
         })
     }
+
+    pub fn list_api(request: &RunnerApiListRequest) -> Result<RunnerApiListResponse> {
+        if let Some(failure) = validate_operation_request(
+            &request.schema,
+            RUNNER_API_LIST_REQUEST_SCHEMA,
+            request.api_version,
+        ) {
+            return Ok(list_failure(failure));
+        }
+
+        Ok(RunnerApiListResponse {
+            schema: RUNNER_API_LIST_RESPONSE_SCHEMA.to_string(),
+            api_version: RUNNER_API_V1,
+            descriptors: Self::list()?,
+            failure: None,
+        })
+    }
+
+    pub fn inspect_api(request: &RunnerApiInspectRequest) -> Result<RunnerApiInspectResponse> {
+        if let Some(failure) = validate_operation_request(
+            &request.schema,
+            RUNNER_API_INSPECT_REQUEST_SCHEMA,
+            request.api_version,
+        ) {
+            return Ok(inspect_failure(request, failure));
+        }
+
+        match Self::inspect(&request.runner_id) {
+            Ok(inspection) => Ok(RunnerApiInspectResponse {
+                schema: RUNNER_API_INSPECT_RESPONSE_SCHEMA.to_string(),
+                api_version: RUNNER_API_V1,
+                runner_id: request.runner_id.clone(),
+                inspection: Some(inspection),
+                failure: None,
+            }),
+            Err(error) if error.code == ErrorCode::RunnerNotFound => Ok(inspect_failure(
+                request,
+                operation_failure(RunnerApiOperationFailureCode::RunnerNotFound, error.message),
+            )),
+            Err(error) => Err(error),
+        }
+    }
+}
+
+fn validate_operation_request(
+    actual_schema: &str,
+    expected_schema: &str,
+    api_version: RunnerApiVersion,
+) -> Option<RunnerApiOperationFailure> {
+    if actual_schema != expected_schema {
+        return Some(operation_failure(
+            RunnerApiOperationFailureCode::InvalidRequestSchema,
+            format!("Unsupported request schema '{actual_schema}'; expected '{expected_schema}'"),
+        ));
+    }
+    (api_version != RUNNER_API_V1).then(|| {
+        operation_failure(
+            RunnerApiOperationFailureCode::UnsupportedApiVersion,
+            format!(
+                "Runner API major {} is not supported; Homeboy supports major {}",
+                api_version.major, RUNNER_API_V1.major
+            ),
+        )
+    })
+}
+
+fn list_failure(failure: RunnerApiOperationFailure) -> RunnerApiListResponse {
+    RunnerApiListResponse {
+        schema: RUNNER_API_LIST_RESPONSE_SCHEMA.to_string(),
+        api_version: RUNNER_API_V1,
+        descriptors: Vec::new(),
+        failure: Some(failure),
+    }
+}
+
+fn inspect_failure(
+    request: &RunnerApiInspectRequest,
+    failure: RunnerApiOperationFailure,
+) -> RunnerApiInspectResponse {
+    RunnerApiInspectResponse {
+        schema: RUNNER_API_INSPECT_RESPONSE_SCHEMA.to_string(),
+        api_version: RUNNER_API_V1,
+        runner_id: request.runner_id.clone(),
+        inspection: None,
+        failure: Some(failure),
+    }
+}
+
+fn operation_failure(
+    code: RunnerApiOperationFailureCode,
+    message: String,
+) -> RunnerApiOperationFailure {
+    RunnerApiOperationFailure { code, message }
 }
 
 fn descriptor(runner: &Runner) -> RunnerDescriptor {
@@ -238,5 +335,85 @@ mod tests {
             );
             assert_eq!(response.compatibility.failures[0].code, expected_failure);
         }
+    }
+
+    #[test]
+    fn list_api_returns_canonical_descriptors() {
+        let response = RunnerDiscoveryService::list_api(&RunnerApiListRequest {
+            schema: RUNNER_API_LIST_REQUEST_SCHEMA.to_string(),
+            api_version: RUNNER_API_V1,
+        })
+        .expect("list Runner API");
+
+        assert_eq!(response.api_version, RUNNER_API_V1);
+        assert!(response.failure.is_none());
+        assert!(response
+            .descriptors
+            .iter()
+            .any(|descriptor| descriptor.runner_id == "local"));
+    }
+
+    #[test]
+    fn inspect_api_returns_the_canonical_inspection() {
+        let response = RunnerDiscoveryService::inspect_api(&RunnerApiInspectRequest {
+            schema: RUNNER_API_INSPECT_REQUEST_SCHEMA.to_string(),
+            api_version: RUNNER_API_V1,
+            runner_id: "local".to_string(),
+        })
+        .expect("inspect Runner API");
+
+        assert!(response.failure.is_none());
+        assert_eq!(
+            response
+                .inspection
+                .expect("inspection")
+                .descriptor
+                .runner_id,
+            "local"
+        );
+    }
+
+    #[test]
+    fn discovery_operations_validate_before_runner_lookup() {
+        let fixtures = [
+            (
+                "homeboy/runner-api-inspect-request/v99",
+                RUNNER_API_V1,
+                RunnerApiOperationFailureCode::InvalidRequestSchema,
+            ),
+            (
+                RUNNER_API_INSPECT_REQUEST_SCHEMA,
+                RunnerApiVersion { major: 99 },
+                RunnerApiOperationFailureCode::UnsupportedApiVersion,
+            ),
+        ];
+
+        for (schema, api_version, expected_failure) in fixtures {
+            let response = RunnerDiscoveryService::inspect_api(&RunnerApiInspectRequest {
+                schema: schema.to_string(),
+                api_version,
+                runner_id: "runner-that-does-not-exist".to_string(),
+            })
+            .expect("validation response");
+
+            assert_eq!(response.inspection, None);
+            assert_eq!(response.failure.expect("failure").code, expected_failure);
+        }
+    }
+
+    #[test]
+    fn inspect_api_types_unknown_runner_failures() {
+        let response = RunnerDiscoveryService::inspect_api(&RunnerApiInspectRequest {
+            schema: RUNNER_API_INSPECT_REQUEST_SCHEMA.to_string(),
+            api_version: RUNNER_API_V1,
+            runner_id: "runner-that-does-not-exist".to_string(),
+        })
+        .expect("unknown runner response");
+
+        assert_eq!(response.inspection, None);
+        assert_eq!(
+            response.failure.expect("failure").code,
+            RunnerApiOperationFailureCode::RunnerNotFound
+        );
     }
 }


### PR DESCRIPTION
## Summary

- define versioned Runner API v1 list and inspect request/response envelopes
- add typed invalid-schema, unsupported-version, and unknown-runner failures
- validate operation requests before runner discovery or lookup
- preserve canonical `RunnerDescriptor` and `RunnerInspection` resources as successful payloads

Closes #13996
Parent: #13881

## Verification

- `cargo test -p homeboy-runner-contract -p homeboy-lab-runner discovery --locked`
- `cargo check --workspace --tests --locked`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

`homeboy review audit --profile architecture` routed to Lab because local load exceeded 38. Three runtime-materialization daemon jobs succeeded, but the local observer timed out before the aggregate audit result returned. CI remains the authoritative audit gate.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode inspected the merged Runner handshake and Extension API operation pattern, implemented the transport-neutral list/inspect contracts and service validation, wrote focused wire and behavior tests, and ran verification. Chris Huber directed the architecture and implementation.