### PR TITLE
Keep agent-task reconciliation store-rooted

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -249,6 +249,20 @@ pub fn discover_runs(filter: AgentTaskDiscoveryFilter) -> Result<AgentTaskDiscov
     discover_runs_with_options(filter, AgentTaskDiscoveryOptions::default())
 }
 
+pub(crate) fn discover_runs_in_store(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    filter: AgentTaskDiscoveryFilter,
+) -> Result<AgentTaskDiscoveryReport> {
+    let (records, record_health) =
+        agent_task_lifecycle::read_records_with_health_in_store(lifecycle_store)?;
+    discovery_report(
+        filter,
+        AgentTaskDiscoveryOptions::default(),
+        records,
+        record_health,
+    )
+}
+
 /// Discovery with operator options (currently `--limit`). The `latest` filter
 /// is inherently a single run, so a limit is a no-op there; `all`/`active`
 /// truncate to the requested cap after filtering and sorting, and report the

--- a/crates/homeboy-agents/src/agent_task_service/reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_service/reconcile.rs
@@ -10,7 +10,9 @@ use crate::agent_task_lifecycle;
 use homeboy_core::Result;
 use std::collections::HashMap;
 
-use super::discovery::{discover_runs, AgentTaskDiscoveryFilter, AgentTaskLiveness};
+use super::discovery::{
+    discover_runs, discover_runs_in_store, AgentTaskDiscoveryFilter, AgentTaskLiveness,
+};
 
 /// Report returned by [`reconcile_stale_active_runs`]. Lists every active run
 /// that was classified non-active, and for the reconcilable ones records the
