### PR TITLE
Fix Lab Cook harvest for behind worktrees

### DIFF
--- a/crates/homeboy-lab-runner/src/lab_workspaces/mod.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces/mod.rs
@@ -9,8 +9,9 @@ use homeboy_agents::agent_task_scheduler::AgentTaskPlan;
 use homeboy_core::{component, Error, Result};
 
 use super::lab_workspaces_deps::{
-    accepted_extra_lab_workspaces, add_candidate_extra_workspace, bare_module_imports,
-    canonical_existing_dir, component_contract_candidate_paths, containing_checkout_or_parent,
+    accepted_extra_lab_workspaces, add_candidate_extra_workspace,
+    add_candidate_extra_workspace_with_git_fetch_refs, bare_module_imports, canonical_existing_dir,
+    component_contract_candidate_paths, containing_checkout_or_parent,
     discovered_validation_dependency_workspaces, provider_config_candidate_paths,
     provider_config_source_cli_files,
 };
@@ -76,6 +77,7 @@ pub(super) struct ExtraLabWorkspace {
     pub(super) role: String,
     pub(super) path: PathBuf,
     pub(super) snapshot_includes: Vec<String>,
+    pub(super) git_fetch_refs: Vec<String>,
     pub(super) allow_dirty_lab_workspace: bool,
     pub(super) source_provenance: Option<serde_json::Value>,
 }
@@ -184,7 +186,7 @@ pub(super) fn sync_extra_lab_workspaces(
                 mode: extra_workspace_sync_mode(&local_path),
                 controller_routed_git: false,
                 changed_since_base: None,
-                git_fetch_refs: Vec::new(),
+                git_fetch_refs: extra.git_fetch_refs.clone(),
                 snapshot_includes: extra.snapshot_includes.clone(),
                 allow_dirty_lab_workspace: extra.allow_dirty_lab_workspace,
                 run_isolation_token: None,
@@ -447,6 +449,7 @@ pub(super) fn parse_runtime_overlays(
                 role,
                 path,
                 snapshot_includes: spec.snapshot_includes,
+                git_fetch_refs: Vec::new(),
                 allow_dirty_lab_workspace: false,
                 source_provenance: None,
             },
@@ -752,6 +755,7 @@ pub(super) fn agent_task_plan_extra_workspaces(
                         role: "agent_task_plan".to_string(),
                         path: canon,
                         snapshot_includes: Vec::new(),
+                        git_fetch_refs: Vec::new(),
                         allow_dirty_lab_workspace: false,
                         source_provenance: None,
                     });
