### PR TITLE
Collapse current runner submission onto Runner API

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/lab_handoff_reconciliation.rs
@@ -317,9 +317,9 @@ pub fn reconcile_pending_runner_submission_intent_in_store(
     }
     let cwd = replay.cwd().unwrap_or_default().to_string();
     let command = replay.command().to_vec();
-    match runner_continuation::with_runner_continuation(|provider| match replay {
+    let submission = match replay {
         PendingRunnerReplay::Envelope(request) => {
-            provider.submit_reverse_broker_envelope_job(&runner_id, request)
+            runner_continuation::RunnerContinuationSubmission::RunnerApi(request)
         }
         PendingRunnerReplay::Legacy(mut request) => {
             let mut metadata = request.metadata.take().unwrap_or_else(|| json!({}));
@@ -330,8 +330,11 @@ pub fn reconcile_pending_runner_submission_intent_in_store(
             metadata["durable_run_id"] = json!(run_id);
             metadata["reconciled_from"] = json!("durable_detached_handoff_intent");
             request.metadata = Some(metadata);
-            provider.submit_reverse_broker_job(&runner_id, request)
+            runner_continuation::RunnerContinuationSubmission::LegacyReplay(request)
         }
+    };
+    match runner_continuation::with_runner_continuation(|provider| {
+        provider.submit_runner_api_request(&runner_id, submission)
     }) {
         Ok(job) => {
             record_detached_lab_run_in_store(

--- a/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/mod.rs
@@ -94,7 +94,8 @@ pub use runner_continuation::{
 };
 pub use runner_continuation::{
     register_runner_continuation_provider, runner_authority, runner_live_job_authority,
-    RunnerAuthority, RunnerContinuationProvider, RunnerJobReconciliation, RunnerLiveJobAuthority,
+    RunnerAuthority, RunnerContinuationProvider, RunnerContinuationSubmission,
+    RunnerJobReconciliation, RunnerLiveJobAuthority,
 };
 pub use runner_exec::*;
 pub use workspace_authority::*;

--- a/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/runner_continuation.rs
@@ -56,6 +56,14 @@ pub enum RunnerLiveJobAuthority {
     Unknown,
 }
 
+/// One reverse-broker submission operation. Current callers use the Runner API;
+/// the legacy variant exists only to replay request-shaped durable records
+/// without changing their established idempotency fingerprint.
+pub enum RunnerContinuationSubmission {
+    RunnerApi(RunnerApiSubmitRequest),
+    LegacyReplay(RemoteRunnerJobRequest),
+}
+
 /// Runner-side operations the agent-task lifecycle needs when reconciling or
 /// resuming a run that was handed off to a remote runner.
 pub trait RunnerContinuationProvider: Send + Sync {
@@ -189,21 +197,11 @@ pub trait RunnerContinuationProvider: Send + Sync {
     ) -> Result<i32>;
 
     /// Submit a replayable reverse-broker request during lifecycle reconciliation.
-    fn submit_reverse_broker_job(
+    fn submit_runner_api_request(
         &self,
         runner_id: &str,
-        request: RemoteRunnerJobRequest,
+        submission: RunnerContinuationSubmission,
     ) -> Result<Job>;
-
-    fn submit_reverse_broker_envelope_job(
-        &self,
-        _runner_id: &str,
-        _request: RunnerApiSubmitRequest,
-    ) -> Result<Job> {
-        Err(Error::internal_unexpected(
-            "runner subsystem does not support Runner API envelope submission",
-        ))
-    }
 
     fn lookup_reverse_broker_submission(
         &self,
@@ -247,10 +245,10 @@ impl RunnerContinuationProvider for NoopProvider {
         ))
     }
 
-    fn submit_reverse_broker_job(
+    fn submit_runner_api_request(
         &self,
         _runner_id: &str,
-        _request: RemoteRunnerJobRequest,
+        _submission: RunnerContinuationSubmission,
     ) -> Result<Job> {
         Err(Error::internal_unexpected(
             "runner subsystem is unavailable: cannot submit reverse broker job",
@@ -400,10 +398,10 @@ mod tests {
             Err(Error::internal_unexpected("unused in fixture"))
         }
 
-        fn submit_reverse_broker_job(
+        fn submit_runner_api_request(
             &self,
             _runner_id: &str,
-            _request: RemoteRunnerJobRequest,
+            _submission: RunnerContinuationSubmission,
         ) -> Result<Job> {
             Err(Error::internal_unexpected("unused in fixture"))
         }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/handoff_and_proxy.rs
@@ -11,7 +11,7 @@ use crate::agent_task_scheduler::{
     AgentTaskAggregate, AgentTaskAggregateStatus, AgentTaskAggregateTotals,
     AGENT_TASK_AGGREGATE_SCHEMA,
 };
-use homeboy_core::api_jobs::{Job, RemoteRunnerJobRequest};
+use homeboy_core::api_jobs::Job;
 use homeboy_core::test_support::with_isolated_home;
 use sha2::{Digest, Sha256};
 use std::process::Command;
@@ -92,10 +92,10 @@ impl RunnerContinuationProvider for ReconciliationProvider {
         Err(Error::internal_unexpected("not used by reconciliation"))
     }
 
-    fn submit_reverse_broker_job(
+    fn submit_runner_api_request(
         &self,
         _runner_id: &str,
-        _request: RemoteRunnerJobRequest,
+        _submission: RunnerContinuationSubmission,
     ) -> Result<Job> {
         Err(Error::internal_unexpected("not used by reconciliation"))
     }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/mod.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/mod.rs
@@ -92,28 +92,19 @@ impl RunnerContinuationProvider for IntentReplayProvider {
         ))
     }
 
-    fn submit_reverse_broker_job(
+    fn submit_runner_api_request(
         &self,
         _runner_id: &str,
-        request: RemoteRunnerJobRequest,
+        submission: RunnerContinuationSubmission,
     ) -> Result<Job> {
-        let job = self.store.submit_remote_runner_job(request)?;
-        self.submitted.lock().expect("submission log").push(job.id);
-        let mut fail = self.fail_after_accept_once.lock().expect("fault flag");
-        if std::mem::take(&mut *fail) {
-            return Err(Error::internal_unexpected(
-                "injected post-accept pre-ack crash",
-            ));
-        }
-        Ok(job)
-    }
-
-    fn submit_reverse_broker_envelope_job(
-        &self,
-        _runner_id: &str,
-        request: homeboy_runner_contract::RunnerApiSubmitRequest,
-    ) -> Result<Job> {
-        let job = self.store.submit_runner_api_request(request)?;
+        let job = match submission {
+            RunnerContinuationSubmission::RunnerApi(request) => {
+                self.store.submit_runner_api_request(request)?
+            }
+            RunnerContinuationSubmission::LegacyReplay(request) => {
+                self.store.submit_remote_runner_job(request)?
+            }
+        };
         self.submitted.lock().expect("submission log").push(job.id);
         let mut fail = self.fail_after_accept_once.lock().expect("fault flag");
         if std::mem::take(&mut *fail) {
@@ -206,10 +197,10 @@ impl RunnerContinuationProvider for ConnectedRunnerProvider {
         ))
     }
 
-    fn submit_reverse_broker_job(
+    fn submit_runner_api_request(
         &self,
         _runner_id: &str,
-        _request: RemoteRunnerJobRequest,
+        _submission: RunnerContinuationSubmission,
     ) -> Result<Job> {
         Err(Error::internal_unexpected("no reverse broker job in test"))
     }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -8,7 +8,7 @@ use crate::agent_task_scheduler::{
     AGENT_TASK_AGGREGATE_SCHEMA,
 };
 use crate::agent_task_service::reconcile_stale_active_runs;
-use homeboy_core::api_jobs::{Job, JobEvent, JobEventKind, JobStore, RemoteRunnerJobRequest};
+use homeboy_core::api_jobs::{Job, JobEvent, JobEventKind, JobStore};
 use homeboy_core::test_support::with_isolated_home;
 use sha2::{Digest, Sha256};
 #[cfg(unix)]
@@ -3147,10 +3147,10 @@ impl RunnerContinuationProvider for CountingRunnerProvider {
         Err(Error::internal_unexpected("counted runner exec"))
     }
 
-    fn submit_reverse_broker_job(
+    fn submit_runner_api_request(
         &self,
         _runner_id: &str,
-        _request: RemoteRunnerJobRequest,
+        _submission: RunnerContinuationSubmission,
     ) -> Result<Job> {
         self.record();
         Err(Error::internal_unexpected("counted reverse broker job"))

--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/terminal_and_reconcile.rs
@@ -8,7 +8,7 @@ use crate::agent_task_scheduler::{
     AGENT_TASK_AGGREGATE_SCHEMA,
 };
 use crate::agent_task_service::{reconcile_run, reconcile_stale_active_runs};
-use homeboy_core::api_jobs::{Job, JobEventKind, RemoteRunnerJobRequest};
+use homeboy_core::api_jobs::{Job, JobEventKind};
 use homeboy_core::test_support::with_isolated_home;
 use sha2::Digest;
 use std::process::Command;
@@ -63,10 +63,10 @@ impl RunnerContinuationProvider for IdleRunnerFixture {
         Err(Error::internal_unexpected("not used by idle fixture"))
     }
 
-    fn submit_reverse_broker_job(
+    fn submit_runner_api_request(
         &self,
         _runner_id: &str,
-        _request: RemoteRunnerJobRequest,
+        _submission: RunnerContinuationSubmission,
     ) -> Result<Job> {
         Err(Error::internal_unexpected("not used by idle fixture"))
     }
@@ -242,10 +242,10 @@ impl RunnerContinuationProvider for TerminalSnapshotProvider {
         ))
     }
 
-    fn submit_reverse_broker_job(
+    fn submit_runner_api_request(
         &self,
         _runner_id: &str,
-        _request: RemoteRunnerJobRequest,
+        _submission: RunnerContinuationSubmission,
     ) -> Result<Job> {
         Err(Error::internal_unexpected(
             "not used by terminal reconciliation",
@@ -286,10 +286,10 @@ impl RunnerContinuationProvider for ServiceRunnerFixture {
         Ok(0)
     }
 
-    fn submit_reverse_broker_job(
+    fn submit_runner_api_request(
         &self,
         _runner_id: &str,
-        _request: RemoteRunnerJobRequest,
+        _submission: RunnerContinuationSubmission,
     ) -> Result<Job> {
         Err(Error::internal_unexpected("not used by service fixture"))
     }

--- a/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/workspace_claims.rs
@@ -1492,10 +1492,10 @@ mod tests {
             ))
         }
 
-        fn submit_reverse_broker_job(
+        fn submit_runner_api_request(
             &self,
             _runner_id: &str,
-            _request: homeboy_core::api_jobs::RemoteRunnerJobRequest,
+            _submission: RunnerContinuationSubmission,
         ) -> Result<homeboy_core::api_jobs::Job> {
             Err(Error::internal_unexpected(
                 "not used by workspace claim tests",

--- a/crates/homeboy-agents/src/agent_task_service/tests.rs
+++ b/crates/homeboy-agents/src/agent_task_service/tests.rs
@@ -3444,10 +3444,10 @@ impl agent_task_lifecycle::RunnerContinuationProvider for RunnerAuthorityFixture
         ))
     }
 
-    fn submit_reverse_broker_job(
+    fn submit_runner_api_request(
         &self,
         _runner_id: &str,
-        _request: homeboy_core::api_jobs::RemoteRunnerJobRequest,
+        _submission: crate::agent_task_lifecycle::RunnerContinuationSubmission,
     ) -> homeboy_core::Result<homeboy_core::api_jobs::Job> {
         Err(homeboy_core::Error::internal_unexpected(
             "unused in fixture",

--- a/crates/homeboy-lab-runner/src/connection.rs
+++ b/crates/homeboy-lab-runner/src/connection.rs
@@ -11,9 +11,10 @@ use reqwest::blocking::Client;
 use serde::Deserialize;
 use serde_json::Value;
 
+use homeboy_agents::agent_task_lifecycle::RunnerContinuationSubmission;
 use homeboy_core::api_jobs::{
-    ActiveRunnerJobSummary, Job, JobClaimMetadata, JobEventKind, JobStatus, RemoteRunnerJobRequest,
-    RemoteRunnerJobResult, RunnerJobSource,
+    ActiveRunnerJobSummary, Job, JobClaimMetadata, JobEventKind, JobStatus, RemoteRunnerJobResult,
+    RunnerJobSource,
 };
 use homeboy_core::daemon::{
     DaemonCandidateReconciliationResult, DaemonFreshnessReport, DaemonLeaselessRecoveryResult,
@@ -3300,21 +3301,45 @@ fn reconcile_terminal_jobs_for_session<T>(
 /// Submit a redacted, replayable request to a connected reverse broker. Secret
 /// values are intentionally absent: the worker resolves named references when
 /// it prepares the claimed process.
-pub fn submit_reverse_broker_job(runner_id: &str, request: RemoteRunnerJobRequest) -> Result<Job> {
-    if request.runner_id != runner_id {
+pub fn submit_runner_api_request(
+    runner_id: &str,
+    submission: RunnerContinuationSubmission,
+) -> Result<Job> {
+    let submitted_runner_id = match &submission {
+        RunnerContinuationSubmission::RunnerApi(request) => request
+            .envelope
+            .dispatch
+            .as_ref()
+            .ok_or_else(|| {
+                Error::validation_invalid_argument(
+                    "envelope.dispatch",
+                    "runner submission envelope requires dispatch",
+                    None,
+                    None,
+                )
+            })?
+            .runner_id
+            .as_str(),
+        RunnerContinuationSubmission::LegacyReplay(request) => request.runner_id.as_str(),
+    };
+    if submitted_runner_id != runner_id {
         return Err(Error::validation_invalid_argument(
             "runner_id",
-            "reverse broker submission runner does not match request runner",
+            "reverse broker submission runner does not match submitted runner",
             Some(runner_id.to_string()),
             None,
         ));
     }
     let broker_url = reverse_broker_url(runner_id)?;
     let client = broker_client("build reverse broker submission client")?;
-    let body = serde_json::to_value(&request).map_err(|error| {
+    let body = match &submission {
+        RunnerContinuationSubmission::RunnerApi(request) => serde_json::to_value(request),
+        RunnerContinuationSubmission::LegacyReplay(request) => serde_json::to_value(request),
+    }
+    .map_err(|error| {
         Error::internal_json(
             error.to_string(),
-            Some("serialize replayable reverse runner job".to_string()),
+            Some("serialize reverse runner submission".to_string()),
         )
     })?;
     let response = broker_http::post_json(
@@ -3322,55 +3347,7 @@ pub fn submit_reverse_broker_job(runner_id: &str, request: RemoteRunnerJobReques
         &broker_url,
         "/runner/jobs",
         body,
-        "replay reverse runner job submission",
-        broker_auth::broker_submit_token_for_runner(runner_id)?.as_deref(),
-    )?;
-    serde_json::from_value(
-        response.get("job").cloned().ok_or_else(|| {
-            Error::internal_unexpected("reverse broker submission returned no job")
-        })?,
-    )
-    .map_err(|error| {
-        Error::internal_json(
-            error.to_string(),
-            Some("parse replayed reverse runner job".to_string()),
-        )
-    })
-}
-
-pub fn submit_reverse_broker_envelope_job(
-    runner_id: &str,
-    request: homeboy_runner_contract::RunnerApiSubmitRequest,
-) -> Result<Job> {
-    let dispatch = request.envelope.dispatch.as_ref().ok_or_else(|| {
-        Error::validation_invalid_argument(
-            "envelope.dispatch",
-            "runner submission envelope requires dispatch",
-            None,
-            None,
-        )
-    })?;
-    if dispatch.runner_id != runner_id {
-        return Err(Error::validation_invalid_argument(
-            "runner_id",
-            "reverse broker submission runner does not match envelope runner",
-            Some(runner_id.to_string()),
-            None,
-        ));
-    }
-    let broker_url = reverse_broker_url(runner_id)?;
-    let client = broker_client("build reverse broker envelope submission client")?;
-    let response = broker_http::post_json(
-        &client,
-        &broker_url,
-        "/runner/jobs",
-        serde_json::to_value(request).map_err(|error| {
-            Error::internal_json(
-                error.to_string(),
-                Some("serialize envelope reverse runner job".to_string()),
-            )
-        })?,
-        "replay reverse runner envelope submission",
+        "replay reverse runner submission",
         broker_auth::broker_submit_token_for_runner(runner_id)?.as_deref(),
     )?;
     if let Some(value) = response.get("response") {
@@ -3392,13 +3369,15 @@ pub fn submit_reverse_broker_envelope_job(
             ));
         }
     }
-    serde_json::from_value(response.get("job").cloned().ok_or_else(|| {
-        Error::internal_unexpected("reverse broker envelope submission returned no job")
-    })?)
+    serde_json::from_value(
+        response.get("job").cloned().ok_or_else(|| {
+            Error::internal_unexpected("reverse broker submission returned no job")
+        })?,
+    )
     .map_err(|error| {
         Error::internal_json(
             error.to_string(),
-            Some("parse replayed envelope reverse runner job".to_string()),
+            Some("parse replayed reverse runner job".to_string()),
         )
     })
 }

--- a/crates/homeboy-lab-runner/src/continuation_provider.rs
+++ b/crates/homeboy-lab-runner/src/continuation_provider.rs
@@ -6,9 +6,10 @@
 //! execution, and evidence functions.
 
 use homeboy_agents::agent_task_lifecycle::{
-    RunnerAuthority, RunnerContinuationProvider, RunnerJobReconciliation, RunnerLiveJobAuthority,
+    RunnerAuthority, RunnerContinuationProvider, RunnerContinuationSubmission,
+    RunnerJobReconciliation, RunnerLiveJobAuthority,
 };
-use homeboy_core::api_jobs::{Job, RemoteRunnerJobRequest, RunnerJobLogSnapshot};
+use homeboy_core::api_jobs::{Job, RunnerJobLogSnapshot};
 use std::time::Duration;
 
 use reqwest::blocking::Client;
@@ -243,20 +244,12 @@ impl RunnerContinuationProvider for RunnerContinuation {
         Ok(exit_code)
     }
 
-    fn submit_reverse_broker_job(
+    fn submit_runner_api_request(
         &self,
         runner_id: &str,
-        request: RemoteRunnerJobRequest,
+        submission: RunnerContinuationSubmission,
     ) -> Result<Job> {
-        super::connection::submit_reverse_broker_job(runner_id, request)
-    }
-
-    fn submit_reverse_broker_envelope_job(
-        &self,
-        runner_id: &str,
-        request: homeboy_runner_contract::RunnerApiSubmitRequest,
-    ) -> Result<Job> {
-        super::connection::submit_reverse_broker_envelope_job(runner_id, request)
+        super::connection::submit_runner_api_request(runner_id, submission)
     }
 
     fn lookup_reverse_broker_submission(

--- a/crates/homeboy-lab-runner/src/execution/broker.rs
+++ b/crates/homeboy-lab-runner/src/execution/broker.rs
@@ -4,9 +4,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use base64::Engine;
-use homeboy_core::api_jobs::{
-    Job, RemoteRunnerJobRequest, RemoteRunnerSubmissionLookup, RunnerJobLifecycleMetadata,
-};
+use homeboy_core::api_jobs::{Job, RemoteRunnerSubmissionLookup, RunnerJobLifecycleMetadata};
 use homeboy_core::error::{Error, Result};
 use homeboy_core::lab_contract::LabRunnerWorkload;
 use homeboy_core::source_snapshot::SourceSnapshot;
@@ -69,51 +67,41 @@ pub(super) fn exec_via_reverse_broker(
             env.insert("HOMEBOY_COMMAND".to_string(), homeboy_path.to_string());
         }
     }
-    let mut request = RemoteRunnerJobRequest {
-        runner_id: runner.id.clone(),
-        project_id,
-        operation: "runner.exec".to_string(),
-        command: command.clone(),
-        cwd: Some(cwd.clone()),
-        env,
-        secret_env_names,
-        secret_env_plan: Default::default(),
-        env_materialization: None,
-        capture_patch,
-        source_snapshot: Some(source_snapshot.clone()),
-        path_materialization_plan: path_materialization_plan.clone(),
-        lab_runner_workload: lab_runner_workload.clone(),
-        metadata: Some({
-            let mut metadata =
-                runner_exec_request_metadata(run_id.as_deref(), "reverse_broker", &runner.id);
-            metadata["submission_key"] = serde_json::json!(run_id.as_deref().map_or_else(
-                || format!("reverse-broker:v1:{}:{}", runner.id, uuid::Uuid::new_v4()),
-                |run_id| reverse_broker_submission_key(&runner.id, run_id),
-            ));
-            metadata
-        }),
-        lifecycle: Some(RunnerJobLifecycleMetadata {
-            source: Some("reverse-broker".to_string()),
-            kind: Some("runner.exec".to_string()),
-            durable_run_id: run_id.clone(),
-            ..Default::default()
-        }),
-        workspace_claim_binding: None,
-        workspace_owner_lease: None,
-        require_paths: require_paths.clone(),
-        extension_env_providers,
-    };
+    let submission_key = run_id.as_deref().map_or_else(
+        || format!("reverse-broker:v1:{}:{}", runner.id, uuid::Uuid::new_v4()),
+        |run_id| reverse_broker_submission_key(&runner.id, run_id),
+    );
+    let mut metadata =
+        runner_exec_request_metadata(run_id.as_deref(), "reverse_broker", &runner.id);
+    metadata["submission_key"] = serde_json::json!(&submission_key);
     let command_assets = durable_command_assets(&command, path_materialization_plan.as_ref())?;
     if !command_assets.is_empty() {
-        request
-            .metadata
-            .as_mut()
-            .expect("reverse broker request metadata")["command_assets"] = serde_json::json!({
+        metadata["command_assets"] = serde_json::json!({
             "schema": "homeboy/reverse-runner-command-assets/v1",
             "assets": command_assets,
         });
     }
-    request.validate_durable_submission()?;
+    let envelope = runner_api_execution_envelope(RunnerApiExecutionInput {
+        runner_id: runner.id.clone(),
+        project_id,
+        command: command.clone(),
+        cwd: cwd.clone(),
+        env,
+        secret_env_names,
+        capture_patch,
+        source_snapshot: source_snapshot.clone(),
+        path_materialization_plan: path_materialization_plan.clone(),
+        workload: lab_runner_workload.clone(),
+        metadata,
+        lifecycle: RunnerJobLifecycleMetadata {
+            source: Some("reverse-broker".to_string()),
+            kind: Some("runner.exec".to_string()),
+            durable_run_id: run_id.clone(),
+            ..Default::default()
+        },
+        require_paths: require_paths.clone(),
+        extension_env_providers,
+    })?;
     persist_runner_execution_transition(
         &RunnerExecutionRecord::planned(
             format!("runner-exec:{}:reverse_broker", runner.id),
@@ -169,30 +157,13 @@ pub(super) fn exec_via_reverse_broker(
             Ok::<_, Error>(lease)
         })
         .transpose()?;
-    request.workspace_owner_lease = workspace_owner_lease.clone();
-    let envelope = request.execution_envelope();
-    let submission_key = request
-        .submission_key()
-        .ok_or_else(|| Error::internal_unexpected("reverse broker submission has no key"))?
-        .to_string();
     let submission = RunnerApiSubmitRequest {
         schema: RUNNER_API_SUBMIT_REQUEST_SCHEMA.to_string(),
         api_version: RUNNER_API_V1,
-        submission_key,
+        submission_key: submission_key.clone(),
         envelope,
-        workspace_claim_binding: request
-            .workspace_claim_binding
-            .as_ref()
-            .map(serde_json::to_value)
-            .transpose()
-            .map_err(|error| {
-                Error::internal_json(
-                    error.to_string(),
-                    Some("serialize workspace claim binding".to_string()),
-                )
-            })?,
-        workspace_owner_lease: request
-            .workspace_owner_lease
+        workspace_claim_binding: None,
+        workspace_owner_lease: workspace_owner_lease
             .as_ref()
             .map(serde_json::to_value)
             .transpose()
@@ -248,7 +219,7 @@ pub(super) fn exec_via_reverse_broker(
     let data = match data {
         Ok(data) => data,
         Err(error) => {
-            let submission_key = request.submission_key().map(str::to_string);
+            let submission_key = Some(submission_key.clone());
             let accepted =
                 submission_key.as_deref().map(|submission_key| {
                     broker_http::post_json(

--- a/crates/homeboy-lab-runner/src/execution/daemon.rs
+++ b/crates/homeboy-lab-runner/src/execution/daemon.rs
@@ -7,9 +7,7 @@ use reqwest::blocking::Client;
 use serde_json::{json, Value};
 
 use crate::agent_task_lifecycle_event::agent_task_run_plan_lifecycle_event_from_workload_result;
-use homeboy_core::api_jobs::{
-    Job, JobEvent, JobStatus, RemoteRunnerJobRequest, RunnerJobLifecycleMetadata,
-};
+use homeboy_core::api_jobs::{Job, JobEvent, JobStatus, RunnerJobLifecycleMetadata};
 use homeboy_core::daemon::{DirectDaemonExecSubmitRequest, WorkspaceOwnerRegisterRequest};
 use homeboy_core::engine::command::CommandCaptureMetadata;
 use homeboy_core::error::{Error, ErrorCode, Result};
@@ -115,36 +113,27 @@ pub(super) fn exec_via_daemon(
     let submission_key = run_id
         .clone()
         .unwrap_or_else(|| format!("direct-daemon:v1:{}:{}", runner.id, uuid::Uuid::new_v4()));
-    let request = RemoteRunnerJobRequest {
+    let envelope = runner_api_execution_envelope(RunnerApiExecutionInput {
         runner_id: runner.id.clone(),
         project_id,
-        operation: "runner.exec".to_string(),
         command: command.clone(),
-        cwd: Some(cwd.clone()),
+        cwd: cwd.clone(),
         env: env.clone(),
         secret_env_names: secret_env_names.clone(),
-        secret_env_plan: Default::default(),
-        env_materialization: None,
         capture_patch,
-        source_snapshot: Some(source_snapshot.clone()),
+        source_snapshot: source_snapshot.clone(),
         path_materialization_plan: path_materialization_plan.clone(),
         require_paths: require_paths.clone(),
         extension_env_providers: extension_env_providers.clone(),
-        lab_runner_workload: lab_runner_workload.clone(),
-        lifecycle: Some(lifecycle),
-        workspace_claim_binding: None,
-        workspace_owner_lease: None,
-        metadata: Some(runner_exec_request_metadata(
-            run_id.as_deref(),
-            "daemon",
-            &runner.id,
-        )),
-    };
+        workload: lab_runner_workload.clone(),
+        lifecycle,
+        metadata: runner_exec_request_metadata(run_id.as_deref(), "daemon", &runner.id),
+    })?;
     let submission = RunnerApiSubmitRequest {
         schema: RUNNER_API_SUBMIT_REQUEST_SCHEMA.to_string(),
         api_version: RUNNER_API_V1,
         submission_key,
-        envelope: request.execution_envelope(),
+        envelope,
         workspace_claim_binding: None,
         workspace_owner_lease: None,
     };

--- a/crates/homeboy-lab-runner/src/execution/mod.rs
+++ b/crates/homeboy-lab-runner/src/execution/mod.rs
@@ -66,6 +66,7 @@ mod process;
 mod recovery;
 pub(crate) mod redaction;
 mod secrets;
+mod submission;
 mod worker;
 
 #[cfg(test)]
@@ -94,6 +95,7 @@ use paths::*;
 use process::*;
 use redaction::*;
 use secrets::*;
+use submission::*;
 
 // Crate-internal surface consumed by sibling `runner` modules (evidence, worker,
 // lab_env, lab/offload) and re-exported by the parent `runner` module.

--- a/crates/homeboy-lab-runner/src/execution/submission.rs
+++ b/crates/homeboy-lab-runner/src/execution/submission.rs
@@ -1,0 +1,224 @@
+use std::collections::HashMap;
+
+use homeboy_core::api_jobs::RunnerJobLifecycleMetadata;
+use homeboy_core::error::{Error, Result};
+use homeboy_core::lab_contract::LabRunnerWorkload;
+use homeboy_core::runner_execution_envelope::{
+    PathMaterializationPlan, RunnerExecutionDispatch, RunnerExecutionEnvelope,
+    RunnerExecutionMutationPolicy, RunnerExecutionResultRefs,
+};
+use homeboy_core::source_snapshot::SourceSnapshot;
+use homeboy_lab_contract::lab::execution_envelope::runner_execution_envelope_from_workload;
+
+use super::{is_internal_control_env, runner_exec_secret_env_plan};
+
+pub(super) struct RunnerApiExecutionInput {
+    pub runner_id: String,
+    pub project_id: Option<String>,
+    pub command: Vec<String>,
+    pub cwd: String,
+    pub env: HashMap<String, String>,
+    pub secret_env_names: Vec<String>,
+    pub capture_patch: bool,
+    pub source_snapshot: SourceSnapshot,
+    pub path_materialization_plan: Option<PathMaterializationPlan>,
+    pub require_paths: Vec<String>,
+    pub extension_env_providers: Vec<String>,
+    pub workload: Option<LabRunnerWorkload>,
+    pub lifecycle: RunnerJobLifecycleMetadata,
+    pub metadata: serde_json::Value,
+}
+
+pub(super) fn runner_api_execution_envelope(
+    input: RunnerApiExecutionInput,
+) -> Result<RunnerExecutionEnvelope> {
+    let base_secret_env_plan = input
+        .workload
+        .as_ref()
+        .map(|workload| workload.required_secrets.secret_env_plan.clone())
+        .filter(|plan| *plan != Default::default());
+    let secret_env_plan = runner_exec_secret_env_plan(
+        &input.command,
+        None,
+        &input.secret_env_names,
+        &input.env,
+        base_secret_env_plan,
+    );
+    let inline_secret_names = secret_env_plan
+        .secret_env_names()
+        .into_iter()
+        .filter(|name| input.env.get(name).is_some_and(|value| !value.is_empty()))
+        .collect::<Vec<_>>();
+    if !inline_secret_names.is_empty() {
+        return Err(Error::validation_invalid_argument(
+            "env",
+            "durable reverse-runner jobs cannot accept inline secret env values",
+            Some("durable_reverse_runner_inline_secret_env".to_string()),
+            Some(vec![format!(
+                "Inline secret variables: {}",
+                inline_secret_names.join(", ")
+            )]),
+        ));
+    }
+
+    let envelope_id = input
+        .workload
+        .as_ref()
+        .map(|workload| workload.workload_id.clone())
+        .or_else(|| input.lifecycle.durable_run_id.clone())
+        .or_else(|| {
+            ["durable_run_id", "run_id", "record_run_id"]
+                .iter()
+                .find_map(|key| input.metadata.get(*key))
+                .and_then(serde_json::Value::as_str)
+                .map(str::trim)
+                .filter(|run_id| !run_id.is_empty())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| format!("remote-runner:{}:runner.exec", input.runner_id));
+    let mut envelope = input
+        .workload
+        .clone()
+        .map(runner_execution_envelope_from_workload)
+        .unwrap_or_else(|| {
+            RunnerExecutionEnvelope::planned(&envelope_id, "remote_runner_job_request")
+        });
+
+    envelope.envelope_id = envelope_id.clone();
+    envelope.source.kind = "remote_runner_job_request".to_string();
+    envelope.source.ref_id = Some(envelope_id);
+    envelope.secret_env = Some(secret_env_plan);
+    envelope.dispatch = Some(RunnerExecutionDispatch {
+        runner_id: input.runner_id,
+        project_id: input.project_id,
+        operation: "runner.exec".to_string(),
+        command: input.command,
+        cwd: Some(input.cwd),
+        env: input
+            .env
+            .into_iter()
+            .filter(|(name, _)| !is_internal_control_env(name))
+            .collect(),
+        source_snapshot: Some(input.source_snapshot),
+        require_paths: input.require_paths,
+        extension_env_providers: input.extension_env_providers,
+    });
+    envelope.metadata = input.metadata;
+    if let Some(path_materialization_plan) = input.path_materialization_plan {
+        if !envelope.metadata.is_object() {
+            envelope.metadata = serde_json::json!({});
+        }
+        envelope.metadata["path_materialization_plan"] =
+            serde_json::to_value(path_materialization_plan).unwrap_or(serde_json::Value::Null);
+    }
+    envelope.lifecycle = Some(input.lifecycle);
+    envelope.mutation_policy = RunnerExecutionMutationPolicy {
+        capture_patch: input.capture_patch,
+        ..envelope.mutation_policy.clone()
+    };
+    if envelope.result_refs.run_id.is_none() {
+        envelope.result_refs.run_id = envelope
+            .lifecycle
+            .as_ref()
+            .and_then(|lifecycle| lifecycle.durable_run_id.clone())
+            .or_else(|| {
+                ["durable_run_id", "run_id", "record_run_id"]
+                    .iter()
+                    .find_map(|key| envelope.metadata.get(*key))
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::trim)
+                    .filter(|run_id| !run_id.is_empty())
+                    .map(str::to_string)
+            });
+    }
+    if envelope.result_refs.artifacts.is_empty() {
+        if let Some(workload) = input.workload.as_ref() {
+            envelope.result_refs = RunnerExecutionResultRefs {
+                artifacts: workload.result_refs.artifacts.clone(),
+                ..envelope.result_refs
+            };
+        }
+    }
+    Ok(envelope)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use homeboy_core::api_jobs::RemoteRunnerJobRequest;
+
+    #[test]
+    fn canonical_execution_input_preserves_the_legacy_envelope_projection() {
+        let source_snapshot = homeboy_core::source_snapshot::existing_remote(
+            "homeboy-lab",
+            "/runner/workspace",
+            Some("/runner"),
+        );
+        let lifecycle = RunnerJobLifecycleMetadata {
+            source: Some("reverse-broker".to_string()),
+            kind: Some("runner.exec".to_string()),
+            durable_run_id: Some("run-17".to_string()),
+            ..Default::default()
+        };
+        let command = vec!["homeboy".to_string(), "status".to_string()];
+        let env = HashMap::from([
+            ("HOMEBOY_COMMAND".to_string(), "/runner/homeboy".to_string()),
+            (
+                "HOMEBOY_RUNNER_PLACEMENT_RESOLVED".to_string(),
+                "1".to_string(),
+            ),
+        ]);
+        let metadata = serde_json::json!({
+            "submission_key": "agent-task:v1:homeboy-lab:run-17",
+            "command_assets": { "schema": "homeboy/reverse-runner-command-assets/v1", "assets": [] },
+        });
+        let expected = RemoteRunnerJobRequest {
+            runner_id: "homeboy-lab".to_string(),
+            project_id: Some("project".to_string()),
+            operation: "runner.exec".to_string(),
+            command: command.clone(),
+            cwd: Some("/runner/workspace".to_string()),
+            env: env.clone(),
+            secret_env_names: vec!["RUNNER_TOKEN".to_string()],
+            secret_env_plan: runner_exec_secret_env_plan(
+                &command,
+                None,
+                &["RUNNER_TOKEN".to_string()],
+                &env,
+                None,
+            ),
+            env_materialization: None,
+            capture_patch: true,
+            source_snapshot: Some(source_snapshot.clone()),
+            path_materialization_plan: None,
+            require_paths: vec![".git".to_string()],
+            extension_env_providers: vec!["provider".to_string()],
+            lab_runner_workload: None,
+            lifecycle: Some(lifecycle.clone()),
+            workspace_claim_binding: None,
+            workspace_owner_lease: None,
+            metadata: Some(metadata.clone()),
+        }
+        .execution_envelope();
+
+        let actual = runner_api_execution_envelope(RunnerApiExecutionInput {
+            runner_id: "homeboy-lab".to_string(),
+            project_id: Some("project".to_string()),
+            command,
+            cwd: "/runner/workspace".to_string(),
+            env,
+            secret_env_names: vec!["RUNNER_TOKEN".to_string()],
+            capture_patch: true,
+            source_snapshot,
+            path_materialization_plan: None,
+            require_paths: vec![".git".to_string()],
+            extension_env_providers: vec!["provider".to_string()],
+            workload: None,
+            lifecycle,
+            metadata,
+        })
+        .expect("canonical envelope");
+
+        assert_eq!(actual, expected);
+    }
+}

--- a/crates/homeboy-lab-runner/src/lib.rs
+++ b/crates/homeboy-lab-runner/src/lib.rs
@@ -350,7 +350,7 @@ pub use connection::{
     persisted_status, persisted_status_until, persisted_statuses, reconcile_status,
     reconcile_status_with_outcome, reconcile_terminal_jobs, reconnect_job_log_owner,
     reverse_broker_artifact, reverse_broker_artifact_content, reverse_broker_reconcile,
-    runner_artifact_content, status, statuses, statuses_indexed, submit_reverse_broker_job,
+    runner_artifact_content, status, statuses, statuses_indexed, submit_runner_api_request,
     PeerSessionMaintenanceReport,
 };
 pub(crate) use connection::{

--- a/crates/homeboy-lab-runner/src/runner_staging_store.rs
+++ b/crates/homeboy-lab-runner/src/runner_staging_store.rs
@@ -1024,33 +1024,44 @@ impl homeboy_core::daemon::runner_staging::RunnerStagingProvider for ProductionS
         let receipt = transport
             .store
             .stage_durable_with_submit(&request.envelope, |envelope| {
-                let job = jobs.submit_remote_runner_job(
-                    homeboy_core::api_jobs::RemoteRunnerJobRequest {
-                        runner_id: envelope.handoff.runner_id.clone(),
-                        project_id: None,
-                        operation: "runner_staged_execution".to_string(),
-                        command: envelope.handoff.recipe.normalized_args.clone(),
-                        cwd: workspace
-                            .as_ref()
-                            .map(|workspace| workspace.remote_cwd.clone()),
-                        env: std::collections::HashMap::new(),
-                        secret_env_names: Vec::new(),
-                        secret_env_plan: Default::default(),
-                        env_materialization: None,
-                        capture_patch: envelope.handoff.recipe.capture_patch,
-                        source_snapshot: None,
-                        path_materialization_plan: None,
-                        require_paths: Vec::new(),
-                        extension_env_providers: Vec::new(),
-                        lab_runner_workload: None,
-                        lifecycle: None,
+                let submission_key = envelope.handoff.idempotency_key.clone();
+                let envelope_id = format!(
+                    "remote-runner:{}:runner_staged_execution",
+                    envelope.handoff.runner_id
+                );
+                let mut execution = homeboy_runner_contract::RunnerExecutionEnvelope::planned(
+                    &envelope_id,
+                    "remote_runner_job_request",
+                );
+                execution.source.ref_id = Some(envelope_id);
+                execution.dispatch = Some(homeboy_runner_contract::RunnerExecutionDispatch {
+                    runner_id: envelope.handoff.runner_id.clone(),
+                    project_id: None,
+                    operation: "runner_staged_execution".to_string(),
+                    command: envelope.handoff.recipe.normalized_args.clone(),
+                    cwd: workspace
+                        .as_ref()
+                        .map(|workspace| workspace.remote_cwd.clone()),
+                    env: Default::default(),
+                    source_snapshot: None,
+                    require_paths: Vec::new(),
+                    extension_env_providers: Vec::new(),
+                });
+                execution.metadata = serde_json::json!({
+                    "submission_key": submission_key,
+                    "staged_source_artifact": source_artifact,
+                    "staged_workspace_materialization": workspace,
+                });
+                execution.mutation_policy.capture_patch = envelope.handoff.recipe.capture_patch;
+                let job = jobs.submit_runner_api_request(
+                    homeboy_runner_contract::RunnerApiSubmitRequest {
+                        schema: homeboy_runner_contract::RUNNER_API_SUBMIT_REQUEST_SCHEMA
+                            .to_string(),
+                        api_version: homeboy_runner_contract::RUNNER_API_V1,
+                        submission_key,
+                        envelope: execution,
                         workspace_claim_binding: None,
                         workspace_owner_lease: None,
-                        metadata: Some(serde_json::json!({
-                            "submission_key": envelope.handoff.idempotency_key,
-                            "staged_source_artifact": source_artifact,
-                            "staged_workspace_materialization": workspace,
-                        })),
                     },
                 )?;
                 Ok(job.id.to_string())


### PR DESCRIPTION
## Summary
- construct canonical Runner API envelopes directly for daemon, reverse-broker, and staged execution
- collapse continuation submission onto one Runner API provider operation while retaining an explicit legacy durable-replay variant
- preserve authority sidecars, old wire and persisted request decoding, and protocol-v1 worker projection

Closes #14184

## Verification
- `cargo fmt --all -- --check`
- `cargo check -p homeboy-agents -p homeboy-lab-runner --all-targets --locked`
- `cargo test -p homeboy-agents agent_task_lifecycle::tests --lib --locked` (276 passed)
- `cargo test -p homeboy-lab-runner execution::tests --lib --locked` (133 passed)
- `cargo test -p homeboy-lab-runner runner_staging_store::tests --lib --locked` (9 passed)
- `cargo test -p homeboy-lab-runner worker::tests --lib --locked` (37 passed)
- Homeboy changed-file audit: zero introduced findings
- independent review: no actionable findings

The broader connection suite retains four existing recovery-fixture failures in untouched recovery code; 164 connection tests passed.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode inspected the runner submission paths, implemented the canonical input refactor, added envelope-equivalence coverage, ran the verification and compatibility audits, and coordinated an independent review. Chris Huber directed the architecture and scope.