### PR TITLE
fix(agent-task): bound readiness invocations

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/agent_task_executor_declaration.rs
+++ b/crates/contracts/homeboy-extension-contract/src/agent_task_executor_declaration.rs
@@ -31,6 +31,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 pub const AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA: &str = "homeboy/agent-task-executor-provider/v1";
+pub const DEFAULT_PROVIDER_READINESS_INVOCATION_TIMEOUT_MS: u64 = 20_000;
+pub const MAX_PROVIDER_READINESS_INVOCATION_TIMEOUT_MS: u64 = 120_000;
 
 fn default_provider_schema() -> String {
     AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA.to_string()
@@ -54,8 +56,49 @@ pub struct AgentTaskExecutorProviderDeclaration {
     /// declare a command that is never executed.
     #[serde(default, deserialize_with = "reject_deprecated_provider_command")]
     pub command: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub readiness_invocation: Option<AgentTaskExecutorReadinessInvocationDeclaration>,
     #[serde(flatten, default)]
     pub extra: BTreeMap<String, Value>,
+}
+
+/// The provider-owned readiness command is generic, but its total wall-clock
+/// budget is a core-owned admission boundary.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskExecutorReadinessInvocationDeclaration {
+    #[serde(
+        default,
+        deserialize_with = "deserialize_readiness_invocation_timeout_ms"
+    )]
+    pub timeout_ms: Option<u64>,
+    #[serde(flatten, default)]
+    pub extra: BTreeMap<String, Value>,
+}
+
+fn deserialize_readiness_invocation_timeout_ms<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<u64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let timeout_ms = Option::<u64>::deserialize(deserializer)?;
+    if let Some(timeout_ms) = timeout_ms {
+        validate_provider_readiness_invocation_timeout_ms(timeout_ms)
+            .map_err(serde::de::Error::custom)?;
+    }
+    Ok(timeout_ms)
+}
+
+pub fn validate_provider_readiness_invocation_timeout_ms(
+    timeout_ms: u64,
+) -> std::result::Result<(), String> {
+    if (1..=MAX_PROVIDER_READINESS_INVOCATION_TIMEOUT_MS).contains(&timeout_ms) {
+        Ok(())
+    } else {
+        Err(format!(
+            "readiness_invocation.timeout_ms must be between 1 and {MAX_PROVIDER_READINESS_INVOCATION_TIMEOUT_MS} milliseconds"
+        ))
+    }
 }
 
 fn reject_deprecated_provider_command<'de, D>(
@@ -173,5 +216,21 @@ mod tests {
 
         assert!(declaration.extra.contains_key("capabilities"));
         assert!(declaration.extra.contains_key("some_future_provider_key"));
+    }
+
+    #[test]
+    fn readiness_invocation_timeout_is_validated_at_install_time() {
+        let error = parse_agent_task_executor_declaration(
+            "wordpress",
+            "wordpress-runtime",
+            &json!({
+                "id": "a",
+                "backend": "b",
+                "readiness_invocation": { "argv": ["provider"], "timeout_ms": 0 }
+            }),
+        )
+        .expect_err("zero readiness timeout must be rejected");
+
+        assert!(error.message.contains("readiness_invocation.timeout_ms"));
     }
 }

--- a/crates/homeboy-agents/src/agent_task_provider.rs
+++ b/crates/homeboy-agents/src/agent_task_provider.rs
@@ -70,6 +70,8 @@ pub use admission::{
     AGENT_TASK_PROVIDER_ADMISSION_PLAN_SCHEMA,
 };
 pub use catalog::*;
+#[cfg(test)]
+pub(crate) use command_runner::run_provider_readiness_invocation_with_test_timeout;
 pub use command_runner::{
     probe_provider_executor_resolves, provider_command_parts, run_provider_readiness_invocation,
     validate_provider_immediate_failure_patterns, ProviderExecutorResolution,

--- a/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/command_runner.rs
@@ -37,7 +37,6 @@ const WORKSPACE_PROGRESS_CHECK_INTERVAL_FLOOR_MS: u64 = 200;
 const WORKSPACE_PROGRESS_CHECK_INTERVAL_CEIL_MS: u64 = 5_000;
 pub const PROVIDER_READINESS_RESULT_SCHEMA: &str =
     "homeboy/agent-task-provider-readiness-result/v1";
-const PROVIDER_READINESS_TIMEOUT: Duration = Duration::from_secs(20);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum ProviderCommandEnvError {
@@ -2525,6 +2524,21 @@ pub fn run_provider_readiness_invocation(
             identity: Value::Null,
         });
     };
