### PR TITLE
refactor(audit): build exact duplicate index once

### DIFF
--- a/crates/homeboy-code-audit/src/duplication.rs
+++ b/crates/homeboy-code-audit/src/duplication.rs
@@ -6,16 +6,14 @@
 //! to detect near-duplicates — functions with identical control flow that differ
 //! only in variable names, constant references, or string values.
 //!
-//! Four outputs:
-//! - `detect_duplicates()` → flat `Vec<Finding>` for exact duplicates
-//! - `detect_duplicate_groups()` → structured `Vec<DuplicateGroup>` for the fixer
+//! Primary outputs:
+//! - `detect_exact_duplicates_scoped()` → exact findings plus fixer groups
 //! - `detect_near_duplicates()` → flat `Vec<Finding>` for structural near-duplicates
 //! - `detect_intra_method_duplicates()` → duplicated blocks within a single method
 //!
-//! # Scope-seeded entry points
+//! # Scope-seeded analysis
 //!
-//! The exact-duplicate family also exposes two-phase, scope-seeded variants —
-//! [`detect_duplicates_scoped`] and [`detect_duplicate_groups_scoped`] — for
+//! The exact-duplicate family exposes a two-phase, scope-seeded analysis for
 //! changed-scope (`--changed-since`) audits. Duplication is a *cross-file*
 //! detector: a duplicate is only a duplicate because a counterpart body exists
 //! somewhere else, and that counterpart may sit outside the changed scope. So
@@ -59,7 +57,7 @@ const MIN_DUPLICATE_LOCATIONS: usize = 2;
 
 /// `(method_name, body_hash)` → the files that contain that exact body.
 ///
-/// The shared grouping behind `detect_duplicates` and `detect_duplicate_groups`.
+/// The shared grouping behind exact duplicate findings and fixer groups.
 type BodyHashGroups = HashMap<(String, String), Vec<String>>;
 
 /// Candidate seed index: `method_name` → the body hashes seen for that name in
@@ -162,35 +160,27 @@ fn pick_canonical(locations: &[String]) -> String {
     sorted[0].clone()
 }
 
