### PR TITLE
Centralize extension manifest loading

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/manifest_action_config.rs
+++ b/crates/contracts/homeboy-extension-contract/src/manifest_action_config.rs
@@ -92,6 +92,42 @@ pub struct SettingConfig {
     pub label: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub placeholder: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_present_json",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub default: Option<serde_json::Value>,
+}
+
+fn deserialize_present_json<'de, D>(deserializer: D) -> Result<Option<serde_json::Value>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    serde_json::Value::deserialize(deserializer).map(Some)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn setting_default_distinguishes_absent_from_null() {
+        let absent: SettingConfig = serde_json::from_value(serde_json::json!({
+            "id": "absent",
+            "type": "json",
+            "label": "Absent"
+        }))
+        .unwrap();
+        let null: SettingConfig = serde_json::from_value(serde_json::json!({
+            "id": "null",
+            "type": "json",
+            "label": "Null",
+            "default": null
+        }))
+        .unwrap();
+
+        assert_eq!(absent.default, None);
+        assert_eq!(null.default, Some(serde_json::Value::Null));
+    }
 }

--- a/crates/homeboy-core/src/extension/bench/run/list.rs
+++ b/crates/homeboy-core/src/extension/bench/run/list.rs
@@ -183,12 +183,7 @@ pub(crate) fn bench_component_script_list_env(
     ));
     env.push((
         "HOMEBOY_SETTINGS_JSON".to_string(),
-        crate::extension::build_settings_json_from_manifest(
-            &serde_json::json!({}),
-            &[],
-            &args.settings,
-            &args.settings_json,
-        )?,
+        crate::extension::build_settings_json(&[], &[], &args.settings, &args.settings_json)?,
     ));
     Ok(env)
 }

--- a/crates/homeboy-core/src/extension/bench/run/workflow.rs
+++ b/crates/homeboy-core/src/extension/bench/run/workflow.rs
@@ -512,12 +512,7 @@ pub(crate) fn bench_component_script_env(
         ),
         (
             "HOMEBOY_SETTINGS_JSON".to_string(),
-            crate::extension::build_settings_json_from_manifest(
-                &serde_json::json!({}),
-                &[],
-                &args.settings,
-                &args.settings_json,
-            )?,
+            crate::extension::build_settings_json(&[], &[], &args.settings, &args.settings_json)?,
         ),
     ];
     if let Some(run_id) = args

--- a/crates/homeboy-core/src/extension/catalog/mod.rs
+++ b/crates/homeboy-core/src/extension/catalog/mod.rs
@@ -88,6 +88,15 @@ pub fn load_extension(id: &str) -> Result<ExtensionManifest> {
     load_extension_in_root(&paths::homeboy()?, id)
 }
 
+/// Load one extension manifest from an already-resolved extension directory.
+pub fn load_extension_from_dir(extension_dir: &Path) -> Result<ExtensionManifest> {
+    let id = extension_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| Error::internal_io("Extension path has no file name".to_string(), None))?;
+    load_extension_at(id, extension_dir).map_err(|failure| manifest_failure_error(&failure))
+}
+
 /// Load a manifest from an injected config root when one is supplied, and from
 /// the ambient process root otherwise.
 ///
