### PR TITLE
fix(extension): preserve durable runtime refresh context

### DIFF
--- a/crates/homeboy-cli/src/commands/extension.rs
+++ b/crates/homeboy-cli/src/commands/extension.rs
@@ -688,6 +688,10 @@ pub struct ExtensionRuntimeDiagnostics {
     pub linked: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_revision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root_manifest_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_generation: Option<String>,
     pub runtime_manifest_found: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub runtime_ids: Vec<String>,
@@ -1745,6 +1749,11 @@ fn extension_runtime_diagnostics(
         .unwrap_or_default();
     let source_revision = source_revision
         .or_else(|| homeboy_core::extension::lifecycle::read_source_revision(extension_id));
+    let root_manifest_path = extension
+        .as_ref()
+        .and_then(|extension| extension.extension_path.as_ref())
+        .and_then(|path| runtime_root_manifest_path(Path::new(path)))
+        .map(|path| path.to_string_lossy().to_string());
     let matching_manifests = discover_agent_runtime_catalog()
         .manifests
         .into_iter()
@@ -1770,6 +1779,8 @@ fn extension_runtime_diagnostics(
         path,
         linked,
         source_revision,
+        root_manifest_path,
+        runtime_generation: active_runtime_generation(),
         runtime_manifest_found: !runtime_ids.is_empty(),
         runtime_ids,
         tools,
@@ -1783,6 +1794,25 @@ fn extension_runtime_diagnostics(
             refresh: format!("homeboy extension refresh <source> --id {}", shell_arg(extension_id)),
         },
     }
+}
+
+fn runtime_root_manifest_path(extension_path: &Path) -> Option<std::path::PathBuf> {
+    let extension_path = std::fs::canonicalize(extension_path).ok()?;
+    let parent = extension_path.parent()?;
+    let root = if parent.file_name()?.to_str()? == "agent-runtimes" {
+        parent.parent()?
+    } else {
+        parent
+    };
+    let manifest = root.join("homeboy-extension-root.json");
+    manifest.is_file().then_some(manifest)
+}
+
+fn active_runtime_generation() -> Option<String> {
+    homeboy_core::paths::homeboy()
+        .ok()
+        .and_then(|root| std::fs::read_link(root.join("runtime-generations/current")).ok())
+        .and_then(|generation| generation.to_str().map(str::to_string))
 }
 
 fn runtime_diagnostic_env<'a>(
@@ -2325,6 +2355,48 @@ mod tests {
             assert!(diagnostics.freshness.refresh_behavior.contains("reports"));
 
             std::env::remove_var("HOMEBOY_GENERIC_TOOL_BIN");
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extension_runtime_diagnostics_reports_durable_root_and_generation() {
+        with_isolated_home(|home| {
+            let config = home.path().join(".config/homeboy");
+            let source = config.join("extension-sources/opencode/agent-runtimes/opencode");
+            fs::create_dir_all(&source).expect("durable extension source");
+            fs::write(
+                source.join("opencode.json"),
+                r#"{"name":"OpenCode","version":"2.0.0"}"#,
+            )
+            .expect("extension manifest");
+            fs::write(
+                config.join("extension-sources/opencode/homeboy-extension-root.json"),
+                r#"{"shared_assets":["agent-runtimes"]}"#,
+            )
+            .expect("root manifest");
+            fs::create_dir_all(config.join("extensions")).expect("extensions directory");
+            symlink(&source, config.join("extensions/opencode")).expect("extension link");
+            fs::create_dir_all(config.join("runtime-generations/generation-2/agent-runtimes"))
+                .expect("runtime generation");
+            symlink("generation-2", config.join("runtime-generations/current"))
+                .expect("current generation link");
+
+            let diagnostics = extension_runtime_diagnostics("opencode", None);
+
+            assert_eq!(
+                diagnostics.root_manifest_path.as_deref(),
+                Some(
+                    config
+                        .join("extension-sources/opencode/homeboy-extension-root.json")
+                        .to_str()
+                        .expect("UTF-8 root manifest path")
+                )
+            );
+            assert_eq!(
+                diagnostics.runtime_generation.as_deref(),
+                Some("generation-2")
+            );
         });
     }
 

--- a/crates/homeboy-core/src/extension/lifecycle/install_sources.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/install_sources.rs
@@ -246,7 +246,7 @@ pub(crate) fn resolve_cloned_extension(
 
         // Cloned installs copy: the clone temp dir is discarded after install,
         // so the shared trees must be materialized as standalone copies.
-        install_shared_assets_from_root(temp_dir, extension_dir, SharedAssetMode::Copy)?;
+        install_shared_assets_from_root(temp_dir, extension_dir, SharedAssetMode::Copy, None)?;
 
         // Move just the subdirectory to the final extension location.
         rename_dir(&subdir, extension_dir)?;
@@ -316,13 +316,14 @@ fn install_shared_assets_from_root(
     source_root: &Path,
     extension_dir: &Path,
     mode: SharedAssetMode,
+    revision: Option<&str>,
 ) -> Result<()> {
     let root_manifest = source_root.join(ROOT_MANIFEST);
     let shared_assets = shared_assets_for_root(source_root);
     if root_manifest.is_file() && runtime_generation_boundary_active()? {
         // Once runtime generations are active, extension refreshes publish a
         // successor generation rather than writing through the stable link.
-        homeboy_core::runtime_package::refresh_shared_assets(source_root)?;
+        homeboy_core::runtime_package::refresh_shared_assets_with_revision(source_root, revision)?;
     }
     for shared_dir in shared_assets {
         if matches!(
@@ -454,12 +455,14 @@ pub(crate) fn install_linked_shared_assets(
     source: &Path,
     extension_dir: &Path,
     source_root: Option<&Path>,
+    revision: Option<&str>,
 ) -> Result<()> {
     if let Some(source_root) = source_root {
         return install_shared_assets_from_root(
             source_root,
             extension_dir,
             SharedAssetMode::Symlink,
+            revision,
         );
     }
 
@@ -468,11 +471,12 @@ pub(crate) fn install_linked_shared_assets(
             source_root,
             extension_dir,
             SharedAssetMode::Symlink,
+            revision,
         );
     }
 
     if let Some(parent) = source.parent() {
-        install_shared_assets_from_root(parent, extension_dir, SharedAssetMode::Symlink)?;
+        install_shared_assets_from_root(parent, extension_dir, SharedAssetMode::Symlink, revision)?;
     }
     Ok(())
 }
@@ -624,7 +628,7 @@ pub(super) fn install_from_path(
 
     local_files::ensure_app_dirs()?;
 
-    install_linked_shared_assets(&source, &extension_dir, source_root)?;
+    install_linked_shared_assets(&source, &extension_dir, source_root, None)?;
 
     // Create symlink
     #[cfg(unix)]

--- a/crates/homeboy-core/src/extension/lifecycle/mod.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/mod.rs
@@ -228,6 +228,23 @@ fn durable_refresh_source(source: &str, extension_id: &str) -> Result<String> {
         remove_path(&staging_root, "replace staged durable extension source")?;
     }
 
+    if let Some(source_root) = runtime_package_source_root(&source) {
+        // Preserve the canonical repository layout. Runtime materialization
+        // resolves the root manifest from the parent of `agent-runtimes`, not
+        // from an isolated runtime package.
+        copy_dir_recursive(
+            &source,
+            &staging_root.join("agent-runtimes").join(extension_id),
+        )?;
+        copy_shared_refresh_assets(Some(source_root), &staging_root)?;
+        replace_durable_refresh_source(&staging_root, &durable_root)?;
+        return Ok(durable_root
+            .join("agent-runtimes")
+            .join(extension_id)
+            .to_string_lossy()
+            .to_string());
+    }
+
     let manifest_at_source = source.join(format!("{}.json", extension_id));
     if manifest_at_source.exists() {
         let staged_extension = staging_root.join(extension_id);
@@ -259,6 +276,13 @@ fn durable_refresh_source(source: &str, extension_id: &str) -> Result<String> {
         Some(source.to_string_lossy().to_string()),
         None,
     ))
+}
+
+fn runtime_package_source_root(source: &Path) -> Option<&Path> {
+    let runtime_packages = source.parent()?;
+    (runtime_packages.file_name()?.to_str()? == "agent-runtimes")
+        .then(|| runtime_packages.parent())
+        .flatten()
 }
 
 fn absolute_source_path(source: &str) -> Result<PathBuf> {
@@ -995,6 +1019,124 @@ exec '{}' "$@"
                     .trim(),
                 "stale-marker",
                 "fixture keeps the copied stale marker that used to win reporting"
+            );
+        });
+    }
+
+    #[test]
+    fn refresh_nested_runtime_package_preserves_root_assets_and_publishes_generation() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let old_source = home.join("old-source");
+            let source = home.join("source-repo");
+            let boundary_source = home.join("boundary-source");
+            write_extension_fixture(&old_source, "opencode");
+            write_extension_fixture_with_version(
+                &source.join("agent-runtimes"),
+                "opencode",
+                "2.0.0",
+            );
+            write_declared_runtime_shared_assets(&source);
+            if !run_git(&source, &["init", "--quiet"]) || !commit_all(&source, "runtime source") {
+                return;
+            }
+            let source_revision =
+                git_output(&source, &["rev-parse", "--short", "HEAD"]).expect("source revision");
+            fs::create_dir_all(&boundary_source).expect("boundary source");
+            write_shared_asset_manifest(&boundary_source, &[]);
+
+            install(
+                &old_source.join("opencode").to_string_lossy(),
+                Some("opencode"),
+            )
+            .expect("install old extension");
+            crate::runtime_package::refresh_shared_assets(&boundary_source)
+                .expect("activate runtime generation boundary");
+
+            refresh(
+                &source.join("agent-runtimes/opencode").to_string_lossy(),
+                Some("opencode"),
+                None,
+            )
+            .expect("refresh nested runtime package");
+
+            assert_eq!(
+                load_extension("opencode")
+                    .expect("refreshed extension")
+                    .version,
+                "2.0.0"
+            );
+            assert!(home
+                .join(".config/homeboy/extension-sources/opencode/homeboy-extension-root.json")
+                .is_file());
+            assert!(home
+                .join(".config/homeboy/agent-runtimes/opencode/opencode.json")
+                .is_file());
+            assert!(fs::read_to_string(
+                home.join(".config/homeboy/agent-runtimes/opencode/opencode.json")
+            )
+            .expect("stable runtime manifest")
+            .contains("2.0.0"));
+            assert_eq!(
+                fs::read_to_string(
+                    home.join(".config/homeboy/agent-runtimes/opencode/.source-revision")
+                )
+                .expect("stable runtime revision")
+                .trim(),
+                source_revision
+            );
+            assert_eq!(
+                fs::read_link(home.join(".config/homeboy/extensions/opencode"))
+                    .expect("durable extension link"),
+                home.join(".config/homeboy/extension-sources/opencode/agent-runtimes/opencode")
+            );
+        });
+    }
+
+    #[test]
+    fn refresh_nested_runtime_package_failure_preserves_extension_and_generation() {
+        with_isolated_home(|home| {
+            let home = home.path();
+            let old_source = home.join("old-source");
+            let source = home.join("source-repo");
+            let boundary_source = home.join("boundary-source");
+            write_extension_fixture(&old_source, "opencode");
+            write_extension_fixture_with_version(
+                &source.join("agent-runtimes"),
+                "opencode",
+                "2.0.0",
+            );
+            fs::write(source.join("homeboy-extension-root.json"), "not json")
+                .expect("malformed root manifest");
+            fs::create_dir_all(&boundary_source).expect("boundary source");
+            write_shared_asset_manifest(&boundary_source, &[]);
+
+            install(
+                &old_source.join("opencode").to_string_lossy(),
+                Some("opencode"),
+            )
+            .expect("install old extension");
+            crate::runtime_package::refresh_shared_assets(&boundary_source)
+                .expect("activate runtime generation boundary");
+            let current = fs::read_link(home.join(".config/homeboy/runtime-generations/current"))
+                .expect("active generation");
+
+            refresh(
+                &source.join("agent-runtimes/opencode").to_string_lossy(),
+                Some("opencode"),
+                None,
+            )
+            .expect_err("malformed root manifest should reject refresh");
+
+            assert_eq!(
+                fs::read_link(home.join(".config/homeboy/runtime-generations/current"))
+                    .expect("preserved generation"),
+                current
+            );
+            assert_eq!(
+                fs::read_link(home.join(".config/homeboy/extensions/opencode"))
+                    .expect("preserved extension link"),
+                old_source.join("opencode")
             );
         });
     }

