### PR TITLE
test: share stack Git fixture execution

### DIFF
--- a/tests/core/stack/push_test.rs
+++ b/tests/core/stack/push_test.rs
@@ -2,7 +2,7 @@
 
 use crate::stack::push::{local_branch_ref, push, remote_branch_ref, PushStatus};
 use crate::stack::spec::{GitRef, StackSpec};
-use std::process::Command;
+use homeboy_core::test_support::GitFixture;
 use tempfile::TempDir;
 
 mod support;
@@ -10,11 +10,7 @@ use support::{commit_file, git, init_repo, rev_parse};
 
 fn init_bare_remote() -> TempDir {
     let remote = TempDir::new().expect("remote tempdir");
-    let out = Command::new("git")
-        .args(["init", "--bare", "-q"])
-        .current_dir(remote.path())
-        .output()
-        .expect("git init --bare");
+    let out = GitFixture::new(remote.path()).execute(&["init", "--bare", "-q"]);
     assert!(
         out.status.success(),
         "git init --bare failed: {}",

--- a/tests/core/stack/support.rs
+++ b/tests/core/stack/support.rs
@@ -1,6 +1,7 @@
 use std::fs;
-use std::process::Command;
+use std::path::Path;
 
+use homeboy_core::test_support::GitFixture;
 use tempfile::TempDir;
 
 pub(crate) fn init_repo() -> (TempDir, String) {
@@ -16,11 +17,7 @@ pub(crate) fn init_repo() -> (TempDir, String) {
 }
 
 pub(crate) fn git(path: &str, args: &[&str]) {
-    let out = Command::new("git")
-        .args(args)
-        .current_dir(path)
-        .output()
-        .unwrap_or_else(|e| panic!("git {:?}: {}", args, e));
+    let out = GitFixture::new(Path::new(path)).execute(args);
     assert!(
         out.status.success(),
         "git {:?} failed: {} / {}",
@@ -38,11 +35,7 @@ pub(crate) fn commit_file(dir: &TempDir, path: &str, file: &str, body: &str, msg
 }
 
 pub(crate) fn rev_parse(path: &str, rev: &str) -> String {
-    let out = Command::new("git")
-        .args(["rev-parse", rev])
-        .current_dir(path)
-        .output()
-        .unwrap();
+    let out = GitFixture::new(Path::new(path)).execute(&["rev-parse", rev]);
     assert!(
         out.status.success(),
         "git rev-parse {rev} failed: {}",


### PR DESCRIPTION
## Summary
Route successful stack-test Git command execution through the shared GitFixture while preserving fixture behavior and reducing duplicated command setup by 11 net lines.

## What changed
- Updated tests/core/stack/support.rs git and rev\_parse wrappers to use GitFixture while retaining existing assertions, diagnostics, output parsing, repository topology, commit identity, and return values.
- Updated tests/core/stack/push\_test.rs init\_bare\_remote to use GitFixture while preserving its success assertion text and bare-remote topology.
- Removed the now-unused Command imports; failure-oriented and raw-status Git commands elsewhere remain explicit and unchanged.
- Change kind is test-fixture-only. The evidence boundary is successful Git execution in the named stack fixtures; no production, lifecycle, HTTP, or filesystem APIs changed.

## How to test
1. Run `cargo fmt --all --check`; expect passes as recorded by Cook's deterministic gate.
2. Run `cargo check --workspace --all-targets -j2`; expect passes as recorded by Cook's deterministic gate.

## Compatibility
Low risk and test-only. Existing wrapper contracts and Git semantics remain unchanged; no runtime behavior or public API compatibility impact is expected. The authoritative formatting and all-target workspace gates remain controller-owned.

## Evidence
- Verified command `cargo fmt --all --check`: status=succeeded; candidate commit `f67d257928e8442bfaa3af8a73b0d06a6adf28f6`, tree `e787385051dd1a7948234ade32bd7929bc92d64c`, fingerprint `7c0fbf1a985208552426848d5b9b69797499ca1ddf2f072277e54428336fc37b`; durable gate `gate-1`
- Verified command `cargo check --workspace --all-targets -j2`: status=succeeded; candidate commit `f67d257928e8442bfaa3af8a73b0d06a6adf28f6`, tree `e787385051dd1a7948234ade32bd7929bc92d64c`, fingerprint `7c0fbf1a985208552426848d5b9b69797499ca1ddf2f072277e54428336fc37b`; durable gate `gate-2`
- Base unchanged since verification: main remains at 9fd4c8b8550c7be0c13053af0e3bf3727500d930.
- CI expected: Homeboy CI after push
- Candidate adoption provenance: the candidate was promoted from the recorded Cook task execution.
- Cook deterministic verification: 2 gate(s) completed green.
- Durable run execution: Succeeded
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/13227
- Task objective: Work from current origin/main. Continue issue #13227 with one bounded Git fixture slice. In tests/core/stack/support.rs, route the successful git and rev\_parse command execution through homeboy\_core::test\_support::GitFixture while preserving each wrapper's existing assertions, output parsing, diagnostics, repository topology, commit identity, and return values. In tests/core/stack/push\_test.rs, route the successful init\_bare\_remote git init command through the same shared GitFixture and preserve its assertion text. Remove now-unused Command imports. Keep all failure-oriented or raw-status Git commands in apply\_test.rs, candidates\_test.rs, and elsewhere explicit; they intentionally inspect failure/status behavior. Do not redesign stack fixtures or broaden to lifecycle, HTTP, filesystem, or production APIs. Require a net line deletion. Run focused stack tests and the all-target workspace check.
- Verified candidate scope: 2 changed file(s): tests/core/stack/push\_test.rs, tests/core/stack/support.rs.
- Verified finalization base: main at 9fd4c8b8550c7be0c13053af0e3bf3727500d930
- deterministic gate passed: sh -lc cargo check --workspace --all-targets -j2 (Passed)
- deterministic gate passed: sh -lc cargo fmt --all --check (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (opencode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Started from the current origin/main commit, inspected the existing GitFixture implementation and nearby fixture family, made the smallest scoped substitutions, confirmed a net deletion and clean diff, and ran focused stack coverage.
