### PR TITLE
Resolve formatting through Extension API v1

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/api/v1.rs
+++ b/crates/contracts/homeboy-extension-contract/src/api/v1.rs
@@ -16,6 +16,7 @@ pub const EXTENSION_API_HANDSHAKE_RESPONSE_SCHEMA: &str =
     "homeboy/extension-api-handshake-response/v1";
 pub const EXTENSION_API_V1: ExtensionApiVersion = ExtensionApiVersion { major: 1 };
 pub const FINGERPRINT_FILE_CAPABILITY_PREFIX: &str = "fingerprint.";
+pub const FORMAT_FILE_CAPABILITY_PREFIX: &str = "format.";
 pub const REFACTOR_FILE_CAPABILITY_PREFIX: &str = "refactor.";
 
 /// A transport-neutral Extension API major version.

--- a/crates/homeboy-core/src/engine/format_write.rs
+++ b/crates/homeboy-core/src/engine/format_write.rs
@@ -8,13 +8,15 @@
 //! Generated code that compiles but isn't formatted is better than no code at
 //! all.
 //!
-//! The format command is resolved via extension manifest `scripts.format`.
+//! Formatter ownership is resolved through Extension API v1. The selected
+//! manifest remains a private execution detail for locating `scripts.format`.
 
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
 use crate::error::{Error, Result};
+use homeboy_extension_contract::api::v1::FORMAT_FILE_CAPABILITY_PREFIX;
 
 /// Result of a post-write format operation.
 #[derive(Debug, Clone, Serialize)]
@@ -118,10 +120,10 @@ pub fn format_after_write(root: &Path, changed_files: &[PathBuf]) -> Result<Form
 
 /// Resolve the format command for a set of changed files.
 ///
