### PR TITLE
Add Runner API v1 capabilities operation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "homeboy"
-version = "0.367.5"
+version = "0.367.6"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "homeboy"
-version = "0.367.4"
+version = "0.367.5"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = ["crates/homeboy-*", "crates/contracts/homeboy-*"]
 
 [package]
 name = "homeboy"
-version = "0.367.5"
+version = "0.367.6"
 edition = "2021"
 default-run = "homeboy"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = ["crates/homeboy-*", "crates/contracts/homeboy-*"]
 
 [package]
 name = "homeboy"
-version = "0.367.4"
+version = "0.367.5"
 edition = "2021"
 default-run = "homeboy"
 license = "MIT"

--- a/crates/contracts/homeboy-runner-contract/src/discovery.rs
+++ b/crates/contracts/homeboy-runner-contract/src/discovery.rs
@@ -18,6 +18,10 @@ pub const RUNNER_API_LIST_REQUEST_SCHEMA: &str = "homeboy/runner-api-list-reques
 pub const RUNNER_API_LIST_RESPONSE_SCHEMA: &str = "homeboy/runner-api-list-response/v1";
 pub const RUNNER_API_INSPECT_REQUEST_SCHEMA: &str = "homeboy/runner-api-inspect-request/v1";
 pub const RUNNER_API_INSPECT_RESPONSE_SCHEMA: &str = "homeboy/runner-api-inspect-response/v1";
+pub const RUNNER_API_CAPABILITIES_REQUEST_SCHEMA: &str =
+    "homeboy/runner-api-capabilities-request/v1";
+pub const RUNNER_API_CAPABILITIES_RESPONSE_SCHEMA: &str =
+    "homeboy/runner-api-capabilities-response/v1";
 pub const RUNNER_API_V1: RunnerApiVersion = RunnerApiVersion { major: 1 };
 
 /// A transport-neutral Runner API major version.
