### PR TITLE
fix(agent-task): validate fanout provider admission

### DIFF
--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -409,10 +409,38 @@ pub fn record_fanout_run_batch_failure_in_store(
         for child in &mut batch.child_runs {
             child.state = AgentTaskRunState::Failed;
         }
+        project_terminal_failure_dependency_graph(&mut batch.metadata);
         batch.state = AgentTaskBatchState::Failed;
         batch.updated_at = Some(now_timestamp());
         store.write_batch(&batch)
     })
+}
+
+/// A coordinator rejection means no child can be dispatched. Keep the durable
+/// graph projection aligned with the failed child rows rather than preserving a
+/// stale pre-admission `ready` frontier.
+fn project_terminal_failure_dependency_graph(metadata: &mut Value) {
+    let Some(nodes) = metadata
+        .get("dependency_graph")
+        .and_then(|graph| graph.get("nodes"))
+        .cloned()
+        .and_then(|nodes| serde_json::from_value::<Vec<AgentTaskDependencyNode>>(nodes).ok())
+    else {
+        return;
+    };
+    let states = nodes
+        .iter()
+        .map(|node| (node.id.clone(), AgentTaskDependencyState::Failed))
+        .collect::<BTreeMap<_, _>>();
+    let Ok((edges, readiness)) = dependency_graph_readiness(&nodes, &states) else {
+        return;
+    };
+    metadata["dependency_graph"] = json!({
+        "schema": "homeboy/agent-task-fanout-dependency-graph/v1",
+        "nodes": nodes,
+        "edges": edges,
+        "readiness": readiness,
+    });
 }
 
 /// Record child failures that occurred before Cook could create a lifecycle
@@ -3348,7 +3376,19 @@ mod tests {
             run_id: "source-run".to_string(),
         }];
         store
-            .persist_fanout_run_batch("source-wave", "source-wave", &children, json!({}))
+            .persist_fanout_run_batch(
+                "source-wave",
+                "source-wave",
+                &children,
+                json!({
+                    "dependency_graph": {
+                        "nodes": [{
+                            "id": "source",
+                            "depends_on": []
+                        }]
+                    }
+                }),
+            )
             .expect("persist");
         let claim_id = store
             .claim_fanout_run_batch("source-wave")
@@ -3379,6 +3419,15 @@ mod tests {
         assert_eq!(
             status.next_actions[0],
             "homeboy agent-task fanout resume source-wave"
+        );
+        assert_eq!(
+            status.batch.metadata["dependency_graph"]["readiness"]["states"]["source"],
+            "failed"
+        );
+        assert!(
+            status.batch.metadata["dependency_graph"]["readiness"]["ready"]
+                .as_array()
+                .is_some_and(Vec::is_empty)
         );
     }
 

