### PR TITLE
Preserve durable candidate presentation

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -6210,7 +6210,7 @@ pub fn artifacts_in_store(
 ///
 /// It intentionally never calls [`status`], which can reconcile a live runner.
 /// The observation-store record read uses its read-only 750ms SQLite busy bound;
-/// aggregate failure is represented in `unavailable_sources` so callers can
+/// aggregate absence is represented in `unavailable_sources` so callers can
 /// still render the durable identity and phase they did obtain.
 #[derive(Debug, Clone)]
 pub struct AgentTaskDurableLocalRead {
@@ -6238,8 +6238,8 @@ pub fn durable_local_read_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
 ) -> Result<AgentTaskDurableLocalRead> {
-    let record = status_in_store(lifecycle_store, run_id)?;
-    durable_local_read_record_in_store(lifecycle_store, record)
+    let run_id = resolve_run_id_in_store(lifecycle_store, run_id)?;
+    durable_local_read_record_in_store(lifecycle_store, &run_id)
 }
 
 /// Read one concrete durable record without resolving a Cook ID through its
@@ -6253,39 +6253,31 @@ pub fn exact_durable_local_read_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
 ) -> Result<AgentTaskDurableLocalRead> {
-    let record = lifecycle_store.read_record_bounded(&sanitize_run_id(run_id))?;
-    durable_local_read_record_in_store(lifecycle_store, record)
+    durable_local_read_record_in_store(lifecycle_store, &sanitize_run_id(run_id))
 }
 
 fn durable_local_read_record_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
