### PR TITLE
fix(cook): compare replacement candidate fingerprints

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -1030,15 +1030,10 @@ pub fn record_replacement_gate_proof(
         accept_inherited_failures,
     )?;
     validate_legacy_replacement_candidate_checkout(run_id, &original, &replacement)?;
-    let expected_candidate = original.provenance.get("candidate");
-    let observed_candidate = replacement.provenance.get("candidate");
-    let same_candidate = observed_candidate == expected_candidate
-        && (original
-            .provenance
-            .get("candidate_checkout")
-            .is_none_or(Value::is_null)
-            || replacement.provenance.get("candidate_checkout")
-                == original.provenance.get("candidate_checkout"));
+    let expected_candidate = canonical_candidate_fingerprint(original.provenance.get("candidate"));
+    let observed_candidate =
+        canonical_candidate_fingerprint(replacement.provenance.get("candidate"));
+    let same_candidate = observed_candidate == expected_candidate;
     let drifted = serde_json::json!({
         "run_id": replacement.source.run_id.as_deref() != Some(run_id),
         "target": replacement.target.worktree != original.target.worktree || replacement.target.path != original.target.path,
@@ -1060,8 +1055,8 @@ pub fn record_replacement_gate_proof(
         );
         error.details["drift"] = drifted;
         error.details["candidate_fingerprint"] = serde_json::json!({
-            "expected": bounded_candidate_fingerprint(expected_candidate),
-            "observed": bounded_candidate_fingerprint(observed_candidate),
+            "expected": expected_candidate,
+            "observed": observed_candidate,
         });
         return Err(error);
     }
@@ -1121,40 +1116,15 @@ pub fn record_replacement_gate_proof(
     Ok(replacement)
 }
 
-fn bounded_candidate_fingerprint(candidate: Option<&Value>) -> Value {
-    const MAX_CHANGED_FILES: usize = 32;
-
+fn canonical_candidate_fingerprint(candidate: Option<&Value>) -> Value {
     let Some(candidate) = candidate else {
         return Value::Null;
     };
-    let Some(fingerprint) = candidate.get("fingerprint") else {
-        return serde_json::json!({ "kind": candidate.get("kind") });
-    };
-    let changed_files = fingerprint
-        .get("changed_files")
-        .and_then(Value::as_array)
-        .map(|files| {
-            files
-                .iter()
-                .take(MAX_CHANGED_FILES)
-                .cloned()
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-    serde_json::json!({
-        "kind": candidate.get("kind"),
-        "schema": fingerprint.get("schema"),
-        "target_path": fingerprint.get("target_path"),
-        "head": fingerprint.get("head"),
-        "base": fingerprint.get("base"),
-        "tree": fingerprint.get("tree"),
-        "sha256": fingerprint.get("sha256"),
-        "changed_files": changed_files,
-        "changed_files_truncated": fingerprint
-            .get("changed_files")
-            .and_then(Value::as_array)
-            .is_some_and(|files| files.len() > MAX_CHANGED_FILES),
-    })
+    serde_json::from_value::<AgentTaskPromotionCandidate>(candidate.clone())
+        .and_then(|candidate| serde_json::to_value(candidate).map_err(Into::into))
+        // Preserve malformed legacy data verbatim so an identity mismatch is
+        // still inspectable rather than silently treated as equivalent.
+        .unwrap_or_else(|_| candidate.clone())
 }
 
 /// Older failed promotions did not retain the checkout used by their gates.

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -20684,7 +20684,7 @@ fn replacement_gate_proof_recovers_failed_candidate_without_hiding_evidence_or_r
             crate::agent_task_gate::AgentTaskGateStatus::Succeeded;
         replacement.deterministic_gates[0].exit_code = 0;
         replacement.deterministic_gates[0].stderr.clear();
-        replacement.provenance["candidate_checkout"] = legacy_checkout;
+        replacement.provenance["candidate_checkout"] = legacy_checkout.clone();
         replacement.command_evidence = vec![
             crate::agent_task_promotion::AgentTaskPromotionCommandReport {
                 command: vec![
@@ -20804,6 +20804,20 @@ fn replacement_gate_proof_recovers_failed_candidate_without_hiding_evidence_or_r
         );
         assert_eq!(error.details["gate_id"], "private-unbound");
 
+        agent_task_lifecycle::rewrite_record_for_test(run_id, |record| {
+            record.metadata["latest_promotion"]["provenance"]["candidate_checkout"] =
+                legacy_checkout.clone();
+            record.metadata["promotions"][0]["provenance"]["candidate_checkout"] =
+                legacy_checkout.clone();
+        })
+        .expect("restore original immutable checkout evidence");
+        replacement.provenance["candidate_checkout"]["commit"] =
+            serde_json::json!("replacement-candidate-checkout");
+        replacement.deterministic_gates[0]
+            .candidate_checkout
+            .as_mut()
+            .unwrap()
+            .commit = "replacement-candidate-checkout".to_string();
         let replacement_for_finalization = replacement.clone();
         let replacement_for_replay = replacement.clone();
         record_replacement_gate_proof(
@@ -20812,7 +20826,7 @@ fn replacement_gate_proof_recovers_failed_candidate_without_hiding_evidence_or_r
             Some("Chris approved external proof".to_string()),
             false,
         )
-        .expect("record bound green replacement proof");
+        .expect("a fresh immutable gate checkout does not change the candidate");
         let replay = record_replacement_gate_proof(
             run_id,
             replacement_for_replay,


### PR DESCRIPTION
## Summary

- compare canonical candidate fingerprints instead of immutable checkout commits during replacement proof verification
- project the same canonical fingerprints in drift diagnostics
- cover unchanged candidates represented by fresh immutable checkout commits

Closes #14035.

## Validation

- `cargo test -p homeboy-agents --lib replacement_gate_proof_recovers_failed_candidate_without_hiding_evidence_or_republishing`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

The full `homeboy-agents` suite reached 2,172 passing tests and one unrelated pre-existing failure: `run_next_redacts_poisoned_recipe_dispatcher_kind`.

## AI Assistance

OpenCode with OpenAI `openai/gpt-5.6-terra` traced the fingerprint mismatch, implemented the fix and regression test, and ran verification. OpenCode with OpenAI `openai/gpt-5.6-sol` orchestrated the isolated worktree, reviewed the result, rebased it, and reran focused verification under Chris Huber’s direction.