### PR TITLE
Expose rig package root to bench extensions

### DIFF
--- a/crates/homeboy-core/src/extension/bench/mod.rs
+++ b/crates/homeboy-core/src/extension/bench/mod.rs
@@ -14,6 +14,7 @@
 //! - `$HOMEBOY_BENCH_ITERATIONS` — iterations per scenario.
 //! - `$HOMEBOY_BENCH_LIST_ONLY` — when `1`, emit scenario inventory only.
 //! - `$HOMEBOY_BENCH_SCENARIOS` — comma-separated exact scenario ids selected by `--scenario`.
+//! - `$HOMEBOY_BENCH_RIG_PACKAGE_ROOT` — canonical owning package root for rig workloads.
 //! - `$HOMEBOY_RUN_DIR` — the per-run directory (same as test/lint/build).
 //! - Passthrough args after `--` forwarded verbatim to the script.
 //!

--- a/crates/homeboy-core/src/extension/bench/run/list.rs
+++ b/crates/homeboy-core/src/extension/bench/run/list.rs
@@ -185,5 +185,8 @@ pub(crate) fn bench_component_script_list_env(
         "HOMEBOY_SETTINGS_JSON".to_string(),
         crate::extension::build_settings_json(&[], &[], &args.settings, &args.settings_json)?,
     ));
+    env.extend(super::types::rig_package_root_env(
+        args.rig_package.as_ref(),
+    ));
     Ok(env)
 }

--- a/crates/homeboy-core/src/extension/bench/run/mod.rs
+++ b/crates/homeboy-core/src/extension/bench/run/mod.rs
@@ -42,6 +42,7 @@ mod tests {
     };
     use homeboy_core::engine::run_dir::{self, RunDir};
     use homeboy_engine_primitives::baseline::BaselineFlags;
+    use homeboy_extension_contract::{RigPackageEvidence, RigPackageFreshness};
     use std::collections::BTreeMap;
     use std::fs;
     use std::path::PathBuf;
@@ -203,6 +204,23 @@ mod tests {
     }
 
     #[test]
+    fn component_script_bench_env_forwards_rig_package_root() {
+        let run_dir = RunDir::create().expect("run dir");
+        let mut args = bench_run_workflow_args_fixture();
+        args.rig_package = Some(rig_package_evidence("/tmp/rig-package"));
+
+        let env = bench_component_script_env(&args, &run_dir).expect("component-script env");
+
+        assert_eq!(
+            env.iter().find_map(|(key, value)|
+                (key == "HOMEBOY_BENCH_RIG_PACKAGE_ROOT").then_some(value)
+            ),
+            Some(&"/tmp/rig-package".to_string())
+        );
+        run_dir.cleanup();
+    }
+
+    #[test]
     fn component_script_bench_env_serializes_passthrough_args() {
         let run_dir = RunDir::create().expect("run dir");
         let mut args = bench_run_workflow_args_fixture();
@@ -291,6 +309,28 @@ mod tests {
         }
     }
 
