### PR TITLE
test: share component registration fixture

### DIFF
--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -16,7 +16,7 @@ use crate::agent_task_scheduler::{
 };
 use homeboy_core::command_invocation::CommandInvocation;
 use homeboy_core::run_lifecycle_record::RunExecutionState;
-use homeboy_core::test_support::with_isolated_home;
+use homeboy_core::test_support::{with_isolated_home, write_component_registration};
 use homeboy_core::worktree;
 use serde_json::Value;
 use std::path::Path;
@@ -3609,20 +3609,6 @@ fn create_git_repo(path: &Path) {
     std::fs::write(path.join("README.md"), "initial\n").expect("readme");
     homeboy_core::test_support::run_git_fixture_command(path, &["add", "."]);
     homeboy_core::test_support::run_git_fixture_command(path, &["commit", "-q", "-m", "initial"]);
-}
-
-fn write_component_registration(home: &Path, id: &str, local_path: &Path) {
-    let dir = home.join(".config/homeboy/components");
-    std::fs::create_dir_all(&dir).expect("components dir");
-    std::fs::write(
-        dir.join(format!("{id}.json")),
-        serde_json::json!({
-            "local_path": local_path,
-            "remote_path": format!("wp-content/plugins/{id}")
-        })
-        .to_string(),
-    )
-    .expect("component registration");
 }
 
 fn test_plan() -> AgentTaskPlan {

--- a/crates/homeboy-core/src/context/mod.rs
+++ b/crates/homeboy-core/src/context/mod.rs
@@ -453,7 +453,7 @@ pub fn resolve_project_ssh_with_base_path(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::with_isolated_home;
+    use crate::test_support::{with_isolated_home, write_component_registration};
 
     fn manifest(id: &str, markers: serde_json::Value) -> ExtensionManifest {
         let mut manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
@@ -509,20 +509,6 @@ mod tests {
         );
 
         assert_eq!(suggestions, vec!["node-like", "typescript-like"]);
-    }
-
-    fn write_component_registration(home: &Path, id: &str, local_path: &Path) {
-        let dir = home.join(".config/homeboy/components");
-        std::fs::create_dir_all(&dir).expect("components dir");
-        std::fs::write(
-            dir.join(format!("{id}.json")),
-            serde_json::json!({
-                "local_path": local_path,
-                "remote_path": format!("wp-content/plugins/{id}")
-            })
-            .to_string(),
-        )
-        .expect("component registration");
     }
 
     fn write_project(home: &Path, id: &str, component_ids: &[&str]) {

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -1578,6 +1578,20 @@ pub fn write_source_extension(home: &std::path::Path, id: &str, file_extension: 
     }
 }
 
+pub fn write_component_registration(home: &Path, id: &str, local_path: &Path) {
+    let dir = home.join(".config/homeboy/components");
+    fs::create_dir_all(&dir).expect("components dir");
+    fs::write(
+        dir.join(format!("{id}.json")),
+        serde_json::json!({
+            "local_path": local_path,
+            "remote_path": format!("wp-content/plugins/{id}")
+        })
+        .to_string(),
+    )
+    .expect("component registration");
+}
+
 /// Git command execution shared by test fixtures.
 ///
 /// Topology-specific setup stays at the caller: branch names, remotes, commit

--- a/crates/homeboy-core/src/worktree/tests.rs
+++ b/crates/homeboy-core/src/worktree/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::test_support::write_component_registration;
 
 /// A caller reading a "missing handle" error needs the handle creation would
 /// actually produce, so the slug rule has to be reachable outside this module.
@@ -351,20 +352,6 @@ fn merged_task_branch_with_stale_upstream(source: &Path, worktree: &Path) {
         .status()
         .unwrap()
         .success());
-}
-
-fn write_component_registration(home: &Path, id: &str, local_path: &Path) {
-    let dir = home.join(".config/homeboy/components");
-    fs::create_dir_all(&dir).expect("components dir");
-    fs::write(
-        dir.join(format!("{id}.json")),
-        serde_json::json!({
-            "local_path": local_path,
-            "remote_path": format!("wp-content/plugins/{id}")
-        })
-        .to_string(),
-    )
-    .expect("component registration");
 }
 
 fn registered_create_fixture(home: &Path, id: &str) -> (PathBuf, WorktreeCreateOptions) {


### PR DESCRIPTION
## Summary
Replace three exact component-registration filesystem fixture copies with one shared test-support helper.

## What changed
- Add one shared write\_component\_registration helper preserving the existing local\_path and remote\_path JSON shape.
- Migrate core context, core worktree, and agent-task service tests and delete their local copies.
- Preserve the distinct fanout remote\_url fixture contract rather than forcing an incorrect abstraction.

## How to test
1. Run `cargo test -p homeboy-core context::tests -- --quiet`; expect 42 tests pass.
2. Run `cargo test -p homeboy-agents service_materializes_component_worktree_before_provider_dispatch -- --quiet`; expect 1 test passes.

## Compatibility
Test support only; production behavior and public contracts are unchanged. The change deletes 27 net lines.

## Evidence
- Base advanced after verification: verified main at 762b777a23666792731c0f1500ff874be50f3d6d; publication observed 774aabb5c76aaf460e8379325942147ac278f723. Candidate ancestry was validated against the verified snapshot.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/13227
- Verified finalization base: main at 762b777a23666792731c0f1500ff874be50f3d6d
- format: passed (cargo fmt --all --check) (Passed)
- workspace-check: passed (cargo check --workspace --all-targets -j2) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** OpenCode identified and implemented the exact fixture consolidation; Homeboy promoted and gated the candidate, and the resulting diff and focused tests were independently reviewed.

## Source relationships
- Relates to #13227
