### PR TITLE
Preflight dirty umbrella reviews before execution

### DIFF
--- a/crates/homeboy-cli/src/commands/review/mod.rs
+++ b/crates/homeboy-cli/src/commands/review/mod.rs
@@ -509,6 +509,10 @@ pub(crate) fn run_umbrella(args: ReviewArgs) -> CmdResult<ReviewCommandOutput> {
         return Ok((output, 0));
     }
 
+    // The test phase restores its checkout, so establish the whole plan is
+    // eligible before dependency hydration or any detector can begin.
+    homeboy_core::extension::test::ensure_clean_review_checkout(Path::new(&source_path))?;
+
     let review_observation = Some(observation::start(observation::ReviewObservationStart {
         component_id: &component.id,
         component_label: &component_label,

--- a/crates/homeboy-core/src/extension/test/mod.rs
+++ b/crates/homeboy-core/src/extension/test/mod.rs
@@ -51,9 +51,10 @@ pub use parsing::{
 };
 pub use report::TestCommandOutput;
 pub use run::{
-    finalize_test_result_after_artifact_hydration, run_main_test_workflow,
-    run_self_check_test_workflow, run_self_check_test_workflow_with_progress, RawTestOutput,
-    TestRunWorkflowArgs, TestRunWorkflowResult,
+    ensure_clean_review_checkout, finalize_test_result_after_artifact_hydration,
+    run_main_test_workflow, run_self_check_test_workflow,
+    run_self_check_test_workflow_with_progress, RawTestOutput, TestRunWorkflowArgs,
+    TestRunWorkflowResult,
 };
 pub use workflow::{
     auto_fix_test_drift, detect_test_drift, AutoFixDriftOutput, AutoFixDriftWorkflowResult,

--- a/crates/homeboy-core/src/extension/test/run.rs
+++ b/crates/homeboy-core/src/extension/test/run.rs
@@ -2244,23 +2244,7 @@ fn run_review_test_lifecycle(
 
 impl TestCheckoutGuard {
     fn capture(path: &Path) -> homeboy_core::Result<Self> {
-        let changes = homeboy_core::git::get_uncommitted_changes(&path.to_string_lossy())?;
-        if changes.has_changes {
-            let files = changes
-                .staged
-                .iter()
-                .chain(changes.unstaged.iter())
-                .chain(changes.untracked.iter())
-                .take(10)
-                .cloned()
-                .collect::<Vec<_>>();
-            return Err(Error::validation_invalid_argument(
-                "working_tree",
-                "Review tests require a clean component checkout",
-                None,
-                Some(vec![format!("Dirty files: {}", files.join(", "))]),
-            ));
-        }
+        ensure_clean_review_checkout(path)?;
 
         let head =
             homeboy_core::git::run_git(path, &["rev-parse", "HEAD"], "capture review test HEAD")?;
@@ -2290,6 +2274,33 @@ impl TestCheckoutGuard {
         }
         Ok(())
     }
+}
+
+/// Confirm that a checkout can safely run the review test lifecycle, which
+/// resets tracked files and removes generated files when it completes.
+pub fn ensure_clean_review_checkout(path: &Path) -> homeboy_core::Result<()> {
+    let changes = homeboy_core::git::get_uncommitted_changes(&path.to_string_lossy())?;
+    if !changes.has_changes {
+        return Ok(());
+    }
+
+    let files = changes
+        .staged
+        .iter()
+        .chain(changes.unstaged.iter())
+        .chain(changes.untracked.iter())
+        .take(10)
+        .cloned()
+        .collect::<Vec<_>>();
+    Err(Error::validation_invalid_argument(
+        "working_tree",
+        "Review tests require a clean component checkout",
+        None,
+        Some(vec![
+            format!("Dirty files: {}", files.join(", ")),
+            "For dirty changed-file review, run `homeboy review --changed-only audit` and `homeboy review --changed-only lint` separately.".to_string(),
+        ]),
+    ))
 }
 
 fn failed_test_workflow(

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -20,5 +20,7 @@ mod product_identity_test;
 mod promotion_provider_stdin;
 #[path = "cli_binary/refactor_transform_test.rs"]
 mod refactor_transform_test;
+#[path = "cli_binary/review_dirty_preflight.rs"]
+mod review_dirty_preflight;
 #[path = "cli_binary/rig_local_artifact_registration.rs"]
 mod rig_local_artifact_registration;

--- a/tests/cli_binary/review_dirty_preflight.rs
+++ b/tests/cli_binary/review_dirty_preflight.rs
@@ -1,0 +1,67 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[test]
+fn dirty_umbrella_review_rejects_before_dependency_setup_or_stages() {
+    let fixture = tempfile::tempdir().expect("fixture");
+    let repository = fixture.path().join("repository");
+    std::fs::create_dir_all(&repository).expect("repository");
+    run_git(&repository, &["init", "-q", "--initial-branch", "main"]);
+    run_git(
+        &repository,
+        &["config", "user.email", "homeboy@example.test"],
+    );
+    run_git(&repository, &["config", "user.name", "Homeboy Test"]);
+    std::fs::write(repository.join("tracked.txt"), "initial\n").expect("tracked file");
+    run_git(&repository, &["add", "tracked.txt"]);
+    run_git(&repository, &["commit", "-q", "-m", "fixture"]);
+    std::fs::write(repository.join("tracked.txt"), "dirty\n").expect("dirty file");
+
+    let output = Command::new(homeboy_bin())
+        .args(["--placement", "local", "review", "fixture", "--path"])
+        .arg(&repository)
+        .args(["--changed-only", "--summary"])
+        .env("HOME", fixture.path())
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+        .output()
+        .expect("run homeboy review");
+
+    assert_eq!(output.status.code(), Some(2), "{output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}\n{stderr}");
+    assert!(
+        combined.contains("Review tests require a clean component checkout"),
+        "stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(combined.contains("Dirty files: tracked.txt"), "{combined}");
+    assert!(
+        combined.contains("homeboy review --changed-only audit")
+            && combined.contains("homeboy review --changed-only lint"),
+        "stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        !combined.contains("phase=dependency_setup")
+            && !combined.contains("review.audit")
+            && !combined.contains("review.lint"),
+        "dirty review must reject before setup or stages\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+fn run_git(path: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(path)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn homeboy_bin() -> PathBuf {
+    PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
+}


### PR DESCRIPTION
## Summary

- expose the existing clean-checkout eligibility check as a reusable review preflight
- reject an ineligible dirty umbrella review before dependency hydration, observations, audit, or lint
- return validated commands for running dirty changed-file audit and lint independently
- cover the user-visible early rejection through the compiled CLI binary

## Verification

- `cargo test --test cli_binary dirty_umbrella_review_rejects_before_dependency_setup_or_stages --locked`
- `cargo fmt --check`
- `git diff --check`

Closes #14146

## AI assistance

OpenAI GPT-5.6 Terra via OpenCode traced the late eligibility failure and implemented the initial candidate. OpenAI GPT-5.6 Sol via OpenCode corrected the remediation syntax, reran focused verification against current main, and published the PR under Chris Huber’s direction.