### PR TITLE
Register agent-task executors through Extension API v1

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/api/v1/operations.rs
+++ b/crates/contracts/homeboy-extension-contract/src/api/v1/operations.rs
@@ -7,11 +7,13 @@ use super::{
     ExtensionApiVersion,
 };
 
+mod agent_task_executor;
 mod deployment;
 mod environment;
 mod external_check_detail;
 mod invocation;
 mod recipe_run;
+pub use agent_task_executor::*;
 pub use deployment::*;
 pub use environment::*;
 pub use external_check_detail::*;

--- a/crates/contracts/homeboy-extension-contract/src/api/v1/operations/agent_task_executor.rs
+++ b/crates/contracts/homeboy-extension-contract/src/api/v1/operations/agent_task_executor.rs
@@ -1,0 +1,188 @@
+//! Typed Extension API v1 registration surface for agent-task executors.
+//!
+//! An extension declares executors under `agent_runtimes[].agent_task_executors[]`.
+//! Those declarations are provider-shaped data, so the values themselves stay
+//! private to the manifest and to the agent-task layer that resolves them. What
+//! this operation exposes is the registration fact: which executor identities an
+//! installed, compatible extension advertises, and whether each one is
+//! resolvable.
+//!
+//! Everything an executor needs in order to *run* — argv, commands, runtime and
+//! extension paths, secret and environment declarations, materialization
+//! contracts, and provider-specific options — is deliberately absent from these
+//! types. A caller that can read this inventory learns identity, ownership,
+//! compatibility, and readiness, and nothing that would let it reconstruct an
+//! execution.
+
+use serde::{Deserialize, Serialize};
+
+use super::{ExtensionApiOperationFailure, ExtensionApiVersion};
+
+pub const AGENT_TASK_EXECUTOR_CAPABILITY_PREFIX: &str = "agent-task-executor.";
+pub const EXTENSION_API_AGENT_TASK_EXECUTOR_INVENTORY_REQUEST_SCHEMA: &str =
+    "homeboy/extension-api-agent-task-executor-inventory-request/v1";
+pub const EXTENSION_API_AGENT_TASK_EXECUTOR_INVENTORY_RESPONSE_SCHEMA: &str =
+    "homeboy/extension-api-agent-task-executor-inventory-response/v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiAgentTaskExecutorInventoryRequest {
+    pub schema: String,
+    pub api_version: ExtensionApiVersion,
+}
+
+/// Whether one declared executor can be selected.
+///
+/// `Duplicate` is not a variant of `Invalid`: a duplicate declaration can be
+/// perfectly well-formed and still unusable, and the two cases have different
+/// remediations.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionApiAgentTaskExecutorValidation {
+    Valid,
+    Invalid,
+    Duplicate,
+}
+
+/// Why an inventory entry is not resolvable. Carried alongside the descriptor
+/// so a caller never has to parse a human-readable message to branch.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionApiAgentTaskExecutorDiagnosticKind {
+    InvalidDeclaration,
+    DuplicateId,
+    ExtensionIncompatible,
+    ExtensionInvalid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiAgentTaskExecutorDiagnostic {
+    pub kind: ExtensionApiAgentTaskExecutorDiagnosticKind,
+    pub message: String,
+}
+
+/// The safe projection of one declared executor.
+///
+/// `id` and `backend` are the selection identity. `owning_extension` and
+/// `runtime_id` are the registration identity — the pair an install-time gate
+/// checks a declaration against, so a provider from another extension or
+/// runtime can never satisfy it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiAgentTaskExecutorDescriptor {
+    pub id: String,
+    pub backend: String,
+    pub owning_extension: String,
+    pub runtime_id: String,
+    /// Declared capability tokens, which are provider-agnostic labels rather
+    /// than execution inputs.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capabilities: Vec<String>,
+    /// Whether the executor declares a readiness probe at all. The probe's
+    /// command stays private; only its existence and budget are public.
+    pub declares_readiness_probe: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub readiness_timeout_ms: Option<u64>,
+    pub resolvable: bool,
+    pub validation: ExtensionApiAgentTaskExecutorValidation,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diagnostic: Option<ExtensionApiAgentTaskExecutorDiagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiAgentTaskExecutorInventoryResponse {
+    pub schema: String,
+    pub api_version: ExtensionApiVersion,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub executors: Vec<ExtensionApiAgentTaskExecutorDescriptor>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<ExtensionApiOperationFailure>,
+}
+
+impl ExtensionApiAgentTaskExecutorInventoryResponse {
+    /// Registration identities an installed extension actually advertises.
+    ///
+    /// Install and repair compare declared executors against this set, so the
+    /// gate and ordinary dispatch agree on what "discoverable" means.
+    pub fn resolvable(&self) -> impl Iterator<Item = &ExtensionApiAgentTaskExecutorDescriptor> {
+        self.executors.iter().filter(|executor| executor.resolvable)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn descriptor() -> ExtensionApiAgentTaskExecutorDescriptor {
+        ExtensionApiAgentTaskExecutorDescriptor {
+            id: "opencode.agent-task-executor".to_string(),
+            backend: "opencode".to_string(),
+            owning_extension: "homeboy-opencode".to_string(),
+            runtime_id: "opencode".to_string(),
+            capabilities: vec!["workspace_permission_root/v1".to_string()],
+            declares_readiness_probe: true,
+            readiness_timeout_ms: Some(20_000),
+            resolvable: true,
+            validation: ExtensionApiAgentTaskExecutorValidation::Valid,
+            diagnostic: None,
+        }
+    }
+
+    #[test]
+    fn a_descriptor_exposes_registration_identity_and_no_execution_inputs() {
+        assert_eq!(
+            serde_json::to_value(descriptor()).expect("descriptor JSON"),
+            serde_json::json!({
+                "id": "opencode.agent-task-executor",
+                "backend": "opencode",
+                "owning_extension": "homeboy-opencode",
+                "runtime_id": "opencode",
+                "capabilities": ["workspace_permission_root/v1"],
+                "declares_readiness_probe": true,
+                "readiness_timeout_ms": 20000,
+                "resolvable": true,
+                "validation": "valid"
+            })
+        );
+    }
+
+    #[test]
+    fn an_unresolvable_entry_keeps_its_identity_and_states_why() {
+        let mut duplicate = descriptor();
+        duplicate.resolvable = false;
+        duplicate.validation = ExtensionApiAgentTaskExecutorValidation::Duplicate;
+        duplicate.diagnostic = Some(ExtensionApiAgentTaskExecutorDiagnostic {
+            kind: ExtensionApiAgentTaskExecutorDiagnosticKind::DuplicateId,
+            message: "declared by multiple sources".to_string(),
+        });
+
+        let encoded = serde_json::to_value(&duplicate).expect("descriptor JSON");
+
+        // Identity survives so the conflict is reportable, but the entry is not
+        // selectable and says which class of problem it is.
+        assert_eq!(encoded["id"], "opencode.agent-task-executor");
+        assert_eq!(encoded["resolvable"], false);
+        assert_eq!(encoded["validation"], "duplicate");
+        assert_eq!(encoded["diagnostic"]["kind"], "duplicate_id");
+    }
+
+    #[test]
+    fn only_resolvable_entries_are_offered_for_selection() {
+        let mut duplicate = descriptor();
+        duplicate.id = "duplicate".to_string();
+        duplicate.resolvable = false;
+        duplicate.validation = ExtensionApiAgentTaskExecutorValidation::Duplicate;
+
+        let response = ExtensionApiAgentTaskExecutorInventoryResponse {
+            schema: EXTENSION_API_AGENT_TASK_EXECUTOR_INVENTORY_RESPONSE_SCHEMA.to_string(),
+            api_version: crate::api::v1::EXTENSION_API_V1,
+            executors: vec![descriptor(), duplicate],
+            failure: None,
+        };
+
+        let resolvable: Vec<_> = response
+            .resolvable()
+            .map(|executor| executor.id.as_str())
+            .collect();
+
+        assert_eq!(resolvable, ["opencode.agent-task-executor"]);
+    }
+}

--- a/crates/homeboy-agents/src/agent_task_provider/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/discovery.rs
@@ -9,17 +9,17 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-use homeboy_extension_contract::agent_task_executor_declaration::parse_agent_task_executor_declaration;
-
 use homeboy_core::agent_runtime_manifest::{
     discover_agent_runtime_catalog, runtime_materialization_plan, AgentRuntimeDiscoveryDiagnostic,
     AgentRuntimeManifest, AgentRuntimeSelectedIdentity, AGENT_RUNTIME_REVISION_PROBE_TIMED_OUT,
     AGENT_RUNTIME_REVISION_PROBE_TIMEOUT,
 };
 use homeboy_core::command_invocation::COMMAND_INVOCATION_SCHEMA;
-use homeboy_core::extension::catalog::load_extension;
 use homeboy_core::{Error, Result};
-use homeboy_extension_contract::ExtensionManifest;
+use homeboy_extension_contract::api::v1::{
+    ExtensionApiAgentTaskExecutorInventoryRequest,
+    EXTENSION_API_AGENT_TASK_EXECUTOR_INVENTORY_REQUEST_SCHEMA, EXTENSION_API_V1,
+};
 
 use super::AgentTaskExecutorProvider;
 
@@ -197,8 +197,7 @@ fn normalize_agent_task_executor_provider_invocation(provider: &mut AgentTaskExe
 pub(crate) fn validate_installed_extension_agent_runtime_provider_discovery(
     extension_id: &str,
 ) -> Result<()> {
-    let extension = load_extension(extension_id)?;
-    let expected = expected_agent_runtime_provider_refs(&extension)?;
+    let expected = expected_agent_runtime_provider_refs(extension_id)?;
     if expected.is_empty() {
         return Ok(());
     }
@@ -250,25 +249,42 @@ struct ExpectedAgentRuntimeProviderRef {
     backend: String,
 }
 
+/// Registration identities the extension advertises, read from the typed
+/// Extension API inventory.
+///
+/// The inventory is the single place declarations are turned into identities, so
+/// the install-time gate and ordinary discovery cannot disagree about what an
+/// extension registers. A declaration that cannot be parsed is surfaced by the
+/// inventory as an unusable entry, and is rejected here rather than silently
+/// installed (#12206).
 fn expected_agent_runtime_provider_refs(
-    extension: &ExtensionManifest,
+    extension_id: &str,
 ) -> Result<Vec<ExpectedAgentRuntimeProviderRef>> {
+    let inventory =
+        homeboy_core::extension::agent_task_executor_api::AgentTaskExecutorApi::discover(
+            &ExtensionApiAgentTaskExecutorInventoryRequest {
+                schema: EXTENSION_API_AGENT_TASK_EXECUTOR_INVENTORY_REQUEST_SCHEMA.to_string(),
+                api_version: EXTENSION_API_V1,
+            },
+        );
     let mut expected = Vec::new();
-    for runtime in &extension.agent_runtimes {
-        for value in &runtime.agent_task_executors {
-            // Parsed through the shared declaration contract rather than the
-            // resolved provider type, so extension install/replace enforces
-            // byte-identical validity without depending on this crate (#12206).
-            // Only `id` and `backend` are consumed here; the resolved provider
-            // is built later by the catalog parse.
-            let declaration =
-                parse_agent_task_executor_declaration(&extension.id, &runtime.id, value)?;
-            expected.push(ExpectedAgentRuntimeProviderRef {
-                runtime_id: runtime.id.clone(),
-                provider_id: declaration.id,
-                backend: declaration.backend,
-            });
+    for executor in inventory.registered_by(extension_id) {
+        if let Some(diagnostic) = executor.diagnostic.as_ref() {
+            return Err(Error::validation_invalid_argument(
+                "agent_runtimes.agent_task_executors",
+                format!(
+                    "Extension '{}' declares an agent runtime provider that cannot be registered: {}",
+                    extension_id, diagnostic.message
+                ),
+                Some(executor.runtime_id.clone()),
+                None,
+            ));
         }
+        expected.push(ExpectedAgentRuntimeProviderRef {
+            runtime_id: executor.runtime_id.clone(),
+            provider_id: executor.id.clone(),
+            backend: executor.backend.clone(),
+        });
     }
     Ok(expected)
 }

--- a/crates/homeboy-core/src/extension/agent_task_executor_api.rs
+++ b/crates/homeboy-core/src/extension/agent_task_executor_api.rs
@@ -1,0 +1,441 @@
+//! Typed Extension API v1 registration inventory for agent-task executors.
+//!
+//! Executor declarations live on agent-runtime manifests, which core already
+//! discovers. What core deliberately does not own is the resolved provider type:
+//! that belongs to the agent-task layer. This module sits exactly on that line.
+//! It answers "which executor identities does an installed, compatible extension
+//! register, and is each one selectable", and it answers it from one immutable
+//! snapshot so a caller cannot observe two different inventories inside a single
+//! decision.
+//!
+//! Execution inputs never cross this boundary. Argv, commands, extension and
+//! runtime paths, secret and environment declarations, materialization
+//! contracts, and provider-specific options stay inside the manifest and the
+//! agent-task layer.
+
+use std::collections::BTreeMap;
+
+use homeboy_extension_contract::agent_task_executor_declaration::{
+    parse_agent_task_executor_declaration, AgentTaskExecutorProviderDeclaration,
+};
+use homeboy_extension_contract::api::v1::{
+    ExtensionApiAgentTaskExecutorDescriptor, ExtensionApiAgentTaskExecutorDiagnostic,
+    ExtensionApiAgentTaskExecutorDiagnosticKind, ExtensionApiAgentTaskExecutorInventoryRequest,
+    ExtensionApiAgentTaskExecutorInventoryResponse, ExtensionApiAgentTaskExecutorValidation,
+    ExtensionApiCatalogEntryStatus, ExtensionApiCatalogRequest, ExtensionApiOperationFailure,
+    AGENT_TASK_EXECUTOR_CAPABILITY_PREFIX,
+    EXTENSION_API_AGENT_TASK_EXECUTOR_INVENTORY_REQUEST_SCHEMA,
+    EXTENSION_API_AGENT_TASK_EXECUTOR_INVENTORY_RESPONSE_SCHEMA,
+    EXTENSION_API_CATALOG_REQUEST_SCHEMA, EXTENSION_API_V1,
+};
+
+use crate::extension::catalog::{snapshot_api, validate_operation_request};
+
+/// One immutable registration inventory of every declared agent-task executor.
+///
+/// Construction is the only point at which extension state is read. Planning and
+/// validation then share this snapshot, so an extension installed or removed
+/// mid-decision cannot change an answer that has already been acted on.
+pub struct AgentTaskExecutorApi {
+    executors: Vec<ExtensionApiAgentTaskExecutorDescriptor>,
+    failure: Option<ExtensionApiOperationFailure>,
+}
+
+impl AgentTaskExecutorApi {
+    pub fn discover(request: &ExtensionApiAgentTaskExecutorInventoryRequest) -> Self {
+        if let Some(failure) = validate_operation_request(
+            &request.schema,
+            EXTENSION_API_AGENT_TASK_EXECUTOR_INVENTORY_REQUEST_SCHEMA,
+            request.api_version,
+        ) {
+            return Self::failed(failure);
+        }
+
+        let snapshot = snapshot_api(&ExtensionApiCatalogRequest {
+            schema: EXTENSION_API_CATALOG_REQUEST_SCHEMA.to_string(),
+            api_version: request.api_version,
+        });
+        if let Some(failure) = snapshot.response.failure {
+            return Self::failed(failure);
+        }
+
+        let mut executors = Vec::new();
+        for entry in snapshot.response.entries {
+            let Some(manifest) = snapshot.manifests.get(&entry.id) else {
+                continue;
+            };
+            // An extension that is present but not usable still registers its
+            // identities, so a caller reporting a missing executor can say why
+            // rather than reporting it as simply absent.
+            let unusable = match entry.status {
+                ExtensionApiCatalogEntryStatus::Available => None,
+                ExtensionApiCatalogEntryStatus::Incompatible => Some((
+                    ExtensionApiAgentTaskExecutorDiagnosticKind::ExtensionIncompatible,
+                    format!(
+                        "Extension '{}' is not compatible with this Homeboy.",
+                        entry.id
+                    ),
+                )),
+                ExtensionApiCatalogEntryStatus::Invalid => Some((
+                    ExtensionApiAgentTaskExecutorDiagnosticKind::ExtensionInvalid,
+                    entry
+                        .diagnostic
+                        .as_ref()
+                        .map(|diagnostic| diagnostic.message.clone())
+                        .unwrap_or_else(|| format!("Extension '{}' is not usable.", entry.id)),
+                )),
+            };
+            let advertised = entry
+                .descriptor
+                .as_ref()
+                .into_iter()
+                .flat_map(|descriptor| &descriptor.capabilities)
+                .map(|capability| capability.id.as_str())
+                .filter(|id| id.starts_with(AGENT_TASK_EXECUTOR_CAPABILITY_PREFIX))
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+
+            for runtime in &manifest.agent_runtimes {
+                for declared in &runtime.agent_task_executors {
+                    let declaration =
+                        parse_agent_task_executor_declaration(&manifest.id, &runtime.id, declared);
+                    executors.push(descriptor(
+                        &manifest.id,
+                        &runtime.id,
+                        declaration,
+                        &advertised,
+                        unusable.clone(),
+                    ));
+                }
+            }
+        }
+
+        mark_duplicate_ids(&mut executors);
+        executors.sort_by(|left, right| {
+            (&left.owning_extension, &left.runtime_id, &left.id).cmp(&(
+                &right.owning_extension,
+                &right.runtime_id,
+                &right.id,
+            ))
+        });
+
+        Self {
+            executors,
+            failure: None,
+        }
+    }
+
+    fn failed(failure: ExtensionApiOperationFailure) -> Self {
+        Self {
+            executors: Vec::new(),
+            failure: Some(failure),
+        }
+    }
+
+    pub fn inventory_api(&self) -> ExtensionApiAgentTaskExecutorInventoryResponse {
+        ExtensionApiAgentTaskExecutorInventoryResponse {
+            schema: EXTENSION_API_AGENT_TASK_EXECUTOR_INVENTORY_RESPONSE_SCHEMA.to_string(),
+            api_version: EXTENSION_API_V1,
+            executors: self.executors.clone(),
+            failure: self.failure.clone(),
+        }
+    }
+
+    /// Executors registered by one installed extension, in deterministic order.
+    pub fn registered_by<'a>(
+        &'a self,
+        extension_id: &'a str,
+    ) -> impl Iterator<Item = &'a ExtensionApiAgentTaskExecutorDescriptor> + 'a {
+        self.executors
+            .iter()
+            .filter(move |executor| executor.owning_extension == extension_id)
+    }
+}
+
+fn descriptor(
+    extension_id: &str,
+    runtime_id: &str,
+    declaration: crate::Result<AgentTaskExecutorProviderDeclaration>,
+    advertised: &[String],
+    unusable: Option<(ExtensionApiAgentTaskExecutorDiagnosticKind, String)>,
+) -> ExtensionApiAgentTaskExecutorDescriptor {
+    let (id, backend, capabilities, readiness, invalid) = match declaration {
+        Ok(declaration) => {
+            let capabilities = declaration
+                .extra
+                .get("capabilities")
+                .and_then(serde_json::Value::as_array)
+                .map(|values| {
+                    values
+                        .iter()
+                        .filter_map(serde_json::Value::as_str)
+                        .map(str::to_string)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            let readiness = declaration.readiness_invocation.as_ref().map(|readiness| {
+                readiness.timeout_ms.unwrap_or(
+                    homeboy_extension_contract::agent_task_executor_declaration::DEFAULT_PROVIDER_READINESS_INVOCATION_TIMEOUT_MS,
+                )
+            });
+            (
+                declaration.id,
+                declaration.backend,
+                capabilities,
+                readiness,
+                None,
+            )
+        }
+        // A declaration that cannot be parsed has no trustworthy identity, so it
+        // is registered as an unnamed unusable entry rather than being silently
+        // dropped from the inventory.
+        Err(error) => (
+            String::new(),
+            String::new(),
+            Vec::new(),
+            None,
+            Some(error.message),
+        ),
+    };
+
+    let capability_advertised = !id.is_empty()
+        && advertised.iter().any(|capability| {
+            *capability == format!("{AGENT_TASK_EXECUTOR_CAPABILITY_PREFIX}{id}")
+        });
+
+    let diagnostic = match (invalid, unusable) {
+        (Some(message), _) => Some(ExtensionApiAgentTaskExecutorDiagnostic {
+            kind: ExtensionApiAgentTaskExecutorDiagnosticKind::InvalidDeclaration,
+            message,
+        }),
+        (None, Some((kind, message))) => {
+            Some(ExtensionApiAgentTaskExecutorDiagnostic { kind, message })
+        }
+        (None, None) if !capability_advertised => Some(ExtensionApiAgentTaskExecutorDiagnostic {
+            kind: ExtensionApiAgentTaskExecutorDiagnosticKind::InvalidDeclaration,
+            message: "The extension does not advertise this executor as a capability.".to_string(),
+        }),
+        (None, None) => None,
+    };
+    let resolvable = diagnostic.is_none();
+
+    ExtensionApiAgentTaskExecutorDescriptor {
+        id,
+        backend,
+        owning_extension: extension_id.to_string(),
+        runtime_id: runtime_id.to_string(),
+        capabilities,
+        declares_readiness_probe: readiness.is_some(),
+        readiness_timeout_ms: readiness,
+        resolvable,
+        validation: if resolvable {
+            ExtensionApiAgentTaskExecutorValidation::Valid
+        } else {
+            ExtensionApiAgentTaskExecutorValidation::Invalid
+        },
+        diagnostic,
+    }
+}
+
+/// An executor id is the selection token, so a colliding id makes every claimant
+/// unusable. Failing all of them keeps selection deterministic instead of
+/// depending on which extension happened to be discovered first.
+fn mark_duplicate_ids(executors: &mut [ExtensionApiAgentTaskExecutorDescriptor]) {
+    let mut sources: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for executor in executors.iter().filter(|executor| executor.resolvable) {
+        sources
+            .entry(executor.id.clone())
+            .or_default()
+            .push(format!(
+                "runtime:{} source:{}",
+                executor.runtime_id, executor.owning_extension
+            ));
+    }
+
+    for executor in executors.iter_mut() {
+        let Some(claimants) = sources.get(&executor.id) else {
+            continue;
+        };
+        if claimants.len() < 2 {
+            continue;
+        }
+        executor.resolvable = false;
+        executor.validation = ExtensionApiAgentTaskExecutorValidation::Duplicate;
+        executor.diagnostic = Some(ExtensionApiAgentTaskExecutorDiagnostic {
+            kind: ExtensionApiAgentTaskExecutorDiagnosticKind::DuplicateId,
+            message: format!(
+                "Agent-task executor id '{}' is declared by multiple sources: {}. Select one source explicitly before dispatching this executor.",
+                executor.id,
+                claimants.join(", ")
+            ),
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn declaration(
+        value: serde_json::Value,
+    ) -> crate::Result<AgentTaskExecutorProviderDeclaration> {
+        parse_agent_task_executor_declaration("ext", "runtime", &value)
+    }
+
+    #[test]
+    fn a_registered_executor_exposes_identity_without_execution_inputs() {
+        let advertised = vec![format!(
+            "{AGENT_TASK_EXECUTOR_CAPABILITY_PREFIX}opencode.exec"
+        )];
+        let entry = descriptor(
+            "homeboy-opencode",
+            "opencode",
+            declaration(json!({
+                "id": "opencode.exec",
+                "backend": "opencode",
+                "capabilities": ["workspace_permission_root/v1"],
+                "argv": ["opencode-provider", "--secret", "token"],
+                "readiness_invocation": { "argv": ["opencode-provider"], "timeout_ms": 5000 }
+            })),
+            &advertised,
+            None,
+        );
+
+        assert!(entry.resolvable);
+        assert_eq!(entry.backend, "opencode");
+        assert_eq!(entry.owning_extension, "homeboy-opencode");
+        assert_eq!(entry.runtime_id, "opencode");
+        assert!(entry.declares_readiness_probe);
+        assert_eq!(entry.readiness_timeout_ms, Some(5000));
+
+        let encoded = serde_json::to_string(&entry).expect("descriptor JSON");
+        assert!(
+            !encoded.contains("argv")
+                && !encoded.contains("opencode-provider")
+                && !encoded.contains("token"),
+            "registration inventory must not carry execution inputs: {encoded}"
+        );
+    }
+
+    #[test]
+    fn an_unparseable_declaration_is_registered_as_unusable_rather_than_dropped() {
+        let entry = descriptor(
+            "ext",
+            "runtime",
+            declaration(json!({ "id": "missing-backend" })),
+            &[],
+            None,
+        );
+
+        assert!(!entry.resolvable);
+        assert_eq!(
+            entry.diagnostic.expect("diagnostic").kind,
+            ExtensionApiAgentTaskExecutorDiagnosticKind::InvalidDeclaration
+        );
+    }
+
+    #[test]
+    fn an_executor_the_extension_does_not_advertise_is_not_resolvable() {
+        let entry = descriptor(
+            "ext",
+            "runtime",
+            declaration(json!({ "id": "unadvertised", "backend": "b" })),
+            &[],
+            None,
+        );
+
+        assert!(!entry.resolvable);
+    }
+
+    #[test]
+    fn an_incompatible_extension_keeps_its_identity_and_reports_why() {
+        let advertised = vec![format!("{AGENT_TASK_EXECUTOR_CAPABILITY_PREFIX}exec")];
+        let entry = descriptor(
+            "ext",
+            "runtime",
+            declaration(json!({ "id": "exec", "backend": "b" })),
+            &advertised,
+            Some((
+                ExtensionApiAgentTaskExecutorDiagnosticKind::ExtensionIncompatible,
+                "too old".to_string(),
+            )),
+        );
+
+        assert_eq!(entry.id, "exec");
+        assert!(!entry.resolvable);
+        assert_eq!(
+            entry.diagnostic.expect("diagnostic").kind,
+            ExtensionApiAgentTaskExecutorDiagnosticKind::ExtensionIncompatible
+        );
+    }
+
+    #[test]
+    fn a_colliding_executor_id_makes_every_claimant_unusable() {
+        let advertised = vec![format!("{AGENT_TASK_EXECUTOR_CAPABILITY_PREFIX}shared")];
+        let mut executors = vec![
+            descriptor(
+                "ext-a",
+                "runtime-a",
+                declaration(json!({ "id": "shared", "backend": "b" })),
+                &advertised,
+                None,
+            ),
+            descriptor(
+                "ext-b",
+                "runtime-b",
+                declaration(json!({ "id": "shared", "backend": "b" })),
+                &advertised,
+                None,
+            ),
+        ];
+
+        mark_duplicate_ids(&mut executors);
+
+        assert!(executors.iter().all(|executor| !executor.resolvable));
+        for executor in &executors {
+            let diagnostic = executor.diagnostic.as_ref().expect("duplicate diagnostic");
+            assert_eq!(
+                diagnostic.kind,
+                ExtensionApiAgentTaskExecutorDiagnosticKind::DuplicateId
+            );
+            // Sources are listed in a stable order so the same collision always
+            // produces the same reported conflict.
+            assert!(
+                diagnostic
+                    .message
+                    .contains("runtime:runtime-a source:ext-a, runtime:runtime-b source:ext-b"),
+                "got {}",
+                diagnostic.message
+            );
+        }
+    }
+
+    #[test]
+    fn a_unique_executor_survives_duplicate_marking() {
+        let advertised = vec![format!("{AGENT_TASK_EXECUTOR_CAPABILITY_PREFIX}only")];
+        let mut executors = vec![descriptor(
+            "ext",
+            "runtime",
+            declaration(json!({ "id": "only", "backend": "b" })),
+            &advertised,
+            None,
+        )];
+
+        mark_duplicate_ids(&mut executors);
+
+        assert!(executors[0].resolvable);
+    }
+
+    #[test]
+    fn an_invalid_request_schema_yields_a_failed_inventory() {
+        let api = AgentTaskExecutorApi::discover(&ExtensionApiAgentTaskExecutorInventoryRequest {
+            schema: "homeboy/wrong-request/v1".to_string(),
+            api_version: EXTENSION_API_V1,
+        });
+
+        let response = api.inventory_api();
+        assert!(response.executors.is_empty());
+        assert!(response.failure.is_some());
+    }
+}

--- a/crates/homeboy-core/src/extension/catalog/api.rs
+++ b/crates/homeboy-core/src/extension/catalog/api.rs
@@ -14,12 +14,12 @@ use homeboy_extension_contract::api::v1::{
     ExtensionApiReadinessDescriptor, ExtensionApiReadinessMode, ExtensionApiReadinessRequest,
     ExtensionApiReadinessResponse, ExtensionApiReadinessState, ExtensionApiReadinessStatus,
     ExtensionApiResolveRequest, ExtensionApiResolveResponse, ExtensionApiRuntimeRequirement,
-    ExtensionApiVersion, COMPILER_WARNINGS_CAPABILITY_ID, COMPILER_WARNINGS_INPUT_SCHEMA,
-    COMPILER_WARNINGS_OUTPUT_SCHEMA, COMPILER_WARNING_FIXES_CAPABILITY_ID,
-    COMPILER_WARNING_FIXES_INPUT_SCHEMA, COMPILER_WARNING_FIXES_OUTPUT_SCHEMA,
-    DEPLOYMENT_PROVIDER_CAPABILITY_PREFIX, ENVIRONMENT_CAPABILITY_ID,
-    EXTENSION_API_CATALOG_REQUEST_SCHEMA, EXTENSION_API_CATALOG_RESPONSE_SCHEMA,
-    EXTENSION_API_DEPLOYMENT_PROVIDER_INVOKE_REQUEST_SCHEMA,
+    ExtensionApiVersion, AGENT_TASK_EXECUTOR_CAPABILITY_PREFIX, COMPILER_WARNINGS_CAPABILITY_ID,
+    COMPILER_WARNINGS_INPUT_SCHEMA, COMPILER_WARNINGS_OUTPUT_SCHEMA,
+    COMPILER_WARNING_FIXES_CAPABILITY_ID, COMPILER_WARNING_FIXES_INPUT_SCHEMA,
+    COMPILER_WARNING_FIXES_OUTPUT_SCHEMA, DEPLOYMENT_PROVIDER_CAPABILITY_PREFIX,
+    ENVIRONMENT_CAPABILITY_ID, EXTENSION_API_CATALOG_REQUEST_SCHEMA,
+    EXTENSION_API_CATALOG_RESPONSE_SCHEMA, EXTENSION_API_DEPLOYMENT_PROVIDER_INVOKE_REQUEST_SCHEMA,
     EXTENSION_API_DEPLOYMENT_PROVIDER_INVOKE_RESPONSE_SCHEMA, EXTENSION_API_DESCRIPTOR_SCHEMA,
     EXTENSION_API_ENVIRONMENT_RESOLVE_REQUEST_SCHEMA,
     EXTENSION_API_ENVIRONMENT_RESOLVE_RESPONSE_SCHEMA, EXTENSION_API_HANDSHAKE_REQUEST_SCHEMA,
@@ -182,6 +182,20 @@ fn api_descriptor_from_manifest(extension: &ExtensionManifest) -> ExtensionApiDe
             .iter()
             .map(|runtime| capability_descriptor(&format!("agent-runtime.{}", runtime.id))),
     );
+    // An executor is registered as its own capability so discovery, install
+    // validation, and dispatch all resolve the same advertised identity rather
+    // than re-deriving it from the runtime's opaque declarations.
+    capabilities.extend(extension.agent_runtimes.iter().flat_map(|runtime| {
+        runtime
+            .agent_task_executors
+            .iter()
+            .filter_map(|declared| declared.get("id").and_then(|id| id.as_str()))
+            .filter(|id| !id.trim().is_empty())
+            .map(|id| {
+                capability_descriptor(&format!("{AGENT_TASK_EXECUTOR_CAPABILITY_PREFIX}{id}"))
+            })
+            .collect::<Vec<_>>()
+    }));
     capabilities.sort_by(|left, right| left.id.cmp(&right.id));
     capabilities.dedup_by(|left, right| left.id == right.id);
 

--- a/crates/homeboy-core/src/extension/mod.rs
+++ b/crates/homeboy-core/src/extension/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent_task_executor_api;
 pub mod audit_compiler_warning_provider;
 pub mod audit_fingerprint_script_provider;
 pub mod audit_grammar_source_provider;

--- a/docs/internals/development/contracts/extension-api-v1.md
+++ b/docs/internals/development/contracts/extension-api-v1.md
@@ -209,6 +209,31 @@ Deployment routing, repository policy validation, payload construction,
 observation phases, and component result aggregation remain deploy-subsystem
 policy over this operation.
 
+## Agent-Task Executor Registration
+
+`extension::agent_task_executor_api::AgentTaskExecutorApi` discovers
+`agent-task-executor.<id>` capabilities from installed extensions and returns one
+immutable registration inventory. Each entry exposes the executor id, backend,
+owning extension, owning runtime, declared capability tokens, whether a readiness
+probe is declared, its readiness budget, resolvability, and a typed diagnostic.
+
+Everything an executor needs in order to run stays private: argv, commands,
+extension and runtime paths, secret and environment declarations, materialization
+contracts, and provider-specific options never enter an inventory response.
+
+Entries are ordered by owning extension, runtime, and executor id. A declaration
+that cannot be parsed, an extension that is incompatible or invalid, and an
+executor id claimed by more than one source are each registered as an unusable
+entry that keeps its identity and states its diagnostic kind, rather than being
+dropped. A colliding id makes every claimant unusable so selection never depends
+on discovery order.
+
+Extension install, replace, and relink validate declared executors against this
+inventory, so the install-time gate and ordinary agent-task discovery cannot
+disagree about what an extension registers. Resolving a declaration into an
+executable provider, selection policy, workspace preparation, retries, and
+dispatch remain agent-task subsystem policy over this operation.
+
 ## External Check Detail Hydration
 
 `extension::external_check_detail_api` discovers


### PR DESCRIPTION
## Summary

- add typed Extension API v1 agent-task executor registration contracts: inventory request/response, safe descriptor, validation states, and typed diagnostic kinds
- project `agent-task-executor.<id>` capabilities from extension agent runtimes
- add `AgentTaskExecutorApi`, an immutable registration inventory built from one catalog snapshot with deterministic ordering and duplicate handling
- make `homeboy-agents` install validation read expected identities from that inventory instead of traversing and re-parsing extension manifests itself

This completes the v1 operation family alongside deployment, environment, external-check-detail, recipe-run, and invocation.

## Ownership boundary

The API owns executor identity, owning extension and runtime, declared capability tokens, readiness declaration, resolvability, and diagnostics. Resolving a declaration into an executable provider, selection policy, workspace preparation, retries, and dispatch remain agent-task subsystem policy.

Execution inputs never cross the boundary. Argv, commands, extension and runtime paths, secret and environment declarations, materialization contracts, and provider-specific options are absent from every response, and a test asserts the serialized descriptor contains none of them.

## Behavior preserved

- Unparseable declarations, incompatible extensions, and invalid extensions are registered as unusable entries that keep their identity and state a typed diagnostic kind, rather than being dropped.
- A colliding executor id makes every claimant unusable, so selection never depends on discovery order. Conflict sources are listed in a stable order.
- Install, replace, and relink still reject an extension whose declared executor is not discoverable, and still roll back. The agent-task rich provider parser remains the discoverability authority, so this change does not weaken the existing gate.

## Scope note

`ExtensionProviderDiscoveryValidator` is intentionally still present. Deleting it requires threading an explicit lifecycle validation dependency through core `install`, `install_with_revision`, `install_for_component`, `replace_with_revision`, and `relink` (~14 call sites), because the agents-side resolved-provider parser is strictly stricter than the portable declaration contract and currently gates install. Removing the registry without that threading would silently weaken install validation, so it is left as a separate follow-up on #14155 rather than folded in here.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-extension-contract --lib` (106 passed, 3 new)
- `cargo test -p homeboy-core extension::agent_task_executor_api --lib` (7 passed)
- `cargo test -p homeboy-core extension --lib` (960 passed)
- `cargo test -p homeboy-agents agent_task_provider --lib` (224 passed)
- `cargo check --workspace`
- `git diff --check`

One agent-task test, `shared_evaluator_uses_effective_config_redacts_runtime_reason_and_deduplicates`, failed once under heavy parallel load and then passed in isolation on this branch, in isolation on clean `origin/main`, and on a full-suite rerun. It is load-sensitive and untouched by this diff.

Refs #14155
Parent #13882

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode audited the remaining opaque Extension API surface, designed the registration inventory boundary, implemented the contracts, core API, capability projection, and agents consumption, wrote the tests and documentation, and ran verification under Chris Huber's direction.