### PR TITLE
test: share extension lifecycle fixtures

### DIFF
--- a/crates/homeboy-core/src/extension/lifecycle/mod.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/mod.rs
@@ -412,7 +412,9 @@ mod tests {
         uninstall, update,
     };
     use homeboy_core::component;
-    use homeboy_core::test_support::with_isolated_home;
+    use homeboy_core::test_support::{
+        with_isolated_home, write_extension_fixture, write_extension_fixture_with_version,
+    };
     use std::fs;
     use std::path::Path;
     use std::process::Command;
@@ -420,26 +422,6 @@ mod tests {
 
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
-
-    fn write_extension_fixture(root: &Path, id: &str) {
-        write_extension_fixture_with_version(root, id, "1.0.0");
-    }
-
-    fn write_extension_fixture_with_version(root: &Path, id: &str, version: &str) {
-        let dir = root.join(id);
-        fs::create_dir_all(&dir).expect("extension dir");
-        fs::write(
-            dir.join(format!("{}.json", id)),
-            format!(
-                r#"{{
-  "name": "{} extension",
-  "version": "{}"
-}}"#,
-                id, version
-            ),
-        )
-        .expect("extension manifest");
-    }
 
     fn write_extension_fixture_with_setup(root: &Path, id: &str) {
         let dir = root.join(id);

--- a/crates/homeboy-core/src/extension/lifecycle/repair.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/repair.rs
@@ -560,31 +560,13 @@ mod tests {
     };
     use crate::extension::catalog::load_extension;
     use crate::extension::lifecycle::{install, read_source_revision, read_source_url};
-    use homeboy_core::test_support::with_isolated_home;
+    use homeboy_core::test_support::{
+        with_isolated_home, write_extension_fixture, write_extension_fixture_with_version,
+    };
     use std::fs;
     use std::path::Path;
     use std::process::Command;
     use tempfile::TempDir;
-
-    fn write_extension_fixture(root: &Path, id: &str) {
-        write_extension_fixture_with_version(root, id, "1.0.0");
-    }
-
-    fn write_extension_fixture_with_version(root: &Path, id: &str, version: &str) {
-        let dir = root.join(id);
-        fs::create_dir_all(&dir).expect("extension dir");
-        fs::write(
-            dir.join(format!("{}.json", id)),
-            format!(
-                r#"{{
-  "name": "{} extension",
-  "version": "{}"
-}}"#,
-                id, version
-            ),
-        )
-        .expect("extension manifest");
-    }
 
     fn write_extension_fixture_with_setup_command(root: &Path, id: &str, setup_command: &str) {
         let dir = root.join(id);

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -1592,6 +1592,26 @@ pub fn write_component_registration(home: &Path, id: &str, local_path: &Path) {
     .expect("component registration");
 }
 
+pub fn write_extension_fixture(root: &Path, id: &str) {
+    write_extension_fixture_with_version(root, id, "1.0.0");
+}
+
+pub fn write_extension_fixture_with_version(root: &Path, id: &str, version: &str) {
+    let dir = root.join(id);
+    fs::create_dir_all(&dir).expect("extension dir");
+    fs::write(
+        dir.join(format!("{}.json", id)),
+        format!(
+            r#"{{
+  "name": "{} extension",
+  "version": "{}"
+}}"#,
+            id, version
+        ),
+    )
+    .expect("extension manifest");
+}
+
 /// Git command execution shared by test fixtures.
 ///
 /// Topology-specific setup stays at the caller: branch names, remotes, commit


### PR DESCRIPTION
## Summary
Deduplicated the exact extension lifecycle filesystem fixture helpers into homeboy-core test support while preserving fixture bytes and behavior.

## What changed
- Moved \`write\_extension\_fixture\` and \`write\_extension\_fixture\_with\_version\` into \`crates/homeboy-core/src/test\_support.rs\`.
- Migrated lifecycle and repair tests to the shared helpers and removed both local pairs.
- Kept all specialized fixture variants local and unchanged.
- Reduced the affected files by 16 net lines: 26 insertions and 42 deletions.

## How to test
1. Run `cargo fmt --all --check`; expect passes as recorded by Cook's deterministic gate.
2. Run `cargo check --workspace --all-targets -j2`; expect passes as recorded by Cook's deterministic gate.

## Compatibility
Test-only refactor with no production API or runtime behavior impact. Manifest content, paths, default and explicit versions, filesystem operations, and failure messages remain identical. Evidence is bounded to the two exact duplicate helper pairs; specialized setup, provider, runtime, component, HTTP, and Git fixtures were not consolidated.

## Evidence
- Verified command `cargo fmt --all --check`: status=succeeded; candidate commit `e756b6191a1dd29146c2e881f9ca104df3ad9f1e`, tree `40542f6542c10c95a1861d262bd1bed74a3ad928`, fingerprint `a25c4eb5e6b38eccf6b2c207c3d0206c51a9ee69c2d2e125f75f6873e0a41264`; durable gate `gate-1`
- Verified command `cargo check --workspace --all-targets -j2`: status=succeeded; candidate commit `e756b6191a1dd29146c2e881f9ca104df3ad9f1e`, tree `40542f6542c10c95a1861d262bd1bed74a3ad928`, fingerprint `a25c4eb5e6b38eccf6b2c207c3d0206c51a9ee69c2d2e125f75f6873e0a41264`; durable gate `gate-2`
- Base unchanged since verification: main remains at bbfbdc9e3db6be28b523d2558e3a4d130803ffcc.
- CI expected: Homeboy CI after push
- Candidate adoption provenance: the candidate was promoted from the recorded Cook task execution.
- Cook deterministic verification: 2 gate(s) completed green.
- Durable run execution: Succeeded
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/13227
- Task objective: Work from current origin/main. Continue issue #13227 with one bounded filesystem-fixture slice. crates/homeboy-core/src/extension/lifecycle/mod.rs and crates/homeboy-core/src/extension/lifecycle/repair.rs each define exact copies of write\_extension\_fixture and write\_extension\_fixture\_with\_version. Move only those two exact helpers into homeboy-core test\_support, migrate both test modules, and delete both local pairs. Preserve byte-for-byte manifest content, paths, versions, and behavior. Do not consolidate setup-command variants, invalid-provider variants, shared-runtime fixtures, component fixtures, HTTP helpers, Git helpers, or production APIs because those contracts differ. Require a net line deletion. Run the focused extension lifecycle test groups and the all-target workspace check.
- Verified candidate scope: 3 changed file(s): crates/homeboy-core/src/extension/lifecycle/mod.rs, crates/homeboy-core/src/extension/lifecycle/repair.rs, crates/homeboy-core/src/test\_support.rs.
- Verified finalization base: main at bbfbdc9e3db6be28b523d2558e3a4d130803ffcc
- deterministic gate passed: sh -lc cargo check --workspace --all-targets -j2 (Passed)
- deterministic gate passed: sh -lc cargo fmt --all --check (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (opencode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Compared the duplicate source implementations and nearby test-support fixture family, moved only exact matches, verified specialized contracts remained local, confirmed a net deletion and clean diff, and ran both focused lifecycle groups. Controller-owned formatting and all-target workspace gates remain authoritative.