+    fn rig_package_evidence(package_root: &str) -> RigPackageEvidence {
+        RigPackageEvidence {
+            rig_id: "fixture".to_string(),
+            package_root: package_root.to_string(),
+            source: "fixture".to_string(),
+            source_root: None,
+            rig_path: None,
+            discovery_path: None,
+            installed_source_revision: None,
+            current_source_revision: None,
+            source_content_hash: None,
+            source_ref: None,
+            source_dirty: false,
+            linked: false,
+            materialized: true,
+            freshness: RigPackageFreshness::Verified,
+            freshness_verified: true,
+            freshness_message: None,
+            refresh_command: None,
+        }
+    }
+
     #[test]
     fn component_script_bench_list_env_includes_typed_settings_json() {
         let env = bench_component_script_list_env(&BenchListWorkflowArgs {
@@ -323,6 +363,29 @@ mod tests {
             parsed["workflow_bench_env"]["WORKFLOW_BENCH_SCENARIO"],
             "plain-site-sample-plugin"
         );
+    }
+
+    #[test]
+    fn component_script_bench_list_env_omits_rig_package_root_without_rig() {
+        let args = BenchListWorkflowArgs {
+            component_label: "studio-web".to_string(),
+            component_id: "studio-web".to_string(),
+            path_override: None,
+            settings: Vec::new(),
+            settings_json: Vec::new(),
+            passthrough_args: Vec::new(),
+            scenario_ids: Vec::new(),
+            extra_workloads: Vec::new(),
+            env_provider_extensions: Vec::new(),
+            rig_package: None,
+            profiles: Vec::new(),
+        };
+
+        let env = bench_component_script_list_env(&args).expect("component-script list env");
+
+        assert!(!env
+            .iter()
+            .any(|(key, _)| key == "HOMEBOY_BENCH_RIG_PACKAGE_ROOT"));
     }
 
     #[test]

--- a/crates/homeboy-core/src/extension/bench/run/runner.rs
+++ b/crates/homeboy-core/src/extension/bench/run/runner.rs
@@ -20,7 +20,7 @@ use super::memory_timeline::{
 };
 use super::results::{is_unmeasured_inventory_results, parse_execution_results_file};
 use super::scenario::apply_scenario_filter;
-use super::types::{BenchRunExecutionOutcome, BenchRunWorkflowArgs};
+use super::types::{rig_package_root_env, BenchRunExecutionOutcome, BenchRunWorkflowArgs};
 
 pub(crate) fn run_sequential_runs(
     execution_context: &ExtensionExecutionContext,
@@ -208,6 +208,10 @@ pub(crate) fn build_runner(
     // these before runner and CI environment so those explicit scopes retain
     // their established override precedence.
     for (key, value) in bench_env_vars(&args.settings, &args.settings_json) {
+        runner = runner.env(&key, &value);
+    }
+
+    if let Some((key, value)) = rig_package_root_env(args.rig_package.as_ref()) {
         runner = runner.env(&key, &value);
     }
 

--- a/crates/homeboy-core/src/extension/bench/run/types.rs
+++ b/crates/homeboy-core/src/extension/bench/run/types.rs
@@ -153,3 +153,14 @@ pub struct BenchListWorkflowResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rig_package: Option<RigPackageEvidence>,
 }
+
+pub(crate) fn rig_package_root_env(
+    rig_package: Option<&RigPackageEvidence>,
+) -> Option<(String, String)> {
+    rig_package.map(|evidence| {
+        (
+            "HOMEBOY_BENCH_RIG_PACKAGE_ROOT".to_string(),
+            evidence.package_root.clone(),
+        )
+    })
+}

--- a/crates/homeboy-core/src/extension/bench/run/workflow.rs
+++ b/crates/homeboy-core/src/extension/bench/run/workflow.rs
@@ -523,6 +523,9 @@ pub(crate) fn bench_component_script_env(
     {
         env.push(("HOMEBOY_BENCH_RUN_ID".to_string(), run_id.to_string()));
     }
+    env.extend(super::types::rig_package_root_env(
+        args.rig_package.as_ref(),
+    ));
     env.extend(args.ci_env.iter().cloned());
     Ok(env)
 }


### PR DESCRIPTION
## Summary

- export `HOMEBOY_BENCH_RIG_PACKAGE_ROOT` for rig-backed extension benchmark runs and discovery
- leave the variable unset for non-rig benchmarks
- document and test the dispatcher contract

This lets adapters preserve package-relative workload layouts instead of flattening files and breaking relative imports.

## Verification

- `cargo test -p homeboy-core extension::bench` (167 passed)
- `cargo fmt --check`

Closes #14074.

## AI assistance

GPT-5.6-sol via OpenCode traced the benchmark dispatch contract, implemented the scoped change under Chris Huber’s direction, and ran the focused verification. Chris reviewed the architecture and diff.