### PR TITLE
fix(lab): project terminal notification state

### DIFF
--- a/crates/homeboy-lab-runner/src/execution/job_flow.rs
+++ b/crates/homeboy-lab-runner/src/execution/job_flow.rs
@@ -281,8 +281,11 @@ where
         flow.run_id.as_deref(),
         mirror_run_id.as_deref(),
     )?;
+    // A detached handoff wrapper is only the transport owner. Once the
+    // runner has mirrored the terminal result, that nested run owns the
+    // operator-visible outcome and its notification.
     fire_runner_direct_notification(
-        flow.run_id.as_deref(),
+        terminal_notification_run_id(mirror_run_id.as_deref(), flow.run_id.as_deref()),
         &job,
         flow.lab_runner_workload
             .as_ref()
@@ -392,6 +395,15 @@ where
         append_runner_exec_diagnostic_hint(&mut output, Some(hint.to_string()));
     }
     Ok((output, exit_code))
+}
+
+pub(super) fn terminal_notification_run_id<'a>(
+    mirrored_run_id: Option<&'a str>,
+    wrapper_run_id: Option<&'a str>,
+) -> Option<&'a str> {
+    mirrored_run_id
+        .filter(|run_id| !run_id.trim().is_empty())
+        .or(wrapper_run_id)
 }
 
 fn observed_agent_task_terminal_job_status(

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -1616,7 +1616,6 @@ pub(super) fn fire_runner_direct_notification(
     let Some(route) = notification_route else {
         return;
     };
-    let status = job.status.as_str();
     let store = match homeboy_core::observation::ObservationStore::open_initialized() {
         Ok(store) => store,
         Err(_) => return,
@@ -1625,16 +1624,32 @@ pub(super) fn fire_runner_direct_notification(
     if already_delivered {
         return;
     }
-    let mut event =
-        homeboy_core::notify::NotifyEvent::run_completed_with_route(run_id, status, Some(route));
+    let run = store.get_run(run_id).ok().flatten();
+    let event = runner_direct_notification_event(run_id, job.status.as_str(), route, run.as_ref());
     // The store is already open for the delivery guard; reuse it so the
     // runner's direct delivery carries the same structured detail the
     // controller's notifier does.
-    if let Ok(Some(run)) = store.get_run(run_id) {
-        event = event.with_payload(homeboy_core::notify::run_completed_payload(&run));
-    }
     let outcome = homeboy_core::notify::dispatch(&event);
     if outcome.delivered {
         let _ = store.mark_notification_delivered(run_id, "runner-direct");
+    }
+}
+
+pub(super) fn runner_direct_notification_event(
+    run_id: &str,
+    fallback_status: &str,
+    route: &homeboy_core::notification_route::NotificationRoute,
+    run: Option<&homeboy_core::observation::RunRecord>,
+) -> homeboy_core::notify::NotifyEvent {
+    // The mirrored run is authoritative when it exists. In particular, a
+    // detached wrapper can remain `running` after its nested run has failed.
+    let status = run
+        .map(|run| run.status.as_str())
+        .unwrap_or(fallback_status);
+    let event =
+        homeboy_core::notify::NotifyEvent::run_completed_with_route(run_id, status, Some(route));
+    match run {
+        Some(run) => event.with_payload(homeboy_core::notify::run_completed_payload(run)),
+        None => event,
     }
 }

--- a/crates/homeboy-lab-runner/src/execution/tests/exec.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/exec.rs
@@ -7,6 +7,7 @@ use homeboy_core::runner_execution_envelope::{
     PATH_MATERIALIZATION_MODE_GIT, PATH_MATERIALIZATION_OWNER_LAB_EXECUTION_CONTEXT,
     PATH_MATERIALIZATION_STATUS_MATERIALIZED,
 };
+use homeboy_core::{notification_route::NotificationRoute, observation::RunRecord};
 use serde_json::json;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -21,6 +22,42 @@ fn extension_runtime_home_keeps_homeboy_data_on_the_runner() {
         durable_homeboy_data_dir_for_job(&job_env, Some("/runner/home"), Some(durable.clone())),
         Some(durable)
     );
+}
+
+#[test]
+fn detached_wrapper_terminal_notification_projects_the_nested_failed_run() {
+    let wrapper_run_id = "detached-wrapper";
+    let nested_run_id = "nested-authoritative-run";
+    let nested_run = RunRecord {
+        id: nested_run_id.to_string(),
+        kind: "runner_exec".to_string(),
+        status: "fail".to_string(),
+        command: Some("homeboy agent-task cook --backend fixture".to_string()),
+        ..Default::default()
+    };
+    let route = NotificationRoute::new("fixture", "thread-14060").expect("route");
+
+    let notification_run_id =
+        super::terminal_notification_run_id(Some(nested_run_id), Some(wrapper_run_id))
+            .expect("nested run owns the terminal notification");
+    let event = super::runner_direct_notification_event(
+        notification_run_id,
+        "running",
+        &route,
+        Some(&nested_run),
+    );
+    let payload = event.payload.expect("terminal payload");
+
+    assert_eq!(event.run_id, nested_run_id);
+    assert_eq!(event.status, "fail");
+    assert_eq!(event.title, "homeboy run fail");
+    assert_eq!(payload.subject.expect("subject").id, nested_run_id);
+    assert_eq!(payload.facts[0].label, "Status");
+    assert_eq!(payload.facts[0].value, "fail");
+    assert!(payload
+        .actions
+        .iter()
+        .any(|action| { action.command == format!("homeboy runs evidence {nested_run_id}") }));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- project detached Lab terminal notifications from the authoritative mirrored nested run
- derive event status and payload status from the same durable record
- add deterministic regression coverage retaining the nested run evidence action

Closes #14060.

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-lab-runner detached_wrapper_terminal_notification_projects_the_nested_failed_run`
- `cargo check -p homeboy-lab-runner --all-targets`

`cargo test -p homeboy-lab-runner` exceeded the 10-minute execution ceiling while existing long staging tests were still running; no failure was reported. `cargo clippy -p homeboy-lab-runner --all-targets -- -D warnings` is blocked by pre-existing `homeboy-core` warnings promoted to errors.

## AI Assistance
OpenAI GPT-5.6 Terra via OpenCode assisted with tracing the detached Lab notification path, implementing the change, and drafting regression coverage. The author directed the work and reviewed the resulting diff and verification output.