-/// Detect duplicate groups with canonical file selection.
-///
-/// Returns structured data the fixer uses to remove duplicates.
-///
-/// Since #12583 the engine calls [`detect_duplicate_groups_scoped`] on both the
-/// scoped and unscoped paths (unscoped passes the full corpus as its own seed),
-/// so this wrapper's only remaining callers are the tests that use it as the
-/// unscoped oracle for the scope-seeded equivalence assertions. It stays compiled
-/// in release builds as the documented unscoped entry point; the `cfg_attr` only
-/// keeps `dead_code` quiet where nothing but tests reach it.
-#[cfg_attr(not(test), allow(dead_code))]
-pub(crate) fn detect_duplicate_groups(fingerprints: &[&FileFingerprint]) -> Vec<DuplicateGroup> {
-    detect_duplicate_groups_scoped(fingerprints, fingerprints)
+#[derive(Default)]
+pub(crate) struct ExactDuplicateAnalysis {
+    pub(crate) findings: Vec<Finding>,
+    pub(crate) groups: Vec<DuplicateGroup>,
 }
 
-/// Scope-seeded [`detect_duplicate_groups`].
+/// Detect exact duplicates and build their fixer groups from one seeded index.
 ///
-/// Seeds candidate `(method_name, body_hash)` keys from `scoped`, then expands
-/// each candidate to its full member list across `all`, so canonical selection
-/// and `remove_from` see every counterpart — including out-of-scope ones.
-///
-/// `scoped` must be a subset of `all`. Output equals `detect_duplicate_groups(all)`
-/// restricted to the groups that have at least one member in `scoped` (a group
-/// with no in-scope member is not actionable for a changed-scope run).
-pub(crate) fn detect_duplicate_groups_scoped(
+/// `scoped` must be a subset of `all`. Candidate keys come from `scoped`, then
+/// expand against `all` so findings and canonical selection retain every
+/// out-of-scope counterpart. Passing `(all, all)` performs an unscoped analysis.
+pub(crate) fn detect_exact_duplicates_scoped(
     scoped: &[&FileFingerprint],
     all: &[&FileFingerprint],
-) -> Vec<DuplicateGroup> {
-    duplicate_groups_from_body_hash_groups(&build_groups_seeded(scoped, all))
+    convention_methods: &HashSet<String>,
+) -> ExactDuplicateAnalysis {
+    let hash_groups = build_groups_seeded(scoped, all);
+    ExactDuplicateAnalysis {
+        findings: duplicate_findings_from_body_hash_groups(&hash_groups, all, convention_methods),
+        groups: duplicate_groups_from_body_hash_groups(&hash_groups),
+    }
 }
 
 /// Shared group-construction phase for both the scoped and unscoped paths.
@@ -311,54 +301,6 @@ fn is_test_location(
     is_test_path(file) || inline_test_methods.contains(&(method_name.to_string(), file.to_string()))
 }
 
-/// Detect exact function body duplicates across files.
-///
-/// Groups functions by `(method_name, body_hash)`. When two or more files
-/// contain a function with the same name and the same normalized body hash, a
-/// finding is emitted for each location.
-///
-/// `convention_methods` are excluded — identical implementations across
-/// convention-following files are expected behavior (e.g. `__construct`,
-/// `checkPermission`, interface methods with identical bodies).
-///
-/// Since #12583 the engine calls [`detect_duplicates_scoped`] on both the scoped
-/// and unscoped paths (unscoped passes the full corpus as its own seed), so this
-/// wrapper's only remaining callers are the tests that use it as the unscoped
-/// oracle for the scope-seeded equivalence assertions. It stays compiled in
-/// release builds as the documented unscoped entry point; the `cfg_attr` only
-/// keeps `dead_code` quiet where nothing but tests reach it.
-#[cfg_attr(not(test), allow(dead_code))]
-pub(crate) fn detect_duplicates(
-    fingerprints: &[&FileFingerprint],
-    convention_methods: &std::collections::HashSet<String>,
-) -> Vec<Finding> {
-    detect_duplicates_scoped(fingerprints, fingerprints, convention_methods)
-}
-
-/// Scope-seeded [`detect_duplicates`].
-///
-/// Phase 1 seeds candidate `(method_name, body_hash)` keys from `scoped`; phase 2
-/// expands each candidate to every counterpart in `all`. Group membership,
-/// severity, the `also in …` list, and the `N files` count are therefore computed
-/// from the full corpus exactly as the unscoped path does — only the *set of
-/// groups considered* is narrowed, to those with at least one in-scope member.
-///
-/// `scoped` must be a subset of `all`.
-///
-/// Findings are still emitted for every member of a surviving group, including
-/// out-of-scope files, so the output is literally a subset of
-/// `detect_duplicates(all, convention_methods)`. The engine drops the
-/// out-of-scope ones in its scope filter, which is the same thing that happens
-/// on the unscoped path; restricted to in-scope files the two agree exactly.
-pub(crate) fn detect_duplicates_scoped(
-    scoped: &[&FileFingerprint],
-    all: &[&FileFingerprint],
-    convention_methods: &std::collections::HashSet<String>,
-) -> Vec<Finding> {
-    let hash_groups = build_groups_seeded(scoped, all);
-    duplicate_findings_from_body_hash_groups(&hash_groups, all, convention_methods)
-}
-
 /// Whether a raw `(method_name, body_hash)` group is a reportable duplicate.
 ///
 /// Two filters, stated once for both passes below: a group needs at least
@@ -474,7 +416,7 @@ const CROSS_NAME_MIN_BODY_LINES: usize = 1;
 ///
 /// `already_flagged_names` are method names already reported by the same-name
 /// exact detector; a cross-name group is still reported (its value is the
-/// *cross-name* link), but same-name-only groups are left to `detect_duplicates`.
+/// *cross-name* link), but same-name-only groups are left to the exact detector.
 pub(crate) fn detect_cross_name_duplicates(fingerprints: &[&FileFingerprint]) -> Vec<Finding> {
     let inline_test_methods = inline_test_context_methods(fingerprints);
     // hash -> list of (file, method_name)

--- a/crates/homeboy-code-audit/src/duplication/tests.rs
+++ b/crates/homeboy-code-audit/src/duplication/tests.rs
@@ -1,6 +1,32 @@
 use super::*;
 use crate::conventions::Language;
 
+fn detect_duplicates(
+    fingerprints: &[&FileFingerprint],
+    convention_methods: &HashSet<String>,
+) -> Vec<Finding> {
+    detect_exact_duplicates_scoped(fingerprints, fingerprints, convention_methods).findings
+}
+
+fn detect_duplicate_groups(fingerprints: &[&FileFingerprint]) -> Vec<DuplicateGroup> {
+    detect_exact_duplicates_scoped(fingerprints, fingerprints, &HashSet::new()).groups
+}
+
+fn detect_duplicates_scoped(
+    scoped: &[&FileFingerprint],
+    all: &[&FileFingerprint],
+    convention_methods: &HashSet<String>,
+) -> Vec<Finding> {
+    detect_exact_duplicates_scoped(scoped, all, convention_methods).findings
+}
+
+fn detect_duplicate_groups_scoped(
+    scoped: &[&FileFingerprint],
+    all: &[&FileFingerprint],
+) -> Vec<DuplicateGroup> {
+    detect_exact_duplicates_scoped(scoped, all, &HashSet::new()).groups
+}
+
 fn make_fingerprint(path: &str, methods: &[&str], hashes: &[(&str, &str)]) -> FileFingerprint {
     make_fingerprint_with_structural(path, methods, hashes, &[])
 }

--- a/crates/homeboy-code-audit/src/engine.rs
+++ b/crates/homeboy-code-audit/src/engine.rs
@@ -8,7 +8,7 @@
 //! declares every detector and `descriptor_runtime::run_descriptor_detectors`
 //! executes it. Only three families are still sequenced by hand below because
 //! they have a non-uniform shape — the convention pipeline, the multi-pass
-//! `duplication` family (five timing spans plus the `duplicate_groups` side
+//! `duplication` family (six timing spans plus the `duplicate_groups` side
 //! output), and `artifact_portability` (logs scan statistics even when empty).
 //!
 //! The detector phase runs CONCURRENTLY (see `parallel`). Detectors are pure
@@ -294,11 +294,11 @@ pub(super) fn audit_internal(
     // corpus below because their correctness for an in-scope file depends on
     // evidence from out-of-scope files (matching bodies, external references).
     //
-    // The two exact-duplicate passes are the exception, and the reason the
+    // The exact-duplicate pass is the exception, and the reason the
     // narrowing above could not close the timeout on its own: the duplication
     // family is this repository's largest finding population and it consumed the
-    // whole corpus. `detect_duplicates_scoped` / `detect_duplicate_groups_scoped`
-    // (#12587) split that cross-file work in two — seed the candidate
+    // whole corpus. `detect_exact_duplicates_scoped` (#12587) splits that
+    // cross-file work in two — seed the candidate
     // `(method_name, body_hash)` keys from the scoped subset, then expand each
     // surviving key against the FULL corpus for counterpart evidence. So they
     // still see every out-of-scope counterpart, and the subset is passed only as
@@ -361,7 +361,7 @@ pub(super) fn audit_internal(
     // the `scoped ⊆ all` precondition those entry points require: the changed-scope
     // arm is a `filter` over `all_fingerprints`, and the unscoped arm is
     // `all_fingerprints` itself — which is exactly the `(all, all)` delegation the
-    // unscoped `detect_duplicates` / `detect_duplicate_groups` already perform.
+    // unscoped analysis performs.
     let per_file_fingerprints: &[&fingerprint::FileFingerprint] = scoped_fingerprints
         .as_ref()
         .map(|(_, subset)| subset.as_slice())
@@ -405,7 +405,7 @@ pub(super) fn audit_internal(
         test_quality_findings: test_quality_findings.as_deref(),
     };
 
-    // The duplication family stays hand-sequenced: it runs five timing spans and
+    // The duplication family stays hand-sequenced: it runs six timing spans and
     // also produces `duplicate_groups`, a side output threaded into the report.
     //
     // "Hand-sequenced" describes the REPORTING, which is still the fixed sequence
@@ -696,8 +696,8 @@ pub(super) fn audit_internal(
 /// Naming each output rather than returning a flat `Vec<Finding>` is what lets
 /// the passes run concurrently while the reporting in `audit_internal` stays in
 /// its original fixed order — each pass has its own log line, and
-/// `detect_duplicate_groups` produces `duplicate_groups`, a side output the report
-/// carries separately from the findings.
+/// the exact pass produces `duplicate_groups`, a side output the report carries
+/// separately from the findings.
 struct DuplicationUnit {
     spans: Vec<AuditTimingSpan>,
     exact: Vec<findings::Finding>,
@@ -709,14 +709,12 @@ struct DuplicationUnit {
     parallel_implementation: Vec<findings::Finding>,
 }
 
-/// Run the duplication family's seven passes concurrently.
+/// Run the duplication family's six passes concurrently.
 ///
 /// Every pass is a pure function of the same two immutable inputs — the
-/// convention fingerprint corpus and the convention method set — and returns an
-/// owned vector. There is no data dependency between them, not even between
-/// `detect_duplicates` and `detect_duplicate_groups`, which each rebuild their own
-/// grouping. So the family's "hand-sequenced" shape was never a sequencing
-/// requirement, only a reporting one.
+/// convention fingerprint corpus and the convention method set — and returns
+/// owned output. The family's "hand-sequenced" shape is a reporting requirement,
+/// not an execution dependency.
 ///
 /// Units are started in pass order and joined in pass order, and the spans are
 /// concatenated in that same order, so the timing report is identical to the
@@ -724,13 +722,13 @@ struct DuplicationUnit {
 /// `HOMEBOY_AUDIT_DETECTOR_THREADS=1`, `spawn_or_run` runs each pass inline at its
 /// start point, which reproduces the original serial execution exactly.
 ///
-/// `scoped_fingerprints` is the changed-scope seed corpus (#12583). The two
-/// exact-duplicate passes use the scope-seeded entry points, which seed candidate
+/// `scoped_fingerprints` is the changed-scope seed corpus (#12583). The exact
+/// duplicate pass uses the scope-seeded entry point, which seeds candidate
 /// `(method_name, body_hash)` keys from it and then expand each candidate against
 /// the full `all_fingerprints` corpus, so counterpart evidence from out-of-scope
 /// files is still found. It must be a SUBSET of `all_fingerprints`; in unscoped
 /// mode the caller passes `all_fingerprints` itself, which is the same `(all, all)`
-/// delegation the unscoped `detect_duplicates` / `detect_duplicate_groups` perform.
+/// delegation an unscoped analysis performs.
 /// The other five passes have no scoped variant and take the full corpus, so this
 /// adds a third immutable input without adding a data dependency: every pass is
 /// still a pure function of borrowed, shared inputs.
@@ -749,26 +747,13 @@ fn run_duplication_family(
                 "detector.duplication.exact",
                 enabled,
                 || {
-                    duplication::detect_duplicates_scoped(
+                    duplication::detect_exact_duplicates_scoped(
                         scoped_fingerprints,
                         all_fingerprints,
                         convention_methods,
                     )
                 },
-                Vec::new,
-            )
-        });
-        let groups = spawn_or_run(scope, || {
-            time_audit_detector_isolated(
-                "detector.duplication.groups",
-                enabled,
-                || {
-                    duplication::detect_duplicate_groups_scoped(
-                        scoped_fingerprints,
-                        all_fingerprints,
-                    )
-                },
-                Vec::new,
+                duplication::ExactDuplicateAnalysis::default,
             )
         });
         let intra_method = spawn_or_run(scope, || {
@@ -819,7 +804,6 @@ fn run_duplication_family(
         });
 
         let (exact, exact_spans) = exact.join();
-        let (groups, groups_spans) = groups.join();
         let (intra_method, intra_method_spans) = intra_method.join();
         let (near_duplicate, near_duplicate_spans) = near_duplicate.join();
         let (cross_name, cross_name_spans) = cross_name.join();
@@ -829,7 +813,6 @@ fn run_duplication_family(
 
         let mut spans = Vec::new();
         spans.extend(exact_spans);
-        spans.extend(groups_spans);
         spans.extend(intra_method_spans);
         spans.extend(near_duplicate_spans);
         spans.extend(cross_name_spans);
@@ -838,8 +821,8 @@ fn run_duplication_family(
 
         DuplicationUnit {
             spans,
-            exact,
-            groups,
+            exact: exact.findings,
+            groups: exact.groups,
             intra_method,
             near_duplicate,
             cross_name,

--- a/crates/homeboy-code-audit/src/engine_duplication_scope_test.rs
+++ b/crates/homeboy-code-audit/src/engine_duplication_scope_test.rs
@@ -3,14 +3,14 @@
 //! Wired into `engine.rs` via
 //! `#[cfg(test)] #[path = ...] mod engine_duplication_scope_test`.
 //!
-//! WHY THIS EXISTS: #12587 added `detect_duplicates_scoped` /
-//! `detect_duplicate_groups_scoped` and proved their EQUIVALENCE against the
-//! unscoped functions, in `duplication/tests.rs`. Nothing called them, so the
+//! WHY THIS EXISTS: #12587 added scope-seeded exact duplicate analysis and
+//! proved its EQUIVALENCE against unscoped analysis in `duplication/tests.rs`.
+//! Nothing called it, so the
 //! whole optimization was dormant and every one of those equivalence tests kept
 //! passing. Equivalence tests cannot see a missing call site.
 //!
 //! So these tests assert the WIRING instead: that `run_duplication_family`
-//! actually threads its `scoped_fingerprints` argument into those two passes, and
+//! actually threads its `scoped_fingerprints` argument into that pass, and
 //! that the five passes without a scoped variant still consume the full corpus.
 //! Together with #12587's equivalence proofs that is the whole risk surface of
 //! the wiring slice.
@@ -104,7 +104,7 @@ fn files(items: &[findings::Finding]) -> Vec<&str> {
 }
 
 #[test]
-fn changed_scope_seeds_the_exact_duplicate_passes_from_the_scoped_subset() {
+fn changed_scope_seeds_exact_duplicate_analysis_from_the_scoped_subset() {
     let owned = corpus();
     let all: Vec<&fingerprint::FileFingerprint> = owned.iter().collect();
     // The engine builds its subset by filtering `all_fingerprints`, so the
@@ -144,7 +144,7 @@ fn changed_scope_seeds_the_exact_duplicate_passes_from_the_scoped_subset() {
     assert_eq!(
         group_names,
         vec!["compute_alpha"],
-        "groups pass must be seeded from the scoped subset too"
+        "fixer groups must come from the same scoped analysis"
     );
     // Expansion still walked the full corpus: the counterpart is out of scope.
     assert_eq!(
@@ -201,8 +201,7 @@ fn unscoped_mode_passes_the_full_corpus_as_its_own_seed() {
 
     // What `audit_internal` does when `scoped_fingerprints` is `None`:
     // `per_file_fingerprints` IS `all_fingerprints`, which is the same `(all, all)`
-    // delegation the unscoped `detect_duplicates` / `detect_duplicate_groups`
-    // perform, so nothing is narrowed.
+    // delegation an unscoped exact analysis performs, so nothing is narrowed.
     let unit = run(&all, &all);
 
     assert_eq!(
@@ -237,7 +236,6 @@ fn span_order_is_pass_order_regardless_of_the_seed() {
 
     let expected = vec![
         "detector.duplication.exact",
-        "detector.duplication.groups",
         "detector.duplication.intra_method",
         "detector.duplication.near_duplicate",
         "detector.duplication.cross_name_duplicate",

--- a/crates/homeboy-code-audit/src/execution_plan.rs
+++ b/crates/homeboy-code-audit/src/execution_plan.rs
@@ -118,7 +118,7 @@ impl DetectorAccess {
 pub(crate) enum DetectorRuntime {
     /// Detectors the engine still sequences by hand because they have a
     /// non-uniform shape: the convention pipeline (`conventions`), the
-    /// multi-pass `duplication` family (five timing spans plus the
+    /// multi-pass `duplication` family (six timing spans plus the
     /// `duplicate_groups` side output), and `artifact_portability` (logs scan
     /// statistics even when it finds nothing). Everything else is data-driven.
     Manual,


### PR DESCRIPTION
## Summary
- build exact duplicate findings and fixer groups from one scope-seeded body-hash index
- remove the redundant duplicate-group detector job and timing span
- retain changed-scope counterpart expansion, canonical selection, output ordering, and fixer behavior

Part of #13755.

## Verification
- `cargo fmt --all --check`
- `cargo test -p homeboy-code-audit duplication::tests` (90 passed)
- `cargo test -p homeboy-code-audit engine::engine_duplication_scope_test` (4 passed)
- `cargo test -p homeboy-code-audit -- --skip detectors::artifact_portability::tests::homeboy_config_declares_homeboy_run_marker`
- `cargo check --workspace --all-targets`

The skipped test is the pre-existing stale `homeboy.json` assertion tracked by #12914. The workspace check retains the pre-existing unused `Duration` import warning in `homeboy-core`.

## AI assistance
GPT-5.6 Sol via OpenCode was used to inspect the audit pipeline, implement the single-index consolidation, update tests and documentation, and run verification. The resulting diff and commit were reviewed before opening this PR.