### PR TITLE
Finalize successful candidate adoption correctly

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
@@ -406,6 +406,7 @@ pub fn finish_candidate_adoption_in_store(
     lifecycle_store: &AgentTaskLifecycleStore,
     run_id: &str,
     error: Option<String>,
+    supersede_pre_execution_failure: bool,
 ) -> Result<AgentTaskRunRecord> {
     let run_id = sanitize_run_id(run_id);
     let record = lifecycle_store.mutate_record(&run_id, |record| {
@@ -427,10 +428,10 @@ pub fn finish_candidate_adoption_in_store(
         }
         .to_string();
         attempt.phase = "terminal".to_string();
-        // A recovered immutable candidate has replaced the failed attempt's
-        // execution result. Keep the pre-execution marker as provenance, but
-        // do not leave it as the run's terminal state after its gates passed.
-        if error.is_none() {
+        // Only a direct successful adoption replaces the failed attempt's
+        // execution result. A completed adoption can instead have dispatched
+        // remediation, whose successor remains authoritative.
+        if error.is_none() && supersede_pre_execution_failure {
             set_run_state(record, AgentTaskRunState::Succeeded);
         }
         record.updated_at = Some(now);
@@ -518,13 +519,10 @@ pub fn candidate_adoption_recovery_outcome(
             }
             None => false,
         };
-    let successful_adoption = record
-        .candidate_adoption
-        .as_ref()
-        .is_some_and(|adoption| adoption.state == "completed" && adoption.terminal_error.is_none());
-    let eligible_failed_preexecution = (record.state == AgentTaskRunState::Failed
-        || successful_adoption)
-        && record.metadata["provider_executions_consumed"] == 0
+    let eligible_failed_preexecution = matches!(
+        record.state,
+        AgentTaskRunState::Failed | AgentTaskRunState::Succeeded
+    ) && record.metadata["provider_executions_consumed"] == 0
         && record.provider_handles.is_empty()
         && no_runner_job_recorded(record)
         && record.lifecycle.external_runtime_ids.is_empty()

--- a/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lifecycle_candidate_adoption.rs
@@ -427,6 +427,12 @@ pub fn finish_candidate_adoption_in_store(
         }
         .to_string();
         attempt.phase = "terminal".to_string();
+        // A recovered immutable candidate has replaced the failed attempt's
+        // execution result. Keep the pre-execution marker as provenance, but
+        // do not leave it as the run's terminal state after its gates passed.
+        if error.is_none() {
+            set_run_state(record, AgentTaskRunState::Succeeded);
+        }
         record.updated_at = Some(now);
         true
     })?;
@@ -512,7 +518,12 @@ pub fn candidate_adoption_recovery_outcome(
             }
             None => false,
         };
-    let eligible_failed_preexecution = record.state == AgentTaskRunState::Failed
+    let successful_adoption = record
+        .candidate_adoption
+        .as_ref()
+        .is_some_and(|adoption| adoption.state == "completed" && adoption.terminal_error.is_none());
+    let eligible_failed_preexecution = (record.state == AgentTaskRunState::Failed
+        || successful_adoption)
         && record.metadata["provider_executions_consumed"] == 0
         && record.provider_handles.is_empty()
         && no_runner_job_recorded(record)

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -236,6 +236,7 @@ fn cook_alias_status_selects_latest_terminal_adoption_then_index_order() {
             &lifecycle_store,
             &run.run_id,
             (attempt != 1).then(|| format!("attempt {attempt} failed")),
+            false,
         )
         .expect("finish terminal adoption");
         runs.push(run);
