### PR TITLE
Fix Lab hydration for nested components

### DIFF
--- a/crates/homeboy-core/src/deps.rs
+++ b/crates/homeboy-core/src/deps.rs
@@ -648,6 +648,11 @@ pub struct DependencyInstallPlanStep {
     /// Portable install invocation the runner can execute without receiving a
     /// controller-local extension path.
     pub invocation: DependencyInstallInvocation,
+    /// Provider command root relative to the workspace passed to
+    /// [`dependency_install_plan`]. Consumers materialize this same relative
+    /// root on another machine before running the command or checking outputs.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub workspace_relative_root: String,
     /// Filesystem outputs that prove this provider's install/build preparation
     /// is present in a materialized workspace.
     pub outputs: Vec<DependencyInstallOutput>,
@@ -685,8 +690,8 @@ pub enum DependencyInstallInvocation {
     },
 }
 
-/// Detect dependency providers for a workspace path and return the install
-/// command each would run, without executing any of them.
+/// Detect dependency providers for a source path and return the install command
+/// each would run, without executing any of them.
 ///
 /// Reuses [`provider::resolve_dependency_providers_optional`] (the detection
 /// behind `homeboy deps install`) so a manifest detected by an existing provider
@@ -700,8 +705,10 @@ pub enum DependencyInstallInvocation {
 /// The lockfile/manifest files are part of the synced snapshot (only built
 /// dependency trees like `vendor/`/`node_modules/` are excluded), so detecting
 /// against the controller-side source path yields the same providers the
-/// materialized runner workspace exposes.
+/// materialized runner workspace exposes. Each provider root is recorded
+/// relative to the source Git repository root, which the runner materializes.
 pub fn dependency_install_plan(path: &Path) -> Result<Vec<DependencyInstallPlanStep>> {
+    let workspace = dependency_install_workspace_root(path)?;
     let (component, resolved_path) =
         resolve_component_path(None, Some(&path.display().to_string()))?;
     let providers =
@@ -724,11 +731,120 @@ pub fn dependency_install_plan(path: &Path) -> Result<Vec<DependencyInstallPlanS
             steps.push(DependencyInstallPlanStep {
                 provider_id: plan.provider_id,
                 invocation: dependency_install_invocation(plan.install.argv())?,
+                workspace_relative_root: dependency_workspace_relative_root(
+                    &workspace,
+                    &plan.install.cwd,
+                )?,
                 outputs: plan.outputs,
             });
         }
     }
     Ok(steps)
