### PR TITLE
Defer stale descendant releases

### DIFF
--- a/crates/homeboy-release/src/release/planner.rs
+++ b/crates/homeboy-release/src/release/planner.rs
@@ -9,8 +9,8 @@ use super::plan_steps::{build_preflight_steps, build_release_steps_with_reconcil
 use super::planning_changelog::{build_changelog_plan, generate_changelog_entries};
 use super::planning_policy::release_skip_plan;
 use super::planning_semver::{
-    build_semver_recommendation, current_version_tag_at_head, current_version_tag_name,
-    release_version_baseline, validate_current_version_tag_reachable,
+    authoritative_descendant_release_tag, build_semver_recommendation, current_version_tag_at_head,
+    current_version_tag_name, release_version_baseline, validate_current_version_tag_reachable,
     validate_release_version_floor,
 };
 use super::planning_worktree::validate_release_worktree;
@@ -44,6 +44,17 @@ pub(crate) fn plan(component_id: &str, options: &ReleaseOptions) -> Result<Relea
 
     let release_scope = ReleaseScope::resolve(&component, component_id)?;
     let version_info = v.capture(version::read_component_version(&component), "version");
+    if !options.pipeline.head {
+        if let Some(info) = version_info.as_ref() {
+            if let Some(tag) = authoritative_descendant_release_tag(&release_scope, &info.version)?
+            {
+                return Ok(super::planning_policy::superseded_release_plan(
+                    component_id,
+                    &tag,
+                ));
+            }
+        }
+    }
     if let Some(ref info) = version_info {
         if let Some(message) = v
             .capture(

--- a/crates/homeboy-release/src/release/planner.rs
+++ b/crates/homeboy-release/src/release/planner.rs
@@ -738,6 +738,68 @@ mod tests {
     }
 
     #[test]
+    fn stale_descendant_release_plans_a_neutral_superseded_skip() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let remote = temp.path().join("remote.git");
+        let seed = temp.path().join("seed");
+        let stale = temp.path().join("stale");
+        let owner = temp.path().join("owner");
+        let remote_path = remote.to_string_lossy().to_string();
+
+        git(
+            temp.path(),
+            &["init", "--bare", "--initial-branch", "main", &remote_path],
+        );
+        git(temp.path(), &["clone", &remote_path, "seed"]);
+        git(&seed, &["config", "user.email", "homeboy@example.test"]);
+        git(&seed, &["config", "user.name", "Homeboy Test"]);
+        std::fs::write(
+            seed.join("homeboy.json"),
+            r#"{"id":"fixture","type":"fixture","version_targets":[{"file":"VERSION","pattern":"([0-9]+\\.[0-9]+\\.[0-9]+)"}]}"#,
+        )
+        .expect("config");
+        std::fs::write(seed.join("VERSION"), "0.1.0\n").expect("version");
+        git(&seed, &["add", "."]);
+        git(&seed, &["commit", "-qm", "release: v0.1.0"]);
+        git(&seed, &["tag", "v0.1.0"]);
+        git(&seed, &["push", "--tags", "origin", "main"]);
+        git(temp.path(), &["clone", &remote_path, "stale"]);
+        git(temp.path(), &["clone", &remote_path, "owner"]);
+        git(&owner, &["config", "user.email", "homeboy@example.test"]);
+        git(&owner, &["config", "user.name", "Homeboy Test"]);
+        std::fs::write(owner.join("VERSION"), "0.1.1\n").expect("release version");
+        git(&owner, &["add", "VERSION"]);
+        git(&owner, &["commit", "-qm", "release: v0.1.1"]);
+        git(&owner, &["tag", "v0.1.1"]);
+        git(&owner, &["push", "--tags", "origin", "main"]);
+
+        let plan = plan(
+            "fixture",
+            &ReleaseOptions {
+                path_override: Some(stale.to_string_lossy().to_string()),
+                bump_type: "patch".to_string(),
+                ..Default::default()
+            },
+        )
+        .expect("stale release must defer without error");
+
+        assert!(!plan.enabled());
+        assert_eq!(
+            plan.plan.steps[0]
+                .inputs
+                .get("reason")
+                .and_then(|value| value.as_str()),
+            Some("release-superseded")
+        );
+        assert_eq!(
+            std::fs::read_to_string(stale.join("VERSION"))
+                .expect("unmutated stale version")
+                .trim(),
+            "0.1.0"
+        );
+    }
+
+    #[test]
     fn guard_fails_closed_when_checkout_is_behind_upstream() {
         let dir = tempfile::TempDir::new().expect("temp dir");
         let local = stale_checkout_fixture(dir.path(), 2);

--- a/crates/homeboy-release/src/release/planning_policy.rs
+++ b/crates/homeboy-release/src/release/planning_policy.rs
@@ -63,6 +63,20 @@ pub(super) fn release_skip_plan(
     None
 }
 
+/// A later workflow already published the release that descends from this
+/// workflow's source commit. This run must defer rather than mutate stale state.
+pub(super) fn superseded_release_plan(component_id: &str, tag: &str) -> ReleasePlan {
+    skipped_release_plan(
+        component_id,
+        "release-superseded",
+        &format!("Release {tag} already published by the authoritative release workflow"),
+        &format!(
+            "Release {tag} descends from this workflow's source commit and is authoritative on the remote release branch. This stale workflow deferred without creating a release commit, tag, or GitHub Release."
+        ),
+        None,
+    )
+}
+
 /// Build the exact `homeboy release` command the operator should run to force a
 /// release, echoing the flags already passed on the current invocation. This is
 /// what the issue asks for: when `--skip-checks` was used and the only blocker
@@ -127,7 +141,7 @@ fn skipped_release_plan(
 
 #[cfg(test)]
 mod tests {
-    use super::release_skip_plan;
+    use super::{release_skip_plan, superseded_release_plan};
     use crate::release::types::{
         ReleaseBumpPolicyOptions, ReleaseOptions, ReleaseSemverRecommendation,
     };
@@ -320,6 +334,22 @@ mod tests {
             hint.contains("homeboy release sample-plugin-code --head"),
             "hint should provide an actionable command: {hint}"
         );
+    }
+
+    #[test]
+    fn superseded_release_plan_is_a_neutral_stale_checkout_diagnostic() {
+        let plan = superseded_release_plan("demo", "v1.2.3");
+
+        assert!(!plan.enabled());
+        assert_eq!(
+            plan.plan.steps[0]
+                .inputs
+                .get("reason")
+                .and_then(|value| value.as_str()),
+            Some("release-superseded")
+        );
+        assert!(plan.plan.hints[0].contains("authoritative"));
+        assert!(plan.plan.hints[0].contains("stale workflow deferred"));
     }
 
     fn semver_recommendation(recommended: &str, requested: &str) -> ReleaseSemverRecommendation {

--- a/crates/homeboy-release/src/release/planning_semver.rs
+++ b/crates/homeboy-release/src/release/planning_semver.rs
@@ -816,7 +816,6 @@ mod tests {
         run_git(&owner, &["config", "user.name", "Homeboy Test"]);
         commit_file(&owner, "VERSION", "0.1.1", "release: v0.1.1");
         run_git(&owner, &["tag", "v0.1.1"]);
-        run_git(&owner, &["push", "--tags", "origin", "main"]);
 
         let component = Component {
             local_path: stale.to_string_lossy().to_string(),
@@ -824,10 +823,48 @@ mod tests {
         };
         let scope = ReleaseScope::resolve(&component, "fixture").expect("release scope");
 
+        // A pushed tag alone cannot supersede the stale workflow: the release
+        // commit must also be authoritative on the configured release branch.
+        run_git(&owner, &["push", "--tags", "origin"]);
+        assert_eq!(
+            authoritative_descendant_release_tag(&scope, "0.1.0")
+                .expect("inspect tag-only release"),
+            None
+        );
+
+        run_git(&owner, &["push", "origin", "main"]);
         assert_eq!(
             authoritative_descendant_release_tag(&scope, "0.1.0").expect("inspect remote release"),
             Some("v0.1.1".to_string())
         );
+
+        // A later descendant tag must still identify an actual release commit.
+        commit_file(
+            &owner,
+            "VERSION",
+            "0.1.2",
+            "chore: invalid release identity",
+        );
+        run_git(&owner, &["tag", "v0.1.2"]);
+        run_git(&owner, &["push", "--tags", "origin", "main"]);
+        assert_eq!(
+            authoritative_descendant_release_tag(&scope, "0.1.0")
+                .expect("inspect malformed release"),
+            None
+        );
+
+        // A higher tag on unrelated history must remain fail-closed too.
+        run_git(&owner, &["checkout", "--orphan", "unrelated-release"]);
+        run_git(&owner, &["rm", "-qrf", "."]);
+        commit_file(&owner, "VERSION", "0.1.3", "release: v0.1.3");
+        run_git(&owner, &["tag", "v0.1.3"]);
+        run_git(&owner, &["push", "--tags", "origin"]);
+        assert_eq!(
+            authoritative_descendant_release_tag(&scope, "0.1.0")
+                .expect("inspect unrelated release"),
+            None
+        );
+
         assert_eq!(
             git::get_head_commit(&scope.git_root).expect("stale HEAD"),
             git::get_tag_commit(&seed.to_string_lossy(), "v0.1.0").expect("source release")

--- a/crates/homeboy-release/src/release/planning_semver.rs
+++ b/crates/homeboy-release/src/release/planning_semver.rs
@@ -235,6 +235,68 @@ pub(super) fn release_version_baseline(
     })
 }
 
+/// Identify a release completed by another workflow after this checkout started.
+///
+/// A newer tag is authoritative only when its release commit descends from this
+/// checkout's HEAD and is itself contained in the configured remote release
+/// branch. All other unreachable tags remain fail-closed as orphaned identities.
+pub(super) fn authoritative_descendant_release_tag(
+    scope: &ReleaseScope,
+    current_version: &str,
+) -> Result<Option<String>> {
+    let current_version = match semver::Version::parse(current_version) {
+        Ok(version) => version,
+        Err(_) => return Ok(None),
+    };
+
+    // Refresh remote branch and tag refs without moving the stale checkout. A
+    // remote that cannot be refreshed cannot authorize this exception, so leave
+    // it to the normal fail-closed unreachable-tag path.
+    if git::fetch_origin(&scope.git_root).is_err() {
+        return Ok(None);
+    }
+
+    let Some(tag) = scope.latest_tag_any()? else {
+        return Ok(None);
+    };
+    let Some(tag_version) = git::extract_version_from_tag(&tag)
+        .and_then(|version| semver::Version::parse(&version).ok())
+    else {
+        return Ok(None);
+    };
+    if tag_version <= current_version || scope.latest_tag()?.as_deref() == Some(tag.as_str()) {
+        return Ok(None);
+    }
+
+    let tag_commit = git::get_tag_commit(&scope.git_root, &tag)?;
+    let head_commit = git::get_head_commit(&scope.git_root)?;
+    if !git::is_ancestor(&scope.git_root, &head_commit, &tag_commit)? {
+        return Ok(None);
+    }
+
+    let subject =
+        git::execute_git_for_release(&scope.git_root, &["log", "-1", "--format=%s", &tag_commit])?;
+    if !subject.status.success()
+        || !matches!(
+            String::from_utf8_lossy(&subject.stdout).trim(),
+            value if value == format!("release: {tag}") || value == format!("release:{tag}")
+        )
+    {
+        return Ok(None);
+    }
+
+    let branch = git::default_branch_name(std::path::Path::new(&scope.git_root))
+        .unwrap_or_else(|| "main".to_string());
+    let Some(remote_head) = git::remote_branch_commit(&scope.git_root, &branch)? else {
+        return Ok(None);
+    };
+    if git::is_ancestor(&scope.git_root, &tag_commit, &remote_head)? {
+        Ok(Some(tag))
+    } else {
+        Ok(None)
+    }
+}
+
 pub(super) fn release_version_floor_base(
     scope: &ReleaseScope,
     current_version: &str,
@@ -382,12 +444,13 @@ fn commit_range(latest_tag: Option<&str>) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_semver_recommendation, low_confidence_bump_warning, release_version_baseline,
-        resolve_tag_and_commits, validate_current_version_tag_reachable,
-        validate_release_version_floor,
+        authoritative_descendant_release_tag, build_semver_recommendation,
+        low_confidence_bump_warning, release_version_baseline, resolve_tag_and_commits,
+        validate_current_version_tag_reachable, validate_release_version_floor,
     };
     use crate::release::scope::ReleaseScope;
     use homeboy_core::component::{CommandScopeConfig, Component, ScopeConfig, VersionTarget};
+    use homeboy_core::git;
     use homeboy_core::git::SemverBump;
 
     fn run_git(dir: &std::path::Path, args: &[&str]) {
@@ -724,6 +787,51 @@ mod tests {
 
         assert!(error.message.contains("v0.2.0"));
         assert!(error.message.contains("not reachable from HEAD"));
+    }
+
+    #[test]
+    fn authoritative_descendant_release_tag_defers_stale_checkout_to_remote_release_owner() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let remote = temp.path().join("remote.git");
+        let seed = temp.path().join("seed");
+        let stale = temp.path().join("stale");
+        let owner = temp.path().join("owner");
+        let remote_path = remote.to_string_lossy().to_string();
+
+        run_git(
+            temp.path(),
+            &["init", "--bare", "--initial-branch", "main", &remote_path],
+        );
+        run_git(temp.path(), &["clone", &remote_path, "seed"]);
+        for checkout in [&seed] {
+            run_git(checkout, &["config", "user.email", "homeboy@example.test"]);
+            run_git(checkout, &["config", "user.name", "Homeboy Test"]);
+        }
+        commit_file(&seed, "VERSION", "0.1.0", "release: v0.1.0");
+        run_git(&seed, &["tag", "v0.1.0"]);
+        run_git(&seed, &["push", "--tags", "origin", "main"]);
+        run_git(temp.path(), &["clone", &remote_path, "stale"]);
+        run_git(temp.path(), &["clone", &remote_path, "owner"]);
+        run_git(&owner, &["config", "user.email", "homeboy@example.test"]);
+        run_git(&owner, &["config", "user.name", "Homeboy Test"]);
+        commit_file(&owner, "VERSION", "0.1.1", "release: v0.1.1");
+        run_git(&owner, &["tag", "v0.1.1"]);
+        run_git(&owner, &["push", "--tags", "origin", "main"]);
+
+        let component = Component {
+            local_path: stale.to_string_lossy().to_string(),
+            ..Default::default()
+        };
+        let scope = ReleaseScope::resolve(&component, "fixture").expect("release scope");
+
+        assert_eq!(
+            authoritative_descendant_release_tag(&scope, "0.1.0").expect("inspect remote release"),
+            Some("v0.1.1".to_string())
+        );
+        assert_eq!(
+            git::get_head_commit(&scope.git_root).expect("stale HEAD"),
+            git::get_tag_commit(&seed.to_string_lossy(), "v0.1.0").expect("source release")
+        );
     }
 
     #[test]

--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -991,7 +991,12 @@ fn release_command_exit_code(
     deploy_exit_code: i32,
     post_release_exit: i32,
 ) -> i32 {
-    if skipped_reason.is_some() {
+    // A stale workflow that proves a descendant release is already authoritative
+    // has completed its coordination responsibility successfully. Other skips
+    // remain distinct non-zero no-ops for callers that requested a release.
+    if skipped_reason == Some("release-superseded") {
+        0
+    } else if skipped_reason.is_some() {
         SKIPPED_RELEASE_EXIT_CODE
     } else if release_step_exit != 0 {
         release_step_exit
@@ -1762,6 +1767,14 @@ mod tests {
         assert_eq!(
             release_command_exit_code(Some("release-already-at-head"), 0, 0, 3),
             SKIPPED_RELEASE_EXIT_CODE
+        );
+    }
+
+    #[test]
+    fn superseded_release_is_a_successful_noop() {
+        assert_eq!(
+            release_command_exit_code(Some("release-superseded"), 1, 1, 3),
+            0
         );
     }
 


### PR DESCRIPTION
## Summary
- recognize a reachable authoritative descendant release tag
- classify the stale checkout as a neutral superseded release instead of a release failure
- preserve fail-closed behavior for unrelated and unreachable tags

## Verification
- `cargo test -p homeboy-release` (560 passed)
- `cargo fmt --all --check`
- `git diff --check`

Closes #13491

## AI Assistance
OpenAI GPT-5.6 Terra via OpenCode was used to investigate, implement, and run verification. Chris Huber reviewed and orchestrated the work.