### PR TITLE
Resolve file capabilities through Extension API v1

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/api/v1.rs
+++ b/crates/contracts/homeboy-extension-contract/src/api/v1.rs
@@ -15,6 +15,8 @@ pub const EXTENSION_API_HANDSHAKE_REQUEST_SCHEMA: &str =
 pub const EXTENSION_API_HANDSHAKE_RESPONSE_SCHEMA: &str =
     "homeboy/extension-api-handshake-response/v1";
 pub const EXTENSION_API_V1: ExtensionApiVersion = ExtensionApiVersion { major: 1 };
+pub const FINGERPRINT_FILE_CAPABILITY_PREFIX: &str = "fingerprint.";
+pub const REFACTOR_FILE_CAPABILITY_PREFIX: &str = "refactor.";
 
 /// A transport-neutral Extension API major version.
 ///

--- a/crates/homeboy-code-audit/src/grammar_source_provider.rs
+++ b/crates/homeboy-code-audit/src/grammar_source_provider.rs
@@ -3,10 +3,9 @@
 //!
 //! The core grammar engine fingerprints a file by loading a grammar
 //! (`grammar.toml`/`grammar.json`) shipped by the extension that handles the
-//! file's extension. Audit used to resolve that by calling
-//! `homeboy_core::extension::resolve::find_installed_file_extension` directly and reading the
-//! matched manifest's `extension_path`, coupling `code_audit` to the extension
-//! registry.
+//! file's extension. Audit used to resolve that through a manifest-returning
+//! extension lookup and read its `extension_path`, coupling `code_audit` to the
+//! extension registry.
 //!
 //! Instead, audit defines the slim view it needs (file extension → the directory
 //! that holds the grammar) plus a provider trait; the extension layer registers

