### PR TITLE
test: share tunnel server fixture

### DIFF
--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -20,6 +20,21 @@ use crate::api_jobs::{
 use crate::daemon::controller_job_driver::{ControllerJobDriver, ControllerJobHandle};
 use crate::error::{Error, Result};
 
+pub fn save_test_server(id: &str, host: &str) -> Result<()> {
+    crate::server::save(&crate::server::Server {
+        id: id.to_string(),
+        aliases: Vec::new(),
+        host: host.to_string(),
+        user: "tester".to_string(),
+        port: 22,
+        identity_file: None,
+        kind: None,
+        auth: None,
+        env: std::collections::HashMap::new(),
+        runner: None,
+    })
+}
+
 /// A real in-memory controller job boundary for domain-driver tests.
 ///
 /// The harness keeps construction internals out of the production API while

--- a/crates/homeboy-tunnel/src/tunnel_tests.rs
+++ b/crates/homeboy-tunnel/src/tunnel_tests.rs
@@ -1,24 +1,11 @@
 use crate::*;
 use homeboy_core::paths;
-use homeboy_core::server::Server;
 use homeboy_core::test_support;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::time::{Duration, Instant};
 
 fn create_server() {
-    homeboy_core::server::save(&Server {
-        id: "private-host".to_string(),
-        aliases: Vec::new(),
-        host: "private.example.test".to_string(),
-        user: "tester".to_string(),
-        port: 22,
-        identity_file: None,
-        kind: None,
-        auth: None,
-        env: HashMap::new(),
-        runner: None,
-    })
-    .expect("save server");
+    test_support::save_test_server("private-host", "private.example.test").expect("save server");
 }
 
 fn reserve_loopback_port() -> u16 {

--- a/tests/commands/tunnel_test.rs
+++ b/tests/commands/tunnel_test.rs
@@ -3,24 +3,11 @@ use super::service::{
 };
 use super::*;
 use crate::test_support;
-use homeboy::core::server::Server;
-use std::collections::HashMap;
 use std::fs;
 
 fn create_server() {
-    homeboy::core::server::save(&Server {
-        id: "private-host".to_string(),
-        aliases: Vec::new(),
-        host: "private.example.test".to_string(),
-        user: "tester".to_string(),
-        port: 22,
-        identity_file: None,
-        kind: None,
-        auth: None,
-        env: HashMap::new(),
-        runner: None,
-    })
-    .expect("save server");
+    homeboy::core::test_support::save_test_server("private-host", "private.example.test")
+        .expect("save server");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Consolidate two identical tunnel test Server fixtures into one parameterized homeboy\_core::test\_support helper, removing duplication without changing behavior.

## What changed
- Added save\_test\_server(id, host), preserving every existing Server field value while returning the original save Result.
- Updated both local create\_server wrappers to use the shared helper while retaining existing call sites and expect("save server") failure behavior.
- Removed unused Server and HashMap imports; the patch deletes 11 net lines.

## How to test
1. Run `cargo fmt --all --check`; expect passes as recorded by Cook's deterministic gate.
2. Run `cargo check --workspace --all-targets -j2`; expect passes as recorded by Cook's deterministic gate.
3. Run `cargo test -p homeboy-tunnel -- --quiet`; expect passes as recorded by Cook's deterministic gate.

## Compatibility
Test-support-only refactor. No production Server API, tunnel behavior, HTTP listener fixtures, defaults, or persisted formats changed.

## Evidence
- Verified command `cargo fmt --all --check`: status=succeeded; candidate commit `e8c28a59e2b7d0766a0ab97a7aa42b839d45dacb`, tree `4bd1065c28c3f062f6452a197a15c877ef3c2b4c`, fingerprint `0ba24cc4d128fb2318ac54dfe4a01456e69562167fedfa8b078e09fe7cbf3747`; durable gate `gate-1`
- Verified command `cargo check --workspace --all-targets -j2`: status=succeeded; candidate commit `e8c28a59e2b7d0766a0ab97a7aa42b839d45dacb`, tree `4bd1065c28c3f062f6452a197a15c877ef3c2b4c`, fingerprint `0ba24cc4d128fb2318ac54dfe4a01456e69562167fedfa8b078e09fe7cbf3747`; durable gate `gate-2`
- Verified command `cargo test -p homeboy-tunnel -- --quiet`: status=succeeded; candidate commit `e8c28a59e2b7d0766a0ab97a7aa42b839d45dacb`, tree `4bd1065c28c3f062f6452a197a15c877ef3c2b4c`, fingerprint `0ba24cc4d128fb2318ac54dfe4a01456e69562167fedfa8b078e09fe7cbf3747`; durable gate `gate-3`; total=68, passed=68, failed=0, ignored=0
- Base unchanged since verification: main remains at 6ab6a0e6e2abd30a97b1e595be5196514f3cc2ba.
- CI expected: Homeboy CI after push
- Candidate adoption provenance: the candidate was promoted from the recorded Cook task execution.
- Cook deterministic verification: 3 gate(s) completed green.
- Durable run execution: Succeeded
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/homeboy/issues/13227
- Task objective: Work from current origin/main. Continue issue #13227 with one bounded test-fixture slice. The create\_server helpers in tests/commands/tunnel\_test.rs and crates/homeboy-tunnel/src/tunnel\_tests.rs are exact duplicated Server construction. Add the smallest parameterized helper in homeboy\_core::test\_support that saves this standard test Server while accepting the fixture id and host. Preserve every existing Server field value and each caller's save failure behavior. Replace both local create\_server implementations with the shared helper, preserving existing test call sites where practical, and remove imports made unused by the consolidation. Do not derive Default, change the production Server API, alter tunnel behavior, or broaden into HTTP listener fixtures. Require a net line deletion. Run focused homeboy-tunnel tests and the all-target workspace check.
- Verified candidate scope: 3 changed file(s): crates/homeboy-core/src/test\_support.rs, crates/homeboy-tunnel/src/tunnel\_tests.rs, tests/commands/tunnel\_test.rs.
- Verified finalization base: main at 6ab6a0e6e2abd30a97b1e595be5196514f3cc2ba
- deterministic gate passed: sh -lc cargo check --workspace --all-targets -j2 (Passed)
- deterministic gate passed: sh -lc cargo fmt --all --check (Passed)
- deterministic gate passed: sh -lc cargo test -p homeboy-tunnel -- --quiet (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (opencode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Source relationship: consolidated exact duplicated Server construction identified in the two requested tunnel test modules. Change kind: bounded test-fixture refactor based on the nearby shared test\_support helper family. Verification capability: focused tunnel tests and all-target workspace compilation. Evidence boundary: test construction and imports only; no runtime or HTTP fixture changes.
