### PR TITLE
Finalize provider worktrees explicitly

### DIFF
--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -1747,6 +1747,43 @@ pub fn read_batch_record_in_store(
     store.read_batch(batch_id)
 }
 
+pub fn provider_worktree_finalization_receipt(
+    batch_id: &str,
+    child_run_id: &str,
+) -> Result<Option<Value>> {
+    let batch = read_batch_record(batch_id)?;
+    Ok(batch.metadata["provider_worktree_finalizations"]
+        .get(child_run_id)
+        .filter(|receipt| receipt.is_object())
+        .cloned())
+}
+
+pub fn record_provider_worktree_finalization_receipt(
+    batch_id: &str,
+    child_run_id: &str,
+    receipt: Value,
+) -> Result<()> {
+    AgentTaskBatchStore::from_current_data_root()?.mutate_batch(batch_id, |batch| {
+        if !batch.metadata.is_object() {
+            batch.metadata = json!({});
+        }
+        let receipts = batch
+            .metadata
+            .as_object_mut()
+            .expect("metadata object")
+            .entry("provider_worktree_finalizations")
+            .or_insert_with(|| json!({}));
+        if !receipts.is_object() {
+            *receipts = json!({});
+        }
+        receipts
+            .as_object_mut()
+            .expect("provider worktree finalization receipts object")
+            .insert(child_run_id.to_string(), receipt);
+        Ok(())
+    })
+}
+
 /// Persist a child's resume-time finalization outcome into the durable batch
 /// record's metadata, keyed by the child run id. Repeated resume calls overwrite
 /// the same key so the batch record stays a single, convergent view of what has

--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -2028,20 +2028,17 @@ pub fn record_provider_worktree_finalization_deferred(
     lifecycle_status: &str,
 ) -> Result<()> {
     AgentTaskBatchStore::from_current_data_root()?.mutate_batch(batch_id, |batch| {
-        let operations = batch
+        let deferrals = batch
             .metadata
             .as_object_mut()
             .expect("batch metadata is validated as an object")
-            .entry("provider_worktree_finalizations")
+            .entry("provider_worktree_finalization_deferrals")
             .or_insert_with(|| json!({}));
-        if operations[child_run_id]["status"] != "completed" {
-            operations[child_run_id] = json!({
-                "schema": "homeboy/agent-task-provider-worktree-finalization/v2",
-                "status": "deferred",
-                "lifecycle_status": lifecycle_status,
-                "recorded_at": chrono::Utc::now().to_rfc3339(),
-            });
-        }
+        deferrals[child_run_id] = json!({
+            "schema": "homeboy/agent-task-provider-worktree-finalization-deferral/v1",
+            "lifecycle_status": lifecycle_status,
+            "recorded_at": chrono::Utc::now().to_rfc3339(),
+        });
         Ok(())
     })?;
     Ok(())

--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -1661,9 +1661,7 @@ impl AgentTaskBatchStore {
     pub fn write_batch(&self, record: &AgentTaskBatchRecord) -> Result<()> {
         let path = self.batch_path(&record.batch_id);
         if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).map_err(|error| {
-                Error::internal_io(error.to_string(), Some(parent.display().to_string()))
-            })?;
+            homeboy_core::engine::local_files::create_dir_all_durably(parent)?;
         }
         let raw = serde_json::to_string_pretty(record).map_err(|error| {
             Error::internal_json(
@@ -1671,13 +1669,12 @@ impl AgentTaskBatchStore {
                 Some(format!("serialize agent-task batch {}", record.batch_id)),
             )
         })?;
-        let temporary = path.with_extension(format!("{}.tmp", Uuid::new_v4()));
-        fs::write(&temporary, raw).map_err(|error| {
-            Error::internal_io(error.to_string(), Some(temporary.display().to_string()))
-        })?;
-        fs::rename(&temporary, &path).map_err(|error| {
-            Error::internal_io(error.to_string(), Some(path.display().to_string()))
-        })
+        homeboy_core::io::write_output_file_atomically(
+            &path,
+            raw,
+            homeboy_core::io::OutputWriteOptions::file(),
+        )
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))
     }
 
     pub fn with_batch_lock<T>(
@@ -1687,9 +1684,7 @@ impl AgentTaskBatchStore {
     ) -> Result<T> {
         let path = self.batch_path(batch_id).with_extension("lock");
         if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).map_err(|error| {
-                Error::internal_io(error.to_string(), Some(parent.display().to_string()))
-            })?;
+            homeboy_core::engine::local_files::create_dir_all_durably(parent)?;
         }
         let lock = OpenOptions::new()
             .create(true)
@@ -1761,76 +1756,295 @@ pub fn finalize_provider_worktree_for_child(
     handle: &str,
     lifecycle: &homeboy_core::worktree_provider::WorktreeProvisionLifecycle,
     disposition: homeboy_core::worktree_provider::WorktreeTerminalDisposition,
+    selected_provider: Option<&homeboy_core::worktree_provider::WorktreeProviderIdentity>,
     config: &homeboy_core::defaults::HomeboyConfig,
 ) -> Result<BatchProviderWorktreeFinalization> {
-    let batch = read_batch_record(batch_id)?;
-    let receipt_matches = batch.metadata["provider_worktree_finalizations"]
-        .get(child_run_id)
-        .filter(|receipt| receipt.is_object())
-        .is_some_and(|receipt| {
-            receipt["schema"] == "homeboy/agent-task-provider-worktree-finalization/v1"
-                && receipt["handle"] == handle
-                && receipt["owner_run_ref"] == lifecycle.owner_run_ref
-                && receipt["disposition"] == disposition.as_str()
-        });
-    match homeboy_core::worktree_provider::finalize_worktree_from_config(
-        handle,
-        lifecycle,
-        disposition,
-        config,
-    )? {
-        homeboy_core::worktree_provider::WorktreeFinalizationLookup::Finalized(finalized) => {
-            record_provider_worktree_finalization_receipt(
-                batch_id,
-                child_run_id,
-                json!({
-                    "schema": "homeboy/agent-task-provider-worktree-finalization/v1",
-                    "handle": handle,
-                    "owner_run_ref": lifecycle.owner_run_ref,
-                    "disposition": disposition.as_str(),
-                    "provider_id": finalized.provider_id,
-                }),
-            )?;
-            Ok(BatchProviderWorktreeFinalization::Finalized)
-        }
-        homeboy_core::worktree_provider::WorktreeFinalizationLookup::NotFound
-            if receipt_matches =>
-        {
-            Ok(BatchProviderWorktreeFinalization::Replayed)
-        }
-        homeboy_core::worktree_provider::WorktreeFinalizationLookup::NotFound => {
-            Ok(BatchProviderWorktreeFinalization::NotFound)
-        }
-        homeboy_core::worktree_provider::WorktreeFinalizationLookup::Unsupported => {
-            Ok(BatchProviderWorktreeFinalization::Unsupported)
-        }
-    }
-}
-
-fn record_provider_worktree_finalization_receipt(
-    batch_id: &str,
-    child_run_id: &str,
-    receipt: Value,
-) -> Result<()> {
-    AgentTaskBatchStore::from_current_data_root()?.mutate_batch(batch_id, |batch| {
+    let store = AgentTaskBatchStore::from_current_data_root()?;
+    store.with_batch_lock(batch_id, || {
+        let mut batch = store.read_batch(batch_id)?;
         if !batch.metadata.is_object() {
             batch.metadata = json!({});
         }
-        let receipts = batch
+        let operations = batch
             .metadata
             .as_object_mut()
             .expect("metadata object")
             .entry("provider_worktree_finalizations")
             .or_insert_with(|| json!({}));
-        if !receipts.is_object() {
-            *receipts = json!({});
+        if !operations.is_object() {
+            *operations = json!({});
         }
-        receipts
-            .as_object_mut()
-            .expect("provider worktree finalization receipts object")
-            .insert(child_run_id.to_string(), receipt);
-        Ok(())
+        let idempotency_key =
+            homeboy_core::worktree_providers::worktree_provider_finalization_idempotency_key(
+                lifecycle,
+            );
+        let selected_provider_id = selected_provider.map(|provider| match provider {
+            homeboy_core::worktree_provider::WorktreeProviderIdentity::Native => "native",
+            homeboy_core::worktree_provider::WorktreeProviderIdentity::Configured(id) => id,
+        });
+        let exact = |operation: &Value| {
+            operation["schema"] == "homeboy/agent-task-provider-worktree-finalization/v2"
+                && operation["handle"] == handle
+                && operation["purpose"] == lifecycle.purpose
+                && operation["owner_run_ref"] == lifecycle.owner_run_ref
+                && operation["cleanup_policy"] == lifecycle.cleanup_policy.as_str()
+                && operation["disposition"] == disposition.as_str()
+                && operation["idempotency_key"] == idempotency_key
+                && operation["provider_id"].as_str().is_some()
+                && selected_provider_id
+                    .is_none_or(|provider_id| operation["provider_id"] == provider_id)
+        };
+        if matches!(
+            operations[child_run_id]["status"].as_str(),
+            Some("preflight_failed" | "deferred")
+        ) {
+            operations
+                .as_object_mut()
+                .expect("provider worktree finalization operations object")
+                .remove(child_run_id);
+        }
+        if let Some(existing) = operations.get(child_run_id) {
+            if !exact(existing) {
+                return Err(Error::validation_invalid_argument(
+                    "provider_worktree_finalization",
+                    "provider worktree finalization conflicts with the durable child operation",
+                    Some(child_run_id.to_string()),
+                    None,
+                ));
+            }
+            if existing["status"] == "completed" {
+                return Ok(BatchProviderWorktreeFinalization::Replayed);
+            }
+            if existing["status"] == "unsupported" {
+                return Ok(BatchProviderWorktreeFinalization::Unsupported);
+            }
+        }
+
+        let replaying_mutation = operations
+            .get(child_run_id)
+            .and_then(|operation| operation["mutation_attempted"].as_bool())
+            .unwrap_or(false);
+
+        let provider = if let Some(provider_id) = operations
+            .get(child_run_id)
+            .and_then(|existing| existing["provider_id"].as_str())
+        {
+            match provider_id {
+                "native" => homeboy_core::worktree_provider::WorktreeProviderIdentity::Native,
+                provider_id => {
+                    homeboy_core::worktree_provider::WorktreeProviderIdentity::Configured(
+                        provider_id.to_string(),
+                    )
+                }
+            }
+        } else {
+            let provider = match selected_provider.cloned().map(Some).map(Ok).unwrap_or_else(|| {
+                homeboy_core::worktree_provider::resolve_worktree_finalization_provider_from_config(
+                    handle, config,
+                )
+            }) {
+                Ok(Some(provider)) => provider,
+                Ok(None) => {
+                    operations
+                        .as_object_mut()
+                        .expect("provider worktree finalization operations object")
+                        .insert(
+                            child_run_id.to_string(),
+                            json!({
+                                "schema": "homeboy/agent-task-provider-worktree-finalization/v2",
+                                "status": "not_found",
+                                "fencing_token": Uuid::new_v4().to_string(),
+                                "handle": handle,
+                                "purpose": lifecycle.purpose,
+                                "owner_run_ref": lifecycle.owner_run_ref,
+                                "cleanup_policy": lifecycle.cleanup_policy.as_str(),
+                                "disposition": disposition.as_str(),
+                                "idempotency_key": idempotency_key,
+                                "last_error": {
+                                    "message": "provider workspace was not found before finalization intent",
+                                    "recorded_at": chrono::Utc::now().to_rfc3339(),
+                                },
+                            }),
+                        );
+                    store.write_batch(&batch)?;
+                    return Ok(BatchProviderWorktreeFinalization::NotFound);
+                }
+                Err(error) => {
+                    operations
+                        .as_object_mut()
+                        .expect("provider worktree finalization operations object")
+                        .insert(
+                            child_run_id.to_string(),
+                            json!({
+                                "schema": "homeboy/agent-task-provider-worktree-finalization/v2",
+                                "status": "resolution_failed",
+                                "fencing_token": Uuid::new_v4().to_string(),
+                                "handle": handle,
+                                "purpose": lifecycle.purpose,
+                                "owner_run_ref": lifecycle.owner_run_ref,
+                                "cleanup_policy": lifecycle.cleanup_policy.as_str(),
+                                "disposition": disposition.as_str(),
+                                "idempotency_key": idempotency_key,
+                                "last_error": {
+                                    "message": error.message,
+                                    "details": error.details,
+                                    "recorded_at": chrono::Utc::now().to_rfc3339(),
+                                },
+                            }),
+                        );
+                    store.write_batch(&batch)?;
+                    return Err(error);
+                }
+            };
+            let provider_id = match &provider {
+                homeboy_core::worktree_provider::WorktreeProviderIdentity::Native => "native",
+                homeboy_core::worktree_provider::WorktreeProviderIdentity::Configured(id) => id,
+            };
+            operations
+                .as_object_mut()
+                .expect("provider worktree finalization operations object")
+                .insert(
+                    child_run_id.to_string(),
+                    json!({
+                        "schema": "homeboy/agent-task-provider-worktree-finalization/v2",
+                        "status": "pending",
+                        "fencing_token": Uuid::new_v4().to_string(),
+                        "handle": handle,
+                        "purpose": lifecycle.purpose,
+                        "owner_run_ref": lifecycle.owner_run_ref,
+                        "cleanup_policy": lifecycle.cleanup_policy.as_str(),
+                        "disposition": disposition.as_str(),
+                        "idempotency_key": idempotency_key,
+                        "provider_id": provider_id,
+                        "mutation_attempted": false,
+                    }),
+                );
+            store.write_batch(&batch)?;
+            provider
+        };
+
+        let outcome =
+            match homeboy_core::worktree_provider::finalize_worktree_with_provider_and_effect_fence_from_config(
+                handle,
+                &provider,
+                lifecycle,
+                disposition,
+                config,
+                || {
+                    batch.metadata["provider_worktree_finalizations"][child_run_id]
+                        ["mutation_attempted"] = Value::Bool(true);
+                    store.write_batch(&batch)
+                },
+            ) {
+                Ok(outcome) => outcome,
+                Err(error) => {
+                    let operation = batch.metadata["provider_worktree_finalizations"]
+                        .get_mut(child_run_id)
+                        .expect("durable finalization intent exists");
+                    operation["last_error"] = json!({
+                        "message": error.message,
+                        "details": error.details,
+                        "recorded_at": chrono::Utc::now().to_rfc3339(),
+                    });
+                    store.write_batch(&batch)?;
+                    return Err(error);
+                }
+            };
+        let operation = batch.metadata["provider_worktree_finalizations"]
+            .get_mut(child_run_id)
+            .expect("durable finalization intent exists");
+        match outcome {
+            homeboy_core::worktree_provider::WorktreeFinalizationLookup::Finalized(finalized) => {
+                operation["status"] = Value::String("completed".to_string());
+                operation["inspection_path"] = Value::String(finalized.inspection_path);
+                store.write_batch(&batch)?;
+                Ok(BatchProviderWorktreeFinalization::Finalized)
+            }
+            homeboy_core::worktree_provider::WorktreeFinalizationLookup::NotFound
+                if replaying_mutation =>
+            {
+                // The durable intent predates the external mutation. A destructive
+                // provider may remove its active lookup before Homeboy can publish
+                // the receipt, so absence completes this same fenced operation.
+                operation["status"] = Value::String("completed".to_string());
+                operation["recovered_from_not_found"] = Value::Bool(true);
+                store.write_batch(&batch)?;
+                Ok(BatchProviderWorktreeFinalization::Replayed)
+            }
+            homeboy_core::worktree_provider::WorktreeFinalizationLookup::NotFound => {
+                operation["last_error"] = json!({
+                    "message": "provider workspace was not found on the first finalization attempt",
+                    "recorded_at": chrono::Utc::now().to_rfc3339(),
+                });
+                store.write_batch(&batch)?;
+                Ok(BatchProviderWorktreeFinalization::NotFound)
+            }
+            homeboy_core::worktree_provider::WorktreeFinalizationLookup::Unsupported => {
+                operation["status"] = Value::String("unsupported".to_string());
+                store.write_batch(&batch)?;
+                Ok(BatchProviderWorktreeFinalization::Unsupported)
+            }
+        }
     })
+}
+
+pub fn record_provider_worktree_finalization_preflight_error(
+    batch_id: &str,
+    child_run_id: &str,
+    error: &Error,
+) -> Result<()> {
+    AgentTaskBatchStore::from_current_data_root()?.mutate_batch(batch_id, |batch| {
+        let operations = batch
+            .metadata
+            .as_object_mut()
+            .expect("batch metadata is validated as an object")
+            .entry("provider_worktree_finalizations")
+            .or_insert_with(|| json!({}));
+        let diagnostic = json!({
+            "message": error.message,
+            "details": error.details,
+            "recorded_at": chrono::Utc::now().to_rfc3339(),
+        });
+        if let Some(existing) = operations.get_mut(child_run_id) {
+            if existing["status"] != "completed" {
+                existing["preflight_error"] = diagnostic;
+            }
+            return Ok(());
+        }
+        operations[child_run_id] = json!({
+            "schema": "homeboy/agent-task-provider-worktree-finalization/v2",
+            "status": "preflight_failed",
+            "fencing_token": Uuid::new_v4().to_string(),
+            "last_error": diagnostic,
+        });
+        Ok(())
+    })?;
+    Ok(())
+}
+
+pub fn record_provider_worktree_finalization_deferred(
+    batch_id: &str,
+    child_run_id: &str,
+    lifecycle_status: &str,
+) -> Result<()> {
+    AgentTaskBatchStore::from_current_data_root()?.mutate_batch(batch_id, |batch| {
+        let operations = batch
+            .metadata
+            .as_object_mut()
+            .expect("batch metadata is validated as an object")
+            .entry("provider_worktree_finalizations")
+            .or_insert_with(|| json!({}));
+        if operations[child_run_id]["status"] != "completed" {
+            operations[child_run_id] = json!({
+                "schema": "homeboy/agent-task-provider-worktree-finalization/v2",
+                "status": "deferred",
+                "lifecycle_status": lifecycle_status,
+                "recorded_at": chrono::Utc::now().to_rfc3339(),
+            });
+        }
+        Ok(())
+    })?;
+    Ok(())
 }
 
 /// Persist a child's resume-time finalization outcome into the durable batch

--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -1747,18 +1747,67 @@ pub fn read_batch_record_in_store(
     store.read_batch(batch_id)
 }
 
-pub fn provider_worktree_finalization_receipt(
-    batch_id: &str,
-    child_run_id: &str,
-) -> Result<Option<Value>> {
-    let batch = read_batch_record(batch_id)?;
-    Ok(batch.metadata["provider_worktree_finalizations"]
-        .get(child_run_id)
-        .filter(|receipt| receipt.is_object())
-        .cloned())
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BatchProviderWorktreeFinalization {
+    Finalized,
+    Replayed,
+    Unsupported,
+    NotFound,
 }
 
-pub fn record_provider_worktree_finalization_receipt(
+pub fn finalize_provider_worktree_for_child(
+    batch_id: &str,
+    child_run_id: &str,
+    handle: &str,
+    lifecycle: &homeboy_core::worktree_provider::WorktreeProvisionLifecycle,
+    disposition: homeboy_core::worktree_provider::WorktreeTerminalDisposition,
+    config: &homeboy_core::defaults::HomeboyConfig,
+) -> Result<BatchProviderWorktreeFinalization> {
+    let batch = read_batch_record(batch_id)?;
+    let receipt_matches = batch.metadata["provider_worktree_finalizations"]
+        .get(child_run_id)
+        .filter(|receipt| receipt.is_object())
+        .is_some_and(|receipt| {
+            receipt["schema"] == "homeboy/agent-task-provider-worktree-finalization/v1"
+                && receipt["handle"] == handle
+                && receipt["owner_run_ref"] == lifecycle.owner_run_ref
+                && receipt["disposition"] == disposition.as_str()
+        });
+    match homeboy_core::worktree_provider::finalize_worktree_from_config(
+        handle,
+        lifecycle,
+        disposition,
+        config,
+    )? {
+        homeboy_core::worktree_provider::WorktreeFinalizationLookup::Finalized(finalized) => {
+            record_provider_worktree_finalization_receipt(
+                batch_id,
+                child_run_id,
+                json!({
+                    "schema": "homeboy/agent-task-provider-worktree-finalization/v1",
+                    "handle": handle,
+                    "owner_run_ref": lifecycle.owner_run_ref,
+                    "disposition": disposition.as_str(),
+                    "provider_id": finalized.provider_id,
+                }),
+            )?;
+            Ok(BatchProviderWorktreeFinalization::Finalized)
+        }
+        homeboy_core::worktree_provider::WorktreeFinalizationLookup::NotFound
+            if receipt_matches =>
+        {
+            Ok(BatchProviderWorktreeFinalization::Replayed)
+        }
+        homeboy_core::worktree_provider::WorktreeFinalizationLookup::NotFound => {
+            Ok(BatchProviderWorktreeFinalization::NotFound)
+        }
+        homeboy_core::worktree_provider::WorktreeFinalizationLookup::Unsupported => {
+            Ok(BatchProviderWorktreeFinalization::Unsupported)
+        }
+    }
+}
+
+fn record_provider_worktree_finalization_receipt(
     batch_id: &str,
     child_run_id: &str,
     receipt: Value,

--- a/crates/homeboy-agents/src/agent_task_fanout_supervisor.rs
+++ b/crates/homeboy-agents/src/agent_task_fanout_supervisor.rs
@@ -320,12 +320,34 @@ impl AgentTaskFanoutPortfolio {
                 CHILD_INACTIVE_FINDING_FINGERPRINT_LIMIT,
             );
             portfolio_findings.extend(findings);
-            let (blocker, action) = reconcile_child(
+            let previous_blocker = child.blocker.clone();
+            let previous_action = child.next_action.clone();
+            let (mut blocker, mut action) = reconcile_child(
                 child,
                 observation,
                 dependencies.readiness(child_id),
                 changed_base,
             );
+            if blocker.is_none()
+                && previous_blocker
+                    .as_ref()
+                    .is_some_and(|blocker| blocker.code == "adapter_action_failed")
+                && previous_action.as_ref().is_some_and(|previous| {
+                    previous == &action
+                        || matches!(
+                            action,
+                            AgentTaskFanoutPortfolioAction::AwaitAcceptance
+                                | AgentTaskFanoutPortfolioAction::None
+                        )
+                })
+            {
+                // Observation alone cannot prove that an adapter mutation whose
+                // result was an error completed. Keep its exact action as retry
+                // ownership until that call succeeds or reconciliation selects
+                // a different concrete mutation.
+                blocker = previous_blocker;
+                action = previous_action.expect("failed adapter action is retained");
+            }
             child.blocker = blocker;
             child.next_action = Some(action);
         }
@@ -495,15 +517,25 @@ impl AgentTaskFanoutPortfolio {
     ) -> Result<AgentTaskFanoutPortfolioRunReport> {
         let mut observations = Vec::new();
         let mut blocked = Vec::new();
+        let mut observation_failed = BTreeSet::new();
         let children = self.children.values().cloned().collect::<Vec<_>>();
         for child in &children {
             match adapter.observe(child) {
                 Ok(observation) => observations.push(observation),
                 Err(error) => {
-                    self.children
+                    let durable_child = self
+                        .children
                         .get_mut(&child.child_id)
-                        .expect("child exists")
-                        .blocker = Some(adapter_blocker(child, "adapter_observe_failed", &error));
+                        .expect("child exists");
+                    if !durable_child
+                        .blocker
+                        .as_ref()
+                        .is_some_and(|blocker| blocker.code == "adapter_action_failed")
+                    {
+                        durable_child.blocker =
+                            Some(adapter_blocker(child, "adapter_observe_failed", &error));
+                    }
+                    observation_failed.insert(child.child_id.clone());
                     blocked.push(child.child_id.clone());
                 }
             }
@@ -516,7 +548,14 @@ impl AgentTaskFanoutPortfolio {
             let Some(action) = child.next_action.clone() else {
                 continue;
             };
-            if child.blocker.is_some() {
+            if observation_failed.contains(&child_id) {
+                continue;
+            }
+            if child
+                .blocker
+                .as_ref()
+                .is_some_and(|blocker| blocker.code != "adapter_action_failed")
+            {
                 blocked.push(child.child_id.clone());
                 continue;
             }
@@ -550,6 +589,16 @@ impl AgentTaskFanoutPortfolio {
                 blocked.push(child_id);
                 continue;
             }
+            if self.children[&child_id]
+                .blocker
+                .as_ref()
+                .is_some_and(|blocker| blocker.code == "adapter_action_failed")
+            {
+                self.children
+                    .get_mut(&child_id)
+                    .expect("child exists")
+                    .blocker = None;
+            }
             advanced.push(child_id);
         }
         // Re-observe after every mutation batch, then persist one convergent
@@ -561,10 +610,18 @@ impl AgentTaskFanoutPortfolio {
             match adapter.observe(child) {
                 Ok(observation) => observations.push(observation),
                 Err(error) => {
-                    self.children
+                    let durable_child = self
+                        .children
                         .get_mut(&child.child_id)
-                        .expect("child exists")
-                        .blocker = Some(adapter_blocker(child, "adapter_observe_failed", &error));
+                        .expect("child exists");
+                    if !durable_child
+                        .blocker
+                        .as_ref()
+                        .is_some_and(|blocker| blocker.code == "adapter_action_failed")
+                    {
+                        durable_child.blocker =
+                            Some(adapter_blocker(child, "adapter_observe_failed", &error));
+                    }
                     if !blocked.contains(&child.child_id) {
                         blocked.push(child.child_id.clone());
                     }
@@ -613,15 +670,24 @@ pub fn write_portfolio(portfolio: &AgentTaskFanoutPortfolio) -> Result<()> {
     .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))
 }
 
-/// Serialize every mutating resume for one fanout. This lock is deliberately
-/// outside the batch receipt lock: resume may take that narrower lock while
-/// persisting exact effects, but no receipt path acquires this lock in reverse.
-pub fn with_portfolio_resume_lock<T>(
-    fanout_id: &str,
-    operation: impl FnOnce() -> Result<T>,
-) -> Result<T> {
+/// Durable outer ownership for every live coordinator and mutating resume of a
+/// fanout. Receipt paths may take narrower locks while this guard is held, but
+/// no receipt path acquires this fence in reverse.
+pub struct FanoutOwnershipFence {
+    lock: std::fs::File,
+}
+
+impl Drop for FanoutOwnershipFence {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.lock);
+    }
+}
+
+pub fn acquire_fanout_ownership_fence(fanout_id: &str) -> Result<FanoutOwnershipFence> {
+    // Preserve the original path so coordinators also contend with resumes from
+    // binaries that predate the shared ownership name.
     let path = portfolio_path(fanout_id)?.with_extension("resume.lock");
-    let parent = path.parent().expect("portfolio resume lock has parent");
+    let parent = path.parent().expect("fanout ownership lock has parent");
     homeboy_core::engine::local_files::create_dir_all_durably(parent)?;
     let lock = OpenOptions::new()
         .create(true)
@@ -631,9 +697,15 @@ pub fn with_portfolio_resume_lock<T>(
         .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
     lock.lock_exclusive()
         .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
-    let result = operation();
-    let _ = FileExt::unlock(&lock);
-    result
+    Ok(FanoutOwnershipFence { lock })
+}
+
+pub fn with_portfolio_resume_lock<T>(
+    fanout_id: &str,
+    operation: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    let _fence = acquire_fanout_ownership_fence(fanout_id)?;
+    operation()
 }
 
 pub fn read_portfolio(fanout_id: &str) -> Result<AgentTaskFanoutPortfolio> {
@@ -982,6 +1054,7 @@ mod tests {
         observations: BTreeMap<String, AgentTaskFanoutPortfolioObservation>,
         actions: Vec<String>,
         fail_observe: BTreeSet<String>,
+        fail_action: BTreeSet<String>,
     }
 
     impl FanoutPortfolioAdapter for FixtureAdapter {
@@ -1026,6 +1099,9 @@ mod tests {
                 if force_with_lease { "-lease" } else { "" },
                 child.child_id
             ));
+            if self.fail_action.contains(&child.child_id) {
+                return Err(Error::internal_unexpected("fixture action failed"));
+            }
             self.observations.get_mut(&child.child_id).unwrap().pr = AgentTaskFanoutPrState::Merged;
             Ok(())
         }
@@ -1067,6 +1143,94 @@ mod tests {
             assert_eq!(second.advanced, vec!["stale"]);
             assert_eq!(second.blocked, vec!["dirty"]);
             assert_eq!(adapter.actions.last(), Some(&"pr:stale".to_string()));
+        });
+    }
+
+    #[test]
+    fn failed_action_retains_exact_retry_ownership_through_reobservation() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut portfolio = AgentTaskFanoutPortfolio::new("failed-action", [child("child")]);
+            let mut adapter = FixtureAdapter::default();
+            adapter
+                .observations
+                .insert("child".into(), observation("child"));
+            adapter.fail_action.insert("child".into());
+
+            let report = portfolio
+                .run(&mut adapter, &IndependentFanoutDependencies)
+                .expect("failed action is persisted as portfolio state");
+
+            assert_eq!(report.blocked, vec!["child"]);
+            let durable = read_portfolio("failed-action").unwrap();
+            assert_eq!(
+                durable.children["child"].blocker.as_ref().unwrap().code,
+                "adapter_action_failed"
+            );
+            assert_eq!(
+                durable.children["child"].next_action,
+                Some(AgentTaskFanoutPortfolioAction::ResumeFinalization)
+            );
+
+            adapter.fail_action.clear();
+            adapter.fail_observe.insert("child".into());
+            let mut unavailable = durable;
+            unavailable
+                .run(&mut adapter, &IndependentFanoutDependencies)
+                .expect("observation outage retains the exact failed action");
+            assert_eq!(adapter.actions, vec!["pr:child"]);
+            let retained = read_portfolio("failed-action").unwrap();
+            assert_eq!(
+                retained.children["child"].blocker.as_ref().unwrap().code,
+                "adapter_action_failed"
+            );
+            assert_eq!(
+                retained.children["child"].next_action,
+                Some(AgentTaskFanoutPortfolioAction::ResumeFinalization)
+            );
+
+            adapter.fail_observe.clear();
+            let mut resumed = retained;
+            resumed
+                .run(&mut adapter, &IndependentFanoutDependencies)
+                .expect("the exact failed action remains retryable");
+            let converged = read_portfolio("failed-action").unwrap();
+            assert!(converged.children["child"].blocker.is_none());
+            assert_eq!(
+                converged.children["child"].next_action,
+                Some(AgentTaskFanoutPortfolioAction::None)
+            );
+        });
+    }
+
+    #[test]
+    fn live_coordinator_and_resume_share_one_ownership_fence() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let (coordinator_entered_tx, coordinator_entered_rx) = mpsc::channel();
+            let (resume_attempted_tx, resume_attempted_rx) = mpsc::channel();
+            let (resume_entered_tx, resume_entered_rx) = mpsc::channel();
+            let (release_tx, release_rx) = mpsc::channel();
+
+            let coordinator = std::thread::spawn(move || -> Result<()> {
+                let _fence = acquire_fanout_ownership_fence("coordinator-resume-race")?;
+                coordinator_entered_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+                Ok(())
+            });
+            coordinator_entered_rx.recv().unwrap();
+
+            let resume = std::thread::spawn(move || -> Result<()> {
+                resume_attempted_tx.send(()).unwrap();
+                let _fence = acquire_fanout_ownership_fence("coordinator-resume-race")?;
+                resume_entered_tx.send(()).unwrap();
+                Ok(())
+            });
+            resume_attempted_rx.recv().unwrap();
+            assert!(resume_entered_rx.try_recv().is_err());
+
+            release_tx.send(()).unwrap();
+            coordinator.join().unwrap().unwrap();
+            resume_entered_rx.recv().unwrap();
+            resume.join().unwrap().unwrap();
         });
     }
 
@@ -1226,6 +1390,7 @@ mod tests {
                 observations: [("child".to_string(), state)].into_iter().collect(),
                 actions: Vec::new(),
                 fail_observe: BTreeSet::new(),
+                fail_action: BTreeSet::new(),
             };
 
             portfolio
@@ -1250,6 +1415,7 @@ mod tests {
                 .collect(),
                 actions: Vec::new(),
                 fail_observe: BTreeSet::new(),
+                fail_action: BTreeSet::new(),
             };
             adapter.observations.get_mut("bad").unwrap().worktree =
                 AgentTaskFanoutWorktreeState::Dirty;

--- a/crates/homeboy-agents/src/agent_task_fanout_supervisor.rs
+++ b/crates/homeboy-agents/src/agent_task_fanout_supervisor.rs
@@ -5,10 +5,11 @@
 //! consumes its answer while reconciling otherwise independent children.
 
 use chrono::Utc;
+use fs4::fs_std::FileExt;
 use homeboy_core::{paths, Error, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs;
+use std::fs::{self, OpenOptions};
 
 pub const AGENT_TASK_FANOUT_PORTFOLIO_SCHEMA: &str = "homeboy/agent-task-fanout-portfolio/v1";
 pub const AGENT_TASK_FANOUT_PORTFOLIO_STATUS_SCHEMA: &str =
@@ -600,14 +601,39 @@ fn adapter_blocker(
 pub fn write_portfolio(portfolio: &AgentTaskFanoutPortfolio) -> Result<()> {
     let path = portfolio_path(&portfolio.fanout_id)?;
     let parent = path.parent().expect("portfolio path has parent");
-    fs::create_dir_all(parent).map_err(|error| {
-        Error::internal_io(error.to_string(), Some(parent.display().to_string()))
-    })?;
+    homeboy_core::engine::local_files::create_dir_all_durably(parent)?;
     let raw = serde_json::to_string_pretty(portfolio).map_err(|error| {
         Error::internal_json(error.to_string(), Some(portfolio.fanout_id.clone()))
     })?;
-    fs::write(&path, raw)
-        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))
+    homeboy_core::io::write_output_file_atomically(
+        &path,
+        raw,
+        homeboy_core::io::OutputWriteOptions::file(),
+    )
+    .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))
+}
+
+/// Serialize every mutating resume for one fanout. This lock is deliberately
+/// outside the batch receipt lock: resume may take that narrower lock while
+/// persisting exact effects, but no receipt path acquires this lock in reverse.
+pub fn with_portfolio_resume_lock<T>(
+    fanout_id: &str,
+    operation: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    let path = portfolio_path(fanout_id)?.with_extension("resume.lock");
+    let parent = path.parent().expect("portfolio resume lock has parent");
+    homeboy_core::engine::local_files::create_dir_all_durably(parent)?;
+    let lock = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(&path)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
+    lock.lock_exclusive()
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
+    let result = operation();
+    let _ = FileExt::unlock(&lock);
+    result
 }
 
 pub fn read_portfolio(fanout_id: &str) -> Result<AgentTaskFanoutPortfolio> {
@@ -800,6 +826,8 @@ fn portfolio_schema() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{mpsc, Arc, Mutex};
+    use std::time::Duration;
     fn child(id: &str) -> AgentTaskFanoutPortfolioChild {
         AgentTaskFanoutPortfolioChild {
             child_id: id.into(),
@@ -1039,6 +1067,107 @@ mod tests {
             assert_eq!(second.advanced, vec!["stale"]);
             assert_eq!(second.blocked, vec!["dirty"]);
             assert_eq!(adapter.actions.last(), Some(&"pr:stale".to_string()));
+        });
+    }
+
+    #[test]
+    fn concurrent_resumes_serialize_mutation_persistence_and_cleanup() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            write_portfolio(&AgentTaskFanoutPortfolio::new(
+                "concurrent-resumes",
+                [child("child")],
+            ))
+            .unwrap();
+            let observation = Arc::new(Mutex::new(observation("child")));
+            let mutations = Arc::new(Mutex::new(0_u8));
+            let cleanups = Arc::new(Mutex::new(0_u8));
+            let cleanup_receipt = Arc::new(Mutex::new(false));
+            let (entered_tx, entered_rx) = mpsc::channel();
+            let (release_tx, release_rx) = mpsc::channel();
+            let release_rx = Arc::new(Mutex::new(release_rx));
+
+            struct SharedAdapter {
+                observation: Arc<Mutex<AgentTaskFanoutPortfolioObservation>>,
+                mutations: Arc<Mutex<u8>>,
+            }
+            impl FanoutPortfolioAdapter for SharedAdapter {
+                fn observe(
+                    &mut self,
+                    _child: &AgentTaskFanoutPortfolioChild,
+                ) -> Result<AgentTaskFanoutPortfolioObservation> {
+                    Ok(self.observation.lock().unwrap().clone())
+                }
+                fn rebase_candidate(
+                    &mut self,
+                    _child: &AgentTaskFanoutPortfolioChild,
+                ) -> Result<()> {
+                    unreachable!()
+                }
+                fn recreate_candidate(
+                    &mut self,
+                    _child: &AgentTaskFanoutPortfolioChild,
+                ) -> Result<()> {
+                    unreachable!()
+                }
+                fn rerun_gates_and_review(
+                    &mut self,
+                    _child: &AgentTaskFanoutPortfolioChild,
+                ) -> Result<()> {
+                    unreachable!()
+                }
+                fn finalize_or_update_pr(
+                    &mut self,
+                    _child: &AgentTaskFanoutPortfolioChild,
+                    _force_with_lease: bool,
+                ) -> Result<()> {
+                    *self.mutations.lock().unwrap() += 1;
+                    self.observation.lock().unwrap().pr = AgentTaskFanoutPrState::Merged;
+                    Ok(())
+                }
+            }
+
+            let spawn_resume = |index: u8, wait_for_release: bool| {
+                let observation = Arc::clone(&observation);
+                let mutations = Arc::clone(&mutations);
+                let cleanups = Arc::clone(&cleanups);
+                let cleanup_receipt = Arc::clone(&cleanup_receipt);
+                let entered_tx = entered_tx.clone();
+                let release_rx = Arc::clone(&release_rx);
+                std::thread::spawn(move || {
+                    with_portfolio_resume_lock("concurrent-resumes", || {
+                        entered_tx.send(index).unwrap();
+                        if wait_for_release {
+                            release_rx.lock().unwrap().recv().unwrap();
+                        }
+                        let mut portfolio = read_portfolio("concurrent-resumes")?;
+                        portfolio.run(
+                            &mut SharedAdapter {
+                                observation,
+                                mutations,
+                            },
+                            &IndependentFanoutDependencies,
+                        )?;
+                        let mut receipt = cleanup_receipt.lock().unwrap();
+                        if !*receipt {
+                            *cleanups.lock().unwrap() += 1;
+                            *receipt = true;
+                        }
+                        Ok(())
+                    })
+                })
+            };
+            let first = spawn_resume(0, true);
+            assert_eq!(entered_rx.recv_timeout(Duration::from_secs(2)).unwrap(), 0);
+            let second = spawn_resume(1, false);
+            assert!(entered_rx.recv_timeout(Duration::from_millis(100)).is_err());
+            release_tx.send(()).unwrap();
+            assert_eq!(entered_rx.recv_timeout(Duration::from_secs(2)).unwrap(), 1);
+            for thread in [first, second] {
+                thread.join().unwrap().unwrap();
+            }
+            assert_eq!(*mutations.lock().unwrap(), 1);
+            assert_eq!(*cleanups.lock().unwrap(), 1);
+            assert_eq!(read_portfolio("concurrent-resumes").unwrap().revision, 4);
         });
     }
 

