### PR TITLE
Queue concurrent controller upgrades

### DIFF
--- a/crates/homeboy-upgrade/src/upgrade/execution.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution.rs
@@ -139,6 +139,7 @@ pub(crate) fn execute_upgrade(
     previous_build_identity: Option<&str>,
     selected_release: Option<&SelectedRelease>,
     promotion_lease: Option<&homeboy_core::runtime_promotion::RuntimePromotionLease>,
+    mut progress: impl FnMut(&str),
 ) -> UpgradeExecutionResult {
     let selected_binary_version = selected_release.map(|release| release.version.as_str());
     let defaults = defaults::load_defaults();
@@ -150,12 +151,14 @@ pub(crate) fn execute_upgrade(
         .transpose()?;
     let output = match method {
         InstallMethod::Homebrew => {
+            progress("installing controller release");
             let cmd = &defaults.install_methods.homebrew.upgrade_command;
             Command::new("sh").args(["-c", cmd]).output().map_err(|e| {
                 Error::internal_io(e.to_string(), Some("run homebrew upgrade".to_string()))
             })?
         }
         InstallMethod::Secondary => {
+            progress("installing controller release");
             // Legacy cargo-installed binaries are replaced with the release
             // asset now that Homeboy's private workspace is not on crates.io.
             let cmd = &defaults.install_methods.binary.upgrade_command;
@@ -195,6 +198,7 @@ pub(crate) fn execute_upgrade(
                 &workspace_root,
                 explicit_source_path,
             )?;
+            progress("building controller candidate");
             run_source_upgrade_command(
                 &cmd,
                 &workspace_root,
@@ -205,6 +209,7 @@ pub(crate) fn execute_upgrade(
             // Source command output is streamed to the invoking process so
             // controller timeouts can distinguish a build from a stalled run.
             // It has already returned a precise error for non-zero exits.
+            progress("running controller candidate admission");
             return complete_source_upgrade(
                 workspace_root,
                 built_binary,
@@ -214,9 +219,11 @@ pub(crate) fn execute_upgrade(
                 previous_build_identity,
                 source_revision,
                 promotion_lease,
+                &mut progress,
             );
         }
         InstallMethod::Binary => {
+            progress("installing controller release");
             let cmd = &defaults.install_methods.binary.upgrade_command;
             // Pin the installer to the release this upgrade selected. Without
             // the pin the installer always resolves `latest/download`, so a
@@ -490,6 +497,7 @@ fn complete_source_upgrade(
     previous_build_identity: Option<&str>,
     source_revision: Option<String>,
     promotion_lease: Option<&homeboy_core::runtime_promotion::RuntimePromotionLease>,
+    progress: &mut impl FnMut(&str),
 ) -> UpgradeExecutionResult {
     let replacement_target = replacement_target.ok_or_else(|| {
         Error::internal_unexpected("active binary path unavailable for source upgrade install")
@@ -528,8 +536,10 @@ fn complete_source_upgrade(
         Some(replacement_target),
     )?;
     promotion_lease.assert_generation()?;
+    progress("installing source-built controller candidate");
     upgrade_phase("installing source-built binary");
     install_source_built_binary(&built_binary, replacement_target)?;
+    progress("verifying installed controller candidate");
     upgrade_phase("verifying installed source binary");
 
     let (_verified_version, active_binary) = verify_upgrade_with_retry(

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -133,6 +133,14 @@ mod controller_upgrade_wait_tests {
                 event.owner_status_command.as_deref(),
                 Some(format!("homeboy upgrade status {owner_id}").as_str())
             );
+            let owner_status = super::super::load_upgrade_operation_status(Some(&owner_id))
+                .expect("owner status remains inspectable while it holds the lease");
+            assert_eq!(owner_status.operation_id, owner_id);
+            assert_eq!(owner_status.phase, "admitted for controller promotion");
+            assert_eq!(
+                owner_status.inspect_command.as_deref(),
+                Some(format!("homeboy upgrade status {owner_id}").as_str())
+            );
 
             drop(owner_lease);
             waiter
@@ -658,7 +666,7 @@ pub fn run_upgrade_with_method(
             extension_revalidation,
         ));
     }
-    operation.set_phase("mutating controller");
+    operation.set_phase("revalidating controller upgrade admission");
     let controller_upgrade = run_controller_mutation_after_runner_preflight(
         runner_preflight,
         || {
@@ -686,6 +694,7 @@ pub fn run_upgrade_with_method(
                 previous_build_identity.as_deref(),
                 selected_release.as_ref(),
                 Some(&controller_mutation_lease),
+                |phase| operation.set_phase(phase),
             )
         },
     )?;
@@ -706,6 +715,7 @@ pub fn run_upgrade_with_method(
         // This is deliberately a short switch, not a drain: records admitted
         // before it retain their immutable runtime pin and remain executable.
         let installed_executable = super::execution::active_binary_path()?;
+        operation.set_phase("rotating controller runtime generation");
         homeboy_core::controller_runtime::activate_installed_generation(&installed_executable)?;
         if success {
             operation.mark_controller_promoted("controller installation completed");

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -5,6 +5,7 @@ use homeboy_core::extension::lifecycle;
 use homeboy_core::extension::lifecycle::is_git_url;
 use homeboy_core::{build_identity, git};
 use semver::Version;
+use serde::Serialize;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
@@ -24,12 +25,148 @@ use super::types::*;
 use super::update_check::RuntimeCompatibility;
 use super::validation::check_for_updates;
 
+const CONTROLLER_UPGRADE_WAIT_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+
+#[derive(Debug, Serialize)]
+struct ControllerUpgradeWaitEvent {
+    #[serde(flatten)]
+    admission: homeboy_core::runtime_promotion::RuntimePromotionWaitEvent,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    owner_operation_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    owner_status_command: Option<String>,
+}
+
 pub fn current_version() -> &'static str {
     VERSION
 }
 
 pub fn current_build_version() -> String {
     build_identity::current().display
+}
+
+fn acquire_controller_upgrade_lease(
+    operation: &mut UpgradeOperation,
+    timeout: Duration,
+    mut progress: impl FnMut(ControllerUpgradeWaitEvent),
+) -> Result<homeboy_core::runtime_promotion::RuntimePromotionLease> {
+    let lease_operation = operation
+        .id()
+        .map(|id| format!("controller upgrade operation={id}"))
+        .unwrap_or_else(|| "controller upgrade".to_string());
+    operation.set_phase("waiting for controller promotion admission");
+    let lease = homeboy_core::runtime_promotion::acquire_waiting_for_compatible(
+        &lease_operation,
+        "active controller",
+        timeout,
+        |admission| {
+            let event = controller_upgrade_wait_event(admission);
+            operation.set_phase(&format!(
+                "queued behind controller promotion owner pid={} operation={}",
+                event.admission.owner_pid, event.admission.owner_operation
+            ));
+            progress(event);
+        },
+    )?;
+    operation.set_phase("admitted for controller promotion");
+    Ok(lease)
+}
+
+fn controller_upgrade_wait_event(
+    admission: homeboy_core::runtime_promotion::RuntimePromotionWaitEvent,
+) -> ControllerUpgradeWaitEvent {
+    let owner_operation_id = admission
+        .owner_operation
+        .strip_prefix("controller upgrade operation=")
+        .filter(|id| !id.is_empty())
+        .map(str::to_string);
+    let owner_status_command = owner_operation_id
+        .as_ref()
+        .map(|id| format!("homeboy upgrade status {id}"));
+    ControllerUpgradeWaitEvent {
+        admission,
+        owner_operation_id,
+        owner_status_command,
+    }
+}
+
+fn emit_controller_upgrade_wait(event: ControllerUpgradeWaitEvent) {
+    eprintln!(
+        "{}",
+        serde_json::to_string(&event).unwrap_or_else(|_| {
+            "{\"schema\":\"homeboy/runtime-promotion-admission/v1\",\"state\":\"queued\",\"resource_class\":\"runtime_promotion\"}".to_string()
+        })
+    );
+}
+
+#[cfg(test)]
+mod controller_upgrade_wait_tests {
+    use super::*;
+    use homeboy_core::ErrorCode;
+    use std::sync::mpsc;
+
+    #[test]
+    fn parallel_controller_upgrades_wait_and_report_the_owner_status_command() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut owner = UpgradeOperation::start("homeboy upgrade");
+            let owner_id = owner.id().expect("owner operation is durable").to_string();
+            let owner_lease =
+                acquire_controller_upgrade_lease(&mut owner, Duration::from_secs(1), |_| {
+                    unreachable!("uncontended owner does not queue")
+                })
+                .expect("owner acquires controller promotion");
+            let (queued_tx, queued_rx) = mpsc::channel();
+
+            let waiter = std::thread::spawn(move || {
+                let mut contender = UpgradeOperation::start("homeboy upgrade");
+                acquire_controller_upgrade_lease(&mut contender, Duration::from_secs(1), |event| {
+                    queued_tx.send(event).expect("report queued owner")
+                })
+                .map(drop)
+            });
+
+            let event = queued_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("contender queues behind the owner");
+            assert_eq!(event.owner_operation_id.as_deref(), Some(owner_id.as_str()));
+            assert_eq!(
+                event.owner_status_command.as_deref(),
+                Some(format!("homeboy upgrade status {owner_id}").as_str())
+            );
+
+            drop(owner_lease);
+            waiter
+                .join()
+                .expect("waiter thread exits")
+                .expect("contender acquires after owner completes");
+        });
+    }
+
+    #[test]
+    fn timed_out_controller_upgrade_waiter_does_not_disturb_the_owner() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut owner = UpgradeOperation::start("homeboy upgrade");
+            let owner_lease =
+                acquire_controller_upgrade_lease(&mut owner, Duration::from_secs(1), |_| {
+                    unreachable!("uncontended owner does not queue")
+                })
+                .expect("owner acquires controller promotion");
+            let waiter = std::thread::spawn(move || {
+                let mut contender = UpgradeOperation::start("homeboy upgrade");
+                acquire_controller_upgrade_lease(&mut contender, Duration::from_millis(10), |_| {})
+                    .map(drop)
+                    .map_err(|error| error.code)
+            });
+
+            assert_eq!(
+                waiter.join().expect("waiter thread exits"),
+                Err(ErrorCode::RuntimePromotionWaitTimeout)
+            );
+            owner_lease
+                .assert_generation()
+                .expect("timed-out contender leaves the owner lease intact");
+        });
+    }
 }
 
 fn fetch_latest_github_version_at(url: &str) -> Result<String> {
@@ -401,9 +538,10 @@ pub fn run_upgrade_with_method(
                 operation.set_phase("refreshing installed extensions");
                 update_all_extensions(operation.id())
             };
-            let promotion_lease = homeboy_core::runtime_promotion::acquire(
-                "controller upgrade completion",
-                "active controller",
+            let promotion_lease = acquire_controller_upgrade_lease(
+                &mut operation,
+                CONTROLLER_UPGRADE_WAIT_TIMEOUT,
+                emit_controller_upgrade_wait,
             )?;
             let (runners_updated, runners_skipped) = if skip_runners {
                 (vec![], vec![])
@@ -498,11 +636,15 @@ pub fn run_upgrade_with_method(
         }
     }
 
+    let mut operation = UpgradeOperation::start("homeboy upgrade");
     // Keep the same promotion authority from compatibility revalidation through
     // the controller swap. Source builds retain their isolated build target, but
     // their final install shares this lease rather than opening a TOCTOU window.
-    let controller_mutation_lease =
-        homeboy_core::runtime_promotion::acquire("controller upgrade", "active controller")?;
+    let controller_mutation_lease = acquire_controller_upgrade_lease(
+        &mut operation,
+        CONTROLLER_UPGRADE_WAIT_TIMEOUT,
+        emit_controller_upgrade_wait,
+    )?;
     controller_mutation_lease.assert_generation()?;
     let extension_revalidation = (!skip_extensions)
         .then(|| preflight_extensions_for_upgrade(&candidate_version))
@@ -516,7 +658,6 @@ pub fn run_upgrade_with_method(
             extension_revalidation,
         ));
     }
-    let mut operation = UpgradeOperation::start("homeboy upgrade");
     operation.set_phase("mutating controller");
     let controller_upgrade = run_controller_mutation_after_runner_preflight(
         runner_preflight,


### PR DESCRIPTION
## Summary
- wait boundedly when another compatible controller promotion owns the mutation lease
- expose the owner operation and status command while waiting
- persist build, admission, promotion, and daemon-rotation progress

## Verification
- `cargo test -p homeboy-upgrade` (231 passed)
- concurrent owner and timeout regressions passed
- `cargo fmt --all --check`
- `git diff --check`

Closes #13969

## AI Assistance
OpenAI GPT-5.6 Terra via OpenCode was used to investigate, implement, and run verification. Chris Huber reviewed and orchestrated the work.