@@ -465,7 +466,7 @@ fn candidate_adoption_status_persists_running_stale_resume_and_completion() {
     let adoption = finalizing.candidate_adoption.expect("attempt");
     assert_eq!(adoption.phase, "finalization");
     assert_eq!(adoption.active_gate, "finalize pull request");
-    finish_candidate_adoption_in_store(&lifecycle_store, &record.run_id, None)
+    finish_candidate_adoption_in_store(&lifecycle_store, &record.run_id, None, false)
         .expect("terminal completion");
     let completed = reconcile_status_in_store(
         &lifecycle_store,
@@ -475,6 +476,7 @@ fn candidate_adoption_status_persists_running_stale_resume_and_completion() {
     )
     .expect("completed status")
     .record;
+    assert_eq!(completed.state, AgentTaskRunState::Queued);
     let adoption = completed
         .candidate_adoption
         .expect("terminal attempt retained");

--- a/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_adoption.rs
@@ -609,8 +609,11 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
     let mut promotion = match promotion {
         Ok(promotion) => promotion,
         Err(error) => {
-            lifecycle_store
-                .finish_candidate_adoption(&record.run_id, Some(error.message.clone()))?;
+            lifecycle_store.finish_candidate_adoption(
+                &record.run_id,
+                Some(error.message.clone()),
+                false,
+            )?;
             return Err(error);
         }
     };
@@ -699,6 +702,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
                     "candidate adoption feedback requested retry without a follow-up request"
                         .to_string(),
                 ),
+                false,
             )?;
             let report = cook_report(CookReportInput {
                 cook_id: cook_id.to_string(),
@@ -744,7 +748,11 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
         };
         if !lifecycle_store.matches_current_environment()? {
             let message = "candidate adoption remediation requires the explicit lifecycle store to match the current Cook runtime root";
-            lifecycle_store.finish_candidate_adoption(&record.run_id, Some(message.to_string()))?;
+            lifecycle_store.finish_candidate_adoption(
+                &record.run_id,
+                Some(message.to_string()),
+                false,
+            )?;
             return Err(Error::validation_invalid_argument(
                 "stores",
                 message,
@@ -771,7 +779,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
         )?;
         return match dispatch {
             CookFollowUpDispatch::Dispatched { run_id } => {
-                lifecycle_store.finish_candidate_adoption(&record.run_id, None)?;
+                lifecycle_store.finish_candidate_adoption(&record.run_id, None, false)?;
                 options.identity.initial_plan = recipe_store.load_recipe(cook_id)?
                     .attempts
                     .into_iter()
@@ -834,6 +842,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
                 lifecycle_store.finish_candidate_adoption(
                     &record.run_id,
                     Some("candidate remediation budget exhausted".to_string()),
+                    false,
                 )?;
                 Ok(report)
             }
@@ -849,7 +858,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
                     invocation_latest_run_id: Some(record.run_id.as_str()),
                 });
                 persist_adoption_terminal_result(lifecycle_store, &record.run_id, &report.value)?;
-                lifecycle_store.finish_candidate_adoption(&record.run_id, Some(reason))?;
+                lifecycle_store.finish_candidate_adoption(&record.run_id, Some(reason), false)?;
                 Ok(report)
             }
         };
