### PR TITLE
Preserve recoverable candidates after provider timeout

### DIFF
--- a/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/engine.rs
@@ -738,6 +738,11 @@ impl AgentTaskScheduler {
                 )
                 .map(|remaining| task_timeout_ms.min(remaining))
                 .unwrap_or(task_timeout_ms);
+                // The scheduler and provider must share one resolved budget.
+                // Without this assignment an inherited/default timeout can
+                // cancel the scheduler while the provider never sees the
+                // actual amount of time it has left to finish cleanly.
+                request.limits.timeout_ms = Some(task_timeout_ms);
                 request.limits.execution_deadline_unix_ms = execution_deadline_unix_ms;
                 let tx = tx.clone();
                 let attempt = scheduled.attempt;
@@ -1023,6 +1028,7 @@ impl AgentTaskScheduler {
                         // Cancellation was requested at the deadline and this
                         // result proves the provider no longer owns the checkout.
                         // Harvest above is therefore race-free.
+                        super::mark_timeout_workspace_candidates_incomplete(&mut outcome);
                         let recovered = outcome.artifacts.iter().any(is_actionable_patch_artifact);
                         outcome.status = if recovered && !rotation_takes_over {
                             AgentTaskOutcomeStatus::CandidateRecoverable
@@ -1067,6 +1073,7 @@ impl AgentTaskScheduler {
                     if candidate_ready_for_convergence
                         && outcome.status == AgentTaskOutcomeStatus::Timeout
                     {
+                        super::mark_timeout_workspace_candidates_incomplete(&mut outcome);
                         outcome.status = AgentTaskOutcomeStatus::CandidateRecoverable;
                         outcome.summary = Some(
                             "provider reported a timeout after producing a recoverable candidate; promote the fingerprinted patch through controller gates".to_string(),

--- a/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/harvest.rs
@@ -121,6 +121,50 @@ pub(super) fn harvest_uncommitted_patch(
     Ok(())
 }
 
+/// A deadline can interrupt an otherwise valid workspace diff before the
+/// provider has completed its result contract. Keep that distinction on the
+/// durable artifact: it is recoverable evidence, never an implicitly complete
+/// provider result.
+pub(super) fn mark_timeout_workspace_candidates_incomplete(outcome: &mut AgentTaskOutcome) {
+    let mut recovered = 0;
+    for artifact in &mut outcome.artifacts {
+        if !is_actionable_patch_artifact(artifact)
+            || artifact
+                .metadata
+                .get("change_source")
+                .and_then(serde_json::Value::as_str)
+                .is_none_or(|source| {
+                    !matches!(source, "uncommitted_attempt_workspace" | "local_commits")
+                })
+        {
+            continue;
+        }
+        if !artifact.metadata.is_object() {
+            artifact.metadata = serde_json::json!({});
+        }
+        let metadata = artifact
+            .metadata
+            .as_object_mut()
+            .expect("patch artifact metadata object");
+        metadata.insert("incomplete".to_string(), serde_json::json!(true));
+        metadata.insert(
+            "recovery_required".to_string(),
+            serde_json::json!(["fresh_review", "deterministic_gates"]),
+        );
+        recovered += 1;
+    }
+    if recovered == 0 {
+        return;
+    }
+    if !outcome.metadata.is_object() {
+        outcome.metadata = serde_json::json!({});
+    }
+    outcome.metadata["timeout_recovery"] = serde_json::json!({
+        "incomplete": true,
+        "recoverable_candidate_count": recovered,
+    });
+}
+
 fn persist_attempt_patch_artifacts(
     outcome: &mut AgentTaskOutcome,
     running: &RunningTask,

--- a/crates/homeboy-agents/src/agent_task_scheduler/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/mod.rs
@@ -57,6 +57,7 @@ use candidate_adoption::{
 };
 pub use engine::*;
 use engine::{QuarantinedTask, ResourceWait, RunningTask, ScheduledTask};
+use harvest::mark_timeout_workspace_candidates_incomplete;
 use harvest::{
     committed_harvest_failure, committed_harvest_preflight_outcome, harvest_committed_patch,
     harvest_uncommitted_patch,

--- a/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/scheduling.rs
@@ -756,6 +756,7 @@ impl AgentTaskScheduleSupport {
                                 .map_err(|error| format!("{error:?}"))
                         });
                         if harvest.is_ok() {
+                            super::mark_timeout_workspace_candidates_incomplete(&mut recovered);
                             // The provider has exited, so runtime artifact discovery can no
                             // longer race its writes to the isolated attempt workspace.
                             Self::reconcile_timeout_artifacts(

--- a/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/timeout.rs
+++ b/crates/homeboy-agents/src/agent_task_scheduler/tests/scheduling_tests/timeout.rs
@@ -4,6 +4,7 @@
 use super::shared::*;
 
 mod timeout_tests {
+    use super::super::concurrency::concurrency_tests::init_git_workspace;
     use super::*;
 
     struct ReturnedTimeoutOnceExecutor {
@@ -146,6 +147,66 @@ mod timeout_tests {
             aggregate.outcomes[0].failure_classification,
             Some(AgentTaskFailureClassification::Timeout)
         );
+        assert!(aggregate.outcomes[0].artifacts.is_empty());
+        assert_eq!(aggregate.totals.candidate_recoverable, 0);
+    }
+
+    #[test]
+    fn timeout_after_workspace_edits_preserves_an_incomplete_recoverable_candidate() {
+        struct EditThenTimeout;
+
+        impl AgentTaskExecutorAdapter for EditThenTimeout {
+            fn execute(
+                &self,
+                request: AgentTaskRequest,
+                _context: AgentTaskExecutionContext,
+            ) -> AgentTaskOutcome {
+                let workspace = request.workspace.root.expect("attempt workspace");
+                fs::write(
+                    std::path::Path::new(&workspace).join("provider-change.txt"),
+                    "partial work survives timeout\n",
+                )
+                .expect("write attempt workspace change");
+                thread::sleep(Duration::from_millis(25));
+                outcome(request.task_id, AgentTaskOutcomeStatus::Succeeded)
+            }
+        }
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let source = temp.path().join("source");
+        init_git_workspace(&source);
+        let scheduler = AgentTaskScheduler::new(Arc::new(EditThenTimeout));
+        let mut plan = plan_with_tasks(1);
+        plan.tasks[0].workspace.root = Some(source.display().to_string());
+        plan.tasks[0].executor.config = json!({
+            "workspace": { "root": source.display().to_string() },
+            "workspace_root": source.display().to_string(),
+        });
+        plan.tasks[0].limits.timeout_ms = Some(1);
+
+        let aggregate = scheduler.run(plan);
+
+        assert_eq!(
+            aggregate.status,
+            AgentTaskAggregateStatus::PartialRecoverable,
+            "a non-empty attempt diff is recoverable rather than discarded"
+        );
+        let outcome = &aggregate.outcomes[0];
+        assert_eq!(outcome.status, AgentTaskOutcomeStatus::CandidateRecoverable);
+        assert_eq!(
+            outcome.metadata["timeout_recovery"]["incomplete"],
+            Value::Bool(true)
+        );
+        let patch = outcome
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.metadata["change_source"] == "uncommitted_attempt_workspace")
+            .expect("harvested attempt-workspace diff");
+        assert_eq!(patch.metadata["incomplete"], Value::Bool(true));
+        assert_eq!(
+            patch.metadata["recovery_required"],
+            json!(["fresh_review", "deterministic_gates"])
+        );
     }
 
     #[test]
@@ -195,6 +256,14 @@ mod timeout_tests {
                 .limits
                 .execution_deadline_unix_ms,
             Some(deadline)
+        );
+        let timeout_ms = observed.lock().expect("observed request")[0]
+            .limits
+            .timeout_ms
+            .expect("resolved timeout");
+        assert!(
+            (59_000..=60_000).contains(&timeout_ms),
+            "providers receive the execution-deadline-bounded timeout rather than an implicit default: {timeout_ms}"
         );
     }
 

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -548,6 +548,26 @@ const COOK_PROVIDER_RESOLVE_BACKOFF: Duration = Duration::from_millis(100);
 const COOK_PROVIDER_RESOLVE_DEADLINE: Duration = Duration::from_secs(121);
 const COOK_PROVIDER_RESOLVE_MIN_BUDGET: Duration = Duration::from_millis(50);
 
+fn provider_timeout_heartbeat_detail(
+    timeout_ms: u64,
+    remaining_ms: u64,
+    supervision_detail: Option<&str>,
+    activity: &CookProviderActivity,
+) -> String {
+    let mut detail = format!(
+        "provider execution is still running; timeout={timeout_ms}ms; remaining={remaining_ms}ms"
+    );
+    if let Some(summary) = activity.summary_line() {
+        detail.push_str("; ");
+        detail.push_str(&summary);
+    }
+    if let Some(supervision_detail) = supervision_detail {
+        detail.push_str("; ");
+        detail.push_str(supervision_detail);
+    }
+    detail.chars().take(512).collect()
+}
+
 /// One Cook progress event, as delivered to a foreground observer.
 ///
 /// This used to be three bare `&str`s — `(phase, cook_id, run_id)` — which is
@@ -5846,6 +5866,16 @@ fn run_cook_spine(
                         .tasks
                         .first()
                         .map(|task| task.executor.backend.clone());
+                    let heartbeat_provider_timeout_ms = dispatch_plan
+                        .tasks
+                        .first()
+                        .map(|task| {
+                            crate::agent_task_timeout::effective_provider_timeout_ms(
+                                task.limits.timeout_ms.or(dispatch_plan.options.timeout_ms),
+                                task.limits.max_runtime_ms,
+                            )
+                        })
+                        .unwrap_or(crate::agent_task_timeout::DEFAULT_PROVIDER_TIMEOUT_MS);
                     // Captured before the spawn: the budget lives in a
                     // thread-local, and the heartbeat runs on a thread of its
                     // own that would otherwise start unbudgeted.
@@ -5858,6 +5888,7 @@ fn run_cook_spine(
                         scope.spawn(move || {
                             let mut supervisor =
                                 CookSupervisor::new(supervision_policy, supervision_backend);
+                            let provider_started_at = Instant::now();
                             let mut deadline_stop_issued = false;
                             let mut next_heartbeat = Instant::now() + COOK_HEARTBEAT_INTERVAL;
                             loop {
@@ -5891,6 +5922,18 @@ fn run_cook_spine(
                                 let activity = heartbeat_activity.sample(activity_owner_pid);
                                 let tick = supervisor.observe(&activity);
                                 let detail = tick.detail_line();
+                                let remaining_ms = heartbeat_provider_timeout_ms
+                                    .saturating_sub(provider_started_at.elapsed().as_millis() as u64)
+                                    .min(heartbeat_deadline
+                                        .deadline()
+                                        .map(|deadline| deadline.remaining_ms())
+                                        .unwrap_or(u64::MAX));
+                                let progress_detail = provider_timeout_heartbeat_detail(
+                                    heartbeat_provider_timeout_ms,
+                                    remaining_ms,
+                                    detail.as_deref(),
+                                    &activity,
+                                );
                                 let _ = report_cook_progress_with_activity(
                                     heartbeat_lifecycle_store,
                                     durable_observer,
@@ -5898,11 +5941,7 @@ fn run_cook_spine(
                                     &heartbeat_run_id,
                                     "heartbeat",
                                     attempt,
-                                    Some(
-                                        detail
-                                            .as_deref()
-                                            .unwrap_or("provider execution is still running"),
-                                    ),
+                                    Some(&progress_detail),
                                     (!activity.is_empty()).then_some(&activity),
                                     None,
                                     None,

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -18834,6 +18834,22 @@ fn finalization_dossier_and_backend_hydration_use_explicit_lifecycle_store() {
 }
 
 #[test]
+fn provider_timeout_heartbeat_reports_resolved_and_remaining_budget() {
+    let detail = provider_timeout_heartbeat_detail(
+        1_200_000,
+        1_184_997,
+        Some("rss_mib exceeded warning threshold"),
+        &CookProviderActivity::default(),
+    );
+
+    assert_eq!(
+        detail,
+        "provider execution is still running; timeout=1200000ms; remaining=1184997ms; rss_mib exceeded warning threshold"
+    );
+    assert!(detail.len() <= 512);
+}
+
+#[test]
 fn cook_observer_failures_write_only_to_the_explicit_lifecycle_store() {
     let left_context = homeboy_core::test_support::HermeticTestContext::new();
     let right_context = homeboy_core::test_support::HermeticTestContext::new();

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -5650,7 +5650,12 @@ pub(crate) fn run_cook_with_executor_and_dispatcher_with_progress(
                     event.phase,
                     Some(event.cook_id),
                     Some(event.run_id),
-                    terminal_outcome.or(activity.as_deref()),
+                    terminal_outcome.or_else(|| {
+                        (event.phase == "heartbeat")
+                            .then_some(event.detail)
+                            .flatten()
+                            .or(activity.as_deref())
+                    }),
                     event.terminal_retry_command,
                 )
             })


### PR DESCRIPTION
## Summary
- harvest non-empty timeout workspace changes as explicitly incomplete candidates
- pass the resolved scheduler timeout budget into provider execution
- expose total and remaining provider budget in Cook heartbeat output

Closes #12568

## Verification
- `cargo fmt --all --check`
- `cargo test -p homeboy-agents timeout_after_workspace_edits_preserves_an_incomplete_recoverable_candidate`
- `cargo test -p homeboy-agents provider_timeout_heartbeat_reports_resolved_and_remaining_budget`
- `cargo check -p homeboy-agents -p homeboy-cli`

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode implemented the repair. OpenAI GPT-5.6 Sol via OpenCode reviewed, rebased, and verified it under Chris Huber’s direct orchestration.