### PR TITLE
Route extension actions through API v1

### DIFF
--- a/crates/contracts/homeboy-extension-contract/src/api/v1/operations.rs
+++ b/crates/contracts/homeboy-extension-contract/src/api/v1/operations.rs
@@ -7,12 +7,14 @@ use super::{
     ExtensionApiVersion,
 };
 
+mod action;
 mod agent_task_executor;
 mod deployment;
 mod environment;
 mod external_check_detail;
 mod invocation;
 mod recipe_run;
+pub use action::*;
 pub use agent_task_executor::*;
 pub use deployment::*;
 pub use environment::*;

--- a/crates/contracts/homeboy-extension-contract/src/api/v1/operations/action.rs
+++ b/crates/contracts/homeboy-extension-contract/src/api/v1/operations/action.rs
@@ -1,0 +1,67 @@
+use serde::{Deserialize, Serialize};
+
+use super::{
+    ExtensionApiInvocationProcessEvidence, ExtensionApiOperationFailure, ExtensionApiVersion,
+};
+
+pub const EXTENSION_API_ACTION_INVOKE_REQUEST_SCHEMA: &str =
+    "homeboy/extension-api-action-invoke-request/v1";
+pub const EXTENSION_API_ACTION_INVOKE_RESPONSE_SCHEMA: &str =
+    "homeboy/extension-api-action-invoke-response/v1";
+pub const ACTION_CAPABILITY_PREFIX: &str = "action.";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiActionInvokeRequest {
+    pub schema: String,
+    pub api_version: ExtensionApiVersion,
+    pub extension_id: String,
+    pub action_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub selected: Vec<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionApiActionInvokeResponse {
+    pub schema: String,
+    pub api_version: ExtensionApiVersion,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub process: Option<ExtensionApiInvocationProcessEvidence>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<ExtensionApiOperationFailure>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::v1::EXTENSION_API_V1;
+
+    #[test]
+    fn action_request_wire_shape_is_versioned() {
+        let request = ExtensionApiActionInvokeRequest {
+            schema: EXTENSION_API_ACTION_INVOKE_REQUEST_SCHEMA.to_string(),
+            api_version: EXTENSION_API_V1,
+            extension_id: "registry".to_string(),
+            action_id: "release.publish".to_string(),
+            project_id: None,
+            selected: Vec::new(),
+            payload: Some(serde_json::json!({"version": "1.2.3"})),
+        };
+
+        assert_eq!(
+            serde_json::to_value(request).expect("request JSON"),
+            serde_json::json!({
+                "schema": EXTENSION_API_ACTION_INVOKE_REQUEST_SCHEMA,
+                "api_version": {"major": 1},
+                "extension_id": "registry",
+                "action_id": "release.publish",
+                "payload": {"version": "1.2.3"}
+            })
+        );
+    }
+}

--- a/crates/homeboy-core/src/extension/catalog/api.rs
+++ b/crates/homeboy-core/src/extension/catalog/api.rs
@@ -14,12 +14,14 @@ use homeboy_extension_contract::api::v1::{
     ExtensionApiReadinessDescriptor, ExtensionApiReadinessMode, ExtensionApiReadinessRequest,
     ExtensionApiReadinessResponse, ExtensionApiReadinessState, ExtensionApiReadinessStatus,
     ExtensionApiResolveRequest, ExtensionApiResolveResponse, ExtensionApiRuntimeRequirement,
-    ExtensionApiVersion, AGENT_TASK_EXECUTOR_CAPABILITY_PREFIX, COMPILER_WARNINGS_CAPABILITY_ID,
-    COMPILER_WARNINGS_INPUT_SCHEMA, COMPILER_WARNINGS_OUTPUT_SCHEMA,
-    COMPILER_WARNING_FIXES_CAPABILITY_ID, COMPILER_WARNING_FIXES_INPUT_SCHEMA,
-    COMPILER_WARNING_FIXES_OUTPUT_SCHEMA, DEPLOYMENT_PROVIDER_CAPABILITY_PREFIX,
-    ENVIRONMENT_CAPABILITY_ID, EXTENSION_API_CATALOG_REQUEST_SCHEMA,
-    EXTENSION_API_CATALOG_RESPONSE_SCHEMA, EXTENSION_API_DEPLOYMENT_PROVIDER_INVOKE_REQUEST_SCHEMA,
+    ExtensionApiVersion, ACTION_CAPABILITY_PREFIX, AGENT_TASK_EXECUTOR_CAPABILITY_PREFIX,
+    COMPILER_WARNINGS_CAPABILITY_ID, COMPILER_WARNINGS_INPUT_SCHEMA,
+    COMPILER_WARNINGS_OUTPUT_SCHEMA, COMPILER_WARNING_FIXES_CAPABILITY_ID,
+    COMPILER_WARNING_FIXES_INPUT_SCHEMA, COMPILER_WARNING_FIXES_OUTPUT_SCHEMA,
+    DEPLOYMENT_PROVIDER_CAPABILITY_PREFIX, ENVIRONMENT_CAPABILITY_ID,
+    EXTENSION_API_ACTION_INVOKE_REQUEST_SCHEMA, EXTENSION_API_ACTION_INVOKE_RESPONSE_SCHEMA,
+    EXTENSION_API_CATALOG_REQUEST_SCHEMA, EXTENSION_API_CATALOG_RESPONSE_SCHEMA,
+    EXTENSION_API_DEPLOYMENT_PROVIDER_INVOKE_REQUEST_SCHEMA,
     EXTENSION_API_DEPLOYMENT_PROVIDER_INVOKE_RESPONSE_SCHEMA, EXTENSION_API_DESCRIPTOR_SCHEMA,
     EXTENSION_API_ENVIRONMENT_RESOLVE_REQUEST_SCHEMA,
     EXTENSION_API_ENVIRONMENT_RESOLVE_RESPONSE_SCHEMA, EXTENSION_API_HANDSHAKE_REQUEST_SCHEMA,
@@ -73,12 +75,13 @@ fn api_descriptor_from_manifest(extension: &ExtensionManifest) -> ExtensionApiDe
     {
         capabilities.push(capability_descriptor("execute"));
     }
-    capabilities.extend(
-        extension
-            .actions
-            .iter()
-            .map(|action| capability_descriptor(&format!("action.{}", action.id))),
-    );
+    capabilities.extend(extension.actions.iter().map(|action| {
+        schema_capability_descriptor(
+            &format!("{ACTION_CAPABILITY_PREFIX}{}", action.id),
+            EXTENSION_API_ACTION_INVOKE_REQUEST_SCHEMA,
+            EXTENSION_API_ACTION_INVOKE_RESPONSE_SCHEMA,
+        )
+    }));
     capabilities.extend(extension.deployment_providers.iter().map(|provider| {
         schema_capability_descriptor(
             &format!("{DEPLOYMENT_PROVIDER_CAPABILITY_PREFIX}{}", provider.id),

--- a/crates/homeboy-core/src/extension/invoke.rs
+++ b/crates/homeboy-core/src/extension/invoke.rs
@@ -16,6 +16,7 @@ use std::path::Path;
 use std::time::Duration;
 
 mod action;
+pub mod action_api;
 mod api;
 mod context;
 pub(crate) mod deadline_process;
@@ -36,7 +37,6 @@ use homeboy_extension_contract::manifest_action_config::RuntimeConfig;
 use homeboy_extension_contract::runner_contract::RunnerStepFilter;
 use homeboy_extension_contract::ExtensionManifest;
 
-pub use action::execute_action;
 pub use api::invoke_api;
 pub use context::ResolvedExtensionInvocationContext;
 pub use env_provider::{resolve_installed, resolve_installed_all, EnvProviderContribution};
@@ -69,7 +69,6 @@ pub struct ExtensionRunResult {
 pub(crate) struct ExtensionExecutionResult {
     pub output: CapturedOutput,
     pub exit_code: i32,
-    pub success: bool,
 }
 
 pub(crate) struct ExtensionExecutionOutcome {
@@ -277,7 +276,27 @@ pub fn run_action(
     project_id: Option<&str>,
     data: Option<&str>,
 ) -> Result<serde_json::Value> {
-    execute_action(extension_id, action_id, project_id, data, None)
+    use homeboy_extension_contract::api::v1::{
+        ExtensionApiActionInvokeRequest, EXTENSION_API_ACTION_INVOKE_REQUEST_SCHEMA,
+        EXTENSION_API_V1,
+    };
+
+    let selected = data
+        .map(serde_json::from_str)
+        .transpose()
+        .map_err(|error| Error::internal_json(error.to_string(), Some("parse action data".into())))?
+        .unwrap_or_default();
+    action_api::response_value(action_api::invoke_action_api(
+        &ExtensionApiActionInvokeRequest {
+            schema: EXTENSION_API_ACTION_INVOKE_REQUEST_SCHEMA.to_string(),
+            api_version: EXTENSION_API_V1,
+            extension_id: extension_id.to_string(),
+            action_id: action_id.to_string(),
+            project_id: project_id.map(str::to_string),
+            selected,
+            payload: None,
+        },
+    ))
 }
 
 fn extension_runtime(extension: &ExtensionManifest) -> Result<&RuntimeConfig> {

--- a/crates/homeboy-core/src/extension/invoke/action.rs
+++ b/crates/homeboy-core/src/extension/invoke/action.rs
@@ -4,6 +4,7 @@ use homeboy_core::error::{Error, Result};
 use homeboy_core::project;
 use homeboy_core::server::http::ApiClient;
 use homeboy_engine_primitives::validation;
+use homeboy_extension_contract::api::v1::ExtensionApiInvocationProcessEvidence;
 
 use super::scope::ExtensionScope;
 use super::{build_action_env, execute_extension_command, ExtensionExecutionMode};
@@ -11,13 +12,18 @@ use crate::extension::catalog::load_extension;
 use homeboy_extension_contract::action_types::{ActionType, HttpMethod};
 use homeboy_extension_contract::manifest_action_config::ActionConfig;
 
-pub fn execute_action(
+pub(super) struct ActionExecution {
+    pub output: Option<serde_json::Value>,
+    pub process: Option<ExtensionApiInvocationProcessEvidence>,
+}
+
+pub(super) fn execute_action_implementation(
     extension_id: &str,
     action_id: &str,
     project_id: Option<&str>,
-    data: Option<&str>,
+    selected: &[serde_json::Value],
     payload: Option<&serde_json::Value>,
-) -> Result<serde_json::Value> {
+) -> Result<ActionExecution> {
     let extension = load_extension(extension_id)?;
     homeboy_extension_contract::validate_core_compatibility(
         "extension",
@@ -54,14 +60,6 @@ pub fn execute_action(
             )
         })?;
 
-    let selected: Vec<serde_json::Value> = if let Some(data_str) = data {
-        serde_json::from_str(data_str).map_err(|e| {
-            Error::internal_json(e.to_string(), Some("parse action data".to_string()))
-        })?
-    } else {
-        Vec::new()
-    };
-
     match action.action_type {
         ActionType::Api => {
             let pid = validation::require(
@@ -91,15 +89,19 @@ pub fn execute_action(
             let method = action.method.as_ref().unwrap_or(&HttpMethod::Post);
             let project = project::load(pid)?;
             let settings = ExtensionScope::effective_settings(extension_id, Some(&project), None)?;
-            let payload = interpolate_action_payload(action, &selected, &settings, payload)?;
+            let payload = interpolate_action_payload(action, selected, &settings, payload)?;
 
-            match method {
+            let output = match method {
                 HttpMethod::Get => client.get(endpoint),
                 HttpMethod::Post => client.post(endpoint, &payload),
                 HttpMethod::Put => client.put(endpoint, &payload),
                 HttpMethod::Patch => client.patch(endpoint, &payload),
                 HttpMethod::Delete => client.delete(endpoint),
-            }
+            }?;
+            Ok(ActionExecution {
+                output: Some(output),
+                process: None,
+            })
         }
         ActionType::Builtin => Err(Error::validation_invalid_argument(
             "action_id",
@@ -117,7 +119,7 @@ pub fn execute_action(
             let component = None;
             let settings =
                 ExtensionScope::effective_settings(extension_id, project.as_ref(), component)?;
-            let payload = interpolate_action_payload(action, &selected, &settings, payload)?;
+            let payload = interpolate_action_payload(action, selected, &settings, payload)?;
             let extension_path = extension.extension_path.as_deref().unwrap_or(".");
             let vars = vec![("extension_path", extension_path)];
 
@@ -143,15 +145,17 @@ pub fn execute_action(
                 &env,
                 ExtensionExecutionMode::Captured,
             )?;
-            Ok(serde_json::json!({
-                "stdout": execution.output.stdout,
-                "stderr": execution.output.stderr,
-                "exitCode": execution.exit_code,
-                "success": execution.success,
-                "command": command_template,
-                "cwd": working_dir,
-                "payload": payload
-            }))
+            let stdout = execution.output.stdout;
+            let stderr = execution.output.stderr;
+            Ok(ActionExecution {
+                output: None,
+                process: Some(ExtensionApiInvocationProcessEvidence {
+                    exit_code: Some(execution.exit_code),
+                    parsed_output: serde_json::from_str(&stdout).ok(),
+                    stdout,
+                    stderr,
+                }),
+            })
         }
     }
 }

--- a/crates/homeboy-core/src/extension/invoke/action_api.rs
+++ b/crates/homeboy-core/src/extension/invoke/action_api.rs
@@ -1,0 +1,227 @@
+use homeboy_core::error::{Error, Result};
+use homeboy_extension_contract::api::v1::{
+    ExtensionApiActionInvokeRequest, ExtensionApiActionInvokeResponse,
+    ExtensionApiOperationFailure, ExtensionApiOperationFailureCode, ExtensionApiResolveRequest,
+    ACTION_CAPABILITY_PREFIX, EXTENSION_API_ACTION_INVOKE_REQUEST_SCHEMA,
+    EXTENSION_API_ACTION_INVOKE_RESPONSE_SCHEMA, EXTENSION_API_RESOLVE_REQUEST_SCHEMA,
+    EXTENSION_API_V1,
+};
+
+use super::action::execute_action_implementation;
+use crate::extension::catalog::{resolve_api, validate_operation_request};
+
+pub fn invoke_action_api(
+    request: &ExtensionApiActionInvokeRequest,
+) -> ExtensionApiActionInvokeResponse {
+    if let Some(failure) = validate_operation_request(
+        &request.schema,
+        EXTENSION_API_ACTION_INVOKE_REQUEST_SCHEMA,
+        request.api_version,
+    ) {
+        return failure_response(failure);
+    }
+
+    let capability_id = format!("{ACTION_CAPABILITY_PREFIX}{}", request.action_id);
+    let resolved = resolve_api(&ExtensionApiResolveRequest {
+        schema: EXTENSION_API_RESOLVE_REQUEST_SCHEMA.to_string(),
+        api_version: request.api_version,
+        extension_id: request.extension_id.clone(),
+        capability_id,
+    });
+    if let Some(failure) = resolved.failure {
+        return failure_response(failure);
+    }
+
+    match execute_action_implementation(
+        &request.extension_id,
+        &request.action_id,
+        request.project_id.as_deref(),
+        &request.selected,
+        request.payload.as_ref(),
+    ) {
+        Ok(execution) => ExtensionApiActionInvokeResponse {
+            schema: EXTENSION_API_ACTION_INVOKE_RESPONSE_SCHEMA.to_string(),
+            api_version: EXTENSION_API_V1,
+            output: execution.output,
+            process: execution.process,
+            failure: None,
+        },
+        Err(error) => failure_response(ExtensionApiOperationFailure {
+            code: ExtensionApiOperationFailureCode::CapabilityExecutionFailed,
+            message: error.to_string(),
+        }),
+    }
+}
+
+/// Project a successful typed response into the value expected by workflow callers.
+pub fn response_value(response: ExtensionApiActionInvokeResponse) -> Result<serde_json::Value> {
+    if let Some(failure) = response.failure {
+        return Err(Error::internal_unexpected(failure.message));
+    }
+    if let Some(output) = response.output {
+        return Ok(output);
+    }
+    if let Some(process) = response.process {
+        let exit_code = process.exit_code.unwrap_or(-1);
+        return Ok(serde_json::json!({
+            "stdout": process.stdout,
+            "stderr": process.stderr,
+            "exitCode": exit_code,
+            "success": exit_code == 0,
+        }));
+    }
+    Ok(serde_json::Value::Null)
+}
+
+pub fn invoke_action(
+    extension_id: &str,
+    action_id: &str,
+    project_id: Option<&str>,
+    selected: &[serde_json::Value],
+    payload: Option<&serde_json::Value>,
+) -> Result<serde_json::Value> {
+    response_value(invoke_action_api(&ExtensionApiActionInvokeRequest {
+        schema: EXTENSION_API_ACTION_INVOKE_REQUEST_SCHEMA.to_string(),
+        api_version: EXTENSION_API_V1,
+        extension_id: extension_id.to_string(),
+        action_id: action_id.to_string(),
+        project_id: project_id.map(str::to_string),
+        selected: selected.to_vec(),
+        payload: payload.cloned(),
+    }))
+}
+
+fn failure_response(failure: ExtensionApiOperationFailure) -> ExtensionApiActionInvokeResponse {
+    ExtensionApiActionInvokeResponse {
+        schema: EXTENSION_API_ACTION_INVOKE_RESPONSE_SCHEMA.to_string(),
+        api_version: EXTENSION_API_V1,
+        output: None,
+        process: None,
+        failure: Some(failure),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use homeboy_extension_contract::ExtensionManifest;
+
+    #[test]
+    fn command_action_resolves_through_v1_without_exposing_execution_inputs() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+                "name": "Registry",
+                "version": "1.0.0",
+                "actions": [{
+                    "id": "release.publish",
+                    "label": "Publish release",
+                    "type": "command",
+                    "command": "printf action-output"
+                }]
+            }))
+            .expect("manifest");
+            manifest.id = "registry".to_string();
+            crate::extension::catalog::save_manifest(&manifest).expect("save manifest");
+
+            let resolved = resolve_api(&ExtensionApiResolveRequest {
+                schema: EXTENSION_API_RESOLVE_REQUEST_SCHEMA.to_string(),
+                api_version: EXTENSION_API_V1,
+                extension_id: "registry".to_string(),
+                capability_id: "action.release.publish".to_string(),
+            });
+            let capability = resolved.capability.expect("advertised action capability");
+            assert_eq!(
+                capability.input_schema.map(|schema| schema.schema),
+                Some(EXTENSION_API_ACTION_INVOKE_REQUEST_SCHEMA.to_string())
+            );
+            assert_eq!(
+                capability.output_schema.map(|schema| schema.schema),
+                Some(EXTENSION_API_ACTION_INVOKE_RESPONSE_SCHEMA.to_string())
+            );
+
+            let response = invoke_action_api(&ExtensionApiActionInvokeRequest {
+                schema: EXTENSION_API_ACTION_INVOKE_REQUEST_SCHEMA.to_string(),
+                api_version: EXTENSION_API_V1,
+                extension_id: "registry".to_string(),
+                action_id: "release.publish".to_string(),
+                project_id: None,
+                selected: Vec::new(),
+                payload: Some(serde_json::json!({"private_input": "must-not-echo"})),
+            });
+
+            assert!(response.failure.is_none());
+            assert!(response.output.is_none());
+            let process = response.process.expect("process evidence");
+            assert_eq!(process.exit_code, Some(0));
+            assert_eq!(process.stdout, "action-output");
+            let wire = serde_json::to_string(&process).expect("response JSON");
+            assert!(!wire.contains("printf action-output"));
+            assert!(!wire.contains("must-not-echo"));
+            assert!(!wire.contains("cwd"));
+        });
+    }
+
+    #[test]
+    fn action_invocation_rejects_unadvertised_action() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+                "name": "Registry",
+                "version": "1.0.0"
+            }))
+            .expect("manifest");
+            manifest.id = "registry".to_string();
+            crate::extension::catalog::save_manifest(&manifest).expect("save manifest");
+
+            let response = invoke_action_api(&ExtensionApiActionInvokeRequest {
+                schema: EXTENSION_API_ACTION_INVOKE_REQUEST_SCHEMA.to_string(),
+                api_version: EXTENSION_API_V1,
+                extension_id: "registry".to_string(),
+                action_id: "release.publish".to_string(),
+                project_id: None,
+                selected: Vec::new(),
+                payload: None,
+            });
+
+            assert_eq!(
+                response.failure.map(|failure| failure.code),
+                Some(ExtensionApiOperationFailureCode::CapabilityNotProvided)
+            );
+        });
+    }
+
+    #[test]
+    fn api_action_validation_failure_is_typed() {
+        homeboy_core::test_support::with_isolated_home(|_| {
+            let mut manifest: ExtensionManifest = serde_json::from_value(serde_json::json!({
+                "name": "Registry",
+                "version": "1.0.0",
+                "actions": [{
+                    "id": "registry.publish",
+                    "label": "Publish",
+                    "type": "api",
+                    "endpoint": "/publish"
+                }]
+            }))
+            .expect("manifest");
+            manifest.id = "registry".to_string();
+            crate::extension::catalog::save_manifest(&manifest).expect("save manifest");
+
+            let response = invoke_action_api(&ExtensionApiActionInvokeRequest {
+                schema: EXTENSION_API_ACTION_INVOKE_REQUEST_SCHEMA.to_string(),
+                api_version: EXTENSION_API_V1,
+                extension_id: "registry".to_string(),
+                action_id: "registry.publish".to_string(),
+                project_id: None,
+                selected: Vec::new(),
+                payload: None,
+            });
+
+            let failure = response.failure.expect("typed validation failure");
+            assert_eq!(
+                failure.code,
+                ExtensionApiOperationFailureCode::CapabilityExecutionFailed
+            );
+            assert!(failure.message.contains("--project is required"));
+        });
+    }
+}

--- a/crates/homeboy-core/src/extension/invoke/environment.rs
+++ b/crates/homeboy-core/src/extension/invoke/environment.rs
@@ -167,7 +167,6 @@ pub(crate) fn execute_extension_command(
             Ok(ExtensionExecutionResult {
                 output: CapturedOutput::default(),
                 exit_code,
-                success: exit_code == 0,
             })
         }
         ExtensionExecutionMode::Captured => {
@@ -175,7 +174,6 @@ pub(crate) fn execute_extension_command(
             Ok(ExtensionExecutionResult {
                 output: CapturedOutput::new(cmd_output.stdout, cmd_output.stderr),
                 exit_code: cmd_output.exit_code,
-                success: cmd_output.success,
             })
         }
     }

--- a/crates/homeboy-release/src/release/cascade.rs
+++ b/crates/homeboy-release/src/release/cascade.rs
@@ -263,11 +263,11 @@ fn update_dependency(
         upstream,
     );
 
-    extension::invoke::execute_action(
+    extension::invoke::action_api::invoke_action(
         &extension_id,
         UPDATE_DEPENDENCY_ACTION,
         None,
-        None,
+        &[],
         Some(&payload),
     )
 }

--- a/crates/homeboy-release/src/release/executor/package.rs
+++ b/crates/homeboy-release/src/release/executor/package.rs
@@ -629,11 +629,11 @@ fn run_package_action_with_retry(
     payload: &serde_json::Value,
 ) -> Result<serde_json::Value> {
     for attempt in 1..=PACKAGE_ACTION_MAX_ATTEMPTS {
-        match extension::invoke::execute_action(
+        match extension::invoke::action_api::invoke_action(
             extension_id,
             "release.package",
             None,
-            None,
+            &[],
             Some(payload),
         ) {
             Ok(response) => {
@@ -747,11 +747,11 @@ pub(crate) fn run_extension_release_preflight(
     }
 
     let payload = build_release_payload(state, component_id, component_local_path, None, None);
-    let response = match extension::invoke::execute_action(
+    let response = match extension::invoke::action_api::invoke_action(
         extension_id,
         action_id,
         None,
-        None,
+        &[],
         Some(&payload),
     ) {
         Ok(response) => response,
@@ -904,9 +904,7 @@ pub(super) fn store_artifacts_from_output(
     // dependency install inside the build script can fail intermittently, and
     // the real error must be visible in the structured error payload.
     if !success {
-        return Err(package_command_failure_error(
-            exit_code, stdout, stderr, response,
-        ));
+        return Err(package_command_failure_error(exit_code, stdout, stderr));
     }
 
     if stdout.trim().is_empty() {
@@ -1024,12 +1022,7 @@ fn safe_artifact_file_name(value: &str) -> String {
 /// Package/build tools commonly write progress to stdout and errors to stderr.
 /// Including both streams ensures the operator can diagnose the real failure
 /// instead of seeing truncated output.  Issue #3238.
-fn package_command_failure_error(
-    exit_code: i64,
-    stdout: &str,
-    stderr: &str,
-    response: &serde_json::Value,
-) -> Error {
+fn package_command_failure_error(exit_code: i64, stdout: &str, stderr: &str) -> Error {
     let stderr_trimmed = stderr.trim();
     let stdout_trimmed = stdout.trim();
     let has_stderr = !stderr_trimmed.is_empty();
@@ -1061,8 +1054,6 @@ fn package_command_failure_error(
         detail,
         serde_json::json!({
             "exit_code": exit_code,
-            "command": response.get("command").and_then(serde_json::Value::as_str),
-            "cwd": response.get("cwd").and_then(serde_json::Value::as_str),
             "relevant_error_lines": relevant_package_error_lines(stdout, stderr),
             "stdout": stdout_trimmed,
             "stderr": stderr_trimmed,

--- a/crates/homeboy-release/src/release/executor/prepare.rs
+++ b/crates/homeboy-release/src/release/executor/prepare.rs
@@ -33,11 +33,11 @@ pub(crate) fn run_prepare(
     let mut responses = Vec::new();
 
     for extension in providers {
-        let response = extension::invoke::execute_action(
+        let response = extension::invoke::action_api::invoke_action(
             &extension.id,
             "release.prepare",
             None,
-            None,
+            &[],
             Some(&payload),
         )?;
         responses.push(serde_json::json!({

--- a/crates/homeboy-release/src/release/executor/publish.rs
+++ b/crates/homeboy-release/src/release/executor/publish.rs
@@ -52,8 +52,13 @@ pub(crate) fn run_publish(
         None,
         extra_config.as_ref(),
     );
-    let response =
-        extension::invoke::execute_action(&extension.id, action_id, None, None, Some(&payload))?;
+    let response = extension::invoke::action_api::invoke_action(
+        &extension.id,
+        action_id,
+        None,
+        &[],
+        Some(&payload),
+    )?;
     let extension_data = serde_json::to_value(&response).map_err(|e| {
         Error::internal_json(e.to_string(), Some("extension action output".to_string()))
     })?;

--- a/crates/homeboy-rig/src/pipeline/lifecycle_step.rs
+++ b/crates/homeboy-rig/src/pipeline/lifecycle_step.rs
@@ -377,11 +377,11 @@ fn run_extension_hook(
         "env": env_map,
     });
 
-    let value = homeboy_core::extension::invoke::execute_action(
+    let value = homeboy_core::extension::invoke::action_api::invoke_action(
         extension_id.trim(),
         action_id.trim(),
         None,
-        None,
+        &[],
         Some(&payload),
     )?;
 

--- a/docs/internals/development/contracts/extension-api-v1.md
+++ b/docs/internals/development/contracts/extension-api-v1.md
@@ -29,6 +29,8 @@ The wire schemas are:
 - `homeboy/extension-api-readiness-response/v1`
 - `homeboy/extension-api-invoke-request/v1`
 - `homeboy/extension-api-invoke-response/v1`
+- `homeboy/extension-api-action-invoke-request/v1`
+- `homeboy/extension-api-action-invoke-response/v1`
 - `homeboy/extension-api-environment-resolve-request/v1`
 - `homeboy/extension-api-environment-resolve-response/v1`
 - `homeboy/extension-api-deployment-provider-inventory-request/v1`
@@ -155,6 +157,21 @@ fallback.
 This synchronous operation is intentionally limited to analysis. It does not
 perform durable mutation and therefore has no idempotency, cancellation,
 reconciliation, activity, or terminal-result lifecycle.
+
+## Action Invocation
+
+`extension::invoke::action_api::invoke_action_api` executes one manifest action
+after resolving its advertised `action.<id>` capability through v1. The typed
+request carries extension and action identity plus selected values, project
+identity, and the action payload. Core keeps the manifest, command, working
+directory, environment, settings, and interpolated payload private.
+
+Command-backed actions return bounded process evidence: exit code, stdout,
+stderr, and parsed stdout when it is JSON. API-backed actions return only the
+remote operation output. Neither response shape exposes command text, cwd,
+payload echoes, environment declarations, extension paths, or provider
+configuration. Release, rig lifecycle, and direct CLI action execution all use
+this operation rather than a parallel manifest-action executor.
 
 ## Environment Resolution
 


### PR DESCRIPTION
## Summary

- define typed, versioned Extension API v1 action invocation request and response contracts
- resolve advertised `action.<id>` capabilities through the shared catalog before execution
- migrate direct CLI, release, and rig action execution to the typed action service
- retain extension output and bounded process evidence while removing command, cwd, and payload echoes from responses
- delete the old public `extension::invoke::execute_action` seam

## Why

The catalog already advertised manifest actions as Extension API capabilities, but production callers executed them through a parallel unversioned service. This made discovery and execution disagree about their owning contract and returned private execution inputs alongside results.

The new adapter keeps manifests, command construction, paths, settings, environment, and interpolated payloads inside core. Command actions return only bounded process evidence; API actions return only their remote output.

## Verification

- `cargo test -p homeboy-extension-contract --lib` (110 passed)
- `cargo test -p homeboy-core extension::invoke::` (85 passed)
- `cargo test -p homeboy-core action_api::tests` (3 passed)
- `cargo test -p homeboy-release` (564 passed)
- `cargo test -p homeboy-rig` (488 passed)
- `cargo test -p homeboy-cli commands::extension` (22 passed)
- `cargo check --workspace --tests`
- `cargo doc -p homeboy-extension-contract --no-deps`
- `cargo fmt --all -- --check`
- `git diff --check`

Known pre-existing warnings remain: the unused `Duration` import in core tests and `pending_for_subject` in release.

Fixes #14185
Parent #13882

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode audited current `main`, identified the advertised-but-bypassed action seam, implemented and verified the typed migration, and prepared this PR under Chris Huber's direction.