### PR TITLE
Make reverse-runner submission envelope-first

### DIFF
--- a/crates/contracts/homeboy-runner-contract/src/discovery.rs
+++ b/crates/contracts/homeboy-runner-contract/src/discovery.rs
@@ -89,6 +89,7 @@ pub enum RunnerApiOperationFailureCode {
     InvalidRequestSchema,
     UnsupportedApiVersion,
     RunnerNotFound,
+    SubmissionRejected,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/contracts/homeboy-runner-contract/src/lib.rs
+++ b/crates/contracts/homeboy-runner-contract/src/lib.rs
@@ -14,6 +14,7 @@ pub mod path_materialization;
 mod resource;
 pub mod secret_env_plan;
 mod session;
+mod submission;
 mod workspace;
 
 pub use artifact::{RunnerArtifactRef, RunnerMutationArtifacts};
@@ -46,6 +47,10 @@ pub use resource::{
 pub use session::{
     RunnerProxyForward, RunnerSession, RunnerSessionRole, RunnerSessionState, RunnerTunnelMode,
     RunnerTunnelProcessStartIdentity,
+};
+pub use submission::{
+    RunnerApiSubmitOutcome, RunnerApiSubmitRequest, RunnerApiSubmitResponse,
+    RUNNER_API_SUBMIT_REQUEST_SCHEMA, RUNNER_API_SUBMIT_RESPONSE_SCHEMA,
 };
 pub use workspace::{
     ByteFileCounts, RunnerWorkspaceCurrentSummary, RunnerWorkspaceLease, RunnerWorkspaceSyncMode,

--- a/crates/contracts/homeboy-runner-contract/src/submission.rs
+++ b/crates/contracts/homeboy-runner-contract/src/submission.rs
@@ -1,0 +1,105 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{RunnerApiOperationFailure, RunnerApiVersion, RunnerExecutionEnvelope};
+
+pub const RUNNER_API_SUBMIT_REQUEST_SCHEMA: &str = "homeboy/runner-api-submit-request/v1";
+pub const RUNNER_API_SUBMIT_RESPONSE_SCHEMA: &str = "homeboy/runner-api-submit-response/v1";
+
+/// The transport-neutral admission request for one canonical runner execution.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerApiSubmitRequest {
+    pub schema: String,
+    pub api_version: RunnerApiVersion,
+    pub submission_key: String,
+    pub envelope: RunnerExecutionEnvelope,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_claim_binding: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_owner_lease: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerApiSubmitResponse {
+    pub schema: String,
+    pub api_version: RunnerApiVersion,
+    pub outcome: RunnerApiSubmitOutcome,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum RunnerApiSubmitOutcome {
+    Accepted { job_id: String, job_status: String },
+    Rejected { failure: RunnerApiOperationFailure },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{RunnerApiOperationFailureCode, RUNNER_API_V1};
+
+    #[test]
+    fn submit_request_has_a_strict_versioned_wire_shape() {
+        let request = RunnerApiSubmitRequest {
+            schema: RUNNER_API_SUBMIT_REQUEST_SCHEMA.to_string(),
+            api_version: RUNNER_API_V1,
+            submission_key: "agent-task:v1:lab:run-1".to_string(),
+            envelope: RunnerExecutionEnvelope::planned("run-1", "test"),
+            workspace_claim_binding: None,
+            workspace_owner_lease: None,
+        };
+        let value = serde_json::to_value(&request).expect("submit request JSON");
+        assert_eq!(value["schema"], RUNNER_API_SUBMIT_REQUEST_SCHEMA);
+        assert!(serde_json::from_value::<RunnerApiSubmitRequest>(value).is_ok());
+        assert!(
+            serde_json::from_value::<RunnerApiSubmitRequest>(serde_json::json!({
+                "schema": RUNNER_API_SUBMIT_REQUEST_SCHEMA,
+                "api_version": { "major": 1 },
+                "submission_key": "one",
+                "envelope": RunnerExecutionEnvelope::planned("one", "test"),
+                "unexpected": true,
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn submit_outcomes_have_explicit_accepted_and_rejected_wire_shapes() {
+        let accepted = RunnerApiSubmitResponse {
+            schema: RUNNER_API_SUBMIT_RESPONSE_SCHEMA.to_string(),
+            api_version: RUNNER_API_V1,
+            outcome: RunnerApiSubmitOutcome::Accepted {
+                job_id: "job-1".to_string(),
+                job_status: "queued".to_string(),
+            },
+        };
+        assert_eq!(
+            serde_json::to_value(accepted).expect("accepted JSON"),
+            serde_json::json!({
+                "schema": RUNNER_API_SUBMIT_RESPONSE_SCHEMA,
+                "api_version": { "major": 1 },
+                "outcome": { "status": "accepted", "job_id": "job-1", "job_status": "queued" },
+            })
+        );
+        let rejected = RunnerApiSubmitResponse {
+            schema: RUNNER_API_SUBMIT_RESPONSE_SCHEMA.to_string(),
+            api_version: RUNNER_API_V1,
+            outcome: RunnerApiSubmitOutcome::Rejected {
+                failure: RunnerApiOperationFailure {
+                    code: RunnerApiOperationFailureCode::SubmissionRejected,
+                    message: "payload drift".to_string(),
+                },
+            },
+        };
+        assert_eq!(
+            serde_json::to_value(rejected).expect("rejected JSON"),
+            serde_json::json!({
+                "schema": RUNNER_API_SUBMIT_RESPONSE_SCHEMA,
+                "api_version": { "major": 1 },
+                "outcome": { "status": "rejected", "failure": { "code": "submission_rejected", "message": "payload drift" } },
+            })
+        );
+    }
+}

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
@@ -8,6 +8,7 @@
 
 use super::*;
 use homeboy_core::api_jobs::RemoteRunnerJobRequest;
+use homeboy_runner_contract::RunnerApiSubmitRequest;
 
 // The ambient `reconcile_active_lab_runner_handoffs()` shim that used to sit
 // above this resolved a root and delegated straight here. It had no callers, so
@@ -262,8 +263,20 @@ pub fn reconcile_pending_runner_submission_intent_in_store(
     metadata["durable_run_id"] = json!(run_id);
     metadata["reconciled_from"] = json!("durable_detached_handoff_intent");
     request.metadata = Some(metadata);
-    match runner_continuation::with_runner_continuation(|provider| {
-        provider.submit_reverse_broker_job(&runner_id, request)
+    let envelope_request = intent
+        .get("replay_envelope_request")
+        .cloned()
+        .map(serde_json::from_value::<RunnerApiSubmitRequest>)
+        .transpose()
+        .map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("parse envelope runner replay request".to_string()),
+            )
+        })?;
+    match runner_continuation::with_runner_continuation(|provider| match envelope_request {
+        Some(request) => provider.submit_reverse_broker_envelope_job(&runner_id, request),
+        None => provider.submit_reverse_broker_job(&runner_id, request),
     }) {
         Ok(job) => {
             record_detached_lab_run_in_store(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
@@ -17,6 +17,7 @@ use homeboy_core::api_jobs::{
 };
 use homeboy_core::error::{Error, Result};
 use homeboy_core::workspace_claim::{WorkspaceClaim, WorkspaceIdentity};
+use homeboy_runner_contract::RunnerApiSubmitRequest;
 
 /// Result of reconciling a runner job across its known daemon generations.
 ///
@@ -194,6 +195,35 @@ pub trait RunnerContinuationProvider: Send + Sync {
         request: RemoteRunnerJobRequest,
     ) -> Result<Job>;
 
+    fn submit_reverse_broker_envelope_job(
+        &self,
+        runner_id: &str,
+        request: RunnerApiSubmitRequest,
+    ) -> Result<Job> {
+        let mut legacy = homeboy_core::api_jobs::legacy_request_from_envelope(&request.envelope)?;
+        legacy.workspace_claim_binding = request
+            .workspace_claim_binding
+            .map(serde_json::from_value)
+            .transpose()
+            .map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("decode replay workspace claim binding".to_string()),
+                )
+            })?;
+        legacy.workspace_owner_lease = request
+            .workspace_owner_lease
+            .map(serde_json::from_value)
+            .transpose()
+            .map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("decode replay workspace owner lease".to_string()),
+                )
+            })?;
+        self.submit_reverse_broker_job(runner_id, legacy)
+    }
+
     fn lookup_reverse_broker_submission(
         &self,
         _runner_id: &str,
@@ -357,9 +387,48 @@ impl Drop for RunnerContinuationTestGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
 
     struct LegacyProvider {
         runner_exists: bool,
+    }
+
+    #[derive(Default)]
+    struct AuthorityCaptureProvider {
+        submitted: Mutex<Option<RemoteRunnerJobRequest>>,
+    }
+
+    impl RunnerContinuationProvider for AuthorityCaptureProvider {
+        fn runner_job_log_snapshot(
+            &self,
+            _runner_id: &str,
+            _job_id: &str,
+        ) -> Result<RunnerJobLogSnapshot> {
+            Err(Error::internal_unexpected("unused in fixture"))
+        }
+
+        fn is_runner_connected(&self, _runner_id: &str) -> bool {
+            false
+        }
+
+        fn run_continuation_exec(
+            &self,
+            _runner_id: &str,
+            _cwd: &str,
+            _command: &[String],
+            _run_id: &str,
+        ) -> Result<i32> {
+            Err(Error::internal_unexpected("unused in fixture"))
+        }
+
+        fn submit_reverse_broker_job(
+            &self,
+            _runner_id: &str,
+            request: RemoteRunnerJobRequest,
+        ) -> Result<Job> {
+            *self.submitted.lock().expect("capture submission") = Some(request);
+            Err(Error::internal_unexpected("submission captured"))
+        }
     }
 
     impl RunnerContinuationProvider for LegacyProvider {
@@ -425,5 +494,58 @@ mod tests {
             .runner_authority("legacy-runner"),
             RunnerAuthority::Unknown
         );
+    }
+
+    #[test]
+    fn default_envelope_adapter_preserves_workspace_authority_sidecars() {
+        use homeboy_core::workspace_claim::{
+            WorkspaceClaimBinding, WorkspaceIdentity, WorkspaceOwnerLease,
+            WorkspaceOwnerLeaseProtocol, WORKSPACE_OWNER_LEASE_SCHEMA,
+        };
+
+        let workspace = WorkspaceIdentity::new("git", "example/repo").expect("workspace");
+        let claim_binding = WorkspaceClaimBinding {
+            workspace: workspace.clone(),
+            lifecycle_revision: 7,
+            claim: None,
+        };
+        let owner_lease = WorkspaceOwnerLease {
+            schema: WORKSPACE_OWNER_LEASE_SCHEMA.to_string(),
+            protocol: WorkspaceOwnerLeaseProtocol::current(),
+            workspace,
+            owner_id: "agent-task:test".to_string(),
+            lifecycle_revision: 7,
+            token: "lease-token".to_string(),
+            expires_at_ms: u64::MAX,
+        };
+        let legacy: RemoteRunnerJobRequest = serde_json::from_value(serde_json::json!({
+            "runner_id": "lab",
+            "command": ["homeboy", "test"]
+        }))
+        .expect("legacy request");
+        let request = RunnerApiSubmitRequest {
+            schema: homeboy_runner_contract::RUNNER_API_SUBMIT_REQUEST_SCHEMA.to_string(),
+            api_version: homeboy_runner_contract::RUNNER_API_V1,
+            submission_key: "agent-task:v1:lab:test".to_string(),
+            envelope: legacy.execution_envelope(),
+            workspace_claim_binding: Some(
+                serde_json::to_value(&claim_binding).expect("claim binding"),
+            ),
+            workspace_owner_lease: Some(serde_json::to_value(&owner_lease).expect("owner lease")),
+        };
+        let provider = AuthorityCaptureProvider::default();
+
+        provider
+            .submit_reverse_broker_envelope_job("lab", request)
+            .expect_err("fixture stops after capture");
+
+        let submitted = provider
+            .submitted
+            .lock()
+            .expect("captured submission")
+            .clone()
+            .expect("submitted request");
+        assert_eq!(submitted.workspace_claim_binding, Some(claim_binding));
+        assert_eq!(submitted.workspace_owner_lease, Some(owner_lease));
     }
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
@@ -1276,3 +1276,19 @@ pub fn record_lab_offload_submission_request(
     lifecycle_store.write_record(&record)?;
     Ok(record)
 }
+
+/// Persist the envelope-first replay input before it crosses the broker.
+pub fn record_lab_offload_submission_envelope(
+    run_id: &str,
+    request: &homeboy_runner_contract::RunnerApiSubmitRequest,
+) -> Result<AgentTaskRunRecord> {
+    let legacy = homeboy_core::api_jobs::legacy_request_from_envelope(&request.envelope)?;
+    let record = record_lab_offload_submission_request(run_id, &legacy)?;
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    lifecycle_store.mutate_record(run_id, |record| {
+        record.ensure_metadata_object()["runner_submission_intent"]["replay_envelope_request"] =
+            serde_json::to_value(request).expect("serialize envelope replay request");
+        true
+    })?;
+    Ok(record)
+}

--- a/crates/homeboy-core/src/api_jobs/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/mod.rs
@@ -13,9 +13,10 @@ use homeboy_api_jobs_contract::types;
 pub use crate::runner_job_execution_context::RunnerJobExecutionContext;
 pub(crate) use persistence::timestamp_ms;
 pub use remote_runner::{
-    JobArtifactMetadata, RemoteRunnerClaimProtocols, RemoteRunnerJobClaim, RemoteRunnerJobRequest,
-    RemoteRunnerJobResult, RemoteRunnerObservationRunDetail, RemoteRunnerSubmissionLookup,
-    RunnerJobLifecycleMetadata, RunnerJobProjectionCancelRequest,
+    legacy_request_from_envelope, JobArtifactMetadata, RemoteRunnerClaimProtocols,
+    RemoteRunnerJobClaim, RemoteRunnerJobRequest, RemoteRunnerJobResult,
+    RemoteRunnerObservationRunDetail, RemoteRunnerSubmissionLookup, RunnerJobLifecycleMetadata,
+    RunnerJobProjectionCancelRequest,
 };
 pub(crate) use runner_job_preparation::with_runner_job_preparation;
 pub use runner_job_preparation::{

--- a/crates/homeboy-core/src/api_jobs/persistence.rs
+++ b/crates/homeboy-core/src/api_jobs/persistence.rs
@@ -370,8 +370,11 @@ pub(super) fn read_durable_store(path: &Path) -> Result<DurableJobStore> {
 
     let content = fs::read_to_string(path)
         .map_err(|e| Error::internal_io(e.to_string(), Some(format!("read {}", path.display()))))?;
-    match serde_json::from_str(&content) {
-        Ok(store) => Ok(store),
+    match serde_json::from_str::<DurableJobStore>(&content) {
+        Ok(store) => {
+            super::remote_runner::validate_stored_remote_runner_jobs(&store.jobs)?;
+            Ok(store)
+        }
         Err(err) => {
             let quarantine_path = path.with_file_name(format!(
                 "{}.corrupt-{}",
@@ -685,9 +688,11 @@ pub(super) fn stale_after_restart_classification(stored: &StoredJob) -> Value {
     let linked_agent_task_run_id = stored
         .remote_runner
         .as_ref()
-        .and_then(|remote_runner| remote_runner.request.lab_runner_workload.as_ref())
-        .and_then(|workload| workload.agent_task.as_ref())
-        .map(|agent_task| agent_task.run_id.trim())
+        .and_then(|remote_runner| remote_runner.request().ok())
+        .and_then(|request| request.lab_runner_workload)
+        .as_ref()
+        .and_then(|workload| workload.agent_task.clone())
+        .map(|agent_task| agent_task.run_id.trim().to_string())
         .filter(|run_id| !run_id.is_empty());
 
     serde_json::json!({
@@ -706,15 +711,15 @@ pub(super) fn stale_after_restart_classification(stored: &StoredJob) -> Value {
             "terminal_result_recorded": false,
             "last_known_event": last_child_event.map(last_known_child_event),
             "output_observed": last_child_event.is_some(),
-            "linked_durable_run": linked_agent_task_run_id.map(|run_id| serde_json::json!({
+            "linked_durable_run": linked_agent_task_run_id.as_deref().map(|run_id| serde_json::json!({
                 "kind": "agent_task",
                 "run_id": run_id,
                 "terminal_result_observed": false,
             })),
         },
         "remote_runner": stored.remote_runner.as_ref().map(|remote_runner| serde_json::json!({
-            "runner_id": remote_runner.request.runner_id.clone(),
-            "project_id": remote_runner.request.project_id.clone(),
+            "runner_id": remote_runner.request().ok().map(|request| request.runner_id),
+            "project_id": remote_runner.request().ok().and_then(|request| request.project_id),
             "claim_id": stored.job.claim_id.clone(),
             "claimed_by_runner_id": stored.job.claimed_by_runner_id.clone(),
             "claimed_at_ms": stored.job.claimed_at_ms,

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -25,7 +25,8 @@ use crate::secret_env_plan::SecretEnvPlan;
 use crate::source_snapshot::SourceSnapshot;
 use homeboy_lab_contract::lab::execution_envelope::runner_execution_envelope_from_workload;
 use homeboy_runner_contract::{
-    is_internal_control_env, RunnerMutationArtifacts, RunnerResourceMetrics,
+    is_internal_control_env, RunnerApiSubmitRequest, RunnerMutationArtifacts,
+    RunnerResourceMetrics, RUNNER_API_SUBMIT_REQUEST_SCHEMA, RUNNER_API_V1,
 };
 
 /// Broker metadata is durable queue input. Keep command-file payloads bounded
@@ -306,6 +307,13 @@ impl RemoteRunnerJobRequest {
         public
     }
 
+    /// Validate and normalize a request before it can be serialized into any
+    /// durable reverse-runner submission representation.
+    pub fn validate_durable_submission(&mut self) -> Result<()> {
+        let secret_env_plan = self.normalize();
+        reject_inline_durable_secret_env(self, &secret_env_plan)
+    }
+
     fn validate_command_assets(&self) -> Result<()> {
         let Some(assets) = self
             .metadata
@@ -430,6 +438,9 @@ fn merge_metadata_value(mut metadata: Value, key: &str, value: Value) -> Value {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RemoteRunnerJobClaim {
     pub job: Job,
+    pub envelope: RunnerExecutionEnvelope,
+    /// Derived compatibility and authority projection. The envelope is the only
+    /// authoritative execution payload; workers must execute `envelope`.
     pub request: RemoteRunnerJobRequest,
     /// Authenticated execution authority derived from this durable claim.
     /// Older brokers omit it on the wire; workers refuse those claims rather
@@ -573,9 +584,14 @@ impl RemoteRunnerJobResult {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(super) struct StoredRemoteRunnerJob {
-    #[serde(default, skip)]
-    pub(super) execution_request: Option<RemoteRunnerJobRequest>,
-    pub(super) request: RemoteRunnerJobRequest,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) envelope: Option<RunnerExecutionEnvelope>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) request: Option<RemoteRunnerJobRequest>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) workspace_claim_binding: Option<crate::workspace_claim::WorkspaceClaimBinding>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) workspace_owner_lease: Option<crate::workspace_claim::WorkspaceOwnerLease>,
     /// Presence records that this claim carried an authenticated execution
     /// context. Its absence is the persisted compatibility signal for legacy
     /// context-free claims.
@@ -585,6 +601,206 @@ pub(super) struct StoredRemoteRunnerJob {
     /// provider boundary after the worker has materialized its inputs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) execution_receipt: Option<RemoteRunnerExecutionReceipt>,
+}
+
+impl StoredRemoteRunnerJob {
+    pub(super) fn validate_representation(&self) -> Result<()> {
+        match (self.envelope.is_some(), self.request.is_some()) {
+            (true, false) | (false, true) => Ok(()),
+            (true, true) => Err(Error::internal_unexpected(
+                "remote runner job has conflicting envelope and legacy request representations",
+            )),
+            (false, false) => Err(Error::internal_unexpected(
+                "remote runner job has no execution representation",
+            )),
+        }
+    }
+
+    pub(super) fn request(&self) -> Result<RemoteRunnerJobRequest> {
+        self.validate_representation()?;
+        if let Some(request) = &self.request {
+            return Ok(request.clone());
+        }
+        self.envelope
+            .as_ref()
+            .ok_or_else(|| {
+                Error::internal_unexpected("remote runner job has no execution representation")
+            })
+            .and_then(legacy_request_from_envelope)
+    }
+
+    pub(super) fn envelope(&self) -> Result<RunnerExecutionEnvelope> {
+        self.validate_representation()?;
+        self.envelope
+            .clone()
+            .or_else(|| {
+                self.request
+                    .as_ref()
+                    .map(RemoteRunnerJobRequest::execution_envelope)
+            })
+            .ok_or_else(|| {
+                Error::internal_unexpected("remote runner job has no execution representation")
+            })
+    }
+
+    pub(super) fn workspace_owner_lease(
+        &self,
+    ) -> Option<crate::workspace_claim::WorkspaceOwnerLease> {
+        if self.envelope.is_some() {
+            self.workspace_owner_lease.clone()
+        } else {
+            self.request
+                .as_ref()
+                .and_then(|request| request.workspace_owner_lease.clone())
+        }
+    }
+
+    pub(super) fn replace_workspace_owner_lease(
+        &mut self,
+        expected: Option<&crate::workspace_claim::WorkspaceOwnerLease>,
+        renewed: Option<crate::workspace_claim::WorkspaceOwnerLease>,
+    ) -> Result<()> {
+        self.validate_representation()?;
+        if self.envelope.is_some() {
+            if self.workspace_owner_lease.as_ref() != expected {
+                return Err(Error::validation_invalid_argument(
+                    "workspace_owner_lease",
+                    "heartbeat owner lease does not match the durable job",
+                    None,
+                    None,
+                ));
+            }
+            self.workspace_owner_lease = renewed;
+            return Ok(());
+        }
+        if let Some(request) = self.request.as_mut() {
+            if request.workspace_owner_lease.as_ref() == expected {
+                request.workspace_owner_lease = renewed;
+                return Ok(());
+            }
+        }
+        Err(Error::validation_invalid_argument(
+            "workspace_owner_lease",
+            "heartbeat owner lease does not match the durable job",
+            None,
+            None,
+        ))
+    }
+}
+
+fn redacted_envelope_for_durable_replay(
+    mut envelope: RunnerExecutionEnvelope,
+) -> RunnerExecutionEnvelope {
+    let secret_env_names = envelope
+        .secret_env
+        .as_ref()
+        .map(SecretEnvPlan::secret_env_names)
+        .unwrap_or_default()
+        .into_iter()
+        .collect::<HashSet<_>>();
+    if let Some(dispatch) = envelope.dispatch.as_mut() {
+        dispatch
+            .env
+            .retain(|name, _| !is_internal_control_env(name));
+        for (name, value) in &mut dispatch.env {
+            if secret_env_names.contains(name) {
+                *value = "<redacted>".to_string();
+            }
+        }
+    }
+    envelope
+}
+
+fn envelope_submission_payload_fingerprint(
+    envelope: &RunnerExecutionEnvelope,
+    workspace_claim_binding: &Option<crate::workspace_claim::WorkspaceClaimBinding>,
+    workspace_owner_lease: &Option<crate::workspace_claim::WorkspaceOwnerLease>,
+) -> Result<String> {
+    let bytes = serde_json::to_vec(&serde_json::json!({
+        "schema": "homeboy/runner-api-submission-payload/v1",
+        "envelope": envelope,
+        "workspace_claim_binding": workspace_claim_binding,
+        "workspace_owner_lease": workspace_owner_lease,
+    }))
+    .map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("fingerprint runner envelope submission".to_string()),
+        )
+    })?;
+    Ok(format!("sha256:{}", content_hash::sha256_hex(&bytes)))
+}
+
+pub(super) fn validate_stored_remote_runner_jobs(
+    jobs: impl IntoIterator<Item = impl std::borrow::Borrow<StoredJob>>,
+) -> Result<()> {
+    for stored in jobs {
+        if let Some(remote) = stored.borrow().remote_runner.as_ref() {
+            remote.validate_representation()?;
+        }
+    }
+    Ok(())
+}
+
+pub fn legacy_request_from_envelope(
+    envelope: &RunnerExecutionEnvelope,
+) -> Result<RemoteRunnerJobRequest> {
+    let dispatch = envelope.dispatch.as_ref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "envelope.dispatch",
+            "runner submission envelope requires dispatch",
+            None,
+            None,
+        )
+    })?;
+    let path_materialization_plan = envelope
+        .metadata
+        .get("path_materialization_plan")
+        .cloned()
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("decode envelope path materialization plan".to_string()),
+            )
+        })?;
+    let lab_runner_workload = envelope
+        .runner_workload
+        .clone()
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("decode envelope runner workload".to_string()),
+            )
+        })?;
+    Ok(RemoteRunnerJobRequest {
+        runner_id: dispatch.runner_id.clone(),
+        project_id: dispatch.project_id.clone(),
+        operation: dispatch.operation.clone(),
+        command: dispatch.command.clone(),
+        cwd: dispatch.cwd.clone(),
+        env: dispatch.env.clone(),
+        secret_env_names: envelope
+            .secret_env
+            .as_ref()
+            .map(SecretEnvPlan::secret_env_names)
+            .unwrap_or_default(),
+        secret_env_plan: envelope.secret_env.clone().unwrap_or_default(),
+        env_materialization: envelope.env_materialization.clone(),
+        capture_patch: envelope.mutation_policy.capture_patch,
+        source_snapshot: dispatch.source_snapshot.clone(),
+        path_materialization_plan,
+        require_paths: dispatch.require_paths.clone(),
+        extension_env_providers: dispatch.extension_env_providers.clone(),
+        lab_runner_workload,
+        lifecycle: envelope.lifecycle.clone(),
+        workspace_claim_binding: None,
+        workspace_owner_lease: None,
+        metadata: (!envelope.metadata.is_null()).then(|| envelope.metadata.clone()),
+    })
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -626,10 +842,12 @@ impl JobStore {
             .jobs
             .get(&job_id)
             .ok_or_else(|| job_not_found(job_id))?;
-        Ok(stored
-            .remote_runner
-            .as_ref()
-            .and_then(|remote| remote.request.workspace_claim_binding.clone()))
+        Ok(stored.remote_runner.as_ref().and_then(|remote| {
+            remote
+                .workspace_claim_binding
+                .clone()
+                .or_else(|| remote.request().ok()?.workspace_claim_binding)
+        }))
     }
 
     pub fn remote_runner_workspace_owner_lease(
@@ -644,7 +862,7 @@ impl JobStore {
         Ok(stored
             .remote_runner
             .as_ref()
-            .and_then(|remote| remote.request.workspace_owner_lease.clone()))
+            .and_then(|remote| remote.workspace_owner_lease()))
     }
 
     pub fn lookup_remote_runner_submission(
@@ -667,7 +885,81 @@ impl JobStore {
         RemoteRunnerSubmissionLookup::Absent
     }
 
-    pub fn submit_remote_runner_job(&self, mut request: RemoteRunnerJobRequest) -> Result<Job> {
+    /// Legacy request admission retained only for existing persisted intents and
+    /// callers that have not migrated to the envelope-first Runner API.
+    pub fn submit_remote_runner_job(&self, request: RemoteRunnerJobRequest) -> Result<Job> {
+        self.submit_remote_runner_job_inner(request, None, None)
+    }
+
+    pub fn submit_runner_api_request(&self, submission: RunnerApiSubmitRequest) -> Result<Job> {
+        if submission.schema != RUNNER_API_SUBMIT_REQUEST_SCHEMA
+            || submission.api_version != RUNNER_API_V1
+        {
+            return Err(Error::validation_invalid_argument(
+                "schema",
+                "unsupported Runner API submit request",
+                Some(submission.schema),
+                None,
+            ));
+        }
+        if submission.submission_key.trim().is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "submission_key",
+                "runner submission requires a caller-owned idempotency key",
+                None,
+                None,
+            ));
+        }
+        let envelope = redacted_envelope_for_durable_replay(submission.envelope);
+        let mut request = legacy_request_from_envelope(&envelope)?;
+        let mut metadata = request
+            .metadata
+            .take()
+            .unwrap_or_else(|| serde_json::json!({}));
+        if !metadata.is_object() {
+            metadata = serde_json::json!({});
+        }
+        metadata["submission_key"] = serde_json::json!(submission.submission_key);
+        request.metadata = Some(metadata);
+        request.workspace_claim_binding = submission
+            .workspace_claim_binding
+            .map(serde_json::from_value)
+            .transpose()
+            .map_err(|error| {
+                Error::validation_invalid_argument(
+                    "workspace_claim_binding",
+                    error.to_string(),
+                    None,
+                    None,
+                )
+            })?;
+        request.workspace_owner_lease = submission
+            .workspace_owner_lease
+            .map(serde_json::from_value)
+            .transpose()
+            .map_err(|error| {
+                Error::validation_invalid_argument(
+                    "workspace_owner_lease",
+                    error.to_string(),
+                    None,
+                    None,
+                )
+            })?;
+        let fingerprint = envelope_submission_payload_fingerprint(
+            &envelope,
+            &request.workspace_claim_binding,
+            &request.workspace_owner_lease,
+        )?;
+        self.submit_remote_runner_job_inner(request, Some(envelope), Some(fingerprint))
+    }
+
+    fn submit_remote_runner_job_inner(
+        &self,
+        mut request: RemoteRunnerJobRequest,
+        envelope: Option<RunnerExecutionEnvelope>,
+        supplied_submission_fingerprint: Option<String>,
+    ) -> Result<Job> {
+        let envelope_first = envelope.is_some();
         if request.runner_id.trim().is_empty() {
             return Err(Error::validation_invalid_argument(
                 "runner_id",
@@ -691,8 +983,8 @@ impl JobStore {
         if let Some(lease) = request.workspace_owner_lease.as_ref() {
             lease.verify_shape(timestamp_ms())?;
         }
-        let secret_env_plan = request.normalize();
-        reject_inline_durable_secret_env(&request, &secret_env_plan)?;
+        request.validate_durable_submission()?;
+        let secret_env_plan = request.secret_env_plan.clone();
         super::with_runner_job_preparation(|p| {
             p.validate_lab_runner_workload_dispatch(
                 request.lab_runner_workload.as_ref(),
@@ -709,7 +1001,10 @@ impl JobStore {
         let submission_key = request.submission_key().map(str::to_string);
         let submission_fingerprint = submission_key
             .as_ref()
-            .map(|_| request.submission_payload_fingerprint())
+            .map(|_| match supplied_submission_fingerprint {
+                Some(fingerprint) => Ok(fingerprint),
+                None => request.submission_payload_fingerprint(),
+            })
             .transpose()?;
         self.durable_transaction(|inner| {
         if let Some(submission_key) = submission_key.as_deref() {
@@ -833,8 +1128,14 @@ impl JobStore {
                     // Durable broker state intentionally contains only the
                     // redacted request. The runner hydrates named references
                     // immediately before dispatch.
-                    execution_request: None,
-                    request: public_request,
+                    envelope,
+                    request: (!envelope_first).then_some(public_request),
+                    workspace_claim_binding: envelope_first
+                        .then(|| request.workspace_claim_binding.clone())
+                        .flatten(),
+                    workspace_owner_lease: envelope_first
+                        .then(|| request.workspace_owner_lease.clone())
+                        .flatten(),
                     execution_context_id: None,
                     execution_receipt: None,
                 }),
@@ -1000,7 +1301,7 @@ impl JobStore {
                 .next()
                 .map(|candidate| candidate.job.id)
             {
-                let (job, request) = {
+                let (job, request, envelope) = {
                     let stored = inner.jobs.get_mut(&job_id).expect("candidate exists");
                     stored.job.status = JobStatus::Running;
                     stored.job.updated_at_ms = now;
@@ -1013,12 +1314,11 @@ impl JobStore {
                         .remote_runner
                         .as_ref()
                         .expect("filtered remote runner job has request");
-                    let request = remote_runner
-                        .execution_request
-                        .as_ref()
-                        .unwrap_or(&remote_runner.request)
-                        .dispatch_request();
-                    (stored.job.clone(), request)
+                    let mut request = remote_runner.request()?.dispatch_request();
+                    request.workspace_claim_binding = remote_runner.workspace_claim_binding.clone();
+                    request.workspace_owner_lease = remote_runner.workspace_owner_lease();
+                    let envelope = remote_runner.envelope()?;
+                    (stored.job.clone(), request, envelope)
                 };
                 let execution_context = match execution_protocol {
                     Some(protocol) => {
@@ -1074,12 +1374,12 @@ impl JobStore {
                         None => serde_json::json!({ "status": JobStatus::Running }),
                     }),
                 )?;
-                return Ok(Some((job, request, execution_context)));
+                return Ok(Some((job, request, envelope, execution_context)));
             }
             Ok(None)
         })?;
 
-        let Some((job, request, execution_context)) = claimed else {
+        let Some((job, request, envelope, execution_context)) = claimed else {
             return Ok(None);
         };
         let execution_protocol = execution_context
@@ -1093,6 +1393,7 @@ impl JobStore {
             .then(crate::workspace_claim::WorkspaceOwnerLeaseProtocol::current);
         Ok(Some(RemoteRunnerJobClaim {
             job,
+            envelope,
             request,
             execution_context,
             execution_protocol,
@@ -1246,15 +1547,7 @@ impl JobStore {
                 .remote_runner
                 .as_mut()
                 .expect("checked remote runner");
-            if remote.request.workspace_owner_lease.as_ref() != expected_owner_lease {
-                return Err(Error::validation_invalid_argument(
-                    "workspace_owner_lease",
-                    "heartbeat owner lease does not match the durable job",
-                    Some(job_id.to_string()),
-                    None,
-                ));
-            }
-            remote.request.workspace_owner_lease = renewed_owner_lease;
+            remote.replace_workspace_owner_lease(expected_owner_lease, renewed_owner_lease)?;
             stored.job.updated_at_ms = now;
             stored.job.claim_expires_at_ms = Some(now.saturating_add(lease_ms.max(1)));
             Ok(stored.job.clone())
@@ -1307,14 +1600,11 @@ impl JobStore {
                         "runner execution receipt was already consumed",
                     ));
                 }
-                let request = remote_runner
-                    .execution_request
-                    .as_ref()
-                    .unwrap_or(&remote_runner.request);
+                let request = remote_runner.request()?;
                 let expected =
                     crate::runner_job_execution_context::RunnerJobExecutionContext::from_claim(
                         &stored.job,
-                        request,
+                        &request,
                     )?;
                 if expected.id() != context_id {
                     return Err(crate::runner_job_execution_context::rejected(
@@ -1573,12 +1863,7 @@ fn reject_inline_durable_secret_env(
     let inline_secret_names = secret_env_plan
         .secret_env_names()
         .into_iter()
-        .filter(|name| {
-            request
-                .env
-                .get(name)
-                .is_some_and(|value| !value.is_empty() && value != "<redacted>")
-        })
+        .filter(|name| request.env.get(name).is_some_and(|value| !value.is_empty()))
         .collect::<Vec<_>>();
     if inline_secret_names.is_empty() {
         return Ok(());

--- a/crates/homeboy-core/src/api_jobs/store/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/store/mod.rs
@@ -329,6 +329,7 @@ impl JobStore {
         inner: &mut JobStoreInner,
     ) -> Result<()> {
         let durable = read_durable_store(path)?;
+        remote_runner::validate_stored_remote_runner_jobs(&durable.jobs)?;
         let next_sequence = durable
             .jobs
             .iter()
@@ -727,6 +728,7 @@ impl JobStore {
         prepare_tombstone_store(&path)?;
         let mut durable: DurableJobStore = serde_json::from_slice(raw)
             .map_err(|err| Error::config_invalid_json(path.display().to_string(), err))?;
+        remote_runner::validate_stored_remote_runner_jobs(&durable.jobs)?;
         let event_retention_limit = event_retention_limit.max(1);
         let terminal_job_retention_limit = terminal_job_retention_limit.max(1);
         let terminal_job_retention_bytes = terminal_job_retention_bytes.max(1);
@@ -3012,7 +3014,9 @@ fn stored_job_durable_run_id(stored: &StoredJob) -> Option<String> {
     stored
         .remote_runner
         .as_ref()
-        .and_then(|remote| remote.request.lifecycle.as_ref())
+        .and_then(|remote| remote.request().ok())
+        .and_then(|request| request.lifecycle)
+        .as_ref()
         .or_else(|| {
             stored
                 .local_runner
@@ -3043,7 +3047,9 @@ fn recovered_terminal_agent_task_result(stored: &StoredJob) -> Option<RecoveredT
     let run_id = stored
         .remote_runner
         .as_ref()
-        .and_then(|remote| remote.request.lab_runner_workload.as_ref())
+        .and_then(|remote| remote.request().ok())
+        .and_then(|request| request.lab_runner_workload)
+        .as_ref()
         .and_then(|workload| workload.agent_task.as_ref())
         .map(|agent_task| agent_task.run_id.trim().to_string())
         .or_else(|| {

--- a/crates/homeboy-core/src/api_jobs/store/reconciliation.rs
+++ b/crates/homeboy-core/src/api_jobs/store/reconciliation.rs
@@ -478,7 +478,9 @@ impl JobStore {
                 stored
                     .remote_runner
                     .as_ref()
-                    .and_then(|remote| remote.request.lifecycle.as_ref())
+                    .and_then(|remote| remote.request().ok())
+                    .and_then(|request| request.lifecycle)
+                    .as_ref()
                     .and_then(|lifecycle| lifecycle.durable_run_id.clone())
                     .map(LinkedDurableRunResolution::Unresolved)
                     .unwrap_or(LinkedDurableRunResolution::None)
@@ -993,7 +995,7 @@ impl JobStore {
                     .map(|remote| {
                         super::super::summary::active_runner_job_summary(
                             &stored.job,
-                            &remote.request,
+                            &remote.request().expect("remote runner representation"),
                             now,
                         )
                     })
@@ -1052,7 +1054,7 @@ impl JobStore {
                 stored.job.status == JobStatus::Failed && stored.job.stale_reason.is_some()
             })
             .filter_map(|stored| {
-                let request = stored.remote_runner.as_ref()?.request.clone();
+                let request = stored.remote_runner.as_ref()?.request().ok()?;
                 Some(super::super::summary::active_runner_job_summary(
                     &stored.job,
                     &request,

--- a/crates/homeboy-core/src/api_jobs/tests/part_b.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_b.rs
@@ -1373,6 +1373,172 @@ fn remote_runner_submission_key_replays_one_redacted_durable_job() {
 }
 
 #[test]
+fn envelope_submission_replays_and_persists_no_legacy_execution_request() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("jobs.json");
+    let store = JobStore::open_without_reconciliation(&path).expect("durable store");
+    let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
+    request.secret_env_names = vec!["TOKEN".to_string()];
+    let mut envelope = request.execution_envelope();
+    envelope.dispatch.as_mut().expect("dispatch").env.insert(
+        "HOMEBOY_RUNNER_PLACEMENT_RESOLVED".to_string(),
+        "internal".to_string(),
+    );
+    let submission = homeboy_runner_contract::RunnerApiSubmitRequest {
+        schema: homeboy_runner_contract::RUNNER_API_SUBMIT_REQUEST_SCHEMA.to_string(),
+        api_version: homeboy_runner_contract::RUNNER_API_V1,
+        submission_key: "agent-task:v1:envelope".to_string(),
+        envelope,
+        workspace_claim_binding: None,
+        workspace_owner_lease: None,
+    };
+    let accepted = store
+        .submit_runner_api_request(submission.clone())
+        .expect("submit envelope");
+    assert_eq!(
+        store
+            .submit_runner_api_request(submission.clone())
+            .expect("replay envelope")
+            .id,
+        accepted.id
+    );
+    assert!(
+        store
+            .submit_runner_api_request({
+                let mut replay = submission.clone();
+                replay
+                    .envelope
+                    .dispatch
+                    .as_mut()
+                    .expect("dispatch")
+                    .env
+                    .insert("TOKEN".to_string(), "<redacted>".to_string());
+                replay
+            })
+            .is_err(),
+        "redacted secret placeholders cannot reach a worker as inline values"
+    );
+    let persisted: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).expect("durable JSON"))
+            .expect("parse durable JSON");
+    let remote = &persisted["jobs"][0]["remote_runner"];
+    assert!(remote.get("envelope").is_some());
+    assert!(remote.get("request").is_none());
+    assert!(remote["envelope"]["dispatch"]["env"].get("TOKEN").is_none());
+    assert!(remote["envelope"]["dispatch"]["env"]
+        .get("HOMEBOY_RUNNER_PLACEMENT_RESOLVED")
+        .is_none());
+    let mut drift = submission;
+    drift
+        .envelope
+        .dispatch
+        .as_mut()
+        .expect("dispatch")
+        .command
+        .push("drift".to_string());
+    assert!(store.submit_runner_api_request(drift).is_err());
+    let claim = store
+        .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, None)
+        .expect("claim envelope")
+        .expect("claimed envelope");
+    assert_eq!(
+        claim.envelope.dispatch.as_ref().expect("dispatch").command,
+        request.command
+    );
+}
+
+#[test]
+fn durable_remote_runner_representation_rejects_dual_or_empty_payloads() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("jobs.json");
+    let store = JobStore::open_without_reconciliation(&path).expect("durable store");
+    let request = remote_runner_request("homeboy-lab", None);
+    store
+        .submit_remote_runner_job(request.clone())
+        .expect("legacy submit");
+    let mut dual: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).expect("store JSON"))
+            .expect("parse store JSON");
+    dual["jobs"][0]["remote_runner"]["envelope"] =
+        serde_json::to_value(request.execution_envelope()).expect("envelope JSON");
+    assert!(JobStore::open_without_reconciliation_from_bytes(
+        temp.path().join("dual.json"),
+        &serde_json::to_vec(&dual).expect("dual JSON"),
+    )
+    .is_err());
+
+    let mut empty = dual;
+    empty["jobs"][0]["remote_runner"]
+        .as_object_mut()
+        .expect("remote job")
+        .remove("envelope");
+    empty["jobs"][0]["remote_runner"]
+        .as_object_mut()
+        .expect("remote job")
+        .remove("request");
+    assert!(JobStore::open_without_reconciliation_from_bytes(
+        temp.path().join("empty.json"),
+        &serde_json::to_vec(&empty).expect("empty JSON"),
+    )
+    .is_err());
+}
+
+#[test]
+fn legacy_request_workspace_owner_lease_renews_in_its_legacy_representation() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("jobs.json");
+    let store = JobStore::open_without_reconciliation(&path).expect("durable store");
+    let workspace = crate::workspace_claim::WorkspaceIdentity::new("test", "legacy-owner")
+        .expect("workspace identity");
+    let lease = crate::workspace_claim::WorkspaceOwnerLease {
+        schema: crate::workspace_claim::WORKSPACE_OWNER_LEASE_SCHEMA.to_string(),
+        protocol: crate::workspace_claim::WorkspaceOwnerLeaseProtocol::current(),
+        workspace,
+        owner_id: "owner".to_string(),
+        lifecycle_revision: 1,
+        token: "legacy-token".to_string(),
+        expires_at_ms: crate::api_jobs::timestamp_ms() + 60_000,
+    };
+    let job = store
+        .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
+        .expect("legacy submit");
+    let claim = store
+        .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
+        .expect("claim")
+        .expect("claimed");
+    let renewed = crate::workspace_claim::WorkspaceOwnerLease {
+        expires_at_ms: lease.expires_at_ms + 30_000,
+        ..lease.clone()
+    };
+    store
+        .renew_remote_runner_claim_with_workspace_owner_lease(
+            job.id,
+            "homeboy-lab",
+            claim.job.claim_id.as_deref().expect("claim id"),
+            30_000,
+            None,
+            Some(renewed.clone()),
+        )
+        .expect("renew legacy owner lease");
+    assert_eq!(
+        store
+            .remote_runner_workspace_owner_lease(job.id)
+            .expect("owner lease"),
+        Some(renewed)
+    );
+    let persisted: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(path).expect("persisted JSON"))
+            .expect("parse persisted JSON");
+    let remote = &persisted["jobs"][0]["remote_runner"];
+    assert!(remote.get("envelope").is_none());
+    assert_eq!(
+        remote["request"]["workspace_owner_lease"]["expires_at_ms"],
+        lease.expires_at_ms + 30_000
+    );
+    assert!(remote.get("workspace_owner_lease").is_none());
+}
+
+#[test]
 fn remote_runner_submit_and_claim_roll_back_after_a_durable_write_failure() {
     let temp = tempfile::tempdir().expect("tempdir");
     let path = temp.path().join("jobs.json");

--- a/crates/homeboy-core/src/daemon/remote_runner.rs
+++ b/crates/homeboy-core/src/daemon/remote_runner.rs
@@ -9,6 +9,11 @@ use crate::api_jobs::{
 use crate::broker_auth::{BrokerAuthStore, BrokerScope};
 use crate::error::{Error, Result};
 use crate::paths;
+use homeboy_runner_contract::{
+    RunnerApiOperationFailure, RunnerApiOperationFailureCode, RunnerApiSubmitOutcome,
+    RunnerApiSubmitRequest, RunnerApiSubmitResponse, RUNNER_API_SUBMIT_RESPONSE_SCHEMA,
+    RUNNER_API_V1,
+};
 use homeboy_runner_contract::{RunnerSession, RunnerSessionRole, RunnerTunnelMode};
 
 /// Per-request broker authentication context extracted from the network layer.
@@ -624,6 +629,88 @@ fn register_session(body: Option<Value>, auth: &BrokerAuthContext) -> Result<Val
 }
 
 fn enqueue(body: Option<Value>, job_store: &JobStore, auth: &BrokerAuthContext) -> Result<Value> {
+    if let Some(value) = body.clone() {
+        if let Ok(submission) = serde_json::from_value::<RunnerApiSubmitRequest>(value) {
+            let runner_id = submission
+                .envelope
+                .dispatch
+                .as_ref()
+                .map(|dispatch| dispatch.runner_id.as_str())
+                .ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        "envelope.dispatch",
+                        "runner submission envelope requires dispatch",
+                        None,
+                        None,
+                    )
+                })?;
+            auth.authorize(BrokerScope::Submit, Some(runner_id))?;
+            let workspace_claim_binding = submission
+                .workspace_claim_binding
+                .as_ref()
+                .map(|binding| serde_json::from_value(binding.clone()))
+                .transpose()
+                .map_err(|error| {
+                    Error::validation_invalid_argument(
+                        "workspace_claim_binding",
+                        format!("malformed reverse runner workspace claim binding: {error}"),
+                        None,
+                        None,
+                    )
+                })?;
+            let workspace_owner_lease = submission
+                .workspace_owner_lease
+                .as_ref()
+                .map(|lease| serde_json::from_value(lease.clone()))
+                .transpose()
+                .map_err(|error| {
+                    Error::validation_invalid_argument(
+                        "workspace_owner_lease",
+                        format!("malformed reverse runner workspace owner lease: {error}"),
+                        None,
+                        None,
+                    )
+                })?;
+            authorize_workspace_claim_binding(workspace_claim_binding.as_ref())?;
+            authorize_workspace_owner_lease(workspace_owner_lease.as_ref())?;
+            let response = match job_store.submit_runner_api_request(submission) {
+                Ok(job) => RunnerApiSubmitResponse {
+                    schema: RUNNER_API_SUBMIT_RESPONSE_SCHEMA.to_string(),
+                    api_version: RUNNER_API_V1,
+                    outcome: RunnerApiSubmitOutcome::Accepted {
+                        job_id: job.id.to_string(),
+                        job_status: serde_json::to_value(job.status)
+                            .expect("serialize job status")
+                            .as_str()
+                            .unwrap_or_default()
+                            .to_string(),
+                    },
+                },
+                Err(error) => RunnerApiSubmitResponse {
+                    schema: RUNNER_API_SUBMIT_RESPONSE_SCHEMA.to_string(),
+                    api_version: RUNNER_API_V1,
+                    outcome: RunnerApiSubmitOutcome::Rejected {
+                        failure: RunnerApiOperationFailure {
+                            code: RunnerApiOperationFailureCode::SubmissionRejected,
+                            message: error.message,
+                        },
+                    },
+                },
+            };
+            let job = match &response.outcome {
+                RunnerApiSubmitOutcome::Accepted { job_id, .. } => {
+                    job_store.get(Uuid::parse_str(job_id).expect("accepted job id"))?
+                }
+                RunnerApiSubmitOutcome::Rejected { .. } => {
+                    return Ok(json!({ "response": response }))
+                }
+            };
+            return Ok(json!({
+                "response": response,
+                "job": job,
+            }));
+        }
+    }
     let mut request: RemoteRunnerJobRequest = parse_body(body, "remote runner job request")?;
     auth.authorize(BrokerScope::Submit, Some(request.runner_id.as_str()))?;
     authorize_workspace_claim_binding(request.workspace_claim_binding.as_ref())?;

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -2139,12 +2139,46 @@ fn handle_reverse_broker_request(
         return ok(json!({ "registered": true }));
     }
     if request.method == "POST" && request.path == "/runner/jobs" {
-        let submitted: RemoteRunnerJobRequest =
-            serde_json::from_value(request.body).expect("parse reverse broker job submission");
-        let job = store
-            .submit_remote_runner_job(submitted)
-            .expect("submit broker job");
+        let typed_submission = serde_json::from_value::<
+            homeboy_runner_contract::RunnerApiSubmitRequest,
+        >(request.body.clone());
+        let is_typed_submission = typed_submission.is_ok();
+        let job = match typed_submission {
+            Ok(submitted) => store
+                .submit_runner_api_request(submitted)
+                .expect("submit envelope broker job"),
+            Err(_) => {
+                let submitted: RemoteRunnerJobRequest = serde_json::from_value(request.body)
+                    .expect("parse legacy reverse broker job submission");
+                store
+                    .submit_remote_runner_job(submitted)
+                    .expect("submit legacy broker job")
+            }
+        };
+        if is_typed_submission {
+            return ok(json!({
+                "response": homeboy_runner_contract::RunnerApiSubmitResponse {
+                    schema: homeboy_runner_contract::RUNNER_API_SUBMIT_RESPONSE_SCHEMA.to_string(),
+                    api_version: homeboy_runner_contract::RUNNER_API_V1,
+                    outcome: homeboy_runner_contract::RunnerApiSubmitOutcome::Accepted {
+                        job_id: job.id.to_string(),
+                        job_status: serde_json::to_value(job.status)
+                            .expect("serialize fixture job status")
+                            .as_str()
+                            .unwrap_or_default()
+                            .to_string(),
+                    },
+                },
+                "job": job,
+            }));
+        }
         return ok(json!({ "job": job }));
+    }
+    if request.method == "POST" && request.path == "/runner/jobs/submissions/lookup" {
+        let submission_key = request.body["submission_key"]
+            .as_str()
+            .expect("fixture submission key");
+        return ok(json!({ "result": store.lookup_remote_runner_submission(submission_key) }));
     }
     if request.method == "POST" && request.path == "/runner/jobs/claim" {
         let claim = store
@@ -2259,14 +2293,37 @@ fn handle_reverse_broker_request(
             "max_chunk_bytes": 64 * 1024,
         }));
     }
+    if request.method == "GET" && request.path.starts_with("/jobs/reconcile") {
+        return ok(json!({ "reconciled": [] }));
+    }
     if request.method == "GET" {
         if let Some(job_path) = request.path.strip_prefix("/jobs/") {
             let (job_id, action) = job_path.split_once('/').unwrap_or((job_path, ""));
-            let job_id = uuid::Uuid::parse_str(job_id).expect("broker job id");
+            let execution_context_probe_runner = matches!(action, "" | "events")
+                .then(|| job_id.strip_prefix("runner-exec:"))
+                .flatten()
+                .and_then(|runner| runner.strip_suffix(":reverse_broker"));
+            let job = uuid::Uuid::parse_str(job_id)
+                .ok()
+                .and_then(|job_id| store.get(job_id).ok())
+                .or_else(|| {
+                    execution_context_probe_runner
+                        .map(|probe_runner| {
+                            // The direct-session cancellation probe identifies the
+                            // planned execution, while the reverse broker owns UUID
+                            // job ids. Resolve only that exact planned-runner shape.
+                            store
+                                .list()
+                                .into_iter()
+                                .find(|job| job.target_runner_id.as_deref() == Some(probe_runner))
+                        })
+                        .flatten()
+                })
+                .expect("broker job");
             return match action {
-                "" => ok(json!({ "job": store.get(job_id).expect("broker job") })),
+                "" => ok(json!({ "job": job })),
                 "events" => ok(json!({
-                    "events": store.events(job_id).expect("broker job events")
+                    "events": store.events(job.id).expect("broker job events")
                 })),
                 _ => json!({
                     "success": false,

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -3338,6 +3338,71 @@ pub fn submit_reverse_broker_job(runner_id: &str, request: RemoteRunnerJobReques
     })
 }
 
+pub fn submit_reverse_broker_envelope_job(
+    runner_id: &str,
+    request: homeboy_runner_contract::RunnerApiSubmitRequest,
+) -> Result<Job> {
+    let dispatch = request.envelope.dispatch.as_ref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "envelope.dispatch",
+            "runner submission envelope requires dispatch",
+            None,
+            None,
+        )
+    })?;
+    if dispatch.runner_id != runner_id {
+        return Err(Error::validation_invalid_argument(
+            "runner_id",
+            "reverse broker submission runner does not match envelope runner",
+            Some(runner_id.to_string()),
+            None,
+        ));
+    }
+    let broker_url = reverse_broker_url(runner_id)?;
+    let client = broker_client("build reverse broker envelope submission client")?;
+    let response = broker_http::post_json(
+        &client,
+        &broker_url,
+        "/runner/jobs",
+        serde_json::to_value(request).map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("serialize envelope reverse runner job".to_string()),
+            )
+        })?,
+        "replay reverse runner envelope submission",
+        broker_auth::broker_submit_token_for_runner(runner_id)?.as_deref(),
+    )?;
+    if let Some(value) = response.get("response") {
+        let response: homeboy_runner_contract::RunnerApiSubmitResponse =
+            serde_json::from_value(value.clone()).map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("parse replayed envelope runner submit response".to_string()),
+                )
+            })?;
+        if let homeboy_runner_contract::RunnerApiSubmitOutcome::Rejected { failure } =
+            response.outcome
+        {
+            return Err(Error::validation_invalid_argument(
+                "runner_submission",
+                failure.message,
+                None,
+                None,
+            ));
+        }
+    }
+    serde_json::from_value(response.get("job").cloned().ok_or_else(|| {
+        Error::internal_unexpected("reverse broker envelope submission returned no job")
+    })?)
+    .map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("parse replayed envelope reverse runner job".to_string()),
+        )
+    })
+}
+
 pub fn lookup_reverse_broker_submission(
     runner_id: &str,
     submission_key: &str,

--- a/crates/homeboy-lab-runner/src/continuation_provider.rs
+++ b/crates/homeboy-lab-runner/src/continuation_provider.rs
@@ -251,6 +251,14 @@ impl RunnerContinuationProvider for RunnerContinuation {
         super::connection::submit_reverse_broker_job(runner_id, request)
     }
 
+    fn submit_reverse_broker_envelope_job(
+        &self,
+        runner_id: &str,
+        request: homeboy_runner_contract::RunnerApiSubmitRequest,
+    ) -> Result<Job> {
+        super::connection::submit_reverse_broker_envelope_job(runner_id, request)
+    }
+
     fn lookup_reverse_broker_submission(
         &self,
         runner_id: &str,

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -10,6 +10,10 @@ use homeboy_core::api_jobs::{
 use homeboy_core::error::{Error, Result};
 use homeboy_core::lab_contract::LabRunnerWorkload;
 use homeboy_core::source_snapshot::SourceSnapshot;
+use homeboy_runner_contract::{
+    RunnerApiSubmitOutcome, RunnerApiSubmitRequest, RunnerApiSubmitResponse,
+    RUNNER_API_SUBMIT_REQUEST_SCHEMA, RUNNER_API_V1,
+};
 use reqwest::blocking::Client;
 
 use super::super::broker_http;
@@ -55,6 +59,61 @@ pub(super) fn exec_via_reverse_broker(
             runner.workspace_root.as_deref(),
         )
     });
+    let redaction_env = env.clone();
+    let redaction_secret_env_names = secret_env_names.clone();
+    let mut env = env;
+    // Snapshot the configured command binary into the durable job. A later
+    // daemon refresh must not redirect work that has already been accepted.
+    if !env.contains_key("HOMEBOY_COMMAND") {
+        if let Some(homeboy_path) = runner.settings.homeboy_path.as_deref() {
+            env.insert("HOMEBOY_COMMAND".to_string(), homeboy_path.to_string());
+        }
+    }
+    let mut request = RemoteRunnerJobRequest {
+        runner_id: runner.id.clone(),
+        project_id,
+        operation: "runner.exec".to_string(),
+        command: command.clone(),
+        cwd: Some(cwd.clone()),
+        env,
+        secret_env_names,
+        secret_env_plan: Default::default(),
+        env_materialization: None,
+        capture_patch,
+        source_snapshot: Some(source_snapshot.clone()),
+        path_materialization_plan: path_materialization_plan.clone(),
+        lab_runner_workload: lab_runner_workload.clone(),
+        metadata: Some({
+            let mut metadata =
+                runner_exec_request_metadata(run_id.as_deref(), "reverse_broker", &runner.id);
+            metadata["submission_key"] = serde_json::json!(run_id.as_deref().map_or_else(
+                || format!("reverse-broker:v1:{}:{}", runner.id, uuid::Uuid::new_v4()),
+                |run_id| reverse_broker_submission_key(&runner.id, run_id),
+            ));
+            metadata
+        }),
+        lifecycle: Some(RunnerJobLifecycleMetadata {
+            source: Some("reverse-broker".to_string()),
+            kind: Some("runner.exec".to_string()),
+            durable_run_id: run_id.clone(),
+            ..Default::default()
+        }),
+        workspace_claim_binding: None,
+        workspace_owner_lease: None,
+        require_paths: require_paths.clone(),
+        extension_env_providers,
+    };
+    let command_assets = durable_command_assets(&command, path_materialization_plan.as_ref())?;
+    if !command_assets.is_empty() {
+        request
+            .metadata
+            .as_mut()
+            .expect("reverse broker request metadata")["command_assets"] = serde_json::json!({
+            "schema": "homeboy/reverse-runner-command-assets/v1",
+            "assets": command_assets,
+        });
+    }
+    request.validate_durable_submission()?;
     persist_runner_execution_transition(
         &RunnerExecutionRecord::planned(
             format!("runner-exec:{}:reverse_broker", runner.id),
@@ -71,16 +130,6 @@ pub(super) fn exec_via_reverse_broker(
         &cwd,
         &command,
     )?;
-    let redaction_env = env.clone();
-    let redaction_secret_env_names = secret_env_names.clone();
-    let mut env = env;
-    // Snapshot the configured command binary into the durable job. A later
-    // daemon refresh must not redirect work that has already been accepted.
-    if !env.contains_key("HOMEBOY_COMMAND") {
-        if let Some(homeboy_path) = runner.settings.homeboy_path.as_deref() {
-            env.insert("HOMEBOY_COMMAND".to_string(), homeboy_path.to_string());
-        }
-    }
     // Reverse jobs hold a renewable owner lease while queued/running. A
     // reconciliation claim is a separate exclusive fence and is never used as
     // ordinary execution ownership.
@@ -120,54 +169,45 @@ pub(super) fn exec_via_reverse_broker(
             Ok::<_, Error>(lease)
         })
         .transpose()?;
-    let mut request = RemoteRunnerJobRequest {
-        runner_id: runner.id.clone(),
-        project_id,
-        operation: "runner.exec".to_string(),
-        command: command.clone(),
-        cwd: Some(cwd.clone()),
-        env,
-        secret_env_names,
-        secret_env_plan: Default::default(),
-        env_materialization: None,
-        capture_patch,
-        source_snapshot: Some(source_snapshot.clone()),
-        path_materialization_plan: path_materialization_plan.clone(),
-        lab_runner_workload: lab_runner_workload.clone(),
-        metadata: Some({
-            let mut metadata =
-                runner_exec_request_metadata(run_id.as_deref(), "reverse_broker", &runner.id);
-            if let Some(run_id) = run_id.as_deref() {
-                metadata["submission_key"] =
-                    serde_json::json!(reverse_broker_submission_key(&runner.id, run_id));
-            }
-            metadata
-        }),
-        lifecycle: Some(RunnerJobLifecycleMetadata {
-            source: Some("reverse-broker".to_string()),
-            kind: Some("runner.exec".to_string()),
-            durable_run_id: run_id.clone(),
-            ..Default::default()
-        }),
-        workspace_claim_binding: None,
-        workspace_owner_lease: workspace_owner_lease.clone(),
-        require_paths: require_paths.clone(),
-        extension_env_providers,
+    request.workspace_owner_lease = workspace_owner_lease.clone();
+    let envelope = request.execution_envelope();
+    let submission_key = request
+        .submission_key()
+        .ok_or_else(|| Error::internal_unexpected("reverse broker submission has no key"))?
+        .to_string();
+    let submission = RunnerApiSubmitRequest {
+        schema: RUNNER_API_SUBMIT_REQUEST_SCHEMA.to_string(),
+        api_version: RUNNER_API_V1,
+        submission_key,
+        envelope,
+        workspace_claim_binding: request
+            .workspace_claim_binding
+            .as_ref()
+            .map(serde_json::to_value)
+            .transpose()
+            .map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("serialize workspace claim binding".to_string()),
+                )
+            })?,
+        workspace_owner_lease: request
+            .workspace_owner_lease
+            .as_ref()
+            .map(serde_json::to_value)
+            .transpose()
+            .map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("serialize workspace owner lease".to_string()),
+                )
+            })?,
     };
-    let command_assets = durable_command_assets(&command, path_materialization_plan.as_ref())?;
-    if !command_assets.is_empty() {
-        request
-            .metadata
-            .as_mut()
-            .expect("reverse broker request metadata")["command_assets"] = serde_json::json!({
-            "schema": "homeboy/reverse-runner-command-assets/v1",
-            "assets": command_assets,
-        });
-    }
     if detach_after_handoff {
         if let Some(run_id) = run_id.as_deref() {
-            homeboy_agents::agent_task_lifecycle::record_lab_offload_submission_request(
-                run_id, &request,
+            homeboy_agents::agent_task_lifecycle::record_lab_offload_submission_envelope(
+                run_id,
+                &submission,
             )?;
         }
     }
@@ -176,7 +216,7 @@ pub(super) fn exec_via_reverse_broker(
         &client,
         broker_url,
         "/runner/jobs",
-        serde_json::to_value(&request).map_err(|err| {
+        serde_json::to_value(&submission).map_err(|err| {
             Error::internal_json(
                 err.to_string(),
                 Some("serialize reverse runner job request".to_string()),
@@ -185,6 +225,26 @@ pub(super) fn exec_via_reverse_broker(
         "submit reverse runner job",
         broker_token.as_deref(),
     );
+    let data = data.and_then(|data| {
+        if let Some(response) = data.get("response") {
+            let response: RunnerApiSubmitResponse = serde_json::from_value(response.clone())
+                .map_err(|error| {
+                    Error::internal_json(
+                        error.to_string(),
+                        Some("parse runner submit response".to_string()),
+                    )
+                })?;
+            if let RunnerApiSubmitOutcome::Rejected { failure } = response.outcome {
+                return Err(Error::validation_invalid_argument(
+                    "runner_submission",
+                    failure.message,
+                    None,
+                    None,
+                ));
+            }
+        }
+        Ok(data)
+    });
     let data = match data {
         Ok(data) => data,
         Err(error) => {

--- a/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/handoff.rs
@@ -735,6 +735,57 @@ fn reverse_broker_exec_detached_surfaces_persisted_run_id() {
 }
 
 #[test]
+fn reverse_broker_rejects_inline_secret_before_detached_intent_persistence() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let run_id = "agent-task-inline-secret-rejected";
+        homeboy_agents::agent_task_lifecycle::record_lab_offload_planned(
+            homeboy_agents::agent_task_lifecycle::LabOffloadProxyPlan {
+                run_id,
+                runner_id: "lab",
+                remote_workspace: "/srv/homeboy/project",
+                remote_command: &["homeboy".to_string(), "test".to_string()],
+                durable_plan: None,
+            },
+        )
+        .expect("controller proxy run recorded");
+        let error = exec_via_reverse_broker(
+            &ssh_runner(),
+            "http://127.0.0.1:1",
+            "/srv/homeboy/project".to_string(),
+            None,
+            vec!["homeboy".to_string(), "test".to_string()],
+            [("DECLARED_TOKEN".to_string(), "must-not-persist".to_string())]
+                .into_iter()
+                .collect(),
+            vec!["DECLARED_TOKEN".to_string()],
+            false,
+            None,
+            None,
+            Vec::new(),
+            Vec::new(),
+            None,
+            Some(run_id.to_string()),
+            false,
+            true,
+            true,
+            true,
+        )
+        .expect_err("inline declared secret is rejected before handoff");
+        assert_eq!(
+            error.code,
+            homeboy_core::error::ErrorCode::ValidationInvalidArgument
+        );
+        let record = homeboy_agents::agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()
+            .expect("lifecycle store")
+            .read_record(run_id)
+            .expect("persisted record");
+        assert!(!serde_json::to_string(&record)
+            .expect("record JSON")
+            .contains("must-not-persist"));
+    });
+}
+
+#[test]
 fn routed_slow_child_streams_promotion_progress_and_replays_it_after_completion() {
     homeboy_core::test_support::with_isolated_home(|_| {
         // The in-process daemon's /exec endpoint drives runner processes through

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -351,7 +351,7 @@ fn run_once_output(
     // of mid-run (#5093). The local worker execution path runs this preflight
     // before handing the claimed job directly to the local runtime.
     let capability_preflight = reverse_worker_capability_preflight(&claim.request);
-    let mut execution_envelope = claim.request.execution_envelope();
+    let mut execution_envelope = claim.envelope.clone();
     // Authorize the exact durable owner lease immediately before any workspace,
     // private-file, or source materialization. This intentionally does not consume
     // the receipt; consume remains at the provider-invocation boundary below.


### PR DESCRIPTION
## Summary

- define versioned Runner API v1 submit request/response contracts around `RunnerExecutionEnvelope`
- persist and claim canonical envelopes for new reverse-runner jobs while preserving deterministic legacy request replay
- execute claimed envelopes directly and preserve workspace authority, secret redaction, idempotency, and detached reconciliation semantics
- retain existing persisted `RemoteRunnerJobRequest` compatibility without writing dual execution representations

Closes #14081.

## Verification

- `cargo test --test reverse_cook_queue_acceptance --locked`
- `cargo test -p homeboy-agents default_envelope_adapter_preserves_workspace_authority_sidecars --locked`
- `cargo test -p homeboy-runner-contract --locked`
- focused reverse-broker submission, inline-secret rejection, legacy replay, lease renewal, and worker execution tests
- `cargo check --workspace --locked`
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`

Repository-wide strict Clippy remains blocked by pre-existing `homeboy-core` warnings outside this diff. The architecture audit was deferred by Homeboy resource admission while the machine was hot; no local override was used.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode inspected the reverse-runner persistence and execution paths, implemented the envelope-first migration, added regression coverage, ran the verification workflow, and performed iterative independent code review. Chris Huber directed the scope and authorized publication.