### PR TITLE
test: consolidate shared Git fixture execution

### DIFF
--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -1578,6 +1578,44 @@ pub fn write_source_extension(home: &std::path::Path, id: &str, file_extension: 
     }
 }
 
+/// Git command execution shared by test fixtures.
+///
+/// Topology-specific setup stays at the caller: branch names, remotes, commit
+/// identity, and failure scenarios remain visible in each test.
+pub struct GitFixture<'a> {
+    repo: &'a Path,
+    identity: Option<(&'static str, &'static str)>,
+}
+
+impl<'a> GitFixture<'a> {
+    pub fn new(repo: &'a Path) -> Self {
+        Self {
+            repo,
+            identity: None,
+        }
+    }
+
+    fn with_identity(repo: &'a Path, name: &'static str, email: &'static str) -> Self {
+        Self {
+            repo,
+            identity: Some((name, email)),
+        }
+    }
+
+    pub fn execute(&self, args: &[&str]) -> Output {
+        let mut command = Command::new("git");
+        command.args(args).current_dir(self.repo);
+        if let Some((name, email)) = self.identity {
+            command
+                .env("GIT_AUTHOR_NAME", name)
+                .env("GIT_AUTHOR_EMAIL", email)
+                .env("GIT_COMMITTER_NAME", name)
+                .env("GIT_COMMITTER_EMAIL", email);
+        }
+        command.output().expect("git fixture command")
+    }
+}
+
 pub fn shared_git_repo_fixture(name: &str) -> (TempDir, PathBuf) {
     git_repo_fixture(name, false)
 }
