### PR TITLE
Report verified upgrade target identity

### DIFF
--- a/crates/homeboy-cli/src/commands/self_cmd.rs
+++ b/crates/homeboy-cli/src/commands/self_cmd.rs
@@ -67,6 +67,9 @@ pub struct UpgradeAdmissionArgs {
     /// Exact version expected from the checksum-verified staged release.
     #[arg(long)]
     pub target_version: Option<String>,
+    /// Release tag or artifact selected by the installer for this candidate.
+    #[arg(long)]
+    pub selected_tag_or_artifact: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -171,9 +174,12 @@ pub fn run(args: SelfArgs) -> CmdResult<Value> {
                             None,
                         ));
                     }
-                    homeboy_upgrade::upgrade::ensure_verified_target_upgrade_admission(
-                        target_version,
-                    )?
+                    let target = homeboy_upgrade::upgrade::VerifiedTargetUpgrade::classify(
+                        args.legacy_identity.clone(),
+                        build_identity::current().display,
+                        args.selected_tag_or_artifact.clone(),
+                    );
+                    homeboy_upgrade::upgrade::ensure_verified_target_upgrade_admission(&target)?
                 }
                 None => homeboy_upgrade::upgrade::ensure_controller_upgrade_admission()?,
             };

--- a/crates/homeboy-core/src/defaults/builtins.rs
+++ b/crates/homeboy-core/src/defaults/builtins.rs
@@ -112,6 +112,7 @@ const BINARY_UPGRADE_BOOTSTRAP: &str = r#"# Keep the installed controller immuta
 # durable records that a legacy controller cannot, without bypassing live work.
 chmod 0755 homeboy
 TARGET_VERSION="${HOMEBOY_UPGRADE_RELEASE_VERSION:?target-version bootstrap recovery requires a selected release version}"
+SELECTED_TAG_OR_ARTIFACT="${HOMEBOY_UPGRADE_RELEASE_TAG:-v$TARGET_VERSION}"
 CANDIDATE_VERSION="$("$TMP_DIR/homeboy" --version 2>/dev/null | awk '{print $NF}' | sed 's/^v//; s/+.*$//')"
 if [ "$CANDIDATE_VERSION" != "$TARGET_VERSION" ]; then
   echo "Target-version bootstrap recovery refused: verified archive candidate reports ${CANDIDATE_VERSION:-unverifiable}, expected $TARGET_VERSION." >&2
@@ -119,7 +120,7 @@ if [ "$CANDIDATE_VERSION" != "$TARGET_VERSION" ]; then
   exit 1
 fi
 LEGACY_IDENTITY="$("$BIN_PATH" self identity 2>/dev/null || "$BIN_PATH" --version 2>/dev/null || printf 'unavailable')"
-"$TMP_DIR/homeboy" self upgrade-admission --legacy-identity "$LEGACY_IDENTITY" --target-version "$TARGET_VERSION"
+"$TMP_DIR/homeboy" self upgrade-admission --legacy-identity "$LEGACY_IDENTITY" --target-version "$TARGET_VERSION" --selected-tag-or-artifact "$SELECTED_TAG_OR_ARTIFACT"
 TMP_BIN="$(dirname "$BIN_PATH")/.homeboy-upgrade.$$"
 
 if [ -w "$BIN_PATH" ] || [ -w "$(dirname "$BIN_PATH")" ]; then"#;
@@ -262,6 +263,7 @@ fi"#;
         assert!(command.contains("LEGACY_IDENTITY=\"$(\"$BIN_PATH\" self identity"));
         assert!(command.contains("HOMEBOY_UPGRADE_RELEASE_VERSION"));
         assert!(command.contains("--target-version \"$TARGET_VERSION\""));
+        assert!(command.contains("--selected-tag-or-artifact \"$SELECTED_TAG_OR_ARTIFACT\""));
         assert!(!command.contains("install -m 0755 homeboy \"$BIN_PATH\""));
         assert!(command.contains("sudo mv \"$TMP_BIN\" \"$BIN_PATH\""));
     }

