### PR TITLE
fix(agent-task): validate fanout preview providers

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/args/definitions/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/args/definitions/fanout.rs
@@ -187,10 +187,11 @@ pub struct AgentTaskFanoutCookBatchArgs {
         value_name = "SECONDS"
     )]
     pub max_duration: Option<u64>,
-    /// Resolve and validate the batch without side effects: no repository
-    /// hydration, provider dispatch, worktree creation, or file reads. Prints
-    /// the static plan, worktree projection, preflight, and a replayable
-    /// command — the batch-wide counterpart of `agent-task cook --preview`.
+    /// Resolve and validate the batch without repository hydration, provider
+    /// dispatch, or worktree creation. Runs the selected provider's bounded
+    /// readiness admission, then prints the static plan, worktree projection,
+    /// preflight, and a replayable command — the batch-wide counterpart of
+    /// `agent-task cook --preview`.
     /// `--dry-run` is accepted as the historical spelling of this flag.
     #[arg(long = "preview", alias = "dry-run")]
     pub preview: bool,

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -10,7 +10,7 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use homeboy::agents::agent_task_provider::AgentTaskProviderProfileDeclaration;
 use homeboy::agents::agent_task_scheduler::{
@@ -186,6 +186,9 @@ const DRY_RUN_PHASE_TIMEOUT: Duration = Duration::from_secs(10);
 const DRY_RUN_MAX_ISSUES: usize = 128;
 const DRY_RUN_MAX_INLINE_JSON_BYTES: usize = 64 * 1024;
 const DRY_RUN_MAX_GATE_BYTES: usize = 8 * 1024;
+/// A preview is a point-in-time admission observation. Execution always probes
+/// again, but callers can use this short bound to avoid treating it as durable.
+const PREVIEW_PROVIDER_DISPATCHABILITY_FRESHNESS: Duration = Duration::from_secs(30);
 const COMPACT_FANOUT_FAILURE_LIMIT: usize = 3;
 
 #[cfg(test)]
@@ -2668,10 +2671,9 @@ fn empty_causal_failure_projection() -> (Option<Value>, Value) {
     )
 }
 