@@ -301,11 +303,19 @@ pub fn reconcile_stale_active_runs(dry_run: bool) -> Result<AgentTaskReconcileRe
 /// reconciliation: a state or ownership change becomes a no-op rather than a
 /// reason to inspect or mutate any other record (#10001).
 pub fn reconcile_run(run_id: &str, dry_run: bool) -> Result<AgentTaskReconcileReport> {
+    let lifecycle_store =
+        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
+    reconcile_run_in_store(&lifecycle_store, run_id, dry_run)
+}
+
+pub(crate) fn reconcile_run_in_store(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    run_id: &str,
+    dry_run: bool,
+) -> Result<AgentTaskReconcileReport> {
     // One store for the whole reconciliation: the scope resolution, every
     // authoritative read, and the expiry or cancellation that follows are one
     // answer about one run.
-    let lifecycle_store =
-        agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
     let requested_run_id = run_id.to_string();
     let resolved_run_ids =
         agent_task_lifecycle::reconcile_scope_run_ids_in_store(&lifecycle_store, run_id)?;
@@ -318,7 +328,7 @@ pub fn reconcile_run(run_id: &str, dry_run: bool) -> Result<AgentTaskReconcileRe
             .runner_id()
             .map(|runner_id| format!("runner:{runner_id}"))
             .unwrap_or_else(|| "local".to_string());
-        let candidate = discover_runs(AgentTaskDiscoveryFilter::Active)?
+        let candidate = discover_runs_in_store(lifecycle_store, AgentTaskDiscoveryFilter::Active)?
             .runs
             .into_iter()
             .find(|run| run.run_id == *resolved_run_id);
@@ -330,12 +340,13 @@ pub fn reconcile_run(run_id: &str, dry_run: bool) -> Result<AgentTaskReconcileRe
                 let refreshed = rooted_exact_status(&lifecycle_store, resolved_run_id)?;
                 let locally_reconcilable_after_runner_idle =
                     refreshed.is_locally_reconcilable_after_runner_idle();
-                let still_reconcilable = discover_runs(AgentTaskDiscoveryFilter::Active)?
-                    .runs
-                    .into_iter()
-                    .find(|run| run.run_id == *resolved_run_id)
-                    .and_then(|run| run.liveness)
-                    .is_some_and(AgentTaskLiveness::is_reconcilable);
+                let still_reconcilable =
+                    discover_runs_in_store(lifecycle_store, AgentTaskDiscoveryFilter::Active)?
+                        .runs
+                        .into_iter()
+                        .find(|run| run.run_id == *resolved_run_id)
+                        .and_then(|run| run.liveness)
+                        .is_some_and(AgentTaskLiveness::is_reconcilable);
                 if refreshed.state.is_terminal() || !still_reconcilable {
                     runs.push(AgentTaskReconcileRun {
                         run_id: resolved_run_id.clone(),

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -2000,6 +2000,42 @@ fn upgrade_admission_repairs_ownerless_queued_runner_record_after_zero_live_reco
 }
 
 #[test]
+fn record_scoped_reconciliation_stays_with_its_explicit_lifecycle_store() {
+    with_isolated_home(|home| {
+        let run_id = "queued-in-explicit-store";
+        let lifecycle_store = agent_task_lifecycle::AgentTaskLifecycleStore::from_data_root(
+            home.path().join("explicit-lifecycle"),
+        );
+        agent_task_lifecycle::submit_plan_in_store(
+            &lifecycle_store,
+            &discovery_plan(),
+            Some(run_id),
+        )
+        .expect("submitted in explicit store");
+        lifecycle_store
+            .mutate_record(run_id, |record| {
+                record.submitted_at = "2000-01-01T00:00:00+00:00".to_string();
+                record.updated_at = None;
+                true
+            })
+            .expect("stale explicit record");
+
+        let repaired = reconcile_run_in_store(&lifecycle_store, run_id, false)
+            .expect("explicit-store reconciliation");
+        assert_eq!(repaired.reconciled, 1, "{repaired:?}");
+        assert_eq!(repaired.runs[0].action, "reconciled");
+        assert_eq!(
+            lifecycle_store
+                .read_record(run_id)
+                .expect("terminal explicit record")
+                .state,
+            AgentTaskRunState::Cancelled
+        );
+        assert!(agent_task_lifecycle::exact_record(run_id).is_err());
+    });
+}
+
+#[test]
 fn upgrade_admission_keeps_ownerless_queued_runner_record_on_runner_plane_without_idle_evidence() {
     with_isolated_home(|_| {
         let run_id = "queued-without-idle-runner-evidence";

--- a/crates/homeboy-agents/src/orchestration.rs
+++ b/crates/homeboy-agents/src/orchestration.rs
@@ -282,7 +282,8 @@ impl OrchestrationService<LifecycleStoreLookup> {
                             }
                         }
                         ControlPlaneAction::Reconcile => {
-                            match crate::agent_task_service::reconcile_run(
+                            match crate::agent_task_service::reconcile_run_in_store(
+                                &self.lookup.store,
                                 requested_id.as_str(),
                                 false,
                             ) {
@@ -1566,6 +1567,59 @@ mod tests {
             assert_eq!(first.result.schema, "homeboy/agent-task-reconcile/v1");
             assert_eq!(
                 service.execute_action(&run, &reconcile).expect("replay"),
+                first
+            );
+        });
+    }
+
+    #[test]
+    fn reconcile_action_mutates_and_completes_in_its_explicit_store() {
+        with_isolated_home(|home| {
+            let store =
+                AgentTaskLifecycleStore::from_data_root(home.path().join("explicit-control-plane"));
+            crate::agent_task_lifecycle::submit_plan_in_store(
+                &store,
+                &AgentTaskPlan::new("explicit-reconcile", Vec::new()),
+                Some(AGENT_TASK_RUN),
+            )
+            .expect("explicit queued record");
+            store
+                .mutate_record(AGENT_TASK_RUN, |record| {
+                    record.submitted_at = "2000-01-01T00:00:00Z".to_string();
+                    record.updated_at = None;
+                    true
+                })
+                .expect("stale explicit record");
+
+            let service = OrchestrationService::new(LifecycleStoreLookup::new(store.clone()));
+            let run = RunId::new(AGENT_TASK_RUN).expect("run");
+            let request = ControlPlaneActionRequest {
+                schema: CONTROL_PLANE_ACTION_REQUEST_SCHEMA.to_string(),
+                action: ControlPlaneAction::Reconcile,
+                idempotency_key: "explicit-reconcile-1".to_string(),
+                actor: "test".to_string(),
+                expected_updated_at: None,
+                parameters: ControlPlaneActionPayload::empty(),
+                confirmed: true,
+            };
+
+            let first = service
+                .execute_action(&run, &request)
+                .expect("reconcile action");
+            assert_eq!(
+                first.outcome,
+                ControlPlaneActionOutcome::Succeeded,
+                "{first:?}"
+            );
+            assert_eq!(
+                store
+                    .read_record(AGENT_TASK_RUN)
+                    .expect("reconciled record")
+                    .state,
+                AgentTaskRunState::Cancelled
+            );
+            assert_eq!(
+                service.execute_action(&run, &request).expect("replay"),
                 first
             );
         });


### PR DESCRIPTION
## Summary

- thread the selected lifecycle store through scoped discovery and reconciliation
- execute canonical reconcile actions against the same store that owns their durable idempotency claim
- add explicit cross-root service and control-plane regression coverage

Closes #13997.

## Root Cause

The control-plane action reserved its operation claim in `LifecycleStoreLookup`, then `reconcile_run()` independently resolved the ambient environment. Reconciliation could therefore mutate a different store before action completion looked for the original claim.

## Verification

- `cargo test -p homeboy-agents record_scoped_reconciliation_stays_with_its_explicit_lifecycle_store`
- `cargo test -p homeboy-agents reconcile_action_mutates_and_completes_in_its_explicit_store`
- `cargo test -p homeboy-agents upgrade_admission_repairs_ownerless_queued_runner_record_after_zero_live_reconciliation`
- `cargo fmt --all --check`
- `git diff --check`

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the cross-root reconciliation failure, traced the lifecycle-store boundary, implemented the store-rooted repair, and ran focused verification under my direction.