+}
+
+/// Return the repository root materialized by a runner for a source path.
+/// Standalone, non-Git callers use the supplied path as their workspace.
+pub fn dependency_install_workspace_root(path: &Path) -> Result<PathBuf> {
+    let workspace = crate::git::get_git_root(&path.display().to_string())
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| path.to_path_buf());
+    workspace.canonicalize().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!(
+                "canonicalize dependency workspace {}",
+                workspace.display()
+            )),
+        )
+    })
+}
+
+/// Resolve a provider plan step's declared root within a workspace. The plan is
+/// allowed to address only its workspace or a normal child path; callers must
+/// not turn a controller-provided root into an out-of-workspace runner cwd.
+pub fn dependency_install_step_workspace_root(
+    workspace: &Path,
+    step: &DependencyInstallPlanStep,
+) -> Result<PathBuf> {
+    let root = Path::new(&step.workspace_relative_root);
+    if root.is_absolute()
+        || root.components().any(|component| {
+            !matches!(
+                component,
+                std::path::Component::Normal(_) | std::path::Component::CurDir
+            )
+        })
+    {
+        return Err(Error::validation_invalid_argument(
+            "dependency_install_plan.workspace_relative_root",
+            "dependency install plan root must be relative to its workspace without traversal",
+            Some(step.workspace_relative_root.clone()),
+            None,
+        ));
+    }
+    Ok(workspace.join(root))
+}
+
+/// Resolve a declared provider output within its validated workspace root.
+pub fn dependency_install_step_output_path(
+    workspace: &Path,
+    step: &DependencyInstallPlanStep,
+    output: &DependencyInstallOutput,
+) -> Result<PathBuf> {
+    let path = Path::new(&output.path);
+    if path.is_absolute()
+        || path.components().any(|component| {
+            !matches!(
+                component,
+                std::path::Component::Normal(_) | std::path::Component::CurDir
+            )
+        })
+    {
+        return Err(Error::validation_invalid_argument(
+            "dependency_install_plan.outputs.path",
+            "dependency install output must be relative to its provider root without traversal",
+            Some(output.path.clone()),
+            None,
+        ));
+    }
+    Ok(dependency_install_step_workspace_root(workspace, step)?.join(path))
+}
+
+fn dependency_workspace_relative_root(workspace: &Path, root: &Path) -> Result<String> {
+    let workspace = workspace.canonicalize().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!(
+                "canonicalize dependency workspace {}",
+                workspace.display()
+            )),
+        )
+    })?;
+    let root = root.canonicalize().map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!(
+                "canonicalize dependency provider root {}",
+                root.display()
+            )),
+        )
+    })?;
+    let relative = root.strip_prefix(&workspace).map_err(|_| {
+        Error::validation_invalid_argument(
+            "dependency_install_plan.workspace_relative_root",
+            "dependency provider root must remain inside the workspace",
+            Some(root.display().to_string()),
+            None,
+        )
+    })?;
+    let step = DependencyInstallPlanStep {
+        provider_id: String::new(),
+        invocation: DependencyInstallInvocation::Argv { argv: Vec::new() },
+        workspace_relative_root: relative.display().to_string(),
+        outputs: Vec::new(),
+    };
+    dependency_install_step_workspace_root(&workspace, &step)?;
+    Ok(step.workspace_relative_root)
 }
 
 fn dependency_install_invocation(argv: Vec<String>) -> Result<DependencyInstallInvocation> {
@@ -1108,6 +1224,70 @@ mod tests {
                 ]
             );
         });
