### PR TITLE
Classify the extension contract surface

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/lib.rs
+++ b/crates/contracts/homeboy-extension-contract/src/lib.rs
@@ -1,13 +1,61 @@
-//! Pure serializable data types for the homeboy extension system.
+//! Serializable contract types for the Homeboy extension system.
 //!
-//! This crate holds behavior-free contract types shared between core, the
-//! extension execution subsystem, and downstream consumers. It depends only on
-//! leaf crates (`homeboy-error`, `homeboy-audit-contract`), which keeps it a
-//! lightweight crate that others can depend on without pulling in the whole
-//! core compile unit.
+//! This crate depends only on leaf crates, which keeps it cheap for downstream
+//! consumers to depend on without pulling in the whole core compile unit.
 //!
-//! Consumers import shared contracts from this crate directly. Core extension
-//! workflow modules expose only the result types that are part of those workflows.
+//! # What is in here
+//!
+//! Everything in this crate is public surface, but not all of it is the same
+//! kind of surface, and the four kinds change for different reasons. Classifying
+//! them is what makes it possible to tell a breaking change from an internal one.
+//!
+//! ## 1. Versioned Extension API — [`api`]
+//!
+//! The negotiated request/response operations Homeboy serves and consumes:
+//! catalog, resolve, readiness, invocation, and the per-capability operations
+//! for deployment providers, environments, external-check detail resolvers,
+//! recipe runs, and agent-task executors. Versioned explicitly; a change here is
+//! an API version change.
+//!
+//! ## 2. Manifest schema — what an extension author writes
+//!
+//! The shape of `extension.json` and everything reachable from it:
+//! [`manifest`], the `manifest_*` configuration sections, and the declaration
+//! contracts for agent-task executors, deployment providers, and external-check
+//! detail resolvers. [`exec_context`] belongs here too: it is the environment
+//! contract an extension script reads at execution time.
+//!
+//! Modules reached only indirectly are still part of this surface. `fuzz_config`
+//! and `autofix_config` are glob-imported by [`manifest`], and `runtime_helper`
+//! is reached through `fuzz_config`.
+//!
+//! ## 3. Extension-produced domain results
+//!
+//! Shapes an extension emits for a domain workflow and Homeboy parses: bench,
+//! test, trace, and lint results, plus their parsing and analysis helpers. These
+//! are contracts because an extension produces them, and they change on their
+//! domain's cadence rather than the API's.
+//!
+//! ## 4. Provider command contracts
+//!
+//! Versioned JSON stdin/stdout command protocols whose other side is implemented
+//! outside Homeboy, such as [`worktree_retention`]. Core invokes these against a
+//! configured provider, so the shape is a promise to that provider.
+//!
+//! # Adding a type
+//!
+//! Decide which of the four it is first. If a type is reachable from
+//! [`manifest`], it is manifest schema no matter how few callers it has. If it
+//! is one side of a command protocol, it is a provider contract. Reachability
+//! from public surface decides this, not the number of Rust call sites.
+//!
+//! # Behavior
+//!
+//! These types are close to behavior-free, but not entirely: [`manifest`]
+//! carries accessors and capability projection, `core_compat` and `version`
+//! evaluate compatibility constraints, and `bench_stage` verifies stage reuse.
+//! Keep behavior here limited to interpreting the contract itself, so that
+//! deciding what a declaration means stays with the declaration.
 
 pub use action_types::HttpMethod;
 pub mod api;


### PR DESCRIPTION
## Summary

- classify every module in `homeboy-extension-contract` into one of four surfaces: versioned Extension API, manifest schema, extension-produced domain results, and provider command contracts
- record the rule for deciding where a new type belongs
- correct the crate doc comment, which claimed the types are behavior-free

No types move and no signatures change. This PR is the classification itself.

## Why no relocation

#14181 originally proposed moving nine modules (~1,050 lines) out of the crate as implementation detail, on the evidence that each had few or single-crate consumers. Verifying that before moving anything showed the premise was wrong, and I have posted the correction on the issue.

- `autofix_config`, `fuzz_config`, and `external_storage_retention` are glob-imported by `manifest.rs`, so extension authors write them.
- `runtime_helper`, `source_metadata_repair`, and `trace_preview` are reached through `fuzz_config`, `update_output`, and `trace_results`.
- `worktree_retention` is a versioned JSON stdin/stdout provider command contract that core invokes against a configured external provider.
- `bench_stage` and `bench_distribution` looked core-internal until the compiler showed `bench_results` imports both, and `bench_results` is extension-produced.

Zero of the nine are safely relocatable. Counting Rust call sites was the wrong test: reachability from public surface decides whether a type is public, not how many callers it has. That rule is now written down in the crate docs so the next person does not repeat the mistake.

## What this changes in practice

A reader can now tell which kind of change they are making. An `api` change is an API version change; a manifest schema change breaks extension authors; a domain result change moves on its domain cadence; a provider contract change breaks an implementation outside this repo. Previously all 96 exports were flat and equally public with nothing distinguishing them.

The behavior note is also now accurate: `manifest` carries accessors and capability projection, `core_compat` and `version` evaluate constraints, and `bench_stage` verifies stage reuse.

## Verification

- `cargo fmt --all -- --check`
- `cargo doc -p homeboy-extension-contract --no-deps` — builds clean, all intra-doc links resolve
- `cargo test -p homeboy-extension-contract --lib` (109 passed)
- `cargo check --workspace --tests`
- `git diff --check`

Refs #14181
Parent #13882

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode measured the crate, attempted the proposed relocation, found the classification premise wrong in three successive rounds of verification, reverted the move, and delivered the classification and corrected documentation under Chris Huber's direction.