### PR TITLE
Verify runner reconciliation projection

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -275,6 +275,23 @@ pub fn discover_runs_with_options(
     discovery_report(filter, options, records, record_health)
 }
 
+/// [`discover_runs_with_options`] against an explicitly injected lifecycle
+/// store. Reconciliation uses this to verify the same durable projection it
+/// just changed rather than consulting ambient storage.
+pub(crate) fn discover_runs_in_store(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    filter: AgentTaskDiscoveryFilter,
+) -> Result<AgentTaskDiscoveryReport> {
+    let (records, record_health) =
+        agent_task_lifecycle::read_records_with_health_in_store(lifecycle_store)?;
+    discovery_report(
+        filter,
+        AgentTaskDiscoveryOptions::default(),
+        records,
+        record_health,
+    )
+}
+
 /// Find the newest run matching list filters without treating a bounded display
 /// snapshot as the complete search corpus.
 pub fn discover_filtered_latest_run(

--- a/crates/homeboy-agents/src/agent_task_service/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_service/discovery.rs
@@ -249,20 +249,6 @@ pub fn discover_runs(filter: AgentTaskDiscoveryFilter) -> Result<AgentTaskDiscov
     discover_runs_with_options(filter, AgentTaskDiscoveryOptions::default())
 }
 
-pub(crate) fn discover_runs_in_store(
-    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
-    filter: AgentTaskDiscoveryFilter,
-) -> Result<AgentTaskDiscoveryReport> {
-    let (records, record_health) =
-        agent_task_lifecycle::read_records_with_health_in_store(lifecycle_store)?;
-    discovery_report(
-        filter,
-        AgentTaskDiscoveryOptions::default(),
-        records,
-        record_health,
-    )
-}
-
 /// Discovery with operator options (currently `--limit`). The `latest` filter
 /// is inherently a single run, so a limit is a no-op there; `all`/`active`
 /// truncate to the requested cap after filtering and sorting, and report the

--- a/crates/homeboy-agents/src/agent_task_service/reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_service/reconcile.rs
@@ -7,7 +7,7 @@
 //! [`register_orchestration_driver`].
 
 use crate::agent_task_lifecycle;
-use homeboy_core::Result;
+use homeboy_core::{Error, Result};
 use std::collections::HashMap;
 
 use super::discovery::{
@@ -89,6 +89,38 @@ fn rooted_exact_status(
         true,
     )?
     .record)