--- a/crates/homeboy-core/src/engine/symbol_graph.rs
+++ b/crates/homeboy-core/src/engine/symbol_graph.rs
@@ -559,10 +559,13 @@ fn apply_rewrites(rewrites: &[ImportRewrite], root: &Path) {
 /// This is a shared utility — same as `core_fingerprint::load_grammar_for_ext`
 /// but accessible from the symbol_graph module without circular dependency.
 fn load_grammar_for_ext(ext: &str) -> Option<Grammar> {
-    let matched = crate::extension::resolve::find_installed_file_extension(
-        ext,
-        crate::extension::resolve::FileExtensionCapability::Fingerprint,
-    )?;
+    let capability_id = format!(
+        "{}{ext}",
+        homeboy_extension_contract::api::v1::FINGERPRINT_FILE_CAPABILITY_PREFIX
+    );
+    let extension_id =
+        crate::extension::resolve::find_installed_capability_provider(&capability_id)?;
+    let matched = crate::extension::catalog::load_extension(&extension_id).ok()?;
     let extension_path = matched.extension_path.as_deref()?;
 
     let grammar_path = Path::new(extension_path).join("grammar.toml");

--- a/crates/homeboy-core/src/extension/audit_fingerprint_script_provider.rs
+++ b/crates/homeboy-core/src/extension/audit_fingerprint_script_provider.rs
@@ -9,6 +9,7 @@
 //! provider hooks.
 
 use homeboy_audit_contract::FingerprintOutput;
+use homeboy_extension_contract::api::v1::FINGERPRINT_FILE_CAPABILITY_PREFIX;
 
 use homeboy_core::code_audit::fingerprint_script_provider::{
     register_fingerprint_script_provider, FingerprintScriptProvider,
@@ -23,10 +24,10 @@ impl FingerprintScriptProvider for ExtensionFingerprintScriptProvider {
         relative_path: &str,
         content: &str,
     ) -> Option<FingerprintOutput> {
-        let matched = crate::extension::resolve::find_installed_file_extension(
-            file_extension,
-            crate::extension::resolve::FileExtensionCapability::Fingerprint,
-        )?;
+        let capability_id = format!("{FINGERPRINT_FILE_CAPABILITY_PREFIX}{file_extension}");
+        let extension_id =
+            crate::extension::resolve::find_installed_capability_provider(&capability_id)?;
+        let matched = crate::extension::catalog::load_extension(&extension_id).ok()?;
         super::fingerprint::run_fingerprint_script(&matched, relative_path, content)
     }
 }

--- a/crates/homeboy-core/src/extension/audit_grammar_source_provider.rs
+++ b/crates/homeboy-core/src/extension/audit_grammar_source_provider.rs
@@ -14,15 +14,16 @@ use std::path::PathBuf;
 use homeboy_core::code_audit::grammar_source_provider::{
     register_grammar_source_provider, GrammarSourceProvider,
 };
+use homeboy_extension_contract::api::v1::FINGERPRINT_FILE_CAPABILITY_PREFIX;
 
 struct ExtensionGrammarSourceProvider;
 
 impl GrammarSourceProvider for ExtensionGrammarSourceProvider {
     fn grammar_dir(&self, file_extension: &str) -> Option<PathBuf> {
-        let matched = crate::extension::resolve::find_installed_file_extension(
-            file_extension,
-            crate::extension::resolve::FileExtensionCapability::Fingerprint,
-        )?;
+        let capability_id = format!("{FINGERPRINT_FILE_CAPABILITY_PREFIX}{file_extension}");
+        let extension_id =
+            crate::extension::resolve::find_installed_capability_provider(&capability_id)?;
+        let matched = crate::extension::catalog::load_extension(&extension_id).ok()?;
         matched.extension_path.map(PathBuf::from)
     }
 }

--- a/crates/homeboy-core/src/extension/catalog/api.rs
+++ b/crates/homeboy-core/src/extension/catalog/api.rs
@@ -19,7 +19,8 @@ use homeboy_extension_contract::api::v1::{
     EXTENSION_API_DESCRIPTOR_SCHEMA, EXTENSION_API_HANDSHAKE_REQUEST_SCHEMA,
     EXTENSION_API_HANDSHAKE_RESPONSE_SCHEMA, EXTENSION_API_READINESS_REQUEST_SCHEMA,
     EXTENSION_API_READINESS_RESPONSE_SCHEMA, EXTENSION_API_RESOLVE_REQUEST_SCHEMA,
-    EXTENSION_API_RESOLVE_RESPONSE_SCHEMA, EXTENSION_API_V1,
+    EXTENSION_API_RESOLVE_RESPONSE_SCHEMA, EXTENSION_API_V1, FINGERPRINT_FILE_CAPABILITY_PREFIX,
+    REFACTOR_FILE_CAPABILITY_PREFIX,
 };
 use homeboy_extension_contract::{evaluate_core_compatibility, ExtensionCapability};
 
@@ -93,6 +94,30 @@ fn api_descriptor(extension_id: &str) -> Result<ExtensionApiDescriptor> {
             COMPILER_WARNING_FIXES_INPUT_SCHEMA,
             COMPILER_WARNING_FIXES_OUTPUT_SCHEMA,
         ));
+    }
+    if extension.fingerprint_script().is_some() {
+        capabilities.extend(
+            extension
+                .provided_file_extensions()
+                .iter()
+                .map(|file_extension| {
+                    capability_descriptor(&format!(
+                        "{FINGERPRINT_FILE_CAPABILITY_PREFIX}{file_extension}"
+                    ))
+                }),
+        );
+    }
+    if extension.refactor_script().is_some() {
+        capabilities.extend(
+            extension
+                .provided_file_extensions()
+                .iter()
+                .map(|file_extension| {
+                    capability_descriptor(&format!(
+                        "{REFACTOR_FILE_CAPABILITY_PREFIX}{file_extension}"
+                    ))
+                }),
+        );
     }
     capabilities.extend(
         extension
@@ -692,8 +717,11 @@ mod tests {
                     "test": { "extension_script": "test.sh" },
                     "scripts": {
                         "compiler_warnings": "warnings.sh",
-                        "compiler_warning_fixes": "warning-fixes.sh"
+                        "compiler_warning_fixes": "warning-fixes.sh",
+                        "fingerprint": "fingerprint.sh",
+                        "refactor": "refactor.sh"
                     },
+                    "provides": { "file_extensions": ["rs", "php"] },
                     "executable": { "runtime": { "run_command": "fixture", "ready_check": "fixture --ready" } },
                     "recipe_run_providers": [{
                         "id": "fixture.recipe",
@@ -724,12 +752,16 @@ mod tests {
                     COMPILER_WARNING_FIXES_CAPABILITY_ID,
                     COMPILER_WARNINGS_CAPABILITY_ID,
                     "execute",
+                    "fingerprint.php",
+                    "fingerprint.rs",
                     "recipe-run-provider.fixture.recipe",
+                    "refactor.php",
+                    "refactor.rs",
                     "test"
                 ]
             );
             assert_eq!(
-                descriptor.capabilities[3].contract_version.as_deref(),
+                descriptor.capabilities[5].contract_version.as_deref(),
                 Some("2")
             );
             let warnings = descriptor

--- a/crates/homeboy-core/src/extension/resolve/catalog_resolution.rs
+++ b/crates/homeboy-core/src/extension/resolve/catalog_resolution.rs
@@ -4,7 +4,6 @@ use homeboy_extension_contract::api::v1::{
     ExtensionApiCatalogEntry, ExtensionApiCatalogEntryStatus, ExtensionApiCatalogRequest,
     EXTENSION_API_CATALOG_REQUEST_SCHEMA, EXTENSION_API_V1,
 };
-use homeboy_extension_contract::ExtensionCapability;
 
 pub(super) struct CapabilityCatalog {
     entries: Vec<ExtensionApiCatalogEntry>,
@@ -46,16 +45,12 @@ impl CapabilityCatalog {
         Ok(entry)
     }
 
-    pub(super) fn provides(
-        &self,
-        entry: &ExtensionApiCatalogEntry,
-        capability: ExtensionCapability,
-    ) -> bool {
+    pub(super) fn provides(&self, entry: &ExtensionApiCatalogEntry, capability_id: &str) -> bool {
         entry.descriptor.as_ref().is_some_and(|descriptor| {
             descriptor
                 .capabilities
                 .iter()
-                .any(|provided| provided.id == capability.label())
+                .any(|provided| provided.id == capability_id)
         })
     }
 
@@ -64,14 +59,14 @@ impl CapabilityCatalog {
     pub(super) fn candidates<'a>(
         &self,
         extension_ids: impl Iterator<Item = &'a String>,
-        capability: ExtensionCapability,
+        capability_id: &str,
     ) -> (Vec<String>, Vec<(String, String)>) {
         let mut matching = Vec::new();
         let mut failures = Vec::new();
 
         for extension_id in extension_ids {
             match self.entry(extension_id) {
-                Some(entry) if self.provides(entry, capability) => {
+                Some(entry) if self.provides(entry, capability_id) => {
                     matching.push(extension_id.clone());
                 }
                 Some(entry) if entry.status == ExtensionApiCatalogEntryStatus::Invalid => failures
@@ -96,6 +91,18 @@ impl CapabilityCatalog {
         matching.sort();
         failures.sort_by(|left, right| left.0.cmp(&right.0));
         (matching, failures)
+    }
+
+    pub(super) fn providers(&self, capability_id: &str) -> Vec<String> {
+        let mut providers = self
+            .entries
+            .iter()
+            .filter(|entry| entry.status == ExtensionApiCatalogEntryStatus::Available)
+            .filter(|entry| self.provides(entry, capability_id))
+            .map(|entry| entry.id.clone())
+            .collect::<Vec<_>>();
+        providers.sort();
+        providers
     }
 
     fn entry(&self, extension_id: &str) -> Option<&ExtensionApiCatalogEntry> {

--- a/crates/homeboy-core/src/extension/resolve/mod.rs
+++ b/crates/homeboy-core/src/extension/resolve/mod.rs
@@ -17,8 +17,7 @@ use catalog_resolution::CapabilityCatalog;
 
 pub use requirements::{validate_extension_requirements, validate_required_extensions};
 pub use surface::{
-    find_installed_file_extension, find_installed_file_extension_in_root, resolve_file_extension,
-    resolve_file_extension_in_root, FileExtensionCapability, FILE_EXTENSIONS_SURFACE,
+    find_installed_capability_provider, resolve_file_capability_provider, FILE_EXTENSIONS_SURFACE,
     REMOTE_PATH_SURFACE, SINCE_TAG_SURFACE,
 };
 
@@ -295,7 +294,7 @@ fn resolve_extension_for_capability_if_available(
         }
 
         let entry = catalog.resolvable_entry(extension_id)?;
-        if !catalog.provides(entry, capability) {
+        if !catalog.provides(entry, capability.label()) {
             return Err(Error::validation_invalid_argument(
                 format!("capability_extensions.{}", capability.label()),
                 format!(
@@ -312,7 +311,8 @@ fn resolve_extension_for_capability_if_available(
         return Ok(Some(extension_id.to_string()));
     }
 
-    let (mut matching, catalog_failures) = catalog.candidates(extensions.keys(), capability);
+    let (mut matching, catalog_failures) =
+        catalog.candidates(extensions.keys(), capability.label());
 
     match matching.len() {
         // Nothing advertises the capability. Invalid catalog entries keep the
@@ -574,7 +574,7 @@ pub fn has_linked_extension_for_capability(
     // for an optional capability — the caller that goes on to actually run it
     // gets the named load failure from `resolve_extension_for_capability`.
     let catalog = CapabilityCatalog::load()?;
-    let (matching, _) = catalog.candidates(extensions.keys(), capability);
+    let (matching, _) = catalog.candidates(extensions.keys(), capability.label());
     Ok(!matching.is_empty())
 }
 
@@ -634,7 +634,7 @@ pub fn resolve_execution_context_for_extension(
 
     let catalog = CapabilityCatalog::load()?;
     let entry = catalog.resolvable_entry(extension_id)?;
-    if !catalog.provides(entry, capability) {
+    if !catalog.provides(entry, capability.label()) {
         return Err(Error::validation_invalid_argument(
             "extension",
             format!(
@@ -801,6 +801,13 @@ mod tests {
         .expect("extension manifest");
     }
 
+    fn fingerprint_capability(file_extension: &str) -> String {
+        format!(
+            "{}{file_extension}",
+            homeboy_extension_contract::api::v1::FINGERPRINT_FILE_CAPABILITY_PREFIX
+        )
+    }
+
     #[test]
     fn component_file_resolution_considers_only_linked_extensions() {
         crate::test_support::with_isolated_home(|home| {
@@ -809,11 +816,11 @@ mod tests {
 
             let component = component_with_extensions(&["zulu"]);
             let resolved =
-                resolve_file_extension(&component, "js", FileExtensionCapability::Fingerprint)
+                resolve_file_capability_provider(&component, &fingerprint_capability("js"))
                     .expect("linked provider resolution")
                     .expect("linked provider");
 
-            assert_eq!(resolved.id, "zulu");
+            assert_eq!(resolved, "zulu");
         });
     }
 
@@ -825,19 +832,19 @@ mod tests {
 
             let mut component = component_with_extensions(&["wordpress", "nodejs"]);
             let composed =
-                resolve_file_extension(&component, "js", FileExtensionCapability::Fingerprint)
+                resolve_file_capability_provider(&component, &fingerprint_capability("js"))
                     .expect("composition resolution")
                     .expect("composition owner");
-            assert_eq!(composed.id, "wordpress");
+            assert_eq!(composed, "wordpress");
 
             component
                 .capability_extensions
                 .insert(FILE_EXTENSIONS_SURFACE.to_string(), "nodejs".to_string());
             let explicit =
-                resolve_file_extension(&component, "js", FileExtensionCapability::Fingerprint)
+                resolve_file_capability_provider(&component, &fingerprint_capability("js"))
                     .expect("explicit resolution")
                     .expect("explicit owner");
-            assert_eq!(explicit.id, "nodejs");
+            assert_eq!(explicit, "nodejs");
         });
     }
 
@@ -848,9 +855,8 @@ mod tests {
             write_file_extension_manifest(home.path(), "zulu", &[]);
 
             let component = component_with_extensions(&["zulu", "alpha"]);
-            let error =
-                resolve_file_extension(&component, "js", FileExtensionCapability::Fingerprint)
-                    .expect_err("unowned providers must remain ambiguous");
+            let error = resolve_file_capability_provider(&component, &fingerprint_capability("js"))
+                .expect_err("unowned providers must remain ambiguous");
 
             assert!(error
                 .message
@@ -864,11 +870,10 @@ mod tests {
             write_file_extension_manifest(home.path(), "zulu", &[]);
             write_file_extension_manifest(home.path(), "alpha", &[]);
 
-            let resolved =
-                find_installed_file_extension("js", FileExtensionCapability::Fingerprint)
-                    .expect("installed fallback");
+            let resolved = find_installed_capability_provider(&fingerprint_capability("js"))
+                .expect("installed fallback");
 
-            assert_eq!(resolved.id, "alpha");
+            assert_eq!(resolved, "alpha");
         });
     }
 
@@ -906,37 +911,6 @@ mod tests {
                 &extension,
                 Some(&missing_component)
             ));
-        });
-    }
-
-    #[test]
-    fn rooted_file_resolution_stays_within_the_injected_config_root() {
-        crate::test_support::with_isolated_home(|home| {
-            let injected_home = home.path().join("injected");
-            let config_root = injected_home.join(".config/homeboy");
-            write_file_extension_manifest(&injected_home, "zulu", &[]);
-
-            let component = component_with_extensions(&["zulu"]);
-            let resolved = resolve_file_extension_in_root(
-                &config_root,
-                &component,
-                "js",
-                FileExtensionCapability::Fingerprint,
-            )
-            .expect("rooted provider resolution")
-            .expect("rooted provider");
-            assert_eq!(resolved.id, "zulu");
-
-            let installed = find_installed_file_extension_in_root(
-                &config_root,
-                "js",
-                FileExtensionCapability::Fingerprint,
-            )
-            .expect("rooted installed fallback");
-            assert_eq!(installed.id, "zulu");
-            assert!(
-                find_installed_file_extension("js", FileExtensionCapability::Fingerprint).is_none()
-            );
         });
     }
 
@@ -1130,7 +1104,8 @@ mod tests {
                 .map(|id| (*id).to_string())
                 .collect();
             let catalog = CapabilityCatalog::load().expect("v1 catalog");
-            let (matching, failures) = catalog.candidates(ids.iter(), ExtensionCapability::Deps);
+            let (matching, failures) =
+                catalog.candidates(ids.iter(), ExtensionCapability::Deps.label());
 
             assert_eq!(matching, vec!["alpha", "mike", "zulu"]);
             assert_eq!(

--- a/crates/homeboy-core/src/extension/resolve/surface.rs
+++ b/crates/homeboy-core/src/extension/resolve/surface.rs
@@ -1,13 +1,6 @@
-use std::path::Path;
-
-use homeboy_extension_contract::ExtensionManifest;
-
-use super::{resolve_owner, resolve_owner_in_root};
+use super::{resolve_owner, CapabilityCatalog};
 use crate::component::Component;
-use crate::error::Result;
-use crate::extension::catalog::{
-    load_all_extensions, load_all_extensions_in_root, load_extension_in_optional_root,
-};
+use crate::error::{Error, Result};
 
 /// Ownership surface for `remote_path` auto-resolution.
 pub const REMOTE_PATH_SURFACE: &str = "remote_path";
@@ -16,145 +9,47 @@ pub const SINCE_TAG_SURFACE: &str = "since_tag";
 /// Ownership surface for `provides.file_extensions` dispatch.
 pub const FILE_EXTENSIONS_SURFACE: &str = "provides.file_extensions";
 
-/// Extension-owned behavior required for a file-type provider.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum FileExtensionCapability {
-    Fingerprint,
-    Refactor,
-    Audit,
-}
-
-impl FileExtensionCapability {
-    pub const fn label(self) -> &'static str {
-        match self {
-            Self::Fingerprint => "fingerprint",
-            Self::Refactor => "refactor",
-            Self::Audit => "audit",
-        }
-    }
-
-    fn is_provided_by(self, manifest: &ExtensionManifest) -> bool {
-        match self {
-            Self::Fingerprint => manifest.fingerprint_script().is_some(),
-            Self::Refactor => manifest.refactor_script().is_some(),
-            Self::Audit => manifest.test_mapping().is_some(),
-        }
-    }
-}
-
-/// Resolve a file-type provider from the extensions linked to `component`.
+/// Resolve an open v1 capability from the extensions linked to `component`.
 ///
 /// A single match wins directly. Multiple matches use the same explicit
 /// `capability_extensions` and `composition.includes` ownership rule as every
 /// other contested extension surface.
-pub fn resolve_file_extension(
+pub fn resolve_file_capability_provider(
     component: &Component,
-    file_extension: &str,
-    capability: FileExtensionCapability,
-) -> Result<Option<ExtensionManifest>> {
-    let manifests = linked_file_extension_candidates(component, file_extension, capability, None)?;
-    select_file_extension_owner(component, manifests, None)
-}
-
-/// [`resolve_file_extension`] against an already-resolved config root.
-pub fn resolve_file_extension_in_root(
-    config_root: &Path,
-    component: &Component,
-    file_extension: &str,
-    capability: FileExtensionCapability,
-) -> Result<Option<ExtensionManifest>> {
-    let manifests =
-        linked_file_extension_candidates(component, file_extension, capability, Some(config_root))?;
-    select_file_extension_owner(component, manifests, Some(config_root))
-}
-
-/// Context-free fallback for provider hooks that have not yet been passed a
-/// component identity. Selection is deterministic over the installed catalog.
-pub fn find_installed_file_extension(
-    file_extension: &str,
-    capability: FileExtensionCapability,
-) -> Option<ExtensionManifest> {
-    load_all_extensions()
-        .ok()?
-        .into_iter()
-        .find(|manifest| handles_file_extension(manifest, file_extension, capability))
-}
-
-/// Rooted sibling of [`find_installed_file_extension`].
-pub fn find_installed_file_extension_in_root(
-    config_root: &Path,
-    file_extension: &str,
-    capability: FileExtensionCapability,
-) -> Option<ExtensionManifest> {
-    load_all_extensions_in_root(config_root)
-        .ok()?
-        .into_iter()
-        .find(|manifest| handles_file_extension(manifest, file_extension, capability))
-}
-
-fn linked_file_extension_candidates(
-    component: &Component,
-    file_extension: &str,
-    capability: FileExtensionCapability,
-    config_root: Option<&Path>,
-) -> Result<Vec<ExtensionManifest>> {
+    capability_id: &str,
+) -> Result<Option<String>> {
     let Some(extensions) = component.extensions.as_ref() else {
-        return Ok(Vec::new());
+        return Ok(None);
     };
-
-    let mut manifests = Vec::new();
-    let mut first_failure = None;
-    let mut extension_ids = extensions.keys().collect::<Vec<_>>();
-    extension_ids.sort();
-    for extension_id in extension_ids {
-        match load_extension_in_optional_root(config_root, extension_id) {
-            Ok(manifest) if handles_file_extension(&manifest, file_extension, capability) => {
-                manifests.push(manifest);
-            }
-            Ok(_) => {}
-            Err(error) if first_failure.is_none() => first_failure = Some(error),
-            Err(_) => {}
-        }
+    if extensions.is_empty() {
+        return Ok(None);
     }
-    if manifests.is_empty() {
-        if let Some(error) = first_failure {
-            return Err(error);
-        }
-    }
-    Ok(manifests)
-}
+    let catalog = CapabilityCatalog::load()?;
+    let (mut candidates, failures) = catalog.candidates(extensions.keys(), capability_id);
 
-fn select_file_extension_owner(
-    component: &Component,
-    mut manifests: Vec<ExtensionManifest>,
-    config_root: Option<&Path>,
-) -> Result<Option<ExtensionManifest>> {
-    match manifests.len() {
-        0 => Ok(None),
-        1 => Ok(manifests.pop()),
-        _ => {
-            let candidates = manifests
-                .iter()
-                .map(|manifest| manifest.id.clone())
-                .collect::<Vec<_>>();
-            let owner = match config_root {
-                Some(config_root) => resolve_owner_in_root(
-                    config_root,
-                    component,
-                    FILE_EXTENSIONS_SURFACE,
-                    &candidates,
-                )?,
-                None => resolve_owner(component, FILE_EXTENSIONS_SURFACE, &candidates)?,
-            };
-            Ok(manifests.into_iter().find(|manifest| manifest.id == owner))
-        }
+    match candidates.len() {
+        0 if failures.is_empty() => Ok(None),
+        0 => Err(Error::validation_invalid_argument(
+            "extension",
+            format!("No readable linked extension provides capability '{capability_id}'"),
+            None,
+            Some(
+                failures
+                    .into_iter()
+                    .map(|(id, detail)| format!("Extension '{id}' failed to load: {detail}"))
+                    .collect(),
+            ),
+        )),
+        1 => Ok(candidates.pop()),
+        _ => resolve_owner(component, FILE_EXTENSIONS_SURFACE, &candidates).map(Some),
     }
 }
 
-fn handles_file_extension(
-    manifest: &ExtensionManifest,
-    file_extension: &str,
-    capability: FileExtensionCapability,
-) -> bool {
-    manifest.handles_file_extension(file_extension) && capability.is_provided_by(manifest)
+/// Context-free deterministic fallback for consumers without a component identity.
+pub fn find_installed_capability_provider(capability_id: &str) -> Option<String> {
+    CapabilityCatalog::load()
+        .ok()?
+        .providers(capability_id)
+        .into_iter()
+        .next()
 }

--- a/crates/homeboy-refactor/src/decompose.rs
+++ b/crates/homeboy-refactor/src/decompose.rs
@@ -395,10 +395,7 @@ fn parse_items(file: &str, content: &str) -> Option<Vec<ParsedItem>> {
     // authoritative source of item boundaries/source extraction. The core
     // grammar parser remains the fallback for languages without a dedicated
     // refactor parser.
-    if let Some(manifest) = homeboy_core::extension::resolve::find_installed_file_extension(
-        ext,
-        homeboy_core::extension::resolve::FileExtensionCapability::Refactor,
-    ) {
+    if let Some(manifest) = crate::move_items::find_refactor_extension_for_extension(ext) {
         // Try extension script first
         let command = serde_json::json!({
             "command": "parse_items",
@@ -443,10 +440,7 @@ fn validate_plan_sources(plan: &DecomposePlan, root: &Path) -> Result<()> {
 
     let ext = Path::new(&plan.file).extension().and_then(|e| e.to_str());
     let grammar = ext.and_then(|ext| {
-        let manifest = homeboy_core::extension::resolve::find_installed_file_extension(
-            ext,
-            homeboy_core::extension::resolve::FileExtensionCapability::Refactor,
-        )?;
+        let manifest = crate::move_items::find_refactor_extension_for_extension(ext)?;
         let ext_path = manifest.extension_path.as_deref()?;
         grammar::load_for_extension_path(Path::new(ext_path), ext)
     });
@@ -557,10 +551,7 @@ fn public_items_for_group(plan: &DecomposePlan, group: &DecomposeGroup) -> Vec<S
 }
 
 fn parse_items_for_group_export(ext: &str, content: &str, file: &str) -> Option<Vec<ParsedItem>> {
-    let manifest = homeboy_core::extension::resolve::find_installed_file_extension(
-        ext,
-        homeboy_core::extension::resolve::FileExtensionCapability::Refactor,
-    )?;
+    let manifest = crate::move_items::find_refactor_extension_for_extension(ext)?;
     crate::move_items::ext_parse_items(&manifest, content, file)
         .or_else(|| crate::move_items::core_parse_items(&manifest, content))
 }

--- a/crates/homeboy-refactor/src/move_items.rs
+++ b/crates/homeboy-refactor/src/move_items.rs
@@ -15,7 +15,7 @@ mod extension_integration;
 mod types;
 mod whole_file_move;
 
-pub(crate) use extension_integration::core_parse_items;
+pub(crate) use extension_integration::{core_parse_items, find_refactor_extension_for_extension};
 // `refactor move` reports these two result shapes in its JSON payload.
 // `MovedItem` is reachable through `MoveResult::items_moved`/`tests_moved`.
 pub(crate) use types::{ImportRewrite, ModuleIndexEntry, MoveOptions};

--- a/crates/homeboy-refactor/src/move_items/extension_integration.rs
+++ b/crates/homeboy-refactor/src/move_items/extension_integration.rs
@@ -4,15 +4,22 @@ use std::path::Path;
 
 use homeboy_core::{self, extension::ParsedItem};
 use homeboy_engine_primitives::grammar::{self, items as grammar_items};
+use homeboy_extension_contract::api::v1::REFACTOR_FILE_CAPABILITY_PREFIX;
 use homeboy_extension_contract::ExtensionManifest;
 
 /// Find a refactor-capable extension for a file based on its extension.
 pub(crate) fn find_refactor_extension(file_path: &str) -> Option<ExtensionManifest> {
     let ext = Path::new(file_path).extension().and_then(|e| e.to_str())?;
-    homeboy_core::extension::resolve::find_installed_file_extension(
-        ext,
-        homeboy_core::extension::resolve::FileExtensionCapability::Refactor,
-    )
+    find_refactor_extension_for_extension(ext)
+}
+
+pub(crate) fn find_refactor_extension_for_extension(
+    file_extension: &str,
+) -> Option<ExtensionManifest> {
+    let capability_id = format!("{REFACTOR_FILE_CAPABILITY_PREFIX}{file_extension}");
+    let extension_id =
+        homeboy_core::extension::resolve::find_installed_capability_provider(&capability_id)?;
+    homeboy_core::extension::catalog::load_extension(&extension_id).ok()
 }
 
 /// Try parsing items using the core grammar engine (no extension script needed).

--- a/crates/homeboy-refactor/src/plan/generate/duplicate_fixes.rs
+++ b/crates/homeboy-refactor/src/plan/generate/duplicate_fixes.rs
@@ -341,10 +341,7 @@ pub(crate) fn generate_duplicate_function_fixes(
         };
 
         let manifest = if use_extract_shared {
-            homeboy_core::extension::resolve::find_installed_file_extension(
-                ext,
-                homeboy_core::extension::resolve::FileExtensionCapability::Refactor,
-            )
+            crate::move_items::find_refactor_extension_for_extension(ext)
         } else {
             None
         };

--- a/crates/homeboy-refactor/src/plan/generate/signatures.rs
+++ b/crates/homeboy-refactor/src/plan/generate/signatures.rs
@@ -135,10 +135,7 @@ pub(crate) fn parse_items_for_dedup(
         }
     }
 
-    let manifest = homeboy_core::extension::resolve::find_installed_file_extension(
-        file_ext,
-        homeboy_core::extension::resolve::FileExtensionCapability::Refactor,
-    )?;
+    let manifest = crate::move_items::find_refactor_extension_for_extension(file_ext)?;
     let parse_cmd = serde_json::json!({
         "command": "parse_items",
         "file_path": file_path,

--- a/docs/internals/development/contracts/extension-api-v1.md
+++ b/docs/internals/development/contracts/extension-api-v1.md
@@ -92,6 +92,11 @@ diagnostics from one v1 catalog snapshot. Explicit ownership,
 over those stable descriptors; execution-context assembly loads the selected
 manifest only for internal script paths and settings.
 
+File-type providers use open capability IDs: `fingerprint.<extension>` and
+`refactor.<extension>`. Resolution matches those IDs in the same catalog and
+returns only the selected extension ID. Manifest paths and script declarations
+remain private execution details.
+
 ## Readiness
 
 `extension::catalog::readiness_api_batch` returns readiness evidence for explicit


### PR DESCRIPTION
## Summary

- project `fingerprint.<extension>` and `refactor.<extension>` as deterministic open v1 capability IDs
- generalize catalog capability matching to strings and return extension IDs from file-capability resolution
- migrate audit, symbol-graph, and refactor consumers and delete the closed `FileExtensionCapability` plus manifest-returning resolver surface

## Verification

- `cargo test -p homeboy-extension-contract api::v1::tests`
- `cargo test -p homeboy-core extension::resolve::tests`
- `cargo test -p homeboy-core extension::catalog::api::tests::descriptor_normalizes_manifest_capabilities_and_requirements`
- `cargo test -p homeboy-refactor`
- `cargo check --workspace --all-targets`
- `cargo run -q -p homeboy -- review audit --profile architecture --changed-since origin/main --placement local`

Closes #14012
Parent: #13882

AI assistance: OpenAI GPT-5.6 Sol via OpenCode audited the manifest-returning file-extension resolver, implemented the v1 capability-ID migration, consolidated consumers, and ran the verification gates under Chris Huber direction.