### PR TITLE
Bound changed-only review audit work and progress

### DIFF
--- a/crates/homeboy-cli/src/commands/audit.rs
+++ b/crates/homeboy-cli/src/commands/audit.rs
@@ -159,6 +159,7 @@ pub fn run(args: AuditArgs) -> CmdResult<AuditCommandOutput> {
     let run_id = active_observation
         .as_ref()
         .map(|observation| observation.run_id().to_string());
+    emit_audit_lifecycle(run_id.as_deref());
     let workflow = run_main_audit_workflow(AuditRunWorkflowArgs {
         component_id: resolved_id.clone(),
         source_path: resolved_path.clone(),
@@ -218,6 +219,28 @@ pub fn run(args: AuditArgs) -> CmdResult<AuditCommandOutput> {
         )?;
     }
     Ok((output, exit_code))
+}
+
+/// Publish the durable run identity before scanning so an interrupted client can
+/// attach to the persisted audit instead of treating a long detector as a hang.
+fn emit_audit_lifecycle(run_id: Option<&str>) {
+    let Some(lifecycle) = audit_lifecycle(run_id) else {
+        return;
+    };
+    eprintln!("{lifecycle}");
+}
+
+fn audit_lifecycle(run_id: Option<&str>) -> Option<serde_json::Value> {
+    let run_id = run_id?;
+    Some(serde_json::json!({
+        "schema": "homeboy/audit-lifecycle/v1",
+        "event": "persisted",
+        "run_id": run_id,
+        "status": "running",
+        "show_command": format!("homeboy runs show {run_id}"),
+        "watch_command": format!("homeboy runs watch {run_id}"),
+        "cancel_command": format!("homeboy runs cancel {run_id}"),
+    }))
 }
 
 const AUDIT_FULL_REPORT_ARTIFACT_PREFIX: &str = "audit-report";
@@ -1136,6 +1159,21 @@ mod tests {
             assert_eq!(run.metadata_json["changed_since"], "origin/main");
             assert_eq!(run.metadata_json["observation_status"], "error");
         });
+    }
+
+    #[test]
+    fn audit_lifecycle_exposes_durable_run_controls_before_work_starts() {
+        let lifecycle = audit_lifecycle(Some("audit-run-123")).expect("lifecycle");
+
+        assert_eq!(lifecycle["schema"], "homeboy/audit-lifecycle/v1");
+        assert_eq!(lifecycle["event"], "persisted");
+        assert_eq!(lifecycle["run_id"], "audit-run-123");
+        assert_eq!(lifecycle["status"], "running");
+        assert_eq!(
+            lifecycle["watch_command"],
+            "homeboy runs watch audit-run-123"
+        );
+        assert!(audit_lifecycle(None).is_none());
     }
 
     #[test]

