### PR TITLE
Honor configured executable tool probes

### DIFF
--- a/crates/homeboy-lab-runner/src/capabilities.rs
+++ b/crates/homeboy-lab-runner/src/capabilities.rs
@@ -668,13 +668,24 @@ fn batch_probe_script(
     let mut lines = Vec::new();
     lines.push("set +e".to_string());
     for (index, probe) in tool_probes.iter().enumerate() {
-        let argv = std::iter::once(&probe.command)
-            .chain(probe.version_args.iter())
-            .map(|arg| shell::quote_arg(arg))
-            .collect::<Vec<_>>()
-            .join(" ");
+        // Only invoke an executable when its registry definition supplies a
+        // non-empty, read-only version probe. A bare required command retains
+        // the prior presence check rather than starting an interactive tool.
+        let condition = if probe.version_args.is_empty() {
+            format!(
+                "command -v {} >/dev/null 2>&1",
+                shell::quote_arg(&probe.command)
+            )
+        } else {
+            std::iter::once(&probe.command)
+                .chain(probe.version_args.iter())
+                .map(|arg| shell::quote_arg(arg))
+                .collect::<Vec<_>>()
+                .join(" ")
+                + " >/dev/null 2>&1"
+        };
         lines.push(format!(
-            "if {argv} >/dev/null 2>&1; then printf 'T\\t{index}\\t1\\n'; else printf 'T\\t{index}\\t0\\n'; fi"
+            "if {condition}; then printf 'T\\t{index}\\t1\\n'; else printf 'T\\t{index}\\t0\\n'; fi"
         ));
     }
     for (index, command) in command_names.iter().enumerate() {
@@ -1546,7 +1557,7 @@ mod tests {
     fn capability_preflight_accepts_configured_homeboy_and_git_version_evidence() {
         let fixture = tempdir().expect("fixture");
         let homeboy = fixture.path().join("configured-homeboy");
-        let git = fixture.path().join("git");
+        let git = fixture.path().join("configured-git");
         fs::write(
             &homeboy,
             "#!/bin/sh\n[ \"$1\" = --version ] && exit 0\nexit 1\n",
@@ -1554,7 +1565,7 @@ mod tests {
         .expect("write configured homeboy");
         fs::write(
             &git,
-            "#!/bin/sh\n[ \"$1\" = --version ] && exit 0\nexit 1\n",
+            "#!/bin/sh\n[ \"$1\" = configured-version ] && exit 0\nexit 1\n",
         )
         .expect("write git on PATH");
         make_executable(&homeboy);
@@ -1574,7 +1585,15 @@ mod tests {
                 ),
             ]),
             secret_env: Default::default(),
-            resources: Default::default(),
+            resources: HashMap::from([(
+                "tools".to_string(),
+                json!({
+                    "git": {
+                        "command": git,
+                        "version_args": ["configured-version"]
+                    }
+                }),
+            )]),
             policy: RunnerPolicy::default(),
         };
         let preflight = RunnerCapabilityPreflight {
@@ -1610,7 +1629,7 @@ mod tests {
 
         fs::write(
             &git,
-            "#!/bin/sh\n[ \"$1\" = --version ] && exit 0\nexit 1\n",
+            "#!/bin/sh\n[ \"$1\" = configured-version ] && exit 0\nexit 1\n",
         )
         .expect("restore git version probe");
         fs::write(&homeboy, "#!/bin/sh\nexit 1\n").expect("make Homeboy version probe fail");
@@ -1769,6 +1788,20 @@ mod tests {
         assert!(output.status.success());
         assert!(!side_effect.exists(), "metacharacter argument executed");
         assert!(String::from_utf8_lossy(&output.stdout).contains("R\t0\t1"));
+    }
+
+    #[test]
+    fn tool_probe_uses_presence_check_without_registry_version_arguments() {
+        let probes = vec![RunnerToolProbe {
+            tool: RunnerRequiredTool::new("interactive-tool"),
+            command: "interactive-tool".to_string(),
+            version_args: Vec::new(),
+        }];
+
+        let script = batch_probe_script(&probes, &[], &[], &[]);
+
+        assert!(script.contains("command -v interactive-tool >/dev/null 2>&1"));
+        assert!(!script.contains("if interactive-tool >/dev/null 2>&1"));
     }
 
     #[cfg(unix)]

--- a/crates/homeboy-lab-runner/src/capabilities.rs
+++ b/crates/homeboy-lab-runner/src/capabilities.rs
@@ -599,14 +599,14 @@ fn runner_tool_probes(
     RunnerToolRegistry::required_tools(runner, preflight)
         .into_iter()
         .map(|tool| {
+            let spec = RunnerToolRegistry::spec_for_runner_required_tool(runner, &tool);
             let (command, version_args) = if tool.id() == "homeboy" {
                 (
                     effective_homeboy_command(runner, "runner capability preflight")?,
-                    vec!["--version".to_string()],
+                    spec.map(|spec| spec.version_args).unwrap_or_default(),
                 )
             } else {
-                RunnerToolRegistry::spec_for_runner_required_tool(runner, &tool)
-                    .map(|spec| (spec.command, spec.version_args))
+                spec.map(|spec| (spec.command, spec.version_args))
                     .unwrap_or_else(|| (tool.id().to_string(), Vec::new()))
             };
             Ok(RunnerToolProbe {
@@ -1579,12 +1579,16 @@ mod tests {
         };
         let preflight = RunnerCapabilityPreflight {
             command: "agent-task cook".to_string(),
-            required_tools: vec![RunnerRequiredTool::git()],
+            required_tools: vec![RunnerRequiredTool::homeboy(), RunnerRequiredTool::git()],
             ..Default::default()
         };
 
         let capabilities = runner_capability_snapshot_for_preflight(&runner, &preflight)
             .expect("capability snapshot");
+        assert!(
+            capabilities.has_tool(&RunnerRequiredTool::homeboy()),
+            "Configured Homeboy version evidence was not recorded: {capabilities:?}"
+        );
         assert!(
             capabilities.has_tool(&RunnerRequiredTool::git()),
             "Git version evidence was not recorded: {capabilities:?}"
@@ -1603,6 +1607,23 @@ mod tests {
         )
         .expect_err("an unusable Git executable blocks handoff before provider execution");
         assert!(error.message.contains("tools: git"));
+
+        fs::write(
+            &git,
+            "#!/bin/sh\n[ \"$1\" = --version ] && exit 0\nexit 1\n",
+        )
+        .expect("restore git version probe");
+        fs::write(&homeboy, "#!/bin/sh\nexit 1\n").expect("make Homeboy version probe fail");
+        let unavailable = runner_capability_snapshot_for_preflight(&runner, &preflight)
+            .expect("capability snapshot");
+        let error = validate_runner_capability_preflight(
+            "local",
+            &preflight,
+            &unavailable,
+            &HashMap::new(),
+        )
+        .expect_err("an unusable configured Homeboy blocks handoff before provider execution");
+        assert!(error.message.contains("tools: homeboy"));
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/capabilities.rs
+++ b/crates/homeboy-lab-runner/src/capabilities.rs
@@ -473,23 +473,11 @@ impl RunnerCapabilitySnapshot {
         client: &SshClient,
         preflight: &RunnerCapabilityPreflight,
     ) -> Result<RunnerCapabilityProbeResult> {
-        let tool_commands = RunnerToolRegistry::required_tools(runner, preflight)
-            .into_iter()
-            .map(|tool| {
-                let command = if tool.id() == "homeboy" {
-                    effective_homeboy_command(runner, "runner capability preflight")?
-                } else {
-                    RunnerToolRegistry::spec_for_required_tool(&tool)
-                        .map(|spec| spec.command)
-                        .unwrap_or_else(|| tool.id().to_string())
-                };
-                Ok((tool, command))
-            })
-            .collect::<Result<Vec<_>>>()?;
+        let tool_probes = runner_tool_probes(runner, preflight)?;
         let command_names = normalized_command_names(&preflight.required_commands);
         let capability_probes = normalized_tool_capability_probes(preflight);
         let script = batch_probe_script(
-            &tool_commands,
+            &tool_probes,
             &command_names,
             &capability_probes,
             &preflight.required_toolchain_probes,
@@ -525,7 +513,7 @@ impl RunnerCapabilitySnapshot {
             }
             Ok(parse_batch_probe_output(
                 &output.stdout,
-                &tool_commands,
+                &tool_probes,
                 &command_names,
                 &capability_probes,
                 &preflight.required_toolchain_probes,
@@ -547,23 +535,11 @@ impl RunnerCapabilitySnapshot {
         runner: &Runner,
         preflight: &RunnerCapabilityPreflight,
     ) -> Result<RunnerCapabilityProbeResult> {
-        let tool_commands = RunnerToolRegistry::required_tools(runner, preflight)
-            .into_iter()
-            .map(|tool| {
-                let command = if tool.id() == "homeboy" {
-                    effective_homeboy_command(runner, "runner capability preflight")?
-                } else {
-                    RunnerToolRegistry::spec_for_required_tool(&tool)
-                        .map(|spec| spec.command)
-                        .unwrap_or_else(|| tool.id().to_string())
-                };
-                Ok((tool, command))
-            })
-            .collect::<Result<Vec<_>>>()?;
+        let tool_probes = runner_tool_probes(runner, preflight)?;
         let command_names = normalized_command_names(&preflight.required_commands);
         let capability_probes = normalized_tool_capability_probes(preflight);
         let script = batch_probe_script(
-            &tool_commands,
+            &tool_probes,
             &command_names,
             &capability_probes,
             &preflight.required_toolchain_probes,
@@ -582,7 +558,7 @@ impl RunnerCapabilitySnapshot {
         let stdout = output.stdout;
         Ok(parse_batch_probe_output(
             &stdout,
-            &tool_commands,
+            &tool_probes,
             &command_names,
             &capability_probes,
             &preflight.required_toolchain_probes,
@@ -616,6 +592,32 @@ fn effective_homeboy_command(runner: &Runner, context: &str) -> Result<String> {
         .unwrap_or_else(|| remote_runner_homeboy_path(runner, context).map(str::to_string))
 }
 
+fn runner_tool_probes(
+    runner: &Runner,
+    preflight: &RunnerCapabilityPreflight,
+) -> Result<Vec<RunnerToolProbe>> {
+    RunnerToolRegistry::required_tools(runner, preflight)
+        .into_iter()
+        .map(|tool| {
+            let (command, version_args) = if tool.id() == "homeboy" {
+                (
+                    effective_homeboy_command(runner, "runner capability preflight")?,
+                    vec!["--version".to_string()],
+                )
+            } else {
+                RunnerToolRegistry::spec_for_runner_required_tool(runner, &tool)
+                    .map(|spec| (spec.command, spec.version_args))
+                    .unwrap_or_else(|| (tool.id().to_string(), Vec::new()))
+            };
+            Ok(RunnerToolProbe {
+                tool,
+                command,
+                version_args,
+            })
+        })
+        .collect()
+}
+
 // `Clone` so one probe's answer can be handed to every caller that coalesced
 // onto it instead of each opening its own connection (#11080).
 #[derive(Debug, Clone, Default)]
@@ -624,6 +626,13 @@ struct RunnerCapabilityProbeResult {
     commands: BTreeSet<String>,
     tool_capabilities: BTreeSet<String>,
     failed_toolchain_probes: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RunnerToolProbe {
+    tool: RunnerRequiredTool,
+    command: String,
+    version_args: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -651,17 +660,21 @@ fn batch_probe_fingerprint(script: &str, env: &HashMap<String, String>) -> Strin
 }
 
 fn batch_probe_script(
-    tool_commands: &[(RunnerRequiredTool, String)],
+    tool_probes: &[RunnerToolProbe],
     command_names: &[String],
     capability_probes: &[RunnerToolCapabilityProbe],
     toolchain_probes: &[RunnerToolchainReadinessProbe],
 ) -> String {
     let mut lines = Vec::new();
     lines.push("set +e".to_string());
-    for (index, (_tool, command)) in tool_commands.iter().enumerate() {
-        let condition = format!("command -v {} >/dev/null 2>&1", shell::quote_arg(command));
+    for (index, probe) in tool_probes.iter().enumerate() {
+        let argv = std::iter::once(&probe.command)
+            .chain(probe.version_args.iter())
+            .map(|arg| shell::quote_arg(arg))
+            .collect::<Vec<_>>()
+            .join(" ");
         lines.push(format!(
-            "if {condition}; then printf 'T\\t{index}\\t1\\n'; else printf 'T\\t{index}\\t0\\n'; fi"
+            "if {argv} >/dev/null 2>&1; then printf 'T\\t{index}\\t1\\n'; else printf 'T\\t{index}\\t0\\n'; fi"
         ));
     }
     for (index, command) in command_names.iter().enumerate() {
@@ -700,7 +713,7 @@ fn tool_capability_probe_script(index: usize, probe: &RunnerToolCapabilityProbe)
 
 fn parse_batch_probe_output(
     stdout: &str,
-    tool_commands: &[(RunnerRequiredTool, String)],
+    tool_probes: &[RunnerToolProbe],
     command_names: &[String],
     capability_probes: &[RunnerToolCapabilityProbe],
     toolchain_probes: &[RunnerToolchainReadinessProbe],
@@ -720,8 +733,8 @@ fn parse_batch_probe_output(
         }
         match kind {
             "T" => {
-                if let Some((tool, _)) = tool_commands.get(index) {
-                    result.tools.insert(tool.clone());
+                if let Some(probe) = tool_probes.get(index) {
+                    result.tools.insert(probe.tool.clone());
                 }
             }
             "C" => {
@@ -1527,6 +1540,69 @@ mod tests {
 
         validate_runner_capability_preflight("lab", &preflight, &capabilities, &env)
             .expect("capability parity passes");
+    }
+
+    #[test]
+    fn capability_preflight_accepts_configured_homeboy_and_git_version_evidence() {
+        let fixture = tempdir().expect("fixture");
+        let homeboy = fixture.path().join("configured-homeboy");
+        let git = fixture.path().join("git");
+        fs::write(
+            &homeboy,
+            "#!/bin/sh\n[ \"$1\" = --version ] && exit 0\nexit 1\n",
+        )
+        .expect("write configured homeboy");
+        fs::write(
+            &git,
+            "#!/bin/sh\n[ \"$1\" = --version ] && exit 0\nexit 1\n",
+        )
+        .expect("write git on PATH");
+        make_executable(&homeboy);
+        make_executable(&git);
+
+        let runner = Runner {
+            id: "local".to_string(),
+            kind: RunnerKind::Local,
+            server_id: None,
+            workspace_root: None,
+            settings: RunnerSettings::default(),
+            env: HashMap::from([
+                ("HOMEBOY_COMMAND".to_string(), homeboy.display().to_string()),
+                (
+                    "PATH".to_string(),
+                    format!("{}:/bin", fixture.path().display()),
+                ),
+            ]),
+            secret_env: Default::default(),
+            resources: Default::default(),
+            policy: RunnerPolicy::default(),
+        };
+        let preflight = RunnerCapabilityPreflight {
+            command: "agent-task cook".to_string(),
+            required_tools: vec![RunnerRequiredTool::git()],
+            ..Default::default()
+        };
+
+        let capabilities = runner_capability_snapshot_for_preflight(&runner, &preflight)
+            .expect("capability snapshot");
+        assert!(
+            capabilities.has_tool(&RunnerRequiredTool::git()),
+            "Git version evidence was not recorded: {capabilities:?}"
+        );
+        validate_runner_capability_preflight("local", &preflight, &capabilities, &HashMap::new())
+            .expect("successful configured Homeboy and Git probes satisfy handoff preflight");
+
+        fs::write(&git, "#!/bin/sh\nexit 1\n").expect("make git version probe fail");
+        let unavailable = runner_capability_snapshot_for_preflight(&runner, &preflight)
+            .expect("capability snapshot");
+        let error = validate_runner_capability_preflight(
+            "local",
+            &preflight,
+            &unavailable,
+            &HashMap::new(),
+        )
+        .expect_err("an unusable Git executable blocks handoff before provider execution");
+        assert!(error.message.contains("tools: git"));
     }
 
     #[test]

--- a/crates/homeboy-lab-runner/src/tool_registry.rs
+++ b/crates/homeboy-lab-runner/src/tool_registry.rs
@@ -56,9 +56,17 @@ impl RunnerToolRegistry {
         runner: &Runner,
         tool: &RunnerRequiredTool,
     ) -> Option<RunnerToolSpec> {
-        Self::doctor_tools(runner)
+        // Runner configuration refines intrinsic defaults for this runner.
+        // Prefer it so capability preflight uses the same command contract the
+        // runner declares, then retain intrinsic metadata as the fallback.
+        declared_tool_specs(runner)
             .into_iter()
             .find(|spec| spec.tool.as_ref() == Some(tool))
+            .or_else(|| {
+                intrinsic_tool_specs()
+                    .into_iter()
+                    .find(|spec| spec.tool.as_ref() == Some(tool))
+            })
     }
 }
 

--- a/crates/homeboy-lab-runner/src/tool_registry.rs
+++ b/crates/homeboy-lab-runner/src/tool_registry.rs
@@ -48,6 +48,18 @@ impl RunnerToolRegistry {
             .into_iter()
             .find(|spec| spec.tool.as_ref() == Some(tool))
     }
+
+    /// Return the same configured tool definition that runner doctor uses.
+    /// Capability preflight must execute this command rather than infer tool
+    /// presence from its identifier alone.
+    pub fn spec_for_runner_required_tool(
+        runner: &Runner,
+        tool: &RunnerRequiredTool,
+    ) -> Option<RunnerToolSpec> {
+        Self::doctor_tools(runner)
+            .into_iter()
+            .find(|spec| spec.tool.as_ref() == Some(tool))
+    }
 }
 
 fn intrinsic_tool_specs() -> Vec<RunnerToolSpec> {


### PR DESCRIPTION
## Summary
- resolve required tool probes from runner-declared commands and arguments
- avoid executing bare interactive tools during capability discovery
- report configured probe failures with deterministic evidence

## Verification
- `cargo fmt --check`
- focused `homeboy-lab-runner` capability and tool-registry tests passed during independent review

This fixes the configured executable probe subset of #7536; the broader issue remains open.

AI assistance: OpenAI GPT-5.6 Terra using OpenCode was used to implement, independently review, rebase, and verify this change under human orchestration.