### PR TITLE
Bind cleanup apply retries to active work

### DIFF
--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -15,7 +15,9 @@ use homeboy::core::controller_runtime::{self, ControllerRuntimeRetentionOverride
 use homeboy::core::daemon::controller_job_driver::{
     self, ControllerJobDriver, ControllerJobHandle, ControllerJobPublicError,
 };
-use homeboy::core::daemon::LocalControllerJobClient;
+use homeboy::core::daemon::{
+    ControllerJobSubmission, ControllerJobSubmissionDisposition, LocalControllerJobClient,
+};
 use homeboy::core::defaults;
 use homeboy::core::engine;
 use homeboy::core::engine::shell::quote_arg;
@@ -508,14 +510,17 @@ fn submit_cleanup(args: CleanupArgs) -> homeboy::core::Result<Value> {
             Some("serialize cleanup job request".to_string()),
         )
     })?;
-    let digest = uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, request.to_string().as_bytes());
-    let job = LocalControllerJobClient::connect()?.submit(serde_json::json!({
-        "type": CLEANUP_JOB_TYPE,
-        "version": CLEANUP_JOB_VERSION,
-        "idempotency_key": format!("cleanup-inventory-{digest}"),
-        "request": request,
-    }))?;
-    Ok(compact_cleanup_job(&job, "submitted"))
+    // A completed cleanup describes the inventory that existed when it ran, not
+    // a standing claim over future inventory with the same command arguments.
+    let invocation_id = uuid::Uuid::new_v4();
+    let submission =
+        LocalControllerJobClient::connect()?.submit_with_disposition(serde_json::json!({
+            "type": CLEANUP_JOB_TYPE,
+            "version": CLEANUP_JOB_VERSION,
+            "idempotency_key": format!("cleanup-inventory-{invocation_id}"),
+            "request": request,
+        }))?;
+    Ok(compact_cleanup_submission(&submission))
 }
 
 fn cleanup_job_status(job_id: &str, full: bool) -> homeboy::core::Result<Value> {
@@ -549,6 +554,17 @@ fn compact_cleanup_job(job: &homeboy::core::api_jobs::Job, command: &'static str
         "status_command": format!("homeboy cleanup status {}", job.get("id").and_then(Value::as_str).unwrap_or("<job-id>")),
         "evidence_command": format!("homeboy cleanup status {} --full", job.get("id").and_then(Value::as_str).unwrap_or("<job-id>")),
     })
+}
+
+fn compact_cleanup_submission(submission: &ControllerJobSubmission) -> Value {
+    let mut output = compact_cleanup_job(&submission.job, "submitted");
+    output["submission"] = serde_json::json!({
+        "disposition": match submission.disposition {
+            ControllerJobSubmissionDisposition::Created => "created",
+            ControllerJobSubmissionDisposition::Reused => "reused",
+        },
+    });
+    output
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/crates/homeboy-cli/src/commands/cleanup.rs
+++ b/crates/homeboy-cli/src/commands/cleanup.rs
@@ -513,13 +513,17 @@ fn submit_cleanup(args: CleanupArgs) -> homeboy::core::Result<Value> {
     // A completed cleanup describes the inventory that existed when it ran, not
     // a standing claim over future inventory with the same command arguments.
     let invocation_id = uuid::Uuid::new_v4();
-    let submission =
-        LocalControllerJobClient::connect()?.submit_with_disposition(serde_json::json!({
+    let active_request_id =
+        uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, request.to_string().as_bytes());
+    let submission = LocalControllerJobClient::connect_current_build()?.submit_with_disposition(
+        serde_json::json!({
             "type": CLEANUP_JOB_TYPE,
             "version": CLEANUP_JOB_VERSION,
             "idempotency_key": format!("cleanup-inventory-{invocation_id}"),
+            "active_idempotency_key": format!("cleanup-inventory-active-{active_request_id}"),
             "request": request,
-        }))?;
+        }),
+    )?;
     Ok(compact_cleanup_submission(&submission))
 }
 
@@ -562,6 +566,7 @@ fn compact_cleanup_submission(submission: &ControllerJobSubmission) -> Value {
         "disposition": match submission.disposition {
             ControllerJobSubmissionDisposition::Created => "created",
             ControllerJobSubmissionDisposition::Reused => "reused",
+            ControllerJobSubmissionDisposition::Unknown => "unknown",
         },
     });
     output

