### PR TITLE
fix(agent-task): emit terminal Cook preview

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -724,10 +724,27 @@ fn cook_preview_replay_argv(args: &AgentTaskCookArgs) -> PreviewReplayArgv {
             .collect::<Vec<_>>();
         rewrite_cook_identity_replay_argv(&mut replay, args);
         append_preview_lifecycle_replay_argv(&mut replay, args);
-        return redact_preview_replay_argv(replay);
+        return finalize_cook_preview_replay(replay, args);
     }
 
-    redact_preview_replay_argv(cook_replay_argv(args))
+    finalize_cook_preview_replay(cook_replay_argv(args), args)
+}
+
+fn finalize_cook_preview_replay(
+    replay: impl IntoIterator<Item = String>,
+    args: &AgentTaskCookArgs,
+) -> PreviewReplayArgv {
+    let mut replay = redact_preview_replay_argv(replay);
+    if args
+        .prompt_snapshot
+        .as_ref()
+        .is_some_and(|snapshot| snapshot.source == "stdin")
+    {
+        replay.requires.push(
+            "replay requires the original non-empty prompt on stdin for `--prompt -`".to_string(),
+        );
+    }
+    replay
 }
 
 // Unit callers do not have the original process argv. Keep their fallback

--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -333,8 +333,20 @@ pub(crate) fn preview_cook(
         }
     }
     bind_cook_preview_lifecycle(&mut args);
