### PR TITLE
fix(agent-task): diagnose invalid provider contracts

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_provider.rs
@@ -87,7 +87,8 @@ pub use dispatchability::{
     preflight_plan_provider_dispatchability_with_providers, preflight_provider_dispatchability,
     preflight_provider_dispatchability_with_config,
     preflight_provider_dispatchability_without_runtime_with_config,
-    AgentTaskProviderCredentialStatus, AgentTaskProviderDispatchability,
+    AgentTaskProviderConfigurationDiagnosis, AgentTaskProviderCredentialStatus,
+    AgentTaskProviderDispatchability, AgentTaskProviderOwner,
 };
 pub(crate) use fixture_gate::fixture_provider_outcome;
 pub use fixture_gate::is_fixture_backend;

--- a/crates/homeboy-agents/src/agent_task_provider/dispatchability.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/dispatchability.rs
@@ -18,6 +18,33 @@ pub struct AgentTaskProviderDispatchability {
     pub ready: bool,
     pub reason: String,
     pub checks: AgentTaskProviderDispatchabilityChecks,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub configuration_diagnosis: Option<AgentTaskProviderConfigurationDiagnosis>,
+}
+
+/// A static provider contract defect that prevents dispatch. This keeps the
+/// provider owner attached to every consumer of the shared verdict.
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentTaskProviderConfigurationDiagnosis {
+    pub kind: &'static str,
+    pub message: String,
+    pub remediation: String,
+    pub owner: AgentTaskProviderOwner,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentTaskProviderOwner {
+    pub provider_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extension_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_package_source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extension_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -151,6 +178,7 @@ pub fn evaluate_provider_dispatchability_with_config(
                     reason: None,
                 },
             },
+            configuration_diagnosis: None,
         }
     };
     let provider = match resolve_provider_for_backend(catalog.providers(), backend, selector) {
@@ -188,10 +216,15 @@ pub fn evaluate_provider_dispatchability_with_config(
         .collect::<Vec<_>>();
     let model_ready = model.is_none_or(|model| supported.is_empty() || supported.contains(&model));
     let credentials = provider_credential_readiness(provider);
+    let configuration_diagnosis = (provider_requires_live_auth_validation(provider)
+        && provider.readiness_invocation.is_none())
+    .then(|| missing_readiness_invocation_diagnosis(provider));
     let configuration = match validate_provider_immediate_failure_patterns(provider) {
         Ok(()) => AgentTaskProviderDispatchabilityCheck {
-            ready: true,
-            reason: None,
+            ready: configuration_diagnosis.is_none(),
+            reason: configuration_diagnosis
+                .as_ref()
+                .map(|diagnosis| diagnosis.message.clone()),
         },
         Err(reason) => AgentTaskProviderDispatchabilityCheck {
             ready: false,
@@ -308,7 +341,11 @@ pub fn evaluate_provider_dispatchability_with_config(
         (
             "configuration_invalid",
             false,
-            "provider immediate-failure configuration is invalid",
+            if configuration_diagnosis.is_some() {
+                "provider-owned authentication has no declared readiness invocation"
+            } else {
+                "provider immediate-failure configuration is invalid"
+            },
         )
     } else if !credentials.dispatchable {
         (
@@ -374,16 +411,38 @@ pub fn evaluate_provider_dispatchability_with_config(
                     && probe_runtime
                     && provider.readiness_invocation.is_none()
                 {
-                    vec![format!(
-                        "Update provider '{}' to declare a bounded readiness_invocation that validates its provider-owned authentication, or select a verified backend.",
-                        provider.id
-                    )]
+                    configuration_diagnosis
+                        .as_ref()
+                        .map(|diagnosis| vec![diagnosis.remediation.clone()])
+                        .unwrap_or_default()
                 } else {
                     runtime_remediation
                 },
             },
             configuration,
             runtime,
+        },
+        configuration_diagnosis,
+    }
+}
+
+fn missing_readiness_invocation_diagnosis(
+    provider: &super::AgentTaskExecutorProvider,
+) -> AgentTaskProviderConfigurationDiagnosis {
+    AgentTaskProviderConfigurationDiagnosis {
+        kind: "missing_readiness_invocation",
+        message: "provider-owned authentication requires a bounded readiness_invocation".to_string(),
+        remediation: format!(
+            "Update provider '{}' to declare a bounded readiness_invocation that validates its provider-owned authentication.",
+            provider.id
+        ),
+        owner: AgentTaskProviderOwner {
+            provider_id: provider.id.clone(),
+            runtime_id: provider.runtime_id.clone(),
+            extension_id: provider.extension_id.clone(),
+            runtime_package_source: provider.runtime_package_source.clone(),
+            runtime_path: provider.runtime_path.clone(),
+            extension_path: provider.extension_path.clone(),
         },
     }
 }
@@ -463,8 +522,10 @@ fn preflight_provider_dispatchability_with_config_and_probe(
     }
     let detail = verdict
         .checks
-        .credentials
+        .configuration
         .reason
+        .as_deref()
+        .or(verdict.checks.credentials.reason.as_deref())
         .as_deref()
         .or(verdict.checks.runtime.reason.as_deref())
         .filter(|reason| *reason != "not requested")
@@ -480,8 +541,9 @@ fn preflight_provider_dispatchability_with_config_and_probe(
     Err(homeboy_core::Error::validation_invalid_argument(
         "provider_dispatchability",
         format!(
-            "agent-task backend `{backend}` is not dispatchable: {}{detail}.{remediation}",
-            verdict.reason.trim_end_matches('.'),
+            "agent-task backend `{backend}` is not dispatchable ({state}): {reason}{detail}.{remediation}",
+            state = verdict.state,
+            reason = verdict.reason.trim_end_matches('.'),
         ),
         Some(backend.to_string()),
         Some(vec![serde_json::to_string(&verdict).unwrap_or_default()]),
@@ -585,7 +647,7 @@ mod tests {
 
         let verdict = evaluate_provider_dispatchability(&catalog, "revocable", None, None, true);
 
-        assert_eq!(verdict.state, "credentials_unverified");
+        assert_eq!(verdict.state, "configuration_invalid");
         assert!(
             !verdict.ready,
             "unverified provider-owned auth must fail closed"
@@ -604,6 +666,12 @@ mod tests {
              verification — reporting it as verified is exactly the #13628 defect"
         );
         assert!(verdict.checks.credentials.remediation[0].contains("readiness_invocation"));
+        let diagnosis = verdict
+            .configuration_diagnosis
+            .expect("missing invocation has a typed diagnosis");
+        assert_eq!(diagnosis.kind, "missing_readiness_invocation");
+        assert_eq!(diagnosis.owner.provider_id, "revocable.agent-task-executor");
+        assert!(!diagnosis.remediation.contains("select a verified backend"));
     }
 
     #[test]
@@ -616,7 +684,7 @@ mod tests {
 
         let verdict = evaluate_provider_dispatchability(&catalog, "revocable", None, None, false);
 
-        assert_eq!(verdict.state, "credentials_present");
+        assert_eq!(verdict.state, "configuration_invalid");
         assert!(!verdict.ready);
         assert_eq!(
             verdict.checks.credentials.status,

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -4704,7 +4704,7 @@ fn compile_cook_with_injected_catalog_rejects_each_unavailable_dimension_before_
                     ..Default::default()
                 },
                 compile_command("unverified", None, None),
-                "no live validation route",
+                "configuration_invalid",
             ),
         ];
 
@@ -4769,6 +4769,53 @@ fn compile_cook_admits_provider_owned_auth_only_after_live_verification() {
         .expect("verified provider-owned auth is admitted before scheduler reservation");
 
         assert_eq!(options.identity.initial_plan.tasks.len(), 1);
+    });
+}
+
+#[test]
+fn cook_preflight_exposes_missing_readiness_invocation_diagnosis_without_provider_switching() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let mut provider = compile_provider("owned-auth.provider", "owned-auth");
+        provider.capabilities = vec!["provider_owned_auth".to_string()];
+        provider.runtime_id = Some("owned-runtime".to_string());
+        provider.extension_id = Some("owned-extension".to_string());
+
+        let error = compile_cook_attempt_with_catalog_and_readiness_cache(
+            compile_options("missing-readiness-cook"),
+            compile_command("owned-auth", None, None),
+            &crate::agent_task_provider::AgentTaskProviderCatalog {
+                providers: vec![provider],
+                ..Default::default()
+            },
+            &mut crate::agent_task_provider::ProviderRuntimeReadinessCache::default(),
+        )
+        .expect_err("a provider-owned auth contract without a probe cannot start Cook");
+
+        assert_eq!(error.details["field"], "provider_dispatchability");
+        assert!(error.message.contains("configuration"), "{error}");
+        assert!(error.message.contains("readiness_invocation"), "{error}");
+        assert!(
+            !error.message.contains("select a verified backend"),
+            "Cook must diagnose the owning provider contract, not suggest switching: {error}"
+        );
+        let verdict = error.details["tried"]
+            .as_array()
+            .and_then(|hints| hints.first())
+            .and_then(|hint| hint.as_str())
+            .and_then(|hint| serde_json::from_str::<serde_json::Value>(hint).ok())
+            .expect("the shared typed dispatchability diagnosis is attached to Cook preflight");
+        assert_eq!(
+            verdict["configuration_diagnosis"]["kind"],
+            "missing_readiness_invocation"
+        );
+        assert_eq!(
+            verdict["configuration_diagnosis"]["owner"]["runtime_id"],
+            "owned-runtime"
+        );
+        assert_eq!(
+            verdict["configuration_diagnosis"]["owner"]["extension_id"],
+            "owned-extension"
+        );
     });
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -2150,7 +2150,7 @@ fn providers_with_catalog(
                 "identity": "agent-task providers",
                 "state": provider_report_state(route.as_ref(), all_providers, Some(&dispatchability)),
                 "risk": if diagnostics.is_empty() { Vec::new() } else { vec![format!("{} discovery diagnostic(s)", diagnostics.len())] },
-                "next_action": route.as_ref().map(ProviderRoute::next_command).unwrap_or(full_command.clone()),
+                "next_action": provider_next_command(route.as_ref(), Some(&dispatchability)).unwrap_or(full_command.clone()),
                 "selection_choices": selection_choices(route.as_ref()),
             },
             "truncation": {
@@ -2168,11 +2168,12 @@ fn providers_with_catalog(
             // not dispatchable reports the credential it is missing here so the
             // remediation survives the `--full` serde presentation too (#11479).
             "credential_readiness": credential_readiness_report(&shown_providers),
-            "dispatchability": serde_json::to_value(dispatchability).unwrap_or(Value::Null),
+            "dispatchability": serde_json::to_value(&dispatchability).unwrap_or(Value::Null),
             "readiness_validation": readiness_validation_projection(
                 validated_provider_identity,
                 validated_provider,
                 route.as_ref(),
+                Some(&dispatchability),
                 args.validate_readiness,
                 declared_backends,
             ),
@@ -2270,6 +2271,9 @@ fn compact_provider(
         "runtime_id": provider.runtime_id.as_deref().map(|value| bounded_text(value, 160)),
         "extension_id": provider.extension_id.as_deref().map(|value| bounded_text(value, 160)),
         "status": provider_status(provider, dispatchability),
+        // Keep the row's state in the same vocabulary as the top-level
+        // dispatchability verdict; `status` remains the filterable availability tier.
+        "state": dispatchability.state,
         "reason": readiness.reason().map(|value| bounded_text(&value, 128))
             .or_else(|| dispatchability.checks.credentials.reason.as_deref().map(|value| bounded_text(value, 128)))
             .or_else(|| (!dispatchability.ready).then(|| bounded_text(&dispatchability.reason, 128))),
@@ -2382,6 +2386,36 @@ impl ProviderRoute {
     }
 }
 
+fn provider_next_command(
+    route: Option<&ProviderRoute>,
+    dispatchability: Option<
+        &homeboy::agents::agent_tasks::provider::AgentTaskProviderDispatchability,
+    >,
+) -> Option<String> {
+    let route = route?;
+    if dispatchability
+        .and_then(|verdict| verdict.configuration_diagnosis.as_ref())
+        .is_some_and(|diagnosis| diagnosis.kind == "missing_readiness_invocation")
+    {
+        if let ProviderRoute::Resolved {
+            backend,
+            provider_id,
+            ..
+        } = route
+        {
+            // Re-running live validation cannot repair a missing contract. Show
+            // the owner-bearing static record instead of suggesting a command
+            // known to fail in the same way.
+            return Some(format!(
+                "homeboy agent-task providers --full --backend {} --selector {}",
+                shell_arg(backend),
+                shell_arg(provider_id)
+            ));
+        }
+    }
+    Some(route.next_command())
+}
+
 fn resolve_provider_route(
     args: &ProvidersArgs,
     catalog: &AgentTaskProviderCatalog,
@@ -2455,11 +2489,19 @@ fn resolve_provider_route_for(
                     ),
                 });
             }
+            let dispatchable = evaluate_provider_dispatchability(
+                catalog,
+                &route.backend,
+                Some(&provider.id),
+                route.model.as_deref(),
+                probe_runtime,
+            )
+            .ready;
             Some(ProviderRoute::Resolved {
                 backend: route.backend,
                 provider_id: provider.id.clone(),
                 model: route.model,
-                dispatchable: provider_credential_readiness(provider).dispatchable,
+                dispatchable,
             })
         }
         ProviderResolution::AmbiguousExtensionAlias { mut candidate_ids } => {
@@ -2690,10 +2732,26 @@ fn declared_backend_readiness(
                         .find(|provider| &provider.id == provider_id),
                     _ => None,
                 });
+            let dispatchability = route.as_ref().and_then(|route| match route {
+                ProviderRoute::Resolved {
+                    backend,
+                    provider_id,
+                    model,
+                    ..
+                } => Some(evaluate_provider_dispatchability(
+                    catalog,
+                    backend,
+                    Some(provider_id),
+                    model.as_deref(),
+                    true,
+                )),
+                _ => None,
+            });
             let mut value = readiness_validation_projection(
                 identity.as_ref(),
                 provider,
                 route.as_ref(),
+                dispatchability.as_ref(),
                 true,
                 None,
             );
@@ -2728,6 +2786,9 @@ fn readiness_validation_projection(
     identity: Option<&(String, String)>,
     provider: Option<&AgentTaskExecutorProvider>,
     route: Option<&ProviderRoute>,
+    dispatchability: Option<
+        &homeboy::agents::agent_tasks::provider::AgentTaskProviderDispatchability,
+    >,
     validation_requested: bool,
     declared_backends: Option<Vec<Value>>,
 ) -> Value {
@@ -2765,7 +2826,7 @@ fn readiness_validation_projection(
         "static_configuration": "declared",
         "live_dispatch": live_dispatch_readiness(provider, validation_requested),
         "route_state": route.map(ProviderRoute::state),
-        "next_command": route.map(ProviderRoute::next_command),
+        "next_command": provider_next_command(route, dispatchability),
         "reason": match route { Some(ProviderRoute::Blocked { reason, .. }) => Some(reason), _ => None },
         "selection_choices": selection_choices(route),
         // One entry per declared backend, each carrying this same projection
@@ -3773,6 +3834,7 @@ mod tests {
                 .find(|backend| backend["backend"] == "failing")
                 .expect("failing backend readiness");
             assert_eq!(failing["validated"], false);
+            assert_eq!(failing["route_state"], "configuration_unavailable");
             assert!(
                 failing["reason"]
                     .as_str()
@@ -3787,6 +3849,20 @@ mod tests {
             assert_eq!(ready["validated"], true);
             assert_eq!(ready["effective_provider_id"], "ready.provider");
             assert_eq!(ready["live_dispatch"], "validated");
+            assert_eq!(ready["route_state"], "ready");
+            let rows = output["providers"].as_array().expect("provider rows");
+            assert_eq!(
+                rows.iter()
+                    .find(|provider| provider["id"] == "failing.provider")
+                    .expect("failing provider row")["state"],
+                "runtime_unavailable"
+            );
+            assert_eq!(
+                rows.iter()
+                    .find(|provider| provider["id"] == "ready.provider")
+                    .expect("ready provider row")["state"],
+                "ready"
+            );
             assert_eq!(
                 validation["ready_backends"],
                 serde_json::json!(["ready"]),
@@ -3954,7 +4030,7 @@ mod tests {
     }
 
     #[test]
-    fn providers_report_resolved_route_credentials_missing() {
+    fn providers_report_resolved_route_configuration_invalid_before_missing_credentials() {
         crate::test_support::with_isolated_home(|_| {
             save_provider_policy(None, None);
             let mut args = providers_args();
@@ -3966,11 +4042,11 @@ mod tests {
             .expect("provider report")
             .0;
 
-            assert_eq!(output["operator_summary"]["state"], "credentials_missing");
+            assert_eq!(output["operator_summary"]["state"], "configuration_invalid");
             assert_eq!(
                 render_agent_task_summary(AgentTaskSummaryKind::Providers, &output),
                 Some(
-                    "Agent task providers\nStatus: credentials_missing\nProviders shown: 1\nNext: homeboy agent-task providers --backend claude-code --selector claude-code.agent-task-executor --validate-readiness".to_string()
+                    "Agent task providers\nStatus: configuration_invalid\nProviders shown: 1\nNext: homeboy agent-task providers --full --backend claude-code --selector claude-code.agent-task-executor".to_string()
                 )
             );
         });
@@ -4301,9 +4377,16 @@ mod tests {
             None,
             false,
         );
-        assert_eq!(provider_status(&provider, &present), "present");
+        assert_eq!(provider_status(&provider, &present), "unavailable");
         assert!(provider_matches_status(&provider, &present, "unavailable"));
-        assert_eq!(compact_provider(&provider, &present)["status"], "present");
+        assert_eq!(
+            compact_provider(&provider, &present)["status"],
+            "unavailable"
+        );
+        assert_eq!(
+            compact_provider(&provider, &present)["state"],
+            "configuration_invalid"
+        );
         assert_eq!(
             compact_provider(&provider, &present)["dispatchability"]["checks"]["credentials"]
                 ["status"],
@@ -4317,8 +4400,65 @@ mod tests {
             None,
             true,
         );
-        assert_eq!(provider_status(&provider, &unverified), "unverified");
-        assert_eq!(unverified.state, "credentials_unverified");
+        assert_eq!(provider_status(&provider, &unverified), "unavailable");
+        assert_eq!(unverified.state, "configuration_invalid");
+        assert_eq!(
+            compact_provider(&provider, &unverified)["dispatchability"]["checks"]["credentials"]
+                ["status"],
+            "unverified"
+        );
+    }
+
+    #[test]
+    fn missing_readiness_invocation_has_a_source_owned_static_diagnosis_and_safe_next_action() {
+        crate::test_support::with_isolated_home(|_| {
+            save_provider_policy(None, None);
+            let mut provider: AgentTaskExecutorProvider =
+                serde_json::from_value(serde_json::json!({
+                    "id": "contract.owner.provider",
+                    "backend": "contract-owner",
+                    "capabilities": ["provider_owned_auth"],
+                }))
+                .expect("provider fixture");
+            provider.runtime_id = Some("contract-runtime".to_string());
+            provider.extension_id = Some("contract-extension".to_string());
+            provider.runtime_package_source = Some("extension-package".to_string());
+            let mut args = providers_args();
+            args.backend = Some("contract-owner".to_string());
+
+            let output = providers_with_catalog(args, provider_catalog(vec![provider]))
+                .expect("static contract diagnosis")
+                .0;
+
+            assert_eq!(output["operator_summary"]["state"], "configuration_invalid");
+            assert_eq!(output["providers"][0]["state"], "configuration_invalid");
+            assert_eq!(
+                output["providers"][0]["dispatchability"]["checks"]["credentials"]["status"],
+                "unverified"
+            );
+            assert_eq!(
+                output["dispatchability"]["configuration_diagnosis"]["kind"],
+                "missing_readiness_invocation"
+            );
+            assert_eq!(
+                output["dispatchability"]["configuration_diagnosis"]["owner"]["extension_id"],
+                "contract-extension"
+            );
+            assert_eq!(
+                output["operator_summary"]["next_action"],
+                "homeboy agent-task providers --full --backend contract-owner --selector contract.owner.provider"
+            );
+            assert!(!output["operator_summary"]["next_action"]
+                .as_str()
+                .expect("next action")
+                .contains("--validate-readiness"));
+            assert_eq!(
+                render_agent_task_summary(AgentTaskSummaryKind::Providers, &output),
+                Some(
+                    "Agent task providers\nStatus: configuration_invalid\nProviders shown: 1\nNext: homeboy agent-task providers --full --backend contract-owner --selector contract.owner.provider".to_string()
+                )
+            );
+        });
     }
 
     #[test]
@@ -4386,8 +4526,14 @@ mod tests {
             "resolved.provider".to_string(),
         );
 
-        let projection =
-            readiness_validation_projection(Some(&identity), Some(&provider), None, true, None);
+        let projection = readiness_validation_projection(
+            Some(&identity),
+            Some(&provider),
+            None,
+            None,
+            true,
+            None,
+        );
 
         assert_eq!(projection["effective_backend"], "resolved-backend");
         assert_eq!(projection["effective_provider_id"], "resolved.provider");
@@ -4410,8 +4556,8 @@ mod tests {
                 .expect("provider envelope")
                 .0;
 
-            assert_eq!(output["dispatchability"]["state"], "credentials_missing");
-            assert_eq!(output["operator_summary"]["state"], "credentials_missing");
+            assert_eq!(output["dispatchability"]["state"], "configuration_invalid");
+            assert_eq!(output["operator_summary"]["state"], "configuration_invalid");
             assert_eq!(output["dispatchability"]["checks"]["route"]["ready"], true);
             assert_eq!(
                 output["dispatchability"]["checks"]["credentials"]["ready"],


### PR DESCRIPTION
## Summary

- classify provider-owned authentication without a readiness invocation as `configuration_invalid` during static contract inspection
- attach provider, runtime, extension, and package ownership to the shared typed diagnosis
- align provider-row and top-level dispatchability states and reserve `available` for admitted providers
- replace a guaranteed-to-fail validation recommendation with executable static inspection
- expose the same diagnosis from Cook preflight without suggesting provider switching

Closes #14024.

Paired runtime repair: Extra-Chill/homeboy-extensions#2761.

## Validation

- `cargo test -p homeboy-agents agent_task_provider::dispatchability::tests --lib`
- `cargo test -p homeboy-agents cook_preflight_exposes_missing_readiness_invocation_diagnosis_without_provider_switching --lib`
- `cargo test -p homeboy-cli commands::agent_task::review::tests --lib`
- `cargo check -p homeboy-agents -p homeboy-cli`
- `cargo fmt --check`
- `git diff --check`

## AI Assistance

OpenCode with OpenAI `openai/gpt-5.6-terra` implemented the typed diagnosis, projections, and tests. OpenCode with OpenAI GPT-5.6 Sol reviewed the diff, rebased it onto current `main`, reran verification, and prepared this pull request under Chris Huber’s direction.