-/// Static dry-run deliberately stops before any repository, provider, workspace,
-/// gate-file, or evidence-file hydration. This makes the planner's wall-clock
-/// bound enforceable without spawning an unkillable helper around a synchronous
-/// dependency.
+/// Preview stops before repository, workspace, gate-file, or evidence-file
+/// hydration. It does run the selected provider's bounded readiness admission,
+/// so a ready result is executable unless the environment changes before replay.
 fn cook_batch_dry_run(
     mut args: AgentTaskFanoutCookBatchArgs,
     placement: Placement,
@@ -2754,6 +2756,20 @@ fn cook_batch_dry_run(
     plan.ensure_placement(invocation_placement_directive(placement))?;
     let replay_args = pin_cook_batch_replay(&args, &plan.fanout_id);
     let plan_ref = batch_plan_reference(&plan)?;
+    let provider_dispatchability_plan = plan.clone();
+    let provider_dispatchability_plan_ref = plan_ref.clone();
+    let provider_dispatchability = planner.run_bounded(
+        "provider_dispatchability",
+        "bounded provider dispatchability",
+        move || {
+            let catalog = AgentTaskProviderCatalog::discover();
+            preview_provider_dispatchability_evidence(
+                &provider_dispatchability_plan,
+                &catalog,
+                &provider_dispatchability_plan_ref,
+            )
+        },
+    )?;
     let workspace_args = args.clone();
     let workspace = planner.run_bounded(
         "gate_workspace",
@@ -2787,7 +2803,8 @@ fn cook_batch_dry_run(
                 "default_branch": args.base_resolution.clone(),
                 "provider_readiness_command": provider_readiness_command(&args),
                 "provider_selection": provider_selection_preflight(&args),
-                "deferred_live_checks": ["provider_runtime_readiness", "workspace_materialization"],
+                "provider_dispatchability": provider_dispatchability,
+                "deferred_live_checks": ["workspace_materialization"],
                 "placement": fanout_placement_preflight(plan.placement.as_ref()),
                 "deterministic_gates": effective_batch_cook_gates(&plan),
             },
@@ -3760,6 +3777,84 @@ fn preflight_batch_cook_recipes(
         agent_task_service::validate_initial_recipe_compatibility(&options)?;
     }
     Ok(())
+}
+
+/// Preview the same provider admission used while compiling each coordinator
+/// child. The evidence is deliberately redacted and short lived: execution
+/// recompiles and revalidates it after workspace materialization.
+fn preview_provider_dispatchability_evidence(
+    plan: &BatchCookFanoutPlan,
+    catalog: &AgentTaskProviderCatalog,
+    plan_ref: &Value,
+) -> Result<Value> {
+    let mut readiness_cache = provider::ProviderRuntimeReadinessCache::default();
+    let mut children = Vec::with_capacity(plan.cooks.len());
+    for cook in &plan.cooks {
+        let mut invocation = cook.to_cook_invocation(plan)?;
+        // Generated fanout cooks carry a future worktree handle. Provider
+        // admission does not need that path, and resolving it here would turn a
+        // preview into workspace materialization.
+        if cook.cwd.is_none() && cook.workspace.is_none() {
+            invocation.dispatch.workspace = None;
+        }
+        let options = agent_task_service::compile_cook_attempt_with_catalog_and_readiness_cache(
+            invocation.options,
+            invocation.dispatch,
+            catalog,
+            &mut readiness_cache,
+        )?;
+        let task = options.identity.initial_plan.tasks.first().ok_or_else(|| {
+            Error::internal_unexpected("compiled fanout cook has no provider task")
+        })?;
+        let dispatchability = preview_provider_dispatchability_for_executor(
+            catalog,
+            &task.executor.backend,
+            task.executor.selector.as_deref(),
+            task.executor.model(),
+            &task.executor.config,
+            &mut readiness_cache,
+        )?;
+        children.push(serde_json::json!({
+            "cook_id": cook.cook_id,
+            "executor": {
+                "backend": task.executor.backend,
+                "selector": task.executor.selector,
+                "model": task.executor.model(),
+            },
+            "dispatchability": dispatchability,
+        }));
+    }
+    let checked_at_unix_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    Ok(serde_json::json!({
+        "schema": "homeboy/agent-task-fanout-provider-dispatchability/v1",
+        "state": "ready",
+        "plan_ref": plan_ref,
+        "checked_at_unix_ms": checked_at_unix_ms,
+        "freshness_window_seconds": PREVIEW_PROVIDER_DISPATCHABILITY_FRESHNESS.as_secs(),
+        "revalidate_before_execution": true,
+        "children": children,
+    }))
+}
+
+fn preview_provider_dispatchability_for_executor(
+    catalog: &AgentTaskProviderCatalog,
+    backend: &str,
+    selector: Option<&str>,
+    model: Option<&str>,
+    config: &Value,
+    readiness_cache: &mut provider::ProviderRuntimeReadinessCache,
+) -> Result<provider::AgentTaskProviderDispatchability> {
+    provider::preflight_provider_dispatchability_with_config(
+        catalog,
+        backend,
+        selector,
+        model,
+        config,
+        readiness_cache,
+    )
 }
 
 fn load_fanout_agent_task_plan(
@@ -10024,6 +10119,53 @@ fi
             dry_error.message.contains("missing_readiness_invocation")
                 || dry_error.message.contains("readiness invocation")
         );
+    }
+
+    #[test]
+    fn preview_provider_dispatchability_rejects_a_live_unready_provider() {
+        let catalog = AgentTaskProviderCatalog {
+            providers: vec![serde_json::from_value(serde_json::json!({
+                "id": "live-unready-provider",
+                "backend": "live-unready",
+                "readiness_invocation": {
+                    "argv": [
+                        "sh",
+                        "-c",
+                        "cat >/dev/null; printf '%s' '{\"schema\":\"homeboy/agent-task-provider-readiness-result/v1\",\"ready\":false,\"classification\":\"unavailable\",\"retryable\":false,\"remediation\":\"start the provider\",\"reason\":\"provider is offline\",\"cache_key\":\"offline\",\"identity\":{}}'"
+                    ]
+                }
+            }))
+            .expect("provider fixture")],
+            ..AgentTaskProviderCatalog::default()
+        };
+        let mut invocation_args = args();
+        invocation_args.backend = Some("live-unready".to_string());
+        invocation_args.selector = None;
+        let plan = BatchCookFanoutPlan::from_value(
+            json!({
+                "schema": AGENT_TASK_BATCH_COOK_FANOUT_PLAN_SCHEMA,
+                "fanout_id": "live-unready-preview",
+                "cooks": [{
+                    "cook_id": "child",
+                    "prompt": "fix the issue",
+                    "to_worktree": "homeboy@live-unready-preview",
+                    "backend": "live-unready",
+                    "verify": ["true"]
+                }]
+            }),
+            &invocation_args,
+        )
+        .expect("fanout plan");
+        let error = preview_provider_dispatchability_evidence(
+            &plan,
+            &catalog,
+            &json!({"fanout_id": plan.fanout_id}),
+        )
+        .expect_err("preview must reject a fanout whose provider live readiness fails");
+
+        assert_eq!(error.details["field"], "provider_dispatchability");
+        assert!(error.message.contains("runtime_unavailable"), "{error}");
+        assert!(error.message.contains("provider is offline"), "{error}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- run bounded live provider dispatchability admission for every fanout preview child
- bind redacted, short-lived readiness evidence to the preview plan and retain execution-time revalidation
- cover a declared provider whose live readiness reports unavailable

Fixes #14112

## Verification
- `cargo test -p homeboy-cli preview_provider_dispatchability_rejects_a_live_unready_provider --lib`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode implemented and verified this change under Chris Huber's direction.