--- a/crates/homeboy-core/src/api_jobs/store/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/store/mod.rs
@@ -126,6 +126,11 @@ pub(crate) struct ControllerJobState {
     /// Driver-owned safe projection exposed in the queued event and API logs.
     pub(crate) public_request: Value,
     pub(crate) request_digest: String,
+    /// Optional semantic identity that coalesces matching work only while its
+    /// durable job remains nonterminal. The caller's idempotency key still
+    /// permanently identifies this particular submission.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) active_idempotency_key: Option<String>,
     /// The controller-minted durable run this job executes for, declared by
     /// the driver from its typed request and persisted at admission — before
     /// any driver work can escape the daemon lifecycle. Recovery reconciles
@@ -1925,6 +1930,26 @@ impl JobStore {
                 Some(idempotency_key),
                 None,
             ));
+        }
+        if let Some(active_idempotency_key) = controller_job.active_idempotency_key.as_deref() {
+            let active = inner.jobs.values().find(|stored| {
+                !stored.job.status.is_terminal()
+                    && stored
+                        .controller_job
+                        .as_ref()
+                        .and_then(|state| state.active_idempotency_key.as_deref())
+                        == Some(active_idempotency_key)
+            });
+            if let Some(active) = active {
+                let active_state = active
+                    .controller_job
+                    .as_ref()
+                    .expect("active controller submission has controller state");
+                if controller_submission_fingerprint(active_state) != fingerprint {
+                    return Err(controller_idempotency_conflict(active_idempotency_key));
+                }
+                return Ok(ControllerJobSubmissionOutcome::Existing(Box::new(active.job.clone())));
+            }
         }
         let job = Job {
             id: Uuid::new_v4(),

--- a/crates/homeboy-core/src/api_jobs/tests/part_b.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_b.rs
@@ -153,6 +153,7 @@ fn admitted_staging_dispatch(store: &JobStore, linked_durable_run_id: Option<&st
                 request: json!({ "schema": "homeboy/lab-staging-dispatch/v1" }),
                 public_request: json!({ "schema": "homeboy/lab-staging-dispatch/v1" }),
                 request_digest: format!("digest-{}", Uuid::new_v4()),
+                active_idempotency_key: None,
                 linked_durable_run_id: linked_durable_run_id.map(str::to_string),
                 checkpoint: None,
                 cancellation_requested: false,

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -164,6 +164,20 @@ pub struct LocalControllerJobClient {
     client: reqwest::blocking::Client,
 }
 
+/// The durable admission result for a typed controller job submission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControllerJobSubmissionDisposition {
+    Created,
+    Reused,
+}
+
+/// A controller job plus the admission decision that selected it.
+#[derive(Debug, Clone)]
+pub struct ControllerJobSubmission {
+    pub job: crate::api_jobs::Job,
+    pub disposition: ControllerJobSubmissionDisposition,
+}
+
 /// Extract the `job` a controller-job endpoint returned.
 ///
 /// Reaches the payload through [`daemon_endpoint_payload`] rather than spelling
@@ -299,6 +313,15 @@ impl LocalControllerJobClient {
     /// Admit and start a typed durable controller job. The daemon, rather than
     /// the submitting CLI process, owns execution after this method returns.
     pub fn submit(&self, request: serde_json::Value) -> Result<crate::api_jobs::Job> {
+        Ok(self.submit_with_disposition(request)?.job)
+    }
+
+    /// Admit and start a typed durable controller job, preserving the daemon's
+    /// durable admission disposition for callers that expose submission receipts.
+    pub fn submit_with_disposition(
+        &self,
+        request: serde_json::Value,
+    ) -> Result<ControllerJobSubmission> {
         let response = self
             .client
             .post(format!("{}/controller/jobs", self.endpoint))
@@ -331,6 +354,18 @@ impl LocalControllerJobClient {
                     Some("parse local controller job".to_string()),
                 )
             })?;
+        let disposition = match daemon_endpoint_payload(&value)
+            .and_then(|payload| payload.pointer("/submission/disposition"))
+            .and_then(serde_json::Value::as_str)
+        {
+            Some("created") => ControllerJobSubmissionDisposition::Created,
+            Some("reused") => ControllerJobSubmissionDisposition::Reused,
+            _ => {
+                return Err(Error::internal_unexpected(
+                    "local controller-job submission response has no recognized disposition",
+                ));
+            }
+        };
         let response = self
             .client
             .post(format!(
@@ -358,15 +393,17 @@ impl LocalControllerJobClient {
                 "local controller job start failed: {value}"
             )));
         }
