### PR TITLE
Adopt merged PR lifecycle reconciliation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,13 +63,13 @@ jobs:
 
   homeboy:
     name: homeboy
-    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@a55a1dde4d52d00656ac9b01ad06d1be2e5b4378
+    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@f1805406709252e4ab25f983b3c72cdba113f2cf
     with:
       commands: review test
       args: --skip-lint
       expected-commands: review lint,review test
       component: homeboy
-      action-ref: a55a1dde4d52d00656ac9b01ad06d1be2e5b4378
+      action-ref: f1805406709252e4ab25f983b3c72cdba113f2cf
       extension-ref: 9c95310bd12a78cb900dc2fe4ed2411396cb30ca
       source: .
       scope: auto


### PR DESCRIPTION
## Summary
- pin Homeboy CI to Homeboy Action v2.15.23
- adopt typed merged-PR lifecycle reconciliation from Extra-Chill/homeboy-action#465
- prevent successful post-merge candidate and baseline evidence from producing stale red final gates

## Evidence
- Extra-Chill/homeboy#14130, #14131, and #14132 all passed candidate and baseline commands before the v2.15.17 reconciler rejected their merged lifecycle state
- Homeboy Action #465 passed its shell and reusable-workflow contract suites and shipped as v2.15.23
- `git diff --check` passes and the pinned commit exposes `.github/workflows/ci.yml`

Tracks the consumer adoption of Extra-Chill/homeboy#13710.

AI assistance: OpenAI GPT-5.6 Sol using OpenCode investigated the post-merge workflow evidence, identified the already-released owning-layer fix, and prepared this minimal consumer pin update under human orchestration.