### PR TITLE
Recover admitted runner jobs without a PID

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
@@ -293,6 +293,67 @@ pub fn reconcile_pending_runner_submission_intent_in_store(
     }
 }
 
+/// Bind a direct-daemon job whose accepted response was lost after the daemon
+/// admitted it. Direct Lab admission records the reservation before `/exec`,
+/// and the daemon indexes active jobs by the durable run id, so this lookup
+/// recovers only that exact admitted handoff without submitting replacement
+/// work.
+pub(crate) fn recover_reserved_lab_runner_job_in_store(
+    lifecycle_store: &AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<bool> {
+    let run_id = sanitize_run_id(run_id);
+    let record = lifecycle_store.read_record(&run_id)?;
+    if record.runner_job_id().is_some() || !record.has_planned_runner_execution() {
+        return Ok(false);
+    }
+    let Some(runner_id) = record.runner_id().map(str::to_string) else {
+        return Ok(false);
+    };
+    if record
+        .metadata
+        .pointer("/lab_admission_reservation/state")
+        .and_then(Value::as_str)
+        != Some("reserved")
+        || record
+            .metadata
+            .pointer("/lab_admission_reservation/runner_id")
+            .and_then(Value::as_str)
+            != Some(runner_id.as_str())
+    {
+        return Ok(false);
+    }
+    let Some(runner_job_id) = super::runner_continuation::with_runner_continuation(|provider| {
+        provider.runner_job_id_for_durable_run(&runner_id, &run_id)
+    })
+    .ok()
+    .flatten() else {
+        return Ok(false);
+    };
+    let remote_workspace = record
+        .metadata
+        .get("remote_workspace")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let remote_command = record
+        .metadata
+        .get("remote_command")
+        .cloned()
+        .and_then(|value| serde_json::from_value::<Vec<String>>(value).ok())
+        .unwrap_or_default();
+    record_detached_lab_run_in_store(
+        lifecycle_store,
+        DetachedLabRunRecord {
+            run_id: &run_id,
+            runner_id: &runner_id,
+            runner_job_id: &runner_job_id,
+            remote_workspace,
+            remote_command: &remote_command,
+        },
+    )?;
+    Ok(true)
+}
+
 /// Resolve a possibly accepted submission without replaying it. This is used
 /// only after the acceptance deadline or an operator cancellation request:
 /// those paths must never create new runner work.

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -5055,6 +5055,9 @@ pub fn reconcile_status_in_store(
     if reconcile_pending_runner_submission_intent_in_store(lifecycle_store, &resolved_run_id)? {
         record = lifecycle_store.read_record(&resolved_run_id)?;
     }
+    if recover_reserved_lab_runner_job_in_store(lifecycle_store, &resolved_run_id)? {
+        record = lifecycle_store.read_record(&resolved_run_id)?;
+    }
     if has_expired_pending_runner_submission_intent(&record, chrono::Utc::now()) {
         let _ = expire_unaccepted_lab_handoff_in_store(lifecycle_store, &resolved_run_id)?;
         record = lifecycle_store.read_record(&resolved_run_id)?;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
@@ -141,6 +141,17 @@ pub trait RunnerContinuationProvider: Send + Sync {
         }
     }
 
+    /// Recover an accepted runner job whose response did not reach the
+    /// controller. The durable run id is the daemon's idempotency key, so a
+    /// unique matching active job is sufficient to bind the handoff safely.
+    fn runner_job_id_for_durable_run(
+        &self,
+        _runner_id: &str,
+        _durable_run_id: &str,
+    ) -> Result<Option<String>> {
+        Ok(None)
+    }
+
     /// Whether the runner currently reports a live connection.
     fn is_runner_connected(&self, runner_id: &str) -> bool;
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -1434,6 +1434,19 @@ fn reserved_lab_admission_recovers_runner_job_after_client_loss() {
             u64::MAX,
         )
         .expect("persist direct daemon reservation before client loss");
+        rewrite_record_for_test(run_id, |record| {
+            // The synchronous caller has exited and its last controller
+            // heartbeat is stale. Recovery must bind the admitted daemon job
+            // before the no-PID watchdog classifies this as ownerless.
+            record.updated_at = Some(
+                (chrono::Utc::now()
+                    - chrono::Duration::minutes(
+                        homeboy_core::observation::RUNNING_HEARTBEAT_STALE_MINUTES,
+                    ))
+                .to_rfc3339(),
+            );
+        })
+        .expect("age interrupted caller heartbeat");
         let _provider = RunnerContinuationTestGuard::install(Box::new(ReconciliationProvider {
             result: Mutex::new(Some(TestRunnerReconciliation::Unconfirmed)),
             recovered_runner_job_id: Mutex::new(Some("accepted-runner-job-1".to_string())),
@@ -1449,6 +1462,7 @@ fn reserved_lab_admission_recovers_runner_job_after_client_loss() {
             "accepted"
         );
         assert!(recovered.metadata.get("stale_running").is_none());
+        assert!(recovered.metadata.get("stale_running_reason").is_none());
     });
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -32,6 +32,7 @@ enum TestRunnerReconciliation {
 
 struct ReconciliationProvider {
     result: Mutex<Option<TestRunnerReconciliation>>,
+    recovered_runner_job_id: Mutex<Option<String>>,
 }
 
 impl RunnerContinuationProvider for ReconciliationProvider {
@@ -59,6 +60,18 @@ impl RunnerContinuationProvider for ReconciliationProvider {
                 RunnerJobReconciliation::UnconfirmedAbsence
             }
         }
+    }
+
+    fn runner_job_id_for_durable_run(
+        &self,
+        _runner_id: &str,
+        _durable_run_id: &str,
+    ) -> Result<Option<String>> {
+        Ok(self
+            .recovered_runner_job_id
+            .lock()
+            .expect("recovered runner job")
+            .clone())
     }
 
     fn is_runner_connected(&self, _runner_id: &str) -> bool {
@@ -1336,6 +1349,7 @@ fn accepted_handoff_adopts_a_job_found_on_another_known_generation() {
             // This represents a 404 on the current generation followed by a
             // matching snapshot on another generation in the durable ledger.
             result: Mutex::new(Some(TestRunnerReconciliation::Snapshot(Box::new(snapshot)))),
+            recovered_runner_job_id: Mutex::new(None),
         }));
 
         let reconciled = reconcile_status(run_id).expect("adopted generation snapshot");
@@ -1354,6 +1368,7 @@ fn accepted_handoff_fails_after_confirmed_absence_across_generations() {
         accepted_detached_handoff(run_id);
         let _provider = RunnerContinuationTestGuard::install(Box::new(ReconciliationProvider {
             result: Mutex::new(Some(TestRunnerReconciliation::ConfirmedAbsent(2))),
+            recovered_runner_job_id: Mutex::new(None),
         }));
 
         let terminal = reconcile_status(run_id).expect("terminal lost accepted job");
@@ -1381,6 +1396,7 @@ fn accepted_handoff_does_not_terminalize_unconfirmed_generation_absence() {
         accepted_detached_handoff(run_id);
         let _provider = RunnerContinuationTestGuard::install(Box::new(ReconciliationProvider {
             result: Mutex::new(Some(TestRunnerReconciliation::Unconfirmed)),
+            recovered_runner_job_id: Mutex::new(None),
         }));
 
         let retained = reconcile_status(run_id).expect("retain unconfirmed handoff");
@@ -1389,6 +1405,50 @@ fn accepted_handoff_does_not_terminalize_unconfirmed_generation_absence() {
         assert!(retained.metadata.get("lost_accepted_runner_job").is_none());
         assert_eq!(retained.metadata["provider_executions_consumed"], 0);
         assert!(retained.provider_handles.is_empty());
+    });
+}
+
+#[test]
+fn reserved_lab_admission_recovers_runner_job_after_client_loss() {
+    with_isolated_home(|_| {
+        let run_id = "recover-reserved-lab-admission";
+        let command = vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+        ];
+        record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id,
+            runner_id: "homeboy-lab",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+            durable_plan: None,
+        })
+        .expect("persist planned proxy before daemon admission");
+        record_lab_admission_reservation_in_store(
+            &test_lifecycle_store(),
+            run_id,
+            "homeboy-lab",
+            "daemon-lease-1",
+            "reservation-job-1",
+            u64::MAX,
+        )
+        .expect("persist direct daemon reservation before client loss");
+        let _provider = RunnerContinuationTestGuard::install(Box::new(ReconciliationProvider {
+            result: Mutex::new(Some(TestRunnerReconciliation::Unconfirmed)),
+            recovered_runner_job_id: Mutex::new(Some("accepted-runner-job-1".to_string())),
+        }));
+
+        let recovered = reconcile_status(run_id).expect("recover admitted runner job");
+
+        assert_eq!(recovered.state, AgentTaskRunState::Running);
+        assert_eq!(recovered.runner_id(), Some("homeboy-lab"));
+        assert_eq!(recovered.runner_job_id(), Some("accepted-runner-job-1"));
+        assert_eq!(
+            recovered.metadata["handoff_acceptance"]["state"],
+            "accepted"
+        );
+        assert!(recovered.metadata.get("stale_running").is_none());
     });
 }
 

