### PR TITLE
Migrate external check resolvers to Extension API v1

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/api/v1.rs
+++ b/crates/contracts/homeboy-extension-contract/src/api/v1.rs
@@ -376,4 +376,34 @@ mod tests {
             })
         );
     }
+
+    #[test]
+    fn external_check_inventory_wire_shape_excludes_private_execution_data() {
+        let response = ExtensionApiExternalCheckDetailInventoryResponse {
+            schema: EXTENSION_API_EXTERNAL_CHECK_DETAIL_INVENTORY_RESPONSE_SCHEMA.to_string(),
+            api_version: EXTENSION_API_V1,
+            providers: vec![ExtensionApiExternalCheckDetailInventoryEntry {
+                provider: Some("example-ci".to_string()),
+                owning_extension: "fixture".to_string(),
+                resolvable: true,
+                validation: ExtensionApiExternalCheckDetailProviderValidation::Valid,
+                diagnostic: None,
+            }],
+            failure: None,
+        };
+
+        assert_eq!(
+            serde_json::to_value(response).expect("inventory response JSON"),
+            serde_json::json!({
+                "schema": EXTENSION_API_EXTERNAL_CHECK_DETAIL_INVENTORY_RESPONSE_SCHEMA,
+                "api_version": { "major": 1 },
+                "providers": [{
+                    "provider": "example-ci",
+                    "owning_extension": "fixture",
+                    "resolvable": true,
+                    "validation": "valid"
+                }]
+            })
+        );
+    }
 }

--- a/crates/contracts/homeboy-extension-contract/src/api/v1/operations.rs
+++ b/crates/contracts/homeboy-extension-contract/src/api/v1/operations.rs
@@ -8,9 +8,11 @@ use super::{
 };
 
 mod environment;
+mod external_check_detail;
 mod invocation;
 mod recipe_run;
 pub use environment::*;
+pub use external_check_detail::*;
 pub use invocation::*;
 pub use recipe_run::*;
 