+    run_provider_readiness_invocation_with_timeout(
+        provider,
+        effective_config,
+        Duration::from_millis(invocation.timeout_ms),
+    )
+}
+
+fn run_provider_readiness_invocation_with_timeout(
+    provider: &AgentTaskExecutorProvider,
+    effective_config: &Value,
+    timeout: Duration,
+) -> Result<ProviderReadinessInvocationResult, String> {
+    let Some(invocation) = provider.readiness_invocation.as_ref() else {
+        unreachable!("readiness invocation timeout requires an invocation")
+    };
     let Some((program, args, cwd)) = invocation_command_parts(provider, invocation) else {
         return Err(format!(
             "provider '{}' declares an empty readiness invocation",
@@ -2603,7 +2617,7 @@ pub fn run_provider_readiness_invocation(
     let status = loop {
         match child.try_wait() {
             Ok(Some(status)) => break status,
-            Ok(None) if started.elapsed() < PROVIDER_READINESS_TIMEOUT => {
+            Ok(None) if started.elapsed() < timeout => {
                 std::thread::sleep(Duration::from_millis(10));
             }
             Ok(None) => {
@@ -2612,9 +2626,9 @@ pub fn run_provider_readiness_invocation(
                     let _ = reader.join();
                 }
                 return Err(format!(
-                    "provider '{}' readiness invocation timed out after {} seconds",
+                    "provider '{}' readiness invocation timed out after {} ms",
                     provider.id,
-                    PROVIDER_READINESS_TIMEOUT.as_secs()
+                    timeout.as_millis()
                 ));
             }
             Err(error) => {
@@ -2657,6 +2671,15 @@ pub fn run_provider_readiness_invocation(
             provider.id
         )
     })
+}
+
+#[cfg(test)]
+pub(crate) fn run_provider_readiness_invocation_with_test_timeout(
+    provider: &AgentTaskExecutorProvider,
+    effective_config: &Value,
+    timeout: Duration,
+) -> Result<ProviderReadinessInvocationResult, String> {
+    run_provider_readiness_invocation_with_timeout(provider, effective_config, timeout)
 }
 
 fn render_provider_command_template(value: &str, provider: &AgentTaskExecutorProvider) -> String {

--- a/crates/homeboy-agents/src/agent_task_provider/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/discovery.rs
@@ -88,11 +88,22 @@ pub(super) fn agent_task_executor_providers_from_runtime_manifests(
         // it declares, so the partial is reported once per runtime.
         let mut reported_revision_probe_timeout = false;
         for provider_value in runtime_manifest.agent_task_executors.clone() {
-            let Ok(mut provider) =
-                serde_json::from_value::<AgentTaskExecutorProvider>(provider_value)
-            else {
-                continue;
-            };
+            let mut provider =
+                match serde_json::from_value::<AgentTaskExecutorProvider>(provider_value) {
+                    Ok(provider) => provider,
+                    Err(error) => {
+                        diagnostics.push(AgentRuntimeDiscoveryDiagnostic {
+                            class: "agent_task_executor_provider.invalid_declaration".to_string(),
+                            message: format!(
+                            "agent-task provider declaration is invalid and was not loaded: {error}"
+                        ),
+                            runtime_id: Some(runtime_manifest.id.clone()),
+                            extension_id: runtime_manifest.extension_id.clone(),
+                            path: runtime_manifest.runtime_path.clone(),
+                        });
+                        continue;
+                    }
+                };
             normalize_agent_task_executor_provider_invocation(&mut provider);
             provider.extension_id = runtime_manifest.extension_id.clone();
             provider.extension_path = runtime_manifest.extension_path.clone();
@@ -324,5 +335,29 @@ mod revision_probe_tests {
         let identity = AgentRuntimeSelectedIdentity::default();
 
         assert!(revision_probe_timeout_diagnostic(&manifest(), &identity).is_none());
+    }
+
+    #[test]
+    fn invalid_readiness_timeout_is_a_scoped_discovery_diagnostic() {
+        let mut runtime = manifest();
+        runtime.agent_task_executors = vec![serde_json::json!({
+            "id": "opencode.agent-task-executor",
+            "backend": "opencode",
+            "readiness_invocation": { "argv": ["opencode-provider"], "timeout_ms": 120001 }
+        })];
+        let mut diagnostics = Vec::new();
+
+        let providers =
+            agent_task_executor_providers_from_runtime_manifests(vec![runtime], &mut diagnostics);
+
+        assert!(providers.is_empty());
+        assert_eq!(
+            diagnostics[0].class,
+            "agent_task_executor_provider.invalid_declaration"
+        );
+        assert!(diagnostics[0]
+            .message
+            .contains("readiness_invocation.timeout_ms"));
+        assert_eq!(diagnostics[0].runtime_id.as_deref(), Some("opencode"));
     }
 }

--- a/crates/homeboy-agents/src/agent_task_provider/dispatchability.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/dispatchability.rs
@@ -605,14 +605,17 @@ mod tests {
             "backend": "test"
         }))
         .expect("provider fixture");
-        provider.readiness_invocation = Some(CommandInvocation {
-            argv: vec![
-                "node".to_string(),
-                script.display().to_string(),
-                count.display().to_string(),
-            ],
-            ..CommandInvocation::default()
-        });
+        provider.readiness_invocation = Some(
+            CommandInvocation {
+                argv: vec![
+                    "node".to_string(),
+                    script.display().to_string(),
+                    count.display().to_string(),
+                ],
+                ..CommandInvocation::default()
+            }
+            .into(),
+        );
         provider
     }
 
@@ -730,10 +733,13 @@ mod tests {
             r#"{"token":"present-and-live-checked"}"#,
         )
         .expect("write auth");
-        live_provider.readiness_invocation = Some(CommandInvocation {
-            argv: vec!["node".to_string(), script.display().to_string()],
-            ..CommandInvocation::default()
-        });
+        live_provider.readiness_invocation = Some(
+            CommandInvocation {
+                argv: vec!["node".to_string(), script.display().to_string()],
+                ..CommandInvocation::default()
+            }
+            .into(),
+        );
         let catalog = catalog(live_provider);
 
         let verdict = evaluate_provider_dispatchability(&catalog, "revocable", None, None, true);
@@ -759,10 +765,13 @@ mod tests {
         )
         .expect("readiness script");
         let mut provider = provider_with_present_but_unverifiable_credential(&auth);
-        provider.readiness_invocation = Some(CommandInvocation {
-            argv: vec!["node".to_string(), script.display().to_string()],
-            ..CommandInvocation::default()
-        });
+        provider.readiness_invocation = Some(
+            CommandInvocation {
+                argv: vec!["node".to_string(), script.display().to_string()],
+                ..CommandInvocation::default()
+            }
+            .into(),
+        );
         let catalog = catalog(provider);
 
         let verdict = evaluate_provider_dispatchability(&catalog, "revocable", None, None, true);

--- a/crates/homeboy-agents/src/agent_task_provider/runtime_readiness.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/runtime_readiness.rs
@@ -215,14 +215,17 @@ mod tests {
             "backend": "runtime"
         }))
         .expect("provider fixture");
-        provider.readiness_invocation = Some(CommandInvocation {
-            argv: vec![
-                "node".to_string(),
-                script.display().to_string(),
-                count.display().to_string(),
-            ],
-            ..CommandInvocation::default()
-        });
+        provider.readiness_invocation = Some(
+            CommandInvocation {
+                argv: vec![
+                    "node".to_string(),
+                    script.display().to_string(),
+                    count.display().to_string(),
+                ],
+                ..CommandInvocation::default()
+            }
+            .into(),
+        );
         provider
     }
 

--- a/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/tests/manifest_tests.rs
@@ -224,12 +224,67 @@ fn provider_readiness_invocation_receives_effective_config_and_fails_closed() {
             script("let fs=require('fs');let req=JSON.parse(fs.readFileSync(0,'utf8'));process.stdout.write(JSON.stringify({schema:'homeboy/agent-task-provider-readiness-result/v1',ready:req.effective_config.marker==='ready',classification:'test',retryable:false,remediation:'configured marker is not ready',reason:'configured_marker',cache_key:'test-cache',identity:{provider:'test'}}));"),
         ],
         ..CommandInvocation::default()
-    });
+    }.into());
 
     assert!(run_provider_readiness_invocation(&provider, &json!({ "marker": "ready" })).is_ok());
     let result = run_provider_readiness_invocation(&provider, &json!({ "marker": "blocked" }))
         .expect("provider-owned readiness result parses");
     assert!(!result.ready);