@@ -1601,15 +1639,8 @@ fn git_repo_fixture(name: &str, committed: bool) -> (TempDir, PathBuf) {
 }
 
 pub fn run_git_fixture_command(repo: &Path, args: &[&str]) {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(repo)
-        .env("GIT_AUTHOR_NAME", "homeboy-test")
-        .env("GIT_AUTHOR_EMAIL", "homeboy-test@example.invalid")
-        .env("GIT_COMMITTER_NAME", "homeboy-test")
-        .env("GIT_COMMITTER_EMAIL", "homeboy-test@example.invalid")
-        .output()
-        .expect("git fixture command");
+    let output = GitFixture::with_identity(repo, "homeboy-test", "homeboy-test@example.invalid")
+        .execute(args);
     assert!(
         output.status.success(),
         "git fixture command {:?} failed: stdout={} stderr={}",
@@ -1639,15 +1670,8 @@ fn run_git_template_command(repo: &Path, args: &[&str]) {
 }
 
 pub fn git_fixture_output(repo: &Path, args: &[&str]) -> String {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(repo)
-        .env("GIT_AUTHOR_NAME", "homeboy-test")
-        .env("GIT_AUTHOR_EMAIL", "homeboy-test@example.invalid")
-        .env("GIT_COMMITTER_NAME", "homeboy-test")
-        .env("GIT_COMMITTER_EMAIL", "homeboy-test@example.invalid")
-        .output()
-        .expect("git fixture command");
+    let output = GitFixture::with_identity(repo, "homeboy-test", "homeboy-test@example.invalid")
+        .execute(args);
     assert!(
         output.status.success(),
         "git fixture command {:?} failed: stdout={} stderr={}",

--- a/crates/homeboy-lab-runner/src/git_dependency_materialization.rs
+++ b/crates/homeboy-lab-runner/src/git_dependency_materialization.rs
@@ -836,6 +836,7 @@ mod tests {
     use std::process::Command;
 
     use homeboy_core::engine::shell;
+    use homeboy_core::test_support::GitFixture as GitRepository;
 
     use super::{
         cache_archive_path, dependency_cache_manifest, ensure_git_dependency_fresh,
@@ -853,7 +854,7 @@ mod tests {
         // seed a synthetic git checkout on the runner so the materialized path
         // is a valid git work tree with a committed HEAD.
         homeboy_core::test_support::with_isolated_home(|_| {
-            let fixture = GitFixture::new();
+            let fixture = GitDependencyFixture::new();
             fixture.commit_file("initial.txt", "initial");
             fixture.push();
             let checkout = fixture.clone_checkout();
@@ -906,7 +907,7 @@ mod tests {
 
     #[test]
     fn auto_update_clean_dependency_fast_forwards_to_upstream() {
-        let fixture = GitFixture::new();
+        let fixture = GitDependencyFixture::new();
         fixture.commit_file("initial.txt", "initial");
         fixture.push();
 
@@ -932,7 +933,7 @@ mod tests {
 
     #[test]
     fn dirty_dependency_fails_before_snapshotting() {
-        let fixture = GitFixture::new();
+        let fixture = GitDependencyFixture::new();
         fixture.commit_file("initial.txt", "initial");
         fixture.push();
 
@@ -951,7 +952,7 @@ mod tests {
 
     #[test]
     fn detached_dependency_without_pinned_ref_fails() {
-        let fixture = GitFixture::new();
+        let fixture = GitDependencyFixture::new();
         fixture.commit_file("initial.txt", "initial");
         fixture.push();
 
@@ -997,7 +998,7 @@ mod tests {
 
     #[test]
     fn explicit_pinned_ref_allows_detached_dependency() {
-        let fixture = GitFixture::new();
+        let fixture = GitDependencyFixture::new();
         fixture.commit_file("initial.txt", "initial");
         fixture.push();
 
@@ -1015,7 +1016,7 @@ mod tests {
 
     #[test]
     fn fetch_failure_uses_cached_upstream_when_checkout_matches() {
-        let fixture = GitFixture::new();
+        let fixture = GitDependencyFixture::new();
         fixture.commit_file("initial.txt", "initial");
         fixture.push();
 
@@ -1047,7 +1048,7 @@ mod tests {
 
     #[test]
     fn fetch_failure_is_terminal_when_cached_upstream_differs() {
-        let fixture = GitFixture::new();
+        let fixture = GitDependencyFixture::new();
         fixture.commit_file("initial.txt", "initial");
         fixture.push();
         fixture.commit_file("next.txt", "next");
@@ -1183,12 +1184,12 @@ mod tests {
         assert_eq!(value["paths"].as_array().expect("paths").len(), 2);
     }
 
-    struct GitFixture {
+    struct GitDependencyFixture {
         remote: tempfile::TempDir,
         work: tempfile::TempDir,
     }
 
-    impl GitFixture {
+    impl GitDependencyFixture {
         fn new() -> Self {
             let remote = tempfile::tempdir().expect("remote");
             run_git(remote.path(), &["init", "--bare"]);
@@ -1243,11 +1244,7 @@ mod tests {
     }
 
     fn run_git(path: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("run git");
+        let output = GitRepository::new(path).execute(args);
         assert!(
             output.status.success(),
             "git {} failed: {}",
@@ -1257,11 +1254,7 @@ mod tests {
     }
 
     fn git_output(path: &Path, args: &[&str]) -> String {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(path)
-            .output()
-            .expect("run git");
+        let output = GitRepository::new(path).execute(args);
         assert!(
             output.status.success(),
             "git {} failed: {}",

--- a/tests/core/rig/install_test.rs
+++ b/tests/core/rig/install_test.rs
@@ -23,7 +23,9 @@ fn test_config_root() -> std::path::PathBuf {
         .to_path_buf()
 }
 
-use crate::rig_test_support::{minimal_rig, minimal_stack, write_rig, write_stack, GitFixture};
+use crate::rig_test_support::{
+    clone_bare, commit_all, init_main, minimal_rig, minimal_stack, write_rig, write_stack,
+};
 
 fn write_single_rig(dir: &Path, id: &str, body: &str) -> std::path::PathBuf {
     fs::create_dir_all(dir).expect("single rig dir");
@@ -34,9 +36,9 @@ fn write_single_rig(dir: &Path, id: &str, body: &str) -> std::path::PathBuf {
 }
 
 fn bare_package(package: &Path) -> tempfile::TempDir {
-    let git = GitFixture::init(package);
-    git.commit("update rigs");
-    git.clone_bare()
+    init_main(package);
+    commit_all(package, "update rigs");
+    clone_bare(package)
 }
 
 mod discovery {
@@ -208,7 +210,8 @@ mod materialization {
             }"#,
         )
         .expect("rig");
-        GitFixture::init(repo.path()).commit("shared template");
+        init_main(repo.path());
+        commit_all(repo.path(), "shared template");
 
         assert_eq!(
             materialize_rig_spec(&rig, &package).expect("materialize"),
@@ -230,7 +233,8 @@ mod materialization {
             r#"{ "extends": "../../../../shared/templates/base.json" }"#,
         )
         .expect("rig");
-        GitFixture::init(repo.path()).commit("undeclared shared template");
+        init_main(repo.path());
+        commit_all(repo.path(), "undeclared shared template");
 
         let error = materialize_rig_spec(&rig, &package).expect_err("undeclared template rejected");
         assert_eq!(error.details["field"], "extends");
@@ -500,7 +504,8 @@ mod install_flows {
                 }
             }"#,
         );
-        GitFixture::init(repo.path()).commit("nested package with shared dependency");
+        init_main(repo.path());
+        commit_all(repo.path(), "nested package with shared dependency");
 
         let result = install(&test_config_root(), nested.to_str().unwrap(), None, false)
             .expect("install nested package");
@@ -619,7 +624,8 @@ mod install_flows {
                 "package_dependencies": ["../../../outside-shared"]
             }"#,
         );
-        GitFixture::init(&repo).commit("bad dependency");
+        init_main(&repo);
+        commit_all(&repo, "bad dependency");
 
         let err = install(&test_config_root(), nested.to_str().unwrap(), None, false)
             .expect_err("dependency outside repo should fail");
@@ -643,7 +649,8 @@ mod install_flows {
                 "package_dependencies": ["/tmp/shared"]
             }"#,
         );
-        GitFixture::init(repo.path()).commit("bad dependency");
+        init_main(repo.path());
+        commit_all(repo.path(), "bad dependency");
 
         let err = install(&test_config_root(), nested.to_str().unwrap(), None, false)
             .expect_err("absolute dependency should fail");

--- a/tests/core/rig/source_test.rs
+++ b/tests/core/rig/source_test.rs
@@ -9,7 +9,8 @@ use std::fs;
 use std::path::Path;
 
 use crate::rig_test_support::{
-    bare_source_path, minimal_rig, minimal_stack, run_git, write_rig, write_stack, GitFixture,
+    bare_source_path, clone_bare, commit_all, init_main, minimal_rig, minimal_stack, push_main,
+    run_git, write_rig, write_stack,
 };
 
 /// The isolated home each test below installs, named as a config root.
@@ -24,32 +25,14 @@ fn test_config_root() -> std::path::PathBuf {
         .to_path_buf()
 }
 
-/// Source-update-only fixture helpers. These live here rather than in the
-/// shared `support.rs` because only the source-update tests attach to an
-/// existing repo and push back to a bare source; keeping them in the shared
-/// module made them appear dead to `install_test.rs`, which includes the same
-/// `#[path]` module but never pushes.
-impl<'a> GitFixture<'a> {
-    /// Attach to an already-initialized repository in `dir` (e.g. one created
-    /// via a raw `git init` elsewhere) to reuse the commit/push helpers.
-    fn attach(dir: &'a Path) -> Self {
-        Self { dir }
-    }
-
-    /// Push the current `HEAD` to the `main` branch of `source`.
-    fn push_main(&self, source: &str) {
-        run_git(self.dir, &["push", source, "HEAD:main"]);
-    }
-}
-
 fn commit_package(package: &Path, message: &str) {
-    GitFixture::attach(package).commit(message);
+    commit_all(package, message);
 }
 
 fn create_bare_source(package: &Path) -> tempfile::TempDir {
-    let git = GitFixture::init(package);
-    git.commit("initial rigs");
-    git.clone_bare()
+    init_main(package);
+    commit_all(package, "initial rigs");
+    clone_bare(package)
 }
 
 #[test]
@@ -85,7 +68,8 @@ fn linked_package_provenance_tracks_execution_time_content_and_dirty_state() {
     let _home = HomeGuard::new();
     let package = tempfile::tempdir().expect("package");
     let rig = write_rig(package.path(), "alpha", &minimal_rig("alpha"));
-    GitFixture::init(package.path()).commit("initial rig");
+    init_main(package.path());
+    commit_all(package.path(), "initial rig");
 
     let installed = install(
         &test_config_root(),
@@ -480,7 +464,7 @@ fn update_git_source_fast_forwards_package_and_refreshes_metadata() {
     )
     .expect("update rig");
     commit_package(package.path(), "update alpha");
-    GitFixture::attach(package.path()).push_main(&source);
+    push_main(package.path(), &source);
 
     let result = update_source_for_rig(&test_config_root(), "alpha").expect("update rig source");
 
@@ -529,7 +513,7 @@ fn update_git_source_refreshes_owned_stack_specs() {
     )
     .expect("update stack");
     commit_package(package.path(), "update alpha stack");
-    GitFixture::attach(package.path()).push_main(&source);
+    push_main(package.path(), &source);
 
     let result = update_source_for_rig(&test_config_root(), "alpha").expect("update rig source");
 
@@ -574,7 +558,7 @@ fn legacy_source_without_a_valid_discovery_path_fails_before_refresh_mutation() 
     )
     .expect("update remote package");
     commit_package(package.path(), "remote update");
-    GitFixture::attach(package.path()).push_main(&source);
+    push_main(package.path(), &source);
 
     let error = update_source_for_rig(&test_config_root(), "alpha")
         .expect_err("invalid provenance must fail closed");
@@ -615,7 +599,7 @@ fn update_all_reports_broken_sources_and_continues() {
     )
     .expect("update good rig");
     commit_package(good_package.path(), "update good rig");
-    GitFixture::attach(good_package.path()).push_main(&good_source);
+    push_main(good_package.path(), &good_source);
 
     let result =
         update_all_sources(&test_config_root()).expect("update all continues after broken source");
@@ -652,7 +636,7 @@ fn refresh_source_selector_updates_recorded_package() {
     )
     .expect("update rig");
     commit_package(package.path(), "refresh alpha");
-    GitFixture::attach(package.path()).push_main(&source);
+    push_main(package.path(), &source);
 
     let package_id = list_sources(&test_config_root()).expect("sources").sources[0]
         .package_id
@@ -691,7 +675,7 @@ fn refresh_without_selector_updates_all_sources() {
     )
     .expect("update rig");
     commit_package(package.path(), "refresh alpha");
-    GitFixture::attach(package.path()).push_main(&source);
+    push_main(package.path(), &source);
 
     let result = update_source(&test_config_root(), None).expect("refresh all sources");
 
@@ -720,7 +704,7 @@ fn update_git_source_skips_user_replaced_stack_specs() {
     )
     .expect("update source stack");
     commit_package(package.path(), "update alpha stack");
-    GitFixture::attach(package.path()).push_main(&source);
+    push_main(package.path(), &source);
 
     let result = update_source_for_rig(&test_config_root(), "alpha").expect("update rig source");
 

--- a/tests/core/rig/support.rs
+++ b/tests/core/rig/support.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+
+pub(crate) use homeboy_core::test_support::GitFixture;
 
 pub(crate) fn write_rig(package: &Path, id: &str, body: &str) -> PathBuf {
     let rig_dir = package.join("rigs").join(id);
@@ -50,11 +51,7 @@ pub(crate) fn write_stack(package: &Path, id: &str, component: &str) -> PathBuf 
 }
 
 pub(crate) fn run_git(dir: &Path, args: &[&str]) {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(dir)
-        .output()
-        .expect("git command");
+    let output = GitFixture::new(dir).execute(args);
     assert!(
         output.status.success(),
         "git {:?} failed: {}{}",
@@ -64,65 +61,44 @@ pub(crate) fn run_git(dir: &Path, args: &[&str]) {
     );
 }
 
-/// Test-only helper for the happy-path git flows shared across rig source and
-/// install tests: repository init, identity-stamped commits, bare clones used
-/// as remote sources, and pushes back to that source.
-///
-/// Tests that assert *failure* behavior or inspect raw git output should keep
-/// using [`run_git`] / explicit `Command::new("git")` calls instead.
-pub(crate) struct GitFixture<'a> {
-    /// Repository working directory. Exposed within the support module so
-    /// per-test-file extension `impl`s (see `source_test.rs`) can build their
-    /// own fixtures without re-running `git init`.
-    pub(crate) dir: &'a Path,
+pub(crate) fn init_main(dir: &Path) {
+    run_git(dir, &["init", "-b", "main"]);
 }
 
-impl<'a> GitFixture<'a> {
-    /// Initialize a git repository in `dir` on the `main` branch.
-    pub(crate) fn init(dir: &'a Path) -> Self {
-        run_git(dir, &["init", "-b", "main"]);
-        Self { dir }
-    }
-
-    /// Stage everything and create a commit with a stable test identity.
-    pub(crate) fn commit(&self, message: &str) {
-        run_git(self.dir, &["add", "."]);
-        run_git(
-            self.dir,
-            &[
-                "-c",
-                "user.name=Test",
-                "-c",
-                "user.email=test@example.com",
-                "commit",
-                "-m",
-                message,
-            ],
-        );
-    }
-
-    /// Clone the repository as a bare `rig-package.git` source inside a fresh
-    /// temp dir, returning the parent [`tempfile::TempDir`] guard so the bare
-    /// clone is cleaned up automatically. Use [`bare_source_path`] to derive
-    /// the source string.
-    pub(crate) fn clone_bare(&self) -> tempfile::TempDir {
-        let bare = tempfile::tempdir().expect("bare parent");
-        let source_path = bare.path().join("rig-package.git");
-        run_git(
-            self.dir,
-            &[
-                "clone",
-                "--bare",
-                self.dir.to_str().expect("package path utf8"),
-                source_path.to_str().expect("bare path utf8"),
-            ],
-        );
-        bare
-    }
+pub(crate) fn commit_all(dir: &Path, message: &str) {
+    run_git(dir, &["add", "."]);
+    run_git(
+        dir,
+        &[
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-m",
+            message,
+        ],
+    );
 }
 
-/// Path to the bare `rig-package.git` clone produced by
-/// [`GitFixture::clone_bare`].
+pub(crate) fn clone_bare(dir: &Path) -> tempfile::TempDir {
+    let bare = tempfile::tempdir().expect("bare parent");
+    run_git(
+        dir,
+        &[
+            "clone",
+            "--bare",
+            dir.to_str().expect("package path utf8"),
+            bare_source_path(&bare).to_str().expect("bare path utf8"),
+        ],
+    );
+    bare
+}
+
+pub(crate) fn push_main(dir: &Path, source: &str) {
+    run_git(dir, &["push", source, "HEAD:main"]);
+}
+
 #[allow(dead_code)]
 pub(crate) fn bare_source_path(bare: &tempfile::TempDir) -> PathBuf {
     bare.path().join("rig-package.git")


### PR DESCRIPTION
## Summary
Consolidate repeated Git command execution behind one shared test-support fixture while keeping topology-specific setup local.

## What changed
- Add one shared homeboy-core GitFixture command boundary.
- Migrate rig and Lab dependency fixtures while preserving their branch, identity, remote, and diagnostic behavior.
- Delete duplicated command execution and rig fixture wrappers for a net 16-line reduction.

## How to test
1. Run `cargo fmt --all --check`; expect passes as recorded by Homeboy's deterministic gate.
2. Run `cargo test -p homeboy-rig install_test`; expect passes as recorded by Homeboy's deterministic gate.
3. Run `cargo test -p homeboy-rig source_test`; expect passes as recorded by Homeboy's deterministic gate.
4. Run `cargo test -p homeboy-lab-runner git_dependency_materialization`; expect passes as recorded by Homeboy's deterministic gate.
5. Run `cargo check --workspace --all-targets -j2`; expect passes as recorded by Homeboy's deterministic gate.

## Compatibility
Test support only; production behavior and public runtime contracts are unchanged.

## Evidence
- Base advanced after verification: verified main at ee6db4a7accc8d8ccf771176fc86daf6813a57ed; publication observed 021906c518dffb34a97ba74e6d8034ecd9b68ec0. Candidate ancestry was validated against the verified snapshot.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/13227
- Verified finalization base: main at ee6db4a7accc8d8ccf771176fc86daf6813a57ed
- manual-verify-1: passed (cargo fmt --all --check) (Passed)
- manual-verify-2: passed (cargo test -p homeboy-rig install\_test) (Passed)
- manual-verify-3: passed (cargo test -p homeboy-rig source\_test) (Passed)
- manual-verify-4: passed (cargo test -p homeboy-lab-runner git\_dependency\_materialization) (Passed)
- manual-verify-5: passed (cargo check --workspace --all-targets -j2) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** OpenCode generated the initial fixture consolidation; the candidate was reviewed, stale-base contamination was removed, and deterministic gates were run through Homeboy.

## Source relationships
- Relates to #13227
