### PR TITLE
Infer Cook repository from the target worktree

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/run.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/run.rs
@@ -4593,11 +4593,29 @@ fn normalize_cook_repository_identity(args: &mut AgentTaskCookArgs) -> homeboy::
         source_identities.push((flag, resolved.clone()));
         identities.extend(resolved);
     }
+    if let Some(to_worktree) = args.to_worktree.as_deref() {
+        // A handle that has not been materialized locally is a provisioning
+        // request, not repository evidence. An existing path or native handle
+        // can attest its Git remote just like --cwd.
+        if cook_workspace_path(to_worktree)?.is_some() {
+            let resolved = cook_repository_identities_for_workspace(
+                "--to-worktree",
+                to_worktree,
+                args.component.as_deref().or(args.dispatch.repo.as_deref()),
+            )?;
+            source_identities.push(("--to-worktree", resolved.clone()));
+            identities.extend(resolved);
+        }
+    }
     if identities.is_empty() {
-        if args.dispatch.workspace.is_some() || args.dispatch.cwd.is_some() {
+        if args.dispatch.workspace.is_some()
+            || args.dispatch.cwd.is_some()
+            || args.to_worktree.is_some()
+        {
             let supplied_workspaces = [
                 args.dispatch.workspace.as_deref(),
                 args.dispatch.cwd.as_deref(),
+                args.to_worktree.as_deref(),
             ]
             .into_iter()
             .flatten()
@@ -5192,7 +5210,7 @@ fn repository_identity_conflict_error(
     homeboy::core::Error::validation_invalid_argument(
         "workspace",
         format!(
-            "--workspace and --cwd must resolve to the same configured repository identity; --repo cannot select one conflicting checkout: {}",
+            "--workspace, --cwd, and --to-worktree must resolve to the same configured repository identity; --repo cannot select one conflicting checkout: {}",
             candidates.join("; ")
         ),
         None,

--- a/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/dispatch.rs
@@ -739,6 +739,8 @@ fn cook_infers_repo_from_an_explicit_linked_worktree_cwd_and_persists_its_proven
             "implement the fix".to_string(),
             "--cwd".to_string(),
             destination.display().to_string(),
+            "--to-worktree".to_string(),
+            "inferred@fix-inferred".to_string(),
             "--task-url".to_string(),
             "https://github.com/example/inferred/issues/13947".to_string(),
             "--backend".to_string(),
@@ -766,6 +768,49 @@ fn cook_infers_repo_from_an_explicit_linked_worktree_cwd_and_persists_its_proven
             plan.metadata["cook_base_resolution"]["source"],
             "compatibility_fallback"
         );
+
+        let inferred_from_worktree =
+            super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+                "homeboy".to_string(),
+                "agent-task".to_string(),
+                "cook".to_string(),
+                "--prompt".to_string(),
+                "implement the fix".to_string(),
+                "--to-worktree".to_string(),
+                destination.display().to_string(),
+                "--backend".to_string(),
+                "fixture".to_string(),
+                "--no-finalize".to_string(),
+            ]))
+            .expect("infer repository from linked worktree destination");
+        assert_eq!(
+            inferred_from_worktree.dispatch.repo.as_deref(),
+            Some("inferred")
+        );
+        assert_eq!(
+            inferred_from_worktree
+                .repository_identity
+                .as_ref()
+                .expect("identity")["provenance"],
+            "--to-worktree:git-remote:origin"
+        );
+
+        let mismatch = super::super::run::resolve_cook_destination(cook_args_from_cli(vec![
+            "homeboy".to_string(),
+            "agent-task".to_string(),
+            "cook".to_string(),
+            "--prompt".to_string(),
+            "implement the fix".to_string(),
+            "--repo".to_string(),
+            "other".to_string(),
+            "--cwd".to_string(),
+            destination.display().to_string(),
+            "--to-worktree".to_string(),
+            destination.display().to_string(),
+            "--no-finalize".to_string(),
+        ]))
+        .expect_err("explicit repository must still match the linked worktree");
+        assert!(mismatch.message.contains("does not match"), "{mismatch:?}");
     });
 }
 


### PR DESCRIPTION
## Summary

- treat an existing `--to-worktree` path or native worktree handle as repository identity evidence
- keep unmaterialized destination handles as provisioning requests rather than probing them as checkouts
- include target-worktree evidence in repository mismatch diagnostics
- cover inference and explicit-repository mismatch behavior with a real linked worktree

## Verification

- `cargo test -p homeboy-cli cook_infers_repo_from_an_explicit_linked_worktree_cwd_and_persists_its_provenance --locked`
- `cargo fmt --check`
- `git diff --check`

Closes #14147

## AI assistance

OpenAI GPT-5.6 Terra via OpenCode traced repository normalization and implemented the initial candidate. OpenAI GPT-5.6 Sol via OpenCode removed unrelated investigation drift, audited scope, reran focused verification against current main, and published the PR under Chris Huber’s direction.