@@ -487,6 +496,35 @@ mod tests {
     fn test_load_extension() {
         crate::test_support::with_isolated_home(|_| {
             assert!(load_extension("missing-extension").is_err());
+        });
+    }
+
+    #[test]
+    fn explicit_directory_loading_is_canonical_and_path_authoritative() {
+        crate::test_support::with_isolated_home(|home| {
+            let ambient_dir = home.path().join(".config/homeboy/extensions/fixture");
+            std::fs::create_dir_all(&ambient_dir).unwrap();
+            std::fs::write(
+                ambient_dir.join("fixture.json"),
+                r#"{"name":"Ambient","version":"1.0.0"}"#,
+            )
+            .unwrap();
+
+            let explicit_root = tempfile::TempDir::new().unwrap();
+            let explicit_dir = explicit_root.path().join("fixture");
+            std::fs::create_dir_all(&explicit_dir).unwrap();
+            let manifest_path = explicit_dir.join("fixture.json");
+            std::fs::write(&manifest_path, r#"{"name":"Explicit","version":"2.0.0"}"#).unwrap();
+
+            let manifest = load_extension_from_dir(&explicit_dir).unwrap();
+            assert_eq!(manifest.id, "fixture");
+            assert_eq!(manifest.name, "Explicit");
+            assert_eq!(manifest.version, "2.0.0");
+            assert_eq!(manifest.extension_path.as_deref(), explicit_dir.to_str());
+
+            std::fs::write(&manifest_path, "{not json").unwrap();
+            let error = load_extension_from_dir(&explicit_dir).unwrap_err();
+            assert_eq!(error.details["category"], "manifest_json_malformed");
         });
     }
 

--- a/crates/homeboy-core/src/extension/invoke.rs
+++ b/crates/homeboy-core/src/extension/invoke.rs
@@ -27,7 +27,7 @@ mod scope;
 mod settings;
 mod tool;
 
-use crate::extension::catalog::load_extension;
+use crate::extension::catalog::{load_extension, load_extension_from_dir};
 use homeboy_core::extension::resolve::ExtensionExecutionContext;
 use homeboy_extension_contract::exec_context;
 use homeboy_extension_contract::manifest_action_config::RuntimeConfig;
@@ -55,8 +55,8 @@ pub use runtime_helper::{
     RUNTIME_SETTINGS_HELPER_ENV, RUNTIME_SETTINGS_HELPER_ID,
 };
 pub use scenario_runner::{build_scenario_runner, ScenarioRunnerOptions};
+pub(crate) use settings::build_settings_json;
 use settings::serialize_settings;
-pub(crate) use settings::{build_settings_json_from_manifest, load_extension_manifest_from_dir};
 pub use tool::exec_tool;
 
 /// Result of executing a extension.
@@ -466,7 +466,7 @@ pub(crate) fn build_capability_env_with_additional_providers(
 
     let mut provider_env = env.clone();
     provider_env.extend(extra_env.iter().cloned());
-    if let Ok(extension) = env_provider::load_manifest_from_dir(extension_path) {
+    if let Ok(extension) = load_extension_from_dir(extension_path) {
         env.extend(env_provider::env_vars(
             &homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local(
                 "homeboy",
@@ -477,7 +477,7 @@ pub(crate) fn build_capability_env_with_additional_providers(
         )?);
     }
     for (_extension_id, provider_path) in additional_env_provider_paths {
-        if let Ok(extension) = env_provider::load_manifest_from_dir(provider_path) {
+        if let Ok(extension) = load_extension_from_dir(provider_path) {
             env.extend(env_provider::env_vars(
                 &homeboy_core::runner_job_execution_context::RunnerJobExecutionContext::local(
                     "homeboy",
@@ -648,6 +648,7 @@ mod tests {
     use super::*;
     use crate::extension::resolve::extract_component_extension_settings;
     use homeboy_core::component::Component;
+    use homeboy_extension_contract::manifest_action_config::SettingConfig;
 
     fn runtime_with_setup_timeout(setup_timeout_seconds: Option<u64>) -> RuntimeConfig {
         RuntimeConfig {
@@ -658,6 +659,16 @@ mod tests {
             env: None,
             entrypoint: None,
             args: None,
+        }
+    }
+
+    fn setting(id: &str, default: serde_json::Value) -> SettingConfig {
+        SettingConfig {
+            id: id.to_string(),
+            setting_type: "json".to_string(),
+            label: id.to_string(),
+            placeholder: None,
+            default: Some(default),
         }
     }
 
@@ -1075,12 +1086,11 @@ mod tests {
     fn build_settings_json_preserves_array_values() {
         // Regression test for #844: array values in extension settings
         // were serialized as empty strings.
-        let manifest = serde_json::json!({
-            "settings": [
-                { "id": "string_setting", "default": "hello" },
-                { "id": "array_default", "default": ["a", "b"] }
-            ]
-        });
+        let manifest_settings = vec![
+            setting("string_setting", serde_json::json!("hello")),
+            setting("array_default", serde_json::json!(["a", "b"])),
+            setting("null_default", serde_json::Value::Null),
+        ];
 
         let extension_settings: Vec<(String, serde_json::Value)> = vec![
             (
@@ -1096,8 +1106,8 @@ mod tests {
         let overrides: Vec<(String, String)> = vec![];
         let json_overrides: Vec<(String, serde_json::Value)> = vec![];
 
-        let json = build_settings_json_from_manifest(
-            &manifest,
+        let json = build_settings_json(
+            &manifest_settings,
             &extension_settings,
             &overrides,
             &json_overrides,
@@ -1120,6 +1130,7 @@ mod tests {
 
         // Array default from manifest is preserved
         assert_eq!(parsed["array_default"], serde_json::json!(["a", "b"]));
+        assert_eq!(parsed["null_default"], serde_json::Value::Null);
     }
 
     #[test]
@@ -1136,14 +1147,13 @@ mod tests {
             }
         }))
         .expect("component config");
-        let manifest = serde_json::json!({
-            "settings": [
-                { "id": "test_backend", "default": "custom-provider" }
-            ]
-        });
+        let manifest_settings = vec![setting(
+            "test_backend",
+            serde_json::json!("custom-provider"),
+        )];
         let extension_settings = extract_component_extension_settings(&component, "sample-runtime");
 
-        let json = build_settings_json_from_manifest(&manifest, &extension_settings, &[], &[])
+        let json = build_settings_json(&manifest_settings, &extension_settings, &[], &[])
             .expect("settings json");
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse settings json");
 
@@ -1153,19 +1163,13 @@ mod tests {
 
     #[test]
     fn build_settings_json_cli_overrides_replace_values() {
-        let manifest = serde_json::json!({});
         let extension_settings: Vec<(String, serde_json::Value)> =
             vec![("key".to_string(), serde_json::json!(["original"]))];
         let overrides = vec![("key".to_string(), "override_value".to_string())];
         let json_overrides: Vec<(String, serde_json::Value)> = vec![];
 
-        let json = build_settings_json_from_manifest(
-            &manifest,
-            &extension_settings,
-            &overrides,
-            &json_overrides,
-        )
-        .expect("should serialize");
+        let json = build_settings_json(&[], &extension_settings, &overrides, &json_overrides)
+            .expect("should serialize");
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("should parse");
 
         // CLI override replaces the array value with a string
@@ -1178,11 +1182,7 @@ mod tests {
         // unlike --setting which would coerce them to a JSON-string-of-an-
         // object. Mirrors the wp_config_defines / bench_env use case
         // (homeboy-extensions #248 / #250).
-        let manifest = serde_json::json!({
-            "settings": [
-                { "id": "bench_env", "default": {} }
-            ]
-        });
+        let manifest_settings = vec![setting("bench_env", serde_json::json!({}))];
         let extension_settings: Vec<(String, serde_json::Value)> = vec![];
         let overrides: Vec<(String, String)> = vec![];
         let json_overrides = vec![(
@@ -1190,8 +1190,8 @@ mod tests {
             serde_json::json!({"BENCH_CORPUS_SIZE": "1000"}),
         )];
 
-        let json = build_settings_json_from_manifest(
-            &manifest,
+        let json = build_settings_json(
+            &manifest_settings,
             &extension_settings,
             &overrides,
             &json_overrides,
@@ -1211,18 +1211,12 @@ mod tests {
     fn build_settings_json_typed_override_wins_on_conflict() {
         // When the same key is targeted by both --setting and --setting-json,
         // the typed override wins (strictly more expressive, applied later).
-        let manifest = serde_json::json!({});
         let extension_settings: Vec<(String, serde_json::Value)> = vec![];
         let overrides = vec![("key".to_string(), "string_value".to_string())];
         let json_overrides = vec![("key".to_string(), serde_json::json!({"nested": true}))];
 
-        let json = build_settings_json_from_manifest(
-            &manifest,
-            &extension_settings,
-            &overrides,
-            &json_overrides,
-        )
-        .expect("should serialize");
+        let json = build_settings_json(&[], &extension_settings, &overrides, &json_overrides)
+            .expect("should serialize");
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("should parse");
 
         assert_eq!(parsed["key"], serde_json::json!({"nested": true}));

--- a/crates/homeboy-core/src/extension/invoke/env_provider.rs
+++ b/crates/homeboy-core/src/extension/invoke/env_provider.rs
@@ -216,16 +216,6 @@ fn provider_command_payload(execution_context: &RunnerJobExecutionContext) -> Re
     Ok(payload)
 }
 
-pub(crate) fn load_manifest_from_dir(extension_path: &Path) -> Result<ExtensionManifest> {
-    let manifest_value = super::load_extension_manifest_from_dir(extension_path)?;
-    let mut manifest =
-        serde_json::from_value::<ExtensionManifest>(manifest_value).map_err(|e| {
-            Error::validation_invalid_json(e, Some("parse extension manifest".to_string()), None)
-        })?;
-    manifest.extension_path = Some(extension_path.to_string_lossy().to_string());
-    Ok(manifest)
-}
-
 fn extension_path(extension: &ExtensionManifest) -> Result<PathBuf> {
     extension
         .extension_path

--- a/crates/homeboy-core/src/extension/invoke/environment.rs
+++ b/crates/homeboy-core/src/extension/invoke/environment.rs
@@ -22,18 +22,19 @@ pub(crate) fn prepare_capability_run(
         )?;
     }
 
-    let manifest = load_extension_manifest_from_dir(&execution.extension_path)?;
+    let manifest =
+        homeboy_core::extension::catalog::load_extension_from_dir(&execution.extension_path)?;
     homeboy_extension_contract::validate_core_compatibility(
         "extension",
         &execution.extension_id,
         manifest
-            .get("requires")
-            .and_then(|requires| requires.get("homeboy"))
-            .and_then(serde_json::Value::as_str),
+            .requires
+            .as_ref()
+            .and_then(|requires| requires.homeboy.as_deref()),
         homeboy_core::extension::lifecycle::read_source_revision(&execution.extension_id),
     )?;
-    let settings_json = build_settings_json_from_manifest(
-        &manifest,
+    let settings_json = build_settings_json(
+        &manifest.settings,
         &execution.settings,
         settings_overrides,
         settings_json_overrides,

--- a/crates/homeboy-core/src/extension/invoke/settings.rs
+++ b/crates/homeboy-core/src/extension/invoke/settings.rs
@@ -1,7 +1,6 @@
 use homeboy_core::error::{Error, Result};
-use homeboy_engine_primitives::local_files;
+use homeboy_extension_contract::manifest_action_config::SettingConfig;
 use std::collections::HashMap;
-use std::path::Path;
 
 pub(super) fn serialize_settings(settings: &HashMap<String, serde_json::Value>) -> Result<String> {
     serde_json::to_string(settings).map_err(|e| {
@@ -12,46 +11,18 @@ pub(super) fn serialize_settings(settings: &HashMap<String, serde_json::Value>) 
     })
 }
 
-pub(crate) fn load_extension_manifest_from_dir(extension_path: &Path) -> Result<serde_json::Value> {
-    let extension_name = extension_path
-        .file_name()
-        .ok_or_else(|| Error::internal_io("Extension path has no file name".to_string(), None))?
-        .to_string_lossy();
-    let manifest_path = extension_path.join(format!("{}.json", extension_name));
-
-    if !manifest_path.exists() {
-        return Err(Error::internal_io(
-            format!("Extension manifest not found: {}", manifest_path.display()),
-            None,
-        ));
-    }
-
-    let content =
-        local_files::read_file(&manifest_path, &format!("read {}", manifest_path.display()))?;
-
-    serde_json::from_str(&content)
-        .map_err(|e| Error::validation_invalid_json(e, Some("parse manifest".to_string()), None))
-}
-
-pub(crate) fn build_settings_json_from_manifest(
-    manifest: &serde_json::Value,
+pub(crate) fn build_settings_json(
+    manifest_settings: &[SettingConfig],
     extension_settings: &[(String, serde_json::Value)],
     settings_overrides: &[(String, String)],
     settings_json_overrides: &[(String, serde_json::Value)],
 ) -> Result<String> {
     let mut settings = serde_json::json!({});
 
-    // Load defaults from manifest — preserve original JSON types.
-    if let Some(manifest_settings) = manifest.get("settings") {
-        if let Some(settings_array) = manifest_settings.as_array() {
-            if let serde_json::Value::Object(ref mut obj) = settings {
-                for setting in settings_array {
-                    if let Some(id) = setting.get("id").and_then(|v| v.as_str()) {
-                        if let Some(default) = setting.get("default") {
-                            obj.insert(id.to_string(), default.clone());
-                        }
-                    }
-                }
+    if let serde_json::Value::Object(ref mut obj) = settings {
+        for setting in manifest_settings {
+            if let Some(default) = &setting.default {
+                obj.insert(setting.id.clone(), default.clone());
             }
         }
     }

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -23,7 +23,7 @@ pub mod trace;
 
 pub(crate) use homeboy_core::extension::resolve::{extension_guidance_hints, stderr_tail};
 
-pub(crate) use invoke::build_settings_json_from_manifest;
+pub(crate) use invoke::build_settings_json;
 
 #[cfg(test)]
 mod tests;

--- a/crates/homeboy-core/src/extension/trace/canonicality.rs
+++ b/crates/homeboy-core/src/extension/trace/canonicality.rs
@@ -217,8 +217,7 @@ pub(crate) fn trace_toolchain_provenance_requirements(
     if !manifest_path.exists() {
         return Ok(Vec::new());
     }
-    let manifest =
-        crate::extension::invoke::env_provider::load_manifest_from_dir(&context.extension_path)?;
+    let manifest = crate::extension::catalog::load_extension_from_dir(&context.extension_path)?;
     Ok(manifest.trace_toolchain_provenance().to_vec())
 }
 


### PR DESCRIPTION
## Summary
- add one catalog-owned loader for explicit extension directories while preserving path authority and structured manifest diagnostics
- build invocation settings from typed `SettingConfig` values and preserve explicit JSON `null` defaults
- delete both invocation-owned manifest loaders and migrate environment, trace, and benchmark consumers

## Verification
- `cargo check --workspace --all-targets`
- `cargo test -p homeboy-extension-contract`
- focused catalog and invocation settings tests
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

## Full-suite note
`cargo test -p homeboy-core --lib` was attempted but exceeded 10 minutes after unrelated failures. `test_support::tests::sweep_removes_stale_hb_test_dirs_and_spares_fresh_and_foreign` reproduces alone because its untouched GNU-style `touch` invocation is rejected by macOS; no full-suite pass is claimed.

Closes #14057

AI assistance: OpenAI GPT-5.6 Sol via OpenCode audited the remaining manifest transports, implemented the catalog consolidation and typed null-preserving settings path, and ran the verification; Chris Huber directed the architecture and sequencing.