-/// Checks installed extensions for `scripts.format`.
+/// Selects installed extensions through their v1 `format.<extension>` capability.
 fn resolve_format_command(root: &Path, changed_files: &[PathBuf]) -> Option<String> {
     // Collect unique file extensions
-    let extensions: Vec<String> = changed_files
+    let mut extensions: Vec<String> = changed_files
         .iter()
         .filter_map(|f| {
             f.extension()
@@ -131,12 +133,21 @@ fn resolve_format_command(root: &Path, changed_files: &[PathBuf]) -> Option<Stri
         .collect::<std::collections::HashSet<_>>()
         .into_iter()
         .collect();
+    extensions.sort();
 
-    // Check installed extensions for a format script
     for ext in &extensions {
-        if let Some(manifest) = find_extension_with_format(ext) {
-            let ext_path = manifest.extension_path.as_deref()?;
-            let script_rel = manifest.format_script()?;
+        let capability_id = format!("{FORMAT_FILE_CAPABILITY_PREFIX}{ext}");
+        let Some(extension_id) =
+            crate::extension::resolve::find_installed_capability_provider(&capability_id)
+        else {
+            continue;
+        };
+        let Ok(manifest) = crate::extension::catalog::load_extension(&extension_id) else {
+            continue;
+        };
+        if let (Some(ext_path), Some(script_rel)) =
+            (manifest.extension_path.as_deref(), manifest.format_script())
+        {
             let script_path = std::path::Path::new(ext_path).join(script_rel);
 
             if script_path.exists() {
@@ -166,19 +177,6 @@ fn scoped_format_arg(root: &Path, path: &Path) -> String {
         .to_string()
 }
 
-/// Find an installed extension that handles a file extension and has scripts.format.
-fn find_extension_with_format(
-    file_ext: &str,
-) -> Option<homeboy_extension_contract::ExtensionManifest> {
-    crate::extension::catalog::load_all_extensions()
-        .ok()
-        .and_then(|manifests| {
-            manifests
-                .into_iter()
-                .find(|m| m.handles_file_extension(file_ext) && m.format_script().is_some())
-        })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -201,6 +199,35 @@ mod tests {
         let result = format_after_write(dir.path(), &files).unwrap();
         assert!(result.success);
         assert!(result.command.is_none());
+    }
+
+    #[test]
+    fn resolves_formatter_from_v1_file_capability() {
+        crate::test_support::with_isolated_home(|_| {
+            let extension_dir = crate::paths::extensions()
+                .expect("extensions path")
+                .join("rust");
+            std::fs::create_dir_all(&extension_dir).expect("extension directory");
+            std::fs::write(extension_dir.join("format.sh"), "#!/bin/sh\n").expect("format script");
+            std::fs::write(
+                extension_dir.join("rust.json"),
+                serde_json::json!({
+                    "name": "Rust",
+                    "version": "1.0.0",
+                    "scripts": { "format": "format.sh" },
+                    "provides": { "file_extensions": ["rs"] }
+                })
+                .to_string(),
+            )
+            .expect("extension manifest");
+
+            let root = TempDir::new().expect("project root");
+            let changed = root.path().join("src/changed file.rs");
+            let command = resolve_format_command(root.path(), &[changed]).expect("format command");
+
+            assert!(command.contains("format.sh"));
+            assert!(command.ends_with("'src/changed file.rs'"));
+        });
     }
 
     #[test]

--- a/crates/homeboy-core/src/extension/catalog/api.rs
+++ b/crates/homeboy-core/src/extension/catalog/api.rs
@@ -20,7 +20,7 @@ use homeboy_extension_contract::api::v1::{
     EXTENSION_API_HANDSHAKE_RESPONSE_SCHEMA, EXTENSION_API_READINESS_REQUEST_SCHEMA,
     EXTENSION_API_READINESS_RESPONSE_SCHEMA, EXTENSION_API_RESOLVE_REQUEST_SCHEMA,
     EXTENSION_API_RESOLVE_RESPONSE_SCHEMA, EXTENSION_API_V1, FINGERPRINT_FILE_CAPABILITY_PREFIX,
-    REFACTOR_FILE_CAPABILITY_PREFIX,
+    FORMAT_FILE_CAPABILITY_PREFIX, REFACTOR_FILE_CAPABILITY_PREFIX,
 };
 use homeboy_extension_contract::{evaluate_core_compatibility, ExtensionCapability};
 
@@ -103,6 +103,18 @@ fn api_descriptor(extension_id: &str) -> Result<ExtensionApiDescriptor> {
                 .map(|file_extension| {
                     capability_descriptor(&format!(
                         "{FINGERPRINT_FILE_CAPABILITY_PREFIX}{file_extension}"
+                    ))
+                }),
+        );
+    }
+    if extension.format_script().is_some() {
+        capabilities.extend(
+            extension
+                .provided_file_extensions()
+                .iter()
+                .map(|file_extension| {
+                    capability_descriptor(&format!(
+                        "{FORMAT_FILE_CAPABILITY_PREFIX}{file_extension}"
                     ))
                 }),
         );
@@ -719,6 +731,7 @@ mod tests {
                         "compiler_warnings": "warnings.sh",
                         "compiler_warning_fixes": "warning-fixes.sh",
                         "fingerprint": "fingerprint.sh",
+                        "format": "format.sh",
                         "refactor": "refactor.sh"
                     },
                     "provides": { "file_extensions": ["rs", "php"] },
@@ -754,6 +767,8 @@ mod tests {
                     "execute",
                     "fingerprint.php",
                     "fingerprint.rs",
+                    "format.php",
+                    "format.rs",
                     "recipe-run-provider.fixture.recipe",
                     "refactor.php",
                     "refactor.rs",
@@ -761,7 +776,7 @@ mod tests {
                 ]
             );
             assert_eq!(
-                descriptor.capabilities[5].contract_version.as_deref(),
+                descriptor.capabilities[7].contract_version.as_deref(),
                 Some("2")
             );
             let warnings = descriptor

--- a/docs/internals/development/contracts/extension-api-v1.md
+++ b/docs/internals/development/contracts/extension-api-v1.md
@@ -92,10 +92,10 @@ diagnostics from one v1 catalog snapshot. Explicit ownership,
 over those stable descriptors; execution-context assembly loads the selected
 manifest only for internal script paths and settings.
 
-File-type providers use open capability IDs: `fingerprint.<extension>` and
-`refactor.<extension>`. Resolution matches those IDs in the same catalog and
-returns only the selected extension ID. Manifest paths and script declarations
-remain private execution details.
+File-type providers use open capability IDs: `fingerprint.<extension>`,
+`format.<extension>`, and `refactor.<extension>`. Resolution matches those IDs
+in the same catalog and returns only the selected extension ID. Manifest paths
+and script declarations remain private execution details.
 
 ## Readiness
 


### PR DESCRIPTION
## Summary

- project `format.<extension>` capabilities into Extension API v1 descriptors
- select formatter providers through the shared v1 capability catalog and load manifests only after ID selection
- delete the parallel manifest-scanning formatter helper and document the completed file-capability family

## Verification

- `cargo test -p homeboy-extension-contract api::v1::tests`
- `cargo test -p homeboy-core engine::format_write::tests`
- `cargo test -p homeboy-core extension::catalog::api::tests::descriptor_normalizes_manifest_capabilities_and_requirements`
- `cargo test -p homeboy-refactor`
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `homeboy review audit homeboy --path . --profile architecture --placement local --changed-since origin/main`
- `git diff --check`

Closes #14038
Parent: #13882

---

AI assistance: OpenAI GPT-5.6 Sol via OpenCode audited the remaining formatter selection path, implemented the v1 capability migration, added behavioral coverage, and ran verification under Chris Huber's direction.