@@ -781,12 +785,28 @@ pub(super) fn agent_task_plan_extra_workspaces(
             .pointer("/workspace/root")
             .and_then(serde_json::Value::as_str)
         {
-            add_candidate_extra_workspace(
+            let git_fetch_refs = task
+                .pointer("/metadata/cook_workspace_base_snapshot")
+                .filter(|snapshot| {
+                    snapshot.get("schema").and_then(serde_json::Value::as_str)
+                        == Some("homeboy/cook-workspace-base-snapshot/v1")
+                        && snapshot.get("mode").and_then(serde_json::Value::as_str)
+                            == Some("isolated_attempt_snapshot")
+                })
+                .and_then(|snapshot| snapshot.get("resolved_base"))
+                .and_then(serde_json::Value::as_str)
+                .filter(|base| {
+                    base.len() == 40 && base.bytes().all(|byte| byte.is_ascii_hexdigit())
+                })
+                .map(|base| vec![base.to_string()])
+                .unwrap_or_default();
+            add_candidate_extra_workspace_with_git_fetch_refs(
                 path,
                 "agent_task_plan_workspace",
                 &source_canon,
                 &mut seen,
                 &mut workspaces,
+                &git_fetch_refs,
             )?;
         }
     }
@@ -1205,6 +1225,7 @@ fn add_candidate_workspace_ref_extra_workspace(
         role: "path_setting_workspace_ref".to_string(),
         path: canon,
         snapshot_includes: Vec::new(),
+        git_fetch_refs: Vec::new(),
         allow_dirty_lab_workspace: false,
         source_provenance: Some(serde_json::json!({
             "source_provenance": "workspace_ref",

--- a/crates/homeboy-lab-runner/src/lab_workspaces/tests/provider_config.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces/tests/provider_config.rs
@@ -595,7 +595,14 @@ fn agent_task_run_plan_workspace_gets_its_own_materialized_provenance() {
                 "task_id": "issue-14145",
                 "instructions": "fix provenance",
                 "executor": { "backend": "test" },
-                "workspace": { "root": issue_worktree }
+                "workspace": { "root": issue_worktree },
+                "metadata": {
+                    "cook_workspace_base_snapshot": {
+                        "schema": "homeboy/cook-workspace-base-snapshot/v1",
+                        "mode": "isolated_attempt_snapshot",
+                        "resolved_base": "0123456789abcdef0123456789abcdef01234567"
+                    }
+                }
             }]
         })
         .to_string(),
@@ -613,6 +620,10 @@ fn agent_task_run_plan_workspace_gets_its_own_materialized_provenance() {
 
     assert_eq!(workspaces.len(), 1);
     assert_eq!(workspaces[0].role, "agent_task_plan_workspace");
+    assert_eq!(
+        workspaces[0].git_fetch_refs,
+        ["0123456789abcdef0123456789abcdef01234567"]
+    );
     assert_eq!(
         workspaces[0].path,
         issue_worktree.canonicalize().expect("issue worktree")
@@ -1163,6 +1174,7 @@ fn workspace_ref_provenance_is_recorded_on_mapping_entry() {
         role: "path_setting_workspace_ref".to_string(),
         path: PathBuf::from("/local/repo@cook"),
         snapshot_includes: Vec::new(),
+        git_fetch_refs: Vec::new(),
         allow_dirty_lab_workspace: false,
         source_provenance: Some(serde_json::json!({
             "source_provenance": "workspace_ref",

--- a/crates/homeboy-lab-runner/src/lab_workspaces_deps.rs
+++ b/crates/homeboy-lab-runner/src/lab_workspaces_deps.rs
@@ -38,6 +38,24 @@ pub(super) fn add_candidate_extra_workspace(
     seen: &mut BTreeSet<PathBuf>,
     workspaces: &mut Vec<ExtraLabWorkspace>,
 ) -> Result<()> {
+    add_candidate_extra_workspace_with_git_fetch_refs(
+        candidate,
+        role,
+        source_canon,
+        seen,
+        workspaces,
+        &[],
+    )
+}
+
+pub(super) fn add_candidate_extra_workspace_with_git_fetch_refs(
+    candidate: &str,
+    role: &str,
+    source_canon: &Path,
+    seen: &mut BTreeSet<PathBuf>,
+    workspaces: &mut Vec<ExtraLabWorkspace>,
+    git_fetch_refs: &[String],
+) -> Result<()> {
     let expanded = shellexpand::tilde(candidate).to_string();
     let path = Path::new(&expanded);
     let (workspace_path, snapshot_includes) = if path.is_dir() {
@@ -67,6 +85,11 @@ pub(super) fn add_candidate_extra_workspace(
                     existing.snapshot_includes.push(include);
                 }
             }
+            for git_ref in git_fetch_refs {
+                if !existing.git_fetch_refs.contains(git_ref) {
+                    existing.git_fetch_refs.push(git_ref.clone());
+                }
+            }
         }
         return Ok(());
     }
@@ -74,6 +97,7 @@ pub(super) fn add_candidate_extra_workspace(
         role: role.to_string(),
         path: canon,
         snapshot_includes,
+        git_fetch_refs: git_fetch_refs.to_vec(),
         allow_dirty_lab_workspace: false,
         source_provenance: None,
     });
@@ -273,6 +297,7 @@ pub(super) fn accepted_extra_lab_workspaces() -> Result<Vec<ExtraLabWorkspace>> 
                 role: "extra".to_string(),
                 path: canonical_existing_dir(&path, "extra_workspace")?,
                 snapshot_includes: Vec::new(),
+                git_fetch_refs: Vec::new(),
                 allow_dirty_lab_workspace: false,
                 source_provenance: None,
             })
@@ -313,6 +338,7 @@ pub(super) fn discovered_validation_dependency_workspaces(
                 role: "dependency".to_string(),
                 path,
                 snapshot_includes: Vec::new(),
+                git_fetch_refs: Vec::new(),
                 allow_dirty_lab_workspace: false,
                 source_provenance: None,
             });

--- a/crates/homeboy-lab-runner/src/workspace/git.rs
+++ b/crates/homeboy-lab-runner/src/workspace/git.rs
@@ -251,6 +251,7 @@ pub(super) fn materialize_git_snapshot_from_controller_bundle(
     local_path: &Path,
     remote_path: &str,
     excludes: &[String],
+    git_fetch_refs: &[String],
 ) -> Result<Option<ControllerGitBundleProvenance>> {
     let head = git_output(local_path, &["rev-parse", "HEAD"])?;
     let branch = git_output(local_path, &["rev-parse", "--abbrev-ref", "HEAD"])
@@ -269,7 +270,7 @@ pub(super) fn materialize_git_snapshot_from_controller_bundle(
             branch: branch.as_deref(),
             remote_url: &remote_url,
             changed_since_base: None,
-            git_fetch_refs: &[],
+            git_fetch_refs,
             allow_dirty_lab_workspace: false,
         },
     )?;

--- a/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
+++ b/crates/homeboy-lab-runner/src/workspace/sync/mod.rs
@@ -190,6 +190,7 @@ pub fn sync_workspace_in_roots(
                     &local_path,
                     &remote_path,
                     &excludes,
+                    &options.git_fetch_refs,
                 ) {
                     Ok(provenance) => {
                         materialization_plan.controller_git_bundle = provenance;

--- a/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/snapshot.rs
@@ -306,6 +306,72 @@ fn snapshot_git_reports_checkout_provenance_for_committed_harvest() {
 }
 
 #[test]
+fn snapshot_git_carries_a_pinned_base_absent_from_destination_history() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let source = tempfile::tempdir().expect("source workspace");
+        let runner_root = tempfile::tempdir().expect("runner root");
+        git(source.path(), &["init", "--quiet", "-b", "main"]);
+        git(source.path(), &["config", "user.name", "Homeboy Test"]);
+        git(
+            source.path(),
+            &["config", "user.email", "test@homeboy.invalid"],
+        );
+        fs::write(source.path().join("file.txt"), "destination\n").expect("destination file");
+        git(source.path(), &["add", "file.txt"]);
+        git(source.path(), &["commit", "--quiet", "-m", "destination"]);
+        let destination =
+            git_output(source.path(), &["rev-parse", "HEAD"]).expect("destination revision");
+        fs::write(source.path().join("file.txt"), "pinned base\n").expect("base file");
+        git(source.path(), &["commit", "-am", "pinned base", "--quiet"]);
+        let pinned_base =
+            git_output(source.path(), &["rev-parse", "HEAD"]).expect("pinned base revision");
+        git(source.path(), &["checkout", "--quiet", &destination]);
+
+        crate::create(
+            &format!(
+                r#"{{"id":"lab-pinned-cook-base","kind":"local","workspace_root":"{}"}}"#,
+                runner_root.path().display()
+            ),
+            false,
+        )
+        .expect("create runner");
+
+        let (synced, _) = sync_workspace(
+            "lab-pinned-cook-base",
+            RunnerWorkspaceSyncOptions {
+                path: source.path().display().to_string(),
+                mode: RunnerWorkspaceSyncMode::SnapshotGit,
+                controller_routed_git: false,
+                changed_since_base: None,
+                git_fetch_refs: vec![pinned_base.clone()],
+                snapshot_includes: Vec::new(),
+                allow_dirty_lab_workspace: false,
+                run_isolation_token: None,
+            },
+        )
+        .expect("materialize behind Cook destination with pinned base");
+
+        let remote = Path::new(&synced.remote_path);
+        assert_eq!(
+            git_output(remote, &["rev-parse", "HEAD"]).expect("runner HEAD"),
+            destination
+        );
+        assert_eq!(
+            git_output(
+                remote,
+                &[
+                    "rev-parse",
+                    "--verify",
+                    &format!("{pinned_base}^{{commit}}")
+                ]
+            )
+            .expect("runner pinned base"),
+            pinned_base
+        );
+    });
+}
+
+#[test]
 fn snapshot_git_materializes_linked_worktree_with_valid_git_before_handoff() {
     homeboy_core::test_support::with_isolated_home(|_| {
         let source = tempfile::tempdir().expect("source repository");


### PR DESCRIPTION
## Summary

- extract Cook’s exact pinned base SHA from the typed isolated-attempt snapshot metadata
- carry that SHA through extra-workspace planning into the existing controller Git bundle refs
- preserve the destination checkout at its original `HEAD` while making the pinned base object available to committed-harvest preflight
- merge required refs when multiple plan inputs resolve to the same extra workspace

## Root cause

Lab’s `snapshot-git` materialization bundled only the destination `HEAD`. A Cook worktree behind its freshly resolved base therefore reached the runner without the pinned base object and failed before provider execution at `git rev-parse --verify <base>^{commit}`.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-lab-runner agent_task_run_plan_workspace_gets_its_own_materialized_provenance --lib`
- `cargo test -p homeboy-lab-runner snapshot_git_carries_a_pinned_base_absent_from_destination_history --lib`
- `cargo test -p homeboy-lab-runner lab_workspaces::tests::provider_config --lib` (31 passed)
- `cargo check -p homeboy-lab-runner`
- `git diff --check origin/main...HEAD`

A broader snapshot module run passed 83 tests and failed two unrelated tests. Both failures reproduce individually on detached `origin/main` at `021906c51`: `snapshot_sync_uses_gitignore_excludes_as_generic_fallback` and `workspace_snapshots_render_metadata_for_synced_workspace`.

Closes #14156

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed the failed Cook/Lab run, traced pinned-base propagation through workspace materialization and controller bundles, implemented the fix and regression tests, and ran verification under Chris Huber’s direction.