+}
+
+#[test]
+fn provider_readiness_invocation_defaults_and_validates_its_total_timeout() {
+    let provider: AgentTaskExecutorProvider = serde_json::from_value(json!({
+        "id": "ready.provider",
+        "backend": "ready",
+        "readiness_invocation": { "argv": ["ready-provider"] }
+    }))
+    .expect("provider manifest");
+
+    assert_eq!(
+        provider
+            .readiness_invocation
+            .as_ref()
+            .expect("readiness invocation")
+            .timeout_ms,
+        homeboy_extension_contract::agent_task_executor_declaration::DEFAULT_PROVIDER_READINESS_INVOCATION_TIMEOUT_MS
+    );
+    assert_eq!(
+        serde_json::to_value(&provider).expect("provider export")["readiness_invocation"]
+            ["timeout_ms"],
+        json!(20_000)
+    );
+
+    let error = serde_json::from_value::<AgentTaskExecutorProvider>(json!({
+        "id": "invalid.provider",
+        "backend": "invalid",
+        "readiness_invocation": { "argv": ["invalid-provider"], "timeout_ms": 120001 }
+    }))
+    .expect_err("timeout above the core maximum must fail");
+    assert!(error
+        .to_string()
+        .contains("readiness_invocation.timeout_ms"));
+}
+
+#[test]
+fn provider_readiness_timeout_uses_an_injected_zero_duration() {
+    let (_, mut provider) = request("timed-readiness", "node ignored.js".to_string());
+    provider.readiness_invocation = Some(
+        CommandInvocation {
+            argv: vec!["node".to_string(), script("setInterval(() => {}, 1000);")],
+            ..CommandInvocation::default()
+        }
+        .into(),
+    );
+
+    let error = run_provider_readiness_invocation_with_test_timeout(
+        &provider,
+        &Value::Null,
+        Duration::ZERO,
+    )
+    .expect_err("zero injected duration must time out without sleeping");
+
+    assert!(error.contains("timed out after 0 ms"), "{error}");
 }
 
 #[test]

