### PR TITLE
refactor(runner): make reverse claims envelope-only

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
@@ -185,15 +185,88 @@ fn has_complete_pending_runner_submission_intent(record: &AgentTaskRunRecord) ->
     else {
         return false;
     };
-    let Ok(request) = serde_json::from_value::<RemoteRunnerJobRequest>(
-        intent.get("replay_request").cloned().unwrap_or(Value::Null),
-    ) else {
+    let Ok(replay) = pending_runner_replay(intent) else {
         return false;
     };
-    request.runner_id == runner_id
-        && request.submission_key() == Some(submission_key)
+    replay.runner_id() == runner_id
+        && replay.submission_key() == Some(submission_key)
         && handoff.runner_id == runner_id
         && handoff.submission_key.as_deref() == Some(submission_key)
+}
+
+enum PendingRunnerReplay {
+    Envelope(RunnerApiSubmitRequest),
+    Legacy(RemoteRunnerJobRequest),
+}
+
+impl PendingRunnerReplay {
+    fn runner_id(&self) -> &str {
+        match self {
+            Self::Envelope(request) => request
+                .envelope
+                .dispatch
+                .as_ref()
+                .map(|dispatch| dispatch.runner_id.as_str())
+                .unwrap_or_default(),
+            Self::Legacy(request) => &request.runner_id,
+        }
+    }
+
+    fn submission_key(&self) -> Option<&str> {
+        match self {
+            Self::Envelope(request) => Some(request.submission_key.trim())
+                .filter(|submission_key| !submission_key.is_empty()),
+            Self::Legacy(request) => request.submission_key(),
+        }
+    }
+
+    fn cwd(&self) -> Option<&str> {
+        match self {
+            Self::Envelope(request) => request
+                .envelope
+                .dispatch
+                .as_ref()
+                .and_then(|dispatch| dispatch.cwd.as_deref()),
+            Self::Legacy(request) => request.cwd.as_deref(),
+        }
+    }
+
+    fn command(&self) -> &[String] {
+        match self {
+            Self::Envelope(request) => request
+                .envelope
+                .dispatch
+                .as_ref()
+                .map(|dispatch| dispatch.command.as_slice())
+                .unwrap_or_default(),
+            Self::Legacy(request) => &request.command,
+        }
+    }
+}
+
+fn pending_runner_replay(intent: &serde_json::Map<String, Value>) -> Result<PendingRunnerReplay> {
+    if let Some(envelope) = intent.get("replay_envelope_request") {
+        return serde_json::from_value(envelope.clone())
+            .map(PendingRunnerReplay::Envelope)
+            .map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("parse envelope runner replay request".to_string()),
+                )
+            });
+    }
+    serde_json::from_value(intent.get("replay_request").cloned().ok_or_else(|| {
+        Error::internal_unexpected(
+            "pending runner submission intent has no complete replay request",
+        )
+    })?)
+    .map(PendingRunnerReplay::Legacy)
+    .map_err(|error| {
+        Error::internal_json(
+            error.to_string(),
+            Some("parse runner replay request".to_string()),
+        )
+    })
 }
 
 /// The replay decision and its consequence must name one installation. This
