### PR TITLE
fix(agent-task): persist Cook before resource admission

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -2892,7 +2892,7 @@ fn preflight_hot_command_with_input(
             if hot_command.lab_offload_supported
                 && cli.runner.is_none()
                 && !matches!(cli.placement, crate::cli_surface::Placement::Local)
-                && !detached_cook_unmaterialized_admission_eligible(cli)
+                && !cook_durable_admission_eligible(cli)
                 && resource_policy::evaluate_with_runner_hint(
                     hot_command,
                     &resources,
@@ -3075,7 +3075,14 @@ fn preflight_hot_command_with_input(
                     warning,
                     cli.placement.is_explicit_local_override() || runner_hosted,
                     is_interactive_shell(),
-                    resource_policy::admission_recovery(normalized_args, lab_readiness.as_ref()),
+                    (!cook_durable_admission_eligible(cli))
+                        .then(|| {
+                            resource_policy::admission_recovery(
+                                normalized_args,
+                                lab_readiness.as_ref(),
+                            )
+                        })
+                        .flatten(),
                     runner_admits_offload || auto_local_capacity_fallback,
                 ) {
                     if let Some(diagnostic) = lab_inventory_diagnostic {
@@ -3083,7 +3090,7 @@ fn preflight_hot_command_with_input(
                             .expect("Lab inventory admission diagnostic serializes");
                     }
                     if review_test_deferred_workload_eligible(cli, warning, runner_admits_offload)
-                        || detached_cook_unmaterialized_admission_eligible(cli)
+                        || cook_durable_admission_eligible(cli)
                     {
                         return None;
                     }
@@ -3187,13 +3194,12 @@ fn controller_owned_unmaterialized_resume(cli: &Cli) -> bool {
     })
 }
 
-/// A detached non-local Cook owns a durable queue boundary. Resource pressure
-/// may influence its Lab placement, but must not prevent routing from creating
-/// that boundary. Explicit local placement remains the only authorization for
-/// controller provider execution.
-fn detached_cook_unmaterialized_admission_eligible(cli: &Cli) -> bool {
-    cli.detach_after_handoff
-        && !matches!(cli.placement, crate::cli_surface::Placement::Local)
+/// A non-local Cook owns a durable admission boundary. Resource pressure may
+/// influence Lab placement, but cannot prevent creating an inspectable Cook.
+/// Explicit local placement remains the only authorization for controller
+/// provider execution.
+fn cook_durable_admission_eligible(cli: &Cli) -> bool {
+    !matches!(cli.placement, crate::cli_surface::Placement::Local)
         && matches!(
             cli.command,
             Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
@@ -4073,6 +4079,33 @@ mod tests {
                 "{placement:?}"
             );
         }
+    }
+
+    #[test]
+    fn nonlocal_cook_persists_before_hot_resource_admission() {
+        let cli = Cli::parse_from([
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--prompt",
+            "implement the fix",
+            "--to-worktree",
+            "fixture@durable-admission",
+            "--verify",
+            "true",
+        ]);
+
+        assert!(cook_durable_admission_eligible(&cli));
+        assert_eq!(
+            preflight_hot_command_with(
+                &cli,
+                None,
+                &output::CommandIdentity::with_operation("agent-task", "cook"),
+                || Ok((hot_resources(), 0)),
+            ),
+            None,
+            "Cook must reach its durable admission lifecycle before resource placement"
+        );
     }
 
     #[test]

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -2892,7 +2892,7 @@ fn preflight_hot_command_with_input(
             if hot_command.lab_offload_supported
                 && cli.runner.is_none()
                 && !matches!(cli.placement, crate::cli_surface::Placement::Local)
-                && !cook_durable_admission_eligible(cli)
+                && !nonlocal_cook_requires_durable_admission(cli)
                 && resource_policy::evaluate_with_runner_hint(
                     hot_command,
                     &resources,
@@ -3075,7 +3075,7 @@ fn preflight_hot_command_with_input(
                     warning,
                     cli.placement.is_explicit_local_override() || runner_hosted,
                     is_interactive_shell(),
-                    (!cook_durable_admission_eligible(cli))
+                    (!nonlocal_cook_requires_durable_admission(cli))
                         .then(|| {
                             resource_policy::admission_recovery(
                                 normalized_args,
@@ -3090,7 +3090,7 @@ fn preflight_hot_command_with_input(
                             .expect("Lab inventory admission diagnostic serializes");
                     }
                     if review_test_deferred_workload_eligible(cli, warning, runner_admits_offload)
-                        || cook_durable_admission_eligible(cli)
+                        || nonlocal_cook_requires_durable_admission(cli)
                     {
                         return None;
                     }
@@ -3198,7 +3198,7 @@ fn controller_owned_unmaterialized_resume(cli: &Cli) -> bool {
 /// influence Lab placement, but cannot prevent creating an inspectable Cook.
 /// Explicit local placement remains the only authorization for controller
 /// provider execution.
-fn cook_durable_admission_eligible(cli: &Cli) -> bool {
+fn nonlocal_cook_requires_durable_admission(cli: &Cli) -> bool {
     !matches!(cli.placement, crate::cli_surface::Placement::Local)
         && matches!(
             cli.command,
@@ -4095,7 +4095,7 @@ mod tests {
             "true",
         ]);
 
-        assert!(cook_durable_admission_eligible(&cli));
+        assert!(nonlocal_cook_requires_durable_admission(&cli));
         assert_eq!(
             preflight_hot_command_with(
                 &cli,

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -208,7 +208,7 @@ pub(crate) fn route_after_parse_with_provenance(
                 .map(|runner| runner.runner_id.clone())
         })
         .flatten();
-    if detached_cook_can_queue(cli) && !is_unmaterialized_replay_worker() {
+    if cook_can_enter_durable_admission(cli) && !is_unmaterialized_replay_worker() {
         // Persist before any bounded refresh. The scoped replay selector owns
         // ready and reverse-capacity admission after this durable boundary.
         return admit_unmaterialized_cook(
@@ -957,9 +957,8 @@ fn split_placement_coordinator_label(command: &Commands) -> Option<&'static str>
     }
 }
 
-fn detached_cook_can_queue(cli: &Cli) -> bool {
-    cli.detach_after_handoff
-        && !matches!(cli.placement, homeboy::cli_surface::Placement::Local)
+fn cook_can_enter_durable_admission(cli: &Cli) -> bool {
+    !matches!(cli.placement, homeboy::cli_surface::Placement::Local)
         && matches!(
             cli.command,
             Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {
@@ -1133,7 +1132,8 @@ fn admit_unmaterialized_cook(
     let admission = record.metadata["unmaterialized_cook_admission"].clone();
     let output = serde_json::json!({
         "schema": "homeboy/unmaterialized-cook-admission-result/v1",
-        "status": admission["state"],
+        "status": "pending_resource_admission",
+        "admission_state": admission["state"],
         "cook_id": cook_id,
         "run_id": cook_id,
         "materialized": false,

--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -208,7 +208,7 @@ pub(crate) fn route_after_parse_with_provenance(
                 .map(|runner| runner.runner_id.clone())
         })
         .flatten();
-    if cook_can_enter_durable_admission(cli) && !is_unmaterialized_replay_worker() {
+    if detached_cook_requires_deferred_admission(cli) && !is_unmaterialized_replay_worker() {
         // Persist before any bounded refresh. The scoped replay selector owns
         // ready and reverse-capacity admission after this durable boundary.
         return admit_unmaterialized_cook(
@@ -957,8 +957,13 @@ fn split_placement_coordinator_label(command: &Commands) -> Option<&'static str>
     }
 }
 
-fn cook_can_enter_durable_admission(cli: &Cli) -> bool {
-    !matches!(cli.placement, homeboy::cli_surface::Placement::Local)
+/// Deferred replay is only needed after an explicitly detached Cook loses its
+/// Lab route. Attached Cooks continue to observe their terminal execution, and
+/// `lab-or-local` continues through its authorized controller fallback.
+fn detached_cook_requires_deferred_admission(cli: &Cli) -> bool {
+    cli.detach_after_handoff
+        && !cli.placement.allows_local_fallback()
+        && !matches!(cli.placement, homeboy::cli_surface::Placement::Local)
         && matches!(
             cli.command,
             Commands::AgentTask(crate::commands::agent_task::AgentTaskArgs {

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -3173,9 +3173,10 @@ fn split_placement_cook_accepts_lab_placement_when_a_runner_is_selected() {
 }
 
 #[test]
-fn nonlocal_cook_is_eligible_for_durable_admission() {
+fn only_detached_cook_without_local_fallback_enters_deferred_admission() {
     let queued = Cli::parse_from([
         "homeboy",
+        "--detach-after-handoff",
         "agent-task",
         "cook",
         "--to-worktree",
@@ -3185,7 +3186,7 @@ fn nonlocal_cook_is_eligible_for_durable_admission() {
         "--prompt",
         "queue this on Lab",
     ]);
-    assert!(cook_can_enter_durable_admission(&queued));
+    assert!(detached_cook_requires_deferred_admission(&queued));
 
     let local = Cli::parse_from([
         "homeboy",
@@ -3201,7 +3202,23 @@ fn nonlocal_cook_is_eligible_for_durable_admission() {
         "--prompt",
         "remain local",
     ]);
-    assert!(!cook_can_enter_durable_admission(&local));
+    assert!(!detached_cook_requires_deferred_admission(&local));
+
+    let fallback = Cli::parse_from([
+        "homeboy",
+        "--placement",
+        "lab-or-local",
+        "--detach-after-handoff",
+        "agent-task",
+        "cook",
+        "--to-worktree",
+        "fixture@fallback",
+        "--verify",
+        "true",
+        "--prompt",
+        "run locally when Lab is unavailable",
+    ]);
+    assert!(!detached_cook_requires_deferred_admission(&fallback));
 }
 
 #[test]

--- a/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/dispatch.rs
@@ -3173,10 +3173,9 @@ fn split_placement_cook_accepts_lab_placement_when_a_runner_is_selected() {
 }
 
 #[test]
-fn detached_cook_is_the_only_split_placement_command_eligible_for_queue_admission() {
+fn nonlocal_cook_is_eligible_for_durable_admission() {
     let queued = Cli::parse_from([
         "homeboy",
-        "--detach-after-handoff",
         "agent-task",
         "cook",
         "--to-worktree",
@@ -3186,7 +3185,7 @@ fn detached_cook_is_the_only_split_placement_command_eligible_for_queue_admissio
         "--prompt",
         "queue this on Lab",
     ]);
-    assert!(detached_cook_can_queue(&queued));
+    assert!(cook_can_enter_durable_admission(&queued));
 
     let local = Cli::parse_from([
         "homeboy",
@@ -3202,7 +3201,7 @@ fn detached_cook_is_the_only_split_placement_command_eligible_for_queue_admissio
         "--prompt",
         "remain local",
     ]);
-    assert!(!detached_cook_can_queue(&local));
+    assert!(!cook_can_enter_durable_admission(&local));
 }
 
 #[test]

--- a/tests/cook_lab_handoff_test.rs
+++ b/tests/cook_lab_handoff_test.rs
@@ -651,6 +651,117 @@ fn foreground_local_cook_survives_client_termination_with_artifacts() {
     );
 }
 
+/// Attached Cooks remain foreground observers. They must reach their normal
+/// terminal execution path rather than returning deferred-admission output.
+#[test]
+fn attached_nonlocal_cook_observes_terminal_execution() {
+    let context = HermeticTestContext::new();
+    let (_checkout_guard, checkout) =
+        homeboy_core::test_support::shared_committed_git_repo_fixture("attached-cook-terminal");
+    let component_id = "attached-cook-terminal";
+    let mut register = context.command(TestBinary::HomeboyFixture);
+    register.args([
+        "component",
+        "create",
+        "--local-path",
+        checkout.to_str().expect("checkout path"),
+    ]);
+    let registered = bounded_output(register);
+    assert!(
+        registered.status.success(),
+        "register Cook component failed"
+    );
+    let task_worktree = context.root().join("attached-cook-terminal-worktree");
+    homeboy_core::test_support::run_git_fixture_command(
+        &checkout,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "attached-cook-terminal",
+            task_worktree.to_str().expect("task worktree path"),
+        ],
+    );
+    std::fs::write(
+        context.config_dir().join("homeboy.json"),
+        r#"{"retention":{"reconstructable_artifact_reserve_bytes":0}}"#,
+    )
+    .expect("disable host-capacity admission for fixture worktree");
+    let mut cook = context.controller_runtime_command(TestBinary::HomeboyFixture);
+    cook.env("GITHUB_ACTIONS", "true").args([
+        "agent-task",
+        "cook",
+        "--run-id",
+        "attached-cook-terminal",
+        "--repo",
+        component_id,
+        "--backend",
+        "fixture",
+        "--prompt",
+        "complete while attached",
+        "--cwd",
+        task_worktree.to_str().expect("task worktree path"),
+        "--to-worktree",
+        task_worktree.to_str().expect("task worktree path"),
+        "--verify",
+        "true",
+        "--max-attempts",
+        "1",
+        "--no-finalize",
+    ]);
+    let output = bounded_output(cook);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("pending_resource_admission"),
+        "attached Cook was deferred instead of observed: {stdout}"
+    );
+    assert!(
+        stdout.contains("Cook terminal"),
+        "attached Cook did not wait for terminal provider execution: {stdout}"
+    );
+}
+
+/// `lab-or-local` authorizes the controller fallback when no Lab runner exists.
+#[test]
+fn no_runner_lab_or_local_cook_reaches_local_execution() {
+    let context = HermeticTestContext::new();
+    let mut cook = context.controller_runtime_command(TestBinary::HomeboyFixture);
+    cook.env("GITHUB_ACTIONS", "true").args([
+        "--placement",
+        "lab-or-local",
+        "agent-task",
+        "cook",
+        "--backend",
+        "fixture",
+        "--prompt",
+        "use the authorized local fallback",
+        "--to-worktree",
+        "missing@lab-or-local-fallback",
+        "--verify",
+        "true",
+    ]);
+    let output = bounded_output(cook);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let result: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("Cook result JSON");
+
+    assert!(
+        !output.status.success(),
+        "fixture target must be unresolved"
+    );
+    assert!(
+        !stdout.contains("pending_resource_admission"),
+        "lab-or-local Cook was deferred instead of run locally: {stdout}"
+    );
+    assert!(
+        result
+            .pointer("/data/terminal_phase")
+            .and_then(serde_json::Value::as_str)
+            == Some("worktree_provider_lookup"),
+        "routing did not reach local Cook execution: {stdout}"
+    );
+}
+
 /// Historical runner recovery belongs to `runner exec`, never an unrelated
 /// Cook admission. This invokes the actual detached Cook command path so the
 /// ownership boundary remains observable.

--- a/tests/reverse_cook_queue_acceptance.rs
+++ b/tests/reverse_cook_queue_acceptance.rs
@@ -443,6 +443,10 @@ fn explicit_lab_route_persists_the_verified_lab_outcome_through_detached_cook_li
     );
     assert!(matches!(
         accepted["status"].as_str(),
+        Some("pending_resource_admission")
+    ));
+    assert!(matches!(
+        accepted["admission_state"].as_str(),
         Some("queued" | "blocked_runner_unavailable")
     ));
     assert_eq!(accepted["materialized"], false);


### PR DESCRIPTION
## Summary
- bypass terminal resource refusal for every non-local Cook so normal Cook lifecycle persistence remains reachable
- defer only detached Cooks with no authorized local fallback when Lab cannot accept work
- retain attached terminal observation and `--placement lab-or-local` controller fallback, covered by hermetic end-to-end tests

Closes #14090.

## Verification
- `cargo fmt --all --check`
- `cargo test -p homeboy-cli nonlocal_cook_persists_before_hot_resource_admission --lib`
- `cargo test -p homeboy-cli only_detached_cook_without_local_fallback_enters_deferred_admission --lib`
- `cargo test -p homeboy --test cook_lab_handoff_test attached_nonlocal_cook_observes_terminal_execution -- --exact --nocapture`
- `cargo test -p homeboy --test cook_lab_handoff_test no_runner_lab_or_local_cook_reaches_local_execution -- --exact --nocapture`

The complete `cook_lab_handoff_test` target was run both normally and with `--test-threads=1`; both runs failed four unrelated local-detach/foreground-durability tests. `cargo test -p homeboy-cli --lib` exceeded the 15-minute gate budget and reported existing promotion-review failures before timeout. `cargo clippy -p homeboy-cli --lib --tests -- -D warnings` is blocked by 28 existing `homeboy-core` warnings promoted to errors by the installed toolchain.

## AI Assistance
OpenAI GPT-5.6 Terra via OpenCode reviewed the Cook admission and routing lifecycle, implemented and verified the scoped repair, and updated this existing PR. Chris Huber provided the issue requirements and directed the simplification constraint.