### PR TITLE
Single-source Extension API capability script projection

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/manifest.rs
+++ b/crates/contracts/homeboy-extension-contract/src/manifest.rs
@@ -8,6 +8,10 @@
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 
+use crate::api::v1::{
+    COMPILER_WARNINGS_CAPABILITY_ID, COMPILER_WARNING_FIXES_CAPABILITY_ID,
+    FINGERPRINT_FILE_CAPABILITY_PREFIX, REFACTOR_FILE_CAPABILITY_PREFIX,
+};
 use crate::autofix_config::*;
 use crate::ci_config::*;
 use crate::extension_contract_producer::*;
@@ -625,10 +629,159 @@ impl ExtensionManifest {
             .as_ref()
             .and_then(|s| s.compiler_warning_fixes.as_deref())
     }
+
+    /// Capability ids this extension provides over the JSON-stdin invocation
+    /// contract, in deterministic order.
+    ///
+    /// Catalog projection advertises exactly these, and API invocation resolves
+    /// exactly these through [`Self::json_capability_script`]. Deriving both
+    /// from one place is what keeps an advertised capability invocable: the two
+    /// used to be written out separately, and `format-file.<ext>` was advertised
+    /// while the invocation path had no branch for it.
+    ///
+    /// `format-file.<ext>` is deliberately absent. Format scripts take file
+    /// arguments rather than JSON on stdin, so they are a different invocation
+    /// shape and are projected separately.
+    pub fn json_capability_ids(&self) -> Vec<String> {
+        let mut capabilities = Vec::new();
+        if self.compiler_warnings_script().is_some() {
+            capabilities.push(COMPILER_WARNINGS_CAPABILITY_ID.to_string());
+        }
+        if self.compiler_warning_fixes_script().is_some() {
+            capabilities.push(COMPILER_WARNING_FIXES_CAPABILITY_ID.to_string());
+        }
+        if self.fingerprint_script().is_some() {
+            capabilities.extend(
+                self.provided_file_extensions()
+                    .iter()
+                    .map(|file_extension| {
+                        format!("{FINGERPRINT_FILE_CAPABILITY_PREFIX}{file_extension}")
+                    }),
+            );
+        }
+        if self.refactor_script().is_some() {
+            capabilities.extend(
+                self.provided_file_extensions()
+                    .iter()
+                    .map(|file_extension| {
+                        format!("{REFACTOR_FILE_CAPABILITY_PREFIX}{file_extension}")
+                    }),
+            );
+        }
+        capabilities
+    }
+
+    /// Script implementing one JSON-stdin capability, if this extension
+    /// provides it. Returns `None` for a capability this extension does not
+    /// advertise, including capabilities that use another invocation shape.
+    pub fn json_capability_script(&self, capability_id: &str) -> Option<&str> {
+        match capability_id {
+            COMPILER_WARNINGS_CAPABILITY_ID => self.compiler_warnings_script(),
+            COMPILER_WARNING_FIXES_CAPABILITY_ID => self.compiler_warning_fixes_script(),
+            capability if capability.starts_with(FINGERPRINT_FILE_CAPABILITY_PREFIX) => self
+                .handles_file_extension(
+                    capability.trim_start_matches(FINGERPRINT_FILE_CAPABILITY_PREFIX),
+                )
+                .then(|| self.fingerprint_script())
+                .flatten(),
+            capability if capability.starts_with(REFACTOR_FILE_CAPABILITY_PREFIX) => self
+                .handles_file_extension(
+                    capability.trim_start_matches(REFACTOR_FILE_CAPABILITY_PREFIX),
+                )
+                .then(|| self.refactor_script())
+                .flatten(),
+            _ => None,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
+
+    /// Every advertised JSON-stdin capability must resolve to a script.
+    ///
+    /// This is the invariant that was already broken once: `format-file.<ext>`
+    /// was advertised by catalog projection while the invocation path had no
+    /// branch for it, so it resolved and then failed as not provided.
+    #[test]
+    fn every_advertised_json_capability_resolves_to_a_script() {
+        let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "id": "fixture",
+            "name": "Fixture",
+            "version": "1.0.0",
+            "provides": { "file_extensions": ["rs", "ts"] },
+            "scripts": {
+                "fingerprint": "bin/fingerprint",
+                "refactor": "bin/refactor",
+                "format": "bin/format",
+                "compiler_warnings": "bin/warnings",
+                "compiler_warning_fixes": "bin/fixes",
+            }
+        }))
+        .expect("fixture manifest");
+
+        let advertised = manifest.json_capability_ids();
+        assert!(
+            advertised.contains(&format!("{FINGERPRINT_FILE_CAPABILITY_PREFIX}rs"))
+                && advertised.contains(&format!("{REFACTOR_FILE_CAPABILITY_PREFIX}ts"))
+                && advertised.contains(&COMPILER_WARNINGS_CAPABILITY_ID.to_string()),
+            "got {advertised:?}"
+        );
+        for capability_id in &advertised {
+            assert!(
+                manifest.json_capability_script(capability_id).is_some(),
+                "advertised capability '{capability_id}' does not resolve to a script"
+            );
+        }
+
+        // Format takes file arguments rather than JSON on stdin, so it is
+        // deliberately not part of this contract and must not be advertised as
+        // though it were invocable here.
+        assert!(!advertised
+            .iter()
+            .any(|id| id.starts_with(crate::api::v1::FORMAT_FILE_CAPABILITY_PREFIX)));
+        assert!(manifest
+            .json_capability_script(&format!(
+                "{}rs",
+                crate::api::v1::FORMAT_FILE_CAPABILITY_PREFIX
+            ))
+            .is_none());
+    }
+
+    #[test]
+    fn a_capability_for_an_unprovided_file_extension_does_not_resolve() {
+        let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "id": "fixture",
+            "name": "Fixture",
+            "version": "1.0.0",
+            "provides": { "file_extensions": ["rs"] },
+            "scripts": { "fingerprint": "bin/fingerprint" }
+        }))
+        .expect("fixture manifest");
+
+        assert!(manifest
+            .json_capability_script(&format!("{FINGERPRINT_FILE_CAPABILITY_PREFIX}rs"))
+            .is_some());
+        assert!(manifest
+            .json_capability_script(&format!("{FINGERPRINT_FILE_CAPABILITY_PREFIX}py"))
+            .is_none());
+    }
+
+    #[test]
+    fn an_extension_without_scripts_advertises_no_json_capabilities() {
+        let manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+            "id": "fixture",
+            "name": "Fixture",
+            "version": "1.0.0",
+            "provides": { "file_extensions": ["rs"] }
+        }))
+        .expect("fixture manifest");
+
+        assert!(manifest.json_capability_ids().is_empty());
+        assert!(manifest
+            .json_capability_script("compiler-warnings")
+            .is_none());
+    }
     use super::*;
 
     fn manifest(transports: Vec<NotificationTransportConfig>) -> ExtensionManifest {

--- a/crates/homeboy-core/src/extension/catalog/api.rs
+++ b/crates/homeboy-core/src/extension/catalog/api.rs
@@ -27,8 +27,8 @@ use homeboy_extension_contract::api::v1::{
     EXTENSION_API_READINESS_RESPONSE_SCHEMA, EXTENSION_API_RECIPE_RUN_PLAN_REQUEST_SCHEMA,
     EXTENSION_API_RECIPE_RUN_PLAN_RESPONSE_SCHEMA, EXTENSION_API_RESOLVE_REQUEST_SCHEMA,
     EXTENSION_API_RESOLVE_RESPONSE_SCHEMA, EXTENSION_API_V1,
-    EXTERNAL_CHECK_DETAIL_RESOLVER_CAPABILITY_PREFIX, FINGERPRINT_FILE_CAPABILITY_PREFIX,
-    FINGERPRINT_INPUT_SCHEMA, FINGERPRINT_OUTPUT_SCHEMA, FORMAT_FILE_CAPABILITY_PREFIX,
+    EXTERNAL_CHECK_DETAIL_RESOLVER_CAPABILITY_PREFIX, FINGERPRINT_INPUT_SCHEMA,
+    FINGERPRINT_OUTPUT_SCHEMA, FORMAT_FILE_CAPABILITY_PREFIX,
     RECIPE_RUN_PROVIDER_CAPABILITY_PREFIX, REFACTOR_ANALYSIS_INPUT_SCHEMA,
     REFACTOR_ANALYSIS_OUTPUT_SCHEMA, REFACTOR_FILE_CAPABILITY_PREFIX,
 };
@@ -122,34 +122,13 @@ fn api_descriptor_from_manifest(extension: &ExtensionManifest) -> ExtensionApiDe
             EXTENSION_API_ENVIRONMENT_RESOLVE_RESPONSE_SCHEMA,
         ));
     }
