### PR TITLE
fix(extension): resolve nested runtime package roots

### DIFF
--- a/crates/homeboy-core/src/extension/lifecycle/install_sources.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/install_sources.rs
@@ -317,12 +317,14 @@ fn install_shared_assets_from_root(
     extension_dir: &Path,
     mode: SharedAssetMode,
 ) -> Result<()> {
-    if runtime_generation_boundary_active()? {
+    let root_manifest = source_root.join(ROOT_MANIFEST);
+    let shared_assets = shared_assets_for_root(source_root);
+    if root_manifest.is_file() && runtime_generation_boundary_active()? {
         // Once runtime generations are active, extension refreshes publish a
         // successor generation rather than writing through the stable link.
         homeboy_core::runtime_package::refresh_shared_assets(source_root)?;
     }
-    for shared_dir in shared_assets_for_root(source_root) {
+    for shared_dir in shared_assets {
         if matches!(
             shared_dir.as_str(),
             "agent-runtimes" | "agent-task-contracts" | "runtime-agent-ci"
@@ -461,10 +463,25 @@ pub(crate) fn install_linked_shared_assets(
         );
     }
 
+    if let Some(source_root) = runtime_package_source_root(source) {
+        return install_shared_assets_from_root(
+            source_root,
+            extension_dir,
+            SharedAssetMode::Symlink,
+        );
+    }
+
     if let Some(parent) = source.parent() {
         install_shared_assets_from_root(parent, extension_dir, SharedAssetMode::Symlink)?;
     }
     Ok(())
+}
+
+fn runtime_package_source_root(source: &Path) -> Option<&Path> {
+    let runtime_packages = source.parent()?;
+    (runtime_packages.file_name()?.to_str()? == "agent-runtimes")
+        .then(|| runtime_packages.parent())
+        .flatten()
 }
 
 /// Scan a cloned repo for subdirectories that contain a matching manifest file.

--- a/crates/homeboy-core/src/extension/lifecycle/repair.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/repair.rs
@@ -787,6 +787,95 @@ mod tests {
     }
 
     #[test]
+    fn relink_nested_runtime_package_publishes_active_generation() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let old_source = home.join("old-source");
+            let new_source = home.join("new-source");
+            let boundary_source = home.join("boundary-source");
+            write_extension_fixture(&old_source, "opencode");
+            write_extension_fixture_with_version(
+                &new_source.join("agent-runtimes"),
+                "opencode",
+                "2.0.0",
+            );
+            write_declared_runtime_shared_assets(&new_source);
+            fs::create_dir_all(&boundary_source).expect("boundary source");
+            write_shared_asset_manifest(&boundary_source, &[]);
+
+            install(
+                &old_source.join("opencode").to_string_lossy(),
+                Some("opencode"),
+            )
+            .expect("install linked extension");
+            crate::runtime_package::refresh_shared_assets(&boundary_source)
+                .expect("activate runtime generation boundary");
+
+            relink(
+                "opencode",
+                &new_source.join("agent-runtimes/opencode").to_string_lossy(),
+            )
+            .expect("relink should publish declared runtime assets");
+
+            assert!(home
+                .join(".config/homeboy/agent-runtimes/sample-runtime/scripts/agent/sample-runtime-agent-task-executor.cjs")
+                .exists());
+            assert_eq!(
+                fs::read_link(home.join(".config/homeboy/extensions/opencode"))
+                    .expect("read replacement link"),
+                new_source.join("agent-runtimes/opencode")
+            );
+        });
+    }
+
+    #[test]
+    fn relink_malformed_runtime_root_preserves_active_generation_and_link() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let old_source = home.join("old-source");
+            let new_source = home.join("new-source");
+            let boundary_source = home.join("boundary-source");
+            write_extension_fixture(&old_source, "opencode");
+            write_extension_fixture_with_version(
+                &new_source.join("agent-runtimes"),
+                "opencode",
+                "2.0.0",
+            );
+            fs::write(new_source.join("homeboy-extension-root.json"), "not json")
+                .expect("malformed root manifest");
+            fs::create_dir_all(&boundary_source).expect("boundary source");
+            write_shared_asset_manifest(&boundary_source, &[]);
+
+            install(
+                &old_source.join("opencode").to_string_lossy(),
+                Some("opencode"),
+            )
+            .expect("install linked extension");
+            crate::runtime_package::refresh_shared_assets(&boundary_source)
+                .expect("activate runtime generation boundary");
+            let current = fs::read_link(home.join(".config/homeboy/runtime-generations/current"))
+                .expect("active generation");
+
+            relink(
+                "opencode",
+                &new_source.join("agent-runtimes/opencode").to_string_lossy(),
+            )
+            .expect_err("malformed root manifest should reject relink");
+
+            assert_eq!(
+                fs::read_link(home.join(".config/homeboy/runtime-generations/current"))
+                    .expect("preserved generation"),
+                current
+            );
+            assert_eq!(
+                fs::read_link(home.join(".config/homeboy/extensions/opencode"))
+                    .expect("preserved extension link"),
+                old_source.join("opencode")
+            );
+        });
+    }
+
+    #[test]
     fn replace_from_monorepo_root_with_id_materializes_declared_shared_agent_runtimes() {
         with_isolated_home(|home| {
             let home = home.path();


### PR DESCRIPTION
## Summary

- resolve canonical `agent-runtimes/<id>` package paths to their owning extension repository root
- invoke immutable shared-runtime generation refresh only when a root manifest exists
- preserve both the active runtime generation and extension link when a declared root is malformed

This lets `extension relink` and `extension refresh` stage repository-level runtime dependencies atomically from a nested runtime package path.

Closes #14094.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-core extension::lifecycle:: -- --nocapture` (78 passed)
- `cargo test -p homeboy-core runtime_package::tests:: -- --nocapture` (10 passed, 1 opt-in ignored)
- `HOMEBOY_OPENCODE_RUNTIME_SOURCE=<patched-homeboy-extensions> cargo test -p homeboy-core runtime_package::tests::installed_opencode_boundary_suite_runs_without_source_siblings -- --ignored --nocapture`
- `cargo build --bin homeboy`
- corrected binary successfully refreshed the real nested OpenCode runtime package at source revision `3bd2f8fd`
- global `homeboy agent-task providers --backend opencode --selector opencode.agent-task-executor --model openai/gpt-5.6-terra --validate-readiness --full` returned `Status: ready` with every dispatchability check passing
- `git diff --check`

`cargo clippy -p homeboy-core --lib -- -D warnings` remains blocked by 27 pre-existing `origin/main` findings outside this diff; Clippy reported no changed-file finding.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode reproduced the nested runtime lifecycle failure, traced root resolution and immutable generation behavior, implemented the generic repair and atomicity coverage, and performed live end-to-end verification under Chris Huber’s direction.