### PR TITLE
Bind Lab Cook harvest to its task workspace

### DIFF
--- a/crates/homeboy-lab-runner/src/lab_workspaces/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces/mod.rs
@@ -768,6 +768,28 @@ pub(super) fn agent_task_plan_extra_workspaces(
         Ok(value) => value,
         Err(_) => return Ok(workspaces),
     };
+    // A derived Cook baseline can be the primary Lab source while its plan
+    // still targets the issue worktree it was derived from. Materialize that
+    // target separately so committed harvest selects its own provenance.
+    for task in value
+        .get("tasks")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        if let Some(path) = task
+            .pointer("/workspace/root")
+            .and_then(serde_json::Value::as_str)
+        {
+            add_candidate_extra_workspace(
+                path,
+                "agent_task_plan_workspace",
+                &source_canon,
+                &mut seen,
+                &mut workspaces,
+            )?;
+        }
+    }
     for candidate in component_contract_candidate_paths(&value) {
         add_candidate_extra_workspace(
             &candidate,

--- a/crates/homeboy-lab-runner/src/lab_workspaces/tests/provider_config.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces/tests/provider_config.rs
@@ -579,6 +579,47 @@ fn agent_task_run_plan_component_contract_paths_get_component_contract_evidence_
 }
 
 #[test]
+fn agent_task_run_plan_workspace_gets_its_own_materialized_provenance() {
+    let controller = tempfile::tempdir().expect("controller");
+    let source = controller.path().join("derived-baseline");
+    let issue_worktree = controller.path().join("homeboy@issue-14145");
+    let plan = source.join(".ci/cook-retry.agent-task-plan.json");
+    std::fs::create_dir_all(plan.parent().expect("plan parent")).expect("plan parent directory");
+    std::fs::create_dir_all(&issue_worktree).expect("issue worktree directory");
+    std::fs::write(
+        &plan,
+        serde_json::json!({
+            "schema": "homeboy/agent-task-plan/v1",
+            "plan_id": "derived-cook-retry",
+            "tasks": [{
+                "task_id": "issue-14145",
+                "instructions": "fix provenance",
+                "executor": { "backend": "test" },
+                "workspace": { "root": issue_worktree }
+            }]
+        })
+        .to_string(),
+    )
+    .expect("plan file");
+
+    let args = vec![
+        "homeboy".to_string(),
+        "agent-task".to_string(),
+        "run-plan".to_string(),
+        format!("--plan=@{}", plan.display()),
+    ];
+
+    let workspaces = agent_task_plan_extra_workspaces(&args, &source).expect("workspaces");
+
+    assert_eq!(workspaces.len(), 1);
+    assert_eq!(workspaces[0].role, "agent_task_plan_workspace");
+    assert_eq!(
+        workspaces[0].path,
+        issue_worktree.canonicalize().expect("issue worktree")
+    );
+}
+
+#[test]
 fn agent_task_run_plan_file_inside_primary_workspace_needs_no_extra_sync() {
     let controller = tempfile::tempdir().expect("controller");
     let source = controller.path().join("primary");


### PR DESCRIPTION
## Summary

- discover each task-level `workspace.root` referenced by an offloaded agent-task plan
- materialize that checkout as its own Lab workspace so committed harvest validates against the matching provenance entry
- preserve existing fail-closed workspace synchronization behavior

## Verification

- `cargo test -p homeboy-lab-runner agent_task_run_plan_workspace_gets_its_own_materialized_provenance --locked`
- `cargo fmt --check`
- `git diff --check`

Closes #14145

## AI assistance

OpenAI GPT-5.6 Terra via OpenCode traced the materialization regression and implemented the initial candidate. OpenAI GPT-5.6 Sol via OpenCode audited scope, reran focused verification against current main, and published the PR under Chris Huber’s direction.