-    if extension.compiler_warnings_script().is_some() {
-        capabilities.push(schema_capability_descriptor(
-            COMPILER_WARNINGS_CAPABILITY_ID,
-            COMPILER_WARNINGS_INPUT_SCHEMA,
-            COMPILER_WARNINGS_OUTPUT_SCHEMA,
-        ));
-    }
-    if extension.compiler_warning_fixes_script().is_some() {
-        capabilities.push(schema_capability_descriptor(
-            COMPILER_WARNING_FIXES_CAPABILITY_ID,
-            COMPILER_WARNING_FIXES_INPUT_SCHEMA,
-            COMPILER_WARNING_FIXES_OUTPUT_SCHEMA,
-        ));
-    }
-    if extension.fingerprint_script().is_some() {
-        capabilities.extend(
-            extension
-                .provided_file_extensions()
-                .iter()
-                .map(|file_extension| {
-                    schema_capability_descriptor(
-                        &format!("{FINGERPRINT_FILE_CAPABILITY_PREFIX}{file_extension}"),
-                        FINGERPRINT_INPUT_SCHEMA,
-                        FINGERPRINT_OUTPUT_SCHEMA,
-                    )
-                }),
-        );
-    }
+    // Advertised JSON-stdin capabilities come from the manifest contract, which
+    // is the same source API invocation resolves through, so an advertised
+    // capability is always invocable.
+    capabilities.extend(extension.json_capability_ids().iter().map(|capability_id| {
+        let (input_schema, output_schema) = json_capability_schemas(capability_id);
+        schema_capability_descriptor(capability_id, input_schema, output_schema)
+    }));
     if extension.format_script().is_some() {
         capabilities.extend(
             extension
@@ -159,20 +138,6 @@ fn api_descriptor_from_manifest(extension: &ExtensionManifest) -> ExtensionApiDe
                     capability_descriptor(&format!(
                         "{FORMAT_FILE_CAPABILITY_PREFIX}{file_extension}"
                     ))
-                }),
-        );
-    }
-    if extension.refactor_script().is_some() {
-        capabilities.extend(
-            extension
-                .provided_file_extensions()
-                .iter()
-                .map(|file_extension| {
-                    schema_capability_descriptor(
-                        &format!("{REFACTOR_FILE_CAPABILITY_PREFIX}{file_extension}"),
-                        REFACTOR_ANALYSIS_INPUT_SCHEMA,
-                        REFACTOR_ANALYSIS_OUTPUT_SCHEMA,
-                    )
                 }),
         );
     }
