### PR TITLE
Fix portable release preflight output

### DIFF
--- a/crates/homeboy-cli/src/commands/release/mod.rs
+++ b/crates/homeboy-cli/src/commands/release/mod.rs
@@ -1,6 +1,6 @@
 use clap::{Args, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::{fs, path::Path};
 
 use homeboy::core::component;
@@ -633,6 +633,17 @@ impl PortableStageDispatcher for CliPortableStageDispatcher {
             )
         })?;
         let mut command = Command::new(executable);
+        let output_dir = tempfile::tempdir().map_err(|error| {
+            homeboy::core::Error::internal_io(
+                format!(
+                    "create portable release {} preflight output directory: {error}",
+                    request.gate
+                ),
+                Some(request.path.to_string()),
+            )
+        })?;
+        let output_path = output_dir.path().join("command-result.json");
+        command.args(["--output", output_path.to_string_lossy().as_ref()]);
         if let Some(runner_id) = request.requested_runner_id {
             command.args(["--runner", runner_id]);
         } else if matches!(request.placement, ReleasePreflightPlacementArg::Lab) {
@@ -647,26 +658,45 @@ impl PortableStageDispatcher for CliPortableStageDispatcher {
             "--release-readiness-source",
             request.source_commit,
         ]);
+        // Review dependencies may stream ordinary progress on stdout. The
+        // global output file is the machine contract; retaining stdout here
+        // would both corrupt that contract and buffer unbounded gate logs.
+        command.stdout(Stdio::null());
         let output = command.output().map_err(|error| {
             homeboy::core::Error::internal_io(
                 format!("start portable release {} preflight: {error}", request.gate),
                 Some(request.path.to_string()),
             )
         })?;
-        let envelope: PortableReviewChildEnvelope = serde_json::from_slice(&output.stdout)
-            .map_err(|error| {
-                homeboy::core::Error::validation_invalid_argument(
-                    "release.preflight",
-                    format!(
-                        "portable {} preflight returned no stable command-result JSON: {error}",
-                        request.gate
-                    ),
-                    Some(String::from_utf8_lossy(&output.stderr).to_string()),
-                    None,
-                )
-            })?;
+        let envelope =
+            read_portable_review_child_envelope(&output_path, request.gate, &output.stderr)?;
         envelope.project(output.status.success(), request.source_commit)
     }
+}
+
+fn read_portable_review_child_envelope(
+    path: &Path,
+    gate: &str,
+    stderr: &[u8],
+) -> homeboy::core::Result<PortableReviewChildEnvelope> {
+    let result = fs::read(path).map_err(|error| {
+        homeboy::core::Error::validation_invalid_argument(
+            "release.preflight",
+            format!("portable {gate} preflight returned no structured command-result: {error}"),
+            Some(String::from_utf8_lossy(stderr).to_string()),
+            None,
+        )
+    })?;
+    serde_json::from_slice(&result).map_err(|error| {
+        homeboy::core::Error::validation_invalid_argument(
+            "release.preflight",
+            format!(
+                "portable {gate} preflight returned invalid structured command-result JSON: {error}"
+            ),
+            Some(String::from_utf8_lossy(stderr).to_string()),
+            None,
+        )
+    })
 }
 
 /// Stable subset of a child command-result envelope consumed by release.
@@ -2458,5 +2488,64 @@ jobs:
             .iter()
             .filter(|gate| ["audit", "lint", "test"].contains(&gate.gate.as_str()))
             .all(|gate| gate.provenance.as_ref() == Some(&child_provenance)));