--- a/crates/homeboy-agents/src/agent_task_dispatch_service.rs
+++ b/crates/homeboy-agents/src/agent_task_dispatch_service.rs
@@ -246,7 +246,12 @@ pub fn preflight_dispatch_provider_admission(
     catalog.apply_provider_runner_secret_env_contracts(&mut plan);
     catalog.validate_selected_models(&plan)?;
     preflight_dispatch_provider_secrets(&plan)?;
-    preflight_plan_provider_config_with_providers(&plan, catalog.providers())
+    preflight_plan_provider_config_with_providers(&plan, catalog.providers())?;
+    crate::agent_task_provider::preflight_plan_provider_dispatchability_without_runtime_with_providers(
+        &plan,
+        catalog,
+        &mut crate::agent_task_provider::ProviderRuntimeReadinessCache::default(),
+    )
 }
 
 pub fn dispatch_with_provider_requirements(

--- a/crates/homeboy-agents/src/agent_task_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_provider.rs
@@ -84,8 +84,9 @@ pub use credential_readiness::{
 };
 pub use dispatchability::{
     evaluate_provider_dispatchability, evaluate_provider_dispatchability_with_config,
-    preflight_plan_provider_dispatchability_with_providers, preflight_provider_dispatchability,
-    preflight_provider_dispatchability_with_config,
+    preflight_plan_provider_dispatchability_with_providers,
+    preflight_plan_provider_dispatchability_without_runtime_with_providers,
+    preflight_provider_dispatchability, preflight_provider_dispatchability_with_config,
     preflight_provider_dispatchability_without_runtime_with_config,
     AgentTaskProviderConfigurationDiagnosis, AgentTaskProviderCredentialStatus,
     AgentTaskProviderDispatchability, AgentTaskProviderOwner,

--- a/crates/homeboy-agents/src/agent_task_provider/dispatchability.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/dispatchability.rs
@@ -570,6 +570,26 @@ pub fn preflight_plan_provider_dispatchability_with_providers(
     Ok(())
 }
 
+/// Reject deterministic provider contract defects after the effective executor
+/// config has been compiled, without invoking provider-owned live readiness.
+pub fn preflight_plan_provider_dispatchability_without_runtime_with_providers(
+    plan: &AgentTaskPlan,
+    catalog: &AgentTaskProviderCatalog,
+    cache: &mut ProviderRuntimeReadinessCache,
+) -> homeboy_core::Result<()> {
+    for task in &plan.tasks {
+        preflight_provider_dispatchability_without_runtime_with_config(
+            catalog,
+            &task.executor.backend,
+            task.executor.selector.as_deref(),
+            task.executor.model(),
+            &task.executor.config,
+            cache,
+        )?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -9998,6 +9998,46 @@ fi
     }
 
     #[test]
+    fn dry_run_and_live_provider_admission_reject_the_same_missing_readiness_invocation() {
+        let catalog = AgentTaskProviderCatalog {
+            providers: vec![serde_json::from_value(serde_json::json!({
+                "id": "opencode.agent-task-executor",
+                "backend": "opencode",
+                "capabilities": ["cli_runtime", "provider_owned_auth"],
+                "cli": {
+                    "profiles": [{ "name": "terra", "model": "openai/gpt-5.6-terra" }]
+                }
+            }))
+            .expect("provider fixture")],
+            ..AgentTaskProviderCatalog::default()
+        };
+        let mut dry_run = cook_batch_args();
+        dry_run.backend = Some("opencode".to_string());
+        dry_run.selector = None;
+        dry_run.model = Some("openai/gpt-5.6-terra".to_string());
+        dry_run.secret_env.clear();
+        dry_run.preview = true;
+        dry_run.run_plan = false;
+        let mut live = dry_run.clone();
+        live.preview = false;
+        live.run_plan = true;
+
+        let dry_error = resolve_and_validate_effective_backend_with_catalog(&mut dry_run, &catalog)
+            .expect_err("preview must reject a provider-owned auth contract without readiness");
+        let live_error = resolve_and_validate_effective_backend_with_catalog(&mut live, &catalog)
+            .expect_err("run-plan admission must reject the same provider contract");
+
+        assert_eq!(dry_error.code, live_error.code);
+        assert_eq!(dry_error.message, live_error.message);
+        assert_eq!(dry_error.details, live_error.details);
+        assert_eq!(dry_error.details["field"], "provider_dispatchability");
+        assert!(
+            dry_error.message.contains("missing_readiness_invocation")
+                || dry_error.message.contains("readiness invocation")
+        );
+    }
+
+    #[test]
     fn dry_run_and_live_provider_admission_share_typed_missing_default_remediation() {
         with_isolated_home(|_| {
             let catalog = AgentTaskProviderCatalog {


### PR DESCRIPTION
## Summary

- validate static provider dispatchability after effective fanout plan compilation
- make preview and run-plan reject the same deterministic invalid provider contracts
- replace stale dependency-ready projections after terminal admission failures

Closes #14044.

## Validation

- `cargo test -p homeboy-agents present_credentials_are_not_admitted_when_live_validation_is_unavailable`
- `cargo test -p homeboy-cli dry_run_and_live_provider_admission_reject_the_same_missing_readiness_invocation`
- `cargo test -p homeboy-agents agent_task_batch::tests::status_projects_the_exact_returned_admission_blocker`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

Focused regressions pass. Broad package attempts exceeded their timeout and exposed unrelated existing failures.

## AI Assistance

OpenCode with OpenAI `openai/gpt-5.6-terra` traced preview/run-plan admission, implemented the shared validation and status projection, added tests, and ran verification. OpenCode with OpenAI `openai/gpt-5.6-sol` reproduced and filed the defect, orchestrated the isolated worktree, reviewed the result, rebased it, and reran focused verification under Chris Huber’s direction.