--- a/crates/homeboy-core/src/extension/lifecycle/repair.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/repair.rs
@@ -152,7 +152,12 @@ fn replace_from_path(
     }
 
     local_files::ensure_app_dirs()?;
-    install_linked_shared_assets(&source, &extension_dir, source_root.as_deref())?;
+    install_linked_shared_assets(
+        &source,
+        &extension_dir,
+        source_root.as_deref(),
+        requested_revision,
+    )?;
 
     let old_path = installed_source_path(&extension_dir);
     let source_revision = git::short_head_revision(&source).or_else(|| {

--- a/crates/homeboy-core/src/extension/lifecycle/update.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/update.rs
@@ -173,7 +173,7 @@ pub fn update_linked_group(extension_ids: &[String], force: bool) -> Result<Vec<
             if initially_clean {
                 restore_linked_checkout(&git_root, old_branch.as_deref(), old_revision.as_deref());
                 for (_, extension_dir, source_dir, _) in &entries {
-                    let _ = install_linked_shared_assets(source_dir, extension_dir, None);
+                    let _ = install_linked_shared_assets(source_dir, extension_dir, None, None);
                 }
             }
             return Err(preserve_dirty_error(error, initially_clean, &git_root));
@@ -482,7 +482,7 @@ fn update_linked_extension(
                 old_branch.as_deref(),
                 old_source_revision.as_deref(),
             );
-            let _ = install_linked_shared_assets(&source_dir, extension_dir, None);
+            let _ = install_linked_shared_assets(&source_dir, extension_dir, None, None);
         }
         return Err(preserve_dirty_error(error, initially_clean, &git_root));
     }