+    }
+
+    #[test]
+    fn dependency_install_plan_preserves_nested_component_root() {
+        crate::test_support::with_isolated_home(|home| {
+            write_builtin_dependency_adapters(home.path());
+            let repository = tempfile::tempdir().expect("repository");
+            crate::test_support::run_git_fixture_command(repository.path(), &["init", "-q"]);
+            let component = repository.path().join("php-transformer");
+            std::fs::create_dir_all(&component).expect("nested component");
+            std::fs::write(component.join("composer.json"), "{}").expect("composer manifest");
+            let plan = dependency_install_plan(&component).expect("composer plan");
+
+            assert_eq!(plan.len(), 1);
+            assert_eq!(plan[0].provider_id, "composer");
+            assert_eq!(plan[0].workspace_relative_root, "php-transformer");
+        });
+    }
+
+    #[test]
+    fn dependency_install_plan_uses_empty_root_for_repository_workspace() {
+        crate::test_support::with_isolated_home(|home| {
+            write_builtin_dependency_adapters(home.path());
+            let repository = tempfile::tempdir().expect("repository");
+            crate::test_support::run_git_fixture_command(repository.path(), &["init", "-q"]);
+            std::fs::write(repository.path().join("composer.json"), "{}")
+                .expect("composer manifest");
+
+            let plan = dependency_install_plan(repository.path()).expect("composer plan");
+
+            assert_eq!(plan.len(), 1);
+            assert_eq!(plan[0].provider_id, "composer");
+            assert_eq!(plan[0].workspace_relative_root, "");
+        });
+    }
+
+    #[test]
+    fn dependency_install_plan_rejects_traversal_roots() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let step = DependencyInstallPlanStep {
+            provider_id: "fixture".to_string(),
+            invocation: DependencyInstallInvocation::Argv { argv: Vec::new() },
+            workspace_relative_root: "../outside".to_string(),
+            outputs: Vec::new(),
+        };
+
+        assert!(dependency_install_step_workspace_root(workspace.path(), &step).is_err());
+    }
+
+    #[test]
+    fn dependency_install_plan_rejects_traversal_outputs() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let step = DependencyInstallPlanStep {
+            provider_id: "fixture".to_string(),
+            invocation: DependencyInstallInvocation::Argv { argv: Vec::new() },
+            workspace_relative_root: String::new(),
+            outputs: Vec::new(),
+        };
+        let output = DependencyInstallOutput {
+            path: "../outside".to_string(),
+            kind: DependencyInstallOutputKind::Directory,
+        };
+
+        assert!(dependency_install_step_output_path(workspace.path(), &step, &output).is_err());
     }
 
     fn hydration_policy(

--- a/crates/homeboy-lab-runner/src/lab/offload/dependency_package.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/dependency_package.rs
@@ -34,24 +34,27 @@ pub(super) fn prepare_in_roots(
     workspace: &Path,
     plan: &[homeboy_core::deps::DependencyInstallPlanStep],
 ) -> Result<Option<DependencyPackage>> {
-    if plan.is_empty()
-        || plan.iter().any(|step| {
-            step.outputs.is_empty()
-                || step.outputs.iter().any(|output| {
-                    let path = workspace.join(&output.path);
-                    match output.kind {
-                        homeboy_core::deps::DependencyInstallOutputKind::Path => !path.exists(),
-                        homeboy_core::deps::DependencyInstallOutputKind::File => !path.is_file(),
-                        homeboy_core::deps::DependencyInstallOutputKind::Directory => {
-                            !path.is_dir()
-                        }
-                    }
-                })
-        })
-    {
+    if plan.is_empty() {
         return Ok(None);
     }
-    let outputs = output_paths(plan);
+    for step in plan {
+        if step.outputs.is_empty() {
+            return Ok(None);
+        }
+        for output in &step.outputs {
+            let path =
+                homeboy_core::deps::dependency_install_step_output_path(workspace, step, output)?;
+            let exists = match output.kind {
+                homeboy_core::deps::DependencyInstallOutputKind::Path => path.exists(),
+                homeboy_core::deps::DependencyInstallOutputKind::File => path.is_file(),
+                homeboy_core::deps::DependencyInstallOutputKind::Directory => path.is_dir(),
+            };
+            if !exists {
+                return Ok(None);
+            }
+        }
+    }
+    let outputs = output_paths(workspace, plan)?;
     let lockfiles = lockfile_identity(workspace)?;
     let outputs_identity = output_identity(workspace, &outputs)?;
     let key = content_hash::sha256_hex(&serde_json::to_vec(&(SCHEMA, plan, lockfiles)).map_err(
@@ -167,14 +170,26 @@ fn output_identity(workspace: &Path, outputs: &[String]) -> Result<String> {
     Ok(format!("{:x}", hasher.finalize()))
 }
 
-fn output_paths(plan: &[homeboy_core::deps::DependencyInstallPlanStep]) -> Vec<String> {
-    let mut paths = plan
-        .iter()
-        .flat_map(|step| step.outputs.iter().map(|output| output.path.clone()))
-        .collect::<Vec<_>>();
+fn output_paths(
+    workspace: &Path,
+    plan: &[homeboy_core::deps::DependencyInstallPlanStep],
+) -> Result<Vec<String>> {
+    let mut paths = Vec::new();
+    for step in plan {
+        for output in &step.outputs {
+            let path =
+                homeboy_core::deps::dependency_install_step_output_path(workspace, step, output)?;
+            paths.push(
+                path.strip_prefix(workspace)
+                    .map_err(|_| Error::internal_unexpected("dependency output escaped workspace"))?
+                    .display()
+                    .to_string(),
+            );
+        }
+    }
     paths.sort();
     paths.dedup();
-    paths
+    Ok(paths)
 }
 
 fn collect_files(path: &Path, workspace: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
@@ -309,6 +324,7 @@ mod tests {
             invocation: DependencyInstallInvocation::Argv {
                 argv: vec!["test".to_string()],
             },
+            workspace_relative_root: String::new(),
             outputs: vec![DependencyInstallOutput {
                 path: "deps".to_string(),
                 kind: DependencyInstallOutputKind::Directory,
@@ -335,6 +351,22 @@ mod tests {
         assert_eq!(first.sha256, second.sha256);
         assert_eq!(first.path, second.path);
     }
+
+    #[test]
+    fn packages_nested_component_outputs_from_their_provider_root() {
+        let data_root = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let output = root.path().join("php-transformer/deps");
+        fs::create_dir_all(&output).unwrap();
+        fs::write(output.join("a"), "ok").unwrap();
+        let mut plan = plan();
+        plan[0].workspace_relative_root = "php-transformer".to_string();
+
+        assert!(prepare_in_roots(data_root.path(), root.path(), &plan)
+            .unwrap()
+            .is_some());
+    }
+
     #[test]
     fn rejects_hash_mismatch() {
         let file = tempfile::NamedTempFile::new().unwrap();
@@ -362,6 +394,7 @@ mod tests {
             invocation: DependencyInstallInvocation::Argv {
                 argv: vec!["test".to_string()],
             },
+            workspace_relative_root: String::new(),
             outputs: Vec::new(),
         });
 

--- a/crates/homeboy-lab-runner/src/lab/offload/hydration.rs
+++ b/crates/homeboy-lab-runner/src/lab/offload/hydration.rs
@@ -88,13 +88,15 @@ impl LabWorkspaceHydrationOutput {
 }
 
 /// Detect dependency providers for the controller-side workspace and run each
-/// provider's install command in the materialized runner workspace root.
+/// provider's install command in the corresponding materialized runner
+/// subdirectory.
 ///
 /// Detection runs against `local_path` (the controller-side source checkout):
 /// the manifest/lockfile files are part of the synced snapshot, so they expose
 /// the same providers the materialized runner workspace does. Execution runs via
-/// the existing runner `exec` path at `remote_path` (the materialized workspace
-/// root), the same primitive source-CLI dependency bootstrap uses, so
+/// the existing runner `exec` path at the provider root below `remote_path`
+/// (the materialized workspace root), the same primitive source-CLI dependency
+/// bootstrap uses, so
 /// the install is recorded as a runner job visible in `runner job logs`.
 ///
 /// A non-zero install exit fails the job before the executor starts with an
@@ -168,6 +170,8 @@ fn hydrate_lab_workspace_dependencies_with_policy(
     offline_only: bool,
 ) -> Result<LabWorkspaceHydrationOutput> {
     let plan = deps::dependency_install_plan(std::path::Path::new(local_path))?;
+    let local_workspace_root =
+        deps::dependency_install_workspace_root(std::path::Path::new(local_path))?;
     if plan.is_empty() {
         return Ok(LabWorkspaceHydrationOutput::skipped_no_provider(
             remote_path,
@@ -189,7 +193,7 @@ fn hydrate_lab_workspace_dependencies_with_policy(
         // it does not use.
         if let Some(package) = super::dependency_package::prepare_in_roots(
             homeboy_core::paths::PathRoots::from_environment()?.data(),
-            std::path::Path::new(local_path),
+            &local_workspace_root,
             &plan,
         )? {
             restore_controller_dependency_package(runner_id, remote_path, &package, &plan)?;
@@ -219,8 +223,9 @@ fn hydrate_lab_workspace_dependencies_with_policy(
     for (index, plan_step) in plan.iter().enumerate() {
         let command = runner_hydration_command(&plan_step.invocation)?;
         let started = std::time::Instant::now();
+        let component_root = dependency_root(remote_path, plan_step)?;
         let options =
-            hydration_runner_exec_options(command.clone(), remote_path, parent_run_id, index);
+            hydration_runner_exec_options(command.clone(), &component_root, parent_run_id, index);
         let (output, exit_code) = exec(
             runner_id,
             // The install command is provider-built shell argv, not a
@@ -309,7 +314,7 @@ fn restore_controller_dependency_package_with_transfer(
     );
     let archive = format!("{cache_dir}/package.zip");
     transfer_package(&runner, &cache_dir, &archive)?;
-    let output_checks = declared_output_checks(remote_path, plan).join(" && ");
+    let output_checks = declared_output_checks(remote_path, plan)?.join(" && ");
     let verify_and_restore = format!(
         "test \"$(wc -c < {archive})\" -le {max} && test \"$(shasum -a 256 {archive} | awk '{{print $1}}')\" = {sha} && unzip -oq {archive} -d {workspace} && {output_checks}",
         archive = shell::quote_arg(&archive), max = super::dependency_package::MAX_PACKAGE_BYTES,
@@ -341,7 +346,7 @@ fn prepared_source_view_is_ready(
     remote_path: &str,
     plan: &[deps::DependencyInstallPlanStep],
 ) -> Result<bool> {
-    let Some(output_tests) = declared_output_checks_for_complete_plan(remote_path, plan) else {
+    let Some(output_tests) = declared_output_checks_for_complete_plan(remote_path, plan)? else {
         return Ok(false);
     };
     let mut checks = vec![format!(
@@ -357,7 +362,7 @@ fn declared_outputs_are_ready(
     remote_path: &str,
     plan: &[deps::DependencyInstallPlanStep],
 ) -> Result<bool> {
-    let checks = declared_output_checks(remote_path, plan);
+    let checks = declared_output_checks(remote_path, plan)?;
     if checks.is_empty() {
         return Ok(true);
     }
@@ -367,29 +372,44 @@ fn declared_outputs_are_ready(
 fn declared_output_checks_for_complete_plan(
     remote_path: &str,
     plan: &[deps::DependencyInstallPlanStep],
-) -> Option<Vec<String>> {
+) -> Result<Option<Vec<String>>> {
     if plan.iter().any(|step| step.outputs.is_empty()) {
-        return None;
+        return Ok(None);
     }
-    Some(declared_output_checks(remote_path, plan))
+    Ok(Some(declared_output_checks(remote_path, plan)?))
 }
 
 fn declared_output_checks(
     remote_path: &str,
     plan: &[deps::DependencyInstallPlanStep],
-) -> Vec<String> {
-    plan.iter()
-        .flat_map(|step| &step.outputs)
-        .map(|output| {
-            let path = format!("{}/{}", remote_path.trim_end_matches('/'), output.path);
+) -> Result<Vec<String>> {
+    let mut checks = Vec::new();
+    for step in plan {
+        for output in &step.outputs {
+            let path = deps::dependency_install_step_output_path(
+                std::path::Path::new(remote_path),
+                step,
+                output,
+            )?
+            .display()
+            .to_string();
             let predicate = match output.kind {
                 deps::DependencyInstallOutputKind::Path => "-e",
                 deps::DependencyInstallOutputKind::File => "-f",
                 deps::DependencyInstallOutputKind::Directory => "-d",
             };
-            format!("test {predicate} {}", shell::quote_arg(&path))
-        })
-        .collect()
+            checks.push(format!("test {predicate} {}", shell::quote_arg(&path)));
+        }
+    }
+    Ok(checks)
+}
+
+fn dependency_root(remote_path: &str, step: &deps::DependencyInstallPlanStep) -> Result<String> {
+    Ok(
+        deps::dependency_install_step_workspace_root(std::path::Path::new(remote_path), step)?
+            .display()
+            .to_string(),
+    )
 }
 
 fn remote_checks_succeed(runner_id: &str, remote_path: &str, checks: Vec<String>) -> Result<bool> {
@@ -761,6 +781,36 @@ mod tests {
         .expect("node adapter");
     }
 
+    fn write_detected_composer_adapter(home: &std::path::Path) {
+        let root = home.join(".config/homeboy/extensions/dependency-adapters");
+        std::fs::create_dir_all(root.join("examples")).expect("adapter directory");
+        std::fs::write(
+            root.join("index.json"),
+            r#"{
+                "schema":"homeboy-extension/dependency-adapter-index/v1",
+                "manifests":[{"id":"composer-package-manager","ecosystem":"php","path":"examples/composer.json"}]
+            }"#,
+        )
+        .expect("adapter index");
+        std::fs::write(
+            root.join("examples/composer.json"),
+            r#"{
+                "schema":"homeboy-extension/dependency-adapter-manifest/v1",
+                "id":"composer-package-manager",
+                "version":1,
+                "ecosystem":"php",
+                "project_signals":{"root_files":["composer.json"]},
+                "package_managers":[{
+                    "id":"composer",
+                    "selection":{"priority":1,"default":true},
+                    "commands":{"install":{"command":"composer install"}},
+                    "outputs":[{"path":"vendor","kind":"directory"},{"path":"vendor/autoload.php","kind":"file"}]
+                }]
+            }"#,
+        )
+        .expect("composer adapter");
+    }
+
     /// `hydration_failure_error` classifies the failure as workspace setup and
     /// records the provider id, command, duration, and exit status so operators
     /// can distinguish a hydration (workspace setup) failure from a later
@@ -1016,6 +1066,45 @@ mod tests {
                 std::fs::read_to_string(remote.path().join("npm-runs")).expect("npm run count"),
                 "x"
             );
+        });
+    }
+
+    #[test]
+    fn detected_composer_hydrates_nested_component_from_repository_root() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            write_detected_composer_adapter(home.path());
+            let path_guard = FakeBinGuard::install(
+                "composer",
+                "#!/bin/sh\nprintf '%s' \"$PWD\" > composer-cwd\nmkdir -p vendor\nprintf autoload > vendor/autoload.php\n",
+            );
+            crate::create(&path_guard.local_runner_spec("lab-nested-composer"), false)
+                .expect("create local runner");
+            let repository = tempfile::tempdir().expect("controller repository");
+            homeboy_core::test_support::run_git_fixture_command(repository.path(), &["init", "-q"]);
+            let component = repository.path().join("php-transformer");
+            std::fs::create_dir_all(&component).expect("controller component");
+            std::fs::write(component.join("composer.json"), "{}").expect("composer manifest");
+            let remote = tempfile::tempdir().expect("runner repository");
+            let remote_component = remote.path().join("php-transformer");
+            std::fs::create_dir_all(&remote_component).expect("runner component");
+            std::fs::write(remote_component.join("composer.json"), "{}")
+                .expect("composer manifest");
+
+            let output = hydrate_lab_workspace_dependencies(
+                "lab-nested-composer",
+                &component.display().to_string(),
+                &remote.path().display().to_string(),
+            )
+            .expect("nested Composer hydration succeeds");
+
+            assert_eq!(output.status, "hydrated");
+            assert_eq!(output.steps[0].provider_id, "composer");
+            assert_eq!(
+                std::fs::read_to_string(remote_component.join("composer-cwd"))
+                    .expect("Composer working directory"),
+                remote_component.display().to_string()
+            );
+            assert!(remote_component.join("vendor/autoload.php").is_file());
         });
     }
 


### PR DESCRIPTION
## Summary

- preserve each dependency provider root relative to the materialized Git workspace
- run Lab installs and validate prepared-cache/package outputs from that provider root
- reject absolute, traversal, and out-of-workspace provider/output paths
- cover nested Composer hydration, nested package creation, and root-workspace behavior

Fixes #14079.

## Verification

- `cargo fmt --all --check`
- `cargo test --locked -p homeboy-core deps::tests -- --test-threads=1` (13 passed; one existing order-dependent fixture failed, then passed with the exact isolated command below)
- `cargo test --locked -p homeboy-core deps::tests::stale_state_runs_exact_declared_command_and_reports_progress -- --exact --nocapture`
- `cargo test --locked -p homeboy-lab-runner lab::offload::dependency_package::tests`
- `cargo test --locked -p homeboy-lab-runner lab::offload::hydration::tests`
- `cargo check --locked --workspace`

## AI assistance

Implemented with OpenCode using OpenAI gpt-5.6-terra, with OpenAI gpt-5.6-sol used for diagnosis, review, regression completion, and verification orchestration. I reviewed the resulting code, evidence, and PR.