--- a/crates/homeboy-cli/src/commands/review/mod.rs
+++ b/crates/homeboy-cli/src/commands/review/mod.rs
@@ -67,9 +67,8 @@ pub struct ReviewArgs {
     // flattens, so `review --changed-since` and `review lint --changed-since`
     // can no longer drift apart.
     //
-    // Only the lint stage scopes `--changed-only` natively; audit and test
-    // run on the full component with a hint noting the limitation. Use
-    // `--changed-since` for full umbrella scoping.
+    // Lint and audit reuse the precomputed working-tree file set for
+    // `--changed-only`; test still runs against the full component.
     #[command(flatten)]
     pub changed: ChangedScopeArgs,
 
@@ -301,7 +300,7 @@ fn dispatch_review_plan_step(
         "review.audit" => {
             let descriptor = ReviewStageDescriptor {
                 name: "audit",
-                include_changed_only_scope: false,
+                include_changed_only_scope: true,
                 build_args: build_audit_args,
                 run: audit::run,
                 finding_count: audit_finding_count,
@@ -339,12 +338,14 @@ fn dispatch_review_plan_step(
 
 pub fn run(args: ReviewArgs) -> CmdResult<Value> {
     match args.command {
-        Some(ReviewCommand::Audit(args)) => {
-            let requested_source = args.audit.release_readiness_source.clone();
-            let component = args.audit.comp.load()?;
+        Some(ReviewCommand::Audit(review_audit)) => {
+            let requested_source = review_audit.audit.release_readiness_source.clone();
+            let component = review_audit.audit.comp.load()?;
             prepare_local_review_dependencies(&component)?;
+            let audit_args =
+                review_audit_args(review_audit.audit, &args.changed, &component.local_path)?;
             to_value_with_readiness_provenance(
-                audit::run(args.audit),
+                audit::run(audit_args),
                 &component,
                 requested_source.as_deref(),
             )
@@ -374,6 +375,24 @@ pub fn run(args: ReviewArgs) -> CmdResult<Value> {
         Some(ReviewCommand::Ci(args)) => to_value(ci::run(args)),
         None => to_value(run_umbrella(args)),
     }
+}
+
+/// Translate review's working-tree scope to audit's existing HEAD-based scoped
+/// workflow. The injected list avoids a second git walk and keeps untracked
+/// files in scope.
+fn review_audit_args(
+    mut audit_args: audit::AuditArgs,
+    changed: &ChangedScopeArgs,
+    source_path: &str,
+) -> homeboy::core::Result<audit::AuditArgs> {
+    if changed.changed_only && audit_args.changed.changed_since.is_none() {
+        audit_args.changed.changed_since = Some("HEAD".to_string());
+        audit_args.changed.precomputed_changed_files = Some(git::get_dirty_files(source_path)?);
+        // `AuditArgs::profile` defaults to full for direct audit. A working-tree
+        // review instead uses the bounded profile promised by review's scope.
+        audit_args.profile = "pr".to_string();
+    }
+    Ok(audit_args)
 }
 
 /// Portable release preflight consumes this child-produced provenance from the
@@ -651,7 +670,7 @@ pub(crate) fn run_umbrella(args: ReviewArgs) -> CmdResult<ReviewCommandOutput> {
 
     if args.changed.changed_only {
         top_hints.push(
-            "--changed-only scopes lint only; audit and test ran on the full component".to_string(),
+            "--changed-only scopes lint and audit; audit uses the bounded pr detector profile while test runs on the full component".to_string(),
         );
     }
 
@@ -1051,7 +1070,14 @@ fn build_audit_args(
         profile: selected_audit_profile(args, review_context),
         baseline_args: args.baseline_args.clone(),
         changed: ChangedSinceArgs {
-            changed_since: args.changed.changed_since().map(str::to_string),
+            // Audit has no separate --changed-only flag. Reusing HEAD with the
+            // already-resolved dirty file list preserves working-tree semantics
+            // while activating its scoped execution path and bounded output.
+            changed_since: args
+                .changed
+                .changed_since()
+                .map(str::to_string)
+                .or(args.changed.changed_only.then_some("HEAD".to_string())),
             precomputed_changed_files: review_context
                 .precomputed_changed_files()
                 .map(<[String]>::to_vec),
@@ -1290,6 +1316,15 @@ mod tests {
     }
 
     #[test]
+    fn parses_changed_only_before_direct_audit() {
+        let cli = TestCli::try_parse_from(["test", "--changed-only", "audit"])
+            .expect("direct audit should retain the parent changed-only scope");
+
+        assert!(cli.review.changed.changed_only);
+        assert!(matches!(cli.review.command, Some(ReviewCommand::Audit(_))));
+    }
+
+    #[test]
     fn parses_report_pr_comment() {
         let cli = TestCli::try_parse_from(["test", "my-comp", "--report=pr-comment"])
             .expect("should parse");
@@ -1504,9 +1539,30 @@ mod tests {
             baseline_args: BaselineArgs::default(),
         };
         assert_eq!(scope_flag_suffix(&args, true), " --changed-only");
-        // audit/test do not support --changed-only, so the suffix is empty
-        // when the caller requests it not be included.
+        // Test still runs full-component, but audit now translates this into its
+        // scoped HEAD workflow.
         assert_eq!(scope_flag_suffix(&args, false), "");
+    }
+
+    #[test]
+    fn changed_only_review_builds_bounded_head_scoped_audit() {
+        let mut args = review_args_fixture();
+        args.changed.changed_only = true;
+        let review_context = ReviewExecutionContext {
+            scope: "changed-only".to_string(),
+            changed_file_count: Some(1),
+            precomputed_changed_files: Some(vec!["src/changed.rs".to_string()]),
+        };
+
+        let audit_args = build_audit_args(&args, &review_context);
+
+        assert_eq!(audit_args.profile, "pr");
+        assert_eq!(audit_args.changed.changed_since.as_deref(), Some("HEAD"));
+        assert_eq!(
+            audit_args.changed.precomputed_changed_files.as_deref(),
+            Some(&["src/changed.rs".to_string()][..]),
+            "working-tree files must be injected instead of recomputing a HEAD diff"
+        );
     }
 
     #[test]

--- a/crates/homeboy-code-audit/src/types.rs
+++ b/crates/homeboy-code-audit/src/types.rs
@@ -4,6 +4,7 @@
 //! re-export in the module root.
 
 use std::collections::HashSet;
+use std::sync::mpsc;
 use std::time::Duration;
 
 use super::fingerprint;
@@ -262,18 +263,83 @@ pub(crate) fn time_audit_detector<T>(
 ) -> T {
     if enabled {
         eprintln!("[audit] Running {id}...");
+        emit_detector_progress(id, "running", 0.0);
         let started = std::time::Instant::now();
-        let value = run();
+        let value = run_with_detector_heartbeat(id, started, run);
         let elapsed = started.elapsed();
         eprintln!(
             "[audit] Completed {id} in {:.0}ms",
             elapsed.as_secs_f64() * 1000.0
         );
+        emit_detector_progress(id, "completed", elapsed.as_secs_f64() * 1000.0);
         timing.push_ok(id, elapsed);
         value
     } else {
         timing.push_skipped(id);
         skipped()
+    }
+}
+
+/// Keep the active detector visible while its synchronous work runs. The audit
+/// cannot safely cancel arbitrary detector code, so this heartbeat is an
+/// operator-facing liveness signal rather than a timeout mechanism.
+fn run_with_detector_heartbeat<T>(
+    id: &str,
+    started: std::time::Instant,
+    run: impl FnOnce() -> T,
+) -> T {
+    let (completed, wait_for_completion) = mpsc::channel();
+    std::thread::scope(|scope| {
+        let heartbeat = scope.spawn(move || loop {
+            match wait_for_completion.recv_timeout(Duration::from_secs(15)) {
+                Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                Err(mpsc::RecvTimeoutError::Timeout) => emit_detector_progress(
+                    id,
+                    "heartbeat",
+                    started.elapsed().as_secs_f64() * 1000.0,
+                ),
+            }
+        });
+        let value = run();
+        let _ = completed.send(());
+        heartbeat.join().expect("detector heartbeat must not panic");
+        value
+    })
+}
+
+/// Emit detector lifecycle events even when stderr is not interactive, so CI
+/// and a foreground review client can distinguish active work from a stall.
+fn emit_detector_progress(id: &str, status: &str, elapsed_ms: f64) {
+    eprintln!(
+        "HOMEBOY_PROGRESS {}",
+        detector_progress(id, status, elapsed_ms)
+    );
+}
+
+fn detector_progress(id: &str, status: &str, elapsed_ms: f64) -> serde_json::Value {
+    serde_json::json!({
+        "phase": "audit_detectors",
+        "current": id,
+        "status": status,
+        "elapsed_ms": elapsed_ms,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::detector_progress;
+
+    #[test]
+    fn detector_progress_names_the_active_detector_and_state() {
+        assert_eq!(
+            detector_progress("detector.structural", "completed", 12.5),
+            serde_json::json!({
+                "phase": "audit_detectors",
+                "current": "detector.structural",
+                "status": "completed",
+                "elapsed_ms": 12.5,
+            })
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- run changed-only review audits through the bounded `pr` detector profile with the precomputed working-tree file set
- publish durable audit run controls before scanning and emit detector lifecycle heartbeats during long synchronous work
- describe the remaining full-component test scope in umbrella review output

## Verification

- `cargo test -p homeboy-code-audit detector_progress_names_the_active_detector_and_state --locked`
- `cargo test -p homeboy-cli changed_only_review_builds_bounded_head_scoped_audit --locked`
- `cargo fmt --check`
- `git diff --check`

Closes #14144

## AI assistance

OpenAI GPT-5.6 Terra via OpenCode investigated the regression and implemented the initial candidate. OpenAI GPT-5.6 Sol via OpenCode audited scope, reran focused verification against current main, and published the PR under Chris Huber’s direction.