@@ -514,7 +514,7 @@ fn refresh_linked_extension_install(
     source_dir: &Path,
     extension_dir: &Path,
 ) -> Result<()> {
-    install_linked_shared_assets(source_dir, extension_dir, None)?;
+    install_linked_shared_assets(source_dir, extension_dir, None, None)?;
     let manifest = load_extension(extension_id)?;
     homeboy_extension_contract::validate_core_compatibility(
         "extension",

--- a/crates/homeboy-core/src/runtime_package.rs
+++ b/crates/homeboy-core/src/runtime_package.rs
@@ -207,8 +207,17 @@ fn refresh_locked_in_root(
 /// Snapshot root-manifest runtime assets into a new generation. Linked extension
 /// installs call this instead of writing through the stable runtime boundary.
 pub fn refresh_shared_assets(source_root: &Path) -> Result<()> {
+    refresh_shared_assets_with_revision(source_root, None)
+}
+
+/// [`refresh_shared_assets`] with explicit source revision evidence supplied by
+/// the extension lifecycle when its durable snapshot no longer has `.git`.
+pub fn refresh_shared_assets_with_revision(
+    source_root: &Path,
+    revision: Option<&str>,
+) -> Result<()> {
     let config_root = paths::homeboy()?;
-    refresh_shared_assets_in_root(&config_root, source_root)
+    refresh_shared_assets_in_root_with_revision(&config_root, source_root, revision)
 }
 
 /// [`refresh_shared_assets`] against an explicitly injected config root.
@@ -216,12 +225,24 @@ pub fn refresh_shared_assets(source_root: &Path) -> Result<()> {
 /// As with [`refresh_in_root`], the lock and the generation store are taken
 /// under one resolution rather than two.
 pub fn refresh_shared_assets_in_root(config_root: &Path, source_root: &Path) -> Result<()> {
+    refresh_shared_assets_in_root_with_revision(config_root, source_root, None)
+}
+
+fn refresh_shared_assets_in_root_with_revision(
+    config_root: &Path,
+    source_root: &Path,
+    revision: Option<&str>,
+) -> Result<()> {
     config::with_config_lock_at(config_root, || {
-        refresh_shared_assets_locked_in_root(config_root, source_root)
+        refresh_shared_assets_locked_in_root(config_root, source_root, revision)
     })
 }
 
-fn refresh_shared_assets_locked_in_root(config_root: &Path, source_root: &Path) -> Result<()> {
+fn refresh_shared_assets_locked_in_root(
+    config_root: &Path,
+    source_root: &Path,
+    revision: Option<&str>,
+) -> Result<()> {
     let store = config_root.join(GENERATIONS);
     fs::create_dir_all(store.join("staging")).map_err(io("prepare runtime generation store"))?;
     recover(&store)?;
@@ -234,6 +255,10 @@ fn refresh_shared_assets_locked_in_root(config_root: &Path, source_root: &Path) 
     remove_if_exists(&stage, "clean linked runtime generation stage")?;
     seed_generation(config_root, &store, &stage)?;
     materialize_all_declared_runtime_assets(&source_root, &stage)?;
+    let source_revision = revision
+        .map(str::to_string)
+        .or_else(|| git::short_head_revision(&source_root));
+    write_shared_runtime_revisions(&stage, source_revision.as_deref())?;
     sync_tree(&stage)?;
     write_journal(
         &store,
@@ -260,6 +285,27 @@ fn refresh_shared_assets_locked_in_root(config_root: &Path, source_root: &Path) 
         "finalize linked runtime generation refresh",
     )?;
     sync_dir(&store)
+}
+
+fn write_shared_runtime_revisions(stage: &Path, revision: Option<&str>) -> Result<()> {
+    let Some(revision) = revision.filter(|revision| !revision.trim().is_empty()) else {
+        return Ok(());
+    };
+    let runtimes = stage.join("agent-runtimes");
+    let Ok(entries) = fs::read_dir(runtimes) else {
+        return Ok(());
+    };
+    for entry in entries {
+        let entry = entry.map_err(io("read staged runtime package"))?;
+        if entry.path().is_dir() {
+            write_synced(
+                &entry.path().join(".source-revision"),
+                revision.as_bytes(),
+                "write shared runtime source revision",
+            )?;
+        }
+    }
+    Ok(())
 }
 
 fn seed_generation(config_root: &Path, store: &Path, stage: &Path) -> Result<()> {


### PR DESCRIPTION
## Summary
- Preserve the repository-root layout when refreshing an extension from `agent-runtimes/<id>`, allowing declared shared runtime assets to publish into a successor generation.
- Carry the source revision into durable runtime metadata and expose the durable root manifest and active runtime generation in diagnostics.
- Cover successful nested-runtime refresh and pre-switch failure preservation.

## Verification
- `cargo test -p homeboy-core refresh_nested_runtime_package --lib`
- `cargo test -p homeboy-cli commands::extension::tests --lib`
- `cargo fmt --check`
- `git diff --check`

## AI assistance
OpenAI GPT-5.6 Terra via OpenCode implemented and verified this change under Chris Huber's direction.

Closes #14111