@@ -252,6 +217,28 @@ fn negotiate_api(
 ) -> Result<ExtensionApiHandshakeResponse> {
     let descriptor = api_descriptor(extension_id)?;
     Ok(negotiate_descriptor(descriptor, request))
+}
+
+/// Input and output schema references for one JSON-stdin capability id.
+fn json_capability_schemas(capability_id: &str) -> (&'static str, &'static str) {
+    if capability_id == COMPILER_WARNINGS_CAPABILITY_ID {
+        (
+            COMPILER_WARNINGS_INPUT_SCHEMA,
+            COMPILER_WARNINGS_OUTPUT_SCHEMA,
+        )
+    } else if capability_id == COMPILER_WARNING_FIXES_CAPABILITY_ID {
+        (
+            COMPILER_WARNING_FIXES_INPUT_SCHEMA,
+            COMPILER_WARNING_FIXES_OUTPUT_SCHEMA,
+        )
+    } else if capability_id.starts_with(REFACTOR_FILE_CAPABILITY_PREFIX) {
+        (
+            REFACTOR_ANALYSIS_INPUT_SCHEMA,
+            REFACTOR_ANALYSIS_OUTPUT_SCHEMA,
+        )
+    } else {
+        (FINGERPRINT_INPUT_SCHEMA, FINGERPRINT_OUTPUT_SCHEMA)
+    }
 }
 
 fn negotiate_descriptor(

--- a/crates/homeboy-core/src/extension/invoke/api.rs
+++ b/crates/homeboy-core/src/extension/invoke/api.rs
@@ -7,10 +7,8 @@ use homeboy_engine_primitives::command::{
 use homeboy_extension_contract::api::v1::{
     ExtensionApiInvocationProcessEvidence, ExtensionApiInvokeRequest, ExtensionApiInvokeResponse,
     ExtensionApiOperationFailure, ExtensionApiOperationFailureCode, ExtensionApiResolveRequest,
-    COMPILER_WARNINGS_CAPABILITY_ID, COMPILER_WARNING_FIXES_CAPABILITY_ID,
     EXTENSION_API_INVOKE_REQUEST_SCHEMA, EXTENSION_API_INVOKE_RESPONSE_SCHEMA,
-    EXTENSION_API_RESOLVE_REQUEST_SCHEMA, EXTENSION_API_V1, FINGERPRINT_FILE_CAPABILITY_PREFIX,
-    REFACTOR_FILE_CAPABILITY_PREFIX,
+    EXTENSION_API_RESOLVE_REQUEST_SCHEMA, EXTENSION_API_V1,
 };
 use homeboy_extension_contract::ExtensionManifest;
 
@@ -190,18 +188,13 @@ pub(super) fn execute_capability_process(
     Ok(output)
 }
 
+/// Resolve the script implementing a capability.
+///
+/// The mapping lives on the manifest contract so catalog projection and this
+/// invocation path cannot drift: an advertised JSON-stdin capability is always
+/// resolvable here.
 fn capability_script<'a>(extension: &'a ExtensionManifest, capability_id: &str) -> Option<&'a str> {
-    match capability_id {
-        COMPILER_WARNINGS_CAPABILITY_ID => extension.compiler_warnings_script(),
-        COMPILER_WARNING_FIXES_CAPABILITY_ID => extension.compiler_warning_fixes_script(),
-        capability if capability.starts_with(FINGERPRINT_FILE_CAPABILITY_PREFIX) => {
-            extension.fingerprint_script()
-        }
-        capability if capability.starts_with(REFACTOR_FILE_CAPABILITY_PREFIX) => {
-            extension.refactor_script()
-        }
-        _ => None,
-    }
+    extension.json_capability_script(capability_id)
 }
 
 fn failure(code: ExtensionApiOperationFailureCode, message: String) -> ExtensionApiInvokeResponse {
@@ -267,6 +260,7 @@ fn is_transient_spawn_error(error: &std::io::Error) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use homeboy_extension_contract::api::v1::COMPILER_WARNINGS_CAPABILITY_ID;
     use std::fs;
 
     fn write_executable(path: &std::path::Path, content: &str) {


### PR DESCRIPTION
## Summary

- add `ExtensionManifest::json_capability_ids()` and `ExtensionManifest::json_capability_script()` as the one place a JSON-stdin capability id maps to its implementing script
- make catalog projection advertise exactly those ids
- make Extension API invocation resolve exactly those ids
- collapse five bespoke per-script projection blocks in `catalog/api.rs` into one

## Problem

Capability-to-script resolution was written out three times and had already drifted:

1. `catalog/api.rs` projected capabilities from five separate script accessors, each with its own block.
2. `invoke/api.rs::capability_script` re-derived the same mapping as a hardcoded `match` — and omitted `format`.
3. `engine/format_write.rs` bypasses the API entirely and reads `format_script()` itself.

Because of (2), an extension declaring a format script advertised `format.<ext>` in its catalog descriptor, resolved that capability successfully, and then failed invocation with `CapabilityNotProvided`. Advertisement and invocation disagreed, and nothing detected it.

## Approach

The mapping now lives on the manifest contract, so catalog projection and invocation read the same source and cannot drift. Adding a capability is one edit instead of two that must be kept in sync.

`format.<ext>` is deliberately excluded and documented: format scripts take file arguments rather than JSON on stdin, so they are a genuinely different invocation shape. Making that explicit is what removes the silent inconsistency. `format_write.rs` keeps its argv-shaped path unchanged; unifying that is a separate question about invocation shape, not about this duplication.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p homeboy-extension-contract --lib` (109 passed, 3 new)
- `cargo test -p homeboy-core extension --lib` (963 passed)
- `cargo check --workspace --tests`
- `git diff --check`

The new contract tests assert the invariant that was already broken: every advertised JSON-stdin capability resolves to a script, a capability for an unprovided file extension does not resolve, and an extension without scripts advertises nothing.

Parent #13882

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode audited the Extension API surface for remaining duplication, found the advertise/invoke divergence, implemented the single-source projection and its invariant tests, and ran verification under Chris Huber's direction.