--- a/crates/contracts/homeboy-extension-contract/src/api/v1/operations/external_check_detail.rs
+++ b/crates/contracts/homeboy-extension-contract/src/api/v1/operations/external_check_detail.rs
@@ -1,0 +1,90 @@
+use serde::{Deserialize, Serialize};
+
+use super::{ExtensionApiOperationFailure, ExtensionApiVersion};
+use crate::ExternalCheckDetailResponse;
+
+pub const EXTERNAL_CHECK_DETAIL_RESOLVER_CAPABILITY_PREFIX: &str =
+    "external-check-detail-resolver.";
+pub const EXTENSION_API_EXTERNAL_CHECK_DETAIL_INVENTORY_REQUEST_SCHEMA: &str =
+    "homeboy/extension-api-external-check-detail-inventory-request/v1";
+pub const EXTENSION_API_EXTERNAL_CHECK_DETAIL_INVENTORY_RESPONSE_SCHEMA: &str =
+    "homeboy/extension-api-external-check-detail-inventory-response/v1";
+pub const EXTENSION_API_EXTERNAL_CHECK_DETAIL_HYDRATE_REQUEST_SCHEMA: &str =
+    "homeboy/extension-api-external-check-detail-hydrate-request/v1";
+pub const EXTENSION_API_EXTERNAL_CHECK_DETAIL_HYDRATE_RESPONSE_SCHEMA: &str =
+    "homeboy/extension-api-external-check-detail-hydrate-response/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiExternalCheckDetailInventoryRequest {
+    pub schema: String,
+    pub api_version: ExtensionApiVersion,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionApiExternalCheckDetailProviderValidation {
+    Valid,
+    Invalid,
+    Duplicate,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiExternalCheckDetailInventoryEntry {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    pub owning_extension: String,
+    pub resolvable: bool,
+    pub validation: ExtensionApiExternalCheckDetailProviderValidation,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diagnostic: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiExternalCheckDetailInventoryResponse {
+    pub schema: String,
+    pub api_version: ExtensionApiVersion,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub providers: Vec<ExtensionApiExternalCheckDetailInventoryEntry>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<ExtensionApiOperationFailure>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiExternalCheckDetailHydrateRequest {
+    pub schema: String,
+    pub api_version: ExtensionApiVersion,
+    pub provider: String,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionApiExternalCheckDetailDiagnosticKind {
+    Unknown,
+    Ambiguous,
+    Malformed,
+    MalformedIdentity,
+    Unavailable,
+    BudgetExhausted,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiExternalCheckDetailDiagnostic {
+    pub provider: String,
+    pub kind: ExtensionApiExternalCheckDetailDiagnosticKind,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiExternalCheckDetailHydrateResponse {
+    pub schema: String,
+    pub api_version: ExtensionApiVersion,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<ExternalCheckDetailResponse>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diagnostic: Option<ExtensionApiExternalCheckDetailDiagnostic>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<ExtensionApiOperationFailure>,
+}

--- a/crates/contracts/homeboy-extension-contract/src/external_check_detail_resolver.rs
+++ b/crates/contracts/homeboy-extension-contract/src/external_check_detail_resolver.rs
@@ -2,6 +2,7 @@
 
 use homeboy_error::{Error, Result};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::collections::HashSet;
 use std::path::{Component, Path};
 
@@ -22,6 +23,26 @@ pub struct ExternalCheckDetailResolverConfig {
     pub public_env: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub secret_env: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum ExternalCheckDetailResolverDeclaration {
+    Config(Box<ExternalCheckDetailResolverConfig>),
+    Malformed(Value),
+}
+
+impl ExternalCheckDetailResolverDeclaration {
+    pub fn declared_provider(&self) -> Option<String> {
+        match self {
+            Self::Config(config) => Some(config.provider.clone()),
+            Self::Malformed(value) => value
+                .as_object()
+                .and_then(|object| object.get("provider"))
+                .and_then(Value::as_str)
+                .map(str::to_string),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/contracts/homeboy-extension-contract/src/lib.rs
+++ b/crates/contracts/homeboy-extension-contract/src/lib.rs
@@ -124,7 +124,8 @@ pub mod runner_contract;
 pub mod runtime_helper;
 pub mod sidecar_config;
 pub use external_check_detail_resolver::{
-    ExternalCheckDetailRequest, ExternalCheckDetailResolverConfig, ExternalCheckDetailResponse,
+    ExternalCheckDetailRequest, ExternalCheckDetailResolverConfig,
+    ExternalCheckDetailResolverDeclaration, ExternalCheckDetailResponse,
     EXTERNAL_CHECK_DETAIL_REQUEST_SCHEMA, EXTERNAL_CHECK_DETAIL_RESOLVER_SCHEMA,
     EXTERNAL_CHECK_DETAIL_RESPONSE_SCHEMA,
 };

--- a/crates/contracts/homeboy-extension-contract/src/manifest.rs
+++ b/crates/contracts/homeboy-extension-contract/src/manifest.rs
@@ -101,7 +101,7 @@ pub struct ExtensionManifest {
 
     /// Extension-owned, opt-in hydration for failed external CI statuses.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub external_check_detail_resolvers: Vec<ExternalCheckDetailResolverConfig>,
+    pub external_check_detail_resolvers: Vec<ExternalCheckDetailResolverDeclaration>,
 
     /// Runtime requirements needed to execute this extension's runner scripts.
     /// Component-declared requirements still win; these are fallbacks for the
@@ -270,18 +270,6 @@ impl ExtensionManifest {
                     "notification_transports.id",
                     "must be unique within an extension manifest",
                     Some(transport.id.clone()),
-                    None,
-                ));
-            }
-        }
-        let mut providers = std::collections::HashSet::new();
-        for resolver in &self.external_check_detail_resolvers {
-            resolver.validate()?;
-            if !providers.insert(&resolver.provider) {
-                return Err(homeboy_error::Error::validation_invalid_argument(
-                    "external_check_detail_resolvers.provider",
-                    "must be unique within an extension manifest",
-                    Some(resolver.provider.clone()),
                     None,
                 ));
             }

--- a/crates/homeboy-cli/src/commands/ci/external_check_detail_resolver.rs
+++ b/crates/homeboy-cli/src/commands/ci/external_check_detail_resolver.rs
@@ -1,27 +1,19 @@
-//! Sandboxed execution of extension-owned external check detail resolvers.
-
-use std::io::{Read, Write};
-use std::path::Path;
-use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
-use homeboy::core::process::{force_terminate_process_tree_bounded, ProcessContainment};
-use homeboy::core::redaction::RedactionPolicy;
-use homeboy_core::extension::catalog::load_all_extensions;
-#[cfg(not(windows))]
-use homeboy_engine_primitives::command::terminate_process_tree_and_reap;
-use homeboy_engine_primitives::command::{terminate_remaining_process_group, ControllerChildGuard};
-use homeboy_extension_contract::external_check_detail_resolver::{
-    ExternalCheckDetailRequest, ExternalCheckDetailResolverConfig, ExternalCheckDetailResponse,
-    EXTERNAL_CHECK_DETAIL_REQUEST_SCHEMA, EXTERNAL_CHECK_DETAIL_RESPONSE_SCHEMA,
+use homeboy_core::extension::external_check_detail_api::{
+    ExternalCheckDetailHydrationContext, ExternalCheckDetailResolverApi,
+};
+use homeboy_extension_contract::api::v1::{
+    ExtensionApiExternalCheckDetailDiagnosticKind, ExtensionApiExternalCheckDetailHydrateRequest,
+    ExtensionApiExternalCheckDetailInventoryRequest,
+    ExtensionApiExternalCheckDetailInventoryResponse,
+    EXTENSION_API_EXTERNAL_CHECK_DETAIL_HYDRATE_REQUEST_SCHEMA,
+    EXTENSION_API_EXTERNAL_CHECK_DETAIL_INVENTORY_REQUEST_SCHEMA, EXTENSION_API_V1,
 };
 use serde::Serialize;
-use tempfile::NamedTempFile;
 
 pub(super) const MAX_RESOLVERS: usize = 8;
 pub(super) const TOTAL_BUDGET: Duration = Duration::from_secs(20);
-const MAX_OUTPUT_BYTES: usize = 64 * 1024;
-const CLEANUP_BUDGET: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ResolverDiagnostic {
@@ -43,522 +35,107 @@ pub struct HydratedDetail {
     pub log_refs: Vec<String>,
 }
 
-#[derive(Debug)]
-enum InvocationFailure {
-    MalformedResponse,
-    Unavailable(String),
+pub(super) struct ResolverSession {
+    api: ExternalCheckDetailResolverApi,
+    inventory: ExtensionApiExternalCheckDetailInventoryResponse,
 }
 
-/// Secure, owned output files avoid blocking on EOF when an escaped resolver
-/// descendant retains an inherited stdout or stderr handle.
-struct ResolverCaptureFiles {
-    stdout: NamedTempFile,
-    stderr: NamedTempFile,
-}
-
-impl ResolverCaptureFiles {
-    fn create() -> Result<Self, InvocationFailure> {
-        Ok(Self {
-            stdout: NamedTempFile::new().map_err(|error| {
-                InvocationFailure::Unavailable(format!(
-                    "Resolver stdout capture file creation failed: {error}"
-                ))
-            })?,
-            stderr: NamedTempFile::new().map_err(|error| {
-                InvocationFailure::Unavailable(format!(
-                    "Resolver stderr capture file creation failed: {error}"
-                ))
-            })?,
-        })
-    }
-
-    fn stdio(&self) -> Result<(Stdio, Stdio), InvocationFailure> {
-        let stdout = self.stdout.reopen().map_err(|error| {
-            InvocationFailure::Unavailable(format!(
-                "Resolver stdout capture file setup failed: {error}"
-            ))
-        })?;
-        let stderr = self.stderr.reopen().map_err(|error| {
-            InvocationFailure::Unavailable(format!(
-                "Resolver stderr capture file setup failed: {error}"
-            ))
-        })?;
-        Ok((Stdio::from(stdout), Stdio::from(stderr)))
-    }
-
-    fn snapshot(&self, stream: &str) -> Result<Vec<u8>, InvocationFailure> {
-        let file = match stream {
-            "stdout" => &self.stdout,
-            "stderr" => &self.stderr,
-            _ => unreachable!("resolver capture stream is fixed"),
-        };
-        let length = file
-            .as_file()
-            .metadata()
-            .map_err(|error| {
-                InvocationFailure::Unavailable(format!(
-                    "Resolver {stream} capture metadata failed: {error}"
-                ))
-            })?
-            .len();
-        if length > MAX_OUTPUT_BYTES as u64 {
-            return Err(InvocationFailure::Unavailable(
-                "Resolver output exceeded the 64 KiB limit.".into(),
-            ));
-        }
-        let mut snapshot = file.reopen().map_err(|error| {
-            InvocationFailure::Unavailable(format!(
-                "Resolver {stream} capture snapshot failed: {error}"
-            ))
-        })?;
-        let mut output = Vec::with_capacity(length as usize);
-        Read::take(&mut snapshot, (MAX_OUTPUT_BYTES + 1) as u64)
-            .read_to_end(&mut output)
-            .map_err(|error| {
-                InvocationFailure::Unavailable(format!(
-                    "Resolver {stream} capture read failed: {error}"
-                ))
-            })?;
-        if output.len() > MAX_OUTPUT_BYTES {
-            return Err(InvocationFailure::Unavailable(
-                "Resolver output exceeded the 64 KiB limit.".into(),
-            ));
-        }
-        Ok(output)
-    }
-}
-
-pub(super) fn hydrate(
-    provider: &str,
-    status: &str,
-    target_url: Option<&str>,
-    deadline: Instant,
-) -> (Vec<HydratedDetail>, Vec<ResolverDiagnostic>) {
-    let mut diagnostics = Vec::new();
-    let mut resolvers = Vec::new();
-    for manifest in load_all_extensions().unwrap_or_default() {
-        for resolver in manifest.external_check_detail_resolvers {
-            if resolver.provider == provider {
-                resolvers.push((
-                    manifest.id.clone(),
-                    manifest.extension_path.clone(),
-                    resolver,
-                ));
-            }
-        }
-    }
-    if resolvers.len() > 1 {
-        return (
-            Vec::new(),
-            vec![ResolverDiagnostic {
-                provider: provider.into(),
-                kind: "ambiguous".into(),
-                message:
-                    "Multiple extensions declare this exact provider; no resolver was invoked."
-                        .into(),
-            }],
+impl ResolverSession {
+    pub(super) fn discover() -> Self {
+        let api = ExternalCheckDetailResolverApi::discover(
+            &ExtensionApiExternalCheckDetailInventoryRequest {
+                schema: EXTENSION_API_EXTERNAL_CHECK_DETAIL_INVENTORY_REQUEST_SCHEMA.to_string(),
+                api_version: EXTENSION_API_V1,
+            },
         );
+        let inventory = api.inventory_api();
+        Self { api, inventory }
     }
-    let Some((extension, extension_path, resolver)) = resolvers.pop() else {
-        return (
-            Vec::new(),
-            vec![ResolverDiagnostic {
-                provider: provider.into(),
-                kind: "unknown".into(),
-                message: "No installed extension declares this provider. Install or enable the extension that owns this provider, then rerun CI triage.".into(),
-            }],
-        );
-    };
-    if let Err(error) = resolver.validate() {
-        diagnostics.push(ResolverDiagnostic {
-            provider: provider.into(),
-            kind: "malformed".into(),
-            message: format!("Extension {extension} declares an invalid resolver: {error}"),
-        });
-        return (Vec::new(), diagnostics);
+
+    pub(super) fn has_unique_provider(&self, provider: &str) -> bool {
+        self.inventory
+            .providers
+            .iter()
+            .filter(|entry| entry.provider.as_deref() == Some(provider))
+            .take(2)
+            .count()
+            == 1
     }
-    let Some(extension_path) = extension_path else {
-        return (
-            Vec::new(),
-            vec![ResolverDiagnostic {
-                provider: provider.into(),
-                kind: "malformed".into(),
-                message: format!("Extension {extension} has no extension path for its resolver."),
-            }],
+
+    pub(super) fn hydrate(
+        &self,
+        provider: &str,
+        status: &str,
+        target_url: Option<&str>,
+        deadline: Instant,
+    ) -> (Vec<HydratedDetail>, Vec<ResolverDiagnostic>) {
+        let resolve_environment = |name: &str| std::env::var(name).ok();
+        let response = self.api.hydrate_api(
+            &ExtensionApiExternalCheckDetailHydrateRequest {
+                schema: EXTENSION_API_EXTERNAL_CHECK_DETAIL_HYDRATE_REQUEST_SCHEMA.to_string(),
+                api_version: EXTENSION_API_V1,
+                provider: provider.to_string(),
+                status: status.to_string(),
+                target_url: target_url.map(str::to_string),
+            },
+            ExternalCheckDetailHydrationContext {
+                deadline,
+                resolve_environment: &resolve_environment,
+            },
         );
-    };
-    // Canonicalize before reading declared secrets. A symlinked program must
-    // never receive projected credentials from outside its extension root.
-    let (extension_path, program) = match resolve_program(Path::new(&extension_path), &resolver) {
-        Ok(paths) => paths,
-        Err(message) => {
-            return (
-                Vec::new(),
-                vec![ResolverDiagnostic {
-                    provider: provider.into(),
-                    kind: if message.starts_with("program cannot be resolved") {
-                        "unavailable".into()
-                    } else {
-                        "malformed".into()
-                    },
-                    message: format!(
-                        "Extension {extension} resolver program is invalid: {message}"
-                    ),
-                }],
-            )
-        }
-    };
-    let secrets = resolver
-        .secret_env
-        .iter()
-        .filter_map(|name| std::env::var(name).ok())
-        .collect::<Vec<_>>();
-    let request = ExternalCheckDetailRequest {
-        schema: EXTERNAL_CHECK_DETAIL_REQUEST_SCHEMA.into(),
-        provider: provider.into(),
-        status: redact(status, &secrets, 512),
-        target_url: target_url.map(normalize_target_url),
-    };
-    match invoke(
-        &resolver,
-        &extension_path,
-        &program,
-        &request,
-        &secrets,
-        deadline,
-    ) {
-        Ok(response)
-            if response.schema == EXTERNAL_CHECK_DETAIL_RESPONSE_SCHEMA
-                && response.provider == provider =>
-        {
-            (
+        let details = response
+            .detail
+            .map(|detail| {
                 vec![HydratedDetail {
-                    provider: provider.into(),
-                    build_id: response.build_id.map(|value| redact(&value, &secrets, 512)),
-                    summary: response
-                        .summary
-                        .map(|value| redact(&value, &secrets, 2048))
-                        .unwrap_or_default(),
-                    actions: response
-                        .actions
-                        .into_iter()
-                        .map(|action| redact(&action, &secrets, 512))
-                        .collect(),
-                    artifact_refs: response
-                        .artifact_refs
-                        .into_iter()
-                        .map(|value| redact(&value, &secrets, 2048))
-                        .collect(),
-                    log_refs: response
-                        .log_refs
-                        .into_iter()
-                        .map(|value| redact(&value, &secrets, 2048))
-                        .collect(),
-                }],
-                diagnostics,
-            )
-        }
-        Ok(_) => (
-            Vec::new(),
-            vec![ResolverDiagnostic {
-                provider: provider.into(),
-                kind: "malformed_identity".into(),
-                message: "Resolver response schema or provider did not match its declaration."
-                    .into(),
-            }],
-        ),
-        Err(InvocationFailure::MalformedResponse) => (
-            Vec::new(),
-            vec![ResolverDiagnostic {
-                provider: provider.into(),
-                kind: "malformed".into(),
-                message: "Resolver returned malformed JSON.".into(),
-            }],
-        ),
-        Err(InvocationFailure::Unavailable(message)) => (
-            Vec::new(),
-            vec![ResolverDiagnostic {
-                provider: provider.into(),
-                kind: "unavailable".into(),
-                message,
-            }],
-        ),
+                    provider: detail.provider,
+                    build_id: detail.build_id,
+                    summary: detail.summary.unwrap_or_default(),
+                    actions: detail.actions,
+                    artifact_refs: detail.artifact_refs,
+                    log_refs: detail.log_refs,
+                }]
+            })
+            .unwrap_or_default();
+        let diagnostic = response
+            .diagnostic
+            .map(|diagnostic| ResolverDiagnostic {
+                provider: diagnostic.provider,
+                kind: diagnostic_kind(diagnostic.kind).to_string(),
+                message: diagnostic.message,
+            })
+            .or_else(|| {
+                response.failure.map(|failure| ResolverDiagnostic {
+                    provider: provider.to_string(),
+                    kind: "unavailable".to_string(),
+                    message: failure.message,
+                })
+            });
+        (details, diagnostic.into_iter().collect())
     }
 }
 
 pub(super) fn skipped_for_budget(provider: &str) -> ResolverDiagnostic {
     ResolverDiagnostic {
-        provider: provider.into(),
-        kind: "budget_exhausted".into(),
-        message: "Resolver invocation limit reached; original check evidence was retained.".into(),
+        provider: provider.to_string(),
+        kind: "budget_exhausted".to_string(),
+        message: "Resolver invocation limit reached; original check evidence was retained."
+            .to_string(),
     }
-}
-
-/// Whether a provider can consume a resolver invocation slot. Invalid resolvers
-/// intentionally count: they are an extension-owned failure, unlike unknown or
-/// ambiguous providers which cannot invoke anything.
-pub(super) fn has_unique_resolver(provider: &str) -> bool {
-    load_all_extensions()
-        .unwrap_or_default()
-        .into_iter()
-        .flat_map(|manifest| manifest.external_check_detail_resolvers)
-        .filter(|resolver| resolver.provider == provider)
-        .take(2)
-        .count()
-        == 1
-}
-
-fn invoke(
-    resolver: &ExternalCheckDetailResolverConfig,
-    extension_path: &Path,
-    program: &Path,
-    request: &ExternalCheckDetailRequest,
-    secrets: &[String],
-    deadline: Instant,
-) -> Result<ExternalCheckDetailResponse, InvocationFailure> {
-    if Instant::now() >= deadline {
-        return Err(InvocationFailure::Unavailable(
-            "Resolver budget exhausted before spawn.".into(),
-        ));
-    }
-    let captures = ResolverCaptureFiles::create()?;
-    let (stdout, stderr) = captures.stdio()?;
-    let mut command = Command::new(program);
-    command
-        .args(&resolver.command[1..])
-        .current_dir(extension_path)
-        .env_clear()
-        .stdin(Stdio::piped())
-        .stdout(stdout)
-        .stderr(stderr);
-    for name in resolver.public_env.iter().chain(&resolver.secret_env) {
-        if let Ok(value) = std::env::var(name) {
-            command.env(name, value);
-        }
-    }
-    let mut containment = ProcessContainment::prepare(&mut command).map_err(|error| {
-        InvocationFailure::Unavailable(format!("Resolver containment setup failed: {error}"))
-    })?;
-    let mut guard = Some(
-        ControllerChildGuard::prepare(&mut command).map_err(|error| {
-            InvocationFailure::Unavailable(format!("Resolver containment setup failed: {error}"))
-        })?,
-    );
-    let mut child = command.spawn().map_err(|error| {
-        InvocationFailure::Unavailable(format!(
-            "Resolver spawn failed; capture files will be removed: {error}"
-        ))
-    })?;
-    if let Err(error) = containment.attach(&child) {
-        let cleanup_errors = cleanup(&containment, &mut child, &mut guard, false);
-        return Err(InvocationFailure::Unavailable(format!(
-            "Resolver containment attach failed: {error}{}",
-            cleanup_diagnostic(&cleanup_errors)
-        )));
-    }
-    if let Err(error) = guard.as_ref().expect("guard exists").attach(&child) {
-        let cleanup_errors = cleanup(&containment, &mut child, &mut guard, false);
-        return Err(InvocationFailure::Unavailable(format!(
-            "Resolver containment attach failed: {error}{}",
-            cleanup_diagnostic(&cleanup_errors)
-        )));
-    }
-    let mut stdin = child.stdin.take().ok_or_else(|| {
-        let cleanup_errors = cleanup(&containment, &mut child, &mut guard, false);
-        InvocationFailure::Unavailable(format!(
-            "Resolver stdin was unavailable.{}",
-            cleanup_diagnostic(&cleanup_errors)
-        ))
-    })?;
-    let payload = match serde_json::to_vec(request) {
-        Ok(payload) => payload,
-        Err(error) => {
-            let cleanup_errors = cleanup(&containment, &mut child, &mut guard, false);
-            return Err(InvocationFailure::Unavailable(format!(
-                "Resolver request serialization failed: {error}{}",
-                cleanup_diagnostic(&cleanup_errors)
-            )));
-        }
-    };
-    if stdin
-        .write_all(&payload)
-        .and_then(|_| stdin.write_all(b"\n"))
-        .is_err()
-    {
-        let cleanup_errors = cleanup(&containment, &mut child, &mut guard, false);
-        return Err(InvocationFailure::Unavailable(format!(
-            "Resolver stdin write failed.{}",
-            cleanup_diagnostic(&cleanup_errors)
-        )));
-    }
-    drop(stdin);
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                // A resolver may exit while a descendant still owns a pipe.
-                // Its process group is ours, so close that escape before taking
-                // nonblocking snapshots of the owned capture files.
-                let cleanup_errors = cleanup(&containment, &mut child, &mut guard, true);
-                if !cleanup_errors.is_empty() {
-                    return Err(InvocationFailure::Unavailable(format!(
-                        "Resolver exited but cleanup could not be verified: {}",
-                        cleanup_errors.join("; ")
-                    )));
-                }
-                let output = captures.snapshot("stdout")?;
-                let stderr = captures.snapshot("stderr")?;
-                if !status.success() {
-                    return Err(InvocationFailure::Unavailable(format!(
-                        "Resolver exited unsuccessfully: {}",
-                        redact(&String::from_utf8_lossy(&stderr), secrets, 512)
-                    )));
-                }
-                return serde_json::from_slice(&output)
-                    .map_err(|_| InvocationFailure::MalformedResponse);
-            }
-            Ok(None) if Instant::now() < deadline => std::thread::sleep(Duration::from_millis(10)),
-            Ok(None) => {
-                let mut cleanup_errors = cleanup(&containment, &mut child, &mut guard, false);
-                cleanup_errors.extend(capture_snapshot_errors(&captures));
-                return Err(InvocationFailure::Unavailable(format!(
-                    "Resolver timed out; capture files were snapshotted without waiting for inherited handles{}.",
-                    cleanup_diagnostic(&cleanup_errors)
-                )));
-            }
-            Err(error) => {
-                let mut cleanup_errors = cleanup(&containment, &mut child, &mut guard, false);
-                cleanup_errors.extend(capture_snapshot_errors(&captures));
-                return Err(InvocationFailure::Unavailable(format!(
-                    "Resolver wait failed: {error}; capture files were snapshotted without waiting for inherited handles{}.",
-                    cleanup_diagnostic(&cleanup_errors)
-                )));
-            }
-        }
-    }
-}
-
-fn resolve_program(
-    extension_path: &Path,
-    resolver: &ExternalCheckDetailResolverConfig,
-) -> Result<(std::path::PathBuf, std::path::PathBuf), String> {
-    let root = extension_path
-        .canonicalize()
-        .map_err(|error| format!("extension root cannot be resolved: {error}"))?;
-    let program = root
-        .join(&resolver.command[0])
-        .canonicalize()
-        .map_err(|error| format!("program cannot be resolved inside the extension: {error}"))?;
-    if !program.starts_with(&root) {
-        return Err("program resolves outside the declaring extension".into());
-    }
-    Ok((root, program))
-}
-
-fn cleanup(
-    containment: &ProcessContainment,
-    child: &mut std::process::Child,
-    guard: &mut Option<ControllerChildGuard>,
-    leader_has_exited: bool,
-) -> Vec<String> {
-    // A resolver can call `setsid` and leave its inherited process group. The
-    // current core primitive snapshots Linux procfs descendants before killing
-    // the leader, so timeout cleanup still reaches that detached session.
-    // On Windows, dropping the guard closes its kill-on-close Job; on Unix it
-    // closes the controller liveness pipe before output is inspected.
-    drop(guard.take());
-    let mut errors = Vec::new();
-    if !leader_has_exited {
-        if let Err(error) = containment.terminate_on_failure_bounded(CLEANUP_BUDGET, false) {
-            errors.push(format!("containment termination: {error}"));
-        }
-        if let Err(error) = force_terminate_process_tree_bounded(child.id(), CLEANUP_BUDGET) {
-            errors.push(format!("process-tree termination: {error}"));
-        }
-        if let Err(error) = reap_child_after_bounded_cleanup(child) {
-            errors.push(format!("child reap: {error}"));
-        }
-    }
-    #[cfg(target_os = "linux")]
-    if let Err(error) = containment.cleanup_after_leader_exit_bounded(CLEANUP_BUDGET) {
-        errors.push(format!("descendant cleanup: {error}"));
-    }
-    if let Err(error) = terminate_remaining_process_group(child.id()) {
-        errors.push(format!("remaining process-group cleanup: {error}"));
-    }
-    errors
-}
-
-#[cfg(not(windows))]
-fn reap_child_after_bounded_cleanup(child: &mut std::process::Child) -> std::io::Result<()> {
-    terminate_process_tree_and_reap(child).map(|_| ())
-}
-
-#[cfg(windows)]
-fn reap_child_after_bounded_cleanup(child: &mut std::process::Child) -> std::io::Result<()> {
-    let pid = child.id();
-    let deadline = Instant::now() + CLEANUP_BUDGET;
-    loop {
-        match child.try_wait() {
-            Ok(Some(_)) => return Ok(()),
-            Ok(None) if Instant::now() >= deadline => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::TimedOut,
-                    child_reap_timeout_evidence(pid, CLEANUP_BUDGET),
-                ));
-            }
-            Ok(None) => std::thread::sleep(Duration::from_millis(10)),
-            Err(error) => return Err(error),
-        }
-    }
-}
-
-#[cfg(any(test, windows))]
-fn child_reap_timeout_evidence(pid: u32, timeout: Duration) -> String {
-    format!(
-        "child {pid} remained alive after bounded cleanup for {} ms; taskkill/Job cleanup may have left a survivor",
-        timeout.as_millis()
-    )
-}
-
-fn cleanup_diagnostic(errors: &[String]) -> String {
-    (!errors.is_empty())
-        .then(|| format!("; cleanup evidence: {}", errors.join("; ")))
-        .unwrap_or_default()
-}
-
-fn capture_snapshot_errors(captures: &ResolverCaptureFiles) -> Vec<String> {
-    ["stdout", "stderr"]
-        .into_iter()
-        .filter_map(|stream| {
-            captures
-                .snapshot(stream)
-                .err()
-                .map(|error| format!("{stream} capture snapshot: {error:?}"))
-        })
-        .collect()
 }
 
 pub(super) fn normalize_target_url(value: &str) -> String {
-    let without_secret_suffix = value.split(['?', '#']).next().unwrap_or_default();
-    let without_credentials = without_secret_suffix
-        .split_once("//")
-        .map(|(scheme, rest)| format!("{scheme}//{}", rest.rsplit('@').next().unwrap_or(rest)))
-        .unwrap_or_else(|| without_secret_suffix.to_string());
-    bound(&without_credentials, 2048)
+    homeboy_core::extension::external_check_detail_api::normalize_target_url(value)
 }
 
-fn redact(value: &str, secrets: &[String], limit: usize) -> String {
-    let mut redacted = RedactionPolicy::default().redact_embedded_urls(value);
-    for secret in secrets {
-        if !secret.is_empty() {
-            redacted = redacted.replace(secret, "[REDACTED]");
-        }
+fn diagnostic_kind(kind: ExtensionApiExternalCheckDetailDiagnosticKind) -> &'static str {
+    match kind {
+        ExtensionApiExternalCheckDetailDiagnosticKind::Unknown => "unknown",
+        ExtensionApiExternalCheckDetailDiagnosticKind::Ambiguous => "ambiguous",
+        ExtensionApiExternalCheckDetailDiagnosticKind::Malformed => "malformed",
+        ExtensionApiExternalCheckDetailDiagnosticKind::MalformedIdentity => "malformed_identity",
+        ExtensionApiExternalCheckDetailDiagnosticKind::Unavailable => "unavailable",
+        ExtensionApiExternalCheckDetailDiagnosticKind::BudgetExhausted => "budget_exhausted",
     }
-    bound(&redacted, limit)
-}
-
-fn bound(value: &str, limit: usize) -> String {
-    value.chars().take(limit).collect()
 }
 
 #[cfg(feature = "test-support")]
@@ -598,17 +175,15 @@ pub(super) fn test_cross_platform_fixture() {
     ] {
         homeboy::core::test_support::with_isolated_home(|_| {
             install_fixture_extension(mode, FIXTURE_MODE_ENV);
+            let session = ResolverSession::discover();
             let started = Instant::now();
-            let (details, diagnostics) = hydrate(
+            let (details, diagnostics) = session.hydrate(
                 "fixture-ci",
                 "failure",
                 Some("https://example.test/build/42"),
                 started + budget,
             );
-            assert!(
-                started.elapsed() < Duration::from_secs(3),
-                "{mode}: resolver timeout did not return after process cleanup"
-            );
+            assert!(started.elapsed() < Duration::from_secs(3));
             assert_eq!(
                 details.len() == 1,
                 expected_detail,
@@ -622,55 +197,13 @@ pub(super) fn test_cross_platform_fixture() {
                 "{mode}"
             );
             if let Some(expected_message) = expected_message {
-                assert!(
-                    diagnostics[0].message.contains(expected_message),
-                    "{mode}: {diagnostics:?}"
-                );
+                assert!(diagnostics[0].message.contains(expected_message));
             }
             if mode == "success" {
                 assert_eq!(details[0].actions, ["fixture-ci replay 42"]);
-                let mut resolver_slots = MAX_RESOLVERS;
-                let check = super::failure_log_triage::hydrate_external(
-                    "fixture-ci".into(),
-                    "failure".into(),
-                    Some("legacy failure description".into()),
-                    Some("https://example.test/build/42".into()),
-                    &mut resolver_slots,
-                    Instant::now() + Duration::from_secs(10),
-                );
-                assert_eq!(check.status, "failure");
-                assert_eq!(
-                    check.description.as_deref(),
-                    Some("legacy failure description")
-                );
-                let summary = super::failure_log_triage::render_human_summary(
-                    "owner/repo",
-                    &super::failure_log_triage::GhPullRequest {
-                        number: 42,
-                        title: "Fixture".into(),
-                        url: "https://example.test/pull/42".into(),
-                        head_sha: "abc".into(),
-                    },
-                    0,
-                    &[],
-                    &[check],
-                    &[],
-                    &[],
-                );
-                assert!(summary.contains("fixture-ci replay 42"));
             }
         });
     }
-    homeboy::core::test_support::with_isolated_home(|_| {
-        let (details, diagnostics) = hydrate(
-            "no-installed-provider",
-            "error",
-            None,
-            Instant::now() + Duration::from_secs(10),
-        );
-        assert!(details.is_empty());
-        assert_eq!(diagnostics[0].kind, "unknown");
-    });
 }
 
 #[cfg(feature = "test-support")]
@@ -704,17 +237,13 @@ fn install_fixture_extension(mode: &str, fixture_mode_env: &str) {
 }
 
 #[cfg(feature = "test-support")]
-fn timeout_fixture_command(extension: &Path) -> Vec<String> {
+fn timeout_fixture_command(extension: &std::path::Path) -> Vec<String> {
     let name = if cfg!(windows) {
         "fixture-resolver.exe"
     } else {
         "fixture-resolver"
     };
-    std::fs::copy(
-        std::env::current_exe().expect("current test executable"),
-        extension.join(name),
-    )
-    .expect("copy portable timeout fixture");
+    std::fs::copy(std::env::current_exe().unwrap(), extension.join(name)).unwrap();
     vec![
         name.to_string(),
         "--ignored".to_string(),
@@ -724,7 +253,7 @@ fn timeout_fixture_command(extension: &Path) -> Vec<String> {
 }
 
 #[cfg(all(feature = "test-support", unix))]
-fn fixture_program(extension: &Path, fixture_mode_env: &str) -> String {
+fn fixture_program(extension: &std::path::Path, fixture_mode_env: &str) -> String {
     use std::os::unix::fs::PermissionsExt;
 
     let name = "fixture-resolver";
@@ -737,73 +266,26 @@ fn fixture_program(extension: &Path, fixture_mode_env: &str) -> String {
     )
     .unwrap();
     std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
-    name.into()
+    name.to_string()
 }
 
 #[cfg(all(feature = "test-support", windows))]
-fn fixture_program(extension: &Path, fixture_mode_env: &str) -> String {
+fn fixture_program(extension: &std::path::Path, fixture_mode_env: &str) -> String {
     let name = "fixture-resolver.cmd";
     let path = extension.join(name);
     std::fs::write(
         &path,
         format!(
-            "@echo off\r\nif \"%{fixture_mode_env}%\"==\"success\" (echo {{\"schema\":\"homeboy/external-check-detail-response/v1\",\"provider\":\"fixture-ci\",\"summary\":\"fixture hydrated failure\",\"actions\":[\"fixture-ci replay 42\"]}}& exit /b 0)\r\nif \"%{fixture_mode_env}%\"==\"malformed\" (set /p =not json<nul& exit /b 0)\r\nif \"%{fixture_mode_env}%\"==\"unavailable\" exit /b 23\r\nif \"%{fixture_mode_env}%\"==\"timeout\" goto wait_forever\r\nexit /b 24\r\n:wait_forever\r\ngoto wait_forever\r\n"
+            "@echo off\r\nif \"%{fixture_mode_env}%\"==\"success\" (echo {{\"schema\":\"homeboy/external-check-detail-response/v1\",\"provider\":\"fixture-ci\",\"summary\":\"fixture hydrated failure\",\"actions\":[\"fixture-ci replay 42\"]}}& exit /b 0)\r\nif \"%{fixture_mode_env}%\"==\"malformed\" (set /p =not json<nul& exit /b 0)\r\nif \"%{fixture_mode_env}%\"==\"unavailable\" exit /b 23\r\n:wait_forever\r\ngoto wait_forever\r\n"
         ),
     )
     .unwrap();
-    name.into()
+    name.to_string()
 }
 
 #[cfg(all(feature = "test-support", target_os = "linux"))]
 pub(super) fn test_inherited_pipe_holder_cleanup() {
-    use std::os::unix::fs::PermissionsExt;
-
-    let extension = tempfile::tempdir().unwrap();
-    let pid_file = extension.path().join("descendant.pid");
-    let script = extension.path().join("resolve");
-    std::fs::write(
-        &script,
-        format!(
-            "#!/bin/sh\nsetsid sh -c 'echo $$ > \"$1\"; sleep 30' sh {} &\nwhile [ ! -s {} ]; do :; done\nexit 0\n",
-            homeboy_engine_primitives::shell::quote_path(&pid_file.to_string_lossy()),
-            homeboy_engine_primitives::shell::quote_path(&pid_file.to_string_lossy()),
-        ),
-    )
-    .unwrap();
-    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
-    let resolver = ExternalCheckDetailResolverConfig {
-        schema: EXTERNAL_CHECK_DETAIL_RESPONSE_SCHEMA.into(),
-        provider: "fixture".into(),
-        command: vec!["resolve".into()],
-        public_env: Vec::new(),
-        secret_env: Vec::new(),
-    };
-    let request = ExternalCheckDetailRequest {
-        schema: EXTERNAL_CHECK_DETAIL_REQUEST_SCHEMA.into(),
-        provider: "fixture".into(),
-        status: "failed".into(),
-        target_url: None,
-    };
-
-    let error = invoke(
-        &resolver,
-        extension.path(),
-        &script,
-        &request,
-        &[],
-        Instant::now() + Duration::from_millis(100),
-    )
-    .expect_err("resolver with no response must fail after pipe-holder cleanup");
-    assert!(matches!(error, InvocationFailure::MalformedResponse));
-    let descendant_pid = std::fs::read_to_string(&pid_file)
-        .unwrap()
-        .trim()
-        .parse::<u32>()
-        .unwrap();
-    assert!(
-        !homeboy::core::process::pid_is_running(descendant_pid),
-        "detached resolver descendant {descendant_pid} survived cleanup"
-    );
+    homeboy_core::extension::external_check_detail_api::test_inherited_pipe_holder_cleanup();
 }
 
 #[cfg(test)]
@@ -811,239 +293,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn target_url_strips_fragments_and_credentials() {
+    fn target_url_normalization_removes_credentials_query_and_fragment() {
         assert_eq!(
-            normalize_target_url("https://user:token@example.test/job/1?token=secret#secret"),
-            "https://example.test/job/1"
+            normalize_target_url("https://token@example.test/build/42?secret=yes#fragment"),
+            "https://example.test/build/42"
         );
     }
 
     #[test]
-    fn response_identity_is_a_separate_contract() {
-        let response: ExternalCheckDetailResponse = serde_json::from_str(r#"{"schema":"homeboy/external-check-detail-response/v1","provider":"example","summary":"failed"}"#).unwrap();
-        assert_eq!(response.provider, "example");
-        assert!(response.actions.is_empty());
-    }
-
-    #[test]
-    fn cleanup_diagnostic_includes_process_failure_evidence() {
-        assert_eq!(
-            cleanup_diagnostic(&[
-                "process-tree termination: taskkill exceeded 2000 ms".into(),
-                "remaining process-group cleanup: survivor 42".into(),
-            ]),
-            "; cleanup evidence: process-tree termination: taskkill exceeded 2000 ms; remaining process-group cleanup: survivor 42"
-        );
-    }
-
-    #[test]
-    fn bounded_reap_timeout_evidence_identifies_a_possible_windows_survivor() {
-        assert_eq!(
-            child_reap_timeout_evidence(42, Duration::from_millis(2000)),
-            "child 42 remained alive after bounded cleanup for 2000 ms; taskkill/Job cleanup may have left a survivor"
-        );
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn bounded_reap_returns_when_a_stubborn_child_survives_the_cleanup_budget() {
-        let mut child = Command::new("powershell")
-            .args(["-NoProfile", "-Command", "Start-Sleep -Seconds 30"])
-            .spawn()
-            .unwrap();
-
-        let error = reap_child_after_bounded_cleanup(&mut child)
-            .expect_err("live child must not reach an unbounded wait");
-        assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
-        assert!(error.to_string().contains("may have left a survivor"));
-
-        let _ = child.kill();
-        let _ = child.wait();
-    }
-
-    #[test]
-    fn capture_snapshot_enforces_output_limit_without_waiting_for_eof() {
-        let mut captures = ResolverCaptureFiles::create().unwrap();
-        captures
-            .stdout
-            .as_file_mut()
-            .write_all(&vec![b'x'; MAX_OUTPUT_BYTES + 1])
-            .unwrap();
-        captures.stdout.as_file_mut().flush().unwrap();
-
-        assert!(matches!(
-            captures.snapshot("stdout"),
-            Err(InvocationFailure::Unavailable(ref message))
-                if message == "Resolver output exceeded the 64 KiB limit."
-        ));
-    }
-
-    #[test]
-    fn capture_files_are_removed_when_the_owner_drops() {
-        let captures = ResolverCaptureFiles::create().unwrap();
-        let stdout = captures.stdout.path().to_path_buf();
-        let stderr = captures.stderr.path().to_path_buf();
-        assert!(stdout.is_file());
-        assert!(stderr.is_file());
-
-        drop(captures);
-
-        assert!(!stdout.exists());
-        assert!(!stderr.exists());
-    }
-
-    #[test]
-    fn redaction_removes_projected_secrets_and_url_suffixes() {
-        assert_eq!(
-            redact(
-                "token=secret https://user:pass@example.test/log?token=secret#fragment",
-                &["secret".into()],
-                512,
-            ),
-            "token=[REDACTED] https://[REDACTED]@example.test/log?token=[REDACTED]"
-        );
-    }
-
-    #[test]
-    fn resolver_program_is_canonicalized_inside_its_extension() {
-        let extension = tempfile::tempdir().unwrap();
-        let script = std::env::current_exe().unwrap();
-        std::fs::copy(&script, extension.path().join("resolve")).unwrap();
-        let config = ExternalCheckDetailResolverConfig {
-            schema: "homeboy/external-check-detail-resolver/v1".into(),
-            provider: "fixture".into(),
-            command: vec!["resolve".into()],
-            public_env: Vec::new(),
-            secret_env: Vec::new(),
-        };
-        let (root, program) = resolve_program(extension.path(), &config).unwrap();
-        assert_eq!(root, extension.path().canonicalize().unwrap());
-        assert!(program.starts_with(root));
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn timeout_reaps_a_detached_session_descendant() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let extension = tempfile::tempdir().unwrap();
-        let pid_file = extension.path().join("descendant.pid");
-        let script = extension.path().join("resolve");
-        std::fs::write(
-            &script,
-            format!(
-                "#!/bin/sh\nperl -MPOSIX -e 'my $child = fork; die \"fork: $!\\n\" unless defined $child; if ($child) {{ wait; exit }} POSIX::setsid() or die \"setsid: $!\\n\"; open my $pid, \">\", $ARGV[0] or die $!; print $pid $$; close $pid; sleep 30' {} &\nwhile [ ! -s {} ]; do :; done\nsleep 30\n",
-                homeboy_engine_primitives::shell::quote_path(&pid_file.to_string_lossy()),
-                pid_file.display(),
-            ),
-        )
-        .unwrap();
-        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
-        let resolver = ExternalCheckDetailResolverConfig {
-            schema: EXTERNAL_CHECK_DETAIL_RESPONSE_SCHEMA.into(),
-            provider: "fixture".into(),
-            command: vec!["resolve".into()],
-            public_env: Vec::new(),
-            secret_env: Vec::new(),
-        };
-        let request = ExternalCheckDetailRequest {
-            schema: EXTERNAL_CHECK_DETAIL_REQUEST_SCHEMA.into(),
-            provider: "fixture".into(),
-            status: "failed".into(),
-            target_url: None,
-        };
-
-        let error = invoke(
-            &resolver,
-            extension.path(),
-            &script,
-            &request,
-            &[],
-            Instant::now() + Duration::from_secs(1),
-        )
-        .expect_err("resolver must time out");
-        assert!(matches!(
-            error,
-            InvocationFailure::Unavailable(ref message) if message.starts_with("Resolver timed out;")
-        ));
-        let descendant_pid = std::fs::read_to_string(&pid_file)
-            .unwrap()
-            .trim()
-            .parse::<u32>()
-            .unwrap();
-        assert!(
-            !homeboy::core::process::pid_is_running(descendant_pid),
-            "detached resolver descendant {descendant_pid} survived timeout cleanup"
-        );
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn leader_exit_reaps_a_detached_session_pipe_holder_before_capture_snapshot() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let extension = tempfile::tempdir().unwrap();
-        let pid_file = extension.path().join("descendant.pid");
-        let script = extension.path().join("resolve");
-        std::fs::write(
-            &script,
-            format!(
-                "#!/bin/sh\nsetsid sh -c 'echo $$ > \"$1\"; sleep 30' sh {} &\nwhile [ ! -s {} ]; do :; done\nexit 0\n",
-                homeboy_engine_primitives::shell::quote_path(&pid_file.to_string_lossy()),
-                homeboy_engine_primitives::shell::quote_path(&pid_file.to_string_lossy()),
-            ),
-        )
-        .unwrap();
-        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
-        let resolver = ExternalCheckDetailResolverConfig {
-            schema: EXTERNAL_CHECK_DETAIL_RESPONSE_SCHEMA.into(),
-            provider: "fixture".into(),
-            command: vec!["resolve".into()],
-            public_env: Vec::new(),
-            secret_env: Vec::new(),
-        };
-        let request = ExternalCheckDetailRequest {
-            schema: EXTERNAL_CHECK_DETAIL_REQUEST_SCHEMA.into(),
-            provider: "fixture".into(),
-            status: "failed".into(),
-            target_url: None,
-        };
-
-        let error = invoke(
-            &resolver,
-            extension.path(),
-            &script,
-            &request,
-            &[],
-            Instant::now() + Duration::from_millis(100),
-        )
-        .expect_err("resolver with no response must fail after pipe-holder cleanup");
-        assert!(matches!(error, InvocationFailure::MalformedResponse));
-        let descendant_pid = std::fs::read_to_string(&pid_file)
-            .unwrap()
-            .trim()
-            .parse::<u32>()
-            .unwrap();
-        assert!(
-            !homeboy::core::process::pid_is_running(descendant_pid),
-            "detached resolver descendant {descendant_pid} survived leader-exit cleanup"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn symlinked_resolver_outside_extension_is_rejected_before_projection() {
-        use std::os::unix::fs::symlink;
-        let extension = tempfile::tempdir().unwrap();
-        let outside = tempfile::NamedTempFile::new().unwrap();
-        symlink(outside.path(), extension.path().join("resolve")).unwrap();
-        let config = ExternalCheckDetailResolverConfig {
-            schema: homeboy_extension_contract::external_check_detail_resolver::EXTERNAL_CHECK_DETAIL_RESOLVER_SCHEMA.into(),
-            provider: "fixture".into(),
-            command: vec!["resolve".into()],
-            public_env: vec![],
-            secret_env: vec!["TOKEN".into()],
-        };
-        assert!(resolve_program(extension.path(), &config).is_err());
+    fn missing_provider_is_diagnostic_only() {
+        homeboy::core::test_support::with_isolated_home(|_| {
+            let session = ResolverSession::discover();
+            let (details, diagnostics) = session.hydrate(
+                "missing",
+                "failure",
+                None,
+                Instant::now() + Duration::from_secs(1),
+            );
+            assert!(details.is_empty());
+            assert_eq!(diagnostics[0].kind, "unknown");
+        });
     }
 }

--- a/crates/homeboy-cli/src/commands/ci/failure_log_triage.rs
+++ b/crates/homeboy-cli/src/commands/ci/failure_log_triage.rs
@@ -9,8 +9,8 @@ use std::collections::HashSet;
 use std::time::Instant;
 
 use super::external_check_detail_resolver::{
-    has_unique_resolver, hydrate, normalize_target_url, skipped_for_budget, HydratedDetail,
-    ResolverDiagnostic, MAX_RESOLVERS, TOTAL_BUDGET,
+    normalize_target_url, skipped_for_budget, HydratedDetail, ResolverDiagnostic, ResolverSession,
+    MAX_RESOLVERS, TOTAL_BUDGET,
 };
 use homeboy::core::error::{Error, Result};
 use homeboy::core::git::GhClient;
@@ -181,8 +181,9 @@ mod engine {
         let runs = fetch_runs_for_head(&gh, &pr.head_sha)?;
         // One fixed deadline is shared by every resolver invocation in this triage.
         let resolver_deadline = Instant::now() + TOTAL_BUDGET;
+        let resolver_session = ResolverSession::discover();
         let (external_checks, api_degradations) =
-            fetch_external_checks(&gh, &pr.head_sha, resolver_deadline);
+            fetch_external_checks(&gh, &pr.head_sha, &resolver_session, resolver_deadline);
 
         let failed_runs: Vec<GhWorkflowRun> = runs.into_iter().filter(is_failed_run).collect();
         let total_failed_runs = failed_runs.len();
@@ -398,6 +399,7 @@ mod engine {
     pub(crate) fn fetch_external_checks(
         gh: &GhClient,
         head_sha: &str,
+        resolver_session: &ResolverSession,
         resolver_deadline: Instant,
     ) -> (Vec<CiExternalCheckSummary>, Vec<CiApiDegradation>) {
         let Ok(repo) = gh.repo_path() else {
@@ -434,6 +436,7 @@ mod engine {
                             continue;
                         }
                         checks.push(hydrate_external(
+                            resolver_session,
                             status.context,
                             status.state.unwrap_or_default(),
                             status.description,
@@ -481,6 +484,7 @@ mod engine {
                             continue;
                         }
                         checks.push(hydrate_external(
+                            resolver_session,
                             check.name,
                             check.conclusion.unwrap_or_default(),
                             None,
@@ -511,6 +515,7 @@ mod engine {
     }
 
     pub(crate) fn hydrate_external(
+        resolver_session: &ResolverSession,
         provider: String,
         status: String,
         description: Option<String>,
@@ -519,17 +524,18 @@ mod engine {
         resolver_deadline: Instant,
     ) -> CiExternalCheckSummary {
         let target_url = target_url.map(|url| normalize_target_url(&url));
-        let (details, resolver_diagnostics) =
-            if has_unique_resolver(&provider) && *resolver_slots == 0 {
-                (Vec::new(), vec![skipped_for_budget(&provider)])
-            } else {
-                // Unknown and ambiguous providers are diagnostic-only and never
-                // consume a bounded resolver invocation slot.
-                if has_unique_resolver(&provider) {
-                    *resolver_slots -= 1;
-                }
-                hydrate(&provider, &status, target_url.as_deref(), resolver_deadline)
-            };
+        let (details, resolver_diagnostics) = if resolver_session.has_unique_provider(&provider)
+            && *resolver_slots == 0
+        {
+            (Vec::new(), vec![skipped_for_budget(&provider)])
+        } else {
+            // Unknown and ambiguous providers are diagnostic-only and never
+            // consume a bounded resolver invocation slot.
+            if resolver_session.has_unique_provider(&provider) {
+                *resolver_slots -= 1;
+            }
+            resolver_session.hydrate(&provider, &status, target_url.as_deref(), resolver_deadline)
+        };
         CiExternalCheckSummary {
             provider,
             status: homeboy::core::redaction::RedactionPolicy::default()
@@ -1203,7 +1209,9 @@ mod tests {
 
     #[test]
     fn legacy_status_keeps_failure_state_when_description_is_missing_or_redacted() {
+        let resolver_session = ResolverSession::discover();
         let empty = hydrate_external(
+            &resolver_session,
             "example-ci".into(),
             "failure".into(),
             None,
@@ -1215,6 +1223,7 @@ mod tests {
         assert_eq!(empty.description, None);
 
         let described = hydrate_external(
+            &resolver_session,
             "example-ci".into(),
             "error".into(),
             Some("see https://user:token@example.test/job?token=secret".into()),

--- a/crates/homeboy-core/src/extension/catalog/api.rs
+++ b/crates/homeboy-core/src/extension/catalog/api.rs
@@ -24,13 +24,15 @@ use homeboy_extension_contract::api::v1::{
     EXTENSION_API_HANDSHAKE_RESPONSE_SCHEMA, EXTENSION_API_READINESS_REQUEST_SCHEMA,
     EXTENSION_API_READINESS_RESPONSE_SCHEMA, EXTENSION_API_RECIPE_RUN_PLAN_REQUEST_SCHEMA,
     EXTENSION_API_RECIPE_RUN_PLAN_RESPONSE_SCHEMA, EXTENSION_API_RESOLVE_REQUEST_SCHEMA,
-    EXTENSION_API_RESOLVE_RESPONSE_SCHEMA, EXTENSION_API_V1, FINGERPRINT_FILE_CAPABILITY_PREFIX,
+    EXTENSION_API_RESOLVE_RESPONSE_SCHEMA, EXTENSION_API_V1,
+    EXTERNAL_CHECK_DETAIL_RESOLVER_CAPABILITY_PREFIX, FINGERPRINT_FILE_CAPABILITY_PREFIX,
     FINGERPRINT_INPUT_SCHEMA, FINGERPRINT_OUTPUT_SCHEMA, FORMAT_FILE_CAPABILITY_PREFIX,
     RECIPE_RUN_PROVIDER_CAPABILITY_PREFIX, REFACTOR_ANALYSIS_INPUT_SCHEMA,
     REFACTOR_ANALYSIS_OUTPUT_SCHEMA, REFACTOR_FILE_CAPABILITY_PREFIX,
 };
 use homeboy_extension_contract::{
     evaluate_core_compatibility, ExtensionCapability, ExtensionManifest,
+    EXTERNAL_CHECK_DETAIL_REQUEST_SCHEMA, EXTERNAL_CHECK_DETAIL_RESPONSE_SCHEMA,
 };
 
 #[cfg(test)]
@@ -92,6 +94,20 @@ fn api_descriptor_from_manifest(extension: &ExtensionManifest) -> ExtensionApiDe
                         provider.declared_str("version"),
                         EXTENSION_API_RECIPE_RUN_PLAN_REQUEST_SCHEMA,
                         EXTENSION_API_RECIPE_RUN_PLAN_RESPONSE_SCHEMA,
+                    )
+                })
+            }),
+    );
+    capabilities.extend(
+        extension
+            .external_check_detail_resolvers
+            .iter()
+            .filter_map(|resolver| {
+                resolver.declared_provider().map(|provider| {
+                    schema_capability_descriptor(
+                        &format!("{EXTERNAL_CHECK_DETAIL_RESOLVER_CAPABILITY_PREFIX}{provider}"),
+                        EXTERNAL_CHECK_DETAIL_REQUEST_SCHEMA,
+                        EXTERNAL_CHECK_DETAIL_RESPONSE_SCHEMA,
                     )
                 })
             }),

--- a/crates/homeboy-core/src/extension/external_check_detail_api.rs
+++ b/crates/homeboy-core/src/extension/external_check_detail_api.rs
@@ -1,0 +1,721 @@
+//! Typed Extension API inventory and hydration for external-check detail resolvers.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use homeboy_extension_contract::api::v1::{
+    ExtensionApiCatalogEntryStatus, ExtensionApiCatalogRequest,
+    ExtensionApiExternalCheckDetailDiagnostic, ExtensionApiExternalCheckDetailDiagnosticKind,
+    ExtensionApiExternalCheckDetailHydrateRequest, ExtensionApiExternalCheckDetailHydrateResponse,
+    ExtensionApiExternalCheckDetailInventoryEntry, ExtensionApiExternalCheckDetailInventoryRequest,
+    ExtensionApiExternalCheckDetailInventoryResponse,
+    ExtensionApiExternalCheckDetailProviderValidation, ExtensionApiOperationFailure,
+    EXTENSION_API_CATALOG_REQUEST_SCHEMA,
+    EXTENSION_API_EXTERNAL_CHECK_DETAIL_HYDRATE_REQUEST_SCHEMA,
+    EXTENSION_API_EXTERNAL_CHECK_DETAIL_HYDRATE_RESPONSE_SCHEMA,
+    EXTENSION_API_EXTERNAL_CHECK_DETAIL_INVENTORY_REQUEST_SCHEMA,
+    EXTENSION_API_EXTERNAL_CHECK_DETAIL_INVENTORY_RESPONSE_SCHEMA, EXTENSION_API_V1,
+    EXTERNAL_CHECK_DETAIL_RESOLVER_CAPABILITY_PREFIX,
+};
+use homeboy_extension_contract::{
+    ExternalCheckDetailRequest, ExternalCheckDetailResolverConfig,
+    ExternalCheckDetailResolverDeclaration, ExternalCheckDetailResponse,
+    EXTERNAL_CHECK_DETAIL_REQUEST_SCHEMA, EXTERNAL_CHECK_DETAIL_RESPONSE_SCHEMA,
+};
+
+use crate::extension::catalog::{snapshot_api, validate_operation_request};
+use crate::extension::invoke::deadline_process::execute_deadline_process;
+use crate::redaction::RedactionPolicy;
+
+const CAPTURE_LIMIT_BYTES: usize = 64 * 1024;
+const CLEANUP_BUDGET: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone)]
+struct ResolverCandidate {
+    entry: ExtensionApiExternalCheckDetailInventoryEntry,
+    config: Option<ExternalCheckDetailResolverConfig>,
+    extension_path: Option<String>,
+}
+
+pub struct ExternalCheckDetailResolverApi {
+    candidates: Vec<ResolverCandidate>,
+    failure: Option<ExtensionApiOperationFailure>,
+}
+
+pub struct ExternalCheckDetailHydrationContext<'a> {
+    pub deadline: Instant,
+    pub resolve_environment: &'a dyn Fn(&str) -> Option<String>,
+}
+
+impl ExternalCheckDetailResolverApi {
+    pub fn discover(request: &ExtensionApiExternalCheckDetailInventoryRequest) -> Self {
+        if let Some(failure) = validate_operation_request(
+            &request.schema,
+            EXTENSION_API_EXTERNAL_CHECK_DETAIL_INVENTORY_REQUEST_SCHEMA,
+            request.api_version,
+        ) {
+            return Self {
+                candidates: Vec::new(),
+                failure: Some(failure),
+            };
+        }
+        match resolver_candidates(request.api_version) {
+            Ok(candidates) => Self {
+                candidates,
+                failure: None,
+            },
+            Err(failure) => Self {
+                candidates: Vec::new(),
+                failure: Some(failure),
+            },
+        }
+    }
+
+    pub fn inventory_api(&self) -> ExtensionApiExternalCheckDetailInventoryResponse {
+        ExtensionApiExternalCheckDetailInventoryResponse {
+            schema: EXTENSION_API_EXTERNAL_CHECK_DETAIL_INVENTORY_RESPONSE_SCHEMA.to_string(),
+            api_version: EXTENSION_API_V1,
+            providers: self
+                .candidates
+                .iter()
+                .map(|candidate| candidate.entry.clone())
+                .collect(),
+            failure: self.failure.clone(),
+        }
+    }
+
+    pub fn hydrate_api(
+        &self,
+        request: &ExtensionApiExternalCheckDetailHydrateRequest,
+        context: ExternalCheckDetailHydrationContext<'_>,
+    ) -> ExtensionApiExternalCheckDetailHydrateResponse {
+        if let Some(failure) = validate_operation_request(
+            &request.schema,
+            EXTENSION_API_EXTERNAL_CHECK_DETAIL_HYDRATE_REQUEST_SCHEMA,
+            request.api_version,
+        ) {
+            return hydrate_failure(failure);
+        }
+        if let Some(failure) = self.failure.clone() {
+            return hydrate_failure(failure);
+        }
+
+        let matches = self
+            .candidates
+            .iter()
+            .filter(|candidate| candidate.entry.provider.as_deref() == Some(&request.provider))
+            .collect::<Vec<_>>();
+        let candidate = match matches.as_slice() {
+            [] => {
+                return hydrate_diagnostic(
+                    &request.provider,
+                    ExtensionApiExternalCheckDetailDiagnosticKind::Unknown,
+                    "No installed extension declares this provider. Install or enable the extension that owns this provider, then rerun CI triage.",
+                );
+            }
+            [candidate]
+                if candidate.entry.validation
+                    != ExtensionApiExternalCheckDetailProviderValidation::Valid =>
+            {
+                return hydrate_diagnostic(
+                    &request.provider,
+                    ExtensionApiExternalCheckDetailDiagnosticKind::Malformed,
+                    candidate
+                        .entry
+                        .diagnostic
+                        .as_deref()
+                        .unwrap_or("The installed resolver declaration is invalid."),
+                );
+            }
+            [candidate] => *candidate,
+            _ => {
+                return hydrate_diagnostic(
+                    &request.provider,
+                    ExtensionApiExternalCheckDetailDiagnosticKind::Ambiguous,
+                    "Multiple extensions declare this exact provider; no resolver was invoked.",
+                );
+            }
+        };
+        let Some(config) = candidate.config.as_ref() else {
+            return hydrate_diagnostic(
+                &request.provider,
+                ExtensionApiExternalCheckDetailDiagnosticKind::Malformed,
+                "The installed resolver declaration is invalid.",
+            );
+        };
+        let Some(extension_path) = candidate.extension_path.as_deref() else {
+            return hydrate_diagnostic(
+                &request.provider,
+                ExtensionApiExternalCheckDetailDiagnosticKind::Malformed,
+                "The declaring extension has no installation path for its resolver.",
+            );
+        };
+        let (extension_root, program) = match resolve_program(Path::new(extension_path), config) {
+            Ok(paths) => paths,
+            Err(message) => {
+                let kind = if message.starts_with("program cannot be resolved") {
+                    ExtensionApiExternalCheckDetailDiagnosticKind::Unavailable
+                } else {
+                    ExtensionApiExternalCheckDetailDiagnosticKind::Malformed
+                };
+                return hydrate_diagnostic(
+                    &request.provider,
+                    kind,
+                    &format!(
+                        "Extension {} resolver program is invalid: {message}",
+                        candidate.entry.owning_extension
+                    ),
+                );
+            }
+        };
+
+        let projected_environment = config
+            .public_env
+            .iter()
+            .chain(&config.secret_env)
+            .filter_map(|name| {
+                (context.resolve_environment)(name).map(|value| (name.clone(), value))
+            })
+            .collect::<Vec<_>>();
+        let secrets = projected_environment
+            .iter()
+            .filter(|(name, _)| config.secret_env.contains(name))
+            .map(|(_, value)| value.clone())
+            .collect::<Vec<_>>();
+        let provider_request = ExternalCheckDetailRequest {
+            schema: EXTERNAL_CHECK_DETAIL_REQUEST_SCHEMA.to_string(),
+            provider: request.provider.clone(),
+            status: redact(&request.status, &secrets, 512),
+            target_url: request.target_url.as_deref().map(normalize_target_url),
+        };
+        let payload = match serde_json::to_vec(&provider_request) {
+            Ok(payload) => payload,
+            Err(error) => {
+                return hydrate_diagnostic(
+                    &request.provider,
+                    ExtensionApiExternalCheckDetailDiagnosticKind::Unavailable,
+                    &format!("Resolver request serialization failed: {error}"),
+                );
+            }
+        };
+        let mut command = Command::new(program);
+        command
+            .args(&config.command[1..])
+            .current_dir(extension_root)
+            .env_clear();
+        for (name, value) in projected_environment {
+            command.env(name, value);
+        }
+        let output = match execute_deadline_process(
+            command,
+            &payload,
+            context.deadline,
+            CLEANUP_BUDGET,
+            CAPTURE_LIMIT_BYTES,
+            "Resolver",
+        ) {
+            Ok(output) => output,
+            Err(error) => {
+                return hydrate_diagnostic(
+                    &request.provider,
+                    ExtensionApiExternalCheckDetailDiagnosticKind::Unavailable,
+                    &redact(&error.message, &secrets, 2048),
+                );
+            }
+        };
+        if !output.status.success() {
+            return hydrate_diagnostic(
+                &request.provider,
+                ExtensionApiExternalCheckDetailDiagnosticKind::Unavailable,
+                &format!(
+                    "Resolver exited unsuccessfully: {}",
+                    redact(&String::from_utf8_lossy(&output.stderr), &secrets, 512)
+                ),
+            );
+        }
+        let mut detail = match serde_json::from_slice::<ExternalCheckDetailResponse>(&output.stdout)
+        {
+            Ok(detail) => detail,
+            Err(_) => {
+                return hydrate_diagnostic(
+                    &request.provider,
+                    ExtensionApiExternalCheckDetailDiagnosticKind::Malformed,
+                    "Resolver returned malformed JSON.",
+                );
+            }
+        };
+        if detail.schema != EXTERNAL_CHECK_DETAIL_RESPONSE_SCHEMA
+            || detail.provider != request.provider
+        {
+            return hydrate_diagnostic(
+                &request.provider,
+                ExtensionApiExternalCheckDetailDiagnosticKind::MalformedIdentity,
+                "Resolver response schema or provider did not match its declaration.",
+            );
+        }
+        detail.build_id = detail.build_id.map(|value| redact(&value, &secrets, 512));
+        detail.summary = detail.summary.map(|value| redact(&value, &secrets, 2048));
+        detail.actions = detail
+            .actions
+            .into_iter()
+            .map(|value| redact(&value, &secrets, 512))
+            .collect();
+        detail.artifact_refs = detail
+            .artifact_refs
+            .into_iter()
+            .map(|value| redact(&value, &secrets, 2048))
+            .collect();
+        detail.log_refs = detail
+            .log_refs
+            .into_iter()
+            .map(|value| redact(&value, &secrets, 2048))
+            .collect();
+
+        ExtensionApiExternalCheckDetailHydrateResponse {
+            schema: EXTENSION_API_EXTERNAL_CHECK_DETAIL_HYDRATE_RESPONSE_SCHEMA.to_string(),
+            api_version: EXTENSION_API_V1,
+            detail: Some(detail),
+            diagnostic: None,
+            failure: None,
+        }
+    }
+}
+
+fn resolver_candidates(
+    api_version: homeboy_extension_contract::api::v1::ExtensionApiVersion,
+) -> Result<Vec<ResolverCandidate>, ExtensionApiOperationFailure> {
+    let snapshot = snapshot_api(&ExtensionApiCatalogRequest {
+        schema: EXTENSION_API_CATALOG_REQUEST_SCHEMA.to_string(),
+        api_version,
+    });
+    if let Some(failure) = snapshot.response.failure {
+        return Err(failure);
+    }
+
+    let mut candidates = Vec::new();
+    for catalog_entry in snapshot.response.entries {
+        let Some(manifest) = snapshot.manifests.get(&catalog_entry.id) else {
+            continue;
+        };
+        let advertised_capabilities = catalog_entry
+            .descriptor
+            .as_ref()
+            .into_iter()
+            .flat_map(|descriptor| &descriptor.capabilities)
+            .map(|capability| capability.id.as_str())
+            .filter(|id| id.starts_with(EXTERNAL_CHECK_DETAIL_RESOLVER_CAPABILITY_PREFIX))
+            .collect::<Vec<_>>();
+        for declaration in &manifest.external_check_detail_resolvers {
+            let provider = declaration.declared_provider();
+            let config = match declaration {
+                ExternalCheckDetailResolverDeclaration::Config(config) => {
+                    config.validate().ok().map(|_| config.as_ref().clone())
+                }
+                ExternalCheckDetailResolverDeclaration::Malformed(_) => None,
+            };
+            let capability_advertised = provider.as_ref().is_some_and(|provider| {
+                advertised_capabilities.iter().any(|capability| {
+                    *capability
+                        == format!("{EXTERNAL_CHECK_DETAIL_RESOLVER_CAPABILITY_PREFIX}{provider}")
+                })
+            });
+            let valid = catalog_entry.status == ExtensionApiCatalogEntryStatus::Available
+                && capability_advertised
+                && config.is_some();
+            candidates.push(ResolverCandidate {
+                entry: ExtensionApiExternalCheckDetailInventoryEntry {
+                    provider,
+                    owning_extension: manifest.id.clone(),
+                    resolvable: valid,
+                    validation: if valid {
+                        ExtensionApiExternalCheckDetailProviderValidation::Valid
+                    } else {
+                        ExtensionApiExternalCheckDetailProviderValidation::Invalid
+                    },
+                    diagnostic: (!valid).then(|| {
+                        "Resolver requires a provider and valid literal command declaration."
+                            .to_string()
+                    }),
+                },
+                config: valid.then_some(config).flatten(),
+                extension_path: manifest.extension_path.clone(),
+            });
+        }
+    }
+    mark_duplicates(&mut candidates);
+    candidates.sort_by(|left, right| {
+        (&left.entry.provider, &left.entry.owning_extension)
+            .cmp(&(&right.entry.provider, &right.entry.owning_extension))
+    });
+    Ok(candidates)
+}
+
+fn mark_duplicates(candidates: &mut [ResolverCandidate]) {
+    let counts = candidates
+        .iter()
+        .filter_map(|candidate| candidate.entry.provider.as_deref())
+        .fold(BTreeMap::new(), |mut counts, provider| {
+            *counts.entry(provider.to_string()).or_insert(0usize) += 1;
+            counts
+        });
+    for candidate in candidates {
+        if candidate.entry.validation == ExtensionApiExternalCheckDetailProviderValidation::Valid
+            && candidate
+                .entry
+                .provider
+                .as_ref()
+                .is_some_and(|provider| counts.get(provider).copied().unwrap_or_default() > 1)
+        {
+            candidate.entry.resolvable = false;
+            candidate.entry.validation =
+                ExtensionApiExternalCheckDetailProviderValidation::Duplicate;
+            candidate.entry.diagnostic =
+                Some("Multiple installed extensions declare this provider.".to_string());
+            candidate.config = None;
+        }
+    }
+}
+
+fn resolve_program(
+    extension_path: &Path,
+    resolver: &ExternalCheckDetailResolverConfig,
+) -> Result<(std::path::PathBuf, std::path::PathBuf), String> {
+    let root = extension_path
+        .canonicalize()
+        .map_err(|error| format!("extension root cannot be resolved: {error}"))?;
+    let program = root
+        .join(&resolver.command[0])
+        .canonicalize()
+        .map_err(|error| format!("program cannot be resolved inside the extension: {error}"))?;
+    if !program.starts_with(&root) {
+        return Err("program resolves outside the declaring extension".to_string());
+    }
+    Ok((root, program))
+}
+
+pub fn normalize_target_url(value: &str) -> String {
+    let without_secret_suffix = value.split(['?', '#']).next().unwrap_or_default();
+    let without_credentials = without_secret_suffix
+        .split_once("//")
+        .map(|(scheme, rest)| format!("{scheme}//{}", rest.rsplit('@').next().unwrap_or(rest)))
+        .unwrap_or_else(|| without_secret_suffix.to_string());
+    bound(&without_credentials, 2048)
+}
+
+fn redact(value: &str, secrets: &[String], limit: usize) -> String {
+    let mut redacted = RedactionPolicy::default().redact_embedded_urls(value);
+    for secret in secrets {
+        if !secret.is_empty() {
+            redacted = redacted.replace(secret, "[REDACTED]");
+        }
+    }
+    bound(&redacted, limit)
+}
+
+fn bound(value: &str, limit: usize) -> String {
+    value.chars().take(limit).collect()
+}
+
+fn hydrate_failure(
+    failure: ExtensionApiOperationFailure,
+) -> ExtensionApiExternalCheckDetailHydrateResponse {
+    ExtensionApiExternalCheckDetailHydrateResponse {
+        schema: EXTENSION_API_EXTERNAL_CHECK_DETAIL_HYDRATE_RESPONSE_SCHEMA.to_string(),
+        api_version: EXTENSION_API_V1,
+        detail: None,
+        diagnostic: None,
+        failure: Some(failure),
+    }
+}
+
+fn hydrate_diagnostic(
+    provider: &str,
+    kind: ExtensionApiExternalCheckDetailDiagnosticKind,
+    message: &str,
+) -> ExtensionApiExternalCheckDetailHydrateResponse {
+    ExtensionApiExternalCheckDetailHydrateResponse {
+        schema: EXTENSION_API_EXTERNAL_CHECK_DETAIL_HYDRATE_RESPONSE_SCHEMA.to_string(),
+        api_version: EXTENSION_API_V1,
+        detail: None,
+        diagnostic: Some(ExtensionApiExternalCheckDetailDiagnostic {
+            provider: provider.to_string(),
+            kind,
+            message: message.to_string(),
+        }),
+        failure: None,
+    }
+}
+
+#[cfg(all(any(test, feature = "test-support"), target_os = "linux"))]
+pub fn test_inherited_pipe_holder_cleanup() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let extension = tempfile::tempdir().unwrap();
+    let pid_file = extension.path().join("descendant.pid");
+    let script = extension.path().join("resolve");
+    std::fs::write(
+        &script,
+        format!(
+            "#!/bin/sh\nsetsid sh -c 'echo $$ > \"$1\"; sleep 30' sh {} &\nwhile [ ! -s {} ]; do :; done\nexit 0\n",
+            homeboy_engine_primitives::shell::quote_path(&pid_file.to_string_lossy()),
+            homeboy_engine_primitives::shell::quote_path(&pid_file.to_string_lossy()),
+        ),
+    )
+    .unwrap();
+    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let mut command = Command::new(&script);
+    command.current_dir(extension.path()).env_clear();
+
+    let output = execute_deadline_process(
+        command,
+        b"{}",
+        Instant::now() + Duration::from_millis(100),
+        CLEANUP_BUDGET,
+        CAPTURE_LIMIT_BYTES,
+        "Resolver",
+    )
+    .expect("leader exit should return captured output after descendant cleanup");
+    assert!(output.status.success());
+    let descendant_pid = std::fs::read_to_string(&pid_file)
+        .unwrap()
+        .trim()
+        .parse::<u32>()
+        .unwrap();
+    assert!(
+        !crate::process::pid_is_running(descendant_pid),
+        "detached resolver descendant {descendant_pid} survived cleanup"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inventory_request() -> ExtensionApiExternalCheckDetailInventoryRequest {
+        ExtensionApiExternalCheckDetailInventoryRequest {
+            schema: EXTENSION_API_EXTERNAL_CHECK_DETAIL_INVENTORY_REQUEST_SCHEMA.to_string(),
+            api_version: EXTENSION_API_V1,
+        }
+    }
+
+    fn install_manifest(id: &str, resolvers: serde_json::Value) -> std::path::PathBuf {
+        let extension = crate::paths::extensions().unwrap().join(id);
+        std::fs::create_dir_all(&extension).unwrap();
+        std::fs::write(
+            extension.join(format!("{id}.json")),
+            serde_json::json!({
+                "name": id,
+                "version": "1.0.0",
+                "external_check_detail_resolvers": resolvers
+            })
+            .to_string(),
+        )
+        .unwrap();
+        extension
+    }
+
+    #[test]
+    fn inventory_retains_safe_valid_malformed_and_duplicate_entries() {
+        crate::test_support::with_isolated_home(|_| {
+            install_manifest(
+                "valid",
+                serde_json::json!([{
+                    "provider": "valid-ci",
+                    "command": ["resolve"],
+                    "secret_env": ["DO_NOT_EXPOSE_TOKEN"]
+                }]),
+            );
+            install_manifest(
+                "malformed",
+                serde_json::json!([{
+                    "provider": "malformed-ci",
+                    "command": "private-command"
+                }]),
+            );
+            for id in ["duplicate-a", "duplicate-b"] {
+                install_manifest(
+                    id,
+                    serde_json::json!([{
+                        "provider": "duplicate-ci",
+                        "command": ["resolve"]
+                    }]),
+                );
+            }
+
+            let api = ExternalCheckDetailResolverApi::discover(&inventory_request());
+            let inventory = api.inventory_api();
+            assert_eq!(inventory.providers.len(), 4);
+            assert!(inventory.providers.iter().any(|entry| {
+                entry.provider.as_deref() == Some("valid-ci")
+                    && entry.validation == ExtensionApiExternalCheckDetailProviderValidation::Valid
+            }));
+            assert!(inventory.providers.iter().any(|entry| {
+                entry.provider.as_deref() == Some("malformed-ci")
+                    && entry.validation
+                        == ExtensionApiExternalCheckDetailProviderValidation::Invalid
+            }));
+            assert_eq!(
+                inventory
+                    .providers
+                    .iter()
+                    .filter(|entry| {
+                        entry.provider.as_deref() == Some("duplicate-ci")
+                            && entry.validation
+                                == ExtensionApiExternalCheckDetailProviderValidation::Duplicate
+                    })
+                    .count(),
+                2
+            );
+            let wire = serde_json::to_string(&inventory).unwrap();
+            assert!(!wire.contains("private-command"));
+            assert!(!wire.contains("DO_NOT_EXPOSE_TOKEN"));
+            assert!(!wire.contains(
+                crate::paths::extensions()
+                    .unwrap()
+                    .to_string_lossy()
+                    .as_ref()
+            ));
+
+            let catalog = crate::extension::catalog::list_api(&ExtensionApiCatalogRequest {
+                schema: EXTENSION_API_CATALOG_REQUEST_SCHEMA.to_string(),
+                api_version: EXTENSION_API_V1,
+            });
+            let capability = catalog
+                .entries
+                .iter()
+                .find(|entry| entry.id == "valid")
+                .and_then(|entry| entry.descriptor.as_ref())
+                .and_then(|descriptor| {
+                    descriptor.capabilities.iter().find(|capability| {
+                        capability.id == "external-check-detail-resolver.valid-ci"
+                    })
+                })
+                .expect("resolver capability");
+            assert_eq!(
+                capability
+                    .input_schema
+                    .as_ref()
+                    .map(|schema| schema.schema.as_str()),
+                Some(EXTERNAL_CHECK_DETAIL_REQUEST_SCHEMA)
+            );
+            assert_eq!(
+                capability
+                    .output_schema
+                    .as_ref()
+                    .map(|schema| schema.schema.as_str()),
+                Some(EXTERNAL_CHECK_DETAIL_RESPONSE_SCHEMA)
+            );
+        });
+    }
+
+    #[test]
+    fn resolver_session_keeps_one_immutable_catalog_snapshot() {
+        crate::test_support::with_isolated_home(|_| {
+            let session = ExternalCheckDetailResolverApi::discover(&inventory_request());
+            install_manifest(
+                "late",
+                serde_json::json!([{
+                    "provider": "late-ci",
+                    "command": ["resolve"]
+                }]),
+            );
+            assert!(session.inventory_api().providers.is_empty());
+            let no_environment = |_name: &str| None;
+            let response = session.hydrate_api(
+                &ExtensionApiExternalCheckDetailHydrateRequest {
+                    schema: EXTENSION_API_EXTERNAL_CHECK_DETAIL_HYDRATE_REQUEST_SCHEMA.to_string(),
+                    api_version: EXTENSION_API_V1,
+                    provider: "late-ci".to_string(),
+                    status: "failure".to_string(),
+                    target_url: None,
+                },
+                ExternalCheckDetailHydrationContext {
+                    deadline: Instant::now() + Duration::from_secs(1),
+                    resolve_environment: &no_environment,
+                },
+            );
+            assert_eq!(
+                response.diagnostic.unwrap().kind,
+                ExtensionApiExternalCheckDetailDiagnosticKind::Unknown
+            );
+            assert_eq!(
+                ExternalCheckDetailResolverApi::discover(&inventory_request())
+                    .inventory_api()
+                    .providers
+                    .len(),
+                1
+            );
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hydration_redacts_secrets_and_expired_deadlines_prevent_spawn() {
+        use std::os::unix::fs::PermissionsExt;
+
+        crate::test_support::with_isolated_home(|_| {
+            let extension = install_manifest(
+                "fixture",
+                serde_json::json!([{
+                    "provider": "fixture-ci",
+                    "command": ["resolve"],
+                    "secret_env": ["FIXTURE_SECRET"]
+                }]),
+            );
+            let marker = extension.join("spawned");
+            let script = extension.join("resolve");
+            std::fs::write(
+                &script,
+                format!(
+                    "#!/bin/sh\ntouch {}\nprintf '{{\"schema\":\"homeboy/external-check-detail-response/v1\",\"provider\":\"fixture-ci\",\"summary\":\"%s\",\"actions\":[\"%s\"]}}\\n' \"$FIXTURE_SECRET\" \"$FIXTURE_SECRET\"\n",
+                    homeboy_engine_primitives::shell::quote_path(&marker.to_string_lossy())
+                ),
+            )
+            .unwrap();
+            std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+            let api = ExternalCheckDetailResolverApi::discover(&inventory_request());
+            let request = ExtensionApiExternalCheckDetailHydrateRequest {
+                schema: EXTENSION_API_EXTERNAL_CHECK_DETAIL_HYDRATE_REQUEST_SCHEMA.to_string(),
+                api_version: EXTENSION_API_V1,
+                provider: "fixture-ci".to_string(),
+                status: "failure secret-value".to_string(),
+                target_url: Some("https://user:token@example.test/build?secret=yes".to_string()),
+            };
+            let resolve_environment =
+                |name: &str| (name == "FIXTURE_SECRET").then(|| "secret-value".to_string());
+
+            let expired = api.hydrate_api(
+                &request,
+                ExternalCheckDetailHydrationContext {
+                    deadline: Instant::now(),
+                    resolve_environment: &resolve_environment,
+                },
+            );
+            assert_eq!(
+                expired.diagnostic.unwrap().kind,
+                ExtensionApiExternalCheckDetailDiagnosticKind::Unavailable
+            );
+            assert!(!marker.exists());
+
+            let hydrated = api.hydrate_api(
+                &request,
+                ExternalCheckDetailHydrationContext {
+                    deadline: Instant::now() + Duration::from_secs(2),
+                    resolve_environment: &resolve_environment,
+                },
+            );
+            let detail = hydrated.detail.expect("resolver detail");
+            assert_eq!(detail.summary.as_deref(), Some("[REDACTED]"));
+            assert_eq!(detail.actions, ["[REDACTED]"]);
+            assert!(marker.exists());
+        });
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn inherited_pipe_holder_is_reaped() {
+        test_inherited_pipe_holder_cleanup();
+    }
+}

--- a/crates/homeboy-core/src/extension/invoke.rs
+++ b/crates/homeboy-core/src/extension/invoke.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 mod action;
 mod api;
 mod context;
+pub(crate) mod deadline_process;
 pub(crate) mod env_provider;
 mod environment;
 mod environment_api;

--- a/crates/homeboy-core/src/extension/invoke/deadline_process.rs
+++ b/crates/homeboy-core/src/extension/invoke/deadline_process.rs
@@ -1,0 +1,272 @@
+use std::io::{Read, Write};
+use std::process::{Command, ExitStatus, Stdio};
+use std::time::{Duration, Instant};
+
+#[cfg(not(windows))]
+use homeboy_engine_primitives::command::terminate_process_tree_and_reap;
+use homeboy_engine_primitives::command::{terminate_remaining_process_group, ControllerChildGuard};
+use tempfile::NamedTempFile;
+
+use crate::process::{force_terminate_process_tree_bounded, ProcessContainment};
+
+pub(crate) struct DeadlineProcessOutput {
+    pub status: ExitStatus,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+}
+
+pub(crate) struct DeadlineProcessFailure {
+    pub message: String,
+}
+
+struct CaptureFiles {
+    stdout: NamedTempFile,
+    stderr: NamedTempFile,
+    limit: usize,
+}
+
+impl CaptureFiles {
+    fn create(limit: usize, label: &str) -> Result<Self, DeadlineProcessFailure> {
+        Ok(Self {
+            stdout: NamedTempFile::new().map_err(|error| {
+                failure(format!(
+                    "{label} stdout capture file creation failed: {error}"
+                ))
+            })?,
+            stderr: NamedTempFile::new().map_err(|error| {
+                failure(format!(
+                    "{label} stderr capture file creation failed: {error}"
+                ))
+            })?,
+            limit,
+        })
+    }
+
+    fn stdio(&self, label: &str) -> Result<(Stdio, Stdio), DeadlineProcessFailure> {
+        let stdout = self.stdout.reopen().map_err(|error| {
+            failure(format!("{label} stdout capture file setup failed: {error}"))
+        })?;
+        let stderr = self.stderr.reopen().map_err(|error| {
+            failure(format!("{label} stderr capture file setup failed: {error}"))
+        })?;
+        Ok((Stdio::from(stdout), Stdio::from(stderr)))
+    }
+
+    fn snapshot(&self, stream: &str, label: &str) -> Result<Vec<u8>, DeadlineProcessFailure> {
+        let file = match stream {
+            "stdout" => &self.stdout,
+            "stderr" => &self.stderr,
+            _ => unreachable!("capture stream is fixed"),
+        };
+        let length = file
+            .as_file()
+            .metadata()
+            .map_err(|error| failure(format!("{label} {stream} capture metadata failed: {error}")))?
+            .len();
+        if length > self.limit as u64 {
+            return Err(failure(format!(
+                "{label} output exceeded the {} byte limit.",
+                self.limit
+            )));
+        }
+        let mut snapshot = file.reopen().map_err(|error| {
+            failure(format!("{label} {stream} capture snapshot failed: {error}"))
+        })?;
+        let mut output = Vec::with_capacity(length as usize);
+        Read::take(&mut snapshot, (self.limit + 1) as u64)
+            .read_to_end(&mut output)
+            .map_err(|error| failure(format!("{label} {stream} capture read failed: {error}")))?;
+        if output.len() > self.limit {
+            return Err(failure(format!(
+                "{label} output exceeded the {} byte limit.",
+                self.limit
+            )));
+        }
+        Ok(output)
+    }
+}
+
+pub(crate) fn execute_deadline_process(
+    mut command: Command,
+    input: &[u8],
+    deadline: Instant,
+    cleanup_budget: Duration,
+    capture_limit: usize,
+    label: &str,
+) -> Result<DeadlineProcessOutput, DeadlineProcessFailure> {
+    if Instant::now() >= deadline {
+        return Err(failure(format!("{label} budget exhausted before spawn.")));
+    }
+    let captures = CaptureFiles::create(capture_limit, label)?;
+    let (stdout, stderr) = captures.stdio(label)?;
+    command.stdin(Stdio::piped()).stdout(stdout).stderr(stderr);
+    let mut containment = ProcessContainment::prepare(&mut command)
+        .map_err(|error| failure(format!("{label} containment setup failed: {error}")))?;
+    let mut guard = Some(
+        ControllerChildGuard::prepare(&mut command)
+            .map_err(|error| failure(format!("{label} containment setup failed: {error}")))?,
+    );
+    let mut child = command.spawn().map_err(|error| {
+        failure(format!(
+            "{label} spawn failed; capture files will be removed: {error}"
+        ))
+    })?;
+    if let Err(error) = containment.attach(&child) {
+        let errors = cleanup(&containment, &mut child, &mut guard, false, cleanup_budget);
+        return Err(failure(format!(
+            "{label} containment attach failed: {error}{}",
+            cleanup_diagnostic(&errors)
+        )));
+    }
+    if let Err(error) = guard.as_ref().expect("guard exists").attach(&child) {
+        let errors = cleanup(&containment, &mut child, &mut guard, false, cleanup_budget);
+        return Err(failure(format!(
+            "{label} containment attach failed: {error}{}",
+            cleanup_diagnostic(&errors)
+        )));
+    }
+    let mut stdin = child.stdin.take().ok_or_else(|| {
+        let errors = cleanup(&containment, &mut child, &mut guard, false, cleanup_budget);
+        failure(format!(
+            "{label} stdin was unavailable.{}",
+            cleanup_diagnostic(&errors)
+        ))
+    })?;
+    if stdin
+        .write_all(input)
+        .and_then(|_| stdin.write_all(b"\n"))
+        .is_err()
+    {
+        let errors = cleanup(&containment, &mut child, &mut guard, false, cleanup_budget);
+        return Err(failure(format!(
+            "{label} stdin write failed.{}",
+            cleanup_diagnostic(&errors)
+        )));
+    }
+    drop(stdin);
+
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let errors = cleanup(&containment, &mut child, &mut guard, true, cleanup_budget);
+                if !errors.is_empty() {
+                    return Err(failure(format!(
+                        "{label} exited but cleanup could not be verified: {}",
+                        errors.join("; ")
+                    )));
+                }
+                return Ok(DeadlineProcessOutput {
+                    status,
+                    stdout: captures.snapshot("stdout", label)?,
+                    stderr: captures.snapshot("stderr", label)?,
+                });
+            }
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Ok(None) => {
+                let mut errors =
+                    cleanup(&containment, &mut child, &mut guard, false, cleanup_budget);
+                errors.extend(capture_snapshot_errors(&captures, label));
+                return Err(failure(format!(
+                    "{label} timed out; capture files were snapshotted without waiting for inherited handles{}.",
+                    cleanup_diagnostic(&errors)
+                )));
+            }
+            Err(error) => {
+                let mut errors =
+                    cleanup(&containment, &mut child, &mut guard, false, cleanup_budget);
+                errors.extend(capture_snapshot_errors(&captures, label));
+                return Err(failure(format!(
+                    "{label} wait failed: {error}; capture files were snapshotted without waiting for inherited handles{}.",
+                    cleanup_diagnostic(&errors)
+                )));
+            }
+        }
+    }
+}
+
+fn cleanup(
+    containment: &ProcessContainment,
+    child: &mut std::process::Child,
+    guard: &mut Option<ControllerChildGuard>,
+    leader_has_exited: bool,
+    cleanup_budget: Duration,
+) -> Vec<String> {
+    drop(guard.take());
+    let mut errors = Vec::new();
+    if !leader_has_exited {
+        if let Err(error) = containment.terminate_on_failure_bounded(cleanup_budget, false) {
+            errors.push(format!("containment termination: {error}"));
+        }
+        if let Err(error) = force_terminate_process_tree_bounded(child.id(), cleanup_budget) {
+            errors.push(format!("process-tree termination: {error}"));
+        }
+        if let Err(error) = reap_child_after_bounded_cleanup(child, cleanup_budget) {
+            errors.push(format!("child reap: {error}"));
+        }
+    }
+    #[cfg(target_os = "linux")]
+    if let Err(error) = containment.cleanup_after_leader_exit_bounded(cleanup_budget) {
+        errors.push(format!("descendant cleanup: {error}"));
+    }
+    if let Err(error) = terminate_remaining_process_group(child.id()) {
+        errors.push(format!("remaining process-group cleanup: {error}"));
+    }
+    errors
+}
+
+#[cfg(not(windows))]
+fn reap_child_after_bounded_cleanup(
+    child: &mut std::process::Child,
+    _cleanup_budget: Duration,
+) -> std::io::Result<()> {
+    terminate_process_tree_and_reap(child).map(|_| ())
+}
+
+#[cfg(windows)]
+fn reap_child_after_bounded_cleanup(
+    child: &mut std::process::Child,
+    cleanup_budget: Duration,
+) -> std::io::Result<()> {
+    let pid = child.id();
+    let deadline = Instant::now() + cleanup_budget;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return Ok(()),
+            Ok(None) if Instant::now() >= deadline => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!(
+                        "child {pid} remained alive after bounded cleanup for {} ms",
+                        cleanup_budget.as_millis()
+                    ),
+                ));
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(10)),
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn cleanup_diagnostic(errors: &[String]) -> String {
+    (!errors.is_empty())
+        .then(|| format!("; cleanup evidence: {}", errors.join("; ")))
+        .unwrap_or_default()
+}
+
+fn capture_snapshot_errors(captures: &CaptureFiles, label: &str) -> Vec<String> {
+    ["stdout", "stderr"]
+        .into_iter()
+        .filter_map(|stream| {
+            captures
+                .snapshot(stream, label)
+                .err()
+                .map(|error| format!("{stream} capture snapshot: {}", error.message))
+        })
+        .collect()
+}
+
+fn failure(message: String) -> DeadlineProcessFailure {
+    DeadlineProcessFailure { message }
+}

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -6,6 +6,7 @@ pub mod bench;
 pub mod build;
 pub mod catalog;
 pub mod component_script;
+pub mod external_check_detail_api;
 pub mod grammar;
 pub mod invoke;
 pub mod lifecycle;

--- a/docs/internals/development/contracts/extension-api-v1.md
+++ b/docs/internals/development/contracts/extension-api-v1.md
@@ -35,6 +35,10 @@ The wire schemas are:
 - `homeboy/extension-api-recipe-run-provider-inventory-response/v1`
 - `homeboy/extension-api-recipe-run-plan-request/v1`
 - `homeboy/extension-api-recipe-run-plan-response/v1`
+- `homeboy/extension-api-external-check-detail-inventory-request/v1`
+- `homeboy/extension-api-external-check-detail-inventory-response/v1`
+- `homeboy/extension-api-external-check-detail-hydrate-request/v1`
+- `homeboy/extension-api-external-check-detail-hydrate-response/v1`
 
 Additive optional fields may be added within v1. Changes to identity,
 capability meaning, compatibility decisions, or required fields require a new
@@ -176,6 +180,23 @@ no shell parsing and no runner execution. The existing runner placement,
 workspace hydration, artifact promotion, and durable terminal-result recording
 consume that plan unchanged.
 
+## External Check Detail Hydration
+
+`extension::external_check_detail_api` discovers
+`external-check-detail-resolver.<provider>` capabilities once per CI triage and
+uses that immutable catalog snapshot for slot accounting, deterministic owner
+selection, and hydration. Inventory responses expose only provider identity,
+owning extension, resolvability, and safe diagnostics. Manifest paths, literal
+argv, and environment declarations remain private to the core adapter.
+
+Hydration accepts the existing extension-owned external-check request fields and
+returns its typed response or an operation-local diagnostic. The host environment
+and absolute aggregate deadline are explicit private service context. Core starts
+from an empty child environment, projects only declared values, bounds output,
+redacts secret values, and terminates contained descendants before returning.
+The CLI retains source check evidence and only adapts the typed result into its
+existing triage presentation.
+
 ## Contract Classification
 
 `homeboy-extension-contract` predates the stable API and contains several kinds
@@ -185,7 +206,7 @@ stability.
 
 | Classification | Modules | Direction |
 | --- | --- | --- |
-| Stable Extension API | `api` | Versioned public descriptor, handshake, discovery, readiness, read-only invocation, environment-resolution, and recipe-provider planning envelopes. |
+| Stable Extension API | `api` | Versioned public descriptor, handshake, discovery, readiness, read-only invocation, environment-resolution, recipe-provider planning, and external-check hydration envelopes. |
 | Stable API candidates | `capability`, `core_compat`, `exec_context`, `runtime_helper`, `sidecar_config` | Reuse or reference from future v1 operations after their wire semantics are reviewed. |
 | Extension-owned domain contracts | `action_types`, `agent_task_executor_declaration`, `autofix_config`, `bench_artifact`, `bench_diagnostics`, `bench_distribution`, `bench_gate`, `bench_metric_preset`, `bench_responsiveness`, `bench_result`, `bench_results`, `bench_stage`, `ci_config`, `ci_context`, `external_check_detail_resolver`, `external_storage_retention`, `fuzz_config`, `lint_result`, `lint_results`, `notification_transport_config`, `source_metadata_repair`, `test_analysis`, `test_drift`, `test_duration`, `test_inventory_config`, `test_parsing`, `test_result`, `test_results`, `test_workflow`, `trace_config`, `trace_parsing`, `trace_preview`, `trace_results`, `trace_spec`, `update_output`, `worktree_retention` | Remain portable domain schemas; the Extension API references their schema IDs rather than absorbing their fields. |
 | Manifest and implementation detail | `extension_contract_producer`, `hook_event`, `manifest`, `manifest_action_config`, `manifest_artifact_cleanup`, `manifest_capabilities`, `manifest_capability_config`, `manifest_deploy_config`, `manifest_test_config`, `manifest_toolchain_config`, `runner_contract`, `version` | Inputs and helpers used to build or execute descriptors. They are not a stable service API. |

--- a/docs/reference/schemas/extension-manifest-schema.md
+++ b/docs/reference/schemas/extension-manifest-schema.md
@@ -248,8 +248,9 @@ and canonicalizes URLs in requests, responses, stderr, actions, and diagnostics.
 Unknown, ambiguous, malformed, unavailable, timed-out, and budget-exhausted
 resolvers preserve the source check and appear as resolver diagnostics. Multiple
 installed extensions that declare a provider are rejected as ambiguous before
-any secret is resolved. Provider names are unique within a manifest and across
-installed manifests; public and secret names are individually unique and disjoint.
+any secret is resolved. Duplicate provider names within one manifest or across
+installed manifests remain visible as typed ambiguity diagnostics; public and
+secret names are individually unique and disjoint.
 
 ## Notification transports
 


### PR DESCRIPTION
## Summary

- add typed Extension API v1 external-check resolver inventory and hydration operations
- advertise safe `external-check-detail-resolver.<provider>` catalog capabilities while keeping paths, argv, and environment declarations private
- retain one immutable catalog snapshot for an entire CI triage and preserve deterministic malformed, duplicate, missing, and budget diagnostics
- add a reusable absolute-deadline process primitive with owned capture files, process containment, bounded output, and descendant cleanup
- remove CLI-owned manifest discovery, secret projection, process execution, and response validation

## Behavior preserved

- eight-resolver limit under one 20-second aggregate deadline
- literal argv and extension-root containment
- empty inherited environment with declared-name projection only
- 64 KiB output bounds and redacted typed results
- original external-check evidence on resolver failure
- cross-platform timeout cleanup and Linux detached-descendant cleanup coverage

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test -p homeboy-extension-contract --lib`
- `cargo test -p homeboy-core extension::catalog::api::tests --lib`
- `cargo test -p homeboy-core extension::external_check_detail_api::tests --lib`
- `cargo test -p homeboy-cli --features test-support --test external_check_detail_resolver_fixture`
- `git diff --check origin/main...HEAD`

CLI lib-test compilation currently encounters an unrelated `origin/main` test-only type mismatch at `commands/agent_task/review.rs:3872`, introduced by #14126. This branch does not modify that file; workspace compilation and the dedicated cross-platform resolver integration target pass.

Closes #14105

---

AI assistance: OpenAI GPT-5.6 Sol via OpenCode audited the existing resolver runtime, implemented the typed API migration and bounded process primitive, added focused coverage, and performed a read-only security and architecture review. Chris Huber selected the target and directed the architecture.