### PR TITLE
fix(runner): converge bounded doctor recovery

### DIFF
--- a/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
@@ -61,32 +61,26 @@ pub(crate) fn run_with_options(
 ) -> CmdResult<RunnerDoctorOutput> {
     options.scope = repair_scope(options.scope, options.repair);
     let target = target::resolve(runner_id)?;
-    let mut report = match &target {
-        target::RunnerTarget::Local { id, runner } => {
-            // The local probe's artifact root is the only filesystem root this
-            // command reads, so it is resolved once here at the entry point
-            // rather than inside the probe. The SSH branch resolves its root on
-            // the remote host and deliberately does not take this one.
-            let artifact_root = crate::core::paths::artifact_root().ok();
-            local::report(id, runner.as_ref(), &options, artifact_root.as_deref())
-        }
-        target::RunnerTarget::Ssh {
-            id,
-            runner,
-            server,
-            client,
-        } => remote::report(id, runner, server, client, &options),
-    };
+    let mut report = report_for_target(&target, &options);
 
     let migration = runner::secret_env_migration_plan(runner_id)?;
     report.secret_env_migration = (!migration.is_empty()).then_some(migration);
 
     if options.repair {
         repair::apply(&target, &options, &mut report);
+
+        // Repair is not success by itself. Re-probe the same resolved target so
+        // the terminal report verifies its identity, binary, SSH, workspace,
+        // daemon, and provider readiness after the mutation.
+        let repairs = std::mem::take(&mut report.repairs);
+        report = report_for_target(&target, &options);
+        let migration = runner::secret_env_migration_plan(runner_id)?;
+        report.secret_env_migration = (!migration.is_empty()).then_some(migration);
+        report.repairs = repairs;
     }
 
     // Only general doctor observes the complete capability surface. Scoped
-    // Lab diagnostics deliberately skip CPU, tools, workspace, and artifact
+    // Lab diagnostics deliberately skip CPU, tools, and artifact
     // probes, so treating that partial report as a complete observation would
     // evict known-good admission evidence.
     if observes_complete_capabilities(options.scope) {
@@ -108,6 +102,28 @@ pub(crate) fn run_with_options(
     }
     let exit_code = report.status.operational_exit_code();
     Ok((report, exit_code))
+}
+
+fn report_for_target(
+    target: &target::RunnerTarget,
+    options: &RunnerDoctorOptions,
+) -> RunnerDoctorOutput {
+    match target {
+        target::RunnerTarget::Local { id, runner } => {
+            // The local probe's artifact root is the only filesystem root this
+            // command reads, so it is resolved once here at the entry point
+            // rather than inside the probe. The SSH branch resolves its root on
+            // the remote host and deliberately does not take this one.
+            let artifact_root = crate::core::paths::artifact_root().ok();
+            local::report(id, runner.as_ref(), &options, artifact_root.as_deref())
+        }
+        target::RunnerTarget::Ssh {
+            id,
+            runner,
+            server,
+            client,
+        } => remote::report(id, runner, server, client, &options),
+    }
 }
 
 const COMPACT_CHECK_LIMIT: usize = 12;

--- a/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/mod.rs
@@ -72,10 +72,20 @@ pub(crate) fn run_with_options(
         // Repair is not success by itself. Re-probe the same resolved target so
         // the terminal report verifies its identity, binary, SSH, workspace,
         // daemon, and provider readiness after the mutation.
-        let repairs = std::mem::take(&mut report.repairs);
+        let mut repairs = std::mem::take(&mut report.repairs);
         report = report_for_target(&target, &options);
-        let migration = runner::secret_env_migration_plan(runner_id)?;
-        report.secret_env_migration = (!migration.is_empty()).then_some(migration);
+        match target.ensure_current() {
+            Ok(()) => {
+                let migration = runner::secret_env_migration_plan(runner_id)?;
+                report.secret_env_migration = (!migration.is_empty()).then_some(migration);
+            }
+            Err(error) => repairs.push(types::RunnerRepair {
+                id: "repair.target_identity".to_string(),
+                status: RunnerDoctorStatus::Error,
+                message: error.message,
+                commands: Vec::new(),
+            }),
+        }
         report.repairs = repairs;
     }
 
@@ -189,6 +199,17 @@ fn compact_projection(report: &RunnerDoctorOutput) -> serde_json::Value {
         readiness.ready_for.len() + readiness.blocked_for.len()
     });
     let runner_id = bounded_text(&report.runner_id);