--- a/crates/homeboy-agents/src/agent_task_provider/types.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/types.rs
@@ -1,4 +1,10 @@
 use super::*;
+use std::ops::Deref;
+
+use homeboy_extension_contract::agent_task_executor_declaration::{
+    validate_provider_readiness_invocation_timeout_ms,
+    DEFAULT_PROVIDER_READINESS_INVOCATION_TIMEOUT_MS,
+};
 
 pub const AGENT_TASK_EXECUTOR_PROVIDER_SCHEMA: &str = "homeboy/agent-task-executor-provider/v1";
 pub const AGENT_TASK_PROVIDER_CAPABILITY_CONTRACT_SCHEMA: &str =
@@ -79,7 +85,7 @@ pub struct AgentTaskExecutorProvider {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub runner_readiness: Vec<AgentTaskProviderRunnerReadiness>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub readiness_invocation: Option<CommandInvocation>,
+    pub readiness_invocation: Option<AgentTaskProviderReadinessInvocation>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub runner_sources: Vec<AgentTaskProviderRunnerSource>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -126,6 +132,51 @@ pub struct AgentTaskExecutorProvider {
     pub runtime_path: Option<String>,
     #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
     pub extra: BTreeMap<String, Value>,
+}
+
+/// A provider-owned readiness command and its total, core-enforced deadline.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentTaskProviderReadinessInvocation {
+    #[serde(flatten)]
+    pub command: CommandInvocation,
+    #[serde(
+        default = "default_provider_readiness_invocation_timeout_ms",
+        deserialize_with = "deserialize_provider_readiness_invocation_timeout_ms"
+    )]
+    pub timeout_ms: u64,
+}
+
+impl Deref for AgentTaskProviderReadinessInvocation {
+    type Target = CommandInvocation;
+
+    fn deref(&self) -> &Self::Target {
+        &self.command
+    }
+}
+
+impl From<CommandInvocation> for AgentTaskProviderReadinessInvocation {
+    fn from(command: CommandInvocation) -> Self {
+        Self {
+            command,
+            timeout_ms: DEFAULT_PROVIDER_READINESS_INVOCATION_TIMEOUT_MS,
+        }
+    }
+}
+
+fn default_provider_readiness_invocation_timeout_ms() -> u64 {
+    DEFAULT_PROVIDER_READINESS_INVOCATION_TIMEOUT_MS
+}
+
+fn deserialize_provider_readiness_invocation_timeout_ms<'de, D>(
+    deserializer: D,
+) -> std::result::Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let timeout_ms = u64::deserialize(deserializer)?;
+    validate_provider_readiness_invocation_timeout_ms(timeout_ms)
+        .map_err(serde::de::Error::custom)?;
+    Ok(timeout_ms)
 }
 
 fn reject_deprecated_provider_command<'de, D>(deserializer: D) -> Result<String, D::Error>

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -1177,10 +1177,13 @@ fn run_next_redacts_adversarial_provider_readiness_diagnostics_everywhere() {
                 "backend": "adversarial-readiness"
             }))
             .expect("provider fixture");
