### PR TITLE
Resolve equivalent controller artifact projections

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/failure_recording.rs
@@ -2334,6 +2334,53 @@ fn reusable_terminal_artifact(
     ))
 }
 
+/// Declared authority of one controller-side projection.
+///
+/// Terminal projection deliberately keeps a legacy import as evidence while the
+/// finalized record carries the derived controller identity, so both records can
+/// legitimately share a task and logical artifact id. Resolution therefore
+/// selects by declared authority rather than by discovery order.
+fn controller_projection_precedence(
+    record: &homeboy_core::observation::ArtifactRecord,
+) -> (u8, &str) {
+    let rank = match record
+        .metadata_json
+        .pointer("/agent_task/projection")
+        .and_then(Value::as_str)
+    {
+        Some("controller_finalized") => 0,
+        Some("controller_local") => 1,
+        Some("runner_mirrored") => 2,
+        _ => 3,
+    };
+    (rank, record.id.as_str())
+}
+
+/// Reduce equivalent controller projections of one logical artifact to the
+/// single authoritative record. Candidates that disagree on content identity
+/// are a real conflict and still fail closed, naming the records involved.
+fn select_controller_artifact_projection(
+    candidates: Vec<homeboy_core::observation::ArtifactRecord>,
+) -> std::result::Result<homeboy_core::observation::ArtifactRecord, Vec<String>> {
+    let identity = |record: &homeboy_core::observation::ArtifactRecord| {
+        (record.sha256.clone(), record.size_bytes)
+    };
+    if let Some(first) = candidates.first().map(&identity) {
+        if candidates.iter().any(|record| identity(record) != first) {
+            let mut conflicting: Vec<String> =
+                candidates.iter().map(|record| record.id.clone()).collect();
+            conflicting.sort();
+            return Err(conflicting);
+        }
+    }
+    candidates
+        .into_iter()
+        .min_by(|left, right| {
+            controller_projection_precedence(left).cmp(&controller_projection_precedence(right))
+        })
+        .ok_or_else(Vec::new)
+}
+
 fn controller_projection_artifact_id(artifact_id: &str) -> String {
     let mut controller_hash = sha2::Sha256::new();
     sha2::Digest::update(&mut controller_hash, b"controller");
@@ -2531,7 +2578,7 @@ pub fn verified_controller_artifact_projection_path_in_store(
     else {
         return Ok(None);
     };
-    let mut candidates: Vec<_> = store
+    let candidates: Vec<_> = store
         .list_artifacts(run_id)?
         .into_iter()
         .filter(|candidate| {
@@ -2562,18 +2609,18 @@ pub fn verified_controller_artifact_projection_path_in_store(
     if candidates.is_empty() {
         return Ok(None);
     }
-    if candidates.len() != 1 {
-        return Err(Error::validation_invalid_argument(
+    let mut candidate = select_controller_artifact_projection(candidates).map_err(|conflicting| {
+        Error::validation_invalid_argument(
             "artifact_id",
             format!(
-                "multiple controller-side artifact projections match run '{run_id}', task '{task_id}', and artifact '{}'",
-                artifact.id
+                "conflicting controller-side artifact projections match run '{run_id}', task '{task_id}', and artifact '{}': {}",
+                artifact.id,
+                conflicting.join(", ")
             ),
             Some(artifact.id.clone()),
             None,
-        ));
-    }
-    let mut candidate = candidates.pop().expect("one candidate checked above");
+        )
+    })?;
     let path = PathBuf::from(&candidate.path);
     let actual_size = std::fs::metadata(&path)
         .ok()
@@ -2672,17 +2719,25 @@ pub fn verified_controller_artifact_projection_in_store(
     if candidates.is_empty() {
         return Ok(None);
     }
-    if candidates.len() != 1 {
-        return Err(Error::validation_invalid_argument(
-            "artifact_id",
-            format!(
-                "multiple controller-side artifact projections match run '{run_id}', task '{task_id}', and artifact '{logical_artifact_id}'"
-            ),
-            Some(logical_artifact_id.to_string()),
-            None,
-        ));
-    }
-    let candidate = &candidates[0];
+    // An explicitly pinned record stays authoritative; selection only resolves
+    // equivalent projections the caller has not already chosen between.
+    let selected = match expected_record_id
+        .and_then(|id| candidates.iter().position(|candidate| candidate.id == id))
+    {
+        Some(index) => candidates.into_iter().nth(index).expect("located candidate"),
+        None => select_controller_artifact_projection(candidates).map_err(|conflicting| {
+            Error::validation_invalid_argument(
+                "artifact_id",
+                format!(
+                    "conflicting controller-side artifact projections match run '{run_id}', task '{task_id}', and artifact '{logical_artifact_id}': {}",
+                    conflicting.join(", ")
+                ),
+                Some(logical_artifact_id.to_string()),
+                None,
+            )
+        })?,
+    };
+    let candidate = &selected;
     if expected_record_id.is_some_and(|id| id != candidate.id) {
         return Err(Error::validation_invalid_argument(
             "gate_feedback_candidate_baseline",
@@ -2994,5 +3049,150 @@ mod tests {
         assert_ne!(left, right);
         assert_eq!(std::fs::read(left).unwrap(), b"left");
         assert_eq!(std::fs::read(right).unwrap(), b"right");
+    }
+
+    /// Register one logical artifact twice the way terminal projection does for
+    /// a Lab run: a legacy import stamped with the lifecycle identity, plus the
+    /// finalized controller projection that carries projection authority.
+    fn record_duplicate_projections(
+        store: &homeboy_core::observation::ObservationStore,
+        run_id: &str,
+        legacy_bytes: &[u8],
+        finalized_bytes: &[u8],
+    ) {
+        let root = store.artifact_root().expect("artifact root");
+        std::fs::create_dir_all(&root).expect("artifact root directory");
+        let legacy_path = root.join("legacy-transcript.txt");
+        let finalized_path = root.join("finalized-transcript.txt");
+        std::fs::write(&legacy_path, legacy_bytes).expect("legacy bytes");
+        std::fs::write(&finalized_path, finalized_bytes).expect("finalized bytes");
+        store
+            .record_verified_artifact_with_id(
+                run_id,
+                "transcript",
+                &legacy_path,
+                "agent-task-legacy",
+                Some(legacy_bytes.len() as i64),
+                Some(&format!("{:x}", sha2::Sha256::digest(legacy_bytes))),
+                json!({
+                    "agent_task": { "task_id": "task", "logical_artifact_id": "transcript" }
+                }),
+            )
+            .expect("legacy projection");
+        store
+            .record_verified_artifact_with_id(
+                run_id,
+                "transcript",
+                &finalized_path,
+                "agent-task-finalized",
+                Some(finalized_bytes.len() as i64),
+                Some(&format!("{:x}", sha2::Sha256::digest(finalized_bytes))),
+                json!({
+                    "agent_task": {
+                        "task_id": "task",
+                        "logical_artifact_id": "transcript",
+                        "projection": "controller_finalized",
+                    }
+                }),
+            )
+            .expect("finalized projection");
+    }
+
+    fn transcript_artifact(bytes: &[u8]) -> AgentTaskArtifact {
+        let mut artifact = artifact("transcript", "transcript", None);
+        artifact.size_bytes = Some(bytes.len() as u64);
+        artifact.sha256 = Some(format!("{:x}", sha2::Sha256::digest(bytes)));
+        artifact
+    }
+
+    #[test]
+    fn equivalent_duplicate_projections_resolve_to_the_finalized_record() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let store = homeboy_core::observation::ObservationStore::open_initialized()
+                .expect("observation store");
+            let run = store
+                .start_run(
+                    homeboy_core::observation::NewRunRecord::builder("agent-task")
+                        .cwd_path(home.path())
+                        .build(),
+                )
+                .expect("run");
+            let bytes = b"transcript bytes";
+            record_duplicate_projections(&store, &run.id, bytes, bytes);
+
+            // A Lab run legitimately retains its legacy import alongside the
+            // finalized projection, so this must resolve rather than abort the
+            // owning Cook (#14164).
+            let resolved = verified_controller_artifact_projection_path_in_store(
+                &store,
+                &run.id,
+                "task",
+                &transcript_artifact(bytes),
+            )
+            .expect("equivalent duplicates resolve")
+            .expect("a controller projection is available");
+
+            // Projection authority, not discovery order, selects the record.
+            assert!(
+                resolved
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.contains("agent-task-finalized")),
+                "expected the finalized projection, got {}",
+                resolved.display()
+            );
+            assert_eq!(std::fs::read(&resolved).expect("resolved bytes"), bytes);
+
+            let (_, bytes_read) = verified_controller_artifact_projection_in_store(
+                &store,
+                &run.id,
+                "task",
+                "transcript",
+                "transcript",
+                &format!("{:x}", sha2::Sha256::digest(bytes)),
+                None,
+            )
+            .expect("equivalent duplicates resolve for byte reads")
+            .expect("a controller projection is available");
+
+            assert_eq!(bytes_read, bytes);
+        });
+    }
+
+    #[test]
+    fn conflicting_duplicate_projections_still_fail_closed() {
+        homeboy_core::test_support::with_isolated_home(|home| {
+            let store = homeboy_core::observation::ObservationStore::open_initialized()
+                .expect("observation store");
+            let run = store
+                .start_run(
+                    homeboy_core::observation::NewRunRecord::builder("agent-task")
+                        .cwd_path(home.path())
+                        .build(),
+                )
+                .expect("run");
+            let bytes = b"transcript bytes";
+            record_duplicate_projections(&store, &run.id, b"different transcript", bytes);
+
+            let error = verified_controller_artifact_projection_path_in_store(
+                &store,
+                &run.id,
+                "task",
+                &transcript_artifact(bytes),
+            )
+            .expect_err("projections that disagree on content must fail closed");
+
+            assert!(
+                error.message.contains("conflicting"),
+                "got {}",
+                error.message
+            );
+            assert!(
+                error.message.contains("agent-task-finalized")
+                    && error.message.contains("agent-task-legacy"),
+                "the conflicting records must be named: {}",
+                error.message
+            );
+        });
     }
 }


### PR DESCRIPTION
## Summary

- select controller-side artifact projections by declared projection authority instead of requiring exactly one match
- keep genuinely conflicting projections failing closed, and name the conflicting records in the diagnostic
- honor an explicitly pinned record id before selection so existing candidate-baseline semantics are unchanged

## Root cause

Terminal projection deliberately registers two records for one logical artifact on a Lab run: the legacy import is retained as evidence and stamped with the lifecycle `task_id` and `logical_artifact_id`, while the finalized record carries the derived controller identity and `projection: controller_finalized`.

Both records then satisfy the resolver filter in `verified_controller_artifact_projection_path_in_store` and `verified_controller_artifact_projection_in_store`, which errored on `candidates.len() != 1`. A retryable provider failure therefore became a durable controller failure that recorded zero attempts and never rotated providers.

Observed on run `agent-task-8f6d488c-ea3b-4523-bbac-7667e79467d0-attempt-1-7280dd48`, which held two `transcript` records (`agent-task-7077d16f…`, `agent-task-934f4f2d…`) with identical sha256 and size, masking the real `OpenCode CLI exited with status 1.` failure.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-agents duplicate_projections --lib` (2 passed)
- `cargo test -p homeboy-agents agent_task_lifecycle --lib` (370 passed)
- `cargo test -p homeboy-agents agent_task_promotion --lib` (106 passed)
- `cargo check --workspace`
- `git diff --check`

One lifecycle test, `command_verifier_accepts_valid_signed_verdict`, failed once under heavy parallel load with "acceptance verifier output capture was incomplete", then passed in isolation on this branch, in isolation on clean `origin/main`, and on a full-suite rerun. It is load-sensitive and untouched by this diff.

Closes #14164

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode diagnosed the failed Cook run, traced the duplicate registration to terminal artifact projection, implemented the deterministic selection and regression tests, and ran verification under Chris Huber's direction.