### PR TITLE
Fix Cook subdirectory component identity

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -4517,6 +4517,18 @@ pub(super) struct CookRepositoryIdentity {
 }
 
 fn normalize_cook_repository_identity(args: &mut AgentTaskCookArgs) -> homeboy::core::Result<()> {
+    if let (Some(repo), Some(component)) =
+        (args.dispatch.repo.as_deref(), args.component.as_deref())
+    {
+        // Preserve the repository/component contract when the component is still
+        // registered. A removed component is instead disproven by the workspace.
+        if homeboy::core::component::inventory::registered_base()?
+            .iter()
+            .any(|registered| registered.id == component)
+        {
+            validate_cook_repository_component_selection(repo, component)?;
+        }
+    }
     if let Some(repository_name) = args.component.as_deref().or(args.dispatch.repo.as_deref()) {
         // Resolve configured aliases before any workspace or provider operation,
         // so every Cook invocation form rejects an ambiguous identity equally.
@@ -4611,7 +4623,43 @@ fn normalize_cook_repository_identity(args: &mut AgentTaskCookArgs) -> homeboy::
         validate_cook_repository_component_selection(repo, component)?;
     }
     args.dispatch.repo = Some(selected.repository_name.clone());
-    let component_id = selected.component_registered.then(|| selected.slug.clone());
+    let component_id = match args.component.as_deref() {
+        Some(component_id) => {
+            let component =
+                homeboy::core::component::registered_by_id(component_id)?.ok_or_else(|| {
+                    homeboy::core::Error::validation_invalid_argument(
+                        "component",
+                        format!("--component `{component_id}` is not a registered component"),
+                        Some(component_id.to_string()),
+                        None,
+                    )
+                })?;
+            let component_remote = component
+                .remote_url
+                .as_deref()
+                .and_then(canonical_remote_identity)
+                .ok_or_else(|| {
+                    homeboy::core::Error::validation_invalid_argument(
+                        "component",
+                        format!("--component `{component_id}` has no canonical configured remote"),
+                        Some(component_id.to_string()),
+                        None,
+                    )
+                })?;
+            if component_remote != selected.remote_identity {
+                return Err(homeboy::core::Error::validation_invalid_argument(
+                    "component",
+                    format!(
+                        "--component `{component_id}` does not match the supplied workspace repository"
+                    ),
+                    Some(component_id.to_string()),
+                    None,
+                ));
+            }
+            Some(component.id)
+        }
+        None => selected.component_registered.then(|| selected.slug.clone()),
+    };
     args.component = component_id.clone();
     let component_cwd = match component_id.as_deref() {
         Some(component_id) => homeboy::core::component::registered_by_id(component_id)?

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -1023,6 +1023,83 @@ fn cook_preserves_repository_and_component_identity_for_every_destination_form()
 }
 
 #[test]
+fn cook_keeps_root_repository_for_an_explicit_subdirectory_component() {
+    with_isolated_home(|_| {
+        let checkout = tempfile::tempdir().expect("repository checkout");
+        init_runtime_component_checkout(checkout.path());
+        let component_path = checkout.path().join("php-transformer");
+        std::fs::create_dir(&component_path).expect("nested component directory");
+        std::fs::write(component_path.join("plugin.php"), "<?php\n")
+            .expect("nested component marker");
+        assert!(Command::new("git")
+            .args(["add", "php-transformer/plugin.php"])
+            .current_dir(checkout.path())
+            .status()
+            .expect("stage nested component")
+            .success());
+        assert!(Command::new("git")
+            .args(["commit", "-m", "add nested component"])
+            .current_dir(checkout.path())
+            .status()
+            .expect("commit nested component")
+            .success());
+        let remote = "https://github.com/example/blocks-engine.git";
+        add_remote(checkout.path(), "origin", remote);
+        register_component("blocks-engine", checkout.path(), remote);
+        register_component("php-transformer", &component_path, remote);
+        register_component(
+            "unrelated",
+            tempfile::tempdir().expect("unrelated component").path(),
+            "https://github.com/example/unrelated.git",
+        );
+
+        let args = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "implement the fix".to_string(),
+            "--repo".to_string(),
+            "blocks-engine".to_string(),
+            "--component".to_string(),
+            "php-transformer".to_string(),
+            "--cwd".to_string(),
+            component_path.display().to_string(),
+            "--no-finalize".to_string(),
+        ]))
+        .expect("resolve explicit subdirectory component");
+
+        assert_eq!(args.dispatch.repo.as_deref(), Some("blocks-engine"));
+        assert_eq!(args.component.as_deref(), Some("php-transformer"));
+        let identity = args.repository_identity.expect("repository identity");
+        assert_eq!(identity["repository_name"], "blocks-engine");
+        assert_eq!(identity["component_id"], "php-transformer");
+        assert_eq!(identity["component_cwd"], "php-transformer");
+        assert_eq!(
+            identity["remote_identity"],
+            "git://github.com/example/blocks-engine"
+        );
+
+        let error = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "implement the fix".to_string(),
+            "--repo".to_string(),
+            "blocks-engine".to_string(),
+            "--component".to_string(),
+            "unrelated".to_string(),
+            "--cwd".to_string(),
+            component_path.display().to_string(),
+            "--no-finalize".to_string(),
+        ]))
+        .expect_err("unrelated component must remain fail-closed");
+        assert!(error.message.contains("belongs to repository"));
+    });
+}
+
+#[test]
 fn cook_replay_preserves_exact_component_when_repository_has_multiple_components() {
     with_isolated_home(|_| {
         let root = tempfile::tempdir().expect("repository root");


### PR DESCRIPTION
## Summary

- preserve the root repository identity when Cook receives an explicit registered subdirectory component
- validate the component against the selected workspace canonical remote
- retain shared-repository disambiguation and stale-component diagnostics
- add root checkout plus nested component regression coverage

Closes #14001.

## Verification

- `cargo fmt --check`
- `cargo test -p homeboy-cli --lib commands::agent_task::tests::dispatch` (59 passed)

## AI assistance

OpenAI `gpt-5.6-terra` via direct OpenCode runs implemented and remediated the candidate. OpenAI `gpt-5.6-sol` via OpenCode diagnosed the live failure, orchestrated isolated worktrees, reviewed the diff, and ran final verification under Chris Huber's direction. Chris remains responsible for the change.