### PR TITLE
Skip mutable release gates during tagged recovery

### DIFF
--- a/crates/homeboy-release/src/release/execution_plan.rs
+++ b/crates/homeboy-release/src/release/execution_plan.rs
@@ -345,7 +345,7 @@ mod tests {
         build_dry_run_preflight_plan, build_initial_preflight_plan, execute_plan_steps,
         initial_executable_preflight_ids, release_tag_version, resolve_head_release,
     };
-    use crate::release::types::{ReleaseOptions, ReleaseStepStatus};
+    use crate::release::types::{ReleaseOptions, ReleasePipelineOptions, ReleaseStepStatus};
     use homeboy_core::plan::PlanStepStatus;
     use semver::Version;
     use std::collections::HashSet;
@@ -511,6 +511,41 @@ mod tests {
             "tag availability must fail before the declared-test-secret gate runs"
         );
         assert_eq!(steps[tag].needs, vec!["preflight.remote_sync"]);
+    }
+
+    #[test]
+    fn tagged_head_recovery_initial_preflight_never_schedules_mutable_quality_gates() {
+        for from_artifacts in [None, Some("artifacts".to_string())] {
+            let options = ReleaseOptions {
+                bump_type: "head".to_string(),
+                pipeline: ReleasePipelineOptions {
+                    head: true,
+                    from_artifacts,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let plan = build_initial_preflight_plan("fixture", &options);
+
+            for step_id in [
+                "preflight.test_secret_env",
+                "preflight.dependencies",
+                "preflight.lint",
+                "preflight.test",
+            ] {
+                let step = plan
+                    .plan
+                    .steps
+                    .iter()
+                    .find(|step| step.id == step_id)
+                    .expect("mutable recovery preflight step");
+                assert_eq!(
+                    step.status,
+                    PlanStepStatus::Disabled,
+                    "{step_id} must not execute before release reconciliation"
+                );
+            }
+        }
     }
 
     /// A missing runner/service credential must be diagnosed before dependency

--- a/crates/homeboy-release/src/release/executor/github_release/tests/delivery_tests.rs
+++ b/crates/homeboy-release/src/release/executor/github_release/tests/delivery_tests.rs
@@ -35,6 +35,27 @@ fn published_release_with_nothing_to_attach_is_an_idempotent_no_op() {
 }
 
 #[test]
+fn completed_publication_is_adopted_when_tagged_recovery_reaches_delivery() {
+    // The release may have completed after recovery began. Delivery sees the
+    // exact published tag and must stop rather than recreate or republish it.
+    let declared = vec![
+        "dist-manifest.json".to_string(),
+        "homeboy-aarch64-apple-darwin.tar.xz".to_string(),
+        "homeboy-x86_64-unknown-linux-gnu.tar.xz".to_string(),
+    ];
+    let published = vec![
+        "dist-manifest.json".to_string(),
+        "homeboy-aarch64-apple-darwin.tar.xz".to_string(),
+        "homeboy-x86_64-unknown-linux-gnu.tar.xz".to_string(),
+    ];
+
+    assert_eq!(
+        existing_release_action(false, false, &published, Some(&declared), true),
+        ExistingReleaseAction::AlreadyPublished
+    );
+}
+
+#[test]
 fn published_release_with_no_assets_is_still_an_idempotent_no_op() {
     // Asset count is only consulted for drafts: a published release with no
     // assets is a delivery problem for `verify-published` to report, not a

--- a/crates/homeboy-release/src/release/plan_steps/preflight.rs
+++ b/crates/homeboy-release/src/release/plan_steps/preflight.rs
@@ -108,7 +108,14 @@ pub(in crate::release) fn build_preflight_steps(
     // test gate. (#10402)
     steps.push(build_test_secret_env_step(options));
 
-    let dependencies_step = if options.skip_deps_hydration {
+    let dependencies_step = if options.pipeline.head {
+        disabled_step(
+            "preflight.dependencies",
+            "preflight.dependencies",
+            "Hydrate release dependencies",
+            string_config("reason", "tagged-head-recovery"),
+        )
+    } else if options.skip_deps_hydration {
         disabled_step(
             "preflight.dependencies",
             "preflight.dependencies",
@@ -199,8 +206,14 @@ fn build_test_secret_env_step(options: &ReleaseOptions) -> PlanStep {
 }
 
 fn quality_plan_options(options: &ReleaseOptions) -> QualityPlanOptions {
-    QualityPlanOptions::release_preflight("release", options.skip_checks)
-        .with_granular_skips(&options.skip_checks_granular)
+    let mut quality = QualityPlanOptions::release_preflight(
+        "release",
+        options.skip_checks || options.pipeline.head,
+    );
+    if options.pipeline.head && !options.skip_checks {
+        quality.skip_reason = "tagged-head-recovery".to_string();
+    }
+    quality.with_granular_skips(&options.skip_checks_granular)
 }
 
 fn build_extension_release_preflight_steps(extensions: &[ExtensionManifest]) -> Vec<PlanStep> {
@@ -226,7 +239,7 @@ fn build_extension_release_preflight_steps(extensions: &[ExtensionManifest]) -> 
 
 fn build_quality_steps(options: &ReleaseOptions) -> Vec<PlanStep> {
     let mut quality_options = quality_plan_options(options);
-    quality_options.lint_needs = vec![if options.skip_deps_hydration {
+    quality_options.lint_needs = vec![if options.skip_deps_hydration || options.pipeline.head {
         "preflight.bump_policy".to_string()
     } else {
         "preflight.dependencies".to_string()

--- a/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
+++ b/crates/homeboy-release/src/release/plan_steps/tests/mod.rs
@@ -259,6 +259,53 @@ fn head_release_with_artifacts_skips_branch_and_working_tree_checks() {
 }
 
 #[test]
+fn tagged_head_recovery_skips_mutable_source_gates() {
+    for from_artifacts in [None, Some("artifacts".to_string())] {
+        let options = ReleaseOptions {
+            bump_type: "head".to_string(),
+            pipeline: ReleasePipelineOptions {
+                head: true,
+                from_artifacts,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let steps = build_preflight_steps(&options, None, &[]);
+        for step_id in [
+            "preflight.test_secret_env",
+            "preflight.dependencies",
+            "preflight.audit",
+            "preflight.lint",
+            "preflight.test",
+        ] {
+            let step = steps
+                .iter()
+                .find(|step| step.id == step_id)
+                .expect("tagged recovery preflight step");
+            assert_eq!(step.status, PlanStepStatus::Disabled, "{step_id}");
+            assert_eq!(
+                step.inputs.get("reason").and_then(|value| value.as_str()),
+                Some("tagged-head-recovery"),
+                "{step_id}"
+            );
+        }
+
+        for step_id in ["preflight.head_identity", "preflight.remote_sync"] {
+            assert_eq!(
+                steps
+                    .iter()
+                    .find(|step| step.id == step_id)
+                    .expect("immutable recovery preflight step")
+                    .status,
+                PlanStepStatus::Ready,
+                "{step_id}"
+            );
+        }
+    }
+}
+
+#[test]
 fn release_plan_records_explicit_quality_preflights() {
     let options = ReleaseOptions {
         bump_type: "patch".to_string(),


### PR DESCRIPTION
## Summary
- treat an exact tagged HEAD as immutable recovery authority
- skip branch, worktree, and source-mutating preflights during that recovery path
- retain artifact identity validation before delivery

## Verification
- `cargo test -p homeboy-release` (559 passed)
- `cargo fmt --all --check`
- `git diff --check`

Closes #14003

## AI Assistance
OpenAI GPT-5.6 Terra via OpenCode was used to investigate, implement, and run verification. Chris Huber reviewed and orchestrated the work.