+    let failed_repairs = report
+        .repairs
+        .iter()
+        .filter(|repair| repair.status != RunnerDoctorStatus::Ok)
+        .map(|repair| serde_json::json!({
+            "id": bounded_text(&repair.id),
+            "status": repair.status,
+            "message": bounded_text(&repair.message),
+            "commands": repair.commands.iter().take(1).map(|command| bounded_text(command)).collect::<Vec<_>>(),
+        }))
+        .collect::<Vec<_>>();
     let projection = serde_json::json!({
         "schema": "homeboy/runner-doctor/v1",
         "command": report.command,
@@ -208,11 +229,12 @@ fn compact_projection(report: &RunnerDoctorOutput) -> serde_json::Value {
             "cpu": { "count": report.resources.cpu.count },
         },
         "checks": checks,
+        "repairs": failed_repairs,
         "provider_readiness": if provider_total == 0 { serde_json::Value::Null } else { serde_json::json!({ "ready_for": ready_for, "blocked_for": blocked_for }) },
         "truncation": {
             "checks": { "shown": checks.len(), "omitted": report.checks.len().saturating_sub(checks.len()), "evidence_ref": "runner:doctor:checks", "full_command": format!("homeboy runner doctor {runner_id} --full") },
             "provider_readiness": { "shown": ready_for.len() + blocked_for.len(), "omitted": provider_total.saturating_sub(ready_for.len() + blocked_for.len()), "evidence_ref": "runner:doctor:provider-readiness", "full_command": format!("homeboy runner doctor {runner_id} --full") },
-            "omitted_sections": ["resource_maps", "probe_details", "diagnostics", "repairs", "secret_env_migration", "daemon_recovery", "admission_summary"],
+            "omitted_sections": ["resource_maps", "probe_details", "diagnostics", "secret_env_migration", "daemon_recovery", "admission_summary"],
         }
     });
     projection
@@ -237,6 +259,15 @@ fn bounded_projection_envelope(projection: serde_json::Value) -> serde_json::Val
     if projection_envelope_bytes(&projection).is_ok_and(|bytes| bytes <= COMPACT_PROJECTION_BYTES) {
         return projection;
     }
+    // Even the size-cap fallback must retain the failed repair that explains
+    // why the operator should not retry a generic connect choreography.
+    let repairs = projection
+        .get("repairs")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|repairs| repairs.first())
+        .cloned()
+        .map(|repair| vec![repair])
+        .unwrap_or_default();
     serde_json::json!({
         "schema": "homeboy/runner-doctor/v1",
         "command": "runner.doctor",
@@ -248,6 +279,7 @@ fn bounded_projection_envelope(projection: serde_json::Value) -> serde_json::Val
             "next_action": "homeboy runner doctor <runner-id> --full",
         },
         "checks": [],
+        "repairs": repairs,
         "truncation": { "checks": { "shown": 0, "omitted": "see_full_output", "full_command": "homeboy runner doctor <runner-id> --full" } },
     })
 }

--- a/crates/homeboy-cli/src/commands/runner/doctor/remote.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/remote.rs
@@ -237,17 +237,15 @@ pub fn report(
         ));
     }
 
-    let workspace_writable = (!scoped)
-        .then(|| probes::remote_path_writable(client, &workspace_root))
-        .unwrap_or(false);
-    if !scoped {
-        checks.push(checks::path_writable_check(
-            "workspace.writable",
-            workspace_writable,
-            Path::new(&workspace_root),
-            "Make the remote workspace root writable by the runner user",
-        ));
-    }
+    // A Lab repair must not report success for a runner that cannot accept a
+    // workspace. Keep this lightweight check in the otherwise bounded scope.
+    let workspace_writable = probes::remote_path_writable(client, &workspace_root);
+    checks.push(checks::path_writable_check(
+        "workspace.writable",
+        workspace_writable,
+        Path::new(&workspace_root),
+        "Make the remote workspace root writable by the runner user",
+    ));
 
     let artifact_store_available = (!scoped)
         .then(|| probes::remote_artifact_store_available(client, &artifact_root))