--- a/crates/homeboy-lab-runner/src/continuation_provider.rs
+++ b/crates/homeboy-lab-runner/src/continuation_provider.rs
@@ -186,6 +186,17 @@ impl RunnerContinuationProvider for RunnerContinuation {
         }
     }
 
+    fn runner_job_id_for_durable_run(
+        &self,
+        runner_id: &str,
+        durable_run_id: &str,
+    ) -> Result<Option<String>> {
+        Ok(
+            super::lab::offload::accepted_runner_job_id(runner_id, durable_run_id)
+                .map(|job| job.id),
+        )
+    }
+
     fn is_runner_connected(&self, runner_id: &str) -> bool {
         // Preserve the original lifecycle semantics: only an affirmative
         // `connected == false` should be treated as disconnected. A status

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1103,7 +1103,7 @@ pub(crate) struct AcceptedRunnerJob {
     pub(crate) daemon_generation: Option<String>,
 }
 
-fn accepted_runner_job_id(runner_id: &str, run_id: &str) -> Option<AcceptedRunnerJob> {
+pub(crate) fn accepted_runner_job_id(runner_id: &str, run_id: &str) -> Option<AcceptedRunnerJob> {
     accepted_runner_job_id_with(runner_id, run_id, || crate::status(runner_id))
 }
 

--- a/crates/homeboy-lab-runner/src/lab/offload/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/mod.rs
@@ -36,6 +36,7 @@ mod tests;
 // Public API surface.
 pub use execute::execute_lab_offload;
 pub use hydration::hydrate_runner_workspace_dependencies;
+pub(crate) use inner::accepted_runner_job_id;
 pub use types::{
     LabJobOverrides, LabOffloadCommand, LabOffloadOutcome, LabOffloadRequest,
     LabOffloadSourcePathMode, LabOffloadWorkspaceModePolicy,


### PR DESCRIPTION
## Summary
- persist runner continuation data before remote acceptance completes
- recover a reserved lab admission after the initiating client exits
- keep accepted handoff reconciliation idempotent and runner-owned

## Verification
- 53 handoff/proxy tests passed
- handoff reconnect integration test passed
- three previously noisy package tests passed in isolation
- one unrelated poisoned-dispatcher assertion reproduces on the exact upstream commit
- `cargo fmt --all --check`
- `git diff --check`

Closes #13804

## AI Assistance
OpenAI GPT-5.6 Terra via OpenCode was used to investigate, implement, and run verification. Chris Huber reviewed and orchestrated the work.