-    record: AgentTaskRunRecord,
+    run_id: &str,
 ) -> Result<AgentTaskDurableLocalRead> {
-    let aggregate = match lifecycle_store.read_aggregate_bounded(&record.run_id) {
-        Ok(aggregate) => Some(aggregate),
-        Err(error) => {
-            return Ok(AgentTaskDurableLocalRead {
-                record,
-                aggregate: None,
-                unavailable_sources: vec![AgentTaskDurableReadUnavailable {
-                    source: "aggregate",
-                    reason_code: if error.details["reason_code"] == "durable_read.oversized" {
-                        "durable_read.oversized"
-                    } else {
-                        "durable_read.unavailable"
-                    },
-                    detail: format!(
-                        "The controller-local aggregate was unavailable within the durable read; the record below remains authoritative partial evidence: {}",
-                        error.message
-                    ),
-                }],
-            });
-        }
-    };
+    let (record, mirrored_aggregate) =
+        lifecycle_store.read_record_with_aggregate_bounded(run_id)?;
+    if let Some(aggregate) = mirrored_aggregate {
+        return Ok(AgentTaskDurableLocalRead {
+            record,
+            aggregate: Some(aggregate),
+            unavailable_sources: Vec::new(),
+        });
+    }
     Ok(AgentTaskDurableLocalRead {
         record,
-        aggregate,
-        unavailable_sources: Vec::new(),
+        aggregate: None,
+        unavailable_sources: vec![AgentTaskDurableReadUnavailable {
+            source: "aggregate",
+            reason_code: "durable_read.authoritative_aggregate_absent",
+            detail: "The authoritative SQLite observation has no mirrored aggregate; aggregate.json was not consulted because it cannot be paired atomically with this record."
+                .to_string(),
+        }],
     })
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -3285,7 +3285,7 @@ fn durable_aggregate_read_returns_partial_local_evidence_without_a_runner_probe(
         assert_eq!(snapshot.unavailable_sources[0].source, "aggregate");
         assert_eq!(
             snapshot.unavailable_sources[0].reason_code,
-            "durable_read.unavailable"
+            "durable_read.authoritative_aggregate_absent"
         );
         assert_eq!(artifacts.run_id, "runner-backed-durable-read");
         assert_eq!(
@@ -3301,11 +3301,8 @@ fn durable_aggregate_read_returns_partial_local_evidence_without_a_runner_probe(
 /// itself names and read back through the sibling handed the same store, so the
 /// partial-read evidence asserted below is about this home's aggregate file.
 ///
-/// `store::DURABLE_AGGREGATE_MAX_BYTES` is the one surviving `store::` token in
-/// this body. It is a `pub(super)` byte-count constant, not a root resolution —
-/// there is no other path to it — so it reaches no ambient state.
 #[test]
-fn durable_aggregate_read_rejects_an_oversized_file_before_deserializing_it() {
+fn durable_aggregate_read_does_not_pair_a_record_with_an_unmirrored_cache() {
     let context = homeboy_core::test_support::HermeticTestContext::new();
     let lifecycle_store =
         crate::agent_task_lifecycle::AgentTaskLifecycleStore::new(context.path_roots());
@@ -3330,7 +3327,7 @@ fn durable_aggregate_read_rejects_an_oversized_file_before_deserializing_it() {
     assert_eq!(snapshot.unavailable_sources[0].source, "aggregate");
     assert_eq!(
         snapshot.unavailable_sources[0].reason_code,
-        "durable_read.oversized"
+        "durable_read.authoritative_aggregate_absent"
     );
 }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -3893,7 +3893,29 @@ fn terminal_projection_is_reader_complete_when_interrupted_after_commit_and_retr
             remote_command: &command,
         })
         .expect("running proxy");
-        let snapshot = terminal_child_snapshot(&succeeded_aggregate(&test_plan()));
+        let patch = b"recoverable patch";
+        let patch_sha256 = format!("{:x}", sha2::Sha256::digest(patch));
+        let mut aggregate = succeeded_aggregate(&test_plan());
+        aggregate.status = AgentTaskAggregateStatus::CandidateRecoverable;
+        aggregate.totals.succeeded = 0;
+        aggregate.totals.candidate_recoverable = 1;
+        aggregate.outcomes[0].status = AgentTaskOutcomeStatus::CandidateRecoverable;
+        aggregate.outcomes[0].artifacts.push(AgentTaskArtifact {
+            schema: crate::agent_task::AGENT_TASK_ARTIFACT_SCHEMA.to_string(),
+            id: "recoverable.patch".to_string(),
+            kind: "patch".to_string(),
+            url: Some(
+                "homeboy://agent-task/run/agent-task-disconnected-child/artifacts#task=task-a&artifact=recoverable.patch"
+                    .to_string(),
+            ),
+            mime: Some("text/x-patch".to_string()),
+            size_bytes: Some(patch.len() as u64),
+            sha256: Some(patch_sha256.clone()),
+            metadata: json!({ "executor_artifact_finalized": true }),
+            ..Default::default()
+        });
+        aggregate.events[0].state = AgentTaskState::CandidateRecoverable;
+        let snapshot = terminal_child_snapshot(&aggregate);
         store::interrupt_after_terminal_commit_for_test();
 
         reconcile_runner_job_snapshot(&mut record, &snapshot)
@@ -3903,7 +3925,7 @@ fn terminal_projection_is_reader_complete_when_interrupted_after_commit_and_retr
             store::read_record("agent-task-disconnected-child")
                 .expect("committed controller projection")
                 .state,
-            AgentTaskRunState::Succeeded
+            AgentTaskRunState::CandidateRecoverable
         );
         assert!(
             !store::aggregate_path(&record.run_id)
@@ -3912,10 +3934,15 @@ fn terminal_projection_is_reader_complete_when_interrupted_after_commit_and_retr
             "the injected fault must run before aggregate.json is cached"
         );
         let durable = durable_local_read(&record.run_id).expect("committed durable pair");
+        let durable_aggregate = durable.aggregate.expect("mirrored aggregate");
         assert_eq!(
-            durable.aggregate.expect("mirrored aggregate").status,
-            AgentTaskAggregateStatus::Succeeded
+            durable_aggregate.status,
+            AgentTaskAggregateStatus::CandidateRecoverable
         );
+        let durable_patch = &durable_aggregate.outcomes[0].artifacts[0];
+        assert_eq!(durable_patch.id, "recoverable.patch");
+        assert_eq!(durable_patch.size_bytes, Some(patch.len() as u64));
+        assert_eq!(durable_patch.sha256.as_deref(), Some(patch_sha256.as_str()));
         assert!(durable.unavailable_sources.is_empty());
         let (status_record, log, artifacts) = std::thread::scope(|scope| {
             let status_reader = scope.spawn(|| reconcile_status("agent-task-disconnected-child"));
@@ -3936,12 +3963,12 @@ fn terminal_projection_is_reader_complete_when_interrupted_after_commit_and_retr
                     .expect("committed artifacts"),
             )
         });
-        assert_eq!(status_record.state, AgentTaskRunState::Succeeded);
-        assert_eq!(log.events[0].data["state"], "succeeded");
-        assert!(artifacts.artifacts.is_empty());
+        assert_eq!(status_record.state, AgentTaskRunState::CandidateRecoverable);
+        assert_eq!(log.events[0].data["state"], "candidate_recoverable");
+        assert_eq!(artifacts.artifacts[0].id, "recoverable.patch");
 
         reconcile_runner_job_snapshot(&mut record, &snapshot).expect("idempotent retry");
-        assert_eq!(record.state, AgentTaskRunState::Succeeded);
+        assert_eq!(record.state, AgentTaskRunState::CandidateRecoverable);
         assert!(store::aggregate_path(&record.run_id)
             .expect("aggregate path")
             .exists());

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/submit_and_persist.rs
@@ -2314,15 +2314,15 @@ fn lifecycle_read_siblings_answer_from_the_injected_store_and_not_a_second_root(
     let cook_id = "rooted-read-cook";
     let attempt_run_id = "rooted-read-cook-attempt-1-a";
     let plan = test_plan();
-    seeded
+    let record = seeded
         .submit_plan_with_runtime_admission(&plan, attempt_run_id, |_| Ok(json!({})))
         .expect("submit attempt into the seeded store");
     seeded
         .write_cook_index_attempt(cook_id, 1, attempt_run_id, now_timestamp(), None)
         .expect("register the Cook attempt in the seeded store");
     seeded
-        .write_aggregate(attempt_run_id, &succeeded_aggregate(&plan))
-        .expect("persist the attempt aggregate in the seeded store");
+        .write_aggregate_and_record(&record, &succeeded_aggregate(&plan))
+        .expect("persist the authoritative attempt pair in the seeded store");
     let aggregate_path = seeded.aggregate_path(attempt_run_id);
 
     // Every read answers from the store it was handed.
@@ -3881,10 +3881,6 @@ fn accepted_handoff_projects_a_remote_timeout_aggregate_even_when_daemon_transpo
     assert_eq!(record.metadata["runner_job_status"], "succeeded");
 }
 
-/// Stays on `with_isolated_home` (#7505). `store::interrupt_after_terminal_commit_for_test`
-/// arms a process-global `AtomicBool`, exactly like the record-write fault
-/// above; the hermetic home's global mutex is what stops a peer test from
-/// consuming the injected interruption.
 #[test]
 fn terminal_projection_is_reader_complete_when_interrupted_after_commit_and_retry_is_idempotent() {
     with_isolated_home(|_| {
@@ -3909,6 +3905,18 @@ fn terminal_projection_is_reader_complete_when_interrupted_after_commit_and_retr
                 .state,
             AgentTaskRunState::Succeeded
         );
+        assert!(
+            !store::aggregate_path(&record.run_id)
+                .expect("aggregate path")
+                .exists(),
+            "the injected fault must run before aggregate.json is cached"
+        );
+        let durable = durable_local_read(&record.run_id).expect("committed durable pair");
+        assert_eq!(
+            durable.aggregate.expect("mirrored aggregate").status,
+            AgentTaskAggregateStatus::Succeeded
+        );
+        assert!(durable.unavailable_sources.is_empty());
         let (status_record, log, artifacts) = std::thread::scope(|scope| {
             let status_reader = scope.spawn(|| reconcile_status("agent-task-disconnected-child"));
             let log_reader = scope.spawn(|| logs("agent-task-disconnected-child"));
@@ -3937,6 +3945,50 @@ fn terminal_projection_is_reader_complete_when_interrupted_after_commit_and_retr
         assert!(store::aggregate_path(&record.run_id)
             .expect("aggregate path")
             .exists());
+    });
+}
+
+#[test]
+fn terminal_projection_ignores_a_stale_aggregate_cache_after_commit() {
+    with_isolated_home(|_| {
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        let mut record = record_detached_lab_run(DetachedLabRunRecord {
+            run_id: "agent-task-stale-terminal-cache",
+            runner_id: "homeboy-lab",
+            runner_job_id: "00000000-0000-0000-0000-000000000123",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+        })
+        .expect("running proxy");
+        let committed_aggregate = succeeded_aggregate(&test_plan());
+        let mut stale_aggregate = committed_aggregate.clone();
+        stale_aggregate.outcomes[0].summary = Some("stale aggregate cache".to_string());
+        store::interrupt_after_terminal_commit_for_test();
+        let mut snapshot = terminal_child_snapshot(&committed_aggregate);
+        snapshot.events[0].data.as_mut().expect("lifecycle event")["identity"]
+            ["persisted_run_id"] = json!(record.run_id);
+        snapshot.events[0].data.as_mut().expect("lifecycle event")["identity"]["run_id"] =
+            json!(record.run_id);
+
+        reconcile_runner_job_snapshot(&mut record, &snapshot)
+            .expect_err("interruption precedes aggregate cache publication");
+        store::write_aggregate(&record.run_id, &stale_aggregate)
+            .expect("replace the missing cache with stale bytes");
+
+        assert_eq!(
+            store::read_aggregate_bounded(&record.run_id)
+                .expect("stale cache remains readable")
+                .outcomes[0]
+                .summary
+                .as_deref(),
+            Some("stale aggregate cache")
+        );
+        let durable = durable_local_read(&record.run_id).expect("committed durable pair");
+        assert_eq!(durable.record.state, AgentTaskRunState::Succeeded);
+        let aggregate = durable.aggregate.expect("mirrored aggregate");
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Succeeded);
+        assert_eq!(aggregate.outcomes[0].summary.as_deref(), Some("ok"));
+        assert!(durable.unavailable_sources.is_empty());
     });
 }
 

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -5,8 +5,6 @@ use std::time::Duration;
 
 #[cfg(any(test, feature = "test-support"))]
 use std::cell::Cell;
-#[cfg(test)]
-use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde_json::{json, Value};
 
@@ -823,6 +821,25 @@ impl AgentTaskLifecycleStore {
         read_record_bounded_in_store(self, run_id)
     }
 
+    /// Read one record and its mirrored aggregate from the same read-only
+    /// SQLite observation. A missing mirror is returned as `None`; callers must
+    /// not pair that record with the independently materialized aggregate cache.
+    pub fn read_record_with_aggregate_bounded(
+        &self,
+        run_id: &str,
+    ) -> Result<(AgentTaskRunRecord, Option<AgentTaskAggregate>)> {
+        let store = self.open_observation_readonly()?;
+        let run = store.get_run(run_id)?.ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "run_id",
+                format!("agent-task run record not found: {run_id}"),
+                Some(run_id.to_string()),
+                None,
+            )
+        })?;
+        record_and_aggregate_from_run(&run)
+    }
+
     pub fn write_record(&self, record: &AgentTaskRunRecord) -> Result<()> {
         self.write_record_with_aggregate(
             record,
@@ -964,7 +981,7 @@ impl AgentTaskLifecycleStore {
             Some(aggregate.clone()),
         )?;
         #[cfg(test)]
-        if INTERRUPT_AFTER_TERMINAL_COMMIT.swap(false, Ordering::SeqCst) {
+        if INTERRUPT_AFTER_TERMINAL_COMMIT.replace(false) {
             return Err(Error::internal_io(
                 "injected interruption after terminal lifecycle commit",
                 Some(record.run_id.clone()),
@@ -1053,9 +1070,9 @@ thread_local! {
     /// One-shot write failure owned by the test thread that armed it. A global
     /// atomic let unrelated parallel tests consume each other's fault (#11897).
     static FAIL_NEXT_RECORD_WRITE: Cell<bool> = const { Cell::new(false) };
+    /// One-shot post-commit failure owned by the test thread that armed it.
+    static INTERRUPT_AFTER_TERMINAL_COMMIT: Cell<bool> = const { Cell::new(false) };
 }
-#[cfg(test)]
-static INTERRUPT_AFTER_TERMINAL_COMMIT: AtomicBool = AtomicBool::new(false);
 
 /// A crashed notifier cannot release its provisional claim. A bounded lease
 /// keeps that crash window from permanently suppressing a detached resume.
@@ -1285,7 +1302,7 @@ pub(super) fn fail_next_record_write_for_test() {
 
 #[cfg(test)]
 pub(super) fn interrupt_after_terminal_commit_for_test() {
-    INTERRUPT_AFTER_TERMINAL_COMMIT.store(true, Ordering::SeqCst);
+    INTERRUPT_AFTER_TERMINAL_COMMIT.set(true);
 }
 
 fn write_record_with_aggregate_without_workspace_authority(
@@ -1815,6 +1832,12 @@ pub(super) fn record_from_run(run: &RunRecord) -> Result<AgentTaskRunRecord> {
     record_from_run_with_schema_policy(run, true)
 }
 
+fn record_and_aggregate_from_run(
+    run: &RunRecord,
+) -> Result<(AgentTaskRunRecord, Option<AgentTaskAggregate>)> {
+    Ok((record_from_run(run)?, aggregate_from_run(run)?))
+}
+
 /// Read a durable record without enforcing the supported-schema guard.
 ///
 /// Record health reconciliation exists to migrate legacy schemas, so it is the
@@ -1894,12 +1917,17 @@ fn read_mirrored_aggregate_in_store(
     let Some(run) = store.get_run(run_id)? else {
         return Ok(None);
     };
-    let Some(value) = run.metadata_json.get("agent_task_aggregate") else {
+    aggregate_from_run(&run)
+}
+
+fn aggregate_from_run(run: &RunRecord) -> Result<Option<AgentTaskAggregate>> {
+    let Some(value) = run
+        .metadata_json
+        .get("agent_task_aggregate")
+        .filter(|value| !value.is_null())
+    else {
         return Ok(None);
     };
-    if value.is_null() {
-        return Ok(None);
-    }
     serde_json::from_value(value.clone())
         .map(Some)
         .map_err(|error| {

--- a/crates/homeboy-cli/src/commands/agent_task/candidate.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/candidate.rs
@@ -138,6 +138,7 @@ impl CandidateResult {
 pub(crate) fn classify_candidates(payload: &Value) -> CandidateResult {
     if let Some(projected) = payload
         .get("canonical_candidate")
+        .or_else(|| payload.pointer("/durable_candidate/canonical_candidate"))
         .and_then(candidate_result_from_projection)
     {
         return projected;

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -29,7 +29,7 @@ use super::args::{
     CancelArgs, DiagnoseArgs, EvidenceArgs, LifecycleReadArgs, LogsArgs, QuarantineArgs, RearmArgs,
     ReconcileArgs, ReplayProviderBoundaryArgs, RuntimeRecoverArgs, RuntimeValidateArgs, StatusArgs,
 };
-use super::candidate::{classify_candidates, CandidateState};
+use super::candidate::{canonical_candidate_projection, classify_candidates, CandidateState};
 use crate::commands::utils::response::{
     CommandActionableMetadata, CommandAgentTaskRef, CommandArtifactRef, CommandNextAction,
     CommandNextActionKind, CommandResultRefs, CommandRunRef, ACTIONABLE_METADATA_KEY,
@@ -116,7 +116,7 @@ pub(crate) fn bounded_full_operation_report(value: Value, operation: &str) -> Va
             "export_command": format!("{evidence_command} --output <path>"),
         }));
     }
-    let output = json!({
+    let mut output = json!({
         "actionable": {
             "operation": operation,
             "terminal_state": bounded_value(&status),
@@ -127,6 +127,7 @@ pub(crate) fn bounded_full_operation_report(value: Value, operation: &str) -> Va
         "schema": source_schema,
         "presentation": "bounded_operator_projection",
         "run_id": bounded_value(&Value::String(run_id.to_string())),
+        "status": bounded_value(&status),
         "evidence_refs": evidence_refs,
         "output_budget": {
             "max_bytes": BOUNDED_FULL_STATUS_BYTE_LIMIT,
@@ -135,6 +136,17 @@ pub(crate) fn bounded_full_operation_report(value: Value, operation: &str) -> Va
             "truncated": true,
         },
     });
+    if operation == "cook" {
+        if let Some(candidate) = value.get("durable_candidate") {
+            output["durable_candidate"] = candidate.clone();
+        }
+        if let Some(selected) = value.get("selected_candidate") {
+            output["selected_candidate"] = compact_fields(
+                selected,
+                &["run_id", "selected_task_id", "selected_artifact_id"],
+            );
+        }
+    }
     if serialized_len(&output) <= BOUNDED_FULL_STATUS_BYTE_LIMIT {
         output
     } else {
@@ -271,7 +283,63 @@ fn status_once(args: StatusArgs) -> CmdResult<Value> {
     } else {
         0
     };
-    Ok((serde_json::to_value(run).unwrap_or(Value::Null), exit_code))
+    let mut value = serde_json::to_value(run).unwrap_or(Value::Null);
+    if matches!(
+        value.get("state").and_then(Value::as_str),
+        Some("candidate_recoverable" | "partial_recoverable")
+    ) {
+        value["durable_candidate"] = durable_candidate_projection(&target.run_id);
+        if let Some(selection) = target.selection {
+            value["selected_candidate"] = selection;
+        }
+    }
+    Ok((value, exit_code))
+}
+
+fn durable_candidate_projection(run_id: &str) -> Value {
+    match agent_task_lifecycle::durable_local_read(run_id) {
+        Ok(snapshot) => {
+            let Some(aggregate) = snapshot.aggregate else {
+                return json!({
+                    "status": "unavailable",
+                    "run_id": snapshot.record.run_id,
+                    "reason": bounded_value(&Value::String(snapshot.unavailable_sources.first().map(|source| source.detail.as_str()).unwrap_or("the authoritative observation has no aggregate").to_string())),
+                });
+            };
+            let record = serde_json::to_value(&snapshot.record).unwrap_or(Value::Null);
+            let aggregate_value = serde_json::to_value(&aggregate).unwrap_or(Value::Null);
+            let candidate = classify_candidates(&json!({
+                "record": record,
+                "aggregate": aggregate_value,
+            }));
+            let artifact_count = aggregate
+                .outcomes
+                .iter()
+                .map(|outcome| outcome.artifacts.len())
+                .sum::<usize>();
+            let outcome_count = aggregate.outcomes.len();
+            let provider_execution_count = candidate
+                .provider_executions
+                .map(|count| count.max(outcome_count))
+                .unwrap_or(outcome_count);
+            json!({
+                "status": "available",
+                "run_id": snapshot.record.run_id,
+                "state": snapshot.record.state,
+                "task_count": snapshot.record.tasks.len(),
+                "aggregate_path": snapshot.record.aggregate_path,
+                "outcome_count": outcome_count,
+                "provider_execution_count": provider_execution_count,
+                "artifact_count": artifact_count,
+                "canonical_candidate": canonical_candidate_projection(candidate),
+            })
+        }
+        Err(error) => json!({
+            "status": "unavailable",
+            "run_id": run_id,
+            "reason": bounded_value(&Value::String(error.message)),
+        }),
+    }
 }
 
 fn control_plane_run_requires_action(
@@ -767,14 +835,29 @@ const OPERATOR_HEAVY_COLLECTIONS: &[&str] =
     &["raw_events", "resource_timeline", "cook_resource_timeline"];
 
 pub(crate) fn project_operator_output(value: &mut Value) {
-    project_operator_value(value, false);
+    project_operator_value(value, false, &mut RawFailureBudget::default());
 }
 
-fn project_operator_value(value: &mut Value, evidence_content: bool) {
+const RAW_FAILURE_COUNT_LIMIT: usize = 8;
+const RAW_FAILURE_BYTE_LIMIT: usize = 8 * 1024;
+const RAW_FAILURE_PARSE_BYTE_LIMIT: usize = 32 * 1024;
+const RAW_FAILURE_JSON_DEPTH_LIMIT: usize = 8;
+
+#[derive(Default)]
+struct RawFailureBudget {
+    retained: usize,
+    bytes: usize,
+}
+
+fn project_operator_value(
+    value: &mut Value,
+    evidence_content: bool,
+    failure_budget: &mut RawFailureBudget,
+) {
     match value {
         Value::Array(items) => {
             for item in items {
-                project_operator_value(item, evidence_content);
+                project_operator_value(item, evidence_content, failure_budget);
             }
         }
         Value::Object(fields) => {
@@ -795,7 +878,9 @@ fn project_operator_value(value: &mut Value, evidence_content: bool) {
                     || (evidence_content && key == "body")
                 {
                     if let Value::String(text) = item {
-                        if text.len() > COMPACT_TEXT_LIMIT && !is_bounded_failure_result(text) {
+                        if let Some(redacted) = bounded_failure_result(text, failure_budget) {
+                            *text = redacted;
+                        } else if is_failure_result(text) || text.len() > COMPACT_TEXT_LIMIT {
                             let digest = content_hash::sha256_hex(text.as_bytes());
                             *text = format!("[omitted {} bytes; sha256={digest}]", text.len());
                         }
@@ -805,21 +890,49 @@ fn project_operator_value(value: &mut Value, evidence_content: bool) {
                 if OPERATOR_HEAVY_COLLECTIONS.contains(&key.as_str()) {
                     continue;
                 }
-                project_operator_value(item, hydrated_evidence && key == "content");
+                project_operator_value(item, hydrated_evidence && key == "content", failure_budget);
             }
         }
         _ => {}
     }
 }
 
-fn is_bounded_failure_result(text: &str) -> bool {
-    if text.len() > 8_192 {
-        return false;
+fn bounded_failure_result(text: &str, budget: &mut RawFailureBudget) -> Option<String> {
+    if text.len() > RAW_FAILURE_PARSE_BYTE_LIMIT {
+        return None;
     }
     let Ok(Value::Object(result)) = serde_json::from_str(text) else {
-        return false;
+        return None;
     };
-    let failed = result.get("success").and_then(Value::as_bool) == Some(false)
+    if !failure_result_object(&result) {
+        return None;
+    }
+    let mut redacted =
+        homeboy::core::redaction::RedactionPolicy::default().redact_json(&Value::Object(result));
+    redact_json_encoded_strings(&mut redacted, 0);
+    let serialized = serde_json::to_string(&redacted).ok()?;
+    if budget.retained >= RAW_FAILURE_COUNT_LIMIT
+        || budget.bytes.saturating_add(serialized.len()) > RAW_FAILURE_BYTE_LIMIT
+    {
+        return None;
+    }
+    budget.retained += 1;
+    budget.bytes += serialized.len();
+    Some(serialized)
+}
+
+fn is_failure_result(text: &str) -> bool {
+    if text.len() > RAW_FAILURE_PARSE_BYTE_LIMIT {
+        return false;
+    }
+    serde_json::from_str::<Value>(text)
+        .ok()
+        .and_then(|value| value.as_object().map(failure_result_object))
+        .unwrap_or(false)
+}
+
+fn failure_result_object(result: &serde_json::Map<String, Value>) -> bool {
+    result.get("success").and_then(Value::as_bool) == Some(false)
         || result
             .get("status")
             .and_then(Value::as_str)
@@ -828,13 +941,54 @@ fn is_bounded_failure_result(text: &str) -> bool {
                     status.to_ascii_lowercase().as_str(),
                     "blocked" | "error" | "failed" | "failure" | "timed_out" | "timeout"
                 )
-            });
-    failed
+            })
+}
+
+fn redact_json_encoded_strings(value: &mut Value, depth: usize) {
+    match value {
+        Value::Array(items) => items
+            .iter_mut()
+            .for_each(|item| redact_json_encoded_strings(item, depth + 1)),
+        Value::Object(fields) => fields
+            .values_mut()
+            .for_each(|item| redact_json_encoded_strings(item, depth + 1)),
+        Value::String(text) => {
+            if text == "[REDACTED]" {
+                return;
+            }
+            let json_shaped = matches!(text.trim_start().as_bytes().first(), Some(b'{' | b'['));
+            if !json_shaped {
+                return;
+            }
+            if depth >= RAW_FAILURE_JSON_DEPTH_LIMIT {
+                *text = "[omitted JSON beyond redaction depth]".to_string();
+                return;
+            }
+            let Ok(parsed) = serde_json::from_str::<Value>(text) else {
+                *text = "[omitted invalid encoded JSON]".to_string();
+                return;
+            };
+            if !matches!(parsed, Value::Array(_) | Value::Object(_)) {
+                return;
+            }
+            let mut parsed =
+                homeboy::core::redaction::RedactionPolicy::default().redact_json(&parsed);
+            redact_json_encoded_strings(&mut parsed, depth + 1);
+            if let Ok(serialized) = serde_json::to_string(&parsed) {
+                *text = serialized;
+            }
+        }
+        _ => {}
+    }
 }
 
 #[cfg(test)]
 mod bounded_failure_result_tests {
-    use super::{is_bounded_failure_result, COMPACT_TEXT_LIMIT};
+    use super::{
+        bounded_failure_result, project_operator_output, RawFailureBudget, COMPACT_TEXT_LIMIT,
+        RAW_FAILURE_BYTE_LIMIT, RAW_FAILURE_COUNT_LIMIT, RAW_FAILURE_JSON_DEPTH_LIMIT,
+        RAW_FAILURE_PARSE_BYTE_LIMIT,
+    };
 
     #[test]
     fn retains_code_less_payloads_for_every_liftable_failure_status() {
@@ -852,7 +1006,10 @@ mod bounded_failure_result_tests {
             })
             .to_string();
             assert!(payload.len() > COMPACT_TEXT_LIMIT);
-            assert!(is_bounded_failure_result(&payload), "status={status}");
+            assert!(
+                bounded_failure_result(&payload, &mut RawFailureBudget::default()).is_some(),
+                "status={status}"
+            );
         }
     }
 
@@ -863,7 +1020,118 @@ mod bounded_failure_result_tests {
             "message": "x".repeat(COMPACT_TEXT_LIMIT),
         })
         .to_string();
-        assert!(is_bounded_failure_result(&payload));
+        assert!(bounded_failure_result(&payload, &mut RawFailureBudget::default()).is_some());
+    }
+
+    #[test]
+    fn redacts_nested_and_json_encoded_secrets() {
+        let payload = serde_json::json!({
+            "success": false,
+            "token": "outer-secret",
+            "nested": { "authorization": "Bearer inner-secret" },
+            "encoded": serde_json::json!({ "api_key": "encoded-secret" }).to_string(),
+        })
+        .to_string();
+        let retained = bounded_failure_result(&payload, &mut RawFailureBudget::default()).unwrap();
+        for secret in ["outer-secret", "inner-secret", "encoded-secret"] {
+            assert!(!retained.contains(secret));
+        }
+        assert!(retained.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn omits_json_encoded_content_at_the_recursion_limit() {
+        let mut nested = serde_json::json!({
+            "encoded": serde_json::json!({ "token": "depth-secret" }).to_string(),
+        });
+        for _ in 0..RAW_FAILURE_JSON_DEPTH_LIMIT {
+            nested = serde_json::json!({ "nested": nested });
+        }
+        let payload = serde_json::json!({
+            "status": "failed",
+            "details": nested,
+        })
+        .to_string();
+        let retained = bounded_failure_result(&payload, &mut RawFailureBudget::default()).unwrap();
+
+        assert!(!retained.contains("depth-secret"));
+        assert!(retained.contains("omitted JSON beyond redaction depth"));
+    }
+
+    #[test]
+    fn omits_json_encoded_content_that_exceeds_the_parser_recursion_limit() {
+        let encoded = format!(
+            "{}{{\"token\":\"parser-depth-secret\"}}{}",
+            "[".repeat(256),
+            "]".repeat(256)
+        );
+        let payload = serde_json::json!({
+            "status": "failed",
+            "encoded": encoded,
+        })
+        .to_string();
+        let retained = bounded_failure_result(&payload, &mut RawFailureBudget::default()).unwrap();
+
+        assert!(!retained.contains("parser-depth-secret"));
+        assert!(retained.contains("omitted invalid encoded JSON"));
+    }
+
+    #[test]
+    fn enforces_one_count_and_byte_budget_across_many_payloads() {
+        let payload = serde_json::json!({
+            "status": "failed",
+            "message": "x".repeat(RAW_FAILURE_BYTE_LIMIT / RAW_FAILURE_COUNT_LIMIT),
+        })
+        .to_string();
+        let mut budget = RawFailureBudget::default();
+        let retained = (0..RAW_FAILURE_COUNT_LIMIT * 2)
+            .filter(|_| bounded_failure_result(&payload, &mut budget).is_some())
+            .count();
+        assert!(retained <= RAW_FAILURE_COUNT_LIMIT);
+        assert!(budget.bytes <= RAW_FAILURE_BYTE_LIMIT);
+    }
+
+    #[test]
+    fn omits_oversized_failure_json_before_parsing() {
+        let payload = serde_json::json!({
+            "status": "failed",
+            "message": "x".repeat(RAW_FAILURE_PARSE_BYTE_LIMIT),
+        })
+        .to_string();
+
+        assert!(bounded_failure_result(&payload, &mut RawFailureBudget::default()).is_none());
+    }
+
+    #[test]
+    fn operator_projection_redacts_and_bounds_recursive_failure_payloads_globally() {
+        let original = serde_json::json!({
+            "attempts": (0..RAW_FAILURE_COUNT_LIMIT * 3).map(|index| serde_json::json!({
+                "content": {
+                    "body": serde_json::json!({
+                        "status": "failed",
+                        "token": format!("secret-{index}"),
+                        "message": "x".repeat(700),
+                    }).to_string()
+                },
+                "kind": "executor_result",
+                "uri": format!("file:///tmp/{index}"),
+                "status": "available",
+            })).collect::<Vec<_>>()
+        });
+        let mut projected = original.clone();
+        project_operator_output(&mut projected);
+        let text = projected.to_string();
+
+        assert_eq!(
+            original["attempts"][0]["content"]["body"]
+                .as_str()
+                .is_some(),
+            true
+        );
+        assert!(!text.contains("secret-"));
+        assert!(text.matches("[omitted ").count() >= RAW_FAILURE_COUNT_LIMIT);
+        assert!(text.matches("[REDACTED]").count() <= RAW_FAILURE_COUNT_LIMIT);
+        assert!(text.len() < original.to_string().len());
     }
 }
 
@@ -4307,14 +4575,16 @@ fn diagnostic_priority(item: &CollectedDiagnostic) -> (u8, u8) {
         0
     } else if is_policy_denial(&class, &text) {
         0
-    } else if is_required_output_diagnostic(&class) {
-        1
     } else if is_provider_structured_error(&class) {
         // The provider's own terminal error event, already normalized by the
         // provider adapter: the most specific execution-layer cause there is.
         1
-    } else if is_provider_contract_diagnostic(&class) {
+    } else if is_required_output_diagnostic(&class) {
+        // Missing required outputs are retained as a consequence, but a typed
+        // provider rejection explains why those outputs were never produced.
         2
+    } else if is_provider_contract_diagnostic(&class) {
+        3
     } else if is_successful_process_exit(&text) {
         // A successful provider process can be useful context, but it cannot
         // explain why the task failed.
@@ -4710,7 +4980,27 @@ fn serialized_len(value: &Value) -> usize {
 /// diagnostic cause. Output only grows on the failure path: `failure_context` is `None`
 /// whenever `exit_code == 0`.
 pub(crate) fn compact_cook_report(value: Value, full: bool) -> Value {
+    let mut value = value;
+    let recoverable = matches!(
+        value.get("status").and_then(Value::as_str),
+        Some("candidate_recoverable" | "partial_recoverable")
+    );
+    let candidate_run_id = recoverable
+        .then(|| {
+            value
+                .pointer("/selected_candidate/run_id")
+                .and_then(Value::as_str)
+                .or_else(|| value.get("latest_run_id").and_then(Value::as_str))
+                .map(str::to_string)
+        })
+        .flatten();
+    let candidate_projection = candidate_run_id
+        .as_deref()
+        .map(durable_candidate_projection);
     if full {
+        if let Some(candidate) = candidate_projection.as_ref() {
+            value["durable_candidate"] = candidate.clone();
+        }
         return value;
     }
     let attempts = value
@@ -4734,6 +5024,9 @@ pub(crate) fn compact_cook_report(value: Value, full: bool) -> Value {
         "finalization": value.get("finalization").map(|finalization| compact_fields(finalization, &["schema", "status", "pr_number", "pr_url", "updated_at", "created_at"])),
         "selected_candidate": value.get("selected_candidate").map(|candidate| compact_fields(candidate, &["latest_attempt_run_id", "run_id", "attempt", "invocation_scoped", "selected_task_id", "selected_artifact_id", "reason", "incomplete", "skipped_newer_attempts", "applied_promotion"])),
     });
+    if let Some(candidate) = candidate_projection {
+        summary["durable_candidate"] = candidate.clone();
+    }
     // The run ids this invocation actually dispatched, so a caller can tell them
     // apart from the cross-invocation history `latest_run_id` may be drawn from.
     if let Some(invocation_run_ids) = value.get("invocation_run_ids") {
@@ -5212,7 +5505,7 @@ fn is_policy_denial(class: &str, text: &str) -> bool {
 }
 
 fn is_required_output_diagnostic(class: &str) -> bool {
-    class.contains("required_output_missing")
+    class.contains("required_output_missing") || class.contains("required_outputs_missing")
 }
 
 fn is_provider_structured_error(class: &str) -> bool {
@@ -6443,6 +6736,8 @@ mod tests {
         assert!(recovery.get("promotion").is_none());
         assert!(recovery.get("passed_gates").is_none());
 
-        assert_eq!(compact_cook_report(report.clone(), true), report);
+        let full = compact_cook_report(report.clone(), true);
+        assert_eq!(full["moving_base_recovery"], report["moving_base_recovery"]);
+        assert_eq!(full["durable_candidate"]["status"], "unavailable");
     }
 }

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -871,7 +871,7 @@ fn project_operator_value(
                 .cloned()
                 .collect::<Vec<_>>();
             for key in collection_keys {
-                project_heavy_collection(fields, &key);
+                project_heavy_collection(fields, &key, failure_budget);
             }
             for (key, item) in fields.iter_mut() {
                 if OPERATOR_HEAVY_FIELDS.contains(&key.as_str())
@@ -1137,7 +1137,11 @@ mod bounded_failure_result_tests {
 
 /// Known event streams retain their array/item schema. The owning evidence
 /// object receives additive metadata describing the omitted durable events.
-fn project_heavy_collection(fields: &mut serde_json::Map<String, Value>, key: &str) {
+fn project_heavy_collection(
+    fields: &mut serde_json::Map<String, Value>,
+    key: &str,
+    failure_budget: &mut RawFailureBudget,
+) {
     let projection = {
         let Some(items) = fields.get_mut(key).and_then(Value::as_array_mut) else {
             return;
@@ -1158,7 +1162,7 @@ fn project_heavy_collection(fields: &mut serde_json::Map<String, Value>, key: &s
             })
         });
         for item in items {
-            project_operator_value(item, true);
+            project_operator_value(item, true, failure_budget);
         }
         projection
     };

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -444,6 +444,135 @@ fn status_omits_scope_for_an_ordinary_non_cook_attempt() {
 }
 
 #[test]
+fn actual_status_command_renders_an_unpromoted_recoverable_candidate() {
+    with_isolated_home(|_| {
+        let run_id = "status-unpromoted-recoverable-candidate";
+        let plan = test_plan();
+        agent_task_lifecycle::submit_plan(&plan, Some(run_id)).expect("submitted");
+        let aggregate = AgentTaskAggregate {
+                schema: "homeboy/agent-task-aggregate/v1".to_string(),
+                plan_id: plan.plan_id.clone(),
+                status: homeboy::agents::agent_tasks::scheduler::AgentTaskAggregateStatus::CandidateRecoverable,
+                totals: Default::default(),
+                outcomes: vec![AgentTaskOutcome {
+                    task_id: "candidate-task".to_string(),
+                    status: AgentTaskOutcomeStatus::CandidateRecoverable,
+                    artifacts: vec![AgentTaskArtifact {
+                        id: "patch".to_string(),
+                        kind: "patch".to_string(),
+                        path: Some("/durable/artifacts/patch.diff".to_string()),
+                        size_bytes: Some(17_000),
+                        sha256: Some("a".repeat(64)),
+                        url: Some(format!("homeboy://agent-task/run/{run_id}/artifacts#patch")),
+                        metadata: json!({
+                            "executor_artifact_finalized": true,
+                            "changed_files": ["src/lib.rs"],
+                        }),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                events: Vec::new(),
+                artifact_lineage: Vec::new(),
+                child_runs: Vec::new(),
+                artifact_bindings: Vec::new(),
+                queue: Default::default(),
+            };
+        agent_task_lifecycle::record_run_aggregate(run_id, &plan, &aggregate)
+            .expect("persist recoverable aggregate");
+
+        let (value, exit_code) = status(StatusArgs {
+            run_id: run_id.to_string(),
+            exact: true,
+            interval: "5s".to_string(),
+            timeout: "30m".to_string(),
+            ..Default::default()
+        })
+        .expect("actual status command");
+        let rendered = crate::commands::agent_task_summary::render_agent_task_summary(
+            crate::commands::agent_task_summary::AgentTaskSummaryKind::Status,
+            &value,
+        )
+        .expect("actual status payload renders");
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(value["state"], "candidate_recoverable");
+        assert_eq!(
+            value["durable_candidate"]["canonical_candidate"]["state"],
+            "patch_available"
+        );
+        assert!(
+            rendered.contains("Status: candidate_recoverable"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("Candidate state: patch_available"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("Patch candidates: 1 non-empty / 0 empty"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("Artifacts: 1"), "{rendered}");
+
+        let report = json!({
+            "schema": "homeboy/agent-task-cook/v1",
+            "cook_id": "cook-unpromoted-recoverable-candidate",
+            "latest_run_id": run_id,
+            "status": "candidate_recoverable",
+            "attempts": [{
+                "attempt": 1,
+                "run_id": run_id,
+                "run_state": "candidate_recoverable",
+            }],
+            "selected_candidate": {
+                "run_id": run_id,
+                "selected_task_id": "candidate-task",
+                "selected_artifact_id": "patch",
+            },
+        });
+        let compact = super::super::status::compact_cook_report(report.clone(), false);
+        let full = super::super::status::compact_cook_report(report, true);
+        let render_cook = |payload: &Value| {
+            crate::commands::agent_task_summary::render_agent_task_summary(
+                crate::commands::agent_task_summary::AgentTaskSummaryKind::Cook,
+                payload,
+            )
+            .expect("Cook payload renders")
+        };
+        for summary in [render_cook(&compact), render_cook(&full)] {
+            assert!(
+                summary.contains("Candidate state: patch_available"),
+                "{summary}"
+            );
+            assert!(
+                summary.contains("Patch candidates: 1 non-empty / 0 empty"),
+                "{summary}"
+            );
+            assert!(
+                summary.contains("Retained candidate: task candidate-task, artifact patch"),
+                "{summary}"
+            );
+        }
+        assert_eq!(compact["durable_candidate"]["artifact_count"], 1);
+        let shipped_full = super::super::status::bounded_full_operation_report(full, "cook");
+        let shipped_summary = render_cook(&shipped_full);
+        assert!(
+            shipped_summary.contains("Candidate state: patch_available"),
+            "{shipped_summary}"
+        );
+        assert!(
+            shipped_summary.contains("Retained candidate: task candidate-task, artifact patch"),
+            "{shipped_summary}"
+        );
+        assert!(
+            shipped_summary.contains("Tasks attempted: 1"),
+            "{shipped_summary}"
+        );
+    });
+}
+
+#[test]
 fn canonical_status_omits_unrelated_high_cardinality_cleanup_inventory() {
     with_isolated_home(|_| {
         let run_id = "status-scoped-cleanup";
@@ -3275,6 +3404,75 @@ fn diagnose_prioritizes_provider_stream_cause_over_malformed_wrapper() {
             .expect("process streams")
             .iter()
             .any(|stream| stream["excerpt"] == "token=[REDACTED]"));
+    });
+}
+
+#[test]
+fn diagnose_ranks_structured_provider_rejection_before_missing_required_outputs() {
+    with_temp_home(|| {
+        let evidence_dir = tempfile::tempdir().expect("evidence dir");
+        let evidence_path = evidence_dir.path().join("executor-result.json");
+        let provider_event = json!({
+            "type": "error",
+            "error": {
+                "name": "APIError",
+                "data": {
+                    "message": "Account has insufficient credits for this request",
+                    "statusCode": 403,
+                    "isRetryable": false,
+                }
+            }
+        })
+        .to_string();
+        std::fs::write(
+            &evidence_path,
+            serde_json::to_string(&json!({
+                "structured_error": {
+                    "schema": "homeboy/provider-structured-error/v1",
+                    "message": "Account has insufficient credits for this request",
+                    "status_code": 403,
+                    "retryable": false,
+                    "failure_classification": "provider_account_blocked",
+                    "error_name": "APIError",
+                },
+                "diagnostics": [{
+                    "class": "opencode.required_outputs_missing",
+                    "message": "Required outputs were not produced: review_form",
+                    "data": { "stdout": provider_event, "stderr": "" }
+                }]
+            }))
+            .expect("evidence json"),
+        )
+        .expect("write evidence");
+
+        let run_id = "run-cli-diagnose-structured-rejection-and-missing-output";
+        run_loaded_plan(
+            test_plan(),
+            Some(run_id),
+            Arc::new(ExecutorResultEvidenceFailureExecutor {
+                evidence_uri: format!("file://{}", evidence_path.display()),
+            }),
+        )
+        .expect("failed outcome persisted");
+        let (value, _) = diagnose(DiagnoseArgs {
+            run_id: run_id.to_string(),
+            full: false,
+        })
+        .expect("diagnosis");
+
+        assert_eq!(value["root_cause"]["class"], "provider.structured_error");
+        assert_eq!(
+            value["root_cause"]["details"]["failure_classification"],
+            "provider_account_blocked"
+        );
+        assert!(value["diagnostic_chain"]
+            .as_array()
+            .expect("diagnostic chain")
+            .iter()
+            .any(|diagnostic| diagnostic["class"] == "opencode.required_outputs_missing"));
+        assert!(!value
+            .to_string()
+            .contains("provider.process_stream\",\"message\":null"));
     });
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
@@ -268,25 +268,29 @@ fn render_cook_summary(payload: &Value) -> Option<String> {
         string_value(payload, &["run_id"]).or_else(|| string_value(payload, &["latest_run_id"]))?;
     let raw_state = string_value(payload, &["state"])
         .or_else(|| string_value(payload, &["record", "state"]))
+        .or_else(|| string_value(payload, &["status"]))
         .unwrap_or("unknown");
+    let durable_unavailable =
+        string_value(payload, &["durable_candidate", "status"]) == Some("unavailable");
     let tasks_planned = usize_value(payload, &["task_count"])
-        .or_else(|| array_len(payload, &["record", "tasks"]))
-        .unwrap_or(0);
+        .or_else(|| usize_value(payload, &["durable_candidate", "task_count"]))
+        .or_else(|| array_len(payload, &["record", "tasks"]));
     let canonical = classify_candidates(payload);
-    let tasks_attempted = canonical
-        .provider_executions
-        .or_else(|| aggregate_outcome_count(payload))
-        .unwrap_or(0);
+    let tasks_attempted = usize_value(payload, &["durable_candidate", "provider_execution_count"])
+        .or(canonical.provider_executions)
+        .or_else(|| aggregate_outcome_count(payload));
     let aggregate_path = string_value(payload, &["aggregate_path"])
+        .or_else(|| string_value(payload, &["durable_candidate", "aggregate_path"]))
         .or_else(|| string_value(payload, &["record", "aggregate_path"]));
     let metrics = code_production_metrics(payload);
     let state = effective_run_state(
         raw_state,
-        tasks_attempted,
+        tasks_attempted.unwrap_or(0),
         metrics.candidate_state,
         metrics.candidate_scan_degraded,
     );
-    let artifact_count = aggregate_artifact_count(payload);
+    let artifact_count = usize_value(payload, &["durable_candidate", "artifact_count"])
+        .or_else(|| Some(aggregate_artifact_count(payload)).filter(|_| !durable_unavailable));
     let first_artifact = string_value(
         payload,
         &["aggregate", "outcomes", "0", "artifacts", "0", "path"],
@@ -323,19 +327,56 @@ fn render_cook_summary(payload: &Value) -> Option<String> {
             lines.push(format!("Next: {command}"));
         }
     }
+    let unavailable_or_zero = || {
+        if durable_unavailable {
+            "unavailable".to_string()
+        } else {
+            "0".to_string()
+        }
+    };
     lines.extend([
         format!("Run: {run_id}"),
         format!("Status: {state}"),
-        format!("Tasks planned: {tasks_planned}"),
-        format!("Tasks attempted: {tasks_attempted}"),
+        format!(
+            "Tasks planned: {}",
+            tasks_planned
+                .map(|count| count.to_string())
+                .unwrap_or_else(unavailable_or_zero)
+        ),
+        format!(
+            "Tasks attempted: {}",
+            tasks_attempted
+                .map(|count| count.to_string())
+                .unwrap_or_else(unavailable_or_zero)
+        ),
     ]);
-    lines.extend(code_production_lines(&metrics));
+    if durable_unavailable {
+        let reason = string_value(payload, &["durable_candidate", "reason"])
+            .unwrap_or("authoritative candidate evidence could not be read");
+        lines.push(format!("Candidate evidence: unavailable ({reason})"));
+    } else {
+        lines.extend(code_production_lines(&metrics));
+    }
     if let Some(path) = aggregate_path {
         lines.push(format!("Aggregate: {path}"));
     }
-    lines.push(format!("Artifacts: {artifact_count}"));
+    lines.push(format!(
+        "Artifacts: {}",
+        artifact_count
+            .map(|count| count.to_string())
+            .unwrap_or_else(unavailable_or_zero)
+    ));
     if let Some(artifact) = first_artifact {
         lines.push(format!("First artifact: {artifact}"));
+    }
+    if matches!(raw_state, "candidate_recoverable" | "partial_recoverable") {
+        if let Some(task) = string_value(payload, &["selected_candidate", "selected_task_id"]) {
+            let artifact = string_value(payload, &["selected_candidate", "selected_artifact_id"])
+                .unwrap_or("unknown");
+            lines.push(format!(
+                "Retained candidate: task {task}, artifact {artifact}"
+            ));
+        }
     }
     if primary_failure.is_some() {
         // Its exact action already leads the report.
@@ -348,12 +389,13 @@ fn render_cook_summary(payload: &Value) -> Option<String> {
 }
 
 fn render_status_summary(payload: &Value) -> Option<String> {
-    let run_id = string_value(payload, &["run_id"])?;
+    let run_id = string_value(payload, &["run_id"]).or_else(|| string_value(payload, &["run"]))?;
     let raw_state = string_value(payload, &["state"]).unwrap_or("unknown");
-    let tasks_planned = array_len(payload, &["tasks"]).unwrap_or(0);
+    let tasks_planned = array_len(payload, &["tasks"])
+        .or_else(|| usize_value(payload, &["durable_candidate", "task_count"]));
     let canonical = classify_candidates(payload);
-    let tasks_attempted = canonical
-        .provider_executions
+    let tasks_attempted = usize_value(payload, &["durable_candidate", "provider_execution_count"])
+        .or(canonical.provider_executions)
         .unwrap_or_else(|| status_attempted_task_count(payload));
     let metrics = code_production_metrics(payload);
     let candidate_state = status_scope_candidate(payload).unwrap_or(metrics.candidate_state);
@@ -370,8 +412,11 @@ fn render_status_summary(payload: &Value) -> Option<String> {
         });
     let completion = cook_completion_summary(payload);
     let cook = cook_outcome_summary(payload, state, candidate_state, completion.as_ref());
-    let artifact_count = array_len(payload, &["artifact_refs"]).unwrap_or(0);
-    let aggregate_path = string_value(payload, &["aggregate_path"]);
+    let artifact_count = array_len(payload, &["artifact_refs"])
+        .or_else(|| array_len(payload, &["artifacts"]))
+        .or_else(|| usize_value(payload, &["durable_candidate", "artifact_count"]));
+    let aggregate_path = string_value(payload, &["aggregate_path"])
+        .or_else(|| string_value(payload, &["durable_candidate", "aggregate_path"]));
 
     let mut lines = vec!["Agent task status".to_string()];
     if let Some(cook) = cook.as_ref() {
@@ -390,10 +435,11 @@ fn render_status_summary(payload: &Value) -> Option<String> {
         lines.push(format!("Status: {state}"));
         lines.push(format!("Run: {run_id}"));
     }
-    lines.extend([
-        format!("Tasks planned: {tasks_planned}"),
-        format!("Tasks attempted: {tasks_attempted}"),
-    ]);
+    lines.push(tasks_planned.map_or_else(
+        || "Tasks planned: unavailable".to_string(),
+        |count| format!("Tasks planned: {count}"),
+    ));
+    lines.push(format!("Tasks attempted: {tasks_attempted}"));
     let mut production_lines = code_production_lines(&metrics);
     if let Some(candidate) = string_value(payload, &["execution_states", "candidate", "state"]) {
         production_lines[1] = format!("Candidate state: {candidate}");
@@ -402,7 +448,10 @@ fn render_status_summary(payload: &Value) -> Option<String> {
     if let Some(diagnostic) = first_actionable_diagnostic(payload) {
         lines.push(format!("Diagnostic: {diagnostic}"));
     }
-    lines.push(format!("Artifacts: {artifact_count}"));
+    lines.push(artifact_count.map_or_else(
+        || "Artifacts: unavailable".to_string(),
+        |count| format!("Artifacts: {count}"),
+    ));
     if let Some(cook) = cook {
         lines.push(format!("Next: {}", cook.next_action(run_id)));
     } else if metrics.candidate_state.is_available() {
@@ -718,6 +767,7 @@ fn first_diagnostic_message<'a>(payload: &'a Value, path: &[&str]) -> Option<&'a
 
 fn aggregate_outcome_count(payload: &Value) -> Option<usize> {
     array_len(payload, &["aggregate", "outcomes"])
+        .or_else(|| usize_value(payload, &["durable_candidate", "outcome_count"]))
 }
 
 fn aggregate_artifact_count(payload: &Value) -> usize {
@@ -965,6 +1015,58 @@ mod tests {
         assert!(summary.contains("First artifact: /tmp/patch.diff\n"));
         assert!(summary.contains("Next: homeboy agent-task review homeboy-4345\n"));
         assert!(!summary.contains("{\n"));
+    }
+
+    #[test]
+    fn cook_summary_marks_authoritative_candidate_counts_unavailable() {
+        let payload = json!({
+            "run_id": "candidate-read-unavailable",
+            "status": "candidate_recoverable",
+            "durable_candidate": {
+                "status": "unavailable",
+                "reason": "the authoritative observation has no aggregate"
+            }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Cook, &payload).unwrap();
+
+        assert!(
+            summary.contains("Tasks planned: unavailable\n"),
+            "{summary}"
+        );
+        assert!(
+            summary.contains("Tasks attempted: unavailable\n"),
+            "{summary}"
+        );
+        assert!(summary.contains("Artifacts: unavailable\n"), "{summary}");
+        assert!(summary.contains(
+            "Candidate evidence: unavailable (the authoritative observation has no aggregate)\n"
+        ));
+        assert!(!summary.contains("Candidate state: unknown"), "{summary}");
+    }
+
+    #[test]
+    fn cook_summary_prefers_durable_provider_executions_over_outcomes() {
+        let payload = json!({
+            "run_id": "candidate-after-retries",
+            "status": "candidate_recoverable",
+            "durable_candidate": {
+                "status": "available",
+                "outcome_count": 1,
+                "provider_execution_count": 3,
+                "canonical_candidate": {
+                    "schema": "homeboy/agent-task-candidate/v1",
+                    "state": "patch_available",
+                    "provider_executions": 3,
+                    "counts": { "patch_available": 1 },
+                    "scan": {}
+                }
+            }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Cook, &payload).unwrap();
+
+        assert!(summary.contains("Tasks attempted: 3\n"), "{summary}");
     }
 
     #[test]


### PR DESCRIPTION
Closes #13972.
Closes #13973.

## Summary
- read the authoritative run record and mirrored aggregate atomically from SQLite
- hydrate unpromoted recoverable candidates in actual status output
- globally bound and redact retained failure payloads
- rank structured provider causes ahead of downstream missing-output consequences

## Verification
- `cargo test -p homeboy-agents terminal_projection_`
- `cargo test -p homeboy-agents durable_aggregate_read_`
- actual status hydration, provider-cause precedence, and global failure redaction tests
- `cargo check`
- `cargo fmt --all --check`
- `git diff --check`
- independent blocking review found no findings and confirmed a clean merge with current main

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented the changes, ran deterministic verification, and performed an independent blocking review under Chris Huber's direction.