+}
+
+/// Read back the durable record and its active discovery projection after an
+/// apply. A successful reconcile must mean the selected record is no longer a
+/// blocking projection, not merely that its cancellation write returned.
+fn verified_reconciled_status(
+    lifecycle_store: &agent_task_lifecycle::AgentTaskLifecycleStore,
+    run_id: &str,
+) -> Result<agent_task_lifecycle::AgentTaskRunRecord> {
+    let record = rooted_exact_status(lifecycle_store, run_id)?;
+    let remains_active = discover_runs_in_store(lifecycle_store, AgentTaskDiscoveryFilter::Active)?
+        .runs
+        .into_iter()
+        .any(|run| run.run_id == run_id);
+    verify_reconciled_postcondition(&record, remains_active)?;
+    Ok(record)
+}
+
+pub(super) fn verify_reconciled_postcondition(
+    record: &agent_task_lifecycle::AgentTaskRunRecord,
+    remains_active: bool,
+) -> Result<()> {
+    if record.state.is_terminal() && !remains_active {
+        return Ok(());
+    }
+
+    Err(Error::internal_unexpected(format!(
+        "agent-task reconciliation did not satisfy its postcondition for `{}`: durable state is {}, unresolved projection remains {}",
+        record.run_id,
+        run_state_label(record.state),
+        if remains_active { "in active discovery" } else { "non-terminal" },
+    )))
 }
 
 fn fenced_record_is_live(record: &agent_task_lifecycle::AgentTaskRunRecord) -> bool {
@@ -418,16 +450,30 @@ pub(crate) fn reconcile_run_in_store(
                             resolved_run_id,
                         ) {
                             Ok(true) => {
+                                let verified =
+                                    verified_reconciled_status(&lifecycle_store, resolved_run_id);
+                                let verified = match verified {
+                                    Ok(record) => record,
+                                    Err(error) => {
+                                        failed += 1;
+                                        runs.push(AgentTaskReconcileRun {
+                                            run_id: resolved_run_id.clone(),
+                                            liveness,
+                                            source: run.source,
+                                            authoritative_state: refreshed.state,
+                                            stale_reason: run.stale_reason,
+                                            action: "failed",
+                                            error: Some(error.message),
+                                        });
+                                        continue;
+                                    }
+                                };
                                 reconciled += 1;
                                 runs.push(AgentTaskReconcileRun {
                                     run_id: resolved_run_id.clone(),
                                     liveness,
                                     source: run.source,
-                                    authoritative_state: rooted_status(
-                                        &lifecycle_store,
-                                        resolved_run_id,
-                                    )?
-                                    .state,
+                                    authoritative_state: verified.state,
                                     stale_reason: run.stale_reason,
                                     action: "reconciled",
                                     error: None,
@@ -471,12 +517,30 @@ pub(crate) fn reconcile_run_in_store(
                         Some(&reason),
                     ) {
                         Ok(record) => {
+                            let verified =
+                                match verified_reconciled_status(&lifecycle_store, resolved_run_id)
+                                {
+                                    Ok(record) => record,
+                                    Err(error) => {
+                                        failed += 1;
+                                        runs.push(AgentTaskReconcileRun {
+                                            run_id: resolved_run_id.clone(),
+                                            liveness,
+                                            source: run.source,
+                                            authoritative_state: record.state,
+                                            stale_reason: run.stale_reason,
+                                            action: "failed",
+                                            error: Some(error.message),
+                                        });
+                                        continue;
+                                    }
+                                };
                             reconciled += 1;
                             runs.push(AgentTaskReconcileRun {
                                 run_id: resolved_run_id.clone(),
                                 liveness,
                                 source: run.source,
-                                authoritative_state: record.state,
+                                authoritative_state: verified.state,
                                 stale_reason: run.stale_reason,
                                 action: "reconciled",
                                 error: None,

--- a/crates/homeboy-agents/src/agent_task_service/reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_service/reconcile.rs
@@ -103,15 +103,20 @@ fn verified_reconciled_status(
         .runs
         .into_iter()
         .any(|run| run.run_id == run_id);
-    verify_reconciled_postcondition(&record, remains_active)?;
+    let runner_projection_resolved = record.runner_id().is_none_or(|runner_id| {
+        agent_task_lifecycle::runner_live_job_authority(runner_id)
+            == agent_task_lifecycle::RunnerLiveJobAuthority::Idle
+    });
+    verify_reconciled_postcondition(&record, remains_active, runner_projection_resolved)?;
     Ok(record)
 }
 
 pub(super) fn verify_reconciled_postcondition(
     record: &agent_task_lifecycle::AgentTaskRunRecord,
     remains_active: bool,
+    runner_projection_resolved: bool,
 ) -> Result<()> {
-    if record.state.is_terminal() && !remains_active {
+    if record.state.is_terminal() && !remains_active && runner_projection_resolved {
         return Ok(());
     }
 
@@ -119,7 +124,13 @@ pub(super) fn verify_reconciled_postcondition(
         "agent-task reconciliation did not satisfy its postcondition for `{}`: durable state is {}, unresolved projection remains {}",
         record.run_id,
         run_state_label(record.state),
-        if remains_active { "in active discovery" } else { "non-terminal" },
+        if remains_active {
+            "in active discovery"
+        } else if !runner_projection_resolved {
+            "on the runner"
+        } else {
+            "non-terminal"
+        },
     )))
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -1990,6 +1990,14 @@ fn upgrade_admission_repairs_ownerless_queued_runner_record_after_zero_live_reco
                 .state,
             AgentTaskRunState::Cancelled
         );
+        assert!(
+            !discover_runs(AgentTaskDiscoveryFilter::Active)
+                .expect("fresh active discovery")
+                .runs
+                .iter()
+                .any(|run| run.run_id == run_id),
+            "a successful runner-owned reconciliation must not survive rediscovery"
+        );
 
         let (records, health) = agent_task_lifecycle::read_records_with_health().expect("records");
         let admitted =
@@ -2032,6 +2040,21 @@ fn record_scoped_reconciliation_stays_with_its_explicit_lifecycle_store() {
             AgentTaskRunState::Cancelled
         );
         assert!(agent_task_lifecycle::exact_record(run_id).is_err());
+    });
+}
+
+#[test]
+fn reconciliation_postcondition_names_an_unresolved_runner_projection() {
+    with_isolated_home(|_| {
+        let run_id = "queued-runner-projection-postcondition";
+        agent_task_lifecycle::submit_plan(&discovery_plan(), Some(run_id)).expect("submitted");
+        let record = agent_task_lifecycle::exact_record(run_id).expect("queued record");
+
+        let error = super::reconcile::verify_reconciled_postcondition(&record, true)
+            .expect_err("an active queued projection cannot report reconciliation success");
+        assert!(error.message.contains(run_id));
+        assert!(error.message.contains("durable state is queued"));
+        assert!(error.message.contains("in active discovery"));
     });
 }
 

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -2048,13 +2048,18 @@ fn reconciliation_postcondition_names_an_unresolved_runner_projection() {
     with_isolated_home(|_| {
         let run_id = "queued-runner-projection-postcondition";
         agent_task_lifecycle::submit_plan(&discovery_plan(), Some(run_id)).expect("submitted");
+        agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+            agent_task_lifecycle::set_run_state(record, AgentTaskRunState::Cancelled);
+            record.tasks[0].state = AgentTaskState::Cancelled;
+        })
+        .expect("terminal controller projection");
         let record = agent_task_lifecycle::exact_record(run_id).expect("queued record");
 
-        let error = super::reconcile::verify_reconciled_postcondition(&record, true)
-            .expect_err("an active queued projection cannot report reconciliation success");
+        let error = super::reconcile::verify_reconciled_postcondition(&record, false, false)
+            .expect_err("an unresolved runner projection cannot report reconciliation success");
         assert!(error.message.contains(run_id));
-        assert!(error.message.contains("durable state is queued"));
-        assert!(error.message.contains("in active discovery"));
+        assert!(error.message.contains("durable state is cancelled"));
+        assert!(error.message.contains("on the runner"));
     });
 }
 


### PR DESCRIPTION
## Summary
- require idle runner evidence before reclaiming ownerless queued records
- verify zero-live reconciliation projects the repaired controller state
- deduplicate rooted discovery through the shared helper

## Verification
- ownerless queued reconciliation regression passed
- live and ambiguous ownership preservation regression passed
- focused discovery, reconciliation, and upgrade-admission tests passed
- `cargo fmt --all --check`
- `git diff --check`

Closes #13869

## AI Assistance
OpenAI GPT-5.6 Terra via OpenCode was used to investigate, implement, and run verification. Chris Huber reviewed and orchestrated the work.