@@ -236,47 +309,29 @@ pub fn reconcile_pending_runner_submission_intent_in_store(
     let submission_key = string("submission_key").ok_or_else(|| {
         Error::internal_unexpected("pending runner submission intent has no submission key")
     })?;
-    let mut request: RemoteRunnerJobRequest =
-        serde_json::from_value(intent.get("replay_request").cloned().ok_or_else(|| {
-            Error::internal_unexpected(
-                "pending runner submission intent has no complete replay request",
-            )
-        })?)
-        .map_err(|error| {
-            Error::internal_json(
-                error.to_string(),
-                Some("parse runner replay request".to_string()),
-            )
-        })?;
-    if request.runner_id != runner_id {
+    let replay = pending_runner_replay(intent)?;
+    if replay.runner_id() != runner_id || replay.submission_key() != Some(&submission_key) {
         return Err(Error::internal_unexpected(
-            "runner replay request does not match pending runner",
+            "runner replay request does not match pending submission authority",
         ));
     }
-    let cwd = request.cwd.clone().unwrap_or_default();
-    let command = request.command.clone();
-    let mut metadata = request.metadata.take().unwrap_or_else(|| json!({}));
-    if !metadata.is_object() {
-        metadata = json!({});
-    }
-    metadata["submission_key"] = json!(submission_key);
-    metadata["durable_run_id"] = json!(run_id);
-    metadata["reconciled_from"] = json!("durable_detached_handoff_intent");
-    request.metadata = Some(metadata);
-    let envelope_request = intent
-        .get("replay_envelope_request")
-        .cloned()
-        .map(serde_json::from_value::<RunnerApiSubmitRequest>)
-        .transpose()
-        .map_err(|error| {
-            Error::internal_json(
-                error.to_string(),
-                Some("parse envelope runner replay request".to_string()),
-            )
-        })?;
-    match runner_continuation::with_runner_continuation(|provider| match envelope_request {
-        Some(request) => provider.submit_reverse_broker_envelope_job(&runner_id, request),
-        None => provider.submit_reverse_broker_job(&runner_id, request),
+    let cwd = replay.cwd().unwrap_or_default().to_string();
+    let command = replay.command().to_vec();
+    match runner_continuation::with_runner_continuation(|provider| match replay {
+        PendingRunnerReplay::Envelope(request) => {
+            provider.submit_reverse_broker_envelope_job(&runner_id, request)
+        }
+        PendingRunnerReplay::Legacy(mut request) => {
+            let mut metadata = request.metadata.take().unwrap_or_else(|| json!({}));
+            if !metadata.is_object() {
+                metadata = json!({});
+            }
+            metadata["submission_key"] = json!(submission_key);
+            metadata["durable_run_id"] = json!(run_id);
+            metadata["reconciled_from"] = json!("durable_detached_handoff_intent");
+            request.metadata = Some(metadata);
+            provider.submit_reverse_broker_job(&runner_id, request)
+        }
     }) {
         Ok(job) => {
             record_detached_lab_run_in_store(
@@ -411,21 +466,10 @@ pub(crate) fn bind_pending_runner_submission_if_accepted_in_store(
     let submission_key = string("submission_key").ok_or_else(|| {
         Error::internal_unexpected("pending runner submission intent has no submission key")
     })?;
-    let request: RemoteRunnerJobRequest =
-        serde_json::from_value(intent.get("replay_request").cloned().ok_or_else(|| {
-            Error::internal_unexpected(
-                "pending runner submission intent has no complete replay request",
-            )
-        })?)
-        .map_err(|error| {
-            Error::internal_json(
-                error.to_string(),
-                Some("parse runner replay request".to_string()),
-            )
-        })?;
-    if request.runner_id != runner_id {
+    let replay = pending_runner_replay(intent)?;
+    if replay.runner_id() != runner_id || replay.submission_key() != Some(&submission_key) {
         return Err(Error::internal_unexpected(
-            "runner replay request does not match pending runner",
+            "runner replay request does not match pending submission authority",
         ));
     }
     let lookup = runner_continuation::with_runner_continuation(|provider| {
@@ -439,8 +483,8 @@ pub(crate) fn bind_pending_runner_submission_if_accepted_in_store(
                     run_id: &run_id,
                     runner_id: &runner_id,
                     runner_job_id: &job.id.to_string(),
-                    remote_workspace: request.cwd.as_deref().unwrap_or_default(),
-                    remote_command: &request.command,
+                    remote_workspace: replay.cwd().unwrap_or_default(),
+                    remote_command: replay.command(),
                 },
             )?;
             Ok(true)

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
@@ -197,31 +197,12 @@ pub trait RunnerContinuationProvider: Send + Sync {
 
     fn submit_reverse_broker_envelope_job(
         &self,
-        runner_id: &str,
-        request: RunnerApiSubmitRequest,
+        _runner_id: &str,
+        _request: RunnerApiSubmitRequest,
     ) -> Result<Job> {
-        let mut legacy = homeboy_core::api_jobs::legacy_request_from_envelope(&request.envelope)?;
-        legacy.workspace_claim_binding = request
-            .workspace_claim_binding
-            .map(serde_json::from_value)
-            .transpose()
-            .map_err(|error| {
-                Error::internal_json(
-                    error.to_string(),
-                    Some("decode replay workspace claim binding".to_string()),
-                )
-            })?;
-        legacy.workspace_owner_lease = request
-            .workspace_owner_lease
-            .map(serde_json::from_value)
-            .transpose()
-            .map_err(|error| {
-                Error::internal_json(
-                    error.to_string(),
-                    Some("decode replay workspace owner lease".to_string()),
-                )
-            })?;
-        self.submit_reverse_broker_job(runner_id, legacy)
+        Err(Error::internal_unexpected(
+            "runner subsystem does not support Runner API envelope submission",
+        ))
     }
 
     fn lookup_reverse_broker_submission(
@@ -387,48 +368,9 @@ impl Drop for RunnerContinuationTestGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
 
     struct LegacyProvider {
         runner_exists: bool,
-    }
-
-    #[derive(Default)]
-    struct AuthorityCaptureProvider {
-        submitted: Mutex<Option<RemoteRunnerJobRequest>>,
-    }
-
-    impl RunnerContinuationProvider for AuthorityCaptureProvider {
-        fn runner_job_log_snapshot(
-            &self,
-            _runner_id: &str,
-            _job_id: &str,
-        ) -> Result<RunnerJobLogSnapshot> {
-            Err(Error::internal_unexpected("unused in fixture"))
-        }
-
-        fn is_runner_connected(&self, _runner_id: &str) -> bool {
-            false
-        }
-
-        fn run_continuation_exec(
-            &self,
-            _runner_id: &str,
-            _cwd: &str,
-            _command: &[String],
-            _run_id: &str,
-        ) -> Result<i32> {
-            Err(Error::internal_unexpected("unused in fixture"))
-        }
-
-        fn submit_reverse_broker_job(
-            &self,
-            _runner_id: &str,
-            request: RemoteRunnerJobRequest,
-        ) -> Result<Job> {
-            *self.submitted.lock().expect("capture submission") = Some(request);
-            Err(Error::internal_unexpected("submission captured"))
-        }
     }
 
     impl RunnerContinuationProvider for LegacyProvider {
@@ -494,58 +436,5 @@ mod tests {
             .runner_authority("legacy-runner"),
             RunnerAuthority::Unknown
         );
-    }
-
-    #[test]
-    fn default_envelope_adapter_preserves_workspace_authority_sidecars() {
-        use homeboy_core::workspace_claim::{
-            WorkspaceClaimBinding, WorkspaceIdentity, WorkspaceOwnerLease,
-            WorkspaceOwnerLeaseProtocol, WORKSPACE_OWNER_LEASE_SCHEMA,
-        };
-
-        let workspace = WorkspaceIdentity::new("git", "example/repo").expect("workspace");
-        let claim_binding = WorkspaceClaimBinding {
-            workspace: workspace.clone(),
-            lifecycle_revision: 7,
-            claim: None,
-        };
-        let owner_lease = WorkspaceOwnerLease {
-            schema: WORKSPACE_OWNER_LEASE_SCHEMA.to_string(),
-            protocol: WorkspaceOwnerLeaseProtocol::current(),
-            workspace,
-            owner_id: "agent-task:test".to_string(),
-            lifecycle_revision: 7,
-            token: "lease-token".to_string(),
-            expires_at_ms: u64::MAX,
-        };
-        let legacy: RemoteRunnerJobRequest = serde_json::from_value(serde_json::json!({
-            "runner_id": "lab",
-            "command": ["homeboy", "test"]
-        }))
-        .expect("legacy request");
-        let request = RunnerApiSubmitRequest {
-            schema: homeboy_runner_contract::RUNNER_API_SUBMIT_REQUEST_SCHEMA.to_string(),
-            api_version: homeboy_runner_contract::RUNNER_API_V1,
-            submission_key: "agent-task:v1:lab:test".to_string(),
-            envelope: legacy.execution_envelope(),
-            workspace_claim_binding: Some(
-                serde_json::to_value(&claim_binding).expect("claim binding"),
-            ),
-            workspace_owner_lease: Some(serde_json::to_value(&owner_lease).expect("owner lease")),
-        };
-        let provider = AuthorityCaptureProvider::default();
-
-        provider
-            .submit_reverse_broker_envelope_job("lab", request)
-            .expect_err("fixture stops after capture");
-
-        let submitted = provider
-            .submitted
-            .lock()
-            .expect("captured submission")
-            .clone()
-            .expect("submitted request");
-        assert_eq!(submitted.workspace_claim_binding, Some(claim_binding));
-        assert_eq!(submitted.workspace_owner_lease, Some(owner_lease));
     }
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_exec.rs
@@ -4,7 +4,9 @@
 
 use serde_json::{json, Value};
 
-use homeboy_core::api_jobs::{JobStatus, RemoteRunnerJobRequest, RunnerJobLogSnapshot};
+#[cfg(test)]
+use homeboy_core::api_jobs::RemoteRunnerJobRequest;
+use homeboy_core::api_jobs::{JobStatus, RunnerJobLogSnapshot};
 use homeboy_core::observation::RunStatus;
 use homeboy_core::redaction::redact_argv;
 
@@ -1228,6 +1230,7 @@ pub fn record_lab_offload_submission_intent_in_store(
 
 /// Replace a preflight intent with the exact normalized, redacted request that
 /// will cross the broker boundary. This is the final durable write before POST.
+#[cfg(test)]
 pub fn record_lab_offload_submission_request(
     run_id: &str,
     request: &RemoteRunnerJobRequest,
@@ -1282,13 +1285,50 @@ pub fn record_lab_offload_submission_envelope(
     run_id: &str,
     request: &homeboy_runner_contract::RunnerApiSubmitRequest,
 ) -> Result<AgentTaskRunRecord> {
-    let legacy = homeboy_core::api_jobs::legacy_request_from_envelope(&request.envelope)?;
-    let record = record_lab_offload_submission_request(run_id, &legacy)?;
-    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
-    lifecycle_store.mutate_record(run_id, |record| {
-        record.ensure_metadata_object()["runner_submission_intent"]["replay_envelope_request"] =
-            serde_json::to_value(request).expect("serialize envelope replay request");
-        true
+    let run_id = sanitize_run_id(run_id);
+    let dispatch = request.envelope.dispatch.as_ref().ok_or_else(|| {
+        Error::internal_unexpected("Lab runner submission envelope has no dispatch")
     })?;
+    if request.submission_key.trim().is_empty() {
+        return Err(Error::internal_unexpected(
+            "Lab runner submission envelope has no stable submission key",
+        ));
+    }
+    let payload_fingerprint =
+        homeboy_core::api_jobs::runner_api_submission_payload_fingerprint(request)?;
+    let lifecycle_store = AgentTaskLifecycleStore::from_current_environment()?;
+    let _lock = LabHandoffLock::lock_in_store(&lifecycle_store, &run_id)?;
+    let mut record = lifecycle_store.read_record(&run_id)?;
+    if record.state.is_terminal() {
+        return Ok(record);
+    }
+    let now = chrono::Utc::now();
+    let mut handoff = AgentTaskLabHandoff::pending(
+        &dispatch.runner_id,
+        now.to_rfc3339(),
+        (now + chrono::Duration::seconds(lab_handoff_acceptance_timeout_seconds())).to_rfc3339(),
+    );
+    handoff.submission_key = Some(request.submission_key.clone());
+    handoff.payload_fingerprint = Some(payload_fingerprint.clone());
+    record.lab_handoff = Some(handoff.clone());
+    record.ensure_metadata_object().insert(
+        "runner_submission_intent".to_string(),
+        json!({
+            "state": "pending",
+            "submission_key": request.submission_key,
+            "payload_fingerprint": payload_fingerprint,
+            "runner_id": dispatch.runner_id,
+            "replay_envelope_request": request,
+        }),
+    );
+    record.ensure_metadata_object().insert(
+        "handoff_acceptance".to_string(),
+        json!({
+            "state": "pending",
+            "started_at": handoff.submitted_at,
+            "deadline_at": handoff.acceptance_deadline_at,
+        }),
+    );
+    lifecycle_store.write_record(&record)?;
     Ok(record)
 }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/mod.rs
@@ -108,6 +108,22 @@ impl RunnerContinuationProvider for IntentReplayProvider {
         Ok(job)
     }
 
+    fn submit_reverse_broker_envelope_job(
+        &self,
+        _runner_id: &str,
+        request: homeboy_runner_contract::RunnerApiSubmitRequest,
+    ) -> Result<Job> {
+        let job = self.store.submit_runner_api_request(request)?;
+        self.submitted.lock().expect("submission log").push(job.id);
+        let mut fail = self.fail_after_accept_once.lock().expect("fault flag");
+        if std::mem::take(&mut *fail) {
+            return Err(Error::internal_unexpected(
+                "injected post-accept pre-ack crash",
+            ));
+        }
+        Ok(job)
+    }
+
     fn lookup_reverse_broker_submission(
         &self,
         _runner_id: &str,

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -566,6 +566,69 @@ fn detached_handoff_persists_redacted_submission_intent_before_broker_ack() {
     });
 }
 
+#[test]
+fn detached_handoff_persists_only_the_runner_api_replay_envelope() {
+    with_isolated_home(|_| {
+        let run_id = "envelope-intent-before-post";
+        let command = vec!["homeboy".to_string(), "agent-task".to_string()];
+        record_lab_offload_planned(LabOffloadProxyPlan {
+            run_id,
+            runner_id: "homeboy-lab",
+            remote_workspace: "/runner/workspace/repo",
+            remote_command: &command,
+            durable_plan: None,
+        })
+        .expect("controller proxy");
+        let legacy = replay_request(run_id, &command);
+        let submission = homeboy_runner_contract::RunnerApiSubmitRequest {
+            schema: homeboy_runner_contract::RUNNER_API_SUBMIT_REQUEST_SCHEMA.to_string(),
+            api_version: homeboy_runner_contract::RUNNER_API_V1,
+            submission_key: legacy.submission_key().expect("submission key").to_string(),
+            envelope: legacy.execution_envelope(),
+            workspace_claim_binding: None,
+            workspace_owner_lease: None,
+        };
+
+        let pending = record_lab_offload_submission_envelope(run_id, &submission)
+            .expect("persist Runner API intent");
+        let intent = &pending.metadata["runner_submission_intent"];
+        let expected_fingerprint =
+            homeboy_core::api_jobs::runner_api_submission_payload_fingerprint(&submission)
+                .expect("fingerprint");
+
+        assert!(intent.get("replay_request").is_none());
+        assert_eq!(intent["replay_envelope_request"], json!(submission));
+        assert_eq!(intent["payload_fingerprint"], expected_fingerprint);
+        assert!(has_live_pending_runner_submission_intent(
+            &pending,
+            chrono::Utc::now()
+        ));
+
+        ensure_runner_continuation_provider_reset_hook();
+        let store = JobStore::default();
+        let submitted = Arc::new(Mutex::new(Vec::new()));
+        let _provider = RunnerContinuationTestGuard::install(Box::new(IntentReplayProvider {
+            store: store.clone(),
+            submitted: Arc::clone(&submitted),
+            lookups: Arc::new(Mutex::new(Vec::new())),
+            fail_after_accept_once: Arc::new(Mutex::new(false)),
+        }));
+        assert!(reconcile_pending_runner_submission_intent_in_store(
+            &test_lifecycle_store(),
+            run_id
+        )
+        .expect("reconcile envelope intent"));
+        let submitted_job_id = submitted.lock().expect("submissions")[0];
+        assert_eq!(
+            store
+                .submit_runner_api_request(submission)
+                .expect("idempotent replay")
+                .id,
+            submitted_job_id
+        );
+    });
+}
+
 /// Rooted in an explicit store rather than a mutated process environment
 /// (#7505). The attempt proxy is created, terminalized and read back through
 /// the same injected store, so "this attempt record is Failed with a staging

--- a/crates/homeboy-core/src/api_jobs/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/mod.rs
@@ -13,7 +13,7 @@ use homeboy_api_jobs_contract::types;
 pub use crate::runner_job_execution_context::RunnerJobExecutionContext;
 pub(crate) use persistence::timestamp_ms;
 pub use remote_runner::{
-    legacy_request_from_envelope, JobArtifactMetadata, RemoteRunnerClaimProtocols,
+    runner_api_submission_payload_fingerprint, JobArtifactMetadata, RemoteRunnerClaimProtocols,
     RemoteRunnerJobClaim, RemoteRunnerJobRequest, RemoteRunnerJobResult,
     RemoteRunnerObservationRunDetail, RemoteRunnerSubmissionLookup, RunnerJobLifecycleMetadata,
     RunnerJobProjectionCancelRequest,

--- a/crates/homeboy-core/src/api_jobs/persistence.rs
+++ b/crates/homeboy-core/src/api_jobs/persistence.rs
@@ -4,12 +4,12 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use homeboy_lab_contract::lab::execution_envelope::lab_runner_workload_from_execution_envelope;
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-use super::remote_runner::RemoteRunnerJobRequest;
 use super::store::{DurableJobStore, StoredJob};
 use super::types::{Job, JobEvent, JobEventKind, JobStatus};
 use crate::error::{Error, Result};
@@ -351,18 +351,6 @@ pub(super) struct JobStoreCompactionEvidence {
     pub(super) active_jobs: usize,
 }
 
-pub(super) fn request_metadata_string(
-    request: &RemoteRunnerJobRequest,
-    key: &str,
-) -> Option<String> {
-    request
-        .metadata
-        .as_ref()
-        .and_then(|metadata| metadata.get(key))
-        .and_then(Value::as_str)
-        .map(str::to_string)
-}
-
 pub(super) fn read_durable_store(path: &Path) -> Result<DurableJobStore> {
     if !path.exists() {
         return Ok(DurableJobStore::default());
@@ -685,13 +673,18 @@ pub(super) fn stale_after_restart_classification(stored: &StoredJob) -> Value {
         .iter()
         .map(|artifact| artifact.id.clone())
         .collect::<Vec<_>>();
-    let linked_agent_task_run_id = stored
+    let remote_envelope = stored
         .remote_runner
         .as_ref()
-        .and_then(|remote_runner| remote_runner.request().ok())
-        .and_then(|request| request.lab_runner_workload)
+        .and_then(|remote_runner| remote_runner.envelope().ok());
+    let linked_agent_task_run_id = remote_envelope
         .as_ref()
-        .and_then(|workload| workload.agent_task.clone())
+        .and_then(|envelope| {
+            lab_runner_workload_from_execution_envelope(envelope)
+                .ok()
+                .flatten()
+        })
+        .and_then(|workload| workload.agent_task)
         .map(|agent_task| agent_task.run_id.trim().to_string())
         .filter(|run_id| !run_id.is_empty());
 
@@ -717,9 +710,9 @@ pub(super) fn stale_after_restart_classification(stored: &StoredJob) -> Value {
                 "terminal_result_observed": false,
             })),
         },
-        "remote_runner": stored.remote_runner.as_ref().map(|remote_runner| serde_json::json!({
-            "runner_id": remote_runner.request().ok().map(|request| request.runner_id),
-            "project_id": remote_runner.request().ok().and_then(|request| request.project_id),
+        "remote_runner": stored.remote_runner.as_ref().map(|_| serde_json::json!({
+            "runner_id": remote_envelope.as_ref().and_then(|envelope| envelope.dispatch.as_ref()).map(|dispatch| dispatch.runner_id.clone()),
+            "project_id": remote_envelope.as_ref().and_then(|envelope| envelope.dispatch.as_ref()).and_then(|dispatch| dispatch.project_id.clone()),
             "claim_id": stored.job.claim_id.clone(),
             "claimed_by_runner_id": stored.job.claimed_by_runner_id.clone(),
             "claimed_at_ms": stored.job.claimed_at_ms,

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -23,7 +23,9 @@ use crate::runner_execution_envelope::{
 };
 use crate::secret_env_plan::SecretEnvPlan;
 use crate::source_snapshot::SourceSnapshot;
-use homeboy_lab_contract::lab::execution_envelope::runner_execution_envelope_from_workload;
+use homeboy_lab_contract::lab::execution_envelope::{
+    lab_runner_workload_from_execution_envelope, runner_execution_envelope_from_workload,
+};
 use homeboy_runner_contract::{
     is_internal_control_env, RunnerApiSubmitRequest, RunnerMutationArtifacts,
     RunnerResourceMetrics, RUNNER_API_SUBMIT_REQUEST_SCHEMA, RUNNER_API_V1,
@@ -311,59 +313,11 @@ impl RemoteRunnerJobRequest {
     /// durable reverse-runner submission representation.
     pub fn validate_durable_submission(&mut self) -> Result<()> {
         let secret_env_plan = self.normalize();
-        reject_inline_durable_secret_env(self, &secret_env_plan)
+        reject_inline_durable_secret_env(&self.env, &secret_env_plan)
     }
 
     fn validate_command_assets(&self) -> Result<()> {
-        let Some(assets) = self
-            .metadata
-            .as_ref()
-            .and_then(|metadata| metadata.get("command_assets"))
-            .and_then(|assets| assets.get("assets"))
-            .and_then(Value::as_array)
-        else {
-            return Ok(());
-        };
-        if assets.len() > MAX_COMMAND_ASSET_COUNT {
-            return Err(Error::validation_invalid_argument(
-                "metadata.command_assets",
-                "remote runner job has too many command assets",
-                None,
-                None,
-            ));
-        }
-        let mut total = 0usize;
-        for asset in assets {
-            let encoded = asset
-                .get("content_base64")
-                .and_then(Value::as_str)
-                .ok_or_else(|| {
-                    Error::validation_invalid_argument(
-                        "metadata.command_assets",
-                        "remote runner command asset is missing base64 content",
-                        None,
-                        None,
-                    )
-                })?;
-            if encoded.len() > MAX_COMMAND_ASSET_BASE64_BYTES {
-                return Err(Error::validation_invalid_argument(
-                    "metadata.command_assets",
-                    "remote runner command asset exceeds the size limit",
-                    None,
-                    None,
-                ));
-            }
-            total = total.saturating_add(encoded.len());
-        }
-        if total > MAX_COMMAND_ASSETS_BASE64_BYTES {
-            return Err(Error::validation_invalid_argument(
-                "metadata.command_assets",
-                "remote runner command assets exceed the aggregate size limit",
-                None,
-                None,
-            ));
-        }
-        Ok(())
+        validate_command_assets(self.metadata.as_ref())
     }
 
     fn dispatch_request(&self) -> Self {
@@ -411,6 +365,56 @@ impl RemoteRunnerJobRequest {
     }
 }
 
+fn validate_command_assets(metadata: Option<&Value>) -> Result<()> {
+    let Some(assets) = metadata
+        .and_then(|metadata| metadata.get("command_assets"))
+        .and_then(|assets| assets.get("assets"))
+        .and_then(Value::as_array)
+    else {
+        return Ok(());
+    };
+    if assets.len() > MAX_COMMAND_ASSET_COUNT {
+        return Err(Error::validation_invalid_argument(
+            "metadata.command_assets",
+            "remote runner job has too many command assets",
+            None,
+            None,
+        ));
+    }
+    let mut total = 0usize;
+    for asset in assets {
+        let encoded = asset
+            .get("content_base64")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "metadata.command_assets",
+                    "remote runner command asset is missing base64 content",
+                    None,
+                    None,
+                )
+            })?;
+        if encoded.len() > MAX_COMMAND_ASSET_BASE64_BYTES {
+            return Err(Error::validation_invalid_argument(
+                "metadata.command_assets",
+                "remote runner command asset exceeds the size limit",
+                None,
+                None,
+            ));
+        }
+        total = total.saturating_add(encoded.len());
+    }
+    if total > MAX_COMMAND_ASSETS_BASE64_BYTES {
+        return Err(Error::validation_invalid_argument(
+            "metadata.command_assets",
+            "remote runner command assets exceed the aggregate size limit",
+            None,
+            None,
+        ));
+    }
+    Ok(())
+}
+
 fn non_empty_string(value: Option<&str>) -> Option<String> {
     value
         .map(str::trim)
@@ -423,6 +427,34 @@ fn metadata_run_id(metadata: &Value) -> Option<String> {
         .iter()
         .find_map(|key| metadata.get(*key))
         .and_then(|run_id| non_empty_string(run_id.as_str()))
+}
+
+fn envelope_run_ref_metadata(
+    envelope: &RunnerExecutionEnvelope,
+    workload: Option<&LabRunnerWorkload>,
+) -> Option<Value> {
+    let durable_run_id = envelope
+        .lifecycle
+        .as_ref()
+        .and_then(|lifecycle| non_empty_string(lifecycle.durable_run_id.as_deref()))
+        .or_else(|| metadata_run_id(&envelope.metadata));
+    let agent_task_run_id = workload
+        .and_then(|workload| workload.agent_task.as_ref())
+        .and_then(|agent_task| non_empty_string(Some(agent_task.run_id.as_str())))
+        .or_else(|| {
+            envelope
+                .metadata
+                .get("agent_task_run_id")
+                .and_then(|run_id| non_empty_string(run_id.as_str()))
+        })
+        .or_else(|| durable_run_id.clone());
+
+    (durable_run_id.is_some() || agent_task_run_id.is_some()).then(|| {
+        serde_json::json!({
+            "durable_run_id": durable_run_id,
+            "agent_task_run_id": agent_task_run_id,
+        })
+    })
 }
 
 fn merge_metadata_value(mut metadata: Value, key: &str, value: Value) -> Value {
@@ -439,9 +471,14 @@ fn merge_metadata_value(mut metadata: Value, key: &str, value: Value) -> Value {
 pub struct RemoteRunnerJobClaim {
     pub job: Job,
     pub envelope: RunnerExecutionEnvelope,
-    /// Derived compatibility and authority projection. The envelope is the only
-    /// authoritative execution payload; workers must execute `envelope`.
-    pub request: RemoteRunnerJobRequest,
+    /// Derived execution projection emitted only for workers that negotiated
+    /// the v1 claim protocol. It is never authoritative for v2 workers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request: Option<RemoteRunnerJobRequest>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_claim_binding: Option<crate::workspace_claim::WorkspaceClaimBinding>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_owner_lease: Option<crate::workspace_claim::WorkspaceOwnerLease>,
     /// Authenticated execution authority derived from this durable claim.
     /// Older brokers omit it on the wire; workers refuse those claims rather
     /// than reconstructing authority from environment or lifecycle projections.
@@ -603,6 +640,18 @@ pub(super) struct StoredRemoteRunnerJob {
     pub(super) execution_receipt: Option<RemoteRunnerExecutionReceipt>,
 }
 
+struct RemoteRunnerAdmission {
+    operation: String,
+    runner_id: String,
+    project_id: Option<String>,
+    source_snapshot: Option<SourceSnapshot>,
+    path_materialization_plan: Option<PathMaterializationPlan>,
+    run_ref_metadata: Option<Value>,
+    submission_key: Option<String>,
+    submission_fingerprint: Option<String>,
+    stored_remote_runner: StoredRemoteRunnerJob,
+}
+
 impl StoredRemoteRunnerJob {
     pub(super) fn validate_representation(&self) -> Result<()> {
         match (self.envelope.is_some(), self.request.is_some()) {
@@ -652,6 +701,18 @@ impl StoredRemoteRunnerJob {
             self.request
                 .as_ref()
                 .and_then(|request| request.workspace_owner_lease.clone())
+        }
+    }
+
+    pub(super) fn workspace_claim_binding(
+        &self,
+    ) -> Option<crate::workspace_claim::WorkspaceClaimBinding> {
+        if self.envelope.is_some() {
+            self.workspace_claim_binding.clone()
+        } else {
+            self.request
+                .as_ref()
+                .and_then(|request| request.workspace_claim_binding.clone())
         }
     }
 
@@ -711,16 +772,15 @@ fn redacted_envelope_for_durable_replay(
     envelope
 }
 
-fn envelope_submission_payload_fingerprint(
-    envelope: &RunnerExecutionEnvelope,
-    workspace_claim_binding: &Option<crate::workspace_claim::WorkspaceClaimBinding>,
-    workspace_owner_lease: &Option<crate::workspace_claim::WorkspaceOwnerLease>,
+pub fn runner_api_submission_payload_fingerprint(
+    submission: &RunnerApiSubmitRequest,
 ) -> Result<String> {
+    let envelope = redacted_envelope_for_durable_replay(submission.envelope.clone());
     let bytes = serde_json::to_vec(&serde_json::json!({
         "schema": "homeboy/runner-api-submission-payload/v1",
         "envelope": envelope,
-        "workspace_claim_binding": workspace_claim_binding,
-        "workspace_owner_lease": workspace_owner_lease,
+        "workspace_claim_binding": submission.workspace_claim_binding,
+        "workspace_owner_lease": submission.workspace_owner_lease,
     }))
     .map_err(|error| {
         Error::internal_json(
@@ -742,7 +802,7 @@ pub(super) fn validate_stored_remote_runner_jobs(
     Ok(())
 }
 
-pub fn legacy_request_from_envelope(
+fn legacy_request_from_envelope(
     envelope: &RunnerExecutionEnvelope,
 ) -> Result<RemoteRunnerJobRequest> {
     let dispatch = envelope.dispatch.as_ref().ok_or_else(|| {
@@ -888,7 +948,7 @@ impl JobStore {
     /// Legacy request admission retained only for existing persisted intents and
     /// callers that have not migrated to the envelope-first Runner API.
     pub fn submit_remote_runner_job(&self, request: RemoteRunnerJobRequest) -> Result<Job> {
-        self.submit_remote_runner_job_inner(request, None, None)
+        self.submit_remote_runner_job_inner(request)
     }
 
     pub fn submit_runner_api_request(&self, submission: RunnerApiSubmitRequest) -> Result<Job> {
@@ -910,30 +970,47 @@ impl JobStore {
                 None,
             ));
         }
+        let fingerprint = runner_api_submission_payload_fingerprint(&submission)?;
         let envelope = redacted_envelope_for_durable_replay(submission.envelope);
-        let mut request = legacy_request_from_envelope(&envelope)?;
-        let mut metadata = request
-            .metadata
-            .take()
-            .unwrap_or_else(|| serde_json::json!({}));
-        if !metadata.is_object() {
-            metadata = serde_json::json!({});
+        let dispatch = envelope.dispatch.as_ref().ok_or_else(|| {
+            Error::validation_invalid_argument(
+                "envelope.dispatch",
+                "runner submission envelope requires dispatch",
+                None,
+                None,
+            )
+        })?;
+        if dispatch.runner_id.trim().is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "runner_id",
+                "remote runner job requires a runner id",
+                None,
+                None,
+            ));
         }
-        metadata["submission_key"] = serde_json::json!(submission.submission_key);
-        request.metadata = Some(metadata);
-        request.workspace_claim_binding = submission
-            .workspace_claim_binding
-            .map(serde_json::from_value)
-            .transpose()
-            .map_err(|error| {
-                Error::validation_invalid_argument(
-                    "workspace_claim_binding",
-                    error.to_string(),
-                    None,
-                    None,
-                )
-            })?;
-        request.workspace_owner_lease = submission
+        if dispatch.command.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "command",
+                "remote runner job requires a command",
+                None,
+                None,
+            ));
+        }
+        validate_command_assets(Some(&envelope.metadata))?;
+        let workspace_claim_binding: Option<crate::workspace_claim::WorkspaceClaimBinding> =
+            submission
+                .workspace_claim_binding
+                .map(serde_json::from_value)
+                .transpose()
+                .map_err(|error| {
+                    Error::validation_invalid_argument(
+                        "workspace_claim_binding",
+                        error.to_string(),
+                        None,
+                        None,
+                    )
+                })?;
+        let workspace_owner_lease: Option<crate::workspace_claim::WorkspaceOwnerLease> = submission
             .workspace_owner_lease
             .map(serde_json::from_value)
             .transpose()
@@ -945,21 +1022,65 @@ impl JobStore {
                     None,
                 )
             })?;
-        let fingerprint = envelope_submission_payload_fingerprint(
-            &envelope,
-            &request.workspace_claim_binding,
-            &request.workspace_owner_lease,
-        )?;
-        self.submit_remote_runner_job_inner(request, Some(envelope), Some(fingerprint))
+        if let Some(binding) = workspace_claim_binding.as_ref() {
+            binding.verify()?;
+        }
+        if let Some(lease) = workspace_owner_lease.as_ref() {
+            lease.verify_shape(timestamp_ms())?;
+        }
+        let secret_env_plan = envelope.secret_env.clone().unwrap_or_default();
+        reject_inline_durable_secret_env(&dispatch.env, &secret_env_plan)?;
+        let lab_runner_workload = lab_runner_workload_from_execution_envelope(&envelope)?;
+        super::with_runner_job_preparation(|preparation| {
+            preparation.validate_lab_runner_workload_dispatch(
+                lab_runner_workload.as_ref(),
+                &dispatch.runner_id,
+                dispatch.cwd.as_deref(),
+                &dispatch.command,
+                &secret_env_plan,
+                envelope.mutation_policy.capture_patch,
+            )
+        })?;
+        let path_materialization_plan = envelope
+            .metadata
+            .get("path_materialization_plan")
+            .cloned()
+            .map(serde_json::from_value)
+            .transpose()
+            .map_err(|error| {
+                Error::internal_json(
+                    error.to_string(),
+                    Some("decode envelope path materialization plan".to_string()),
+                )
+            })?;
+        let now = timestamp_ms();
+        self.admit_remote_runner_job(
+            RemoteRunnerAdmission {
+                operation: dispatch.operation.clone(),
+                runner_id: dispatch.runner_id.clone(),
+                project_id: dispatch.project_id.clone(),
+                source_snapshot: dispatch.source_snapshot.clone(),
+                path_materialization_plan,
+                run_ref_metadata: envelope_run_ref_metadata(
+                    &envelope,
+                    lab_runner_workload.as_ref(),
+                ),
+                submission_key: Some(submission.submission_key),
+                submission_fingerprint: Some(fingerprint),
+                stored_remote_runner: StoredRemoteRunnerJob {
+                    envelope: Some(envelope),
+                    request: None,
+                    workspace_claim_binding,
+                    workspace_owner_lease,
+                    execution_context_id: None,
+                    execution_receipt: None,
+                },
+            },
+            now,
+        )
     }
 
-    fn submit_remote_runner_job_inner(
-        &self,
-        mut request: RemoteRunnerJobRequest,
-        envelope: Option<RunnerExecutionEnvelope>,
-        supplied_submission_fingerprint: Option<String>,
-    ) -> Result<Job> {
-        let envelope_first = envelope.is_some();
+    fn submit_remote_runner_job_inner(&self, mut request: RemoteRunnerJobRequest) -> Result<Job> {
         if request.runner_id.trim().is_empty() {
             return Err(Error::validation_invalid_argument(
                 "runner_id",
@@ -1001,11 +1122,41 @@ impl JobStore {
         let submission_key = request.submission_key().map(str::to_string);
         let submission_fingerprint = submission_key
             .as_ref()
-            .map(|_| match supplied_submission_fingerprint {
-                Some(fingerprint) => Ok(fingerprint),
-                None => request.submission_payload_fingerprint(),
-            })
+            .map(|_| request.submission_payload_fingerprint())
             .transpose()?;
+        let admission = RemoteRunnerAdmission {
+            operation: request.operation.clone(),
+            runner_id: request.runner_id.clone(),
+            project_id: request.project_id.clone(),
+            source_snapshot: request.source_snapshot.clone(),
+            path_materialization_plan: request.path_materialization_plan.clone(),
+            run_ref_metadata: public_request.run_ref_metadata(),
+            submission_key,
+            submission_fingerprint,
+            stored_remote_runner: StoredRemoteRunnerJob {
+                envelope: None,
+                request: Some(public_request),
+                workspace_claim_binding: None,
+                workspace_owner_lease: None,
+                execution_context_id: None,
+                execution_receipt: None,
+            },
+        };
+        self.admit_remote_runner_job(admission, now)
+    }
+
+    fn admit_remote_runner_job(&self, admission: RemoteRunnerAdmission, now: u64) -> Result<Job> {
+        let RemoteRunnerAdmission {
+            operation,
+            runner_id,
+            project_id,
+            source_snapshot,
+            path_materialization_plan,
+            run_ref_metadata,
+            submission_key,
+            submission_fingerprint,
+            stored_remote_runner,
+        } = admission;
         self.durable_transaction(|inner| {
         if let Some(submission_key) = submission_key.as_deref() {
             let fingerprint = submission_fingerprint
@@ -1094,19 +1245,19 @@ impl JobStore {
         }
         let mut job = Job {
             id: Uuid::new_v4(),
-            operation: request.operation.clone(),
+            operation,
             status: JobStatus::Queued,
             created_at_ms: now,
             updated_at_ms: now,
             started_at_ms: None,
             finished_at_ms: None,
             event_count: 0,
-            source_snapshot: request.source_snapshot.clone(),
-            path_materialization_plan: request.path_materialization_plan.clone(),
+            source_snapshot,
+            path_materialization_plan,
             stale_reason: None,
             daemon_lease_id: self.daemon_lease_id.clone(),
-            target_runner_id: Some(request.runner_id.clone()),
-            target_project_id: request.project_id.clone(),
+            target_runner_id: Some(runner_id),
+            target_project_id: project_id,
             claim_id: None,
             claimed_by_runner_id: None,
             claimed_at_ms: None,
@@ -1115,7 +1266,6 @@ impl JobStore {
             runner_job_projection: None,
         };
 
-        let run_ref_metadata = public_request.run_ref_metadata();
         inner.jobs.insert(
             job.id,
             StoredJob {
@@ -1124,27 +1274,13 @@ impl JobStore {
                 admission_idempotency_key: None,
                 controller_job: None,
                 admission_lease: None,
-                remote_runner: Some(StoredRemoteRunnerJob {
-                    // Durable broker state intentionally contains only the
-                    // redacted request. The runner hydrates named references
-                    // immediately before dispatch.
-                    envelope,
-                    request: (!envelope_first).then_some(public_request),
-                    workspace_claim_binding: envelope_first
-                        .then(|| request.workspace_claim_binding.clone())
-                        .flatten(),
-                    workspace_owner_lease: envelope_first
-                        .then(|| request.workspace_owner_lease.clone())
-                        .flatten(),
-                    execution_context_id: None,
-                    execution_receipt: None,
-                }),
+                remote_runner: Some(stored_remote_runner),
                 local_runner: None,
                 local_child: None,
             },
         );
         if let (Some(submission_key), Some(fingerprint)) =
-            (submission_key, submission_fingerprint.clone())
+            (submission_key.clone(), submission_fingerprint.clone())
         {
             inner.submission_keys.insert(
                 submission_key,
@@ -1157,7 +1293,7 @@ impl JobStore {
         let mut evidence = run_ref_metadata.unwrap_or_else(|| serde_json::json!({}));
         evidence["status"] = serde_json::json!("queued");
         if let (Some(submission_key), Some(fingerprint)) =
-            (request.submission_key(), submission_fingerprint.as_deref())
+            (submission_key.as_deref(), submission_fingerprint.as_deref())
         {
             evidence["submission"] = serde_json::json!({
                 "schema": "homeboy/remote-runner-submission/v1",
@@ -1301,7 +1437,7 @@ impl JobStore {
                 .next()
                 .map(|candidate| candidate.job.id)
             {
-                let (job, request, envelope) = {
+                let (job, request, envelope, workspace_claim_binding, workspace_owner_lease) = {
                     let stored = inner.jobs.get_mut(&job_id).expect("candidate exists");
                     stored.job.status = JobStatus::Running;
                     stored.job.updated_at_ms = now;
@@ -1314,36 +1450,53 @@ impl JobStore {
                         .remote_runner
                         .as_ref()
                         .expect("filtered remote runner job has request");
-                    let mut request = remote_runner.request()?.dispatch_request();
-                    request.workspace_claim_binding = remote_runner.workspace_claim_binding.clone();
-                    request.workspace_owner_lease = remote_runner.workspace_owner_lease();
                     let envelope = remote_runner.envelope()?;
-                    (stored.job.clone(), request, envelope)
+                    let workspace_claim_binding = remote_runner.workspace_claim_binding();
+                    let workspace_owner_lease = remote_runner.workspace_owner_lease();
+                    let request = execution_protocol
+                        .is_none_or(|protocol| !protocol.uses_envelope_only_claim())
+                        .then(|| {
+                            let mut request = remote_runner.request()?.dispatch_request();
+                            request.workspace_claim_binding = workspace_claim_binding.clone();
+                            request.workspace_owner_lease = workspace_owner_lease.clone();
+                            Ok::<RemoteRunnerJobRequest, Error>(request)
+                        })
+                        .transpose()?;
+                    (
+                        stored.job.clone(),
+                        request,
+                        envelope,
+                        workspace_claim_binding,
+                        workspace_owner_lease,
+                    )
                 };
                 let execution_context = match execution_protocol {
                     Some(protocol) => {
                         protocol.verify()?;
                         Some(
                             crate::runner_job_execution_context::RunnerJobExecutionContext::from_claim(
-                                &job, &request,
+                                &job, &envelope,
                             )?,
                         )
                     }
-                    None if request.requires_execution_context() => {
+                    None if envelope
+                        .dispatch
+                        .as_ref()
+                        .is_some_and(|dispatch| !dispatch.extension_env_providers.is_empty()) => {
                         return Err(crate::runner_job_execution_context::rejected(
                             "worker did not advertise the required execution-context protocol",
                         ));
                     }
                     None => None,
                 };
-                if request.requires_workspace_claim_protocol() {
+                if workspace_claim_binding.is_some() {
                     workspace_claim_protocol
                         .ok_or_else(|| crate::runner_job_execution_context::rejected(
                             "worker did not advertise the required workspace-claim protocol",
                         ))?
                         .verify()?;
                 }
-                if request.requires_workspace_owner_lease_protocol() {
+                if workspace_owner_lease.is_some() {
                     workspace_owner_lease_protocol
                         .ok_or_else(|| crate::runner_job_execution_context::rejected(
                             "worker did not advertise the required workspace-owner-lease protocol",
@@ -1374,27 +1527,44 @@ impl JobStore {
                         None => serde_json::json!({ "status": JobStatus::Running }),
                     }),
                 )?;
-                return Ok(Some((job, request, envelope, execution_context)));
+                return Ok(Some((
+                    job,
+                    request,
+                    envelope,
+                    workspace_claim_binding,
+                    workspace_owner_lease,
+                    execution_context,
+                )));
             }
             Ok(None)
         })?;
 
-        let Some((job, request, envelope, execution_context)) = claimed else {
+        let Some((
+            job,
+            request,
+            envelope,
+            workspace_claim_binding,
+            workspace_owner_lease,
+            execution_context,
+        )) = claimed
+        else {
             return Ok(None);
         };
         let execution_protocol = execution_context
             .as_ref()
             .and_then(|_| execution_protocol.cloned());
-        let workspace_claim_protocol = request
-            .requires_workspace_claim_protocol()
+        let workspace_claim_protocol = workspace_claim_binding
+            .is_some()
             .then(crate::workspace_claim::WorkspaceClaimProtocol::current);
-        let workspace_owner_lease_protocol = request
-            .requires_workspace_owner_lease_protocol()
+        let workspace_owner_lease_protocol = workspace_owner_lease
+            .is_some()
             .then(crate::workspace_claim::WorkspaceOwnerLeaseProtocol::current);
         Ok(Some(RemoteRunnerJobClaim {
             job,
             envelope,
             request,
+            workspace_claim_binding,
+            workspace_owner_lease,
             execution_context,
             execution_protocol,
             workspace_claim_protocol,
@@ -1600,11 +1770,11 @@ impl JobStore {
                         "runner execution receipt was already consumed",
                     ));
                 }
-                let request = remote_runner.request()?;
+                let envelope = remote_runner.envelope()?;
                 let expected =
                     crate::runner_job_execution_context::RunnerJobExecutionContext::from_claim(
                         &stored.job,
-                        &request,
+                        &envelope,
                     )?;
                 if expected.id() != context_id {
                     return Err(crate::runner_job_execution_context::rejected(
@@ -1857,13 +2027,13 @@ impl JobStore {
 }
 
 fn reject_inline_durable_secret_env(
-    request: &RemoteRunnerJobRequest,
+    env: &HashMap<String, String>,
     secret_env_plan: &SecretEnvPlan,
 ) -> Result<()> {
     let inline_secret_names = secret_env_plan
         .secret_env_names()
         .into_iter()
-        .filter(|name| request.env.get(name).is_some_and(|value| !value.is_empty()))
+        .filter(|name| env.get(name).is_some_and(|value| !value.is_empty()))
         .collect::<Vec<_>>();
     if inline_secret_names.is_empty() {
         return Ok(());

--- a/crates/homeboy-core/src/api_jobs/store/reconciliation.rs
+++ b/crates/homeboy-core/src/api_jobs/store/reconciliation.rs
@@ -995,7 +995,7 @@ impl JobStore {
                     .map(|remote| {
                         super::super::summary::active_runner_job_summary(
                             &stored.job,
-                            &remote.request().expect("remote runner representation"),
+                            &remote.envelope().expect("remote runner representation"),
                             now,
                         )
                     })
@@ -1048,10 +1048,10 @@ impl JobStore {
                 stored.job.status == JobStatus::Failed && stored.job.stale_reason.is_some()
             })
             .filter_map(|stored| {
-                let request = stored.remote_runner.as_ref()?.request().ok()?;
+                let envelope = stored.remote_runner.as_ref()?.envelope().ok()?;
                 Some(super::super::summary::active_runner_job_summary(
                     &stored.job,
-                    &request,
+                    &envelope,
                     now,
                 ))
             })

--- a/crates/homeboy-core/src/api_jobs/summary.rs
+++ b/crates/homeboy-core/src/api_jobs/summary.rs
@@ -1,35 +1,38 @@
 use serde_json::Value;
 
-use super::persistence::request_metadata_string;
-use super::remote_runner::RemoteRunnerJobRequest;
 use super::store::LocalRunnerJob;
 use super::types::{ActiveRunnerJobRunSummary, ActiveRunnerJobSummary, Job, JobStatus};
 use crate::redaction::redact_argv_display;
+use crate::runner_execution_envelope::RunnerExecutionEnvelope;
 
 pub(super) fn active_runner_job_summary(
     job: &Job,
-    request: &RemoteRunnerJobRequest,
+    envelope: &RunnerExecutionEnvelope,
     now_ms: u64,
 ) -> ActiveRunnerJobSummary {
+    let dispatch = envelope
+        .dispatch
+        .as_ref()
+        .expect("validated remote runner envelope has dispatch");
     let started_at_ms = job.started_at_ms.unwrap_or(job.created_at_ms);
-    let lifecycle = request.lifecycle.clone();
+    let lifecycle = envelope.lifecycle.clone();
     ActiveRunnerJobSummary {
-        runner_id: request.runner_id.clone(),
+        runner_id: dispatch.runner_id.clone(),
         job_id: job.id.to_string(),
         operation: job.operation.clone(),
         source: lifecycle
             .as_ref()
             .and_then(|lifecycle| lifecycle.source.clone())
-            .or_else(|| request_metadata_string(request, "source"))
+            .or_else(|| envelope_metadata_string(envelope, "source"))
             .unwrap_or_else(|| "runner-daemon".to_string()),
         kind: lifecycle
             .as_ref()
             .and_then(|lifecycle| lifecycle.kind.clone())
-            .or_else(|| request_metadata_string(request, "kind"))
+            .or_else(|| envelope_metadata_string(envelope, "kind"))
             .unwrap_or_else(|| job.operation.clone()),
         status: job.status,
-        command: redact_argv_display(&request.command),
-        cwd: request.cwd.clone(),
+        command: redact_argv_display(&dispatch.command),
+        cwd: dispatch.cwd.clone(),
         started_at_ms,
         updated_at_ms: job.updated_at_ms,
         elapsed_ms: now_ms.saturating_sub(started_at_ms),
@@ -47,20 +50,20 @@ pub(super) fn active_runner_job_summary(
         durable_run_id: lifecycle
             .as_ref()
             .and_then(|lifecycle| lifecycle.durable_run_id.clone())
-            .or_else(|| request_metadata_string(request, "durable_run_id"))
-            .or_else(|| request_metadata_string(request, "run_id"))
-            .or_else(|| request_metadata_string(request, "record_run_id")),
+            .or_else(|| envelope_metadata_string(envelope, "durable_run_id"))
+            .or_else(|| envelope_metadata_string(envelope, "run_id"))
+            .or_else(|| envelope_metadata_string(envelope, "record_run_id")),
         stale_reason: job.stale_reason.clone(),
         lifecycle_state: Some(runner_job_lifecycle_state(job).to_string()),
         retryable: Some(runner_job_retryable(job)),
         active_child_count: lifecycle
             .as_ref()
             .and_then(|lifecycle| lifecycle.active_child_count)
-            .or_else(|| request_metadata_u64(request, "active_child_count")),
+            .or_else(|| envelope_metadata_u64(envelope, "active_child_count")),
         active_cell_count: lifecycle
             .as_ref()
             .and_then(|lifecycle| lifecycle.active_cell_count)
-            .or_else(|| request_metadata_u64(request, "active_cell_count")),
+            .or_else(|| envelope_metadata_u64(envelope, "active_cell_count")),
     }
 }
 
@@ -156,12 +159,18 @@ pub(super) fn active_local_runner_job_summary(
     }
 }
 
-fn request_metadata_u64(request: &RemoteRunnerJobRequest, key: &str) -> Option<u64> {
-    request
+fn envelope_metadata_string(envelope: &RunnerExecutionEnvelope, key: &str) -> Option<String> {
+    envelope
         .metadata
-        .as_ref()
-        .and_then(|metadata| metadata.get(key))
-        .and_then(Value::as_u64)
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn envelope_metadata_u64(envelope: &RunnerExecutionEnvelope, key: &str) -> Option<u64> {
+    envelope.metadata.get(key).and_then(Value::as_u64)
 }
 
 pub fn active_runner_job_run_summary(job: ActiveRunnerJobSummary) -> ActiveRunnerJobRunSummary {

--- a/crates/homeboy-core/src/api_jobs/tests/part_b.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_b.rs
@@ -1442,6 +1442,11 @@ fn envelope_submission_replays_and_persists_no_legacy_execution_request() {
         .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, None)
         .expect("claim envelope")
         .expect("claimed envelope");
+    assert!(claim.request.is_none());
+    assert!(serde_json::to_value(&claim)
+        .expect("claim serializes")
+        .get("request")
+        .is_none());
     assert_eq!(
         claim.envelope.dispatch.as_ref().expect("dispatch").command,
         request.command
@@ -2040,13 +2045,19 @@ fn remote_runner_job_env_is_scoped_to_submitted_job() {
 
     assert_eq!(
         first_claim
-            .request
+            .envelope
+            .dispatch
+            .as_ref()
+            .expect("typed dispatch")
             .env
             .get("STUDIO_NATIVE_TRACE_SAMPLE_RUNTIME_PLUGIN_PATH"),
         Some(&"/tmp/sample-runtime".to_string())
     );
     assert!(!second_claim
-        .request
+        .envelope
+        .dispatch
+        .as_ref()
+        .expect("typed dispatch")
         .env
         .contains_key("STUDIO_NATIVE_TRACE_SAMPLE_RUNTIME_PLUGIN_PATH"));
 }

--- a/crates/homeboy-core/src/api_jobs/tests/part_c.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_c.rs
@@ -26,7 +26,15 @@ fn remote_runner_job_claim_returns_oldest_matching_job() {
         .expect("matching job is claimed");
 
     assert_eq!(claim.job.id, first.id);
-    assert_eq!(claim.request.runner_id, "homeboy-lab");
+    assert_eq!(
+        claim
+            .envelope
+            .dispatch
+            .as_ref()
+            .expect("typed dispatch")
+            .runner_id,
+        "homeboy-lab"
+    );
     assert_eq!(claim.job.status, JobStatus::Running);
     assert_eq!(
         claim.job.claimed_by_runner_id.as_deref(),
@@ -275,14 +283,14 @@ fn remote_runner_claim_persists_and_requires_authenticated_execution_context() {
         "reverse_broker:homeboy-lab:cook-42:attempt-2"
     );
     let verified_context = context
-        .verify_claim(&claim.job, &claim.request)
+        .verify_claim(&claim.job, &claim.envelope)
         .expect("context verifies claimed job");
     assert!(verified_context.verify_integrity().is_ok());
     let mut tampered_value = serde_json::to_value(context).expect("serialize context");
     tampered_value["runner_job_id"] = serde_json::json!("different-job");
     let tampered: crate::runner_job_execution_context::RunnerJobExecutionContext =
         serde_json::from_value(tampered_value).expect("decode tampered context");
-    assert!(tampered.verify_claim(&claim.job, &claim.request).is_err());
+    assert!(tampered.verify_claim(&claim.job, &claim.envelope).is_err());
     assert!(store.events(job.id).expect("events").iter().any(|event| {
         event
             .data
@@ -323,13 +331,13 @@ fn remote_runner_context_rejects_expired_or_different_durable_claims() {
 
     assert_ne!(first.id, second.id);
     assert!(context
-        .verify_claim(&second_claim.job, &second_claim.request)
+        .verify_claim(&second_claim.job, &second_claim.envelope)
         .is_err());
 
     let mut expired = first_claim.job.clone();
     expired.claim_expires_at_ms = Some(crate::api_jobs::timestamp_ms().saturating_sub(1));
     assert!(context
-        .verify_claim(&expired, &first_claim.request)
+        .verify_claim(&expired, &first_claim.envelope)
         .is_err());
 }
 
@@ -511,6 +519,7 @@ fn remote_runner_legacy_claims_remain_available_only_for_context_free_jobs() {
         .expect("legacy worker can claim context-free work")
         .expect("legacy job is claimed");
     assert_eq!(claim.job.id, job.id);
+    assert!(claim.request.is_some());
     assert!(claim.execution_context.is_none());
     assert!(claim.execution_protocol.is_none());
     assert!(store.events(job.id).expect("events").iter().all(|event| {
@@ -520,6 +529,126 @@ fn remote_runner_legacy_claims_remain_available_only_for_context_free_jobs() {
             .and_then(|data| data.get("runner_job_execution_context"))
             .is_none()
     }));
+}
+
+#[test]
+fn remote_runner_protocol_v1_claim_retains_legacy_request_projection() {
+    let store = JobStore::default();
+    let request = remote_runner_request("homeboy-lab", Some("extrachill"));
+    let job = store
+        .submit_runner_api_request(homeboy_runner_contract::RunnerApiSubmitRequest {
+            schema: homeboy_runner_contract::RUNNER_API_SUBMIT_REQUEST_SCHEMA.to_string(),
+            api_version: homeboy_runner_contract::RUNNER_API_V1,
+            submission_key: "submission-v1-worker".to_string(),
+            envelope: request.execution_envelope(),
+            workspace_claim_binding: None,
+            workspace_owner_lease: None,
+        })
+        .expect("runner API request queues");
+    let protocol = crate::runner_job_execution_context::RunnerJobExecutionProtocol {
+        capability: crate::runner_job_execution_context::RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY
+            .to_string(),
+        version: 1,
+    };
+
+    let claim = store
+        .claim_remote_runner_job_with_execution_protocol(
+            "homeboy-lab",
+            Some("extrachill"),
+            30_000,
+            None,
+            Some(&protocol),
+        )
+        .expect("v1 claim succeeds")
+        .expect("matching job is claimed");
+
+    assert_eq!(claim.job.id, job.id);
+    assert_eq!(
+        claim.request.expect("v1 request projection").command,
+        claim.envelope.dispatch.expect("typed dispatch").command
+    );
+}
+
+#[test]
+fn runner_api_claim_sidecars_match_across_v2_and_v1_projections() {
+    let store = JobStore::default();
+    let workspace =
+        crate::workspace_claim::WorkspaceIdentity::new("test", "claim-sidecars").expect("identity");
+    let binding = crate::workspace_claim::WorkspaceClaimBinding {
+        workspace: workspace.clone(),
+        lifecycle_revision: 4,
+        claim: Some(crate::workspace_claim::WorkspaceClaim {
+            schema: crate::workspace_claim::WORKSPACE_CLAIM_SCHEMA.to_string(),
+            protocol: crate::workspace_claim::WorkspaceClaimProtocol::current(),
+            workspace: workspace.clone(),
+            lifecycle_revision: 4,
+            token: "claim-token".to_string(),
+            expires_at_ms: crate::api_jobs::timestamp_ms() + 30_000,
+        }),
+    };
+    let owner_lease = crate::workspace_claim::WorkspaceOwnerLease {
+        schema: crate::workspace_claim::WORKSPACE_OWNER_LEASE_SCHEMA.to_string(),
+        protocol: crate::workspace_claim::WorkspaceOwnerLeaseProtocol::current(),
+        workspace,
+        owner_id: "agent-task:claim-sidecars".to_string(),
+        lifecycle_revision: 4,
+        token: "owner-token".to_string(),
+        expires_at_ms: crate::api_jobs::timestamp_ms() + 30_000,
+    };
+    let submit = |submission_key: &str| {
+        let request = remote_runner_request("homeboy-lab", None);
+        store
+            .submit_runner_api_request(homeboy_runner_contract::RunnerApiSubmitRequest {
+                schema: homeboy_runner_contract::RUNNER_API_SUBMIT_REQUEST_SCHEMA.to_string(),
+                api_version: homeboy_runner_contract::RUNNER_API_V1,
+                submission_key: submission_key.to_string(),
+                envelope: request.execution_envelope(),
+                workspace_claim_binding: Some(serde_json::to_value(&binding).expect("binding")),
+                workspace_owner_lease: Some(
+                    serde_json::to_value(&owner_lease).expect("owner lease"),
+                ),
+            })
+            .expect("Runner API request queues")
+    };
+
+    let v2_job = submit("claim-sidecars-v2");
+    let v2 = store
+        .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
+        .expect("v2 claim succeeds")
+        .expect("v2 claim");
+    assert_eq!(v2.job.id, v2_job.id);
+    assert!(v2.request.is_none());
+    assert_eq!(v2.workspace_claim_binding, Some(binding.clone()));
+    assert_eq!(v2.workspace_owner_lease, Some(owner_lease.clone()));
+
+    let v1_job = submit("claim-sidecars-v1");
+    let execution = crate::runner_job_execution_context::RunnerJobExecutionProtocol {
+        capability: crate::runner_job_execution_context::RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY
+            .to_string(),
+        version: 1,
+    };
+    let workspace_claim = crate::workspace_claim::WorkspaceClaimProtocol::current();
+    let workspace_owner_lease = crate::workspace_claim::WorkspaceOwnerLeaseProtocol::current();
+    let v1 = store
+        .claim_remote_runner_job_with_protocols(
+            "homeboy-lab",
+            None,
+            30_000,
+            None,
+            super::remote_runner::RemoteRunnerClaimProtocols {
+                execution: Some(&execution),
+                workspace_claim: Some(&workspace_claim),
+                workspace_owner_lease: Some(&workspace_owner_lease),
+            },
+        )
+        .expect("v1 claim succeeds")
+        .expect("v1 claim");
+    assert_eq!(v1.job.id, v1_job.id);
+    assert_eq!(v1.workspace_claim_binding, Some(binding.clone()));
+    assert_eq!(v1.workspace_owner_lease, Some(owner_lease.clone()));
+    let projected = v1.request.expect("v1 request projection");
+    assert_eq!(projected.workspace_claim_binding, Some(binding));
+    assert_eq!(projected.workspace_owner_lease, Some(owner_lease));
 }
 
 #[test]
@@ -1094,8 +1223,9 @@ fn remote_runner_jobs_persist_request_and_claim_state() {
         .expect("persisted job is claimed");
 
     assert_eq!(claim.job.id, job.id);
-    assert_eq!(claim.request.command, vec!["homeboy", "test"]);
-    assert_eq!(claim.request.project_id.as_deref(), Some("extrachill"));
+    let dispatch = claim.envelope.dispatch.as_ref().expect("typed dispatch");
+    assert_eq!(dispatch.command, vec!["homeboy", "test"]);
+    assert_eq!(dispatch.project_id.as_deref(), Some("extrachill"));
 }
 
 #[test]

--- a/crates/homeboy-core/src/daemon/mod.rs
+++ b/crates/homeboy-core/src/daemon/mod.rs
@@ -24,6 +24,7 @@ use crate::process::{pid_has_ownership_token, pid_is_running};
 use crate::runner_execution_envelope::PathMaterializationPlan;
 use crate::secret_env_plan::SecretEnvPlan;
 use crate::source_snapshot::SourceSnapshot;
+use homeboy_lab_contract::lab::execution_envelope::lab_runner_workload_from_execution_envelope;
 use homeboy_runner_contract::{
     RunnerApiSubmitRequest, RunnerExecutionEnvelope, RUNNER_API_SUBMIT_REQUEST_SCHEMA,
     RUNNER_API_V1,
@@ -3288,12 +3289,35 @@ fn enqueue_exec_job(
     job_store: &JobStore,
 ) -> Result<serde_json::Value> {
     let request = decode_exec_request(body)?;
-    let mut execution = crate::api_jobs::legacy_request_from_envelope(&request.envelope)?;
-    execution.workspace_claim_binding = request.workspace_claim_binding.clone();
+    let dispatch = request.envelope.dispatch.as_ref().ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "envelope.dispatch",
+            "runner execution envelope requires dispatch",
+            None,
+            None,
+        )
+    })?;
+    let workload = lab_runner_workload_from_execution_envelope(&request.envelope)?;
+    let secret_env_plan = request.envelope.secret_env.clone().unwrap_or_default();
+    let path_materialization_plan = request
+        .envelope
+        .metadata
+        .get("path_materialization_plan")
+        .cloned()
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("decode envelope path materialization plan".to_string()),
+            )
+        })?;
+    let execution_metadata =
+        (!request.envelope.metadata.is_null()).then_some(&request.envelope.metadata);
     // Reconciliation bindings are not direct execution authority. Existing
     // clients may still send one only for ordinary compatibility; workspace
     // work must carry an owner registration request negotiated through v2.
-    if request.workspace_owner_request.is_some() && execution.workspace_claim_binding.is_some() {
+    if request.workspace_owner_request.is_some() && request.workspace_claim_binding.is_some() {
         return Err(Error::validation_invalid_argument(
             "workspace_claim_binding",
             "direct workspace execution uses an owner lease, not a reconciliation claim",
@@ -3301,40 +3325,58 @@ fn enqueue_exec_job(
             None,
         ));
     }
-    let secret_env_plan = if request.legacy_submission_key_is_run_id {
-        execution.normalize()
-    } else {
-        execution.validate_durable_submission()?;
-        execution.secret_env_plan.clone()
-    };
+    if !request.legacy_submission_key_is_run_id {
+        let inline_secret_names = secret_env_plan
+            .secret_env_names()
+            .into_iter()
+            .filter(|name| {
+                dispatch
+                    .env
+                    .get(name)
+                    .is_some_and(|value| !value.is_empty())
+            })
+            .collect::<Vec<_>>();
+        if !inline_secret_names.is_empty() {
+            return Err(Error::validation_invalid_argument(
+                "env",
+                "durable reverse-runner jobs cannot accept inline secret env values",
+                Some("durable_reverse_runner_inline_secret_env".to_string()),
+                Some(vec![format!(
+                    "Inline secret variables: {}",
+                    inline_secret_names.join(", ")
+                )]),
+            ));
+        }
+    }
     crate::api_jobs::with_runner_job_preparation(|p| {
         p.validate_lab_runner_workload_dispatch(
-            execution.lab_runner_workload.as_ref(),
-            &execution.runner_id,
-            execution.cwd.as_deref(),
-            &execution.command,
+            workload.as_ref(),
+            &dispatch.runner_id,
+            dispatch.cwd.as_deref(),
+            &dispatch.command,
             &secret_env_plan,
-            execution.capture_patch,
+            request.envelope.mutation_policy.capture_patch,
         )
     })?;
     let submission_key = request.submission_key.clone();
     let plan = runner_exec_driver::prepare_exec(runner_exec_driver::RunnerExecPrepareRequest {
-        runner_id: execution.runner_id.clone(),
+        runner_id: dispatch.runner_id.clone(),
         runner: request.runner.clone(),
-        cwd: execution.cwd.clone(),
-        project_id: execution.project_id.clone(),
-        command: execution.command.clone(),
-        env: execution.env.clone(),
-        secret_env_names: execution.secret_env_names.clone(),
+        cwd: dispatch.cwd.clone(),
+        project_id: dispatch.project_id.clone(),
+        command: dispatch.command.clone(),
+        env: dispatch.env.clone(),
+        secret_env_names: secret_env_plan.secret_env_names(),
         secret_env_plan: Some(
             serde_json::to_value(&secret_env_plan).unwrap_or(serde_json::Value::Null),
         ),
-        capture_patch: execution.capture_patch,
+        capture_patch: request.envelope.mutation_policy.capture_patch,
         raw_exec: request.raw_exec,
-        source_snapshot: execution.source_snapshot.clone(),
-        require_paths: execution.require_paths.clone(),
-        extension_env_providers: execution.extension_env_providers.clone(),
-        authoritative_run_id: execution
+        source_snapshot: dispatch.source_snapshot.clone(),
+        require_paths: dispatch.require_paths.clone(),
+        extension_env_providers: dispatch.extension_env_providers.clone(),
+        authoritative_run_id: request
+            .envelope
             .lifecycle
             .as_ref()
             .and_then(|lifecycle| lifecycle.durable_run_id.clone())
@@ -3342,9 +3384,8 @@ fn enqueue_exec_job(
         validate_require_paths_on_host: true,
     })?;
     let source_snapshot = Some(plan.source_snapshot.clone());
-    let path_materialization_plan = execution.path_materialization_plan.clone();
 
-    let mut lifecycle = execution.lifecycle.clone();
+    let mut lifecycle = request.envelope.lifecycle.clone();
     if request.legacy_submission_key_is_run_id {
         if let Some(durable_run_id) = submission_key.clone() {
             lifecycle
@@ -3356,7 +3397,7 @@ fn enqueue_exec_job(
         "runner_id": plan.runner_id,
         "cwd": plan.cwd,
         "command": plan.command,
-        "capture_patch": execution.capture_patch,
+        "capture_patch": request.envelope.mutation_policy.capture_patch,
         "source_snapshot": source_snapshot,
         "path_materialization_plan": path_materialization_plan,
         "extension_env_providers": plan.extension_env_provenance,
@@ -3386,12 +3427,9 @@ fn enqueue_exec_job(
     }
 
     let operation = "runner.exec".to_string();
-    let mut run_ref_metadata = exec_request_run_ref_metadata(
-        lifecycle.as_ref(),
-        execution.lab_runner_workload.as_ref(),
-        execution.metadata.as_ref(),
-    )
-    .unwrap_or_else(|| json!({}));
+    let mut run_ref_metadata =
+        exec_request_run_ref_metadata(lifecycle.as_ref(), workload.as_ref(), execution_metadata)
+            .unwrap_or_else(|| json!({}));
     run_ref_metadata["runner_job_projection"] = json!({
         "runner_id": plan.runner_id,
         "command": crate::redaction::redact_argv_display(&plan.command),
@@ -3403,7 +3441,7 @@ fn enqueue_exec_job(
     // Capture any potentially slow baseline before reserving child capacity.
     // Once the reservation is durable, the worker performs only the bounded
     // process-spawn handoff before persisting child ownership.
-    let baseline = if execution.capture_patch {
+    let baseline = if request.envelope.mutation_policy.capture_patch {
         Some(capture_baseline(&plan.cwd, source_snapshot.as_ref())?)
     } else {
         None
@@ -3441,21 +3479,17 @@ fn enqueue_exec_job(
         command: plan.command.clone(),
         cwd: Some(plan.cwd.clone()),
         lifecycle: lifecycle.clone(),
-        workspace_claim_binding: execution.workspace_claim_binding.clone(),
+        workspace_claim_binding: request.workspace_claim_binding.clone(),
         workspace_owner_lease: workspace_owner_lease.clone(),
     };
     let execution_controller_run_id = lifecycle
         .as_ref()
         .and_then(|lifecycle| lifecycle.durable_run_id.clone());
-    let execution_controller_attempt_id = execution
-        .metadata
-        .as_ref()
+    let execution_controller_attempt_id = execution_metadata
         .and_then(|metadata| metadata.get("controller_attempt_id"))
         .and_then(serde_json::Value::as_str)
         .map(str::to_string);
-    let execution_accepted_handoff_id = execution
-        .metadata
-        .as_ref()
+    let execution_accepted_handoff_id = execution_metadata
         .and_then(|metadata| metadata.get("accepted_handoff_id"))
         .and_then(serde_json::Value::as_str)
         .map(str::to_string);

--- a/crates/homeboy-core/src/runner_job_execution_context.rs
+++ b/crates/homeboy-core/src/runner_job_execution_context.rs
@@ -8,14 +8,15 @@
 use homeboy_engine_primitives::content_hash;
 use serde::{Deserialize, Serialize};
 
-use crate::api_jobs::{Job, RemoteRunnerJobRequest};
+use crate::api_jobs::Job;
 use crate::error::{Error, ErrorCode, Result};
+use crate::runner_execution_envelope::RunnerExecutionEnvelope;
 
 pub const RUNNER_JOB_EXECUTION_CONTEXT_SCHEMA: &str = "homeboy/runner-job-execution-context/v1";
 pub const RUNNER_JOB_EXECUTION_CONTEXT_EVIDENCE_SCHEMA: &str =
     "homeboy/runner-job-execution-context-evidence/v1";
 pub const RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY: &str = "runner-job-execution-context";
-pub const RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY_VERSION: u32 = 1;
+pub const RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY_VERSION: u32 = 2;
 pub const RUNNER_JOB_ID_ENV: &str = "HOMEBOY_RUNNER_JOB_ID";
 pub const RUNNER_CHILD_RESERVATION_ENV: &str = "HOMEBOY_RUNNER_CHILD_RESERVATION";
 pub const RUNNER_JOB_EXECUTION_CONTEXT_ID_ENV: &str = "HOMEBOY_RUNNER_JOB_EXECUTION_CONTEXT_ID";
@@ -40,13 +41,17 @@ impl RunnerJobExecutionProtocol {
 
     pub fn verify(&self) -> Result<()> {
         if self.capability == RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY
-            && self.version == RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY_VERSION
+            && (1..=RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY_VERSION).contains(&self.version)
         {
             return Ok(());
         }
         Err(rejected(
             "worker does not advertise the required execution-context protocol",
         ))
+    }
+
+    pub fn uses_envelope_only_claim(&self) -> bool {
+        self.version >= 2
     }
 }
 
@@ -94,36 +99,39 @@ impl RunnerJobExecutionContext {
     /// Construct the only remote context source: a durable accepted job with a
     /// live broker claim. Generic runner jobs use their durable run/job identity
     /// as their controller attempt; agent-task callers retain their explicit IDs.
-    pub fn from_claim(job: &Job, request: &RemoteRunnerJobRequest) -> Result<Self> {
+    pub fn from_claim(job: &Job, envelope: &RunnerExecutionEnvelope) -> Result<Self> {
+        let dispatch = envelope
+            .dispatch
+            .as_ref()
+            .ok_or_else(|| rejected("accepted dispatch has no typed runner dispatch"))?;
         let runner_id = required(&job.claimed_by_runner_id, "claimed runner")?;
         let expected_runner_id = required(&job.target_runner_id, "target runner")?;
-        if runner_id != expected_runner_id || runner_id != request.runner_id.trim() {
+        if runner_id != expected_runner_id || runner_id != dispatch.runner_id.trim() {
             return Err(rejected(
                 "runner identity does not match the accepted dispatch receipt",
             ));
         }
         let claim_id = required(&job.claim_id, "claim")?;
-        let controller_run_id = metadata_id(request, "controller_run_id")
+        let controller_run_id = metadata_id(&envelope.metadata, "controller_run_id")
             .or_else(|| {
-                request
+                envelope
                     .lifecycle
                     .as_ref()
                     .and_then(|l| l.durable_run_id.clone())
             })
             .or_else(|| {
-                request
+                envelope
                     .metadata
-                    .as_ref()
-                    .and_then(|m| m.get("run_id"))
+                    .get("run_id")
                     .and_then(|v| v.as_str())
                     .map(str::to_string)
             })
             .unwrap_or_else(|| job.id.to_string());
-        let controller_attempt_id = metadata_id(request, "controller_attempt_id")
+        let controller_attempt_id = metadata_id(&envelope.metadata, "controller_attempt_id")
             .unwrap_or_else(|| controller_run_id.clone());
-        let accepted_handoff_id = metadata_id(request, "accepted_handoff_id")
+        let accepted_handoff_id = metadata_id(&envelope.metadata, "accepted_handoff_id")
             .unwrap_or_else(|| format!("{}:{}", controller_attempt_id, job.id));
-        let runtime_id = request
+        let runtime_id = dispatch
             .command
             .first()
             .map(String::as_str)
@@ -261,7 +269,7 @@ impl RunnerJobExecutionContext {
     /// Turn a received assertion into a capability after proving it against the
     /// actual broker claim. The authentication bit is never serialized, so a
     /// forged JSON payload cannot reach a provider entry point.
-    pub fn verify_claim(&self, job: &Job, request: &RemoteRunnerJobRequest) -> Result<Self> {
+    pub fn verify_claim(&self, job: &Job, envelope: &RunnerExecutionEnvelope) -> Result<Self> {
         if job.status != crate::api_jobs::JobStatus::Running
             || job
                 .claim_expires_at_ms
@@ -269,7 +277,7 @@ impl RunnerJobExecutionContext {
         {
             return Err(rejected("durable runner claim is no longer live"));
         }
-        let verified = Self::from_claim(job, request)?;
+        let verified = Self::from_claim(job, envelope)?;
         if self != &verified {
             return Err(rejected(
                 "dispatch receipt does not match the accepted runner job",
@@ -433,10 +441,8 @@ impl RunnerJobExecutionContext {
     }
 }
 
-fn metadata_id(request: &RemoteRunnerJobRequest, key: &str) -> Option<String> {
-    request
-        .metadata
-        .as_ref()?
+fn metadata_id(metadata: &serde_json::Value, key: &str) -> Option<String> {
+    metadata
         .get(key)?
         .as_str()
         .map(str::trim)

--- a/crates/homeboy-lab-runner/src/worker/result.rs
+++ b/crates/homeboy-lab-runner/src/worker/result.rs
@@ -8,11 +8,11 @@ use crate::agent_task_handoff_event::{
 };
 use crate::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_job_events;
 use homeboy_core::api_jobs::{
-    Job, JobArtifactMetadata, RemoteRunnerJobRequest, RemoteRunnerJobResult,
-    RemoteRunnerObservationRunDetail,
+    Job, JobArtifactMetadata, RemoteRunnerJobResult, RemoteRunnerObservationRunDetail,
 };
 use homeboy_core::execution_contract::EXECUTION_CONTRACT;
 use homeboy_core::run_outcome_envelope::RunOutcomeEnvelope;
+use homeboy_core::runner_execution_envelope::RunnerExecutionEnvelope;
 
 use super::super::capabilities::RunnerCapabilityPreflight;
 use super::types::{ReverseRunnerWorkerOptions, ReverseRunnerWorkerOutput};
@@ -378,9 +378,11 @@ pub(super) fn cancelled_output(
 /// available on this runner before execution starts, mirroring the direct
 /// `runner exec` path's preflight contract (#5093).
 pub(super) fn reverse_worker_capability_preflight(
-    request: &RemoteRunnerJobRequest,
+    envelope: &RunnerExecutionEnvelope,
 ) -> Option<RunnerCapabilityPreflight> {
-    let required_commands: Vec<String> = request
+    let required_commands: Vec<String> = envelope
+        .dispatch
+        .as_ref()?
         .command
         .first()
         .filter(|program| !program.trim().is_empty())

--- a/crates/homeboy-lab-runner/src/worker/run.rs
+++ b/crates/homeboy-lab-runner/src/worker/run.rs
@@ -275,7 +275,7 @@ fn run_once_output(
             )
         })?
         .verify()?;
-    if claim.request.requires_workspace_claim_protocol() {
+    if claim.workspace_claim_binding.is_some() {
         claim
             .workspace_claim_protocol
             .as_ref()
@@ -289,7 +289,7 @@ fn run_once_output(
             })?
             .verify()?;
     }
-    if claim.request.requires_workspace_owner_lease_protocol() {
+    if claim.workspace_owner_lease.is_some() {
         claim
             .workspace_owner_lease_protocol
             .as_ref()
@@ -303,7 +303,7 @@ fn run_once_output(
             })?
             .verify()?;
     }
-    let execution_context = execution_context.verify_claim(&claim.job, &claim.request)?;
+    let execution_context = execution_context.verify_claim(&claim.job, &claim.envelope)?;
 
     // Commit runner-owned evidence before materializing any broker input. The
     // controller persists the same identity in its claim event; keeping both
@@ -334,15 +334,15 @@ fn run_once_output(
             "phase": "runner_job_execution_context_verified",
             "runner_job_execution_context": execution_context.evidence_record()?,
         }),
-        claim.request.workspace_claim_binding.as_ref(),
-        claim.request.workspace_owner_lease.as_ref(),
+        claim.workspace_claim_binding.as_ref(),
+        claim.workspace_owner_lease.as_ref(),
     )?;
     let heartbeat = start_claim_heartbeat(
         &client,
         &options,
         &claim.job,
-        claim.request.workspace_claim_binding.clone(),
-        claim.request.workspace_owner_lease.clone(),
+        claim.workspace_claim_binding.clone(),
+        claim.workspace_owner_lease.clone(),
     )?;
     let current_owner_lease = heartbeat.owner_lease_handle();
     // Remote capability-parity preflight: validate that this runner can satisfy
@@ -350,8 +350,15 @@ fn run_once_output(
     // starting execution, so a missing tool fails before remote dispatch instead
     // of mid-run (#5093). The local worker execution path runs this preflight
     // before handing the claimed job directly to the local runtime.
-    let capability_preflight = reverse_worker_capability_preflight(&claim.request);
+    let capability_preflight = reverse_worker_capability_preflight(&claim.envelope);
     let mut execution_envelope = claim.envelope.clone();
+    let lab_runner_workload = lab_runner_workload_from_execution_envelope(&execution_envelope)
+        .map_err(|error| {
+            Error::internal_json(
+                error.to_string(),
+                Some("decode claimed runner workload".to_string()),
+            )
+        })?;
     // Authorize the exact durable owner lease immediately before any workspace,
     // private-file, or source materialization. This intentionally does not consume
     // the receipt; consume remains at the provider-invocation boundary below.
@@ -388,7 +395,7 @@ fn run_once_output(
             &options.runner_id,
             &claim.job,
             result,
-            claim.request.workspace_claim_binding.as_ref(),
+            claim.workspace_claim_binding.as_ref(),
             current_owner_lease
                 .lock()
                 .expect("owner lease lock")
@@ -401,7 +408,7 @@ fn run_once_output(
     let progress_client = client.clone();
     let progress_options = options.clone();
     let progress_job = claim.job.clone();
-    let progress_workspace_claim_binding = claim.request.workspace_claim_binding.clone();
+    let progress_workspace_claim_binding = claim.workspace_claim_binding.clone();
     let progress_owner_lease = current_owner_lease.clone();
     let progress_sink = Arc::new(move |data| {
         append_progress_data(
@@ -442,7 +449,7 @@ fn run_once_output(
                 &options.runner_id,
                 &claim.job,
                 recovered.id(),
-                claim.request.workspace_claim_binding.as_ref(),
+                claim.workspace_claim_binding.as_ref(),
                 current_owner_lease
                     .lock()
                     .expect("owner lease lock")
@@ -525,7 +532,7 @@ fn run_once_output(
     let job = finish(remote_runner_result_from_exec_output(
         exec_output,
         exit_code,
-        claim.request.lab_runner_workload.clone(),
+        lab_runner_workload,
     ))?;
 
     Ok((


### PR DESCRIPTION
## Summary
- persist and execute Runner API submissions directly from `RunnerExecutionEnvelope`
- introduce execution-context protocol v2 claims that omit `RemoteRunnerJobRequest`, with explicit workspace authority sidecars
- retain request-only persisted-job decoding and derive request projections only for negotiated protocol v1 workers
- move direct-daemon execution, active/stale summaries, worker preflight, and agent-task handoff replay onto the canonical envelope
- stop new handoff records and continuation providers from silently downgrading Runner API submissions

## Compatibility
- protocol v1 workers still receive the legacy request projection
- request-only persisted jobs remain readable and claimable
- old agent-task `replay_request` records remain reconcilable
- v1 and v2 claims carry identical workspace claim/owner-lease authority

## Verification
- `cargo check --workspace --all-targets --locked`
- `cargo test -p homeboy-core api_jobs::tests --lib` (109 passed in independent review)
- `cargo test -p homeboy-agents agent_task_lifecycle::tests --lib` (276 passed in independent review)
- `cargo test -p homeboy-lab-runner worker::tests --lib --locked` (37 passed)
- direct-daemon admission, envelope replay reconciliation, legacy replay, cancellation, and authenticated reverse-broker fallback tests passed
- independent review found no behavioral, authority/security, compatibility, fingerprint, or direct-daemon regressions

A broad `homeboy-lab-runner` run exceeded the 15-minute command budget and surfaced two unrelated connection-recovery fixture failures in untouched files; changed worker and handoff slices pass independently.

Closes #14165

## AI Assistance
Implemented and verified with OpenCode using OpenAI GPT-5.6 Sol. OpenAI GPT-5.6 Terra independently reviewed the diff for authority, mixed-version compatibility, persistence, fingerprinting, and direct-daemon regressions; its two low-risk test-gap recommendations were added before publication.