-        provider.readiness_invocation = Some(CommandInvocation {
-            argv: vec!["node".to_string(), script.display().to_string()],
-            ..CommandInvocation::default()
-        });
+        provider.readiness_invocation = Some(
+            CommandInvocation {
+                argv: vec!["node".to_string(), script.display().to_string()],
+                ..CommandInvocation::default()
+            }
+            .into(),
+        );
         assert_eq!(provider.backend, "adversarial-readiness");
         assert!(provider.readiness_invocation.is_some());
 

--- a/docs/commands/agent-task.md
+++ b/docs/commands/agent-task.md
@@ -1459,6 +1459,10 @@ belong on each `agent_task_executors[]` entry:
       "remediation": "Configure EXAMPLE_API_TOKEN with homeboy agent-task auth."
     }
   ],
+  "readiness_invocation": {
+    "argv": ["example-provider", "--readiness"],
+    "timeout_ms": 30000
+  },
   "workspace_materialization": {
     "cwd": "git_checkout",
     "requires_git": true,
@@ -1484,6 +1488,10 @@ Homeboy treats these declarations as generic contracts:
 
 - `secret_env_requirements` and `runner_readiness` describe required secret env
   names and redacted readiness probes without exposing values.
+- `readiness_invocation.timeout_ms` bounds the complete provider-owned readiness
+  command, including all child probes. It defaults to 20,000 milliseconds and
+  must be between 1 and 120,000 milliseconds; providers must keep their own
+  sequential child budgets within this total.
 - `workspace_materialization` describes the checkout shape a provider needs; it
   does not name any workspace manager or product runtime.
 - `timeout_artifact_discovery` extends timeout evidence recovery with declared


### PR DESCRIPTION
## Summary
- add a validated total `readiness_invocation.timeout_ms` contract with a 20-second default and 120-second maximum
- enforce the effective timeout for provider readiness subprocesses and expose invalid declarations as scoped discovery diagnostics
- cover defaults, bounds, zero-duration timeout injection, and discovery diagnostics

Closes #14108

## Validation
- `cargo fmt --check`
- `cargo test -p homeboy-extension-contract`
- focused `homeboy-agents` readiness, discovery, dispatchability, and runtime-readiness tests
- `cargo test -p homeboy-agents --lib` was started and ran beyond the 10-minute command limit without a reported failure

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode assisted with this pull request under Chris Huber's direction.