-        serde_json::from_value(controller_job_response(&value).cloned().ok_or_else(|| {
-            Error::internal_unexpected("local controller-job start response has no job")
-        })?)
-        .map_err(|error| {
-            Error::internal_json(
-                error.to_string(),
-                Some("parse local controller job".to_string()),
-            )
-        })
+        let job =
+            serde_json::from_value(controller_job_response(&value).cloned().ok_or_else(|| {
+                Error::internal_unexpected("local controller-job start response has no job")
+            })?)
+            .map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("parse local controller job".to_string()),
+                )
+            })?;
+        Ok(ControllerJobSubmission { job, disposition })
     }
 
     pub fn status(&self, job_id: &str) -> Result<crate::api_jobs::Job> {
@@ -3687,19 +3724,20 @@ fn enqueue_controller_job(
         request.idempotency_key.clone(),
         controller_job,
     )?;
-    let (job, compacted) = match outcome {
+    let (job, compacted, disposition) = match outcome {
         crate::api_jobs::ControllerJobSubmissionOutcome::Submitted(job_id) => {
-            (job_store.get(job_id)?, false)
+            (job_store.get(job_id)?, false, "created")
         }
         crate::api_jobs::ControllerJobSubmissionOutcome::Existing(job) => {
             let compacted = job_store.get(job.id).is_err();
-            (*job, compacted)
+            (*job, compacted, "reused")
         }
     };
     let job_id = job.id;
     Ok(json!({
         "command": "api.controller.jobs.create",
         "job": job,
+        "submission": { "disposition": disposition },
         "terminal_tombstone": if compacted { json!({ "status": "terminal", "compacted": true }) } else { serde_json::Value::Null },
         "poll": if compacted { json!({ "job": serde_json::Value::Null, "events": serde_json::Value::Null }) } else { json!({ "job": format!("/jobs/{job_id}"), "events": format!("/jobs/{job_id}/events") }) },
         "start": if compacted { serde_json::Value::Null } else { json!({ "method": "POST", "path": format!("/controller/jobs/{job_id}/start") }) },

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -169,6 +169,8 @@ pub struct LocalControllerJobClient {
 pub enum ControllerJobSubmissionDisposition {
     Created,
     Reused,
+    /// An older daemon accepted the request before submission receipts existed.
+    Unknown,
 }
 
 /// A controller job plus the admission decision that selected it.
@@ -360,11 +362,12 @@ impl LocalControllerJobClient {
         {
             Some("created") => ControllerJobSubmissionDisposition::Created,
             Some("reused") => ControllerJobSubmissionDisposition::Reused,
-            _ => {
+            Some(_) => {
                 return Err(Error::internal_unexpected(
                     "local controller-job submission response has no recognized disposition",
                 ));
             }
+            None => ControllerJobSubmissionDisposition::Unknown,
         };
         let response = self
             .client
@@ -1031,6 +1034,8 @@ struct ControllerJobRequest {
     job_type: String,
     version: u32,
     idempotency_key: String,
+    #[serde(default)]
+    active_idempotency_key: Option<String>,
     request: serde_json::Value,
 }
 
@@ -3712,6 +3717,11 @@ fn enqueue_controller_job(
         request: request.request.clone(),
         public_request,
         request_digest,
+        active_idempotency_key: request
+            .active_idempotency_key
+            .as_deref()
+            .filter(|key| !key.trim().is_empty())
+            .map(str::to_string),
         linked_durable_run_id,
         checkpoint: None,
         cancellation_requested: false,
@@ -4371,6 +4381,7 @@ mod tests {
                     request: json!({ "schema": "homeboy/lab-staging-dispatch/v1" }),
                     public_request: json!({ "schema": "homeboy/lab-staging-dispatch/v1" }),
                     request_digest: format!("digest-{}", uuid::Uuid::new_v4()),
+                    active_idempotency_key: None,
                     linked_durable_run_id: run_id.map(str::to_string),
                     checkpoint: None,
                     cancellation_requested: false,

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -52,6 +52,7 @@ impl ControllerJobHarness {
                 request,
                 public_request,
                 request_digest,
+                active_idempotency_key: None,
                 checkpoint: None,
                 cancellation_requested: false,
                 cancellation_reason: None,

--- a/tests/cleanup_next_actions.rs
+++ b/tests/cleanup_next_actions.rs
@@ -268,6 +268,91 @@ fn explicit_local_shared_cargo_apply_succeeds_without_a_daemon() {
     );
 }
 
+#[test]
+#[cfg(unix)]
+fn async_shared_cargo_apply_does_not_reuse_a_historical_terminal_job() {
+    let fixture = tempfile::tempdir().expect("fixture");
+    let invocation_dir = fixture.path().join("operator-cwd");
+    let cargo_root = fixture.path().join("cargo-targets");
+    let historical = cargo_root.join(format!("homeboy-{}", "a".repeat(64)));
+    let current = cargo_root.join(format!("homeboy-{}", "b".repeat(64)));
+    std::fs::create_dir_all(&invocation_dir).expect("operator directory");
+    create_old_cargo_target(&historical);
+
+    let first = run_cleanup_with_cargo_root(
+        fixture.path(),
+        &invocation_dir,
+        &["--include", "shared-cargo-targets", "--apply"],
+        &cargo_root,
+    );
+    assert_eq!(first["success"], true, "{first:#}");
+    assert_eq!(first["data"]["submission"]["disposition"], "created");
+    let first_job_id = first["data"]["job_id"].as_str().expect("first job ID");
+    let first_completed = wait_for_cleanup_job(
+        fixture.path(),
+        &invocation_dir,
+        first_job_id,
+        &std::env::var("PATH").unwrap_or_default(),
+    );
+    assert_eq!(
+        first_completed["data"]["status"], "succeeded",
+        "{first_completed:#}"
+    );
+    assert!(!historical.exists(), "historical candidate must be removed");
+
+    create_old_cargo_target(&current);
+    let second = run_cleanup_with_cargo_root(
+        fixture.path(),
+        &invocation_dir,
+        &["--include", "shared-cargo-targets", "--apply"],
+        &cargo_root,
+    );
+    assert_eq!(second["success"], true, "{second:#}");
+    assert_eq!(second["data"]["submission"]["disposition"], "created");
+    let second_job_id = second["data"]["job_id"].as_str().expect("second job ID");
+    assert_ne!(second_job_id, first_job_id, "{second:#}");
+    let second_completed = wait_for_cleanup_job(
+        fixture.path(),
+        &invocation_dir,
+        second_job_id,
+        &std::env::var("PATH").unwrap_or_default(),
+    );
+    assert_eq!(
+        second_completed["data"]["status"], "succeeded",
+        "{second_completed:#}"
+    );
+    assert!(!current.exists(), "current candidate must be removed");
+
+    let stopped = run_homeboy(
+        fixture.path(),
+        &invocation_dir,
+        &["daemon", "stop"],
+        &std::env::var("PATH").unwrap_or_default(),
+    );
+    assert_eq!(stopped["success"], true, "{stopped:#}");
+}
+
+#[cfg(unix)]
+fn create_old_cargo_target(path: &Path) {
+    std::fs::create_dir_all(path).expect("cargo target store");
+    let artifact = path.join("artifact");
+    std::fs::write(&artifact, "artifact").expect("cargo target artifact");
+    let touch = Command::new("touch")
+        .args([
+            "-t",
+            "202001010000",
+            artifact.to_str().expect("artifact path"),
+            path.to_str().expect("store path"),
+        ])
+        .output()
+        .expect("age cargo target store");
+    assert!(
+        touch.status.success(),
+        "{}",
+        String::from_utf8_lossy(&touch.stderr)
+    );
+}
+
 fn run_cleanup(home: &Path, cwd: &Path, args: &[&str]) -> Value {
     run_cleanup_with_path(home, cwd, args, &std::env::var("PATH").unwrap_or_default())
 }
@@ -276,6 +361,28 @@ fn run_cleanup_with_path(home: &Path, cwd: &Path, args: &[&str], path: &str) -> 
     let mut command = vec!["cleanup"];
     command.extend_from_slice(args);
     run_homeboy(home, cwd, &command, path)
+}
+
+fn run_cleanup_with_cargo_root(home: &Path, cwd: &Path, args: &[&str], cargo_root: &Path) -> Value {
+    let mut command = vec!["cleanup"];
+    command.extend_from_slice(args);
+    let output = Command::new(homeboy_bin())
+        .args(command)
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env("HOMEBOY_CARGO_TARGET_ROOT", cargo_root)
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .env_remove("HOMEBOY_LAB_EXECUTION_RUNNER_ID")
+        .env_remove("HOMEBOY_RUNNER_HOSTED_EXEC")
+        .output()
+        .expect("run cleanup");
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "cleanup output was not JSON ({error}); status={:?}; stderr={}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
 }
 
 fn run_homeboy(home: &Path, cwd: &Path, args: &[&str], path: &str) -> Value {

--- a/tests/core/daemon_test.rs
+++ b/tests/core/daemon_test.rs
@@ -310,7 +310,7 @@ fn controller_jobs_are_durable_idempotent_and_fail_closed_after_restart() {
     }))
     .expect("register controller driver once");
     let request = serde_json::json!({
-        "type": "test.blocking", "version": 1, "idempotency_key": "run-9421", "request": { "schema": "test/v1", "private_input": "not-public" }
+        "type": "test.blocking", "version": 1, "idempotency_key": "run-9421", "active_idempotency_key": "run-9421-active", "request": { "schema": "test/v1", "private_input": "not-public" }
     });
 
     // Admission is phase one: it is durable but cannot execute until start.
@@ -355,9 +355,20 @@ fn controller_jobs_are_durable_idempotent_and_fail_closed_after_restart() {
         "not-public"
     ));
 
-    // No submitting-client state is retained: replay returns one daemon job and never executes twice.
-    let duplicate = route_with_body("POST", "/controller/jobs", Some(request), &store);
+    // A retry has a new one-shot key but coalesces with matching active work.
+    let duplicate = route_with_body(
+        "POST",
+        "/controller/jobs",
+        Some(serde_json::json!({
+            "type": "test.blocking", "version": 1, "idempotency_key": "run-9421-retry", "active_idempotency_key": "run-9421-active", "request": { "schema": "test/v1", "private_input": "not-public" }
+        })),
+        &store,
+    );
     assert_eq!(duplicate.body["body"]["job"]["id"], job_id.to_string());
+    assert_eq!(
+        duplicate.body["body"]["submission"]["disposition"],
+        "reused"
+    );
     assert_eq!(executions.load(Ordering::SeqCst), 1);
     let conflict = route_with_body(
         "POST",
@@ -382,6 +393,19 @@ fn controller_jobs_are_durable_idempotent_and_fail_closed_after_restart() {
     wait_for(
         "store.get(job_id).expect( first job ).status.is_terminal()",
         || store.get(job_id).expect("first job").status.is_terminal(),
+    );
+    let successor = route_with_body(
+        "POST",
+        "/controller/jobs",
+        Some(serde_json::json!({
+            "type": "test.blocking", "version": 1, "idempotency_key": "run-9421-successor", "active_idempotency_key": "run-9421-active", "request": { "schema": "test/v1", "private_input": "not-public" }
+        })),
+        &store,
+    );
+    assert_ne!(successor.body["body"]["job"]["id"], job_id.to_string());
+    assert_eq!(
+        successor.body["body"]["submission"]["disposition"],
+        "created"
     );
 
     let cancelled = route_with_body(


### PR DESCRIPTION
## Summary
- give each cleanup apply invocation a fresh durable idempotency identity
- coalesce retries only while identical work is active
- permit a fresh apply after the prior job reaches a terminal state

## Verification
- `cargo fmt --check`
- `cargo test -p homeboy-core --lib controller_jobs_are_durable_idempotent_and_fail_closed_after_restart`
- the full CLI integration fixture exceeded the local compile timeout and is delegated to repository CI

Closes #14098

AI assistance: OpenAI GPT-5.6 Terra using OpenCode was used to implement, independently review, rebase, and verify this change under human orchestration.