@@ -126,6 +130,26 @@ pub struct RunnerApiInspectResponse {
     pub runner_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inspection: Option<RunnerInspection>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<RunnerApiOperationFailure>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerApiCapabilitiesRequest {
+    pub schema: String,
+    pub api_version: RunnerApiVersion,
+    pub runner_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerApiCapabilitiesResponse {
+    pub schema: String,
+    pub api_version: RunnerApiVersion,
+    pub runner_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<RunnerCapabilities>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failure: Option<RunnerApiOperationFailure>,
 }
@@ -306,6 +330,73 @@ mod tests {
             serde_json::to_value(response).expect("inspect response JSON"),
             serde_json::json!({
                 "schema": RUNNER_API_INSPECT_RESPONSE_SCHEMA,
+                "api_version": { "major": 1 },
+                "runner_id": "missing",
+                "failure": {
+                    "code": "runner_not_found",
+                    "message": "Runner 'missing' was not found"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn capabilities_operation_wire_shapes_are_explicitly_versioned() {
+        let request = RunnerApiCapabilitiesRequest {
+            schema: RUNNER_API_CAPABILITIES_REQUEST_SCHEMA.to_string(),
+            api_version: RUNNER_API_V1,
+            runner_id: "local".to_string(),
+        };
+        assert_eq!(
+            serde_json::to_value(request).expect("capabilities request JSON"),
+            serde_json::json!({
+                "schema": RUNNER_API_CAPABILITIES_REQUEST_SCHEMA,
+                "api_version": { "major": 1 },
+                "runner_id": "local"
+            })
+        );
+
+        let success = RunnerApiCapabilitiesResponse {
+            schema: RUNNER_API_CAPABILITIES_RESPONSE_SCHEMA.to_string(),
+            api_version: RUNNER_API_V1,
+            runner_id: "local".to_string(),
+            capabilities: Some(RunnerCapabilities {
+                schema: RUNNER_CAPABILITIES_SCHEMA.to_string(),
+                runner_id: "local".to_string(),
+                runtime_ids: BTreeSet::from(["homeboy".to_string()]),
+                capabilities: BTreeSet::from(["cargo".to_string()]),
+            }),
+            failure: None,
+        };
+        assert_eq!(
+            serde_json::to_value(success).expect("capabilities success JSON"),
+            serde_json::json!({
+                "schema": RUNNER_API_CAPABILITIES_RESPONSE_SCHEMA,
+                "api_version": { "major": 1 },
+                "runner_id": "local",
+                "capabilities": {
+                    "schema": RUNNER_CAPABILITIES_SCHEMA,
+                    "runner_id": "local",
+                    "runtime_ids": ["homeboy"],
+                    "capabilities": ["cargo"]
+                }
+            })
+        );
+
+        let failure = RunnerApiCapabilitiesResponse {
+            schema: RUNNER_API_CAPABILITIES_RESPONSE_SCHEMA.to_string(),
+            api_version: RUNNER_API_V1,
+            runner_id: "missing".to_string(),
+            capabilities: None,
+            failure: Some(RunnerApiOperationFailure {
+                code: RunnerApiOperationFailureCode::RunnerNotFound,
+                message: "Runner 'missing' was not found".to_string(),
+            }),
+        };
+        assert_eq!(
+            serde_json::to_value(failure).expect("capabilities failure JSON"),
+            serde_json::json!({
+                "schema": RUNNER_API_CAPABILITIES_RESPONSE_SCHEMA,
                 "api_version": { "major": 1 },
                 "runner_id": "missing",
                 "failure": {

--- a/crates/contracts/homeboy-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-runner-contract/src/lib.rs
@@ -19,11 +19,13 @@ pub use capability::{
     RunnerToolchainReadinessProbe,
 };
 pub use discovery::{
-    RunnerApiCompatibility, RunnerApiCompatibilityFailure, RunnerApiCompatibilityFailureCode,
-    RunnerApiCompatibilityStatus, RunnerApiHandshakeRequest, RunnerApiHandshakeResponse,
-    RunnerApiInspectRequest, RunnerApiInspectResponse, RunnerApiListRequest, RunnerApiListResponse,
+    RunnerApiCapabilitiesRequest, RunnerApiCapabilitiesResponse, RunnerApiCompatibility,
+    RunnerApiCompatibilityFailure, RunnerApiCompatibilityFailureCode, RunnerApiCompatibilityStatus,
+    RunnerApiHandshakeRequest, RunnerApiHandshakeResponse, RunnerApiInspectRequest,
+    RunnerApiInspectResponse, RunnerApiListRequest, RunnerApiListResponse,
     RunnerApiOperationFailure, RunnerApiOperationFailureCode, RunnerApiVersion, RunnerCapabilities,
     RunnerDescriptor, RunnerInspection, RunnerKind, RunnerReadiness,
+    RUNNER_API_CAPABILITIES_REQUEST_SCHEMA, RUNNER_API_CAPABILITIES_RESPONSE_SCHEMA,
     RUNNER_API_HANDSHAKE_REQUEST_SCHEMA, RUNNER_API_HANDSHAKE_RESPONSE_SCHEMA,
     RUNNER_API_INSPECT_REQUEST_SCHEMA, RUNNER_API_INSPECT_RESPONSE_SCHEMA,
     RUNNER_API_LIST_REQUEST_SCHEMA, RUNNER_API_LIST_RESPONSE_SCHEMA, RUNNER_API_V1,

--- a/crates/homeboy-cli/src/commands/extension.rs
+++ b/crates/homeboy-cli/src/commands/extension.rs
@@ -52,11 +52,8 @@ enum ExtensionCommand {
         #[arg(short, long)]
         project: Option<String>,
         /// Run live readiness probes concurrently and refresh cached readiness
-        #[arg(long, conflicts_with = "skip_ready_check")]
+        #[arg(long)]
         live_readiness: bool,
-        /// Deprecated compatibility flag; inventory is metadata-only by default
-        #[arg(long, hide = true)]
-        skip_ready_check: bool,
     },
     /// Compare installed extension revisions with their current checkout HEADs
     DiffInstalled {
@@ -71,11 +68,8 @@ enum ExtensionCommand {
         /// Extension ID
         extension_id: String,
         /// Run the live readiness probe and refresh cached readiness
-        #[arg(long, conflicts_with = "skip_ready_check")]
+        #[arg(long)]
         live_readiness: bool,
-        /// Deprecated compatibility flag; inspection is metadata-only by default
-        #[arg(long, hide = true)]
-        skip_ready_check: bool,
     },
     /// Execute a extension
     Run {
@@ -229,8 +223,7 @@ pub fn run(args: ExtensionArgs) -> CmdResult<ExtensionOutput> {
         ExtensionCommand::List {
             project,
             live_readiness,
-            skip_ready_check,
-        } => list(project, readiness_mode(live_readiness, skip_ready_check)),
+        } => list(project, readiness_mode(live_readiness)),
         ExtensionCommand::DiffInstalled {
             extension_id,
             runner,
@@ -238,11 +231,7 @@ pub fn run(args: ExtensionArgs) -> CmdResult<ExtensionOutput> {
         ExtensionCommand::Show {
             extension_id,
             live_readiness,
-            skip_ready_check,
-        } => show_extension(
-            &extension_id,
-            readiness_mode(live_readiness, skip_ready_check),
-        ),
+        } => show_extension(&extension_id, readiness_mode(live_readiness)),
         ExtensionCommand::Run {
             extension_id,
             project,
@@ -751,7 +740,7 @@ pub struct InstalledExtensionDiff {
 }
 
 /// Inventory is static by default; callers must explicitly request live probes.
-fn readiness_mode(live_readiness: bool, _skip_ready_check: bool) -> ExtensionReadinessMode {
+fn readiness_mode(live_readiness: bool) -> ExtensionReadinessMode {
     if live_readiness {
         ExtensionReadinessMode::Probe
     } else {
@@ -2273,9 +2262,8 @@ mod tests {
 
     #[test]
     fn extension_inventory_defaults_to_cached_readiness() {
-        assert_eq!(readiness_mode(false, false), ExtensionReadinessMode::Cached);
-        assert_eq!(readiness_mode(false, true), ExtensionReadinessMode::Cached);
-        assert_eq!(readiness_mode(true, false), ExtensionReadinessMode::Probe);
+        assert_eq!(readiness_mode(false), ExtensionReadinessMode::Cached);
+        assert_eq!(readiness_mode(true), ExtensionReadinessMode::Probe);
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/release/mod.rs
+++ b/crates/homeboy-cli/src/commands/release/mod.rs
@@ -1,6 +1,6 @@
 use clap::{Args, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::{fs, path::Path};
 
 use homeboy::core::component;
@@ -633,6 +633,17 @@ impl PortableStageDispatcher for CliPortableStageDispatcher {
             )
         })?;
         let mut command = Command::new(executable);
+        let output_dir = tempfile::tempdir().map_err(|error| {
+            homeboy::core::Error::internal_io(
+                format!(
+                    "create portable release {} preflight output directory: {error}",
+                    request.gate
+                ),
+                Some(request.path.to_string()),
+            )
+        })?;
+        let output_path = output_dir.path().join("command-result.json");
+        command.args(["--output", output_path.to_string_lossy().as_ref()]);
         if let Some(runner_id) = request.requested_runner_id {
             command.args(["--runner", runner_id]);
         } else if matches!(request.placement, ReleasePreflightPlacementArg::Lab) {
@@ -647,26 +658,45 @@ impl PortableStageDispatcher for CliPortableStageDispatcher {
             "--release-readiness-source",
             request.source_commit,
         ]);
+        // Review dependencies may stream ordinary progress on stdout. The
+        // global output file is the machine contract; retaining stdout here
+        // would both corrupt that contract and buffer unbounded gate logs.
+        command.stdout(Stdio::null());
         let output = command.output().map_err(|error| {
             homeboy::core::Error::internal_io(
                 format!("start portable release {} preflight: {error}", request.gate),
                 Some(request.path.to_string()),
             )
         })?;
-        let envelope: PortableReviewChildEnvelope = serde_json::from_slice(&output.stdout)
-            .map_err(|error| {
-                homeboy::core::Error::validation_invalid_argument(
-                    "release.preflight",
-                    format!(
-                        "portable {} preflight returned no stable command-result JSON: {error}",
-                        request.gate
-                    ),
-                    Some(String::from_utf8_lossy(&output.stderr).to_string()),
-                    None,
-                )
-            })?;
+        let envelope =
+            read_portable_review_child_envelope(&output_path, request.gate, &output.stderr)?;
         envelope.project(output.status.success(), request.source_commit)
     }
+}
+
+fn read_portable_review_child_envelope(
+    path: &Path,
+    gate: &str,
+    stderr: &[u8],
+) -> homeboy::core::Result<PortableReviewChildEnvelope> {
+    let result = fs::read(path).map_err(|error| {
+        homeboy::core::Error::validation_invalid_argument(
+            "release.preflight",
+            format!("portable {gate} preflight returned no structured command-result: {error}"),
+            Some(String::from_utf8_lossy(stderr).to_string()),
+            None,
+        )
+    })?;
+    serde_json::from_slice(&result).map_err(|error| {
+        homeboy::core::Error::validation_invalid_argument(
+            "release.preflight",
+            format!(
+                "portable {gate} preflight returned invalid structured command-result JSON: {error}"
+            ),
+            Some(String::from_utf8_lossy(stderr).to_string()),
+            None,
+        )
+    })
 }
 
 /// Stable subset of a child command-result envelope consumed by release.
@@ -2458,5 +2488,64 @@ jobs:
             .iter()
             .filter(|gate| ["audit", "lint", "test"].contains(&gate.gate.as_str()))
             .all(|gate| gate.provenance.as_ref() == Some(&child_provenance)));
+    }
+
+    #[test]
+    fn portable_preflight_reads_only_the_structured_output_file() {
+        let output = tempfile::NamedTempFile::new().expect("output file");
+        std::fs::write(
+            output.path(),
+            serde_json::to_vec(&serde_json::json!({
+                "success": true,
+                "evidence": [{ "uri": "run://portable-test" }],
+                "data": {
+                    "release_readiness": {
+                        "requested_source_commit": "source",
+                        "source_commit": "source",
+                        "runner_id": "homeboy-lab",
+                        "provenance": { "dependencies": { "fixture": "locked" } }
+                    }
+                }
+            }))
+            .expect("serialize envelope"),
+        )
+        .expect("write envelope");
+
+        let envelope = read_portable_review_child_envelope(
+            output.path(),
+            "test",
+            b"ordinary child progress remains outside the structured result",
+        )
+        .expect("structured output is authoritative");
+        let projected = envelope.project(true, "source").expect("valid evidence");
+
+        assert!(projected.passed);
+        assert_eq!(projected.runner_id.as_deref(), Some("homeboy-lab"));
+    }
+
+    #[test]
+    fn portable_preflight_fails_closed_for_missing_or_invalid_structured_output() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let missing = match read_portable_review_child_envelope(
+            &directory.path().join("missing.json"),
+            "lint",
+            b"diagnostic",
+        ) {
+            Ok(_) => panic!("missing output must fail"),
+            Err(error) => error,
+        };
+        assert!(missing.message.contains("no structured command-result"));
+
+        let invalid_path = directory.path().join("invalid.json");
+        std::fs::write(&invalid_path, "progress before JSON\n{not-json}")
+            .expect("write invalid output");
+        let invalid =
+            match read_portable_review_child_envelope(&invalid_path, "lint", b"diagnostic") {
+                Ok(_) => panic!("invalid output must fail"),
+                Err(error) => error,
+            };
+        assert!(invalid
+            .message
+            .contains("invalid structured command-result JSON"));
     }
 }

--- a/crates/homeboy-cli/src/commands/review/mod.rs
+++ b/crates/homeboy-cli/src/commands/review/mod.rs
@@ -395,13 +395,11 @@ fn to_value_with_readiness_provenance<T: Serialize>(
     if let Some(requested_source) = requested_source {
         let provenance = homeboy_release::release::readiness_provenance(component)?;
         let source_commit = homeboy::core::git::get_head_commit(&component.local_path)?;
-        let runner_id =
-            crate::commands::utils::execution_provenance::captured().and_then(|value| {
-                value
-                    .pointer("/resolved_execution/runner_id")
-                    .and_then(|value| value.as_str())
-                    .map(str::to_string)
-            });
+        let execution_provenance = crate::commands::utils::execution_provenance::captured();
+        let runner_id = release_readiness_runner_id(
+            execution_provenance.as_ref(),
+            homeboy::core::resource_policy_context::lab_execution_runner_id(),
+        );
         object.insert(
             "release_readiness".to_string(),
             serde_json::to_value(ReviewChildReadinessEvidence {
@@ -418,6 +416,20 @@ fn to_value_with_readiness_provenance<T: Serialize>(
         );
     }
     Ok((value, exit_code))
+}
+
+fn release_readiness_runner_id(
+    execution_provenance: Option<&Value>,
+    lab_execution_runner_id: Option<String>,
+) -> Option<String> {
+    execution_provenance
+        .and_then(|value| {
+            value
+                .pointer("/resolved_execution/runner_id")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+        .or(lab_execution_runner_id)
 }
 
 fn to_value<T: Serialize>(result: CmdResult<T>) -> CmdResult<Value> {
@@ -1220,6 +1232,35 @@ mod tests {
         assert_eq!(cli.review.changed.changed_since(), Some("trunk"));
         assert!(!cli.review.changed.changed_only);
         assert_eq!(cli.review.comp.component.as_deref(), Some("my-comp"));
+    }
+
+    #[test]
+    fn release_readiness_runner_prefers_routed_provenance() {
+        let provenance = serde_json::json!({
+            "resolved_execution": { "runner_id": "routed-runner" }
+        });
+
+        assert_eq!(
+            release_readiness_runner_id(Some(&provenance), Some("durable-runner".to_string()))
+                .as_deref(),
+            Some("routed-runner")
+        );
+    }
+
+    #[test]
+    fn release_readiness_runner_uses_durable_lab_execution_provenance() {
+        let local_child_provenance = serde_json::json!({
+            "resolved_execution": { "location": "controller", "runner_id": null }
+        });
+
+        assert_eq!(
+            release_readiness_runner_id(
+                Some(&local_child_provenance),
+                Some("homeboy-lab".to_string()),
+            )
+            .as_deref(),
+            Some("homeboy-lab")
+        );
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/upgrade.rs
+++ b/crates/homeboy-cli/src/commands/upgrade.rs
@@ -28,23 +28,6 @@ pub struct UpgradeArgs {
     #[arg(long)]
     pub no_restart_services: bool,
 
-    /// Accepted and ignored. `--no-restart` was declared but never read: it was
-    /// born inert in `90adfed70` and `git log -S'args.no_restart,'` finds no
-    /// commit in which it was consulted. `--no-restart-services` is the flag
-    /// that actually skips restarts.
-    ///
-    /// It is retained hidden purely as a cross-version compatibility shim,
-    /// because Homeboy passed it to itself over SSH: a controller older than
-    /// this change still emits `<homeboy> upgrade --no-restart ...` when
-    /// upgrading a runner. `upgrade --runner-only` installs the new binary on
-    /// the runner and *then* invokes it with the old controller's argv, so
-    /// rejecting the argument would break the very upgrade that creates the
-    /// skew. Accepting it costs nothing; refusing it bricks that path.
-    ///
-    /// Remove once no supported controller emits it. Tracked in #11786.
-    #[arg(long, hide = true)]
-    pub no_restart: bool,
-
     /// Select the configured runner to converge with the controller. Repeat to target multiple runners.
     #[arg(
         long = "upgrade-runner",

--- a/crates/homeboy-core/src/project/component/report.rs
+++ b/crates/homeboy-core/src/project/component/report.rs
@@ -5,8 +5,10 @@ use serde::{Deserialize, Serialize};
 use crate::component::Component;
 use crate::error::{Error, Result};
 use crate::project::{
-    component_local_path_blockers, load, resolve_project_components, Project,
-    ProjectComponentAttachment,
+    component_local_path_blockers, component_local_path_diagnostic, load,
+    resolve_project_component_with_standalone_snapshot, resolve_project_components,
+    ComponentLocalPathDiagnostic, Project, ProjectComponentAttachment,
+    StandaloneComponentConfigSnapshot,
 };
 
 use super::{
@@ -19,6 +21,7 @@ use super::{
 pub struct ProjectComponentsOutput {
     pub action: String,
     pub project_id: String,
+    pub status: ProjectComponentsStatus,
     pub component_ids: Vec<String>,
     pub component_count: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -29,10 +32,19 @@ pub struct ProjectComponentsOutput {
     pub components: Vec<Component>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub local_path_diagnostics: Vec<ComponentLocalPathDiagnostic>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub batch: Option<BatchComponentAttachmentOutput>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub monorepo: Option<MonorepoComponentAttachmentOutput>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectComponentsStatus {
+    Complete,
+    Partial,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -124,7 +136,7 @@ pub struct BatchComponentAttachmentOutput {
 
 pub fn list_components(project_id: &str) -> Result<ProjectComponentsOutput> {
     let project = load(project_id)?;
-    build_components_output(project_id, "list", &project)
+    build_components_list_output(project_id, &project)
 }
 
 pub fn set_components(project_id: &str, json_spec: &str) -> Result<ProjectComponentsOutput> {
@@ -337,6 +349,7 @@ pub fn attach_component_paths_report(
     Ok(ProjectComponentsOutput {
         action: "attach_paths".to_string(),
         project_id: project_id.to_string(),
+        status: ProjectComponentsStatus::Complete,
         component_ids: project
             .as_ref()
             .map(project_component_ids)
@@ -352,6 +365,7 @@ pub fn attach_component_paths_report(
             .as_ref()
             .map(component_local_path_blockers)
             .unwrap_or_default(),
+        local_path_diagnostics: Vec::new(),
         batch: Some(batch),
         monorepo: None,
     })
@@ -431,12 +445,54 @@ fn build_components_output(
     Ok(ProjectComponentsOutput {
         action: action.to_string(),
         project_id: project_id.to_string(),
+        status: ProjectComponentsStatus::Complete,
         component_ids: project_component_ids(project),
         component_count: project.components.len(),
         attached_component_id: None,
         attached_path: None,
         components,
         warnings: Vec::new(),
+        local_path_diagnostics: Vec::new(),
+        batch: None,
+        monorepo: None,
+    })
+}
+
+fn build_components_list_output(
+    project_id: &str,
+    project: &Project,
+) -> Result<ProjectComponentsOutput> {
+    let standalone_snapshot = StandaloneComponentConfigSnapshot::load();
+    let mut components = Vec::new();
+    let mut local_path_diagnostics = Vec::new();
+
+    for attachment in &project.components {
+        if let Some(diagnostic) = component_local_path_diagnostic(project, attachment) {
+            local_path_diagnostics.push(diagnostic);
+            continue;
+        }
+        components.push(resolve_project_component_with_standalone_snapshot(
+            project,
+            &attachment.id,
+            Some(&standalone_snapshot),
+        )?);
+    }
+
+    Ok(ProjectComponentsOutput {
+        action: "list".to_string(),
+        project_id: project_id.to_string(),
+        status: if local_path_diagnostics.is_empty() {
+            ProjectComponentsStatus::Complete
+        } else {
+            ProjectComponentsStatus::Partial
+        },
+        component_ids: project_component_ids(project),
+        component_count: project.components.len(),
+        attached_component_id: None,
+        attached_path: None,
+        components,
+        warnings: Vec::new(),
+        local_path_diagnostics,
         batch: None,
         monorepo: None,
     })
@@ -452,12 +508,14 @@ fn build_components_summary(
     Ok(ProjectComponentsOutput {
         action: action.to_string(),
         project_id: project_id.to_string(),
+        status: ProjectComponentsStatus::Complete,
         component_ids: project_component_ids(project),
         component_count: project.components.len(),
         attached_component_id,
         attached_path,
         components: Vec::new(),
         warnings: component_local_path_blockers(project),
+        local_path_diagnostics: Vec::new(),
         batch: None,
         monorepo: None,
     })
@@ -466,12 +524,14 @@ fn build_components_summary(
 #[cfg(test)]
 mod tests {
     use super::{
-        attach_component_paths_report, build_components_summary, remove_components_report,
-        BatchComponentAttachmentFailurePolicy, BatchComponentAttachmentInput,
-        BatchComponentAttachmentItemStatus, BatchComponentAttachmentWorktreePolicy,
+        attach_component_paths_report, build_components_summary, list_components,
+        remove_components_report, BatchComponentAttachmentFailurePolicy,
+        BatchComponentAttachmentInput, BatchComponentAttachmentItemStatus,
+        BatchComponentAttachmentWorktreePolicy, ProjectComponentsStatus,
     };
     use crate::project::{
-        build_components_output, load, save, Project, ProjectComponentAttachment,
+        build_components_output, load, resolve_project_component, save, Project,
+        ProjectComponentAttachment,
     };
     use crate::test_support::with_isolated_home;
     use std::fs;
@@ -570,6 +630,55 @@ mod tests {
             let project = load("site").expect("project still loads");
             assert_eq!(project.components.len(), 1);
             assert_eq!(project.components[0].id, "stale-remaining");
+        });
+    }
+
+    #[test]
+    fn list_components_returns_healthy_rows_and_stale_path_diagnostics() {
+        with_isolated_home(|home| {
+            let healthy = home.path().join("healthy");
+            write_component(&healthy, "healthy");
+            let stale = home.path().join("stale");
+            save(&Project {
+                id: "site".to_string(),
+                components: vec![
+                    ProjectComponentAttachment {
+                        id: "healthy".to_string(),
+                        local_path: healthy.to_string_lossy().to_string(),
+                        ..Default::default()
+                    },
+                    ProjectComponentAttachment {
+                        id: "stale".to_string(),
+                        local_path: stale.to_string_lossy().to_string(),
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            })
+            .expect("save project");
+
+            let output = list_components("site").expect("partial list output");
+
+            assert!(matches!(output.status, ProjectComponentsStatus::Partial));
+            assert_eq!(output.components.len(), 1);
+            assert_eq!(output.components[0].id, "healthy");
+            assert_eq!(output.local_path_diagnostics.len(), 1);
+            let diagnostic = &output.local_path_diagnostics[0];
+            assert_eq!(diagnostic.component_id, "stale");
+            assert!(matches!(
+                diagnostic.status,
+                crate::project::ComponentLocalPathDiagnosticStatus::Stale
+            ));
+            assert_eq!(diagnostic.local_path, stale.to_string_lossy());
+            assert_eq!(
+                diagnostic.repair_command,
+                "homeboy project components attach-path site <local-path>"
+            );
+
+            let project = load("site").expect("load project");
+            let error = resolve_project_component(&project, "stale")
+                .expect_err("targeted resolution must reject stale component");
+            assert_eq!(error.code.as_str(), "validation.invalid_argument");
         });
     }
 

--- a/crates/homeboy-core/src/project/mod.rs
+++ b/crates/homeboy-core/src/project/mod.rs
@@ -46,8 +46,10 @@ pub use pins::{
 };
 pub(crate) use readiness::component_local_path_blockers;
 pub use readiness::{
-    calculate_deploy_readiness, component_local_path_findings, validate_component_local_path,
-    validate_component_local_paths, validate_deploy_component_local_paths,
+    calculate_deploy_readiness, component_local_path_diagnostic, component_local_path_findings,
+    validate_component_local_path, validate_component_local_paths,
+    validate_deploy_component_local_paths, ComponentLocalPathDiagnostic,
+    ComponentLocalPathDiagnosticStatus,
 };
 pub use report::{
     build_components_output, build_create_output, build_delete_output, build_init_output,

--- a/crates/homeboy-core/src/project/readiness.rs
+++ b/crates/homeboy-core/src/project/readiness.rs
@@ -5,6 +5,22 @@ use crate::error::{Error, Result};
 
 use super::Project;
 
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComponentLocalPathDiagnosticStatus {
+    Missing,
+    Stale,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ComponentLocalPathDiagnostic {
+    pub component_id: String,
+    pub local_path: String,
+    pub status: ComponentLocalPathDiagnosticStatus,
+    pub message: String,
+    pub repair_command: String,
+}
+
 pub fn calculate_deploy_readiness(project: &Project) -> (bool, Vec<String>) {
     let mut blockers = Vec::new();
     let standalone_snapshot = super::StandaloneComponentConfigSnapshot::load();
@@ -123,16 +139,14 @@ pub fn validate_deploy_component_local_paths(
     let mut scoped_blockers = Vec::new();
     let mut hygiene_blockers = Vec::new();
     for attachment in &project.components {
-        let Some(blocker) =
-            component_local_path_blocker(project, &attachment.id, &attachment.local_path)
-        else {
+        let Some(blocker) = component_local_path_diagnostic(project, attachment) else {
             continue;
         };
 
         if scoped_ids.contains(&attachment.id) {
-            scoped_blockers.push(blocker);
+            scoped_blockers.push(blocker.message);
         } else {
-            hygiene_blockers.push(blocker);
+            hygiene_blockers.push(blocker.message);
         }
     }
 
@@ -211,9 +225,8 @@ pub fn component_local_path_findings(project: &Project, component_id: &str) -> V
         .components
         .iter()
         .filter(|attachment| attachment.id == component_id)
-        .filter_map(|attachment| {
-            component_local_path_blocker(project, &attachment.id, &attachment.local_path)
-        })
+        .filter_map(|attachment| component_local_path_diagnostic(project, attachment))
+        .map(|diagnostic| diagnostic.message)
         .collect()
 }
 
@@ -240,23 +253,31 @@ pub(crate) fn component_local_path_blockers(project: &Project) -> Vec<String> {
     project
         .components
         .iter()
-        .filter_map(|attachment| {
-            component_local_path_blocker(project, &attachment.id, &attachment.local_path)
-        })
+        .filter_map(|attachment| component_local_path_diagnostic(project, attachment))
+        .map(|diagnostic| diagnostic.message)
         .collect()
 }
 
-fn component_local_path_blocker(
+pub fn component_local_path_diagnostic(
     project: &Project,
-    component_id: &str,
-    local_path: &str,
-) -> Option<String> {
-    let trimmed = local_path.trim();
+    attachment: &super::ProjectComponentAttachment,
+) -> Option<ComponentLocalPathDiagnostic> {
+    let trimmed = attachment.local_path.trim();
     if trimmed.is_empty() {
-        return Some(format!(
-            "Component '{}' is missing local_path - attach a checkout with: homeboy project components attach-path {} <local-path>",
-            component_id, project.id
-        ));
+        let repair_command = format!(
+            "homeboy project components attach-path {} <local-path>",
+            project.id
+        );
+        return Some(ComponentLocalPathDiagnostic {
+            component_id: attachment.id.clone(),
+            local_path: attachment.local_path.clone(),
+            status: ComponentLocalPathDiagnosticStatus::Missing,
+            message: format!(
+                "Component '{}' is missing local_path - attach a checkout with: {}",
+                attachment.id, repair_command
+            ),
+            repair_command,
+        });
     }
 
     let expanded = shellexpand::tilde(trimmed);
@@ -265,10 +286,20 @@ fn component_local_path_blocker(
         return None;
     }
 
-    Some(format!(
-        "Component '{}' local_path '{}' does not exist - update it with: homeboy project components attach-path {} <local-path>",
-        component_id, trimmed, project.id
-    ))
+    let repair_command = format!(
+        "homeboy project components attach-path {} <local-path>",
+        project.id
+    );
+    Some(ComponentLocalPathDiagnostic {
+        component_id: attachment.id.clone(),
+        local_path: attachment.local_path.clone(),
+        status: ComponentLocalPathDiagnosticStatus::Stale,
+        message: format!(
+            "Component '{}' local_path '{}' does not exist - update it with: {}",
+            attachment.id, trimmed, repair_command
+        ),
+        repair_command,
+    })
 }
 
 #[cfg(test)]

--- a/crates/homeboy-lab-runner/src/discovery.rs
+++ b/crates/homeboy-lab-runner/src/discovery.rs
@@ -2,11 +2,13 @@
 
 use homeboy_core::{error::ErrorCode, Result};
 use homeboy_runner_contract::{
-    RunnerApiCompatibility, RunnerApiCompatibilityFailure, RunnerApiCompatibilityFailureCode,
-    RunnerApiCompatibilityStatus, RunnerApiHandshakeRequest, RunnerApiHandshakeResponse,
-    RunnerApiInspectRequest, RunnerApiInspectResponse, RunnerApiListRequest, RunnerApiListResponse,
+    RunnerApiCapabilitiesRequest, RunnerApiCapabilitiesResponse, RunnerApiCompatibility,
+    RunnerApiCompatibilityFailure, RunnerApiCompatibilityFailureCode, RunnerApiCompatibilityStatus,
+    RunnerApiHandshakeRequest, RunnerApiHandshakeResponse, RunnerApiInspectRequest,
+    RunnerApiInspectResponse, RunnerApiListRequest, RunnerApiListResponse,
     RunnerApiOperationFailure, RunnerApiOperationFailureCode, RunnerApiVersion, RunnerCapabilities,
     RunnerDescriptor, RunnerInspection, RunnerKind, RunnerReadiness,
+    RUNNER_API_CAPABILITIES_REQUEST_SCHEMA, RUNNER_API_CAPABILITIES_RESPONSE_SCHEMA,
     RUNNER_API_HANDSHAKE_REQUEST_SCHEMA, RUNNER_API_HANDSHAKE_RESPONSE_SCHEMA,
     RUNNER_API_INSPECT_REQUEST_SCHEMA, RUNNER_API_INSPECT_RESPONSE_SCHEMA,
     RUNNER_API_LIST_REQUEST_SCHEMA, RUNNER_API_LIST_RESPONSE_SCHEMA, RUNNER_API_V1,
@@ -164,6 +166,33 @@ impl RunnerDiscoveryService {
             Err(error) => Err(error),
         }
     }
+
+    pub fn capabilities_api(
+        request: &RunnerApiCapabilitiesRequest,
+    ) -> Result<RunnerApiCapabilitiesResponse> {
+        if let Some(failure) = validate_operation_request(
+            &request.schema,
+            RUNNER_API_CAPABILITIES_REQUEST_SCHEMA,
+            request.api_version,
+        ) {
+            return Ok(capabilities_failure(request, failure));
+        }
+
+        match Self::capabilities(&request.runner_id) {
+            Ok(capabilities) => Ok(RunnerApiCapabilitiesResponse {
+                schema: RUNNER_API_CAPABILITIES_RESPONSE_SCHEMA.to_string(),
+                api_version: RUNNER_API_V1,
+                runner_id: request.runner_id.clone(),
+                capabilities: Some(capabilities),
+                failure: None,
+            }),
+            Err(error) if error.code == ErrorCode::RunnerNotFound => Ok(capabilities_failure(
+                request,
+                operation_failure(RunnerApiOperationFailureCode::RunnerNotFound, error.message),
+            )),
+            Err(error) => Err(error),
+        }
+    }
 }
 
 fn validate_operation_request(
@@ -206,6 +235,19 @@ fn inspect_failure(
         api_version: RUNNER_API_V1,
         runner_id: request.runner_id.clone(),
         inspection: None,
+        failure: Some(failure),
+    }
+}
+
+fn capabilities_failure(
+    request: &RunnerApiCapabilitiesRequest,
+    failure: RunnerApiOperationFailure,
+) -> RunnerApiCapabilitiesResponse {
+    RunnerApiCapabilitiesResponse {
+        schema: RUNNER_API_CAPABILITIES_RESPONSE_SCHEMA.to_string(),
+        api_version: RUNNER_API_V1,
+        runner_id: request.runner_id.clone(),
+        capabilities: None,
         failure: Some(failure),
     }
 }
@@ -411,6 +453,67 @@ mod tests {
         .expect("unknown runner response");
 
         assert_eq!(response.inspection, None);
+        assert_eq!(
+            response.failure.expect("failure").code,
+            RunnerApiOperationFailureCode::RunnerNotFound
+        );
+    }
+
+    #[test]
+    fn capabilities_api_returns_the_canonical_inventory() {
+        let response = RunnerDiscoveryService::capabilities_api(&RunnerApiCapabilitiesRequest {
+            schema: RUNNER_API_CAPABILITIES_REQUEST_SCHEMA.to_string(),
+            api_version: RUNNER_API_V1,
+            runner_id: "local".to_string(),
+        })
+        .expect("capabilities Runner API");
+
+        assert!(response.failure.is_none());
+        assert_eq!(
+            response.capabilities.expect("capabilities").runner_id,
+            "local"
+        );
+    }
+
+    #[test]
+    fn capabilities_api_validates_before_runner_lookup() {
+        let fixtures = [
+            (
+                "homeboy/runner-api-capabilities-request/v99",
+                RUNNER_API_V1,
+                RunnerApiOperationFailureCode::InvalidRequestSchema,
+            ),
+            (
+                RUNNER_API_CAPABILITIES_REQUEST_SCHEMA,
+                RunnerApiVersion { major: 99 },
+                RunnerApiOperationFailureCode::UnsupportedApiVersion,
+            ),
+        ];
+
+        for (schema, api_version, expected_failure) in fixtures {
+            let response =
+                RunnerDiscoveryService::capabilities_api(&RunnerApiCapabilitiesRequest {
+                    schema: schema.to_string(),
+                    api_version,
+                    runner_id: "runner-that-does-not-exist".to_string(),
+                })
+                .expect("validation response");
+
+            assert_eq!(response.capabilities, None);
+            assert_eq!(response.failure.expect("failure").code, expected_failure);
+        }
+    }
+
+    #[test]
+    fn capabilities_api_types_unknown_runner_failures() {
+        let response = RunnerDiscoveryService::capabilities_api(&RunnerApiCapabilitiesRequest {
+            schema: RUNNER_API_CAPABILITIES_REQUEST_SCHEMA.to_string(),
+            api_version: RUNNER_API_V1,
+            runner_id: "runner-that-does-not-exist".to_string(),
+        })
+        .expect("unknown runner response");
+
+        assert_eq!(response.capabilities, None);
         assert_eq!(
             response.failure.expect("failure").code,
             RunnerApiOperationFailureCode::RunnerNotFound

--- a/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
+++ b/crates/homeboy-lab-runner/src/upgrade_runners/orchestration.rs
@@ -72,7 +72,6 @@ fn runner_manifest_preflight_with_executor(
         homeboy_path.to_string(),
         "extension".to_string(),
         "list".to_string(),
-        "--skip-ready-check".to_string(),
     ];
     let inventory_options =
         runner_manifest_query_options(runner, inventory_command, allow_diagnostic_ssh);
@@ -87,7 +86,7 @@ fn runner_manifest_preflight_with_executor(
     };
     if inventory_exit_code != 0 {
         return Some(format!(
-            "runner manifest preflight could not query installed extension inventory; recover with: {homeboy_path} extension list --skip-ready-check"
+            "runner manifest preflight could not query installed extension inventory; recover with: {homeboy_path} extension list"
         ));
     }
     let inventory = match runner_extension_inventory(&inventory_output.stdout) {
@@ -111,7 +110,6 @@ fn runner_manifest_preflight_with_executor(
                 "extension".to_string(),
                 "show".to_string(),
                 extension_id.clone(),
-                "--skip-ready-check".to_string(),
             ],
             allow_diagnostic_ssh,
         );
@@ -125,7 +123,7 @@ fn runner_manifest_preflight_with_executor(
             }
         };
         if exit_code != 0 {
-            return Some(format!("runner manifest preflight failed for installed extension `{extension_id}`; recover with: {homeboy_path} extension show {extension_id} --skip-ready-check"));
+            return Some(format!("runner manifest preflight failed for installed extension `{extension_id}`; recover with: {homeboy_path} extension show {extension_id}"));
         }
         let requires_homeboy =
             match runner_extension_requires_homeboy(&output.stdout, &extension_id) {
@@ -444,10 +442,7 @@ mod manifest_preflight_tests {
         let mut exec = |runner_id: &str, options: RunnerExecOptions| {
             call_count += 1;
             assert_eq!(runner_id, "lab-a");
-            assert_eq!(
-                options.command,
-                ["homeboy", "extension", "list", "--skip-ready-check"]
-            );
+            assert_eq!(options.command, ["homeboy", "extension", "list"]);
             assert!(!options.read_only_artifact_access);
             Ok(successful_output(
                 runner_id,
@@ -473,22 +468,13 @@ mod manifest_preflight_tests {
         let mut exec = |runner_id: &str, options: RunnerExecOptions| {
             let stdout = match call_count {
                 0 => {
-                    assert_eq!(
-                        options.command,
-                        ["homeboy", "extension", "list", "--skip-ready-check"]
-                    );
+                    assert_eq!(options.command, ["homeboy", "extension", "list"]);
                     r#"{"success":true,"data":{"extensions":[{"id":"runner-only"}]}}"#
                 }
                 1 => {
                     assert_eq!(
                         options.command,
-                        [
-                            "homeboy",
-                            "extension",
-                            "show",
-                            "runner-only",
-                            "--skip-ready-check"
-                        ]
+                        ["homeboy", "extension", "show", "runner-only"]
                     );
                     r#"{"success":true,"data":{"extension":{"id":"runner-only","core_compatibility":{"requires_homeboy":">=3.0.0"}}}}"#
                 }
@@ -530,17 +516,11 @@ mod manifest_preflight_tests {
         let mut exec = |runner_id: &str, options: RunnerExecOptions| {
             let stdout = match call_count {
                 0 => {
-                    assert_eq!(
-                        options.command,
-                        ["homeboy", "extension", "list", "--skip-ready-check"]
-                    );
+                    assert_eq!(options.command, ["homeboy", "extension", "list"]);
                     r#"{"success":true,"data":{"extensions":[{"id":"discord","error":"manifest_deserialize_incompatible","diagnostic":"The extension manifest does not match the supported schema."},{"id":"rust"}]}}"#
                 }
                 1 => {
-                    assert_eq!(
-                        options.command,
-                        ["homeboy", "extension", "show", "rust", "--skip-ready-check"]
-                    );
+                    assert_eq!(options.command, ["homeboy", "extension", "show", "rust"]);
                     r#"{"success":true,"data":{"extension":{"id":"rust","core_compatibility":{"requires_homeboy":">=2.0.0"}}}}"#
                 }
                 _ => {
@@ -570,16 +550,10 @@ mod manifest_preflight_tests {
         let mut exec = |runner_id: &str, options: RunnerExecOptions| {
             assert_eq!(runner_id, "lab-a");
             let stdout = if call_count % 2 == 0 {
-                assert_eq!(
-                    options.command,
-                    ["homeboy", "extension", "list", "--skip-ready-check"]
-                );
+                assert_eq!(options.command, ["homeboy", "extension", "list"]);
                 r#"{"success":true,"data":{"extensions":[{"id":"rust"}]}}"#
             } else {
-                assert_eq!(
-                    options.command,
-                    ["homeboy", "extension", "show", "rust", "--skip-ready-check"]
-                );
+                assert_eq!(options.command, ["homeboy", "extension", "show", "rust"]);
                 manifests[call_count / 2]
             };
             assert!(!options.read_only_artifact_access);

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,11 @@ All notable changes to Homeboy CLI are documented in this file.
 
 (This file is embedded into the CLI binary and is also viewable via `homeboy changelog`.)
 
+## [0.367.6] - 2026-08-31
+
+### Fixed
+- Fix portable release preflight output
+
 ## [0.367.5] - 2026-08-31
 
 ### Changed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,12 @@ All notable changes to Homeboy CLI are documented in this file.
 
 (This file is embedded into the CLI binary and is also viewable via `homeboy changelog`.)
 
+## [0.367.5] - 2026-08-31
+
+### Changed
+- Migrate runner list to API v1
+- Bound default operator payloads
+
 ## [0.367.4] - 2026-08-31
 
 ### Changed

--- a/docs/commands/extension.md
+++ b/docs/commands/extension.md
@@ -11,13 +11,13 @@ homeboy extension <COMMAND>
 ### `list`
 
 ```sh
-homeboy extension list [-p|--project <project_id>] [--skip-ready-check]
+homeboy extension list [-p|--project <project_id>] [--live-readiness]
 ```
 
 ### `show`
 
 ```sh
-homeboy extension show <extension_id> [--skip-ready-check]
+homeboy extension show <extension_id> [--live-readiness]
 ```
 
 Print detailed manifest, runtime, capability, and readiness information for one installed extension.
@@ -33,33 +33,24 @@ Use the discovered ID as the route-less default or pair it with an explicit
 route for a schedule:
 
 ```sh
-homeboy extension list --skip-ready-check
+homeboy extension list
 homeboy config set /notifications/default_transport '"<transport-id>"'
 homeboy schedule add --notification-transport <transport-id> --notification-route '<transport-route>' ...
 ```
 
-### Readiness is the expensive part of inventory
+### Live readiness is explicit
 
-Everything `list`/`show` report except `ready`, `ready_reason`, and
-`ready_detail` is read from the installed manifest. `ready` comes from running
-the extension's `ready_check`, an arbitrary operator-authored shell command —
-a WordPress doctor, an npm probe, a Codebox health script. Both commands still
-probe by default, so their output is unchanged; two things bound the cost:
+`list` and `show` read installed manifests and cached readiness without spawning
+extension processes. Pass `--live-readiness` to run each extension's
+operator-authored `ready_check`, such as a WordPress doctor, npm probe, or
+Codebox health script, and refresh the cached result.
 
-- **`--skip-ready-check`** answers "what is installed, from where, at which
-  revision" without spawning anything. `ready_reason` is then
-  `ready_check_skipped` and `ready` carries no live signal — the same shape the
-  re-entrancy guard has always used, so the JSON contract does not change.
-- **Every `ready_check` is bounded** at 30s, overridable with
-  `HOMEBOY_EXTENSION_READY_CHECK_TIMEOUT_SECONDS`. A probe that hits the bound
-  has its process group terminated and reports
-  `ready_reason: "ready_check_timeout"`; the surrounding metadata is still
-  returned. Before this, a slow doctor could hang inventory indefinitely
-  (#10517).
-
-The bound is per extension, not aggregate: `list` over *n* extensions is bounded
-by *n* × the per-check budget. Use `--skip-ready-check` when only metadata is
-wanted.
+Every live `ready_check` is bounded at 30s, overridable with
+`HOMEBOY_EXTENSION_READY_CHECK_TIMEOUT_SECONDS`. A probe that hits the bound
+has its process group terminated and reports `ready_reason:
+"ready_check_timeout"`; the surrounding metadata is still returned. The bound
+is per extension, not aggregate: live inventory over *n* extensions is bounded
+by *n* times the per-check budget (#10517).
 
 ### Invalid installed manifests
 


### PR DESCRIPTION
## Summary

- add versioned Runner API capabilities request and response contracts
- expose canonical capability inventory without evaluating readiness or aggregate inspection
- validate schema and API version before runner lookup
- return typed unknown-runner failures
- pin deterministic request, success, and failure wire shapes

Closes #14016
Parent: #13881

## Verification

- `cargo test -p homeboy-runner-contract capabilities_operation_wire_shapes_are_explicitly_versioned --locked`
- `cargo test -p homeboy-lab-runner capabilities_api --locked`
- `cargo check --workspace --tests --locked`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

The architecture audit was admitted to neither local execution nor Lab: local resource policy reported load 30.1/18 CPUs, the Lab inventory was stale, and Homeboy created no audit run. Changed-PR CI remains authoritative rather than overriding resource admission.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode inspected capability admission and existing Runner API conventions, implemented the contract and service operation, and ran verification. Chris Huber directed the architecture and scope.