### PR TITLE
fix(worktree): retain list diagnostics

### DIFF
--- a/crates/homeboy-cli/src/commands/worktree.rs
+++ b/crates/homeboy-cli/src/commands/worktree.rs
@@ -1004,6 +1004,7 @@ mod tests {
         let output = serde_json::to_value(WorktreeOutput::List(WorktreeListCommandOutput {
             native: WorktreeListOutput {
                 worktrees: Vec::new(),
+                diagnostics: Vec::new(),
             },
             provider_worktrees: Vec::new(),
         }))

--- a/crates/homeboy-core/src/worktree/mod.rs
+++ b/crates/homeboy-core/src/worktree/mod.rs
@@ -31,13 +31,13 @@ pub use types::{
     WorktreeImportOptions, WorktreeImportOutput, WorktreeInventoryApplyRefusal,
     WorktreeInventoryAuthorization, WorktreeInventoryCrossTab, WorktreeInventoryLocalEvidence,
     WorktreeInventoryOptions, WorktreeInventoryOutput, WorktreeInventoryRecord,
-    WorktreeLeaseActivity, WorktreeListOutput, WorktreeLivenessAuthority, WorktreeOwnershipProbe,
-    WorktreeQueueCreateFailure, WorktreeQueueCreateOptions, WorktreeQueueCreateOutput,
-    WorktreeQueueCreateRequest, WorktreeQueueCreateRow, WorktreeQueueCreateStatus,
-    WorktreeQueueLockHolder, WorktreeReconciliationAction, WorktreeReconciliationAuthority,
-    WorktreeReconciliationResult, WorktreeRemoveOptions, WorktreeRemoveOutput,
-    WorktreeSafetyReport, WorktreeStatusOutput, TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY,
-    TERMINAL_WORKSPACE_AUTHORITY_SCHEMA,
+    WorktreeLeaseActivity, WorktreeListDiagnostic, WorktreeListOutput, WorktreeLivenessAuthority,
+    WorktreeOwnershipProbe, WorktreeQueueCreateFailure, WorktreeQueueCreateOptions,
+    WorktreeQueueCreateOutput, WorktreeQueueCreateRequest, WorktreeQueueCreateRow,
+    WorktreeQueueCreateStatus, WorktreeQueueLockHolder, WorktreeReconciliationAction,
+    WorktreeReconciliationAuthority, WorktreeReconciliationResult, WorktreeRemoveOptions,
+    WorktreeRemoveOutput, WorktreeSafetyReport, WorktreeStatusOutput,
+    TERMINAL_WORKSPACE_AUTHORITY_CAPABILITY, TERMINAL_WORKSPACE_AUTHORITY_SCHEMA,
 };
 
 /// The managed handle a repo and branch pair resolves to. Creation slugifies the

--- a/crates/homeboy-core/src/worktree/store_ops.rs
+++ b/crates/homeboy-core/src/worktree/store_ops.rs
@@ -895,20 +895,38 @@ fn create_evidence(
 
 pub(super) fn list_with_store(store_dir: &Path) -> Result<WorktreeListOutput> {
     let mut worktrees = Vec::new();
+    let mut diagnostics = Vec::new();
     if !store_dir.exists() {
-        return Ok(WorktreeListOutput { worktrees });
+        return Ok(WorktreeListOutput {
+            worktrees,
+            diagnostics,
+        });
     }
-    for entry in fs::read_dir(store_dir)
+    let mut entries: Vec<_> = fs::read_dir(store_dir)
         .map_err(|err| Error::internal_io(err.to_string(), Some(store_dir.display().to_string())))?
-    {
-        let entry = entry.map_err(|err| Error::internal_io(err.to_string(), None))?;
+        .collect::<std::result::Result<_, _>>()
+        .map_err(|err| {
+            Error::internal_io(err.to_string(), Some(store_dir.display().to_string()))
+        })?;
+    entries.sort_by_key(|entry| entry.file_name());
+    for entry in entries {
         if entry.path().extension().and_then(|ext| ext.to_str()) != Some("json") {
             continue;
         }
-        worktrees.push(read_record_path(&entry.path())?);
+        match read_record_path(&entry.path()) {
+            Ok(record) => worktrees.push(record),
+            Err(error) => diagnostics.push(WorktreeListDiagnostic::from_error(
+                error,
+                None,
+                Some(entry.path().display().to_string()),
+            )),
+        }
     }
     worktrees.sort_by(|a, b| a.id.cmp(&b.id));
-    Ok(WorktreeListOutput { worktrees })
+    Ok(WorktreeListOutput {
+        worktrees,
+        diagnostics,
+    })
 }
 
 pub(super) fn inventory_with_store_and_authority(

--- a/crates/homeboy-core/src/worktree/tests.rs
+++ b/crates/homeboy-core/src/worktree/tests.rs
@@ -1649,6 +1649,27 @@ fn status_reports_missing_source_checkout_as_validation_diagnostic() {
 }
 
 #[test]
+fn list_retains_valid_records_and_diagnoses_malformed_manifests() {
+    let dir = tempfile::tempdir().unwrap();
+    let source = git_repo();
+    let store = dir.path().join("store");
+    let record = fixture_record(source.path(), &dir.path().join("fixture@task"));
+    write_record(&store, &record).unwrap();
+    fs::write(store.join("malformed.json"), "not json\n").unwrap();
+
+    let output = list_with_store(&store).unwrap();
+
+    assert_eq!(output.worktrees, vec![record]);
+    assert_eq!(output.diagnostics.len(), 1);
+    let diagnostic = &output.diagnostics[0];
+    assert_eq!(diagnostic.code, "internal.json_error");
+    assert_eq!(
+        diagnostic.record_path.as_deref(),
+        Some(store.join("malformed.json").to_str().unwrap())
+    );
+}
+
+#[test]
 fn cleanup_skips_unrepairable_missing_source_and_continues() {
     use crate::test_support::with_isolated_home;
 

--- a/crates/homeboy-core/src/worktree/types.rs
+++ b/crates/homeboy-core/src/worktree/types.rs
@@ -1,5 +1,5 @@
 use crate::workspace_claim::{WorkspaceClaim, WorkspaceIdentity};
-use crate::Result;
+use crate::{Error, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -404,6 +404,37 @@ pub struct WorktreeAdoptOutput {
 #[derive(Debug, Clone, Serialize)]
 pub struct WorktreeListOutput {
     pub worktrees: Vec<TaskWorktreeRecord>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<WorktreeListDiagnostic>,
+}
+
+/// A record-scoped failure retained by `worktree list` while unaffected records
+/// remain available to operators.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct WorktreeListDiagnostic {
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub record_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub record_path: Option<String>,
+    pub details: serde_json::Value,
+}
+
+impl WorktreeListDiagnostic {
+    pub(crate) fn from_error(
+        error: Error,
+        record_id: Option<String>,
+        record_path: Option<String>,
+    ) -> Self {
+        Self {
+            code: error.code.as_str().to_string(),
+            message: error.message,
+            record_id,
+            record_path,
+            details: error.details,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/crates/homeboy-core/src/worktree_provider.rs
+++ b/crates/homeboy-core/src/worktree_provider.rs
@@ -562,69 +562,92 @@ impl WorktreeInventoryProvider for NativeWorktreeProvider {
         worktree::list_workspace_refs()?
             .into_iter()
             .filter(|record| record.state() == &worktree::TaskWorktreeState::Active)
-            .map(|record| {
-                let (
-                    kind,
-                    branch,
-                    task_url,
-                    repository,
-                    owner_run_ref,
-                    terminal_disposition,
-                    safety,
-                ) = match &record {
-                    worktree::WorkspaceRefRecord::Task(record) => {
-                        let safety = worktree::safety_report_for_provider(record)?;
-                        (
-                            WorktreeWorkspaceKind::TaskWorktree,
-                            Some(record.branch.clone()),
-                            record.task_url.clone(),
-                            Some(record.component_id.clone()),
-                            record.run_id.clone(),
-                            record.terminal_disposition.clone(),
-                            WorktreeProviderSafety {
-                                dirty: safety.dirty,
-                                unpushed: safety.unpushed_commits > 0,
-                                primary: safety.primary_checkout,
-                                missing: safety.worktree_missing,
-                            },
-                        )
-                    }
-                    worktree::WorkspaceRefRecord::Adopted(record) => (
-                        WorktreeWorkspaceKind::AdoptedWorkspace,
-                        None,
-                        None,
-                        None,
-                        None,
-                        None,
-                        WorktreeProviderSafety {
-                            dirty: false,
-                            unpushed: false,
-                            primary: false,
-                            missing: !Path::new(&record.path).is_dir(),
-                        },
-                    ),
-                };
-                Ok(WorktreeProviderWorkspace {
-                    ownership: WorktreeOwnership {
-                        provider: WorktreeProviderIdentity::Native,
-                        handle: record.handle().to_string(),
-                        path: record.path().to_string(),
-                        kind,
-                        branch,
-                        task_url,
-                        provenance: record.provenance().cloned(),
-                    },
-                    repository,
-                    owner_run_ref,
-                    created_at: Some(match record {
-                        worktree::WorkspaceRefRecord::Task(record) => record.created_at,
-                        worktree::WorkspaceRefRecord::Adopted(record) => record.created_at,
-                    }),
-                    terminal_disposition,
-                    safety,
-                })
-            })
+            .map(|record| Self::workspace_from_record(&record))
             .collect()
+    }
+}
+
+impl NativeWorktreeProvider {
+    fn workspaces_from_records(
+        records: impl IntoIterator<Item = worktree::WorkspaceRefRecord>,
+    ) -> (
+        Vec<WorktreeProviderWorkspace>,
+        Vec<worktree::WorktreeListDiagnostic>,
+    ) {
+        let mut workspaces = Vec::new();
+        let mut diagnostics = Vec::new();
+        for record in records {
+            if record.state() != &worktree::TaskWorktreeState::Active {
+                continue;
+            }
+            match Self::workspace_from_record(&record) {
+                Ok(workspace) => workspaces.push(workspace),
+                Err(error) => diagnostics.push(worktree::WorktreeListDiagnostic::from_error(
+                    error,
+                    Some(record.handle().to_string()),
+                    Some(record.path().to_string()),
+                )),
+            }
+        }
+        (workspaces, diagnostics)
+    }
+
+    fn workspace_from_record(
+        record: &worktree::WorkspaceRefRecord,
+    ) -> Result<WorktreeProviderWorkspace> {
+        let (kind, branch, task_url, repository, owner_run_ref, terminal_disposition, safety) =
+            match record {
+                worktree::WorkspaceRefRecord::Task(record) => {
+                    let safety = worktree::safety_report_for_provider(record)?;
+                    (
+                        WorktreeWorkspaceKind::TaskWorktree,
+                        Some(record.branch.clone()),
+                        record.task_url.clone(),
+                        Some(record.component_id.clone()),
+                        record.run_id.clone(),
+                        record.terminal_disposition.clone(),
+                        WorktreeProviderSafety {
+                            dirty: safety.dirty,
+                            unpushed: safety.unpushed_commits > 0,
+                            primary: safety.primary_checkout,
+                            missing: safety.worktree_missing,
+                        },
+                    )
+                }
+                worktree::WorkspaceRefRecord::Adopted(record) => (
+                    WorktreeWorkspaceKind::AdoptedWorkspace,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    WorktreeProviderSafety {
+                        dirty: false,
+                        unpushed: false,
+                        primary: false,
+                        missing: !Path::new(&record.path).is_dir(),
+                    },
+                ),
+            };
+        Ok(WorktreeProviderWorkspace {
+            ownership: WorktreeOwnership {
+                provider: WorktreeProviderIdentity::Native,
+                handle: record.handle().to_string(),
+                path: record.path().to_string(),
+                kind,
+                branch,
+                task_url,
+                provenance: record.provenance().cloned(),
+            },
+            repository,
+            owner_run_ref,
+            created_at: Some(match record {
+                worktree::WorkspaceRefRecord::Task(record) => record.created_at.clone(),
+                worktree::WorkspaceRefRecord::Adopted(record) => record.created_at.clone(),
+            }),
+            terminal_disposition,
+            safety,
+        })
     }
 }
 
@@ -1318,10 +1341,13 @@ impl<'a> WorktreeProviderRegistry<'a> {
     }
 
     pub fn list_report(&self) -> Result<WorktreeListReport> {
-        let native = worktree::list()?;
-        let provider_worktrees = self
-            .list()?
+        let mut native = worktree::list()?;
+        let (native_worktrees, mut diagnostics) =
+            NativeWorktreeProvider::workspaces_from_records(worktree::list_workspace_refs()?);
+        native.diagnostics.append(&mut diagnostics);
+        let provider_worktrees = native_worktrees
             .into_iter()
+            .chain(CommandWorktreeProvider::new(self.config).list()?)
             .filter(|workspace| {
                 matches!(
                     workspace.ownership.provider,
@@ -2230,6 +2256,64 @@ mod tests {
                 .expect_err("terminal disposition cannot change");
             std::fs::write(path.join("dirty"), "dirty\n").expect("dirty native worktree");
             assert_unsafe_lookup(&NativeWorktreeProvider, "fixture@native");
+        });
+    }
+
+    #[test]
+    fn list_report_keeps_valid_inventory_when_a_record_source_is_unrecoverable() {
+        crate::test_support::with_isolated_home(|home| {
+            let (source, path) = initialize_native_worktree(home.path());
+            worktree::record_active_with_source_for_test("fixture@native", source.path(), &path);
+
+            let missing_source = home.path().join("missing-source");
+            let missing_worktree = home.path().join("missing-worktree");
+            worktree::record_active_with_source_for_test(
+                "missing@source",
+                &missing_source,
+                &missing_worktree,
+            );
+            let record_path = crate::paths::observation_db()
+                .expect("observation database")
+                .parent()
+                .expect("observation database parent")
+                .join("task-worktrees")
+                .join(format!(
+                    "{}.json",
+                    crate::paths::sanitize_path_segment("missing@source")
+                ));
+            let mut record: serde_json::Value = serde_json::from_slice(
+                &std::fs::read(&record_path).expect("missing-source record"),
+            )
+            .expect("parse missing-source record");
+            record["component_id"] = serde_json::json!("unrecoverable-component");
+            std::fs::write(
+                &record_path,
+                serde_json::to_vec_pretty(&record).expect("serialize missing-source record"),
+            )
+            .expect("write missing-source record");
+
+            let report = WorktreeProviderRegistry::new(&defaults::load_config())
+                .list_report()
+                .expect("list report");
+
+            assert!(report
+                .native
+                .worktrees
+                .iter()
+                .any(|record| record.id == "missing@source"));
+            assert!(report
+                .native
+                .worktrees
+                .iter()
+                .any(|record| record.id == "fixture@native"));
+            assert_eq!(report.native.diagnostics.len(), 1);
+            let diagnostic = &report.native.diagnostics[0];
+            assert_eq!(diagnostic.code, "validation.invalid_argument");
+            assert_eq!(diagnostic.record_id.as_deref(), Some("missing@source"));
+            assert_eq!(
+                diagnostic.details["field"].as_str(),
+                Some("source_checkout")
+            );
         });
     }
 


### PR DESCRIPTION
## Summary

- preserve valid worktree inventory when one retained record is malformed or has an unrecoverable source checkout
- emit typed per-record diagnostics instead of failing the entire list operation
- cover malformed manifests and missing-source records across core/provider/CLI boundaries

Closes #11283.

## Validation

- `cargo test -p homeboy-core worktree_provider::tests::list_report_keeps_valid_inventory_when_a_record_source_is_unrecoverable`
- `cargo test -p homeboy-core worktree::tests::list_retains_valid_records_and_diagnoses_malformed_manifests`
- `cargo test -p homeboy-cli worktree_list`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

Focused regressions pass. A broader core worktree run exposed unrelated existing provider lifecycle failures.

## AI Assistance

OpenCode with OpenAI `openai/gpt-5.6-terra` traced the global list failure, implemented per-record fault isolation and tests, and ran verification. OpenCode with OpenAI `openai/gpt-5.6-sol` reproduced the regression, reopened the tracker, orchestrated the isolated worktree, reviewed the result, rebased it, and reran focused verification under Chris Huber’s direction.