--- a/crates/homeboy-upgrade/src/upgrade/admission.rs
+++ b/crates/homeboy-upgrade/src/upgrade/admission.rs
@@ -32,6 +32,68 @@ pub struct ControllerUpgradeBlocker {
     pub recovery_command: String,
 }
 
+/// Immutable installer facts reported when a staged candidate cannot replace
+/// the installed controller.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct VerifiedTargetUpgrade {
+    pub installed_identity: String,
+    pub candidate_identity: String,
+    pub selected_tag_or_artifact: Option<String>,
+    pub operation_class: &'static str,
+}
+
+impl VerifiedTargetUpgrade {
+    pub fn classify(
+        installed_identity: String,
+        candidate_identity: String,
+        selected_tag_or_artifact: Option<String>,
+    ) -> Self {
+        let installed_version = identity_version(&installed_identity);
+        let candidate_version = identity_version(&candidate_identity);
+        let installed_display = normalized_identity(&installed_identity);
+        let candidate_display = normalized_identity(&candidate_identity);
+        let operation_class = match (installed_version, candidate_version) {
+            (Some(installed), Some(candidate)) if candidate > installed => "version_upgrade",
+            (Some(installed), Some(candidate)) if candidate < installed => "version_downgrade",
+            (Some(_), Some(_)) if installed_display != candidate_display => {
+                "source_build_replacement"
+            }
+            (Some(_), Some(_)) => "exact_version_repair",
+            _ => "unverified_replacement",
+        };
+        Self {
+            installed_identity,
+            candidate_identity,
+            selected_tag_or_artifact,
+            operation_class,
+        }
+    }
+}
+
+fn identity_version(identity: &str) -> Option<semver::Version> {
+    let identity = normalized_identity(identity);
+    identity
+        .trim()
+        .strip_prefix("homeboy ")?
+        .trim_start_matches('v')
+        .split('+')
+        .next()
+        .filter(|version| !version.is_empty())
+        .and_then(|version| semver::Version::parse(version).ok())
+}
+
+fn normalized_identity(identity: &str) -> String {
+    let json_identity = serde_json::from_str::<serde_json::Value>(identity)
+        .ok()
+        .and_then(|identity| {
+            identity
+                .get("display")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+        });
+    json_identity.unwrap_or_else(|| identity.trim().to_string())
+}
+
 impl ControllerUpgradeAdmission {
     pub fn allows_controller_replacement(&self) -> bool {
         self.blockers.is_empty()
@@ -90,17 +152,17 @@ pub fn ensure_controller_upgrade_admission() -> Result<ControllerUpgradeAdmissio
 /// target version is included in errors so operators can distinguish this from
 /// a same-version repair attempt on the installed controller.
 pub fn ensure_verified_target_upgrade_admission(
-    target_version: &str,
+    target: &VerifiedTargetUpgrade,
 ) -> Result<ControllerUpgradeAdmission> {
     let admission = with_controller_upgrade_admission(|provider| {
         provider.recover_controller_upgrade_admission_for_verified_target()
     })?;
-    ensure_admission(admission, Some(target_version))
+    ensure_admission(admission, Some(target))
 }
 
 fn ensure_admission(
     admission: ControllerUpgradeAdmission,
-    target_version: Option<&str>,
+    target: Option<&VerifiedTargetUpgrade>,
 ) -> Result<ControllerUpgradeAdmission> {
     if admission.allows_controller_replacement() {
         return Ok(admission);
@@ -115,8 +177,17 @@ fn ensure_admission(
         "controller_upgrade",
         format!(
             "refusing {} while durable orchestration ownership is live or unverified: {}",
-            target_version
-                .map(|version| format!("target-version bootstrap recovery to {version}"))
+            target
+                .map(|target| format!(
+                    "{} (installed: {}; candidate: {}; selected tag/artifact: {})",
+                    target.operation_class,
+                    target.installed_identity,
+                    target.candidate_identity,
+                    target
+                        .selected_tag_or_artifact
+                        .as_deref()
+                        .unwrap_or("unavailable"),
+                ))
                 .unwrap_or_else(|| "same-version controller repair".to_string()),
             admission
                 .blockers
@@ -130,5 +201,124 @@ fn ensure_admission(
     );
     error.details["controller_upgrade_admission"] = serde_json::to_value(&admission)
         .map_err(|error| Error::internal_json(error.to_string(), None))?;
+    if let Some(target) = target {
+        error.details["verified_target_upgrade"] = serde_json::to_value(target)
+            .map_err(|error| Error::internal_json(error.to_string(), None))?;
+    }
     Err(error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verified_target_classifies_version_upgrade() {
+        let target = VerifiedTargetUpgrade::classify(
+            "homeboy 0.367.1+02c50568c814".to_string(),
+            "homeboy 0.367.3+4eb24ce80".to_string(),
+            Some("v0.367.3".to_string()),
+        );
+
+        assert_eq!(target.operation_class, "version_upgrade");
+        assert_eq!(target.installed_identity, "homeboy 0.367.1+02c50568c814");
+        assert_eq!(target.candidate_identity, "homeboy 0.367.3+4eb24ce80");
+        assert_eq!(target.selected_tag_or_artifact.as_deref(), Some("v0.367.3"));
+    }
+
+    #[test]
+    fn verified_target_classifies_json_identity_from_installed_controller() {
+        let target = VerifiedTargetUpgrade::classify(
+            r#"{"active_binary":"/usr/local/bin/homeboy","version":"0.367.1","display":"homeboy 0.367.1+02c50568c814"}"#.to_string(),
+            "homeboy 0.367.3+4eb24ce80".to_string(),
+            Some("v0.367.3".to_string()),
+        );
+
+        assert_eq!(target.operation_class, "version_upgrade");
+    }
+
+    #[test]
+    fn verified_target_classifies_matching_json_identity_as_exact_repair() {
+        let target = VerifiedTargetUpgrade::classify(
+            r#"{"display":"homeboy 0.367.3+4eb24ce80"}"#.to_string(),
+            "homeboy 0.367.3+4eb24ce80".to_string(),
+            Some("v0.367.3".to_string()),
+        );
+
+        assert_eq!(target.operation_class, "exact_version_repair");
+    }
+
+    #[test]
+    fn verified_target_classifies_exact_version_repair() {
+        let target = VerifiedTargetUpgrade::classify(
+            "homeboy 0.367.3+4eb24ce80".to_string(),
+            "homeboy 0.367.3+4eb24ce80".to_string(),
+            Some("v0.367.3".to_string()),
+        );
+
+        assert_eq!(target.operation_class, "exact_version_repair");
+        assert_eq!(target.installed_identity, target.candidate_identity);
+    }
+
+    #[test]
+    fn verified_target_classifies_equal_version_source_replacement() {
+        let target = VerifiedTargetUpgrade::classify(
+            "homeboy 0.367.3+02c50568c814".to_string(),
+            "homeboy 0.367.3+4eb24ce80".to_string(),
+            None,
+        );
+
+        assert_eq!(target.operation_class, "source_build_replacement");
+    }
+
+    #[test]
+    fn verified_target_classifies_version_downgrade() {
+        let target = VerifiedTargetUpgrade::classify(
+            "homeboy 0.367.3+4eb24ce80".to_string(),
+            "homeboy 0.367.1+02c50568c814".to_string(),
+            Some("v0.367.1".to_string()),
+        );
+
+        assert_eq!(target.operation_class, "version_downgrade");
+    }
+
+    #[test]
+    fn staged_candidate_blocker_preserves_admission_diagnostics() {
+        let admission = ControllerUpgradeAdmission {
+            schema: "homeboy/controller-upgrade-admission/v1",
+            active: 1,
+            stale: 0,
+            suspect: 0,
+            unreconciled: 0,
+            reconcilable: 0,
+            record_health: serde_json::Value::Null,
+            blockers: vec![ControllerUpgradeBlocker {
+                run_id: "run-1".to_string(),
+                owner: "agent-task".to_string(),
+                scope: "run-1".to_string(),
+                postcondition: "terminal".to_string(),
+                liveness: "live",
+                reason: "active".to_string(),
+                action: "homeboy agent-task reconcile run-1".to_string(),
+                recovery_command: "homeboy agent-task reconcile run-1".to_string(),
+            }],
+        };
+        let target = VerifiedTargetUpgrade::classify(
+            "homeboy 0.367.1+02c50568c814".to_string(),
+            "homeboy 0.367.3+4eb24ce80".to_string(),
+            Some("v0.367.3".to_string()),
+        );
+
+        let error =
+            ensure_admission(admission, Some(&target)).expect_err("staged candidate blocks");
+
+        assert!(error.message.contains("version_upgrade"));
+        assert!(error.message.contains("0.367.1+02c50568c814"));
+        assert!(error.message.contains("0.367.3+4eb24ce80"));
+        assert!(error.message.contains("v0.367.3"));
+        assert_eq!(
+            error.details["verified_target_upgrade"]["operation_class"],
+            "version_upgrade"
+        );
+    }
 }

--- a/crates/homeboy-upgrade/src/upgrade/execution.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution.rs
@@ -373,7 +373,12 @@ fn verify_source_candidate_target_admission(
     let legacy_identity = installed_binary
         .and_then(|path| candidate_legacy_identity(path).ok())
         .unwrap_or_else(|| "unavailable".to_string());
-    run_verified_target_admission(built_binary, candidate_version, &legacy_identity)
+    run_verified_target_admission(
+        built_binary,
+        candidate_version,
+        &legacy_identity,
+        &format!("source candidate {}", built_binary.display()),
+    )
 }
 
 fn source_workspace_package_version(workspace_root: &Path) -> Result<String> {
@@ -415,6 +420,7 @@ fn run_verified_target_admission(
     candidate: &Path,
     target_version: &str,
     legacy_identity: &str,
+    selected_tag_or_artifact: &str,
 ) -> Result<()> {
     upgrade_phase("running verified source candidate admission");
     let output = Command::new(candidate)
@@ -425,6 +431,8 @@ fn run_verified_target_admission(
             legacy_identity,
             "--target-version",
             target_version,
+            "--selected-tag-or-artifact",
+            selected_tag_or_artifact,
         ])
         .output()
         .map_err(|error| {

--- a/crates/homeboy-upgrade/src/upgrade/execution/tests/part_a.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution/tests/part_a.rs
@@ -149,7 +149,7 @@ fn staged_source_candidate_owns_admission_and_preserves_installed_bytes_on_failu
     std::fs::write(
         &candidate,
         format!(
-            "#!/bin/sh\nif [ \"$1\" = --version ]; then printf 'homeboy 0.352.0+new\\n'; exit 0; fi\nprintf '%s|%s|%s\\n' \"$1\" \"$4\" \"$6\" > {}\nexit 0\n",
+            "#!/bin/sh\nif [ \"$1\" = --version ]; then printf 'homeboy 0.352.0+new\\n'; exit 0; fi\nprintf '%s|%s|%s|%s\\n' \"$1\" \"$4\" \"$6\" \"$8\" > {}\nexit 0\n",
             quote_path(&evidence.display().to_string())
         ),
     )
@@ -163,7 +163,10 @@ fn staged_source_candidate_owns_admission_and_preserves_installed_bytes_on_failu
         .expect("new candidate, not the old controller, admits replacement");
     assert_eq!(
         std::fs::read_to_string(&evidence).expect("admission evidence"),
-        "self|homeboy 0.351.0+old|0.352.0\n"
+        format!(
+            "self|homeboy 0.351.0+old|0.352.0|source candidate {}\n",
+            candidate.display()
+        )
     );
 
     std::fs::write(

--- a/crates/homeboy-upgrade/src/upgrade/mod.rs
+++ b/crates/homeboy-upgrade/src/upgrade/mod.rs
@@ -16,6 +16,7 @@ pub use admission::{
     controller_upgrade_admission, ensure_controller_upgrade_admission,
     ensure_verified_target_upgrade_admission, register_controller_upgrade_admission_provider,
     ControllerUpgradeAdmission, ControllerUpgradeAdmissionProvider, ControllerUpgradeBlocker,
+    VerifiedTargetUpgrade,
 };
 pub use execution::parse_build_identity_display;
 pub use helpers::{

--- a/scripts/homeboy-installer.sh
+++ b/scripts/homeboy-installer.sh
@@ -109,6 +109,7 @@ LEGACY_IDENTITY="$("$BIN_PATH" self identity 2>/dev/null || "$BIN_PATH" --versio
 set -- self upgrade-admission --legacy-identity "$LEGACY_IDENTITY"
 if [ -n "$TARGET_VERSION" ]; then
   set -- "$@" --target-version "$TARGET_VERSION"
+  set -- "$@" --selected-tag-or-artifact "$TAG"
 fi
 "$EXTRACTED_BIN" "$@"
 

--- a/tests/homeboy_installer_test.rs
+++ b/tests/homeboy_installer_test.rs
@@ -29,7 +29,7 @@ fn archive(root: &Path, destination: &Path, fixture: ArchiveFixture) {
     let candidate = target.join("homeboy");
     write_executable(
         &candidate,
-        "#!/bin/sh\nif [ \"$1\" = --version ]; then printf 'homeboy %s\\n' \"${HOMEBOY_TEST_TARGET_VERSION:-0.351.3+fixture}\"; exit 0; fi\nif [ \"$1\" = self ] && [ \"$2\" = upgrade-admission ]; then\n  printf '%s|%s|%s\\n' \"$0\" \"$4\" \"$6\" > \"$HOMEBOY_TEST_EVIDENCE\"\n  printf 'admission\\n' >> \"$HOMEBOY_TEST_EVENTS\"\n  exit ${HOMEBOY_TEST_CANDIDATE_EXIT:-0}\nfi\nexit 64\n",
+        "#!/bin/sh\nif [ \"$1\" = --version ]; then printf 'homeboy %s\\n' \"${HOMEBOY_TEST_TARGET_VERSION:-0.351.3+fixture}\"; exit 0; fi\nif [ \"$1\" = self ] && [ \"$2\" = upgrade-admission ]; then\n  printf '%s|%s|%s|%s\\n' \"$0\" \"$4\" \"$6\" \"$8\" > \"$HOMEBOY_TEST_EVIDENCE\"\n  printf 'admission\\n' >> \"$HOMEBOY_TEST_EVENTS\"\n  exit ${HOMEBOY_TEST_CANDIDATE_EXIT:-0}\nfi\nexit 64\n",
     );
 
     let mut entries = vec![TARGET.to_string()];
@@ -136,6 +136,7 @@ fn run_installer(
         .env("HOMEBOY_TEST_EVIDENCE", &evidence)
         .env("HOMEBOY_TEST_EVENTS", &events)
         .env("HOMEBOY_TEST_BIN_DIR", &install_dir)
+        .env("HOMEBOY_UPGRADE_RELEASE_TAG", "v0.351.3")
         .env("HOMEBOY_UPGRADE_RELEASE_VERSION", "0.351.3")
         // Archive inspection must be independent of caller tar defaults.
         .env("TAR_OPTIONS", "--invalid-homeboy-installer-option")
@@ -157,6 +158,7 @@ fn installer_admits_a_staged_candidate_and_preserves_bytes_on_admission_failure(
     assert!(installed.contains("upgrade-admission"));
     assert!(evidence.contains("legacy-controller-identity"));
     assert!(evidence.contains("0.351.3"));
+    assert!(evidence.contains("v0.351.3"));
     assert!(evidence
         .split('|')
         .next()


### PR DESCRIPTION
## Summary
- classify staged upgrade candidates from their verified binary identity
- distinguish exact repair, source replacement, upgrade, and downgrade operations
- preserve selected and installed identities in failure diagnostics

## Verification
- `cargo test -p homeboy-upgrade` (236 passed)
- installer and CLI focused checks
- `cargo fmt --all --check`
- `git diff --check`

Closes #14004

## AI Assistance
OpenAI GPT-5.6 Terra via OpenCode was used to investigate, implement, and run verification. Chris Huber reviewed and orchestrated the work.