### PR TITLE
fix(upgrade): persist refresh phase progress

### DIFF
--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -544,7 +544,10 @@ pub fn run_upgrade_with_method(
                 (vec![], vec![])
             } else {
                 operation.set_phase("refreshing installed extensions");
-                update_all_extensions(operation.id())
+                let (updated, skipped) = update_all_extensions(operation.id());
+                let status = extension_component_status(true, false, &updated, &skipped);
+                operation.mark_extensions(&status.status, &status.summary);
+                (updated, skipped)
             };
             let promotion_lease = acquire_controller_upgrade_lease(
                 &mut operation,
@@ -554,6 +557,7 @@ pub fn run_upgrade_with_method(
             let (runners_updated, runners_skipped) = if skip_runners {
                 (vec![], vec![])
             } else {
+                operation.set_phase("refreshing configured runners");
                 super::with_runner_upgrade(|p| {
                     p.upgrade_configured_runners_with_explicit_source_path(
                         force,
@@ -734,7 +738,10 @@ pub fn run_upgrade_with_method(
     // mismatches and inconsistent audit findings.
     let (extensions_updated, extension_skips) = if upgrade_completed && !skip_extensions {
         operation.set_phase("refreshing installed extensions");
-        update_all_extensions(operation.id())
+        let (updated, skipped) = update_all_extensions(operation.id());
+        let status = extension_component_status(true, false, &updated, &skipped);
+        operation.mark_extensions(&status.status, &status.summary);
+        (updated, skipped)
     } else if skip_extensions {
         operation.mark_extensions("skipped", "extension refresh skipped");
         (vec![], vec![])

--- a/crates/homeboy-upgrade/src/upgrade/operation.rs
+++ b/crates/homeboy-upgrade/src/upgrade/operation.rs
@@ -90,6 +90,15 @@ impl UpgradeOperation {
     pub fn set_phase(&mut self, phase: &str) {
         emit_upgrade_phase(phase);
         self.metadata["phase"] = json!(phase);
+        match phase {
+            "refreshing installed extensions" => {
+                self.metadata["extensions"] = component("running", "extension refresh in progress");
+            }
+            "refreshing configured runners" => {
+                self.metadata["runners"] = component("running", "runner refresh in progress");
+            }
+            _ => {}
+        }
         self.metadata["elapsed_seconds"] = json!(self.started.elapsed().as_secs());
         self.persist();
     }
@@ -478,6 +487,35 @@ mod tests {
                 .unwrap_or_default()
                 .contains("wordpress"));
             assert_eq!(status.elapsed_seconds, 45);
+        });
+    }
+
+    #[test]
+    fn runner_refresh_phase_preserves_completed_extensions_and_started_runners() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
+            let id = operation.id().expect("persisted operation").to_string();
+            operation.mark_controller_promoted("controller installation completed");
+            operation.set_phase("refreshing installed extensions");
+            operation.mark_extensions("completed", "7 updated, 0 skipped");
+            operation.set_phase("refreshing configured runners");
+
+            let status = load_upgrade_operation_status(Some(&id)).expect("load status");
+            assert_eq!(status.phase, "refreshing configured runners");
+            assert_eq!(
+                status
+                    .extensions
+                    .as_ref()
+                    .map(|component| (component.status.as_str(), component.summary.as_str())),
+                Some(("completed", "7 updated, 0 skipped"))
+            );
+            assert_eq!(
+                status
+                    .runners
+                    .as_ref()
+                    .map(|component| component.status.as_str()),
+                Some("running")
+            );
         });
     }
 


### PR DESCRIPTION
## Summary

- persist refresh phase entry before extension and runner work
- retain completed extension results before runner refresh begins
- preserve truthful progress on the no-controller-update path

Closes #14037.

## Validation

- `cargo test -p homeboy-upgrade runner_refresh_phase_preserves_completed_extensions_and_started_runners`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

The broad CLI suite exceeded its timeout and showed unrelated existing agent-task failures; the issue-specific regression passes.

## AI Assistance

OpenCode with OpenAI `openai/gpt-5.6-terra` traced interrupted upgrade persistence, implemented the phase checkpoints and regression test, and ran verification. OpenCode with OpenAI `openai/gpt-5.6-sol` orchestrated the isolated worktree, reviewed the result, rebased it, and reran focused verification under Chris Huber’s direction.