### PR TITLE
Execute declared test plans through typed gate lifecycle

### DIFF
--- a/crates/homeboy-agents/src/agent_task_finalization.rs
+++ b/crates/homeboy-agents/src/agent_task_finalization.rs
@@ -876,18 +876,8 @@ fn inherit_promotion_gates(
         .deterministic_gates
         .iter()
         .map(|gate| {
-            let [shell, flag, command] = gate.command.as_slice() else {
-                return Err(Error::validation_invalid_argument(
-                    "latest_promotion.deterministic_gates.command",
-                    "green promotion reuse requires each retained gate to preserve its exact shell command",
-                    None,
-                    None,
-                ));
-            };
+            let invocation = gate.invocation()?;
             if gate.id.trim().is_empty()
-                || shell != "sh"
-                || flag != "-lc"
-                || command.trim().is_empty()
                 || gate.candidate_checkout.as_ref() != Some(&candidate)
             {
                 return Err(Error::validation_invalid_argument(
@@ -899,9 +889,7 @@ fn inherit_promotion_gates(
             }
             Ok((
                 gate.id.clone(),
-                homeboy_engine_primitives::content_hash::nul_separated_digest(
-                    gate.command.iter().map(String::as_str),
-                ),
+                invocation.identity_digest()?,
             ))
         })
         .collect::<Result<Vec<_>>>()?;

--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -1814,10 +1814,13 @@ fn run_gate_argv_with_supervision(
     selected_environment.configure_cargo_target(cwd, gate_environment.shared_cargo_target)?;
     selected_environment.report.package_artifacts = package_artifacts;
     selected_environment.apply(&mut process);
-    // Cook's persisted gate deadline is the only deadline policy here. When a
-    // shell gate starts Cargo, propagate it into the hermetic binary runner so
-    // a hung test binary gets the same bound and process-group cleanup.
-    if let Some(supervision) = supervision {
+    if let Some(plan) = declared_plan {
+        let (name, value) = plan.suite_timeout_env();
+        process.env(name, value);
+    }
+    // Legacy shell gates inherit Cook's deadline. Declared plans already set
+    // their own deadline above, so supervision cannot silently rewrite it.
+    if let Some(supervision) = supervision.filter(|_| declared_plan.is_none()) {
         let plan =
             homeboy_engine_primitives::test_execution::TestExecutionPlan::with_suite_timeout(
                 supervision.timeout,
@@ -2124,6 +2127,10 @@ fn run_gate_argv_with_timeout(
     selected_environment.configure_cargo_target(cwd, gate_environment.shared_cargo_target)?;
     selected_environment.report.package_artifacts = package_artifacts;
     selected_environment.apply(&mut process);
+    if let Some(plan) = declared_plan {
+        let (name, value) = plan.suite_timeout_env();
+        process.env(name, value);
+    }
     // See the matching comment in `run_gate_command_with_supervision`: this
     // gate spawns build/test tooling that must not outlive an agent process
     // killed out from under it (#13649).
@@ -4966,6 +4973,53 @@ mod tests {
                 "-lc",
                 command.as_str(),
             ])
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn declared_baseline_executor_exports_the_plan_deadline() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let workspace = tempfile::tempdir().expect("workspace");
+        let bin = workspace.path().join("bin");
+        std::fs::create_dir(&bin).expect("bin");
+        let homeboy = bin.join("homeboy");
+        std::fs::write(
+            &homeboy,
+            "#!/bin/sh\nprintf %s \"$HOMEBOY_TEST_TIMEOUT_SECONDS\"\n",
+        )
+        .expect("adapter");
+        let mut permissions = std::fs::metadata(&homeboy).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&homeboy, permissions).unwrap();
+        let plan = homeboy_engine_primitives::test_execution::TestExecutionPlan::declared_homeboy_review_test(
+            vec!["homeboy".to_string(), "review".to_string(), "test".to_string()],
+            42,
+        )
+        .unwrap();
+        let mut environment = AgentTaskGateEnvironmentPolicy::default();
+        environment
+            .variables
+            .insert("PATH".to_string(), format!("{}:/bin", bin.display()));
+        let runtime = tempfile::tempdir().expect("runtime");
+
+        let report = run_declared_test_with_timeout(
+            workspace.path(),
+            1,
+            &plan,
+            AgentTaskGateVisibility::Visible,
+            AgentTaskGateRevealPolicy::FullEvidence,
+            runtime.path(),
+            &environment,
+            &[],
+        )
+        .expect("baseline execution");
+
+        assert_eq!(report.stdout, "42");
+        assert_eq!(
+            report.test_execution_outcome,
+            Some(homeboy_engine_primitives::test_execution::TestExecutionOutcome::Passed)
         );
     }
 

--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -891,11 +891,23 @@ impl AgentTaskGateInvocation {
     }
 
     pub(crate) fn identity_digest(&self) -> Result<String> {
-        let encoded = serde_json::to_vec(self)
-            .map_err(|error| Error::internal_json(error.to_string(), None))?;
-        Ok(homeboy_engine_primitives::content_hash::sha256_hex(
-            &encoded,
-        ))
+        match self {
+            // Finalization receipts persisted this exact digest before typed
+            // plans existed; preserving it keeps inherited proof stable across
+            // a controller upgrade.
+            Self::LegacyShell { command } => Ok(
+                homeboy_engine_primitives::content_hash::nul_separated_digest([
+                    "sh", "-lc", command,
+                ]),
+            ),
+            Self::DeclaredTest { .. } => {
+                let encoded = serde_json::to_vec(self)
+                    .map_err(|error| Error::internal_json(error.to_string(), None))?;
+                Ok(homeboy_engine_primitives::content_hash::sha256_hex(
+                    &encoded,
+                ))
+            }
+        }
     }
 }
 
@@ -4938,6 +4950,22 @@ mod tests {
             AgentTaskGateInvocation::DeclaredTest { plan: changed_argv }
                 .identity_digest()
                 .unwrap()
+        );
+    }
+
+    #[test]
+    fn legacy_shell_invocation_keeps_the_historical_gate_command_digest() {
+        let command = "cargo test --locked".to_string();
+        let invocation = AgentTaskGateInvocation::LegacyShell {
+            command: command.clone(),
+        };
+        assert_eq!(
+            invocation.identity_digest().unwrap(),
+            homeboy_engine_primitives::content_hash::nul_separated_digest([
+                "sh",
+                "-lc",
+                command.as_str(),
+            ])
         );
     }
 

--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -589,6 +589,10 @@ pub struct AgentTaskGateReport {
     pub reveal_policy: AgentTaskGateRevealPolicy,
     pub status: AgentTaskGateStatus,
     pub command: Vec<String>,
+    /// The durable execution contract. Older reports only have `command`; they
+    /// are decoded as legacy `sh -lc` invocations by `invocation()`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invocation: Option<AgentTaskGateInvocation>,
     pub exit_code: i32,
     /// Terminal classification distinguishes a command's semantic exit from
     /// controller wall-clock or progress-deadline termination.
@@ -862,6 +866,39 @@ pub enum AgentTaskGateTermination {
     NoProgress,
 }
 
+/// One replayable deterministic-gate invocation. Shell source remains the
+/// explicit legacy escape hatch while declared tests retain their typed plan.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AgentTaskGateInvocation {
+    LegacyShell {
+        command: String,
+    },
+    DeclaredTest {
+        plan: homeboy_engine_primitives::test_execution::TestExecutionPlan,
+    },
+}
+
+impl AgentTaskGateInvocation {
+    pub(crate) fn reviewer_command(&self) -> String {
+        match self {
+            Self::LegacyShell { command } => command.clone(),
+            Self::DeclaredTest { plan } => homeboy_engine_primitives::shell::quote_args(
+                plan.declared_command()
+                    .expect("declared test invocation was validated before persistence"),
+            ),
+        }
+    }
+
+    pub(crate) fn identity_digest(&self) -> Result<String> {
+        let encoded = serde_json::to_vec(self)
+            .map_err(|error| Error::internal_json(error.to_string(), None))?;
+        Ok(homeboy_engine_primitives::content_hash::sha256_hex(
+            &encoded,
+        ))
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AgentTaskGateCapture {
     pub stdout: homeboy_engine_primitives::command::CaptureMetadata,
@@ -1127,6 +1164,28 @@ fn gate_diagnostic_record_schema() -> String {
 }
 
 impl AgentTaskGateReport {
+    pub(crate) fn invocation(&self) -> Result<AgentTaskGateInvocation> {
+        if let Some(invocation) = &self.invocation {
+            if let AgentTaskGateInvocation::DeclaredTest { plan } = invocation {
+                plan.declared_command()
+                    .map_err(|message| Error::invalid_argument("gate.invocation", message))?;
+            }
+            return Ok(invocation.clone());
+        }
+        match self.command.as_slice() {
+            [shell, flag, command] if shell == "sh" && flag == "-lc" => {
+                Ok(AgentTaskGateInvocation::LegacyShell {
+                    command: command.clone(),
+                })
+            }
+            _ => Err(Error::validation_invalid_argument(
+                "gate.command",
+                "historical gate reports must contain a concrete `sh -lc` invocation",
+                Some(self.id.clone()),
+                None,
+            )),
+        }
+    }
     #[expect(
         clippy::too_many_arguments,
         reason = "constructor mirrors persisted gate result fields"
@@ -1143,6 +1202,14 @@ impl AgentTaskGateReport {
         environment: AgentTaskGateEnvironment,
     ) -> Self {
         let id = id.into();
+        let invocation = match command.as_slice() {
+            [shell, flag, source] if shell == "sh" && flag == "-lc" => {
+                Some(AgentTaskGateInvocation::LegacyShell {
+                    command: source.clone(),
+                })
+            }
+            _ => None,
+        };
         let status = if exit_code == 0 {
             AgentTaskGateStatus::Succeeded
         } else {
@@ -1181,6 +1248,7 @@ impl AgentTaskGateReport {
             reveal_policy,
             status,
             command,
+            invocation,
             exit_code,
             termination: AgentTaskGateTermination::Completed,
             test_execution_outcome: None,
@@ -1206,6 +1274,14 @@ impl AgentTaskGateReport {
         blocking_gate_id: impl Into<String>,
     ) -> Self {
         let id = id.into();
+        let invocation = match command.as_slice() {
+            [shell, flag, source] if shell == "sh" && flag == "-lc" => {
+                Some(AgentTaskGateInvocation::LegacyShell {
+                    command: source.clone(),
+                })
+            }
+            _ => None,
+        };
         let skip_reason = AgentTaskGateSkipReason {
             blocking_gate_id: blocking_gate_id.into(),
             reason: "ordered_fail_fast".to_string(),
@@ -1236,6 +1312,7 @@ impl AgentTaskGateReport {
             reveal_policy,
             status: AgentTaskGateStatus::Skipped,
             command,
+            invocation,
             exit_code: 0,
             termination: AgentTaskGateTermination::Completed,
             test_execution_outcome: None,
@@ -1645,6 +1722,12 @@ pub(crate) fn run_gate_command_with_supervision(
         package_artifacts,
         None,
     )
+    .map(|mut report| {
+        report.invocation = Some(AgentTaskGateInvocation::LegacyShell {
+            command: command.to_string(),
+        });
+        report
+    })
 }
 
 /// Execute a declared test adapter as argv. This is deliberately separate from
@@ -1683,6 +1766,10 @@ pub(crate) fn run_declared_test_with_supervision(
         package_artifacts,
         Some(plan),
     )
+    .map(|mut report| {
+        report.invocation = Some(AgentTaskGateInvocation::DeclaredTest { plan: plan.clone() });
+        report
+    })
 }
 
 #[expect(
@@ -1939,10 +2026,81 @@ pub(crate) fn run_gate_command_with_timeout(
     gate_environment: &AgentTaskGateEnvironmentPolicy,
     package_artifacts: &[AgentTaskGatePackageArtifactRequirement],
 ) -> Result<AgentTaskGateReport> {
-    let command_vec = vec!["sh".to_string(), "-lc".to_string(), command.to_string()];
-    let mut process = Command::new("sh");
+    run_gate_argv_with_timeout(
+        cwd,
+        index,
+        vec!["sh".to_string(), "-lc".to_string(), command.to_string()],
+        command,
+        visibility,
+        reveal_policy,
+        runtime_tmpdir,
+        timeout,
+        gate_environment,
+        package_artifacts,
+        None,
+    )
+    .map(|mut report| {
+        report.invocation = Some(AgentTaskGateInvocation::LegacyShell {
+            command: command.to_string(),
+        });
+        report
+    })
+}
+
+pub(crate) fn run_declared_test_with_timeout(
+    cwd: &Path,
+    index: usize,
+    plan: &homeboy_engine_primitives::test_execution::TestExecutionPlan,
+    visibility: AgentTaskGateVisibility,
+    reveal_policy: AgentTaskGateRevealPolicy,
+    runtime_tmpdir: &Path,
+    gate_environment: &AgentTaskGateEnvironmentPolicy,
+    package_artifacts: &[AgentTaskGatePackageArtifactRequirement],
+) -> Result<AgentTaskGateReport> {
+    let argv = plan
+        .declared_command()
+        .map_err(|message| Error::invalid_argument("test_execution_plan", message))?
+        .to_vec();
+    let label = homeboy_engine_primitives::shell::quote_args(&argv);
+    run_gate_argv_with_timeout(
+        cwd,
+        index,
+        argv,
+        &label,
+        visibility,
+        reveal_policy,
+        runtime_tmpdir,
+        plan.suite_timeout(),
+        gate_environment,
+        package_artifacts,
+        Some(plan),
+    )
+    .map(|mut report| {
+        report.invocation = Some(AgentTaskGateInvocation::DeclaredTest { plan: plan.clone() });
+        report
+    })
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "shell and declared baseline replays share one bounded executor"
+)]
+fn run_gate_argv_with_timeout(
+    cwd: &Path,
+    index: usize,
+    command_vec: Vec<String>,
+    command: &str,
+    visibility: AgentTaskGateVisibility,
+    reveal_policy: AgentTaskGateRevealPolicy,
+    runtime_tmpdir: &Path,
+    timeout: Duration,
+    gate_environment: &AgentTaskGateEnvironmentPolicy,
+    package_artifacts: &[AgentTaskGatePackageArtifactRequirement],
+    declared_plan: Option<&homeboy_engine_primitives::test_execution::TestExecutionPlan>,
+) -> Result<AgentTaskGateReport> {
+    let mut process = Command::new(&command_vec[0]);
     process
-        .args(["-lc", command])
+        .args(&command_vec[1..])
         .current_dir(cwd)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -2005,14 +2163,22 @@ pub(crate) fn run_gate_command_with_timeout(
     } else {
         output.status.code().unwrap_or(1)
     };
-    let test_result = cargo_test_result(command, runner_exit_code, &stdout, &stderr);
-    let cargo_selection = cargo_selection(
-        command,
-        &command_vec,
-        &stdout,
-        &stderr,
-        test_result.as_ref(),
-    );
+    let test_result = declared_plan
+        .is_none()
+        .then(|| cargo_test_result(command, runner_exit_code, &stdout, &stderr))
+        .flatten();
+    let cargo_selection = declared_plan
+        .is_none()
+        .then(|| {
+            cargo_selection(
+                command,
+                &command_vec,
+                &stdout,
+                &stderr,
+                test_result.as_ref(),
+            )
+        })
+        .flatten();
     let exit_code = effective_gate_exit_code(runner_exit_code, cargo_selection.as_ref());
     let failure_evidence = (exit_code != 0).then(|| {
         gate_failure_evidence(
@@ -2042,6 +2208,15 @@ pub(crate) fn run_gate_command_with_timeout(
     } else {
         AgentTaskGateTermination::Completed
     };
+    report.test_execution_outcome = declared_plan.map(|_| {
+        if timed_out {
+            homeboy_engine_primitives::test_execution::TestExecutionOutcome::TimedOut
+        } else if exit_code == 0 {
+            homeboy_engine_primitives::test_execution::TestExecutionOutcome::Passed
+        } else {
+            homeboy_engine_primitives::test_execution::TestExecutionOutcome::Failed
+        }
+    });
     report.capture = AgentTaskGateCapture {
         stdout: output.capture.stdout,
         stderr: output.capture.stderr,
@@ -4724,6 +4899,45 @@ mod tests {
         assert_eq!(
             report.test_execution_outcome,
             Some(homeboy_engine_primitives::test_execution::TestExecutionOutcome::TimedOut)
+        );
+    }
+
+    #[test]
+    fn gate_invocation_identity_includes_declared_adapter_argv_and_deadline() {
+        let first = homeboy_engine_primitives::test_execution::TestExecutionPlan::declared_homeboy_review_test(
+            vec!["homeboy".to_string(), "review".to_string(), "test".to_string()],
+            10,
+        )
+        .unwrap();
+        let changed_deadline = homeboy_engine_primitives::test_execution::TestExecutionPlan::declared_homeboy_review_test(
+            vec!["homeboy".to_string(), "review".to_string(), "test".to_string()],
+            11,
+        )
+        .unwrap();
+        let changed_argv = homeboy_engine_primitives::test_execution::TestExecutionPlan::declared_homeboy_review_test(
+            vec![
+                "homeboy".to_string(),
+                "review".to_string(),
+                "test".to_string(),
+                "component".to_string(),
+            ],
+            10,
+        )
+        .unwrap();
+        let first = AgentTaskGateInvocation::DeclaredTest { plan: first };
+        assert_ne!(
+            first.identity_digest().unwrap(),
+            AgentTaskGateInvocation::DeclaredTest {
+                plan: changed_deadline
+            }
+            .identity_digest()
+            .unwrap()
+        );
+        assert_ne!(
+            first.identity_digest().unwrap(),
+            AgentTaskGateInvocation::DeclaredTest { plan: changed_argv }
+                .identity_digest()
+                .unwrap()
         );
     }
 

--- a/crates/homeboy-agents/src/agent_task_gate.rs
+++ b/crates/homeboy-agents/src/agent_task_gate.rs
@@ -66,6 +66,10 @@ pub struct VerifyGateOptions {
     /// gated from follow-up agents.
     #[serde(default)]
     pub private_verify: Vec<String>,
+    /// A declared adapter-owned test plan. This stays typed in Cook recipes;
+    /// `verify` and `private_verify` are the explicit legacy shell paths.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test_execution_plan: Option<homeboy_engine_primitives::test_execution::TestExecutionPlan>,
     /// Provenance for each gate input captured by the controller before Cook
     /// becomes durable. Commands remain the execution contract for compatibility.
     #[serde(default)]
@@ -472,6 +476,7 @@ impl Default for VerifyGateOptions {
         Self {
             verify: Vec::new(),
             private_verify: Vec::new(),
+            test_execution_plan: None,
             input_sources: Vec::new(),
             private_gate_reveal: default_private_gate_reveal(),
             execution_policy: AgentTaskGateExecutionPolicy::OrderedFailFast,
@@ -589,6 +594,11 @@ pub struct AgentTaskGateReport {
     /// controller wall-clock or progress-deadline termination.
     #[serde(default)]
     pub termination: AgentTaskGateTermination,
+    /// Adapter-owned terminal result for a declared test plan. Shell gates do
+    /// not set this because their result is intentionally just process status.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test_execution_outcome:
+        Option<homeboy_engine_primitives::test_execution::TestExecutionOutcome>,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub stdout: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
@@ -1173,6 +1183,7 @@ impl AgentTaskGateReport {
             command,
             exit_code,
             termination: AgentTaskGateTermination::Completed,
+            test_execution_outcome: None,
             stdout: stdout.into(),
             stderr: stderr.into(),
             capture: AgentTaskGateCapture::default(),
@@ -1227,6 +1238,7 @@ impl AgentTaskGateReport {
             command,
             exit_code: 0,
             termination: AgentTaskGateTermination::Completed,
+            test_execution_outcome: None,
             stdout: String::new(),
             stderr: String::new(),
             capture: AgentTaskGateCapture::default(),
@@ -1620,7 +1632,76 @@ pub(crate) fn run_gate_command_with_supervision(
     gate_environment: &AgentTaskGateEnvironmentPolicy,
     package_artifacts: &[AgentTaskGatePackageArtifactRequirement],
 ) -> Result<AgentTaskGateReport> {
-    let command_vec = vec!["sh".to_string(), "-lc".to_string(), command.to_string()];
+    run_gate_argv_with_supervision(
+        cwd,
+        index,
+        vec!["sh".to_string(), "-lc".to_string(), command.to_string()],
+        command,
+        visibility,
+        reveal_policy,
+        runtime_tmpdir,
+        supervision,
+        gate_environment,
+        package_artifacts,
+        None,
+    )
+}
+
+/// Execute a declared test adapter as argv. This is deliberately separate from
+/// the legacy shell-gate wrapper above: persisted declared commands never pass
+/// through a shell or need their outcome reconstructed from English output.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "supervision callbacks and durable gate inputs remain independently auditable"
+)]
+pub(crate) fn run_declared_test_with_supervision(
+    cwd: &Path,
+    index: usize,
+    plan: &homeboy_engine_primitives::test_execution::TestExecutionPlan,
+    visibility: AgentTaskGateVisibility,
+    reveal_policy: AgentTaskGateRevealPolicy,
+    runtime_tmpdir: Option<&Path>,
+    supervision: Option<&GateSupervision>,
+    gate_environment: &AgentTaskGateEnvironmentPolicy,
+    package_artifacts: &[AgentTaskGatePackageArtifactRequirement],
+) -> Result<AgentTaskGateReport> {
+    let argv = plan
+        .declared_command()
+        .map_err(|message| Error::invalid_argument("test_execution_plan", message))?
+        .to_vec();
+    let label = homeboy_engine_primitives::shell::quote_args(&argv);
+    run_gate_argv_with_supervision(
+        cwd,
+        index,
+        argv,
+        &label,
+        visibility,
+        reveal_policy,
+        runtime_tmpdir,
+        supervision,
+        gate_environment,
+        package_artifacts,
+        Some(plan),
+    )
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "shell and declared gates share one process supervisor"
+)]
+fn run_gate_argv_with_supervision(
+    cwd: &Path,
+    index: usize,
+    command_vec: Vec<String>,
+    command: &str,
+    visibility: AgentTaskGateVisibility,
+    reveal_policy: AgentTaskGateRevealPolicy,
+    runtime_tmpdir: Option<&Path>,
+    supervision: Option<&GateSupervision>,
+    gate_environment: &AgentTaskGateEnvironmentPolicy,
+    package_artifacts: &[AgentTaskGatePackageArtifactRequirement],
+    declared_plan: Option<&homeboy_engine_primitives::test_execution::TestExecutionPlan>,
+) -> Result<AgentTaskGateReport> {
     let mut process = Command::new(&command_vec[0]);
     process
         .args(&command_vec[1..])
@@ -1775,14 +1856,24 @@ pub(crate) fn run_gate_command_with_supervision(
     };
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-    let test_result = cargo_test_result(command, runner_exit_code, &stdout, &stderr);
-    let cargo_selection = cargo_selection(
-        command,
-        &command_vec,
-        &stdout,
-        &stderr,
-        test_result.as_ref(),
-    );
+    // Declared adapters own their typed result. Legacy shell gates retain the
+    // historical Cargo-output projection for compatibility.
+    let test_result = declared_plan
+        .is_none()
+        .then(|| cargo_test_result(command, runner_exit_code, &stdout, &stderr))
+        .flatten();
+    let cargo_selection = declared_plan
+        .is_none()
+        .then(|| {
+            cargo_selection(
+                command,
+                &command_vec,
+                &stdout,
+                &stderr,
+                test_result.as_ref(),
+            )
+        })
+        .flatten();
     let exit_code = effective_gate_exit_code(runner_exit_code, cargo_selection.as_ref());
     let failure_evidence = (exit_code != 0).then(|| {
         gate_failure_evidence(
@@ -1809,6 +1900,20 @@ pub(crate) fn run_gate_command_with_supervision(
     report.test_result = test_result;
     report.cargo_selection = cargo_selection;
     report.termination = termination;
+    report.test_execution_outcome = declared_plan.map(|_| match termination {
+        AgentTaskGateTermination::Completed if exit_code == 0 => {
+            homeboy_engine_primitives::test_execution::TestExecutionOutcome::Passed
+        }
+        AgentTaskGateTermination::Completed => {
+            homeboy_engine_primitives::test_execution::TestExecutionOutcome::Failed
+        }
+        AgentTaskGateTermination::TimedOut | AgentTaskGateTermination::NoProgress => {
+            homeboy_engine_primitives::test_execution::TestExecutionOutcome::TimedOut
+        }
+        AgentTaskGateTermination::Cancelled => {
+            homeboy_engine_primitives::test_execution::TestExecutionOutcome::Cancelled
+        }
+    });
     report.capture = AgentTaskGateCapture {
         stdout: output.capture.stdout,
         stderr: output.capture.stderr,
@@ -4545,6 +4650,81 @@ mod tests {
         }
 
         assert!(std::env::var_os("__HOMEBOY_TEST_ENV_GUARD_ABSENT__").is_none());
+    }
+
+    #[test]
+    fn declared_test_executor_uses_direct_argv_and_reports_a_typed_outcome() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let plan = homeboy_engine_primitives::test_execution::TestExecutionPlan::declared_homeboy_review_test(
+            vec!["homeboy".to_string(), "review".to_string(), "test".to_string()],
+            1,
+        )
+        .expect("declared plan");
+
+        let report = run_gate_argv_with_supervision(
+            workspace.path(),
+            1,
+            vec!["printf".to_string(), "%s".to_string(), "$HOME".to_string()],
+            "homeboy review test",
+            AgentTaskGateVisibility::Visible,
+            AgentTaskGateRevealPolicy::FullEvidence,
+            None,
+            None,
+            &AgentTaskGateEnvironmentPolicy::default(),
+            &[],
+            Some(&plan),
+        )
+        .expect("direct argv execution");
+
+        assert_eq!(report.command, ["printf", "%s", "$HOME"]);
+        assert_eq!(report.stdout, "$HOME", "a shell would expand this argument");
+        assert_eq!(
+            report.test_execution_outcome,
+            Some(homeboy_engine_primitives::test_execution::TestExecutionOutcome::Passed)
+        );
+        assert!(
+            report.test_result.is_none(),
+            "declared outcomes are not parsed"
+        );
+    }
+
+    #[test]
+    fn declared_test_executor_reports_its_suite_deadline() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let plan = homeboy_engine_primitives::test_execution::TestExecutionPlan::declared_homeboy_review_test(
+            vec!["homeboy".to_string(), "review".to_string(), "test".to_string()],
+            1,
+        )
+        .expect("declared plan");
+        let supervision = GateSupervision {
+            timeout: Duration::from_millis(10),
+            no_progress_timeout: Duration::from_secs(1),
+            heartbeat_interval: Duration::from_millis(1),
+            on_spawn: Arc::new(|_, _| Ok(())),
+            on_heartbeat: Arc::new(|_| Ok(())),
+            is_cancelled: Arc::new(|| false),
+        };
+
+        let report = run_gate_argv_with_supervision(
+            workspace.path(),
+            1,
+            vec!["sleep".to_string(), "1".to_string()],
+            "homeboy review test",
+            AgentTaskGateVisibility::Visible,
+            AgentTaskGateRevealPolicy::FullEvidence,
+            None,
+            Some(&supervision),
+            &AgentTaskGateEnvironmentPolicy::default(),
+            &[],
+            Some(&plan),
+        )
+        .expect("timed execution report");
+
+        assert_eq!(report.termination, AgentTaskGateTermination::TimedOut);
+        assert_eq!(
+            report.test_execution_outcome,
+            Some(homeboy_engine_primitives::test_execution::TestExecutionOutcome::TimedOut)
+        );
     }
 
     #[test]

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -1906,7 +1906,9 @@ fn run_promotion_gates(
         )?;
     }
     if options.dry_run
-        || (options.gates.verify.is_empty() && options.gates.private_verify.is_empty())
+        || (options.gates.verify.is_empty()
+            && options.gates.private_verify.is_empty()
+            && options.gates.test_execution_plan.is_none())
     {
         return Ok(PromotionGateRun::without_gates(options.dry_run));
     }
@@ -1993,10 +1995,38 @@ fn run_promotion_gates(
         }));
     let mut deterministic_gates = Vec::new();
     let mut blocking_gate_id = None;
-    for (index, (command, visibility, reveal_policy)) in declared_gates.enumerate() {
+    if let Some(plan) = options.gates.test_execution_plan.as_ref() {
         let gate = if let Some(blocking_gate_id) = blocking_gate_id.as_deref() {
             crate::agent_task_gate::AgentTaskGateReport::skipped(
-                format!("gate-{}", index + 1),
+                "gate-1".to_string(),
+                plan.declared_command()
+                    .map_err(|message| Error::invalid_argument("test_execution_plan", message))?
+                    .to_vec(),
+                AgentTaskGateVisibility::Visible,
+                AgentTaskGateRevealPolicy::FullEvidence,
+                blocking_gate_id,
+            )
+        } else {
+            emit_promotion_progress(
+                "gate",
+                Some("gate-1".to_string()),
+                Some("starting declared test plan".to_string()),
+            );
+            run_declared_promotion_test(options, &gate_workspace, 1, plan)?
+        };
+        if gate.status == AgentTaskGateStatus::Failed
+            && options.gates.execution_policy
+                == crate::agent_task_gate::AgentTaskGateExecutionPolicy::OrderedFailFast
+        {
+            blocking_gate_id = Some(gate.id.clone());
+        }
+        deterministic_gates.push(gate);
+    }
+    for (index, (command, visibility, reveal_policy)) in declared_gates.enumerate() {
+        let index = index + deterministic_gates.len() + 1;
+        let gate = if let Some(blocking_gate_id) = blocking_gate_id.as_deref() {
+            crate::agent_task_gate::AgentTaskGateReport::skipped(
+                format!("gate-{index}"),
                 vec!["sh".to_string(), "-lc".to_string(), command.to_string()],
                 visibility,
                 reveal_policy,
@@ -2005,14 +2035,14 @@ fn run_promotion_gates(
         } else {
             emit_promotion_progress(
                 "gate",
-                Some(format!("gate-{}", index + 1)),
+                Some(format!("gate-{index}")),
                 Some("starting deterministic gate".to_string()),
             );
             run_promotion_gate(
                 options,
                 provider,
                 &gate_workspace,
-                index + 1,
+                index,
                 command,
                 visibility,
                 reveal_policy,
@@ -2063,6 +2093,52 @@ fn run_promotion_gates(
         destination_gate_setup,
         candidate_checkout,
     })
+}
+
+fn run_declared_promotion_test(
+    options: &AgentTaskPromotionOptions,
+    worktree_path: &Path,
+    index: usize,
+    plan: &homeboy_engine_primitives::test_execution::TestExecutionPlan,
+) -> Result<crate::agent_task_gate::AgentTaskGateReport> {
+    let run_dir = homeboy_core::engine::run_dir::RunDir::create()?;
+    let runtime_tmpdir = homeboy_core::engine::invocation::InvocationGuard::acquire(
+        &run_dir,
+        &homeboy_core::engine::invocation::InvocationRequirements::default(),
+    )?;
+    let mut gate_environment = options.gates.gate_environment.clone();
+    gate_environment.hydrate_rust_cache &= options.gates.hydrate_dependencies;
+    let supervision = GATE_SUPERVISION.with(|slot| slot.borrow().clone());
+    let timeout = plan.suite_timeout();
+    let supervision = supervision.map(|supervision| crate::agent_task_gate::GateSupervision {
+        timeout,
+        no_progress_timeout: supervision.no_progress_timeout,
+        heartbeat_interval: supervision.heartbeat_interval,
+        on_spawn: supervision.on_spawn.clone(),
+        on_heartbeat: supervision.on_heartbeat.clone(),
+        is_cancelled: supervision.is_cancelled.clone(),
+    });
+    let fallback_supervision = crate::agent_task_gate::GateSupervision {
+        timeout,
+        no_progress_timeout: timeout,
+        heartbeat_interval: Duration::from_secs(5),
+        on_spawn: Arc::new(|_, _| Ok(())),
+        on_heartbeat: Arc::new(|_| Ok(())),
+        is_cancelled: Arc::new(|| false),
+    };
+    let result = crate::agent_task_gate::run_declared_test_with_supervision(
+        worktree_path,
+        index,
+        plan,
+        AgentTaskGateVisibility::Visible,
+        AgentTaskGateRevealPolicy::FullEvidence,
+        Some(&runtime_tmpdir.context().tmp_dir),
+        supervision.as_ref().or(Some(&fallback_supervision)),
+        &gate_environment,
+        &options.gates.gate_package_artifacts,
+    );
+    finish_promotion_gate_run_dir(&run_dir, result.is_ok());
+    result
 }
 
 fn gate_workspace_path(options: &AgentTaskPromotionOptions, worktree_path: &Path) -> PathBuf {

--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -1996,24 +1996,12 @@ fn run_promotion_gates(
     let mut deterministic_gates = Vec::new();
     let mut blocking_gate_id = None;
     if let Some(plan) = options.gates.test_execution_plan.as_ref() {
-        let gate = if let Some(blocking_gate_id) = blocking_gate_id.as_deref() {
-            crate::agent_task_gate::AgentTaskGateReport::skipped(
-                "gate-1".to_string(),
-                plan.declared_command()
-                    .map_err(|message| Error::invalid_argument("test_execution_plan", message))?
-                    .to_vec(),
-                AgentTaskGateVisibility::Visible,
-                AgentTaskGateRevealPolicy::FullEvidence,
-                blocking_gate_id,
-            )
-        } else {
-            emit_promotion_progress(
-                "gate",
-                Some("gate-1".to_string()),
-                Some("starting declared test plan".to_string()),
-            );
-            run_declared_promotion_test(options, &gate_workspace, 1, plan)?
-        };
+        emit_promotion_progress(
+            "gate",
+            Some("gate-1".to_string()),
+            Some("starting declared test plan".to_string()),
+        );
+        let gate = run_declared_promotion_test(options, &gate_workspace, 1, plan)?;
         if gate.status == AgentTaskGateStatus::Failed
             && options.gates.execution_policy
                 == crate::agent_task_gate::AgentTaskGateExecutionPolicy::OrderedFailFast
@@ -2022,8 +2010,9 @@ fn run_promotion_gates(
         }
         deterministic_gates.push(gate);
     }
+    let legacy_gate_offset = deterministic_gates.len();
     for (index, (command, visibility, reveal_policy)) in declared_gates.enumerate() {
-        let index = index + deterministic_gates.len() + 1;
+        let index = index + legacy_gate_offset + 1;
         let gate = if let Some(blocking_gate_id) = blocking_gate_id.as_deref() {
             crate::agent_task_gate::AgentTaskGateReport::skipped(
                 format!("gate-{index}"),

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_b.rs
@@ -1671,6 +1671,94 @@ fn continue_all_gate_policy_runs_downstream_command_after_failure() {
         report.deterministic_gates[1].status,
         AgentTaskGateStatus::Succeeded
     );
+    assert_eq!(
+        report
+            .deterministic_gates
+            .iter()
+            .map(|gate| gate.id.as_str())
+            .collect::<Vec<_>>(),
+        ["gate-1", "gate-2"]
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn typed_plan_and_legacy_gate_keep_contiguous_gate_ids() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir(&workspace).expect("workspace");
+    git(&workspace, &["init", "-b", "main"]);
+    git(&workspace, &["config", "user.email", "test@example.com"]);
+    git(&workspace, &["config", "user.name", "Homeboy Test"]);
+    std::fs::create_dir_all(workspace.join("src")).expect("source directory");
+    std::fs::write(workspace.join("src/lib.rs"), "old\n").expect("base file");
+    git(&workspace, &["add", "."]);
+    git(&workspace, &["commit", "-m", "base"]);
+    let (source_path, source) = write_patch_source(&temp);
+    let bin = temp.path().join("bin");
+    std::fs::create_dir(&bin).expect("bin");
+    let homeboy = bin.join("homeboy");
+    std::fs::write(
+        &homeboy,
+        "#!/bin/sh\ntest \"$1\" = review && test \"$2\" = test\n",
+    )
+    .expect("homeboy adapter");
+    let mut permissions = std::fs::metadata(&homeboy).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&homeboy, permissions).unwrap();
+    let mut environment = AgentTaskGateEnvironmentPolicy::default();
+    environment
+        .variables
+        .insert("PATH".to_string(), format!("{}:/bin", bin.display()));
+    let mut provider = FakePromotionWorkspaceProvider {
+        workspace_path: Some(workspace),
+        apply_to_git: true,
+        run_verify_command: true,
+        ..Default::default()
+    };
+
+    let report = promote_with_provider(
+        AgentTaskPromotionOptions {
+            source,
+            source_run_id: Some("typed-and-legacy-ids".to_string()),
+            source_path: Some(source_path),
+            source_worktree_path: None,
+            base_ref: None,
+            task_base_sha: None,
+            candidate_ref: None,
+            to_worktree: "fixture@target".to_string(),
+            task_id: None,
+            artifact_id: None,
+            dry_run: false,
+            gates: VerifyGateOptions {
+                verify: vec!["true".to_string()],
+                test_execution_plan: Some(
+                    homeboy_engine_primitives::test_execution::TestExecutionPlan::declared_homeboy_review_test(
+                        vec!["homeboy".to_string(), "review".to_string(), "test".to_string()],
+                        30,
+                    )
+                    .expect("plan"),
+                ),
+                gate_environment: environment,
+                ..Default::default()
+            },
+            provider_command: None,
+            provider_invocation: None,
+        },
+        &mut provider,
+    )
+    .expect("promotion");
+
+    assert_eq!(
+        report
+            .deterministic_gates
+            .iter()
+            .map(|gate| gate.id.as_str())
+            .collect::<Vec<_>>(),
+        ["gate-1", "gate-2"]
+    );
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_promotion/types.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/types.rs
@@ -159,7 +159,10 @@ impl AgentTaskPromotionReport {
             AgentTaskPromotionStatus::Applied | AgentTaskPromotionStatus::VerifiedNoChanges
         ) && self.deterministic_gates.iter().any(|gate| {
             gate.visibility == HomeboyGateVisibility::Visible
-                && gate.command.as_slice() == ["sh", "-lc", command]
+                && gate
+                    .invocation()
+                    .map(|invocation| invocation.reviewer_command() == command)
+                    .unwrap_or(false)
                 && durable_gate_passed(gate)
                 && self.gate_candidate_identity_matches(gate)
         })

--- a/crates/homeboy-agents/src/agent_task_review_dossier.rs
+++ b/crates/homeboy-agents/src/agent_task_review_dossier.rs
@@ -400,13 +400,8 @@ pub(crate) fn verified_commands_from_promotion(
         .deterministic_gates
         .iter()
         .filter_map(|gate| {
-            let [shell, flag, command] = gate.command.as_slice() else {
-                return None;
-            };
-            if shell != "sh"
-                || flag != "-lc"
-                || !promotion.has_visible_passed_gate_for_command(command)
-            {
+            let command = gate.invocation().ok()?.reviewer_command();
+            if !promotion.has_visible_passed_gate_for_command(&command) {
                 return None;
             }
             let candidate = gate.candidate_checkout.as_ref()?;
@@ -417,7 +412,7 @@ pub(crate) fn verified_commands_from_promotion(
                 },
             );
             Some(AgentTaskReviewVerifiedCommand {
-                command: command.clone(),
+                command,
                 status: format!("{:?}", gate.status).to_ascii_lowercase(),
                 candidate_commit: candidate.commit.clone(),
                 candidate_tree: candidate.tree.clone(),

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -348,11 +348,13 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
     // Resolve the caller input to the commit object before durable ownership is
     // claimed, then use that immutable SHA for every subsequent operation.
     let candidate_sha = resolve_candidate_revision(&source_worktree, candidate_ref)?;
-    let gate_identity = if options.gates.verify.is_empty() {
-        "promotion verification".to_string()
-    } else {
-        options.gates.verify.join(" && ")
-    };
+    let gate_identity = serde_json::to_string(&serde_json::json!({
+        "verify": options.gates.verify,
+        "private_verify": options.gates.private_verify,
+        "test_execution_plan": options.gates.test_execution_plan,
+    }))
+    .map(|contract| homeboy_engine_primitives::content_hash::sha256_hex(contract.as_bytes()))
+    .map_err(|error| Error::internal_json(error.to_string(), None))?;
     let persisted_adoption_result = record
         .candidate_adoption
         .as_ref()

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -348,13 +348,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
     // Resolve the caller input to the commit object before durable ownership is
     // claimed, then use that immutable SHA for every subsequent operation.
     let candidate_sha = resolve_candidate_revision(&source_worktree, candidate_ref)?;
-    let gate_identity = serde_json::to_string(&serde_json::json!({
-        "verify": options.gates.verify,
-        "private_verify": options.gates.private_verify,
-        "test_execution_plan": options.gates.test_execution_plan,
-    }))
-    .map(|contract| homeboy_engine_primitives::content_hash::sha256_hex(contract.as_bytes()))
-    .map_err(|error| Error::internal_json(error.to_string(), None))?;
+    let gate_identity = adoption_gate_identity(&options.gates)?;
     let persisted_adoption_result = record
         .candidate_adoption
         .as_ref()
@@ -960,6 +954,30 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
     }))
 }
 
+/// Keep the historical adoption key for recipes without declared tests: durable
+/// interrupted/completed adoption state is keyed by this exact string.
+fn adoption_gate_identity(gates: &crate::agent_task_gate::VerifyGateOptions) -> Result<String> {
+    let Some(plan) = gates.test_execution_plan.as_ref() else {
+        return Ok(if gates.verify.is_empty() {
+            "promotion verification".to_string()
+        } else {
+            gates.verify.join(" && ")
+        });
+    };
+    plan.declared_command()
+        .map_err(|message| Error::invalid_argument("test_execution_plan", message))?;
+    let contract = serde_json::json!({
+        "verify": gates.verify,
+        "private_verify": gates.private_verify,
+        "test_execution_plan": plan,
+    });
+    let encoded = serde_json::to_vec(&contract)
+        .map_err(|error| Error::internal_json(error.to_string(), None))?;
+    Ok(homeboy_engine_primitives::content_hash::sha256_hex(
+        &encoded,
+    ))
+}
+
 /// PR/finalization evidence is a projection of the durable decision, never a
 /// fresh interpretation of runner or environment metadata.
 fn project_execution_placement(finalization: &mut Value, metadata: &Value) {
@@ -1494,6 +1512,71 @@ mod projection_tests {
         assert_eq!(
             finalization["execution_placement_decision"]["decision_id"],
             finalization["execution_placement_outcome"]["decision_id"]
+        );
+    }
+
+    #[test]
+    fn adoption_gate_identity_preserves_legacy_values_and_binds_declared_plans() {
+        let empty = crate::agent_task_gate::VerifyGateOptions::default();
+        assert_eq!(
+            adoption_gate_identity(&empty).unwrap(),
+            "promotion verification"
+        );
+
+        let legacy = crate::agent_task_gate::VerifyGateOptions {
+            verify: vec!["cargo test".to_string(), "cargo fmt --check".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(
+            adoption_gate_identity(&legacy).unwrap(),
+            "cargo test && cargo fmt --check"
+        );
+
+        let typed = |command: Vec<String>, timeout| {
+            crate::agent_task_gate::VerifyGateOptions {
+            verify: vec!["legacy companion".to_string()],
+            private_verify: vec!["private companion".to_string()],
+            test_execution_plan: Some(
+                homeboy_engine_primitives::test_execution::TestExecutionPlan::declared_homeboy_review_test(
+                    command, timeout,
+                )
+                .unwrap(),
+            ),
+            ..Default::default()
+        }
+        };
+        let first = typed(
+            vec![
+                "homeboy".to_string(),
+                "review".to_string(),
+                "test".to_string(),
+            ],
+            10,
+        );
+        let changed_argv = typed(
+            vec![
+                "homeboy".to_string(),
+                "review".to_string(),
+                "test".to_string(),
+                "component".to_string(),
+            ],
+            10,
+        );
+        let changed_deadline = typed(
+            vec![
+                "homeboy".to_string(),
+                "review".to_string(),
+                "test".to_string(),
+            ],
+            11,
+        );
+        assert_ne!(
+            adoption_gate_identity(&first).unwrap(),
+            adoption_gate_identity(&changed_argv).unwrap()
+        );
+        assert_ne!(
+            adoption_gate_identity(&first).unwrap(),
+            adoption_gate_identity(&changed_deadline).unwrap()
         );
     }
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
@@ -1112,7 +1112,7 @@ mod tests {
         let homeboy = bin.join("homeboy");
         std::fs::write(
             &homeboy,
-            "#!/bin/sh\ntest \"$1\" = review && test \"$2\" = test || exit 97\ncat marker >&2\nexit 1\n",
+            "#!/bin/sh\ntest \"$1\" = review && test \"$2\" = test || exit 97\n/bin/cat marker >&2\nexit 1\n",
         )
         .expect("homeboy adapter");
         let mut permissions = std::fs::metadata(&homeboy).unwrap().permissions();

--- a/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_baseline.rs
@@ -14,8 +14,9 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use crate::agent_task_gate::{
-    failure_fingerprint, run_gate_command_with_timeout, AgentTaskGateBaselineComparison,
-    AgentTaskGateDifferentialResult, AgentTaskGateStatus,
+    failure_fingerprint, run_declared_test_with_timeout, run_gate_command_with_timeout,
+    AgentTaskGateBaselineComparison, AgentTaskGateDifferentialResult, AgentTaskGateInvocation,
+    AgentTaskGateStatus,
 };
 use crate::agent_task_promotion::{normalize_promotion_patch, AgentTaskPromotionReport};
 use crate::agent_task_scheduler::AgentTaskPlan;
@@ -418,24 +419,40 @@ pub(crate) fn compare_gate_failures_to_verified_base(
                 });
                 continue;
             };
-            let command = gate.command.last().cloned().unwrap_or_default();
+            let invocation = gate.invocation()?;
             let baseline_run_dir = homeboy_core::engine::run_dir::RunDir::create()?;
             let baseline = (|| {
                 let runtime = homeboy_core::engine::invocation::InvocationGuard::acquire(
                     &baseline_run_dir,
                     &homeboy_core::engine::invocation::InvocationRequirements::default(),
                 )?;
-                run_gate_command_with_timeout(
-                    &baseline_gate_workspace,
-                    index + 1,
-                    &command,
-                    gate.visibility,
-                    gate.reveal_policy,
-                    &runtime.context().tmp_dir,
-                    timeout,
-                    &gate.environment.replay_policy(),
-                    &package_artifacts,
-                )
+                match &invocation {
+                    AgentTaskGateInvocation::LegacyShell { command } => {
+                        run_gate_command_with_timeout(
+                            &baseline_gate_workspace,
+                            index + 1,
+                            command,
+                            gate.visibility,
+                            gate.reveal_policy,
+                            &runtime.context().tmp_dir,
+                            timeout,
+                            &gate.environment.replay_policy(),
+                            &package_artifacts,
+                        )
+                    }
+                    AgentTaskGateInvocation::DeclaredTest { plan } => {
+                        run_declared_test_with_timeout(
+                            &baseline_gate_workspace,
+                            index + 1,
+                            plan,
+                            gate.visibility,
+                            gate.reveal_policy,
+                            &runtime.context().tmp_dir,
+                            &gate.environment.replay_policy(),
+                            &package_artifacts,
+                        )
+                    }
+                }
             })();
             if let Ok(baseline) = &baseline {
                 if baseline.environment.package_artifacts != gate.environment.package_artifacts {
@@ -1073,6 +1090,95 @@ mod tests {
                 .expect("comparison")
                 .result,
             AgentTaskGateDifferentialResult::BaselineRed
+        );
+    }
+
+    #[test]
+    fn differential_gate_comparison_replays_a_declared_plan_without_shell_projection() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("repository");
+        git_output(temp.path(), &["init", "-b", "main"]).expect("init");
+        git_output(temp.path(), &["config", "user.name", "Homeboy Test"]).expect("name");
+        git_output(temp.path(), &["config", "user.email", "test@example.test"]).expect("email");
+        std::fs::write(temp.path().join("marker"), "base\n").expect("base marker");
+        git_output(temp.path(), &["add", "marker"]).expect("add");
+        git_output(temp.path(), &["commit", "-m", "base"]).expect("commit");
+        let base = git_output(temp.path(), &["rev-parse", "HEAD"]).expect("base sha");
+        std::fs::write(temp.path().join("marker"), "candidate\n").expect("candidate marker");
+
+        let bin = temp.path().join("bin");
+        std::fs::create_dir(&bin).expect("bin");
+        let homeboy = bin.join("homeboy");
+        std::fs::write(
+            &homeboy,
+            "#!/bin/sh\ntest \"$1\" = review && test \"$2\" = test || exit 97\ncat marker >&2\nexit 1\n",
+        )
+        .expect("homeboy adapter");
+        let mut permissions = std::fs::metadata(&homeboy).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&homeboy, permissions).unwrap();
+
+        let plan = homeboy_engine_primitives::test_execution::TestExecutionPlan::declared_homeboy_review_test(
+            vec!["homeboy".to_string(), "review".to_string(), "test".to_string()],
+            1,
+        )
+        .expect("plan");
+        let mut promotion: AgentTaskPromotionReport = serde_json::from_value(serde_json::json!({
+            "schema": "homeboy/agent-task-promotion-report/v1",
+            "status": "gate_failed",
+            "source": {"kind": "aggregate", "task_id": "task"},
+            "to_worktree": "fixture",
+            "target": {"worktree": "fixture", "path": temp.path()},
+            "patch_artifact": {"id": "patch", "kind": "patch", "path": "patch"},
+            "deterministic_gates": [],
+            "operator_notification": {"status": "blocked", "message": "red"}
+        }))
+        .expect("promotion");
+        let mut gate = crate::agent_task_gate::AgentTaskGateReport::new(
+            "declared",
+            vec![
+                "homeboy".to_string(),
+                "review".to_string(),
+                "test".to_string(),
+            ],
+            1,
+            "",
+            "candidate\n",
+            None,
+            HomeboyGateVisibility::Visible,
+            AgentTaskGateRevealPolicy::FullEvidence,
+            crate::agent_task_gate::AgentTaskGateEnvironment {
+                inherited: vec![crate::agent_task_gate::AgentTaskGateEnvironmentVariable {
+                    name: "PATH".to_string(),
+                    value: bin.display().to_string(),
+                }],
+                ..Default::default()
+            },
+        );
+        gate.invocation = Some(AgentTaskGateInvocation::DeclaredTest { plan: plan.clone() });
+        gate.test_execution_outcome =
+            Some(homeboy_engine_primitives::test_execution::TestExecutionOutcome::Failed);
+        promotion.deterministic_gates.push(gate);
+
+        compare_gate_failures_to_verified_base(
+            &mut promotion,
+            temp.path(),
+            temp.path(),
+            &base,
+            std::time::Duration::from_secs(5),
+            |_compared, _total| Ok(()),
+        )
+        .expect("typed baseline replay");
+
+        let gate = &promotion.deterministic_gates[0];
+        assert_eq!(
+            gate.invocation().expect("typed invocation"),
+            AgentTaskGateInvocation::DeclaredTest { plan }
+        );
+        assert_eq!(
+            gate.baseline_comparison.as_ref().unwrap().result,
+            AgentTaskGateDifferentialResult::CandidateRegression
         );
     }
 }

--- a/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_promotion.rs
@@ -1266,15 +1266,7 @@ fn validate_replacement_proof_finalization_eligibility(
     if visible_gates.is_empty() {
         return Err(failed("visibility", None));
     }
-    let shell_gates = visible_gates
-        .iter()
-        .copied()
-        .filter(|gate| matches!(gate.command.as_slice(), [shell, flag, _] if shell == "sh" && flag == "-lc"))
-        .collect::<Vec<_>>();
-    if shell_gates.is_empty() {
-        return Err(failed("shell_command", None));
-    }
-    let candidate_bound_gates = shell_gates
+    let candidate_bound_gates = visible_gates
         .iter()
         .copied()
         .filter(|gate| match gate.status {
@@ -1288,10 +1280,13 @@ fn validate_replacement_proof_finalization_eligibility(
     if candidate_bound_gates.is_empty() {
         return Err(failed("candidate_checkout", None));
     }
-    if !candidate_bound_gates
-        .iter()
-        .any(|gate| crate::agent_task_review_dossier::reviewer_runnable_command(&gate.command[2]))
-    {
+    if !candidate_bound_gates.iter().any(|gate| {
+        gate.invocation()
+            .map(|invocation| invocation.reviewer_command())
+            .is_ok_and(|command| {
+                crate::agent_task_review_dossier::reviewer_runnable_command(&command)
+            })
+    }) {
         return Err(failed("reviewer_runnable_command", None));
     }
     Ok(())
@@ -1422,14 +1417,18 @@ fn verify_replacement_gates_owned(
             None,
         ));
     }
-    if !gates
-        .verify
-        .iter()
-        .any(|command| crate::agent_task_review_dossier::reviewer_runnable_command(command))
-    {
+    let has_reviewer_runnable_gate = gates
+        .test_execution_plan
+        .as_ref()
+        .and_then(|plan| plan.declared_command().ok())
+        .map(homeboy_engine_primitives::shell::quote_args)
+        .into_iter()
+        .chain(gates.verify.iter().cloned())
+        .any(|command| crate::agent_task_review_dossier::reviewer_runnable_command(&command));
+    if !has_reviewer_runnable_gate {
         let mut error = Error::validation_invalid_argument(
             "replacement_gate_proof",
-            "replacement verification requires a reviewer-runnable visible gate before shell execution",
+            "replacement verification requires a reviewer-runnable visible gate",
             Some(run_id.to_string()),
             None,
         );
@@ -1497,7 +1496,7 @@ fn verify_replacement_gates_owned(
         &observation_store,
         || {
             // This fence is deliberately irreversible. Artifact hydration and
-            // candidate validation are retryable; shell gates are not.
+            // candidate validation are retryable; durable gates are not.
             mark_replacement_gate_execution_started(lifecycle_store, run_id)
         },
     )?;
@@ -4304,15 +4303,11 @@ fn cook_review_dossier_with_stores(
         .deterministic_gates
         .iter()
         .filter_map(|gate| {
-            let [shell, flag, command] = gate.command.as_slice() else {
-                return None;
-            };
-            (shell == "sh"
-                && flag == "-lc"
-                && verification_promotion.has_visible_passed_gate_for_command(command)
-                && crate::agent_task_review_dossier::reviewer_runnable_command(command))
+            let command = gate.invocation().ok()?.reviewer_command();
+            (verification_promotion.has_visible_passed_gate_for_command(&command)
+                && crate::agent_task_review_dossier::reviewer_runnable_command(&command))
             .then(|| AgentTaskReviewTestStep {
-                command: command.clone(),
+                command,
                 expected: "passes as recorded by Cook's deterministic gate".to_string(),
             })
         })

--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/cook.rs
@@ -363,6 +363,7 @@ impl From<VerifyGateArgs> for VerifyGateOptions {
         Self {
             verify: args.verify,
             private_verify: args.private_verify,
+            test_execution_plan: None,
             input_sources: args.input_sources,
             private_gate_reveal: args.private_gate_reveal,
             execution_policy: match args.gate_execution_policy.as_str() {

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -4594,23 +4594,13 @@ impl BatchCookSpec {
                     attempt_dispatcher: None,
                 },
                 gates: VerifyGateOptions {
-                    verify: self
-                        .test_execution_plan
-                        .as_ref()
-                        .map(project_declared_test_command)
-                        .transpose()?
-                        .into_iter()
-                        .chain(self.verify.clone())
-                        .collect(),
+                    verify: self.verify.clone(),
                     private_verify: self.private_verify.clone(),
+                    test_execution_plan: self.test_execution_plan.clone(),
                     input_sources: self.input_sources.clone(),
                     private_gate_reveal: self.private_gate_reveal,
                     execution_policy: self.execution_policy,
-                    gate_timeout_seconds: self
-                        .test_execution_plan
-                        .as_ref()
-                        .map(|plan| plan.suite_timeout().as_secs())
-                        .unwrap_or(self.gate_timeout_seconds),
+                    gate_timeout_seconds: self.gate_timeout_seconds,
                     gate_heartbeat_interval_seconds: self.gate_heartbeat_interval_seconds,
                     gate_no_progress_timeout_seconds: self.gate_no_progress_timeout_seconds,
                     rerun_completed_gates: self.rerun_completed_gates,
@@ -5057,13 +5047,6 @@ impl VerificationProfiles {
             Some(profile.plan.clone()),
         ))
     }
-}
-
-fn project_declared_test_command(
-    plan: &homeboy_engine_primitives::test_execution::TestExecutionPlan,
-) -> Result<String> {
-    let command = plan.declared_command().map_err(invalid_fanout)?;
-    Ok(homeboy_engine_primitives::shell::quote_args(command))
 }
 
 fn sources_for_executed_gates(
@@ -9314,8 +9297,8 @@ fi
                     .expect("Lab handoff invocation")
                     .options
                     .gates
-                    .verify,
-                vec!["homeboy review test homeboy"]
+                    .test_execution_plan,
+                plan.cooks[1].test_execution_plan
             );
             assert_eq!(
                 round_trip.cooks[1]
@@ -9324,7 +9307,7 @@ fi
                     .options
                     .gates
                     .gate_timeout_seconds,
-                123
+                batch_args.gates.gate_timeout_seconds
             );
         });
     }

--- a/crates/homeboy-engine-primitives/src/test_execution.rs
+++ b/crates/homeboy-engine-primitives/src/test_execution.rs
@@ -34,6 +34,17 @@ pub enum TestExecutionAdapter {
     HomeboyReviewTest,
 }
 
+/// Terminal result emitted by the executor of a declared test plan. Consumers
+/// project this value directly rather than inferring a timeout from output.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TestExecutionOutcome {
+    Passed,
+    Failed,
+    TimedOut,
+    Cancelled,
+}
+
 impl TestExecutionPlan {
     /// A suite deadline must be positive. Zero is never an implicit request for
     /// unbounded execution.
@@ -162,5 +173,24 @@ mod tests {
         )
         .expect_err("unsupported scope is not silently ignored");
         assert!(error.to_string().contains("scope"));
+    }
+
+    #[test]
+    fn declared_plan_round_trips_as_a_concrete_durable_contract() {
+        let plan = TestExecutionPlan::declared_homeboy_review_test(
+            vec![
+                "homeboy".to_string(),
+                "review".to_string(),
+                "test".to_string(),
+                "component".to_string(),
+            ],
+            42,
+        )
+        .unwrap();
+        let persisted = serde_json::to_string(&plan).unwrap();
+        assert_eq!(
+            serde_json::from_str::<TestExecutionPlan>(&persisted).unwrap(),
+            plan
+        );
     }
 }

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -530,9 +530,9 @@ assignment must match one child; unmatched selectors return the typed
 ```
 
 Each profile selects one `TestExecutionPlan`. The current declared contract
-enforces a canonical `homeboy review test` argv and a positive suite timeout,
-then projects that timeout once for both Cook and Lab handoff. Use `--verify`
-only for arbitrary shell programs.
+enforces a canonical `homeboy review test` argv and a positive suite timeout.
+The typed declaration is persisted unchanged through Cook and Lab handoff; use
+`--verify` only for arbitrary shell programs.
 
 Add `--dry-run` to inspect the derived branch/worktree names and batch-cook spec
 without creating worktrees. Add `--run-plan` after reviewing provider readiness


### PR DESCRIPTION
## Summary
- persist `TestExecutionPlan` unchanged through fanout, Cook recipes, and Lab handoff instead of projecting it into shell text
- execute declared adapters as direct argv with typed passed, failed, timed-out, and cancelled outcomes
- replay the same typed invocation for immutable baseline comparison, candidate adoption, replacement verification, finalization fingerprints, and reviewer evidence
- retain explicit `verify` and `private_verify` shell gates plus historical report, fingerprint, and adoption-key compatibility
- bind adapter argv and suite deadline into typed invocation identity and export the plan-owned deadline consistently

Part of #13714.

## Verification
- `cargo test -p homeboy-agents --lib agent_task_gate::tests` (66 passed)
- `cargo test -p homeboy-agents --lib agent_task_service::cook_baseline::tests` (4 passed)
- `cargo test -p homeboy-agents --lib typed_plan_and_legacy_gate_keep_contiguous_gate_ids`
- `cargo test -p homeboy-agents --lib verify_replacement_gates_replays_completed_proof_without_rerunning_gates`
- `cargo test -p homeboy-agents --lib adoption_gate_identity_preserves_legacy_values_and_binds_declared_plans`
- `cargo test -p homeboy-engine-primitives test_execution` (4 passed)
- `cargo test -p homeboy-cli cook_batch_projects_a_declared_verification_plan_to_cook_and_lab`
- `cargo check -p homeboy-agents -p homeboy-cli`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI assistance
OpenAI GPT-5.6 Terra and GPT-5.6 Sol via OpenCode traced the gate lifecycle, implemented the typed execution and replay contracts, reviewed upgrade compatibility and gate identity behavior, and ran focused verification. Chris Huber directed the architecture and reviewed the resulting diff.