### PR TITLE
Converge cancelled provider ownership

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/cancellation.rs
@@ -967,8 +967,8 @@ fn classify_live_cancellation(record: &AgentTaskRunRecord) -> Result<LiveCancell
     }
 
     // No reachable live process (stale running record, or no recorded pid): the
-    // record is being reclaimed. If a pid was recorded, still hand back recovery
-    // commands so a now-orphaned tree can be cleaned up by hand.
+    // record is being reclaimed. A dead PID is authoritative absence, so do not
+    // recommend signals that cannot execute against it.
     if let Some(pid) = owner_pid {
         return Ok(LiveCancellationOutcome::Unsupported(
             UnsupportedLiveCancellation {
@@ -976,7 +976,7 @@ fn classify_live_cancellation(record: &AgentTaskRunRecord) -> Result<LiveCancell
                 owner_pid: Some(pid),
                 runner_id: None,
                 runner_job_id: None,
-                recovery_commands: homeboy_core::process::process_tree_recovery_commands(pid),
+                recovery_commands: Vec::new(),
             },
         ));
     }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -93,12 +93,13 @@ fn record_interrupted_local_owner_locked(
 ) -> Result<(AgentTaskRunRecord, Option<AgentTaskAggregate>)> {
     let plan = lifecycle_store.read_controller_plan(&record.run_id)?;
     let now = now_timestamp();
-    let (has_succeeded, has_failed, recovery_identity) = match decision {
+    let (has_succeeded, has_failed, has_cancelled, recovery_identity) = match decision {
         LocalProviderOwnerDecision::Interrupted {
             has_succeeded,
             has_failed,
+            has_cancelled,
             recovery_identity,
-        } => (has_succeeded, has_failed, recovery_identity),
+        } => (has_succeeded, has_failed, has_cancelled, recovery_identity),
         LocalProviderOwnerDecision::StayRunning | LocalProviderOwnerDecision::NotApplicable => {
             let identity = record
                 .metadata
@@ -111,7 +112,7 @@ fn record_interrupted_local_owner_locked(
                         .collect()
                 })
                 .unwrap_or_default();
-            (false, false, identity)
+            (false, false, false, identity)
         }
     };
     let consumed = record
