### PR TITLE
Complete the controller upgrade queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,6 +1319,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "toml",
 ]

--- a/crates/homeboy-core/src/observation/store/runs.rs
+++ b/crates/homeboy-core/src/observation/store/runs.rs
@@ -767,6 +767,50 @@ impl ObservationStore {
         self.get_run(run_id)
     }
 
+    /// Finish an active run only if its metadata still matches the caller's
+    /// snapshot. This closes the read/merge/write window for lifecycle owners
+    /// that must preserve concurrent progress updates before terminalization.
+    pub fn finish_running_run_if_metadata(
+        &self,
+        run_id: &str,
+        status: RunStatus,
+        mut metadata_json: serde_json::Value,
+        expected_metadata_json: &serde_json::Value,
+    ) -> Result<Option<RunRecord>> {
+        validate_required("run_id", run_id)?;
+        if crate::notification_route::NotificationRoute::from_metadata(&metadata_json).is_none() {
+            if let Some(route) =
+                crate::notification_route::NotificationRoute::from_metadata(expected_metadata_json)
+            {
+                route.insert_into_metadata(&mut metadata_json);
+            }
+        }
+        let finished_at = chrono::Utc::now().to_rfc3339();
+        let serialized = serialize_metadata(&metadata_json)?;
+        let expected = serialize_metadata(expected_metadata_json)?;
+        let rows = execute_with_retry("finish running run record with metadata CAS", || {
+            self.connection.execute(
+                r#"
+                UPDATE runs
+                SET finished_at = ?1, status = ?2, metadata_json = ?3
+                WHERE id = ?4 AND status = ?5 AND metadata_json = ?6
+                "#,
+                params![
+                    finished_at,
+                    status.as_str(),
+                    serialized,
+                    run_id,
+                    RunStatus::Running.as_str(),
+                    expected,
+                ],
+            )
+        })?;
+        if rows == 0 {
+            return Ok(None);
+        }
+        self.get_run(run_id)
+    }
+
     pub fn update_run_metadata(
         &self,
         run_id: &str,
@@ -799,6 +843,31 @@ impl ObservationStore {
                 "Updated run record {run_id} but could not read it back"
             ))
         })
+    }
+
+    /// Replace metadata only while the run remains active. A terminal winner
+    /// must never be overwritten by a late heartbeat or progress writer.
+    pub fn update_running_run_metadata(
+        &self,
+        run_id: &str,
+        metadata_json: serde_json::Value,
+    ) -> Result<Option<RunRecord>> {
+        validate_required("run_id", run_id)?;
+        let serialized = serialize_metadata(&metadata_json)?;
+        let rows = execute_with_retry("update running run metadata", || {
+            self.connection.execute(
+                r#"
+                UPDATE runs
+                SET metadata_json = ?1
+                WHERE id = ?2 AND status = ?3
+                "#,
+                params![serialized, run_id, RunStatus::Running.as_str()],
+            )
+        })?;
+        if rows == 0 {
+            return Ok(None);
+        }
+        self.get_run(run_id)
     }
 
     pub fn get_run(&self, run_id: &str) -> Result<Option<RunRecord>> {

--- a/crates/homeboy-core/src/runtime_promotion.rs
+++ b/crates/homeboy-core/src/runtime_promotion.rs
@@ -19,6 +19,7 @@ use crate::paths;
 const LEASE_DIR: &str = "promotion.lock";
 const LEASE_FILE: &str = "lease.json";
 const ADMISSION_LOCK_FILE: &str = "admission.lock";
+const ADMISSION_OWNER_DIR: &str = "admission-owners";
 const PIN_DIR: &str = "pins";
 const DEFAULT_TTL: Duration = Duration::from_secs(30 * 60);
 const PIN_DRAIN_POLL: Duration = Duration::from_millis(100);
@@ -45,8 +46,13 @@ pub struct RuntimePromotionWaitEvent {
     pub resource_class: &'static str,
     pub wait_timeout_ms: u128,
     pub waited_ms: u128,
+    pub wait_stage: &'static str,
     pub owner_pid: u32,
     pub owner_operation: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner_operation_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner_status_command: Option<String>,
     pub target: String,
     pub owner_generation: String,
 }
@@ -56,6 +62,11 @@ pub struct RuntimePromotionLeaseRecord {
     pub schema: String,
     pub pid: u32,
     pub operation: String,
+    /// Optional owning-layer operation identity and read-only inspection command.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status_command: Option<String>,
     pub target: String,
     pub generation: String,
     /// Non-secret result fingerprint used for exact compatible-owner waits.
@@ -82,6 +93,12 @@ pub struct RuntimePromotionLeaseRecord {
     /// boundary. The promotion directory is already local-user state.
     #[serde(default)]
     pub capability: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimePromotionOwnerStatus {
+    pub operation_id: String,
+    pub status_command: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -111,6 +128,14 @@ struct LocalLeaseDelegation {
     target: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RuntimePromotionBlockerIdentity {
+    pid: u32,
+    operation: String,
+    operation_id: Option<String>,
+    target: String,
+}
+
 struct LocalLeaseDelegationGuard(Vec<LocalLeaseDelegation>);
 
 impl Drop for LocalLeaseDelegationGuard {
@@ -136,6 +161,12 @@ struct RuntimeGenerationPin {
     cook_id: String,
     generation: String,
     started_at: String,
+    #[serde(default)]
+    linux_starttime_ticks: Option<u64>,
+    #[serde(default)]
+    process_start_identity: Option<crate::process::ProcessStartIdentity>,
+    #[serde(default)]
+    transaction: Option<SubprocessLeaseCapability>,
 }
 
 /// Held while a controller/runner runtime transaction is in progress.
@@ -158,6 +189,14 @@ pub struct RuntimePromotionLease {
 #[derive(Debug)]
 pub struct RuntimeGenerationPinGuard {
     path: PathBuf,
+}
+
+/// Protects a selected controller identity from replacement without claiming
+/// mutation ownership.
+#[derive(Debug)]
+pub struct RuntimeSelectionGuard {
+    admission_lock: fs::File,
+    owner_path: PathBuf,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -201,6 +240,174 @@ impl Drop for RuntimeGenerationPinGuard {
     }
 }
 
+impl Drop for RuntimeSelectionGuard {
+    fn drop(&mut self) {
+        let _ = self.admission_lock.unlock();
+        // Keep diagnostics published until the lock is actually available.
+        // A contender that acquires the lock never consults this stale record.
+        let _ = fs::remove_file(&self.owner_path);
+    }
+}
+
+/// Hold shared controller-selection admission for a read/refresh transaction.
+/// Controller mutation waits on the exclusive side of the same OS lock.
+pub fn protect_runtime_selection_with_status(
+    operation: &str,
+    target: impl Into<String>,
+    owner_status: RuntimePromotionOwnerStatus,
+) -> Result<RuntimeSelectionGuard> {
+    let root = paths::runtime_promotion_dir()?;
+    fs::create_dir_all(&root).map_err(io("create runtime promotion directory"))?;
+    let admission_lock = open_admission_lock(&root)?;
+    admission_lock
+        .lock_shared()
+        .map_err(io("protect runtime selection"))?;
+    publish_selection_guard(
+        operation,
+        target.into(),
+        owner_status,
+        admission_lock,
+        &root,
+    )
+}
+
+fn publish_selection_guard(
+    operation: &str,
+    target: String,
+    owner_status: RuntimePromotionOwnerStatus,
+    admission_lock: fs::File,
+    root: &Path,
+) -> Result<RuntimeSelectionGuard> {
+    let owner_dir = root.join(ADMISSION_OWNER_DIR);
+    fs::create_dir_all(&owner_dir).map_err(io("create runtime admission owner directory"))?;
+    let owner_path = owner_dir.join(format!("{}.json", uuid::Uuid::new_v4()));
+    let temporary_path = owner_path.with_extension("json.tmp");
+    let pid = std::process::id();
+    let record = RuntimePromotionLeaseRecord {
+        schema: "homeboy/runtime-promotion-admission-owner/v1".to_string(),
+        pid,
+        operation: operation.to_string(),
+        operation_id: Some(owner_status.operation_id),
+        status_command: Some(owner_status.status_command),
+        target,
+        generation: current_generation(),
+        compatibility_key: String::new(),
+        started_at: now(),
+        linux_starttime_ticks: crate::process::linux_process_starttime_ticks(pid)
+            .ok()
+            .flatten(),
+        process_start_identity: crate::process::process_start_identity(pid).ok().flatten(),
+        heartbeat_at: now(),
+        expires_at: expiry(),
+        capability: String::new(),
+    };
+    if let Err(error) = fs::write(
+        &temporary_path,
+        serde_json::to_vec_pretty(&record)
+            .map_err(|error| Error::internal_json(error.to_string(), None))?,
+    )
+    .map_err(io("write runtime admission owner"))
+    .and_then(|_| {
+        fs::rename(&temporary_path, &owner_path).map_err(io("publish runtime admission owner"))
+    }) {
+        let _ = fs::remove_file(&temporary_path);
+        let _ = admission_lock.unlock();
+        return Err(error);
+    }
+    Ok(RuntimeSelectionGuard {
+        admission_lock,
+        owner_path,
+    })
+}
+
+/// Wait boundedly for shared controller-selection admission while reporting the
+/// exclusive mutation owner that currently blocks it.
+pub fn protect_runtime_selection_waiting_with_status(
+    operation: &str,
+    target: impl Into<String>,
+    owner_status: RuntimePromotionOwnerStatus,
+    timeout: Duration,
+    mut progress: impl FnMut(RuntimePromotionWaitEvent),
+) -> Result<RuntimeSelectionGuard> {
+    let root = paths::runtime_promotion_dir()?;
+    fs::create_dir_all(&root).map_err(io("create runtime promotion directory"))?;
+    let admission_lock = open_admission_lock(&root)?;
+    let started = Instant::now();
+    let deadline = started + timeout;
+    let mut last_progress = None;
+    loop {
+        match FileExt::try_lock_shared(&admission_lock) {
+            Ok(true) => break,
+            Ok(false) => {
+                let owner = match selection_blocker_after_busy(|| {
+                    read_record_for_acquisition(&root.join(LEASE_DIR))
+                })? {
+                    Some(owner) => owner,
+                    None => {
+                        let remaining = deadline.saturating_duration_since(Instant::now());
+                        if remaining.is_zero() {
+                            match FileExt::try_lock_shared(&admission_lock) {
+                                Ok(true) => break,
+                                Ok(false) => {
+                                    return Err(selection_wait_timeout_without_owner(timeout));
+                                }
+                                Err(error) => {
+                                    return Err(io("protect runtime selection")(error));
+                                }
+                            }
+                        }
+                        std::thread::sleep(remaining.min(COMPATIBLE_WAIT_POLL));
+                        continue;
+                    }
+                };
+                if last_progress
+                    .is_none_or(|last: Instant| last.elapsed() >= COMPATIBLE_WAIT_HEARTBEAT)
+                {
+                    progress(RuntimePromotionWaitEvent {
+                        schema: "homeboy/runtime-promotion-admission/v1",
+                        state: "queued",
+                        resource_class: "runtime_promotion",
+                        wait_timeout_ms: timeout.as_millis(),
+                        waited_ms: started.elapsed().min(timeout).as_millis(),
+                        wait_stage: "os_lock",
+                        owner_pid: owner.pid,
+                        owner_operation: owner.operation.clone(),
+                        owner_operation_id: owner.operation_id.clone(),
+                        owner_status_command: owner.status_command.clone(),
+                        target: owner.target.clone(),
+                        owner_generation: owner.generation.clone(),
+                    });
+                    last_progress = Some(Instant::now());
+                }
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    return Err(wait_timeout_error(&owner, timeout, "os_lock"));
+                }
+                std::thread::sleep(remaining.min(COMPATIBLE_WAIT_POLL));
+            }
+            Err(error) => return Err(io("protect runtime selection")(error)),
+        }
+    }
+
+    publish_selection_guard(
+        operation,
+        target.into(),
+        owner_status,
+        admission_lock,
+        &root,
+    )
+}
+
+fn selection_blocker_after_busy(
+    read: impl FnOnce() -> std::result::Result<RuntimePromotionLeaseRecord, LeaseRecordReadError>,
+) -> Result<Option<RuntimePromotionLeaseRecord>> {
+    match read() {
+        Ok(owner) => Ok(Some(owner)),
+        Err(LeaseRecordReadError::Disappeared(_)) => Ok(None),
+        Err(LeaseRecordReadError::Failure(error)) => Err(error),
+    }
+}
+
 /// Acquire the global writer lease. A nested call must retain the same target
 /// and generation. A child process must present the capability explicitly
 /// attached by [`RuntimePromotionLease::authorize_subprocess`].
@@ -209,7 +416,9 @@ pub fn acquire(operation: &str, target: impl Into<String>) -> Result<RuntimeProm
         operation,
         target.into(),
         String::new(),
+        None,
         ForeignPinPolicy::Block,
+        None,
     )
 }
 
@@ -228,58 +437,124 @@ pub fn acquire_waiting_for_compatible(
     acquire_waiting_for_compatible_key(operation, target, "", timeout, progress)
 }
 
+/// Wait for a compatible owner while publishing this owner's durable status
+/// identity if the caller acquires the lease.
+pub fn acquire_waiting_for_compatible_with_status(
+    operation: &str,
+    target: impl Into<String>,
+    owner_status: RuntimePromotionOwnerStatus,
+    timeout: Duration,
+    progress: impl FnMut(RuntimePromotionWaitEvent),
+) -> Result<RuntimePromotionLease> {
+    acquire_waiting_for_compatible_key_and_status(
+        operation,
+        target,
+        "",
+        Some(owner_status),
+        CompatibleOwnerPolicy::SameGeneration,
+        timeout,
+        progress,
+    )
+}
+
+/// Wait for an owner mutating the same target, even when independently built
+/// controller candidates report different runtime generations.
+pub fn acquire_waiting_for_target_with_status(
+    operation: &str,
+    target: impl Into<String>,
+    owner_status: RuntimePromotionOwnerStatus,
+    timeout: Duration,
+    progress: impl FnMut(RuntimePromotionWaitEvent),
+) -> Result<RuntimePromotionLease> {
+    acquire_waiting_for_compatible_key_and_status(
+        operation,
+        target,
+        "",
+        Some(owner_status),
+        CompatibleOwnerPolicy::SameTarget,
+        timeout,
+        progress,
+    )
+}
+
 /// Wait only for an owner with an exactly matching opaque result key.
 pub fn acquire_waiting_for_compatible_key(
     operation: &str,
     target: impl Into<String>,
     compatibility_key: impl Into<String>,
     timeout: Duration,
+    progress: impl FnMut(RuntimePromotionWaitEvent),
+) -> Result<RuntimePromotionLease> {
+    acquire_waiting_for_compatible_key_and_status(
+        operation,
+        target,
+        compatibility_key,
+        None,
+        CompatibleOwnerPolicy::SameGeneration,
+        timeout,
+        progress,
+    )
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CompatibleOwnerPolicy {
+    SameGeneration,
+    SameTarget,
+}
+
+fn acquire_waiting_for_compatible_key_and_status(
+    operation: &str,
+    target: impl Into<String>,
+    compatibility_key: impl Into<String>,
+    owner_status: Option<RuntimePromotionOwnerStatus>,
+    owner_policy: CompatibleOwnerPolicy,
+    timeout: Duration,
     mut progress: impl FnMut(RuntimePromotionWaitEvent),
 ) -> Result<RuntimePromotionLease> {
     let target = target.into();
     let compatibility_key = compatibility_key.into();
     let generation = current_generation();
-    let deadline = Instant::now() + timeout;
+    let started = Instant::now();
+    let deadline = started + timeout;
     let mut last_owner = None;
     let mut last_progress = None;
 
     loop {
+        let mut admission = BoundedAdmission {
+            timeout,
+            started,
+            deadline,
+            progress: &mut progress,
+            last_progress: &mut last_progress,
+        };
         match acquire_with_pin_policy(
             operation,
             target.clone(),
             compatibility_key.clone(),
+            owner_status.clone(),
             ForeignPinPolicy::Block,
+            Some(&mut admission),
         ) {
             Ok(lease) => return Ok(lease),
             Err(error) if is_contention_error(&error) => {
                 let owner = contention_owner(&error)?;
-                if !is_compatible_owner(&owner, &target, &generation, &compatibility_key) {
+                if !is_compatible_owner(
+                    &owner,
+                    &target,
+                    &generation,
+                    &compatibility_key,
+                    owner_policy,
+                ) {
                     return Err(error);
                 }
-                let owner_identity = format!("{}:{}:{}", owner.pid, owner.operation, owner.target);
-                if last_owner.as_ref() != Some(&owner_identity)
-                    || last_progress
-                        .is_none_or(|last: Instant| last.elapsed() >= COMPATIBLE_WAIT_HEARTBEAT)
-                {
-                    progress(RuntimePromotionWaitEvent {
-                        schema: "homeboy/runtime-promotion-admission/v1",
-                        state: "queued",
-                        resource_class: "runtime_promotion",
-                        wait_timeout_ms: timeout.as_millis(),
-                        waited_ms: timeout
-                            .saturating_sub(deadline.saturating_duration_since(Instant::now()))
-                            .as_millis(),
-                        owner_pid: owner.pid,
-                        owner_operation: owner.operation.clone(),
-                        target: owner.target.clone(),
-                        owner_generation: owner.generation.clone(),
-                    });
+                let owner_identity = blocker_identity(&owner);
+                if last_owner.as_ref() != Some(&owner_identity) || admission.should_publish() {
+                    admission.publish(&owner, "lease_record");
                     last_owner = Some(owner_identity);
-                    last_progress = Some(Instant::now());
                 }
                 let remaining = deadline.saturating_duration_since(Instant::now());
                 if remaining.is_zero() {
-                    return Err(wait_timeout_error(&owner, timeout));
+                    return Err(wait_timeout_error(&owner, timeout, "lease_record"));
                 }
                 std::thread::sleep(remaining.min(COMPATIBLE_WAIT_POLL));
             }
@@ -302,7 +577,9 @@ pub fn acquire_for_generation_rotation(
         operation,
         target.into(),
         String::new(),
+        None,
         ForeignPinPolicy::Allow,
+        None,
     )
 }
 
@@ -312,11 +589,50 @@ enum ForeignPinPolicy {
     Allow,
 }
 
+struct BoundedAdmission<'a> {
+    timeout: Duration,
+    started: Instant,
+    deadline: Instant,
+    progress: &'a mut dyn FnMut(RuntimePromotionWaitEvent),
+    last_progress: &'a mut Option<Instant>,
+}
+
+impl BoundedAdmission<'_> {
+    fn should_publish(&self) -> bool {
+        self.last_progress
+            .is_none_or(|last| last.elapsed() >= COMPATIBLE_WAIT_HEARTBEAT)
+    }
+
+    fn publish(&mut self, owner: &RuntimePromotionLeaseRecord, wait_stage: &'static str) {
+        (self.progress)(RuntimePromotionWaitEvent {
+            schema: "homeboy/runtime-promotion-admission/v1",
+            state: "queued",
+            resource_class: "runtime_promotion",
+            wait_timeout_ms: self.timeout.as_millis(),
+            waited_ms: self.started.elapsed().min(self.timeout).as_millis(),
+            wait_stage,
+            owner_pid: owner.pid,
+            owner_operation: owner.operation.clone(),
+            owner_operation_id: owner.operation_id.clone(),
+            owner_status_command: owner.status_command.clone(),
+            target: owner.target.clone(),
+            owner_generation: owner.generation.clone(),
+        });
+        *self.last_progress = Some(Instant::now());
+    }
+
+    fn remaining(&self) -> Duration {
+        self.deadline.saturating_duration_since(Instant::now())
+    }
+}
+
 fn acquire_with_pin_policy(
     operation: &str,
     target: String,
     compatibility_key: String,
+    owner_status: Option<RuntimePromotionOwnerStatus>,
     foreign_pin_policy: ForeignPinPolicy,
+    mut admission: Option<&mut BoundedAdmission<'_>>,
 ) -> Result<RuntimePromotionLease> {
     let root = paths::runtime_promotion_dir()?;
     fs::create_dir_all(&root).map_err(io("create runtime promotion directory"))?;
@@ -334,6 +650,12 @@ fn acquire_with_pin_policy(
                 schema: "homeboy/runtime-promotion-lease/v2".to_string(),
                 pid,
                 operation: operation.to_string(),
+                operation_id: owner_status
+                    .as_ref()
+                    .map(|status| status.operation_id.clone()),
+                status_command: owner_status
+                    .as_ref()
+                    .map(|status| status.status_command.clone()),
                 target: target.clone(),
                 generation: generation.clone(),
                 compatibility_key: compatibility_key.clone(),
@@ -355,7 +677,9 @@ fn acquire_with_pin_policy(
                         operation,
                         target,
                         compatibility_key,
+                        owner_status,
                         foreign_pin_policy,
+                        admission.as_deref_mut(),
                     );
                 }
                 return Err(error);
@@ -408,7 +732,9 @@ fn acquire_with_pin_policy(
                             operation,
                             target,
                             compatibility_key,
+                            owner_status,
                             foreign_pin_policy,
+                            admission.as_deref_mut(),
                         )
                     }
                     Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -416,7 +742,9 @@ fn acquire_with_pin_policy(
                             operation,
                             target,
                             compatibility_key,
+                            owner_status,
                             foreign_pin_policy,
+                            admission.as_deref_mut(),
                         )
                     }
                     Err(error) => return Err(io("archive stale runtime promotion lease")(error)),
@@ -428,10 +756,15 @@ fn acquire_with_pin_policy(
 
     if foreign_pin_policy == ForeignPinPolicy::Block && lease.primary {
         let admission_lock = open_admission_lock(&root)?;
-        admission_lock
-            .lock_exclusive()
-            .map_err(io("reserve runtime promotion admission"))?;
-        wait_for_foreign_generation_pins(&root, pid, subprocess_capability.as_ref())?;
+        if let Some(admission) = admission.as_deref_mut() {
+            wait_for_admission_lock(&lease, &admission_lock, admission)?;
+            wait_for_foreign_generation_pins(&root, &lease, Some((&lease, admission)))?;
+        } else {
+            admission_lock
+                .lock_exclusive()
+                .map_err(io("reserve runtime promotion admission"))?;
+            wait_for_foreign_generation_pins(&root, &lease, None)?;
+        }
         lease.admission_lock = Some(admission_lock);
     }
     Ok(lease)
@@ -597,10 +930,19 @@ impl RuntimePromotionLease {
 pub fn pin_cook_generation(cook_id: &str) -> Result<RuntimeGenerationPinGuard> {
     let promotion_root = paths::runtime_promotion_dir()?;
     fs::create_dir_all(&promotion_root).map_err(io("create runtime promotion directory"))?;
-    let admission_lock = open_admission_lock(&promotion_root)?;
-    admission_lock
-        .lock_shared()
-        .map_err(io("join runtime promotion admission"))?;
+    let transaction = validated_pin_transaction(&promotion_root);
+    // The exact transaction capability already owns exclusive admission. Trying
+    // to reacquire the shared side here would deadlock before the pin exemption
+    // below could be observed by the owner.
+    let _admission_lock = if transaction.is_none() {
+        let admission_lock = open_admission_lock(&promotion_root)?;
+        admission_lock
+            .lock_shared()
+            .map_err(io("join runtime promotion admission"))?;
+        Some(admission_lock)
+    } else {
+        None
+    };
     let root = promotion_root.join(PIN_DIR);
     fs::create_dir_all(&root).map_err(io("create runtime generation pin directory"))?;
     prune_pins(&root)?;
@@ -616,6 +958,11 @@ pub fn pin_cook_generation(cook_id: &str) -> Result<RuntimeGenerationPinGuard> {
         cook_id: cook_id.to_string(),
         generation: current_generation(),
         started_at: now(),
+        linux_starttime_ticks: crate::process::linux_process_starttime_ticks(pid)
+            .ok()
+            .flatten(),
+        process_start_identity: crate::process::process_start_identity(pid).ok().flatten(),
+        transaction,
     };
     fs::write(
         &path,
@@ -855,6 +1202,8 @@ fn blocked_error(held: &RuntimePromotionLeaseRecord, reclaimable: bool) -> Error
             "target": held.target,
             "holder_pid": held.pid,
             "holder_operation": held.operation,
+            "holder_operation_id": held.operation_id,
+            "holder_status_command": held.status_command,
             "holder_generation": held.generation,
             "holder_compatibility_key": held.compatibility_key,
             "reclaimable": reclaimable,
@@ -877,6 +1226,10 @@ fn contention_owner(error: &Error) -> Result<RuntimePromotionLeaseRecord> {
         schema: "homeboy/runtime-promotion-lease/v2".to_string(),
         pid,
         operation: string("holder_operation")?,
+        operation_id: details["holder_operation_id"].as_str().map(str::to_string),
+        status_command: details["holder_status_command"]
+            .as_str()
+            .map(str::to_string),
         target: string("target")?,
         generation: string("holder_generation")?,
         compatibility_key: details["holder_compatibility_key"]
@@ -897,15 +1250,52 @@ fn is_compatible_owner(
     target: &str,
     generation: &str,
     compatibility_key: &str,
+    policy: CompatibleOwnerPolicy,
 ) -> bool {
     owner.target == target
-        && owner.generation == generation
+        && (matches!(policy, CompatibleOwnerPolicy::SameTarget) || owner.generation == generation)
         && (compatibility_key.is_empty()
             || (!owner.compatibility_key.is_empty()
                 && owner.compatibility_key == compatibility_key))
 }
 
-fn wait_timeout_error(owner: &RuntimePromotionLeaseRecord, timeout: Duration) -> Error {
+fn blocker_identity(owner: &RuntimePromotionLeaseRecord) -> RuntimePromotionBlockerIdentity {
+    RuntimePromotionBlockerIdentity {
+        pid: owner.pid,
+        operation: owner.operation.clone(),
+        operation_id: owner.operation_id.clone(),
+        target: owner.target.clone(),
+    }
+}
+
+fn wait_timeout_error(
+    owner: &RuntimePromotionLeaseRecord,
+    timeout: Duration,
+    wait_stage: &'static str,
+) -> Error {
+    let (queue_state, tried) = match wait_stage {
+        "os_lock" => (
+            "timed_out_waiting_for_admission_lock",
+            vec![
+                "The runtime admission lock owner did not finish before the deadline.",
+                "Retry after the reported owner completes or inspect its status command.",
+            ],
+        ),
+        "foreign_generation_pins" => (
+            "timed_out_waiting_for_generation_pin",
+            vec![
+                "The pinned runtime operation did not finish before the deadline.",
+                "Retry after the reported pin owner completes.",
+            ],
+        ),
+        _ => (
+            "timed_out_waiting_for_compatible_owner",
+            vec![
+                "The compatible promotion owner did not finish before the admission deadline.",
+                "Retry the same command after the owner completes or inspect its runtime-promotion lease.",
+            ],
+        ),
+    };
     Error::new(
         ErrorCode::RuntimePromotionWaitTimeout,
         format!(
@@ -917,16 +1307,41 @@ fn wait_timeout_error(owner: &RuntimePromotionLeaseRecord, timeout: Duration) ->
         ),
         serde_json::json!({
             "schema": "homeboy/runtime-promotion-admission/v1",
-            "queue_state": "timed_out_waiting_for_compatible_owner",
+            "queue_state": queue_state,
+            "wait_stage": wait_stage,
             "resource_class": "runtime_promotion",
             "state": "busy",
             "wait_timeout_seconds": timeout.as_secs(),
             "target": owner.target,
             "holder_pid": owner.pid,
             "holder_operation": owner.operation,
+            "holder_operation_id": owner.operation_id,
+            "holder_status_command": owner.status_command,
             "holder_generation": owner.generation,
             "holder_compatibility_key": owner.compatibility_key,
-            "tried": ["The compatible promotion owner did not finish before the admission deadline.", "Retry the same command after the owner completes or inspect its runtime-promotion lease."],
+            "tried": tried,
+        }),
+    )
+}
+
+fn selection_wait_timeout_without_owner(timeout: Duration) -> Error {
+    Error::new(
+        ErrorCode::RuntimePromotionWaitTimeout,
+        format!(
+            "runtime promotion wait timed out after {}s while the admission owner was completing teardown",
+            timeout.as_secs()
+        ),
+        serde_json::json!({
+            "schema": "homeboy/runtime-promotion-admission/v1",
+            "queue_state": "timed_out_waiting_for_admission_lock",
+            "wait_stage": "os_lock",
+            "resource_class": "runtime_promotion",
+            "state": "busy",
+            "wait_timeout_seconds": timeout.as_secs(),
+            "tried": [
+                "The durable owner record disappeared while the admission lock remained busy.",
+                "Retry after the previous owner finishes releasing the admission lock."
+            ]
         }),
     )
 }
@@ -974,13 +1389,77 @@ fn prune_pins(root: &Path) -> Result<()> {
         let Ok(pin) = serde_json::from_str::<RuntimeGenerationPin>(&content) else {
             continue;
         };
-        if !crate::process::pid_is_running(pin.pid)
-            || age_seconds(&pin.started_at).is_some_and(|age| age >= DEFAULT_TTL.as_secs() as i64)
-        {
+        if pin_reclaimable(&pin) {
             let _ = fs::remove_file(path);
         }
     }
     Ok(())
+}
+
+fn pin_reclaimable(pin: &RuntimeGenerationPin) -> bool {
+    pin_reclaimable_with(pin, |pid, linux_starttime_ticks, start_identity| {
+        crate::process::process_identity_state_with_start_identity(
+            pid,
+            linux_starttime_ticks,
+            start_identity,
+        )
+    })
+}
+
+fn pin_reclaimable_with(
+    pin: &RuntimeGenerationPin,
+    inspect: impl FnOnce(
+        u32,
+        Option<u64>,
+        Option<&crate::process::ProcessStartIdentity>,
+    ) -> crate::process::ProcessIdentityState,
+) -> bool {
+    matches!(
+        inspect(
+            pin.pid,
+            pin.linux_starttime_ticks,
+            pin.process_start_identity.as_ref(),
+        ),
+        crate::process::ProcessIdentityState::Dead
+            | crate::process::ProcessIdentityState::IdentityMismatch
+    )
+}
+
+fn pin_blocks_lease(pin: &RuntimeGenerationPin, lease: &RuntimePromotionLease) -> bool {
+    pin.transaction.as_ref().is_none_or(|transaction| {
+        transaction.owner_pid != lease.owner_pid
+            || transaction.target != lease.target
+            || transaction.generation != lease.generation
+            || transaction.capability != lease.capability
+    })
+}
+
+fn validated_pin_transaction(root: &Path) -> Option<SubprocessLeaseCapability> {
+    let lease = read_record(&root.join(LEASE_DIR)).ok()?;
+    let local = LOCAL_LEASE_CAPABILITIES.with(|capabilities| {
+        capabilities
+            .borrow()
+            .iter()
+            .rev()
+            .find(|capability| capability_matches_record(capability, &lease))
+            .cloned()
+    });
+    local.or_else(|| {
+        subprocess_capability_from_env()
+            .filter(|capability| capability_matches_record(capability, &lease))
+    })
+}
+
+fn capability_matches_record(
+    capability: &SubprocessLeaseCapability,
+    lease: &RuntimePromotionLeaseRecord,
+) -> bool {
+    capability.owner_pid == lease.pid
+        && capability.target == lease.target
+        && capability.generation == lease.generation
+        && capability.capability == lease.capability
+        && capability.owner_linux_starttime_ticks == lease.linux_starttime_ticks
+        && capability.owner_process_start_identity == lease.process_start_identity
 }
 
 /// A pending promotion holds exclusive admission while existing pins drain.
@@ -988,8 +1467,8 @@ fn prune_pins(root: &Path) -> Result<()> {
 /// no foreign pin the promotion is ahead of all later cook admission.
 fn wait_for_foreign_generation_pins(
     root: &Path,
-    pid: u32,
-    subprocess_capability: Option<&SubprocessLeaseCapability>,
+    waiting_lease: &RuntimePromotionLease,
+    mut bounded: Option<(&RuntimePromotionLease, &mut BoundedAdmission<'_>)>,
 ) -> Result<()> {
     let pins = root.join(PIN_DIR);
     if !pins.exists() {
@@ -997,22 +1476,145 @@ fn wait_for_foreign_generation_pins(
     }
     loop {
         prune_pins(&pins)?;
-        let foreign_pin = fs::read_dir(&pins)
+        let mut foreign_pins = fs::read_dir(&pins)
             .map_err(io("read runtime generation pins"))?
             .filter_map(|entry| entry.ok())
             .map(|entry| entry.path())
             .filter_map(|path| fs::read_to_string(path).ok())
             .filter_map(|content| serde_json::from_str::<RuntimeGenerationPin>(&content).ok())
-            .any(|pin| {
-                pin.pid != pid
-                    && subprocess_capability
-                        .is_none_or(|capability| capability.owner_pid != pin.pid)
-            });
-        if !foreign_pin {
+            .filter(|pin| pin_blocks_lease(pin, waiting_lease))
+            .collect::<Vec<_>>();
+        foreign_pins.sort_by(|left, right| {
+            (&left.started_at, left.pid, &left.cook_id).cmp(&(
+                &right.started_at,
+                right.pid,
+                &right.cook_id,
+            ))
+        });
+        let Some(foreign_pin) = foreign_pins.first() else {
             return Ok(());
+        };
+        let owner = pin_owner_record(foreign_pin);
+        if let Some((lease, admission)) = bounded.as_mut() {
+            heartbeat_wait(lease, admission, &owner, "foreign_generation_pins")?;
+            let remaining = admission.remaining();
+            if remaining.is_zero() {
+                return Err(wait_timeout_error(
+                    &owner,
+                    admission.timeout,
+                    "foreign_generation_pins",
+                ));
+            }
+            std::thread::sleep(remaining.min(PIN_DRAIN_POLL));
+        } else {
+            std::thread::sleep(PIN_DRAIN_POLL);
         }
-        std::thread::sleep(PIN_DRAIN_POLL);
     }
+}
+
+fn wait_for_admission_lock(
+    lease: &RuntimePromotionLease,
+    admission_lock: &fs::File,
+    admission: &mut BoundedAdmission<'_>,
+) -> Result<()> {
+    loop {
+        match admission_lock.try_lock_exclusive() {
+            Ok(true) => return Ok(()),
+            Ok(false) => {
+                let owner = admission_lock_owner(&lease.path)?;
+                heartbeat_wait(lease, admission, &owner, "os_lock")?;
+                let remaining = admission.remaining();
+                if remaining.is_zero() {
+                    return Err(wait_timeout_error(&owner, admission.timeout, "os_lock"));
+                }
+                std::thread::sleep(remaining.min(COMPATIBLE_WAIT_POLL));
+            }
+            Err(error) => return Err(io("reserve runtime promotion admission")(error)),
+        }
+    }
+}
+
+fn heartbeat_wait(
+    lease: &RuntimePromotionLease,
+    admission: &mut BoundedAdmission<'_>,
+    owner: &RuntimePromotionLeaseRecord,
+    wait_stage: &'static str,
+) -> Result<()> {
+    if admission.should_publish() {
+        lease.heartbeat()?;
+        admission.publish(owner, wait_stage);
+    }
+    Ok(())
+}
+
+fn pin_owner_record(pin: &RuntimeGenerationPin) -> RuntimePromotionLeaseRecord {
+    RuntimePromotionLeaseRecord {
+        schema: "homeboy/runtime-generation-pin/v1".to_string(),
+        pid: pin.pid,
+        operation: "runtime generation pin".to_string(),
+        operation_id: None,
+        status_command: None,
+        target: pin.cook_id.clone(),
+        generation: pin.generation.clone(),
+        compatibility_key: String::new(),
+        started_at: pin.started_at.clone(),
+        linux_starttime_ticks: pin.linux_starttime_ticks,
+        process_start_identity: pin.process_start_identity.clone(),
+        heartbeat_at: String::new(),
+        expires_at: String::new(),
+        capability: String::new(),
+    }
+}
+
+fn admission_lock_owner(lease_path: &Path) -> Result<RuntimePromotionLeaseRecord> {
+    let owner_dir = lease_path
+        .parent()
+        .expect("runtime promotion lease has a parent")
+        .join(ADMISSION_OWNER_DIR);
+    if owner_dir.exists() {
+        let mut owners = Vec::new();
+        for entry in fs::read_dir(&owner_dir).map_err(io("read runtime admission owners"))? {
+            let path = entry.map_err(io("read runtime admission owner"))?.path();
+            let Ok(content) = fs::read_to_string(&path) else {
+                continue;
+            };
+            let Ok(owner) = serde_json::from_str::<RuntimePromotionLeaseRecord>(&content) else {
+                continue;
+            };
+            if reclaimable(&owner) {
+                let _ = fs::remove_file(path);
+            } else {
+                owners.push(owner);
+            }
+        }
+        owners.sort_by(|left, right| {
+            (&left.started_at, left.pid, &left.operation).cmp(&(
+                &right.started_at,
+                right.pid,
+                &right.operation,
+            ))
+        });
+        if let Some(owner) = owners.into_iter().next() {
+            return Ok(owner);
+        }
+    }
+
+    Ok(RuntimePromotionLeaseRecord {
+        schema: "homeboy/runtime-promotion-admission-owner/v1".to_string(),
+        pid: 0,
+        operation: "unknown admission lock owner".to_string(),
+        operation_id: None,
+        status_command: None,
+        target: "runtime promotion admission".to_string(),
+        generation: String::new(),
+        compatibility_key: String::new(),
+        started_at: String::new(),
+        linux_starttime_ticks: None,
+        process_start_identity: None,
+        heartbeat_at: String::new(),
+        expires_at: String::new(),
+        capability: String::new(),
+    })
 }
 
 fn current_generation() -> String {
@@ -1044,6 +1646,8 @@ mod tests {
             schema: "v1".to_string(),
             pid: u32::MAX,
             operation: "upgrade".to_string(),
+            operation_id: None,
+            status_command: None,
             target: "main".to_string(),
             generation: "old".to_string(),
             compatibility_key: String::new(),
@@ -1099,6 +1703,8 @@ mod tests {
             schema: "v1".to_string(),
             pid: 42,
             operation: "runner refresh".to_string(),
+            operation_id: None,
+            status_command: None,
             target: "lab".to_string(),
             generation: "old".to_string(),
             compatibility_key: String::new(),
@@ -1170,6 +1776,49 @@ mod tests {
     }
 
     #[test]
+    fn compatible_wait_exposes_the_owner_operation_status_contract() {
+        crate::test_support::with_isolated_home(|_| {
+            let owner = acquire_waiting_for_compatible_with_status(
+                "controller upgrade",
+                "active controller",
+                RuntimePromotionOwnerStatus {
+                    operation_id: "upgrade-123".to_string(),
+                    status_command: "homeboy upgrade status upgrade-123".to_string(),
+                },
+                Duration::from_secs(1),
+                |_| unreachable!("uncontended owner does not queue"),
+            )
+            .expect("owner acquires lease");
+            let contender = std::thread::spawn(|| {
+                let events = std::sync::Mutex::new(Vec::new());
+                let error = acquire_waiting_for_compatible(
+                    "controller upgrade",
+                    "active controller",
+                    Duration::ZERO,
+                    |event| events.lock().expect("collect event").push(event),
+                )
+                .expect_err("live compatible owner remains bounded");
+                (error, events.into_inner().expect("events are not poisoned"))
+            });
+
+            let (error, events) = contender.join().expect("contender exits");
+            drop(owner);
+            assert_eq!(error.code, ErrorCode::RuntimePromotionWaitTimeout);
+            assert_eq!(error.details["holder_operation_id"], "upgrade-123");
+            assert_eq!(
+                error.details["holder_status_command"],
+                "homeboy upgrade status upgrade-123"
+            );
+            assert_eq!(events.len(), 1);
+            assert_eq!(events[0].owner_operation_id.as_deref(), Some("upgrade-123"));
+            assert_eq!(
+                events[0].owner_status_command.as_deref(),
+                Some("homeboy upgrade status upgrade-123")
+            );
+        });
+    }
+
+    #[test]
     fn compatible_wait_timeout_leaves_no_queue_state() {
         crate::test_support::with_isolated_home(|_| {
             let mut owner = compatible_wait_owner();
@@ -1214,6 +1863,211 @@ mod tests {
     }
 
     #[test]
+    fn bounded_admission_deadline_covers_the_os_lock() {
+        crate::test_support::with_isolated_home(|_| {
+            let root = paths::runtime_promotion_dir().expect("runtime promotion directory");
+            let blocker = protect_runtime_selection_with_status(
+                "controller extension refresh",
+                "active controller",
+                RuntimePromotionOwnerStatus {
+                    operation_id: "upgrade-blocker".to_string(),
+                    status_command: "homeboy upgrade status upgrade-blocker".to_string(),
+                },
+            )
+            .expect("hold shared controller selection");
+            let events = std::sync::Mutex::new(Vec::new());
+
+            let error = acquire_waiting_for_target_with_status(
+                "controller upgrade",
+                "active controller",
+                RuntimePromotionOwnerStatus {
+                    operation_id: "upgrade-contender".to_string(),
+                    status_command: "homeboy upgrade status upgrade-contender".to_string(),
+                },
+                Duration::from_millis(25),
+                |event| events.lock().expect("collect admission events").push(event),
+            )
+            .expect_err("the shared OS lock consumes the same bounded deadline");
+
+            assert_eq!(error.code, ErrorCode::RuntimePromotionWaitTimeout);
+            assert_eq!(error.details["wait_stage"], "os_lock");
+            assert_eq!(error.details["holder_pid"], std::process::id());
+            assert_eq!(error.details["holder_operation_id"], "upgrade-blocker");
+            assert_eq!(
+                error.details["holder_operation"],
+                "controller extension refresh"
+            );
+            let events = events.into_inner().expect("events are not poisoned");
+            assert!(
+                events.len() >= 2,
+                "OS-lock waiting emits progress heartbeats"
+            );
+            assert!(events.iter().all(|event| event.wait_stage == "os_lock"));
+            assert!(events.iter().all(|event| {
+                event.owner_operation_id.as_deref() == Some("upgrade-blocker")
+                    && event.owner_operation == "controller extension refresh"
+            }));
+            assert!(
+                !root.join(LEASE_DIR).exists(),
+                "timed-out owner lease is removed"
+            );
+            drop(blocker);
+        });
+    }
+
+    #[test]
+    fn shared_selection_blocks_replacement_for_its_full_lifetime() {
+        crate::test_support::with_isolated_home(|_| {
+            let guard = protect_runtime_selection_with_status(
+                "controller extension refresh",
+                "active controller",
+                RuntimePromotionOwnerStatus {
+                    operation_id: "refresh-owner".to_string(),
+                    status_command: "homeboy upgrade status refresh-owner".to_string(),
+                },
+            )
+            .expect("protect extension refresh");
+            let (queued_tx, queued_rx) = std::sync::mpsc::channel();
+            let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
+            let contender = std::thread::spawn(move || {
+                let lease = acquire_waiting_for_target_with_status(
+                    "controller replacement",
+                    "active controller",
+                    RuntimePromotionOwnerStatus {
+                        operation_id: "replacement".to_string(),
+                        status_command: "homeboy upgrade status replacement".to_string(),
+                    },
+                    Duration::from_secs(1),
+                    |_| {
+                        let _ = queued_tx.send(());
+                    },
+                )
+                .expect("replacement acquires after refresh");
+                acquired_tx.send(()).expect("report replacement admission");
+                lease
+            });
+
+            queued_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("replacement waits on the shared selection");
+            assert!(acquired_rx.try_recv().is_err());
+            drop(guard);
+            acquired_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("replacement proceeds after refresh guard drops");
+            drop(contender.join().expect("replacement exits"));
+        });
+    }
+
+    #[test]
+    fn shared_selection_wait_is_bounded_and_names_the_mutation_owner() {
+        crate::test_support::with_isolated_home(|_| {
+            let owner = acquire_waiting_for_target_with_status(
+                "controller replacement",
+                "active controller",
+                RuntimePromotionOwnerStatus {
+                    operation_id: "replacement-owner".to_string(),
+                    status_command: "homeboy upgrade status replacement-owner".to_string(),
+                },
+                Duration::from_secs(1),
+                |_| unreachable!("uncontended replacement does not wait"),
+            )
+            .expect("hold exclusive controller mutation");
+            let events = std::sync::Mutex::new(Vec::new());
+
+            let error = protect_runtime_selection_waiting_with_status(
+                "controller extension refresh",
+                "active controller",
+                RuntimePromotionOwnerStatus {
+                    operation_id: "refresh-contender".to_string(),
+                    status_command: "homeboy upgrade status refresh-contender".to_string(),
+                },
+                Duration::from_millis(25),
+                |event| events.lock().expect("collect wait event").push(event),
+            )
+            .expect_err("shared selection wait remains bounded");
+
+            assert_eq!(error.code, ErrorCode::RuntimePromotionWaitTimeout);
+            assert_eq!(error.details["wait_stage"], "os_lock");
+            assert_eq!(error.details["holder_operation_id"], "replacement-owner");
+            assert_eq!(
+                error.details["queue_state"],
+                "timed_out_waiting_for_admission_lock"
+            );
+            let events = events.into_inner().expect("events are not poisoned");
+            assert!(events.iter().all(|event| {
+                event.owner_operation_id.as_deref() == Some("replacement-owner")
+                    && event.owner_operation == "controller replacement"
+            }));
+            drop(owner);
+        });
+    }
+
+    #[test]
+    fn bounded_admission_deadline_covers_foreign_generation_pins() {
+        crate::test_support::with_isolated_home(|_| {
+            let mut foreign_owner = Command::new("sleep")
+                .arg("30")
+                .spawn()
+                .expect("start foreign generation owner");
+            let root = paths::runtime_promotion_dir().expect("runtime promotion directory");
+            let pins = root.join(PIN_DIR);
+            fs::create_dir_all(&pins).expect("create pin directory");
+            fs::write(
+                pins.join("foreign.json"),
+                serde_json::to_vec_pretty(&RuntimeGenerationPin {
+                    pid: foreign_owner.id(),
+                    cook_id: "foreign-cook".to_string(),
+                    generation: "previous-generation".to_string(),
+                    started_at: now(),
+                    linux_starttime_ticks: None,
+                    process_start_identity: None,
+                    transaction: None,
+                })
+                .expect("serialize foreign pin"),
+            )
+            .expect("write foreign pin");
+            let events = std::sync::Mutex::new(Vec::new());
+
+            let error = acquire_waiting_for_target_with_status(
+                "controller upgrade",
+                "active controller",
+                RuntimePromotionOwnerStatus {
+                    operation_id: "upgrade-contender".to_string(),
+                    status_command: "homeboy upgrade status upgrade-contender".to_string(),
+                },
+                Duration::from_millis(25),
+                |event| events.lock().expect("collect admission events").push(event),
+            )
+            .expect_err("foreign pins consume the same bounded deadline");
+
+            foreign_owner.kill().expect("stop foreign owner");
+            foreign_owner.wait().expect("reap foreign owner");
+            assert_eq!(error.code, ErrorCode::RuntimePromotionWaitTimeout);
+            assert_eq!(error.details["wait_stage"], "foreign_generation_pins");
+            assert_eq!(error.details["holder_pid"], foreign_owner.id());
+            assert_eq!(error.details["holder_operation"], "runtime generation pin");
+            assert_eq!(error.details["target"], "foreign-cook");
+            assert_eq!(error.details["holder_generation"], "previous-generation");
+            let events = events.into_inner().expect("events are not poisoned");
+            assert!(events.len() >= 2, "pin draining emits progress heartbeats");
+            assert!(events
+                .iter()
+                .all(|event| event.wait_stage == "foreign_generation_pins"));
+            assert!(events.iter().all(|event| {
+                event.owner_pid == foreign_owner.id()
+                    && event.owner_operation == "runtime generation pin"
+                    && event.target == "foreign-cook"
+                    && event.owner_generation == "previous-generation"
+            }));
+            assert!(
+                !root.join(LEASE_DIR).exists(),
+                "timed-out owner lease is removed"
+            );
+        });
+    }
+
+    #[test]
     fn incompatible_contender_remains_fail_closed() {
         crate::test_support::with_isolated_home(|_| {
             let _owner = acquire("owner operation", "lab").expect("owner acquires lease");
@@ -1239,34 +2093,52 @@ mod tests {
             &owner,
             "lab",
             "generation-a",
-            "candidate-a"
+            "candidate-a",
+            CompatibleOwnerPolicy::SameGeneration,
         ));
         assert!(!is_compatible_owner(
             &owner,
             "other-lab",
             "generation-a",
-            "candidate-a"
+            "candidate-a",
+            CompatibleOwnerPolicy::SameGeneration,
         ));
         assert!(!is_compatible_owner(
             &owner,
             "lab",
             "generation-b",
-            "candidate-a"
+            "candidate-a",
+            CompatibleOwnerPolicy::SameGeneration,
         ));
         assert!(!is_compatible_owner(
             &owner,
             "lab",
             "generation-a",
-            "candidate-b"
+            "candidate-b",
+            CompatibleOwnerPolicy::SameGeneration,
         ));
         let mut legacy_owner = owner.clone();
         legacy_owner.compatibility_key.clear();
-        assert!(is_compatible_owner(&owner, "lab", "generation-a", ""));
+        assert!(is_compatible_owner(
+            &owner,
+            "lab",
+            "generation-a",
+            "",
+            CompatibleOwnerPolicy::SameGeneration,
+        ));
+        assert!(is_compatible_owner(
+            &owner,
+            "lab",
+            "generation-b",
+            "",
+            CompatibleOwnerPolicy::SameTarget,
+        ));
         assert!(!is_compatible_owner(
             &legacy_owner,
             "lab",
             "generation-a",
-            "candidate-a"
+            "candidate-a",
+            CompatibleOwnerPolicy::SameGeneration,
         ));
     }
 
@@ -1304,6 +2176,8 @@ mod tests {
             schema: "homeboy/runtime-promotion-lease/v2".to_string(),
             pid: 42,
             operation: "runner refresh".to_string(),
+            operation_id: None,
+            status_command: None,
             target: "lab".to_string(),
             generation: "generation-a".to_string(),
             compatibility_key: "candidate-a".to_string(),
@@ -1327,6 +2201,128 @@ mod tests {
             generation: record.generation.clone(),
             capability: record.capability.clone(),
         }
+    }
+
+    fn generation_pin(pid: u32) -> RuntimeGenerationPin {
+        RuntimeGenerationPin {
+            pid,
+            cook_id: "cook".to_string(),
+            generation: "generation-a".to_string(),
+            started_at: "2000-01-01T00:00:00Z".to_string(),
+            linux_starttime_ticks: None,
+            process_start_identity: None,
+            transaction: None,
+        }
+    }
+
+    #[test]
+    fn old_live_pin_is_not_reclaimed_by_age() {
+        crate::test_support::with_isolated_home(|_| {
+            let pins = paths::runtime_promotion_dir()
+                .expect("promotion root")
+                .join(PIN_DIR);
+            fs::create_dir_all(&pins).expect("create pins");
+            let path = pins.join("old-live.json");
+            fs::write(
+                &path,
+                serde_json::to_vec(&generation_pin(std::process::id())).expect("serialize pin"),
+            )
+            .expect("write pin");
+
+            prune_pins(&pins).expect("prune pins");
+            assert!(path.exists(), "age alone cannot expire a live pin");
+        });
+    }
+
+    #[test]
+    fn pin_reclamation_requires_dead_or_invalid_owner_evidence() {
+        let pin = generation_pin(42);
+        assert!(pin_reclaimable_with(&pin, |_, _, _| {
+            crate::process::ProcessIdentityState::Dead
+        }));
+        assert!(pin_reclaimable_with(&pin, |_, _, _| {
+            crate::process::ProcessIdentityState::IdentityMismatch
+        }));
+        assert!(!pin_reclaimable_with(&pin, |_, _, _| {
+            crate::process::ProcessIdentityState::Live
+        }));
+        assert!(!pin_reclaimable_with(&pin, |_, _, _| {
+            crate::process::ProcessIdentityState::Unverifiable
+        }));
+    }
+
+    #[test]
+    fn pin_exemption_requires_the_exact_transaction_capability() {
+        let record = lease_record();
+        let lease = RuntimePromotionLease {
+            path: PathBuf::new(),
+            primary: false,
+            generation: record.generation.clone(),
+            target: record.target.clone(),
+            compatibility_key: record.compatibility_key.clone(),
+            owner_pid: record.pid,
+            capability: record.capability.clone(),
+            admission_lock: None,
+        };
+        let mut pin = generation_pin(record.pid);
+        assert!(pin_blocks_lease(&pin, &lease));
+        pin.transaction = Some(capability(&record));
+        assert!(!pin_blocks_lease(&pin, &lease));
+        pin.transaction.as_mut().expect("transaction").capability = "other".to_string();
+        assert!(pin_blocks_lease(&pin, &lease));
+    }
+
+    #[test]
+    fn transaction_owner_can_publish_a_pin_without_relocking_admission() {
+        crate::test_support::with_isolated_home(|_| {
+            let lease = acquire("controller upgrade", "active controller")
+                .expect("acquire exclusive admission");
+
+            let pin = pin_cook_generation("same-transaction-cook")
+                .expect("transaction pin does not self-deadlock");
+            let pins = paths::runtime_promotion_dir()
+                .expect("promotion root")
+                .join(PIN_DIR);
+            let record = fs::read_dir(pins)
+                .expect("read pins")
+                .next()
+                .expect("published pin")
+                .expect("pin entry");
+            let pin_record: RuntimeGenerationPin =
+                serde_json::from_slice(&fs::read(record.path()).expect("read pin record"))
+                    .expect("parse pin record");
+            assert!(pin_record.transaction.is_some());
+            assert!(!pin_blocks_lease(&pin_record, &lease));
+            drop(pin);
+        });
+    }
+
+    #[test]
+    fn selection_wait_retries_only_a_disappearing_owner_record() {
+        let disappeared = selection_blocker_after_busy(|| {
+            Err(LeaseRecordReadError::Disappeared(std::io::Error::from(
+                std::io::ErrorKind::NotFound,
+            )))
+        })
+        .expect("teardown disappearance is retryable");
+        assert!(disappeared.is_none());
+
+        let error = selection_blocker_after_busy(|| {
+            Err(LeaseRecordReadError::Failure(Error::internal_unexpected(
+                "malformed owner",
+            )))
+        })
+        .expect_err("malformed owners remain fail closed");
+        assert!(error.message.contains("malformed owner"));
+    }
+
+    #[test]
+    fn blocker_identity_includes_the_durable_operation_id() {
+        let mut first = lease_record();
+        first.operation_id = Some("upgrade-1".to_string());
+        let mut second = first.clone();
+        second.operation_id = Some("upgrade-2".to_string());
+        assert_ne!(blocker_identity(&first), blocker_identity(&second));
     }
 
     #[test]
@@ -1407,6 +2403,27 @@ mod tests {
     }
 
     #[test]
+    fn unrelated_same_process_pin_blocks_promotion() {
+        crate::test_support::with_isolated_home(|_| {
+            let pin = pin_cook_generation("same-process-cook").expect("pin cook generation");
+            let error = acquire_waiting_for_target_with_status(
+                "controller upgrade",
+                "active controller",
+                RuntimePromotionOwnerStatus {
+                    operation_id: "upgrade".to_string(),
+                    status_command: "homeboy upgrade status upgrade".to_string(),
+                },
+                Duration::ZERO,
+                |_| {},
+            )
+            .expect_err("same-process pin is unrelated without an exact capability");
+            assert_eq!(error.code, ErrorCode::RuntimePromotionWaitTimeout);
+            assert_eq!(error.details["wait_stage"], "foreign_generation_pins");
+            drop(pin);
+        });
+    }
+
+    #[test]
     fn generation_rotation_retains_writer_serialization_without_waiting_for_foreign_cooks() {
         crate::test_support::with_isolated_home(|_| {
             let mut foreign_owner = Command::new("sleep")
@@ -1424,6 +2441,9 @@ mod tests {
                     cook_id: "foreign-cook".to_string(),
                     generation: "existing-generation".to_string(),
                     started_at: now(),
+                    linux_starttime_ticks: None,
+                    process_start_identity: None,
+                    transaction: None,
                 })
                 .expect("serialize foreign pin"),
             )
@@ -1458,6 +2478,9 @@ mod tests {
                     cook_id: "existing-attempt".to_string(),
                     generation: "existing-generation".to_string(),
                     started_at: now(),
+                    linux_starttime_ticks: None,
+                    process_start_identity: None,
+                    transaction: None,
                 })
                 .expect("serialize existing pin"),
             )

--- a/crates/homeboy-core/src/runtime_promotion.rs
+++ b/crates/homeboy-core/src/runtime_promotion.rs
@@ -185,6 +185,14 @@ pub struct RuntimePromotionLease {
     admission_lock: Option<fs::File>,
 }
 
+/// Keeps the exact admission-lock file description alive until a mutating
+/// subprocess has inherited it. Descendants inherit the same fence, so stale
+/// lease-record reclamation cannot admit a successor while installer code can
+/// still mutate the runtime.
+pub struct RuntimePromotionSubprocessFence {
+    _admission_lock: fs::File,
+}
+
 /// Pins the generation required by a cook until its lifecycle finalizes.
 #[derive(Debug)]
 pub struct RuntimeGenerationPinGuard {
@@ -879,6 +887,62 @@ impl RuntimePromotionLease {
         let payload = serde_json::to_vec(&capability)
             .expect("runtime promotion subprocess capability serializes");
         command.env(SUBPROCESS_LEASE_ENV, URL_SAFE_NO_PAD.encode(payload));
+    }
+
+    /// Authorize a subprocess and make the OS admission lock inheritable for
+    /// the lifetime of its process tree. The returned fence must be retained
+    /// through `Command::spawn`; the child then owns the duplicated handle.
+    pub fn authorize_mutating_subprocess(
+        &self,
+        command: &mut Command,
+    ) -> Result<RuntimePromotionSubprocessFence> {
+        self.assert_generation()?;
+        self.authorize_subprocess(command);
+        let admission_lock = self.admission_lock.as_ref().ok_or_else(|| {
+            Error::internal_unexpected(
+                "installer mutation requires primary runtime admission ownership",
+            )
+        })?;
+        let inherited = admission_lock
+            .try_clone()
+            .map_err(io("duplicate runtime admission lock for installer"))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+            let fd = inherited.as_raw_fd();
+            let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+            if flags < 0 || unsafe { libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) } < 0
+            {
+                return Err(io("make runtime admission lock inheritable")(
+                    std::io::Error::last_os_error(),
+                ));
+            }
+        }
+
+        #[cfg(windows)]
+        {
+            use std::os::windows::io::AsRawHandle;
+            use windows_sys::Win32::Foundation::{SetHandleInformation, HANDLE_FLAG_INHERIT};
+            let handle = inherited.as_raw_handle();
+            if unsafe { SetHandleInformation(handle, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT) }
+                == 0
+            {
+                return Err(io("make runtime admission lock inheritable")(
+                    std::io::Error::last_os_error(),
+                ));
+            }
+        }
+
+        #[cfg(not(any(unix, windows)))]
+        return Err(Error::internal_unexpected(
+            "inheritable runtime admission fences are unsupported on this platform",
+        ));
+
+        #[cfg(any(unix, windows))]
+        Ok(RuntimePromotionSubprocessFence {
+            _admission_lock: inherited,
+        })
     }
 
     /// Refuse to continue a multi-step mutation after another runtime generation

--- a/crates/homeboy-engine-primitives/Cargo.toml
+++ b/crates/homeboy-engine-primitives/Cargo.toml
@@ -31,4 +31,4 @@ sha2 = "0.10.9"
 tempfile = "3.14"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_JobObjects", "Win32_System_Threading"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_IO", "Win32_System_JobObjects", "Win32_System_Threading"] }

--- a/crates/homeboy-engine-primitives/src/command.rs
+++ b/crates/homeboy-engine-primitives/src/command.rs
@@ -754,7 +754,7 @@ pub fn wait_with_bounded_output_supervised_guarded(
         let live_output = Arc::clone(&live_output);
         move |stream| {
             thread::spawn(move || {
-                capture_tail_with_live_snapshot(stream, byte_limit, true, live_output)
+                capture_tail_with_live_snapshot(stream, byte_limit, true, live_output, None)
             })
         }
     });
@@ -762,7 +762,7 @@ pub fn wait_with_bounded_output_supervised_guarded(
         let live_output = Arc::clone(&live_output);
         move |stream| {
             thread::spawn(move || {
-                capture_tail_with_live_snapshot(stream, byte_limit, false, live_output)
+                capture_tail_with_live_snapshot(stream, byte_limit, false, live_output, None)
             })
         }
     });

--- a/crates/homeboy-engine-primitives/src/command.rs
+++ b/crates/homeboy-engine-primitives/src/command.rs
@@ -19,12 +19,15 @@ const MAX_OBSERVED_LINE_BYTES: usize = 64 * 1024;
 const PROCESS_TREE_TERM_GRACE: Duration = Duration::from_secs(2);
 #[cfg(unix)]
 const PROCESS_TREE_KILL_GRACE: Duration = Duration::from_secs(2);
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 const PROCESS_TREE_POLL_INTERVAL: Duration = Duration::from_millis(25);
 const CAPTURE_JOIN_GRACE: Duration = Duration::from_secs(2);
+const PROCESS_TREE_CLEANUP_DEADLINE: Duration = Duration::from_secs(4);
 
 #[cfg(target_os = "linux")]
 static CHILD_SUBREAPER_ENABLED: std::sync::OnceLock<io::Result<()>> = std::sync::OnceLock::new();
+#[cfg(target_os = "linux")]
+static CHILD_GUARD_SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
 
 pub type StdoutLineObserver = Arc<dyn Fn(&str) + Send + Sync + 'static>;
 pub type StreamChunkObserver = Arc<dyn Fn(&[u8], bool) + Send + Sync + 'static>;
@@ -48,7 +51,7 @@ pub fn parent_stream_passthrough() -> StreamChunkObserver {
 /// tree. Callers that require fail-closed child identity persistence must check
 /// this before spawning.
 pub const fn supports_process_tree_isolation() -> bool {
-    cfg!(unix)
+    cfg!(any(unix, windows))
 }
 
 /// Whether a PID still names a process that can execute work.
@@ -96,6 +99,12 @@ pub struct ControllerChildGuard {
     controller_liveness_fd: RawFd,
     #[cfg(unix)]
     owned_processes: Mutex<Vec<UnixProcessIdentity>>,
+    #[cfg(target_os = "linux")]
+    controller_pid: u32,
+    #[cfg(target_os = "linux")]
+    guard_pid: Mutex<Option<u32>>,
+    #[cfg(target_os = "linux")]
+    guard_id: u64,
     #[cfg(windows)]
     job: Mutex<windows_sys::Win32::Foundation::HANDLE>,
 }
@@ -106,6 +115,10 @@ impl ControllerChildGuard {
     pub fn prepare(command: &mut Command) -> io::Result<Self> {
         #[cfg(unix)]
         {
+            #[cfg(target_os = "linux")]
+            let guard_id = CHILD_GUARD_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            #[cfg(target_os = "linux")]
+            command.env("HOMEBOY_CHILD_GUARD_ID", guard_id.to_string());
             let mut fds = [-1; 2];
             if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
                 return Err(io::Error::last_os_error());
@@ -124,6 +137,12 @@ impl ControllerChildGuard {
                 controller_liveness_read_fd: fds[0],
                 controller_liveness_fd: fds[1],
                 owned_processes: Mutex::new(Vec::new()),
+                #[cfg(target_os = "linux")]
+                controller_pid: std::process::id(),
+                #[cfg(target_os = "linux")]
+                guard_pid: Mutex::new(None),
+                #[cfg(target_os = "linux")]
+                guard_id,
             })
         }
 
@@ -150,7 +169,17 @@ impl ControllerChildGuard {
                     self.controller_liveness_fd,
                     child.id(),
                 ),
-                _ => Ok(()),
+                _guard_pid => {
+                    #[cfg(target_os = "linux")]
+                    {
+                        *self
+                            .guard_pid
+                            .lock()
+                            .map_err(|_| io::Error::other("guard PID lock poisoned"))? =
+                            Some(_guard_pid as u32);
+                    }
+                    Ok(())
+                }
             }
         }
 
@@ -167,31 +196,67 @@ impl ControllerChildGuard {
         }
     }
 
-    fn terminate_and_reap(&mut self, child: &mut Child) -> io::Result<ExitStatus> {
+    fn terminate_and_reap(
+        &mut self,
+        child: &mut Child,
+        deadline: std::time::Instant,
+    ) -> io::Result<ExitStatus> {
         #[cfg(unix)]
-        return terminate_owned_processes_and_reap(child, &self.owned_processes);
+        {
+            let _ = deadline;
+            self.observe_owned_processes(child.id())?;
+            terminate_owned_processes_and_reap(child, &self.owned_processes)
+        }
 
         #[cfg(windows)]
-        self.close_windows_job(true)?;
-        #[cfg(not(unix))]
+        {
+            self.close_windows_job(true, deadline)?;
+            return reap_child_until(child, deadline);
+        }
+        #[cfg(not(any(unix, windows)))]
         terminate_process_tree_and_reap(child)
     }
 
-    fn close_after_root_exit(&mut self, root_pid: u32) -> io::Result<()> {
+    /// Synchronously clean up after a supervision infrastructure error before
+    /// the caller releases mutation ownership.
+    pub fn terminate_and_reap_bounded(&mut self, child: &mut Child) -> io::Result<ExitStatus> {
+        let deadline = std::time::Instant::now() + PROCESS_TREE_CLEANUP_DEADLINE;
+        match self.terminate_and_reap(child, deadline) {
+            Ok(status) => Ok(status),
+            Err(primary) => {
+                #[cfg(unix)]
+                let _ = signal_process_group(child.id(), libc::SIGKILL);
+                let _ = child.kill();
+                reap_child_until(child, deadline).map_err(|fallback| {
+                    io::Error::other(format!(
+                        "{primary}; direct process-group fallback also failed: {fallback}"
+                    ))
+                })
+            }
+        }
+    }
+
+    fn close_after_root_exit(
+        &mut self,
+        root_pid: u32,
+        deadline: std::time::Instant,
+    ) -> io::Result<()> {
         #[cfg(unix)]
         {
+            let _ = deadline;
+            self.observe_owned_processes(root_pid)?;
             // A short-lived root can spawn and exit between identity snapshots.
             // Its ordinary descendants remain in the isolated process group;
             // drain that group before handling tracked session escapees.
             terminate_remaining_process_group(root_pid)?;
-            return terminate_owned_processes_after_root_exit(root_pid, &self.owned_processes);
+            terminate_owned_processes_after_root_exit(root_pid, &self.owned_processes)
         }
 
         #[cfg(not(unix))]
         {
             let _ = root_pid;
             #[cfg(windows)]
-            return self.close_windows_job(true);
+            return self.close_windows_job(true, deadline);
         }
 
         #[cfg(not(any(unix, windows)))]
@@ -208,14 +273,32 @@ impl ControllerChildGuard {
             .owned_processes
             .lock()
             .map_err(|_| io::Error::other("owned process identity lock poisoned"))?;
-        extend_owned_processes(&mut owned, root_pid, &snapshot);
+        #[cfg(target_os = "linux")]
+        let adopted = Some((
+            self.controller_pid,
+            *self
+                .guard_pid
+                .lock()
+                .map_err(|_| io::Error::other("guard PID lock poisoned"))?,
+            self.guard_id,
+        ));
+        #[cfg(not(target_os = "linux"))]
+        let adopted = None;
+        extend_owned_processes(&mut owned, root_pid, &snapshot, adopted);
         Ok(())
     }
 
     #[cfg(windows)]
-    fn close_windows_job(&mut self, terminate: bool) -> io::Result<()> {
+    fn close_windows_job(
+        &mut self,
+        terminate: bool,
+        deadline: std::time::Instant,
+    ) -> io::Result<()> {
         use windows_sys::Win32::Foundation::CloseHandle;
-        use windows_sys::Win32::System::JobObjects::TerminateJobObject;
+        use windows_sys::Win32::System::JobObjects::{
+            JobObjectBasicAccountingInformation, QueryInformationJobObject, TerminateJobObject,
+            JOBOBJECT_BASIC_ACCOUNTING_INFORMATION,
+        };
 
         let mut job = self
             .job
@@ -224,16 +307,43 @@ impl ControllerChildGuard {
         if job.is_null() {
             return Ok(());
         }
-        let termination_error = if terminate && unsafe { TerminateJobObject(*job, 1) } == 0 {
-            Some(io::Error::last_os_error())
-        } else {
-            None
-        };
+        let termination_error = (terminate && unsafe { TerminateJobObject(*job, 1) } == 0)
+            .then(io::Error::last_os_error);
+        let mut drain_error = None;
+        if termination_error.is_none() {
+            loop {
+                let mut accounting = JOBOBJECT_BASIC_ACCOUNTING_INFORMATION::default();
+                let queried = unsafe {
+                    QueryInformationJobObject(
+                        *job,
+                        JobObjectBasicAccountingInformation,
+                        (&mut accounting as *mut JOBOBJECT_BASIC_ACCOUNTING_INFORMATION).cast(),
+                        std::mem::size_of_val(&accounting) as u32,
+                        std::ptr::null_mut(),
+                    )
+                };
+                if queried == 0 {
+                    drain_error = Some(io::Error::last_os_error());
+                    break;
+                }
+                if accounting.ActiveProcesses == 0 {
+                    break;
+                }
+                if std::time::Instant::now() >= deadline {
+                    drain_error = Some(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "Windows process job remained active at cleanup deadline",
+                    ));
+                    break;
+                }
+                thread::sleep(PROCESS_TREE_POLL_INTERVAL);
+            }
+        }
         unsafe {
             CloseHandle(*job);
         }
         *job = std::ptr::null_mut();
-        termination_error.map_or(Ok(()), Err)
+        termination_error.or(drain_error).map_or(Ok(()), Err)
     }
 }
 
@@ -768,24 +878,32 @@ pub fn wait_with_bounded_output_supervised_guarded(
     });
     let started = std::time::Instant::now();
     let mut last_heartbeat = started.checked_sub(heartbeat_interval).unwrap_or(started);
-    let (status, termination) = loop {
+    let supervision: io::Result<_> = loop {
         #[cfg(unix)]
-        guard.observe_owned_processes(child.id())?;
-        if let Some(status) = child.try_wait()? {
-            guard.close_after_root_exit(child.id())?;
-            break (status, SupervisedCommandTermination::Completed);
+        if let Err(error) = guard.observe_owned_processes(child.id()) {
+            break Err(error);
+        }
+        let status = match child.try_wait() {
+            Ok(status) => status,
+            Err(error) => break Err(error),
+        };
+        if let Some(status) = status {
+            let deadline = std::time::Instant::now() + PROCESS_TREE_CLEANUP_DEADLINE;
+            break guard
+                .close_after_root_exit(child.id(), deadline)
+                .map(|()| (status, SupervisedCommandTermination::Completed, deadline));
         }
         if is_cancelled() {
-            break (
-                guard.terminate_and_reap(child)?,
-                SupervisedCommandTermination::Cancelled,
-            );
+            let deadline = std::time::Instant::now() + PROCESS_TREE_CLEANUP_DEADLINE;
+            break guard
+                .terminate_and_reap(child, deadline)
+                .map(|status| (status, SupervisedCommandTermination::Cancelled, deadline));
         }
         if started.elapsed() >= timeout {
-            break (
-                guard.terminate_and_reap(child)?,
-                SupervisedCommandTermination::TimedOut,
-            );
+            let deadline = std::time::Instant::now() + PROCESS_TREE_CLEANUP_DEADLINE;
+            break guard
+                .terminate_and_reap(child, deadline)
+                .map(|status| (status, SupervisedCommandTermination::TimedOut, deadline));
         }
         if last_heartbeat.elapsed() >= heartbeat_interval {
             let heartbeat = live_output
@@ -793,19 +911,37 @@ pub fn wait_with_bounded_output_supervised_guarded(
                 .map(|tail| tail.heartbeat(started.elapsed()))
                 .unwrap_or_default();
             if let Err(error) = on_heartbeat(heartbeat.elapsed, &heartbeat.output_tail) {
-                return match guard.terminate_and_reap(child) {
-                    Ok(_) => Err(error),
-                    Err(cleanup_error) => Err(io::Error::other(format!(
+                let deadline = std::time::Instant::now() + PROCESS_TREE_CLEANUP_DEADLINE;
+                break Err(match guard.terminate_and_reap(child, deadline) {
+                    Ok(_) => error,
+                    Err(cleanup_error) => io::Error::other(format!(
                         "{error}; failed to terminate guarded child after heartbeat failure: {cleanup_error}"
-                    ))),
-                };
+                    )),
+                });
             }
             last_heartbeat = std::time::Instant::now();
         }
         thread::sleep(Duration::from_millis(50));
     };
-    let stdout = join_capture_bounded(stdout_handle, CAPTURE_JOIN_GRACE)?;
-    let stderr = join_capture_bounded(stderr_handle, CAPTURE_JOIN_GRACE)?;
+    let (status, termination, cleanup_deadline) = match supervision {
+        Ok(supervision) => supervision,
+        Err(primary) => {
+            let deadline = std::time::Instant::now() + PROCESS_TREE_CLEANUP_DEADLINE;
+            let cleanup = guard.terminate_and_reap_bounded(child).err();
+            let capture = join_capture_pair(stdout_handle, stderr_handle, deadline).err();
+            return Err(io::Error::other(format!(
+                "{primary}{}{}",
+                cleanup
+                    .map(|error| format!("; guarded cleanup failed: {error}"))
+                    .unwrap_or_default(),
+                capture
+                    .map(|error| format!("; output cleanup failed: {error}"))
+                    .unwrap_or_default(),
+            )));
+        }
+    };
+    let capture_deadline = cleanup_deadline.min(std::time::Instant::now() + CAPTURE_JOIN_GRACE);
+    let (stdout, stderr) = join_capture_pair(stdout_handle, stderr_handle, capture_deadline)?;
     Ok(SupervisedCommandOutput {
         output: BoundedCommandOutput {
             status,
@@ -818,6 +954,22 @@ pub fn wait_with_bounded_output_supervised_guarded(
         },
         termination,
     })
+}
+
+fn join_capture_pair(
+    stdout: Option<thread::JoinHandle<io::Result<BoundedStreamCapture>>>,
+    stderr: Option<thread::JoinHandle<io::Result<BoundedStreamCapture>>>,
+    deadline: std::time::Instant,
+) -> io::Result<(BoundedStreamCapture, BoundedStreamCapture)> {
+    let stdout = join_capture_bounded(stdout, deadline);
+    let stderr = join_capture_bounded(stderr, deadline);
+    match (stdout, stderr) {
+        (Ok(stdout), Ok(stderr)) => Ok((stdout, stderr)),
+        (Err(stdout), Err(stderr)) => Err(io::Error::other(format!(
+            "stdout capture cleanup failed: {stdout}; stderr capture cleanup failed: {stderr}"
+        ))),
+        (Err(error), _) | (_, Err(error)) => Err(error),
+    }
 }
 
 /// Supervise a command with wall-clock and optional structured-progress
@@ -847,6 +999,7 @@ pub fn wait_with_bounded_output_supervised_with_progress(
 
 /// Supervise a command with optional structured progress and an immediate
 /// bounded-output stream tee.
+#[allow(clippy::too_many_arguments)]
 pub fn wait_with_bounded_output_supervised_with_progress_and_passthrough(
     child: &mut Child,
     byte_limit: usize,
@@ -1190,6 +1343,7 @@ fn extend_owned_processes(
     owned: &mut Vec<UnixProcessIdentity>,
     root_pid: u32,
     snapshot: &[UnixProcessIdentity],
+    adopted: Option<(u32, Option<u32>, u64)>,
 ) {
     if owned.is_empty() {
         if let Some(root) = snapshot.iter().find(|process| process.pid == root_pid) {
@@ -1202,7 +1356,13 @@ fn extend_owned_processes(
             if owned.iter().any(|known| known.pid == process.pid) {
                 continue;
             }
-            if owned.iter().any(|known| known.pid == process.parent_pid) {
+            let adopted_descendant =
+                adopted.is_some_and(|(controller_pid, guard_pid, guard_id)| {
+                    process.parent_pid == controller_pid
+                        && Some(process.pid) != guard_pid
+                        && process_has_guard_id(process.pid, guard_id)
+                });
+            if adopted_descendant || owned.iter().any(|known| known.pid == process.parent_pid) {
                 owned.push(process.clone());
                 changed = true;
             }
@@ -1211,6 +1371,23 @@ fn extend_owned_processes(
             break;
         }
     }
+}
+
+#[cfg(target_os = "linux")]
+fn process_has_guard_id(pid: u32, guard_id: u64) -> bool {
+    let expected = format!("HOMEBOY_CHILD_GUARD_ID={guard_id}");
+    std::fs::read(format!("/proc/{pid}/environ"))
+        .ok()
+        .is_some_and(|environment| {
+            environment
+                .split(|byte| *byte == 0)
+                .any(|entry| entry == expected.as_bytes())
+        })
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn process_has_guard_id(_pid: u32, _guard_id: u64) -> bool {
+    false
 }
 
 #[cfg(unix)]
@@ -1233,7 +1410,7 @@ fn signal_owned_processes(
     signal: libc::c_int,
 ) -> io::Result<Vec<u32>> {
     let snapshot = unix_process_snapshot()?;
-    extend_owned_processes(owned, root_pid, &snapshot);
+    extend_owned_processes(owned, root_pid, &snapshot, None);
     let pids = live_owned_pids(owned, &snapshot);
     signal_pids(&pids, signal);
     Ok(pids)
@@ -1323,7 +1500,7 @@ fn wait_for_owned_process_exit(
     let deadline = std::time::Instant::now() + grace;
     loop {
         let snapshot = unix_process_snapshot()?;
-        extend_owned_processes(owned, root_pid, &snapshot);
+        extend_owned_processes(owned, root_pid, &snapshot, None);
         signal_pids(&live_owned_pids(owned, &snapshot), signal);
         if status.is_none() {
             *status = child.try_wait()?;
@@ -1349,7 +1526,7 @@ fn wait_for_owned_process_exit_without_child(
     let deadline = std::time::Instant::now() + grace;
     loop {
         let snapshot = unix_process_snapshot()?;
-        extend_owned_processes(owned, root_pid, &snapshot);
+        extend_owned_processes(owned, root_pid, &snapshot, None);
         signal_pids(&live_owned_pids(owned, &snapshot), signal);
         reap_exited_process_group_children(root_pid);
         if live_owned_pids(owned, &snapshot).is_empty() {
@@ -1712,7 +1889,28 @@ pub fn terminate_process_tree_and_reap(child: &mut Child) -> io::Result<ExitStat
                 return Err(error);
             }
         }
-        child.wait()
+        reap_child_until(
+            child,
+            std::time::Instant::now() + PROCESS_TREE_CLEANUP_DEADLINE,
+        )
+    }
+}
+
+fn reap_child_until(child: &mut Child, deadline: std::time::Instant) -> io::Result<ExitStatus> {
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(status);
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!(
+                    "child {} was not reaped before cleanup deadline",
+                    child.id()
+                ),
+            ));
+        }
+        thread::sleep(Duration::from_millis(10));
     }
 }
 
@@ -1760,7 +1958,7 @@ fn join_capture(
 
 fn join_capture_bounded(
     handle: Option<thread::JoinHandle<io::Result<BoundedStreamCapture>>>,
-    timeout: Duration,
+    deadline: std::time::Instant,
 ) -> io::Result<BoundedStreamCapture> {
     let Some(handle) = handle else {
         return Ok(BoundedStreamCapture {
@@ -1768,28 +1966,23 @@ fn join_capture_bounded(
             metadata: CaptureMetadata::default(),
         });
     };
-    let (sender, receiver) = std::sync::mpsc::sync_channel(1);
-    thread::spawn(move || {
-        let result = handle
-            .join()
-            .map_err(|_| io::Error::other("capture thread panicked"))
-            .and_then(|result| result);
-        let _ = sender.send(result);
-    });
-    receiver
-        .recv_timeout(timeout)
-        .map_err(|error| match error {
-            std::sync::mpsc::RecvTimeoutError::Timeout => io::Error::new(
-                io::ErrorKind::TimedOut,
-                format!(
-                    "capture reader did not close within {}ms",
-                    timeout.as_millis()
-                ),
-            ),
-            std::sync::mpsc::RecvTimeoutError::Disconnected => {
-                io::Error::other("capture join channel disconnected")
+    while !handle.is_finished() {
+        if std::time::Instant::now() >= deadline {
+            #[cfg(windows)]
+            unsafe {
+                use std::os::windows::io::AsRawHandle;
+                windows_sys::Win32::System::IO::CancelSynchronousIo(handle.as_raw_handle().cast());
             }
-        })?
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "capture reader did not close before cleanup deadline",
+            ));
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    handle
+        .join()
+        .map_err(|_| io::Error::other("capture thread panicked"))?
 }
 
 fn capture_tail(mut stream: impl Read, byte_limit: usize) -> io::Result<BoundedStreamCapture> {

--- a/crates/homeboy-engine-primitives/src/command.rs
+++ b/crates/homeboy-engine-primitives/src/command.rs
@@ -21,6 +21,7 @@ const PROCESS_TREE_TERM_GRACE: Duration = Duration::from_secs(2);
 const PROCESS_TREE_KILL_GRACE: Duration = Duration::from_secs(2);
 #[cfg(unix)]
 const PROCESS_TREE_POLL_INTERVAL: Duration = Duration::from_millis(25);
+const CAPTURE_JOIN_GRACE: Duration = Duration::from_secs(2);
 
 #[cfg(target_os = "linux")]
 static CHILD_SUBREAPER_ENABLED: std::sync::OnceLock<io::Result<()>> = std::sync::OnceLock::new();
@@ -93,6 +94,8 @@ pub struct ControllerChildGuard {
     controller_liveness_read_fd: RawFd,
     #[cfg(unix)]
     controller_liveness_fd: RawFd,
+    #[cfg(unix)]
+    owned_processes: Mutex<Vec<UnixProcessIdentity>>,
     #[cfg(windows)]
     job: Mutex<windows_sys::Win32::Foundation::HANDLE>,
 }
@@ -120,6 +123,7 @@ impl ControllerChildGuard {
             Ok(Self {
                 controller_liveness_read_fd: fds[0],
                 controller_liveness_fd: fds[1],
+                owned_processes: Mutex::new(Vec::new()),
             })
         }
 
@@ -137,14 +141,17 @@ impl ControllerChildGuard {
     /// standard library's private spawn error pipe.
     pub fn attach(&self, child: &Child) -> io::Result<()> {
         #[cfg(unix)]
-        match unsafe { libc::fork() } {
-            -1 => Err(io::Error::last_os_error()),
-            0 => controller_death_guard_loop(
-                self.controller_liveness_read_fd,
-                self.controller_liveness_fd,
-                child.id(),
-            ),
-            _ => Ok(()),
+        {
+            self.observe_owned_processes(child.id())?;
+            match unsafe { libc::fork() } {
+                -1 => Err(io::Error::last_os_error()),
+                0 => controller_death_guard_loop(
+                    self.controller_liveness_read_fd,
+                    self.controller_liveness_fd,
+                    child.id(),
+                ),
+                _ => Ok(()),
+            }
         }
 
         #[cfg(not(unix))]
@@ -158,6 +165,75 @@ impl ControllerChildGuard {
                 Ok(())
             }
         }
+    }
+
+    fn terminate_and_reap(&mut self, child: &mut Child) -> io::Result<ExitStatus> {
+        #[cfg(unix)]
+        return terminate_owned_processes_and_reap(child, &self.owned_processes);
+
+        #[cfg(windows)]
+        self.close_windows_job(true)?;
+        #[cfg(not(unix))]
+        terminate_process_tree_and_reap(child)
+    }
+
+    fn close_after_root_exit(&mut self, root_pid: u32) -> io::Result<()> {
+        #[cfg(unix)]
+        {
+            // A short-lived root can spawn and exit between identity snapshots.
+            // Its ordinary descendants remain in the isolated process group;
+            // drain that group before handling tracked session escapees.
+            terminate_remaining_process_group(root_pid)?;
+            return terminate_owned_processes_after_root_exit(root_pid, &self.owned_processes);
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = root_pid;
+            #[cfg(windows)]
+            return self.close_windows_job(true);
+        }
+
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = root_pid;
+            Ok(())
+        }
+    }
+
+    #[cfg(unix)]
+    fn observe_owned_processes(&self, root_pid: u32) -> io::Result<()> {
+        let snapshot = unix_process_snapshot()?;
+        let mut owned = self
+            .owned_processes
+            .lock()
+            .map_err(|_| io::Error::other("owned process identity lock poisoned"))?;
+        extend_owned_processes(&mut owned, root_pid, &snapshot);
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    fn close_windows_job(&mut self, terminate: bool) -> io::Result<()> {
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::System::JobObjects::TerminateJobObject;
+
+        let mut job = self
+            .job
+            .lock()
+            .map_err(|_| io::Error::other("controller job handle lock poisoned"))?;
+        if job.is_null() {
+            return Ok(());
+        }
+        let termination_error = if terminate && unsafe { TerminateJobObject(*job, 1) } == 0 {
+            Some(io::Error::last_os_error())
+        } else {
+            None
+        };
+        unsafe {
+            CloseHandle(*job);
+        }
+        *job = std::ptr::null_mut();
+        termination_error.map_or(Ok(()), Err)
     }
 }
 
@@ -228,25 +304,88 @@ fn controller_death_guard_loop(read_fd: RawFd, write_fd: RawFd, process_group: u
     // timeout instead of running. Close everything except the liveness read
     // end, which is the only descriptor this loop uses.
     close_inherited_descriptors_except(read_fd);
-    if unsafe { libc::setpgid(0, process_group as libc::pid_t) } != 0 {
-        unsafe {
-            libc::_exit(1);
-        }
-    }
     let mut byte = 0_u8;
     loop {
         let read = unsafe { libc::read(read_fd, (&mut byte as *mut u8).cast(), 1) };
         if read == 0 {
-            unsafe {
-                libc::kill(-(process_group as libc::pid_t), libc::SIGKILL);
-                libc::_exit(0);
-            }
+            controller_death_cleanup(process_group);
         }
         if read < 0 && io::Error::last_os_error().kind() != io::ErrorKind::Interrupted {
             unsafe {
                 libc::_exit(1);
             }
         }
+    }
+}
+
+/// The death watcher is already a single-threaded fork child. Exec a standalone
+/// shell so process discovery can allocate safely while repeatedly tracking
+/// descendants by both PID and kernel-reported start time. The root is still
+/// alive when controller death closes the pipe, so session/group escapees remain
+/// connected through PPID for the first snapshot.
+#[cfg(unix)]
+fn controller_death_cleanup(root_pid: u32) -> ! {
+    const SCRIPT: &str = concat!(
+        r#"
+set -eu
+root=$1
+state=${TMPDIR:-/tmp}/homeboy-child-guard-$$
+snapshot=$state.snapshot
+trap 'rm -f "$state" "$snapshot"' EXIT
+: > "$state"
+discover() {
+  /bin/ps -axo pid=,ppid=,lstart= > "$snapshot"
+  /usr/bin/awk -v root="$root" '
+    FILENAME==ARGV[1] { owned[$1 FS $2 FS $3 FS $4 FS $5 FS $6]=1; next }
+    { pid=$1; ppid=$2; ident=$3 FS $4 FS $5 FS $6 FS $7; row[pid]=ident; parent[pid]=ppid }
+    END {
+      if (length(owned)==0 && row[root]!="") owned[root FS row[root]]=1
+      changed=1
+      while (changed) {
+        changed=0
+        for (pid in row) {
+          for (key in owned) {
+            split(key, fields, FS)
+            if (parent[pid]==fields[1] && !((pid FS row[pid]) in owned)) {
+              owned[pid FS row[pid]]=1; changed=1
+            }
+          }
+        }
+      }
+      for (key in owned) print key
+    }
+  ' "$state" "$snapshot" > "$state.next"
+  mv "$state.next" "$state"
+}
+signal_owned() {
+  sig=$1
+  discover
+  /usr/bin/awk 'FILENAME==ARGV[1] { current[$1]=$3 FS $4 FS $5 FS $6 FS $7; next }
+    { pid=$1; ident=$2 FS $3 FS $4 FS $5 FS $6; if (current[pid]==ident) print pid }
+  ' "$snapshot" "$state" | while read -r pid; do kill -"$sig" "$pid" 2>/dev/null || true; done
+}
+for _ in 1 2 3 4 5 6 7 8; do signal_owned TERM; sleep .025; done
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do signal_owned KILL; sleep .025; done
+discover
+/usr/bin/awk 'FILENAME==ARGV[1] { current[$1]=$3 FS $4 FS $5 FS $6 FS $7; next }
+  { pid=$1; ident=$2 FS $3 FS $4 FS $5 FS $6; if (current[pid]==ident) exit 1 }
+' "$snapshot" "$state"
+"#,
+        "\0"
+    );
+    let root = std::ffi::CString::new(root_pid.to_string()).expect("pid has no NUL");
+    unsafe {
+        libc::execl(
+            c"/bin/sh".as_ptr(),
+            c"sh".as_ptr(),
+            c"-c".as_ptr(),
+            SCRIPT.as_ptr().cast::<libc::c_char>(),
+            c"homeboy-child-guard".as_ptr(),
+            root.as_ptr(),
+            std::ptr::null::<libc::c_char>(),
+        );
+        libc::kill(-(root_pid as libc::pid_t), libc::SIGKILL);
+        libc::_exit(1);
     }
 }
 
@@ -596,6 +735,91 @@ pub fn wait_with_bounded_output_supervised_with_passthrough(
     )
 }
 
+/// Supervise a child whose platform containment must be closed before output
+/// readers are joined. This is required for Windows jobs, where descendants can
+/// otherwise retain inherited pipe handles after the direct child exits.
+pub fn wait_with_bounded_output_supervised_guarded(
+    child: &mut Child,
+    guard: &mut ControllerChildGuard,
+    byte_limit: usize,
+    timeout: Duration,
+    heartbeat_interval: Duration,
+    mut is_cancelled: impl FnMut() -> bool,
+    mut on_heartbeat: impl FnMut(Duration, &str) -> io::Result<()>,
+) -> io::Result<SupervisedCommandOutput> {
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+    let live_output = Arc::new(Mutex::new(LiveOutputTail::new(byte_limit)));
+    let stdout_handle = stdout.map({
+        let live_output = Arc::clone(&live_output);
+        move |stream| {
+            thread::spawn(move || {
+                capture_tail_with_live_snapshot(stream, byte_limit, true, live_output)
+            })
+        }
+    });
+    let stderr_handle = stderr.map({
+        let live_output = Arc::clone(&live_output);
+        move |stream| {
+            thread::spawn(move || {
+                capture_tail_with_live_snapshot(stream, byte_limit, false, live_output)
+            })
+        }
+    });
+    let started = std::time::Instant::now();
+    let mut last_heartbeat = started.checked_sub(heartbeat_interval).unwrap_or(started);
+    let (status, termination) = loop {
+        #[cfg(unix)]
+        guard.observe_owned_processes(child.id())?;
+        if let Some(status) = child.try_wait()? {
+            guard.close_after_root_exit(child.id())?;
+            break (status, SupervisedCommandTermination::Completed);
+        }
+        if is_cancelled() {
+            break (
+                guard.terminate_and_reap(child)?,
+                SupervisedCommandTermination::Cancelled,
+            );
+        }
+        if started.elapsed() >= timeout {
+            break (
+                guard.terminate_and_reap(child)?,
+                SupervisedCommandTermination::TimedOut,
+            );
+        }
+        if last_heartbeat.elapsed() >= heartbeat_interval {
+            let heartbeat = live_output
+                .lock()
+                .map(|tail| tail.heartbeat(started.elapsed()))
+                .unwrap_or_default();
+            if let Err(error) = on_heartbeat(heartbeat.elapsed, &heartbeat.output_tail) {
+                return match guard.terminate_and_reap(child) {
+                    Ok(_) => Err(error),
+                    Err(cleanup_error) => Err(io::Error::other(format!(
+                        "{error}; failed to terminate guarded child after heartbeat failure: {cleanup_error}"
+                    ))),
+                };
+            }
+            last_heartbeat = std::time::Instant::now();
+        }
+        thread::sleep(Duration::from_millis(50));
+    };
+    let stdout = join_capture_bounded(stdout_handle, CAPTURE_JOIN_GRACE)?;
+    let stderr = join_capture_bounded(stderr_handle, CAPTURE_JOIN_GRACE)?;
+    Ok(SupervisedCommandOutput {
+        output: BoundedCommandOutput {
+            status,
+            stdout: stdout.bytes,
+            stderr: stderr.bytes,
+            capture: CommandCaptureMetadata {
+                stdout: stdout.metadata,
+                stderr: stderr.metadata,
+            },
+        },
+        termination,
+    })
+}
+
 /// Supervise a command with wall-clock and optional structured-progress
 /// deadlines. `no_progress_timeout` is measured from spawn until the first
 /// valid `HOMEBOY_PROGRESS` marker and between subsequent markers. Ordinary
@@ -882,8 +1106,8 @@ pub fn isolate_process_tree(command: &mut Command) {
     }
 }
 
+#[cfg(unix)]
 fn signal_process_group(root_pid: u32, signal: libc::c_int) -> io::Result<()> {
-    #[cfg(unix)]
     unsafe {
         let pgid = -(root_pid as libc::pid_t);
         if libc::kill(pgid, signal) != 0 {
@@ -893,14 +1117,6 @@ fn signal_process_group(root_pid: u32, signal: libc::c_int) -> io::Result<()> {
             }
         }
         Ok(())
-    }
-
-    #[cfg(not(unix))]
-    {
-        let _ = (root_pid, signal);
-        Err(io::Error::other(
-            "process tree cancellation is not implemented on this platform",
-        ))
     }
 }
 
@@ -931,6 +1147,219 @@ fn descendant_pids(root_pid: u32) -> io::Result<Vec<u32>> {
         cursor += 1;
     }
     Ok(descendants)
+}
+
+#[cfg(unix)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct UnixProcessIdentity {
+    pid: u32,
+    parent_pid: u32,
+    started_at: String,
+}
+
+#[cfg(unix)]
+fn unix_process_snapshot() -> io::Result<Vec<UnixProcessIdentity>> {
+    let output = Command::new("ps")
+        .env("PATH", "/usr/bin:/bin")
+        .args(["-axo", "pid=,ppid=,lstart="])
+        .output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "process identity discovery failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let fields = line.split_whitespace().collect::<Vec<_>>();
+            if fields.len() < 7 {
+                return None;
+            }
+            Some(UnixProcessIdentity {
+                pid: fields[0].parse().ok()?,
+                parent_pid: fields[1].parse().ok()?,
+                started_at: fields[2..7].join(" "),
+            })
+        })
+        .collect())
+}
+
+#[cfg(unix)]
+fn extend_owned_processes(
+    owned: &mut Vec<UnixProcessIdentity>,
+    root_pid: u32,
+    snapshot: &[UnixProcessIdentity],
+) {
+    if owned.is_empty() {
+        if let Some(root) = snapshot.iter().find(|process| process.pid == root_pid) {
+            owned.push(root.clone());
+        }
+    }
+    loop {
+        let mut changed = false;
+        for process in snapshot {
+            if owned.iter().any(|known| known.pid == process.pid) {
+                continue;
+            }
+            if owned.iter().any(|known| known.pid == process.parent_pid) {
+                owned.push(process.clone());
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+}
+
+#[cfg(unix)]
+fn live_owned_pids(owned: &[UnixProcessIdentity], snapshot: &[UnixProcessIdentity]) -> Vec<u32> {
+    owned
+        .iter()
+        .filter_map(|known| {
+            snapshot
+                .iter()
+                .any(|process| process.pid == known.pid && process.started_at == known.started_at)
+                .then_some(known.pid)
+        })
+        .collect()
+}
+
+#[cfg(unix)]
+fn signal_owned_processes(
+    owned: &mut Vec<UnixProcessIdentity>,
+    root_pid: u32,
+    signal: libc::c_int,
+) -> io::Result<Vec<u32>> {
+    let snapshot = unix_process_snapshot()?;
+    extend_owned_processes(owned, root_pid, &snapshot);
+    let pids = live_owned_pids(owned, &snapshot);
+    signal_pids(&pids, signal);
+    Ok(pids)
+}
+
+#[cfg(unix)]
+fn terminate_owned_processes_and_reap(
+    child: &mut Child,
+    owned_processes: &Mutex<Vec<UnixProcessIdentity>>,
+) -> io::Result<ExitStatus> {
+    enable_child_subreaper()?;
+    let root_pid = child.id();
+    let mut owned = owned_processes
+        .lock()
+        .map_err(|_| io::Error::other("owned process identity lock poisoned"))?;
+    signal_process_group(root_pid, libc::SIGTERM)?;
+    signal_owned_processes(&mut owned, root_pid, libc::SIGTERM)?;
+    let mut status = child.try_wait()?;
+    if !wait_for_owned_process_exit(
+        child,
+        root_pid,
+        &mut owned,
+        PROCESS_TREE_TERM_GRACE,
+        libc::SIGTERM,
+        &mut status,
+    )? {
+        signal_process_group(root_pid, libc::SIGKILL)?;
+        signal_owned_processes(&mut owned, root_pid, libc::SIGKILL)?;
+        if !wait_for_owned_process_exit(
+            child,
+            root_pid,
+            &mut owned,
+            PROCESS_TREE_KILL_GRACE,
+            libc::SIGKILL,
+            &mut status,
+        )? {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!("owned process tree {root_pid} remained alive after SIGKILL"),
+            ));
+        }
+    }
+    status.map(Ok).unwrap_or_else(|| child.wait())
+}
+
+#[cfg(unix)]
+fn terminate_owned_processes_after_root_exit(
+    root_pid: u32,
+    owned_processes: &Mutex<Vec<UnixProcessIdentity>>,
+) -> io::Result<()> {
+    let mut owned = owned_processes
+        .lock()
+        .map_err(|_| io::Error::other("owned process identity lock poisoned"))?;
+    signal_owned_processes(&mut owned, root_pid, libc::SIGTERM)?;
+    if wait_for_owned_process_exit_without_child(
+        root_pid,
+        &mut owned,
+        PROCESS_TREE_TERM_GRACE,
+        libc::SIGTERM,
+    )? {
+        return Ok(());
+    }
+    signal_owned_processes(&mut owned, root_pid, libc::SIGKILL)?;
+    if wait_for_owned_process_exit_without_child(
+        root_pid,
+        &mut owned,
+        PROCESS_TREE_KILL_GRACE,
+        libc::SIGKILL,
+    )? {
+        return Ok(());
+    }
+    Err(io::Error::new(
+        io::ErrorKind::TimedOut,
+        format!("owned process tree {root_pid} remained alive after root exit"),
+    ))
+}
+
+#[cfg(unix)]
+fn wait_for_owned_process_exit(
+    child: &mut Child,
+    root_pid: u32,
+    owned: &mut Vec<UnixProcessIdentity>,
+    grace: Duration,
+    signal: libc::c_int,
+    status: &mut Option<ExitStatus>,
+) -> io::Result<bool> {
+    let deadline = std::time::Instant::now() + grace;
+    loop {
+        let snapshot = unix_process_snapshot()?;
+        extend_owned_processes(owned, root_pid, &snapshot);
+        signal_pids(&live_owned_pids(owned, &snapshot), signal);
+        if status.is_none() {
+            *status = child.try_wait()?;
+        }
+        reap_exited_process_group_children(root_pid);
+        if live_owned_pids(owned, &snapshot).is_empty() {
+            return Ok(true);
+        }
+        if std::time::Instant::now() >= deadline {
+            return Ok(false);
+        }
+        thread::sleep(PROCESS_TREE_POLL_INTERVAL);
+    }
+}
+
+#[cfg(unix)]
+fn wait_for_owned_process_exit_without_child(
+    root_pid: u32,
+    owned: &mut Vec<UnixProcessIdentity>,
+    grace: Duration,
+    signal: libc::c_int,
+) -> io::Result<bool> {
+    let deadline = std::time::Instant::now() + grace;
+    loop {
+        let snapshot = unix_process_snapshot()?;
+        extend_owned_processes(owned, root_pid, &snapshot);
+        signal_pids(&live_owned_pids(owned, &snapshot), signal);
+        reap_exited_process_group_children(root_pid);
+        if live_owned_pids(owned, &snapshot).is_empty() {
+            return Ok(true);
+        }
+        if std::time::Instant::now() >= deadline {
+            return Ok(false);
+        }
+        thread::sleep(PROCESS_TREE_POLL_INTERVAL);
+    }
 }
 
 #[cfg(unix)]
@@ -1182,13 +1611,14 @@ mod supervisor_zombie_guard_tests {
         command.args(["-c", "sleep 5"]);
         command.stdout(Stdio::piped()).stderr(Stdio::piped());
 
-        let guard = ControllerChildGuard::prepare(&mut command).expect("prepare guard");
+        let mut guard = ControllerChildGuard::prepare(&mut command).expect("prepare guard");
         let mut child = command.spawn().expect("spawn child");
         guard.attach(&child).expect("attach guard");
 
         let started = Instant::now();
-        let supervised = wait_with_bounded_output_supervised(
+        let supervised = wait_with_bounded_output_supervised_guarded(
             &mut child,
+            &mut guard,
             4096,
             Duration::from_millis(50),
             Duration::from_millis(50),
@@ -1326,6 +1756,40 @@ fn join_capture(
             metadata: CaptureMetadata::default(),
         }),
     }
+}
+
+fn join_capture_bounded(
+    handle: Option<thread::JoinHandle<io::Result<BoundedStreamCapture>>>,
+    timeout: Duration,
+) -> io::Result<BoundedStreamCapture> {
+    let Some(handle) = handle else {
+        return Ok(BoundedStreamCapture {
+            bytes: Vec::new(),
+            metadata: CaptureMetadata::default(),
+        });
+    };
+    let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+    thread::spawn(move || {
+        let result = handle
+            .join()
+            .map_err(|_| io::Error::other("capture thread panicked"))
+            .and_then(|result| result);
+        let _ = sender.send(result);
+    });
+    receiver
+        .recv_timeout(timeout)
+        .map_err(|error| match error {
+            std::sync::mpsc::RecvTimeoutError::Timeout => io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!(
+                    "capture reader did not close within {}ms",
+                    timeout.as_millis()
+                ),
+            ),
+            std::sync::mpsc::RecvTimeoutError::Disconnected => {
+                io::Error::other("capture join channel disconnected")
+            }
+        })?
 }
 
 fn capture_tail(mut stream: impl Read, byte_limit: usize) -> io::Result<BoundedStreamCapture> {

--- a/crates/homeboy-upgrade/Cargo.toml
+++ b/crates/homeboy-upgrade/Cargo.toml
@@ -19,6 +19,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 semver = "1.0"
 regex = "1.11"
+sha2 = "0.10.9"
 toml = "1.0.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls", "socks", "http2", "charset", "system-proxy"] }
 libc = "0.2"

--- a/crates/homeboy-upgrade/src/upgrade/execution.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution.rs
@@ -4,7 +4,8 @@ use homeboy_core::error::{Error, Result};
 use homeboy_core::git::{run_git, run_git_output};
 use homeboy_core::stream_capture::StreamCaptureMetadata;
 use homeboy_engine_primitives::command::{
-    terminate_process_tree_and_reap, terminate_remaining_process_group, ControllerChildGuard,
+    terminate_process_tree_and_reap, terminate_remaining_process_group,
+    wait_with_bounded_output_supervised, ControllerChildGuard, SupervisedCommandTermination,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -14,6 +15,8 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
+#[cfg(unix)]
+use std::{io, os::fd::RawFd};
 
 use super::constants::{
     RELEASE_TAG_ENV, RELEASE_VERSION_ENV, VERIFY_READBACK_ATTEMPTS, VERIFY_READBACK_DELAY,
@@ -30,6 +33,8 @@ use super::types::InstallMethod;
 /// `agent_task_promotion` / runner exec captures (#5297).
 const UPGRADE_CAPTURE_LIMIT_BYTES: usize = 65_536;
 const SOURCE_UPGRADE_TIMEOUT: Duration = Duration::from_secs(20 * 60);
+const INSTALLER_UPGRADE_TIMEOUT: Duration = Duration::from_secs(20 * 60);
+const INSTALLER_SUPERVISION_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const CLEANUP_ERROR_CONTEXT_LIMIT_CHARS: usize = 1_024;
 
 /// Environment variable set in the shell child's environment and checked at the
@@ -231,20 +236,25 @@ pub(crate) fn execute_upgrade(
     let output = match method {
         InstallMethod::Homebrew => {
             let cmd = &defaults.install_methods.homebrew.upgrade_command;
-            Command::new("sh").args(["-c", cmd]).output().map_err(|e| {
-                Error::internal_io(e.to_string(), Some("run homebrew upgrade".to_string()))
-            })?
+            run_installer_shell_command(
+                cmd,
+                promotion_lease,
+                INSTALLER_UPGRADE_TIMEOUT,
+                "run homebrew upgrade",
+                |_| {},
+            )?
         }
         InstallMethod::Secondary => {
             // Legacy cargo-installed binaries are replaced with the release
             // asset now that Homeboy's private workspace is not on crates.io.
             let cmd = &defaults.install_methods.binary.upgrade_command;
-            Command::new("sh").args(["-c", cmd]).output().map_err(|e| {
-                Error::internal_io(
-                    e.to_string(),
-                    Some("run release binary upgrade".to_string()),
-                )
-            })?
+            run_installer_shell_command(
+                cmd,
+                promotion_lease,
+                INSTALLER_UPGRADE_TIMEOUT,
+                "run release binary upgrade",
+                |_| {},
+            )?
         }
         InstallMethod::Source => {
             if env::var_os(REENTRANCY_GUARD_ENV).is_some() {
@@ -305,17 +315,24 @@ pub(crate) fn execute_upgrade(
             // the pin the installer always resolves `latest/download`, so a
             // newest release missing this target's asset is unreachable past —
             // there is no older release the operator can be moved to (#11750).
-            let mut command = Command::new("sh");
-            command.args(["-c", cmd]);
-            if let Some(release) = selected_release {
-                command.env(RELEASE_TAG_ENV, &release.tag);
-                command.env(RELEASE_VERSION_ENV, &release.version);
-            }
-            match command.output() {
+            match run_installer_shell_command(
+                cmd,
+                promotion_lease,
+                INSTALLER_UPGRADE_TIMEOUT,
+                "run binary upgrade",
+                |command| {
+                    if let Some(release) = selected_release {
+                        command.env(RELEASE_TAG_ENV, &release.tag);
+                        command.env(RELEASE_VERSION_ENV, &release.version);
+                    }
+                },
+            ) {
                 Ok(output) => output,
                 Err(error) => {
                     if let Some(checkpoint) = binary_checkpoint.as_ref() {
-                        replacement_checkpoint(&checkpoint.with_state("not_applied"))?;
+                        replacement_checkpoint(
+                            &checkpoint.with_state(replacement_observed_state(checkpoint)?),
+                        )?;
                     }
                     return Err(Error::internal_io(
                         error.to_string(),
@@ -422,6 +439,221 @@ pub(crate) fn execute_upgrade(
     // believe the roll-forward succeeded. Fail loudly with an actionable reason
     // so urgent source fixes are not silently dropped (#5772).
     Ok((success, new_version, new_build_identity, None, false))
+}
+
+fn run_installer_shell_command(
+    script: &str,
+    promotion_lease: Option<&homeboy_core::runtime_promotion::RuntimePromotionLease>,
+    timeout: Duration,
+    context: &str,
+    configure: impl FnOnce(&mut Command),
+) -> Result<std::process::Output> {
+    let promotion_lease = promotion_lease.ok_or_else(|| {
+        Error::internal_unexpected("installer mutation requires controller promotion ownership")
+    })?;
+    promotion_lease.assert_generation()?;
+    supervise_installer_shell_command(
+        script,
+        timeout,
+        context,
+        |command| promotion_lease.authorize_subprocess(command),
+        configure,
+    )
+}
+
+fn supervise_installer_shell_command(
+    script: &str,
+    timeout: Duration,
+    context: &str,
+    authorize_before_spawn: impl FnOnce(&mut Command),
+    configure: impl FnOnce(&mut Command),
+) -> Result<std::process::Output> {
+    let mut start_gate = InstallerStartGate::new()
+        .map_err(|error| Error::internal_io(error.to_string(), Some(context.to_string())))?;
+    let mut command = start_gate.command(script);
+    configure(&mut command);
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let guard = ControllerChildGuard::prepare(&mut command)
+        .map_err(|error| Error::internal_io(error.to_string(), Some(context.to_string())))?;
+    // The capability is intentionally scoped to this exact supervised spawn.
+    authorize_before_spawn(&mut command);
+    let mut child = command
+        .spawn()
+        .map_err(|error| Error::internal_io(error.to_string(), Some(context.to_string())))?;
+    #[cfg(test)]
+    if let Some(ready) = std::env::var_os("HOMEBOY_INSTALLER_BEFORE_ATTACH_READY") {
+        if let Some(pid_file) = std::env::var_os("HOMEBOY_INSTALLER_GATE_PID_FILE") {
+            std::fs::write(pid_file, child.id().to_string()).map_err(|error| {
+                Error::internal_io(error.to_string(), Some(context.to_string()))
+            })?;
+        }
+        std::fs::write(ready, b"spawned before guard attachment")
+            .map_err(|error| Error::internal_io(error.to_string(), Some(context.to_string())))?;
+        loop {
+            std::thread::park_timeout(Duration::from_secs(30));
+        }
+    }
+    if let Err(error) = guard.attach(&child) {
+        let primary = Error::internal_io(
+            format!("failed to attach installer process guard: {error}"),
+            Some(context.to_string()),
+        );
+        return Err(append_cleanup_failure_context(
+            primary,
+            terminate_process_tree_and_reap(&mut child).err(),
+        ));
+    }
+    start_gate.release().map_err(|error| {
+        append_cleanup_failure_context(
+            Error::internal_io(error.to_string(), Some(context.to_string())),
+            terminate_process_tree_and_reap(&mut child).err(),
+        )
+    })?;
+    let supervised = wait_with_bounded_output_supervised(
+        &mut child,
+        UPGRADE_CAPTURE_LIMIT_BYTES,
+        timeout,
+        INSTALLER_SUPERVISION_POLL_INTERVAL,
+        || false,
+        |_, _| Ok(()),
+    );
+    let supervised = match supervised {
+        Ok(supervised) => supervised,
+        Err(error) => {
+            return Err(append_cleanup_failure_context(
+                Error::internal_io(error.to_string(), Some(context.to_string())),
+                terminate_process_tree_and_reap(&mut child).err(),
+            ));
+        }
+    };
+    match supervised.termination {
+        SupervisedCommandTermination::Completed => Ok(supervised.output.into_output()),
+        SupervisedCommandTermination::TimedOut => Err(Error::internal_io(
+            format!("installer timed out after {}s", timeout.as_secs()),
+            Some(context.to_string()),
+        )),
+        termination => Err(Error::internal_io(
+            format!("installer terminated before completion: {termination:?}"),
+            Some(context.to_string()),
+        )),
+    }
+}
+
+#[cfg(unix)]
+struct InstallerStartGate {
+    read_fd: RawFd,
+    write_fd: RawFd,
+}
+
+#[cfg(unix)]
+impl InstallerStartGate {
+    fn new() -> io::Result<Self> {
+        let mut fds = [-1; 2];
+        if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if unsafe { libc::fcntl(fds[1], libc::F_SETFD, libc::FD_CLOEXEC) } != 0 {
+            unsafe {
+                libc::close(fds[0]);
+                libc::close(fds[1]);
+            }
+            return Err(io::Error::last_os_error());
+        }
+        Ok(Self {
+            read_fd: fds[0],
+            write_fd: fds[1],
+        })
+    }
+
+    fn command(&self, script: &str) -> Command {
+        let mut command = Command::new("sh");
+        command
+            .args([
+                "-c",
+                &format!(
+                    "IFS= read -r _ <&{} || exit 125; exec sh -c \"$HOMEBOY_INSTALLER_SCRIPT\"",
+                    self.read_fd
+                ),
+            ])
+            .env("HOMEBOY_INSTALLER_SCRIPT", script);
+        command
+    }
+
+    fn release(&mut self) -> io::Result<()> {
+        let bytes = b"1\n";
+        let written = unsafe { libc::write(self.write_fd, bytes.as_ptr().cast(), bytes.len()) };
+        if written != bytes.len() as isize {
+            return Err(io::Error::last_os_error());
+        }
+        unsafe {
+            libc::close(self.read_fd);
+            libc::close(self.write_fd);
+        }
+        self.read_fd = -1;
+        self.write_fd = -1;
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+impl Drop for InstallerStartGate {
+    fn drop(&mut self) {
+        unsafe {
+            if self.read_fd >= 0 {
+                libc::close(self.read_fd);
+            }
+            if self.write_fd >= 0 {
+                libc::close(self.write_fd);
+            }
+        }
+    }
+}
+
+#[cfg(not(unix))]
+struct InstallerStartGate {
+    path: PathBuf,
+}
+
+#[cfg(not(unix))]
+impl InstallerStartGate {
+    fn new() -> std::io::Result<Self> {
+        let gate = tempfile::Builder::new()
+            .prefix("homeboy-installer-start-")
+            .tempfile()?;
+        let path = gate.path().to_path_buf();
+        gate.close()?;
+        Ok(Self { path })
+    }
+
+    fn command(&self, script: &str) -> Command {
+        let mut command = Command::new("sh");
+        command
+            .args([
+                "-c",
+                "attempt=0; while [ ! -f \"$HOMEBOY_INSTALLER_START_GATE\" ]; do attempt=$((attempt + 1)); [ \"$attempt\" -ge 500 ] && exit 125; sleep 0.01; done; exec sh -c \"$HOMEBOY_INSTALLER_SCRIPT\"",
+            ])
+            .env("HOMEBOY_INSTALLER_START_GATE", &self.path)
+            .env("HOMEBOY_INSTALLER_SCRIPT", script);
+        command
+    }
+
+    fn release(&mut self) -> std::io::Result<()> {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&self.path)
+            .map(|_| ())
+    }
+}
+
+#[cfg(not(unix))]
+impl Drop for InstallerStartGate {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
 }
 
 fn validate_binary_replacement_eligibility(

--- a/crates/homeboy-upgrade/src/upgrade/execution.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution.rs
@@ -136,10 +136,12 @@ pub(crate) fn execute_upgrade(
     source_path: Option<&Path>,
     explicit_source_path: bool,
     force: bool,
+    deliberate_replacement: bool,
     previous_build_identity: Option<&str>,
     selected_release: Option<&SelectedRelease>,
     promotion_lease: Option<&homeboy_core::runtime_promotion::RuntimePromotionLease>,
-    mut progress: impl FnMut(&str),
+    phase: &mut dyn FnMut(&str) -> Result<()>,
+    replacement_checkpoint: &mut dyn FnMut(&str, &Path, Option<&str>, Option<&str>) -> Result<()>,
 ) -> UpgradeExecutionResult {
     let selected_binary_version = selected_release.map(|release| release.version.as_str());
     let defaults = defaults::load_defaults();
@@ -149,16 +151,46 @@ pub(crate) fn execute_upgrade(
     let binary_destination = (method == InstallMethod::Binary)
         .then(active_binary_path)
         .transpose()?;
+    if method == InstallMethod::Binary {
+        promotion_lease
+            .ok_or_else(|| {
+                Error::internal_unexpected(
+                    "binary replacement eligibility must be revalidated under promotion ownership",
+                )
+            })?
+            .assert_generation()?;
+        validate_binary_replacement_eligibility(
+            deliberate_replacement,
+            selected_binary_version.expect("binary upgrades select a release"),
+            installed_target_build_identity_from_disk(
+                binary_destination
+                    .as_deref()
+                    .expect("binary upgrades capture a destination"),
+            )?,
+        )?;
+    }
+    if method != InstallMethod::Source {
+        phase("running_candidate_admission")?;
+        phase("installing_controller")?;
+    }
+    if method == InstallMethod::Binary {
+        replacement_checkpoint(
+            "pending",
+            binary_destination
+                .as_deref()
+                .expect("binary upgrades capture a destination"),
+            selected_binary_version,
+            None,
+        )?;
+    }
     let output = match method {
         InstallMethod::Homebrew => {
-            progress("installing controller release");
             let cmd = &defaults.install_methods.homebrew.upgrade_command;
             Command::new("sh").args(["-c", cmd]).output().map_err(|e| {
                 Error::internal_io(e.to_string(), Some("run homebrew upgrade".to_string()))
             })?
         }
         InstallMethod::Secondary => {
-            progress("installing controller release");
             // Legacy cargo-installed binaries are replaced with the release
             // asset now that Homeboy's private workspace is not on crates.io.
             let cmd = &defaults.install_methods.binary.upgrade_command;
@@ -198,7 +230,7 @@ pub(crate) fn execute_upgrade(
                 &workspace_root,
                 explicit_source_path,
             )?;
-            progress("building controller candidate");
+            phase("building_candidate")?;
             run_source_upgrade_command(
                 &cmd,
                 &workspace_root,
@@ -209,7 +241,6 @@ pub(crate) fn execute_upgrade(
             // Source command output is streamed to the invoking process so
             // controller timeouts can distinguish a build from a stalled run.
             // It has already returned a precise error for non-zero exits.
-            progress("running controller candidate admission");
             return complete_source_upgrade(
                 workspace_root,
                 built_binary,
@@ -219,11 +250,11 @@ pub(crate) fn execute_upgrade(
                 previous_build_identity,
                 source_revision,
                 promotion_lease,
-                &mut progress,
+                phase,
+                replacement_checkpoint,
             );
         }
         InstallMethod::Binary => {
-            progress("installing controller release");
             let cmd = &defaults.install_methods.binary.upgrade_command;
             // Pin the installer to the release this upgrade selected. Without
             // the pin the installer always resolves `latest/download`, so a
@@ -260,6 +291,19 @@ pub(crate) fn execute_upgrade(
             selected_release,
         ));
     }
+
+    if method == InstallMethod::Binary {
+        replacement_checkpoint(
+            "applied",
+            binary_destination
+                .as_deref()
+                .expect("binary upgrades capture a destination"),
+            selected_binary_version,
+            None,
+        )?;
+    }
+
+    phase("verifying_install")?;
 
     // The upgrade command above succeeded, so the new binary is already on
     // disk. Reading the version back can race the just-replaced binary (atomic
@@ -316,6 +360,39 @@ pub(crate) fn execute_upgrade(
     Ok((success, new_version, new_build_identity, None, false))
 }
 
+fn validate_binary_replacement_eligibility(
+    deliberate_replacement: bool,
+    selected_version: &str,
+    installed: Option<homeboy_core::build_identity::BuildIdentity>,
+) -> Result<()> {
+    if deliberate_replacement {
+        return Ok(());
+    }
+    let installed = installed.ok_or_else(|| {
+        Error::internal_unexpected(
+            "cannot revalidate the installed controller before binary replacement",
+        )
+        .with_hint("Retry after the PATH-active controller reports a readable build identity.")
+    })?;
+    if installed.version == selected_version
+        || version_is_newer(&installed.version, selected_version)
+    {
+        return Err(Error::validation_invalid_argument(
+            "selected_release",
+            format!(
+                "Selected controller {selected_version} is no longer newer than installed controller {}",
+                installed.version
+            ),
+            Some(selected_version.to_string()),
+            Some(vec![
+                "A queued upgrade must not reinstall or downgrade a controller promoted by an earlier owner. Re-run update discovery against the active controller."
+                    .to_string(),
+            ]),
+        ));
+    }
+    Ok(())
+}
+
 /// Verify a source-built candidate while it is still staged, then let that
 /// candidate decide whether durable ownership permits replacement. This is the
 /// source equivalent of the release installer's verified-target admission.
@@ -324,7 +401,7 @@ fn verify_source_candidate_target_admission(
     built_binary: &Path,
     source_revision: Option<&str>,
     installed_binary: Option<&Path>,
-) -> Result<()> {
+) -> Result<ActiveBinaryInfo> {
     let expected_version = source_workspace_package_version(workspace_root)?;
     if let Some(revision) = source_revision {
         let observed = source_workspace_revision(workspace_root)?;
@@ -345,7 +422,7 @@ fn verify_source_candidate_target_admission(
             built_binary.display()
         ))
     })?;
-    let candidate_version = candidate.version.as_deref().ok_or_else(|| {
+    let candidate_version = candidate.version.clone().ok_or_else(|| {
         Error::internal_unexpected(format!(
             "source-built candidate did not report a version: {}",
             built_binary.display()
@@ -382,10 +459,11 @@ fn verify_source_candidate_target_admission(
         .unwrap_or_else(|| "unavailable".to_string());
     run_verified_target_admission(
         built_binary,
-        candidate_version,
+        &candidate_version,
         &legacy_identity,
         &format!("source candidate {}", built_binary.display()),
-    )
+    )?;
+    Ok(candidate)
 }
 
 fn source_workspace_package_version(workspace_root: &Path) -> Result<String> {
@@ -505,7 +583,8 @@ fn complete_source_upgrade(
     previous_build_identity: Option<&str>,
     source_revision: Option<String>,
     promotion_lease: Option<&homeboy_core::runtime_promotion::RuntimePromotionLease>,
-    progress: &mut impl FnMut(&str),
+    phase: &mut dyn FnMut(&str) -> Result<()>,
+    replacement_checkpoint: &mut dyn FnMut(&str, &Path, Option<&str>, Option<&str>) -> Result<()>,
 ) -> UpgradeExecutionResult {
     let replacement_target = replacement_target.ok_or_else(|| {
         Error::internal_unexpected("active binary path unavailable for source upgrade install")
@@ -524,7 +603,7 @@ fn complete_source_upgrade(
         }
     };
     let active_identity = installed_target_build_identity()?;
-    if source_promotion_is_superseded(force, active_identity.as_ref(), &workspace_root) {
+    if source_promotion_is_superseded(force, active_identity.as_ref(), &workspace_root)? {
         let active = active_identity.expect("identity checked above");
         return Ok((
             false,
@@ -537,17 +616,30 @@ fn complete_source_upgrade(
     // The promotion decision above verifies source ancestry against the final
     // installed target. The staged binary owns recovery and admission before
     // this lease permits a byte change.
-    verify_source_candidate_target_admission(
+    phase("running_candidate_admission")?;
+    let candidate_identity = verify_source_candidate_target_admission(
         &workspace_root,
         &built_binary,
         source_revision.as_deref(),
         Some(replacement_target),
     )?;
     promotion_lease.assert_generation()?;
-    progress("installing source-built controller candidate");
+    phase("installing_controller")?;
+    replacement_checkpoint(
+        "pending",
+        replacement_target,
+        candidate_identity.version.as_deref(),
+        candidate_identity.build_identity.as_deref(),
+    )?;
     upgrade_phase("installing source-built binary");
     install_source_built_binary(&built_binary, replacement_target)?;
-    progress("verifying installed controller candidate");
+    replacement_checkpoint(
+        "applied",
+        replacement_target,
+        candidate_identity.version.as_deref(),
+        candidate_identity.build_identity.as_deref(),
+    )?;
+    phase("verifying_install")?;
     upgrade_phase("verifying installed source binary");
 
     let (_verified_version, active_binary) = verify_upgrade_with_retry(
@@ -577,7 +669,7 @@ fn complete_source_upgrade(
         source_workspace: Some(&workspace_root),
         built_binary: Some(&built_binary),
         replacement_target: Some(replacement_target),
-        built_binary_identity: previous_build_identity,
+        built_binary_identity: candidate_identity.build_identity.as_deref(),
     }) {
         return Err(error);
     }
@@ -596,10 +688,17 @@ fn source_promotion_is_superseded(
     force: bool,
     active: Option<&homeboy_core::build_identity::BuildIdentity>,
     workspace_root: &Path,
-) -> bool {
-    !force
-        && active
-            .is_some_and(|active| !source_promotion_decision(active, workspace_root).upgrades())
+) -> Result<bool> {
+    if force {
+        return Ok(false);
+    }
+    let active = active.ok_or_else(|| {
+        Error::internal_unexpected(
+            "cannot revalidate the installed controller before source replacement",
+        )
+        .with_hint("Retry after the PATH-active controller reports a readable build identity.")
+    })?;
+    Ok(!source_promotion_decision(active, workspace_root).upgrades())
 }
 
 fn upgrade_phase(phase: &str) {
@@ -948,6 +1047,15 @@ fn install_source_built_binary(built_binary: &Path, replacement_target: &Path) -
 
     make_source_install_executable(&temp_target)?;
 
+    std::fs::File::open(&temp_target)
+        .and_then(|file| file.sync_all())
+        .map_err(|e| {
+            Error::internal_io(
+                format!("sync {} failed: {}", temp_target.display(), e),
+                Some("install source-built binary".to_string()),
+            )
+        })?;
+
     std::fs::rename(&temp_target, replacement_target).map_err(|err| {
         Error::internal_io(
             format!(
@@ -960,9 +1068,28 @@ fn install_source_built_binary(built_binary: &Path, replacement_target: &Path) -
         )
     })?;
 
+    sync_source_install_parent(parent)?;
+
     // Rename succeeded; the file is at its final path. Prevent the guard from
     // deleting it on drop.
     guard.into_owned();
+    Ok(())
+}
+
+#[cfg(unix)]
+fn sync_source_install_parent(parent: &Path) -> Result<()> {
+    std::fs::File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|e| {
+            Error::internal_io(
+                format!("sync directory {} failed: {}", parent.display(), e),
+                Some("install source-built binary".to_string()),
+            )
+        })
+}
+
+#[cfg(not(unix))]
+fn sync_source_install_parent(_parent: &Path) -> Result<()> {
     Ok(())
 }
 
@@ -1514,7 +1641,15 @@ pub(crate) fn installed_target_build_identity(
         }
     }
 
-    let Some(info) = active_binary_info_at(&target_path)? else {
+    installed_target_build_identity_from_disk(&target_path)
+}
+
+/// Execute the selected on-disk target so replacement at the current process's
+/// pathname cannot be mistaken for the still-running process identity.
+pub(crate) fn installed_target_build_identity_from_disk(
+    target_path: &Path,
+) -> Result<Option<homeboy_core::build_identity::BuildIdentity>> {
+    let Some(info) = active_binary_info_at(target_path)? else {
         return Ok(None);
     };
     Ok(info

--- a/crates/homeboy-upgrade/src/upgrade/execution.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution.rs
@@ -5,7 +5,8 @@ use homeboy_core::git::{run_git, run_git_output};
 use homeboy_core::stream_capture::StreamCaptureMetadata;
 use homeboy_engine_primitives::command::{
     terminate_process_tree_and_reap, terminate_remaining_process_group,
-    wait_with_bounded_output_supervised, ControllerChildGuard, SupervisedCommandTermination,
+    wait_with_bounded_output_supervised_guarded, ControllerChildGuard,
+    SupervisedCommandTermination,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -456,16 +457,16 @@ fn run_installer_shell_command(
         script,
         timeout,
         context,
-        |command| promotion_lease.authorize_subprocess(command),
+        |command| promotion_lease.authorize_mutating_subprocess(command),
         configure,
     )
 }
 
-fn supervise_installer_shell_command(
+fn supervise_installer_shell_command<A>(
     script: &str,
     timeout: Duration,
     context: &str,
-    authorize_before_spawn: impl FnOnce(&mut Command),
+    authorize_before_spawn: impl FnOnce(&mut Command) -> Result<A>,
     configure: impl FnOnce(&mut Command),
 ) -> Result<std::process::Output> {
     let mut start_gate = InstallerStartGate::new()
@@ -476,13 +477,14 @@ fn supervise_installer_shell_command(
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let guard = ControllerChildGuard::prepare(&mut command)
+    let mut guard = ControllerChildGuard::prepare(&mut command)
         .map_err(|error| Error::internal_io(error.to_string(), Some(context.to_string())))?;
     // The capability is intentionally scoped to this exact supervised spawn.
-    authorize_before_spawn(&mut command);
+    let mutation_fence = authorize_before_spawn(&mut command)?;
     let mut child = command
         .spawn()
         .map_err(|error| Error::internal_io(error.to_string(), Some(context.to_string())))?;
+    drop(mutation_fence);
     #[cfg(test)]
     if let Some(ready) = std::env::var_os("HOMEBOY_INSTALLER_BEFORE_ATTACH_READY") {
         if let Some(pid_file) = std::env::var_os("HOMEBOY_INSTALLER_GATE_PID_FILE") {
@@ -512,8 +514,9 @@ fn supervise_installer_shell_command(
             terminate_process_tree_and_reap(&mut child).err(),
         )
     })?;
-    let supervised = wait_with_bounded_output_supervised(
+    let supervised = wait_with_bounded_output_supervised_guarded(
         &mut child,
+        &mut guard,
         UPGRADE_CAPTURE_LIMIT_BYTES,
         timeout,
         INSTALLER_SUPERVISION_POLL_INTERVAL,

--- a/crates/homeboy-upgrade/src/upgrade/execution.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution.rs
@@ -6,7 +6,11 @@ use homeboy_core::stream_capture::StreamCaptureMetadata;
 use homeboy_engine_primitives::command::{
     terminate_process_tree_and_reap, terminate_remaining_process_group, ControllerChildGuard,
 };
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::env;
+use std::fs::File;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
@@ -81,6 +85,43 @@ struct SourceSwapVerification<'a> {
     built_binary_identity: Option<&'a str>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ReplacementCheckpoint {
+    pub state: String,
+    pub target: PathBuf,
+    pub expected_version: Option<String>,
+    pub expected_build_identity: Option<String>,
+    pub expected_sha256: Option<String>,
+    pub previous_build_identity: Option<String>,
+    pub previous_sha256: String,
+}
+
+impl ReplacementCheckpoint {
+    pub(crate) fn pending(
+        target: &Path,
+        expected_version: Option<&str>,
+        expected_build_identity: Option<&str>,
+        expected_sha256: Option<String>,
+    ) -> Result<Self> {
+        Ok(Self {
+            state: "pending".to_string(),
+            target: target.to_path_buf(),
+            expected_version: expected_version.map(str::to_string),
+            expected_build_identity: expected_build_identity.map(str::to_string),
+            expected_sha256,
+            previous_build_identity: installed_target_build_identity_from_disk(target)?
+                .map(|identity| identity.display),
+            previous_sha256: sha256_file(target)?,
+        })
+    }
+
+    pub(crate) fn with_state(&self, state: &str) -> Self {
+        let mut checkpoint = self.clone();
+        checkpoint.state = state.to_string();
+        checkpoint
+    }
+}
+
 /// Bound a captured stream to a retained-byte cap, keeping the trailing bytes
 /// (the most relevant tail for a failure message) and returning the retained
 /// text plus truncation metadata. Mirrors the `bound_captured_stream` pattern
@@ -141,7 +182,7 @@ pub(crate) fn execute_upgrade(
     selected_release: Option<&SelectedRelease>,
     promotion_lease: Option<&homeboy_core::runtime_promotion::RuntimePromotionLease>,
     phase: &mut dyn FnMut(&str) -> Result<()>,
-    replacement_checkpoint: &mut dyn FnMut(&str, &Path, Option<&str>, Option<&str>) -> Result<()>,
+    replacement_checkpoint: &mut dyn FnMut(&ReplacementCheckpoint) -> Result<()>,
 ) -> UpgradeExecutionResult {
     let selected_binary_version = selected_release.map(|release| release.version.as_str());
     let defaults = defaults::load_defaults();
@@ -173,16 +214,20 @@ pub(crate) fn execute_upgrade(
         phase("running_candidate_admission")?;
         phase("installing_controller")?;
     }
-    if method == InstallMethod::Binary {
-        replacement_checkpoint(
-            "pending",
+    let binary_checkpoint = if method == InstallMethod::Binary {
+        let checkpoint = ReplacementCheckpoint::pending(
             binary_destination
                 .as_deref()
                 .expect("binary upgrades capture a destination"),
             selected_binary_version,
             None,
+            None,
         )?;
-    }
+        replacement_checkpoint(&checkpoint)?;
+        Some(checkpoint)
+    } else {
+        None
+    };
     let output = match method {
         InstallMethod::Homebrew => {
             let cmd = &defaults.install_methods.homebrew.upgrade_command;
@@ -266,9 +311,18 @@ pub(crate) fn execute_upgrade(
                 command.env(RELEASE_TAG_ENV, &release.tag);
                 command.env(RELEASE_VERSION_ENV, &release.version);
             }
-            command.output().map_err(|e| {
-                Error::internal_io(e.to_string(), Some("run binary upgrade".to_string()))
-            })?
+            match command.output() {
+                Ok(output) => output,
+                Err(error) => {
+                    if let Some(checkpoint) = binary_checkpoint.as_ref() {
+                        replacement_checkpoint(&checkpoint.with_state("not_applied"))?;
+                    }
+                    return Err(Error::internal_io(
+                        error.to_string(),
+                        Some("run binary upgrade".to_string()),
+                    ));
+                }
+            }
         }
         InstallMethod::Unknown => {
             return Err(Error::validation_invalid_argument(
@@ -281,6 +335,10 @@ pub(crate) fn execute_upgrade(
     };
 
     if !output.status.success() {
+        if let Some(checkpoint) = binary_checkpoint.as_ref() {
+            let state = replacement_observed_state(checkpoint)?;
+            replacement_checkpoint(&checkpoint.with_state(state))?;
+        }
         // Keep both bounded streams: installers may log progress to stderr while
         // a staged candidate returns the actionable failure contract on stdout.
         let error_detail = upgrade_failure_detail(&output.stderr, &output.stdout)
@@ -293,14 +351,20 @@ pub(crate) fn execute_upgrade(
     }
 
     if method == InstallMethod::Binary {
-        replacement_checkpoint(
-            "applied",
-            binary_destination
-                .as_deref()
-                .expect("binary upgrades capture a destination"),
-            selected_binary_version,
-            None,
-        )?;
+        let checkpoint = binary_checkpoint
+            .as_ref()
+            .expect("binary replacement has a pending checkpoint");
+        if !replacement_was_applied(checkpoint)? {
+            replacement_checkpoint(
+                &checkpoint.with_state(replacement_observed_state(checkpoint)?),
+            )?;
+            return Err(binary_swap_failure(
+                selected_binary_version.expect("binary upgrades select a release version"),
+                binary_destination.as_deref(),
+                active_binary_info_at(&checkpoint.target)?.as_ref(),
+            ));
+        }
+        replacement_checkpoint(&checkpoint.with_state("applied"))?;
     }
 
     phase("verifying_install")?;
@@ -584,7 +648,7 @@ fn complete_source_upgrade(
     source_revision: Option<String>,
     promotion_lease: Option<&homeboy_core::runtime_promotion::RuntimePromotionLease>,
     phase: &mut dyn FnMut(&str) -> Result<()>,
-    replacement_checkpoint: &mut dyn FnMut(&str, &Path, Option<&str>, Option<&str>) -> Result<()>,
+    replacement_checkpoint: &mut dyn FnMut(&ReplacementCheckpoint) -> Result<()>,
 ) -> UpgradeExecutionResult {
     let replacement_target = replacement_target.ok_or_else(|| {
         Error::internal_unexpected("active binary path unavailable for source upgrade install")
@@ -625,20 +689,26 @@ fn complete_source_upgrade(
     )?;
     promotion_lease.assert_generation()?;
     phase("installing_controller")?;
-    replacement_checkpoint(
-        "pending",
+    let replacement = ReplacementCheckpoint::pending(
         replacement_target,
         candidate_identity.version.as_deref(),
         candidate_identity.build_identity.as_deref(),
+        Some(sha256_file(&built_binary)?),
     )?;
+    replacement_checkpoint(&replacement)?;
     upgrade_phase("installing source-built binary");
-    install_source_built_binary(&built_binary, replacement_target)?;
-    replacement_checkpoint(
-        "applied",
-        replacement_target,
-        candidate_identity.version.as_deref(),
-        candidate_identity.build_identity.as_deref(),
-    )?;
+    if let Err(error) = install_source_built_binary(&built_binary, replacement_target) {
+        let state = replacement_observed_state(&replacement)?;
+        replacement_checkpoint(&replacement.with_state(state))?;
+        return Err(error);
+    }
+    if !replacement_was_applied(&replacement)? {
+        replacement_checkpoint(&replacement.with_state(replacement_observed_state(&replacement)?))?;
+        return Err(Error::internal_unexpected(
+            "source installer completed without an observable controller byte transition",
+        ));
+    }
+    replacement_checkpoint(&replacement.with_state("applied"))?;
     phase("verifying_install")?;
     upgrade_phase("verifying installed source binary");
 
@@ -1127,6 +1197,106 @@ fn make_source_install_executable(path: &Path) -> Result<()> {
 
 fn display_path(path: &Path) -> String {
     path.display().to_string()
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let mut file = File::open(path).map_err(|error| {
+        Error::internal_io(
+            error.to_string(),
+            Some(format!(
+                "hash controller replacement target {}",
+                path.display()
+            )),
+        )
+    })?;
+    let mut digest = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer).map_err(|error| {
+            Error::internal_io(
+                error.to_string(),
+                Some(format!(
+                    "hash controller replacement target {}",
+                    path.display()
+                )),
+            )
+        })?;
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", digest.finalize()))
+}
+
+pub(crate) fn replacement_applied_identity(
+    checkpoint: &ReplacementCheckpoint,
+) -> Result<Option<homeboy_core::build_identity::BuildIdentity>> {
+    let current_sha256 = match sha256_file(&checkpoint.target) {
+        Ok(digest) => digest,
+        Err(_) => return Ok(None),
+    };
+    if current_sha256 == checkpoint.previous_sha256
+        || checkpoint
+            .expected_sha256
+            .as_ref()
+            .is_some_and(|expected| expected != &current_sha256)
+    {
+        return Ok(None);
+    }
+    let Some(identity) = installed_target_build_identity_from_disk(&checkpoint.target)? else {
+        return Ok(None);
+    };
+    let matches_expected = checkpoint.expected_build_identity.as_deref().map_or_else(
+        || {
+            checkpoint
+                .expected_version
+                .as_deref()
+                .is_some_and(|expected| identity.version == expected)
+        },
+        |expected| identity.display == expected,
+    );
+    Ok(matches_expected.then_some(identity))
+}
+
+pub(crate) fn replacement_was_applied(checkpoint: &ReplacementCheckpoint) -> Result<bool> {
+    let current_sha256 = match sha256_file(&checkpoint.target) {
+        Ok(digest) => digest,
+        Err(_) => return Ok(false),
+    };
+    if current_sha256 == checkpoint.previous_sha256 {
+        return Ok(false);
+    }
+    if let Some(expected) = checkpoint.expected_sha256.as_deref() {
+        return Ok(current_sha256 == expected);
+    }
+    Ok(replacement_applied_identity(checkpoint)
+        .ok()
+        .flatten()
+        .is_some())
+}
+
+fn replacement_target_changed(checkpoint: &ReplacementCheckpoint) -> Option<bool> {
+    if !checkpoint.target.exists() {
+        return None;
+    }
+    sha256_file(&checkpoint.target)
+        .ok()
+        .map(|current| current != checkpoint.previous_sha256)
+}
+
+pub(crate) fn replacement_observed_state(
+    checkpoint: &ReplacementCheckpoint,
+) -> Result<&'static str> {
+    if replacement_was_applied(checkpoint)? {
+        Ok("applied")
+    } else {
+        match replacement_target_changed(checkpoint) {
+            Some(true) => Ok("changed_unverified"),
+            Some(false) => Ok("not_applied"),
+            None => Ok("evidence_unavailable"),
+        }
+    }
 }
 
 /// Read back the active binary version after a successful swap, retrying while

--- a/crates/homeboy-upgrade/src/upgrade/execution.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution.rs
@@ -4,7 +4,7 @@ use homeboy_core::error::{Error, Result};
 use homeboy_core::git::{run_git, run_git_output};
 use homeboy_core::stream_capture::StreamCaptureMetadata;
 use homeboy_engine_primitives::command::{
-    terminate_process_tree_and_reap, terminate_remaining_process_group,
+    supports_process_tree_isolation, terminate_process_tree_and_reap,
     wait_with_bounded_output_supervised_guarded, ControllerChildGuard,
     SupervisedCommandTermination,
 };
@@ -178,6 +178,7 @@ fn upgrade_failure_detail(stderr: &[u8], stdout: &[u8]) -> Option<String> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn execute_upgrade(
     method: InstallMethod,
     source_path: Option<&Path>,
@@ -195,24 +196,23 @@ pub(crate) fn execute_upgrade(
     // The binary installer replaces `command -v homeboy`. Capture that path
     // before its shell runs so verification proves the intended PATH target was
     // replaced rather than merely finding some other Homeboy afterward.
-    let binary_destination = (method == InstallMethod::Binary)
-        .then(active_binary_path)
-        .transpose()?;
-    if method == InstallMethod::Binary {
+    let release_binary = matches!(method, InstallMethod::Binary | InstallMethod::Secondary);
+    let binary_destination = release_binary.then(active_binary_path).transpose()?;
+    if release_binary {
         promotion_lease
             .ok_or_else(|| {
                 Error::internal_unexpected(
-                    "binary replacement eligibility must be revalidated under promotion ownership",
+                    "release replacement eligibility must be revalidated under promotion ownership",
                 )
             })?
             .assert_generation()?;
         validate_binary_replacement_eligibility(
             deliberate_replacement,
-            selected_binary_version.expect("binary upgrades select a release"),
+            selected_binary_version.expect("release upgrades select a release"),
             installed_target_build_identity_from_disk(
                 binary_destination
                     .as_deref()
-                    .expect("binary upgrades capture a destination"),
+                    .expect("release upgrades capture a destination"),
             )?,
         )?;
     }
@@ -220,11 +220,11 @@ pub(crate) fn execute_upgrade(
         phase("running_candidate_admission")?;
         phase("installing_controller")?;
     }
-    let binary_checkpoint = if method == InstallMethod::Binary {
+    let binary_checkpoint = if release_binary {
         let checkpoint = ReplacementCheckpoint::pending(
             binary_destination
                 .as_deref()
-                .expect("binary upgrades capture a destination"),
+                .expect("release upgrades capture a destination"),
             selected_binary_version,
             None,
             None,
@@ -234,6 +234,22 @@ pub(crate) fn execute_upgrade(
     } else {
         None
     };
+    let release_stage = release_binary
+        .then(|| {
+            tempfile::Builder::new()
+                .prefix("homeboy-release-stage-")
+                .tempdir()
+                .map_err(|error| {
+                    Error::internal_io(
+                        error.to_string(),
+                        Some("create release staging directory".to_string()),
+                    )
+                })
+        })
+        .transpose()?;
+    let staged_release_binary = release_stage
+        .as_ref()
+        .map(|stage| stage.path().join("homeboy"));
     let output = match method {
         InstallMethod::Homebrew => {
             let cmd = &defaults.install_methods.homebrew.upgrade_command;
@@ -245,17 +261,41 @@ pub(crate) fn execute_upgrade(
                 |_| {},
             )?
         }
-        InstallMethod::Secondary => {
-            // Legacy cargo-installed binaries are replaced with the release
-            // asset now that Homeboy's private workspace is not on crates.io.
+        InstallMethod::Secondary | InstallMethod::Binary => {
+            // Legacy cargo-installed binaries use the same pinned release asset,
+            // replacement checkpoints, and read-back contract as binary installs.
             let cmd = &defaults.install_methods.binary.upgrade_command;
-            run_installer_shell_command(
+            match run_installer_shell_command(
                 cmd,
                 promotion_lease,
                 INSTALLER_UPGRADE_TIMEOUT,
                 "run release binary upgrade",
-                |_| {},
-            )?
+                |command| {
+                    command.env(
+                        "HOMEBOY_INSTALL_PATH",
+                        staged_release_binary
+                            .as_deref()
+                            .expect("release upgrades have an isolated stage"),
+                    );
+                    if let Some(release) = selected_release {
+                        command.env(RELEASE_TAG_ENV, &release.tag);
+                        command.env(RELEASE_VERSION_ENV, &release.version);
+                    }
+                },
+            ) {
+                Ok(output) => output,
+                Err(error) => {
+                    if let Some(checkpoint) = binary_checkpoint.as_ref() {
+                        replacement_checkpoint(
+                            &checkpoint.with_state(replacement_observed_state(checkpoint)?),
+                        )?;
+                    }
+                    return Err(Error::internal_io(
+                        error.to_string(),
+                        Some("run release binary upgrade".to_string()),
+                    ));
+                }
+            }
         }
         InstallMethod::Source => {
             if env::var_os(REENTRANCY_GUARD_ENV).is_some() {
@@ -310,38 +350,6 @@ pub(crate) fn execute_upgrade(
                 replacement_checkpoint,
             );
         }
-        InstallMethod::Binary => {
-            let cmd = &defaults.install_methods.binary.upgrade_command;
-            // Pin the installer to the release this upgrade selected. Without
-            // the pin the installer always resolves `latest/download`, so a
-            // newest release missing this target's asset is unreachable past —
-            // there is no older release the operator can be moved to (#11750).
-            match run_installer_shell_command(
-                cmd,
-                promotion_lease,
-                INSTALLER_UPGRADE_TIMEOUT,
-                "run binary upgrade",
-                |command| {
-                    if let Some(release) = selected_release {
-                        command.env(RELEASE_TAG_ENV, &release.tag);
-                        command.env(RELEASE_VERSION_ENV, &release.version);
-                    }
-                },
-            ) {
-                Ok(output) => output,
-                Err(error) => {
-                    if let Some(checkpoint) = binary_checkpoint.as_ref() {
-                        replacement_checkpoint(
-                            &checkpoint.with_state(replacement_observed_state(checkpoint)?),
-                        )?;
-                    }
-                    return Err(Error::internal_io(
-                        error.to_string(),
-                        Some("run binary upgrade".to_string()),
-                    ));
-                }
-            }
-        }
         InstallMethod::Unknown => {
             return Err(Error::validation_invalid_argument(
                 "install_method",
@@ -368,16 +376,63 @@ pub(crate) fn execute_upgrade(
         ));
     }
 
-    if method == InstallMethod::Binary {
+    if release_binary {
         let checkpoint = binary_checkpoint
             .as_ref()
-            .expect("binary replacement has a pending checkpoint");
+            .expect("release replacement has a pending checkpoint");
+        let staged = staged_release_binary
+            .as_deref()
+            .expect("release upgrades have an isolated stage");
+        let selected_version =
+            selected_binary_version.expect("release upgrades select a release version");
+        let staged_identity = active_binary_info_at(staged)?.ok_or_else(|| {
+            Error::internal_unexpected(format!(
+                "release installer did not produce a verifiable staged candidate at {}",
+                staged.display()
+            ))
+        })?;
+        if staged_identity.version.as_deref() != Some(selected_version) {
+            replacement_checkpoint(
+                &checkpoint.with_state(replacement_observed_state(checkpoint)?),
+            )?;
+            return Err(binary_swap_failure(
+                selected_version,
+                Some(staged),
+                Some(&staged_identity),
+            ));
+        }
+        run_verified_target_admission(
+            staged,
+            selected_version,
+            &candidate_legacy_identity(
+                binary_destination
+                    .as_deref()
+                    .expect("release upgrades capture a destination"),
+            )?,
+            &selected_release
+                .expect("release upgrades select a release")
+                .tag,
+        )?;
+        promotion_lease
+            .expect("release replacement requires promotion ownership")
+            .assert_generation()?;
+        if let Err(error) = install_source_built_binary(
+            staged,
+            binary_destination
+                .as_deref()
+                .expect("release upgrades capture a destination"),
+        ) {
+            replacement_checkpoint(
+                &checkpoint.with_state(replacement_observed_state(checkpoint)?),
+            )?;
+            return Err(error);
+        }
         if !replacement_was_applied(checkpoint)? {
             replacement_checkpoint(
                 &checkpoint.with_state(replacement_observed_state(checkpoint)?),
             )?;
             return Err(binary_swap_failure(
-                selected_binary_version.expect("binary upgrades select a release version"),
+                selected_version,
                 binary_destination.as_deref(),
                 active_binary_info_at(&checkpoint.target)?.as_ref(),
             ));
@@ -397,7 +452,7 @@ pub(crate) fn execute_upgrade(
     let (success, active_binary) = if let Some(selected_version) = selected_binary_version {
         let destination = binary_destination
             .as_deref()
-            .expect("binary upgrades capture a PATH destination");
+            .expect("release upgrades capture a PATH destination");
         verify_binary_upgrade_with_retry(
             destination,
             selected_version,
@@ -423,9 +478,9 @@ pub(crate) fn execute_upgrade(
         .as_ref()
         .and_then(|info| info.build_identity.clone());
 
-    if method == InstallMethod::Binary && !success {
+    if release_binary && !success {
         return Err(binary_swap_failure(
-            selected_binary_version.expect("binary upgrades select a release version"),
+            selected_binary_version.expect("release upgrades select a release version"),
             binary_destination.as_deref(),
             active_binary.as_ref(),
         ));
@@ -469,6 +524,11 @@ fn supervise_installer_shell_command<A>(
     authorize_before_spawn: impl FnOnce(&mut Command) -> Result<A>,
     configure: impl FnOnce(&mut Command),
 ) -> Result<std::process::Output> {
+    if !supports_process_tree_isolation() {
+        return Err(Error::internal_unexpected(
+            "installer supervision requires native process-tree containment on this platform",
+        ));
+    }
     let mut start_gate = InstallerStartGate::new()
         .map_err(|error| Error::internal_io(error.to_string(), Some(context.to_string())))?;
     let mut command = start_gate.command(script);
@@ -528,7 +588,7 @@ fn supervise_installer_shell_command<A>(
         Err(error) => {
             return Err(append_cleanup_failure_context(
                 Error::internal_io(error.to_string(), Some(context.to_string())),
-                terminate_process_tree_and_reap(&mut child).err(),
+                guard.terminate_and_reap_bounded(&mut child).err(),
             ));
         }
     };
@@ -839,9 +899,11 @@ fn run_verified_target_admission(
         "controller_upgrade",
         format!(
             "verified source candidate refused controller replacement{}",
-            (!detail.is_empty())
-                .then(|| format!(": {detail}"))
-                .unwrap_or_default()
+            if detail.is_empty() {
+                String::new()
+            } else {
+                format!(": {detail}")
+            }
         ),
         None,
         None,
@@ -873,6 +935,7 @@ fn binary_swap_failure(
     .with_hint("Retry explicitly after correcting the active destination: homeboy upgrade --force --method binary")
 }
 
+#[allow(clippy::too_many_arguments)]
 fn complete_source_upgrade(
     workspace_root: PathBuf,
     built_binary: PathBuf,
@@ -1016,6 +1079,11 @@ fn run_source_upgrade_command(
     timeout: Duration,
     cargo_target: Option<(&Path, &str)>,
 ) -> Result<()> {
+    if !supports_process_tree_isolation() {
+        return Err(Error::internal_unexpected(
+            "source upgrade supervision requires native process-tree containment on this platform",
+        ));
+    }
     upgrade_phase("building source workspace");
     let mut child_command = Command::new("sh");
     child_command
@@ -1029,7 +1097,7 @@ fn run_source_upgrade_command(
             .env("CARGO_TARGET_DIR", cargo_target_dir)
             .env("HOMEBOY_CARGO_TARGET_RESOLUTION", resolution);
     }
-    let guard = ControllerChildGuard::prepare(&mut child_command).map_err(|error| {
+    let mut guard = ControllerChildGuard::prepare(&mut child_command).map_err(|error| {
         Error::internal_io(error.to_string(), Some("run source upgrade".to_string()))
     })?;
     let mut child = child_command
@@ -1045,44 +1113,38 @@ fn run_source_upgrade_command(
             terminate_process_tree_and_reap(&mut child).err(),
         ));
     }
-    let start = Instant::now();
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                let cleanup = terminate_remaining_process_group(child.id());
-                if status.success() {
-                    return cleanup.map_err(|error| {
-                        Error::internal_io(
-                            error.to_string(),
-                            Some("run source upgrade".to_string()),
-                        )
-                    });
-                }
-                return Err(append_cleanup_failure_context(
-                    source_upgrade_command_failure(status, cargo_target.map(|(path, _)| path)),
-                    cleanup.err(),
-                ));
-            }
-            Ok(None) if start.elapsed() >= timeout => {
-                let primary = Error::internal_io(
-                    format!("source upgrade timed out after {}s", timeout.as_secs()),
-                    Some("run source upgrade".to_string()),
-                );
-                return Err(append_cleanup_failure_context(
-                    primary,
-                    terminate_process_tree_and_reap(&mut child).err(),
-                ));
-            }
-            Ok(None) => std::thread::sleep(Duration::from_millis(25)),
-            Err(e) => {
-                let primary =
-                    Error::internal_io(e.to_string(), Some("wait for source upgrade".to_string()));
-                return Err(append_cleanup_failure_context(
-                    primary,
-                    terminate_process_tree_and_reap(&mut child).err(),
-                ));
-            }
+    let supervised = wait_with_bounded_output_supervised_guarded(
+        &mut child,
+        &mut guard,
+        0,
+        timeout,
+        INSTALLER_SUPERVISION_POLL_INTERVAL,
+        || false,
+        |_, _| Ok(()),
+    );
+    let supervised = match supervised {
+        Ok(supervised) => supervised,
+        Err(error) => {
+            return Err(append_cleanup_failure_context(
+                Error::internal_io(error.to_string(), Some("run source upgrade".to_string())),
+                guard.terminate_and_reap_bounded(&mut child).err(),
+            ));
         }
+    };
+    match supervised.termination {
+        SupervisedCommandTermination::Completed if supervised.output.status.success() => Ok(()),
+        SupervisedCommandTermination::Completed => Err(source_upgrade_command_failure(
+            supervised.output.status,
+            cargo_target.map(|(path, _)| path),
+        )),
+        SupervisedCommandTermination::TimedOut => Err(Error::internal_io(
+            format!("source upgrade timed out after {}s", timeout.as_secs()),
+            Some("run source upgrade".to_string()),
+        )),
+        termination => Err(Error::internal_io(
+            format!("source upgrade terminated before completion: {termination:?}"),
+            Some("run source upgrade".to_string()),
+        )),
     }
 }
 
@@ -1691,7 +1753,9 @@ fn upgrade_failure_error(
         Some("execute upgrade".to_string()),
     );
 
-    if method == InstallMethod::Binary && error_detail.contains("404") {
+    if matches!(method, InstallMethod::Binary | InstallMethod::Secondary)
+        && error_detail.contains("404")
+    {
         error = error.with_hint("No release asset was found for this Homeboy version.");
 
         if let Some(release) = selected_release {

--- a/crates/homeboy-upgrade/src/upgrade/execution/tests/mod.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution/tests/mod.rs
@@ -66,6 +66,61 @@ fn queued_binary_revalidates_target_before_install() {
         .expect("explicit replacement preserves deliberate downgrade semantics");
 }
 
+#[cfg(unix)]
+#[test]
+fn successful_same_version_noop_installer_does_not_prove_replacement() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let directory = tempfile::tempdir().expect("target directory");
+    let target = directory.path().join("homeboy");
+    std::fs::write(&target, "#!/bin/sh\necho 'homeboy 0.370.0'\n")
+        .expect("write installed fixture");
+    let mut permissions = std::fs::metadata(&target)
+        .expect("target metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&target, permissions).expect("make fixture executable");
+    let checkpoint = ReplacementCheckpoint::pending(&target, Some("0.370.0"), None, None)
+        .expect("capture replacement baseline");
+
+    // Model a successful installer that exits without swapping the target.
+    assert!(replacement_applied_identity(&checkpoint)
+        .expect("inspect unchanged target")
+        .is_none());
+    assert_eq!(checkpoint.with_state("not_applied").state, "not_applied");
+}
+
+#[cfg(unix)]
+#[test]
+fn exact_source_bytes_prove_replacement_even_when_identity_probe_fails() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let directory = tempfile::tempdir().expect("target directory");
+    let target = directory.path().join("homeboy");
+    let candidate = directory.path().join("candidate");
+    std::fs::write(&target, "#!/bin/sh\necho 'homeboy 0.370.0'\n# old\n")
+        .expect("write installed fixture");
+    let mut permissions = std::fs::metadata(&target)
+        .expect("target metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&target, permissions).expect("make fixture executable");
+    std::fs::write(&candidate, b"selected source bytes that cannot execute")
+        .expect("write candidate bytes");
+    let checkpoint = ReplacementCheckpoint::pending(
+        &target,
+        Some("0.370.0"),
+        None,
+        Some(sha256_file(&candidate).expect("hash candidate")),
+    )
+    .expect("capture replacement baseline");
+
+    std::fs::copy(&candidate, &target).expect("replace target bytes");
+
+    assert!(replacement_was_applied(&checkpoint).expect("inspect exact source bytes"));
+    assert!(replacement_applied_identity(&checkpoint).is_err());
+}
+
 pub(super) fn git_stdout(path: &Path, args: &[&str]) -> String {
     let output = std::process::Command::new("git")
         .arg("-C")

--- a/crates/homeboy-upgrade/src/upgrade/execution/tests/mod.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution/tests/mod.rs
@@ -45,6 +45,27 @@ pub(super) fn git(path: &Path, args: &[&str]) {
     );
 }
 
+#[test]
+fn queued_binary_revalidates_target_before_install() {
+    let identity = |version: &str| homeboy_core::build_identity::BuildIdentity {
+        version: version.to_string(),
+        git_commit: None,
+        git_dirty: None,
+        display: version.to_string(),
+    };
+
+    validate_binary_replacement_eligibility(false, "0.370.0", Some(identity("0.369.0")))
+        .expect("older installed controller remains eligible");
+    validate_binary_replacement_eligibility(false, "0.370.0", Some(identity("0.370.0")))
+        .expect_err("queued upgrade does not reinstall selected version");
+    validate_binary_replacement_eligibility(false, "0.370.0", Some(identity("0.371.0")))
+        .expect_err("queued upgrade does not downgrade a newer controller");
+    validate_binary_replacement_eligibility(false, "0.370.0", None)
+        .expect_err("missing target identity is not eligible");
+    validate_binary_replacement_eligibility(true, "0.370.0", Some(identity("0.371.0")))
+        .expect("explicit replacement preserves deliberate downgrade semantics");
+}
+
 pub(super) fn git_stdout(path: &Path, args: &[&str]) -> String {
     let output = std::process::Command::new("git")
         .arg("-C")

--- a/crates/homeboy-upgrade/src/upgrade/execution/tests/part_a.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution/tests/part_a.rs
@@ -380,7 +380,7 @@ fn installer_completion_reaps_background_process_group() {
         &shell,
         Duration::from_secs(1),
         "test installer",
-        |_| {},
+        |_| Ok(()),
         |_| {},
     )
     .expect("installer command completes");
@@ -411,7 +411,7 @@ fn installer_timeout_terminates_and_reaps_the_process_tree() {
         &shell,
         Duration::from_millis(50),
         "test installer",
-        |_| {},
+        |_| Ok(()),
         |_| {},
     )
     .expect_err("installer command times out");
@@ -453,7 +453,7 @@ fn installer_timeout_classifies_bytes_mutated_before_the_hang() {
         &shell,
         Duration::from_millis(50),
         "test binary installer",
-        |_| {},
+        |_| Ok(()),
         |_| {},
     )
     .expect_err("installer mutates and then times out");
@@ -471,20 +471,94 @@ fn installer_controller_death_fixture() {
     let pid_file = std::env::var("HOMEBOY_INSTALLER_PID_FILE").expect("pid file");
     let release_file = std::env::var("HOMEBOY_INSTALLER_RELEASE_FILE").expect("release file");
     let target = std::env::var("HOMEBOY_INSTALLER_TARGET").expect("target");
+    let shell = if std::env::var_os("HOMEBOY_INSTALLER_ESCAPE_SETSID").is_some() {
+        let test_binary = std::env::current_exe().expect("test executable");
+        format!(
+            "{} --ignored --exact upgrade::execution::tests::part_a::installer_setsid_descendant_fixture --nocapture & wait",
+            quote_path(&test_binary.display().to_string()),
+        )
+    } else {
+        format!(
+            "echo $$ > {}; while [ ! -e {} ]; do sleep 0.02; done; printf stale > {}",
+            quote_path(&pid_file),
+            quote_path(&release_file),
+            quote_path(&target),
+        )
+    };
+    if std::env::var_os("HOMEBOY_INSTALLER_USE_PROMOTION_LEASE").is_some() {
+        let lease = homeboy_core::runtime_promotion::acquire(
+            "controller-death fixture",
+            "active controller",
+        )
+        .expect("acquire fixture mutation lease");
+        run_installer_shell_command(
+            &shell,
+            Some(&lease),
+            Duration::from_secs(30),
+            "controller-death fixture",
+            |_| {},
+        )
+        .expect("fixture installer completes only when not killed");
+    } else {
+        supervise_installer_shell_command(
+            &shell,
+            Duration::from_secs(30),
+            "controller-death fixture",
+            |_| Ok(()),
+            |_| {},
+        )
+        .expect("fixture installer completes only when not killed");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+#[ignore = "subprocess fixture for escaped installer descendant"]
+fn installer_setsid_descendant_fixture() {
+    let target = std::env::var("HOMEBOY_INSTALLER_TARGET").expect("target");
+    assert_ne!(unsafe { libc::setsid() }, -1, "detach installer descendant");
+    if let Some(pid_file) = std::env::var_os("HOMEBOY_INSTALLER_PID_FILE") {
+        std::fs::write(pid_file, std::process::id().to_string()).expect("publish escaped PID");
+    }
+    if let Some(release_file) = std::env::var_os("HOMEBOY_INSTALLER_RELEASE_FILE") {
+        let release_file = PathBuf::from(release_file);
+        while !release_file.exists() {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    } else {
+        std::thread::sleep(Duration::from_millis(250));
+    }
+    std::fs::write(target, b"stale").expect("escaped descendant mutation");
+    std::thread::sleep(Duration::from_secs(30));
+}
+
+#[cfg(unix)]
+#[test]
+fn installer_timeout_kills_setsid_descendant_before_delayed_mutation() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let target = workspace.path().join("homeboy");
+    std::fs::write(&target, b"original").expect("write target");
+    let test_binary = std::env::current_exe().expect("test executable");
     let shell = format!(
-        "echo $$ > {}; while [ ! -e {} ]; do sleep 0.02; done; printf stale > {}",
-        quote_path(&pid_file),
-        quote_path(&release_file),
-        quote_path(&target),
+        "{} --ignored --exact upgrade::execution::tests::part_a::installer_setsid_descendant_fixture --nocapture & wait",
+        quote_path(&test_binary.display().to_string()),
     );
     supervise_installer_shell_command(
         &shell,
-        Duration::from_secs(30),
-        "controller-death fixture",
-        |_| {},
-        |_| {},
+        Duration::from_millis(75),
+        "setsid descendant installer",
+        |_| Ok(()),
+        |command| {
+            command.env("HOMEBOY_INSTALLER_TARGET", &target);
+        },
     )
-    .expect("fixture installer completes only when not killed");
+    .expect_err("installer with escaped descendant times out");
+    std::thread::sleep(Duration::from_millis(300));
+    assert_eq!(
+        std::fs::read(&target).expect("read target"),
+        b"original",
+        "setsid descendant mutated after installer cleanup"
+    );
 }
 
 #[cfg(unix)]
@@ -506,45 +580,57 @@ fn wait_for_installer_pid(path: &Path, deadline: Instant) -> u32 {
 #[cfg(unix)]
 #[test]
 fn controller_death_cannot_leave_an_installer_to_mutate_after_successor_handoff() {
-    let workspace = tempfile::tempdir().expect("workspace");
-    let pid_file = workspace.path().join("installer.pid");
-    let release_file = workspace.path().join("release");
-    let target = workspace.path().join("homeboy");
-    let mut controller = Command::new(std::env::current_exe().expect("test executable"));
-    controller
-        .args([
-            "--ignored",
-            "--exact",
-            "upgrade::execution::tests::part_a::installer_controller_death_fixture",
-            "--nocapture",
-        ])
-        .env("HOMEBOY_INSTALLER_PID_FILE", &pid_file)
-        .env("HOMEBOY_INSTALLER_RELEASE_FILE", &release_file)
-        .env("HOMEBOY_INSTALLER_TARGET", &target)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
-    let mut controller = controller.spawn().expect("spawn controller fixture");
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let pid_file = workspace.path().join("installer.pid");
+        let release_file = workspace.path().join("release");
+        let target = workspace.path().join("homeboy");
+        let mut controller = Command::new(std::env::current_exe().expect("test executable"));
+        controller
+            .args([
+                "--ignored",
+                "--exact",
+                "upgrade::execution::tests::part_a::installer_controller_death_fixture",
+                "--nocapture",
+            ])
+            .env("HOMEBOY_INSTALLER_PID_FILE", &pid_file)
+            .env("HOMEBOY_INSTALLER_RELEASE_FILE", &release_file)
+            .env("HOMEBOY_INSTALLER_TARGET", &target)
+            .env("HOMEBOY_INSTALLER_USE_PROMOTION_LEASE", "1")
+            .env("HOMEBOY_INSTALLER_ESCAPE_SETSID", "1")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let mut controller = controller.spawn().expect("spawn controller fixture");
 
-    let installer_pid = wait_for_installer_pid(&pid_file, Instant::now() + Duration::from_secs(5));
-    controller.kill().expect("kill old controller");
-    controller.wait().expect("reap old controller");
+        let installer_pid =
+            wait_for_installer_pid(&pid_file, Instant::now() + Duration::from_secs(5));
+        controller.kill().expect("kill old controller");
+        controller.wait().expect("reap old controller");
 
-    let deadline = Instant::now() + Duration::from_secs(5);
-    while homeboy_core::process::pid_is_running(installer_pid) {
+        // Race immediately. The inherited admission fence, not a PID polling
+        // barrier in this test, must delay successor mutation until cleanup has
+        // synchronously made the old installer non-runnable.
+        let successor = homeboy_core::runtime_promotion::acquire_waiting_for_compatible(
+            "successor controller",
+            "active controller",
+            Duration::from_secs(5),
+            |_| {},
+        )
+        .expect("successor acquires only after installer cleanup");
         assert!(
-            Instant::now() < deadline,
-            "old controller's installer remained runnable"
+            !homeboy_core::process::pid_is_running(installer_pid),
+            "successor acquired while the old installer remained runnable"
         );
-        std::thread::sleep(Duration::from_millis(10));
-    }
-    std::fs::write(&target, b"successor").expect("successor mutates after lease handoff");
-    std::fs::write(&release_file, b"release stale installer").expect("release barrier");
-    std::thread::sleep(Duration::from_millis(100));
-    assert_eq!(
-        std::fs::read(&target).expect("read installed bytes"),
-        b"successor",
-        "orphaned installer mutated after successor handoff"
-    );
+        std::fs::write(&target, b"successor").expect("successor mutation");
+        drop(successor);
+        std::fs::write(&release_file, b"release stale installer").expect("release barrier");
+        std::thread::sleep(Duration::from_millis(100));
+        assert_eq!(
+            std::fs::read(&target).expect("read installed bytes"),
+            b"successor",
+            "orphaned installer mutated after successor handoff"
+        );
+    });
 }
 
 #[cfg(unix)]

--- a/crates/homeboy-upgrade/src/upgrade/execution/tests/part_a.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution/tests/part_a.rs
@@ -488,6 +488,22 @@ fn installer_controller_death_fixture() {
 }
 
 #[cfg(unix)]
+fn wait_for_installer_pid(path: &Path, deadline: Instant) -> u32 {
+    loop {
+        if let Ok(contents) = std::fs::read_to_string(path) {
+            if let Ok(pid) = contents.trim().parse::<u32>() {
+                return pid;
+            }
+        }
+        assert!(
+            Instant::now() < deadline,
+            "installer fixture did not publish its PID"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[cfg(unix)]
 #[test]
 fn controller_death_cannot_leave_an_installer_to_mutate_after_successor_handoff() {
     let workspace = tempfile::tempdir().expect("workspace");
@@ -509,16 +525,7 @@ fn controller_death_cannot_leave_an_installer_to_mutate_after_successor_handoff(
         .stderr(Stdio::null());
     let mut controller = controller.spawn().expect("spawn controller fixture");
 
-    let deadline = Instant::now() + Duration::from_secs(5);
-    while !pid_file.exists() {
-        assert!(Instant::now() < deadline, "installer fixture did not start");
-        std::thread::sleep(Duration::from_millis(10));
-    }
-    let installer_pid = std::fs::read_to_string(&pid_file)
-        .expect("installer pid")
-        .trim()
-        .parse::<u32>()
-        .expect("numeric installer pid");
+    let installer_pid = wait_for_installer_pid(&pid_file, Instant::now() + Duration::from_secs(5));
     controller.kill().expect("kill old controller");
     controller.wait().expect("reap old controller");
 
@@ -573,11 +580,7 @@ fn controller_death_before_guard_attachment_cannot_start_installer_mutation() {
         );
         std::thread::sleep(Duration::from_millis(10));
     }
-    let installer_pid = std::fs::read_to_string(&pid_file)
-        .expect("installer pid")
-        .trim()
-        .parse::<u32>()
-        .expect("numeric installer pid");
+    let installer_pid = wait_for_installer_pid(&pid_file, deadline);
     controller
         .kill()
         .expect("kill controller before guard attachment");

--- a/crates/homeboy-upgrade/src/upgrade/execution/tests/part_a.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution/tests/part_a.rs
@@ -526,10 +526,113 @@ fn installer_setsid_descendant_fixture() {
             std::thread::sleep(Duration::from_millis(20));
         }
     } else {
-        std::thread::sleep(Duration::from_millis(250));
+        std::thread::sleep(Duration::from_millis(
+            std::env::var("HOMEBOY_INSTALLER_MUTATION_DELAY_MS")
+                .ok()
+                .and_then(|value| value.parse().ok())
+                .unwrap_or(250),
+        ));
     }
     std::fs::write(target, b"stale").expect("escaped descendant mutation");
     std::thread::sleep(Duration::from_secs(30));
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+#[ignore = "subprocess fixture for a rapidly reparented installer descendant"]
+fn installer_fast_double_fork_fixture() {
+    use std::ffi::CString;
+
+    let target = std::env::var("HOMEBOY_INSTALLER_TARGET").expect("target");
+    let pid_file = std::env::var("HOMEBOY_INSTALLER_PID_FILE").expect("pid file");
+    let script = CString::new(format!(
+        "printf '%s' $$ > {}; sleep 0.25; printf stale > {}; sleep 30",
+        quote_path(&pid_file),
+        quote_path(&target),
+    ))
+    .expect("fixture script");
+    let shell = c"/bin/sh";
+    let shell_name = c"sh";
+    let command_flag = c"-c";
+
+    let intermediate = unsafe { libc::fork() };
+    assert_ne!(intermediate, -1, "fork intermediate");
+    if intermediate == 0 {
+        let daemon = unsafe { libc::fork() };
+        if daemon < 0 {
+            unsafe { libc::_exit(2) };
+        }
+        if daemon > 0 {
+            unsafe { libc::_exit(0) };
+        }
+        if unsafe { libc::setsid() } == -1 {
+            unsafe { libc::_exit(3) };
+        }
+        let max = unsafe { libc::sysconf(libc::_SC_OPEN_MAX) };
+        for fd in 0..if max > 0 { max as i32 } else { 1024 } {
+            unsafe {
+                libc::close(fd);
+            }
+        }
+        unsafe {
+            libc::execl(
+                shell.as_ptr(),
+                shell_name.as_ptr(),
+                command_flag.as_ptr(),
+                script.as_ptr(),
+                std::ptr::null::<libc::c_char>(),
+            );
+            libc::_exit(4);
+        }
+    }
+    let mut status = 0;
+    assert_eq!(
+        unsafe { libc::waitpid(intermediate, &mut status, 0) },
+        intermediate,
+        "reap intermediate"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn installer_completion_contains_fast_double_fork_after_inherited_descriptors_close() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let target = workspace.path().join("homeboy");
+    let pid_file = workspace.path().join("daemon.pid");
+    std::fs::write(&target, b"original").expect("write target");
+    let test_binary = std::env::current_exe().expect("test executable");
+    let shell = format!(
+        "{} --ignored --exact upgrade::execution::tests::part_a::installer_fast_double_fork_fixture --nocapture",
+        quote_path(&test_binary.display().to_string()),
+    );
+
+    let output = supervise_installer_shell_command(
+        &shell,
+        Duration::from_secs(2),
+        "fast double-fork installer",
+        |_| Ok(()),
+        |command| {
+            command
+                .env("HOMEBOY_INSTALLER_TARGET", &target)
+                .env("HOMEBOY_INSTALLER_PID_FILE", &pid_file);
+        },
+    )
+    .expect("root completion contains reparented descendant");
+    assert!(output.status.success());
+    std::thread::sleep(Duration::from_millis(350));
+    assert_eq!(
+        std::fs::read(&target).expect("read target"),
+        b"original",
+        "descriptor-closing daemon mutated after root completion"
+    );
+    let daemon_pid = std::fs::read_to_string(&pid_file)
+        .expect("daemon pid")
+        .parse::<u32>()
+        .expect("numeric daemon pid");
+    assert!(
+        !homeboy_core::process::pid_is_running(daemon_pid),
+        "successor could start while descriptor-closing daemon remained runnable"
+    );
 }
 
 #[cfg(unix)]
@@ -558,6 +661,29 @@ fn installer_timeout_kills_setsid_descendant_before_delayed_mutation() {
         std::fs::read(&target).expect("read target"),
         b"original",
         "setsid descendant mutated after installer cleanup"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn source_timeout_kills_setsid_descendant_before_staged_validation() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let target = workspace.path().join("built-candidate");
+    std::fs::write(&target, b"original").expect("write staged target");
+    let test_binary = std::env::current_exe().expect("test executable");
+    let command = format!(
+        "HOMEBOY_INSTALLER_TARGET={} HOMEBOY_INSTALLER_MUTATION_DELAY_MS=1000 {} --ignored --exact upgrade::execution::tests::part_a::installer_setsid_descendant_fixture --nocapture & wait",
+        quote_path(&target.display().to_string()),
+        quote_path(&test_binary.display().to_string()),
+    );
+
+    run_source_upgrade_command(&command, workspace.path(), Duration::from_millis(250), None)
+        .expect_err("source command with escaped descendant times out");
+    std::thread::sleep(Duration::from_millis(300));
+    assert_eq!(
+        std::fs::read(&target).expect("read staged target"),
+        b"original",
+        "source descendant mutated after guarded cleanup"
     );
 }
 

--- a/crates/homeboy-upgrade/src/upgrade/execution/tests/part_a.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution/tests/part_a.rs
@@ -367,6 +367,239 @@ fn source_upgrade_timeout_terminates_the_entire_child_process_group() {
     panic!("source-upgrade child must not be orphaned");
 }
 
+#[cfg(unix)]
+#[test]
+fn installer_completion_reaps_background_process_group() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let pid_file = workspace.path().join("child.pid");
+    let shell = format!(
+        "sleep 30 & echo $! > {}; printf installed",
+        quote_path(&pid_file.display().to_string())
+    );
+    let output = supervise_installer_shell_command(
+        &shell,
+        Duration::from_secs(1),
+        "test installer",
+        |_| {},
+        |_| {},
+    )
+    .expect("installer command completes");
+    assert!(output.status.success());
+    assert_eq!(output.stdout, b"installed");
+
+    let child_pid = std::fs::read_to_string(&pid_file)
+        .expect("background child pid")
+        .trim()
+        .parse::<u32>()
+        .expect("numeric pid");
+    assert!(
+        !homeboy_core::process::pid_is_running(child_pid),
+        "successful installer left a runnable descendant"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn installer_timeout_terminates_and_reaps_the_process_tree() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let pid_file = workspace.path().join("child.pid");
+    let shell = format!(
+        "sleep 30 & echo $! > {}; wait",
+        quote_path(&pid_file.display().to_string())
+    );
+    let error = supervise_installer_shell_command(
+        &shell,
+        Duration::from_millis(50),
+        "test installer",
+        |_| {},
+        |_| {},
+    )
+    .expect_err("installer command times out");
+    assert!(error
+        .details
+        .to_string()
+        .to_lowercase()
+        .contains("timed out"));
+    let child_pid = std::fs::read_to_string(&pid_file)
+        .expect("background child pid")
+        .trim()
+        .parse::<u32>()
+        .expect("numeric pid");
+    assert!(
+        !homeboy_core::process::pid_is_running(child_pid),
+        "timed-out installer left a runnable descendant"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn installer_timeout_classifies_bytes_mutated_before_the_hang() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let workspace = tempfile::tempdir().expect("workspace");
+    let target = workspace.path().join("homeboy");
+    std::fs::write(&target, "#!/bin/sh\necho 'homeboy 0.2.0'\n# old\n")
+        .expect("write installed fixture");
+    std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755))
+        .expect("make fixture executable");
+    let checkpoint = ReplacementCheckpoint::pending(&target, Some("0.2.0"), None, None)
+        .expect("capture immutable pre-install evidence");
+    let shell = format!(
+        "printf changed > {}; sleep 30",
+        quote_path(&target.display().to_string())
+    );
+
+    supervise_installer_shell_command(
+        &shell,
+        Duration::from_millis(50),
+        "test binary installer",
+        |_| {},
+        |_| {},
+    )
+    .expect_err("installer mutates and then times out");
+
+    assert_eq!(
+        replacement_observed_state(&checkpoint).expect("classify post-timeout bytes"),
+        "changed_unverified"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+#[ignore = "subprocess fixture for controller-death supervision"]
+fn installer_controller_death_fixture() {
+    let pid_file = std::env::var("HOMEBOY_INSTALLER_PID_FILE").expect("pid file");
+    let release_file = std::env::var("HOMEBOY_INSTALLER_RELEASE_FILE").expect("release file");
+    let target = std::env::var("HOMEBOY_INSTALLER_TARGET").expect("target");
+    let shell = format!(
+        "echo $$ > {}; while [ ! -e {} ]; do sleep 0.02; done; printf stale > {}",
+        quote_path(&pid_file),
+        quote_path(&release_file),
+        quote_path(&target),
+    );
+    supervise_installer_shell_command(
+        &shell,
+        Duration::from_secs(30),
+        "controller-death fixture",
+        |_| {},
+        |_| {},
+    )
+    .expect("fixture installer completes only when not killed");
+}
+
+#[cfg(unix)]
+#[test]
+fn controller_death_cannot_leave_an_installer_to_mutate_after_successor_handoff() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let pid_file = workspace.path().join("installer.pid");
+    let release_file = workspace.path().join("release");
+    let target = workspace.path().join("homeboy");
+    let mut controller = Command::new(std::env::current_exe().expect("test executable"));
+    controller
+        .args([
+            "--ignored",
+            "--exact",
+            "upgrade::execution::tests::part_a::installer_controller_death_fixture",
+            "--nocapture",
+        ])
+        .env("HOMEBOY_INSTALLER_PID_FILE", &pid_file)
+        .env("HOMEBOY_INSTALLER_RELEASE_FILE", &release_file)
+        .env("HOMEBOY_INSTALLER_TARGET", &target)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut controller = controller.spawn().expect("spawn controller fixture");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !pid_file.exists() {
+        assert!(Instant::now() < deadline, "installer fixture did not start");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let installer_pid = std::fs::read_to_string(&pid_file)
+        .expect("installer pid")
+        .trim()
+        .parse::<u32>()
+        .expect("numeric installer pid");
+    controller.kill().expect("kill old controller");
+    controller.wait().expect("reap old controller");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while homeboy_core::process::pid_is_running(installer_pid) {
+        assert!(
+            Instant::now() < deadline,
+            "old controller's installer remained runnable"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    std::fs::write(&target, b"successor").expect("successor mutates after lease handoff");
+    std::fs::write(&release_file, b"release stale installer").expect("release barrier");
+    std::thread::sleep(Duration::from_millis(100));
+    assert_eq!(
+        std::fs::read(&target).expect("read installed bytes"),
+        b"successor",
+        "orphaned installer mutated after successor handoff"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn controller_death_before_guard_attachment_cannot_start_installer_mutation() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let pid_file = workspace.path().join("installer.pid");
+    let ready_file = workspace.path().join("spawned-before-attach");
+    let release_file = workspace.path().join("release");
+    let target = workspace.path().join("homeboy");
+    let mut controller = Command::new(std::env::current_exe().expect("test executable"));
+    controller
+        .args([
+            "--ignored",
+            "--exact",
+            "upgrade::execution::tests::part_a::installer_controller_death_fixture",
+            "--nocapture",
+        ])
+        .env("HOMEBOY_INSTALLER_PID_FILE", &pid_file)
+        .env("HOMEBOY_INSTALLER_GATE_PID_FILE", &pid_file)
+        .env("HOMEBOY_INSTALLER_BEFORE_ATTACH_READY", &ready_file)
+        .env("HOMEBOY_INSTALLER_RELEASE_FILE", &release_file)
+        .env("HOMEBOY_INSTALLER_TARGET", &target)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut controller = controller.spawn().expect("spawn controller fixture");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !ready_file.exists() || !pid_file.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "pre-attach fixture did not start"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let installer_pid = std::fs::read_to_string(&pid_file)
+        .expect("installer pid")
+        .trim()
+        .parse::<u32>()
+        .expect("numeric installer pid");
+    controller
+        .kill()
+        .expect("kill controller before guard attachment");
+    controller.wait().expect("reap controller fixture");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while homeboy_core::process::pid_is_running(installer_pid) {
+        assert!(
+            Instant::now() < deadline,
+            "start-gated installer survived its controller"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    std::fs::write(&target, b"successor").expect("successor mutation");
+    std::fs::write(&release_file, b"release").expect("release stale mutation barrier");
+    std::thread::sleep(Duration::from_millis(100));
+    assert_eq!(
+        std::fs::read(&target).expect("read successor bytes"),
+        b"successor"
+    );
+}
+
 #[test]
 fn test_execute_upgrade() {
     assert_eq!(

--- a/crates/homeboy-upgrade/src/upgrade/execution/tests/part_a.rs
+++ b/crates/homeboy-upgrade/src/upgrade/execution/tests/part_a.rs
@@ -159,8 +159,18 @@ fn staged_source_candidate_owns_admission_and_preserves_installed_bytes_on_failu
             .expect("executable fixture");
     }
 
-    verify_source_candidate_target_admission(workspace.path(), &candidate, None, Some(&installed))
-        .expect("new candidate, not the old controller, admits replacement");
+    let candidate_identity = verify_source_candidate_target_admission(
+        workspace.path(),
+        &candidate,
+        None,
+        Some(&installed),
+    )
+    .expect("new candidate, not the old controller, admits replacement");
+    assert_eq!(candidate_identity.version.as_deref(), Some("0.352.0"));
+    assert_eq!(
+        candidate_identity.build_identity.as_deref(),
+        Some("homeboy 0.352.0+new")
+    );
     assert_eq!(
         std::fs::read_to_string(&evidence).expect("admission evidence"),
         format!(
@@ -208,11 +218,10 @@ fn older_source_completion_is_superseded_unless_forced() {
 
     // This models the old build completing after the newer build has already
     // promoted: re-reading active identity under the lease makes it a no-op.
-    assert!(source_promotion_is_superseded(
-        false,
-        Some(&newer_active),
-        workspace.path()
-    ));
+    assert!(
+        source_promotion_is_superseded(false, Some(&newer_active), workspace.path())
+            .expect("readable identity decides admission")
+    );
     let older_active = homeboy_core::build_identity::BuildIdentity {
         display: "homeboy 1.2.2+old".to_string(),
         version: "1.2.2".to_string(),
@@ -220,16 +229,34 @@ fn older_source_completion_is_superseded_unless_forced() {
         git_dirty: Some(false),
     };
     // In the reverse completion order, the newer candidate remains eligible.
-    assert!(!source_promotion_is_superseded(
-        false,
-        Some(&older_active),
-        workspace.path()
-    ));
-    assert!(!source_promotion_is_superseded(
-        true,
-        Some(&newer_active),
-        workspace.path()
-    ));
+    assert!(
+        !source_promotion_is_superseded(false, Some(&older_active), workspace.path())
+            .expect("readable identity decides admission")
+    );
+    assert!(
+        !source_promotion_is_superseded(true, Some(&newer_active), workspace.path())
+            .expect("force bypasses supersession")
+    );
+}
+
+#[test]
+fn source_completion_fails_closed_when_installed_identity_disappears() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    std::fs::write(
+        workspace.path().join("Cargo.toml"),
+        "[package]\nname = \"homeboy\"\nversion = \"1.2.3\"\n",
+    )
+    .expect("candidate manifest");
+
+    let error = source_promotion_is_superseded(false, None, workspace.path())
+        .expect_err("missing final identity blocks source replacement");
+    assert!(error
+        .message
+        .contains("cannot revalidate the installed controller"));
+    assert!(
+        !source_promotion_is_superseded(true, None, workspace.path())
+            .expect("force explicitly permits missing identity")
+    );
 }
 
 #[test]

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -454,6 +454,14 @@ fn run_controller_upgrade_with_operation(
             // Even when no binary update is needed, still run extension updates.
             let selection_guard =
                 acquire_controller_selection_guard(operation, "controller extension refresh")?;
+            // Acquiring shared admission proves every prior installer mutation
+            // fence has drained. Freeze its pending byte evidence before this
+            // operation can return the same-version/no-update result.
+            super::operation::freeze_prior_pending_replacements(
+                operation
+                    .id()
+                    .expect("controller upgrades require a durable operation"),
+            )?;
             let initial_completion = reconcile_controller_identity(
                 observed_installed_controller_identity()?,
                 previous_build_identity.as_deref(),

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -883,13 +883,6 @@ fn run_controller_upgrade_with_operation(
         (vec![], vec![])
     };
 
-    // After a verified binary swap, long-running services still hold the old
-    // binary in memory until restarted. Restart each declared resident service
-    // (config-driven; nothing is hardcoded in core) unless restarts were
-    // skipped, in which case report each as pending with its recovery command.
-    let (services_restarted, services_pending_restart) =
-        restart_resident_services_after_swap(success, skip_services);
-
     let final_selection_guard =
         acquire_controller_selection_guard(operation, "controller upgrade result")?;
     let completion = reconcile_controller_identity(
@@ -908,6 +901,14 @@ fn run_controller_upgrade_with_operation(
         runners_updated.clear();
         runners_skipped.clear();
     }
+
+    // Protect the reconciled controller identity while resident services are
+    // restarted so their evidence cannot describe a later contender's binary.
+    let (services_restarted, services_pending_restart) = if completion_superseded {
+        (Vec::new(), Vec::new())
+    } else {
+        restart_resident_services_after_swap(success, skip_services)
+    };
 
     let runner_disposition = runner_convergence_disposition(
         runner_completion_is_skipped(skip_runners, upgrade_completed, completion_superseded),
@@ -2170,6 +2171,7 @@ fn acquire_controller_selection_guard(
         |event| operation.record_promotion_wait(&event),
     )?;
     operation.clear_promotion_wait_durable()?;
+    operation.take_persistence_error()?;
     Ok(guard)
 }
 

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -461,19 +461,19 @@ fn run_controller_upgrade_with_operation(
             )?;
             let (mut extensions_updated, mut extension_skips) =
                 if !controller_allows_extension_refresh(false, &initial_completion) {
-                    operation.mark_extensions(
+                    operation.mark_extensions_durable(
                         "not_run",
                         "controller changed before extension refresh admission",
-                    );
+                    )?;
                     (vec![], vec![])
                 } else if skip_extensions {
-                    operation.mark_extensions("skipped", "extension refresh skipped");
+                    operation.mark_extensions_durable("skipped", "extension refresh skipped")?;
                     (vec![], vec![])
                 } else {
                     operation.set_phase_durable("refreshing installed extensions")?;
                     let (updated, skipped) = update_all_extensions(operation.id())?;
                     let status = extension_component_status(true, false, &updated, &skipped);
-                    operation.mark_extensions(&status.status, &status.summary);
+                    operation.mark_extensions_durable(&status.status, &status.summary)?;
                     (updated, skipped)
                 };
             let mut completion;
@@ -675,6 +675,26 @@ fn run_controller_upgrade_with_operation(
             }
         },
         || {
+            if matches!(
+                install_method,
+                InstallMethod::Homebrew | InstallMethod::Secondary
+            ) && !deliberate
+            {
+                let completion = reconcile_controller_identity(
+                    observed_installed_controller_identity()?,
+                    previous_build_identity.as_deref(),
+                    Some(previous_version.as_str()),
+                )?;
+                if completion.superseded {
+                    return Ok((
+                        false,
+                        completion.version,
+                        completion.build_identity,
+                        None,
+                        true,
+                    ));
+                }
+            }
             let operation_id = operation
                 .id()
                 .expect("controller upgrades require a durable operation")
@@ -807,22 +827,22 @@ fn run_controller_upgrade_with_operation(
     // mismatches and inconsistent audit findings.
     let (mut extensions_updated, mut extension_skips) =
         if !controller_allows_extension_refresh(superseded, &initial_completion) {
-            operation.mark_extensions(
+            operation.mark_extensions_durable(
                 "not_run",
                 "controller changed before extension refresh admission",
-            );
+            )?;
             (vec![], vec![])
         } else if upgrade_completed && !skip_extensions {
             operation.set_phase_durable("refreshing installed extensions")?;
             let (updated, skipped) = update_all_extensions(operation.id())?;
             let status = extension_component_status(true, false, &updated, &skipped);
-            operation.mark_extensions(&status.status, &status.summary);
+            operation.mark_extensions_durable(&status.status, &status.summary)?;
             (updated, skipped)
         } else if skip_extensions {
-            operation.mark_extensions("skipped", "extension refresh skipped");
+            operation.mark_extensions_durable("skipped", "extension refresh skipped")?;
             (vec![], vec![])
         } else {
-            operation.mark_extensions("not_run", "extension refresh was not attempted");
+            operation.mark_extensions_durable("not_run", "extension refresh was not attempted")?;
             (vec![], vec![])
         };
 

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -459,7 +459,7 @@ fn run_controller_upgrade_with_operation(
                 previous_build_identity.as_deref(),
                 Some(previous_version.as_str()),
             )?;
-            let (extensions_updated, extension_skips) =
+            let (mut extensions_updated, mut extension_skips) =
                 if !controller_allows_extension_refresh(false, &initial_completion) {
                     operation.mark_extensions(
                         "not_run",
@@ -478,7 +478,7 @@ fn run_controller_upgrade_with_operation(
                 };
             let mut completion;
             drop(selection_guard);
-            let (runners_updated, runners_skipped) = if skip_runners {
+            let (mut runners_updated, mut runners_skipped) = if skip_runners {
                 (vec![], vec![])
             } else {
                 let promotion_lease =
@@ -513,6 +513,12 @@ fn run_controller_upgrade_with_operation(
                 previous_build_identity.as_deref(),
                 Some(previous_version.as_str()),
             )?;
+            if completion.superseded {
+                extensions_updated.clear();
+                extension_skips.clear();
+                runners_updated.clear();
+                runners_skipped.clear();
+            }
             let partial = runner_convergence_failed(
                 &runners_updated,
                 &runners_skipped,
@@ -524,13 +530,17 @@ fn run_controller_upgrade_with_operation(
                 &runners_skipped,
                 completion.version.as_deref(),
             );
-            let extensions_status = extension_component_status(
-                !skip_extensions,
-                skip_extensions,
-                &extensions_updated,
-                &extension_skips,
-            );
-            let result = UpgradeResult {
+            let extensions_status = if completion.superseded {
+                superseded_extension_status()
+            } else {
+                extension_component_status(
+                    !skip_extensions,
+                    skip_extensions,
+                    &extensions_updated,
+                    &extension_skips,
+                )
+            };
+            let mut result = UpgradeResult {
                 command: "upgrade".to_string(),
                 install_method,
                 previous_version: previous_version.clone(),
@@ -561,33 +571,42 @@ fn run_controller_upgrade_with_operation(
                     },
                 )),
                 extensions: Some(extensions_status.clone()),
-                runners: Some(runner_component_status(
-                    runner_disposition,
-                    &runners_updated,
-                    &runners_skipped,
-                    false,
-                )),
+                runners: Some(if completion.superseded {
+                    superseded_runner_status()
+                } else {
+                    runner_component_status(
+                        runner_disposition,
+                        &runners_updated,
+                        &runners_skipped,
+                        false,
+                    )
+                }),
                 partial,
                 runner_convergence: Some(runner_disposition),
-                message: format!(
-                    "{}{}",
-                    match runner_disposition {
-                        RunnerConvergenceDisposition::Partial => {
-                            "PARTIAL: controller is already current, but configured runners did not converge"
+                message: if completion.superseded {
+                    superseded_completion_message(completion.build_identity.as_deref())
+                } else {
+                    format!(
+                        "{}{}",
+                        match runner_disposition {
+                            RunnerConvergenceDisposition::Partial => {
+                                "PARTIAL: controller is already current, but configured runners did not converge"
                                 .to_string()
-                        }
-                        RunnerConvergenceDisposition::Skipped => {
-                            "Already at latest version; runner convergence skipped".to_string()
-                        }
-                        RunnerConvergenceDisposition::NoRunnersConfigured => {
-                            "Already at latest version; no configured runners".to_string()
-                        }
-                        RunnerConvergenceDisposition::Converged => {
-                            "Already at latest version; configured runners converged".to_string()
-                        }
-                    },
-                    extension_partial_clause(Some(&extensions_status)),
-                ),
+                            }
+                            RunnerConvergenceDisposition::Skipped => {
+                                "Already at latest version; runner convergence skipped".to_string()
+                            }
+                            RunnerConvergenceDisposition::NoRunnersConfigured => {
+                                "Already at latest version; no configured runners".to_string()
+                            }
+                            RunnerConvergenceDisposition::Converged => {
+                                "Already at latest version; configured runners converged"
+                                    .to_string()
+                            }
+                        },
+                        extension_partial_clause(Some(&extensions_status)),
+                    )
+                },
                 restart_required: false,
                 extensions_unrefreshed: warn_unrefreshed_symlinked_extensions(&extensions_updated),
                 extensions_updated,
@@ -604,7 +623,10 @@ fn run_controller_upgrade_with_operation(
                 services_pending_restart: Vec::new(),
                 operation_id: None,
             };
-            drop(final_selection_guard);
+            if completion.superseded {
+                invalidate_superseded_evidence(&mut result);
+            }
+            finish_completed_under_selection(operation, &result, final_selection_guard)?;
             return Ok(result);
         }
     }
@@ -614,6 +636,11 @@ fn run_controller_upgrade_with_operation(
     // their final install shares this lease rather than opening a TOCTOU window.
     let controller_mutation_lease =
         acquire_controller_upgrade_lease(operation, "controller upgrade")?;
+    super::operation::freeze_prior_pending_replacements(
+        operation
+            .id()
+            .expect("controller upgrades require a durable operation"),
+    )?;
     controller_mutation_lease.assert_generation()?;
     let extension_revalidation = (!skip_extensions)
         .then(|| preflight_extensions_for_upgrade(&candidate_version))
@@ -690,19 +717,11 @@ fn run_controller_upgrade_with_operation(
                         result
                     };
                     let mut replacement_checkpoint =
-                        |state: &str,
-                         target: &Path,
-                         expected_version: Option<&str>,
-                         expected_build_identity: Option<&str>| {
+                        |checkpoint: &super::execution::ReplacementCheckpoint| {
                             let _phase = phase_sync.lock().expect("serialize upgrade progress");
                             operation
                                 .borrow_mut()
-                                .record_replacement_checkpoint_durable(
-                                    state,
-                                    target,
-                                    expected_version,
-                                    expected_build_identity,
-                                )
+                                .record_replacement_checkpoint_durable(checkpoint)
                         };
                     execute_upgrade(
                         install_method,
@@ -786,7 +805,7 @@ fn run_controller_upgrade_with_operation(
     // Auto-update all installed extensions after the upgrade command completes.
     // This prevents CI/local extension version drift that causes baseline
     // mismatches and inconsistent audit findings.
-    let (extensions_updated, extension_skips) =
+    let (mut extensions_updated, mut extension_skips) =
         if !controller_allows_extension_refresh(superseded, &initial_completion) {
             operation.mark_extensions(
                 "not_run",
@@ -809,7 +828,7 @@ fn run_controller_upgrade_with_operation(
 
     drop(selection_guard);
 
-    let (runners_updated, runners_skipped) = if upgrade_completed && !skip_runners {
+    let (mut runners_updated, mut runners_skipped) = if upgrade_completed && !skip_runners {
         let promotion_lease =
             acquire_controller_upgrade_lease(operation, "controller upgrade completion")?;
         promotion_lease.assert_generation()?;
@@ -864,6 +883,10 @@ fn run_controller_upgrade_with_operation(
             "superseded",
             "controller changed before upgrade completion was recorded",
         )?;
+        extensions_updated.clear();
+        extension_skips.clear();
+        runners_updated.clear();
+        runners_skipped.clear();
     }
 
     let runner_disposition = runner_convergence_disposition(
@@ -873,14 +896,18 @@ fn run_controller_upgrade_with_operation(
         completion.version.as_deref(),
     );
 
-    let extensions_status = extension_component_status(
-        upgrade_completed,
-        skip_extensions,
-        &extensions_updated,
-        &extension_skips,
-    );
+    let extensions_status = if completion_superseded {
+        superseded_extension_status()
+    } else {
+        extension_component_status(
+            upgrade_completed,
+            skip_extensions,
+            &extensions_updated,
+            &extension_skips,
+        )
+    };
 
-    let result = UpgradeResult {
+    let mut result = UpgradeResult {
         command: "upgrade".to_string(),
         install_method,
         previous_version,
@@ -912,27 +939,35 @@ fn run_controller_upgrade_with_operation(
             },
         )),
         extensions: Some(extensions_status.clone()),
-        runners: Some(runner_component_status(
-            runner_disposition,
-            &runners_updated,
-            &runners_skipped,
-            !upgrade_completed && !skip_runners,
-        )),
+        runners: Some(if completion_superseded {
+            superseded_runner_status()
+        } else {
+            runner_component_status(
+                runner_disposition,
+                &runners_updated,
+                &runners_skipped,
+                !upgrade_completed && !skip_runners,
+            )
+        }),
         partial: runner_convergence_failed(
             &runners_updated,
             &runners_skipped,
             completion.version.as_deref(),
         ),
         runner_convergence: Some(runner_disposition),
-        message: upgrade_message(
-            success,
-            completion.version.as_deref(),
-            completion.build_identity.as_deref(),
-            runner_disposition,
-            &runners_updated,
-            &runners_skipped,
-            Some(&extensions_status),
-        ),
+        message: if completion_superseded {
+            superseded_completion_message(completion.build_identity.as_deref())
+        } else {
+            upgrade_message(
+                success,
+                completion.version.as_deref(),
+                completion.build_identity.as_deref(),
+                runner_disposition,
+                &runners_updated,
+                &runners_skipped,
+                Some(&extensions_status),
+            )
+        },
         // Source replacement updates the on-disk executable, but this command
         // exits immediately afterwards. Re-execing only `--version` skips the
         // normal completion path and provides no lifecycle benefit.
@@ -950,7 +985,10 @@ fn run_controller_upgrade_with_operation(
         services_pending_restart,
         operation_id: None,
     };
-    drop(final_selection_guard);
+    if completion_superseded {
+        invalidate_superseded_evidence(&mut result);
+    }
+    finish_completed_under_selection(operation, &result, final_selection_guard)?;
     Ok(result)
 }
 
@@ -1541,6 +1579,44 @@ fn component_status(status: &str, summary: &str) -> UpgradeComponentStatus {
     }
 }
 
+fn superseded_extension_status() -> UpgradeComponentStatus {
+    component_status(
+        "not_run",
+        "extension evidence was invalidated after controller supersession",
+    )
+}
+
+fn superseded_runner_status() -> UpgradeComponentStatus {
+    component_status(
+        "not_run",
+        "runner evidence was invalidated after controller supersession",
+    )
+}
+
+fn superseded_completion_message(active_identity: Option<&str>) -> String {
+    match active_identity {
+        Some(identity) => format!(
+            "Controller operation was superseded by active build {identity}; extension and runner evidence was invalidated"
+        ),
+        None => "Controller operation was superseded; extension and runner evidence was invalidated"
+            .to_string(),
+    }
+}
+
+fn invalidate_superseded_evidence(result: &mut UpgradeResult) {
+    result.extensions = Some(superseded_extension_status());
+    result.runners = Some(superseded_runner_status());
+    result.partial = false;
+    result.runner_convergence = Some(RunnerConvergenceDisposition::Skipped);
+    result.message = superseded_completion_message(result.new_build_identity.as_deref());
+    result.extensions_updated.clear();
+    result.extensions_skipped.clear();
+    result.extension_skips.clear();
+    result.extensions_unrefreshed.clear();
+    result.runners_updated.clear();
+    result.runners_skipped.clear();
+}
+
 fn extension_component_status(
     attempted: bool,
     skipped_by_flag: bool,
@@ -2029,6 +2105,30 @@ fn complete_upgrade_operation(
         return Err(error);
     }
     Ok(result)
+}
+
+fn finish_completed_under_selection(
+    operation: &mut UpgradeOperation,
+    result: &UpgradeResult,
+    selection_guard: homeboy_core::runtime_promotion::RuntimeSelectionGuard,
+) -> Result<()> {
+    let terminal = match operation.finish_completed_durable(result) {
+        Ok(()) => Ok(()),
+        Err(completion_error) => {
+            match operation.replace_pending_terminal_with_failure(&completion_error) {
+                Ok(()) => Err(completion_error),
+                Err(mut terminal_error) => {
+                    terminal_error.details["completion_error"] = serde_json::json!({
+                        "code": format!("{:?}", completion_error.code),
+                        "message": completion_error.message,
+                    });
+                    Err(terminal_error)
+                }
+            }
+        }
+    };
+    drop(selection_guard);
+    terminal
 }
 
 fn acquire_controller_selection_guard(
@@ -2758,6 +2858,152 @@ mod runner_source_upgrade_tests {
                     .expect("operation remains inspectable");
             assert_eq!(status.status, "pass");
             assert_eq!(status.phase, "completed");
+        });
+    }
+
+    #[test]
+    fn final_identity_and_terminal_cas_block_the_exact_controller_contender_interleaving() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
+            let operation_id = operation.id().expect("durable operation").to_string();
+            let selection_guard =
+                homeboy_core::runtime_promotion::protect_runtime_selection_with_status(
+                    "controller upgrade result",
+                    "active controller",
+                    homeboy_core::runtime_promotion::RuntimePromotionOwnerStatus {
+                        operation_id: operation_id.clone(),
+                        status_command: format!("homeboy upgrade status {operation_id}"),
+                    },
+                )
+                .expect("protect final identity");
+            let result = source_upgrade_noop_result(
+                InstallMethod::Source,
+                "0.367.2".to_string(),
+                Some("0.367.2+selected".to_string()),
+                SourceUpgradeDecision::SameIdentity,
+            );
+            let (waiting_tx, waiting_rx) = std::sync::mpsc::channel();
+            let acquired = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let contender_acquired = acquired.clone();
+            let contender = std::thread::spawn(move || {
+                let lease =
+                    homeboy_core::runtime_promotion::acquire_waiting_for_target_with_status(
+                        "contending controller upgrade",
+                        "active controller",
+                        homeboy_core::runtime_promotion::RuntimePromotionOwnerStatus {
+                            operation_id: "contender".to_string(),
+                            status_command: "homeboy upgrade status contender".to_string(),
+                        },
+                        std::time::Duration::from_secs(2),
+                        |event| {
+                            if event.wait_stage == "os_lock" {
+                                let _ = waiting_tx.send(());
+                            }
+                        },
+                    )
+                    .expect("contender acquires after terminal CAS");
+                contender_acquired.store(true, std::sync::atomic::Ordering::Release);
+                drop(lease);
+            });
+            let progress_id = operation_id.clone();
+            let acquired_before_terminal = acquired.clone();
+            operation.before_terminal_write(move || {
+                waiting_rx
+                    .recv_timeout(std::time::Duration::from_secs(1))
+                    .expect("contender reaches final-read/terminal-CAS window");
+                assert!(
+                    !acquired_before_terminal.load(std::sync::atomic::Ordering::Acquire),
+                    "contender cannot supersede identity before completion"
+                );
+                super::super::operation::persist_extension_progress(
+                    &progress_id,
+                    "wordpress",
+                    1,
+                    2,
+                    std::time::Duration::from_secs(1),
+                )
+                .expect("force terminal metadata CAS retry");
+            });
+
+            finish_completed_under_selection(&mut operation, &result, selection_guard)
+                .expect("terminal CAS completes under selection guard");
+            contender.join().expect("contender exits");
+            assert!(acquired.load(std::sync::atomic::Ordering::Acquire));
+            let status =
+                super::super::operation::load_upgrade_operation_status(Some(&operation_id))
+                    .expect("load terminal operation");
+            assert_eq!(status.status, "pass");
+            assert_eq!(status.phase, "completed");
+        });
+    }
+
+    #[test]
+    fn exhausted_completion_cas_is_frozen_as_failure_before_selection_release() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
+            let operation_id = operation.id().expect("durable operation").to_string();
+            operation.fail_next_terminal_writes(3);
+            let selection_guard =
+                homeboy_core::runtime_promotion::protect_runtime_selection_with_status(
+                    "controller upgrade result",
+                    "active controller",
+                    homeboy_core::runtime_promotion::RuntimePromotionOwnerStatus {
+                        operation_id: operation_id.clone(),
+                        status_command: format!("homeboy upgrade status {operation_id}"),
+                    },
+                )
+                .expect("protect final identity");
+            let result = source_upgrade_noop_result(
+                InstallMethod::Source,
+                "0.367.2".to_string(),
+                Some("0.367.2+selected".to_string()),
+                SourceUpgradeDecision::SameIdentity,
+            );
+
+            finish_completed_under_selection(&mut operation, &result, selection_guard)
+                .expect_err("completion CAS exhaustion remains an operation error");
+            let status =
+                super::super::operation::load_upgrade_operation_status(Some(&operation_id))
+                    .expect("load terminal operation");
+            assert_eq!(status.status, "error");
+            assert_eq!(status.phase, "failed");
+        });
+    }
+
+    #[test]
+    fn exhausted_completion_and_failure_cas_retain_a_retryable_failure_intent() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
+            let operation_id = operation.id().expect("durable operation").to_string();
+            operation.fail_next_terminal_writes(6);
+            let selection_guard =
+                homeboy_core::runtime_promotion::protect_runtime_selection_with_status(
+                    "controller upgrade result",
+                    "active controller",
+                    homeboy_core::runtime_promotion::RuntimePromotionOwnerStatus {
+                        operation_id: operation_id.clone(),
+                        status_command: format!("homeboy upgrade status {operation_id}"),
+                    },
+                )
+                .expect("protect final identity");
+            let result = source_upgrade_noop_result(
+                InstallMethod::Source,
+                "0.367.2".to_string(),
+                Some("0.367.2+selected".to_string()),
+                SourceUpgradeDecision::SameIdentity,
+            );
+
+            let terminal_error =
+                finish_completed_under_selection(&mut operation, &result, selection_guard)
+                    .expect_err("both bounded terminal attempts are exhausted");
+            operation
+                .finish_failed_durable(&terminal_error)
+                .expect("outer error handling retries the retained failure intent");
+            let status =
+                super::super::operation::load_upgrade_operation_status(Some(&operation_id))
+                    .expect("load terminal operation");
+            assert_eq!(status.status, "error");
+            assert_eq!(status.phase, "failed");
         });
     }
 
@@ -3844,6 +4090,114 @@ mod convergence_tests {
             exit_code: 0,
             detail: String::new(),
         }
+    }
+
+    #[test]
+    fn late_supersession_invalidates_the_complete_prior_generation_result() {
+        let stale_runner = runner("0.309.0", "0.310.0", true);
+        let stale_extension = ExtensionUpgradeEntry {
+            extension_id: "wordpress".to_string(),
+            old_version: "1".to_string(),
+            new_version: "2".to_string(),
+            linked: false,
+            source_path: None,
+            git_root: None,
+            source_url: None,
+            source_revision: None,
+            source_update: Default::default(),
+        };
+        let stale_skip = ExtensionUpgradeSkip {
+            extension_id: "woocommerce".to_string(),
+            reason: "stale generation failure".to_string(),
+        };
+        let mut result = UpgradeResult {
+            command: "upgrade".to_string(),
+            install_method: InstallMethod::Binary,
+            previous_version: "0.309.0".to_string(),
+            new_version: Some("0.311.0".to_string()),
+            previous_build_identity: Some("0.309.0+old".to_string()),
+            new_build_identity: Some("0.311.0+contender".to_string()),
+            source_revision: None,
+            upgraded: true,
+            outcome: Some("controller_superseded".to_string()),
+            preflight: None,
+            controller: Some(component_status("superseded", "controller superseded")),
+            extensions: Some(component_status("partial", "stale extension evidence")),
+            runners: Some(component_status("partial", "stale runner evidence")),
+            partial: true,
+            runner_convergence: Some(RunnerConvergenceDisposition::Partial),
+            message: "stale runner and extension classifications".to_string(),
+            restart_required: false,
+            extensions_updated: vec![stale_extension],
+            extensions_skipped: vec!["woocommerce".to_string()],
+            extension_skips: vec![stale_skip],
+            runners_updated: vec![stale_runner.clone()],
+            runners_skipped: vec![stale_runner],
+            extensions_unrefreshed: vec![UnrefreshedExtensionWarning {
+                extension_id: "wordpress".to_string(),
+                invoking_user: "alice".to_string(),
+                symlink_path: "/tmp/extensions/wordpress".to_string(),
+                source_path: "/tmp/wordpress".to_string(),
+                behind: Some(1),
+                dirty: false,
+                dirty_paths: Vec::new(),
+                recovery_command: "git pull".to_string(),
+            }],
+            services_restarted: Vec::new(),
+            services_pending_restart: Vec::new(),
+            operation_id: None,
+        };
+
+        invalidate_superseded_evidence(&mut result);
+
+        assert_eq!(result.new_version.as_deref(), Some("0.311.0"));
+        assert_eq!(
+            result.new_build_identity.as_deref(),
+            Some("0.311.0+contender")
+        );
+        assert_eq!(result.outcome.as_deref(), Some("controller_superseded"));
+        assert_eq!(
+            result
+                .controller
+                .as_ref()
+                .map(|status| status.status.as_str()),
+            Some("superseded")
+        );
+        assert_eq!(
+            result
+                .extensions
+                .as_ref()
+                .map(|status| status.status.as_str()),
+            Some("not_run")
+        );
+        assert_eq!(
+            result.runners.as_ref().map(|status| status.status.as_str()),
+            Some("not_run")
+        );
+        assert_eq!(
+            result.runner_convergence,
+            Some(RunnerConvergenceDisposition::Skipped)
+        );
+        assert!(!result.partial);
+        assert!(result.message.contains("0.311.0+contender"));
+        assert!(result.message.contains("evidence was invalidated"));
+        let payload = serde_json::to_value(&result).expect("serialize result");
+        for field in [
+            "extensions_updated",
+            "extensions_skipped",
+            "extension_skips",
+            "extensions_unrefreshed",
+            "runners_updated",
+            "runners_skipped",
+        ] {
+            assert!(
+                payload.get(field).is_none(),
+                "stale field survived: {field}"
+            );
+        }
+        assert!(!payload.to_string().contains("wordpress"));
+        assert!(!payload.to_string().contains("woocommerce"));
+        assert!(!payload.to_string().contains("lab"));
     }
 
     #[test]

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -23,7 +23,7 @@ use super::release_catalog::{self, InstallableSelection, ReleaseEntry, SelectedR
 use super::services;
 use super::types::*;
 use super::update_check::RuntimeCompatibility;
-use super::validation::check_for_updates;
+use super::validation::{check_for_updates, selects_an_installable_release};
 
 const CONTROLLER_UPGRADE_PROMOTION_WAIT_TIMEOUT: Duration = Duration::from_secs(20 * 60);
 
@@ -303,7 +303,7 @@ fn run_controller_upgrade_with_operation(
     // selected candidate, so it must not prevent building or staging it.
     if !matches!(
         install_method,
-        InstallMethod::Binary | InstallMethod::Source
+        InstallMethod::Binary | InstallMethod::Secondary | InstallMethod::Source
     ) {
         operation.set_phase_durable("running_candidate_admission")?;
         ensure_controller_upgrade_admission()?;
@@ -363,7 +363,7 @@ fn run_controller_upgrade_with_operation(
     // Resolve the binary candidate and validate installed extension sources
     // before the no-op branch can refresh extensions without swapping the
     // controller. This keeps every extension mutation behind the same gate.
-    let selected_release = if install_method == InstallMethod::Binary {
+    let selected_release = if selects_an_installable_release(install_method) {
         Some(resolve_binary_release(pinned_version)?)
     } else {
         None
@@ -395,9 +395,11 @@ fn run_controller_upgrade_with_operation(
         runner_method_override,
         source_upgrade_path.as_deref(),
     );
-    let extension_preflight = (!skip_extensions)
-        .then(|| preflight_extensions_for_upgrade(&candidate_version))
-        .unwrap_or_default();
+    let extension_preflight = if skip_extensions {
+        Vec::new()
+    } else {
+        preflight_extensions_for_upgrade(&candidate_version)
+    };
     if !extension_preflight.is_empty() {
         return Ok(extension_preflight_failure_result(
             install_method,
@@ -650,9 +652,11 @@ fn run_controller_upgrade_with_operation(
             .expect("controller upgrades require a durable operation"),
     )?;
     controller_mutation_lease.assert_generation()?;
-    let extension_revalidation = (!skip_extensions)
-        .then(|| preflight_extensions_for_upgrade(&candidate_version))
-        .unwrap_or_default();
+    let extension_revalidation = if skip_extensions {
+        Vec::new()
+    } else {
+        preflight_extensions_for_upgrade(&candidate_version)
+    };
     if !extension_revalidation.is_empty() {
         let result = extension_preflight_failure_result(
             install_method,
@@ -683,11 +687,7 @@ fn run_controller_upgrade_with_operation(
             }
         },
         || {
-            if matches!(
-                install_method,
-                InstallMethod::Homebrew | InstallMethod::Secondary
-            ) && !deliberate
-            {
+            if matches!(install_method, InstallMethod::Homebrew) && !deliberate {
                 let completion = reconcile_controller_identity(
                     observed_installed_controller_identity()?,
                     previous_build_identity.as_deref(),
@@ -1347,7 +1347,7 @@ fn validate_pinned_version(pinned_version: Option<&str>, method: InstallMethod) 
     let Some(requested) = pinned_version else {
         return Ok(());
     };
-    if method == InstallMethod::Binary {
+    if matches!(method, InstallMethod::Binary | InstallMethod::Secondary) {
         return Ok(());
     }
 
@@ -2706,14 +2706,17 @@ pub(crate) fn source_promotion_decision(
         return SourceUpgradeDecision::IdentityUnavailable;
     }
 
-    Command::new("git")
+    if Command::new("git")
         .arg("-C")
         .arg(source_path)
         .args(["merge-base", "--is-ancestor", active_commit, "HEAD"])
         .status()
         .is_ok_and(|status| status.success())
-        .then_some(SourceUpgradeDecision::DifferentIdentity)
-        .unwrap_or(SourceUpgradeDecision::OlderVersion)
+    {
+        SourceUpgradeDecision::DifferentIdentity
+    } else {
+        SourceUpgradeDecision::OlderVersion
+    }
 }
 
 fn source_upgrade_decision_for_identity(
@@ -4688,13 +4691,10 @@ mod pinned_release_tests {
     #[test]
     fn a_pin_is_refused_for_install_methods_that_download_no_release_asset() {
         assert!(validate_pinned_version(Some("v0.332.0"), InstallMethod::Binary).is_ok());
+        assert!(validate_pinned_version(Some("v0.332.0"), InstallMethod::Secondary).is_ok());
         assert!(validate_pinned_version(None, InstallMethod::Source).is_ok());
 
-        for method in [
-            InstallMethod::Source,
-            InstallMethod::Homebrew,
-            InstallMethod::Secondary,
-        ] {
+        for method in [InstallMethod::Source, InstallMethod::Homebrew] {
             let error = validate_pinned_version(Some("v0.332.0"), method)
                 .expect_err("a pin is meaningless without a release download");
             assert!(
@@ -4729,11 +4729,7 @@ mod pinned_release_tests {
 
     #[test]
     fn an_explicit_incompatible_method_with_a_pin_fails_closed() {
-        for method in [
-            InstallMethod::Source,
-            InstallMethod::Homebrew,
-            InstallMethod::Secondary,
-        ] {
+        for method in [InstallMethod::Source, InstallMethod::Homebrew] {
             let (resolved, inferred) =
                 resolve_install_method(Some(method), Some("v0.332.0"), || {
                     panic!("explicit methods must not trigger detection")

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -5,19 +5,19 @@ use homeboy_core::extension::lifecycle;
 use homeboy_core::extension::lifecycle::is_git_url;
 use homeboy_core::{build_identity, git};
 use semver::Version;
-use serde::Serialize;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
 use super::constants::{GITHUB_RELEASES_API, VERSION};
 use super::execution::{
-    execute_upgrade, installed_target_build_identity, prepare_source_workspace_for_upgrade,
+    active_binary_path, execute_upgrade, installed_target_build_identity,
+    installed_target_build_identity_from_disk, prepare_source_workspace_for_upgrade,
     resolve_source_workspace,
 };
 use super::operation::{
-    persist_extension_progress, run_with_upgrade_heartbeats, UpgradeOperation,
-    UPGRADE_PROGRESS_HEARTBEAT_INTERVAL,
+    persist_extension_progress, persist_upgrade_heartbeat, run_with_upgrade_heartbeats,
+    UpgradeOperation, UPGRADE_PROGRESS_HEARTBEAT_INTERVAL,
 };
 use super::release_catalog::{self, InstallableSelection, ReleaseEntry, SelectedRelease};
 use super::services;
@@ -25,17 +25,7 @@ use super::types::*;
 use super::update_check::RuntimeCompatibility;
 use super::validation::check_for_updates;
 
-const CONTROLLER_UPGRADE_WAIT_TIMEOUT: Duration = Duration::from_secs(15 * 60);
-
-#[derive(Debug, Serialize)]
-struct ControllerUpgradeWaitEvent {
-    #[serde(flatten)]
-    admission: homeboy_core::runtime_promotion::RuntimePromotionWaitEvent,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    owner_operation_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    owner_status_command: Option<String>,
-}
+const CONTROLLER_UPGRADE_PROMOTION_WAIT_TIMEOUT: Duration = Duration::from_secs(20 * 60);
 
 pub fn current_version() -> &'static str {
     VERSION
@@ -43,138 +33,6 @@ pub fn current_version() -> &'static str {
 
 pub fn current_build_version() -> String {
     build_identity::current().display
-}
-
-fn acquire_controller_upgrade_lease(
-    operation: &mut UpgradeOperation,
-    timeout: Duration,
-    mut progress: impl FnMut(ControllerUpgradeWaitEvent),
-) -> Result<homeboy_core::runtime_promotion::RuntimePromotionLease> {
-    let lease_operation = operation
-        .id()
-        .map(|id| format!("controller upgrade operation={id}"))
-        .unwrap_or_else(|| "controller upgrade".to_string());
-    operation.set_phase("waiting for controller promotion admission");
-    let lease = homeboy_core::runtime_promotion::acquire_waiting_for_compatible(
-        &lease_operation,
-        "active controller",
-        timeout,
-        |admission| {
-            let event = controller_upgrade_wait_event(admission);
-            operation.set_phase(&format!(
-                "queued behind controller promotion owner pid={} operation={}",
-                event.admission.owner_pid, event.admission.owner_operation
-            ));
-            progress(event);
-        },
-    )?;
-    operation.set_phase("admitted for controller promotion");
-    Ok(lease)
-}
-
-fn controller_upgrade_wait_event(
-    admission: homeboy_core::runtime_promotion::RuntimePromotionWaitEvent,
-) -> ControllerUpgradeWaitEvent {
-    let owner_operation_id = admission
-        .owner_operation
-        .strip_prefix("controller upgrade operation=")
-        .filter(|id| !id.is_empty())
-        .map(str::to_string);
-    let owner_status_command = owner_operation_id
-        .as_ref()
-        .map(|id| format!("homeboy upgrade status {id}"));
-    ControllerUpgradeWaitEvent {
-        admission,
-        owner_operation_id,
-        owner_status_command,
-    }
-}
-
-fn emit_controller_upgrade_wait(event: ControllerUpgradeWaitEvent) {
-    eprintln!(
-        "{}",
-        serde_json::to_string(&event).unwrap_or_else(|_| {
-            "{\"schema\":\"homeboy/runtime-promotion-admission/v1\",\"state\":\"queued\",\"resource_class\":\"runtime_promotion\"}".to_string()
-        })
-    );
-}
-
-#[cfg(test)]
-mod controller_upgrade_wait_tests {
-    use super::*;
-    use homeboy_core::ErrorCode;
-    use std::sync::mpsc;
-
-    #[test]
-    fn parallel_controller_upgrades_wait_and_report_the_owner_status_command() {
-        homeboy_core::test_support::with_isolated_home(|_| {
-            let mut owner = UpgradeOperation::start("homeboy upgrade");
-            let owner_id = owner.id().expect("owner operation is durable").to_string();
-            let owner_lease =
-                acquire_controller_upgrade_lease(&mut owner, Duration::from_secs(1), |_| {
-                    unreachable!("uncontended owner does not queue")
-                })
-                .expect("owner acquires controller promotion");
-            let (queued_tx, queued_rx) = mpsc::channel();
-
-            let waiter = std::thread::spawn(move || {
-                let mut contender = UpgradeOperation::start("homeboy upgrade");
-                acquire_controller_upgrade_lease(&mut contender, Duration::from_secs(1), |event| {
-                    queued_tx.send(event).expect("report queued owner")
-                })
-                .map(drop)
-            });
-
-            let event = queued_rx
-                .recv_timeout(Duration::from_secs(1))
-                .expect("contender queues behind the owner");
-            assert_eq!(event.owner_operation_id.as_deref(), Some(owner_id.as_str()));
-            assert_eq!(
-                event.owner_status_command.as_deref(),
-                Some(format!("homeboy upgrade status {owner_id}").as_str())
-            );
-            let owner_status = super::super::load_upgrade_operation_status(Some(&owner_id))
-                .expect("owner status remains inspectable while it holds the lease");
-            assert_eq!(owner_status.operation_id, owner_id);
-            assert_eq!(owner_status.phase, "admitted for controller promotion");
-            assert_eq!(
-                owner_status.inspect_command.as_deref(),
-                Some(format!("homeboy upgrade status {owner_id}").as_str())
-            );
-
-            drop(owner_lease);
-            waiter
-                .join()
-                .expect("waiter thread exits")
-                .expect("contender acquires after owner completes");
-        });
-    }
-
-    #[test]
-    fn timed_out_controller_upgrade_waiter_does_not_disturb_the_owner() {
-        homeboy_core::test_support::with_isolated_home(|_| {
-            let mut owner = UpgradeOperation::start("homeboy upgrade");
-            let owner_lease =
-                acquire_controller_upgrade_lease(&mut owner, Duration::from_secs(1), |_| {
-                    unreachable!("uncontended owner does not queue")
-                })
-                .expect("owner acquires controller promotion");
-            let waiter = std::thread::spawn(move || {
-                let mut contender = UpgradeOperation::start("homeboy upgrade");
-                acquire_controller_upgrade_lease(&mut contender, Duration::from_millis(10), |_| {})
-                    .map(drop)
-                    .map_err(|error| error.code)
-            });
-
-            assert_eq!(
-                waiter.join().expect("waiter thread exits"),
-                Err(ErrorCode::RuntimePromotionWaitTimeout)
-            );
-            owner_lease
-                .assert_generation()
-                .expect("timed-out contender leaves the owner lease intact");
-        });
-    }
 }
 
 fn fetch_latest_github_version_at(url: &str) -> Result<String> {
@@ -373,6 +231,52 @@ pub fn run_upgrade_with_method(
         return run_targeted_runner_upgrade(force, method_override, runner_targets, source_path);
     }
 
+    let mut operation = UpgradeOperation::start_durable("homeboy upgrade")?;
+    let upgrade_result = run_controller_upgrade_with_operation(
+        force,
+        method_override,
+        skip_extensions,
+        skip_runners,
+        skip_services,
+        runner_targets,
+        source_path,
+        pinned_version,
+        &mut operation,
+    );
+    match upgrade_result {
+        Ok(result) => complete_upgrade_operation(operation, result),
+        Err(mut error) => {
+            let operation_id = operation.id().map(str::to_string);
+            let terminal_result = operation.finish_failed_durable(&error);
+            if let Some(operation_id) = operation_id {
+                error.details["operation_id"] = serde_json::Value::String(operation_id.clone());
+                if let Err(mut terminal_error) = terminal_result {
+                    terminal_error.details["operation_id"] =
+                        serde_json::Value::String(operation_id);
+                    terminal_error.details["upgrade_error"] = serde_json::json!({
+                        "code": format!("{:?}", error.code),
+                        "message": error.message,
+                    });
+                    return Err(terminal_error);
+                }
+            }
+            Err(error)
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_controller_upgrade_with_operation(
+    force: bool,
+    method_override: Option<InstallMethod>,
+    skip_extensions: bool,
+    skip_runners: bool,
+    skip_services: bool,
+    runner_targets: &[String],
+    source_path: Option<&Path>,
+    pinned_version: Option<&str>,
+    operation: &mut UpgradeOperation,
+) -> Result<UpgradeResult> {
     let (install_method, inferred_from_pin) =
         resolve_install_method(method_override, pinned_version, detect_install_method);
 
@@ -401,6 +305,7 @@ pub fn run_upgrade_with_method(
         install_method,
         InstallMethod::Binary | InstallMethod::Source
     ) {
+        operation.set_phase_durable("running_candidate_admission")?;
         ensure_controller_upgrade_admission()?;
     }
     validate_pinned_version(pinned_version, install_method)?;
@@ -448,16 +353,7 @@ pub fn run_upgrade_with_method(
             })
             .transpose()?;
 
-    if let Some(decision) = source_upgrade_decision {
-        if !decision.upgrades() {
-            return Ok(source_upgrade_noop_result(
-                install_method,
-                previous_version,
-                previous_build_identity,
-                decision,
-            ));
-        }
-    }
+    let source_noop = source_upgrade_decision.is_some_and(|decision| !decision.upgrades());
 
     // An approved explicit source build is the controller target, regardless of
     // whether the latest published release has the same semantic version.
@@ -472,7 +368,9 @@ pub fn run_upgrade_with_method(
     } else {
         None
     };
-    let candidate_version = if let Some(release) = selected_release.as_ref() {
+    let candidate_version = if source_noop {
+        target_version.clone()
+    } else if let Some(release) = selected_release.as_ref() {
         release.version.clone()
     } else if install_method == InstallMethod::Source {
         source_upgrade_path
@@ -492,6 +390,11 @@ pub fn run_upgrade_with_method(
     } else {
         current_version().to_string()
     };
+    let (convergence_runner_method, convergence_source_path) = convergence_inputs(
+        source_noop,
+        runner_method_override,
+        source_upgrade_path.as_deref(),
+    );
     let extension_preflight = (!skip_extensions)
         .then(|| preflight_extensions_for_upgrade(&candidate_version))
         .unwrap_or_default();
@@ -509,11 +412,11 @@ pub fn run_upgrade_with_method(
     } else {
         super::with_runner_upgrade(|provider| {
             provider.preflight_configured_runners_for_upgrade(
-                runner_method_override,
-                source_upgrade_path.as_deref(),
+                convergence_runner_method,
+                convergence_source_path,
                 // A resolved source workspace is the controller-selected build
                 // input, even when it was inferred from the source install.
-                source_upgrade_path.is_some(),
+                convergence_source_path.is_some(),
                 runner_targets,
                 &candidate_version,
             )
@@ -530,57 +433,96 @@ pub fn run_upgrade_with_method(
 
     // Check if a release update is available unless an explicit source target
     // has already been approved for controller replacement.
-    if !replacement_approved {
-        let check = check_for_updates()?;
-        if !controller_replacement_proceeds(
-            deliberate,
-            source_upgrade_decision,
-            check.update_available,
-        ) {
+    if source_noop || !replacement_approved {
+        let replacement_now_required = if source_noop {
+            controller_replacement_required_after_discovery(
+                true,
+                deliberate,
+                source_upgrade_decision,
+                false,
+            )
+        } else {
+            let check = check_for_updates()?;
+            controller_replacement_required_after_discovery(
+                false,
+                deliberate,
+                source_upgrade_decision,
+                check.update_available,
+            )
+        };
+        if !replacement_now_required {
             // Even when no binary update is needed, still run extension updates.
-            let mut operation = UpgradeOperation::start("homeboy upgrade");
-            let (extensions_updated, extension_skips) = if skip_extensions {
-                operation.mark_extensions("skipped", "extension refresh skipped");
-                (vec![], vec![])
-            } else {
-                operation.set_phase("refreshing installed extensions");
-                let (updated, skipped) = update_all_extensions(operation.id());
-                let status = extension_component_status(true, false, &updated, &skipped);
-                operation.mark_extensions(&status.status, &status.summary);
-                (updated, skipped)
-            };
-            let promotion_lease = acquire_controller_upgrade_lease(
-                &mut operation,
-                CONTROLLER_UPGRADE_WAIT_TIMEOUT,
-                emit_controller_upgrade_wait,
+            let selection_guard =
+                acquire_controller_selection_guard(operation, "controller extension refresh")?;
+            let initial_completion = reconcile_controller_identity(
+                observed_installed_controller_identity()?,
+                previous_build_identity.as_deref(),
+                Some(previous_version.as_str()),
             )?;
+            let (extensions_updated, extension_skips) =
+                if !controller_allows_extension_refresh(false, &initial_completion) {
+                    operation.mark_extensions(
+                        "not_run",
+                        "controller changed before extension refresh admission",
+                    );
+                    (vec![], vec![])
+                } else if skip_extensions {
+                    operation.mark_extensions("skipped", "extension refresh skipped");
+                    (vec![], vec![])
+                } else {
+                    operation.set_phase_durable("refreshing installed extensions")?;
+                    let (updated, skipped) = update_all_extensions(operation.id())?;
+                    let status = extension_component_status(true, false, &updated, &skipped);
+                    operation.mark_extensions(&status.status, &status.summary);
+                    (updated, skipped)
+                };
+            let mut completion;
+            drop(selection_guard);
             let (runners_updated, runners_skipped) = if skip_runners {
                 (vec![], vec![])
             } else {
-                operation.set_phase("refreshing configured runners");
-                super::with_runner_upgrade(|p| {
-                    p.upgrade_configured_runners_with_explicit_source_path(
-                        force,
-                        runner_method_override,
-                        source_upgrade_path.as_deref(),
-                        source_upgrade_path.is_some(),
-                        None,
-                        runner_targets,
-                        &extensions_updated,
-                        Some(&promotion_lease),
-                    )
-                })?
+                let promotion_lease =
+                    acquire_controller_upgrade_lease(operation, "controller upgrade completion")?;
+                completion = reconcile_controller_identity(
+                    observed_installed_controller_identity()?,
+                    previous_build_identity.as_deref(),
+                    Some(previous_version.as_str()),
+                )?;
+                if completion.superseded {
+                    (vec![], vec![])
+                } else {
+                    operation.set_phase_durable("refreshing configured runners")?;
+                    super::with_runner_upgrade(|p| {
+                        p.upgrade_configured_runners_with_explicit_source_path(
+                            force,
+                            convergence_runner_method,
+                            convergence_source_path,
+                            convergence_source_path.is_some(),
+                            None,
+                            runner_targets,
+                            &extensions_updated,
+                            Some(&promotion_lease),
+                        )
+                    })?
+                }
             };
+            let final_selection_guard =
+                acquire_controller_selection_guard(operation, "controller upgrade result")?;
+            completion = reconcile_controller_identity(
+                observed_installed_controller_identity()?,
+                previous_build_identity.as_deref(),
+                Some(previous_version.as_str()),
+            )?;
             let partial = runner_convergence_failed(
                 &runners_updated,
                 &runners_skipped,
-                Some(previous_version.as_str()),
+                completion.version.as_deref(),
             );
             let runner_disposition = runner_convergence_disposition(
-                skip_runners,
+                runner_completion_is_skipped(skip_runners, true, completion.superseded),
                 &runners_updated,
                 &runners_skipped,
-                Some(previous_version.as_str()),
+                completion.version.as_deref(),
             );
             let extensions_status = extension_component_status(
                 !skip_extensions,
@@ -592,14 +534,32 @@ pub fn run_upgrade_with_method(
                 command: "upgrade".to_string(),
                 install_method,
                 previous_version: previous_version.clone(),
-                new_version: Some(previous_version),
+                new_version: completion.version.clone(),
                 previous_build_identity,
-                new_build_identity: None,
+                new_build_identity: completion.build_identity.clone(),
                 source_revision: None,
                 upgraded: false,
-                outcome: Some("controller_unchanged".to_string()),
+                outcome: Some(
+                    if completion.superseded {
+                        "controller_superseded"
+                    } else {
+                        "controller_unchanged"
+                    }
+                    .to_string(),
+                ),
                 preflight: None,
-                controller: Some(component_status("unchanged", "controller already current")),
+                controller: Some(component_status(
+                    if completion.superseded {
+                        "superseded"
+                    } else {
+                        "unchanged"
+                    },
+                    if completion.superseded {
+                        "controller changed while optional extension refresh was running"
+                    } else {
+                        "controller already current"
+                    },
+                )),
                 extensions: Some(extensions_status.clone()),
                 runners: Some(runner_component_status(
                     runner_disposition,
@@ -644,33 +604,31 @@ pub fn run_upgrade_with_method(
                 services_pending_restart: Vec::new(),
                 operation_id: None,
             };
-            return Ok(complete_upgrade_operation(operation, result));
+            drop(final_selection_guard);
+            return Ok(result);
         }
     }
 
-    let mut operation = UpgradeOperation::start("homeboy upgrade");
     // Keep the same promotion authority from compatibility revalidation through
     // the controller swap. Source builds retain their isolated build target, but
     // their final install shares this lease rather than opening a TOCTOU window.
-    let controller_mutation_lease = acquire_controller_upgrade_lease(
-        &mut operation,
-        CONTROLLER_UPGRADE_WAIT_TIMEOUT,
-        emit_controller_upgrade_wait,
-    )?;
+    let controller_mutation_lease =
+        acquire_controller_upgrade_lease(operation, "controller upgrade")?;
     controller_mutation_lease.assert_generation()?;
     let extension_revalidation = (!skip_extensions)
         .then(|| preflight_extensions_for_upgrade(&candidate_version))
         .unwrap_or_default();
     if !extension_revalidation.is_empty() {
-        return Ok(extension_preflight_failure_result(
+        let result = extension_preflight_failure_result(
             install_method,
             previous_version,
             previous_build_identity,
             &candidate_version,
             extension_revalidation,
-        ));
+        );
+        return Ok(result);
     }
-    operation.set_phase("revalidating controller upgrade admission");
+    operation.set_phase_durable("mutating controller")?;
     let controller_upgrade = run_controller_mutation_after_runner_preflight(
         runner_preflight,
         || {
@@ -690,85 +648,198 @@ pub fn run_upgrade_with_method(
             }
         },
         || {
-            execute_upgrade(
-                install_method,
-                source_upgrade_path.as_deref(),
-                source_path.is_some(),
-                force,
-                previous_build_identity.as_deref(),
-                selected_release.as_ref(),
-                Some(&controller_mutation_lease),
-                |phase| operation.set_phase(phase),
-            )
+            let operation_id = operation
+                .id()
+                .expect("controller upgrades require a durable operation")
+                .to_string();
+            let lease_heartbeat_failure = std::sync::Mutex::new(None);
+            let progress_heartbeat_failure = std::sync::Mutex::new(None);
+            let phase_sync = std::sync::Mutex::new(());
+            let execution_started = std::time::Instant::now();
+            let result = run_with_upgrade_heartbeats(
+                UPGRADE_PROGRESS_HEARTBEAT_INTERVAL,
+                |elapsed| {
+                    let _phase = phase_sync.lock().expect("serialize upgrade progress");
+                    if let Err(error) = controller_mutation_lease.heartbeat() {
+                        let mut failure = lease_heartbeat_failure
+                            .lock()
+                            .expect("record lease heartbeat failure");
+                        if failure.is_none() {
+                            *failure = Some(error);
+                        }
+                    }
+                    if let Err(error) = persist_upgrade_heartbeat(&operation_id, elapsed) {
+                        let mut failure = progress_heartbeat_failure
+                            .lock()
+                            .expect("record progress heartbeat failure");
+                        if failure.is_none() {
+                            *failure = Some(error);
+                        }
+                    }
+                },
+                || {
+                    let operation = std::cell::RefCell::new(&mut *operation);
+                    let mut report_phase = |phase: &str| {
+                        let _phase = phase_sync.lock().expect("serialize upgrade progress");
+                        let result = operation.borrow_mut().set_phase_durable(phase);
+                        if result.is_ok() {
+                            *progress_heartbeat_failure
+                                .lock()
+                                .expect("clear recovered progress heartbeat failure") = None;
+                        }
+                        result
+                    };
+                    let mut replacement_checkpoint =
+                        |state: &str,
+                         target: &Path,
+                         expected_version: Option<&str>,
+                         expected_build_identity: Option<&str>| {
+                            let _phase = phase_sync.lock().expect("serialize upgrade progress");
+                            operation
+                                .borrow_mut()
+                                .record_replacement_checkpoint_durable(
+                                    state,
+                                    target,
+                                    expected_version,
+                                    expected_build_identity,
+                                )
+                        };
+                    execute_upgrade(
+                        install_method,
+                        source_upgrade_path.as_deref(),
+                        source_path.is_some(),
+                        force,
+                        deliberate,
+                        previous_build_identity.as_deref(),
+                        selected_release.as_ref(),
+                        Some(&controller_mutation_lease),
+                        &mut report_phase,
+                        &mut replacement_checkpoint,
+                    )
+                },
+            );
+            controller_mutation_lease.assert_generation()?;
+            *lease_heartbeat_failure
+                .lock()
+                .expect("clear recovered lease heartbeat failure") = None;
+            persist_upgrade_heartbeat(&operation_id, execution_started.elapsed())?;
+            *progress_heartbeat_failure
+                .lock()
+                .expect("clear recovered progress heartbeat failure") = None;
+            if let Some(error) = lease_heartbeat_failure
+                .into_inner()
+                .expect("lease heartbeat failures are not poisoned")
+            {
+                return Err(error);
+            }
+            if let Some(error) = progress_heartbeat_failure
+                .into_inner()
+                .expect("progress heartbeat failures are not poisoned")
+            {
+                return Err(error);
+            }
+            result
         },
     )?;
     let (success, new_version, new_build_identity, source_revision, superseded) =
         match controller_upgrade {
             Ok(result) => result,
             Err(runners_skipped) => {
-                return Ok(runner_preflight_failure_result(
+                let result = runner_preflight_failure_result(
                     install_method,
                     previous_version,
                     previous_build_identity,
                     runners_skipped,
-                ));
+                );
+                return Ok(result);
             }
         };
+    controller_mutation_lease.assert_generation()?;
     let upgrade_completed = !superseded && should_sync_after_upgrade(new_version.as_deref());
     if upgrade_completed {
         // This is deliberately a short switch, not a drain: records admitted
         // before it retain their immutable runtime pin and remain executable.
+        operation.set_phase_durable("rotating_controller_generation")?;
         let installed_executable = super::execution::active_binary_path()?;
-        operation.set_phase("rotating controller runtime generation");
         homeboy_core::controller_runtime::activate_installed_generation(&installed_executable)?;
         if success {
-            operation.mark_controller_promoted("controller installation completed");
+            operation.mark_controller_promoted_durable("controller installation completed")?;
         }
     } else if superseded {
-        operation.mark_controller(
+        operation.mark_controller_durable(
             "superseded",
             "controller promotion was superseded by the active build",
-        );
+        )?;
     } else {
-        operation.mark_controller("failed", "controller installation did not complete");
+        operation.mark_controller_durable("failed", "controller installation did not complete")?;
     }
+    drop(controller_mutation_lease);
+
+    let selection_guard =
+        acquire_controller_selection_guard(operation, "controller extension refresh")?;
+    let initial_completion = reconcile_controller_identity(
+        observed_installed_controller_identity()?,
+        new_build_identity.as_deref(),
+        new_version.as_deref(),
+    )?;
 
     // Auto-update all installed extensions after the upgrade command completes.
     // This prevents CI/local extension version drift that causes baseline
     // mismatches and inconsistent audit findings.
-    let (extensions_updated, extension_skips) = if upgrade_completed && !skip_extensions {
-        operation.set_phase("refreshing installed extensions");
-        let (updated, skipped) = update_all_extensions(operation.id());
-        let status = extension_component_status(true, false, &updated, &skipped);
-        operation.mark_extensions(&status.status, &status.summary);
-        (updated, skipped)
-    } else if skip_extensions {
-        operation.mark_extensions("skipped", "extension refresh skipped");
-        (vec![], vec![])
-    } else {
-        operation.mark_extensions("not_run", "extension refresh was not attempted");
-        (vec![], vec![])
-    };
+    let (extensions_updated, extension_skips) =
+        if !controller_allows_extension_refresh(superseded, &initial_completion) {
+            operation.mark_extensions(
+                "not_run",
+                "controller changed before extension refresh admission",
+            );
+            (vec![], vec![])
+        } else if upgrade_completed && !skip_extensions {
+            operation.set_phase_durable("refreshing installed extensions")?;
+            let (updated, skipped) = update_all_extensions(operation.id())?;
+            let status = extension_component_status(true, false, &updated, &skipped);
+            operation.mark_extensions(&status.status, &status.summary);
+            (updated, skipped)
+        } else if skip_extensions {
+            operation.mark_extensions("skipped", "extension refresh skipped");
+            (vec![], vec![])
+        } else {
+            operation.mark_extensions("not_run", "extension refresh was not attempted");
+            (vec![], vec![])
+        };
 
-    let promotion_lease = homeboy_core::runtime_promotion::acquire(
-        "controller upgrade completion",
-        "active controller",
-    )?;
-    promotion_lease.assert_generation()?;
+    drop(selection_guard);
+
     let (runners_updated, runners_skipped) = if upgrade_completed && !skip_runners {
-        operation.set_phase("refreshing configured runners");
-        super::with_runner_upgrade(|p| {
-            p.upgrade_configured_runners_with_explicit_source_path(
-                force,
-                runner_method_override,
-                source_upgrade_path.as_deref(),
-                source_upgrade_path.is_some(),
-                new_build_identity.as_deref(),
-                runner_targets,
-                &extensions_updated,
-                Some(&promotion_lease),
-            )
-        })?
+        let promotion_lease =
+            acquire_controller_upgrade_lease(operation, "controller upgrade completion")?;
+        promotion_lease.assert_generation()?;
+        let completion = reconcile_controller_identity(
+            observed_installed_controller_identity()?,
+            new_build_identity.as_deref(),
+            new_version.as_deref(),
+        )?;
+        let runner_completion_superseded = superseded || completion.superseded;
+        if runner_completion_superseded {
+            operation.mark_controller_durable(
+                "superseded",
+                "controller changed before configured runner convergence",
+            )?;
+            (vec![], vec![])
+        } else {
+            operation.set_phase_durable("refreshing configured runners")?;
+            super::with_runner_upgrade(|p| {
+                p.upgrade_configured_runners_with_explicit_source_path(
+                    force,
+                    runner_method_override,
+                    source_upgrade_path.as_deref(),
+                    source_upgrade_path.is_some(),
+                    new_build_identity.as_deref(),
+                    runner_targets,
+                    &extensions_updated,
+                    Some(&promotion_lease),
+                )
+            })?
+        }
     } else {
         (vec![], vec![])
     };
@@ -780,11 +851,26 @@ pub fn run_upgrade_with_method(
     let (services_restarted, services_pending_restart) =
         restart_resident_services_after_swap(success, skip_services);
 
+    let final_selection_guard =
+        acquire_controller_selection_guard(operation, "controller upgrade result")?;
+    let completion = reconcile_controller_identity(
+        observed_installed_controller_identity()?,
+        new_build_identity.as_deref(),
+        new_version.as_deref(),
+    )?;
+    let completion_superseded = superseded || completion.superseded;
+    if completion_superseded {
+        operation.mark_controller_durable(
+            "superseded",
+            "controller changed before upgrade completion was recorded",
+        )?;
+    }
+
     let runner_disposition = runner_convergence_disposition(
-        skip_runners || !upgrade_completed,
+        runner_completion_is_skipped(skip_runners, upgrade_completed, completion_superseded),
         &runners_updated,
         &runners_skipped,
-        new_version.as_deref(),
+        completion.version.as_deref(),
     );
 
     let extensions_status = extension_component_status(
@@ -798,26 +884,26 @@ pub fn run_upgrade_with_method(
         command: "upgrade".to_string(),
         install_method,
         previous_version,
-        new_version: new_version.clone(),
+        new_version: completion.version.clone(),
         previous_build_identity,
-        new_build_identity: new_build_identity.clone(),
+        new_build_identity: completion.build_identity.clone(),
         source_revision,
         upgraded: success,
-        outcome: Some(if superseded {
+        outcome: Some(if completion_superseded {
             "controller_superseded".to_string()
         } else {
             upgrade_outcome(success, runner_disposition).to_string()
         }),
         preflight: None,
         controller: Some(component_status(
-            if superseded {
+            if completion_superseded {
                 "superseded"
             } else if success {
                 "updated"
             } else {
                 "failed"
             },
-            if superseded {
+            if completion_superseded {
                 "controller promotion was superseded by the active build"
             } else if success {
                 "controller installation completed"
@@ -835,13 +921,13 @@ pub fn run_upgrade_with_method(
         partial: runner_convergence_failed(
             &runners_updated,
             &runners_skipped,
-            new_version.as_deref(),
+            completion.version.as_deref(),
         ),
         runner_convergence: Some(runner_disposition),
         message: upgrade_message(
             success,
-            new_version.as_deref(),
-            new_build_identity.as_deref(),
+            completion.version.as_deref(),
+            completion.build_identity.as_deref(),
             runner_disposition,
             &runners_updated,
             &runners_skipped,
@@ -864,9 +950,11 @@ pub fn run_upgrade_with_method(
         services_pending_restart,
         operation_id: None,
     };
-    Ok(complete_upgrade_operation(operation, result))
+    drop(final_selection_guard);
+    Ok(result)
 }
 
+#[cfg(test)]
 fn source_upgrade_noop_result(
     install_method: InstallMethod,
     previous_version: String,
@@ -1854,17 +1942,144 @@ fn runner_method_override_for_method(
         .or_else(|| (install_method == InstallMethod::Source).then_some(InstallMethod::Source))
 }
 
+fn convergence_inputs(
+    source_noop: bool,
+    runner_method: Option<InstallMethod>,
+    source_path: Option<&Path>,
+) -> (Option<InstallMethod>, Option<&Path>) {
+    if source_noop {
+        (None, None)
+    } else {
+        (runner_method, source_path)
+    }
+}
+
 pub(crate) fn should_sync_after_upgrade(new_version: Option<&str>) -> bool {
     new_version.is_some()
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ControllerCompletionIdentity {
+    superseded: bool,
+    version: Option<String>,
+    build_identity: Option<String>,
+}
+
+fn reconcile_controller_identity(
+    active: Option<build_identity::BuildIdentity>,
+    expected_build_identity: Option<&str>,
+    expected_version: Option<&str>,
+) -> Result<ControllerCompletionIdentity> {
+    let active = active.ok_or_else(|| {
+        Error::internal_unexpected(
+            "active controller identity is unavailable after synchronized refresh",
+        )
+        .with_hint("Retry after the PATH-active controller reports a readable build identity.")
+    })?;
+    let matches_expected = match expected_build_identity {
+        Some(expected) => active.display == expected,
+        None => expected_version.is_some_and(|expected| active.version == expected),
+    };
+    Ok(ControllerCompletionIdentity {
+        superseded: !matches_expected,
+        version: Some(active.version),
+        build_identity: Some(active.display),
+    })
+}
+
+fn observed_installed_controller_identity() -> Result<Option<build_identity::BuildIdentity>> {
+    let target = active_binary_path()?;
+    installed_target_build_identity_from_disk(&target)
+}
+
+fn controller_allows_extension_refresh(
+    already_superseded: bool,
+    completion: &ControllerCompletionIdentity,
+) -> bool {
+    !already_superseded && !completion.superseded
+}
+
+fn runner_completion_is_skipped(
+    skip_runners: bool,
+    upgrade_completed: bool,
+    completion_superseded: bool,
+) -> bool {
+    skip_runners || !upgrade_completed || completion_superseded
+}
+
+fn controller_replacement_required_after_discovery(
+    source_noop: bool,
+    deliberate: bool,
+    source_decision: Option<SourceUpgradeDecision>,
+    update_available: bool,
+) -> bool {
+    !source_noop && controller_replacement_proceeds(deliberate, source_decision, update_available)
 }
 
 fn complete_upgrade_operation(
     mut operation: UpgradeOperation,
     mut result: UpgradeResult,
-) -> UpgradeResult {
-    operation.finish_completed(&result);
-    result.operation_id = operation.id().map(str::to_string);
-    result
+) -> Result<UpgradeResult> {
+    let operation_id = operation.id().map(str::to_string);
+    result.operation_id = operation_id.clone();
+    if let Err(mut error) = operation.finish_completed_durable(&result) {
+        if let Some(operation_id) = operation_id {
+            error.details["operation_id"] = serde_json::Value::String(operation_id);
+        }
+        return Err(error);
+    }
+    Ok(result)
+}
+
+fn acquire_controller_selection_guard(
+    operation: &mut UpgradeOperation,
+    operation_name: &str,
+) -> Result<homeboy_core::runtime_promotion::RuntimeSelectionGuard> {
+    let operation_id = operation
+        .id()
+        .ok_or_else(|| Error::internal_unexpected("controller selection requires an operation"))?
+        .to_string();
+    let guard = homeboy_core::runtime_promotion::protect_runtime_selection_waiting_with_status(
+        operation_name,
+        "active controller",
+        homeboy_core::runtime_promotion::RuntimePromotionOwnerStatus {
+            status_command: format!("homeboy upgrade status {operation_id}"),
+            operation_id,
+        },
+        CONTROLLER_UPGRADE_PROMOTION_WAIT_TIMEOUT,
+        |event| operation.record_promotion_wait(&event),
+    )?;
+    operation.clear_promotion_wait_durable()?;
+    Ok(guard)
+}
+
+fn acquire_controller_upgrade_lease(
+    operation: &mut UpgradeOperation,
+    operation_name: &str,
+) -> Result<homeboy_core::runtime_promotion::RuntimePromotionLease> {
+    let lease = if let Some(operation_id) = operation.id().map(str::to_string) {
+        let status_command = format!("homeboy upgrade status {operation_id}");
+        homeboy_core::runtime_promotion::acquire_waiting_for_target_with_status(
+            operation_name,
+            "active controller",
+            homeboy_core::runtime_promotion::RuntimePromotionOwnerStatus {
+                operation_id,
+                status_command,
+            },
+            CONTROLLER_UPGRADE_PROMOTION_WAIT_TIMEOUT,
+            |event| operation.record_promotion_wait(&event),
+        )?
+    } else {
+        homeboy_core::runtime_promotion::acquire_waiting_for_compatible(
+            operation_name,
+            "active controller",
+            CONTROLLER_UPGRADE_PROMOTION_WAIT_TIMEOUT,
+            |event| operation.record_promotion_wait(&event),
+        )?
+    };
+    operation.clear_promotion_wait_durable()?;
+    operation.take_persistence_error()?;
+    Ok(lease)
 }
 
 /// Update all installed extensions. Best-effort — failures are logged, and the
@@ -1872,10 +2087,10 @@ fn complete_upgrade_operation(
 /// structured result can say *why* it was skipped (#12181).
 fn update_all_extensions(
     operation_id: Option<&str>,
-) -> (Vec<ExtensionUpgradeEntry>, Vec<ExtensionUpgradeSkip>) {
+) -> Result<(Vec<ExtensionUpgradeEntry>, Vec<ExtensionUpgradeSkip>)> {
     let extension_ids = homeboy_core::extension::catalog::available_extension_ids();
     if extension_ids.is_empty() {
-        return (vec![], vec![]);
+        return Ok((vec![], vec![]));
     }
 
     homeboy_core::log_status!(
@@ -1895,12 +2110,30 @@ fn update_all_extensions(
 
         let current = index + 1;
         let total = extension_ids.len();
-        report_extension_progress(operation_id, id, current, total, Duration::ZERO);
+        report_extension_progress(operation_id, id, current, total, Duration::ZERO)?;
+        let progress_failure = std::sync::Mutex::new(None);
         let update_result = run_with_upgrade_heartbeats(
             UPGRADE_PROGRESS_HEARTBEAT_INTERVAL,
-            |elapsed| report_extension_progress(operation_id, id, current, total, elapsed),
+            |elapsed| {
+                if let Err(error) =
+                    report_extension_progress(operation_id, id, current, total, elapsed)
+                {
+                    let mut failure = progress_failure
+                        .lock()
+                        .expect("record extension progress failure");
+                    if failure.is_none() {
+                        *failure = Some(error);
+                    }
+                }
+            },
             || lifecycle::update(id, false),
         );
+        if let Some(error) = progress_failure
+            .into_inner()
+            .expect("extension progress failures are not poisoned")
+        {
+            return Err(error);
+        }
 
         match update_result {
             Ok(result) => {
@@ -1970,7 +2203,7 @@ fn update_all_extensions(
         }
     }
 
-    (updated, skipped)
+    Ok((updated, skipped))
 }
 
 fn report_extension_progress(
@@ -1979,10 +2212,9 @@ fn report_extension_progress(
     current: usize,
     total: usize,
     elapsed: Duration,
-) {
+) -> Result<()> {
     if let Some(run_id) = operation_id {
-        persist_extension_progress(run_id, extension_id, current, total, elapsed);
-        return;
+        return persist_extension_progress(run_id, extension_id, current, total, elapsed);
     }
     upgrade_phase(&super::operation::upgrade_extension_progress_message(
         extension_id,
@@ -1990,6 +2222,7 @@ fn report_extension_progress(
         total,
         elapsed,
     ));
+    Ok(())
 }
 
 /// Detect unrefreshed symlinked extension clones and log a loud, actionable
@@ -2251,6 +2484,7 @@ impl SourceUpgradeDecision {
         matches!(self, Self::NewerVersion | Self::DifferentIdentity)
     }
 
+    #[cfg(test)]
     fn no_op_message(self) -> String {
         match self {
             Self::OlderVersion => "Source checkout is older than the active binary; skipping downgrade".to_string(),
@@ -2476,6 +2710,137 @@ mod runner_source_upgrade_tests {
     use std::cell::RefCell;
     use std::process::Command;
     use tempfile::tempdir;
+
+    #[test]
+    fn controller_upgrade_errors_preserve_the_durable_operation_id() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let error = run_upgrade_with_method(
+                false,
+                Some(InstallMethod::Unknown),
+                true,
+                true,
+                true,
+                false,
+                &[],
+                None,
+                None,
+            )
+            .expect_err("unknown method fails after operation admission");
+            let operation_id = error.details["operation_id"]
+                .as_str()
+                .expect("error preserves operation identity");
+            let status = super::super::operation::load_upgrade_operation_status(Some(operation_id))
+                .expect("failed operation remains inspectable");
+            assert_eq!(status.operation_id, operation_id);
+            assert_eq!(status.status, "error");
+            assert_eq!(status.phase, "failed");
+        });
+    }
+
+    #[test]
+    fn completion_persistence_failure_retries_the_same_operation_id() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
+            let operation_id = operation.id().expect("durable operation").to_string();
+            operation.fail_next_terminal_write();
+            let result = source_upgrade_noop_result(
+                InstallMethod::Source,
+                "0.367.2".to_string(),
+                Some("0.367.2+old".to_string()),
+                SourceUpgradeDecision::SameIdentity,
+            );
+
+            let result = complete_upgrade_operation(operation, result)
+                .expect("one-shot persistence failure is retried");
+            assert_eq!(result.operation_id.as_deref(), Some(operation_id.as_str()));
+            let status =
+                super::super::operation::load_upgrade_operation_status(Some(&operation_id))
+                    .expect("operation remains inspectable");
+            assert_eq!(status.status, "pass");
+            assert_eq!(status.phase, "completed");
+        });
+    }
+
+    #[test]
+    fn supersession_reports_the_actual_active_controller_identity() {
+        let completion = reconcile_controller_identity(
+            Some(build_identity::BuildIdentity {
+                version: "0.369.0".to_string(),
+                git_commit: Some("replacement".to_string()),
+                git_dirty: Some(false),
+                display: "0.369.0+replacement".to_string(),
+            }),
+            Some("0.368.0+candidate"),
+            Some("0.368.0"),
+        )
+        .expect("active replacement identity is readable");
+
+        assert!(completion.superseded);
+        assert_eq!(completion.version.as_deref(), Some("0.369.0"));
+        assert_eq!(
+            completion.build_identity.as_deref(),
+            Some("0.369.0+replacement")
+        );
+        assert!(!controller_allows_extension_refresh(false, &completion));
+    }
+
+    #[test]
+    fn skip_runners_supersession_uses_the_active_post_refresh_identity() {
+        let completion = reconcile_controller_identity(
+            Some(build_identity::BuildIdentity {
+                version: "0.369.0".to_string(),
+                git_commit: Some("replacement".to_string()),
+                git_dirty: Some(false),
+                display: "0.369.0+replacement".to_string(),
+            }),
+            Some("0.368.0+baseline"),
+            Some("0.368.0"),
+        )
+        .expect("active replacement identity is readable");
+
+        assert!(runner_completion_is_skipped(
+            true,
+            true,
+            completion.superseded
+        ));
+        assert_eq!(completion.version.as_deref(), Some("0.369.0"));
+        assert_eq!(
+            completion.build_identity.as_deref(),
+            Some("0.369.0+replacement")
+        );
+    }
+
+    #[test]
+    fn missing_active_identity_is_unknown_not_supersession() {
+        let error = reconcile_controller_identity(None, Some("0.368.0+candidate"), Some("0.368.0"))
+            .expect_err("missing identity cannot prove supersession");
+        assert!(error.message.contains("identity is unavailable"));
+    }
+
+    #[test]
+    fn source_noop_uses_the_refresh_and_convergence_path() {
+        assert!(!controller_replacement_required_after_discovery(
+            true,
+            false,
+            Some(SourceUpgradeDecision::SameIdentity),
+            true,
+        ));
+        assert!(!controller_replacement_required_after_discovery(
+            true,
+            false,
+            Some(SourceUpgradeDecision::OlderVersion),
+            true,
+        ));
+        assert_eq!(
+            convergence_inputs(
+                true,
+                Some(InstallMethod::Source),
+                Some(Path::new("/tmp/rejected-source")),
+            ),
+            (None, None),
+            "a rejected source checkout must not drive runner convergence"
+        );
+    }
 
     #[test]
     fn changed_runner_compatibility_revalidation_precedes_controller_mutation() {

--- a/crates/homeboy-upgrade/src/upgrade/helpers.rs
+++ b/crates/homeboy-upgrade/src/upgrade/helpers.rs
@@ -904,11 +904,12 @@ fn run_controller_upgrade_with_operation(
 
     // Protect the reconciled controller identity while resident services are
     // restarted so their evidence cannot describe a later contender's binary.
-    let (services_restarted, services_pending_restart) = if completion_superseded {
-        (Vec::new(), Vec::new())
-    } else {
-        restart_resident_services_after_swap(success, skip_services)
-    };
+    let (services_restarted, services_pending_restart) =
+        restart_resident_services_after_reconciliation(
+            completion_superseded,
+            &final_selection_guard,
+            || restart_resident_services_after_swap(success, skip_services),
+        );
 
     let runner_disposition = runner_convergence_disposition(
         runner_completion_is_skipped(skip_runners, upgrade_completed, completion_superseded),
@@ -1996,6 +1997,18 @@ fn restart_resident_services_after_swap(
     (restarted, pending)
 }
 
+fn restart_resident_services_after_reconciliation(
+    completion_superseded: bool,
+    _selection_guard: &homeboy_core::runtime_promotion::RuntimeSelectionGuard,
+    restart: impl FnOnce() -> (Vec<ServiceRestartEntry>, Vec<ServiceRestartEntry>),
+) -> (Vec<ServiceRestartEntry>, Vec<ServiceRestartEntry>) {
+    if completion_superseded {
+        (Vec::new(), Vec::new())
+    } else {
+        restart()
+    }
+}
+
 /// Surface declared resident services that still hold the old binary, with the
 /// exact recovery command, instead of failing the upgrade silently.
 fn warn_pending_resident_services(pending: &[ServiceRestartEntry]) {
@@ -2956,6 +2969,121 @@ mod runner_source_upgrade_tests {
                     .expect("load terminal operation");
             assert_eq!(status.status, "pass");
             assert_eq!(status.phase, "completed");
+        });
+    }
+
+    #[test]
+    fn reconciled_selection_blocks_a_controller_contender_during_resident_service_restart() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
+            let selection_guard =
+                acquire_controller_selection_guard(&mut operation, "controller upgrade result")
+                    .expect("protect reconciled controller identity");
+            let (waiting_tx, waiting_rx) = std::sync::mpsc::channel();
+            let acquired = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let contender_acquired = acquired.clone();
+            let contender = std::thread::spawn(move || {
+                let lease =
+                    homeboy_core::runtime_promotion::acquire_waiting_for_target_with_status(
+                        "contending controller upgrade",
+                        "active controller",
+                        homeboy_core::runtime_promotion::RuntimePromotionOwnerStatus {
+                            operation_id: "restart-contender".to_string(),
+                            status_command: "homeboy upgrade status restart-contender".to_string(),
+                        },
+                        std::time::Duration::from_secs(2),
+                        |event| {
+                            if event.wait_stage == "os_lock" {
+                                let _ = waiting_tx.send(());
+                            }
+                        },
+                    )
+                    .expect("contender acquires after protected restart");
+                contender_acquired.store(true, std::sync::atomic::Ordering::Release);
+                drop(lease);
+            });
+
+            let restarted =
+                restart_resident_services_after_reconciliation(false, &selection_guard, || {
+                    waiting_rx
+                        .recv_timeout(std::time::Duration::from_secs(1))
+                        .expect("contender reaches resident-service restart window");
+                    assert!(
+                        !acquired.load(std::sync::atomic::Ordering::Acquire),
+                        "contender cannot replace the reconciled controller during restart"
+                    );
+                    (Vec::new(), Vec::new())
+                });
+            assert_eq!(restarted, (Vec::new(), Vec::new()));
+            assert!(!acquired.load(std::sync::atomic::Ordering::Acquire));
+
+            drop(selection_guard);
+            contender.join().expect("contender exits");
+            assert!(acquired.load(std::sync::atomic::Ordering::Acquire));
+        });
+    }
+
+    #[test]
+    fn selection_and_mutation_admission_fail_on_recorded_wait_persistence_errors() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mutation_owner = homeboy_core::runtime_promotion::acquire(
+                "blocking controller upgrade",
+                "active controller",
+            )
+            .expect("acquire blocking mutation");
+            let (release_tx, release_rx) = std::sync::mpsc::channel();
+            let release_owner = std::thread::spawn(move || {
+                release_rx
+                    .recv_timeout(std::time::Duration::from_secs(1))
+                    .expect("selection wait reports persistence attempt");
+                drop(mutation_owner);
+            });
+            let mut selection_operation = UpgradeOperation::start("homeboy upgrade");
+            selection_operation.fail_next_progress_write();
+            selection_operation.after_promotion_wait(move || {
+                release_tx.send(()).expect("release mutation owner");
+            });
+
+            let selection_error = acquire_controller_selection_guard(
+                &mut selection_operation,
+                "controller upgrade result",
+            )
+            .expect_err("selection admission fails closed on wait persistence");
+            assert!(selection_error
+                .message
+                .contains("injected upgrade progress persistence failure"));
+            release_owner.join().expect("selection blocker exits");
+
+            let selection_owner =
+                homeboy_core::runtime_promotion::protect_runtime_selection_with_status(
+                    "blocking controller selection",
+                    "active controller",
+                    homeboy_core::runtime_promotion::RuntimePromotionOwnerStatus {
+                        operation_id: "selection-owner".to_string(),
+                        status_command: "homeboy upgrade status selection-owner".to_string(),
+                    },
+                )
+                .expect("acquire blocking selection");
+            let (release_tx, release_rx) = std::sync::mpsc::channel();
+            let release_owner = std::thread::spawn(move || {
+                release_rx
+                    .recv_timeout(std::time::Duration::from_secs(1))
+                    .expect("mutation wait reports persistence attempt");
+                drop(selection_owner);
+            });
+            let mut mutation_operation = UpgradeOperation::start("homeboy upgrade");
+            mutation_operation.fail_next_progress_write();
+            mutation_operation.after_promotion_wait(move || {
+                release_tx.send(()).expect("release selection owner");
+            });
+
+            let mutation_error =
+                acquire_controller_upgrade_lease(&mut mutation_operation, "controller upgrade")
+                    .expect_err("mutation admission fails closed on wait persistence");
+            assert!(mutation_error
+                .message
+                .contains("injected upgrade progress persistence failure"));
+            release_owner.join().expect("mutation blocker exits");
         });
     }
 

--- a/crates/homeboy-upgrade/src/upgrade/mod.rs
+++ b/crates/homeboy-upgrade/src/upgrade/mod.rs
@@ -23,7 +23,9 @@ pub use helpers::{
     current_build_version, current_version, detect_install_method, fetch_latest_version,
     run_upgrade_with_method, version_is_newer,
 };
-pub use operation::{load_upgrade_operation_status, UpgradeOperationStatus};
+pub use operation::{
+    load_upgrade_operation_status, UpgradeOperationStatus, UpgradePromotionWaitStatus,
+};
 pub use planning::resolve_binary_on_path;
 pub use release_catalog::{
     running_target_triple, InstallableSelection, ReleaseRef, SelectedRelease,
@@ -33,8 +35,9 @@ pub use runner_upgrade_provider::{register_runner_upgrade_provider, RunnerUpgrad
 pub use services::restart_extension_services;
 pub use types::{
     ExtensionPreflightBlocker, ExtensionUpgradeEntry, ExtensionUpgradeSkip, InstallMethod,
-    RunnerDaemonDriftEntry, RunnerExtensionSyncEntry, RunnerUpgradeEntry, ServiceRestartEntry,
-    UpgradeComponentStatus, UpgradePreflight, UpgradeResult, VersionCheck,
+    RunnerConvergenceDisposition, RunnerDaemonDriftEntry, RunnerExtensionSyncEntry,
+    RunnerUpgradeEntry, ServiceRestartEntry, UpgradeComponentStatus, UpgradePreflight,
+    UpgradeResult, VersionCheck,
 };
 pub use validation::check_for_updates;
 

--- a/crates/homeboy-upgrade/src/upgrade/operation.rs
+++ b/crates/homeboy-upgrade/src/upgrade/operation.rs
@@ -16,7 +16,7 @@ use homeboy_core::observation::{
     RunListFilter, RunRecord, RunStatus,
 };
 
-use super::types::{UpgradeComponentStatus, UpgradeResult};
+use super::types::{RunnerConvergenceDisposition, UpgradeComponentStatus, UpgradeResult};
 
 pub const UPGRADE_OPERATION_KIND: &str = "upgrade";
 pub const UPGRADE_OPERATION_SCHEMA: &str = "homeboy/upgrade-operation/v1";
@@ -41,6 +41,26 @@ pub struct UpgradeOperationStatus {
     pub note: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inspect_command: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub promotion_wait: Option<UpgradePromotionWaitStatus>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UpgradePromotionWaitStatus {
+    pub schema: String,
+    pub state: String,
+    pub resource_class: String,
+    pub wait_timeout_ms: u128,
+    pub waited_ms: u128,
+    pub wait_stage: String,
+    pub owner_pid: u32,
+    pub owner_operation: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_operation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_status_command: Option<String>,
+    pub target: String,
+    pub owner_generation: String,
 }
 
 pub struct UpgradeOperation {
@@ -48,20 +68,28 @@ pub struct UpgradeOperation {
     metadata: Value,
     started: Instant,
     finished: bool,
+    pending_terminal: Option<TerminalIntent>,
     controller_promoted: bool,
+    persistence_error: Option<Error>,
+    #[cfg(test)]
+    fail_next_terminal_write: bool,
+    #[cfg(test)]
+    fail_next_progress_write: bool,
+    #[cfg(test)]
+    before_terminal_write: Option<Box<dyn FnOnce() + Send>>,
+}
+
+#[derive(Clone)]
+struct TerminalIntent {
+    status: RunStatus,
+    metadata: Value,
+    intent_id: String,
 }
 
 impl UpgradeOperation {
+    #[cfg(test)]
     pub fn start(command: impl Into<String>) -> Self {
-        let metadata = json!({
-            "schema": UPGRADE_OPERATION_SCHEMA,
-            "phase": "admitted",
-            "elapsed_seconds": 0,
-            "controller": component("pending", "controller mutation has not started"),
-            "extensions": component("pending", "extension refresh has not started"),
-            "runners": component("pending", "runner refresh has not started"),
-            "homeboy_run_owner": { "pid": std::process::id() },
-        });
+        let metadata = initial_metadata();
         let observation = ActiveObservation::start_best_effort(
             NewRunRecord::builder(UPGRADE_OPERATION_KIND)
                 .component_id("homeboy")
@@ -75,7 +103,12 @@ impl UpgradeOperation {
             metadata,
             started: Instant::now(),
             finished: false,
+            pending_terminal: None,
             controller_promoted: false,
+            persistence_error: None,
+            fail_next_terminal_write: false,
+            fail_next_progress_write: false,
+            before_terminal_write: None,
         };
         if let Some(id) = operation.id() {
             emit_upgrade_phase(&format!("operation={id}"));
@@ -83,11 +116,43 @@ impl UpgradeOperation {
         operation
     }
 
+    pub fn start_durable(command: impl Into<String>) -> Result<Self> {
+        let metadata = initial_metadata();
+        let observation = ActiveObservation::start(
+            NewRunRecord::builder(UPGRADE_OPERATION_KIND)
+                .component_id("homeboy")
+                .command(command.into())
+                .current_homeboy_version()
+                .metadata(metadata.clone())
+                .build(),
+        )?;
+        let operation = Self {
+            observation: Some(observation),
+            metadata,
+            started: Instant::now(),
+            finished: false,
+            pending_terminal: None,
+            controller_promoted: false,
+            persistence_error: None,
+            #[cfg(test)]
+            fail_next_terminal_write: false,
+            #[cfg(test)]
+            fail_next_progress_write: false,
+            #[cfg(test)]
+            before_terminal_write: None,
+        };
+        emit_upgrade_phase(&format!(
+            "operation={}",
+            operation.id().expect("durable operation has an id")
+        ));
+        Ok(operation)
+    }
+
     pub fn id(&self) -> Option<&str> {
         self.observation.as_ref().map(ActiveObservation::run_id)
     }
 
-    pub fn set_phase(&mut self, phase: &str) {
+    pub fn set_phase_durable(&mut self, phase: &str) -> Result<()> {
         emit_upgrade_phase(phase);
         self.metadata["phase"] = json!(phase);
         match phase {
@@ -100,23 +165,78 @@ impl UpgradeOperation {
             _ => {}
         }
         self.metadata["elapsed_seconds"] = json!(self.started.elapsed().as_secs());
-        self.persist();
+        self.persist_durable()
     }
 
-    pub fn mark_controller_promoted(&mut self, summary: &str) {
+    pub fn record_promotion_wait(
+        &mut self,
+        event: &homeboy_core::runtime_promotion::RuntimePromotionWaitEvent,
+    ) {
+        emit_upgrade_phase(
+            &serde_json::to_string(event)
+                .unwrap_or_else(|_| "runtime promotion queued".to_string()),
+        );
+        self.metadata["promotion_wait"] = json!(event);
+        if let Err(error) = self.set_phase_durable(match event.wait_stage {
+            "os_lock" => "waiting_for_controller_admission_lock",
+            "foreign_generation_pins" => "waiting_for_foreign_generation_pins",
+            _ => "waiting_for_compatible_controller_upgrade",
+        }) {
+            self.persistence_error.get_or_insert(error);
+        }
+    }
+
+    pub fn take_persistence_error(&mut self) -> Result<()> {
+        self.persistence_error.take().map_or(Ok(()), Err)
+    }
+
+    pub fn clear_promotion_wait_durable(&mut self) -> Result<()> {
+        if let Some(metadata) = self.metadata.as_object_mut() {
+            metadata.remove("promotion_wait");
+        }
+        self.persist_durable()
+    }
+
+    pub fn mark_controller_promoted_durable(&mut self, summary: &str) -> Result<()> {
         self.controller_promoted = true;
         self.metadata["controller"] = component("updated", summary);
-        self.set_phase(
+        self.set_phase_durable(
             "controller installation verified; continuing with optional post-install refresh",
-        );
+        )
     }
 
-    pub fn mark_controller(&mut self, status: &str, summary: &str) {
+    pub fn mark_controller_durable(&mut self, status: &str, summary: &str) -> Result<()> {
         if status == "updated" {
             self.controller_promoted = true;
         }
         self.metadata["controller"] = component(status, summary);
-        self.persist();
+        self.persist_durable()
+    }
+
+    pub fn record_replacement_checkpoint_durable(
+        &mut self,
+        state: &str,
+        target: &std::path::Path,
+        expected_version: Option<&str>,
+        expected_build_identity: Option<&str>,
+    ) -> Result<()> {
+        self.metadata["replacement"] = json!({
+            "state": state,
+            "target": target.display().to_string(),
+            "expected_version": expected_version,
+            "expected_build_identity": expected_build_identity,
+        });
+        if state == "applied" {
+            self.controller_promoted = true;
+            self.metadata["controller"] = component(
+                "replacement_applied",
+                "controller replacement applied; verification pending",
+            );
+            self.metadata["phase"] = json!("controller_replacement_applied");
+        } else {
+            self.metadata["phase"] = json!("controller_replacement_pending");
+        }
+        self.persist_durable()
     }
 
     pub fn mark_extensions(&mut self, status: &str, summary: &str) {
@@ -124,7 +244,15 @@ impl UpgradeOperation {
         self.persist();
     }
 
+    #[cfg(test)]
     pub fn finish_completed(&mut self, result: &UpgradeResult) {
+        let _ = self.finish_completed_durable(result);
+    }
+
+    pub fn finish_completed_durable(&mut self, result: &UpgradeResult) -> Result<()> {
+        if let Some(metadata) = self.metadata.as_object_mut() {
+            metadata.remove("promotion_wait");
+        }
         if let Some(status) = &result.controller {
             self.metadata["controller"] = json!(status);
             if status.status == "updated" {
@@ -139,54 +267,203 @@ impl UpgradeOperation {
         }
         self.metadata["phase"] = json!("completed");
         self.metadata["elapsed_seconds"] = json!(self.started.elapsed().as_secs());
-        let status = if result
-            .controller
-            .as_ref()
-            .is_some_and(|controller| controller.status == "failed")
-        {
+        let status = if result.runner_convergence == Some(RunnerConvergenceDisposition::Partial)
+            || result.controller.as_ref().is_some_and(|controller| {
+                matches!(
+                    controller.status.as_str(),
+                    "failed" | "runner_preflight_failed" | "extension_preflight_failed"
+                )
+            }) {
             RunStatus::Fail
         } else {
             RunStatus::Pass
         };
-        self.finish(status);
+        self.finish_durable(status)
+    }
+
+    pub fn finish_failed_durable(&mut self, error: &Error) -> Result<()> {
+        if let Some(metadata) = self.metadata.as_object_mut() {
+            metadata.remove("promotion_wait");
+        }
+        self.metadata["phase"] = json!("failed");
+        self.metadata["error"] = json!({
+            "code": format!("{:?}", error.code),
+            "message": error.message,
+        });
+        self.finish_durable(RunStatus::Error)
     }
 
     fn persist(&mut self) {
+        let _ = self.persist_durable();
+    }
+
+    fn persist_durable(&mut self) -> Result<()> {
         let Some(observation) = &self.observation else {
-            return;
+            return Err(Error::internal_unexpected(
+                "upgrade operation has no durable observation",
+            ));
         };
         self.metadata["elapsed_seconds"] = json!(self.started.elapsed().as_secs());
-        let _ = observation
+        #[cfg(test)]
+        if std::mem::take(&mut self.fail_next_progress_write) {
+            return Err(Error::internal_unexpected(
+                "injected upgrade progress persistence failure",
+            ));
+        }
+        let updated = observation
             .store()
-            .update_run_metadata(observation.run_id(), self.metadata.clone());
+            .update_running_run_metadata(observation.run_id(), self.metadata.clone())?;
+        updated.map(|_| ()).ok_or_else(|| {
+            Error::internal_unexpected(format!(
+                "upgrade operation is no longer running: {}",
+                observation.run_id()
+            ))
+        })
     }
 
     fn finish(&mut self, status: RunStatus) {
+        let _ = self.finish_durable(status);
+    }
+
+    fn finish_durable(&mut self, status: RunStatus) -> Result<()> {
         if self.finished {
-            return;
+            return Ok(());
         }
-        self.finished = true;
         let Some(observation) = &self.observation else {
-            return;
+            return Err(Error::internal_unexpected(
+                "upgrade operation has no durable observation",
+            ));
         };
-        if let Ok(Some(run)) = observation.store().get_run(observation.run_id()) {
-            merge_component_fields(&mut self.metadata, &run.metadata_json);
-            if let Some(elapsed) = run.metadata_json.get("elapsed_seconds") {
-                self.metadata["elapsed_seconds"] = elapsed.clone();
-            }
+        let run = observation
+            .store()
+            .get_run(observation.run_id())?
+            .ok_or_else(|| {
+                Error::internal_unexpected(format!(
+                    "upgrade operation disappeared during terminalization: {}",
+                    observation.run_id()
+                ))
+            })?;
+        merge_component_fields(&mut self.metadata, &run.metadata_json);
+        if let Some(elapsed) = run.metadata_json.get("elapsed_seconds") {
+            self.metadata["elapsed_seconds"] = elapsed.clone();
         }
         self.metadata["elapsed_seconds"] = json!(self.started.elapsed().as_secs());
-        let _ = observation.store().finish_running_run(
-            observation.run_id(),
-            status,
-            Some(self.metadata.clone()),
-        );
+        if self.pending_terminal.is_none() {
+            let intent_id = format!("upgrade-terminal:{}", observation.run_id());
+            self.metadata["terminal_intent_id"] = json!(intent_id);
+            self.pending_terminal = Some(TerminalIntent {
+                status,
+                metadata: self.metadata.clone(),
+                intent_id,
+            });
+        } else if let Some(intent) = self.pending_terminal.as_mut() {
+            merge_component_fields(&mut intent.metadata, &run.metadata_json);
+        }
+        let mut expected_metadata = run.metadata_json;
+        let mut last_error = None;
+        for _ in 0..3 {
+            #[cfg(test)]
+            if let Some(before_write) = self.before_terminal_write.take() {
+                before_write();
+            }
+            let intent = self
+                .pending_terminal
+                .clone()
+                .expect("terminal intent initialized");
+            #[cfg(test)]
+            if std::mem::take(&mut self.fail_next_terminal_write) {
+                last_error = Some(Error::internal_unexpected(
+                    "injected upgrade terminal persistence failure",
+                ));
+                continue;
+            }
+            match observation.store().finish_running_run_if_metadata(
+                observation.run_id(),
+                intent.status,
+                intent.metadata.clone(),
+                &expected_metadata,
+            ) {
+                Ok(Some(run)) if terminal_run_matches(&run, &intent) => {
+                    self.finished = true;
+                    self.pending_terminal = None;
+                    return Ok(());
+                }
+                Ok(Some(_)) => {
+                    return Err(terminal_conflict_error(observation.run_id()));
+                }
+                Ok(None) | Err(_) => match observation.store().get_run(observation.run_id()) {
+                    Ok(Some(run)) if terminal_run_matches(&run, &intent) => {
+                        self.finished = true;
+                        self.pending_terminal = None;
+                        return Ok(());
+                    }
+                    Ok(Some(run)) if run.status == RunStatus::Running.as_str() => {
+                        if let Some(intent) = self.pending_terminal.as_mut() {
+                            merge_component_fields(&mut intent.metadata, &run.metadata_json);
+                        }
+                        expected_metadata = run.metadata_json;
+                        last_error = Some(Error::internal_unexpected(
+                            "upgrade terminal write raced with running progress",
+                        ));
+                    }
+                    Ok(Some(_)) => {
+                        return Err(terminal_conflict_error(observation.run_id()));
+                    }
+                    Ok(None) => {
+                        return Err(Error::internal_unexpected(format!(
+                            "upgrade operation disappeared during terminalization: {}",
+                            observation.run_id()
+                        )));
+                    }
+                    Err(error) => last_error = Some(error),
+                },
+            }
+        }
+        Err(last_error.unwrap_or_else(|| {
+            Error::internal_unexpected("upgrade terminalization retries were exhausted")
+        }))
     }
+
+    #[cfg(test)]
+    pub(crate) fn fail_next_terminal_write(&mut self) {
+        self.fail_next_terminal_write = true;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_next_progress_write(&mut self) {
+        self.fail_next_progress_write = true;
+    }
+
+    #[cfg(test)]
+    fn before_terminal_write(&mut self, callback: impl FnOnce() + Send + 'static) {
+        self.before_terminal_write = Some(Box::new(callback));
+    }
+}
+
+fn initial_metadata() -> Value {
+    json!({
+        "schema": UPGRADE_OPERATION_SCHEMA,
+        "phase": "admitted",
+        "elapsed_seconds": 0,
+        "controller": component("pending", "controller mutation has not started"),
+        "extensions": component("pending", "extension refresh has not started"),
+        "runners": component("pending", "runner refresh has not started"),
+        "homeboy_run_owner": { "pid": std::process::id() },
+    })
 }
 
 impl Drop for UpgradeOperation {
     fn drop(&mut self) {
         if self.finished {
+            return;
+        }
+        if self.pending_terminal.is_some() {
+            let status = self
+                .pending_terminal
+                .as_ref()
+                .expect("pending terminal exists")
+                .status;
+            let _ = self.finish_durable(status);
             return;
         }
         if self.controller_promoted {
@@ -205,6 +482,17 @@ impl Drop for UpgradeOperation {
         self.metadata["phase"] = json!("interrupted");
         self.finish(RunStatus::Error);
     }
+}
+
+fn terminal_run_matches(run: &RunRecord, intent: &TerminalIntent) -> bool {
+    run.status == intent.status.as_str()
+        && run.metadata_json["terminal_intent_id"].as_str() == Some(intent.intent_id.as_str())
+}
+
+fn terminal_conflict_error(run_id: &str) -> Error {
+    Error::internal_unexpected(format!(
+        "upgrade operation terminal state changed before completion: {run_id}"
+    ))
 }
 
 pub fn load_upgrade_operation_status(id: Option<&str>) -> Result<UpgradeOperationStatus> {
@@ -242,7 +530,7 @@ pub fn persist_extension_progress(
     current: usize,
     total: usize,
     elapsed: Duration,
-) {
+) -> Result<()> {
     emit_upgrade_phase(&upgrade_extension_progress_message(
         extension_id,
         current,
@@ -256,7 +544,7 @@ pub fn persist_extension_progress(
             "running",
             format!("refreshing {extension_id} ({current}/{total})"),
         );
-    });
+    })
 }
 
 pub fn run_with_upgrade_heartbeats<T>(
@@ -289,6 +577,23 @@ pub fn run_with_upgrade_heartbeats<T>(
     })
 }
 
+pub fn persist_upgrade_heartbeat(run_id: &str, elapsed: Duration) -> Result<()> {
+    let store = ObservationStore::open_initialized()?;
+    let Some(run) = store.get_run(run_id)? else {
+        return Err(Error::internal_unexpected(format!(
+            "upgrade operation disappeared while heartbeating: {run_id}"
+        )));
+    };
+    let mut metadata = run.metadata_json;
+    metadata["elapsed_seconds"] = json!(elapsed.as_secs());
+    store
+        .update_running_run_metadata(run_id, metadata)?
+        .map(|_| ())
+        .ok_or_else(|| {
+            Error::internal_unexpected(format!("upgrade operation is no longer running: {run_id}"))
+        })
+}
+
 pub(crate) fn emit_upgrade_phase(phase: &str) {
     eprintln!("[upgrade] {phase}");
 }
@@ -312,25 +617,38 @@ fn component(status: impl Into<String>, summary: impl Into<String>) -> Value {
     })
 }
 
-fn patch_metadata(run_id: &str, patch: impl FnOnce(&mut Value)) {
-    let Ok(store) = ObservationStore::open_initialized() else {
-        return;
-    };
-    let Ok(Some(run)) = store.get_run(run_id) else {
-        return;
+fn patch_metadata(run_id: &str, patch: impl FnOnce(&mut Value)) -> Result<()> {
+    let store = ObservationStore::open_initialized()?;
+    let Some(run) = store.get_run(run_id)? else {
+        return Err(Error::internal_unexpected(format!(
+            "upgrade operation disappeared while recording progress: {run_id}"
+        )));
     };
     if run.kind != UPGRADE_OPERATION_KIND {
-        return;
+        return Err(Error::internal_unexpected(format!(
+            "run {run_id} is not an upgrade operation"
+        )));
     }
     let mut metadata = run.metadata_json;
     patch(&mut metadata);
-    let _ = store.update_run_metadata(run_id, metadata);
+    store
+        .update_running_run_metadata(run_id, metadata)?
+        .map(|_| ())
+        .ok_or_else(|| {
+            Error::internal_unexpected(format!("upgrade operation is no longer running: {run_id}"))
+        })
 }
 
 fn merge_component_fields(target: &mut Value, source: &Value) {
-    for key in ["controller", "extensions", "runners", "phase"] {
+    for key in ["controller", "extensions", "runners"] {
         if let Some(value) = source.get(key) {
-            if target.get(key).is_none() {
+            let target_is_pending = target
+                .get(key)
+                .and_then(|component| component.get("status"))
+                .and_then(Value::as_str)
+                == Some("pending");
+            let source_is_pending = value.get("status").and_then(Value::as_str) == Some("pending");
+            if target.get(key).is_none() || (target_is_pending && !source_is_pending) {
                 target[key] = value.clone();
             }
         }
@@ -362,28 +680,80 @@ fn status_from_run(run: &RunRecord) -> Result<UpgradeOperationStatus> {
             None,
         ));
     }
+    let mut metadata = run.metadata_json.clone();
+    reconcile_replacement_projection(&mut metadata);
     Ok(UpgradeOperationStatus {
         command: "upgrade.status".to_string(),
         operation_id: run.id.clone(),
         status: run.status.clone(),
-        phase: run
-            .metadata_json
+        phase: metadata
             .get("phase")
             .and_then(Value::as_str)
             .unwrap_or("unknown")
             .to_string(),
-        elapsed_seconds: run
-            .metadata_json
+        elapsed_seconds: metadata
             .get("elapsed_seconds")
             .and_then(Value::as_u64)
             .unwrap_or(0),
-        controller: component_from_metadata(&run.metadata_json, "controller"),
-        extensions: component_from_metadata(&run.metadata_json, "extensions"),
-        runners: component_from_metadata(&run.metadata_json, "runners"),
+        controller: component_from_metadata(&metadata, "controller"),
+        extensions: component_from_metadata(&metadata, "extensions"),
+        runners: component_from_metadata(&metadata, "runners"),
         owner_pid: run_owner_pid(run),
         note: running_status_note(run),
         inspect_command: Some(format!("homeboy upgrade status {}", run.id)),
+        promotion_wait: run
+            .metadata_json
+            .get("promotion_wait")
+            .cloned()
+            .and_then(|value| serde_json::from_value(value).ok()),
     })
+}
+
+fn reconcile_replacement_projection(metadata: &mut Value) {
+    let Some(replacement) = metadata.get("replacement") else {
+        return;
+    };
+    // Only a pending checkpoint represents the crash window where disk state is
+    // authoritative. Applied and terminal history must not change when a later
+    // operation installs another controller.
+    if replacement.get("state").and_then(Value::as_str) != Some("pending") {
+        return;
+    }
+    let Some(target) = replacement.get("target").and_then(Value::as_str) else {
+        return;
+    };
+    let expected_build = replacement
+        .get("expected_build_identity")
+        .and_then(Value::as_str);
+    let expected_version = replacement.get("expected_version").and_then(Value::as_str);
+    match super::execution::installed_target_build_identity_from_disk(std::path::Path::new(target))
+    {
+        Ok(Some(identity))
+            if expected_build.is_some_and(|expected| identity.display == expected)
+                || (expected_build.is_none()
+                    && expected_version.is_some_and(|expected| identity.version == expected)) =>
+        {
+            metadata["controller"] = component(
+                "replacement_applied",
+                format!("installed controller is {}", identity.display),
+            );
+            if metadata["phase"] == "controller_replacement_pending" {
+                metadata["phase"] = json!("controller_replacement_applied");
+            }
+        }
+        Ok(Some(identity)) => {
+            metadata["controller"] = component(
+                "different_installed_identity",
+                format!("installed controller is {}", identity.display),
+            );
+        }
+        Ok(None) | Err(_) => {
+            metadata["controller"] = component(
+                "identity_unknown",
+                "installed controller identity could not be verified",
+            );
+        }
+    }
 }
 
 fn component_from_metadata(metadata: &Value, key: &str) -> Option<UpgradeComponentStatus> {
@@ -457,12 +827,82 @@ mod tests {
     }
 
     #[test]
+    fn promotion_wait_is_visible_through_upgrade_status() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let owner_operation = UpgradeOperation::start("homeboy upgrade");
+            let owner_id = owner_operation
+                .id()
+                .expect("persisted owner operation")
+                .to_string();
+            let owner_lease =
+                homeboy_core::runtime_promotion::acquire_waiting_for_target_with_status(
+                    "controller upgrade",
+                    "active controller",
+                    homeboy_core::runtime_promotion::RuntimePromotionOwnerStatus {
+                        operation_id: owner_id.clone(),
+                        status_command: format!("homeboy upgrade status {owner_id}"),
+                    },
+                    Duration::from_secs(1),
+                    |_| unreachable!("uncontended owner does not wait"),
+                )
+                .expect("owner acquires controller admission");
+            let (queued, queued_event) = std::sync::mpsc::channel();
+            let contender = std::thread::spawn(move || {
+                let mut operation = UpgradeOperation::start("homeboy upgrade");
+                let id = operation.id().expect("persisted operation").to_string();
+                let lease =
+                    homeboy_core::runtime_promotion::acquire_waiting_for_target_with_status(
+                        "controller upgrade",
+                        "active controller",
+                        homeboy_core::runtime_promotion::RuntimePromotionOwnerStatus {
+                            operation_id: id.clone(),
+                            status_command: format!("homeboy upgrade status {id}"),
+                        },
+                        Duration::from_secs(1),
+                        |event| {
+                            operation.record_promotion_wait(&event);
+                            queued.send(()).expect("report queued contender");
+                        },
+                    )
+                    .expect("contender acquires after deterministic handoff");
+                drop(lease);
+                (id, operation)
+            });
+            queued_event
+                .recv_timeout(Duration::from_secs(1))
+                .expect("contender reaches durable wait state");
+            drop(owner_lease);
+            let (id, mut operation) = contender.join().expect("contender exits");
+
+            let status = load_upgrade_operation_status(Some(&id)).expect("load status");
+            assert_eq!(status.phase, "waiting_for_compatible_controller_upgrade");
+            let wait = status.promotion_wait.expect("promotion wait status");
+            assert_eq!(wait.wait_stage, "lease_record");
+            assert_eq!(wait.owner_operation_id.as_deref(), Some(owner_id.as_str()));
+            assert_eq!(
+                wait.owner_status_command.as_deref(),
+                Some(format!("homeboy upgrade status {owner_id}").as_str())
+            );
+            assert_ne!(id, owner_id);
+
+            operation
+                .clear_promotion_wait_durable()
+                .expect("clear completed wait metadata");
+            let status = load_upgrade_operation_status(Some(&id)).expect("reload status");
+            assert!(status.promotion_wait.is_none());
+        });
+    }
+
+    #[test]
     fn controller_promotion_stays_inspectable_while_extension_refresh_runs() {
         homeboy_core::test_support::with_isolated_home(|_| {
             let mut operation = UpgradeOperation::start("homeboy upgrade");
             let id = operation.id().expect("persisted operation").to_string();
-            operation.mark_controller_promoted("controller installation completed");
-            persist_extension_progress(&id, "wordpress", 2, 3, Duration::from_secs(45));
+            operation
+                .mark_controller_promoted_durable("controller installation completed")
+                .expect("persist controller promotion");
+            persist_extension_progress(&id, "wordpress", 2, 3, Duration::from_secs(45))
+                .expect("persist extension progress");
 
             let status = load_upgrade_operation_status(Some(&id)).expect("load status");
             assert_eq!(status.status, RunStatus::Running.as_str());
@@ -525,8 +965,11 @@ mod tests {
             let id = {
                 let mut operation = UpgradeOperation::start("homeboy upgrade");
                 let id = operation.id().expect("persisted operation").to_string();
-                operation.mark_controller_promoted("controller installation completed");
-                persist_extension_progress(&id, "wordpress", 1, 2, Duration::from_secs(12));
+                operation
+                    .mark_controller_promoted_durable("controller installation completed")
+                    .expect("persist controller promotion");
+                persist_extension_progress(&id, "wordpress", 1, 2, Duration::from_secs(12))
+                    .expect("persist extension progress");
                 id
             };
 
@@ -571,43 +1014,7 @@ mod tests {
         homeboy_core::test_support::with_isolated_home(|_| {
             let mut operation = UpgradeOperation::start("homeboy upgrade");
             let id = operation.id().expect("persisted operation").to_string();
-            let result = UpgradeResult {
-                command: "upgrade".to_string(),
-                install_method: super::super::types::InstallMethod::Binary,
-                previous_version: "0.1.0".to_string(),
-                new_version: Some("0.2.0".to_string()),
-                previous_build_identity: None,
-                new_build_identity: None,
-                source_revision: None,
-                upgraded: true,
-                outcome: Some("controller_updated".to_string()),
-                preflight: None,
-                controller: Some(UpgradeComponentStatus {
-                    status: "updated".to_string(),
-                    summary: "controller installation completed".to_string(),
-                }),
-                extensions: Some(UpgradeComponentStatus {
-                    status: "completed".to_string(),
-                    summary: "1 updated, 0 skipped".to_string(),
-                }),
-                runners: Some(UpgradeComponentStatus {
-                    status: "skipped".to_string(),
-                    summary: "runner convergence skipped".to_string(),
-                }),
-                partial: false,
-                runner_convergence: None,
-                message: "Upgraded".to_string(),
-                restart_required: false,
-                extensions_updated: Vec::new(),
-                extensions_skipped: Vec::new(),
-                extension_skips: Vec::new(),
-                runners_updated: Vec::new(),
-                runners_skipped: Vec::new(),
-                extensions_unrefreshed: Vec::new(),
-                services_restarted: Vec::new(),
-                services_pending_restart: Vec::new(),
-                operation_id: None,
-            };
+            let result = completed_upgrade_result();
             operation.finish_completed(&result);
 
             let status = load_upgrade_operation_status(Some(&id)).expect("load status");
@@ -628,5 +1035,321 @@ mod tests {
                 Some("completed")
             );
         });
+    }
+
+    #[test]
+    fn runner_partial_completion_is_durable_terminal_fail() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
+            let id = operation.id().expect("persisted operation").to_string();
+            let mut result = completed_upgrade_result();
+            result.partial = true;
+            result.outcome = Some("controller_updated_runner_failed".to_string());
+            result.runner_convergence = Some(RunnerConvergenceDisposition::Partial);
+            result.runners = Some(UpgradeComponentStatus {
+                status: "partial".to_string(),
+                summary: "0 converged, 1 requires repair".to_string(),
+            });
+
+            operation
+                .finish_completed_durable(&result)
+                .expect("persist typed partial completion");
+            let status = load_upgrade_operation_status(Some(&id)).expect("load status");
+            assert_eq!(status.status, RunStatus::Fail.as_str());
+            assert_eq!(status.phase, "completed");
+            assert_eq!(
+                status
+                    .controller
+                    .as_ref()
+                    .map(|value| value.status.as_str()),
+                Some("updated")
+            );
+            assert_eq!(
+                status.runners.as_ref().map(|value| value.status.as_str()),
+                Some("partial")
+            );
+        });
+    }
+
+    #[test]
+    fn replacement_applied_checkpoint_precedes_verification() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
+            let id = operation.id().expect("persisted operation").to_string();
+            operation
+                .record_replacement_checkpoint_durable(
+                    "pending",
+                    std::path::Path::new("/tmp/homeboy-target"),
+                    Some("0.2.0"),
+                    Some("0.2.0+candidate"),
+                )
+                .expect("persist replacement intent");
+            operation
+                .record_replacement_checkpoint_durable(
+                    "applied",
+                    std::path::Path::new("/tmp/homeboy-target"),
+                    Some("0.2.0"),
+                    Some("0.2.0+candidate"),
+                )
+                .expect("persist replacement application");
+
+            let run = operation
+                .observation
+                .as_ref()
+                .expect("observation")
+                .store()
+                .get_run(&id)
+                .expect("read operation")
+                .expect("operation exists");
+            assert_eq!(run.metadata_json["replacement"]["state"], "applied");
+            assert_eq!(run.metadata_json["phase"], "controller_replacement_applied");
+            assert_eq!(
+                run.metadata_json["controller"]["status"],
+                "replacement_applied"
+            );
+        });
+    }
+
+    #[test]
+    fn applied_checkpoint_survives_the_following_persistence_failure() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
+            let id = operation.id().expect("persisted operation").to_string();
+            operation
+                .record_replacement_checkpoint_durable(
+                    "pending",
+                    std::path::Path::new("/tmp/homeboy-target"),
+                    Some("0.2.0"),
+                    None,
+                )
+                .expect("persist replacement intent");
+            operation.fail_next_progress_write();
+            let checkpoint_error = operation
+                .record_replacement_checkpoint_durable(
+                    "applied",
+                    std::path::Path::new("/tmp/homeboy-target"),
+                    Some("0.2.0"),
+                    None,
+                )
+                .expect_err("inject applied-checkpoint persistence failure");
+            operation
+                .finish_failed_durable(&checkpoint_error)
+                .expect("terminal retry carries in-memory applied state");
+
+            let run = operation
+                .observation
+                .as_ref()
+                .expect("observation")
+                .store()
+                .get_run(&id)
+                .expect("read operation")
+                .expect("operation exists");
+            assert_eq!(run.status, RunStatus::Error.as_str());
+            assert_eq!(run.metadata_json["replacement"]["state"], "applied");
+            assert_eq!(
+                run.metadata_json["controller"]["status"],
+                "replacement_applied"
+            );
+        });
+    }
+
+    #[test]
+    fn failed_terminalization_preserves_concurrent_component_progress() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
+            let id = operation.id().expect("persisted operation").to_string();
+            persist_extension_progress(&id, "wordpress", 1, 2, Duration::from_secs(12))
+                .expect("persist concurrent extension progress");
+
+            operation
+                .finish_failed_durable(&Error::internal_unexpected("injected failure"))
+                .expect("terminalize failure");
+
+            let status = load_upgrade_operation_status(Some(&id)).expect("load status");
+            assert_eq!(status.phase, "failed");
+            assert_eq!(
+                status
+                    .extensions
+                    .as_ref()
+                    .map(|value| value.status.as_str()),
+                Some("running")
+            );
+            assert!(status
+                .extensions
+                .as_ref()
+                .is_some_and(|value| value.summary.contains("wordpress")));
+        });
+    }
+
+    #[test]
+    fn terminal_cas_retries_progress_written_after_its_merge_read() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
+            let id = operation.id().expect("persisted operation").to_string();
+            let progress_id = id.clone();
+            operation.before_terminal_write(move || {
+                persist_extension_progress(
+                    &progress_id,
+                    "woocommerce",
+                    2,
+                    3,
+                    Duration::from_secs(18),
+                )
+                .expect("persist progress in terminal CAS window");
+            });
+
+            operation
+                .finish_failed_durable(&Error::internal_unexpected("injected failure"))
+                .expect("terminal CAS retries merged progress");
+
+            let status = load_upgrade_operation_status(Some(&id)).expect("load status");
+            assert_eq!(status.status, RunStatus::Error.as_str());
+            assert_eq!(status.phase, "failed");
+            assert!(status
+                .extensions
+                .as_ref()
+                .is_some_and(|value| value.summary.contains("woocommerce")));
+        });
+    }
+
+    #[test]
+    fn applied_replacement_history_is_not_reconciled_against_current_disk() {
+        let mut metadata = json!({
+            "phase": "completed",
+            "controller": component("updated", "controller installation completed"),
+            "replacement": {
+                "state": "applied",
+                "target": "/definitely/not/the/current/controller",
+                "expected_version": "0.2.0"
+            }
+        });
+
+        reconcile_replacement_projection(&mut metadata);
+
+        assert_eq!(metadata["phase"], "completed");
+        assert_eq!(metadata["controller"]["status"], "updated");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pending_replacement_status_reconciles_the_actual_installed_identity() {
+        use std::os::unix::fs::PermissionsExt;
+
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let target_dir = tempfile::tempdir().expect("target directory");
+            let target = target_dir.path().join("homeboy");
+            std::fs::write(&target, "#!/bin/sh\necho 'homeboy 0.2.0+candidate'\n")
+                .expect("write target fixture");
+            let mut permissions = std::fs::metadata(&target)
+                .expect("target metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&target, permissions).expect("make target executable");
+
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
+            let id = operation.id().expect("persisted operation").to_string();
+            operation
+                .record_replacement_checkpoint_durable("pending", &target, Some("0.2.0"), None)
+                .expect("persist replacement intent");
+
+            let status = load_upgrade_operation_status(Some(&id)).expect("reconcile status");
+            assert_eq!(
+                status
+                    .controller
+                    .as_ref()
+                    .map(|component| component.status.as_str()),
+                Some("replacement_applied")
+            );
+            assert_eq!(status.phase, "controller_replacement_applied");
+        });
+    }
+
+    #[test]
+    fn lost_terminal_cas_is_a_conflict_not_success() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
+            let id = operation.id().expect("persisted operation").to_string();
+            operation
+                .observation
+                .as_ref()
+                .expect("observation")
+                .store()
+                .finish_running_run(&id, RunStatus::Skipped, None)
+                .expect("competing terminal write")
+                .expect("competing CAS wins");
+
+            let error = operation
+                .finish_completed_durable(&completed_upgrade_result())
+                .expect_err("lost terminal CAS cannot count as success");
+            assert!(error.message.contains("terminal state changed"));
+            let run = operation
+                .observation
+                .as_ref()
+                .expect("observation")
+                .store()
+                .get_run(&id)
+                .expect("read operation")
+                .expect("operation exists");
+            assert_eq!(run.status, RunStatus::Skipped.as_str());
+        });
+    }
+
+    #[test]
+    fn late_progress_cannot_overwrite_terminal_metadata() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
+            let id = operation.id().expect("persisted operation").to_string();
+            operation
+                .finish_completed_durable(&completed_upgrade_result())
+                .expect("terminalize operation");
+            let store = operation.observation.as_ref().expect("observation").store();
+            let before = store.get_run(&id).expect("read terminal").expect("run");
+            let update = store
+                .update_running_run_metadata(&id, json!({"phase": "late_progress"}))
+                .expect("late progress CAS");
+            assert!(update.is_none());
+            let after = store.get_run(&id).expect("read terminal").expect("run");
+            assert_eq!(after.metadata_json, before.metadata_json);
+        });
+    }
+
+    fn completed_upgrade_result() -> UpgradeResult {
+        UpgradeResult {
+            command: "upgrade".to_string(),
+            install_method: super::super::types::InstallMethod::Binary,
+            previous_version: "0.1.0".to_string(),
+            new_version: Some("0.2.0".to_string()),
+            previous_build_identity: None,
+            new_build_identity: None,
+            source_revision: None,
+            upgraded: true,
+            outcome: Some("controller_updated".to_string()),
+            preflight: None,
+            controller: Some(UpgradeComponentStatus {
+                status: "updated".to_string(),
+                summary: "controller installation completed".to_string(),
+            }),
+            extensions: Some(UpgradeComponentStatus {
+                status: "completed".to_string(),
+                summary: "1 updated, 0 skipped".to_string(),
+            }),
+            runners: Some(UpgradeComponentStatus {
+                status: "skipped".to_string(),
+                summary: "runner convergence skipped".to_string(),
+            }),
+            partial: false,
+            runner_convergence: None,
+            message: "Upgraded".to_string(),
+            restart_required: false,
+            extensions_updated: Vec::new(),
+            extensions_skipped: Vec::new(),
+            extension_skips: Vec::new(),
+            runners_updated: Vec::new(),
+            runners_skipped: Vec::new(),
+            extensions_unrefreshed: Vec::new(),
+            services_restarted: Vec::new(),
+            services_pending_restart: Vec::new(),
+            operation_id: None,
+        }
     }
 }

--- a/crates/homeboy-upgrade/src/upgrade/operation.rs
+++ b/crates/homeboy-upgrade/src/upgrade/operation.rs
@@ -1333,6 +1333,43 @@ mod tests {
     }
 
     #[test]
+    fn successful_noop_installer_is_terminal_error_with_not_applied_evidence() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
+            let id = operation.id().expect("persisted operation").to_string();
+            let checkpoint = replacement_checkpoint("pending", "/tmp/homeboy-target");
+            operation
+                .record_replacement_checkpoint_durable(&checkpoint)
+                .expect("persist replacement intent");
+            operation
+                .record_replacement_checkpoint_durable(&checkpoint.with_state("not_applied"))
+                .expect("persist successful installer no-op");
+
+            operation
+                .finish_failed_durable(&Error::internal_unexpected(
+                    "binary installer exited successfully without replacing the controller",
+                ))
+                .expect("terminalize successful installer no-op");
+
+            let run = operation
+                .observation
+                .as_ref()
+                .expect("observation")
+                .store()
+                .get_run(&id)
+                .expect("read operation")
+                .expect("operation exists");
+            assert_eq!(run.status, RunStatus::Error.as_str());
+            assert_eq!(run.metadata_json["phase"], "failed");
+            assert_eq!(run.metadata_json["replacement"]["state"], "not_applied");
+            assert_eq!(
+                run.metadata_json["controller"]["status"],
+                "replacement_not_applied"
+            );
+        });
+    }
+
+    #[test]
     fn applied_checkpoint_survives_the_following_persistence_failure() {
         homeboy_core::test_support::with_isolated_home(|_| {
             let mut operation = UpgradeOperation::start("homeboy upgrade");

--- a/crates/homeboy-upgrade/src/upgrade/operation.rs
+++ b/crates/homeboy-upgrade/src/upgrade/operation.rs
@@ -72,7 +72,7 @@ pub struct UpgradeOperation {
     controller_promoted: bool,
     persistence_error: Option<Error>,
     #[cfg(test)]
-    fail_next_terminal_write: bool,
+    fail_terminal_writes_remaining: usize,
     #[cfg(test)]
     fail_next_progress_write: bool,
     #[cfg(test)]
@@ -106,7 +106,7 @@ impl UpgradeOperation {
             pending_terminal: None,
             controller_promoted: false,
             persistence_error: None,
-            fail_next_terminal_write: false,
+            fail_terminal_writes_remaining: 0,
             fail_next_progress_write: false,
             before_terminal_write: None,
         };
@@ -135,7 +135,7 @@ impl UpgradeOperation {
             controller_promoted: false,
             persistence_error: None,
             #[cfg(test)]
-            fail_next_terminal_write: false,
+            fail_terminal_writes_remaining: 0,
             #[cfg(test)]
             fail_next_progress_write: false,
             #[cfg(test)]
@@ -215,28 +215,45 @@ impl UpgradeOperation {
 
     pub fn record_replacement_checkpoint_durable(
         &mut self,
-        state: &str,
-        target: &std::path::Path,
-        expected_version: Option<&str>,
-        expected_build_identity: Option<&str>,
+        checkpoint: &super::execution::ReplacementCheckpoint,
     ) -> Result<()> {
-        self.metadata["replacement"] = json!({
-            "state": state,
-            "target": target.display().to_string(),
-            "expected_version": expected_version,
-            "expected_build_identity": expected_build_identity,
-        });
-        if state == "applied" {
+        let previous_metadata = self.metadata.clone();
+        let previous_controller_promoted = self.controller_promoted;
+        self.metadata["replacement"] = json!(checkpoint);
+        if checkpoint.state == "applied" {
             self.controller_promoted = true;
             self.metadata["controller"] = component(
                 "replacement_applied",
                 "controller replacement applied; verification pending",
             );
             self.metadata["phase"] = json!("controller_replacement_applied");
-        } else {
+        } else if checkpoint.state == "pending" {
             self.metadata["phase"] = json!("controller_replacement_pending");
+        } else if checkpoint.state == "not_applied" {
+            self.metadata["controller"] = component(
+                "replacement_not_applied",
+                "controller replacement did not change the installed target",
+            );
+            self.metadata["phase"] = json!("controller_replacement_not_applied");
+        } else if checkpoint.state == "changed_unverified" {
+            self.metadata["controller"] = component(
+                "replacement_changed_unverified",
+                "controller target changed, but the selected identity could not be verified",
+            );
+            self.metadata["phase"] = json!("controller_replacement_changed_unverified");
+        } else if checkpoint.state == "evidence_unavailable" {
+            self.metadata["controller"] = component(
+                "replacement_evidence_unavailable",
+                "controller replacement evidence could not be read",
+            );
+            self.metadata["phase"] = json!("controller_replacement_evidence_unavailable");
         }
-        self.persist_durable()
+        let persisted = self.persist_durable();
+        if persisted.is_err() && checkpoint.state == "pending" {
+            self.metadata = previous_metadata;
+            self.controller_promoted = previous_controller_promoted;
+        }
+        persisted
     }
 
     pub fn mark_extensions(&mut self, status: &str, summary: &str) {
@@ -291,6 +308,12 @@ impl UpgradeOperation {
             "message": error.message,
         });
         self.finish_durable(RunStatus::Error)
+    }
+
+    pub(crate) fn replace_pending_terminal_with_failure(&mut self, error: &Error) -> Result<()> {
+        self.pending_terminal = None;
+        self.finished = false;
+        self.finish_failed_durable(error)
     }
 
     fn persist(&mut self) {
@@ -371,7 +394,8 @@ impl UpgradeOperation {
                 .clone()
                 .expect("terminal intent initialized");
             #[cfg(test)]
-            if std::mem::take(&mut self.fail_next_terminal_write) {
+            if self.fail_terminal_writes_remaining > 0 {
+                self.fail_terminal_writes_remaining -= 1;
                 last_error = Some(Error::internal_unexpected(
                     "injected upgrade terminal persistence failure",
                 ));
@@ -426,7 +450,12 @@ impl UpgradeOperation {
 
     #[cfg(test)]
     pub(crate) fn fail_next_terminal_write(&mut self) {
-        self.fail_next_terminal_write = true;
+        self.fail_terminal_writes_remaining = 1;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_next_terminal_writes(&mut self, count: usize) {
+        self.fail_terminal_writes_remaining = count;
     }
 
     #[cfg(test)]
@@ -435,7 +464,7 @@ impl UpgradeOperation {
     }
 
     #[cfg(test)]
-    fn before_terminal_write(&mut self, callback: impl FnOnce() + Send + 'static) {
+    pub(crate) fn before_terminal_write(&mut self, callback: impl FnOnce() + Send + 'static) {
         self.before_terminal_write = Some(Box::new(callback));
     }
 }
@@ -455,6 +484,11 @@ fn initial_metadata() -> Value {
 impl Drop for UpgradeOperation {
     fn drop(&mut self) {
         if self.finished {
+            return;
+        }
+        // Panic unwinding and a hard process crash must leave the same
+        // lease-recoverable checkpoint for the next mutation owner to freeze.
+        if self.metadata["replacement"]["state"].as_str() == Some("pending") {
             return;
         }
         if self.pending_terminal.is_some() {
@@ -719,41 +753,111 @@ fn reconcile_replacement_projection(metadata: &mut Value) {
     if replacement.get("state").and_then(Value::as_str) != Some("pending") {
         return;
     }
-    let Some(target) = replacement.get("target").and_then(Value::as_str) else {
+    let Ok(checkpoint) =
+        serde_json::from_value::<super::execution::ReplacementCheckpoint>(replacement.clone())
+    else {
+        metadata["controller"] = component(
+            "replacement_evidence_missing",
+            "pending replacement has no pre-mutation byte evidence",
+        );
         return;
     };
-    let expected_build = replacement
-        .get("expected_build_identity")
-        .and_then(Value::as_str);
-    let expected_version = replacement.get("expected_version").and_then(Value::as_str);
-    match super::execution::installed_target_build_identity_from_disk(std::path::Path::new(target))
-    {
-        Ok(Some(identity))
-            if expected_build.is_some_and(|expected| identity.display == expected)
-                || (expected_build.is_none()
-                    && expected_version.is_some_and(|expected| identity.version == expected)) =>
-        {
+    match super::execution::replacement_was_applied(&checkpoint) {
+        Ok(true) => {
+            let identity = super::execution::replacement_applied_identity(&checkpoint)
+                .ok()
+                .flatten();
             metadata["controller"] = component(
                 "replacement_applied",
-                format!("installed controller is {}", identity.display),
+                identity.map_or_else(
+                    || "installed controller bytes match the selected replacement".to_string(),
+                    |identity| format!("installed controller is {}", identity.display),
+                ),
             );
             if metadata["phase"] == "controller_replacement_pending" {
                 metadata["phase"] = json!("controller_replacement_applied");
             }
         }
-        Ok(Some(identity)) => {
+        Ok(false) => {
             metadata["controller"] = component(
-                "different_installed_identity",
-                format!("installed controller is {}", identity.display),
+                "replacement_not_observed",
+                "installed controller bytes do not prove this replacement was applied",
             );
         }
-        Ok(None) | Err(_) => {
+        Err(_) => {
             metadata["controller"] = component(
                 "identity_unknown",
                 "installed controller identity could not be verified",
             );
         }
     }
+}
+
+pub(crate) fn freeze_prior_pending_replacements(current_operation_id: &str) -> Result<()> {
+    let store = ObservationStore::open_initialized()?;
+    let runs = store.list_runs_all(RunListFilter {
+        kind: Some(UPGRADE_OPERATION_KIND.to_string()),
+        status: Some(RunStatus::Running.as_str().to_string()),
+        ..RunListFilter::default()
+    })?;
+    for run in runs {
+        if run.id == current_operation_id
+            || run.metadata_json["replacement"]["state"].as_str() != Some("pending")
+        {
+            continue;
+        }
+        let mut metadata = run.metadata_json;
+        let checkpoint = serde_json::from_value::<super::execution::ReplacementCheckpoint>(
+            metadata["replacement"].clone(),
+        )
+        .map_err(|error| {
+            Error::internal_unexpected(format!(
+                "prior upgrade operation has invalid replacement evidence: {}: {error}",
+                run.id
+            ))
+        })?;
+        let state = super::execution::replacement_observed_state(&checkpoint)?;
+        metadata["replacement"]["state"] = json!(state);
+        match state {
+            "applied" => {
+                metadata["controller"] = component(
+                    "replacement_applied",
+                    "installed controller bytes prove the selected replacement was applied",
+                );
+                metadata["phase"] = json!("controller_replacement_applied");
+            }
+            "changed_unverified" => {
+                metadata["controller"] = component(
+                    "replacement_changed_unverified",
+                    "controller target changed, but the selected identity could not be verified",
+                );
+                metadata["phase"] = json!("controller_replacement_changed_unverified");
+            }
+            "not_applied" => {
+                metadata["controller"] = component(
+                    "replacement_not_applied",
+                    "controller replacement did not change the installed target",
+                );
+                metadata["phase"] = json!("controller_replacement_not_applied");
+            }
+            _ => {
+                metadata["controller"] = component(
+                    "replacement_evidence_unavailable",
+                    "controller replacement evidence could not be read",
+                );
+                metadata["phase"] = json!("controller_replacement_evidence_unavailable");
+            }
+        }
+        store
+            .update_running_run_metadata(&run.id, metadata)?
+            .ok_or_else(|| {
+                Error::internal_unexpected(format!(
+                    "prior upgrade operation changed while freezing replacement evidence: {}",
+                    run.id
+                ))
+            })?;
+    }
+    Ok(())
 }
 
 fn component_from_metadata(metadata: &Value, key: &str) -> Option<UpgradeComponentStatus> {
@@ -1076,21 +1180,12 @@ mod tests {
         homeboy_core::test_support::with_isolated_home(|_| {
             let mut operation = UpgradeOperation::start("homeboy upgrade");
             let id = operation.id().expect("persisted operation").to_string();
+            let checkpoint = replacement_checkpoint("pending", "/tmp/homeboy-target");
             operation
-                .record_replacement_checkpoint_durable(
-                    "pending",
-                    std::path::Path::new("/tmp/homeboy-target"),
-                    Some("0.2.0"),
-                    Some("0.2.0+candidate"),
-                )
+                .record_replacement_checkpoint_durable(&checkpoint)
                 .expect("persist replacement intent");
             operation
-                .record_replacement_checkpoint_durable(
-                    "applied",
-                    std::path::Path::new("/tmp/homeboy-target"),
-                    Some("0.2.0"),
-                    Some("0.2.0+candidate"),
-                )
+                .record_replacement_checkpoint_durable(&checkpoint.with_state("applied"))
                 .expect("persist replacement application");
 
             let run = operation
@@ -1111,26 +1206,44 @@ mod tests {
     }
 
     #[test]
+    fn failed_pending_checkpoint_is_not_replayed_into_terminal_metadata() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
+            let id = operation.id().expect("persisted operation").to_string();
+            let checkpoint = replacement_checkpoint("pending", "/tmp/homeboy-target");
+            operation.fail_next_progress_write();
+            let checkpoint_error = operation
+                .record_replacement_checkpoint_durable(&checkpoint)
+                .expect_err("inject pending-checkpoint persistence failure");
+            operation
+                .finish_failed_durable(&checkpoint_error)
+                .expect("terminalize the pre-mutation failure");
+
+            let run = operation
+                .observation
+                .as_ref()
+                .expect("observation")
+                .store()
+                .get_run(&id)
+                .expect("read operation")
+                .expect("operation exists");
+            assert!(run.metadata_json.get("replacement").is_none());
+            assert_eq!(run.status, RunStatus::Error.as_str());
+        });
+    }
+
+    #[test]
     fn applied_checkpoint_survives_the_following_persistence_failure() {
         homeboy_core::test_support::with_isolated_home(|_| {
             let mut operation = UpgradeOperation::start("homeboy upgrade");
             let id = operation.id().expect("persisted operation").to_string();
+            let checkpoint = replacement_checkpoint("pending", "/tmp/homeboy-target");
             operation
-                .record_replacement_checkpoint_durable(
-                    "pending",
-                    std::path::Path::new("/tmp/homeboy-target"),
-                    Some("0.2.0"),
-                    None,
-                )
+                .record_replacement_checkpoint_durable(&checkpoint)
                 .expect("persist replacement intent");
             operation.fail_next_progress_write();
             let checkpoint_error = operation
-                .record_replacement_checkpoint_durable(
-                    "applied",
-                    std::path::Path::new("/tmp/homeboy-target"),
-                    Some("0.2.0"),
-                    None,
-                )
+                .record_replacement_checkpoint_durable(&checkpoint.with_state("applied"))
                 .expect_err("inject applied-checkpoint persistence failure");
             operation
                 .finish_failed_durable(&checkpoint_error)
@@ -1232,25 +1345,70 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn pending_replacement_status_reconciles_the_actual_installed_identity() {
-        use std::os::unix::fs::PermissionsExt;
-
+    fn crash_before_byte_swap_does_not_reconcile_same_version_replacement() {
         homeboy_core::test_support::with_isolated_home(|_| {
             let target_dir = tempfile::tempdir().expect("target directory");
             let target = target_dir.path().join("homeboy");
-            std::fs::write(&target, "#!/bin/sh\necho 'homeboy 0.2.0+candidate'\n")
-                .expect("write target fixture");
-            let mut permissions = std::fs::metadata(&target)
-                .expect("target metadata")
-                .permissions();
-            permissions.set_mode(0o755);
-            std::fs::set_permissions(&target, permissions).expect("make target executable");
+            write_executable(&target, "#!/bin/sh\necho 'homeboy 0.2.0'\n# old\n");
+            let checkpoint = super::super::execution::ReplacementCheckpoint::pending(
+                &target,
+                Some("0.2.0"),
+                None,
+                None,
+            )
+            .expect("capture pre-mutation evidence");
 
             let mut operation = UpgradeOperation::start("homeboy upgrade");
             let id = operation.id().expect("persisted operation").to_string();
             operation
-                .record_replacement_checkpoint_durable("pending", &target, Some("0.2.0"), None)
+                .record_replacement_checkpoint_durable(&checkpoint)
                 .expect("persist replacement intent");
+
+            let status = load_upgrade_operation_status(Some(&id)).expect("reconcile status");
+            assert_eq!(
+                status
+                    .controller
+                    .as_ref()
+                    .map(|component| component.status.as_str()),
+                Some("replacement_not_observed")
+            );
+            assert_eq!(status.phase, "controller_replacement_pending");
+
+            freeze_prior_pending_replacements("next-controller-operation")
+                .expect("freeze crash evidence before admitting the next mutation");
+            write_executable(&target, "#!/bin/sh\necho 'homeboy 0.2.0'\n# later retry\n");
+            let frozen = load_upgrade_operation_status(Some(&id)).expect("reload frozen status");
+            assert_eq!(
+                frozen
+                    .controller
+                    .as_ref()
+                    .map(|component| component.status.as_str()),
+                Some("replacement_not_applied")
+            );
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn crash_after_same_version_byte_swap_reconciles_deliberate_replacement() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let target_dir = tempfile::tempdir().expect("target directory");
+            let target = target_dir.path().join("homeboy");
+            write_executable(&target, "#!/bin/sh\necho 'homeboy 0.2.0'\n# old\n");
+            let checkpoint = super::super::execution::ReplacementCheckpoint::pending(
+                &target,
+                Some("0.2.0"),
+                None,
+                None,
+            )
+            .expect("capture pre-mutation evidence");
+
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
+            let id = operation.id().expect("persisted operation").to_string();
+            operation
+                .record_replacement_checkpoint_durable(&checkpoint)
+                .expect("persist replacement intent");
+            write_executable(&target, "#!/bin/sh\necho 'homeboy 0.2.0'\n# replacement\n");
 
             let status = load_upgrade_operation_status(Some(&id)).expect("reconcile status");
             assert_eq!(
@@ -1262,6 +1420,159 @@ mod tests {
             );
             assert_eq!(status.phase, "controller_replacement_applied");
         });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn panic_after_pending_remains_recoverable_by_the_next_mutation_owner() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let target_dir = tempfile::tempdir().expect("target directory");
+            let target = target_dir.path().join("homeboy");
+            write_executable(&target, "#!/bin/sh\necho 'homeboy 0.2.0'\n# old\n");
+            let checkpoint = super::super::execution::ReplacementCheckpoint::pending(
+                &target,
+                Some("0.2.0"),
+                None,
+                None,
+            )
+            .expect("capture pre-mutation evidence");
+            let operation_id = std::panic::catch_unwind(|| {
+                let mut operation = UpgradeOperation::start("homeboy upgrade");
+                let id = operation.id().expect("persisted operation").to_string();
+                operation
+                    .record_replacement_checkpoint_durable(&checkpoint)
+                    .expect("persist replacement intent");
+                std::panic::panic_any(id);
+            })
+            .expect_err("inject panic after pending")
+            .downcast::<String>()
+            .expect("panic carries operation id");
+
+            let pending = load_upgrade_operation_status(Some(&operation_id))
+                .expect("panic leaves pending operation inspectable");
+            assert_eq!(pending.status, RunStatus::Running.as_str());
+            freeze_prior_pending_replacements("next-controller-operation")
+                .expect("next owner freezes panic evidence");
+            let frozen =
+                load_upgrade_operation_status(Some(&operation_id)).expect("load frozen operation");
+            assert_eq!(
+                frozen
+                    .controller
+                    .as_ref()
+                    .map(|component| component.status.as_str()),
+                Some("replacement_not_applied")
+            );
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn crash_with_changed_unverifiable_bytes_freezes_distinct_evidence() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let target_dir = tempfile::tempdir().expect("target directory");
+            let target = target_dir.path().join("homeboy");
+            write_executable(&target, "#!/bin/sh\necho 'homeboy 0.2.0'\n# old\n");
+            let checkpoint = super::super::execution::ReplacementCheckpoint::pending(
+                &target,
+                Some("0.2.0"),
+                None,
+                None,
+            )
+            .expect("capture pre-mutation evidence");
+            let operation_id = {
+                let mut operation = UpgradeOperation::start("homeboy upgrade");
+                let id = operation.id().expect("persisted operation").to_string();
+                operation
+                    .record_replacement_checkpoint_durable(&checkpoint)
+                    .expect("persist replacement intent");
+                std::fs::write(&target, b"changed bytes that cannot execute")
+                    .expect("simulate crash after byte transition");
+                id
+            };
+
+            freeze_prior_pending_replacements("next-controller-operation")
+                .expect("next owner freezes changed evidence");
+            let frozen =
+                load_upgrade_operation_status(Some(&operation_id)).expect("load frozen operation");
+            assert_eq!(
+                frozen
+                    .controller
+                    .as_ref()
+                    .map(|component| component.status.as_str()),
+                Some("replacement_changed_unverified")
+            );
+            assert_eq!(frozen.phase, "controller_replacement_changed_unverified");
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn spawning_failure_checkpoint_cannot_be_reclassified_by_later_swap() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let target_dir = tempfile::tempdir().expect("target directory");
+            let target = target_dir.path().join("homeboy");
+            write_executable(&target, "#!/bin/sh\necho 'homeboy 0.2.0'\n# old\n");
+            let checkpoint = super::super::execution::ReplacementCheckpoint::pending(
+                &target,
+                Some("0.2.0"),
+                None,
+                None,
+            )
+            .expect("capture pre-mutation evidence")
+            .with_state("not_applied");
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
+            let id = operation.id().expect("persisted operation").to_string();
+            operation
+                .record_replacement_checkpoint_durable(&checkpoint)
+                .expect("persist spawn failure");
+            write_executable(
+                &target,
+                "#!/bin/sh\necho 'homeboy 0.2.0'\n# later operation\n",
+            );
+
+            let status = load_upgrade_operation_status(Some(&id)).expect("load status");
+            assert_ne!(
+                status
+                    .controller
+                    .as_ref()
+                    .map(|component| component.status.as_str()),
+                Some("replacement_applied")
+            );
+            assert_eq!(
+                status
+                    .controller
+                    .as_ref()
+                    .map(|component| component.status.as_str()),
+                Some("replacement_not_applied")
+            );
+        });
+    }
+
+    fn replacement_checkpoint(
+        state: &str,
+        target: &str,
+    ) -> super::super::execution::ReplacementCheckpoint {
+        super::super::execution::ReplacementCheckpoint {
+            state: state.to_string(),
+            target: target.into(),
+            expected_version: Some("0.2.0".to_string()),
+            expected_build_identity: Some("0.2.0+candidate".to_string()),
+            expected_sha256: None,
+            previous_build_identity: Some("0.1.0+old".to_string()),
+            previous_sha256: "old-digest".to_string(),
+        }
+    }
+
+    #[cfg(unix)]
+    fn write_executable(path: &std::path::Path, contents: &str) {
+        use std::os::unix::fs::PermissionsExt;
+
+        std::fs::write(path, contents).expect("write executable fixture");
+        let mut permissions = std::fs::metadata(path)
+            .expect("target metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).expect("make target executable");
     }
 
     #[test]

--- a/crates/homeboy-upgrade/src/upgrade/operation.rs
+++ b/crates/homeboy-upgrade/src/upgrade/operation.rs
@@ -1039,10 +1039,16 @@ mod tests {
         homeboy_core::test_support::with_isolated_home(|_| {
             let mut operation = UpgradeOperation::start("homeboy upgrade");
             let id = operation.id().expect("persisted operation").to_string();
-            operation.mark_controller_promoted("controller installation completed");
-            operation.set_phase("refreshing installed extensions");
+            operation
+                .mark_controller_promoted_durable("controller installation completed")
+                .expect("persist controller promotion");
+            operation
+                .set_phase_durable("refreshing installed extensions")
+                .expect("persist extension refresh phase");
             operation.mark_extensions("completed", "7 updated, 0 skipped");
-            operation.set_phase("refreshing configured runners");
+            operation
+                .set_phase_durable("refreshing configured runners")
+                .expect("persist runner refresh phase");
 
             let status = load_upgrade_operation_status(Some(&id)).expect("load status");
             assert_eq!(status.phase, "refreshing configured runners");

--- a/crates/homeboy-upgrade/src/upgrade/operation.rs
+++ b/crates/homeboy-upgrade/src/upgrade/operation.rs
@@ -935,21 +935,36 @@ pub(crate) fn freeze_prior_pending_replacements(current_operation_id: &str) -> R
         metadata["outcome"] = json!("controller_replacement_interrupted");
         metadata["superseded_by_operation_id"] = json!(current_operation_id);
         metadata["terminal_intent_id"] = json!(format!("upgrade-superseded:{}", run.id));
-        store
-            .finish_running_run_if_metadata(
-                &run.id,
-                RunStatus::Error,
-                metadata,
-                &expected_metadata,
-            )?
-            .ok_or_else(|| {
-                Error::internal_unexpected(format!(
-                    "prior upgrade operation changed while freezing replacement evidence: {}",
-                    run.id
-                ))
-            })?;
+        let frozen = store.finish_running_run_if_metadata(
+            &run.id,
+            RunStatus::Error,
+            metadata,
+            &expected_metadata,
+        )?;
+        accept_freeze_cas_result(&store, &run.id, frozen)?;
     }
     Ok(())
+}
+
+fn accept_freeze_cas_result(
+    store: &ObservationStore,
+    run_id: &str,
+    frozen: Option<RunRecord>,
+) -> Result<()> {
+    if frozen.is_some() {
+        return Ok(());
+    }
+    let current = store.get_run(run_id)?.ok_or_else(|| {
+        Error::internal_unexpected(format!(
+            "prior upgrade operation disappeared while freezing replacement evidence: {run_id}"
+        ))
+    })?;
+    if current.status != RunStatus::Running.as_str() {
+        return Ok(());
+    }
+    Err(Error::internal_unexpected(format!(
+        "prior upgrade operation changed while freezing replacement evidence: {run_id}"
+    )))
 }
 
 fn component_from_metadata(metadata: &Value, key: &str) -> Option<UpgradeComponentStatus> {
@@ -1541,6 +1556,39 @@ mod tests {
 
         assert_eq!(metadata["phase"], "completed");
         assert_eq!(metadata["controller"]["status"], "updated");
+    }
+
+    #[test]
+    fn freeze_cas_loss_accepts_a_concurrently_terminal_predecessor() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let operation = UpgradeOperation::start("homeboy upgrade");
+            let id = operation.id().expect("persisted operation").to_string();
+            let store = ObservationStore::open_initialized().expect("open store");
+            let running = store
+                .get_run(&id)
+                .expect("read predecessor")
+                .expect("predecessor exists");
+            store
+                .finish_running_run_if_metadata(
+                    &id,
+                    RunStatus::Pass,
+                    running.metadata_json.clone(),
+                    &running.metadata_json,
+                )
+                .expect("terminal winner")
+                .expect("winner updates predecessor");
+
+            accept_freeze_cas_result(&store, &id, None)
+                .expect("stale freeze accepts the terminal winner");
+            assert_eq!(
+                store
+                    .get_run(&id)
+                    .expect("reread predecessor")
+                    .expect("predecessor remains")
+                    .status,
+                RunStatus::Pass.as_str()
+            );
+        });
     }
 
     #[cfg(unix)]

--- a/crates/homeboy-upgrade/src/upgrade/operation.rs
+++ b/crates/homeboy-upgrade/src/upgrade/operation.rs
@@ -4,6 +4,8 @@
 //! Persisting them before mutation lets a timed-out client inspect whether the
 //! controller actually promoted, instead of guessing from a silent hang.
 
+#[cfg(test)]
+use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
@@ -76,7 +78,7 @@ pub struct UpgradeOperation {
     #[cfg(test)]
     fail_next_progress_write: bool,
     #[cfg(test)]
-    before_terminal_write: Option<Box<dyn FnOnce() + Send>>,
+    before_terminal_writes: VecDeque<Box<dyn FnOnce() + Send>>,
     #[cfg(test)]
     after_promotion_wait: Option<Box<dyn FnOnce() + Send>>,
 }
@@ -110,7 +112,7 @@ impl UpgradeOperation {
             persistence_error: None,
             fail_terminal_writes_remaining: 0,
             fail_next_progress_write: false,
-            before_terminal_write: None,
+            before_terminal_writes: VecDeque::new(),
             after_promotion_wait: None,
         };
         if let Some(id) = operation.id() {
@@ -142,7 +144,7 @@ impl UpgradeOperation {
             #[cfg(test)]
             fail_next_progress_write: false,
             #[cfg(test)]
-            before_terminal_write: None,
+            before_terminal_writes: VecDeque::new(),
             #[cfg(test)]
             after_promotion_wait: None,
         };
@@ -331,7 +333,10 @@ impl UpgradeOperation {
                 "upgrade operation has no durable observation",
             ));
         };
-        self.metadata["elapsed_seconds"] = json!(self.started.elapsed().as_secs());
+        merge_elapsed_seconds(&mut self.metadata, self.started.elapsed().as_secs());
+        if let Some(run) = observation.store().get_run(observation.run_id())? {
+            merge_elapsed_from_metadata(&mut self.metadata, &run.metadata_json);
+        }
         #[cfg(test)]
         if std::mem::take(&mut self.fail_next_progress_write) {
             return Err(Error::internal_unexpected(
@@ -371,11 +376,8 @@ impl UpgradeOperation {
                     observation.run_id()
                 ))
             })?;
-        merge_component_fields(&mut self.metadata, &run.metadata_json);
-        if let Some(elapsed) = run.metadata_json.get("elapsed_seconds") {
-            self.metadata["elapsed_seconds"] = elapsed.clone();
-        }
-        self.metadata["elapsed_seconds"] = json!(self.started.elapsed().as_secs());
+        merge_latest_monotonic_progress(&mut self.metadata, &run.metadata_json);
+        merge_elapsed_seconds(&mut self.metadata, self.started.elapsed().as_secs());
         if self.pending_terminal.is_none() {
             let intent_id = format!("upgrade-terminal:{}", observation.run_id());
             self.metadata["terminal_intent_id"] = json!(intent_id);
@@ -385,14 +387,17 @@ impl UpgradeOperation {
                 intent_id,
             });
         } else if let Some(intent) = self.pending_terminal.as_mut() {
-            merge_component_fields(&mut intent.metadata, &run.metadata_json);
+            merge_latest_monotonic_progress(&mut intent.metadata, &run.metadata_json);
         }
         let mut expected_metadata = run.metadata_json;
         let mut last_error = None;
-        for _ in 0..3 {
+        for attempt in 1..=3 {
             #[cfg(test)]
-            if let Some(before_write) = self.before_terminal_write.take() {
+            if let Some(before_write) = self.before_terminal_writes.pop_front() {
                 before_write();
+            }
+            if let Some(intent) = self.pending_terminal.as_mut() {
+                merge_latest_monotonic_progress(&mut intent.metadata, &expected_metadata);
             }
             let intent = self
                 .pending_terminal
@@ -428,11 +433,16 @@ impl UpgradeOperation {
                     }
                     Ok(Some(run)) if run.status == RunStatus::Running.as_str() => {
                         if let Some(intent) = self.pending_terminal.as_mut() {
-                            merge_component_fields(&mut intent.metadata, &run.metadata_json);
+                            merge_latest_monotonic_progress(
+                                &mut intent.metadata,
+                                &run.metadata_json,
+                            );
                         }
                         expected_metadata = run.metadata_json;
                         last_error = Some(Error::internal_unexpected(
-                            "upgrade terminal write raced with running progress",
+                            format!(
+                                "upgrade terminal write raced with running progress on attempt {attempt}"
+                            ),
                         ));
                     }
                     Ok(Some(_)) => {
@@ -448,9 +458,27 @@ impl UpgradeOperation {
                 },
             }
         }
-        Err(last_error.unwrap_or_else(|| {
-            Error::internal_unexpected("upgrade terminalization retries were exhausted")
-        }))
+        let phase = expected_metadata["phase"].as_str().unwrap_or("unknown");
+        let elapsed = expected_metadata["elapsed_seconds"].as_u64().unwrap_or(0);
+        let components = ["controller", "extensions", "runners"]
+            .into_iter()
+            .map(|key| {
+                format!(
+                    "{key}={}",
+                    expected_metadata[key]["status"]
+                        .as_str()
+                        .unwrap_or("unknown")
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        let cause = last_error
+            .map(|error| error.message)
+            .unwrap_or_else(|| "unknown terminal write failure".to_string());
+        Err(Error::internal_unexpected(format!(
+            "upgrade terminalization retries exhausted for {} after 3 attempts; final observed phase={phase}, elapsed_seconds={elapsed}, {components}; last error: {cause}",
+            observation.run_id()
+        )))
     }
 
     #[cfg(test)]
@@ -470,7 +498,7 @@ impl UpgradeOperation {
 
     #[cfg(test)]
     pub(crate) fn before_terminal_write(&mut self, callback: impl FnOnce() + Send + 'static) {
-        self.before_terminal_write = Some(Box::new(callback));
+        self.before_terminal_writes.push_back(Box::new(callback));
     }
 
     #[cfg(test)]
@@ -583,7 +611,7 @@ pub fn persist_extension_progress(
     ));
     patch_metadata(run_id, |metadata| {
         metadata["phase"] = json!("refreshing_installed_extensions");
-        metadata["elapsed_seconds"] = json!(elapsed.as_secs());
+        merge_elapsed_seconds(metadata, elapsed.as_secs());
         metadata["extensions"] = component(
             "running",
             format!("refreshing {extension_id} ({current}/{total})"),
@@ -629,7 +657,7 @@ pub fn persist_upgrade_heartbeat(run_id: &str, elapsed: Duration) -> Result<()> 
         )));
     };
     let mut metadata = run.metadata_json;
-    metadata["elapsed_seconds"] = json!(elapsed.as_secs());
+    merge_elapsed_seconds(&mut metadata, elapsed.as_secs());
     store
         .update_running_run_metadata(run_id, metadata)?
         .map(|_| ())
@@ -674,7 +702,9 @@ fn patch_metadata(run_id: &str, patch: impl FnOnce(&mut Value)) -> Result<()> {
         )));
     }
     let mut metadata = run.metadata_json;
+    let previous_elapsed = metadata["elapsed_seconds"].as_u64().unwrap_or(0);
     patch(&mut metadata);
+    merge_elapsed_seconds(&mut metadata, previous_elapsed);
     store
         .update_running_run_metadata(run_id, metadata)?
         .map(|_| ())
@@ -686,16 +716,58 @@ fn patch_metadata(run_id: &str, patch: impl FnOnce(&mut Value)) -> Result<()> {
 fn merge_component_fields(target: &mut Value, source: &Value) {
     for key in ["controller", "extensions", "runners"] {
         if let Some(value) = source.get(key) {
-            let target_is_pending = target
+            let target_status = target
                 .get(key)
                 .and_then(|component| component.get("status"))
-                .and_then(Value::as_str)
-                == Some("pending");
-            let source_is_pending = value.get("status").and_then(Value::as_str) == Some("pending");
-            if target.get(key).is_none() || (target_is_pending && !source_is_pending) {
+                .and_then(Value::as_str);
+            let source_status = value.get("status").and_then(Value::as_str);
+            let target_rank = component_progress_rank(target_status);
+            let source_rank = component_progress_rank(source_status);
+            if target.get(key).is_none()
+                || source_rank > target_rank
+                || (source_rank == target_rank && source_rank <= 1)
+            {
                 target[key] = value.clone();
             }
         }
+    }
+}
+
+fn component_progress_rank(status: Option<&str>) -> u8 {
+    match status {
+        None | Some("pending") => 0,
+        Some("running") => 1,
+        Some(_) => 2,
+    }
+}
+
+fn merge_elapsed_seconds(metadata: &mut Value, proposed: u64) {
+    let elapsed = metadata["elapsed_seconds"]
+        .as_u64()
+        .unwrap_or(0)
+        .max(proposed);
+    metadata["elapsed_seconds"] = json!(elapsed);
+}
+
+fn merge_elapsed_from_metadata(target: &mut Value, source: &Value) {
+    merge_elapsed_seconds(
+        target,
+        source["elapsed_seconds"].as_u64().unwrap_or_default(),
+    );
+}
+
+fn merge_latest_monotonic_progress(target: &mut Value, source: &Value) {
+    merge_component_fields(target, source);
+    merge_elapsed_from_metadata(target, source);
+    let Some(source_replacement) = source.get("replacement") else {
+        return;
+    };
+    let target_state = target["replacement"]["state"].as_str();
+    let source_state = source_replacement["state"].as_str();
+    if target.get("replacement").is_none()
+        || (target_state == Some("pending") && source_state.is_some_and(|state| state != "pending"))
+    {
+        target["replacement"] = source_replacement.clone();
     }
 }
 
@@ -816,7 +888,8 @@ pub(crate) fn freeze_prior_pending_replacements(current_operation_id: &str) -> R
         {
             continue;
         }
-        let mut metadata = run.metadata_json;
+        let expected_metadata = run.metadata_json;
+        let mut metadata = expected_metadata.clone();
         let checkpoint = serde_json::from_value::<super::execution::ReplacementCheckpoint>(
             metadata["replacement"].clone(),
         )
@@ -858,8 +931,17 @@ pub(crate) fn freeze_prior_pending_replacements(current_operation_id: &str) -> R
                 metadata["phase"] = json!("controller_replacement_evidence_unavailable");
             }
         }
+        metadata["phase"] = json!("controller_replacement_superseded");
+        metadata["outcome"] = json!("controller_replacement_interrupted");
+        metadata["superseded_by_operation_id"] = json!(current_operation_id);
+        metadata["terminal_intent_id"] = json!(format!("upgrade-superseded:{}", run.id));
         store
-            .update_running_run_metadata(&run.id, metadata)?
+            .finish_running_run_if_metadata(
+                &run.id,
+                RunStatus::Error,
+                metadata,
+                &expected_metadata,
+            )?
             .ok_or_else(|| {
                 Error::internal_unexpected(format!(
                     "prior upgrade operation changed while freezing replacement evidence: {}",
@@ -1328,6 +1410,14 @@ mod tests {
                 )
                 .expect("persist progress in terminal CAS window");
             });
+            let progress_id = id.clone();
+            operation.before_terminal_write(move || {
+                patch_metadata(&progress_id, |metadata| {
+                    metadata["elapsed_seconds"] = json!(27);
+                    metadata["runners"] = component("running", "refreshing runner docker (2/3)");
+                })
+                .expect("persist second progress advance in terminal CAS window");
+            });
 
             operation
                 .finish_failed_durable(&Error::internal_unexpected("injected failure"))
@@ -1340,6 +1430,61 @@ mod tests {
                 .extensions
                 .as_ref()
                 .is_some_and(|value| value.summary.contains("woocommerce")));
+            assert!(status
+                .runners
+                .as_ref()
+                .is_some_and(|value| value.summary.contains("docker")));
+            assert_eq!(status.elapsed_seconds, 27);
+        });
+    }
+
+    #[test]
+    fn terminal_retry_exhaustion_reports_final_observed_progress() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
+            let id = operation.id().expect("persisted operation").to_string();
+            persist_upgrade_heartbeat(&id, Duration::from_secs(41))
+                .expect("persist durable elapsed progress");
+            operation.fail_next_terminal_writes(3);
+
+            let error = operation
+                .finish_failed_durable(&Error::internal_unexpected("injected failure"))
+                .expect_err("terminal writes are exhausted");
+            assert!(error.message.contains(&id));
+            assert!(error.message.contains("after 3 attempts"));
+            assert!(error.message.contains("elapsed_seconds=41"));
+            assert!(error.message.contains("extensions=pending"));
+        });
+    }
+
+    #[test]
+    fn elapsed_seconds_never_regresses_across_progress_clock_origins() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut operation = UpgradeOperation::start("homeboy upgrade");
+            let id = operation.id().expect("persisted operation").to_string();
+
+            persist_upgrade_heartbeat(&id, Duration::from_secs(30))
+                .expect("persist queued ownership elapsed time");
+            persist_upgrade_heartbeat(&id, Duration::from_secs(1))
+                .expect("mutation heartbeat uses a newer clock origin");
+            assert_eq!(
+                load_upgrade_operation_status(Some(&id))
+                    .expect("load heartbeat status")
+                    .elapsed_seconds,
+                30
+            );
+
+            persist_extension_progress(&id, "wordpress", 1, 2, Duration::from_secs(45))
+                .expect("first extension progress");
+            persist_extension_progress(&id, "woocommerce", 1, 2, Duration::from_secs(2))
+                .expect("second extension clock restarts");
+            operation
+                .set_phase_durable("refreshing configured runners")
+                .expect("stale operation clock persists a later phase");
+
+            let status = load_upgrade_operation_status(Some(&id)).expect("load final status");
+            assert_eq!(status.elapsed_seconds, 45);
+            assert_eq!(status.phase, "refreshing configured runners");
         });
     }
 
@@ -1396,6 +1541,8 @@ mod tests {
                 .expect("freeze crash evidence before admitting the next mutation");
             write_executable(&target, "#!/bin/sh\necho 'homeboy 0.2.0'\n# later retry\n");
             let frozen = load_upgrade_operation_status(Some(&id)).expect("reload frozen status");
+            assert_eq!(frozen.status, RunStatus::Error.as_str());
+            assert_eq!(frozen.phase, "controller_replacement_superseded");
             assert_eq!(
                 frozen
                     .controller
@@ -1473,6 +1620,8 @@ mod tests {
                 .expect("next owner freezes panic evidence");
             let frozen =
                 load_upgrade_operation_status(Some(&operation_id)).expect("load frozen operation");
+            assert_eq!(frozen.status, RunStatus::Error.as_str());
+            assert_eq!(frozen.phase, "controller_replacement_superseded");
             assert_eq!(
                 frozen
                     .controller
@@ -1512,6 +1661,7 @@ mod tests {
                 .expect("next owner freezes changed evidence");
             let frozen =
                 load_upgrade_operation_status(Some(&operation_id)).expect("load frozen operation");
+            assert_eq!(frozen.status, RunStatus::Error.as_str());
             assert_eq!(
                 frozen
                     .controller
@@ -1519,7 +1669,24 @@ mod tests {
                     .map(|component| component.status.as_str()),
                 Some("replacement_changed_unverified")
             );
-            assert_eq!(frozen.phase, "controller_replacement_changed_unverified");
+            assert_eq!(frozen.phase, "controller_replacement_superseded");
+            let run = ObservationStore::open_initialized()
+                .expect("open store")
+                .get_run(&operation_id)
+                .expect("read run")
+                .expect("run exists");
+            assert_eq!(
+                run.metadata_json["outcome"],
+                "controller_replacement_interrupted"
+            );
+            assert_eq!(
+                run.metadata_json["superseded_by_operation_id"],
+                "next-controller-operation"
+            );
+            assert_eq!(
+                run.metadata_json["replacement"],
+                json!(checkpoint.with_state("changed_unverified"))
+            );
         });
     }
 

--- a/crates/homeboy-upgrade/src/upgrade/operation.rs
+++ b/crates/homeboy-upgrade/src/upgrade/operation.rs
@@ -256,9 +256,9 @@ impl UpgradeOperation {
         persisted
     }
 
-    pub fn mark_extensions(&mut self, status: &str, summary: &str) {
+    pub fn mark_extensions_durable(&mut self, status: &str, summary: &str) -> Result<()> {
         self.metadata["extensions"] = component(status, summary);
-        self.persist();
+        self.persist_durable()
     }
 
     #[cfg(test)]
@@ -314,10 +314,6 @@ impl UpgradeOperation {
         self.pending_terminal = None;
         self.finished = false;
         self.finish_failed_durable(error)
-    }
-
-    fn persist(&mut self) {
-        let _ = self.persist_durable();
     }
 
     fn persist_durable(&mut self) -> Result<()> {
@@ -1045,7 +1041,9 @@ mod tests {
             operation
                 .set_phase_durable("refreshing installed extensions")
                 .expect("persist extension refresh phase");
-            operation.mark_extensions("completed", "7 updated, 0 skipped");
+            operation
+                .mark_extensions_durable("completed", "7 updated, 0 skipped")
+                .expect("persist completed extension refresh");
             operation
                 .set_phase_durable("refreshing configured runners")
                 .expect("persist runner refresh phase");

--- a/crates/homeboy-upgrade/src/upgrade/operation.rs
+++ b/crates/homeboy-upgrade/src/upgrade/operation.rs
@@ -77,6 +77,8 @@ pub struct UpgradeOperation {
     fail_next_progress_write: bool,
     #[cfg(test)]
     before_terminal_write: Option<Box<dyn FnOnce() + Send>>,
+    #[cfg(test)]
+    after_promotion_wait: Option<Box<dyn FnOnce() + Send>>,
 }
 
 #[derive(Clone)]
@@ -109,6 +111,7 @@ impl UpgradeOperation {
             fail_terminal_writes_remaining: 0,
             fail_next_progress_write: false,
             before_terminal_write: None,
+            after_promotion_wait: None,
         };
         if let Some(id) = operation.id() {
             emit_upgrade_phase(&format!("operation={id}"));
@@ -140,6 +143,8 @@ impl UpgradeOperation {
             fail_next_progress_write: false,
             #[cfg(test)]
             before_terminal_write: None,
+            #[cfg(test)]
+            after_promotion_wait: None,
         };
         emit_upgrade_phase(&format!(
             "operation={}",
@@ -183,6 +188,10 @@ impl UpgradeOperation {
             _ => "waiting_for_compatible_controller_upgrade",
         }) {
             self.persistence_error.get_or_insert(error);
+        }
+        #[cfg(test)]
+        if let Some(after_wait) = self.after_promotion_wait.take() {
+            after_wait();
         }
     }
 
@@ -462,6 +471,11 @@ impl UpgradeOperation {
     #[cfg(test)]
     pub(crate) fn before_terminal_write(&mut self, callback: impl FnOnce() + Send + 'static) {
         self.before_terminal_write = Some(Box::new(callback));
+    }
+
+    #[cfg(test)]
+    pub(crate) fn after_promotion_wait(&mut self, callback: impl FnOnce() + Send + 'static) {
+        self.after_promotion_wait = Some(Box::new(callback));
     }
 }
 

--- a/crates/homeboy-upgrade/src/upgrade/validation.rs
+++ b/crates/homeboy-upgrade/src/upgrade/validation.rs
@@ -10,12 +10,8 @@ use super::types::{InstallMethod, VersionCheck};
 /// downloading it. That is the only method for which the check can promise the
 /// reported release is the one the upgrade will install.
 ///
-/// The legacy secondary method runs the same installer but is not
-/// release-pinned — it always resolves `latest/download` — so reporting an
-/// older installable release for it would describe an upgrade it cannot
-/// perform. It keeps the newest-tag semantics it has always had.
 pub(crate) fn selects_an_installable_release(method: InstallMethod) -> bool {
-    matches!(method, InstallMethod::Binary)
+    matches!(method, InstallMethod::Binary | InstallMethod::Secondary)
 }
 
 pub fn check_for_updates() -> Result<VersionCheck> {
@@ -237,12 +233,11 @@ mod tests {
         assert!(check.uninstallable_versions.is_empty());
     }
 
-    /// Only the method that pins a chosen release may report installability;
-    /// the others would be describing an upgrade they cannot perform.
+    /// Both release-asset methods pin the selected installable release.
     #[test]
     fn only_the_release_pinning_method_consults_the_release_catalog() {
         assert!(selects_an_installable_release(InstallMethod::Binary));
-        assert!(!selects_an_installable_release(InstallMethod::Secondary));
+        assert!(selects_an_installable_release(InstallMethod::Secondary));
         assert!(!selects_an_installable_release(InstallMethod::Homebrew));
         assert!(!selects_an_installable_release(InstallMethod::Source));
         assert!(!selects_an_installable_release(InstallMethod::Unknown));


### PR DESCRIPTION
Closes #13969.

## Summary
- complete durable controller upgrade queueing so a contender cannot supersede identity between the final read and terminal CAS
- fence installer process trees so a successor never receives mutation authority while an installer descendant can still act, using Linux subreaper plus guard-id adoption for fast double-fork descendants
- bound Windows and non-Unix terminate/reap with a hard deadline and output-handle closure so cleanup cannot block indefinitely
- route source upgrades through the same guarded descendant cleanup before staged validation and promotion
- prove same-version deliberate replacement from pre-mutation identity and digest evidence across spawn failure, no-op, and crash
- make repeated terminal CAS merge the latest monotonic progress, terminalize abandoned crashed replacements, and keep elapsed time monotonic
- give `InstallMethod::Secondary` the same replacement checkpoints and verified target admission as `Binary`

## Verification
- `cargo test -p homeboy-upgrade -p homeboy-engine-primitives`: 524 passed, 2 Linux-only fixtures correctly skipped on macOS
- `cargo test -p homeboy-core --lib runtime_promotion`: 40 passed
- `cargo test -p homeboy-cli --lib commands::utils::response`: 40 passed, confirming no #13970 delta
- `cargo check --workspace --all-targets`, `cargo fmt --all -- --check`, `git diff --check`
- independent blocking review compared branch and merge-base baselines directly; both fully green, no regressions, mergeable with no blocking defects

## Known limitation
Fast double-fork plus full process-group detachment cannot be adopted on macOS/BSD, which have no `PR_SET_CHILD_SUBREAPER` equivalent. This is scoped explicitly rather than claimed as covered; prior behavior on that platform was strictly weaker.

## AI assistance
Anthropic Claude Sonnet 5 and OpenAI GPT-5.6 Sol via OpenCode implemented the upgrade queue and process containment changes, ran deterministic verification, and performed independent blocking reviews under Chris Huber's direction.