### PR TITLE
Keep Cook retries on their controller

### DIFF
--- a/crates/homeboy-cli/src/commands/infra/route.rs
+++ b/crates/homeboy-cli/src/commands/infra/route.rs
@@ -4574,7 +4574,7 @@ fn controller_owns_agent_task_lifecycle_command(cli: &Cli) -> homeboy::core::Res
         AgentTaskCommand::Evidence(args) => Some(&args.run_id),
         AgentTaskCommand::Diagnose(args) => Some(&args.run_id),
         AgentTaskCommand::Review(args) => Some(&args.run_id),
-        AgentTaskCommand::Retry(args) if !args.run => Some(&args.run_id),
+        AgentTaskCommand::Retry(args) => Some(&args.run_id),
         AgentTaskCommand::Reconcile(args) => Some(&args.run_id),
         _ => None,
     };
@@ -4583,13 +4583,24 @@ fn controller_owns_agent_task_lifecycle_command(cli: &Cli) -> homeboy::core::Res
     };
     let lifecycle_store =
         agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()?;
-    Some(agent_task_lifecycle::run_record_exists_resolved_in_store(
-        &lifecycle_store,
-        run_id,
-    )?)
-    .map(Ok)
-    .transpose()
-    .map(|present| present.unwrap_or(false))
+    let present =
+        agent_task_lifecycle::run_record_exists_resolved_in_store(&lifecycle_store, run_id)?;
+    if !present {
+        return Ok(false);
+    }
+    if let AgentTaskCommand::Retry(args) = &agent_task.command {
+        if args.run {
+            let record = agent_task_lifecycle::reconcile_status_in_store(
+                &lifecycle_store,
+                run_id,
+                agent_task_lifecycle::AgentTaskStatusOptions::default(),
+                false,
+            )?
+            .record;
+            return Ok(record.metadata["cook_id"].is_string());
+        }
+    }
+    Ok(true)
 }
 
 fn lab_offload_command_for_materialized_args(

--- a/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
+++ b/crates/homeboy-cli/src/commands/infra/route/tests/handoff.rs
@@ -1135,7 +1135,7 @@ fn controller_local_lifecycle_reads_never_acquire_a_default_lab_runner() {
 }
 
 #[test]
-fn controller_local_record_owns_lifecycle_reads_before_default_lab_selection() {
+fn controller_local_record_owns_lifecycle_reads_and_cook_retries_before_lab_selection() {
     crate::test_support::with_isolated_home(|_| {
         let inferred = connected_default_lab_runner();
         let plan = homeboy::agents::agent_tasks::scheduler::AgentTaskPlan::new(
@@ -1180,20 +1180,53 @@ fn controller_local_record_owns_lifecycle_reads_before_default_lab_selection() {
                 .expect("plan-only retry owner resolves")
         );
 
-        let executable_retry = Cli::try_parse_from([
+        let executable_retry_args = [
             "homeboy",
+            "--runner",
+            "homeboy-lab",
             "agent-task",
             "retry",
             OWNER_LOCAL_RUN_ID,
             "--run",
-            "--runner",
-            "homeboy-lab",
-        ])
-        .expect("executable retry parses");
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+        let executable_retry =
+            Cli::try_parse_from(&executable_retry_args).expect("executable retry parses");
         assert!(
             !controller_owns_agent_task_lifecycle_command(&executable_retry)
                 .expect("executable retry owner resolves"),
             "retry --run must reach controller preflight and Lab handoff materialization"
+        );
+
+        agent_task_lifecycle::rewrite_record_for_test(OWNER_LOCAL_RUN_ID, |record| {
+            record.metadata["cook_id"] = serde_json::json!("cook-owner-routing");
+            record.metadata["runner_id"] = serde_json::json!("homeboy-lab");
+        })
+        .expect("mark the retry as Cook-owned");
+
+        assert!(
+            controller_owns_agent_task_lifecycle_command(&executable_retry)
+                .expect("Cook retry owner resolves"),
+            "a Cook retry must remain on its controller before replaying provider work"
+        );
+        assert_eq!(
+            route_after_parse_with_provenance(
+                &executable_retry,
+                &executable_retry_args,
+                None,
+                None,
+            )
+            .expect("route the generated Cook retry action"),
+            None,
+            "the routing layer must return a Cook retry to its controller before Lab preflight"
+        );
+        assert!(
+            materialize_agent_task_retry_handoff(&executable_retry, &executable_retry_args,)
+                .expect("Cook retry handoff decision")
+                .is_none(),
+            "Cook retries are replayed by their controller lifecycle, not generic Lab routing"
         );
     });
 }


### PR DESCRIPTION
## Summary

- keep executable retries for controller-resolvable Cook attempts on the controller lifecycle
- preserve ordinary generic retry Lab handoff behavior
- cover the exact generated runner-bound retry command through the routing layer

## Root Cause

The Lab retry materializer already declined Cook-owned retries so Cook could retain promotion, gate, and finalization ownership. The earlier lifecycle ownership check excluded every `retry --run`, however, so a runner-bound Cook retry fell through to generic Lab routing. That route materialized the caller's current directory instead of reserving a successor from the persisted Cook plan.

The production reproduction waited 20 minutes, created no retry record, and left the original zero-provider-consumption attempt cancelled with `agent_task.runner_missing_pid`.

## Verification

- `cargo test -p homeboy-cli controller_local_record_owns_lifecycle_reads_and_cook_retries_before_lab_selection -- --test-threads=1`
- `cargo test -p homeboy-cli retry_action_is_typed_and_bound_to_its_runner -- --test-threads=1`
- `cargo test -p homeboy-cli hot_cook_with_explicit_lab_placement_uses_the_admitted_ready_runner -- --test-threads=1`
- `cargo check -p homeboy-cli`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #14157.

## AI Assistance

OpenAI GPT-5.6-sol via OpenCode reproduced the failed recovery action, traced the routing ownership contradiction, implemented the focused repair and regression coverage, and ran verification. Chris Huber directed and owns the change.
