### PR TITLE
Fix Lab harvest provenance for remapped worktrees

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/attempt_workspace.rs
@@ -142,6 +142,78 @@ impl HarvestExecutionContext {
             )
         })
     }
+
+    fn transport_for_workspace(
+        &self,
+        workspace: &Path,
+    ) -> Result<
+        (
+            homeboy_core::source_snapshot::SourceSnapshot,
+            serde_json::Value,
+        ),
+        HarvestError,
+    > {
+        let source_snapshot = self.source_snapshot()?;
+        let mut lab_offload = self.lab_offload()?;
+        let observed_path = workspace.display().to_string();
+        let entries = lab_offload
+            .pointer("/workspace_provenance/entries")
+            .and_then(serde_json::Value::as_array);
+        let Some(entries) = entries else {
+            return Ok((source_snapshot, lab_offload));
+        };
+        let matches = entries
+            .iter()
+            .filter(|entry| {
+                entry.get("remote_path").and_then(serde_json::Value::as_str)
+                    == Some(observed_path.as_str())
+            })
+            .collect::<Vec<_>>();
+        let [entry] = matches.as_slice() else {
+            let expected_paths = entries
+                .iter()
+                .filter_map(|entry| entry.get("remote_path").and_then(serde_json::Value::as_str))
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(snapshot_harvest_error(
+                workspace,
+                format!(
+                    "workspace provenance mapping is ambiguous or missing (expected one of [{expected_paths}], observed {observed_path})"
+                ),
+            ));
+        };
+        let snapshot = entry
+            .get("source_snapshot")
+            .cloned()
+            .and_then(|value| serde_json::from_value(value).ok())
+            .ok_or_else(|| {
+                snapshot_harvest_error(
+                    workspace,
+                    "workspace provenance entry has invalid source snapshot".to_string(),
+                )
+            })?;
+        let verification = entry
+            .get("workspace_verification")
+            .cloned()
+            .ok_or_else(|| {
+                snapshot_harvest_error(
+                    workspace,
+                    "workspace provenance entry is missing verification".to_string(),
+                )
+            })?;
+        let materialization_mode = entry.get("materialization_mode").cloned().ok_or_else(|| {
+            snapshot_harvest_error(
+                workspace,
+                "workspace provenance entry is missing materialization mode".to_string(),
+            )
+        })?;
+        lab_offload["remote_workspace"] = serde_json::json!(observed_path);
+        lab_offload["sync_mode"] = materialization_mode;
+        lab_offload["source_snapshot"] =
+            serde_json::to_value(&snapshot).unwrap_or(serde_json::Value::Null);
+        lab_offload["workspace_verification"] = verification;
+        Ok((snapshot, lab_offload))
+    }
 }
 
 fn incomplete_transport_error(message: String) -> homeboy_core::Error {
@@ -264,8 +336,7 @@ pub(super) fn prepare_committed_harvest(
             "parent_snapshot": capability.parent_snapshot(),
         }))
     } else if snapshot_signaled {
-        let source_snapshot = context.source_snapshot()?;
-        let lab_offload = context.lab_offload()?;
+        let (source_snapshot, lab_offload) = context.transport_for_workspace(root)?;
         let provenance =
             homeboy_core::lab_workspace_provenance::with_lab_workspace_provenance(|p| {
                 p.verify_lab_workspace(
@@ -329,8 +400,7 @@ pub(super) fn prepare_committed_harvest(
         None
     };
     if !is_repository {
-        let source_snapshot = context.source_snapshot()?;
-        let lab_offload = context.lab_offload()?;
+        let (source_snapshot, lab_offload) = context.transport_for_workspace(root)?;
         homeboy_core::lab_workspace_provenance::with_lab_workspace_provenance(|p| {
             p.materialize_verified_lab_snapshot_git_baseline(
                 &root.display().to_string(),

--- a/crates/homeboy-lab-runner/src/lab/offload/inner.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/inner.rs
@@ -1990,6 +1990,7 @@ pub(crate) fn run_lab_offload_inner(
         workspace_mapping,
         path_materialization_plan,
         source_snapshot,
+        workspace_snapshots,
         mut remapped_args,
         agent_task_run_id,
         runner_required_extensions,
@@ -2162,6 +2163,7 @@ pub(crate) fn run_lab_offload_inner(
         &mut lab_metadata,
         LabWorkspaceMetadataInputs {
             source_snapshot: &source_snapshot,
+            workspace_snapshots: &workspace_snapshots,
             legacy_path_materialization_plan: &path_materialization_plan,
             primary_synced_workspace: &synced,
         },

--- a/crates/homeboy-lab-runner/src/lab/offload/metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/metadata.rs
@@ -766,6 +766,7 @@ pub(crate) fn lab_materialization_proof_metadata(
 /// legacy dispatch metadata, while the synced workspace binds verification.
 pub(crate) struct LabWorkspaceMetadataInputs<'a> {
     pub(crate) source_snapshot: &'a SourceSnapshot,
+    pub(crate) workspace_snapshots: &'a [SourceSnapshot],
     pub(crate) legacy_path_materialization_plan: &'a PathMaterializationPlan,
     pub(crate) primary_synced_workspace: &'a RunnerWorkspaceSyncOutput,
 }
@@ -812,6 +813,40 @@ pub(crate) fn attach_lab_workspace_metadata(
         "sync_excludes": source_snapshot.sync_excludes,
         "source_snapshot": source_snapshot,
         "primary_workspace": primary_workspace_plan,
+    });
+    lab_metadata["workspace_provenance"] = serde_json::json!({
+        "schema": "homeboy/lab-workspace-provenance/v1",
+        "entries": inputs.workspace_snapshots.iter().map(|snapshot| {
+            let source_path = Path::new(snapshot.local_path.as_deref().unwrap_or_default());
+            let content_hash = crate::workspace_content_hash(source_path, &snapshot.sync_excludes)?;
+            let content_manifest = crate::workspace_content_manifest_for_policy(
+                source_path,
+                &snapshot.sync_excludes,
+                permission_policy,
+            )?;
+            Ok(serde_json::json!({
+                "remote_path": snapshot.remote_path,
+                "materialization_mode": inputs.legacy_path_materialization_plan.entries.iter()
+                    .find(|entry| entry.remote_path == snapshot.remote_path.as_deref().unwrap_or_default())
+                    .map(|entry| entry.materialization_mode.as_str())
+                    .ok_or_else(|| Error::internal_unexpected("workspace provenance snapshot has no materialization plan entry"))?,
+                "source_snapshot": snapshot,
+                "workspace_verification": {
+                    "schema": "homeboy/lab-workspace-verification/v2",
+                    "identity": snapshot.workspace_snapshot_identity,
+                    "content_hash_algorithm": content_hash_algorithm,
+                    "permission_policy": permission_policy,
+                    "content_hash": content_hash,
+                    "content_manifest": content_manifest,
+                    "sync_excludes": snapshot.sync_excludes,
+                    "source_snapshot": snapshot,
+                    "primary_workspace": {
+                        "identity": snapshot.workspace_snapshot_identity,
+                        "remote_path": snapshot.remote_path,
+                    },
+                },
+            }))
+        }).collect::<Result<Vec<_>>>()?,
     });
     Ok(())
 }

--- a/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/tests/capability_metadata.rs
@@ -307,6 +307,7 @@ fn lab_offload_workspace_verification_metadata_survives_process_env_hydration() 
         &mut metadata,
         LabWorkspaceMetadataInputs {
             source_snapshot: &missing_source_path,
+            workspace_snapshots: &[missing_source_path.clone()],
             legacy_path_materialization_plan: &path_materialization_plan,
             primary_synced_workspace: &synced_workspace,
         },
@@ -317,6 +318,7 @@ fn lab_offload_workspace_verification_metadata_survives_process_env_hydration() 
         &mut metadata,
         LabWorkspaceMetadataInputs {
             source_snapshot: &snapshot,
+            workspace_snapshots: &[snapshot.clone()],
             legacy_path_materialization_plan: &path_materialization_plan,
             primary_synced_workspace: &synced_workspace,
         },

--- a/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/workspace_stage.rs
@@ -66,6 +66,7 @@ pub(crate) struct LabOffloadWorkspaceStage {
     pub(crate) workspace_mapping: Vec<LabWorkspaceMappingEntry>,
     pub(crate) path_materialization_plan: PathMaterializationPlan,
     pub(crate) source_snapshot: SourceSnapshot,
+    pub(crate) workspace_snapshots: Vec<SourceSnapshot>,
     pub(crate) remapped_args: Vec<String>,
     pub(crate) agent_task_run_id: Option<String>,
     pub(crate) runner_required_extensions: Vec<String>,
@@ -496,6 +497,22 @@ fn prepare_lab_offload_workspace_stage_inner(
     source_snapshot.synthetic_checkout_tree =
         synced.current_workspace.synthetic_checkout_tree.clone();
     validate_lab_source_snapshot_handoff(source_path, &synced, &source_snapshot)?;
+    let mut workspace_snapshots = vec![source_snapshot.clone()];
+    for extra in &synced_extra_workspaces {
+        let mut snapshot = homeboy_core::source_snapshot::collect_local(
+            runner_id,
+            Path::new(&extra.local_path),
+            Some(&extra.remote_path),
+            "lab_offload",
+        );
+        snapshot.sync_excludes = extra.excludes.clone();
+        snapshot.workspace_snapshot_identity = Some(extra.snapshot_identity.clone());
+        snapshot.synthetic_checkout_commit =
+            extra.current_workspace.synthetic_checkout_commit.clone();
+        snapshot.synthetic_checkout_ref = extra.current_workspace.synthetic_checkout_ref.clone();
+        snapshot.synthetic_checkout_tree = extra.current_workspace.synthetic_checkout_tree.clone();
+        workspace_snapshots.push(snapshot);
+    }
     if contract.requires_extension_parity {
         plan = with_step(
             plan,
@@ -720,6 +737,7 @@ fn prepare_lab_offload_workspace_stage_inner(
         workspace_mapping,
         path_materialization_plan,
         source_snapshot,
+        workspace_snapshots,
         remapped_args,
         agent_task_run_id,
         runner_required_extensions,

--- a/crates/homeboy-lab-runner/src/lab_staging_controller.rs
+++ b/crates/homeboy-lab-runner/src/lab_staging_controller.rs
@@ -3193,6 +3193,7 @@ impl LabStagingStageOperations for ProductionLabStagingOperations {
             &mut lab_metadata,
             crate::lab::offload::LabWorkspaceMetadataInputs {
                 source_snapshot: &stage.source_snapshot,
+                workspace_snapshots: &stage.workspace_snapshots,
                 legacy_path_materialization_plan: &stage.path_materialization_plan,
                 primary_synced_workspace: &stage.synced,
             },

--- a/crates/homeboy-lab-runner/src/lab_workspaces/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces/mod.rs
@@ -167,7 +167,7 @@ pub(super) fn sync_extra_lab_workspaces(
     primary_local_path: &str,
     extra_workspaces: Vec<ExtraLabWorkspace>,
     workspace_mapping: &mut Vec<LabWorkspaceMappingEntry>,
-) -> Result<Vec<LabWorkspaceMappingEntry>> {
+) -> Result<Vec<RunnerWorkspaceSyncOutput>> {
     let primary = canonical_existing_dir(primary_local_path, "path")?;
     let mut seen = HashSet::from([primary]);
     let mut synced_entries = Vec::new();
@@ -194,7 +194,7 @@ pub(super) fn sync_extra_lab_workspaces(
         let mut entry = workspace_mapping_entry(&extra.role, &synced);
         entry.source_provenance = extra.source_provenance.clone();
         workspace_mapping.push(entry.clone());
-        synced_entries.push(entry);
+        synced_entries.push(synced);
     }
 
     Ok(synced_entries)

--- a/crates/homeboy-lab-runner/src/workspace/provenance.rs
+++ b/crates/homeboy-lab-runner/src/workspace/provenance.rs
@@ -1805,6 +1805,92 @@ mod tests {
     }
 
     #[test]
+    fn multi_workspace_cook_uses_the_remapped_workspace_provenance() {
+        let _home = homeboy_core::test_support::HomeGuard::new();
+        crate::register_lab_workspace_provenance_provider();
+        let primary = tempfile::tempdir().expect("primary workspace");
+        let task = tempfile::tempdir().expect("issue worktree");
+        let unmatched = tempfile::tempdir().expect("unmatched workspace");
+        std::fs::write(primary.path().join("file.txt"), "primary\n").expect("primary source");
+        std::fs::write(task.path().join("file.txt"), "task\n").expect("task source");
+        std::fs::write(unmatched.path().join("file.txt"), "unmatched\n").expect("unmatched source");
+
+        let primary_snapshot = snapshot(primary.path());
+        let task_snapshot = snapshot(task.path());
+        let primary_lab = lab(primary.path(), &primary_snapshot);
+        let task_lab = lab(task.path(), &task_snapshot);
+        let mut transport = primary_lab.clone();
+        transport["workspace_provenance"] = serde_json::json!({
+            "schema": "homeboy/lab-workspace-provenance/v1",
+            "entries": [
+                {
+                    "remote_path": primary.path().display().to_string(),
+                    "materialization_mode": "snapshot",
+                    "source_snapshot": primary_snapshot,
+                    "workspace_verification": primary_lab["workspace_verification"],
+                },
+                {
+                    "remote_path": task.path().display().to_string(),
+                    "materialization_mode": "snapshot",
+                    "source_snapshot": task_snapshot.clone(),
+                    "workspace_verification": task_lab["workspace_verification"],
+                },
+            ],
+        });
+
+        let dispatched = Arc::new(AtomicBool::new(false));
+        let aggregate = AgentTaskScheduler::new(Arc::new(FilesystemSnapshotProvider {
+            change_workspace: true,
+            dispatched: Arc::clone(&dispatched),
+        }))
+        .with_harvest_context(
+            HarvestExecutionContext::from_lab_transport(primary_snapshot, transport.clone())
+                .expect("paired Lab transport"),
+        )
+        .run(AgentTaskPlan::new(
+            "multi-workspace-cook",
+            vec![filesystem_snapshot_request(task.path())],
+        ));
+        assert!(
+            dispatched.load(Ordering::SeqCst),
+            "task worktree reaches provider"
+        );
+        let patch = aggregate.outcomes[0]
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.kind == "patch")
+            .expect("task candidate is harvested");
+        assert_eq!(
+            patch.metadata["source_provenance"]["workspace_snapshot_identity"],
+            task_snapshot
+                .workspace_snapshot_identity
+                .expect("task identity")
+        );
+
+        let rejected = Arc::new(AtomicBool::new(false));
+        let failed = AgentTaskScheduler::new(Arc::new(FilesystemSnapshotProvider {
+            change_workspace: true,
+            dispatched: Arc::clone(&rejected),
+        }))
+        .with_harvest_context(
+            HarvestExecutionContext::from_lab_transport(snapshot(primary.path()), transport)
+                .expect("paired Lab transport"),
+        )
+        .run(AgentTaskPlan::new(
+            "unmatched-workspace-cook",
+            vec![filesystem_snapshot_request(unmatched.path())],
+        ));
+        assert!(
+            !rejected.load(Ordering::SeqCst),
+            "unmatched path fails before provider"
+        );
+        assert!(failed.outcomes[0]
+            .summary
+            .as_deref()
+            .is_some_and(|summary| summary.contains("observed")));
+    }
+
+    #[test]
     fn snapshot_baseline_replaces_dangling_linked_worktree_gitfile_before_handoff() {
         let workspace = tempfile::tempdir().expect("workspace");
         std::fs::write(workspace.path().join("file.txt"), "baseline\n").expect("source file");


### PR DESCRIPTION
## Summary
- retain per-workspace source snapshots in Lab offload metadata
- bind committed-change harvest to the provenance entry for the remapped task worktree
- fail closed when workspace provenance is missing or ambiguous

Closes #14075

## Verification
- `cargo fmt --all --check`
- `cargo test -p homeboy-lab-runner multi_workspace_cook_uses_the_remapped_workspace_provenance`
- `cargo check -p homeboy-lab-runner -p homeboy-agents`

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode implemented the repair. OpenAI GPT-5.6 Sol via OpenCode reviewed, rebased, and verified it under Chris Huber’s direct orchestration.