### PR TITLE
refactor(agents): separate record decoding from schema acceptance

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/health.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/health.rs
@@ -1,3 +1,4 @@
+use super::lifecycle_store::decode_record_from_run;
 use super::*;
 use homeboy_core::observation::RunRecord;
 
@@ -40,20 +41,15 @@ pub(crate) fn diagnose_run(
     } else {
         "run `homeboy agent-task reconcile-records --dry-run` to inspect repair evidence"
     };
-    // Diagnosis must be able to read a legacy record in order to classify it as
-    // LegacySchema; the strict guard would report it as malformed metadata and
-    // send it to quarantine instead of migration.
-    let record = store::record_from_run_allowing_legacy_schema(run).map_err(|_| {
-        AgentTaskRecordHealthItem {
-            run_id: run.id.clone(),
-            reason: if run.metadata_json.get("agent_task_run").is_none() {
-                AgentTaskRecordHealthReason::MissingMetadata
-            } else {
-                AgentTaskRecordHealthReason::MalformedMetadata
-            },
-            quarantined,
-            remediation: remediation.to_string(),
-        }
+    let record = decode_record_from_run(run).map_err(|_| AgentTaskRecordHealthItem {
+        run_id: run.id.clone(),
+        reason: if run.metadata_json.get("agent_task_run").is_none() {
+            AgentTaskRecordHealthReason::MissingMetadata
+        } else {
+            AgentTaskRecordHealthReason::MalformedMetadata
+        },
+        quarantined,
+        remediation: remediation.to_string(),
     })?;
     let reason = if quarantined
         && run
@@ -63,8 +59,6 @@ pub(crate) fn diagnose_run(
             == Some(FIXTURE_RUNNER_QUARANTINE_REASON)
     {
         Some(AgentTaskRecordHealthReason::FixtureRunnerProvenance)
-    } else if record.lab_handoff_validation_error().is_some() {
-        Some(AgentTaskRecordHealthReason::MalformedMetadata)
     } else if record.schema != schemas::RUN
         || record.lifecycle.schema != RUN_LIFECYCLE_RECORD_SCHEMA
     {
@@ -116,17 +110,6 @@ pub fn record_health_summary_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
 ) -> Result<AgentTaskRecordHealthSummary> {
     Ok(lifecycle_store.read_records_with_health()?.1)
-}
-
-/// Parse a durable observation row without the supported-schema guard.
-///
-/// This is a pure `RunRecord` -> typed-record conversion: it opens no store and
-/// resolves no root, so calling it from a rooted body is not an ambient reach.
-/// It exists only so [`reconcile_record_health_in_store`] never has to name the
-/// `store::` shim path, which is how the #7505 scanner recognises a body that
-/// manufactured its own root — and which would be a false positive here.
-fn legacy_record_from_run(run: &RunRecord) -> Result<AgentTaskRunRecord> {
-    store::record_from_run_allowing_legacy_schema(run)
 }
 
 /// Quarantine only records whose durable plan and accepted handoff prove they
@@ -244,7 +227,7 @@ pub fn reconcile_record_health_in_store(
             lifecycle_store.write_record(&reconstruct_record_in_store(lifecycle_store, &run)?)?;
             report.migrated += 1;
         } else if item.reason == AgentTaskRecordHealthReason::LegacySchema {
-            let mut record = legacy_record_from_run(&run)?;
+            let mut record = decode_record_from_run(&run)?;
             let original = serde_json::to_value(&record).unwrap_or(Value::Null);
             record.schema = schemas::RUN.to_string();
             record.lifecycle.schema = RUN_LIFECYCLE_RECORD_SCHEMA.to_string();

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -1829,50 +1829,8 @@ fn merge_observation_metadata(mut existing: Value, typed: Value) -> Value {
 }
 
 pub(super) fn record_from_run(run: &RunRecord) -> Result<AgentTaskRunRecord> {
-    record_from_run_with_schema_policy(run, true)
-}
-
-fn record_and_aggregate_from_run(
-    run: &RunRecord,
-) -> Result<(AgentTaskRunRecord, Option<AgentTaskAggregate>)> {
-    Ok((record_from_run(run)?, aggregate_from_run(run)?))
-}
-
-/// Read a durable record without enforcing the supported-schema guard.
-///
-/// Record health reconciliation exists to migrate legacy schemas, so it is the
-/// one caller that must be able to read one. #11446 added the guard inside
-/// `record_from_run`, which is exactly what the migration branch calls, making
-/// legacy migration unreachable: the reconciler reported the unsupported-schema
-/// diagnostic instead of migrating.
-pub(super) fn record_from_run_allowing_legacy_schema(
-    run: &RunRecord,
-) -> Result<AgentTaskRunRecord> {
-    record_from_run_with_schema_policy(run, false)
-}
-
-fn record_from_run_with_schema_policy(
-    run: &RunRecord,
-    enforce_schema: bool,
-) -> Result<AgentTaskRunRecord> {
-    let value = run.metadata_json.get("agent_task_run").ok_or_else(|| {
-        Error::new(
-            ErrorCode::InternalJsonError,
-            format!(
-                "observation run {} is missing agent_task_run metadata",
-                run.id
-            ),
-            json!({ "context": run.id }),
-        )
-    })?;
-    let mut record: AgentTaskRunRecord =
-        serde_json::from_value(value.clone()).map_err(|error| {
-            Error::internal_json(
-                error.to_string(),
-                Some(format!("parse agent-task run {}", run.id)),
-            )
-        })?;
-    if enforce_schema && record.schema != super::records::schemas::RUN {
+    let record = parse_record_from_run(run)?;
+    if record.schema != super::records::schemas::RUN {
         return Err(Error::validation_invalid_argument(
             "agent_task_run.schema",
             format!(
@@ -1884,6 +1842,48 @@ fn record_from_run_with_schema_policy(
             None,
         ));
     }
+    normalize_decoded_record(run, record)
+}
+
+fn record_and_aggregate_from_run(
+    run: &RunRecord,
+) -> Result<(AgentTaskRunRecord, Option<AgentTaskAggregate>)> {
+    Ok((record_from_run(run)?, aggregate_from_run(run)?))
+}
+
+/// Decode a durable record without requiring the current schema.
+///
+/// Health reconciliation uses this boundary to classify and migrate legacy
+/// schemas. All normal reads go through [`record_from_run`], which accepts only
+/// the current schema.
+pub(super) fn decode_record_from_run(run: &RunRecord) -> Result<AgentTaskRunRecord> {
+    let record = parse_record_from_run(run)?;
+    normalize_decoded_record(run, record)
+}
+
+fn parse_record_from_run(run: &RunRecord) -> Result<AgentTaskRunRecord> {
+    let value = run.metadata_json.get("agent_task_run").ok_or_else(|| {
+        Error::new(
+            ErrorCode::InternalJsonError,
+            format!(
+                "observation run {} is missing agent_task_run metadata",
+                run.id
+            ),
+            json!({ "context": run.id }),
+        )
+    })?;
+    serde_json::from_value(value.clone()).map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some(format!("parse agent-task run {}", run.id)),
+        )
+    })
+}
+
+fn normalize_decoded_record(
+    run: &RunRecord,
+    mut record: AgentTaskRunRecord,
+) -> Result<AgentTaskRunRecord> {
     record.hydrate_legacy_lab_handoff();
     if let Some(problem) = record.lab_handoff_validation_error() {
         return Err(Error::internal_json(


### PR DESCRIPTION
## Summary
- separate raw durable-record parsing from current-schema acceptance and post-decode normalization
- let normal readers reject unsupported schemas while health reconciliation decodes them explicitly for classification and migration
- remove the schema-policy boolean, both legacy bypass wrappers, and an unreachable health validation branch

Closes #13754.

## Verification
- `cargo fmt --all --check`
- `cargo test -p homeboy-agents record_health` (6 passed)
- `cargo test -p homeboy-agents durable_cook_inspection_reports_an_unsupported_run_schema` (1 passed)
- `cargo check --workspace --all-targets`
- `cargo test -p homeboy-agents` reached 2,181 passed and 6 ignored, with two unrelated failures: the provider runtime-tool test passed when rerun alone; `run_next_redacts_poisoned_recipe_dispatcher_kind` retains its existing diagnostic-string failure and also fails outside this branch

The workspace check retains the pre-existing unused `Duration` import warning in `homeboy-core`.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode inspected the durable record read and reconciliation paths, implemented the decode/acceptance separation, preserved strict diagnostic ordering, removed the compensating wrappers, and ran verification. The resulting diff and commit were reviewed before opening this PR.