--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
@@ -2,7 +2,7 @@
 
 use super::runner_continuation::with_runner_continuation;
 use super::*;
-use homeboy_core::engine::local_files::write_json_file_owner_only;
+use homeboy_core::engine::local_files::{remove_file_durably, write_json_file_owner_only};
 use homeboy_core::workspace_claim::{
     WorkspaceClaim, WorkspaceClaimBinding, WorkspaceClaimStore, WorkspaceIdentity,
     WorkspaceOwnerLease, MAX_WORKSPACE_CLAIM_TTL_MS,
@@ -869,9 +869,7 @@ fn retry_pending_composite_workspace_cleanup(
         };
         match release_composite_workspace_claim(&mut claim)? {
             CompositeWorkspaceClaimRelease::Released => {
-                fs::remove_file(path).map_err(|error| {
-                    Error::internal_io(error.to_string(), Some("pending composite cleanup".into()))
-                })?;
+                remove_file_durably(&path, "pending composite cleanup")?;
                 Ok(CompositeWorkspaceCleanupStatus::Released)
             }
             CompositeWorkspaceClaimRelease::Partial { failures } => {
@@ -964,14 +962,7 @@ fn write_composite_acquisition_intent(intent: &CompositeAcquisitionIntent) -> Re
 
 fn remove_composite_acquisition_intent(workspace: &WorkspaceIdentity) -> Result<()> {
     let path = composite_acquisition_intent_path(workspace)?;
-    match fs::remove_file(&path) {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(Error::internal_io(
-            error.to_string(),
-            Some(path.display().to_string()),
-        )),
-    }
+    remove_file_durably(&path, &path.display().to_string())
 }
 
 fn composite_acquisition_intent_for_workspace(
@@ -1146,8 +1137,7 @@ fn quarantine_pending_composite_cleanup(
     };
     let quarantine_path = path.with_file_name(format!("{recovery_id}.quarantine.json"));
     write_json_file_owner_only(&quarantine_path, &quarantine)?;
-    fs::remove_file(path)
-        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))
+    remove_file_durably(path, &path.display().to_string())
 }
 
 fn quarantined_composite_cleanup_for_workspace(

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -2877,7 +2877,7 @@ pub fn run_cook_batch_with_control(
                         // reported, never silently dropped, so `total` and the
                         // per-child ordering are the same shape callers already
                         // join their own metadata onto.
-                        let cell = match claim_disposition(&batch_id, &cook, control) {
+                        let mut cell = match claim_disposition(&batch_id, &cook, control) {
                             ClaimDisposition::Run => {
                                 let result = (|| {
                                     let store = CookRecipeStore::from_current_data_root()?;
@@ -2925,11 +2925,20 @@ pub fn run_cook_batch_with_control(
                         // children. A replay that skips an unrecoverable child
                         // must still terminalize its batch slot.
                         if control.publish_child_terminalization {
-                            let _ = crate::agent_task_batch::record_child_finalization(
+                            if let Err(error) = crate::agent_task_batch::record_child_finalization(
                                 &batch_id,
                                 &cell.initial_run_id,
                                 child_finalization_value(&cell),
-                            );
+                            ) {
+                                // Cleanup cannot consume a successful outcome
+                                // until its batch checkpoint is durable.
+                                if cell.exit_code == 0 {
+                                    cell.status = "publication_persistence_failed".to_string();
+                                    cell.exit_code = 1;
+                                    cell.result = None;
+                                    cell.error = Some(AgentTaskCookCellError::from_error(&error));
+                                }
+                            }
                         }
                         let _ = tx.send((index, cell));
                     })

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -209,9 +209,9 @@ pub mod batch {
     pub use super::super::agent_task_batch::status;
     pub use super::super::agent_task_batch::{
         artifacts, claim_fanout_run_batch, fanout_dependency_graph_with_finalization_statuses,
-        heartbeat_fanout_run_batch, owned_child_run_ids, persist_fanout_run_batch,
-        provider_worktree_finalization_receipt, read_batch_record, record_fanout_run_batch_failure,
-        record_provider_worktree_finalization_receipt, start_fanout_run_batch,
+        finalize_provider_worktree_for_child, heartbeat_fanout_run_batch, owned_child_run_ids,
+        persist_fanout_run_batch, read_batch_record, record_fanout_run_batch_failure,
+        start_fanout_run_batch, BatchProviderWorktreeFinalization,
     };
     pub use super::super::agent_task_batch::{
         fanout_aggregate_state, record_fanout_run_batch_failed_admissions, submit_plan_batch,

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -211,7 +211,9 @@ pub mod batch {
         artifacts, claim_fanout_run_batch, fanout_dependency_graph_with_finalization_statuses,
         finalize_provider_worktree_for_child, heartbeat_fanout_run_batch, owned_child_run_ids,
         persist_fanout_run_batch, read_batch_record, record_fanout_run_batch_failure,
-        start_fanout_run_batch, BatchProviderWorktreeFinalization,
+        record_provider_worktree_finalization_deferred,
+        record_provider_worktree_finalization_preflight_error, start_fanout_run_batch,
+        BatchProviderWorktreeFinalization,
     };
     pub use super::super::agent_task_batch::{
         fanout_aggregate_state, record_fanout_run_batch_failed_admissions, submit_plan_batch,

--- a/crates/homeboy-agents/src/agent_tasks.rs
+++ b/crates/homeboy-agents/src/agent_tasks.rs
@@ -210,7 +210,8 @@ pub mod batch {
     pub use super::super::agent_task_batch::{
         artifacts, claim_fanout_run_batch, fanout_dependency_graph_with_finalization_statuses,
         heartbeat_fanout_run_batch, owned_child_run_ids, persist_fanout_run_batch,
-        read_batch_record, record_fanout_run_batch_failure, start_fanout_run_batch,
+        provider_worktree_finalization_receipt, read_batch_record, record_fanout_run_batch_failure,
+        record_provider_worktree_finalization_receipt, start_fanout_run_batch,
     };
     pub use super::super::agent_task_batch::{
         fanout_aggregate_state, record_fanout_run_batch_failed_admissions, submit_plan_batch,

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -546,12 +546,12 @@ fn batch_resume(args: AgentTaskFanoutBatchStatusArgs, placement: Placement) -> C
         Arc::new(provider::ExtensionProviderAgentTaskExecutor::discover()),
         crate::commands::infra::route::reconstruct_cook_attempt_dispatcher,
     )?;
-    finalize_resumed_provider_worktrees(&args.batch_id)?;
+    finalize_resumed_provider_worktrees(&args.batch_id, Some(&result.value))?;
     reconcile_fanout_pr_states(&args.batch_id, true)?;
     let exit_code = result.exit_code;
     let batch = batch::read_batch_record(&args.batch_id)?;
     let portfolio = run_portfolio(&batch)?;
-    finalize_resumed_provider_worktrees(&args.batch_id)?;
+    finalize_resumed_provider_worktrees(&args.batch_id, None)?;
     Ok(batch_resume_result(
         result.value,
         exit_code,
@@ -1872,28 +1872,74 @@ fn finalize_provider_worktrees(
     first_error.map_or(Ok(()), Err)
 }
 
-fn finalize_resumed_provider_worktrees(batch_id: &str) -> Result<()> {
+fn finalize_resumed_provider_worktrees(
+    batch_id: &str,
+    resumed: Option<&agent_task_service::AgentTaskCookBatchReport>,
+) -> Result<()> {
     let batch = batch::read_batch_record(batch_id)?;
     let config = homeboy::core::defaults::load_config();
     let mut first_error = None;
     for child in &batch.child_runs {
-        let disposition = match child.state {
-            agent_task_lifecycle::AgentTaskRunState::Succeeded => {
-                homeboy::core::worktree_provider::WorktreeTerminalDisposition::Succeeded
-            }
-            agent_task_lifecycle::AgentTaskRunState::PartialFailure
-            | agent_task_lifecycle::AgentTaskRunState::Failed
-            | agent_task_lifecycle::AgentTaskRunState::Cancelled => {
-                homeboy::core::worktree_provider::WorktreeTerminalDisposition::Failed
-            }
-            // Recoverable children still need Cook promotion, gates, and PR
-            // finalization before their provider workspace may be released.
-            agent_task_lifecycle::AgentTaskRunState::Queued
-            | agent_task_lifecycle::AgentTaskRunState::Running
-            | agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable
-            | agent_task_lifecycle::AgentTaskRunState::PartialRecoverable => continue,
-        };
         let result = (|| {
+            let live_state = || -> Result<Option<agent_task_lifecycle::AgentTaskRunState>> {
+                match agent_task_lifecycle::reconcile_status(&child.run_id) {
+                    Ok(current) => Ok(Some(current.state)),
+                    Err(error) if error.message.contains("agent-task run record not found") => {
+                        Ok(None)
+                    }
+                    Err(error) => Err(error),
+                }
+            };
+            let state = resumed
+                .and_then(|report| {
+                    report.cooks.iter().find(|cook| {
+                        cook.initial_run_id == child.run_id && cook.lifecycle().terminal
+                    })
+                })
+                .map(|cook| {
+                    if cook.exit_code == 0 {
+                        agent_task_lifecycle::AgentTaskRunState::Succeeded
+                    } else {
+                        agent_task_lifecycle::AgentTaskRunState::Failed
+                    }
+                })
+                .map_or_else(
+                    || {
+                        let live = live_state()?;
+                        let finalizable = |state| {
+                            matches!(
+                                state,
+                                agent_task_lifecycle::AgentTaskRunState::Succeeded
+                                    | agent_task_lifecycle::AgentTaskRunState::PartialFailure
+                                    | agent_task_lifecycle::AgentTaskRunState::Failed
+                                    | agent_task_lifecycle::AgentTaskRunState::Cancelled
+                            )
+                        };
+                        Ok::<_, Error>(match live {
+                            Some(state) if finalizable(state) => Some(state),
+                            _ if finalizable(child.state) => Some(child.state),
+                            state => state,
+                        })
+                    },
+                    |state| Ok(Some(state)),
+                )?;
+            let Some(state) = state else { return Ok(()) };
+            let disposition = match state {
+                agent_task_lifecycle::AgentTaskRunState::Succeeded => {
+                    homeboy::core::worktree_provider::WorktreeTerminalDisposition::Succeeded
+                }
+                agent_task_lifecycle::AgentTaskRunState::PartialFailure
+                | agent_task_lifecycle::AgentTaskRunState::Failed
+                | agent_task_lifecycle::AgentTaskRunState::Cancelled => {
+                    homeboy::core::worktree_provider::WorktreeTerminalDisposition::Failed
+                }
+                // Recoverable children still need Cook promotion, gates, and PR
+                // finalization before their provider workspace may be released.
+                agent_task_lifecycle::AgentTaskRunState::Queued
+                | agent_task_lifecycle::AgentTaskRunState::Running
+                | agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable
+                | agent_task_lifecycle::AgentTaskRunState::PartialRecoverable => return Ok(()),
+            };
             let recipe =
                 agent_task_service::load_recipe_for_attempt(&child.run_id)?.ok_or_else(|| {
                     Error::validation_invalid_argument(
@@ -6804,7 +6850,7 @@ mod tests {
         std::fs::write(
             &script,
             format!(
-                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  if [ \"$2\" = \"${{HOMEBOY_FAKE_PROVIDER_MISSING_HANDLE:-}}\" ]; then printf '{{\"worktrees\":[]}}\\n'; exit 0; fi\n  printf '{{\"worktrees\":[{{\"handle\":\"%s\",\"path\":\"{}\",\"branch\":\"fixture\",\"safety\":{{\"dirty\":{},\"unpushed\":false,\"primary\":false}}}}]}}\\n' \"$2\"\nelse\n  printf '%s|%s|%s|%s|%s|%s\\n' \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" \"$7\" >> '{}'\n  if [ \"$1\" = finalize ] && [ \"$2\" = \"${{HOMEBOY_FAKE_PROVIDER_FINALIZE_FAIL_HANDLE:-}}\" ]; then exit 1; fi\nfi\n",
+                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  if [ \"$2\" = \"${{HOMEBOY_FAKE_PROVIDER_MISSING_HANDLE:-}}\" ]; then printf '{{\"worktrees\":[]}}\\n'; exit 0; fi\n  printf '{{\"worktrees\":[{{\"handle\":\"%s\",\"path\":\"{}\",\"branch\":\"fixture\",\"safety\":{{\"dirty\":{},\"unpushed\":false,\"primary\":false}}}}]}}\\n' \"$2\"\nelse\n  printf '%s|%s|%s|%s|%s|%s\\n' \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" \"$7\" >> '{}'\n  if [ \"$1\" = finalize ] && {{ [ \"$2\" = \"${{HOMEBOY_FAKE_PROVIDER_FINALIZE_FAIL_HANDLE:-}}\" ] || [ \"${{HOMEBOY_FAKE_PROVIDER_FINALIZE_FAIL_HANDLE:-}}\" = '*' ]; }}; then exit 1; fi\nfi\n",
                 workspace.display(),
                 dirty,
                 records.display(),
@@ -6977,11 +7023,12 @@ mod tests {
             assert!(expected
                 .iter()
                 .all(|line| initial.matches(line).count() == 1));
+            assert_eq!(initial.lines().count(), 2);
 
             let error = {
                 let _fail = homeboy::core::test_support::EnvVarGuard::set(
                     "HOMEBOY_FAKE_PROVIDER_FINALIZE_FAIL_HANDLE",
-                    format!("homeboy@{}", plan.cooks[0].cook_id),
+                    "*",
                 );
                 batch_resume(
                     AgentTaskFanoutBatchStatusArgs {
@@ -6997,11 +7044,10 @@ mod tests {
             );
             let failed_resume =
                 std::fs::read_to_string(&records).expect("failed resume finalizations");
-            assert!(
-                expected
-                    .iter()
-                    .all(|line| failed_resume.matches(line).count() == 2),
-                "a first-child failure must not strand later provider finalization"
+            assert_eq!(
+                failed_resume.lines().count(),
+                4,
+                "one provider failure must not strand later child finalization"
             );
 
             batch_resume(
@@ -7012,9 +7058,56 @@ mod tests {
             )
             .expect("idempotent command-path resume");
             let converged = std::fs::read_to_string(records).expect("converged finalizations");
-            assert!(expected
-                .iter()
-                .all(|line| converged.matches(line).count() == 4));
+            assert_eq!(converged.lines().count(), 8);
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn batch_resume_finalizes_live_terminal_children_despite_a_stale_running_roster() {
+        with_isolated_home(|home| {
+            install_fanout_agent_task_providers(home.path());
+            let (_fixture, records, mut plan) = provider_finalization_fixture(false);
+            plan.cooks.truncate(1);
+            let cook = &plan.cooks[0];
+            let dispatcher: &CookAttemptDispatcherFactory =
+                &|_| std::sync::Arc::new(FailingFanoutDispatcher);
+            run_batch_cook_fanout_plan_with_attempt_dispatcher(plan.clone(), dispatcher)
+                .expect("initial dispatcher fanout result");
+            let recipe = agent_task_service::load_recipe_for_attempt(&cook.run_id())
+                .expect("load durable recipe")
+                .expect("durable recipe");
+            let durable_handle = recipe.finalization["to_worktree"]
+                .as_str()
+                .expect("durable provider handle");
+            let expected = format!(
+                "{durable_handle}|agent_task_cook|{}|remove_on_success|failed|finalize:{}",
+                cook.run_id(),
+                cook.run_id(),
+            );
+            let before = std::fs::read_to_string(&records).expect("initial finalizations");
+
+            homeboy::agents::agent_task_batch::AgentTaskBatchStore::from_current_data_root()
+                .expect("batch store")
+                .mutate_batch(&plan.fanout_id, |batch| {
+                    batch.child_runs[0].state = agent_task_lifecycle::AgentTaskRunState::Running;
+                    Ok(())
+                })
+                .expect("make durable roster stale before command-path resume");
+            batch_resume(
+                AgentTaskFanoutBatchStatusArgs {
+                    batch_id: plan.fanout_id.clone(),
+                },
+                Placement::Auto,
+            )
+            .expect("resume reconciles live child lifecycle state");
+
+            let after = std::fs::read_to_string(records).expect("resumed finalizations");
+            assert_eq!(
+                after.matches(&expected).count(),
+                before.matches(&expected).count() + 2,
+                "both pre- and post-portfolio passes must use live terminal child state"
+            );
         });
     }
 

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -1672,9 +1672,6 @@ fn run_batch_cook_fanout_plan_with_attempt_dispatcher_claim(
         Some(claim) => claim,
         None => claim_fanout_run_batch_coordinator(&plan, placement)?,
     };
-    let previously_terminal = retry
-        .then(|| durable_terminal_worktree_paths(&plan))
-        .transpose()?;
     let outcome = (|| {
         let heartbeat = CoordinatorHeartbeat::start(
             plan.fanout_id.clone(),
@@ -1708,7 +1705,7 @@ fn run_batch_cook_fanout_plan_with_attempt_dispatcher_claim(
         });
         heartbeat.finish()?;
         let result = result?;
-        finalize_provider_worktrees(&plan, &result.value, previously_terminal.as_ref())?;
+        finalize_provider_worktrees(&plan, &result.value)?;
         record_terminal_batch_admission_failures(&plan, &result.value)?;
         notify_batch_wave_complete(&plan.fanout_id, &result.value, result.exit_code);
         let result = batch_cook_result(&plan, result, &concurrency);
@@ -1744,9 +1741,6 @@ fn run_batch_cook_fanout_plan_with_executor_claim(
         Some(claim) => claim,
         None => claim_fanout_run_batch_coordinator(&plan, placement)?,
     };
-    let previously_terminal = retry
-        .then(|| durable_terminal_worktree_paths(&plan))
-        .transpose()?;
     let outcome = (|| {
         let heartbeat = CoordinatorHeartbeat::start(
             plan.fanout_id.clone(),
@@ -1777,7 +1771,7 @@ fn run_batch_cook_fanout_plan_with_executor_claim(
         });
         heartbeat.finish()?;
         let result = result?;
-        finalize_provider_worktrees(&plan, &result.value, previously_terminal.as_ref())?;
+        finalize_provider_worktrees(&plan, &result.value)?;
         record_terminal_batch_admission_failures(&plan, &result.value)?;
         notify_batch_wave_complete(&plan.fanout_id, &result.value, result.exit_code);
         let result = batch_cook_result(&plan, result, &concurrency);
@@ -1841,7 +1835,6 @@ fn record_gate_contract_validation(options: &mut CookRequest, validation: &GateC
 fn finalize_provider_worktrees(
     plan: &BatchCookFanoutPlan,
     report: &agent_task_service::AgentTaskCookBatchReport,
-    previously_terminal: Option<&BTreeMap<String, String>>,
 ) -> Result<()> {
     let config = homeboy::core::defaults::load_config();
     let mut first_error = None;
@@ -1862,34 +1855,14 @@ fn finalize_provider_worktrees(
             homeboy::core::worktree_provider::WorktreeTerminalDisposition::Failed
         };
         let result = (|| {
-            let finalization = homeboy::core::worktree_provider::finalize_worktree_from_config(
+            finalize_fanout_provider_worktree(
+                &plan.fanout_id,
+                &cook.run_id(),
                 &cook.to_worktree,
-                &homeboy::core::worktree_provider::WorktreeProvisionLifecycle {
-                    purpose: "agent_task_cook".to_string(),
-                    owner_run_ref: cook.run_id(),
-                    cleanup_policy:
-                        homeboy::core::worktree_provider::WorktreeCleanupPolicy::RemoveOnSuccess,
-                },
+                &cook.run_id(),
                 disposition,
                 &config,
-            )?;
-            let not_found = matches!(
-                finalization,
-                homeboy::core::worktree_provider::WorktreeFinalizationLookup::NotFound
-            );
-            if not_found
-                && configured_provider_workspace_creation()?
-                && !previously_terminal
-                    .is_some_and(|terminal| terminal.contains_key(&cook.run_id()))
-            {
-                return Err(
-                    homeboy::core::worktree_provider::worktree_finalization_not_found_error(
-                        &cook.to_worktree,
-                        &config,
-                    ),
-                );
-            }
-            Ok(())
+            )
         })();
         if let Err(error) = result {
             first_error.get_or_insert(error);
@@ -1948,24 +1921,94 @@ fn finalize_resumed_provider_worktrees(batch_id: &str) -> Result<()> {
                         None,
                     )
                 })?;
-            homeboy::core::worktree_provider::finalize_worktree_from_config(
+            finalize_fanout_provider_worktree(
+                batch_id,
+                &child.run_id,
                 handle,
-                &homeboy::core::worktree_provider::WorktreeProvisionLifecycle {
-                    purpose: "agent_task_cook".to_string(),
-                    owner_run_ref: owner,
-                    cleanup_policy:
-                        homeboy::core::worktree_provider::WorktreeCleanupPolicy::RemoveOnSuccess,
-                },
+                &owner,
                 disposition,
                 &config,
-            )?;
-            Ok(())
+            )
         })();
         if let Err(error) = result {
             first_error.get_or_insert(error);
         }
     }
     first_error.map_or(Ok(()), Err)
+}
+
+fn finalize_fanout_provider_worktree(
+    batch_id: &str,
+    child_run_id: &str,
+    handle: &str,
+    owner: &str,
+    disposition: homeboy::core::worktree_provider::WorktreeTerminalDisposition,
+    config: &homeboy::core::defaults::HomeboyConfig,
+) -> Result<()> {
+    let receipt = provider_worktree_finalization_receipt(batch_id, child_run_id)?;
+    let receipt_matches = receipt.as_ref().is_some_and(|receipt| {
+        receipt["schema"] == "homeboy/agent-task-provider-worktree-finalization/v1"
+            && receipt["handle"] == handle
+            && receipt["owner_run_ref"] == owner
+            && receipt["disposition"] == disposition.as_str()
+    });
+    let finalization = homeboy::core::worktree_provider::finalize_worktree_from_config(
+        handle,
+        &homeboy::core::worktree_provider::WorktreeProvisionLifecycle {
+            purpose: "agent_task_cook".to_string(),
+            owner_run_ref: owner.to_string(),
+            cleanup_policy:
+                homeboy::core::worktree_provider::WorktreeCleanupPolicy::RemoveOnSuccess,
+        },
+        disposition,
+        config,
+    )?;
+    match finalization {
+        homeboy::core::worktree_provider::WorktreeFinalizationLookup::Finalized(finalized) => {
+            record_provider_worktree_finalization_receipt(
+                batch_id,
+                child_run_id,
+                serde_json::json!({
+                    "schema": "homeboy/agent-task-provider-worktree-finalization/v1",
+                    "handle": handle,
+                    "owner_run_ref": owner,
+                    "disposition": disposition.as_str(),
+                    "provider_id": finalized.provider_id,
+                }),
+            )
+        }
+        homeboy::core::worktree_provider::WorktreeFinalizationLookup::NotFound
+            if receipt_matches =>
+        {
+            Ok(())
+        }
+        homeboy::core::worktree_provider::WorktreeFinalizationLookup::NotFound
+            if configured_provider_workspace_creation()? =>
+        {
+            Err(
+                homeboy::core::worktree_provider::worktree_finalization_not_found_error(
+                    handle, config,
+                ),
+            )
+        }
+        homeboy::core::worktree_provider::WorktreeFinalizationLookup::NotFound
+        | homeboy::core::worktree_provider::WorktreeFinalizationLookup::Unsupported => Ok(()),
+    }
+}
+
+fn provider_worktree_finalization_receipt(
+    batch_id: &str,
+    child_run_id: &str,
+) -> Result<Option<Value>> {
+    batch::provider_worktree_finalization_receipt(batch_id, child_run_id)
+}
+
+fn record_provider_worktree_finalization_receipt(
+    batch_id: &str,
+    child_run_id: &str,
+    receipt: Value,
+) -> Result<()> {
+    batch::record_provider_worktree_finalization_receipt(batch_id, child_run_id, receipt)
 }
 
 /// HOOK — wave-completion notification. Intentionally not implemented here.
@@ -6796,7 +6839,7 @@ mod tests {
         std::fs::write(
             &script,
             format!(
-                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  printf '{{\"worktrees\":[{{\"handle\":\"%s\",\"path\":\"{}\",\"branch\":\"fixture\",\"safety\":{{\"dirty\":{},\"unpushed\":false,\"primary\":false}}}}]}}\\n' \"$2\"\nelse\n  printf '%s|%s|%s|%s|%s|%s\\n' \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" \"$7\" >> '{}'\n  if [ \"$1\" = finalize ] && [ \"$2\" = \"${{HOMEBOY_FAKE_PROVIDER_FINALIZE_FAIL_HANDLE:-}}\" ]; then exit 1; fi\nfi\n",
+                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  if [ \"$2\" = \"${{HOMEBOY_FAKE_PROVIDER_MISSING_HANDLE:-}}\" ]; then printf '{{\"worktrees\":[]}}\\n'; exit 0; fi\n  printf '{{\"worktrees\":[{{\"handle\":\"%s\",\"path\":\"{}\",\"branch\":\"fixture\",\"safety\":{{\"dirty\":{},\"unpushed\":false,\"primary\":false}}}}]}}\\n' \"$2\"\nelse\n  printf '%s|%s|%s|%s|%s|%s\\n' \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" \"$7\" >> '{}'\n  if [ \"$1\" = finalize ] && [ \"$2\" = \"${{HOMEBOY_FAKE_PROVIDER_FINALIZE_FAIL_HANDLE:-}}\" ]; then exit 1; fi\nfi\n",
                 workspace.display(),
                 dirty,
                 records.display(),
@@ -6853,6 +6896,40 @@ mod tests {
         (fixture, records, plan)
     }
 
+    fn persist_provider_finalization_test_batch(plan: &BatchCookFanoutPlan) {
+        let children = plan
+            .cooks
+            .iter()
+            .map(|cook| batch::FanoutRunBatchChild {
+                task_id: cook.cook_id.clone(),
+                run_id: cook.run_id(),
+            })
+            .collect::<Vec<_>>();
+        batch::persist_fanout_run_batch(
+            &plan.fanout_id,
+            &plan.fanout_id,
+            &children,
+            serde_json::json!({}),
+        )
+        .expect("persist provider finalization test batch");
+    }
+
+    struct TestCurrentDirGuard(PathBuf);
+
+    impl TestCurrentDirGuard {
+        fn set(path: &Path) -> Self {
+            let previous = std::env::current_dir().expect("current directory");
+            std::env::set_current_dir(path).expect("set current directory");
+            Self(previous)
+        }
+    }
+
+    impl Drop for TestCurrentDirGuard {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.0).expect("restore current directory");
+        }
+    }
+
     #[cfg(unix)]
     #[test]
     fn dispatcher_fanout_terminalization_finalizes_success_and_failure_provider_records() {
@@ -6885,9 +6962,9 @@ mod tests {
                     )
                     .collect(),
             };
+            persist_provider_finalization_test_batch(&plan);
 
-            finalize_provider_worktrees(&plan, &report, None)
-                .expect("dispatcher fanout terminalization");
+            finalize_provider_worktrees(&plan, &report).expect("dispatcher fanout terminalization");
 
             let records = std::fs::read_to_string(records).expect("provider finalization records");
             assert!(records.contains(&format!(
@@ -6978,6 +7055,107 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn batch_resume_refuses_provider_finalization_from_its_live_workspace() {
+        with_isolated_home(|home| {
+            install_fanout_agent_task_providers(home.path());
+            let (fixture, records, mut plan) = provider_finalization_fixture(false);
+            plan.cooks.truncate(1);
+            let dispatcher: &CookAttemptDispatcherFactory =
+                &|_| std::sync::Arc::new(FailingFanoutDispatcher);
+            run_batch_cook_fanout_plan_with_attempt_dispatcher(plan.clone(), dispatcher)
+                .expect("initial dispatcher fanout result");
+
+            let nested = fixture.path().join("workspace/nested");
+            std::fs::create_dir(&nested).expect("nested provider workspace directory");
+            let error = {
+                let _cwd = TestCurrentDirGuard::set(&nested);
+                batch_resume(
+                    AgentTaskFanoutBatchStatusArgs {
+                        batch_id: plan.fanout_id.clone(),
+                    },
+                    Placement::Auto,
+                )
+                .expect_err("live provider workspace blocks resume finalization")
+            };
+
+            assert!(
+                error.message.contains("live current working directory"),
+                "unexpected resume error: {error:?}"
+            );
+            let records = std::fs::read_to_string(records).expect("provider finalizations");
+            assert_eq!(records.lines().count(), 1, "blocked finalizer must not run");
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn batch_resume_accepts_missing_provider_workspace_only_with_durable_receipt() {
+        with_isolated_home(|home| {
+            install_fanout_agent_task_providers(home.path());
+            let (_fixture, records, plan) = provider_finalization_fixture(false);
+            let cook = &plan.cooks[0];
+            let dispatcher: &CookAttemptDispatcherFactory =
+                &|_| std::sync::Arc::new(FailingFanoutDispatcher);
+            run_batch_cook_fanout_plan_with_attempt_dispatcher(plan.clone(), dispatcher)
+                .expect("initial dispatcher fanout result");
+            let recipe = agent_task_service::load_recipe_for_attempt(&cook.run_id())
+                .expect("load durable recipe")
+                .expect("durable recipe");
+            let durable_handle = recipe.finalization["to_worktree"]
+                .as_str()
+                .expect("durable provider handle");
+            let _missing = homeboy::core::test_support::EnvVarGuard::set(
+                "HOMEBOY_FAKE_PROVIDER_MISSING_HANDLE",
+                durable_handle,
+            );
+            record_provider_worktree_finalization_receipt(
+                &plan.fanout_id,
+                &cook.run_id(),
+                serde_json::json!({"schema": "untrusted/receipt"}),
+            )
+            .expect("replace receipt with malformed evidence");
+            let error = batch_resume(
+                AgentTaskFanoutBatchStatusArgs {
+                    batch_id: plan.fanout_id.clone(),
+                },
+                Placement::Auto,
+            )
+            .expect_err("first missing lookup has no finalization evidence");
+            assert!(
+                error.message.contains("not a Homeboy task worktree"),
+                "unexpected resume error: {error:?}"
+            );
+
+            record_provider_worktree_finalization_receipt(
+                &plan.fanout_id,
+                &cook.run_id(),
+                serde_json::json!({
+                    "schema": "homeboy/agent-task-provider-worktree-finalization/v1",
+                    "handle": durable_handle,
+                    "owner_run_ref": cook.run_id(),
+                    "disposition": "failed",
+                    "provider_id": "fixture",
+                }),
+            )
+            .expect("restore durable receipt");
+            batch_resume(
+                AgentTaskFanoutBatchStatusArgs {
+                    batch_id: plan.fanout_id.clone(),
+                },
+                Placement::Auto,
+            )
+            .expect("receipt proves idempotent missing-workspace replay");
+            let records = std::fs::read_to_string(records).expect("provider finalizations");
+            assert_eq!(
+                records.lines().count(),
+                4,
+                "the missing child must not mutate while its sibling continues on each resume"
+            );
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn dispatcher_fanout_finalizes_a_terminal_provider_owned_dirty_candidate() {
         with_isolated_home(|_| {
             let (_fixture, records, mut plan) = provider_finalization_fixture(true);
@@ -7003,8 +7181,9 @@ mod tests {
                     error: None,
                 }],
             };
+            persist_provider_finalization_test_batch(&plan);
 
-            finalize_provider_worktrees(&plan, &report, None)
+            finalize_provider_worktrees(&plan, &report)
                 .expect("terminal owner may finalize its dirty candidate");
 
             let records = std::fs::read_to_string(records).expect("provider finalization record");
@@ -7109,9 +7288,9 @@ mod tests {
                     error: None,
                 }],
             };
+            persist_provider_finalization_test_batch(&plan);
 
-            finalize_provider_worktrees(&plan, &report, None)
-                .expect("native terminal finalization");
+            finalize_provider_worktrees(&plan, &report).expect("native terminal finalization");
             let record = homeboy::core::worktree::resolve(&plan.cooks[0].to_worktree)
                 .expect("native record");
             assert_eq!(

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -1854,9 +1854,6 @@ fn finalize_provider_worktrees(
         else {
             continue;
         };
-        if previously_terminal.is_some_and(|terminal| terminal.contains_key(&cook.run_id())) {
-            continue;
-        }
         let disposition = if cell.exit_code == 0 {
             homeboy::core::worktree_provider::WorktreeTerminalDisposition::Succeeded
         } else {
@@ -1873,10 +1870,13 @@ fn finalize_provider_worktrees(
             disposition,
             &config,
         )?;
-        if matches!(
+        let not_found = matches!(
             finalization,
             homeboy::core::worktree_provider::WorktreeFinalizationLookup::NotFound
-        ) && configured_provider_workspace_creation()?
+        );
+        if not_found
+            && configured_provider_workspace_creation()?
+            && !previously_terminal.is_some_and(|terminal| terminal.contains_key(&cook.run_id()))
         {
             return Err(
                 homeboy::core::worktree_provider::worktree_finalization_not_found_error(
@@ -6823,6 +6823,58 @@ mod tests {
                 plan.cooks[1].run_id(),
                 plan.cooks[1].run_id(),
             )));
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dispatcher_fanout_terminalization_replays_provider_finalization_on_recovery() {
+        with_isolated_home(|_| {
+            let (_fixture, records, mut plan) = provider_finalization_fixture(false);
+            plan.cooks.truncate(1);
+            let cook = &plan.cooks[0];
+            let report = agent_task_service::AgentTaskCookBatchReport {
+                schema: "homeboy/agent-task-cook-batch/v1",
+                batch_id: plan.fanout_id.clone(),
+                status: "succeeded".to_string(),
+                total: 1,
+                queued: 0,
+                running: 0,
+                succeeded: 1,
+                failed: 0,
+                cancelled: 0,
+                timed_out: 0,
+                cooks: vec![agent_task_service::AgentTaskCookBatchCellReport {
+                    cook_id: cook.cook_id.clone(),
+                    initial_run_id: cook.run_id(),
+                    status: "succeeded".to_string(),
+                    exit_code: 0,
+                    result: None,
+                    error: None,
+                }],
+            };
+
+            finalize_provider_worktrees(&plan, &report, None).expect("initial finalization");
+            finalize_provider_worktrees(&plan, &report, None)
+                .expect("recovered finalization replay");
+
+            let expected = format!(
+                "homeboy@{}|agent_task_cook|{}|remove_on_success|succeeded|finalize:{}",
+                cook.cook_id,
+                cook.run_id(),
+                cook.run_id(),
+            );
+            let records = std::fs::read_to_string(records).expect("provider finalization records");
+            assert_eq!(records.lines().filter(|line| *line == expected).count(), 2);
+
+            std::fs::remove_dir_all(_fixture.path().join("workspace"))
+                .expect("provider cleanup removed workspace");
+            let previously_terminal = BTreeMap::from([(
+                cook.run_id(),
+                _fixture.path().join("workspace").display().to_string(),
+            )]);
+            finalize_provider_worktrees(&plan, &report, Some(&previously_terminal))
+                .expect("missing finalized provider workspace is converged on recovery");
         });
     }
 

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -551,6 +551,7 @@ fn batch_resume(args: AgentTaskFanoutBatchStatusArgs, placement: Placement) -> C
     let exit_code = result.exit_code;
     let batch = batch::read_batch_record(&args.batch_id)?;
     let portfolio = run_portfolio(&batch)?;
+    finalize_resumed_provider_worktrees(&args.batch_id)?;
     Ok(batch_resume_result(
         result.value,
         exit_code,
@@ -1945,14 +1946,9 @@ fn finalize_fanout_provider_worktree(
     disposition: homeboy::core::worktree_provider::WorktreeTerminalDisposition,
     config: &homeboy::core::defaults::HomeboyConfig,
 ) -> Result<()> {
-    let receipt = provider_worktree_finalization_receipt(batch_id, child_run_id)?;
-    let receipt_matches = receipt.as_ref().is_some_and(|receipt| {
-        receipt["schema"] == "homeboy/agent-task-provider-worktree-finalization/v1"
-            && receipt["handle"] == handle
-            && receipt["owner_run_ref"] == owner
-            && receipt["disposition"] == disposition.as_str()
-    });
-    let finalization = homeboy::core::worktree_provider::finalize_worktree_from_config(
+    let finalization = batch::finalize_provider_worktree_for_child(
+        batch_id,
+        child_run_id,
         handle,
         &homeboy::core::worktree_provider::WorktreeProvisionLifecycle {
             purpose: "agent_task_cook".to_string(),
@@ -1964,25 +1960,7 @@ fn finalize_fanout_provider_worktree(
         config,
     )?;
     match finalization {
-        homeboy::core::worktree_provider::WorktreeFinalizationLookup::Finalized(finalized) => {
-            record_provider_worktree_finalization_receipt(
-                batch_id,
-                child_run_id,
-                serde_json::json!({
-                    "schema": "homeboy/agent-task-provider-worktree-finalization/v1",
-                    "handle": handle,
-                    "owner_run_ref": owner,
-                    "disposition": disposition.as_str(),
-                    "provider_id": finalized.provider_id,
-                }),
-            )
-        }
-        homeboy::core::worktree_provider::WorktreeFinalizationLookup::NotFound
-            if receipt_matches =>
-        {
-            Ok(())
-        }
-        homeboy::core::worktree_provider::WorktreeFinalizationLookup::NotFound
+        batch::BatchProviderWorktreeFinalization::NotFound
             if configured_provider_workspace_creation()? =>
         {
             Err(
@@ -1991,24 +1969,11 @@ fn finalize_fanout_provider_worktree(
                 ),
             )
         }
-        homeboy::core::worktree_provider::WorktreeFinalizationLookup::NotFound
-        | homeboy::core::worktree_provider::WorktreeFinalizationLookup::Unsupported => Ok(()),
+        batch::BatchProviderWorktreeFinalization::Finalized
+        | batch::BatchProviderWorktreeFinalization::Replayed
+        | batch::BatchProviderWorktreeFinalization::Unsupported
+        | batch::BatchProviderWorktreeFinalization::NotFound => Ok(()),
     }
-}
-
-fn provider_worktree_finalization_receipt(
-    batch_id: &str,
-    child_run_id: &str,
-) -> Result<Option<Value>> {
-    batch::provider_worktree_finalization_receipt(batch_id, child_run_id)
-}
-
-fn record_provider_worktree_finalization_receipt(
-    batch_id: &str,
-    child_run_id: &str,
-    receipt: Value,
-) -> Result<()> {
-    batch::record_provider_worktree_finalization_receipt(batch_id, child_run_id, receipt)
 }
 
 /// HOOK — wave-completion notification. Intentionally not implemented here.
@@ -7049,7 +7014,7 @@ mod tests {
             let converged = std::fs::read_to_string(records).expect("converged finalizations");
             assert!(expected
                 .iter()
-                .all(|line| converged.matches(line).count() == 3));
+                .all(|line| converged.matches(line).count() == 4));
         });
     }
 
@@ -7089,7 +7054,55 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn batch_resume_accepts_missing_provider_workspace_only_with_durable_receipt() {
+    fn provider_finalization_missing_without_receipt_fails_and_continues_children() {
+        with_isolated_home(|_| {
+            let (_fixture, records, plan) = provider_finalization_fixture(false);
+            persist_provider_finalization_test_batch(&plan);
+            let missing = &plan.cooks[0];
+            let _missing = homeboy::core::test_support::EnvVarGuard::set(
+                "HOMEBOY_FAKE_PROVIDER_MISSING_HANDLE",
+                &missing.to_worktree,
+            );
+            let report = agent_task_service::AgentTaskCookBatchReport {
+                schema: "homeboy/agent-task-cook-batch/v1",
+                batch_id: plan.fanout_id.clone(),
+                status: "failed".to_string(),
+                total: 2,
+                queued: 0,
+                running: 0,
+                succeeded: 0,
+                failed: 2,
+                cancelled: 0,
+                timed_out: 0,
+                cooks: plan
+                    .cooks
+                    .iter()
+                    .map(|cook| agent_task_service::AgentTaskCookBatchCellReport {
+                        cook_id: cook.cook_id.clone(),
+                        initial_run_id: cook.run_id(),
+                        status: "failed".to_string(),
+                        exit_code: 1,
+                        result: None,
+                        error: None,
+                    })
+                    .collect(),
+            };
+
+            let error = finalize_provider_worktrees(&plan, &report)
+                .expect_err("first missing lookup has no finalization evidence");
+            assert!(
+                error.message.contains("not a Homeboy task worktree"),
+                "unexpected finalization error: {error:?}"
+            );
+            let records = std::fs::read_to_string(records).expect("later child finalization");
+            assert!(records.contains(&plan.cooks[1].to_worktree));
+            assert!(!records.contains(&missing.to_worktree));
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn batch_resume_accepts_missing_provider_workspace_with_durable_receipt() {
         with_isolated_home(|home| {
             install_fanout_agent_task_providers(home.path());
             let (_fixture, records, plan) = provider_finalization_fixture(false);
@@ -7108,36 +7121,6 @@ mod tests {
                 "HOMEBOY_FAKE_PROVIDER_MISSING_HANDLE",
                 durable_handle,
             );
-            record_provider_worktree_finalization_receipt(
-                &plan.fanout_id,
-                &cook.run_id(),
-                serde_json::json!({"schema": "untrusted/receipt"}),
-            )
-            .expect("replace receipt with malformed evidence");
-            let error = batch_resume(
-                AgentTaskFanoutBatchStatusArgs {
-                    batch_id: plan.fanout_id.clone(),
-                },
-                Placement::Auto,
-            )
-            .expect_err("first missing lookup has no finalization evidence");
-            assert!(
-                error.message.contains("not a Homeboy task worktree"),
-                "unexpected resume error: {error:?}"
-            );
-
-            record_provider_worktree_finalization_receipt(
-                &plan.fanout_id,
-                &cook.run_id(),
-                serde_json::json!({
-                    "schema": "homeboy/agent-task-provider-worktree-finalization/v1",
-                    "handle": durable_handle,
-                    "owner_run_ref": cook.run_id(),
-                    "disposition": "failed",
-                    "provider_id": "fixture",
-                }),
-            )
-            .expect("restore durable receipt");
             batch_resume(
                 AgentTaskFanoutBatchStatusArgs {
                     batch_id: plan.fanout_id.clone(),

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -541,6 +541,14 @@ fn batch_status(args: AgentTaskFanoutBatchStatusArgs, placement: Placement) -> C
 /// contract, reconciling per-child state back into the durable batch record so
 /// repeated resume calls converge without duplicate PRs (#9525).
 fn batch_resume(args: AgentTaskFanoutBatchStatusArgs, placement: Placement) -> CmdResult<Value> {
+    let batch_id = args.batch_id.clone();
+    supervisor::with_portfolio_resume_lock(&batch_id, || batch_resume_locked(args, placement))
+}
+
+fn batch_resume_locked(
+    args: AgentTaskFanoutBatchStatusArgs,
+    placement: Placement,
+) -> CmdResult<Value> {
     let result = agent_task_service::resume_cook_batch(
         &args.batch_id,
         Arc::new(provider::ExtensionProviderAgentTaskExecutor::discover()),
@@ -906,7 +914,14 @@ fn load_portfolio(
     batch_record: &homeboy::agents::agent_tasks::AgentTaskBatchRecord,
 ) -> Result<supervisor::AgentTaskFanoutPortfolio> {
     match supervisor::read_portfolio(&batch_record.batch_id) {
-        Ok(portfolio) => Ok(portfolio),
+        Ok(mut portfolio) => {
+            for child in &batch_record.child_runs {
+                if let Some(portfolio_child) = portfolio.children.get_mut(&child.task_id) {
+                    portfolio_child.run_id.clone_from(&child.run_id);
+                }
+            }
+            Ok(portfolio)
+        }
         Err(_) if !supervisor::portfolio_exists(&batch_record.batch_id)? => {
             Ok(supervisor::AgentTaskFanoutPortfolio::new(
                 batch_record.batch_id.clone(),
@@ -1861,6 +1876,14 @@ fn finalize_provider_worktrees(
             }
             continue;
         };
+        if portfolio_vetoes_success_cleanup(&plan.fanout_id, &cook.run_id(), disposition)? {
+            batch::record_provider_worktree_finalization_deferred(
+                &plan.fanout_id,
+                &cook.run_id(),
+                "portfolio_retention_blocker",
+            )?;
+            continue;
+        }
         // Cleanup failures are durable lifecycle-operation failures. They must
         // not flow into the coordinator failure recorder and rewrite successful
         // children as failed.
@@ -1970,7 +1993,8 @@ fn finalize_resumed_provider_worktrees(
                     .metadata
                     .get("cook_finalization")
                     .and_then(|finalization| finalization.get("status"))
-                    .and_then(Value::as_str),
+                    .and_then(Value::as_str)
+                    .or(live_terminal_status),
                 None => resumed_cell.map(|cell| cell.status.as_str()),
             };
             let disposition = match state {
@@ -2000,6 +2024,14 @@ fn finalize_resumed_provider_worktrees(
                 | agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable
                 | agent_task_lifecycle::AgentTaskRunState::PartialRecoverable => return Ok(()),
             };
+            if portfolio_vetoes_success_cleanup(batch_id, &child.run_id, disposition)? {
+                batch::record_provider_worktree_finalization_deferred(
+                    batch_id,
+                    &child.run_id,
+                    "portfolio_retention_blocker",
+                )?;
+                return Ok(());
+            }
             let recipe =
                 agent_task_service::load_recipe_for_attempt(&child.run_id)?.ok_or_else(|| {
                     Error::validation_invalid_argument(
@@ -2047,6 +2079,34 @@ fn finalize_resumed_provider_worktrees(
         }
     }
     Ok(())
+}
+
+fn portfolio_vetoes_success_cleanup(
+    batch_id: &str,
+    child_run_id: &str,
+    disposition: homeboy::core::worktree_provider::WorktreeTerminalDisposition,
+) -> Result<bool> {
+    if disposition != homeboy::core::worktree_provider::WorktreeTerminalDisposition::Succeeded
+        || !supervisor::portfolio_exists(batch_id)?
+    {
+        return Ok(false);
+    }
+    let portfolio = supervisor::read_portfolio(batch_id)?;
+    let batch = batch::read_batch_record(batch_id)?;
+    let task_id = batch
+        .child_runs
+        .iter()
+        .find(|child| child.run_id == child_run_id)
+        .map(|child| child.task_id.as_str());
+    Ok(task_id
+        .and_then(|task_id| portfolio.children.get(task_id))
+        .or_else(|| {
+            portfolio
+                .children
+                .values()
+                .find(|child| child.run_id == child_run_id)
+        })
+        .is_some_and(|child| child.blocker.is_some()))
 }
 
 fn finalize_fanout_provider_worktree(
@@ -6974,10 +7034,11 @@ mod tests {
         std::fs::write(
             &script,
             format!(
-                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  if [ \"$2\" = \"${{HOMEBOY_FAKE_PROVIDER_MISSING_HANDLE:-}}\" ]; then printf '{{\"worktrees\":[]}}\\n'; exit 0; fi\n  printf '{{\"worktrees\":[{{\"handle\":\"%s\",\"path\":\"{}\",\"branch\":\"fixture\",\"safety\":{{\"dirty\":{},\"unpushed\":false,\"primary\":false}}}}]}}\\n' \"$2\"\nelse\n  printf '%s|%s|%s|%s|%s|%s\\n' \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" \"$7\" >> '{}'\n  if [ \"$1\" = finalize ] && {{ [ \"$2\" = \"${{HOMEBOY_FAKE_PROVIDER_FINALIZE_FAIL_HANDLE:-}}\" ] || [ \"${{HOMEBOY_FAKE_PROVIDER_FINALIZE_FAIL_HANDLE:-}}\" = '*' ]; }}; then exit 1; fi\nfi\n",
+                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  if [ \"$2\" = \"${{HOMEBOY_FAKE_PROVIDER_MISSING_HANDLE:-}}\" ]; then printf '{{\"worktrees\":[]}}\\n'; exit 0; fi\n  printf '{{\"worktrees\":[{{\"handle\":\"%s\",\"path\":\"{}\",\"branch\":\"fixture\",\"safety\":{{\"dirty\":{},\"unpushed\":false,\"primary\":false}}}}]}}\\n' \"$2\"\nelse\n  printf '%s|%s|%s|%s|%s|%s\\n' \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" \"$7\" >> '{}'\n  if [ \"$1\" = finalize ] && {{ [ \"$2\" = \"${{HOMEBOY_FAKE_PROVIDER_FINALIZE_FAIL_HANDLE:-}}\" ] || [ \"${{HOMEBOY_FAKE_PROVIDER_FINALIZE_FAIL_HANDLE:-}}\" = '*' ]; }}; then exit 1; fi\n  if [ \"$1\" = finalize ] && [ \"$2\" = \"${{HOMEBOY_FAKE_PROVIDER_REMOVE_HANDLE:-}}\" ] && [ \"$6\" = succeeded ]; then rm -rf '{}'; fi\nfi\n",
                 workspace.display(),
                 dirty,
                 records.display(),
+                workspace.display(),
             ),
         )
         .expect("write provider");
@@ -7304,6 +7365,133 @@ mod tests {
                 std::fs::read_to_string(records).unwrap(),
                 before,
                 "stale terminal evidence must not invoke the provider"
+            );
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resumed_live_successful_terminal_status_finalizes_after_crash_before_cleanup() {
+        with_isolated_home(|home| {
+            install_fanout_agent_task_providers(home.path());
+            let (_fixture, records, mut plan) = provider_finalization_fixture(false);
+            plan.cooks.truncate(1);
+            let cook = &plan.cooks[0];
+            let dispatcher: &CookAttemptDispatcherFactory =
+                &|_| std::sync::Arc::new(FailingFanoutDispatcher);
+            run_batch_cook_fanout_plan_with_attempt_dispatcher(plan.clone(), dispatcher)
+                .expect("seed durable Cook recipe");
+            homeboy::agents::agent_task_batch::AgentTaskBatchStore::from_current_data_root()
+                .unwrap()
+                .mutate_batch(&plan.fanout_id, |batch| {
+                    batch.metadata["provider_worktree_finalizations"] = json!({});
+                    Ok(())
+                })
+                .unwrap();
+            agent_task_lifecycle::rewrite_record_for_test(&cook.run_id(), |record| {
+                record.state = agent_task_lifecycle::AgentTaskRunState::Succeeded;
+                record
+                    .metadata
+                    .as_object_mut()
+                    .unwrap()
+                    .remove("cook_finalization");
+                record.metadata["cook_progress"]["terminal_status"] =
+                    json!("intentional_no_change");
+            })
+            .unwrap();
+
+            finalize_resumed_provider_worktrees(&plan.fanout_id, None)
+                .expect("resume successful cleanup after crash");
+
+            let expected = format!(
+                "homeboy@{}|agent_task_cook|{}|remove_on_success|succeeded|finalize:{}",
+                cook.cook_id,
+                cook.run_id(),
+                cook.run_id(),
+            );
+            assert_eq!(
+                std::fs::read_to_string(records)
+                    .unwrap()
+                    .matches(&expected)
+                    .count(),
+                1
+            );
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn publication_then_dirty_resume_vetoes_destructive_success_cleanup() {
+        with_isolated_home(|home| {
+            install_fanout_agent_task_providers(home.path());
+            let (fixture, records, mut plan) = provider_finalization_fixture(false);
+            plan.cooks.truncate(1);
+            let cook = &plan.cooks[0];
+            let dispatcher: &CookAttemptDispatcherFactory =
+                &|_| std::sync::Arc::new(FailingFanoutDispatcher);
+            run_batch_cook_fanout_plan_with_attempt_dispatcher(plan.clone(), dispatcher)
+                .expect("seed durable Cook recipe");
+            homeboy::agents::agent_task_batch::AgentTaskBatchStore::from_current_data_root()
+                .unwrap()
+                .mutate_batch(&plan.fanout_id, |batch| {
+                    batch.metadata["provider_worktree_finalizations"] = json!({});
+                    Ok(())
+                })
+                .unwrap();
+            agent_task_lifecycle::rewrite_record_for_test(&cook.run_id(), |record| {
+                record.state = agent_task_lifecycle::AgentTaskRunState::Succeeded;
+                record.metadata["cook_finalization"] = json!({
+                    "status": "review_ready",
+                    "publication_proof": { "binding": { "candidate_sha": "published" } }
+                });
+                record.metadata["cook_progress"]["terminal_status"] = json!("review_ready");
+            })
+            .unwrap();
+            let retained_edit = fixture.path().join("workspace/retained-edit.txt");
+            std::fs::write(&retained_edit, "do not delete").unwrap();
+            let mut portfolio = supervisor::AgentTaskFanoutPortfolio::new(
+                plan.fanout_id.clone(),
+                [supervisor::AgentTaskFanoutPortfolioChild {
+                    child_id: cook.cook_id.clone(),
+                    tracker_ref: "homeboy://test/publication".into(),
+                    run_id: "replaced-predecessor".into(),
+                    source_sha: None,
+                    base_sha: None,
+                    head_sha: Some("published".into()),
+                    evidence_generation: 0,
+                    finding_fingerprints: Default::default(),
+                    finding_fingerprint_recency: Default::default(),
+                    blocker: Some(supervisor::AgentTaskFanoutPortfolioBlocker {
+                        code: "unsafe_worktree".into(),
+                        detail: "dirty candidate worktree is retained without overwrite".into(),
+                        evidence_ref: "homeboy://test/dirty".into(),
+                    }),
+                    next_action: Some(
+                        supervisor::AgentTaskFanoutPortfolioAction::InspectBlockedCandidate,
+                    ),
+                }],
+            );
+            portfolio.revision = 1;
+            supervisor::write_portfolio(&portfolio).unwrap();
+            let before = std::fs::read_to_string(&records).unwrap();
+            let _destructive = homeboy::core::test_support::EnvVarGuard::set(
+                "HOMEBOY_FAKE_PROVIDER_REMOVE_HANDLE",
+                &cook.to_worktree,
+            );
+
+            finalize_resumed_provider_worktrees(&plan.fanout_id, None)
+                .expect("portfolio blocker vetoes RemoveOnSuccess cleanup");
+
+            assert_eq!(std::fs::read_to_string(records).unwrap(), before);
+            assert_eq!(
+                std::fs::read_to_string(retained_edit).unwrap(),
+                "do not delete"
+            );
+            let batch = batch::read_batch_record(&plan.fanout_id).unwrap();
+            assert_eq!(
+                batch.metadata["provider_worktree_finalizations"][&cook.run_id()]
+                    ["lifecycle_status"],
+                "portfolio_retention_blocker"
             );
         });
     }

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -546,12 +546,14 @@ fn batch_resume(args: AgentTaskFanoutBatchStatusArgs, placement: Placement) -> C
         Arc::new(provider::ExtensionProviderAgentTaskExecutor::discover()),
         crate::commands::infra::route::reconstruct_cook_attempt_dispatcher,
     )?;
-    finalize_resumed_provider_worktrees(&args.batch_id, Some(&result.value))?;
     reconcile_fanout_pr_states(&args.batch_id, true)?;
     let exit_code = result.exit_code;
     let batch = batch::read_batch_record(&args.batch_id)?;
     let portfolio = run_portfolio(&batch)?;
-    finalize_resumed_provider_worktrees(&args.batch_id, None)?;
+    // Portfolio publication can add durable PR evidence. Reconcile it before a
+    // RemoveOnSuccess provider is allowed to destroy the source workspace.
+    reconcile_fanout_pr_states(&args.batch_id, true)?;
+    finalize_resumed_provider_worktrees(&args.batch_id, Some(&result.value))?;
     Ok(batch_resume_result(
         result.value,
         exit_code,
@@ -1838,7 +1840,6 @@ fn finalize_provider_worktrees(
     report: &agent_task_service::AgentTaskCookBatchReport,
 ) -> Result<()> {
     let config = homeboy::core::defaults::load_config();
-    let mut first_error = None;
     for cell in &report.cooks {
         if !cell.lifecycle().terminal {
             continue;
@@ -1850,26 +1851,67 @@ fn finalize_provider_worktrees(
         else {
             continue;
         };
-        let disposition = if cell.exit_code == 0 {
-            homeboy::core::worktree_provider::WorktreeTerminalDisposition::Succeeded
-        } else {
-            homeboy::core::worktree_provider::WorktreeTerminalDisposition::Failed
+        let Some(disposition) = provider_disposition(cell.status.as_str(), cell.exit_code) else {
+            if cell.status == "review_form_timeout" {
+                let _ = batch::record_provider_worktree_finalization_deferred(
+                    &plan.fanout_id,
+                    &cook.run_id(),
+                    &cell.status,
+                );
+            }
+            continue;
         };
-        let result = (|| {
+        // Cleanup failures are durable lifecycle-operation failures. They must
+        // not flow into the coordinator failure recorder and rewrite successful
+        // children as failed.
+        let result = durable_worktree_provider(&cook.run_id()).and_then(|selected_provider| {
             finalize_fanout_provider_worktree(
                 &plan.fanout_id,
                 &cook.run_id(),
                 &cook.to_worktree,
                 &cook.run_id(),
                 disposition,
+                Some(&selected_provider),
                 &config,
             )
-        })();
+        });
         if let Err(error) = result {
-            first_error.get_or_insert(error);
+            let _ = batch::record_provider_worktree_finalization_preflight_error(
+                &plan.fanout_id,
+                &cook.run_id(),
+                &error,
+            );
         }
     }
-    first_error.map_or(Ok(()), Err)
+    Ok(())
+}
+
+fn provider_disposition(
+    status: &str,
+    exit_code: i32,
+) -> Option<homeboy::core::worktree_provider::WorktreeTerminalDisposition> {
+    use homeboy::core::worktree_provider::WorktreeTerminalDisposition as Disposition;
+    match status {
+        // These successful/recoverable outcomes still own the workspace until
+        // later publication or acceptance reaches a provider-terminal state.
+        "green_no_finalize" | "awaiting_acceptance" => None,
+        "cancelled" => Some(Disposition::Cancelled),
+        "timed_out" => Some(Disposition::TimedOut),
+        "review_form_timeout" => None,
+        "pre_artifact_interruption" => Some(Disposition::Interrupted),
+        "review_ready"
+        | "draft_published"
+        | "completed"
+        | "intentional_no_change"
+        | "no_candidate"
+        | "no_changes"
+            if exit_code == 0 =>
+        {
+            Some(Disposition::Succeeded)
+        }
+        _ if exit_code == 0 => None,
+        _ => Some(Disposition::Failed),
+    }
 }
 
 fn finalize_resumed_provider_worktrees(
@@ -1878,60 +1920,78 @@ fn finalize_resumed_provider_worktrees(
 ) -> Result<()> {
     let batch = batch::read_batch_record(batch_id)?;
     let config = homeboy::core::defaults::load_config();
-    let mut first_error = None;
     for child in &batch.child_runs {
         let result = (|| {
-            let live_state = || -> Result<Option<agent_task_lifecycle::AgentTaskRunState>> {
-                match agent_task_lifecycle::reconcile_status(&child.run_id) {
-                    Ok(current) => Ok(Some(current.state)),
-                    Err(error) if error.message.contains("agent-task run record not found") => {
-                        Ok(None)
-                    }
-                    Err(error) => Err(error),
-                }
+            let live_record = || match agent_task_lifecycle::reconcile_status(&child.run_id) {
+                Ok(current) => Ok(Some(current)),
+                Err(error) if error.message.contains("agent-task run record not found") => Ok(None),
+                Err(error) => Err(error),
             };
-            let state = resumed
-                .and_then(|report| {
-                    report.cooks.iter().find(|cook| {
-                        cook.initial_run_id == child.run_id && cook.lifecycle().terminal
+            let live = live_record()?;
+            // A live record always outranks the resumed report and batch roster.
+            // In particular, a live nonterminal child fences stale terminal data.
+            if live
+                .as_ref()
+                .is_some_and(|record| !record.state.is_terminal())
+            {
+                return Ok(());
+            }
+            let resumed_cell = resumed.and_then(|report| {
+                report
+                    .cooks
+                    .iter()
+                    .find(|cook| cook.initial_run_id == child.run_id && cook.lifecycle().terminal)
+            });
+            let state = live
+                .as_ref()
+                .map(|record| record.state)
+                .or_else(|| {
+                    resumed_cell.map(|cook| {
+                        if cook.exit_code == 0 {
+                            agent_task_lifecycle::AgentTaskRunState::Succeeded
+                        } else {
+                            agent_task_lifecycle::AgentTaskRunState::Failed
+                        }
                     })
                 })
-                .map(|cook| {
-                    if cook.exit_code == 0 {
-                        agent_task_lifecycle::AgentTaskRunState::Succeeded
-                    } else {
-                        agent_task_lifecycle::AgentTaskRunState::Failed
-                    }
-                })
-                .map_or_else(
-                    || {
-                        let live = live_state()?;
-                        let finalizable = |state| {
-                            matches!(
-                                state,
-                                agent_task_lifecycle::AgentTaskRunState::Succeeded
-                                    | agent_task_lifecycle::AgentTaskRunState::PartialFailure
-                                    | agent_task_lifecycle::AgentTaskRunState::Failed
-                                    | agent_task_lifecycle::AgentTaskRunState::Cancelled
-                            )
-                        };
-                        Ok::<_, Error>(match live {
-                            Some(state) if finalizable(state) => Some(state),
-                            _ if finalizable(child.state) => Some(child.state),
-                            state => state,
-                        })
-                    },
-                    |state| Ok(Some(state)),
-                )?;
+                .or_else(|| child.state.is_terminal().then_some(child.state));
             let Some(state) = state else { return Ok(()) };
+            let deferred_status = batch.metadata["provider_worktree_finalizations"][&child.run_id]
+                ["lifecycle_status"]
+                .as_str();
+            let live_terminal_status = live.as_ref().and_then(|record| {
+                record
+                    .metadata
+                    .pointer("/cook_progress/terminal_status")
+                    .and_then(Value::as_str)
+            });
+            let status = match live.as_ref() {
+                Some(record) => record
+                    .metadata
+                    .get("cook_finalization")
+                    .and_then(|finalization| finalization.get("status"))
+                    .and_then(Value::as_str),
+                None => resumed_cell.map(|cell| cell.status.as_str()),
+            };
             let disposition = match state {
                 agent_task_lifecycle::AgentTaskRunState::Succeeded => {
-                    homeboy::core::worktree_provider::WorktreeTerminalDisposition::Succeeded
+                    let Some(disposition) = provider_disposition(status.unwrap_or_default(), 0)
+                    else {
+                        return Ok(());
+                    };
+                    disposition
                 }
                 agent_task_lifecycle::AgentTaskRunState::PartialFailure
-                | agent_task_lifecycle::AgentTaskRunState::Failed
-                | agent_task_lifecycle::AgentTaskRunState::Cancelled => {
+                | agent_task_lifecycle::AgentTaskRunState::Failed => {
+                    if deferred_status == Some("review_form_timeout")
+                        && live_terminal_status.is_none_or(|status| status == "review_form_timeout")
+                    {
+                        return Ok(());
+                    }
                     homeboy::core::worktree_provider::WorktreeTerminalDisposition::Failed
+                }
+                agent_task_lifecycle::AgentTaskRunState::Cancelled => {
+                    homeboy::core::worktree_provider::WorktreeTerminalDisposition::Cancelled
                 }
                 // Recoverable children still need Cook promotion, gates, and PR
                 // finalization before their provider workspace may be released.
@@ -1974,14 +2034,19 @@ fn finalize_resumed_provider_worktrees(
                 handle,
                 &owner,
                 disposition,
+                Some(&durable_worktree_provider(&child.run_id)?),
                 &config,
             )
         })();
         if let Err(error) = result {
-            first_error.get_or_insert(error);
+            let _ = batch::record_provider_worktree_finalization_preflight_error(
+                batch_id,
+                &child.run_id,
+                &error,
+            );
         }
     }
-    first_error.map_or(Ok(()), Err)
+    Ok(())
 }
 
 fn finalize_fanout_provider_worktree(
@@ -1990,6 +2055,7 @@ fn finalize_fanout_provider_worktree(
     handle: &str,
     owner: &str,
     disposition: homeboy::core::worktree_provider::WorktreeTerminalDisposition,
+    selected_provider: Option<&homeboy::core::worktree_provider::WorktreeProviderIdentity>,
     config: &homeboy::core::defaults::HomeboyConfig,
 ) -> Result<()> {
     let finalization = batch::finalize_provider_worktree_for_child(
@@ -2003,6 +2069,7 @@ fn finalize_fanout_provider_worktree(
                 homeboy::core::worktree_provider::WorktreeCleanupPolicy::RemoveOnSuccess,
         },
         disposition,
+        selected_provider,
         config,
     )?;
     match finalization {
@@ -2020,6 +2087,39 @@ fn finalize_fanout_provider_worktree(
         | batch::BatchProviderWorktreeFinalization::Unsupported
         | batch::BatchProviderWorktreeFinalization::NotFound => Ok(()),
     }
+}
+
+fn durable_worktree_provider(
+    run_id: &str,
+) -> Result<homeboy::core::worktree_provider::WorktreeProviderIdentity> {
+    let plan = agent_task_lifecycle::load_controller_plan(run_id)?;
+    let evidence = &plan.metadata["cook_provision"];
+    if evidence["provider_identity"] == "native" {
+        return Ok(homeboy::core::worktree_provider::WorktreeProviderIdentity::Native);
+    }
+    let provider_id = evidence
+        .pointer("/provider_identity/configured")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            evidence
+                .pointer("/workspace_identity/provider_id")
+                .and_then(Value::as_str)
+        })
+        .or_else(|| evidence.get("worktree_provider_id").and_then(Value::as_str));
+    provider_id
+        .map(|provider_id| {
+            homeboy::core::worktree_provider::WorktreeProviderIdentity::Configured(
+                provider_id.to_string(),
+            )
+        })
+        .ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "provider_worktree_finalization",
+                "durable lifecycle plan does not identify the selected worktree provider",
+                Some(run_id.to_string()),
+                None,
+            )
+        })
 }
 
 /// HOOK — wave-completion notification. Intentionally not implemented here.
@@ -2142,6 +2242,30 @@ fn compile_batch_cooks(
                 invocation.dispatch,
                 &mut readiness_cache,
             )?;
+            if options.workspace.source_worktree_path.is_some() {
+                let config = homeboy::core::defaults::load_config();
+                if let homeboy::core::worktree_provider::WorktreeProvisionLookup::Admitted(
+                    destination,
+                ) = homeboy::core::worktree_provider::admit_worktree_provision_from_config(
+                    &options.workspace.to_worktree,
+                    None,
+                    &config,
+                )? {
+                    options.identity.initial_plan.metadata["cook_provision"]
+                        ["provider_identity"] = match destination.ownership.provider {
+                        homeboy::core::worktree_provider::WorktreeProviderIdentity::Native => {
+                            serde_json::json!("native")
+                        }
+                        homeboy::core::worktree_provider::WorktreeProviderIdentity::Configured(
+                            provider_id,
+                        ) => {
+                            options.identity.initial_plan.metadata["cook_provision"]
+                                ["worktree_provider_id"] = serde_json::json!(provider_id.clone());
+                            serde_json::json!({ "configured": provider_id })
+                        }
+                    };
+                }
+            }
             if !cook.repository_identity.is_null() {
                 options.identity.initial_plan.metadata["cook_repository_identity"] =
                     cook.repository_identity.clone();
@@ -6923,6 +7047,30 @@ mod tests {
             serde_json::json!({}),
         )
         .expect("persist provider finalization test batch");
+        let config = homeboy::core::defaults::load_config();
+        let lifecycle_store =
+            agent_task_lifecycle::AgentTaskLifecycleStore::from_current_environment()
+                .expect("lifecycle store");
+        for cook in &plan.cooks {
+            let provider = homeboy::core::worktree_provider::resolve_worktree_finalization_provider_from_config(
+                &cook.to_worktree,
+                &config,
+            )
+            .expect("resolve provider fixture")
+            .expect("provider fixture must exist");
+            let mut child_plan = AgentTaskPlan::new(cook.run_id(), Vec::new());
+            child_plan.metadata["cook_provision"]["provider_identity"] = match provider {
+                homeboy::core::worktree_provider::WorktreeProviderIdentity::Native => {
+                    json!("native")
+                }
+                homeboy::core::worktree_provider::WorktreeProviderIdentity::Configured(
+                    provider_id,
+                ) => json!({ "configured": provider_id }),
+            };
+            lifecycle_store
+                .write_controller_plan(&cook.run_id(), &child_plan)
+                .expect("persist provider selection evidence");
+        }
     }
 
     struct TestCurrentDirGuard(PathBuf);
@@ -6965,7 +7113,7 @@ mod tests {
                         |(index, cook)| agent_task_service::AgentTaskCookBatchCellReport {
                             cook_id: cook.cook_id.clone(),
                             initial_run_id: cook.run_id(),
-                            status: if index == 0 { "succeeded" } else { "failed" }.to_string(),
+                            status: if index == 0 { "review_ready" } else { "failed" }.to_string(),
                             exit_code: index as i32,
                             result: None,
                             error: None,
@@ -6995,7 +7143,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn batch_resume_replays_all_provider_finalizations_before_downstream_processing() {
+    fn batch_resume_exact_receipts_suppress_repeated_provider_mutation() {
         with_isolated_home(|home| {
             install_fanout_agent_task_providers(home.path());
             let (_fixture, records, plan) = provider_finalization_fixture(false);
@@ -7025,7 +7173,7 @@ mod tests {
                 .all(|line| initial.matches(line).count() == 1));
             assert_eq!(initial.lines().count(), 2);
 
-            let error = {
+            {
                 let _fail = homeboy::core::test_support::EnvVarGuard::set(
                     "HOMEBOY_FAKE_PROVIDER_FINALIZE_FAIL_HANDLE",
                     "*",
@@ -7036,19 +7184,11 @@ mod tests {
                     },
                     Placement::Auto,
                 )
-                .expect_err("provider finalization failure stops downstream resume processing")
-            };
-            assert!(
-                error.message.contains("finalize command failed"),
-                "unexpected resume error: {error:?}"
-            );
+                .expect("completed receipts bypass provider mutation");
+            }
             let failed_resume =
                 std::fs::read_to_string(&records).expect("failed resume finalizations");
-            assert_eq!(
-                failed_resume.lines().count(),
-                4,
-                "one provider failure must not strand later child finalization"
-            );
+            assert_eq!(failed_resume.lines().count(), 2);
 
             batch_resume(
                 AgentTaskFanoutBatchStatusArgs {
@@ -7058,7 +7198,7 @@ mod tests {
             )
             .expect("idempotent command-path resume");
             let converged = std::fs::read_to_string(records).expect("converged finalizations");
-            assert_eq!(converged.lines().count(), 8);
+            assert_eq!(converged.lines().count(), 2);
         });
     }
 
@@ -7105,15 +7245,165 @@ mod tests {
             let after = std::fs::read_to_string(records).expect("resumed finalizations");
             assert_eq!(
                 after.matches(&expected).count(),
-                before.matches(&expected).count() + 2,
-                "both pre- and post-portfolio passes must use live terminal child state"
+                before.matches(&expected).count(),
+                "the exact completion receipt must suppress repeated mutation"
             );
         });
     }
 
     #[cfg(unix)]
     #[test]
-    fn batch_resume_refuses_provider_finalization_from_its_live_workspace() {
+    fn resumed_live_running_child_overrides_stale_terminal_report_and_roster() {
+        with_isolated_home(|home| {
+            install_fanout_agent_task_providers(home.path());
+            let (_fixture, records, mut plan) = provider_finalization_fixture(false);
+            plan.cooks.truncate(1);
+            let cook = &plan.cooks[0];
+            let dispatcher: &CookAttemptDispatcherFactory =
+                &|_| std::sync::Arc::new(FailingFanoutDispatcher);
+            run_batch_cook_fanout_plan_with_attempt_dispatcher(plan.clone(), dispatcher)
+                .expect("initial dispatcher fanout result");
+            let before = std::fs::read_to_string(&records).expect("initial finalization");
+            homeboy::agents::agent_task_batch::AgentTaskBatchStore::from_current_data_root()
+                .expect("batch store")
+                .mutate_batch(&plan.fanout_id, |batch| {
+                    batch.child_runs[0].state = agent_task_lifecycle::AgentTaskRunState::Failed;
+                    batch.metadata["provider_worktree_finalizations"] = json!({});
+                    Ok(())
+                })
+                .expect("seed stale terminal roster");
+            agent_task_lifecycle::rewrite_record_for_test(&cook.run_id(), |record| {
+                record.state = agent_task_lifecycle::AgentTaskRunState::Running;
+            })
+            .expect("make live child nonterminal");
+            let stale_report = agent_task_service::AgentTaskCookBatchReport {
+                schema: "homeboy/agent-task-cook-batch/v1",
+                batch_id: plan.fanout_id.clone(),
+                status: "failed".to_string(),
+                total: 1,
+                queued: 0,
+                running: 0,
+                succeeded: 0,
+                failed: 1,
+                cancelled: 0,
+                timed_out: 0,
+                cooks: vec![agent_task_service::AgentTaskCookBatchCellReport {
+                    cook_id: cook.cook_id.clone(),
+                    initial_run_id: cook.run_id(),
+                    status: "failed".to_string(),
+                    exit_code: 1,
+                    result: None,
+                    error: None,
+                }],
+            };
+
+            finalize_resumed_provider_worktrees(&plan.fanout_id, Some(&stale_report))
+                .expect("live nonterminal child fences stale terminal evidence");
+
+            assert_eq!(
+                std::fs::read_to_string(records).unwrap(),
+                before,
+                "stale terminal evidence must not invoke the provider"
+            );
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exact_provider_receipt_fences_concurrent_finalizers() {
+        with_isolated_home(|_| {
+            let (_fixture, records, mut plan) = provider_finalization_fixture(false);
+            plan.cooks.truncate(1);
+            persist_provider_finalization_test_batch(&plan);
+            let cook = plan.cooks[0].clone();
+            let config = homeboy::core::defaults::load_config();
+            let mut threads = Vec::new();
+            for _ in 0..2 {
+                let batch_id = plan.fanout_id.clone();
+                let cook = cook.clone();
+                let config = config.clone();
+                threads.push(std::thread::spawn(move || {
+                    finalize_fanout_provider_worktree(
+                        &batch_id,
+                        &cook.run_id(),
+                        &cook.to_worktree,
+                        &cook.run_id(),
+                        homeboy::core::worktree_provider::WorktreeTerminalDisposition::Failed,
+                        None,
+                        &config,
+                    )
+                }));
+            }
+            for thread in threads {
+                thread.join().expect("join finalizer").expect("finalize");
+            }
+            assert_eq!(std::fs::read_to_string(records).unwrap().lines().count(), 1);
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pending_destructive_finalization_recovers_receipt_from_not_found() {
+        with_isolated_home(|_| {
+            let (fixture, records, mut plan) = provider_finalization_fixture(false);
+            plan.cooks.truncate(1);
+            persist_provider_finalization_test_batch(&plan);
+            let cook = &plan.cooks[0];
+            let config = homeboy::core::defaults::load_config();
+            finalize_fanout_provider_worktree(
+                &plan.fanout_id,
+                &cook.run_id(),
+                &cook.to_worktree,
+                &cook.run_id(),
+                homeboy::core::worktree_provider::WorktreeTerminalDisposition::Failed,
+                None,
+                &config,
+            )
+            .expect("initial destructive mutation");
+            homeboy::agents::agent_task_batch::AgentTaskBatchStore::from_current_data_root()
+                .expect("batch store")
+                .mutate_batch(&plan.fanout_id, |batch| {
+                    batch.metadata["provider_worktree_finalizations"][&cook.run_id()]["status"] =
+                        json!("pending");
+                    Ok(())
+                })
+                .expect("simulate crash before receipt publication");
+            std::fs::remove_dir_all(fixture.path().join("workspace"))
+                .expect("destructive provider removed workspace");
+            let _missing = homeboy::core::test_support::EnvVarGuard::set(
+                "HOMEBOY_FAKE_PROVIDER_MISSING_HANDLE",
+                &cook.to_worktree,
+            );
+
+            finalize_fanout_provider_worktree(
+                &plan.fanout_id,
+                &cook.run_id(),
+                &cook.to_worktree,
+                &cook.run_id(),
+                homeboy::core::worktree_provider::WorktreeTerminalDisposition::Failed,
+                None,
+                &config,
+            )
+            .expect("pending intent recovers from provider absence");
+
+            assert_eq!(std::fs::read_to_string(records).unwrap().lines().count(), 1);
+            let batch = batch::read_batch_record(&plan.fanout_id).unwrap();
+            let operation = &batch.metadata["provider_worktree_finalizations"][&cook.run_id()];
+            assert_eq!(operation["status"], "completed");
+            assert_eq!(operation["recovered_from_not_found"], true);
+        });
+    }
+
+    #[test]
+    fn green_and_awaiting_acceptance_are_not_provider_terminal() {
+        assert_eq!(provider_disposition("green_no_finalize", 0), None);
+        assert_eq!(provider_disposition("awaiting_acceptance", 1), None);
+        assert_eq!(provider_disposition("review_form_timeout", 1), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn provider_finalization_error_is_durable_and_does_not_fail_the_batch() {
         with_isolated_home(|home| {
             install_fanout_agent_task_providers(home.path());
             let (fixture, records, mut plan) = provider_finalization_fixture(false);
@@ -7123,25 +7413,38 @@ mod tests {
             run_batch_cook_fanout_plan_with_attempt_dispatcher(plan.clone(), dispatcher)
                 .expect("initial dispatcher fanout result");
 
+            homeboy::agents::agent_task_batch::AgentTaskBatchStore::from_current_data_root()
+                .expect("batch store")
+                .mutate_batch(&plan.fanout_id, |batch| {
+                    batch.metadata["provider_worktree_finalizations"] = json!({});
+                    Ok(())
+                })
+                .expect("clear finalization receipt");
+
             let nested = fixture.path().join("workspace/nested");
             std::fs::create_dir(&nested).expect("nested provider workspace directory");
-            let error = {
+            {
                 let _cwd = TestCurrentDirGuard::set(&nested);
-                batch_resume(
-                    AgentTaskFanoutBatchStatusArgs {
-                        batch_id: plan.fanout_id.clone(),
-                    },
-                    Placement::Auto,
-                )
-                .expect_err("live provider workspace blocks resume finalization")
-            };
-
-            assert!(
-                error.message.contains("live current working directory"),
-                "unexpected resume error: {error:?}"
-            );
+                let _ = finalize_fanout_provider_worktree(
+                    &plan.fanout_id,
+                    &plan.cooks[0].run_id(),
+                    &plan.cooks[0].to_worktree,
+                    &plan.cooks[0].run_id(),
+                    homeboy::core::worktree_provider::WorktreeTerminalDisposition::Failed,
+                    None,
+                    &homeboy::core::defaults::load_config(),
+                );
+            }
             let records = std::fs::read_to_string(records).expect("provider finalizations");
             assert_eq!(records.lines().count(), 1, "blocked finalizer must not run");
+            let batch = batch::read_batch_record(&plan.fanout_id).expect("durable batch");
+            let operation =
+                &batch.metadata["provider_worktree_finalizations"][&plan.cooks[0].run_id()];
+            assert_eq!(operation["status"], "pending");
+            assert!(operation["last_error"]["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("live current working directory")));
+            assert!(batch.metadata.get("terminal_failure").is_none());
         });
     }
 
@@ -7181,15 +7484,17 @@ mod tests {
                     .collect(),
             };
 
-            let error = finalize_provider_worktrees(&plan, &report)
-                .expect_err("first missing lookup has no finalization evidence");
-            assert!(
-                error.message.contains("not a Homeboy task worktree"),
-                "unexpected finalization error: {error:?}"
-            );
+            finalize_provider_worktrees(&plan, &report)
+                .expect("missing provider cleanup is lifecycle-specific");
+            finalize_provider_worktrees(&plan, &report)
+                .expect("repeated lookup-only absence remains incomplete");
             let records = std::fs::read_to_string(records).expect("later child finalization");
             assert!(records.contains(&plan.cooks[1].to_worktree));
             assert!(!records.contains(&missing.to_worktree));
+            let batch = batch::read_batch_record(&plan.fanout_id).expect("durable batch");
+            let operation = &batch.metadata["provider_worktree_finalizations"][&missing.run_id()];
+            assert_eq!(operation["status"], "pending");
+            assert_eq!(operation["mutation_attempted"], false);
         });
     }
 
@@ -7224,8 +7529,8 @@ mod tests {
             let records = std::fs::read_to_string(records).expect("provider finalizations");
             assert_eq!(
                 records.lines().count(),
-                4,
-                "the missing child must not mutate while its sibling continues on each resume"
+                2,
+                "completed receipts suppress both missing-child and sibling mutation"
             );
         });
     }
@@ -7251,7 +7556,7 @@ mod tests {
                 cooks: vec![agent_task_service::AgentTaskCookBatchCellReport {
                     cook_id: cook.cook_id.clone(),
                     initial_run_id: cook.run_id(),
-                    status: "succeeded".to_string(),
+                    status: "review_ready".to_string(),
                     exit_code: 0,
                     result: None,
                     error: None,
@@ -7287,6 +7592,13 @@ mod tests {
                     .expect("dispatcher fanout result");
 
             assert_ne!(exit_code, 0);
+            assert_eq!(
+                durable_worktree_provider(&plan.cooks[0].run_id())
+                    .expect("durable selected provider"),
+                homeboy::core::worktree_provider::WorktreeProviderIdentity::Configured(
+                    "fixture".to_string()
+                )
+            );
             let records = std::fs::read_to_string(records).expect("provider finalization record");
             assert!(records.contains(&format!(
                 "homeboy@{}|agent_task_cook|{}|remove_on_success|failed|finalize:{}",
@@ -9230,7 +9542,7 @@ fi
             std::fs::write(
                 &provider,
                 format!(
-                    "#!/bin/sh\ncase \"$1\" in\nresolve)\n  path='{}/'$2\n  if [ -d \"$path\" ]; then\n    branch=$(git -C \"$path\" branch --show-current)\n    printf '{{\"worktrees\":[{{\"handle\":\"%s\",\"path\":\"%s\",\"branch\":\"%s\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}\\n' \"$2\" \"$path\" \"$branch\"\n  else\n    printf '{{\"status\":\"error\",\"error\":{{\"code\":\"worktree_not_found\"}}}}\\n'\n  fi\n  ;;\nensure)\n  path='{}/'$2\n  git init --quiet -b \"$5\" \"$path\"\n  printf '%s|%s|%s|%s\\n' \"$2\" \"$8\" \"$9\" \"${{10}}\" >> '{}'\n  ;;\nesac\n",
+                    "#!/bin/sh\ncase \"$1\" in\nresolve)\n  path='{}/'$2\n  if [ -d \"$path\" ]; then\n    branch=$(git -C \"$path\" branch --show-current)\n    task_url=$(cat \"$path/.task-url\")\n    printf '{{\"worktrees\":[{{\"handle\":\"%s\",\"path\":\"%s\",\"branch\":\"%s\",\"task_url\":\"%s\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}\\n' \"$2\" \"$path\" \"$branch\" \"$task_url\"\n  else\n    printf '{{\"status\":\"error\",\"error\":{{\"code\":\"worktree_not_found\"}}}}\\n'\n  fi\n  ;;\nensure)\n  path='{}/'$2\n  git init --quiet -b \"$5\" \"$path\"\n  printf '%s' \"$6\" > \"$path/.task-url\"\n  printf '%s|%s|%s|%s\\n' \"$2\" \"$8\" \"$9\" \"${{10}}\" >> '{}'\n  ;;\nesac\n",
                     workspace_root.display(),
                     workspace_root.display(),
                     ensured.display(),
@@ -9284,7 +9596,7 @@ fi
                             dirty: "$.safety.dirty".to_string(),
                             unpushed: "$.safety.unpushed".to_string(),
                             primary: "$.safety.primary".to_string(),
-                            task_url: None,
+                            task_url: Some("$.task_url".to_string()),
                         },
                     ),
                 },

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -542,7 +542,8 @@ fn batch_status(args: AgentTaskFanoutBatchStatusArgs, placement: Placement) -> C
 /// repeated resume calls converge without duplicate PRs (#9525).
 fn batch_resume(args: AgentTaskFanoutBatchStatusArgs, placement: Placement) -> CmdResult<Value> {
     let batch_id = args.batch_id.clone();
-    supervisor::with_portfolio_resume_lock(&batch_id, || batch_resume_locked(args, placement))
+    let _fence = supervisor::acquire_fanout_ownership_fence(&batch_id)?;
+    batch_resume_locked(args, placement)
 }
 
 fn batch_resume_locked(
@@ -1658,6 +1659,7 @@ fn run_batch_cook_fanout_plan_with_attempt_dispatcher_and_placement(
     attempt_dispatcher: &CookAttemptDispatcherFactory,
     placement: Placement,
 ) -> CmdResult<Value> {
+    let _fence = supervisor::acquire_fanout_ownership_fence(&plan.fanout_id)?;
     run_batch_cook_fanout_plan_with_attempt_dispatcher_claim(
         plan,
         attempt_dispatcher,
@@ -1739,6 +1741,7 @@ fn run_batch_cook_fanout_plan_with_placement(
     plan: BatchCookFanoutPlan,
     placement: Placement,
 ) -> CmdResult<Value> {
+    let _fence = supervisor::acquire_fanout_ownership_fence(&plan.fanout_id)?;
     run_batch_cook_fanout_plan_with_executor_claim(
         plan,
         Arc::new(provider::ExtensionProviderAgentTaskExecutor::discover()),
@@ -1979,9 +1982,16 @@ fn finalize_resumed_provider_worktrees(
                 })
                 .or_else(|| child.state.is_terminal().then_some(child.state));
             let Some(state) = state else { return Ok(()) };
-            let deferred_status = batch.metadata["provider_worktree_finalizations"][&child.run_id]
-                ["lifecycle_status"]
-                .as_str();
+            let deferred_status = batch.metadata["provider_worktree_finalization_deferrals"]
+                [&child.run_id]["lifecycle_status"]
+                .as_str()
+                .or_else(|| {
+                    // Compatibility for records written before deferral became
+                    // orthogonal to the exact provider mutation intent.
+                    batch.metadata["provider_worktree_finalizations"][&child.run_id]
+                        ["lifecycle_status"]
+                        .as_str()
+                });
             let live_terminal_status = live.as_ref().and_then(|record| {
                 record
                     .metadata
@@ -2106,7 +2116,12 @@ fn portfolio_vetoes_success_cleanup(
                 .values()
                 .find(|child| child.run_id == child_run_id)
         })
-        .is_some_and(|child| child.blocker.is_some()))
+        .is_some_and(|child| {
+            child.blocker.is_some()
+                || child.next_action.as_ref().is_some_and(|action| {
+                    !matches!(action, supervisor::AgentTaskFanoutPortfolioAction::None)
+                })
+        }))
 }
 
 fn finalize_fanout_provider_worktree(
@@ -2573,6 +2588,9 @@ fn cook_batch_inner(
         .iter()
         .any(|cook| !cook.private_verify.is_empty());
     let persisted = args.run_plan && !args.preview;
+    let _fence = persisted
+        .then(|| supervisor::acquire_fanout_ownership_fence(&plan.fanout_id))
+        .transpose()?;
     let claim = persisted
         .then(|| claim_fanout_run_batch_coordinator(&plan, placement))
         .transpose()?;
@@ -7421,7 +7439,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn publication_then_dirty_resume_vetoes_destructive_success_cleanup() {
+    fn failed_pr_update_then_observation_vetoes_destructive_success_cleanup() {
         with_isolated_home(|home| {
             install_fanout_agent_task_providers(home.path());
             let (fixture, records, mut plan) = provider_finalization_fixture(false);
@@ -7454,25 +7472,86 @@ mod tests {
                 [supervisor::AgentTaskFanoutPortfolioChild {
                     child_id: cook.cook_id.clone(),
                     tracker_ref: "homeboy://test/publication".into(),
-                    run_id: "replaced-predecessor".into(),
+                    run_id: cook.run_id(),
                     source_sha: None,
                     base_sha: None,
                     head_sha: Some("published".into()),
                     evidence_generation: 0,
                     finding_fingerprints: Default::default(),
                     finding_fingerprint_recency: Default::default(),
-                    blocker: Some(supervisor::AgentTaskFanoutPortfolioBlocker {
-                        code: "unsafe_worktree".into(),
-                        detail: "dirty candidate worktree is retained without overwrite".into(),
-                        evidence_ref: "homeboy://test/dirty".into(),
-                    }),
-                    next_action: Some(
-                        supervisor::AgentTaskFanoutPortfolioAction::InspectBlockedCandidate,
-                    ),
+                    blocker: None,
+                    next_action: None,
                 }],
             );
-            portfolio.revision = 1;
-            supervisor::write_portfolio(&portfolio).unwrap();
+            struct FailedPrAdapter(supervisor::AgentTaskFanoutPortfolioObservation);
+            impl supervisor::FanoutPortfolioAdapter for FailedPrAdapter {
+                fn observe(
+                    &mut self,
+                    _child: &supervisor::AgentTaskFanoutPortfolioChild,
+                ) -> Result<supervisor::AgentTaskFanoutPortfolioObservation> {
+                    Ok(self.0.clone())
+                }
+                fn rebase_candidate(
+                    &mut self,
+                    _child: &supervisor::AgentTaskFanoutPortfolioChild,
+                ) -> Result<()> {
+                    unreachable!()
+                }
+                fn recreate_candidate(
+                    &mut self,
+                    _child: &supervisor::AgentTaskFanoutPortfolioChild,
+                ) -> Result<()> {
+                    unreachable!()
+                }
+                fn rerun_gates_and_review(
+                    &mut self,
+                    _child: &supervisor::AgentTaskFanoutPortfolioChild,
+                ) -> Result<()> {
+                    unreachable!()
+                }
+                fn finalize_or_update_pr(
+                    &mut self,
+                    _child: &supervisor::AgentTaskFanoutPortfolioChild,
+                    _force_with_lease: bool,
+                ) -> Result<()> {
+                    Err(Error::internal_unexpected("fixture PR update failed"))
+                }
+            }
+            portfolio
+                .run(
+                    &mut FailedPrAdapter(supervisor::AgentTaskFanoutPortfolioObservation {
+                        child_id: cook.cook_id.clone(),
+                        tracker: supervisor::AgentTaskFanoutTrackerState::Open,
+                        provider: supervisor::AgentTaskFanoutProviderState::Succeeded,
+                        worktree: supervisor::AgentTaskFanoutWorktreeState::Clean,
+                        candidate: supervisor::AgentTaskFanoutCandidateState {
+                            source_sha: Some("source".into()),
+                            base_sha: Some("base".into()),
+                            head_sha: Some("published".into()),
+                            current_base_sha: Some("base".into()),
+                            remote_head_sha: None,
+                            publication_receipt_current: false,
+                            can_rebase: true,
+                            can_recreate: true,
+                        },
+                        gates: supervisor::AgentTaskFanoutEvidenceState::Current,
+                        acceptance: supervisor::AgentTaskFanoutEvidenceState::Current,
+                        pr: supervisor::AgentTaskFanoutPrState::Missing,
+                        findings: Vec::new(),
+                    }),
+                    &supervisor::IndependentFanoutDependencies,
+                )
+                .expect("failed PR action is durably re-observed");
+            assert_eq!(
+                supervisor::read_portfolio(&plan.fanout_id)
+                    .unwrap()
+                    .children[&cook.cook_id]
+                    .blocker
+                    .as_ref()
+                    .unwrap()
+                    .code,
+                "adapter_action_failed"
+            );
             let before = std::fs::read_to_string(&records).unwrap();
             let _destructive = homeboy::core::test_support::EnvVarGuard::set(
                 "HOMEBOY_FAKE_PROVIDER_REMOVE_HANDLE",
@@ -7489,7 +7568,7 @@ mod tests {
             );
             let batch = batch::read_batch_record(&plan.fanout_id).unwrap();
             assert_eq!(
-                batch.metadata["provider_worktree_finalizations"][&cook.run_id()]
+                batch.metadata["provider_worktree_finalization_deferrals"][&cook.run_id()]
                     ["lifecycle_status"],
                 "portfolio_retention_blocker"
             );
@@ -7556,6 +7635,16 @@ mod tests {
                     Ok(())
                 })
                 .expect("simulate crash before receipt publication");
+            batch::record_provider_worktree_finalization_deferred(
+                &plan.fanout_id,
+                &cook.run_id(),
+                "portfolio_retention_blocker",
+            )
+            .expect("record blocker without replacing exact mutation intent");
+            let deferred = batch::read_batch_record(&plan.fanout_id).unwrap();
+            let pending = &deferred.metadata["provider_worktree_finalizations"][&cook.run_id()];
+            assert_eq!(pending["status"], "pending");
+            assert_eq!(pending["mutation_attempted"], true);
             std::fs::remove_dir_all(fixture.path().join("workspace"))
                 .expect("destructive provider removed workspace");
             let _missing = homeboy::core::test_support::EnvVarGuard::set(

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -541,12 +541,13 @@ fn batch_status(args: AgentTaskFanoutBatchStatusArgs, placement: Placement) -> C
 /// contract, reconciling per-child state back into the durable batch record so
 /// repeated resume calls converge without duplicate PRs (#9525).
 fn batch_resume(args: AgentTaskFanoutBatchStatusArgs, placement: Placement) -> CmdResult<Value> {
-    reconcile_fanout_pr_states(&args.batch_id, true)?;
     let result = agent_task_service::resume_cook_batch(
         &args.batch_id,
         Arc::new(provider::ExtensionProviderAgentTaskExecutor::discover()),
         crate::commands::infra::route::reconstruct_cook_attempt_dispatcher,
     )?;
+    finalize_resumed_provider_worktrees(&args.batch_id)?;
+    reconcile_fanout_pr_states(&args.batch_id, true)?;
     let exit_code = result.exit_code;
     let batch = batch::read_batch_record(&args.batch_id)?;
     let portfolio = run_portfolio(&batch)?;
@@ -1843,6 +1844,7 @@ fn finalize_provider_worktrees(
     previously_terminal: Option<&BTreeMap<String, String>>,
 ) -> Result<()> {
     let config = homeboy::core::defaults::load_config();
+    let mut first_error = None;
     for cell in &report.cooks {
         if !cell.lifecycle().terminal {
             continue;
@@ -1859,34 +1861,111 @@ fn finalize_provider_worktrees(
         } else {
             homeboy::core::worktree_provider::WorktreeTerminalDisposition::Failed
         };
-        let finalization = homeboy::core::worktree_provider::finalize_worktree_from_config(
-            &cook.to_worktree,
-            &homeboy::core::worktree_provider::WorktreeProvisionLifecycle {
-                purpose: "agent_task_cook".to_string(),
-                owner_run_ref: cook.run_id(),
-                cleanup_policy:
-                    homeboy::core::worktree_provider::WorktreeCleanupPolicy::RemoveOnSuccess,
-            },
-            disposition,
-            &config,
-        )?;
-        let not_found = matches!(
-            finalization,
-            homeboy::core::worktree_provider::WorktreeFinalizationLookup::NotFound
-        );
-        if not_found
-            && configured_provider_workspace_creation()?
-            && !previously_terminal.is_some_and(|terminal| terminal.contains_key(&cook.run_id()))
-        {
-            return Err(
-                homeboy::core::worktree_provider::worktree_finalization_not_found_error(
-                    &cook.to_worktree,
-                    &config,
-                ),
+        let result = (|| {
+            let finalization = homeboy::core::worktree_provider::finalize_worktree_from_config(
+                &cook.to_worktree,
+                &homeboy::core::worktree_provider::WorktreeProvisionLifecycle {
+                    purpose: "agent_task_cook".to_string(),
+                    owner_run_ref: cook.run_id(),
+                    cleanup_policy:
+                        homeboy::core::worktree_provider::WorktreeCleanupPolicy::RemoveOnSuccess,
+                },
+                disposition,
+                &config,
+            )?;
+            let not_found = matches!(
+                finalization,
+                homeboy::core::worktree_provider::WorktreeFinalizationLookup::NotFound
             );
+            if not_found
+                && configured_provider_workspace_creation()?
+                && !previously_terminal
+                    .is_some_and(|terminal| terminal.contains_key(&cook.run_id()))
+            {
+                return Err(
+                    homeboy::core::worktree_provider::worktree_finalization_not_found_error(
+                        &cook.to_worktree,
+                        &config,
+                    ),
+                );
+            }
+            Ok(())
+        })();
+        if let Err(error) = result {
+            first_error.get_or_insert(error);
         }
     }
-    Ok(())
+    first_error.map_or(Ok(()), Err)
+}
+
+fn finalize_resumed_provider_worktrees(batch_id: &str) -> Result<()> {
+    let batch = batch::read_batch_record(batch_id)?;
+    let config = homeboy::core::defaults::load_config();
+    let mut first_error = None;
+    for child in &batch.child_runs {
+        let disposition = match child.state {
+            agent_task_lifecycle::AgentTaskRunState::Succeeded => {
+                homeboy::core::worktree_provider::WorktreeTerminalDisposition::Succeeded
+            }
+            agent_task_lifecycle::AgentTaskRunState::PartialFailure
+            | agent_task_lifecycle::AgentTaskRunState::Failed
+            | agent_task_lifecycle::AgentTaskRunState::Cancelled => {
+                homeboy::core::worktree_provider::WorktreeTerminalDisposition::Failed
+            }
+            // Recoverable children still need Cook promotion, gates, and PR
+            // finalization before their provider workspace may be released.
+            agent_task_lifecycle::AgentTaskRunState::Queued
+            | agent_task_lifecycle::AgentTaskRunState::Running
+            | agent_task_lifecycle::AgentTaskRunState::CandidateRecoverable
+            | agent_task_lifecycle::AgentTaskRunState::PartialRecoverable => continue,
+        };
+        let result = (|| {
+            let recipe =
+                agent_task_service::load_recipe_for_attempt(&child.run_id)?.ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        "run_id",
+                        "terminal fanout child is missing its durable Cook recipe",
+                        Some(child.run_id.clone()),
+                        None,
+                    )
+                })?;
+            let owner = recipe
+                .attempts
+                .first()
+                .expect("validated Cook recipe has an initial attempt")
+                .run_id
+                .clone();
+            let handle = recipe
+                .finalization
+                .get("to_worktree")
+                .and_then(Value::as_str)
+                .filter(|handle| !handle.trim().is_empty())
+                .ok_or_else(|| {
+                    Error::validation_invalid_argument(
+                        "cook_recipe.finalization.to_worktree",
+                        "terminal fanout child recipe has no provider worktree handle",
+                        Some(recipe.cook_id.clone()),
+                        None,
+                    )
+                })?;
+            homeboy::core::worktree_provider::finalize_worktree_from_config(
+                handle,
+                &homeboy::core::worktree_provider::WorktreeProvisionLifecycle {
+                    purpose: "agent_task_cook".to_string(),
+                    owner_run_ref: owner,
+                    cleanup_policy:
+                        homeboy::core::worktree_provider::WorktreeCleanupPolicy::RemoveOnSuccess,
+                },
+                disposition,
+                &config,
+            )?;
+            Ok(())
+        })();
+        if let Err(error) = result {
+            first_error.get_or_insert(error);
+        }
+    }
+    first_error.map_or(Ok(()), Err)
 }
 
 /// HOOK — wave-completion notification. Intentionally not implemented here.
@@ -6717,7 +6796,7 @@ mod tests {
         std::fs::write(
             &script,
             format!(
-                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  printf '{{\"worktrees\":[{{\"handle\":\"%s\",\"path\":\"{}\",\"branch\":\"fixture\",\"safety\":{{\"dirty\":{},\"unpushed\":false,\"primary\":false}}}}]}}\\n' \"$2\"\nelse\n  printf '%s|%s|%s|%s|%s|%s\\n' \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" \"$7\" >> '{}'\nfi\n",
+                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  printf '{{\"worktrees\":[{{\"handle\":\"%s\",\"path\":\"{}\",\"branch\":\"fixture\",\"safety\":{{\"dirty\":{},\"unpushed\":false,\"primary\":false}}}}]}}\\n' \"$2\"\nelse\n  printf '%s|%s|%s|%s|%s|%s\\n' \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" \"$7\" >> '{}'\n  if [ \"$1\" = finalize ] && [ \"$2\" = \"${{HOMEBOY_FAKE_PROVIDER_FINALIZE_FAIL_HANDLE:-}}\" ]; then exit 1; fi\nfi\n",
                 workspace.display(),
                 dirty,
                 records.display(),
@@ -6828,53 +6907,72 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn dispatcher_fanout_terminalization_replays_provider_finalization_on_recovery() {
-        with_isolated_home(|_| {
-            let (_fixture, records, mut plan) = provider_finalization_fixture(false);
-            plan.cooks.truncate(1);
-            let cook = &plan.cooks[0];
-            let report = agent_task_service::AgentTaskCookBatchReport {
-                schema: "homeboy/agent-task-cook-batch/v1",
-                batch_id: plan.fanout_id.clone(),
-                status: "succeeded".to_string(),
-                total: 1,
-                queued: 0,
-                running: 0,
-                succeeded: 1,
-                failed: 0,
-                cancelled: 0,
-                timed_out: 0,
-                cooks: vec![agent_task_service::AgentTaskCookBatchCellReport {
-                    cook_id: cook.cook_id.clone(),
-                    initial_run_id: cook.run_id(),
-                    status: "succeeded".to_string(),
-                    exit_code: 0,
-                    result: None,
-                    error: None,
-                }],
+    fn batch_resume_replays_all_provider_finalizations_before_downstream_processing() {
+        with_isolated_home(|home| {
+            install_fanout_agent_task_providers(home.path());
+            let (_fixture, records, plan) = provider_finalization_fixture(false);
+            let dispatcher: &CookAttemptDispatcherFactory =
+                &|_| std::sync::Arc::new(FailingFanoutDispatcher);
+
+            let (_, exit_code) =
+                run_batch_cook_fanout_plan_with_attempt_dispatcher(plan.clone(), dispatcher)
+                    .expect("initial dispatcher fanout result");
+            assert_ne!(exit_code, 0);
+
+            let expected = plan
+                .cooks
+                .iter()
+                .map(|cook| {
+                    format!(
+                        "homeboy@{}|agent_task_cook|{}|remove_on_success|failed|finalize:{}",
+                        cook.cook_id,
+                        cook.run_id(),
+                        cook.run_id(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            let initial = std::fs::read_to_string(&records).expect("initial finalizations");
+            assert!(expected
+                .iter()
+                .all(|line| initial.matches(line).count() == 1));
+
+            let error = {
+                let _fail = homeboy::core::test_support::EnvVarGuard::set(
+                    "HOMEBOY_FAKE_PROVIDER_FINALIZE_FAIL_HANDLE",
+                    format!("homeboy@{}", plan.cooks[0].cook_id),
+                );
+                batch_resume(
+                    AgentTaskFanoutBatchStatusArgs {
+                        batch_id: plan.fanout_id.clone(),
+                    },
+                    Placement::Auto,
+                )
+                .expect_err("provider finalization failure stops downstream resume processing")
             };
-
-            finalize_provider_worktrees(&plan, &report, None).expect("initial finalization");
-            finalize_provider_worktrees(&plan, &report, None)
-                .expect("recovered finalization replay");
-
-            let expected = format!(
-                "homeboy@{}|agent_task_cook|{}|remove_on_success|succeeded|finalize:{}",
-                cook.cook_id,
-                cook.run_id(),
-                cook.run_id(),
+            assert!(
+                error.message.contains("finalize command failed"),
+                "unexpected resume error: {error:?}"
             );
-            let records = std::fs::read_to_string(records).expect("provider finalization records");
-            assert_eq!(records.lines().filter(|line| *line == expected).count(), 2);
+            let failed_resume =
+                std::fs::read_to_string(&records).expect("failed resume finalizations");
+            assert!(
+                expected
+                    .iter()
+                    .all(|line| failed_resume.matches(line).count() == 2),
+                "a first-child failure must not strand later provider finalization"
+            );
 
-            std::fs::remove_dir_all(_fixture.path().join("workspace"))
-                .expect("provider cleanup removed workspace");
-            let previously_terminal = BTreeMap::from([(
-                cook.run_id(),
-                _fixture.path().join("workspace").display().to_string(),
-            )]);
-            finalize_provider_worktrees(&plan, &report, Some(&previously_terminal))
-                .expect("missing finalized provider workspace is converged on recovery");
+            batch_resume(
+                AgentTaskFanoutBatchStatusArgs {
+                    batch_id: plan.fanout_id.clone(),
+                },
+                Placement::Auto,
+            )
+            .expect("idempotent command-path resume");
+            let converged = std::fs::read_to_string(records).expect("converged finalizations");
+            assert!(expected
+                .iter()
+                .all(|line| converged.matches(line).count() == 3));
         });
     }
 

--- a/crates/homeboy-cli/src/commands/release/mod.rs
+++ b/crates/homeboy-cli/src/commands/release/mod.rs
@@ -2308,6 +2308,7 @@ jobs:
                 finalization_lease: None,
                 finalization_lease_started_ms: None,
                 attempt_count: 1,
+                mutation_attempted: false,
                 continuation_evidence: Vec::new(),
                 attributes: Default::default(),
             };
@@ -2347,6 +2348,7 @@ jobs:
                 finalization_lease: None,
                 finalization_lease_started_ms: None,
                 attempt_count: 1,
+                mutation_attempted: false,
                 continuation_evidence: Vec::new(),
                 attributes: Default::default(),
             };

--- a/crates/homeboy-core/src/io/output_file.rs
+++ b/crates/homeboy-core/src/io/output_file.rs
@@ -94,10 +94,7 @@ where
     let cleanup = || {
         let _ = std::fs::remove_file(&temp);
     };
-    let mut file = match create(&temp) {
-        Ok(file) => file,
-        Err(error) => return Err(error),
-    };
+    let mut file = create(&temp)?;
     if let Err(error) = write(&mut file, contents) {
         drop(file);
         cleanup();

--- a/crates/homeboy-core/src/io/output_file.rs
+++ b/crates/homeboy-core/src/io/output_file.rs
@@ -7,6 +7,7 @@
 //! infrastructure and lives in core so the command layer stays a thin adapter.
 
 use crate::{Error, Result};
+use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -54,7 +55,8 @@ pub fn write_output_file_atomically(
     if options.create_parent_dirs {
         if let Some(parent) = target.parent() {
             if !parent.as_os_str().is_empty() {
-                std::fs::create_dir_all(parent)?;
+                crate::engine::local_files::create_dir_all_durably(parent)
+                    .map_err(|error| std::io::Error::other(error.to_string()))?;
             }
         }
     }
@@ -63,14 +65,15 @@ pub fn write_output_file_atomically(
         target,
         contents.as_ref(),
         options,
-        |path| std::fs::File::create(path),
+        |path| OpenOptions::new().write(true).create_new(true).open(path),
         |file, bytes| file.write_all(bytes),
         std::fs::File::sync_all,
         |from, to| std::fs::rename(from, to),
+        |parent| OpenOptions::new().read(true).open(parent)?.sync_all(),
     )
 }
 
-fn write_output_file_atomically_with<C, W, S, R>(
+fn write_output_file_atomically_with<C, W, S, R, D>(
     target: &Path,
     contents: &[u8],
     options: OutputWriteOptions,
@@ -78,12 +81,14 @@ fn write_output_file_atomically_with<C, W, S, R>(
     mut write: W,
     sync: S,
     rename: R,
+    sync_parent: D,
 ) -> std::io::Result<()>
 where
     C: FnOnce(&Path) -> std::io::Result<std::fs::File>,
     W: FnMut(&mut std::fs::File, &[u8]) -> std::io::Result<()>,
     S: FnOnce(&std::fs::File) -> std::io::Result<()>,
     R: FnOnce(&Path, &Path) -> std::io::Result<()>,
+    D: FnOnce(&Path) -> std::io::Result<()>,
 {
     let temp = atomic_output_temp_path(target);
     let cleanup = || {
@@ -91,10 +96,7 @@ where
     };
     let mut file = match create(&temp) {
         Ok(file) => file,
-        Err(error) => {
-            cleanup();
-            return Err(error);
-        }
+        Err(error) => return Err(error),
     };
     if let Err(error) = write(&mut file, contents) {
         cleanup();
@@ -113,7 +115,7 @@ where
     drop(file);
 
     match rename(&temp, target) {
-        Ok(()) => Ok(()),
+        Ok(()) => sync_parent(target.parent().unwrap_or_else(|| Path::new("."))),
         Err(err) => {
             let _ = std::fs::remove_file(&temp);
             Err(err)
@@ -131,7 +133,7 @@ fn atomic_output_temp_path(target: &Path) -> PathBuf {
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("output");
-    let temp_name = format!(".{file_name}.{}.tmp", std::process::id());
+    let temp_name = format!(".{file_name}.{}.tmp", uuid::Uuid::new_v4());
     target.with_file_name(temp_name)
 }
 
@@ -199,6 +201,7 @@ mod tests {
                 }
             },
             |from, to| std::fs::rename(from, to),
+            |parent| std::fs::File::open(parent)?.sync_all(),
         )
         .expect_err("injected failure");
 
@@ -218,5 +221,25 @@ mod tests {
     #[test]
     fn atomic_writer_removes_temp_after_sync_failure() {
         assert_injected_staging_failure_removes_temp(false, true);
+    }
+
+    #[test]
+    fn atomic_writer_surfaces_parent_directory_sync_failure_after_rename() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let output_path = dir.path().join("output.json");
+        let error = write_output_file_atomically_with(
+            &output_path,
+            b"{}",
+            OutputWriteOptions::artifact(),
+            |path| std::fs::File::create(path),
+            |file, bytes| file.write_all(bytes),
+            |file| file.sync_all(),
+            |from, to| std::fs::rename(from, to),
+            |_| Err(std::io::Error::other("injected directory sync failure")),
+        )
+        .expect_err("directory sync failure must not report durable success");
+
+        assert!(error.to_string().contains("directory sync failure"));
+        assert_eq!(std::fs::read_to_string(output_path).unwrap(), "{}");
     }
 }

--- a/crates/homeboy-core/src/io/output_file.rs
+++ b/crates/homeboy-core/src/io/output_file.rs
@@ -99,23 +99,32 @@ where
         Err(error) => return Err(error),
     };
     if let Err(error) = write(&mut file, contents) {
+        drop(file);
         cleanup();
         return Err(error);
     }
     if options.trailing_newline == TrailingNewline::Ensure && !contents.ends_with(b"\n") {
         if let Err(error) = write(&mut file, b"\n") {
+            drop(file);
             cleanup();
             return Err(error);
         }
     }
     if let Err(error) = sync(&file) {
+        drop(file);
         cleanup();
         return Err(error);
     }
     drop(file);
 
     match rename(&temp, target) {
-        Ok(()) => sync_parent(target.parent().unwrap_or_else(|| Path::new("."))),
+        Ok(()) => {
+            let parent = target
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+                .unwrap_or_else(|| Path::new("."));
+            sync_parent(parent)
+        }
         Err(err) => {
             let _ = std::fs::remove_file(&temp);
             Err(err)
@@ -178,6 +187,36 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&output_path).unwrap(), "{}\n");
     }
 
+    #[test]
+    fn atomic_writer_fsyncs_dot_for_a_bare_relative_target() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = Path::new("output.json");
+        write_output_file_atomically_with(
+            path,
+            b"published",
+            OutputWriteOptions::file(),
+            |relative| {
+                OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(dir.path().join(relative))
+            },
+            |file, bytes| file.write_all(bytes),
+            |file| file.sync_all(),
+            |from, to| std::fs::rename(dir.path().join(from), dir.path().join(to)),
+            |parent| {
+                assert_eq!(parent, Path::new("."));
+                std::fs::File::open(dir.path())?.sync_all()
+            },
+        )
+        .expect("a published bare relative output must not fail its parent fsync");
+
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join(path)).unwrap(),
+            "published"
+        );
+    }
+
     fn assert_injected_staging_failure_removes_temp(fail_write: bool, fail_sync: bool) {
         let dir = tempfile::tempdir().expect("temp dir");
         let output_path = dir.path().join("output.json");
@@ -185,7 +224,7 @@ mod tests {
             &output_path,
             b"{}",
             OutputWriteOptions::artifact(),
-            |path| std::fs::File::create(path),
+            |path| OpenOptions::new().write(true).create_new(true).open(path),
             move |file, bytes| {
                 if fail_write {
                     Err(std::io::Error::other("injected write failure"))

--- a/crates/homeboy-core/src/workspace_claim.rs
+++ b/crates/homeboy-core/src/workspace_claim.rs
@@ -572,7 +572,7 @@ impl WorkspaceClaimStore {
         count: u64,
     ) -> Result<()> {
         workspace.verify()?;
-        fs::create_dir_all(&self.root).map_err(io_error)?;
+        crate::engine::local_files::create_dir_all_durably(&self.root)?;
         fs::write(
             self.owner_release_failure_path(workspace),
             count.to_string(),
@@ -626,6 +626,26 @@ impl WorkspaceClaimStore {
                 .reconciliation
                 .as_ref()
                 == Some(claim))
+        })
+    }
+
+    /// Hold the workspace authority lock while a destructive reconciliation
+    /// mutation runs. Expiry cannot admit a new owner until this closure exits.
+    pub fn with_reconciliation_fence<T>(
+        &self,
+        claim: &WorkspaceClaim,
+        operation: impl FnOnce() -> Result<T>,
+    ) -> Result<T> {
+        claim.workspace.verify()?;
+        self.with_lock(&claim.workspace, || {
+            let state = self.read_or_empty(&claim.workspace)?;
+            if state.reconciliation.as_ref() != Some(claim) {
+                return Err(invalid(
+                    "workspace_claim",
+                    "reconciliation claim no longer matches durable authority",
+                ));
+            }
+            operation()
         })
     }
     /// Return whether this authority still has a live reconciliation claim or
@@ -742,7 +762,7 @@ impl WorkspaceClaimStore {
         workspace: &WorkspaceIdentity,
         operation: impl FnOnce() -> Result<T>,
     ) -> Result<T> {
-        fs::create_dir_all(&self.root).map_err(io_error)?;
+        crate::engine::local_files::create_dir_all_durably(&self.root)?;
         sync_dir(&self.root)?;
         let lock = OpenOptions::new()
             .create(true)

--- a/crates/homeboy-core/src/worktree/mod.rs
+++ b/crates/homeboy-core/src/worktree/mod.rs
@@ -253,6 +253,15 @@ pub fn finalize_provider_lifecycle(
     owner_run_ref: &str,
     disposition: crate::worktree_provider::WorktreeTerminalDisposition,
 ) -> Result<TaskWorktreeRecord> {
+    finalize_provider_lifecycle_with_effect_fence(id, owner_run_ref, disposition, || Ok(()))
+}
+
+pub fn finalize_provider_lifecycle_with_effect_fence(
+    id: &str,
+    owner_run_ref: &str,
+    disposition: crate::worktree_provider::WorktreeTerminalDisposition,
+    before_effect: impl FnOnce() -> Result<()>,
+) -> Result<TaskWorktreeRecord> {
     with_task_worktree_registry_write_lock(|| {
         let store = metadata_dir()?;
         let mut record = read_record(&store, id)?;
@@ -291,6 +300,7 @@ pub fn finalize_provider_lifecycle(
             )
         })?;
         record.terminal_workspace_authority = None;
+        before_effect()?;
         store_ops::write_record_unlocked(&store, &record)?;
         Ok(record)
     })
@@ -518,27 +528,7 @@ pub(crate) fn with_task_worktree_registry_read_lock<T>(
         .get_or_init(|| RwLock::new(()))
         .read()
         .map_err(|_| Error::internal_unexpected("task worktree registry read gate poisoned"))?;
-    let store = metadata_dir()?;
-    let parent = store.parent().ok_or_else(|| {
-        Error::internal_unexpected(format!(
-            "task worktree store has no parent: {}",
-            store.display()
-        ))
-    })?;
-    let lock = match OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open(parent.join("task-worktrees.lock"))
-    {
-        Ok(lock) => lock,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return operation(),
-        Err(error) => {
-            return Err(Error::internal_io(
-                error.to_string(),
-                Some("open task worktree registry lock for read".to_string()),
-            ));
-        }
-    };
+    let lock = open_task_worktree_registry_lock()?;
     lock.lock_shared().map_err(|error| {
         Error::internal_io(
             error.to_string(),
@@ -573,12 +563,7 @@ fn open_task_worktree_registry_lock() -> Result<std::fs::File> {
             store.display()
         ))
     })?;
-    fs::create_dir_all(parent).map_err(|error| {
-        Error::internal_io(
-            error.to_string(),
-            Some(format!("create {}", parent.display())),
-        )
-    })?;
+    crate::engine::local_files::create_dir_all_durably(parent)?;
     OpenOptions::new()
         .create(true)
         .truncate(false)

--- a/crates/homeboy-core/src/worktree/store_ops.rs
+++ b/crates/homeboy-core/src/worktree/store_ops.rs
@@ -297,14 +297,13 @@ fn cleanup_skip_reasons(
     live_owner_count: usize,
 ) -> Vec<String> {
     let mut reasons = Vec::new();
-    if record.terminal_disposition.as_deref() != Some("succeeded") || record.run_id.is_none() {
-        reasons.push(record.run_id.as_deref().map_or_else(
-            || "cleanup requires explicit succeeded lifecycle finalization".to_string(),
-            |owner| {
-                format!(
-                    "cleanup requires explicit succeeded finalization from lifecycle owner `{owner}`"
-                )
-            },
+    if let Some(owner) = record
+        .run_id
+        .as_deref()
+        .filter(|_| record.terminal_disposition.as_deref() != Some("succeeded"))
+    {
+        reasons.push(format!(
+            "cleanup requires explicit succeeded finalization from lifecycle owner `{owner}`"
         ));
     }
     if safety.primary_checkout {

--- a/crates/homeboy-core/src/worktree/store_ops.rs
+++ b/crates/homeboy-core/src/worktree/store_ops.rs
@@ -311,8 +311,12 @@ fn cleanup_skip_reasons(
     if safety.worktree_missing {
         reasons.push("missing active worktree requires `worktree inventory --apply` reconciliation authority".to_string());
     }
-    if safety.live_caller_cwd {
-        reasons.push("refuses to remove the caller's live current working directory".to_string());
+    if safety
+        .reasons
+        .iter()
+        .any(|reason| reason == LIVE_CWD_REASON)
+    {
+        reasons.push(LIVE_CWD_REASON.to_string());
     }
     if !force {
         if safety.dirty {
@@ -1391,7 +1395,11 @@ pub(super) fn remove_with_store(
             Some(safety.reasons.clone()),
         ));
     }
-    if safety.live_caller_cwd {
+    if safety
+        .reasons
+        .iter()
+        .any(|reason| reason == LIVE_CWD_REASON)
+    {
         return Err(Error::validation_invalid_argument(
             "worktree",
             "Task worktree contains the caller's live current working directory",
@@ -1594,11 +1602,11 @@ pub(super) fn safety_report(record: &TaskWorktreeRecord) -> Result<WorktreeSafet
     let worktree_missing = !raw_worktree.exists();
     let primary_checkout = source == worktree;
     let path_contained = worktree.starts_with(parent) && worktree != source;
-    let live_caller_cwd = !worktree_missing
-        && std::env::current_dir()
-            .ok()
-            .map(|cwd| normalize_missing_path(&cwd))
-            .is_some_and(|cwd| cwd == worktree || cwd.starts_with(&worktree));
+    let caller_cwd =
+        std::env::current_dir().map_err(|error| Error::internal_io(error.to_string(), None))?;
+    let caller_cwd = normalize_missing_path(&caller_cwd);
+    let live_caller_cwd =
+        !worktree_missing && (caller_cwd == worktree || caller_cwd.starts_with(&worktree));
     let dirty = !worktree_missing && is_dirty(&worktree)?;
     let unpushed_commits = if worktree_missing {
         0
@@ -1618,14 +1626,9 @@ pub(super) fn safety_report(record: &TaskWorktreeRecord) -> Result<WorktreeSafet
     if !path_contained {
         reasons.push("worktree path is outside the component checkout parent".to_string());
     }
-    let terminal_owner_evidence = record.run_id.as_deref().and_then(|owner| {
-        (record.terminal_disposition.as_deref() == Some("succeeded")).then(|| {
-            format!(
-                "lifecycle owner `{owner}` explicitly finalized succeeded at revision {}",
-                record.lifecycle_revision
-            )
-        })
-    });
+    if live_caller_cwd {
+        reasons.push(LIVE_CWD_REASON.to_string());
+    }
     let safe = reasons.is_empty();
     Ok(WorktreeSafetyReport {
         dirty,
@@ -1633,12 +1636,12 @@ pub(super) fn safety_report(record: &TaskWorktreeRecord) -> Result<WorktreeSafet
         primary_checkout,
         path_contained,
         worktree_missing,
-        live_caller_cwd,
-        terminal_owner_evidence,
         safe,
         reasons,
     })
 }
+
+const LIVE_CWD_REASON: &str = "refuses to remove the caller's live current working directory";
 
 pub(super) fn is_dirty(path: &Path) -> Result<bool> {
     Ok(

--- a/crates/homeboy-core/src/worktree/store_ops.rs
+++ b/crates/homeboy-core/src/worktree/store_ops.rs
@@ -215,7 +215,8 @@ pub(super) fn cleanup_with_store(
         };
         let branch_cleanup = branch_cleanup_report(&record)
             .unwrap_or_else(|error| branch_cleanup_unknown(&record, error.message));
-        let skip_reasons = cleanup_skip_reasons(&record, &safety, options.force);
+        let live_owner_count = live_workspace_owner_count(&record, store)?;
+        let skip_reasons = cleanup_skip_reasons(&record, &safety, options.force, live_owner_count);
         if !skip_reasons.is_empty() {
             skipped.push(WorktreeCleanupSkipped {
                 record,
@@ -293,14 +294,18 @@ fn cleanup_skip_reasons(
     record: &TaskWorktreeRecord,
     safety: &WorktreeSafetyReport,
     force: bool,
+    live_owner_count: usize,
 ) -> Vec<String> {
     let mut reasons = Vec::new();
-    if record.terminal_disposition.as_deref() != Some("succeeded") {
-        if let Some(owner) = record.run_id.as_deref() {
-            reasons.push(format!(
-                "cleanup requires explicit succeeded finalization from lifecycle owner `{owner}`"
-            ));
-        }
+    if record.terminal_disposition.as_deref() != Some("succeeded") || record.run_id.is_none() {
+        reasons.push(record.run_id.as_deref().map_or_else(
+            || "cleanup requires explicit succeeded lifecycle finalization".to_string(),
+            |owner| {
+                format!(
+                    "cleanup requires explicit succeeded finalization from lifecycle owner `{owner}`"
+                )
+            },
+        ));
     }
     if safety.primary_checkout {
         reasons.push("refuses to remove primary checkout".to_string());
@@ -317,6 +322,11 @@ fn cleanup_skip_reasons(
         .any(|reason| reason == LIVE_CWD_REASON)
     {
         reasons.push(LIVE_CWD_REASON.to_string());
+    }
+    if live_owner_count > 0 {
+        reasons.push(format!(
+            "refuses to remove workspace held by {live_owner_count} durable live owner(s)"
+        ));
     }
     if !force {
         if safety.dirty {
@@ -1376,8 +1386,21 @@ pub(super) fn remove_with_store(
     options: WorktreeRemoveOptions,
     store_dir: &Path,
 ) -> Result<WorktreeRemoveOutput> {
+    with_task_worktree_registry_write_lock(|| remove_with_store_unlocked(options, store_dir))
+}
+
+fn remove_with_store_unlocked(
+    options: WorktreeRemoveOptions,
+    store_dir: &Path,
+) -> Result<WorktreeRemoveOutput> {
+    // The registry lease fences the complete decision and Git mutation. Always
+    // re-read under it so finalization that won the lease first is preserved.
     let mut record = read_record(store_dir, &options.id)?;
-    repair_record_source_checkout_if_needed(&mut record, store_dir)?;
+    if !Path::new(&record.source_checkout).exists() {
+        record.source_checkout = recovered_component_source_checkout(&record)?
+            .to_string_lossy()
+            .to_string();
+    }
     let safety = safety_report(&record)?;
     if !options.force && !safety.safe {
         return Err(Error::validation_invalid_argument(
@@ -1407,33 +1430,112 @@ pub(super) fn remove_with_store(
             Some(safety.reasons.clone()),
         ));
     }
+    let live_owner_count = live_workspace_owner_count(&record, store_dir)?;
+    if live_owner_count > 0 {
+        return Err(Error::validation_invalid_argument(
+            "workspace_claim",
+            format!("Task worktree is held by {live_owner_count} durable live owner(s)"),
+            Some(record.id.clone()),
+            None,
+        ));
+    }
 
-    if !safety.worktree_missing {
-        let mut args = vec!["worktree", "remove"];
-        if options.force {
-            args.push("--force");
+    let claims = workspace_claim_store_for_worktrees(store_dir)?;
+    let claim = claims.acquire(
+        record.effective_workspace_identity()?,
+        crate::workspace_claim::MAX_WORKSPACE_CLAIM_TTL_MS,
+        now_ms(),
+    )?;
+    let worktree_parent = Path::new(&record.worktree_path)
+        .parent()
+        .map(Path::to_path_buf);
+    let git_common_dir = git_common_dir(Path::new(&record.source_checkout))?;
+    let result = claims.with_reconciliation_fence(&claim, || {
+        if !safety.worktree_missing {
+            let mut args = vec!["worktree", "remove"];
+            if options.force {
+                args.push("--force");
+            }
+            args.push(&record.worktree_path);
+            git::run_git(
+                Path::new(&record.source_checkout),
+                &args,
+                "git worktree remove",
+            )?;
         }
-        args.push(&record.worktree_path);
-        git::run_git(
-            Path::new(&record.source_checkout),
-            &args,
-            "git worktree remove",
-        )?;
+        if let Some(parent) = &worktree_parent {
+            fs::File::open(parent)
+                .and_then(|directory| directory.sync_all())
+                .map_err(|error| {
+                    Error::internal_io(error.to_string(), Some(parent.display().to_string()))
+                })?;
+        }
+        let registrations = git_common_dir.join("worktrees");
+        let git_metadata_parent = if registrations.exists() {
+            registrations.as_path()
+        } else {
+            git_common_dir.as_path()
+        };
+        fs::File::open(git_metadata_parent)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(git_metadata_parent.display().to_string()),
+                )
+            })?;
+        let mut branch_cleanup = branch_cleanup_report(&record)
+            .unwrap_or_else(|error| branch_cleanup_unknown(&record, error.message));
+        if options.cleanup_branch {
+            branch_cleanup =
+                apply_branch_cleanup(&record, branch_cleanup, options.allow_unmerged_branch)?;
+        }
+        record.state = TaskWorktreeState::Removed;
+        record.lifecycle_revision = record.lifecycle_revision.checked_add(1).ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "lifecycle_revision",
+                "task worktree lifecycle revision overflowed during removal",
+                Some(record.id.clone()),
+                None,
+            )
+        })?;
+        write_record_unlocked(store_dir, &record)?;
+        Ok(WorktreeRemoveOutput {
+            record,
+            safety,
+            branch_cleanup,
+            removed: true,
+        })
+    });
+    let release = claims.release(&claim, now_ms());
+    match result {
+        Err(error) => Err(error),
+        Ok(output) => {
+            release?;
+            Ok(output)
+        }
     }
-    let mut branch_cleanup = branch_cleanup_report(&record)
-        .unwrap_or_else(|error| branch_cleanup_unknown(&record, error.message));
-    if options.cleanup_branch {
-        branch_cleanup =
-            apply_branch_cleanup(&record, branch_cleanup, options.allow_unmerged_branch)?;
-    }
-    record.state = TaskWorktreeState::Removed;
-    write_record(store_dir, &record)?;
-    Ok(WorktreeRemoveOutput {
-        record,
-        safety,
-        branch_cleanup,
-        removed: true,
-    })
+}
+
+fn live_workspace_owner_count(record: &TaskWorktreeRecord, store_dir: &Path) -> Result<usize> {
+    let claims = workspace_claim_store_for_worktrees(store_dir)?;
+    Ok(claims
+        .owner_status(&record.effective_workspace_identity()?, now_ms())?
+        .len())
+}
+
+fn workspace_claim_store_for_worktrees(
+    store_dir: &Path,
+) -> Result<crate::workspace_claim::WorkspaceClaimStore> {
+    let data_root = store_dir.parent().ok_or_else(|| {
+        Error::internal_unexpected(format!(
+            "task worktree store `{}` has no data root",
+            store_dir.display()
+        ))
+    })?;
+    Ok(crate::workspace_claim::WorkspaceClaimStore::new(
+        data_root.join(crate::workspace_claim::LOCAL_WORKSPACE_CLAIMS_DIR),
+    ))
 }
 
 pub(super) fn branch_cleanup_report(
@@ -1823,9 +1925,7 @@ pub(super) fn write_record(store_dir: &Path, record: &TaskWorktreeRecord) -> Res
 
 pub(super) fn write_record_unlocked(store_dir: &Path, record: &TaskWorktreeRecord) -> Result<()> {
     let store_owner = ownership::owner_for_path_or_ancestor(store_dir)?;
-    fs::create_dir_all(store_dir).map_err(|err| {
-        Error::internal_io(err.to_string(), Some(store_dir.display().to_string()))
-    })?;
+    crate::engine::local_files::create_dir_all_durably(store_dir)?;
     let json = serde_json::to_string_pretty(record)
         .map_err(|err| Error::internal_json(err.to_string(), Some(record.id.clone())))?;
     let path = record_path(store_dir, &record.id);

--- a/crates/homeboy-core/src/worktree/store_ops.rs
+++ b/crates/homeboy-core/src/worktree/store_ops.rs
@@ -215,7 +215,7 @@ pub(super) fn cleanup_with_store(
         };
         let branch_cleanup = branch_cleanup_report(&record)
             .unwrap_or_else(|error| branch_cleanup_unknown(&record, error.message));
-        let skip_reasons = cleanup_skip_reasons(&safety, options.force);
+        let skip_reasons = cleanup_skip_reasons(&record, &safety, options.force);
         if !skip_reasons.is_empty() {
             skipped.push(WorktreeCleanupSkipped {
                 record,
@@ -289,8 +289,19 @@ pub(super) fn cleanup_with_store(
     })
 }
 
-fn cleanup_skip_reasons(safety: &WorktreeSafetyReport, force: bool) -> Vec<String> {
+fn cleanup_skip_reasons(
+    record: &TaskWorktreeRecord,
+    safety: &WorktreeSafetyReport,
+    force: bool,
+) -> Vec<String> {
     let mut reasons = Vec::new();
+    if record.terminal_disposition.as_deref() != Some("succeeded") {
+        if let Some(owner) = record.run_id.as_deref() {
+            reasons.push(format!(
+                "cleanup requires explicit succeeded finalization from lifecycle owner `{owner}`"
+            ));
+        }
+    }
     if safety.primary_checkout {
         reasons.push("refuses to remove primary checkout".to_string());
     }
@@ -299,6 +310,9 @@ fn cleanup_skip_reasons(safety: &WorktreeSafetyReport, force: bool) -> Vec<Strin
     }
     if safety.worktree_missing {
         reasons.push("missing active worktree requires `worktree inventory --apply` reconciliation authority".to_string());
+    }
+    if safety.live_caller_cwd {
+        reasons.push("refuses to remove the caller's live current working directory".to_string());
     }
     if !force {
         if safety.dirty {
@@ -1377,6 +1391,14 @@ pub(super) fn remove_with_store(
             Some(safety.reasons.clone()),
         ));
     }
+    if safety.live_caller_cwd {
+        return Err(Error::validation_invalid_argument(
+            "worktree",
+            "Task worktree contains the caller's live current working directory",
+            Some(record.id.clone()),
+            Some(safety.reasons.clone()),
+        ));
+    }
 
     if !safety.worktree_missing {
         let mut args = vec!["worktree", "remove"];
@@ -1572,6 +1594,11 @@ pub(super) fn safety_report(record: &TaskWorktreeRecord) -> Result<WorktreeSafet
     let worktree_missing = !raw_worktree.exists();
     let primary_checkout = source == worktree;
     let path_contained = worktree.starts_with(parent) && worktree != source;
+    let live_caller_cwd = !worktree_missing
+        && std::env::current_dir()
+            .ok()
+            .map(|cwd| normalize_missing_path(&cwd))
+            .is_some_and(|cwd| cwd == worktree || cwd.starts_with(&worktree));
     let dirty = !worktree_missing && is_dirty(&worktree)?;
     let unpushed_commits = if worktree_missing {
         0
@@ -1591,6 +1618,14 @@ pub(super) fn safety_report(record: &TaskWorktreeRecord) -> Result<WorktreeSafet
     if !path_contained {
         reasons.push("worktree path is outside the component checkout parent".to_string());
     }
+    let terminal_owner_evidence = record.run_id.as_deref().and_then(|owner| {
+        (record.terminal_disposition.as_deref() == Some("succeeded")).then(|| {
+            format!(
+                "lifecycle owner `{owner}` explicitly finalized succeeded at revision {}",
+                record.lifecycle_revision
+            )
+        })
+    });
     let safe = reasons.is_empty();
     Ok(WorktreeSafetyReport {
         dirty,
@@ -1598,6 +1633,8 @@ pub(super) fn safety_report(record: &TaskWorktreeRecord) -> Result<WorktreeSafet
         primary_checkout,
         path_contained,
         worktree_missing,
+        live_caller_cwd,
+        terminal_owner_evidence,
         safe,
         reasons,
     })

--- a/crates/homeboy-core/src/worktree/tests.rs
+++ b/crates/homeboy-core/src/worktree/tests.rs
@@ -650,8 +650,12 @@ fn owned_worktree_survives_push_and_pr_boundary_until_finalization_and_cwd_exit(
 
             let active_status = status(&created.record.id).expect("active owned status");
             assert!(
-                active_status.safety.safe,
-                "lifecycle cleanup eligibility must not make an active worktree unsafe for lookup"
+                active_status
+                    .safety
+                    .reasons
+                    .iter()
+                    .any(|reason| reason.contains("live current working directory")),
+                "active lookup must report why the caller workspace cannot be removed"
             );
             let before_pr = cleanup(WorktreeCleanupOptions {
                 force: true,
@@ -735,11 +739,12 @@ fi
             )
             .expect("explicit terminal owner finalization");
             let finalized_status = status(&created.record.id).expect("finalized status");
-            assert!(finalized_status
-                .safety
-                .terminal_owner_evidence
-                .as_deref()
-                .is_some_and(|evidence| evidence.contains(owner)));
+            assert_eq!(finalized_status.record.run_id.as_deref(), Some(owner));
+            assert_eq!(
+                finalized_status.record.terminal_disposition.as_deref(),
+                Some("succeeded")
+            );
+            assert_eq!(finalized_status.record.lifecycle_revision, 1);
 
             let direct_remove = remove(WorktreeRemoveOptions {
                 id: created.record.id.clone(),

--- a/crates/homeboy-core/src/worktree/tests.rs
+++ b/crates/homeboy-core/src/worktree/tests.rs
@@ -601,6 +601,184 @@ fn finalization_is_owner_bound_idempotent_conflict_safe_and_never_cleans_up() {
 }
 
 #[test]
+fn owned_worktree_survives_push_and_pr_boundary_until_finalization_and_cwd_exit() {
+    crate::test_support::with_isolated_home(|home| {
+        let developer = home.path().join("Developer");
+        let remote = home.path().join("remote.git");
+        let source = developer.join("lifecycle-fixture");
+        fs::create_dir_all(&developer).expect("developer directory");
+        fs::create_dir_all(&remote).expect("remote directory");
+        run_git(&remote, &["init", "--bare", "-q"]);
+        run_git(
+            &developer,
+            &[
+                "clone",
+                "-q",
+                &remote.to_string_lossy(),
+                "lifecycle-fixture",
+            ],
+        );
+        run_git(&source, &["config", "user.email", "homeboy@example.com"]);
+        run_git(&source, &["config", "user.name", "Homeboy Test"]);
+        fs::write(source.join("README.md"), "initial\n").expect("initial file");
+        fs::write(source.join("homeboy.json"), r#"{"id":"lifecycle-fixture"}"#)
+            .expect("component manifest");
+        run_git(&source, &["add", "."]);
+        run_git(&source, &["commit", "-q", "-m", "initial"]);
+        run_git(&source, &["branch", "-M", "main"]);
+        run_git(&source, &["push", "-q", "-u", "origin", "main"]);
+        write_component_registration(home.path(), "lifecycle-fixture", &source);
+
+        let owner = "cook-lifecycle-attempt-1";
+        let created = create(WorktreeCreateOptions {
+            component_id: "lifecycle-fixture".to_string(),
+            branch: "fix/lifecycle".to_string(),
+            from: Some("main".to_string()),
+            task_url: Some("https://github.com/Extra-Chill/homeboy/issues/13971".to_string()),
+            run_id: Some(owner.to_string()),
+            cleanup_policy: Some(CleanupPolicy::RemoveWhenSafe),
+            require_handoff_freshness: false,
+        })
+        .expect("owned worktree");
+        let path = PathBuf::from(&created.record.worktree_path);
+        fs::write(path.join("fix.txt"), "fixed\n").expect("task change");
+        run_git(&path, &["add", "."]);
+        run_git(&path, &["commit", "-q", "-m", "fix lifecycle"]);
+        {
+            let _cwd = CurrentDirGuard::set(&path);
+            run_git(&path, &["push", "-q", "-u", "origin", "fix/lifecycle"]);
+
+            let active_status = status(&created.record.id).expect("active owned status");
+            assert!(
+                active_status.safety.safe,
+                "lifecycle cleanup eligibility must not make an active worktree unsafe for lookup"
+            );
+            let before_pr = cleanup(WorktreeCleanupOptions {
+                force: true,
+                dry_run: false,
+                cleanup_branches: false,
+                allow_unmerged_branches: false,
+            })
+            .expect("cleanup before PR creation");
+            assert_eq!(before_pr.counts.removed, 0);
+            assert!(before_pr.skipped[0]
+                .reasons
+                .iter()
+                .any(|reason| reason.contains("explicit succeeded finalization")));
+            assert!(path.exists(), "a clean push is not terminal owner evidence");
+
+            let bin = home.path().join("bin");
+            fs::create_dir(&bin).expect("fake gh bin");
+            let gh_log = home.path().join("gh-cwd.log");
+            let fake_gh = bin.join("gh");
+            fs::write(
+                &fake_gh,
+                r#"#!/bin/sh
+if [ "$1 $2" = "pr create" ]; then
+  test -d "$PWD" || exit 2
+  pwd > "$HOMEBOY_FAKE_GH_CWD_LOG"
+  printf '%s\n' 'https://github.com/example/lifecycle-fixture/pull/13971'
+fi
+"#,
+            )
+            .expect("write fake gh");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                fs::set_permissions(&fake_gh, fs::Permissions::from_mode(0o755))
+                    .expect("make fake gh executable");
+            }
+            let mut command_path = std::ffi::OsString::from(bin.as_os_str());
+            command_path.push(":");
+            command_path.push(std::env::var_os("PATH").unwrap_or_default());
+            let _path_env = crate::test_support::EnvVarGuard::set("PATH", command_path);
+            let _gh_log_env =
+                crate::test_support::EnvVarGuard::set("HOMEBOY_FAKE_GH_CWD_LOG", &gh_log);
+            fs::write(
+                home.path()
+                    .join(".config/homeboy/components/lifecycle-fixture.json"),
+                serde_json::json!({
+                    "local_path": source,
+                    "remote_path": "wp-content/plugins/lifecycle-fixture",
+                    "remote_url": "https://github.com/example/lifecycle-fixture.git"
+                })
+                .to_string(),
+            )
+            .expect("GitHub component registration");
+
+            let pr = crate::git::pr_create(
+                Some("lifecycle-fixture"),
+                crate::git::PrCreateOptions {
+                    base: "main".to_string(),
+                    head: "fix/lifecycle".to_string(),
+                    title: "Fix lifecycle".to_string(),
+                    body: "Lifecycle fixture".to_string(),
+                    draft: false,
+                    path: Some(path.display().to_string()),
+                },
+            )
+            .expect("create PR through fake gh");
+            assert_eq!(pr.number, Some(13971));
+            assert_eq!(
+                PathBuf::from(fs::read_to_string(&gh_log).expect("fake gh cwd").trim()),
+                path.canonicalize().expect("canonical worktree")
+            );
+            assert!(
+                path.exists(),
+                "PR creation must retain its caller workspace"
+            );
+
+            finalize_provider_lifecycle(
+                &created.record.id,
+                owner,
+                crate::worktree_provider::WorktreeTerminalDisposition::Succeeded,
+            )
+            .expect("explicit terminal owner finalization");
+            let finalized_status = status(&created.record.id).expect("finalized status");
+            assert!(finalized_status
+                .safety
+                .terminal_owner_evidence
+                .as_deref()
+                .is_some_and(|evidence| evidence.contains(owner)));
+
+            let direct_remove = remove(WorktreeRemoveOptions {
+                id: created.record.id.clone(),
+                force: true,
+                cleanup_branch: false,
+                allow_unmerged_branch: false,
+            })
+            .expect_err("forced direct removal cannot remove the caller cwd");
+            assert!(direct_remove
+                .message
+                .contains("live current working directory"));
+            let live_cwd = cleanup(WorktreeCleanupOptions {
+                force: true,
+                dry_run: false,
+                cleanup_branches: false,
+                allow_unmerged_branches: false,
+            })
+            .expect("cleanup while caller cwd is live");
+            assert_eq!(live_cwd.counts.removed, 0);
+            assert!(live_cwd.skipped[0]
+                .reasons
+                .iter()
+                .any(|reason| reason.contains("live current working directory")));
+            assert!(path.exists());
+        }
+
+        let after_cwd_exit = cleanup(WorktreeCleanupOptions {
+            force: false,
+            dry_run: false,
+            cleanup_branches: false,
+            allow_unmerged_branches: false,
+        })
+        .expect("cleanup after terminal finalization and cwd exit");
+        assert_eq!(after_cwd_exit.counts.removed, 1);
+        assert!(!path.exists());
+    });
+}
+
+#[test]
 fn create_restores_missing_active_record_from_an_unclaimed_existing_branch() {
     crate::test_support::with_isolated_home(|home| {
         let (source, options) = registered_create_fixture(home.path(), "restore-fixture");

--- a/crates/homeboy-core/src/worktree/tests.rs
+++ b/crates/homeboy-core/src/worktree/tests.rs
@@ -609,6 +609,73 @@ fn finalization_is_owner_bound_idempotent_conflict_safe_and_never_cleans_up() {
 }
 
 #[test]
+fn default_ownerless_create_remains_eligible_for_safe_cleanup() {
+    crate::test_support::with_isolated_home(|home| {
+        let (_, options) = registered_create_fixture(home.path(), "ownerless-cleanup");
+        let created = create(options).expect("create ownerless task worktree");
+        let path = PathBuf::from(&created.record.worktree_path);
+        assert_eq!(created.record.run_id, None);
+        assert_eq!(created.record.terminal_disposition, None);
+        assert_eq!(created.record.cleanup_policy, CleanupPolicy::RemoveWhenSafe);
+
+        let output = cleanup(WorktreeCleanupOptions {
+            force: false,
+            dry_run: false,
+            cleanup_branches: false,
+            allow_unmerged_branches: false,
+        })
+        .expect("clean up ownerless task worktree");
+
+        assert_eq!(output.counts.removed, 1);
+        assert_eq!(output.counts.skipped, 0);
+        assert!(!path.exists());
+    });
+}
+
+#[test]
+fn owned_remove_when_safe_worktree_requires_succeeded_terminal_finalization() {
+    let data_root = tempfile::tempdir().unwrap();
+    let source = git_repo();
+    let worktree = sibling_worktree_path(source.path(), "owned-nonterminal-cleanup");
+    run_git(
+        source.path(),
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "owned-nonterminal-cleanup",
+            &worktree.to_string_lossy(),
+        ],
+    );
+    let store = data_root.path().join("task-worktrees");
+    let mut record = fixture_record(source.path(), &worktree);
+    record.run_id = Some("lifecycle-owner".to_string());
+    write_record(&store, &record).unwrap();
+
+    for terminal_disposition in [None, Some("failed".to_string())] {
+        record.terminal_disposition = terminal_disposition;
+        write_record(&store, &record).unwrap();
+        let output = cleanup_with_store(
+            WorktreeCleanupOptions {
+                force: true,
+                dry_run: false,
+                cleanup_branches: false,
+                allow_unmerged_branches: false,
+            },
+            &store,
+        )
+        .unwrap();
+
+        assert_eq!(output.counts.removed, 0);
+        assert_eq!(output.counts.skipped, 1);
+        assert!(output.skipped[0].reasons.iter().any(|reason| {
+            reason.contains("explicit succeeded finalization from lifecycle owner")
+        }));
+        assert!(worktree.exists());
+    }
+}
+
+#[test]
 fn owned_worktree_survives_push_and_pr_boundary_until_finalization_and_cwd_exit() {
     crate::test_support::with_isolated_home(|home| {
         let developer = home.path().join("Developer");

--- a/crates/homeboy-core/src/worktree/tests.rs
+++ b/crates/homeboy-core/src/worktree/tests.rs
@@ -93,6 +93,14 @@ fn fixture_record(source: &Path, worktree: &Path) -> TaskWorktreeRecord {
     }
 }
 
+fn succeeded_record(source: &Path, worktree: &Path) -> TaskWorktreeRecord {
+    let mut record = fixture_record(source, worktree);
+    record.run_id = Some("completed-owner".to_string());
+    record.terminal_disposition = Some("succeeded".to_string());
+    record.lifecycle_revision = 1;
+    record
+}
+
 fn exact_terminal_proof(record: &TaskWorktreeRecord) -> TerminalWorkspaceAuthorityProof {
     let authority_set = vec!["controller".to_string()];
     TerminalWorkspaceAuthorityProof {
@@ -1255,7 +1263,7 @@ fn cleanup_marks_missing_worktree_record_removed() {
     let source = git_repo();
     let worktree = sibling_worktree_path(source.path(), "missing-cleanup");
     let store = dir.path().join("store");
-    let record = fixture_record(source.path(), &worktree);
+    let record = succeeded_record(source.path(), &worktree);
     write_record(&store, &record).unwrap();
 
     let output = cleanup_with_store(
@@ -1276,6 +1284,86 @@ fn cleanup_marks_missing_worktree_record_removed() {
     assert_eq!(output.counts.reconciliation_blockers, 1);
     assert!(output.skipped[0].reasons[0].contains("inventory --apply"));
     assert_eq!(updated.state, TaskWorktreeState::Active);
+}
+
+#[test]
+fn cleanup_and_remove_refuse_durable_live_workspace_owners_even_with_force() {
+    let data_root = tempfile::tempdir().unwrap();
+    let source = git_repo();
+    let worktree = sibling_worktree_path(source.path(), "durably-owned-cleanup");
+    run_git(
+        source.path(),
+        &["worktree", "add", "-b", "task", &worktree.to_string_lossy()],
+    );
+    let store = data_root.path().join("task-worktrees");
+    let mut record = fixture_record(source.path(), &worktree);
+    record.run_id = Some("completed-owner".to_string());
+    record.terminal_disposition = Some("succeeded".to_string());
+    record.lifecycle_revision = 1;
+    write_record(&store, &record).unwrap();
+    let claims = crate::workspace_claim::WorkspaceClaimStore::new(
+        data_root
+            .path()
+            .join(crate::workspace_claim::LOCAL_WORKSPACE_CLAIMS_DIR),
+    );
+    let now = now_ms();
+    let owner = claims
+        .register_owner(
+            record.effective_workspace_identity().unwrap(),
+            "live-agent",
+            60_000,
+            now,
+        )
+        .unwrap();
+
+    for force in [false, true] {
+        let output = cleanup_with_store(
+            WorktreeCleanupOptions {
+                force,
+                dry_run: false,
+                cleanup_branches: false,
+                allow_unmerged_branches: false,
+            },
+            &store,
+        )
+        .unwrap();
+        assert_eq!(output.counts.removed, 0);
+        assert!(output.skipped[0]
+            .reasons
+            .iter()
+            .any(|reason| reason.contains("durable live owner")));
+        assert!(worktree.exists());
+    }
+    let error = remove_with_store(
+        WorktreeRemoveOptions {
+            id: record.id.clone(),
+            force: true,
+            cleanup_branch: false,
+            allow_unmerged_branch: false,
+        },
+        &store,
+    )
+    .expect_err("direct removal must honor durable ownership");
+    assert!(error.message.contains("durable live owner"));
+
+    claims.release_owner(&owner, now + 1).unwrap();
+    let removed = remove_with_store(
+        WorktreeRemoveOptions {
+            id: record.id,
+            force: false,
+            cleanup_branch: false,
+            allow_unmerged_branch: false,
+        },
+        &store,
+    )
+    .unwrap();
+    assert!(removed.removed);
+    assert_eq!(
+        removed.record.terminal_disposition.as_deref(),
+        Some("succeeded")
+    );
+    assert_eq!(removed.record.lifecycle_revision, 2);
+    assert!(!worktree.exists());
 }
 
 #[test]
@@ -1567,7 +1655,7 @@ fn cleanup_deletes_merged_task_branch_when_requested() {
     let worktree = sibling_worktree_path(source.path(), "merged-branch-cleanup");
     merged_task_branch_with_stale_upstream(source.path(), &worktree);
     let store = dir.path().join("store");
-    let record = fixture_record(source.path(), &worktree);
+    let record = succeeded_record(source.path(), &worktree);
     write_record(&store, &record).unwrap();
 
     let output = cleanup_with_store(
@@ -1662,11 +1750,11 @@ fn cleanup_keeps_branch_when_worktree_removal_fails_and_continues() {
         &["worktree", "lock", &locked_worktree.to_string_lossy()],
     );
     let store = dir.path().join("store");
-    let mut locked_record = fixture_record(source.path(), &locked_worktree);
+    let mut locked_record = succeeded_record(source.path(), &locked_worktree);
     locked_record.id = "fixture@locked".to_string();
     locked_record.branch = "locked-task".to_string();
     let removable_worktree = sibling_worktree_path(source.path(), "cleanup-continues");
-    let mut removable_record = fixture_record(source.path(), &removable_worktree);
+    let mut removable_record = succeeded_record(source.path(), &removable_worktree);
     removable_record.id = "fixture@removable".to_string();
     write_record(&store, &locked_record).unwrap();
     write_record(&store, &removable_record).unwrap();
@@ -1717,8 +1805,8 @@ fn cleanup_separates_actionable_candidates_from_reconciliation_blockers() {
             &removable.to_string_lossy(),
         ],
     );
-    let removable_record = fixture_record(source.path(), &removable);
-    let mut missing_record = fixture_record(
+    let removable_record = succeeded_record(source.path(), &removable);
+    let mut missing_record = succeeded_record(
         source.path(),
         &sibling_worktree_path(source.path(), "mixed-missing"),
     );
@@ -1755,7 +1843,7 @@ fn cleanup_reports_unmerged_task_branch_without_deleting_by_default() {
     run_git(source.path(), &["checkout", "-q", "-"]);
     let worktree = sibling_worktree_path(source.path(), "unmerged-branch-cleanup");
     let store = dir.path().join("store");
-    let record = fixture_record(source.path(), &worktree);
+    let record = succeeded_record(source.path(), &worktree);
     write_record(&store, &record).unwrap();
 
     let output = cleanup_with_store(
@@ -1994,7 +2082,7 @@ fn cleanup_dry_run_reports_safe_candidate_without_removing() {
         ],
     );
     let store = dir.path().join("store");
-    let record = fixture_record(source.path(), &worktree);
+    let record = succeeded_record(source.path(), &worktree);
     write_record(&store, &record).unwrap();
 
     let output = cleanup_with_store(
@@ -2036,7 +2124,7 @@ fn cleanup_force_removes_dirty_worktree_after_homeboy_gates_pass() {
     );
     fs::write(worktree.join("dirty.txt"), "dirty\n").unwrap();
     let store = dir.path().join("store");
-    let record = fixture_record(source.path(), &worktree);
+    let record = succeeded_record(source.path(), &worktree);
     write_record(&store, &record).unwrap();
 
     let output = cleanup_with_store(
@@ -2267,7 +2355,7 @@ fn queue_create_uses_provider_lifecycle_with_per_child_metadata() {
         std::fs::write(
             &script,
             format!(
-                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  if [ -d '{}' ]; then printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"homeboy@fix-12124\",\"path\":\"{}\",\"branch\":\"fix/12124\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'; else printf '%s\\n' '{{\"worktrees\":[]}}'; fi\nelif [ \"$1\" = ensure ]; then\n  printf 'ensure|%s|%s|%s|%s|%s|%s|%s|%s\\n' \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" \"$7\" \"$8\" \"$9\" >> '{}'\n  if [ ! -d '{}' ]; then git init -q -b fix/12124 '{}'; fi\nelse\n  printf 'finalize|%s|%s|%s|%s|%s|%s\\n' \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" \"$7\" >> '{}'\nfi\n",
+                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  if [ -d '{}' ]; then printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"homeboy@fix-12124\",\"path\":\"{}\",\"branch\":\"fix/12124\",\"task_url\":\"https://github.com/Extra-Chill/homeboy/issues/12124\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'; else printf '%s\\n' '{{\"worktrees\":[]}}'; fi\nelif [ \"$1\" = ensure ]; then\n  printf 'ensure|%s|%s|%s|%s|%s|%s|%s|%s\\n' \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" \"$7\" \"$8\" \"$9\" >> '{}'\n  if [ ! -d '{}' ]; then git init -q -b fix/12124 '{}'; fi\nelse\n  printf 'finalize|%s|%s|%s|%s|%s|%s\\n' \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" \"$7\" >> '{}'\nfi\n",
                 workspace.display(),
                 workspace.display(),
                 records.display(),
@@ -2322,7 +2410,7 @@ fn queue_create_uses_provider_lifecycle_with_per_child_metadata() {
                     dirty: "$.safety.dirty".to_string(),
                     unpushed: "$.safety.unpushed".to_string(),
                     primary: "$.safety.primary".to_string(),
-                    task_url: None,
+                    task_url: Some("$.task_url".to_string()),
                 }),
             },
         );

--- a/crates/homeboy-core/src/worktree/types.rs
+++ b/crates/homeboy-core/src/worktree/types.rs
@@ -318,6 +318,9 @@ pub struct WorktreeSafetyReport {
     pub primary_checkout: bool,
     pub path_contained: bool,
     pub worktree_missing: bool,
+    pub live_caller_cwd: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal_owner_evidence: Option<String>,
     pub safe: bool,
     pub reasons: Vec<String>,
 }

--- a/crates/homeboy-core/src/worktree/types.rs
+++ b/crates/homeboy-core/src/worktree/types.rs
@@ -318,9 +318,6 @@ pub struct WorktreeSafetyReport {
     pub primary_checkout: bool,
     pub path_contained: bool,
     pub worktree_missing: bool,
-    pub live_caller_cwd: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub terminal_owner_evidence: Option<String>,
     pub safe: bool,
     pub reasons: Vec<String>,
 }

--- a/crates/homeboy-core/src/worktree_provider.rs
+++ b/crates/homeboy-core/src/worktree_provider.rs
@@ -824,6 +824,18 @@ impl WorktreeFinalizationProvider for NativeWorktreeProvider {
         lifecycle: &WorktreeProvisionLifecycle,
         disposition: WorktreeTerminalDisposition,
     ) -> Result<WorktreeFinalizationLookup> {
+        self.finalize_with_effect_fence(handle, lifecycle, disposition, || Ok(()))
+    }
+}
+
+impl NativeWorktreeProvider {
+    fn finalize_with_effect_fence(
+        &self,
+        handle: &str,
+        lifecycle: &WorktreeProvisionLifecycle,
+        disposition: WorktreeTerminalDisposition,
+        before_effect: impl FnOnce() -> Result<()>,
+    ) -> Result<WorktreeFinalizationLookup> {
         let Some(workspace) = worktree::resolve_workspace_ref_if_present(handle)? else {
             return Ok(WorktreeFinalizationLookup::NotFound);
         };
@@ -841,8 +853,12 @@ impl WorktreeFinalizationProvider for NativeWorktreeProvider {
                 None,
             ));
         }
-        let record =
-            worktree::finalize_provider_lifecycle(handle, &lifecycle.owner_run_ref, disposition)?;
+        let record = worktree::finalize_provider_lifecycle_with_effect_fence(
+            handle,
+            &lifecycle.owner_run_ref,
+            disposition,
+            before_effect,
+        )?;
         Ok(WorktreeFinalizationLookup::Finalized(
             WorktreeFinalization {
                 provider_id: "native".to_string(),
@@ -870,6 +886,59 @@ pub struct CommandWorktreeProvider<'a> {
 impl<'a> CommandWorktreeProvider<'a> {
     pub fn new(config: &'a HomeboyConfig) -> Self {
         Self { config }
+    }
+
+    fn finalize_with_provider_and_effect_fence(
+        &self,
+        handle: &str,
+        provider_id: &str,
+        lifecycle: &WorktreeProvisionLifecycle,
+        disposition: WorktreeTerminalDisposition,
+        before_effect: impl FnOnce() -> Result<()>,
+    ) -> Result<WorktreeFinalizationLookup> {
+        let resolution = match worktree_providers::resolve_apply_enabled_worktree_provider_by_id_unchecked_from_config(
+            handle,
+            provider_id,
+            self.config,
+        ) {
+            Ok(resolution) => resolution,
+            Err(error) if worktree_providers::is_worktree_provider_not_found(&error) => {
+                return Ok(WorktreeFinalizationLookup::NotFound);
+            }
+            Err(error) => return Err(error),
+        };
+        if worktree_providers::worktree_provider_lifecycle_finalizer_argv_from_config(
+            provider_id,
+            self.config,
+        )?
+        .is_none()
+        {
+            return Ok(WorktreeFinalizationLookup::Unsupported);
+        }
+        Ok(WorktreeFinalizationLookup::Finalized(
+            worktree_providers::finalize_apply_enabled_worktree_provider_with_effect_fence_from_config(
+                &resolution,
+                lifecycle,
+                disposition,
+                self.config,
+                before_effect,
+            )?,
+        ))
+    }
+
+    fn ensure_with_provider(
+        &self,
+        intent: &WorktreeProvisionIntent,
+        lifecycle: &WorktreeProvisionLifecycle,
+        provider_id: &str,
+    ) -> Result<WorktreeProvision> {
+        let provision = worktree_providers::provision_apply_enabled_worktree_provider_with_selected_lifecycle_from_config(
+            intent,
+            lifecycle,
+            provider_id,
+            self.config,
+        )?;
+        Ok(command_provision(provision))
     }
 }
 
@@ -1488,7 +1557,16 @@ impl<'a> WorktreeProviderRegistry<'a> {
                 NativeWorktreeProvider.ensure(intent, lifecycle)
             }
             Some(WorktreeProviderIdentity::Configured(_)) => {
-                CommandWorktreeProvider::new(self.config).ensure(intent, lifecycle)
+                let WorktreeProviderIdentity::Configured(provider_id) =
+                    selected_provider.expect("configured provider")
+                else {
+                    unreachable!()
+                };
+                CommandWorktreeProvider::new(self.config).ensure_with_provider(
+                    intent,
+                    lifecycle,
+                    provider_id,
+                )
             }
             None if configured_provisioning_declared(self.config) => {
                 CommandWorktreeProvider::new(self.config).ensure(intent, lifecycle)
@@ -1508,6 +1586,49 @@ impl<'a> WorktreeProviderRegistry<'a> {
             outcome => return Ok(outcome),
         }
         CommandWorktreeProvider::new(self.config).finalize(handle, lifecycle, disposition)
+    }
+
+    pub fn finalize_with_provider(
+        &self,
+        handle: &str,
+        provider: &WorktreeProviderIdentity,
+        lifecycle: &WorktreeProvisionLifecycle,
+        disposition: WorktreeTerminalDisposition,
+    ) -> Result<WorktreeFinalizationLookup> {
+        self.finalize_with_provider_and_effect_fence(
+            handle,
+            provider,
+            lifecycle,
+            disposition,
+            || Ok(()),
+        )
+    }
+
+    pub fn finalize_with_provider_and_effect_fence(
+        &self,
+        handle: &str,
+        provider: &WorktreeProviderIdentity,
+        lifecycle: &WorktreeProvisionLifecycle,
+        disposition: WorktreeTerminalDisposition,
+        before_effect: impl FnOnce() -> Result<()>,
+    ) -> Result<WorktreeFinalizationLookup> {
+        match provider {
+            WorktreeProviderIdentity::Native => NativeWorktreeProvider.finalize_with_effect_fence(
+                handle,
+                lifecycle,
+                disposition,
+                before_effect,
+            ),
+            WorktreeProviderIdentity::Configured(provider_id) => {
+                CommandWorktreeProvider::new(self.config).finalize_with_provider_and_effect_fence(
+                    handle,
+                    provider_id,
+                    lifecycle,
+                    disposition,
+                    before_effect,
+                )
+            }
+        }
     }
 
     pub fn create(
@@ -1580,6 +1701,13 @@ pub fn resolve_worktree_ownership(handle: &str) -> Result<WorktreeOwnership> {
 
 pub fn resolve_worktree_ownership_if_present(handle: &str) -> Result<Option<WorktreeOwnership>> {
     WorktreeProviderRegistry::new(&defaults::load_config()).resolve_if_present(handle)
+}
+
+pub fn resolve_worktree_ownership_if_present_from_config(
+    handle: &str,
+    config: &HomeboyConfig,
+) -> Result<Option<WorktreeOwnership>> {
+    WorktreeProviderRegistry::new(config).resolve_if_present(handle)
 }
 
 pub fn resolve_worktree_ownership_from_config(
@@ -1882,6 +2010,58 @@ pub fn finalize_worktree_from_config(
     config: &HomeboyConfig,
 ) -> Result<WorktreeFinalizationLookup> {
     WorktreeProviderRegistry::new(config).finalize(handle, lifecycle, disposition)
+}
+
+/// Resolve the provider that owns terminal finalization without applying the
+/// write-safety gates used for ordinary workspace mutation. Dirty terminal
+/// candidates must remain finalizable so their failure disposition is retained.
+pub fn resolve_worktree_finalization_provider_from_config(
+    handle: &str,
+    config: &HomeboyConfig,
+) -> Result<Option<WorktreeProviderIdentity>> {
+    if let WorktreeProviderLookup::Found(ownership) = NativeWorktreeProvider.resolve(handle)? {
+        return Ok(Some(ownership.provider));
+    }
+    match worktree_providers::observe_apply_enabled_worktree_provider_from_config(handle, config) {
+        Ok(resolution) => Ok(Some(WorktreeProviderIdentity::Configured(
+            resolution.provider_id,
+        ))),
+        Err(error) if worktree_providers::is_worktree_provider_not_found(&error) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+/// Finalize only through the provider durably selected before the mutation.
+pub fn finalize_worktree_with_provider_from_config(
+    handle: &str,
+    provider: &WorktreeProviderIdentity,
+    lifecycle: &WorktreeProvisionLifecycle,
+    disposition: WorktreeTerminalDisposition,
+    config: &HomeboyConfig,
+) -> Result<WorktreeFinalizationLookup> {
+    WorktreeProviderRegistry::new(config).finalize_with_provider(
+        handle,
+        provider,
+        lifecycle,
+        disposition,
+    )
+}
+
+pub fn finalize_worktree_with_provider_and_effect_fence_from_config(
+    handle: &str,
+    provider: &WorktreeProviderIdentity,
+    lifecycle: &WorktreeProvisionLifecycle,
+    disposition: WorktreeTerminalDisposition,
+    config: &HomeboyConfig,
+    before_effect: impl FnOnce() -> Result<()>,
+) -> Result<WorktreeFinalizationLookup> {
+    WorktreeProviderRegistry::new(config).finalize_with_provider_and_effect_fence(
+        handle,
+        provider,
+        lifecycle,
+        disposition,
+        before_effect,
+    )
 }
 
 pub fn worktree_finalization_not_found_error(handle: &str, config: &HomeboyConfig) -> Error {
@@ -2547,7 +2727,7 @@ mod tests {
             std::fs::write(
                 &script,
                 format!(
-                    "#!/bin/sh\ncase \"$1\" in\nresolve)\n  if [ -f '{state}' ]; then printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"fixture@command-lifecycle\",\"path\":\"{workspace}\",\"branch\":\"command-lifecycle\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'; else exit 1; fi\n  ;;\nplan)\n  printf '%s\\n' \"{{\\\"worktrees\\\":[{{\\\"handle\\\":\\\"$2\\\",\\\"path\\\":\\\"{workspace}\\\",\\\"branch\\\":\\\"$5\\\",\\\"safety\\\":{{\\\"dirty\\\":false,\\\"unpushed\\\":false,\\\"primary\\\":false}}}}]}}\"\n  ;;\nensure)\n  git -C '{source}' worktree add -q -b command-lifecycle '{workspace}' main\n  touch '{state}'\n  ;;\ncleanup)\n  printf '%s\\n' '{{\"mode\":\"preview\"}}'\n  ;;\nfinalize)\n  key=\"${{10}}\"\n  if [ ! -f '{finalizations}' ] || ! grep -Fqx \"$key\" '{finalizations}'; then printf '%s\\n' \"$key\" >> '{finalizations}'; fi\n  ;;\nesac\n",
+                    "#!/bin/sh\ncase \"$1\" in\nresolve)\n  if [ -f '{state}' ]; then printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"fixture@command-lifecycle\",\"path\":\"{workspace}\",\"branch\":\"command-lifecycle\",\"task_url\":\"https://example.test/issues/8017\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'; else exit 1; fi\n  ;;\nplan)\n  printf '%s\\n' \"{{\\\"worktrees\\\":[{{\\\"handle\\\":\\\"$2\\\",\\\"path\\\":\\\"{workspace}\\\",\\\"branch\\\":\\\"$5\\\",\\\"task_url\\\":\\\"$6\\\",\\\"safety\\\":{{\\\"dirty\\\":false,\\\"unpushed\\\":false,\\\"primary\\\":false}}}}]}}\"\n  ;;\nensure)\n  git -C '{source}' worktree add -q -b command-lifecycle '{workspace}' main\n  touch '{state}'\n  ;;\ncleanup)\n  printf '%s\\n' '{{\"mode\":\"preview\"}}'\n  ;;\nfinalize)\n  key=\"${{10}}\"\n  if [ ! -f '{finalizations}' ] || ! grep -Fqx \"$key\" '{finalizations}'; then printf '%s\\n' \"$key\" >> '{finalizations}'; fi\n  ;;\nesac\n",
                     state = state.display(),
                     workspace = workspace.display(),
                     source = source.display(),
@@ -2599,7 +2779,7 @@ mod tests {
                         dirty: "$.safety.dirty".to_string(),
                         unpushed: "$.safety.unpushed".to_string(),
                         primary: "$.safety.primary".to_string(),
-                        task_url: None,
+                        task_url: Some("$.task_url".to_string()),
                     }),
                 },
             );

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -2266,6 +2266,7 @@ pub fn finalize_apply_enabled_worktree_provider_from_config(
             None,
         ));
     }
+    ensure_provider_finalization_cwd_safe(&resolution.worktree.path)?;
     let command =
         worktree_provider_lifecycle_finalizer_argv_from_config(&resolution.provider_id, config)?
             .ok_or_else(|| {
@@ -2300,6 +2301,30 @@ pub fn finalize_apply_enabled_worktree_provider_from_config(
         lifecycle_state: disposition.lifecycle_state().to_string(),
         inspection_path: resolution.worktree.path.clone(),
     })
+}
+
+fn ensure_provider_finalization_cwd_safe(workspace: &str) -> Result<()> {
+    let cwd =
+        std::env::current_dir().map_err(|error| Error::internal_io(error.to_string(), None))?;
+    let workspace = match std::fs::canonicalize(workspace) {
+        Ok(workspace) => workspace,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(Error::internal_io(
+                error.to_string(),
+                Some(workspace.to_string()),
+            ))
+        }
+    };
+    if cwd == workspace || cwd.starts_with(&workspace) {
+        return Err(Error::validation_invalid_argument(
+            "worktree",
+            "Provider worktree contains the caller's live current working directory",
+            Some(workspace.display().to_string()),
+            None,
+        ));
+    }
+    Ok(())
 }
 
 pub fn worktree_provider_idempotency_key(intent: &WorktreeProviderCreateIntent) -> String {

--- a/crates/homeboy-core/src/worktree_providers.rs
+++ b/crates/homeboy-core/src/worktree_providers.rs
@@ -1012,7 +1012,7 @@ pub fn resolve_apply_enabled_worktree_provider_by_id_from_config(
 /// safety state. Exact-identity and safety attestation callers need this
 /// observation boundary so Cook can attribute an owned promoted candidate
 /// before the normal dirty-worktree policy decides admission.
-fn resolve_apply_enabled_worktree_provider_by_id_unchecked_from_config(
+pub(crate) fn resolve_apply_enabled_worktree_provider_by_id_unchecked_from_config(
     handle: &str,
     provider_id: &str,
     config: &HomeboyConfig,
@@ -1701,7 +1701,7 @@ pub fn provision_apply_enabled_worktree_provider_from_config(
     intent: &WorktreeProviderCreateIntent,
     config: &HomeboyConfig,
 ) -> Result<WorktreeProviderProvision> {
-    provision_apply_enabled_worktree_provider_from_config_with_lifecycle(intent, None, config)
+    provision_apply_enabled_worktree_provider_from_config_with_lifecycle(intent, None, None, config)
 }
 
 /// Determine the provider that will own an ensure before the external command
@@ -2053,13 +2053,18 @@ fn escape_json_pointer_token(token: &str) -> String {
 fn provision_apply_enabled_worktree_provider_from_config_with_lifecycle(
     intent: &WorktreeProviderCreateIntent,
     lifecycle: Option<&WorktreeProviderLifecycleIntent>,
+    selected_provider: Option<&str>,
     config: &HomeboyConfig,
 ) -> Result<WorktreeProviderProvision> {
     // Purpose-owned callers select once using the creation capability contract.
     // Keep that exact identity through ensure and postcondition lookup.
-    let lifecycle_provider = lifecycle
-        .map(|_| select_apply_enabled_worktree_provider_from_config(intent, config))
-        .transpose()?;
+    let lifecycle_provider = match (lifecycle, selected_provider) {
+        (Some(_), Some(provider_id)) => Some(provider_id.to_string()),
+        (Some(_), None) => Some(select_apply_enabled_worktree_provider_from_config(
+            intent, config,
+        )?),
+        (None, _) => None,
+    };
     match resolve_apply_enabled_worktree_provider_from_config(&intent.handle, config, None) {
         Ok(resolution) => {
             if let Some(lifecycle) = lifecycle {
@@ -2189,9 +2194,15 @@ fn provision_apply_enabled_worktree_provider_from_config_with_lifecycle(
         ));
     }
     run_provider_ensure_command(provider_id, provider, &command)?;
-    let resolution =
-        resolve_apply_enabled_worktree_provider_from_config(&intent.handle, config, None)
-            .map_err(mark_bootstrap_postcondition_failure)?;
+    let resolution = match lifecycle_provider.as_deref() {
+        Some(provider_id) => resolve_apply_enabled_worktree_provider_by_id_unchecked_from_config(
+            &intent.handle,
+            provider_id,
+            config,
+        ),
+        None => resolve_apply_enabled_worktree_provider_from_config(&intent.handle, config, None),
+    }
+    .map_err(mark_bootstrap_postcondition_failure)?;
     if intent.task_url.as_deref().is_some_and(|expected| {
         resolution
             .worktree
@@ -2235,6 +2246,21 @@ pub fn provision_apply_enabled_worktree_provider_with_lifecycle_from_config(
     provision_apply_enabled_worktree_provider_from_config_with_lifecycle(
         intent,
         Some(lifecycle),
+        None,
+        config,
+    )
+}
+
+pub fn provision_apply_enabled_worktree_provider_with_selected_lifecycle_from_config(
+    intent: &WorktreeProviderCreateIntent,
+    lifecycle: &WorktreeProviderLifecycleIntent,
+    provider_id: &str,
+    config: &HomeboyConfig,
+) -> Result<WorktreeProviderProvision> {
+    provision_apply_enabled_worktree_provider_from_config_with_lifecycle(
+        intent,
+        Some(lifecycle),
+        Some(provider_id),
         config,
     )
 }
@@ -2246,6 +2272,22 @@ pub fn finalize_apply_enabled_worktree_provider_from_config(
     lifecycle: &WorktreeProviderLifecycleIntent,
     disposition: WorktreeProviderTerminalDisposition,
     config: &HomeboyConfig,
+) -> Result<WorktreeProviderFinalization> {
+    finalize_apply_enabled_worktree_provider_with_effect_fence_from_config(
+        resolution,
+        lifecycle,
+        disposition,
+        config,
+        || Ok(()),
+    )
+}
+
+pub fn finalize_apply_enabled_worktree_provider_with_effect_fence_from_config(
+    resolution: &WorktreeProviderResolution,
+    lifecycle: &WorktreeProviderLifecycleIntent,
+    disposition: WorktreeProviderTerminalDisposition,
+    config: &HomeboyConfig,
+    before_effect: impl FnOnce() -> Result<()>,
 ) -> Result<WorktreeProviderFinalization> {
     let provider = config
         .worktree_providers
@@ -2292,6 +2334,7 @@ pub fn finalize_apply_enabled_worktree_provider_from_config(
                 .replace("{lifecycle_state}", disposition.lifecycle_state())
         })
         .collect::<Vec<_>>();
+    before_effect()?;
     run_provider_mutation_command(&resolution.provider_id, provider, &command, "finalize")?;
     Ok(WorktreeProviderFinalization {
         provider_id: resolution.provider_id.clone(),
@@ -5989,7 +6032,7 @@ mod tests {
         fs::write(
             &selected,
             format!(
-                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  if [ -f '{}' ]; then printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"homeboy@fix-12124\",\"path\":\"{}\",\"branch\":\"fix/12124\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'; else exit 1; fi\nelse\n  touch '{}'\n  git init -q -b fix/12124 '{}'\nfi\n",
+                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  if [ -f '{}' ]; then printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"homeboy@fix-12124\",\"path\":\"{}\",\"branch\":\"fix/12124\",\"task_url\":\"https://github.com/Extra-Chill/homeboy/issues/12124\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'; else exit 1; fi\nelse\n  touch '{}'\n  git init -q -b fix/12124 '{}'\nfi\n",
                 selected_effect.display(),
                 workspace.display(),
                 selected_effect.display(),
@@ -6569,7 +6612,7 @@ mod tests {
         fs::write(
             &script,
             format!(
-                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  if [ -d '{}' ]; then\n    printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"homeboy@fix-9908\",\"path\":\"{}\",\"branch\":\"fix/9908\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'\n  else\n    printf '%s\\n' '{{\"worktrees\":[]}}'\n  fi\nelse\n  printf '%s\\n' \"$7\" >> '{}'\n  if mkdir '{}' 2>/dev/null; then\n    git init -b fix/9908 '{}' >/dev/null\n    rmdir '{}'\n  else\n    while [ -d '{}' ]; do sleep 0.01; done\n  fi\nfi\n",
+                "#!/bin/sh\nif [ \"$1\" = resolve ]; then\n  if [ -d '{}' ]; then\n    printf '%s\\n' '{{\"worktrees\":[{{\"handle\":\"homeboy@fix-9908\",\"path\":\"{}\",\"branch\":\"fix/9908\",\"task_url\":\"https://github.com/Extra-Chill/homeboy/issues/9908\",\"safety\":{{\"dirty\":false,\"unpushed\":false,\"primary\":false}}}}]}}'\n  else\n    printf '%s\\n' '{{\"worktrees\":[]}}'\n  fi\nelse\n  printf '%s\\n' \"$7\" >> '{}'\n  if mkdir '{}' 2>/dev/null; then\n    git init -b fix/9908 '{}' >/dev/null\n    rmdir '{}'\n  else\n    while [ -d '{}' ]; do sleep 0.01; done\n  fi\nfi\n",
                 workspace.display(),
                 workspace.display(),
                 keys.display(),
@@ -6620,7 +6663,7 @@ mod tests {
                     dirty: "$.safety.dirty".to_string(),
                     unpushed: "$.safety.unpushed".to_string(),
                     primary: "$.safety.primary".to_string(),
-                    task_url: None,
+                    task_url: Some("$.task_url".to_string()),
                 }),
             },
         );
@@ -8692,7 +8735,7 @@ mod tests {
             handle: "fixture@cook-target".to_string(),
             path: workspace.path().display().to_string(),
             branch: "cook-target".to_string(),
-            task_url: None,
+            task_url: Some("$.task_url".to_string()),
             safety: WorktreeProviderHandleSafety {
                 dirty: true,
                 unpushed: false,
@@ -9969,7 +10012,7 @@ printf '{{"schema":"%s","provider_id":"fixture","handle":"%s","task_url":"%s","p
             dirty: "$.safety.dirty".to_string(),
             unpushed: "$.safety.unpushed".to_string(),
             primary: "$.safety.primary".to_string(),
-            task_url: None,
+            task_url: Some("$.task_url".to_string()),
         }
     }
 

--- a/crates/homeboy-engine-primitives/src/local_files.rs
+++ b/crates/homeboy-engine-primitives/src/local_files.rs
@@ -161,6 +161,11 @@ fn write_file_atomic_with_owner_only(
             Some(operation.to_string()),
         )
     })?;
+    let parent = if parent.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        parent
+    };
 
     let filename = path.file_name().ok_or_else(|| {
         Error::internal_io(
@@ -172,11 +177,7 @@ fn write_file_atomic_with_owner_only(
     let tmp_path = unique_temp_path(parent, filename.to_string_lossy().as_ref());
 
     if owner_only {
-        if let Err(error) =
-            write_file_owner_only(&tmp_path, content, &format!("{} (write temp)", operation))
-        {
-            return Err(error);
-        }
+        write_file_owner_only(&tmp_path, content, &format!("{} (write temp)", operation))?;
     } else {
         let mut file = fs::OpenOptions::new()
             .write(true)
@@ -263,6 +264,11 @@ fn write_json_file_with_owner_only<T: Serialize>(
     let parent = path.parent().ok_or_else(|| {
         Error::internal_unexpected(format!("path has no parent: {}", path.display()))
     })?;
+    let parent = if parent.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        parent
+    };
     create_dir_all_durably(parent)?;
     let json = serde_json::to_string_pretty(value).map_err(|error| {
         Error::internal_json(error.to_string(), Some(path.display().to_string()))
@@ -470,5 +476,23 @@ mod tests {
             fs::read_to_string(path).unwrap(),
             "{\n  \"name\": \"homeboy\"\n}\n"
         );
+    }
+
+    #[test]
+    fn atomic_writer_accepts_a_relative_filename() {
+        let filename = format!(
+            ".homeboy-local-files-relative-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        );
+        let path = Path::new(&filename);
+
+        write_file_atomic(path, "relative content", "relative atomic write").unwrap();
+
+        assert_eq!(fs::read_to_string(path).unwrap(), "relative content");
+        fs::remove_file(path).unwrap();
     }
 }

--- a/crates/homeboy-engine-primitives/src/local_files.rs
+++ b/crates/homeboy-engine-primitives/src/local_files.rs
@@ -172,17 +172,54 @@ fn write_file_atomic_with_owner_only(
     let tmp_path = unique_temp_path(parent, filename.to_string_lossy().as_ref());
 
     if owner_only {
-        write_file_owner_only(&tmp_path, content, &format!("{} (write temp)", operation))?;
+        if let Err(error) =
+            write_file_owner_only(&tmp_path, content, &format!("{} (write temp)", operation))
+        {
+            return Err(error);
+        }
     } else {
-        fs::write(&tmp_path, content).map_err(|e| {
-            Error::internal_io(e.to_string(), Some(format!("{} (write temp)", operation)))
-        })?;
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp_path)
+            .map_err(|error| {
+                Error::internal_io(
+                    error.to_string(),
+                    Some(format!("{} (create temp)", operation)),
+                )
+            })?;
+        use std::io::Write;
+        if let Err(error) = file.write_all(content.as_bytes()) {
+            drop(file);
+            let _ = fs::remove_file(&tmp_path);
+            return Err(Error::internal_io(
+                error.to_string(),
+                Some(format!("{} (write temp)", operation)),
+            ));
+        }
     }
-
-    fs::rename(&tmp_path, path)
-        .map_err(|e| Error::internal_io(e.to_string(), Some(format!("{} (rename)", operation))))?;
-
-    Ok(())
+    if let Err(error) = fs::File::open(&tmp_path).and_then(|file| file.sync_all()) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(Error::internal_io(
+            error.to_string(),
+            Some(format!("{} (sync temp)", operation)),
+        ));
+    }
+    if let Err(error) = fs::rename(&tmp_path, path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(Error::internal_io(
+            error.to_string(),
+            Some(format!("{} (rename)", operation)),
+        ));
+    }
+    fs::File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!("{} (sync parent)", operation)),
+            )
+        })
 }
 
 /// Create parent directories and atomically persist pretty-printed JSON.
@@ -195,6 +232,29 @@ pub fn write_json_file_owner_only<T: Serialize>(path: &Path, value: &T) -> Resul
     write_json_file_with_owner_only(path, value, true)
 }
 
+/// Remove a durable marker and sync its directory so a crash cannot resurrect it.
+pub fn remove_file_durably(path: &Path, operation: &str) -> Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(Error::internal_io(
+                error.to_string(),
+                Some(operation.to_string()),
+            ));
+        }
+    }
+    let parent = path.parent().ok_or_else(|| {
+        Error::internal_io(
+            format!("Invalid path: {}", path.display()),
+            Some(operation.to_string()),
+        )
+    })?;
+    fs::File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| Error::internal_io(error.to_string(), Some(operation.to_string())))
+}
+
 fn write_json_file_with_owner_only<T: Serialize>(
     path: &Path,
     value: &T,
@@ -203,9 +263,7 @@ fn write_json_file_with_owner_only<T: Serialize>(
     let parent = path.parent().ok_or_else(|| {
         Error::internal_unexpected(format!("path has no parent: {}", path.display()))
     })?;
-    fs::create_dir_all(parent).map_err(|error| {
-        Error::internal_io(error.to_string(), Some(parent.display().to_string()))
-    })?;
+    create_dir_all_durably(parent)?;
     let json = serde_json::to_string_pretty(value).map_err(|error| {
         Error::internal_json(error.to_string(), Some(path.display().to_string()))
     })?;
@@ -215,6 +273,31 @@ fn write_json_file_with_owner_only<T: Serialize>(
         &path.display().to_string(),
         owner_only,
     )
+}
+
+pub fn create_dir_all_durably(path: &Path) -> Result<()> {
+    let mut missing = Vec::new();
+    let mut current = path;
+    while !current.exists() {
+        missing.push(current.to_path_buf());
+        current = current.parent().ok_or_else(|| {
+            Error::internal_unexpected(format!(
+                "directory has no existing ancestor: {}",
+                path.display()
+            ))
+        })?;
+    }
+    fs::create_dir_all(path)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(path.display().to_string())))?;
+    for directory in missing.iter().rev() {
+        let parent = directory.parent().expect("missing directory has parent");
+        fs::File::open(parent)
+            .and_then(|parent| parent.sync_all())
+            .map_err(|error| {
+                Error::internal_io(error.to_string(), Some(parent.display().to_string()))
+            })?;
+    }
+    Ok(())
 }
 
 /// Create a file owner-only on Unix before writing its contents.
@@ -244,9 +327,13 @@ fn unique_temp_path(parent: &Path, filename: &str) -> PathBuf {
     static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
     parent.join(format!(
-        ".{}.{}.{}.tmp",
+        ".{}.{}.{}.{}.tmp",
         filename,
         std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos(),
         TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
     ))
 }

--- a/crates/homeboy-engine-primitives/src/local_files.rs
+++ b/crates/homeboy-engine-primitives/src/local_files.rs
@@ -155,6 +155,22 @@ fn write_file_atomic_with_owner_only(
     operation: &str,
     owner_only: bool,
 ) -> Result<()> {
+    write_file_atomic_with_owner_only_writer(
+        path,
+        content,
+        operation,
+        owner_only,
+        write_file_owner_only,
+    )
+}
+
+fn write_file_atomic_with_owner_only_writer(
+    path: &Path,
+    content: &str,
+    operation: &str,
+    owner_only: bool,
+    owner_only_writer: fn(&Path, &str, &str) -> Result<()>,
+) -> Result<()> {
     let parent = path.parent().ok_or_else(|| {
         Error::internal_io(
             format!("Invalid path: {}", path.display()),
@@ -177,7 +193,12 @@ fn write_file_atomic_with_owner_only(
     let tmp_path = unique_temp_path(parent, filename.to_string_lossy().as_ref());
 
     if owner_only {
-        write_file_owner_only(&tmp_path, content, &format!("{} (write temp)", operation))?;
+        if let Err(error) =
+            owner_only_writer(&tmp_path, content, &format!("{} (write temp)", operation))
+        {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(error);
+        }
     } else {
         let mut file = fs::OpenOptions::new()
             .write(true)
@@ -352,6 +373,24 @@ mod tests {
     use tempfile::tempdir;
     use tempfile::NamedTempFile;
 
+    fn partially_write_owner_only_then_fail(
+        path: &Path,
+        content: &str,
+        operation: &str,
+    ) -> Result<()> {
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(path)
+            .map_err(|error| Error::internal_io(error.to_string(), Some(operation.to_string())))?;
+        file.write_all(&content.as_bytes()[..1])
+            .map_err(|error| Error::internal_io(error.to_string(), Some(operation.to_string())))?;
+        Err(Error::internal_io(
+            "injected owner-only partial-write failure",
+            Some(operation.to_string()),
+        ))
+    }
+
     #[test]
     fn test_local_fs_write_read() {
         let dir = tempdir().unwrap();
@@ -389,6 +428,42 @@ mod tests {
         serde_json::from_str::<serde_json::Value>(&content).expect("valid json");
         let temp_files: Vec<_> = fs::read_dir(dir.path())
             .expect("list tempdir")
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "tmp"))
+            .collect();
+        assert!(
+            temp_files.is_empty(),
+            "temp files left behind: {temp_files:?}"
+        );
+    }
+
+    #[test]
+    fn owner_only_atomic_write_cleans_temp_after_partial_write_failure() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        fs::write(&path, "original").unwrap();
+
+        let error = write_file_atomic_with_owner_only_writer(
+            &path,
+            "replacement",
+            "replace owner-only config",
+            true,
+            partially_write_owner_only_then_fail,
+        )
+        .expect_err("injected partial write must fail");
+
+        assert_eq!(error.code.as_str(), "internal.io_error");
+        assert_eq!(
+            error.details["error"],
+            "injected owner-only partial-write failure"
+        );
+        assert_eq!(
+            error.details["context"],
+            "replace owner-only config (write temp)"
+        );
+        assert_eq!(fs::read_to_string(&path).unwrap(), "original");
+        let temp_files: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
             .filter_map(|entry| entry.ok())
             .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "tmp"))
             .collect();

--- a/crates/homeboy-release/src/release/operation_record.rs
+++ b/crates/homeboy-release/src/release/operation_record.rs
@@ -27,6 +27,8 @@ pub struct OperationRecord {
     #[serde(default)]
     pub finalization_lease_started_ms: Option<u128>,
     pub attempt_count: u32,
+    #[serde(default)]
+    pub mutation_attempted: bool,
     pub continuation_evidence: Vec<String>,
     #[serde(default)]
     pub attributes: serde_json::Map<String, Value>,
@@ -118,7 +120,9 @@ impl OperationRecordStore {
     /// Claims finalization before an external provider call. A live lease is
     /// never stolen; only a bounded stale lease can be retried.
     pub(crate) fn claim_finalization(&self, owner_run_ref: &str) -> Result<FinalizationClaim> {
-        const STALE_LEASE_MS: u128 = 5 * 60 * 1000;
+        // Configured provider mutation timeouts may be as high as fifteen
+        // minutes. Never steal a lease while that mutation can still be live.
+        const STALE_LEASE_MS: u128 = 16 * 60 * 1000;
         let now = now_ms();
         let candidate_lease = uuid::Uuid::new_v4().to_string();
         self.update(owner_run_ref, |record| {
@@ -166,6 +170,7 @@ impl OperationRecordStore {
         &self,
         owner_run_ref: &str,
         lease: &str,
+        receipt: Value,
     ) -> Result<OperationRecord> {
         self.update(owner_run_ref, |record| {
             let mut record = record.ok_or_else(|| {
@@ -177,15 +182,50 @@ impl OperationRecordStore {
                 )
             })?;
             if record.finalization_lease.as_deref() != Some(lease) {
-                return Ok(record);
+                return Err(Error::validation_invalid_argument(
+                    "finalization_lease",
+                    "finalization lease no longer matches durable authority",
+                    Some(owner_run_ref.to_string()),
+                    None,
+                ));
             }
             record.finalization_status = "completed".to_string();
             record.lifecycle_state = "finalized".to_string();
             record.finalization_lease = None;
             record.finalization_lease_started_ms = None;
             record
+                .attributes
+                .insert("finalization_receipt".to_string(), receipt);
+            record
                 .continuation_evidence
                 .push("provider finalization completed".to_string());
+            Ok(record)
+        })
+    }
+
+    pub(crate) fn mark_mutation_attempted(
+        &self,
+        owner_run_ref: &str,
+        lease: &str,
+    ) -> Result<OperationRecord> {
+        self.update(owner_run_ref, |record| {
+            let mut record = record.ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "owner_run_ref",
+                    "operation record does not exist",
+                    Some(owner_run_ref.to_string()),
+                    None,
+                )
+            })?;
+            if record.finalization_lease.as_deref() != Some(lease) {
+                return Err(Error::validation_invalid_argument(
+                    "finalization_lease",
+                    "finalization lease no longer matches durable authority",
+                    Some(owner_run_ref.to_string()),
+                    None,
+                ));
+            }
+            record.mutation_attempted = true;
             Ok(record)
         })
     }
@@ -289,8 +329,7 @@ fn record_path_in_roots(data_root: &Path, owner_run_ref: &str) -> PathBuf {
 
 fn lock_in_roots(data_root: &Path) -> Result<std::fs::File> {
     let dir = store_dir_in_roots(data_root);
-    fs::create_dir_all(&dir)
-        .map_err(|error| Error::internal_io(error.to_string(), Some(dir.display().to_string())))?;
+    homeboy_core::engine::local_files::create_dir_all_durably(&dir)?;
     let file = OpenOptions::new()
         .create(true)
         .read(true)
@@ -371,6 +410,7 @@ mod tests {
             finalization_lease: None,
             finalization_lease_started_ms: None,
             attempt_count: 0,
+            mutation_attempted: false,
             continuation_evidence: vec!["created".to_string()],
             attributes: serde_json::Map::new(),
         }
@@ -430,7 +470,11 @@ mod tests {
                         // This is the provider-effect boundary: only a claimant may cross it.
                         effects.fetch_add(1, Ordering::SeqCst);
                         store
-                            .complete_finalization(&owner, &lease)
+                            .complete_finalization(
+                                &owner,
+                                &lease,
+                                serde_json::json!({"test": true}),
+                            )
                             .expect("complete");
                     }
                 })

--- a/crates/homeboy-release/src/release/workflow.rs
+++ b/crates/homeboy-release/src/release/workflow.rs
@@ -90,6 +90,7 @@ pub fn run_command_with_workspace(
             finalization_lease: None,
             finalization_lease_started_ms: None,
             attempt_count: 1,
+            mutation_attempted: false,
             continuation_evidence: readiness.evidence_refs.clone(),
             attributes: serde_json::Map::from_iter([(
                 "readiness".to_string(),
@@ -1357,6 +1358,7 @@ mod tests {
                     finalization_lease: None,
                     finalization_lease_started_ms: None,
                     attempt_count: 1,
+                    mutation_attempted: false,
                     continuation_evidence: Vec::new(),
                     attributes: Default::default(),
                 })

--- a/crates/homeboy-release/src/release/workspace.rs
+++ b/crates/homeboy-release/src/release/workspace.rs
@@ -1135,6 +1135,7 @@ mod tests {
                         finalization_lease: None,
                         finalization_lease_started_ms: None,
                         attempt_count: 0,
+                        mutation_attempted: false,
                         continuation_evidence: Vec::new(),
                         attributes: serde_json::Map::new(),
                     })

--- a/crates/homeboy-release/src/release/workspace.rs
+++ b/crates/homeboy-release/src/release/workspace.rs
@@ -8,10 +8,10 @@ use homeboy_core::git;
 use homeboy_core::worktree_provider::{
     self, worktree_provision_idempotency_key as worktree_provider_idempotency_key,
     WorktreeCleanupPolicy as WorktreeProviderCleanupPolicy, WorktreeFinalizationLookup,
-    WorktreeProviderIdentity, WorktreeProvisionDestination,
+    WorktreeOwnership, WorktreeProviderIdentity, WorktreeProvisionDestination,
     WorktreeProvisionIntent as WorktreeProviderCreateIntent,
-    WorktreeProvisionLifecycle as WorktreeProviderLifecycleIntent,
-    WorktreeTerminalDisposition as WorktreeProviderTerminalDisposition,
+    WorktreeProvisionLifecycle as WorktreeProviderLifecycleIntent, WorktreeProvisionLookup,
+    WorktreeTerminalDisposition as WorktreeProviderTerminalDisposition, WorktreeWorkspaceKind,
 };
 use uuid::Uuid;
 
@@ -75,6 +75,36 @@ impl ReleaseWorkspace {
             head: branch,
             task_url: None,
         };
+        // Publish ownership before provider planning or mutation so selection
+        // failures and ensure crashes retain one durable reconciliation handle.
+        store.create(&OperationRecord {
+            owner_run_ref: lifecycle.owner_run_ref.clone(),
+            operation: "provider_workspace".to_string(),
+            subject: component.id.clone(),
+            provider: "unselected".to_string(),
+            handle: intent.handle.clone(),
+            path: None,
+            source_sha: source_sha.clone(),
+            cleanup_policy: "remove_on_success".to_string(),
+            lifecycle_state: "planning".to_string(),
+            terminal_disposition: None,
+            finalization_status: "pending".to_string(),
+            finalization_lease: None,
+            finalization_lease_started_ms: None,
+            attempt_count: 0,
+            mutation_attempted: false,
+            continuation_evidence: vec![
+                "release workspace ownership persisted before provider selection".to_string(),
+            ],
+            attributes: serde_json::Map::from_iter([(
+                "provision_intent".to_string(),
+                serde_json::json!({
+                    "repo": intent.repo.clone(), "base": intent.base.clone(), "head": intent.head.clone(),
+                    "task_url": intent.task_url.clone(),
+                    "idempotency_key": worktree_provider_idempotency_key(&intent),
+                }),
+            )]),
+        })?;
         let planned =
             worktree_provider::plan_worktree_provision_from_config(&intent, &lifecycle, &config)?;
         let destination = match planned {
@@ -88,32 +118,23 @@ impl ReleaseWorkspace {
         let selected_provider_id = provider_evidence_id(&selected_provider);
         // Publish ownership before invoking the provider. A crash during ensure
         // is therefore recoverable through the same idempotency owner reference.
-        store.create(&OperationRecord {
-            owner_run_ref: lifecycle.owner_run_ref.clone(),
-            operation: "provider_workspace".to_string(),
-            subject: component.id.clone(),
-            provider: selected_provider_id.clone(),
-            handle: intent.handle.clone(),
-            path: None,
-            source_sha: source_sha.clone(),
-            cleanup_policy: "remove_on_success".to_string(),
-            lifecycle_state: "provisioning".to_string(),
-            terminal_disposition: None,
-            finalization_status: "pending".to_string(),
-            finalization_lease: None,
-            finalization_lease_started_ms: None,
-            attempt_count: 0,
-            continuation_evidence: vec![
-                "release workspace ownership persisted before provider ensure".to_string(),
-            ],
-            attributes: serde_json::Map::from_iter([(
+        store.update(&lifecycle.owner_run_ref, |record| {
+            let mut record = record.ok_or_else(|| missing_record(&lifecycle.owner_run_ref))?;
+            record.provider = selected_provider_id.clone();
+            record.handle = intent.handle.clone();
+            record.lifecycle_state = "provisioning".to_string();
+            record.attributes.insert(
                 "provision_intent".to_string(),
                 serde_json::json!({
                     "repo": intent.repo.clone(), "base": intent.base.clone(), "head": intent.head.clone(),
                     "task_url": intent.task_url.clone(),
                     "idempotency_key": worktree_provider_idempotency_key(&intent),
                 }),
-            )]),
+            );
+            record
+                .continuation_evidence
+                .push("provider selected before ensure".to_string());
+            Ok(record)
         })?;
         let provision = worktree_provider::ensure_worktree_provision_from_config(
             &intent,
@@ -210,7 +231,15 @@ impl ReleaseWorkspace {
                     Some("provider-owned workspace has no durable owner record".to_string());
                 return self.output.clone();
             };
-            let _ = self.store.update(owner, |record| {
+            if disposition == WorktreeProviderTerminalDisposition::Succeeded && !release_pushed {
+                self.output.final_disposition = Some("finalization_pending".to_string());
+                self.output.finalization_error = Some(
+                    "successful workspace cleanup requires durable publication evidence"
+                        .to_string(),
+                );
+                return self.output.clone();
+            }
+            if let Err(error) = self.store.update(owner, |record| {
                 let mut record = record.ok_or_else(|| missing_record(owner))?;
                 record.terminal_disposition = Some(disposition.as_str().to_string());
                 record.attributes.insert(
@@ -218,7 +247,11 @@ impl ReleaseWorkspace {
                     serde_json::Value::Bool(release_pushed),
                 );
                 Ok(record)
-            });
+            }) {
+                self.output.final_disposition = Some("finalization_pending".to_string());
+                self.output.finalization_error = Some(error.to_string());
+                return self.output.clone();
+            }
             match finalize_record(&self.store, owner, resolution, lifecycle, disposition) {
                 Ok(_) => {
                     self.owned = None;
@@ -263,7 +296,7 @@ pub(super) fn reconcile_pending(
     selector: Option<&str>,
 ) -> Result<Option<OperationRecord>> {
     let store = OperationRecordStore::in_roots(roots);
-    let record = match selector {
+    let mut record = match selector {
         Some(owner) => match store.load(owner)? {
             Some(record) => record,
             None => return Ok(None),
@@ -282,7 +315,15 @@ pub(super) fn reconcile_pending(
     // provider lookup so a removed provider or workspace cannot revive legacy
     // Git recovery behavior.
     if record.finalization_status == "completed" {
-        return Ok(Some(record));
+        if release_finalization_receipt_matches_record(&record) {
+            return Ok(Some(record));
+        }
+        return Err(Error::validation_invalid_argument(
+            "owner_run_ref",
+            "completed provider finalization record lacks an exact durable receipt",
+            Some(record.owner_run_ref),
+            None,
+        ));
     }
     let intent = record
         .attributes
@@ -311,7 +352,7 @@ pub(super) fn reconcile_pending(
         owner_run_ref: record.owner_run_ref.clone(),
         cleanup_policy: WorktreeProviderCleanupPolicy::RemoveOnSuccess,
     };
-    let create_intent = WorktreeProviderCreateIntent {
+    let mut create_intent = WorktreeProviderCreateIntent {
         handle: record.handle.clone(),
         repo: intent.repo,
         base: intent.base,
@@ -319,6 +360,27 @@ pub(super) fn reconcile_pending(
         task_url: intent.task_url,
     };
     let config = defaults::load_config();
+    if record.provider == "unselected" {
+        let planned = worktree_provider::plan_worktree_provision_from_config(
+            &create_intent,
+            &lifecycle,
+            &config,
+        )?;
+        let destination = match planned {
+            homeboy_core::worktree_provider::WorktreeProvisionPlan::Admitted(destination)
+            | homeboy_core::worktree_provider::WorktreeProvisionPlan::Planned(destination) => {
+                destination
+            }
+        };
+        record = store.update(&record.owner_run_ref, |current| {
+            let mut current = current.ok_or_else(|| missing_record(&record.owner_run_ref))?;
+            current.provider = provider_evidence_id(&destination.ownership.provider);
+            current.handle = destination.ownership.handle.clone();
+            current.lifecycle_state = "provisioning".to_string();
+            Ok(current)
+        })?;
+        create_intent.handle = record.handle.clone();
+    }
     // A crash may happen before ensure or after it returns but before the record
     // update. Re-running ensure with the persisted key closes both windows.
     let selected_provider = provider_identity_from_evidence(&record.provider);
@@ -348,12 +410,38 @@ pub(super) fn reconcile_pending(
         })?;
         provision.destination
     } else {
-        worktree_provider::admit_worktree_provision_from_config(
+        match worktree_provider::admit_worktree_provision_from_config(
             &record.handle,
             Some(&selected_provider),
             &config,
-        )?
-        .into_admitted(&record.handle)?
+        )? {
+            WorktreeProvisionLookup::Admitted(destination) => destination,
+            WorktreeProvisionLookup::NotFound if record.mutation_attempted => {
+                WorktreeProvisionDestination {
+                    ownership: WorktreeOwnership {
+                        provider: selected_provider.clone(),
+                        handle: record.handle.clone(),
+                        path: record.path.clone().unwrap_or_default(),
+                        kind: match selected_provider {
+                            WorktreeProviderIdentity::Native => WorktreeWorkspaceKind::TaskWorktree,
+                            WorktreeProviderIdentity::Configured(_) => {
+                                WorktreeWorkspaceKind::Configured
+                            }
+                        },
+                        branch: Some(create_intent.head.clone()),
+                        task_url: create_intent.task_url.clone(),
+                        provenance: None,
+                    },
+                    exact_identity: None,
+                }
+            }
+            WorktreeProvisionLookup::NotFound => {
+                return Err(worktree_provider::worktree_finalization_not_found_error(
+                    &record.handle,
+                    &config,
+                ));
+            }
+        }
     };
     if destination.ownership.provider != selected_provider
         || record
@@ -383,6 +471,13 @@ pub(super) fn reconcile_pending(
         Some("timed_out") => WorktreeProviderTerminalDisposition::TimedOut,
         _ => WorktreeProviderTerminalDisposition::Interrupted,
     };
+    if record.terminal_disposition.as_deref() != Some(disposition.as_str()) {
+        store.update(&record.owner_run_ref, |current| {
+            let mut current = current.ok_or_else(|| missing_record(&record.owner_run_ref))?;
+            current.terminal_disposition = Some(disposition.as_str().to_string());
+            Ok(current)
+        })?;
+    }
     finalize_record(
         &store,
         &record.owner_run_ref,
@@ -435,8 +530,22 @@ fn finalize_record(
     lifecycle: &WorktreeProviderLifecycleIntent,
     disposition: WorktreeProviderTerminalDisposition,
 ) -> Result<OperationRecord> {
+    let replaying = store
+        .load(owner)?
+        .is_some_and(|record| record.mutation_attempted);
     match store.claim_finalization(owner)? {
-        FinalizationClaim::AlreadyCompleted(record) => Ok(record),
+        FinalizationClaim::AlreadyCompleted(record) => {
+            if release_finalization_receipt_matches(&record, destination, lifecycle, disposition) {
+                Ok(record)
+            } else {
+                Err(Error::validation_invalid_argument(
+                    "release.workspace",
+                    "completed provider finalization receipt does not exactly match the request",
+                    Some(owner.to_string()),
+                    None,
+                ))
+            }
+        }
         FinalizationClaim::InProgress(record) => Err(Error::validation_invalid_argument(
             "owner_run_ref",
             "provider workspace finalization is already in progress",
@@ -446,15 +555,49 @@ fn finalize_record(
                     .to_string(),
             ]),
         )),
-        FinalizationClaim::Claimed { lease, record: _ } => {
-            match worktree_provider::finalize_worktree_from_config(
+        FinalizationClaim::Claimed { lease, record } => {
+            let provider = provider_identity_from_evidence(&record.provider);
+            if provider != destination.ownership.provider
+                || record.handle != destination.ownership.handle
+                || record.owner_run_ref != lifecycle.owner_run_ref
+                || record.terminal_disposition.as_deref() != Some(disposition.as_str())
+            {
+                let error = Error::validation_invalid_argument(
+                    "release.workspace",
+                    "provider finalization claim does not exactly match durable lifecycle intent",
+                    Some(owner.to_string()),
+                    None,
+                );
+                let _ = store.fail_finalization(owner, &lease, error.to_string());
+                return Err(error);
+            }
+            let idempotency_key =
+                homeboy_core::worktree_providers::worktree_provider_finalization_idempotency_key(
+                    lifecycle,
+                );
+            let receipt = |recovered_from_not_found: bool| {
+                serde_json::json!({
+                    "schema": "homeboy/release-provider-worktree-finalization/v1",
+                    "provider_id": record.provider,
+                    "handle": destination.ownership.handle,
+                    "owner_run_ref": lifecycle.owner_run_ref,
+                    "purpose": lifecycle.purpose,
+                    "cleanup_policy": lifecycle.cleanup_policy.as_str(),
+                    "disposition": disposition.as_str(),
+                    "idempotency_key": idempotency_key,
+                    "recovered_from_not_found": recovered_from_not_found,
+                })
+            };
+            match worktree_provider::finalize_worktree_with_provider_and_effect_fence_from_config(
                 &destination.ownership.handle,
+                &provider,
                 lifecycle,
                 disposition,
                 &defaults::load_config(),
+                || store.mark_mutation_attempted(owner, &lease).map(|_| ()),
             ) {
                 Ok(WorktreeFinalizationLookup::Finalized(_)) => {
-                    store.complete_finalization(owner, &lease)
+                    store.complete_finalization(owner, &lease, receipt(false))
                 }
                 Ok(WorktreeFinalizationLookup::Unsupported) => {
                     let error = Error::validation_invalid_argument(
@@ -465,6 +608,11 @@ fn finalize_record(
                     );
                     let _ = store.fail_finalization(owner, &lease, error.to_string());
                     Err(error)
+                }
+                Ok(WorktreeFinalizationLookup::NotFound) if replaying => {
+                    // The durable lease predates the provider mutation. A
+                    // destructive finalizer may disappear before receipt write.
+                    store.complete_finalization(owner, &lease, receipt(true))
                 }
                 Ok(WorktreeFinalizationLookup::NotFound) => {
                     let error = worktree_provider::worktree_finalization_not_found_error(
@@ -481,6 +629,52 @@ fn finalize_record(
             }
         }
     }
+}
+
+fn release_finalization_receipt_matches(
+    record: &OperationRecord,
+    destination: &WorktreeProvisionDestination,
+    lifecycle: &WorktreeProviderLifecycleIntent,
+    disposition: WorktreeProviderTerminalDisposition,
+) -> bool {
+    if record.provider != provider_evidence_id(&destination.ownership.provider)
+        || record.handle != destination.ownership.handle
+        || record.owner_run_ref != lifecycle.owner_run_ref
+        || record.cleanup_policy != lifecycle.cleanup_policy.as_str()
+        || record.terminal_disposition.as_deref() != Some(disposition.as_str())
+    {
+        return false;
+    }
+    release_finalization_receipt_matches_record(record)
+}
+
+fn release_finalization_receipt_matches_record(record: &OperationRecord) -> bool {
+    if record.provider == "unselected" || record.cleanup_policy != "remove_on_success" {
+        return false;
+    }
+    let Some(receipt) = record.attributes.get("finalization_receipt") else {
+        return false;
+    };
+    let Some(disposition) = record.terminal_disposition.as_deref() else {
+        return false;
+    };
+    let lifecycle = WorktreeProviderLifecycleIntent {
+        purpose: "release_staging".to_string(),
+        owner_run_ref: record.owner_run_ref.clone(),
+        cleanup_policy: WorktreeProviderCleanupPolicy::RemoveOnSuccess,
+    };
+    receipt["schema"] == "homeboy/release-provider-worktree-finalization/v1"
+        && receipt["provider_id"] == record.provider
+        && receipt["handle"] == record.handle
+        && receipt["owner_run_ref"] == record.owner_run_ref
+        && receipt["purpose"] == "release_staging"
+        && receipt["cleanup_policy"] == record.cleanup_policy
+        && receipt["disposition"] == disposition
+        && receipt["recovered_from_not_found"].as_bool().is_some()
+        && receipt["idempotency_key"]
+            == homeboy_core::worktree_providers::worktree_provider_finalization_idempotency_key(
+                &lifecycle,
+            )
 }
 
 fn in_place_eligible(component: &Component, head_release: bool) -> bool {
@@ -868,6 +1062,11 @@ mod tests {
     #[test]
     fn completed_recovery_never_looks_up_a_removed_provider_or_workspace() {
         homeboy_core::test_support::with_isolated_home(|_| {
+            let lifecycle = WorktreeProviderLifecycleIntent {
+                purpose: "release_staging".to_string(),
+                owner_run_ref: "release/completed".to_string(),
+                cleanup_policy: WorktreeProviderCleanupPolicy::RemoveOnSuccess,
+            };
             let record = OperationRecord {
                 owner_run_ref: "release/completed".to_string(),
                 operation: "provider_workspace".to_string(),
@@ -883,8 +1082,22 @@ mod tests {
                 finalization_lease: None,
                 finalization_lease_started_ms: None,
                 attempt_count: 1,
+                mutation_attempted: true,
                 continuation_evidence: Vec::new(),
-                attributes: serde_json::Map::new(),
+                attributes: serde_json::Map::from_iter([(
+                    "finalization_receipt".to_string(),
+                    serde_json::json!({
+                        "schema": "homeboy/release-provider-worktree-finalization/v1",
+                        "provider_id": "removed-provider",
+                        "handle": "deleted-workspace",
+                        "owner_run_ref": lifecycle.owner_run_ref,
+                        "purpose": lifecycle.purpose,
+                        "cleanup_policy": lifecycle.cleanup_policy.as_str(),
+                        "disposition": "succeeded",
+                        "idempotency_key": homeboy_core::worktree_providers::worktree_provider_finalization_idempotency_key(&lifecycle),
+                        "recovered_from_not_found": false,
+                    }),
+                )]),
             };
             test_store()
                 .create(&record)
@@ -961,6 +1174,7 @@ mod tests {
                     finalization_lease: None,
                     finalization_lease_started_ms: None,
                     attempt_count: 0,
+                    mutation_attempted: false,
                     continuation_evidence: Vec::new(),
                     attributes: serde_json::Map::new(),
                 })
@@ -1081,7 +1295,7 @@ mod tests {
             save_config(&config).expect("save provider config");
             let owner = "release/pre-ensure";
             test_store().create(&OperationRecord {
-                owner_run_ref: owner.to_string(), operation: "provider_workspace".to_string(), subject: "component".to_string(), provider: "fixture".to_string(), handle: "release-fixture".to_string(), path: None, source_sha: "abc".to_string(), cleanup_policy: "remove_on_success".to_string(), lifecycle_state: "provisioning".to_string(), terminal_disposition: None, finalization_status: "pending".to_string(), finalization_lease: None, finalization_lease_started_ms: None, attempt_count: 0, continuation_evidence: Vec::new(),
+                owner_run_ref: owner.to_string(), operation: "provider_workspace".to_string(), subject: "component".to_string(), provider: "fixture".to_string(), handle: "release-fixture".to_string(), path: None, source_sha: "abc".to_string(), cleanup_policy: "remove_on_success".to_string(), lifecycle_state: "provisioning".to_string(), terminal_disposition: None, finalization_status: "pending".to_string(), finalization_lease: None, finalization_lease_started_ms: None, attempt_count: 0, mutation_attempted: false, continuation_evidence: Vec::new(),
                 attributes: serde_json::Map::from_iter([("provision_intent".to_string(), serde_json::json!({ "repo": "repo", "base": "main", "head": "abc", "task_url": null, "idempotency_key": "release-fixture:repo:main:abc" }))]),
             }).expect("persist pre-ensure record");
 


### PR DESCRIPTION
Closes #13971.

## Summary
- gate destructive provider cleanup on explicit successful terminal finalization for owner-bound worktrees, while preserving ordinary safe cleanup for ownerless `RemoveWhenSafe` worktrees
- retain workspaces across the push and PR boundary until finalization, including `green_no_finalize` and `awaiting_acceptance` outcomes
- give configured-provider finalization durable intent and idempotent receipts so a crash before receipt publication still converges, including missing-workspace replay
- share one ownership fence across the live coordinator and concurrent resumes covering candidate mutation, portfolio work, and cleanup
- let portfolio safety blockers veto destructive cleanup and preserve retry ownership through re-observation
- reconcile PR and portfolio state from durable publication evidence before any destructive removal
- make lifecycle and portfolio persistence atomic and fsynced, including relative paths and owner-only temp cleanup

## Verification
- `cargo test -p homeboy-cli --lib commands::agent_task::fanout::tests`: 135 passed
- `cargo test -p homeboy-core worktree::`, `workspace_claim::`, `io::output_file::`
- `cargo test -p homeboy-agents agent_task_fanout_supervisor::`, `agent_task_batch::`, `workspace_claims::`
- `cargo test -p homeboy-engine-primitives local_files::`
- `cargo test -p homeboy-release release::workspace::`
- `cargo check --workspace --all-targets`, `cargo fmt --all -- --check`, `git diff --check`
- independent blocking review: no blocking defects; three observed test failures were reproduced identically on the merge-base and are pre-existing

## AI assistance
Anthropic Claude Sonnet 5 and OpenAI GPT-5.6 Sol via OpenCode implemented the finalization lifecycle changes, ran deterministic verification, and performed independent blocking reviews under Chris Huber's direction.