+    }
+
+    #[test]
+    fn portable_preflight_reads_only_the_structured_output_file() {
+        let output = tempfile::NamedTempFile::new().expect("output file");
+        std::fs::write(
+            output.path(),
+            serde_json::to_vec(&serde_json::json!({
+                "success": true,
+                "evidence": [{ "uri": "run://portable-test" }],
+                "data": {
+                    "release_readiness": {
+                        "requested_source_commit": "source",
+                        "source_commit": "source",
+                        "runner_id": "homeboy-lab",
+                        "provenance": { "dependencies": { "fixture": "locked" } }
+                    }
+                }
+            }))
+            .expect("serialize envelope"),
+        )
+        .expect("write envelope");
+
+        let envelope = read_portable_review_child_envelope(
+            output.path(),
+            "test",
+            b"ordinary child progress remains outside the structured result",
+        )
+        .expect("structured output is authoritative");
+        let projected = envelope.project(true, "source").expect("valid evidence");
+
+        assert!(projected.passed);
+        assert_eq!(projected.runner_id.as_deref(), Some("homeboy-lab"));
+    }
+
+    #[test]
+    fn portable_preflight_fails_closed_for_missing_or_invalid_structured_output() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let missing = match read_portable_review_child_envelope(
+            &directory.path().join("missing.json"),
+            "lint",
+            b"diagnostic",
+        ) {
+            Ok(_) => panic!("missing output must fail"),
+            Err(error) => error,
+        };
+        assert!(missing.message.contains("no structured command-result"));
+
+        let invalid_path = directory.path().join("invalid.json");
+        std::fs::write(&invalid_path, "progress before JSON\n{not-json}")
+            .expect("write invalid output");
+        let invalid =
+            match read_portable_review_child_envelope(&invalid_path, "lint", b"diagnostic") {
+                Ok(_) => panic!("invalid output must fail"),
+                Err(error) => error,
+            };
+        assert!(invalid
+            .message
+            .contains("invalid structured command-result JSON"));
     }
 }

--- a/crates/homeboy-cli/src/commands/review/mod.rs
+++ b/crates/homeboy-cli/src/commands/review/mod.rs
@@ -395,13 +395,11 @@ fn to_value_with_readiness_provenance<T: Serialize>(
     if let Some(requested_source) = requested_source {
         let provenance = homeboy_release::release::readiness_provenance(component)?;
         let source_commit = homeboy::core::git::get_head_commit(&component.local_path)?;
-        let runner_id =
-            crate::commands::utils::execution_provenance::captured().and_then(|value| {
-                value
-                    .pointer("/resolved_execution/runner_id")
-                    .and_then(|value| value.as_str())
-                    .map(str::to_string)
-            });
+        let execution_provenance = crate::commands::utils::execution_provenance::captured();
+        let runner_id = release_readiness_runner_id(
+            execution_provenance.as_ref(),
+            homeboy::core::resource_policy_context::lab_execution_runner_id(),
+        );
         object.insert(
             "release_readiness".to_string(),
             serde_json::to_value(ReviewChildReadinessEvidence {
@@ -418,6 +416,20 @@ fn to_value_with_readiness_provenance<T: Serialize>(
         );
     }
     Ok((value, exit_code))
+}
+
+fn release_readiness_runner_id(
+    execution_provenance: Option<&Value>,
+    lab_execution_runner_id: Option<String>,
+) -> Option<String> {
+    execution_provenance
+        .and_then(|value| {
+            value
+                .pointer("/resolved_execution/runner_id")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+        .or(lab_execution_runner_id)
 }
 
 fn to_value<T: Serialize>(result: CmdResult<T>) -> CmdResult<Value> {
@@ -1220,6 +1232,35 @@ mod tests {
         assert_eq!(cli.review.changed.changed_since(), Some("trunk"));
         assert!(!cli.review.changed.changed_only);
         assert_eq!(cli.review.comp.component.as_deref(), Some("my-comp"));
+    }
+
+    #[test]
+    fn release_readiness_runner_prefers_routed_provenance() {
+        let provenance = serde_json::json!({
+            "resolved_execution": { "runner_id": "routed-runner" }
+        });
+
+        assert_eq!(
+            release_readiness_runner_id(Some(&provenance), Some("durable-runner".to_string()))
+                .as_deref(),
+            Some("routed-runner")
+        );
+    }
+
+    #[test]
+    fn release_readiness_runner_uses_durable_lab_execution_provenance() {
+        let local_child_provenance = serde_json::json!({
+            "resolved_execution": { "location": "controller", "runner_id": null }
+        });
+
+        assert_eq!(
+            release_readiness_runner_id(
+                Some(&local_child_provenance),
+                Some("homeboy-lab".to_string()),
+            )
+            .as_deref(),
+            Some("homeboy-lab")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- consume nested review results from Homeboy's structured `--output` contract instead of streamed stdout
- discard unbounded child stdout while preserving stderr diagnostics and fail-closed parsing
- retain durable Lab runner identity after runner-local placement normalization

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-cli commands::release` (54 passed)
- `cargo test -p homeboy-cli commands::review` (28 passed)

Closes #13831.

## AI assistance
Implemented and verified with OpenAI gpt-5.6-sol using OpenCode. The AI traced the retained release-readiness evidence, reproduced the output-boundary failure, implemented the structured transport and runner-provenance fixes, and ran the focused and module-level Rust tests under human direction.