### PR TITLE
fix(agent-task): retain gate-blocked candidates

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -7243,6 +7243,11 @@ pub fn record_promotion_in_store(
             .expect("promotions array")
             .push(promotion.clone());
         metadata.insert("latest_promotion".to_string(), promotion.clone());
+        // A promoted patch blocked by deterministic gates is still the durable
+        // candidate, but it cannot be reported as a successful completed run.
+        if promotion.get("status").and_then(Value::as_str) == Some("gate_failed") {
+            set_run_state(record, AgentTaskRunState::CandidateRecoverable);
+        }
         if let Some(acceptance) = record.acceptance.as_mut() {
             let candidate = acceptance_candidate(&promotion);
             let base_sha = promotion

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -2433,6 +2433,14 @@ fn corrected_promotion_replaces_gate_failed_latest_proof() {
 
     record_promotion_in_store(&lifecycle_store, run_id, gate_failed)
         .expect("gate failure recorded");
+    let gate_failed_record = lifecycle_store
+        .read_record(run_id)
+        .expect("gate failure lifecycle state");
+    assert_eq!(
+        gate_failed_record.state,
+        AgentTaskRunState::CandidateRecoverable,
+        "a promoted candidate blocked by gates remains recoverable rather than successful"
+    );
     let updated = record_promotion_in_store(&lifecycle_store, run_id, corrected.clone())
         .expect("correction recorded");
 
@@ -2451,6 +2459,7 @@ fn corrected_promotion_replaces_gate_failed_latest_proof() {
             .len(),
         2
     );
+    assert_eq!(updated.state, AgentTaskRunState::CandidateRecoverable);
 }
 
 #[test]

--- a/crates/homeboy-agents/src/orchestration.rs
+++ b/crates/homeboy-agents/src/orchestration.rs
@@ -1845,6 +1845,32 @@ mod tests {
     }
 
     #[test]
+    fn gate_failed_promotion_projects_a_recoverable_candidate_not_success() {
+        let mut record = record(AGENT_TASK_RUN);
+        record.state = crate::agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable;
+        record.lifecycle.execution.state =
+            homeboy_core::run_lifecycle_record::RunExecutionState::CandidateRecoverable;
+        record.metadata["latest_promotion"]["status"] = json!("gate_failed");
+        record.metadata["latest_promotion"]["deterministic_gates"] = json!([
+            { "id": "test", "status": "failed" }
+        ]);
+        record.metadata["cook_finalization"] = serde_json::Value::Null;
+
+        let resource = project_record(&record, None).expect("project gate failure");
+
+        assert_eq!(resource.state, ControlPlaneRunState::CandidateRecoverable);
+        assert_eq!(
+            resource
+                .candidate
+                .as_ref()
+                .map(|candidate| candidate.state.as_str()),
+            Some("gate_failed")
+        );
+        assert_eq!(resource.gates[0].state, "failed");
+        assert!(resource.publication.is_none());
+    }
+
+    #[test]
     fn injected_plan_is_used_once_for_retry_eligibility() {
         let mut failed = record(AGENT_TASK_RUN);
         failed.state = crate::agent_task_lifecycle::AgentTaskRunState::Failed;


### PR DESCRIPTION
## Summary

- transition gate-failed promotions to durable `candidate_recoverable` state
- retain terminal timestamps for recoverable candidates
- project gate-failed candidates as recoverable rather than successful

Closes #14036.

## Validation

- `cargo test -p homeboy-agents --lib set_run_state_stamps_finished_at_for_candidate_recoverable_terminal_runs`
- `cargo test -p homeboy-agents --lib gate_failed_promotion_projects_a_recoverable_candidate_not_success`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

The broad package suite exposed unrelated existing failures/timeouts; both issue-specific regressions pass.

## AI Assistance

OpenCode with OpenAI `openai/gpt-5.6-terra` traced the lifecycle projection, implemented the durable recovery state and tests, and ran verification. OpenCode with OpenAI `openai/gpt-5.6-sol` orchestrated the isolated worktree, reviewed the result, rebased it, and reran focused verification under Chris Huber’s direction.