@@ -860,7 +869,11 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
             // durable baseline proof and must not spend another provider attempt.
         } else {
             let reason = "candidate and immutable baseline failed the same required gate; repair the inherited infrastructure or gate environment before retrying adoption";
-            lifecycle_store.finish_candidate_adoption(&record.run_id, Some(reason.to_string()))?;
+            lifecycle_store.finish_candidate_adoption(
+                &record.run_id,
+                Some(reason.to_string()),
+                false,
+            )?;
             return Ok(cook_report(CookReportInput {
                 cook_id: cook_id.to_string(),
                 status: "baseline_red",
@@ -881,6 +894,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
         lifecycle_store.finish_candidate_adoption(
             &record.run_id,
             Some("adopted candidate did not pass the original deterministic gates".to_string()),
+            false,
         )?;
         return Ok(cook_report(CookReportInput {
             cook_id: cook_id.to_string(),
@@ -896,7 +910,7 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
         }));
     }
     if options.finalization.no_finalize {
-        lifecycle_store.finish_candidate_adoption(&record.run_id, None)?;
+        lifecycle_store.finish_candidate_adoption(&record.run_id, None, true)?;
         return Ok(cook_report(CookReportInput {
             cook_id: cook_id.to_string(),
             status: "green_no_finalize",
@@ -926,22 +940,22 @@ pub(crate) fn adopt_cook_candidate_with_dispatcher_and_backend_for_attempt_with_
     ) {
         Ok(finalization) => finalization,
         Err(error) => {
-            lifecycle_store
-                .finish_candidate_adoption(&record.run_id, Some(error.message.clone()))?;
+            lifecycle_store.finish_candidate_adoption(
+                &record.run_id,
+                Some(error.message.clone()),
+                false,
+            )?;
             return Err(error);
         }
     };
     project_execution_placement(&mut finalization, &record.metadata);
-    lifecycle_store.finish_candidate_adoption(&record.run_id, None)?;
     let status = finalization["status"]
         .as_str()
         .unwrap_or("unknown")
         .to_string();
-    let exit_code = if matches!(status.as_str(), "review_ready" | "draft_published") {
-        0
-    } else {
-        1
-    };
+    let publication_succeeded = matches!(status.as_str(), "review_ready" | "draft_published");
+    lifecycle_store.finish_candidate_adoption(&record.run_id, None, publication_succeeded)?;
+    let exit_code = if publication_succeeded { 0 } else { 1 };
     Ok(cook_report(CookReportInput {
         cook_id: cook_id.to_string(),
         status: &status,

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -3271,7 +3271,7 @@ fn candidate_adoption_lifecycle_and_promotion_evidence_do_not_alias_across_expli
         store
             .record_candidate_adoption_result(run_id, serde_json::json!({ "root": root }))
             .unwrap();
-        store.finish_candidate_adoption(run_id, None).unwrap();
+        store.finish_candidate_adoption(run_id, None, true).unwrap();
     }
 
     for (store, candidate_sha, model, root) in [
@@ -14553,6 +14553,7 @@ fn legacy_adoption_budget_failure_reenters_once_through_review_authority() {
             &test_lifecycle_store(),
             &fixture.run_id,
             Some("candidate remediation budget exhausted".to_string()),
+            false,
         )
         .unwrap();
         agent_task_lifecycle::record_candidate_adoption_result_in_store(

--- a/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook_tests.rs
@@ -6046,6 +6046,28 @@ fn dirty_destination_recovery_actions_commit_review_and_adopt_through_publicatio
             .as_ref()
             .is_some_and(|promotion| promotion.finalization_eligible(false)));
         assert!(backend.committed && backend.pushed && backend.created);
+
+        let record = agent_task_lifecycle::reconcile_status(&fixture.run_id)
+            .expect("successful adoption supersedes the historical refusal");
+        assert_eq!(
+            record.state,
+            agent_task_lifecycle::AgentTaskRunState::Succeeded
+        );
+        assert_eq!(
+            record.lifecycle.execution.state,
+            RunExecutionState::Succeeded
+        );
+        assert_eq!(
+            record.metadata["pre_execution_failure"]["candidate_adoption_recovery"]["reason"],
+            "dirty_destination_first_provider_admission",
+            "the initial refusal remains authenticated adoption provenance"
+        );
+        assert!(candidate_adoption_source_in_store(
+            &test_lifecycle_store(),
+            &record,
+            &fixture.options.identity.initial_plan.tasks[0]
+        )
+        .is_ok());
     });
 }
 

--- a/crates/homeboy-agents/src/lifecycle_store.rs
+++ b/crates/homeboy-agents/src/lifecycle_store.rs
@@ -523,8 +523,14 @@ impl AgentTaskLifecycleStore {
         &self,
         run_id: &str,
         error: Option<String>,
+        supersede_pre_execution_failure: bool,
     ) -> Result<AgentTaskRunRecord> {
-        super::lifecycle_candidate_adoption::finish_candidate_adoption_in_store(self, run_id, error)
+        super::lifecycle_candidate_adoption::finish_candidate_adoption_in_store(
+            self,
+            run_id,
+            error,
+            supersede_pre_execution_failure,
+        )
     }
 
     pub fn record_candidate_adoption_result(&self, run_id: &str, result: Value) -> Result<()> {


### PR DESCRIPTION
## Summary
- finalize immutable candidate adoption only after direct adoption or publication succeeds
- prevent remediation and finalization failures from being projected as adopted success
- keep retained pre-execution provenance distinct from the adopted candidate identity

## Verification
- `cargo fmt --check`
- focused lifecycle adoption and Cook adoption tests passed during independent review

Closes #14088

AI assistance: OpenAI GPT-5.6 Terra using OpenCode was used to implement, independently review, rebase, and verify this change under human orchestration.