@@ -177,6 +178,12 @@ fn record_interrupted_local_owner_locked(
             crate::agent_task_scheduler::AgentTaskAggregateStatus::Failed,
             "provider_failed",
             false,
+        )
+    } else if has_cancelled {
+        (
+            crate::agent_task_scheduler::AgentTaskAggregateStatus::Cancelled,
+            "provider_cancelled",
+            true,
         )
     } else {
         (

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_ops.rs
@@ -4170,6 +4170,7 @@ pub(crate) enum LocalProviderOwnerDecision {
     Interrupted {
         has_succeeded: bool,
         has_failed: bool,
+        has_cancelled: bool,
         recovery_identity: Vec<Value>,
     },
 }
@@ -4195,13 +4196,17 @@ pub(crate) fn annotate_local_provider_ownership(
     let mut has_unverifiable_owner = false;
     let mut has_succeeded = false;
     let mut has_failed = false;
+    let mut has_cancelled = false;
     let mut recovery_identity = Vec::new();
     for execution in executions.iter_mut() {
         match execution["state"].as_str() {
-            Some("running") | Some("succeeded") | Some("failed") => {
+            // A cancelled provider is terminal authority too. Excluding it left
+            // an interrupted foreground Cook projected as running forever.
+            Some("running") | Some("succeeded") | Some("failed") | Some("cancelled") => {
                 has_reconcilable_execution = true;
                 has_succeeded |= execution["state"] == json!("succeeded");
                 has_failed |= execution["state"] == json!("failed");
+                has_cancelled |= execution["state"] == json!("cancelled");
                 recovery_identity.push(execution["owner_identity"].clone());
                 let identity_state = execution
                     .get("owner_pid")
@@ -4239,7 +4244,7 @@ pub(crate) fn annotate_local_provider_ownership(
             _ => {}
         }
     }
-    if has_live_owner || (has_unverifiable_owner && !has_failed) {
+    if has_live_owner || (has_unverifiable_owner && !has_failed && !has_cancelled) {
         return LocalProviderOwnerDecision::StayRunning;
     }
     if !has_reconcilable_execution {
@@ -4248,6 +4253,7 @@ pub(crate) fn annotate_local_provider_ownership(
     LocalProviderOwnerDecision::Interrupted {
         has_succeeded,
         has_failed,
+        has_cancelled,
         recovery_identity,
     }
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -3283,6 +3283,18 @@ fn cancel_run_reclaims_stale_running_record() {
     );
     assert!(cancelled.metadata["provider_executions"][0]["finished_at"].is_string());
     assert!(cancelled.metadata.get("stale_running").is_none());
+    let recovery = &cancelled.metadata["live_cancellation_unsupported"];
+    assert_eq!(
+        recovery["reason"],
+        json!("recorded owner pid is not running on this host")
+    );
+    assert!(
+        recovery["recovery_commands"]
+            .as_array()
+            .expect("recovery commands")
+            .is_empty(),
+        "a PID already proved absent must not receive signal advice"
+    );
 }
 
 /// Rooted in an explicit store rather than a mutated process environment
@@ -3818,6 +3830,61 @@ fn terminal_provider_failure_without_owner_persists_interrupted_owner_aggregate(
             aggregate.outcomes[0].diagnostics[0].class,
             "interrupted_owner"
         );
+    });
+}
+
+/// A provider-side cancellation is terminal authority just like a provider
+/// failure. An interrupted foreground Cook must not leave its lifecycle running
+/// after its provider has already recorded cancellation.
+#[test]
+fn terminal_provider_cancellation_without_owner_converges_and_is_idempotent() {
+    with_isolated_home(|_| {
+        let plan = test_plan();
+        submit_plan(&plan, Some("provider-cancelled-no-owner")).expect("submitted");
+        mark_running("provider-cancelled-no-owner").expect("running");
+        reserve_provider_execution_in_store(
+            &test_lifecycle_store(),
+            "provider-cancelled-no-owner",
+            &plan.tasks[0],
+            1,
+        )
+        .expect("reserved");
+        record_provider_execution_terminal_in_store(
+            &test_lifecycle_store(),
+            "provider-cancelled-no-owner",
+            "task-a",
+            1,
+            "cancelled",
+        )
+        .expect("provider cancellation recorded");
+        rewrite_record_for_test("provider-cancelled-no-owner", |record| {
+            let execution = record.metadata["provider_executions"][0]
+                .as_object_mut()
+                .expect("provider execution object");
+            execution.remove("owner_pid");
+            execution.remove("owner_linux_starttime_ticks");
+            execution.remove("owner_identity");
+        })
+        .expect("interrupted foreground owner fixture");
+
+        let terminal = reconcile_status("provider-cancelled-no-owner").expect("reconciled status");
+        let replay = reconcile_status("provider-cancelled-no-owner").expect("idempotent status");
+
+        assert_eq!(terminal.state, AgentTaskRunState::Cancelled);
+        assert_eq!(replay.state, AgentTaskRunState::Cancelled);
+        assert_eq!(replay.tasks[0].state, AgentTaskState::Cancelled);
+        assert_eq!(
+            replay.metadata["provider_executions"][0]["state"],
+            json!("cancelled")
+        );
+        assert_eq!(
+            replay.metadata["local_provider_ownership"]["state"],
+            json!("provider_cancelled")
+        );
+        let aggregate = test_lifecycle_store()
+            .read_aggregate("provider-cancelled-no-owner")
+            .expect("interrupted-owner aggregate");
+        assert_eq!(aggregate.status, AgentTaskAggregateStatus::Cancelled);
     });
 }
 


### PR DESCRIPTION
## Summary
- treat provider-side cancellation as terminal lifecycle authority
- converge interrupted foreground Cook records to cancelled state idempotently
- omit process-signal recovery commands when the recorded owner PID is already absent

Closes #9716

## Verification
- `cargo fmt --all --check`
- `cargo test -p homeboy-agents terminal_provider_cancellation_without_owner_converges_and_is_idempotent`
- `cargo test -p homeboy-agents cancel_run_reclaims_stale_running_record`
- `cargo check -p homeboy-agents`

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode implemented the repair. OpenAI GPT-5.6 Sol via OpenCode reviewed, rebased, and verified it under Chris Huber’s direct orchestration.