--- a/crates/homeboy-cli/src/commands/runner/doctor/repair.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/repair.rs
@@ -109,8 +109,9 @@ pub fn apply(
     // Connect owns lease-safe dead-daemon adoption. A failed disconnect must not
     // force operators through repeated stop/adopt cycles when its authoritative
     // probe has already established that the recorded owner is gone.
-    match retry_runtime_promotion_wait(|| target.ensure_current().and_then(|_| runner::connect(id)))
-    {
+    match retry_runtime_promotion_wait(target, || {
+        target.ensure_current().and_then(|_| runner::connect(id))
+    }) {
         Ok((_, 0)) => {
             report.checks.retain(|check| check.id != "daemon.exec");
             let workspace_root = runner_config.workspace_root.as_deref().unwrap_or(".");
@@ -222,6 +223,13 @@ mod tests {
     use crate::commands::runner::doctor::types::{
         RunnerCapabilities, RunnerResources, RunnerTargetSummary,
     };
+
+    fn local_target() -> target::RunnerTarget {
+        target::RunnerTarget::Local {
+            id: "local".to_string(),
+            runner: None,
+        }
+    }
 
     #[test]
     fn unavailable_lease_missing_ownership_with_a_plan_is_terminal() {
@@ -338,8 +346,9 @@ mod tests {
 
     #[test]
     fn promotion_timeout_retries_once_and_converges() {
+        let target = local_target();
         let mut calls = 0;
-        let result = retry_runtime_promotion_wait(|| {
+        let result = retry_runtime_promotion_wait(&target, || {
             calls += 1;
             if calls == 1 {
                 Err(homeboy::core::Error::new(
@@ -358,8 +367,9 @@ mod tests {
 
     #[test]
     fn promotion_contention_retries_once_and_converges() {
+        let target = local_target();
         let mut calls = 0;
-        let result = retry_runtime_promotion_wait(|| {
+        let result = retry_runtime_promotion_wait(&target, || {
             calls += 1;
             if calls == 1 {
                 Err(homeboy::core::Error::new(
@@ -397,7 +407,7 @@ mod tests {
             .expect("hold promotion lease");
             let mut calls = 0;
 
-            let error = retry_runtime_promotion_wait(|| {
+            let error = retry_runtime_promotion_wait::<()>(&target, || {
                 calls += 1;
                 if calls == 1 {
                     let mut changed = server::load("promotion-identity").expect("load server");
@@ -409,20 +419,21 @@ mod tests {
                         serde_json::Value::Null,
                     ));
                 }
-                target.ensure_current()
+                panic!("a changed target must block the retry before connecting")
             })
             .expect_err("retry must reject the changed target");
 
             drop(lease);
-            assert_eq!(calls, 2);
+            assert_eq!(calls, 1);
             assert!(error.message.contains("target changed"), "{error:?}");
         });
     }
 
     #[test]
     fn promotion_timeout_stops_at_the_bounded_attempt_limit() {
+        let target = local_target();
         let mut calls = 0;
-        let error = retry_runtime_promotion_wait::<()>(|| {
+        let error = retry_runtime_promotion_wait::<()>(&target, || {
             calls += 1;
             Err(homeboy::core::Error::new(
                 ErrorCode::RuntimePromotionWaitTimeout,
@@ -438,8 +449,9 @@ mod tests {
 
     #[test]
     fn non_promotion_failures_are_not_retried() {
+        let target = local_target();
         let mut calls = 0;
-        let error = retry_runtime_promotion_wait::<()>(|| {
+        let error = retry_runtime_promotion_wait::<()>(&target, || {
             calls += 1;
             Err(homeboy::core::Error::new(
                 ErrorCode::SshConnectFailed,
@@ -563,13 +575,13 @@ fn apply_daemon_repair_plan(
                 .and_then(|_| runner::disconnect(runner_id))
                 .map(|_| ())
                 .map_err(|error| error.message),
-            DaemonRepairDispatch::Connect => connect_outcome_after_promotion_wait(|| {
+            DaemonRepairDispatch::Connect => connect_outcome_after_promotion_wait(target, || {
                 target
                     .ensure_current()
                     .and_then(|_| runner::connect(runner_id))
             }),
             DaemonRepairDispatch::AdoptOrphanLease { lease_id } => {
-                connect_outcome_after_promotion_wait(|| {
+                connect_outcome_after_promotion_wait(target, || {
                     target.ensure_current().and_then(|_| {
                         runner::connect_with_orphan_adoption(
                             runner_id,
@@ -584,7 +596,7 @@ fn apply_daemon_repair_plan(
                 })
             }
             DaemonRepairDispatch::ReconcileLeaselessOrphans => {
-                connect_outcome_after_promotion_wait(|| {
+                connect_outcome_after_promotion_wait(target, || {
                     target.ensure_current().and_then(|_| {
                         runner::connect_with_orphan_adoption(
                             runner_id,
@@ -599,7 +611,7 @@ fn apply_daemon_repair_plan(
                 })
             }
             DaemonRepairDispatch::ReconcileUnleasedCandidates => {
-                connect_outcome_after_promotion_wait(|| {
+                connect_outcome_after_promotion_wait(target, || {
                     target.ensure_current().and_then(|_| {
                         runner::connect_with_unleased_candidate_reconciliation(runner_id)
                     })
@@ -702,15 +714,17 @@ fn connect_outcome(
 }
 
 fn connect_outcome_after_promotion_wait(
+    target: &target::RunnerTarget,
     connect: impl FnMut() -> homeboy::core::Result<(runner::RunnerConnectReport, i32)>,
 ) -> Result<(), String> {
-    match retry_runtime_promotion_wait(connect) {
+    match retry_runtime_promotion_wait(target, connect) {
         Ok(result) => connect_outcome(Ok(result)),
         Err(error) => Err(error.message),
     }
 }
 
 fn retry_runtime_promotion_wait<T>(
+    target: &target::RunnerTarget,
     mut action: impl FnMut() -> homeboy::core::Result<T>,
 ) -> homeboy::core::Result<T> {
     for attempt in 0..PROMOTION_WAIT_CONNECT_ATTEMPTS {
@@ -724,6 +738,7 @@ fn retry_runtime_promotion_wait<T>(
                 // `connect` emitted owner/watch events during the first wait.
                 // A second bounded admission wait converges a promotion that
                 // completed at the timeout boundary without changing identity.
+                target.ensure_current()?;
             }
             result => return result,
         }

--- a/crates/homeboy-cli/src/commands/runner/doctor/repair.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/repair.rs
@@ -1,5 +1,11 @@
 use super::*;
+use homeboy::core::ErrorCode;
 use types::{RunnerDoctorOutput, RunnerDoctorStatus, RunnerRepair};
+
+/// A connect attempt already waits for controller promotion admission. Retry a
+/// timed-out wait once because a promotion can finish just after that bounded
+/// wait without making a different runner mutation safe.
+const PROMOTION_WAIT_CONNECT_ATTEMPTS: usize = 2;
 
 pub fn apply(
     target: &target::RunnerTarget,
@@ -95,7 +101,7 @@ pub fn apply(
     // Connect owns lease-safe dead-daemon adoption. A failed disconnect must not
     // force operators through repeated stop/adopt cycles when its authoritative
     // probe has already established that the recorded owner is gone.
-    match runner::connect(id) {
+    match retry_runtime_promotion_wait(|| runner::connect(id)) {
         Ok((_, 0)) => {
             report.checks.retain(|check| check.id != "daemon.exec");
             let workspace_root = runner_config.workspace_root.as_deref().unwrap_or(".");
@@ -305,6 +311,60 @@ mod tests {
         assert!(repair.commands.is_empty());
         assert!(repair.message.contains("no validated recovery action"));
     }
+
+    #[test]
+    fn promotion_timeout_retries_once_and_converges() {
+        let mut calls = 0;
+        let result = retry_runtime_promotion_wait(|| {
+            calls += 1;
+            if calls == 1 {
+                Err(homeboy::core::Error::new(
+                    ErrorCode::RuntimePromotionWaitTimeout,
+                    "promotion still active",
+                    serde_json::Value::Null,
+                ))
+            } else {
+                Ok("connected")
+            }
+        });
+
+        assert_eq!(result.expect("second bounded wait succeeds"), "connected");
+        assert_eq!(calls, 2);
+    }
+
+    #[test]
+    fn promotion_timeout_stops_at_the_bounded_attempt_limit() {
+        let mut calls = 0;
+        let error = retry_runtime_promotion_wait::<()>(|| {
+            calls += 1;
+            Err(homeboy::core::Error::new(
+                ErrorCode::RuntimePromotionWaitTimeout,
+                "promotion still active",
+                serde_json::Value::Null,
+            ))
+        })
+        .expect_err("the second bounded wait remains terminal");
+
+        assert_eq!(error.code, ErrorCode::RuntimePromotionWaitTimeout);
+        assert_eq!(calls, PROMOTION_WAIT_CONNECT_ATTEMPTS);
+    }
+
+    #[test]
+    fn non_promotion_failures_are_not_retried() {
+        let mut calls = 0;
+        let error = retry_runtime_promotion_wait::<()>(|| {
+            calls += 1;
+            Err(homeboy::core::Error::new(
+                ErrorCode::SshConnectFailed,
+                "ssh unavailable",
+                serde_json::Value::Null,
+            ))
+        })
+        .expect_err("transport errors do not become recovery retries");
+
+        assert_eq!(error.code, ErrorCode::SshConnectFailed);
+        assert_eq!(calls, 1);
+    }
 }
 
 /// What an executor should do about one typed repair step.
@@ -407,17 +467,21 @@ fn apply_daemon_repair_plan(runner_id: &str, report: &mut RunnerDoctorOutput) ->
             DaemonRepairDispatch::Disconnect => runner::disconnect(runner_id)
                 .map(|_| ())
                 .map_err(|error| error.message),
-            DaemonRepairDispatch::Connect => connect_outcome(runner::connect(runner_id)),
+            DaemonRepairDispatch::Connect => {
+                connect_outcome_after_promotion_wait(|| runner::connect(runner_id))
+            }
             DaemonRepairDispatch::AdoptOrphanLease { lease_id } => {
-                connect_outcome(runner::connect_with_orphan_adoption(
-                    runner_id,
-                    Some(&lease_id),
-                    &[],
-                    false,
-                    None,
-                    None,
-                    None,
-                ))
+                connect_outcome_after_promotion_wait(|| {
+                    runner::connect_with_orphan_adoption(
+                        runner_id,
+                        Some(&lease_id),
+                        &[],
+                        false,
+                        None,
+                        None,
+                        None,
+                    )
+                })
             }
             DaemonRepairDispatch::ReconcileLeaselessOrphans => connect_outcome(
                 runner::connect_with_orphan_adoption(runner_id, None, &[], true, None, None, None),
@@ -516,6 +580,34 @@ fn connect_outcome(
             .unwrap_or_else(|| format!("runner connect exited with code {exit_code}"))),
         Err(error) => Err(error.message),
     }
+}
+
+fn connect_outcome_after_promotion_wait(
+    connect: impl FnMut() -> homeboy::core::Result<(runner::RunnerConnectReport, i32)>,
+) -> Result<(), String> {
+    match retry_runtime_promotion_wait(connect) {
+        Ok(result) => connect_outcome(Ok(result)),
+        Err(error) => Err(error.message),
+    }
+}
+
+fn retry_runtime_promotion_wait<T>(
+    mut action: impl FnMut() -> homeboy::core::Result<T>,
+) -> homeboy::core::Result<T> {
+    for attempt in 0..PROMOTION_WAIT_CONNECT_ATTEMPTS {
+        match action() {
+            Err(error)
+                if error.code == ErrorCode::RuntimePromotionWaitTimeout
+                    && attempt + 1 < PROMOTION_WAIT_CONNECT_ATTEMPTS =>
+            {
+                // `connect` emitted owner/watch events during the first wait.
+                // A second bounded admission wait converges a promotion that
+                // completed at the timeout boundary without changing identity.
+            }
+            result => return result,
+        }
+    }
+    unreachable!("the bounded promotion retry returns from its final attempt")
 }
 
 fn refresh_outcome(

--- a/crates/homeboy-cli/src/commands/runner/doctor/repair.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/repair.rs
@@ -61,6 +61,11 @@ pub fn apply(
         return;
     };
 
+    if let Err(error) = target.ensure_current() {
+        report.repairs.push(identity_repair(error.message));
+        return;
+    }
+
     repair_managed_sources(client, report);
 
     if let Some(repair) = terminal_daemon_recovery_repair(report) {
@@ -72,7 +77,7 @@ pub fn apply(
     // Executing it is the whole point of `--repair`; the fixed
     // disconnect/connect pair below is the fallback for a connected daemon whose
     // exec probe failed without any typed plan behind it (#11103).
-    if apply_daemon_repair_plan(id, report) {
+    if apply_daemon_repair_plan(target, report) {
         return;
     }
 
@@ -97,11 +102,15 @@ pub fn apply(
         format!("homeboy runner disconnect {id}"),
         format!("homeboy runner connect {id}"),
     ];
-    let disconnect_error = runner::disconnect(id).err();
+    let disconnect_error = target
+        .ensure_current()
+        .and_then(|_| runner::disconnect(id))
+        .err();
     // Connect owns lease-safe dead-daemon adoption. A failed disconnect must not
     // force operators through repeated stop/adopt cycles when its authoritative
     // probe has already established that the recorded owner is gone.
-    match retry_runtime_promotion_wait(|| runner::connect(id)) {
+    match retry_runtime_promotion_wait(|| target.ensure_current().and_then(|_| runner::connect(id)))
+    {
         Ok((_, 0)) => {
             report.checks.retain(|check| check.id != "daemon.exec");
             let workspace_root = runner_config.workspace_root.as_deref().unwrap_or(".");
@@ -198,6 +207,15 @@ fn terminal_daemon_recovery_repair(report: &RunnerDoctorOutput) -> Option<Runner
     })
 }
 
+fn identity_repair(message: String) -> RunnerRepair {
+    RunnerRepair {
+        id: "repair.target_identity".to_string(),
+        status: RunnerDoctorStatus::Error,
+        message,
+        commands: Vec::new(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -253,7 +271,13 @@ mod tests {
             };
 
             assert!(
-                !apply_daemon_repair_plan("lab", &mut report),
+                !apply_daemon_repair_plan(
+                    &target::RunnerTarget::Local {
+                        id: "lab".to_string(),
+                        runner: None,
+                    },
+                    &mut report,
+                ),
                 "unavailable ownership must reject a non-empty reconciliation plan"
             );
             let repair = terminal_daemon_recovery_repair(&report).expect("terminal repair result");
@@ -330,6 +354,69 @@ mod tests {
 
         assert_eq!(result.expect("second bounded wait succeeds"), "connected");
         assert_eq!(calls, 2);
+    }
+
+    #[test]
+    fn promotion_contention_retries_once_and_converges() {
+        let mut calls = 0;
+        let result = retry_runtime_promotion_wait(|| {
+            calls += 1;
+            if calls == 1 {
+                Err(homeboy::core::Error::new(
+                    ErrorCode::RuntimePromotionContended,
+                    "another promotion owns the lease",
+                    serde_json::Value::Null,
+                ))
+            } else {
+                Ok("connected")
+            }
+        });
+
+        assert_eq!(result.expect("second bounded wait succeeds"), "connected");
+        assert_eq!(calls, 2);
+    }
+
+    #[test]
+    fn contended_repair_never_retries_against_a_changed_registry_target() {
+        crate::test_support::with_isolated_home(|_| {
+            server::create(
+                r#"{"id":"promotion-identity","host":"first.test","user":"runner"}"#,
+                false,
+            )
+            .expect("create server");
+            runner::create(
+                r#"{"id":"promotion-identity","kind":"ssh","server_id":"promotion-identity","workspace_root":"/tmp"}"#,
+                false,
+            )
+            .expect("create runner");
+            let target = target::resolve("promotion-identity").expect("resolve target");
+            let lease = homeboy::core::runtime_promotion::acquire(
+                "doctor repair integration test",
+                "promotion-identity",
+            )
+            .expect("hold promotion lease");
+            let mut calls = 0;
+
+            let error = retry_runtime_promotion_wait(|| {
+                calls += 1;
+                if calls == 1 {
+                    let mut changed = server::load("promotion-identity").expect("load server");
+                    changed.host = "second.test".to_string();
+                    server::save(&changed).expect("change registry target");
+                    return Err(homeboy::core::Error::new(
+                        ErrorCode::RuntimePromotionContended,
+                        "held promotion lease contended direct connect",
+                        serde_json::Value::Null,
+                    ));
+                }
+                target.ensure_current()
+            })
+            .expect_err("retry must reject the changed target");
+
+            drop(lease);
+            assert_eq!(calls, 2);
+            assert!(error.message.contains("target changed"), "{error:?}");
+        });
     }
 
     #[test]
@@ -449,7 +536,14 @@ pub(super) fn dispatch_for(
 ///
 /// Returns `false` when there is no plan to act on, so the caller falls through
 /// to its own probe-driven recovery.
-fn apply_daemon_repair_plan(runner_id: &str, report: &mut RunnerDoctorOutput) -> bool {
+fn apply_daemon_repair_plan(
+    target: &target::RunnerTarget,
+    report: &mut RunnerDoctorOutput,
+) -> bool {
+    let runner_id = match target {
+        target::RunnerTarget::Ssh { id, .. } => id,
+        target::RunnerTarget::Local { .. } => return false,
+    };
     let Some(recovery) = report.daemon_recovery.as_ref() else {
         return false;
     };
@@ -464,35 +558,60 @@ fn apply_daemon_repair_plan(runner_id: &str, report: &mut RunnerDoctorOutput) ->
     let mut applied = 0usize;
     for step in &plan {
         let outcome = match dispatch_for(step, lease_id.as_deref()) {
-            DaemonRepairDispatch::Disconnect => runner::disconnect(runner_id)
+            DaemonRepairDispatch::Disconnect => target
+                .ensure_current()
+                .and_then(|_| runner::disconnect(runner_id))
                 .map(|_| ())
                 .map_err(|error| error.message),
-            DaemonRepairDispatch::Connect => {
-                connect_outcome_after_promotion_wait(|| runner::connect(runner_id))
-            }
+            DaemonRepairDispatch::Connect => connect_outcome_after_promotion_wait(|| {
+                target
+                    .ensure_current()
+                    .and_then(|_| runner::connect(runner_id))
+            }),
             DaemonRepairDispatch::AdoptOrphanLease { lease_id } => {
                 connect_outcome_after_promotion_wait(|| {
-                    runner::connect_with_orphan_adoption(
-                        runner_id,
-                        Some(&lease_id),
-                        &[],
-                        false,
-                        None,
-                        None,
-                        None,
-                    )
+                    target.ensure_current().and_then(|_| {
+                        runner::connect_with_orphan_adoption(
+                            runner_id,
+                            Some(&lease_id),
+                            &[],
+                            false,
+                            None,
+                            None,
+                            None,
+                        )
+                    })
                 })
             }
-            DaemonRepairDispatch::ReconcileLeaselessOrphans => connect_outcome(
-                runner::connect_with_orphan_adoption(runner_id, None, &[], true, None, None, None),
-            ),
-            DaemonRepairDispatch::ReconcileUnleasedCandidates => connect_outcome(
-                runner::connect_with_unleased_candidate_reconciliation(runner_id),
-            ),
+            DaemonRepairDispatch::ReconcileLeaselessOrphans => {
+                connect_outcome_after_promotion_wait(|| {
+                    target.ensure_current().and_then(|_| {
+                        runner::connect_with_orphan_adoption(
+                            runner_id,
+                            None,
+                            &[],
+                            true,
+                            None,
+                            None,
+                            None,
+                        )
+                    })
+                })
+            }
+            DaemonRepairDispatch::ReconcileUnleasedCandidates => {
+                connect_outcome_after_promotion_wait(|| {
+                    target.ensure_current().and_then(|_| {
+                        runner::connect_with_unleased_candidate_reconciliation(runner_id)
+                    })
+                })
+            }
             DaemonRepairDispatch::RefreshHomeboy {
                 git_ref,
                 allow_downgrade,
-            } => refresh_outcome(runner_id, git_ref, allow_downgrade),
+            } => target
+                .ensure_current()
+                .map_err(|error| error.message)
+                .and_then(|_| refresh_outcome(runner_id, git_ref, allow_downgrade)),
             // A read-only diagnosis, or a recovery command a runner advertised
             // as text with no argv behind it. The operator gets the plan and an
             // explicit reason instead of silence.
@@ -533,7 +652,7 @@ fn apply_daemon_repair_plan(runner_id: &str, report: &mut RunnerDoctorOutput) ->
         .map(|step| step.code.as_str())
         .collect::<Vec<_>>()
         .join(", ");
-    match daemon_admission_ready(runner_id) {
+    match target.ensure_current().and_then(|_| daemon_admission_ready(runner_id)) {
         Ok(true) => report.repairs.push(RunnerRepair {
             id: "repair.daemon".to_string(),
             status: RunnerDoctorStatus::Ok,
@@ -597,8 +716,10 @@ fn retry_runtime_promotion_wait<T>(
     for attempt in 0..PROMOTION_WAIT_CONNECT_ATTEMPTS {
         match action() {
             Err(error)
-                if error.code == ErrorCode::RuntimePromotionWaitTimeout
-                    && attempt + 1 < PROMOTION_WAIT_CONNECT_ATTEMPTS =>
+                if matches!(
+                    error.code,
+                    ErrorCode::RuntimePromotionContended | ErrorCode::RuntimePromotionWaitTimeout
+                ) && attempt + 1 < PROMOTION_WAIT_CONNECT_ATTEMPTS =>
             {
                 // `connect` emitted owner/watch events during the first wait.
                 // A second bounded admission wait converges a promotion that

--- a/crates/homeboy-cli/src/commands/runner/doctor/target.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/target.rs
@@ -24,6 +24,48 @@ pub fn resolve(runner_id: &str) -> homeboy::core::Result<RunnerTarget> {
     }
 }
 
+impl RunnerTarget {
+    /// Lifecycle operations still accept a runner id and therefore reload its
+    /// registry entry. Refuse that operation if the entry no longer names the
+    /// target diagnosed at the start of this doctor invocation.
+    pub fn ensure_current(&self) -> homeboy::core::Result<()> {
+        let Self::Ssh {
+            id, runner, server, ..
+        } = self
+        else {
+            return Ok(());
+        };
+        let current = resolve(id)?;
+        let Self::Ssh {
+            runner: current_runner,
+            server: current_server,
+            ..
+        } = current
+        else {
+            return Err(target_changed(id));
+        };
+        if same_identity(runner, &current_runner) && same_identity(server.as_ref(), &current_server)
+        {
+            Ok(())
+        } else {
+            Err(target_changed(id))
+        }
+    }
+}
+
+fn same_identity<T: serde::Serialize>(left: &T, right: &T) -> bool {
+    serde_json::to_value(left).ok() == serde_json::to_value(right).ok()
+}
+
+fn target_changed(runner_id: &str) -> homeboy::core::Error {
+    homeboy::core::Error::validation_invalid_argument(
+        "runner",
+        "runner registry target changed during doctor; no repair was applied to a different target",
+        Some(runner_id.to_string()),
+        None,
+    )
+}
+
 fn from_registry(runner_id: &str, runner: Runner) -> homeboy::core::Result<RunnerTarget> {
     match runner.kind {
         RunnerKind::Local => Ok(RunnerTarget::Local {

--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/shape.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/shape.rs
@@ -111,6 +111,29 @@ fn compact_doctor_puts_blockers_and_remediation_before_informational_checks() {
 }
 
 #[test]
+fn compact_doctor_retains_failed_repair_cause_and_remediation() {
+    let (mut report, _) = run("local").expect("local doctor report");
+    report.repairs.push(types::RunnerRepair {
+        id: "repair.daemon".to_string(),
+        status: RunnerDoctorStatus::Error,
+        message: "promotion lease remained contended after the bounded wait".to_string(),
+        commands: vec!["homeboy runner doctor local --scope lab-offload --repair".to_string()],
+    });
+
+    let compact = output_projection(report, false);
+
+    assert_eq!(compact["repairs"][0]["id"], "repair.daemon");
+    assert_eq!(
+        compact["repairs"][0]["message"],
+        "promotion lease remained contended after the bounded wait"
+    );
+    assert_eq!(
+        compact["repairs"][0]["commands"][0],
+        "homeboy runner doctor local --scope lab-offload --repair"
+    );
+}
+
+#[test]
 fn compact_doctor_hard_bounds_oversized_identity_and_command_metadata() {
     let (mut report, _) = run("local").expect("local doctor report");
     report.runner_id = "runner-".repeat(10_000);
@@ -179,6 +202,34 @@ fn compact_doctor_falls_back_when_escaped_untrusted_fields_exceed_the_wire_budge
         compact["truncation"]["checks"]["omitted"],
         "see_full_output"
     );
+}
+
+#[test]
+fn compact_doctor_size_fallback_retains_failed_repair() {
+    let (mut report, _) = run("local").expect("local doctor report");
+    let escaped = "\"\\\n".repeat(10_000);
+    report.checks = (0..COMPACT_CHECK_LIMIT)
+        .map(|_| types::RunnerCheck {
+            id: escaped.clone(),
+            status: RunnerDoctorStatus::Error,
+            message: escaped.clone(),
+            remediation: Some(escaped.clone()),
+            remediation_action: None,
+            details: BTreeMap::new(),
+        })
+        .collect();
+    report.repairs.push(types::RunnerRepair {
+        id: "repair.daemon".to_string(),
+        status: RunnerDoctorStatus::Error,
+        message: "promotion wait exhausted; do not use generic reconnect".to_string(),
+        commands: vec!["homeboy runner doctor local --scope lab-offload --repair".to_string()],
+    });
+
+    let compact = output_projection(report, false);
+
+    assert_eq!(compact["checks"].as_array().unwrap().len(), 0);
+    assert_eq!(compact["repairs"][0]["id"], "repair.daemon");
+    assert!(projection_envelope_bytes(&compact).unwrap() <= COMPACT_PROJECTION_BYTES);
 }
 
 #[test]

--- a/crates/homeboy-cli/src/commands/runner/doctor/tests/shape.rs
+++ b/crates/homeboy-cli/src/commands/runner/doctor/tests/shape.rs
@@ -229,6 +229,10 @@ fn compact_doctor_size_fallback_retains_failed_repair() {
 
     assert_eq!(compact["checks"].as_array().unwrap().len(), 0);
     assert_eq!(compact["repairs"][0]["id"], "repair.daemon");
+    assert_eq!(
+        compact["repairs"][0]["message"],
+        "promotion wait exhausted; do not use generic reconnect"
+    );
     assert!(projection_envelope_bytes(&compact).unwrap() <= COMPACT_PROJECTION_BYTES);
 }
 


### PR DESCRIPTION
Closes #14092

## Summary
- retry bounded controller-promotion admission for direct contention and wait timeouts, only after revalidating the originally resolved runner target
- bind diagnosis, repair mutations, and terminal verification to the originally resolved SSH runner; fail closed if its registry target changes
- keep transport errors terminal and retain failed repair cause and remediation in compact doctor output, including its size-cap fallback

## Testing
- `cargo fmt --check`
- `cargo test -p homeboy-cli commands::runner::doctor --lib` (96 passed)
- `cargo clippy -p homeboy-cli --lib --tests -- -D warnings` (blocked by 28 pre-existing `homeboy-core` warnings promoted to errors)

## AI assistance
Implemented with OpenAI GPT-5.6 Terra via OpenCode.