-    if let Some(backend) = unresolved_cook_backend_preview(&args)? {
-        return Ok((backend, 0));
+    if let Some((provider, replay)) = unresolved_cook_backend_preview(&args)? {
+        return Ok((
+            cook_preview_result(
+                cook_preview_resolved_request(
+                    &args,
+                    preview_placement_policy_with_admission(&replay.argv),
+                ),
+                progress,
+                replay,
+                Some(provider),
+                None,
+            ),
+            0,
+        ));
     }
     // Source policy is a static validation and must apply to preview exactly as
     // it applies before an execution route can inspect the destination.
@@ -357,31 +369,16 @@ pub(crate) fn preview_cook(
         Some("materialization_required" | "unresolved_provider")
     ) {
         let failure = provision.get("failure").cloned();
+        let exit_code = if provision["action"] == "unresolved_provider" {
+            1
+        } else {
+            0
+        };
+        let mut resolved = cook_preview_resolved_request(&args, placement);
+        resolved["workspace"] = provision;
         return Ok((
-            serde_json::json!({
-                "schema": "homeboy/agent-task-cook-preview/v1",
-                "mutates": false,
-                "resolved": {
-                    "repository": cook_provision_repository(&args),
-                    "component": cook_component_id(&args),
-                    "repository_identity": args.repository_identity,
-                    "worktree": args.to_worktree,
-                    "base": args.base,
-                    "head": args.head,
-                    "placement": placement,
-                    "workspace": provision,
-                    "notification_resolution": notification_resolution,
-                },
-                "progress": progress,
-                "failure": failure,
-                "replay_argv": replay.argv,
-                "replay_requires": replay.requires,
-            }),
-            if provision["action"] == "unresolved_provider" {
-                1
-            } else {
-                0
-            },
+            cook_preview_result(resolved, progress, replay, None, failure),
+            exit_code,
         ));
     }
     let gate_workspace = args.dispatch.cwd.as_deref().map(Path::new).or_else(|| {
@@ -463,38 +460,64 @@ pub(crate) fn preview_cook(
         .first()
         .map(|task| serde_json::to_value(&task.executor).unwrap_or(Value::Null))
         .unwrap_or(Value::Null);
+    let mut resolved = cook_preview_resolved_request(&args, placement);
+    resolved["workspace"] = provision;
+    resolved["provider"] = executor;
+    resolved["retry_budget"] = plan.metadata["cook_retry_policy"].clone();
+    resolved["notification_resolution"] = serde_json::to_value(notification_resolution)
+        .map_err(|error| homeboy::core::Error::internal_json(error.to_string(), None))?;
     Ok((
-        serde_json::json!({
-            "schema": "homeboy/agent-task-cook-preview/v1",
-            "mutates": false,
-            "resolved": {
-                "repository": cook_provision_repository(&args),
-                "component": cook_component_id(&args),
-                "repository_identity": args.repository_identity,
-                "worktree": args.to_worktree,
-                "base": args.base,
-                "head": args.head,
-                "workspace": provision,
-                "placement": placement,
-                "provider": executor,
-                "gates": {
-                    "public": args.gates.verify.len(),
-                    "private": args.gates.private_verify.len(),
-                },
-                "retry_budget": plan.metadata["cook_retry_policy"],
-                "publication": {
-                    "finalize": !args.no_finalize,
-                    "draft": args.draft_pr,
-                    "ai_tool": args.ai_tool,
-                },
-                "notification_resolution": notification_resolution,
-            },
-            "progress": progress,
-            "replay_argv": replay.argv,
-            "replay_requires": replay.requires,
-        }),
+        cook_preview_result(resolved, progress, replay, None, None),
         0,
     ))
+}
+
+fn cook_preview_result(
+    resolved: Value,
+    progress: Vec<Value>,
+    replay: PreviewReplayArgv,
+    provider: Option<Value>,
+    failure: Option<Value>,
+) -> Value {
+    let mut result = serde_json::json!({
+        "schema": "homeboy/agent-task-cook-preview/v1",
+        "mutates": false,
+        "resolved": resolved,
+        "progress": progress,
+        "replay_argv": replay.argv,
+        "replay_requires": replay.requires,
+    });
+    if let Some(provider) = provider {
+        result["resolved"]["provider"] = provider;
+    }
+    if let Some(failure) = failure {
+        result["failure"] = failure;
+    }
+    result
+}
+
+fn cook_preview_resolved_request(args: &AgentTaskCookArgs, placement: Value) -> Value {
+    serde_json::json!({
+        "repository": cook_provision_repository(args),
+        "component": cook_component_id(args),
+        "repository_identity": args.repository_identity,
+        "worktree": args.to_worktree,
+        "base": args.base,
+        "head": args.head,
+        "placement": placement,
+        "workspace": null,
+        "provider": null,
+        "gates": {
+            "public": args.gates.verify.len(),
+            "private": args.gates.private_verify.len(),
+        },
+        "publication": {
+            "finalize": !args.no_finalize,
+            "draft": args.draft_pr,
+            "ai_tool": args.ai_tool,
+        },
+        "notification_resolution": homeboy::core::notification_route::current_resolution(),
+    })
 }
 
 fn record_preview_phase(progress: &mut Vec<Value>, phase: &'static str) {
@@ -567,7 +590,7 @@ fn with_preview_heartbeat<T>(
 /// prompt, evidence, or gates.
 fn unresolved_cook_backend_preview(
     args: &AgentTaskCookArgs,
-) -> homeboy::core::Result<Option<Value>> {
+) -> homeboy::core::Result<Option<(Value, PreviewReplayArgv)>> {
     let resolution =
         dispatch_service::resolve_dispatch_request(dispatch_args_for_cook(args).into());
     let Err(error) = resolution else {
@@ -578,7 +601,7 @@ fn unresolved_cook_backend_preview(
     }
 
     let catalog = homeboy::agents::agent_tasks::provider::AgentTaskProviderCatalog::discover();
-    Ok(Some(missing_backend_preview_value(
+    Ok(Some(missing_backend_preview_resolution(
         args,
         ready_cook_backends(&catalog),
     )))
@@ -614,10 +637,10 @@ fn is_missing_default_backend_policy_error(error: &homeboy::core::Error) -> bool
 
 const MAX_READY_BACKEND_CHOICES: usize = 10;
 
-fn missing_backend_preview_value(
+fn missing_backend_preview_resolution(
     args: &AgentTaskCookArgs,
     mut ready_backends: Vec<String>,
-) -> Value {
+) -> (Value, PreviewReplayArgv) {
     ready_backends.sort_unstable();
     ready_backends.dedup();
     let ready_backend_count = ready_backends.len();
@@ -658,24 +681,21 @@ fn missing_backend_preview_value(
         );
     }
 
-    serde_json::json!({
-            "schema": "homeboy/agent-task-cook-preview/v1",
-            "mutates": false,
-            "resolved": {
-                "backend": {
-                    "state": state,
-                    "default_policy": "missing",
-                    "ready_backends": ready_backends.into_iter().take(MAX_READY_BACKEND_CHOICES).collect::<Vec<_>>(),
-                    "ready_backend_count": ready_backend_count,
-                    "ready_backends_omitted": ready_backends_omitted,
-                    "ready_choices": ready_choices,
-                    "replay_backend": replay_backend,
-                    "readiness_command": "homeboy agent-task providers --validate-readiness",
-                },
+    (
+        serde_json::json!({
+            "backend": {
+                "state": state,
+                "default_policy": "missing",
+                "ready_backends": ready_backends.into_iter().take(MAX_READY_BACKEND_CHOICES).collect::<Vec<_>>(),
+                "ready_backend_count": ready_backend_count,
+                "ready_backends_omitted": ready_backends_omitted,
+                "ready_choices": ready_choices,
+                "replay_backend": replay_backend,
+                "readiness_command": "homeboy agent-task providers --validate-readiness",
             },
-            "replay_argv": replay.argv,
-            "replay_requires": replay.requires,
-    })
+        }),
+        replay,
+    )
 }
 
 const MAX_PREVIEW_REPLAY_ARGS: usize = 128;
@@ -1158,7 +1178,7 @@ mod preview_tests {
 
     #[test]
     fn missing_backend_preview_requires_policy_when_no_ready_backend_exists() {
-        let preview = missing_backend_preview_value(
+        let (provider, replay) = missing_backend_preview_resolution(
             &cook(&[
                 "homeboy",
                 "agent-task",
@@ -1171,14 +1191,10 @@ mod preview_tests {
         );
 
         assert_eq!(
-            preview["resolved"]["backend"]["state"],
+            provider["backend"]["state"],
             "backend_required_no_ready_route"
         );
-        assert!(preview["replay_argv"]
-            .as_array()
-            .expect("replay argv")
-            .iter()
-            .all(|arg| arg != "--backend"));
+        assert!(replay.argv.iter().all(|arg| arg != "--backend"));
     }
 
     #[test]
@@ -1219,21 +1235,35 @@ mod preview_tests {
                     .expect("missing policy returns backend guidance before prompt validation");
 
             assert_eq!(exit_code, 0);
-            assert_eq!(preview["resolved"]["backend"]["default_policy"], "missing");
+            assert_eq!(
+                preview["resolved"]["provider"]["backend"]["default_policy"],
+                "missing"
+            );
             assert!(matches!(
-                preview["resolved"]["backend"]["state"].as_str(),
+                preview["resolved"]["provider"]["backend"]["state"].as_str(),
                 Some(
                     "ready_backend_unambiguous"
                         | "backend_required_no_ready_route"
                         | "backend_required_multiple_ready_routes"
                 )
             ));
+            assert_eq!(
+                preview["progress"],
+                serde_json::json!([
+                    { "event": "cook_preview_progress", "phase": "prompt_input" },
+                    { "event": "cook_preview_progress", "phase": "input_validation" },
+                ])
+            );
+            assert!(
+                preview["replay_argv"].is_array(),
+                "terminal preview has replay"
+            );
         });
     }
 
     #[test]
     fn missing_backend_preview_replays_the_one_ready_backend() {
-        let preview = missing_backend_preview_value(
+        let (provider, replay) = missing_backend_preview_resolution(
             &cook(&[
                 "homeboy",
                 "agent-task",
@@ -1245,26 +1275,19 @@ mod preview_tests {
             vec!["fixture".to_string()],
         );
 
-        assert_eq!(
-            preview["resolved"]["backend"]["state"],
-            "ready_backend_unambiguous"
-        );
-        assert_eq!(preview["resolved"]["backend"]["replay_backend"], "fixture");
-        let replay = preview["replay_argv"].as_array().expect("replay argv");
+        assert_eq!(provider["backend"]["state"], "ready_backend_unambiguous");
+        assert_eq!(provider["backend"]["replay_backend"], "fixture");
+        let replay = replay.argv;
         assert!(replay
             .windows(2)
             .any(|pair| pair == ["--backend", "fixture"]));
-        Cli::try_parse_from(
-            replay
-                .iter()
-                .map(|value| value.as_str().expect("argv string")),
-        )
-        .expect("ready-backend replay parses as Cook");
+        Cli::try_parse_from(replay.iter().map(String::as_str))
+            .expect("ready-backend replay parses as Cook");
     }
 
     #[test]
     fn missing_backend_preview_keeps_multiple_ready_backends_explicit() {
-        let preview = missing_backend_preview_value(
+        let (provider, replay) = missing_backend_preview_resolution(
             &cook(&[
                 "homeboy",
                 "agent-task",
@@ -1277,11 +1300,11 @@ mod preview_tests {
         );
 
         assert_eq!(
-            preview["resolved"]["backend"]["state"],
+            provider["backend"]["state"],
             "backend_required_multiple_ready_routes"
         );
-        assert!(preview["resolved"]["backend"]["replay_backend"].is_null());
-        let choices = preview["resolved"]["backend"]["ready_choices"]
+        assert!(provider["backend"]["replay_backend"].is_null());
+        let choices = provider["backend"]["ready_choices"]
             .as_array()
             .expect("ready choices");
         assert_eq!(
@@ -1308,14 +1331,10 @@ mod preview_tests {
                 argv
             );
         }
-        assert!(preview["replay_requires"]
-            .as_array()
-            .expect("replay requirements")
+        assert!(replay
+            .requires
             .iter()
-            .any(|value| value
-                .as_str()
-                .unwrap_or_default()
-                .contains("multiple eligible routes")));
+            .any(|value| value.contains("multiple eligible routes")));
     }
 
     #[test]
@@ -1325,7 +1344,7 @@ mod preview_tests {
             .map(|index| format!("backend-{index:02}"))
             .chain(std::iter::once("backend-00".to_string()))
             .collect();
-        let preview = missing_backend_preview_value(
+        let (provider, _) = missing_backend_preview_resolution(
             &cook(&[
                 "homeboy",
                 "agent-task",
@@ -1336,7 +1355,7 @@ mod preview_tests {
             ]),
             ready_backends,
         );
-        let backend = &preview["resolved"]["backend"];
+        let backend = &provider["backend"];
 
         assert_eq!(
             backend["ready_backend_count"],
@@ -2167,6 +2186,18 @@ mod preview_tests {
             assert_eq!(exit_code, 0);
             assert_eq!(preview["schema"], "homeboy/agent-task-cook-preview/v1");
             assert_eq!(preview["mutates"], false);
+            assert_eq!(
+                preview["progress"],
+                serde_json::json!([
+                    { "event": "cook_preview_progress", "phase": "prompt_input" },
+                    { "event": "cook_preview_progress", "phase": "input_validation" },
+                    { "event": "cook_preview_progress", "phase": "destination_resolution" },
+                    { "event": "cook_preview_progress", "phase": "placement_projection" },
+                    { "event": "cook_preview_progress", "phase": "gate_contract_validation" },
+                    { "event": "cook_preview_progress", "phase": "provider_preflight" },
+                    { "event": "cook_preview_progress", "phase": "plan_compilation" },
+                ])
+            );
             assert!(preview["resolved"]["provider"].is_object());
             assert_eq!(
                 preview["resolved"]["placement"]["admission"]["schema"],
@@ -2509,6 +2540,21 @@ mod preview_tests {
             assert_eq!(exit_code, 0);
             assert_eq!(preview["schema"], "homeboy/agent-task-cook-preview/v1");
             assert_eq!(preview["mutates"], false);
+            assert_eq!(
+                preview["progress"],
+                serde_json::json!([
+                    { "event": "cook_preview_progress", "phase": "prompt_input" },
+                    { "event": "cook_preview_progress", "phase": "input_validation" },
+                    { "event": "cook_preview_progress", "phase": "destination_resolution" },
+                    { "event": "cook_preview_progress", "phase": "placement_projection" },
+                ])
+            );
+            assert!(
+                preview["replay_argv"].is_array(),
+                "terminal preview has replay"
+            );
+            assert_eq!(preview["resolved"]["gates"]["public"], 0);
+            assert_eq!(preview["resolved"]["gates"]["private"], 0);
             assert_eq!(
                 preview["resolved"]["placement"]["admission"]["schema"],
                 "homeboy/cook-preview-placement-admission/v1"

--- a/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
@@ -407,6 +407,10 @@ fn render_cook_preview_summary(payload: &Value) -> Option<String> {
             })
         })
         .unwrap_or("unresolved");
+    let model = resolved
+        .pointer("/provider/model")
+        .and_then(Value::as_str)
+        .unwrap_or("unresolved");
     let destination = resolved
         .pointer("/workspace/path")
         .and_then(Value::as_str)
@@ -436,6 +440,7 @@ fn render_cook_preview_summary(payload: &Value) -> Option<String> {
         "Cook preview".to_string(),
         format!("Placement: {placement}"),
         format!("Provider: {provider}"),
+        format!("Model: {model}"),
         format!("Destination: {destination}"),
         format!("Gates: {public_gates} public, {private_gates} private"),
         format!(
@@ -1043,7 +1048,7 @@ mod tests {
 
         assert_eq!(
             render_agent_task_summary(AgentTaskSummaryKind::Cook, &payload),
-            Some("Cook preview\nPlacement: local\nProvider: fixture\nDestination: /tmp/worktree\nGates: 1 public, 2 private\nReplay: homeboy agent-task cook --backend fixture\n".to_string())
+            Some("Cook preview\nPlacement: local\nProvider: fixture\nModel: test-model\nDestination: /tmp/worktree\nGates: 1 public, 2 private\nReplay: homeboy agent-task cook --backend fixture\n".to_string())
         );
     }
 

--- a/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
@@ -264,6 +264,9 @@ fn render_providers_summary(payload: &Value) -> Option<String> {
 }
 
 fn render_cook_summary(payload: &Value) -> Option<String> {
+    if payload.get("schema").and_then(Value::as_str) == Some("homeboy/agent-task-cook-preview/v1") {
+        return render_cook_preview_summary(payload);
+    }
     let run_id =
         string_value(payload, &["run_id"]).or_else(|| string_value(payload, &["latest_run_id"]))?;
     let raw_state = string_value(payload, &["state"])
@@ -384,6 +387,64 @@ fn render_cook_summary(payload: &Value) -> Option<String> {
         lines.push(format!("Next: homeboy agent-task review {run_id}"));
     } else {
         lines.push(format!("Next: homeboy agent-task logs {run_id}"));
+    }
+    Some(finish(lines))
+}
+
+fn render_cook_preview_summary(payload: &Value) -> Option<String> {
+    let resolved = payload.get("resolved")?;
+    let placement = resolved
+        .pointer("/placement/requested")
+        .and_then(Value::as_str)?;
+    let provider = resolved
+        .get("provider")
+        .and_then(Value::as_object)
+        .and_then(|provider| {
+            provider.get("backend").and_then(|backend| {
+                backend
+                    .as_str()
+                    .or_else(|| backend.get("state").and_then(Value::as_str))
+            })
+        })
+        .unwrap_or("unresolved");
+    let destination = resolved
+        .pointer("/workspace/path")
+        .and_then(Value::as_str)
+        .or_else(|| resolved.get("worktree").and_then(Value::as_str))
+        .or_else(|| {
+            resolved
+                .pointer("/workspace/action")
+                .and_then(Value::as_str)
+        })
+        .unwrap_or("unresolved");
+    let public_gates = resolved
+        .pointer("/gates/public")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let private_gates = resolved
+        .pointer("/gates/private")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let replay = payload
+        .get("replay_argv")
+        .and_then(Value::as_array)?
+        .iter()
+        .filter_map(Value::as_str)
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    let mut lines = vec![
+        "Cook preview".to_string(),
+        format!("Placement: {placement}"),
+        format!("Provider: {provider}"),
+        format!("Destination: {destination}"),
+        format!("Gates: {public_gates} public, {private_gates} private"),
+        format!(
+            "Replay: {}",
+            homeboy::core::engine::shell::quote_args(&replay)
+        ),
+    ];
+    if let Some(failure) = payload.pointer("/failure/message").and_then(Value::as_str) {
+        lines.push(format!("Blocked: {failure}"));
     }
     Some(finish(lines))
 }
@@ -966,6 +1027,25 @@ fn finish(lines: Vec<String>) -> String {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn cook_preview_summary_renders_the_terminal_preview_payload() {
+        let payload = json!({
+            "schema": "homeboy/agent-task-cook-preview/v1",
+            "resolved": {
+                "placement": { "requested": "local" },
+                "provider": { "backend": "fixture", "model": "test-model" },
+                "workspace": { "path": "/tmp/worktree" },
+                "gates": { "public": 1, "private": 2 },
+            },
+            "replay_argv": ["homeboy", "agent-task", "cook", "--backend", "fixture"],
+        });
+
+        assert_eq!(
+            render_agent_task_summary(AgentTaskSummaryKind::Cook, &payload),
+            Some("Cook preview\nPlacement: local\nProvider: fixture\nDestination: /tmp/worktree\nGates: 1 public, 2 private\nReplay: homeboy agent-task cook --backend fixture\n".to_string())
+        );
+    }
 
     #[test]
     fn providers_summary_presents_selection_without_calling_it_blocked() {

--- a/crates/homeboy-cli/src/commands/json_output/mod.rs
+++ b/crates/homeboy-cli/src/commands/json_output/mod.rs
@@ -53,7 +53,7 @@ pub(crate) fn run_command_output(
             let bounded_operation = agent_task_bounded_operation(&args);
             if matches!(
                 &args.command,
-                crate::commands::agent_task::AgentTaskCommand::Cook(_)
+                crate::commands::agent_task::AgentTaskCommand::Cook(cook_args) if !cook_args.preview
             ) {
                 if let Some(path) = output_file {
                     let full = agent_task_requests_full_output(&args);

--- a/tests/cli_binary/cook_preview_lifecycle.rs
+++ b/tests/cli_binary/cook_preview_lifecycle.rs
@@ -1,10 +1,13 @@
 use serde_json::Value;
+use std::io::Write;
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 #[test]
 fn unresolved_backend_preview_binds_stable_replay_lifecycle_without_mutation() {
     let home = tempfile::tempdir().expect("home");
+    let output_dir = tempfile::tempdir().expect("output directory");
+    let output_path = output_dir.path().join("preview.json");
     let output = Command::new(homeboy_bin())
         .args([
             "agent-task",
@@ -22,6 +25,8 @@ fn unresolved_backend_preview_binds_stable_replay_lifecycle_without_mutation() {
             "--verify",
             "cargo test -p homeboy-cli",
             "--preview",
+            "--output",
+            output_path.to_str().expect("output path"),
         ])
         .env("HOME", home.path())
         .env("XDG_CONFIG_HOME", home.path().join(".config"))
@@ -45,6 +50,21 @@ fn unresolved_backend_preview_binds_stable_replay_lifecycle_without_mutation() {
     let preview = &envelope["data"];
     assert_eq!(preview["schema"], "homeboy/agent-task-cook-preview/v1");
     assert_eq!(preview["mutates"], false);
+    assert_eq!(
+        serde_json::from_str::<Value>(
+            &std::fs::read_to_string(&output_path).expect("preview output")
+        )
+        .expect("preview output JSON")["data"]["mutates"],
+        false,
+        "--output must contain the read-only terminal preview"
+    );
+    assert!(
+        !output_dir
+            .path()
+            .join(".preview.json.homeboy-cook-output.lock")
+            .exists(),
+        "preview must not create a Cook output lease"
+    );
     assert_eq!(
         preview["resolved"]["provider"]["backend"]["default_policy"],
         "missing"
@@ -78,6 +98,71 @@ fn unresolved_backend_preview_binds_stable_replay_lifecycle_without_mutation() {
             .count(),
         0,
         "preview must not create Homeboy state"
+    );
+}
+
+#[test]
+fn stdin_prompt_preview_declares_replay_requirement() {
+    let home = tempfile::tempdir().expect("home");
+    let mut command = Command::new(homeboy_bin());
+    command
+        .args([
+            "agent-task",
+            "cook",
+            "--repo",
+            "homeboy",
+            "--task-url",
+            "https://github.com/Extra-Chill/homeboy/issues/13490",
+            "--head",
+            "fix/13490-cook-preview-lifecycle-chubes",
+            "--base",
+            "main",
+            "--verify",
+            "cargo test -p homeboy-cli",
+            "--prompt",
+            "-",
+            "--preview",
+        ])
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .env("XDG_DATA_HOME", home.path().join(".local/share"))
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command.spawn().expect("run Cook preview");
+    child
+        .stdin
+        .take()
+        .expect("preview stdin")
+        .write_all(b"Fix the preview replay contract.\n")
+        .expect("write preview prompt");
+    let output = child.wait_with_output().expect("wait for Cook preview");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let preview: Value = serde_json::from_slice(&output.stdout).expect("preview JSON");
+    let replay = preview["data"]["replay_argv"]
+        .as_array()
+        .expect("preview replay argv");
+    assert!(
+        replay
+            .windows(2)
+            .any(|pair| pair[0] == "--prompt" && pair[1] == "-"),
+        "stdin source remains explicit in the replay: {replay:?}"
+    );
+    assert!(
+        preview["data"]["replay_requires"]
+            .as_array()
+            .expect("preview replay requirements")
+            .iter()
+            .any(|requirement| requirement
+                == "replay requires the original non-empty prompt on stdin for `--prompt -`"),
+        "stdin replay requirement is explicit: {preview}"
     );
 }
 

--- a/tests/cli_binary/cook_preview_lifecycle.rs
+++ b/tests/cli_binary/cook_preview_lifecycle.rs
@@ -45,7 +45,10 @@ fn unresolved_backend_preview_binds_stable_replay_lifecycle_without_mutation() {
     let preview = &envelope["data"];
     assert_eq!(preview["schema"], "homeboy/agent-task-cook-preview/v1");
     assert_eq!(preview["mutates"], false);
-    assert_eq!(preview["resolved"]["backend"]["default_policy"], "missing");
+    assert_eq!(
+        preview["resolved"]["provider"]["backend"]["default_policy"],
+        "missing"
+    );
 
     let replay = preview["replay_argv"]
         .as_array()
@@ -55,7 +58,7 @@ fn unresolved_backend_preview_binds_stable_replay_lifecycle_without_mutation() {
     assert_eq!(run_id, attempt_run_id);
     assert!(run_id.starts_with("agent-task-"), "{run_id}");
 
-    for choice in preview["resolved"]["backend"]["ready_choices"]
+    for choice in preview["resolved"]["provider"]["backend"]["ready_choices"]
         .as_array()
         .expect("ready backend choices")
     {


### PR DESCRIPTION
## Summary
- unify every successful Cook preview behind one read-only terminal result payload
- route preview `--output` through the terminal artifact writer without Cook output leases or handoff state
- declare stdin replay requirements and render both the resolved provider and model compactly

Closes #14091

## Verification
- cargo fmt --check
- cargo test -p homeboy-cli --lib commands::agent_task_summary::tests::cook_preview_summary_renders_the_terminal_preview_payload -- --exact (1 passed)
- cargo test -p homeboy --test cli_binary cook_preview_lifecycle::unresolved_backend_preview_binds_stable_replay_lifecycle_without_mutation -- --exact (1 passed)
- cargo test -p homeboy --test cli_binary cook_preview_lifecycle::stdin_prompt_preview_declares_replay_requirement -- --exact (1 passed)
- cargo test -p homeboy --test cli_binary cook_preview_lifecycle --no-fail-fast (2 passed)
- cargo test -p homeboy-cli --lib commands::agent_task::run::preview_tests --no-fail-fast (27 passed, 1 existing provider postcondition failure)

## AI assistance
Implemented with OpenAI GPT-5.6 Terra via OpenCode.