### PR TITLE
Make extension lifecycle executor validation an explicit dependency

### DIFF
--- a/crates/homeboy-agents/src/agent_task_provider/discovery.rs
+++ b/crates/homeboy-agents/src/agent_task_provider/discovery.rs
@@ -289,24 +289,20 @@ fn expected_agent_runtime_provider_refs(
     Ok(expected)
 }
 
-/// Agent-task implementation of core's extension provider-discovery validator.
-struct ExtensionProviderDiscoveryValidatorImpl;
+/// Resolves an extension's registered executors against this host's agent-task
+/// providers, so extension install, replace, and relink can reject a declaration
+/// that registers cleanly but cannot actually be dispatched.
+///
+/// Pass this into a lifecycle mutation from a caller that has the agent-task
+/// subsystem. A caller without it uses
+/// `ExtensionLifecycleValidation::declaration_only`, which still enforces
+/// registrability.
+pub struct AgentTaskExecutorDiscovery;
 
-impl homeboy_core::extension::registry::ExtensionProviderDiscoveryValidator
-    for ExtensionProviderDiscoveryValidatorImpl
-{
-    fn validate_installed_extension_provider_discovery(&self, extension_id: &str) -> Result<()> {
+impl homeboy_core::extension::registry::ExtensionExecutorDiscovery for AgentTaskExecutorDiscovery {
+    fn validate_registered_executors(&self, extension_id: &str) -> Result<()> {
         validate_installed_extension_agent_runtime_provider_discovery(extension_id)
     }
-}
-
-/// Register the extension provider-discovery validator so core's extension
-/// install/repair can verify declared agent-runtime providers are discoverable
-/// without depending on the agent-task subsystem.
-pub fn register() {
-    homeboy_core::extension::registry::register_extension_provider_discovery_validator(Box::new(
-        ExtensionProviderDiscoveryValidatorImpl,
-    ));
 }
 
 #[cfg(test)]

--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -572,7 +572,6 @@ fn register_startup_providers_after_reconcile(
     crate::agents::agent_task_secrets::register();
     // Register the extension provider-discovery validator so core's
     // extension install/repair can verify declared agent-runtime providers.
-    crate::agents::agent_task_provider::discovery::register();
     // Register the command-label resolver so core::runner can map dispatched
     // argv to a hot-command label without depending on the full CLI parser.
     crate::runner::set_command_label_resolver(|argv| {

--- a/crates/homeboy-cli/src/commands/extension.rs
+++ b/crates/homeboy-cli/src/commands/extension.rs
@@ -1,5 +1,7 @@
 use clap::{Args, Subcommand};
+use homeboy_agents::agent_task_provider::discovery::AgentTaskExecutorDiscovery;
 use homeboy_core::extension;
+use homeboy_core::extension::registry::ExtensionLifecycleValidation;
 use serde::{Deserialize, Serialize};
 
 use homeboy::agents::agent_tasks::provider::AgentTaskProviderCatalog;
@@ -1403,6 +1405,7 @@ fn install_extension(
             source,
             id.as_deref(),
             revision.as_deref(),
+            ExtensionLifecycleValidation::with_executor_discovery(&AgentTaskExecutorDiscovery),
         )?;
         return Ok((
             ExtensionOutput::Replace {
@@ -1422,6 +1425,7 @@ fn install_extension(
         source,
         id.as_deref(),
         revision.as_deref(),
+        ExtensionLifecycleValidation::with_executor_discovery(&AgentTaskExecutorDiscovery),
     )?;
     let linked = is_extension_linked(&result.extension_id);
 
@@ -1443,7 +1447,12 @@ fn refresh_extension(
     id: Option<&str>,
     revision: Option<&str>,
 ) -> CmdResult<ExtensionOutput> {
-    let result = homeboy_core::extension::lifecycle::refresh(source, id, revision)?;
+    let result = homeboy_core::extension::lifecycle::refresh(
+        source,
+        id,
+        revision,
+        ExtensionLifecycleValidation::with_executor_discovery(&AgentTaskExecutorDiscovery),
+    )?;
     let linked = is_extension_linked(&result.extension_id);
 
     Ok((
@@ -1465,7 +1474,11 @@ fn refresh_extension(
 }
 
 fn relink_extension(extension_id: &str, source: &str) -> CmdResult<ExtensionOutput> {
-    let result = homeboy_core::extension::lifecycle::relink(extension_id, source)?;
+    let result = homeboy_core::extension::lifecycle::relink(
+        extension_id,
+        source,
+        ExtensionLifecycleValidation::with_executor_discovery(&AgentTaskExecutorDiscovery),
+    )?;
 
     Ok((
         ExtensionOutput::Replace {
@@ -1495,7 +1508,11 @@ fn dev_run_extension(
 
 fn install_for_component(source: &str, path: Option<&str>) -> CmdResult<ExtensionOutput> {
     let component = resolve_install_component(path)?;
-    let result = homeboy_core::extension::lifecycle::install_for_component(&component, source)?;
+    let result = homeboy_core::extension::lifecycle::install_for_component(
+        &component,
+        source,
+        ExtensionLifecycleValidation::with_executor_discovery(&AgentTaskExecutorDiscovery),
+    )?;
 
     let installed = result
         .installed

--- a/crates/homeboy-cli/src/commands/runner/recipe_run.rs
+++ b/crates/homeboy-cli/src/commands/runner/recipe_run.rs
@@ -150,6 +150,7 @@ fn validate_workspace_relative_path(argument: &str, value: &str) -> homeboy::cor
 #[cfg(test)]
 mod tests {
     use super::*;
+    use homeboy_core::extension::registry::ExtensionLifecycleValidation;
     fn install_fixture_extension(
         id: &str,
         provider_id: &str,
@@ -171,8 +172,12 @@ mod tests {
             .to_string(),
         )
         .expect("manifest");
-        homeboy_core::extension::lifecycle::install(&source.path().display().to_string(), Some(id))
-            .expect("install extension");
+        homeboy_core::extension::lifecycle::install(
+            &source.path().display().to_string(),
+            Some(id),
+            ExtensionLifecycleValidation::declaration_only(),
+        )
+        .expect("install extension");
         // Installed extensions are linked to their source. Keep the fixture
         // alive until discovery and execution complete.
         source

--- a/crates/homeboy-cli/src/commands/runner/tests/exec.rs
+++ b/crates/homeboy-cli/src/commands/runner/tests/exec.rs
@@ -117,6 +117,7 @@ fn synced_node_workload_receives_runner_extension_environment() {
         homeboy_core::extension::lifecycle::install(
             &extension.path().display().to_string(),
             Some("fixture"),
+            homeboy_core::extension::registry::ExtensionLifecycleValidation::declaration_only(),
         )
         .expect("install fixture extension");
         runner::create(

--- a/crates/homeboy-core/src/extension/invoke/env_provider.rs
+++ b/crates/homeboy-core/src/extension/invoke/env_provider.rs
@@ -145,6 +145,7 @@ fn resolve(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::extension::registry::ExtensionLifecycleValidation;
 
     #[cfg(unix)]
     fn install_provider_fixture(root: &Path, id: &str, output: &str) {
@@ -164,8 +165,12 @@ mod tests {
             .expect("provider script");
         std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
             .expect("provider executable");
-        crate::extension::lifecycle::install(&source.display().to_string(), Some(id))
-            .expect("install provider fixture");
+        crate::extension::lifecycle::install(
+            &source.display().to_string(),
+            Some(id),
+            ExtensionLifecycleValidation::declaration_only(),
+        )
+        .expect("install provider fixture");
     }
 
     #[cfg(unix)]

--- a/crates/homeboy-core/src/extension/lifecycle/install_sources.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/install_sources.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 
 use homeboy_core::config::{self, from_str};
 use homeboy_core::error::{Error, Result};
-use homeboy_core::extension::registry::validate_installed_extension_provider_discovery;
+use homeboy_core::extension::registry::ExtensionLifecycleValidation;
 use homeboy_core::git;
 use homeboy_core::paths;
 use homeboy_engine_primitives::local_files;
@@ -105,9 +105,10 @@ pub(crate) fn shared_assets_for_extension_source(source: &Path) -> Vec<(String, 
 pub(super) fn install_configured_extension(
     source: &str,
     extension_id: &str,
+    validation: ExtensionLifecycleValidation<'_>,
 ) -> Result<InstallResult> {
     if super::is_git_url(source) {
-        return super::install(source, Some(extension_id));
+        return super::install(source, Some(extension_id), validation);
     }
 
     let source_path = Path::new(source);
@@ -122,10 +123,11 @@ pub(super) fn install_configured_extension(
             Some(extension_id),
             Some(source_path),
             None,
+            validation,
         );
     }
 
-    super::install(source, Some(extension_id))
+    super::install(source, Some(extension_id), validation)
 }
 
 /// Install a extension by cloning from a git repository URL.
@@ -137,6 +139,7 @@ pub(super) fn install_from_url(
     url: &str,
     id_override: Option<&str>,
     revision: Option<&str>,
+    validation: ExtensionLifecycleValidation<'_>,
 ) -> Result<InstallResult> {
     let extension_id = match id_override {
         Some(id) => slugify_id(id)?,
@@ -201,7 +204,7 @@ pub(super) fn install_from_url(
     }
 
     let manifest_path = paths::extension_manifest(&extension_id)?;
-    if let Err(err) = validate_installed_extension_provider_discovery(&extension_id) {
+    if let Err(err) = validation.validate_installed_extension(&extension_id) {
         let _ = std::fs::remove_dir_all(&extension_dir);
         return Err(err);
     }
@@ -546,6 +549,7 @@ pub(super) fn install_from_path(
     id_override: Option<&str>,
     source_root: Option<&Path>,
     revision: Option<&str>,
+    validation: ExtensionLifecycleValidation<'_>,
 ) -> Result<InstallResult> {
     let source = Path::new(source_path);
 
@@ -596,6 +600,7 @@ pub(super) fn install_from_path(
                     Some(&extension_id),
                     Some(&source),
                     revision,
+                    validation,
                 );
             }
         }
@@ -654,7 +659,7 @@ pub(super) fn install_from_path(
         return Err(err);
     }
     let manifest_path = paths::extension_manifest(&extension_id)?;
-    if let Err(err) = validate_installed_extension_provider_discovery(&extension_id) {
+    if let Err(err) = validation.validate_installed_extension(&extension_id) {
         let _ = std::fs::remove_file(&extension_dir);
         return Err(err);
     }

--- a/crates/homeboy-core/src/extension/lifecycle/mod.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/mod.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::extension::catalog::load_extension;
+use crate::extension::registry::ExtensionLifecycleValidation;
 
 pub(crate) const EXTENSION_SOURCE_PREPARE_TIMEOUT: Duration = Duration::from_secs(120);
 
@@ -76,8 +77,12 @@ fn manifest_path_for_extension(extension_dir: &Path, id: &str) -> PathBuf {
 
 /// Install a extension from a git URL or link a local directory.
 /// Automatically detects whether source is a URL (git clone) or local path (symlink).
-pub fn install(source: &str, id_override: Option<&str>) -> Result<InstallResult> {
-    install_with_revision(source, id_override, None)
+pub fn install(
+    source: &str,
+    id_override: Option<&str>,
+    validation: ExtensionLifecycleValidation<'_>,
+) -> Result<InstallResult> {
+    install_with_revision(source, id_override, None, validation)
 }
 
 /// Install a extension from a git URL or link a local directory.
@@ -86,11 +91,12 @@ pub fn install_with_revision(
     source: &str,
     id_override: Option<&str>,
     revision: Option<&str>,
+    validation: ExtensionLifecycleValidation<'_>,
 ) -> Result<InstallResult> {
     if is_git_url(source) {
-        install_from_url(source, id_override, revision)
+        install_from_url(source, id_override, revision, validation)
     } else {
-        install_from_path(source, id_override, None, revision)
+        install_from_path(source, id_override, None, revision, validation)
     }
 }
 
@@ -100,6 +106,7 @@ pub fn install_with_revision(
 pub fn install_for_component(
     component: &homeboy_core::component::Component,
     source: &str,
+    validation: ExtensionLifecycleValidation<'_>,
 ) -> Result<InstallForComponentResult> {
     let extensions = component.extensions.as_ref().ok_or_else(|| {
         Error::validation_invalid_argument(
@@ -131,7 +138,11 @@ pub fn install_for_component(
             continue;
         }
 
-        installed.push(install_configured_extension(source, &extension_id)?);
+        installed.push(install_configured_extension(
+            source,
+            &extension_id,
+            validation,
+        )?);
     }
 
     Ok(InstallForComponentResult {
@@ -163,6 +174,7 @@ pub fn refresh(
     source: &str,
     id_override: Option<&str>,
     revision: Option<&str>,
+    validation: ExtensionLifecycleValidation<'_>,
 ) -> Result<RefreshResult> {
     let extension_id = match id_override {
         Some(id) => slugify_id(id)?,
@@ -184,6 +196,7 @@ pub fn refresh(
             &install_source,
             Some(&extension_id),
             effective_revision,
+            validation,
         )?;
         InstallResult {
             extension_id: replaced.extension_id,
@@ -193,7 +206,12 @@ pub fn refresh(
             source_revision: replaced.source_revision,
         }
     } else {
-        install_with_revision(&install_source, Some(&extension_id), effective_revision)?
+        install_with_revision(
+            &install_source,
+            Some(&extension_id),
+            effective_revision,
+            validation,
+        )?
     };
 
     Ok(RefreshResult {
@@ -411,6 +429,7 @@ mod tests {
         register_component_install_runner, shared_assets_for_extension_source, source_metadata,
         uninstall, update,
     };
+    use crate::extension::registry::ExtensionLifecycleValidation;
     use homeboy_core::component;
     use homeboy_core::test_support::{
         with_isolated_home, write_extension_fixture, write_extension_fixture_with_version,
@@ -739,8 +758,12 @@ exec '{}' "$@"
             write_component_fixture(&component_dir, &["alpha", "beta"]);
             let component = component::discover_from_portable(&component_dir).expect("component");
 
-            let result = install_for_component(&component, &source.to_string_lossy())
-                .expect("install should succeed");
+            let result = install_for_component(
+                &component,
+                &source.to_string_lossy(),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("install should succeed");
 
             let installed_ids = result
                 .installed
@@ -805,11 +828,19 @@ exec '{}' "$@"
             write_component_fixture(&component_dir, &["alpha", "beta"]);
             let component = component::discover_from_portable(&component_dir).expect("component");
 
-            install(&source.join("alpha").to_string_lossy(), Some("alpha"))
-                .expect("pre-install alpha");
+            install(
+                &source.join("alpha").to_string_lossy(),
+                Some("alpha"),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("pre-install alpha");
 
-            let result = install_for_component(&component, &source.to_string_lossy())
-                .expect("install should succeed");
+            let result = install_for_component(
+                &component,
+                &source.to_string_lossy(),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("install should succeed");
 
             let installed_ids = result
                 .installed
@@ -835,8 +866,12 @@ exec '{}' "$@"
 
             let component = component::discover_from_portable(&component_dir)
                 .expect("component should resolve from portable path");
-            let result = install_for_component(&component, &source.to_string_lossy())
-                .expect("install should succeed");
+            let result = install_for_component(
+                &component,
+                &source.to_string_lossy(),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("install should succeed");
 
             assert_eq!(result.component_id, "multi-extension-component");
             assert_eq!(result.installed.len(), 2);
@@ -850,8 +885,13 @@ exec '{}' "$@"
             let source = home.join("source");
             write_extension_fixture(&source, "alpha");
 
-            let result = refresh(&source.join("alpha").to_string_lossy(), Some("alpha"), None)
-                .expect("first-time refresh should install");
+            let result = refresh(
+                &source.join("alpha").to_string_lossy(),
+                Some("alpha"),
+                None,
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("first-time refresh should install");
 
             assert_eq!(result.extension_id, "alpha");
             assert!(
@@ -869,13 +909,23 @@ exec '{}' "$@"
             let source = home.join("source");
             write_extension_fixture_with_version(&source, "alpha", "1.0.0");
 
-            install(&source.join("alpha").to_string_lossy(), Some("alpha")).expect("pre-install");
+            install(
+                &source.join("alpha").to_string_lossy(),
+                Some("alpha"),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("pre-install");
 
             // Update the source, then refresh — the reinstall should pick it up
             // without erroring on the pre-existing install.
             write_extension_fixture_with_version(&source, "alpha", "2.0.0");
-            let result = refresh(&source.join("alpha").to_string_lossy(), Some("alpha"), None)
-                .expect("refresh over existing install should succeed");
+            let result = refresh(
+                &source.join("alpha").to_string_lossy(),
+                Some("alpha"),
+                None,
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("refresh over existing install should succeed");
 
             assert!(
                 result.uninstalled_previous,
@@ -905,11 +955,17 @@ exec '{}' "$@"
             install(
                 &old_source.join("wordpress").to_string_lossy(),
                 Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("pre-install");
 
-            let err = refresh(&invalid_source.to_string_lossy(), Some("wordpress"), None)
-                .expect_err("refresh should reject the invalid replacement");
+            let err = refresh(
+                &invalid_source.to_string_lossy(),
+                Some("wordpress"),
+                None,
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect_err("refresh should reject the invalid replacement");
 
             assert!(!err.message.is_empty());
             let installed_path = home.join(".config/homeboy/extensions/wordpress");
@@ -944,6 +1000,7 @@ exec '{}' "$@"
                 &lab_source.join("alpha").to_string_lossy(),
                 Some("alpha"),
                 None,
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("refresh should install from transient source");
 
@@ -984,6 +1041,7 @@ exec '{}' "$@"
                 &source.join("nodejs").to_string_lossy(),
                 Some("nodejs"),
                 None,
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("refresh should install from local git source");
 
@@ -1030,6 +1088,7 @@ exec '{}' "$@"
             install(
                 &old_source.join("opencode").to_string_lossy(),
                 Some("opencode"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install old extension");
             crate::runtime_package::refresh_shared_assets(&boundary_source)
@@ -1039,6 +1098,7 @@ exec '{}' "$@"
                 &source.join("agent-runtimes/opencode").to_string_lossy(),
                 Some("opencode"),
                 None,
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("refresh nested runtime package");
 
@@ -1096,6 +1156,7 @@ exec '{}' "$@"
             install(
                 &old_source.join("opencode").to_string_lossy(),
                 Some("opencode"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install old extension");
             crate::runtime_package::refresh_shared_assets(&boundary_source)
@@ -1107,6 +1168,7 @@ exec '{}' "$@"
                 &source.join("agent-runtimes/opencode").to_string_lossy(),
                 Some("opencode"),
                 None,
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect_err("malformed root manifest should reject refresh");
 
@@ -1130,11 +1192,19 @@ exec '{}' "$@"
             let source = home.join("source");
             write_extension_fixture(&source, "swift");
 
-            install(&source.join("swift").to_string_lossy(), Some("swift"))
-                .expect("initial install");
+            install(
+                &source.join("swift").to_string_lossy(),
+                Some("swift"),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("initial install");
 
-            let err = install(&source.join("swift").to_string_lossy(), Some("swift"))
-                .expect_err("second install should still fail");
+            let err = install(
+                &source.join("swift").to_string_lossy(),
+                Some("swift"),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect_err("second install should still fail");
 
             assert!(err.to_string().contains("already exists"));
         });
@@ -1152,8 +1222,12 @@ exec '{}' "$@"
             };
 
             let extension_source = source.join("wordpress");
-            install(&extension_source.to_string_lossy(), Some("wordpress"))
-                .expect("install linked extension");
+            install(
+                &extension_source.to_string_lossy(),
+                Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("install linked extension");
 
             let before = read_source_revision("wordpress").expect("linked git revision");
             assert!(!extension_source.join(".source-revision").exists());
@@ -1183,6 +1257,7 @@ exec '{}' "$@"
                 &source.join("wordpress").to_string_lossy(),
                 Some("wordpress"),
                 Some("abc1234"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install linked staged extension");
 
@@ -1271,8 +1346,12 @@ exec '{}' "$@"
             };
             let remote_url = remote.path().join("extension.git");
 
-            let result = install(&remote_url.to_string_lossy(), Some("wordpress"))
-                .expect("install cloned extension");
+            let result = install(
+                &remote_url.to_string_lossy(),
+                Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("install cloned extension");
 
             assert!(result.path.join(".source-revision").exists());
             assert_eq!(
@@ -1311,8 +1390,12 @@ exec '{}' "$@"
             };
             let remote_url = remote.path().join("extension.git");
 
-            let installed = install(&remote_url.to_string_lossy(), Some("rust"))
-                .expect("install cloned extension");
+            let installed = install(
+                &remote_url.to_string_lossy(),
+                Some("rust"),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("install cloned extension");
 
             assert!(home
                 .join(".config/homeboy/extensions/rust/rust.json")
@@ -1346,8 +1429,12 @@ exec '{}' "$@"
             };
             let remote_url = remote.path().join("extension.git");
 
-            install(&remote_url.to_string_lossy(), Some("wordpress"))
-                .expect("install cloned extension");
+            install(
+                &remote_url.to_string_lossy(),
+                Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("install cloned extension");
 
             assert!(home
                 .join(".config/homeboy/extensions/wordpress/wordpress.json")
@@ -1382,8 +1469,12 @@ exec '{}' "$@"
             };
             let remote_url = remote.path().join("extension.git");
 
-            install(&remote_url.to_string_lossy(), Some("wordpress"))
-                .expect("install cloned extension");
+            install(
+                &remote_url.to_string_lossy(),
+                Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("install cloned extension");
 
             // Cloned installs must keep copying: the clone temp dir is discarded,
             // so the shared trees have to be standalone copies, not symlinks.
@@ -1408,8 +1499,12 @@ exec '{}' "$@"
             };
             let remote_url = remote.path().join("extension.git");
 
-            install(&remote_url.to_string_lossy(), Some("wordpress"))
-                .expect("install cloned extension");
+            install(
+                &remote_url.to_string_lossy(),
+                Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("install cloned extension");
 
             write_declared_runtime_shared_assets(&source);
             assert!(commit_all(&source, "add runtime package"));
@@ -1455,6 +1550,7 @@ exec '{}' "$@"
             install(
                 &source.join("wordpress").to_string_lossy(),
                 Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install linked extension");
 
@@ -1479,6 +1575,7 @@ exec '{}' "$@"
             install(
                 &source.join("wordpress").to_string_lossy(),
                 Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install linked extension");
 
@@ -1521,6 +1618,7 @@ exec '{}' "$@"
             install(
                 &source.join("wordpress").to_string_lossy(),
                 Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install linked extension");
 
@@ -1578,6 +1676,7 @@ exec '{}' "$@"
             install(
                 &source.join("wordpress").to_string_lossy(),
                 Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install linked extension");
 
@@ -1612,8 +1711,12 @@ exec '{}' "$@"
             write_extension_fixture(&source, "wordpress");
             write_declared_runtime_shared_assets(&source);
 
-            install(&source.to_string_lossy(), Some("wordpress"))
-                .expect("install linked extension from monorepo root");
+            install(
+                &source.to_string_lossy(),
+                Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("install linked extension from monorepo root");
 
             assert!(home
                 .join(".config/homeboy/extensions/wordpress/wordpress.json")
@@ -1638,6 +1741,7 @@ exec '{}' "$@"
             let result = install(
                 &source.join("wordpress").to_string_lossy(),
                 Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install linked extension");
 
@@ -1661,6 +1765,7 @@ exec '{}' "$@"
             let err = install(
                 &source.join("wordpress").to_string_lossy(),
                 Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect_err("install should fail invalid provider declaration");
 
@@ -1681,8 +1786,12 @@ exec '{}' "$@"
             )
             .expect("extension manifest");
 
-            let _err = install(&extension_dir.to_string_lossy(), Some("wordpress"))
-                .expect_err("failed setup must fail installation");
+            let _err = install(
+                &extension_dir.to_string_lossy(),
+                Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect_err("failed setup must fail installation");
 
             assert!(
                 std::fs::symlink_metadata(home.path().join(".config/homeboy/extensions/wordpress"))
@@ -1716,6 +1825,7 @@ exec '{}' "$@"
                 &remote_url.to_string_lossy(),
                 Some("wordpress"),
                 Some(&pinned_revision),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install pinned revision");
 
@@ -1756,6 +1866,7 @@ exec '{}' "$@"
                 &remote_url.to_string_lossy(),
                 Some("wordpress"),
                 Some("next-extension"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install branch revision");
 
@@ -1790,6 +1901,7 @@ exec '{}' "$@"
                 &remote_url.to_string_lossy(),
                 Some("wordpress"),
                 Some(&pinned_revision),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install pinned extracted extension");
             update("wordpress", false).expect("update pinned extracted extension");
@@ -1821,6 +1933,7 @@ exec '{}' "$@"
             install(
                 &source.join("wordpress").to_string_lossy(),
                 Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install linked extension");
 
@@ -1846,6 +1959,7 @@ exec '{}' "$@"
             install(
                 &source.join("wordpress").to_string_lossy(),
                 Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install linked extension");
 
@@ -1883,11 +1997,13 @@ exec '{}' "$@"
             install(
                 &source.join("fixture-a").to_string_lossy(),
                 Some("fixture-a"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install linked fixture-a extension");
             install(
                 &source.join("fixture-b").to_string_lossy(),
                 Some("fixture-b"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install linked fixture-b extension");
             // Install now runs setup, so restore the fixture checkout to the
@@ -1982,6 +2098,7 @@ exec '{}' "$@"
             install(
                 &source.join("wordpress").to_string_lossy(),
                 Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install linked extension");
 
@@ -2025,8 +2142,12 @@ exec '{}' "$@"
             };
             let remote_url = remote.path().join("extension.git");
 
-            let result = install(&remote_url.to_string_lossy(), Some("wordpress"))
-                .expect("install extracted extension");
+            let result = install(
+                &remote_url.to_string_lossy(),
+                Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("install extracted extension");
             assert!(!result.path.join(".git").exists());
 
             write_extension_fixture_with_version(&source, "wordpress", "2.0.0");
@@ -2058,8 +2179,12 @@ exec '{}' "$@"
             };
             let remote_url = remote.path().join("extension.git");
 
-            let result = install(&remote_url.to_string_lossy(), Some("wordpress"))
-                .expect("install extracted extension");
+            let result = install(
+                &remote_url.to_string_lossy(),
+                Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("install extracted extension");
 
             fs::write(source.join("wordpress/wordpress.json"), "not json")
                 .expect("write invalid manifest");
@@ -2257,7 +2382,11 @@ impl homeboy_core::component_install_provider::ComponentInstallRunner
         source: &str,
     ) -> homeboy_core::Result<homeboy_core::component_install_provider::ComponentInstallResult>
     {
-        let result = install_for_component(component, source)?;
+        let result = install_for_component(
+            component,
+            source,
+            homeboy_core::extension::registry::ExtensionLifecycleValidation::declaration_only(),
+        )?;
         Ok(
             homeboy_core::component_install_provider::ComponentInstallResult {
                 component_id: result.component_id,

--- a/crates/homeboy-core/src/extension/lifecycle/repair.rs
+++ b/crates/homeboy-core/src/extension/lifecycle/repair.rs
@@ -1,7 +1,7 @@
 use super::is_git_url;
 use homeboy_core::config::{self, from_str};
 use homeboy_core::error::{Error, Result};
-use homeboy_core::extension::registry::validate_installed_extension_provider_discovery;
+use homeboy_core::extension::registry::ExtensionLifecycleValidation;
 use homeboy_core::git;
 use homeboy_core::paths;
 use homeboy_engine_primitives::local_files;
@@ -27,30 +27,40 @@ pub struct ReplaceResult {
     pub source_revision: Option<String>,
 }
 
-pub fn replace(source: &str, id_override: Option<&str>) -> Result<ReplaceResult> {
-    replace_with_revision(source, id_override, None)
+pub fn replace(
+    source: &str,
+    id_override: Option<&str>,
+    validation: ExtensionLifecycleValidation<'_>,
+) -> Result<ReplaceResult> {
+    replace_with_revision(source, id_override, None, validation)
 }
 
 pub fn replace_with_revision(
     source: &str,
     id_override: Option<&str>,
     revision: Option<&str>,
+    validation: ExtensionLifecycleValidation<'_>,
 ) -> Result<ReplaceResult> {
     if is_git_url(source) {
-        replace_from_url(source, id_override, revision)
+        replace_from_url(source, id_override, revision, validation)
     } else {
-        replace_from_path(source, id_override, false, revision)
+        replace_from_path(source, id_override, false, revision, validation)
     }
 }
 
-pub fn relink(extension_id: &str, source: &str) -> Result<ReplaceResult> {
-    replace_from_path(source, Some(extension_id), true, None)
+pub fn relink(
+    extension_id: &str,
+    source: &str,
+    validation: ExtensionLifecycleValidation<'_>,
+) -> Result<ReplaceResult> {
+    replace_from_path(source, Some(extension_id), true, None, validation)
 }
 
 fn replace_from_url(
     url: &str,
     id_override: Option<&str>,
     revision: Option<&str>,
+    validation: ExtensionLifecycleValidation<'_>,
 ) -> Result<ReplaceResult> {
     let extension_id = match id_override {
         Some(id) => slugify_id(id)?,
@@ -105,7 +115,12 @@ fn replace_from_url(
     }
 
     run_setup_or_restore(&extension_id, &extension_dir, &backup_dir)?;
-    validate_agent_runtime_discovery_or_restore(&extension_id, &extension_dir, &backup_dir)?;
+    validate_agent_runtime_discovery_or_restore(
+        &extension_id,
+        &extension_dir,
+        &backup_dir,
+        validation,
+    )?;
     remove_existing_install(&backup_dir)?;
     let manifest_path = paths::extension_manifest(&extension_id)?;
 
@@ -125,6 +140,7 @@ fn replace_from_path(
     id_override: Option<&str>,
     require_existing_link: bool,
     requested_revision: Option<&str>,
+    validation: ExtensionLifecycleValidation<'_>,
 ) -> Result<ReplaceResult> {
     let mut source = resolve_local_source(source_path)?;
     let extension_id = local_extension_id(&source, source_path, id_override)?;
@@ -187,7 +203,7 @@ fn replace_from_path(
         restore_relinked_install(&extension_dir, &backup_dir, &metadata);
         return Err(err);
     }
-    if let Err(err) = validate_installed_extension_provider_discovery(&extension_id) {
+    if let Err(err) = validation.validate_installed_extension(&extension_id) {
         restore_relinked_install(&extension_dir, &backup_dir, &metadata);
         return Err(err);
     }
@@ -472,8 +488,9 @@ fn validate_agent_runtime_discovery_or_restore(
     extension_id: &str,
     extension_dir: &Path,
     backup_dir: &Path,
+    validation: ExtensionLifecycleValidation<'_>,
 ) -> Result<()> {
-    if let Err(err) = validate_installed_extension_provider_discovery(extension_id) {
+    if let Err(err) = validation.validate_installed_extension(extension_id) {
         let _ = remove_existing_install(extension_dir);
         let _ = restore_existing_install(backup_dir, extension_dir);
         return Err(err);
@@ -560,6 +577,7 @@ mod tests {
     };
     use crate::extension::catalog::load_extension;
     use crate::extension::lifecycle::{install, read_source_revision, read_source_url};
+    use crate::extension::registry::ExtensionLifecycleValidation;
     use homeboy_core::test_support::{
         with_isolated_home, write_extension_fixture, write_extension_fixture_with_version,
     };
@@ -803,11 +821,19 @@ mod tests {
             write_extension_fixture(&old_source, "swift");
             write_extension_fixture_with_version(&new_source, "swift", "2.0.0");
 
-            install(&old_source.join("swift").to_string_lossy(), Some("swift"))
-                .expect("install linked extension");
+            install(
+                &old_source.join("swift").to_string_lossy(),
+                Some("swift"),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("install linked extension");
 
-            let result = relink("swift", &new_source.join("swift").to_string_lossy())
-                .expect("relink should replace symlink");
+            let result = relink(
+                "swift",
+                &new_source.join("swift").to_string_lossy(),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("relink should replace symlink");
 
             let installed_path = home.join(".config/homeboy/extensions/swift");
             assert!(installed_path.is_symlink());
@@ -843,6 +869,7 @@ mod tests {
             install(
                 &durable_source.join("opencode").to_string_lossy(),
                 Some("opencode"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install durable linked extension");
             let metadata_dir = home.join(".config/homeboy/extensions");
@@ -852,8 +879,12 @@ mod tests {
             )
             .expect("durable requested ref");
 
-            relink("opencode", &worktree.join("opencode").to_string_lossy())
-                .expect("relink to git worktree");
+            relink(
+                "opencode",
+                &worktree.join("opencode").to_string_lossy(),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("relink to git worktree");
 
             let installed = metadata_dir.join("opencode");
             assert_eq!(
@@ -893,12 +924,14 @@ mod tests {
             install(
                 &old_source.join("wordpress").to_string_lossy(),
                 Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install linked extension");
 
             let err = replace(
                 &new_source.join("wordpress").to_string_lossy(),
                 Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect_err("replace should fail invalid provider declaration");
 
@@ -927,11 +960,16 @@ mod tests {
             install(
                 &old_source.join("wordpress").to_string_lossy(),
                 Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install linked extension");
 
-            relink("wordpress", &new_source.join("wordpress").to_string_lossy())
-                .expect("relink should materialize shared runtime");
+            relink(
+                "wordpress",
+                &new_source.join("wordpress").to_string_lossy(),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("relink should materialize shared runtime");
 
             assert!(home
                 .join(".config/homeboy/agent-runtimes/sample-runtime/scripts/agent/sample-runtime-agent-task-executor.cjs")
@@ -962,6 +1000,7 @@ mod tests {
             install(
                 &old_source.join("opencode").to_string_lossy(),
                 Some("opencode"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install linked extension");
             crate::runtime_package::refresh_shared_assets(&boundary_source)
@@ -970,6 +1009,7 @@ mod tests {
             relink(
                 "opencode",
                 &new_source.join("agent-runtimes/opencode").to_string_lossy(),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("relink should publish declared runtime assets");
 
@@ -1005,6 +1045,7 @@ mod tests {
             install(
                 &old_source.join("opencode").to_string_lossy(),
                 Some("opencode"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install linked extension");
             crate::runtime_package::refresh_shared_assets(&boundary_source)
@@ -1015,6 +1056,7 @@ mod tests {
             relink(
                 "opencode",
                 &new_source.join("agent-runtimes/opencode").to_string_lossy(),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect_err("malformed root manifest should reject relink");
 
@@ -1044,11 +1086,16 @@ mod tests {
             install(
                 &old_source.join("wordpress").to_string_lossy(),
                 Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install linked extension");
 
-            replace(&new_source.to_string_lossy(), Some("wordpress"))
-                .expect("replace should resolve monorepo root and materialize shared runtime");
+            replace(
+                &new_source.to_string_lossy(),
+                Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("replace should resolve monorepo root and materialize shared runtime");
 
             let installed_path = home.join(".config/homeboy/extensions/wordpress");
             assert!(installed_path.is_symlink());
@@ -1077,6 +1124,7 @@ mod tests {
             install(
                 &old_source.join("wordpress").to_string_lossy(),
                 Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install linked extension");
 
@@ -1084,6 +1132,7 @@ mod tests {
                 &new_source.to_string_lossy(),
                 Some("wordpress"),
                 Some("fix/runtime-contract-preservation"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("replace should preserve requested revision");
 
@@ -1107,8 +1156,12 @@ mod tests {
                 "bash {{extension_path}}/scripts/build/setup.sh",
             );
 
-            install(&old_source.join("swift").to_string_lossy(), Some("swift"))
-                .expect("install linked extension");
+            install(
+                &old_source.join("swift").to_string_lossy(),
+                Some("swift"),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("install linked extension");
             let metadata_dir = home.join(".config/homeboy/extensions");
             fs::write(
                 metadata_dir.join(".swift.source-requested-ref"),
@@ -1121,8 +1174,12 @@ mod tests {
             )
             .expect("old source revision");
 
-            let err = relink("swift", &new_source.join("swift").to_string_lossy())
-                .expect_err("relink should fail when setup fails");
+            let err = relink(
+                "swift",
+                &new_source.join("swift").to_string_lossy(),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect_err("relink should fail when setup fails");
 
             assert_eq!(err.message, "IO error");
             assert!(err.details.to_string().contains("Setup command failed"));
@@ -1161,16 +1218,24 @@ mod tests {
             };
             let remote_url = remote.path().join("extension.git");
 
-            let install_result = install(&remote_url.to_string_lossy(), Some("swift"))
-                .expect("install copied extension");
+            let install_result = install(
+                &remote_url.to_string_lossy(),
+                Some("swift"),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("install copied extension");
             assert!(!install_result.path.is_symlink());
 
             write_extension_fixture_with_version(&source, "swift", "2.0.0");
             assert!(commit_all(&source, "update extension"));
             assert!(run_git(&source, &["push", "origin", "HEAD"]));
 
-            let result = replace(&remote_url.to_string_lossy(), Some("swift"))
-                .expect("replace copied extension");
+            let result = replace(
+                &remote_url.to_string_lossy(),
+                Some("swift"),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("replace copied extension");
 
             assert_eq!(result.extension_id, "swift");
             assert_eq!(result.old_path, install_result.path);
@@ -1202,8 +1267,12 @@ mod tests {
             };
             let remote_url = remote.path().join("extension.git");
 
-            install(&remote_url.to_string_lossy(), Some("swift"))
-                .expect("install copied extension");
+            install(
+                &remote_url.to_string_lossy(),
+                Some("swift"),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("install copied extension");
 
             write_extension_fixture_with_version(&source, "swift", "2.0.0");
             assert!(commit_all(&source, "update extension"));
@@ -1213,6 +1282,7 @@ mod tests {
                 &remote_url.to_string_lossy(),
                 Some("swift"),
                 Some(&pinned_revision),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("replace copied extension at pinned revision");
 

--- a/crates/homeboy-core/src/extension/recipe_run_api.rs
+++ b/crates/homeboy-core/src/extension/recipe_run_api.rs
@@ -377,6 +377,7 @@ fn plan_selection_failure(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::extension::registry::ExtensionLifecycleValidation;
 
     fn install_extension(id: &str, providers: serde_json::Value) -> tempfile::TempDir {
         let source = tempfile::tempdir().expect("extension source");
@@ -390,8 +391,12 @@ mod tests {
             .to_string(),
         )
         .expect("manifest");
-        crate::extension::lifecycle::install(&source.path().display().to_string(), Some(id))
-            .expect("install extension");
+        crate::extension::lifecycle::install(
+            &source.path().display().to_string(),
+            Some(id),
+            ExtensionLifecycleValidation::declaration_only(),
+        )
+        .expect("install extension");
         source
     }
 

--- a/crates/homeboy-core/src/extension/registry.rs
+++ b/crates/homeboy-core/src/extension/registry.rs
@@ -1,88 +1,181 @@
-//! Extension provider registration and discovery validation.
+//! Validation an extension install, replace, or relink runs after setup.
 //!
-//! When an extension is installed or repaired, core verifies that every
-//! agent-runtime executor provider the extension declares is actually
-//! discoverable. That check reads the extension's agent-task executor provider
-//! catalog, which is agent-task behavior, so it is inverted behind this
-//! provider: core owns extension install/repair, the agent-task layer validates
-//! provider discovery.
+//! The check has two halves, and only one of them belongs to core.
 //!
-//! The check has two halves, and only one of them is agent-task behavior:
+//! - **Is every declared executor registrable?** A malformed
+//!   `agent_runtimes[].agent_task_executors[]` entry, a duplicate executor id,
+//!   or an executor the extension never advertises is wrong whether or not the
+//!   agent-task subsystem exists. Core answers this from the typed Extension API
+//!   registration inventory.
+//! - **Does each registered executor resolve to something dispatchable?** That
+//!   requires the agent-task layer's resolved provider type, which core cannot
+//!   see, so the caller supplies it.
 //!
-//! - **Is the declaration well-formed?** A malformed
-//!   `agent_runtimes[].agent_task_executors[]` entry is malformed whether or not
-//!   the agent-task subsystem is present, so this is validated unconditionally
-//!   against the shared declaration contract.
-//! - **Is the declared provider discoverable?** This reads the extension's
-//!   agent-task executor provider catalog, which *is* agent-task behavior, so it
-//!   stays inverted behind the provider below.
-//!
-//! Collapsing both halves into the inverted hook is what regressed #12206: with
-//! no provider registered the no-op validated *nothing*, so an extension
-//! declaring a provider that cannot be parsed installed silently instead of
-//! being rejected and rolled back.
-//!
-//! With no provider registered (no agent-task subsystem present) the no-op
-//! still validates no *discoverability* — an install without the agent-task
-//! subsystem has no agent-task providers to discover.
+//! The second half used to be an ambient global that the CLI registered at
+//! startup. Nothing in a signature said the check existed, and with no provider
+//! registered the no-op silently validated nothing — which is what regressed
+//! #12206. It is now an explicit parameter: a caller that has the agent-task
+//! subsystem passes it, and a caller that does not cannot accidentally appear to
+//! have run a check it never ran.
 
-use homeboy_extension_contract::agent_task_executor_declaration::parse_agent_task_executor_declaration;
+use homeboy_extension_contract::api::v1::{
+    ExtensionApiAgentTaskExecutorInventoryRequest,
+    EXTENSION_API_AGENT_TASK_EXECUTOR_INVENTORY_REQUEST_SCHEMA, EXTENSION_API_V1,
+};
 
-use crate::Result;
+use crate::extension::agent_task_executor_api::AgentTaskExecutorApi;
+use crate::{Error, Result};
 
-/// Validates that an installed extension's declared agent-runtime providers are
-/// discoverable.
-pub trait ExtensionProviderDiscoveryValidator: Send + Sync {
-    /// Validate that the given extension's declared agent-runtime executor
-    /// providers are discoverable. Returns an error describing the first
-    /// missing/duplicate provider.
-    fn validate_installed_extension_provider_discovery(&self, extension_id: &str) -> Result<()>;
-}
-
-struct NoopProvider;
-
-impl ExtensionProviderDiscoveryValidator for NoopProvider {
-    fn validate_installed_extension_provider_discovery(&self, _extension_id: &str) -> Result<()> {
-        Ok(())
-    }
-}
-
-homeboy_engine_primitives::provider_registry! {
-    provider: dyn ExtensionProviderDiscoveryValidator,
-    noop: NoopProvider,
-    /// Register the extension provider-discovery validator. Called once at startup
-    /// by the agent-task layer.
-    register: pub fn register_extension_provider_discovery_validator,
-    /// Run `f` against the registered provider, or the no-op provider if none
-    /// is registered.
-    with: fn with_provider,
-}
-
-/// Validate an installed extension's agent-runtime provider discovery.
+/// Resolves registered agent-task executors into dispatchable providers.
 ///
-/// Declaration well-formedness is checked unconditionally; discoverability is
-/// delegated to the registered validator (or the no-op when the agent-task
-/// subsystem is absent).
-pub fn validate_installed_extension_provider_discovery(extension_id: &str) -> Result<()> {
-    validate_declared_agent_task_executors(extension_id)?;
-    with_provider(|p| p.validate_installed_extension_provider_discovery(extension_id))
+/// Implemented by the agent-task layer, which owns the resolved provider type.
+pub trait ExtensionExecutorDiscovery {
+    /// Confirm every executor the extension registers resolves to a provider
+    /// this host can dispatch. Returns an error describing the first executor
+    /// that does not.
+    fn validate_registered_executors(&self, extension_id: &str) -> Result<()>;
 }
 
-/// Reject an extension that declares an agent-task executor which cannot be
-/// parsed, independently of whether the agent-task subsystem is registered.
+/// The validation an extension lifecycle mutation runs after setup.
 ///
-/// A manifest that cannot be loaded at all is left to the caller's own manifest
-/// handling rather than reported here as a provider-declaration fault.
-fn validate_declared_agent_task_executors(extension_id: &str) -> Result<()> {
-    let Ok(extension) = crate::extension::catalog::load_extension(extension_id) else {
-        return Ok(());
-    };
+/// Construct this at the composition root, where both core and the agent-task
+/// subsystem are visible, and pass it into install, replace, and relink.
+#[derive(Default, Clone, Copy)]
+pub struct ExtensionLifecycleValidation<'a> {
+    executor_discovery: Option<&'a dyn ExtensionExecutorDiscovery>,
+}
 
-    for runtime in &extension.agent_runtimes {
-        for declared in &runtime.agent_task_executors {
-            parse_agent_task_executor_declaration(&extension.id, &runtime.id, declared)?;
+impl<'a> ExtensionLifecycleValidation<'a> {
+    /// Validate declarations only.
+    ///
+    /// This is the correct choice for a host without the agent-task subsystem:
+    /// there are no executors to resolve, so there is no resolution to check.
+    /// It is not a way to skip validation — declaration registrability is still
+    /// enforced.
+    pub fn declaration_only() -> Self {
+        Self {
+            executor_discovery: None,
         }
     }
 
+    pub fn with_executor_discovery(discovery: &'a dyn ExtensionExecutorDiscovery) -> Self {
+        Self {
+            executor_discovery: Some(discovery),
+        }
+    }
+
+    /// Run both halves in order. Declarations are always checked; resolution is
+    /// checked when the caller supplied a discoverer.
+    pub fn validate_installed_extension(&self, extension_id: &str) -> Result<()> {
+        validate_registered_executor_declarations(extension_id)?;
+        match self.executor_discovery {
+            Some(discovery) => discovery.validate_registered_executors(extension_id),
+            None => Ok(()),
+        }
+    }
+}
+
+/// Reject an extension whose declared executors cannot be registered.
+///
+/// The typed inventory is the single place declarations become identities, so an
+/// entry it marks unusable is rejected here rather than installed and then found
+/// undispatchable later.
+fn validate_registered_executor_declarations(extension_id: &str) -> Result<()> {
+    let inventory =
+        AgentTaskExecutorApi::discover(&ExtensionApiAgentTaskExecutorInventoryRequest {
+            schema: EXTENSION_API_AGENT_TASK_EXECUTOR_INVENTORY_REQUEST_SCHEMA.to_string(),
+            api_version: EXTENSION_API_V1,
+        });
+
+    for executor in inventory.registered_by(extension_id) {
+        let Some(diagnostic) = executor.diagnostic.as_ref() else {
+            continue;
+        };
+        return Err(Error::validation_invalid_argument(
+            "agent_runtimes.agent_task_executors",
+            format!(
+                "Extension '{}' declares an agent-task executor that cannot be registered: {}",
+                extension_id, diagnostic.message
+            ),
+            Some(if executor.id.is_empty() {
+                executor.runtime_id.clone()
+            } else {
+                executor.id.clone()
+            }),
+            None,
+        ));
+    }
+
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    struct RecordingDiscovery {
+        called: Cell<bool>,
+        result: Option<&'static str>,
+    }
+
+    impl ExtensionExecutorDiscovery for RecordingDiscovery {
+        fn validate_registered_executors(&self, _extension_id: &str) -> Result<()> {
+            self.called.set(true);
+            match self.result {
+                Some(message) => Err(Error::validation_invalid_argument(
+                    "source", message, None, None,
+                )),
+                None => Ok(()),
+            }
+        }
+    }
+
+    #[test]
+    fn declaration_only_validation_never_reports_a_resolution_it_did_not_run() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            // No agent-task subsystem: there is nothing to resolve, so this must
+            // succeed rather than silently claim a check that never ran.
+            ExtensionLifecycleValidation::declaration_only()
+                .validate_installed_extension("absent-extension")
+                .expect("declaration-only validation accepts an extension with no executors");
+        });
+    }
+
+    #[test]
+    fn supplied_discovery_runs_and_its_rejection_fails_the_lifecycle_mutation() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let discovery = RecordingDiscovery {
+                called: Cell::new(false),
+                result: Some("declared provider was not discoverable"),
+            };
+
+            let error = ExtensionLifecycleValidation::with_executor_discovery(&discovery)
+                .validate_installed_extension("absent-extension")
+                .expect_err("a supplied discoverer's rejection must fail the mutation");
+
+            assert!(discovery.called.get(), "the supplied discoverer must run");
+            assert!(
+                error.message.contains("not discoverable"),
+                "got {}",
+                error.message
+            );
+        });
+    }
+
+    #[test]
+    fn supplied_discovery_acceptance_passes_the_lifecycle_mutation() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let discovery = RecordingDiscovery {
+                called: Cell::new(false),
+                result: None,
+            };
+
+            ExtensionLifecycleValidation::with_executor_discovery(&discovery)
+                .validate_installed_extension("absent-extension")
+                .expect("an accepted extension installs");
+
+            assert!(discovery.called.get(), "the supplied discoverer must run");
+        });
+    }
 }

--- a/crates/homeboy-core/src/extension/resolve/requirements.rs
+++ b/crates/homeboy-core/src/extension/resolve/requirements.rs
@@ -196,6 +196,7 @@ fn extension_source(ext_config: &homeboy_core::component::ScopedExtensionConfig)
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::extension::registry::ExtensionLifecycleValidation;
     use homeboy_core::component::Component;
 
     #[test]
@@ -253,8 +254,12 @@ mod tests {
             // requirement because dev iteration may lag the published constraint.
             let source = home.join("source/wordpress");
             write_extension_manifest(&source, "wordpress", "1.0.0");
-            crate::extension::lifecycle::install(&source.to_string_lossy(), Some("wordpress"))
-                .expect("install linked extension");
+            crate::extension::lifecycle::install(
+                &source.to_string_lossy(),
+                Some("wordpress"),
+                ExtensionLifecycleValidation::declaration_only(),
+            )
+            .expect("install linked extension");
             assert!(homeboy_core::extension::catalog::is_extension_linked(
                 "wordpress"
             ));

--- a/crates/homeboy-lab-runner/src/execution/tests/daemon_exec.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/daemon_exec.rs
@@ -11,6 +11,7 @@
 
 use homeboy_core::api_jobs::{Job, JobEventKind, JobStatus, JobStore, RemoteRunnerJobRequest};
 use homeboy_core::daemon::{route_with_body, DirectDaemonExecSubmitRequest};
+use homeboy_core::extension::registry::ExtensionLifecycleValidation;
 use homeboy_core::observation::ObservationStore;
 use homeboy_core::test_support::HomeGuard;
 use homeboy_runner_contract::{
@@ -319,6 +320,7 @@ fn daemon_exec_injects_extension_env_and_redacts_provider_secret() {
     homeboy_core::extension::lifecycle::install(
         &extension.path().display().to_string(),
         Some("fixture"),
+        ExtensionLifecycleValidation::declaration_only(),
     )
     .expect("install fixture extension");
     let store = JobStore::default();

--- a/crates/homeboy-lab-runner/src/execution/tests/exec.rs
+++ b/crates/homeboy-lab-runner/src/execution/tests/exec.rs
@@ -3,6 +3,7 @@ use crate::{
     RunnerActiveJobSource, RunnerActiveJobState, RunnerSession, RunnerSessionRole,
     RunnerSessionState, RunnerStaleDaemonWarning, RunnerStatusReport, RunnerTunnelMode,
 };
+use homeboy_core::extension::registry::ExtensionLifecycleValidation;
 use homeboy_core::runner_execution_envelope::{
     PATH_MATERIALIZATION_MODE_GIT, PATH_MATERIALIZATION_STATUS_MATERIALIZED,
 };
@@ -1329,6 +1330,7 @@ fn runner_exec_explicit_run_id_overrides_conflicting_run_id_env() {
         homeboy_core::extension::lifecycle::install(
             &extension.path().display().to_string(),
             Some("fixture"),
+            ExtensionLifecycleValidation::declaration_only(),
         )
         .expect("install provider fixture");
 

--- a/crates/homeboy-lab-runner/src/extension_materialization.rs
+++ b/crates/homeboy-lab-runner/src/extension_materialization.rs
@@ -898,6 +898,7 @@ fn shell_arg(value: &str) -> String {
 mod tests {
     use super::*;
     use crate::Runner;
+    use homeboy_core::extension::registry::ExtensionLifecycleValidation;
     use std::sync::{Arc, Barrier};
 
     fn runner() -> Runner {
@@ -1278,6 +1279,7 @@ mod tests {
             homeboy_core::extension::lifecycle::install(
                 &nodejs.display().to_string(),
                 Some("nodejs"),
+                ExtensionLifecycleValidation::declaration_only(),
             )
             .expect("install linked nodejs extension");
 

--- a/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
@@ -24,6 +24,7 @@ use super::support::{
 };
 use super::worker_options;
 use crate::runner_staging_operation::SourceArtifactTransfer;
+use homeboy_core::extension::registry::ExtensionLifecycleValidation;
 
 #[test]
 fn reverse_worker_executes_claimed_job_and_finishes_it() {
@@ -817,6 +818,7 @@ fn reverse_worker_injects_lifecycle_run_id_into_claimed_job_env() {
         homeboy_core::extension::lifecycle::install(
             &extension.path().display().to_string(),
             Some("fixture"),
+            ExtensionLifecycleValidation::declaration_only(),
         )
         .expect("install provider fixture");
         let store = JobStore::default();

--- a/crates/homeboy-lab-runner/src/workspace/tests/git.rs
+++ b/crates/homeboy-lab-runner/src/workspace/tests/git.rs
@@ -10,6 +10,7 @@ use crate::workspace::git::{
 use crate::workspace::sync::{list_workspaces, sync_workspace};
 use crate::workspace::types::{RunnerWorkspaceSyncMode, RunnerWorkspaceSyncOptions};
 use crate::workspace::util::git_output;
+use homeboy_core::extension::registry::ExtensionLifecycleValidation;
 
 #[test]
 fn changed_since_private_origin_without_controller_closure_falls_back_to_snapshot() {
@@ -767,6 +768,7 @@ fn git_sync_of_detached_extension_source_preserves_source_revision() {
         let install = homeboy_core::extension::lifecycle::install(
             &remote.join("wordpress").display().to_string(),
             Some("wordpress"),
+            ExtensionLifecycleValidation::declaration_only(),
         )
         .expect("install extension from synced detached workspace");
 


### PR DESCRIPTION
## Summary

- delete the `ExtensionProviderDiscoveryValidator` global provider registry and its startup registration
- replace it with `ExtensionLifecycleValidation`, an explicit parameter on extension install, replace, relink, refresh, and component install
- validate declaration registrability in core from the typed Extension API v1 executor inventory
- keep executor resolution in the agent-task layer behind the new `ExtensionExecutorDiscovery` trait, implemented by `AgentTaskExecutorDiscovery`
- pass the agent-task-backed validation from the CLI, which is the composition root that can see both layers

Completes #14155 alongside #14171.

## Why the global had to go

The check has two halves. Whether a declared executor is *registrable* is true or false regardless of the agent-task subsystem, and core can now answer it from the typed inventory. Whether a registered executor *resolves* to a dispatchable provider needs the agent-task resolved provider type, which core cannot see.

Collapsing both halves into an ambient global is what regressed #12206: with no provider registered, the no-op validated nothing and a malformed declaration installed silently. Nothing in any signature said the check existed.

Validation is now visible in the type system. A caller without the agent-task subsystem uses `ExtensionLifecycleValidation::declaration_only()`, which still enforces registrability and cannot be mistaken for a resolution check that never ran.

## Behavior preserved

- The agent-task resolved-provider parser remains the resolution authority for the CLI path, so the install gate is not weakened.
- Fresh install cleanup and replace/relink restoration on rejection are unchanged.
- Setup-before-validation ordering is unchanged.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-core extension::registry --lib` (3 new tests: declaration-only accepts, supplied discovery runs and its rejection fails the mutation, supplied discovery acceptance passes)
- `cargo test -p homeboy-core extension --lib` (963 passed)
- `cargo test -p homeboy-agents agent_task_provider --lib` (224 passed)
- `cargo test -p homeboy-extension-contract --lib` (106 passed)
- `cargo check --workspace --tests`
- `git diff --check`

One core test, `declared_result_parser_rejects_malformed_successful_stdout_json`, failed once under parallel load and then passed in isolation on this branch, in isolation on clean `main`, and on a full-suite rerun. Recorded on #14175, which now tracks three tests across two crates showing the same pattern.

Closes #14155
Parent #13882

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode designed the explicit validation boundary, removed the global registry, threaded the dependency through the lifecycle API and its call sites, wrote the tests, and ran verification under Chris Huber's direction.