### PR TITLE
Refactor runner records to one canonical envelope

### DIFF
--- a/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
+++ b/crates/homeboy-agents/src/agent_task_lifecycle/tests/status_and_recovery.rs
@@ -1202,7 +1202,7 @@ fn pending_submission_owns_running_proxy_until_job_projection_arrives() {
         record_lab_offload_submission_request(run_id, &request)
             .expect("persist pending broker request");
         let accepted_job = store
-            .submit_remote_runner_job(request)
+            .submit_runner_api_fixture(request)
             .expect("broker accepts before response projection");
         rewrite_record_for_test(run_id, |record| {
             set_run_state(record, AgentTaskRunState::Running);
@@ -1445,7 +1445,7 @@ fn expired_or_cancelled_pending_submission_binds_and_cancels_the_accepted_job() 
             let request = replay_request(run_id, &command);
             record_lab_offload_submission_request(run_id, &request).expect("pending request");
             let job = store
-                .submit_remote_runner_job(request)
+                .submit_runner_api_fixture(request)
                 .expect("accepted broker job");
 
             if run_id == "accepted-then-expired" {

--- a/crates/homeboy-core/src/api_jobs/persistence.rs
+++ b/crates/homeboy-core/src/api_jobs/persistence.rs
@@ -359,10 +359,7 @@ pub(super) fn read_durable_store(path: &Path) -> Result<DurableJobStore> {
     let content = fs::read_to_string(path)
         .map_err(|e| Error::internal_io(e.to_string(), Some(format!("read {}", path.display()))))?;
     match serde_json::from_str::<DurableJobStore>(&content) {
-        Ok(store) => {
-            super::remote_runner::validate_stored_remote_runner_jobs(&store.jobs)?;
-            Ok(store)
-        }
+        Ok(store) => Ok(store),
         Err(err) => {
             let quarantine_path = path.with_file_name(format!(
                 "{}.corrupt-{}",
@@ -676,9 +673,8 @@ pub(super) fn stale_after_restart_classification(stored: &StoredJob) -> Value {
     let remote_envelope = stored
         .remote_runner
         .as_ref()
-        .and_then(|remote_runner| remote_runner.envelope().ok());
+        .map(|remote_runner| &remote_runner.envelope);
     let linked_agent_task_run_id = remote_envelope
-        .as_ref()
         .and_then(|envelope| {
             lab_runner_workload_from_execution_envelope(envelope)
                 .ok()

--- a/crates/homeboy-core/src/api_jobs/remote_runner.rs
+++ b/crates/homeboy-core/src/api_jobs/remote_runner.rs
@@ -619,12 +619,9 @@ impl RemoteRunnerJobResult {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub(super) struct StoredRemoteRunnerJob {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(super) envelope: Option<RunnerExecutionEnvelope>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(super) request: Option<RemoteRunnerJobRequest>,
+    pub(super) envelope: RunnerExecutionEnvelope,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) workspace_claim_binding: Option<crate::workspace_claim::WorkspaceClaimBinding>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -640,6 +637,73 @@ pub(super) struct StoredRemoteRunnerJob {
     pub(super) execution_receipt: Option<RemoteRunnerExecutionReceipt>,
 }
 
+#[derive(Deserialize)]
+struct StoredRemoteRunnerJobCompat {
+    #[serde(default)]
+    envelope: Option<RunnerExecutionEnvelope>,
+    #[serde(default)]
+    request: Option<RemoteRunnerJobRequest>,
+    #[serde(default)]
+    workspace_claim_binding: Option<crate::workspace_claim::WorkspaceClaimBinding>,
+    #[serde(default)]
+    workspace_owner_lease: Option<crate::workspace_claim::WorkspaceOwnerLease>,
+    #[serde(default)]
+    execution_context_id: Option<String>,
+    #[serde(default)]
+    execution_receipt: Option<RemoteRunnerExecutionReceipt>,
+}
+
+impl<'de> Deserialize<'de> for StoredRemoteRunnerJob {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let stored = StoredRemoteRunnerJobCompat::deserialize(deserializer)?;
+        let (envelope, legacy_claim_binding, legacy_owner_lease) =
+            match (stored.envelope, stored.request) {
+                (Some(envelope), None) => (envelope, None, None),
+                (None, Some(request)) => {
+                    let claim_binding = request.workspace_claim_binding.clone();
+                    let owner_lease = request.workspace_owner_lease.clone();
+                    (request.execution_envelope(), claim_binding, owner_lease)
+                }
+                (Some(_), Some(_)) => {
+                    return Err(serde::de::Error::custom(
+                    "remote runner job has conflicting envelope and legacy request representations",
+                ));
+                }
+                (None, None) => {
+                    return Err(serde::de::Error::custom(
+                        "remote runner job has no execution representation",
+                    ));
+                }
+            };
+        if stored.workspace_claim_binding.is_some()
+            && legacy_claim_binding.is_some()
+            && stored.workspace_claim_binding != legacy_claim_binding
+        {
+            return Err(serde::de::Error::custom(
+                "legacy runner record has conflicting workspace claim authority",
+            ));
+        }
+        if stored.workspace_owner_lease.is_some()
+            && legacy_owner_lease.is_some()
+            && stored.workspace_owner_lease != legacy_owner_lease
+        {
+            return Err(serde::de::Error::custom(
+                "legacy runner record has conflicting workspace owner authority",
+            ));
+        }
+        Ok(Self {
+            envelope,
+            workspace_claim_binding: stored.workspace_claim_binding.or(legacy_claim_binding),
+            workspace_owner_lease: stored.workspace_owner_lease.or(legacy_owner_lease),
+            execution_context_id: stored.execution_context_id,
+            execution_receipt: stored.execution_receipt,
+        })
+    }
+}
+
 struct RemoteRunnerAdmission {
     operation: String,
     runner_id: String,
@@ -653,67 +717,20 @@ struct RemoteRunnerAdmission {
 }
 
 impl StoredRemoteRunnerJob {
-    pub(super) fn validate_representation(&self) -> Result<()> {
-        match (self.envelope.is_some(), self.request.is_some()) {
-            (true, false) | (false, true) => Ok(()),
-            (true, true) => Err(Error::internal_unexpected(
-                "remote runner job has conflicting envelope and legacy request representations",
-            )),
-            (false, false) => Err(Error::internal_unexpected(
-                "remote runner job has no execution representation",
-            )),
-        }
-    }
-
-    pub(super) fn request(&self) -> Result<RemoteRunnerJobRequest> {
-        self.validate_representation()?;
-        if let Some(request) = &self.request {
-            return Ok(request.clone());
-        }
-        self.envelope
-            .as_ref()
-            .ok_or_else(|| {
-                Error::internal_unexpected("remote runner job has no execution representation")
-            })
-            .and_then(legacy_request_from_envelope)
-    }
-
-    pub(super) fn envelope(&self) -> Result<RunnerExecutionEnvelope> {
-        self.validate_representation()?;
-        self.envelope
-            .clone()
-            .or_else(|| {
-                self.request
-                    .as_ref()
-                    .map(RemoteRunnerJobRequest::execution_envelope)
-            })
-            .ok_or_else(|| {
-                Error::internal_unexpected("remote runner job has no execution representation")
-            })
+    pub(super) fn protocol_v1_request(&self) -> Result<RemoteRunnerJobRequest> {
+        legacy_request_from_envelope(&self.envelope)
     }
 
     pub(super) fn workspace_owner_lease(
         &self,
     ) -> Option<crate::workspace_claim::WorkspaceOwnerLease> {
-        if self.envelope.is_some() {
-            self.workspace_owner_lease.clone()
-        } else {
-            self.request
-                .as_ref()
-                .and_then(|request| request.workspace_owner_lease.clone())
-        }
+        self.workspace_owner_lease.clone()
     }
 
     pub(super) fn workspace_claim_binding(
         &self,
     ) -> Option<crate::workspace_claim::WorkspaceClaimBinding> {
-        if self.envelope.is_some() {
-            self.workspace_claim_binding.clone()
-        } else {
-            self.request
-                .as_ref()
-                .and_then(|request| request.workspace_claim_binding.clone())
-        }
+        self.workspace_claim_binding.clone()
     }
 
     pub(super) fn replace_workspace_owner_lease(
@@ -721,31 +738,16 @@ impl StoredRemoteRunnerJob {
         expected: Option<&crate::workspace_claim::WorkspaceOwnerLease>,
         renewed: Option<crate::workspace_claim::WorkspaceOwnerLease>,
     ) -> Result<()> {
-        self.validate_representation()?;
-        if self.envelope.is_some() {
-            if self.workspace_owner_lease.as_ref() != expected {
-                return Err(Error::validation_invalid_argument(
-                    "workspace_owner_lease",
-                    "heartbeat owner lease does not match the durable job",
-                    None,
-                    None,
-                ));
-            }
-            self.workspace_owner_lease = renewed;
-            return Ok(());
+        if self.workspace_owner_lease.as_ref() != expected {
+            return Err(Error::validation_invalid_argument(
+                "workspace_owner_lease",
+                "heartbeat owner lease does not match the durable job",
+                None,
+                None,
+            ));
         }
-        if let Some(request) = self.request.as_mut() {
-            if request.workspace_owner_lease.as_ref() == expected {
-                request.workspace_owner_lease = renewed;
-                return Ok(());
-            }
-        }
-        Err(Error::validation_invalid_argument(
-            "workspace_owner_lease",
-            "heartbeat owner lease does not match the durable job",
-            None,
-            None,
-        ))
+        self.workspace_owner_lease = renewed;
+        Ok(())
     }
 }
 
@@ -789,17 +791,6 @@ pub fn runner_api_submission_payload_fingerprint(
         )
     })?;
     Ok(format!("sha256:{}", content_hash::sha256_hex(&bytes)))
-}
-
-pub(super) fn validate_stored_remote_runner_jobs(
-    jobs: impl IntoIterator<Item = impl std::borrow::Borrow<StoredJob>>,
-) -> Result<()> {
-    for stored in jobs {
-        if let Some(remote) = stored.borrow().remote_runner.as_ref() {
-            remote.validate_representation()?;
-        }
-    }
-    Ok(())
 }
 
 fn legacy_request_from_envelope(
@@ -902,12 +893,10 @@ impl JobStore {
             .jobs
             .get(&job_id)
             .ok_or_else(|| job_not_found(job_id))?;
-        Ok(stored.remote_runner.as_ref().and_then(|remote| {
-            remote
-                .workspace_claim_binding
-                .clone()
-                .or_else(|| remote.request().ok()?.workspace_claim_binding)
-        }))
+        Ok(stored
+            .remote_runner
+            .as_ref()
+            .and_then(|remote| remote.workspace_claim_binding.clone()))
     }
 
     pub fn remote_runner_workspace_owner_lease(
@@ -945,10 +934,40 @@ impl JobStore {
         RemoteRunnerSubmissionLookup::Absent
     }
 
-    /// Legacy request admission retained only for existing persisted intents and
-    /// callers that have not migrated to the envelope-first Runner API.
+    /// Test-only alias for compatibility fixtures. Shipped legacy wire decoding
+    /// enters through the crate-private method below.
+    #[cfg(any(test, feature = "test-support"))]
     pub fn submit_remote_runner_job(&self, request: RemoteRunnerJobRequest) -> Result<Job> {
-        self.submit_remote_runner_job_inner(request)
+        self.submit_legacy_remote_runner_job(request)
+    }
+
+    /// Submits existing request fixtures through the canonical Runner API.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn submit_runner_api_fixture(&self, request: RemoteRunnerJobRequest) -> Result<Job> {
+        let submission_key = request
+            .submission_key()
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("test:runner-api:{}", Uuid::new_v4()));
+        let workspace_claim_binding = request
+            .workspace_claim_binding
+            .as_ref()
+            .map(serde_json::to_value)
+            .transpose()
+            .map_err(|error| Error::internal_json(error.to_string(), None))?;
+        let workspace_owner_lease = request
+            .workspace_owner_lease
+            .as_ref()
+            .map(serde_json::to_value)
+            .transpose()
+            .map_err(|error| Error::internal_json(error.to_string(), None))?;
+        self.submit_runner_api_request(RunnerApiSubmitRequest {
+            schema: RUNNER_API_SUBMIT_REQUEST_SCHEMA.to_string(),
+            api_version: RUNNER_API_V1,
+            submission_key,
+            envelope: request.execution_envelope(),
+            workspace_claim_binding,
+            workspace_owner_lease,
+        })
     }
 
     pub fn submit_runner_api_request(&self, submission: RunnerApiSubmitRequest) -> Result<Job> {
@@ -1068,8 +1087,7 @@ impl JobStore {
                 submission_key: Some(submission.submission_key),
                 submission_fingerprint: Some(fingerprint),
                 stored_remote_runner: StoredRemoteRunnerJob {
-                    envelope: Some(envelope),
-                    request: None,
+                    envelope,
                     workspace_claim_binding,
                     workspace_owner_lease,
                     execution_context_id: None,
@@ -1080,7 +1098,10 @@ impl JobStore {
         )
     }
 
-    fn submit_remote_runner_job_inner(&self, mut request: RemoteRunnerJobRequest) -> Result<Job> {
+    pub(crate) fn submit_legacy_remote_runner_job(
+        &self,
+        mut request: RemoteRunnerJobRequest,
+    ) -> Result<Job> {
         if request.runner_id.trim().is_empty() {
             return Err(Error::validation_invalid_argument(
                 "runner_id",
@@ -1124,6 +1145,7 @@ impl JobStore {
             .as_ref()
             .map(|_| request.submission_payload_fingerprint())
             .transpose()?;
+        let envelope = public_request.execution_envelope();
         let admission = RemoteRunnerAdmission {
             operation: request.operation.clone(),
             runner_id: request.runner_id.clone(),
@@ -1134,10 +1156,9 @@ impl JobStore {
             submission_key,
             submission_fingerprint,
             stored_remote_runner: StoredRemoteRunnerJob {
-                envelope: None,
-                request: Some(public_request),
-                workspace_claim_binding: None,
-                workspace_owner_lease: None,
+                envelope,
+                workspace_claim_binding: public_request.workspace_claim_binding,
+                workspace_owner_lease: public_request.workspace_owner_lease,
                 execution_context_id: None,
                 execution_receipt: None,
             },
@@ -1450,13 +1471,13 @@ impl JobStore {
                         .remote_runner
                         .as_ref()
                         .expect("filtered remote runner job has request");
-                    let envelope = remote_runner.envelope()?;
+                    let envelope = remote_runner.envelope.clone();
                     let workspace_claim_binding = remote_runner.workspace_claim_binding();
                     let workspace_owner_lease = remote_runner.workspace_owner_lease();
                     let request = execution_protocol
                         .is_none_or(|protocol| !protocol.uses_envelope_only_claim())
                         .then(|| {
-                            let mut request = remote_runner.request()?.dispatch_request();
+                            let mut request = remote_runner.protocol_v1_request()?.dispatch_request();
                             request.workspace_claim_binding = workspace_claim_binding.clone();
                             request.workspace_owner_lease = workspace_owner_lease.clone();
                             Ok::<RemoteRunnerJobRequest, Error>(request)
@@ -1770,7 +1791,7 @@ impl JobStore {
                         "runner execution receipt was already consumed",
                     ));
                 }
-                let envelope = remote_runner.envelope()?;
+                let envelope = remote_runner.envelope.clone();
                 let expected =
                     crate::runner_job_execution_context::RunnerJobExecutionContext::from_claim(
                         &stored.job,

--- a/crates/homeboy-core/src/api_jobs/store/mod.rs
+++ b/crates/homeboy-core/src/api_jobs/store/mod.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 use std::thread::{self, JoinHandle};
 
 use fs4::fs_std::FileExt;
+use homeboy_lab_contract::lab::execution_envelope::lab_runner_workload_from_execution_envelope;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -334,7 +335,6 @@ impl JobStore {
         inner: &mut JobStoreInner,
     ) -> Result<()> {
         let durable = read_durable_store(path)?;
-        remote_runner::validate_stored_remote_runner_jobs(&durable.jobs)?;
         let next_sequence = durable
             .jobs
             .iter()
@@ -733,7 +733,6 @@ impl JobStore {
         prepare_tombstone_store(&path)?;
         let mut durable: DurableJobStore = serde_json::from_slice(raw)
             .map_err(|err| Error::config_invalid_json(path.display().to_string(), err))?;
-        remote_runner::validate_stored_remote_runner_jobs(&durable.jobs)?;
         let event_retention_limit = event_retention_limit.max(1);
         let terminal_job_retention_limit = terminal_job_retention_limit.max(1);
         let terminal_job_retention_bytes = terminal_job_retention_bytes.max(1);
@@ -3039,9 +3038,7 @@ fn stored_job_durable_run_id(stored: &StoredJob) -> Option<String> {
     stored
         .remote_runner
         .as_ref()
-        .and_then(|remote| remote.request().ok())
-        .and_then(|request| request.lifecycle)
-        .as_ref()
+        .and_then(|remote| remote.envelope.lifecycle.as_ref())
         .or_else(|| {
             stored
                 .local_runner
@@ -3072,10 +3069,12 @@ fn recovered_terminal_agent_task_result(stored: &StoredJob) -> Option<RecoveredT
     let run_id = stored
         .remote_runner
         .as_ref()
-        .and_then(|remote| remote.request().ok())
-        .and_then(|request| request.lab_runner_workload)
-        .as_ref()
-        .and_then(|workload| workload.agent_task.as_ref())
+        .and_then(|remote| {
+            lab_runner_workload_from_execution_envelope(&remote.envelope)
+                .ok()
+                .flatten()
+        })
+        .and_then(|workload| workload.agent_task)
         .map(|agent_task| agent_task.run_id.trim().to_string())
         .or_else(|| {
             stored

--- a/crates/homeboy-core/src/api_jobs/store/reconciliation.rs
+++ b/crates/homeboy-core/src/api_jobs/store/reconciliation.rs
@@ -478,9 +478,7 @@ impl JobStore {
                 stored
                     .remote_runner
                     .as_ref()
-                    .and_then(|remote| remote.request().ok())
-                    .and_then(|request| request.lifecycle)
-                    .as_ref()
+                    .and_then(|remote| remote.envelope.lifecycle.as_ref())
                     .and_then(|lifecycle| lifecycle.durable_run_id.clone())
                     .map(LinkedDurableRunResolution::Unresolved)
                     .unwrap_or(LinkedDurableRunResolution::None)
@@ -995,7 +993,7 @@ impl JobStore {
                     .map(|remote| {
                         super::super::summary::active_runner_job_summary(
                             &stored.job,
-                            &remote.envelope().expect("remote runner representation"),
+                            &remote.envelope,
                             now,
                         )
                     })
@@ -1048,10 +1046,10 @@ impl JobStore {
                 stored.job.status == JobStatus::Failed && stored.job.stale_reason.is_some()
             })
             .filter_map(|stored| {
-                let envelope = stored.remote_runner.as_ref()?.envelope().ok()?;
+                let envelope = &stored.remote_runner.as_ref()?.envelope;
                 Some(super::super::summary::active_runner_job_summary(
                     &stored.job,
-                    &envelope,
+                    envelope,
                     now,
                 ))
             })

--- a/crates/homeboy-core/src/api_jobs/tests/part_b.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_b.rs
@@ -18,7 +18,7 @@ fn remote_runner_submission_lookup_is_non_mutating() {
     let mut request = remote_runner_request("homeboy-lab", None);
     request.metadata = Some(json!({ "submission_key": "lookup-key" }));
     let accepted = store
-        .submit_remote_runner_job(request)
+        .submit_runner_api_fixture(request)
         .expect("accept runner submission");
 
     let lookup = store.lookup_remote_runner_submission("lookup-key");
@@ -41,7 +41,7 @@ fn confirmed_recovery_fails_closed_for_unresolved_linked_durable_run() {
         active_cell_count: None,
     });
     let job = store
-        .submit_remote_runner_job(request)
+        .submit_runner_api_fixture(request)
         .expect("queue linked job");
 
     let error = store
@@ -734,7 +734,7 @@ fn leaseless_recovery_fails_before_historical_mutation_when_unowned_work_is_ambi
 fn leaseless_recovery_preserves_queued_remote_jobs_and_expires_claims_through_broker() {
     let queued = JobStore::default().with_daemon_lease("lease-remote".to_string());
     let queued_job = queued
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", None))
         .expect("queue remote job");
 
     let preserved = queued
@@ -749,7 +749,7 @@ fn leaseless_recovery_preserves_queued_remote_jobs_and_expires_claims_through_br
 
     let expired = JobStore::default().with_daemon_lease("lease-expired".to_string());
     let expired_job = expired
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", None))
         .expect("queue remote job");
     expired
         .claim_remote_runner_job("homeboy-lab", None, 1, None)
@@ -797,7 +797,7 @@ fn durable_store_stale_restart_classification_preserves_last_child_evidence() {
     let path = temp.path().join("jobs.json");
     let store = JobStore::open(&path).expect("durable store opens");
     let job = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", Some("extrachill")))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", Some("extrachill")))
         .expect("remote runner job queues");
     let claim = store
         .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, None)
@@ -1278,7 +1278,7 @@ fn oversized_terminal_result_remains_observable_when_it_exceeds_the_byte_budget(
 fn remote_runner_job_submit_targets_runner_and_project() {
     let store = JobStore::default();
     let job = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", Some("extrachill")))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", Some("extrachill")))
         .expect("remote runner job queues");
 
     assert_eq!(job.status, JobStatus::Queued);
@@ -1289,7 +1289,17 @@ fn remote_runner_job_submit_targets_runner_and_project() {
 
     let events = store.events(job.id).expect("events are readable");
     assert_eq!(events[0].kind, JobEventKind::Status);
-    assert_eq!(events[0].data, Some(json!({ "status": "queued" })));
+    assert_eq!(
+        events[0].data.as_ref().map(|data| &data["status"]),
+        Some(&json!("queued"))
+    );
+    assert_eq!(
+        events[0]
+            .data
+            .as_ref()
+            .map(|data| &data["submission"]["decision"]),
+        Some(&json!("new"))
+    );
 }
 
 #[test]
@@ -1308,7 +1318,7 @@ fn remote_runner_job_rejects_inline_secret_env_before_durable_persistence() {
     request.secret_env_names = vec!["RUNNER_SECRET_TOKEN".to_string()];
 
     let error = store
-        .submit_remote_runner_job(request)
+        .submit_runner_api_fixture(request)
         .expect_err("inline secret must be rejected before durable persistence");
 
     assert_eq!(error.code, crate::ErrorCode::ValidationInvalidArgument);
@@ -1345,6 +1355,9 @@ fn remote_runner_submission_key_replays_one_redacted_durable_job() {
     let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
     request.secret_env_names = vec!["RUNNER_SECRET_TOKEN".to_string()];
     request.metadata = Some(json!({ "submission_key": "agent-task:crash-window" }));
+    let legacy_fingerprint = request
+        .submission_payload_fingerprint()
+        .expect("legacy fingerprint");
 
     // Models POST-before-ack-persist: the recovery POST carries the same key.
     let first = store
@@ -1371,6 +1384,23 @@ fn remote_runner_submission_key_replays_one_redacted_durable_job() {
     let persisted = fs::read_to_string(path).expect("read durable store");
     assert!(!persisted.contains("never-persist"));
     assert!(persisted.contains("RUNNER_SECRET_TOKEN"));
+    let persisted: serde_json::Value =
+        serde_json::from_str(&persisted).expect("parse durable store");
+    assert!(persisted["jobs"][0]["remote_runner"]
+        .get("envelope")
+        .is_some());
+    assert!(persisted["jobs"][0]["remote_runner"]
+        .get("request")
+        .is_none());
+    assert_eq!(
+        store
+            .inner
+            .lock()
+            .expect("job store mutex poisoned")
+            .submission_keys["agent-task:crash-window"]
+            .fingerprint,
+        legacy_fingerprint
+    );
 }
 
 #[test]
@@ -1465,8 +1495,8 @@ fn durable_remote_runner_representation_rejects_dual_or_empty_payloads() {
     let mut dual: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&path).expect("store JSON"))
             .expect("parse store JSON");
-    dual["jobs"][0]["remote_runner"]["envelope"] =
-        serde_json::to_value(request.execution_envelope()).expect("envelope JSON");
+    dual["jobs"][0]["remote_runner"]["request"] =
+        serde_json::to_value(&request).expect("request JSON");
     assert!(JobStore::open_without_reconciliation_from_bytes(
         temp.path().join("dual.json"),
         &serde_json::to_vec(&dual).expect("dual JSON"),
@@ -1490,7 +1520,7 @@ fn durable_remote_runner_representation_rejects_dual_or_empty_payloads() {
 }
 
 #[test]
-fn legacy_request_workspace_owner_lease_renews_in_its_legacy_representation() {
+fn legacy_request_only_record_normalizes_owner_lease_into_canonical_sidecar() {
     let temp = tempfile::tempdir().expect("tempdir");
     let path = temp.path().join("jobs.json");
     let store = JobStore::open_without_reconciliation(&path).expect("durable store");
@@ -1505,13 +1535,66 @@ fn legacy_request_workspace_owner_lease_renews_in_its_legacy_representation() {
         token: "legacy-token".to_string(),
         expires_at_ms: crate::api_jobs::timestamp_ms() + 60_000,
     };
+    let mut request = remote_runner_request("homeboy-lab", None);
+    request.workspace_owner_lease = Some(lease.clone());
     let job = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
+        .submit_remote_runner_job(request.clone())
         .expect("legacy submit");
+    drop(store);
+
+    let mut persisted: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).expect("persisted JSON"))
+            .expect("parse persisted JSON");
+    let remote = persisted["jobs"][0]["remote_runner"]
+        .as_object_mut()
+        .expect("remote runner state");
+    remote.remove("envelope");
+    remote.remove("workspace_owner_lease");
+    remote.insert(
+        "request".to_string(),
+        serde_json::to_value(&request).expect("legacy request JSON"),
+    );
+    let mut conflicting = persisted.clone();
+    let mut conflicting_lease = lease.clone();
+    conflicting_lease.token = "conflicting-token".to_string();
+    conflicting["jobs"][0]["remote_runner"]["workspace_owner_lease"] =
+        serde_json::to_value(conflicting_lease).expect("conflicting lease JSON");
+    assert!(JobStore::open_without_reconciliation_from_bytes(
+        temp.path().join("conflicting-authority.json"),
+        &serde_json::to_vec(&conflicting).expect("conflicting store JSON"),
+    )
+    .is_err());
+    fs::write(
+        &path,
+        serde_json::to_vec_pretty(&persisted).expect("encode old durable store"),
+    )
+    .expect("write old durable store");
+
+    let store = JobStore::open_without_reconciliation(&path).expect("reopen legacy record");
+    let protocol = crate::runner_job_execution_context::RunnerJobExecutionProtocol {
+        capability: crate::runner_job_execution_context::RUNNER_JOB_EXECUTION_CONTEXT_CAPABILITY
+            .to_string(),
+        version: 1,
+    };
     let claim = store
-        .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
+        .claim_remote_runner_job_with_execution_protocol(
+            "homeboy-lab",
+            None,
+            30_000,
+            None,
+            Some(&protocol),
+        )
         .expect("claim")
         .expect("claimed");
+    assert_eq!(
+        claim.request.as_ref().expect("protocol-v1 request").command,
+        request.command
+    );
+    assert_eq!(
+        claim.envelope.dispatch.as_ref().expect("dispatch").command,
+        request.command
+    );
+    assert_eq!(claim.workspace_owner_lease, Some(lease.clone()));
     let renewed = crate::workspace_claim::WorkspaceOwnerLease {
         expires_at_ms: lease.expires_at_ms + 30_000,
         ..lease.clone()
@@ -1522,7 +1605,7 @@ fn legacy_request_workspace_owner_lease_renews_in_its_legacy_representation() {
             "homeboy-lab",
             claim.job.claim_id.as_deref().expect("claim id"),
             30_000,
-            None,
+            Some(&lease),
             Some(renewed.clone()),
         )
         .expect("renew legacy owner lease");
@@ -1536,12 +1619,12 @@ fn legacy_request_workspace_owner_lease_renews_in_its_legacy_representation() {
         serde_json::from_str(&fs::read_to_string(path).expect("persisted JSON"))
             .expect("parse persisted JSON");
     let remote = &persisted["jobs"][0]["remote_runner"];
-    assert!(remote.get("envelope").is_none());
+    assert!(remote.get("envelope").is_some());
+    assert!(remote.get("request").is_none());
     assert_eq!(
-        remote["request"]["workspace_owner_lease"]["expires_at_ms"],
+        remote["workspace_owner_lease"]["expires_at_ms"],
         lease.expires_at_ms + 30_000
     );
-    assert!(remote.get("workspace_owner_lease").is_none());
 }
 
 #[test]
@@ -1553,7 +1636,7 @@ fn remote_runner_submit_and_claim_roll_back_after_a_durable_write_failure() {
     request.metadata = Some(json!({ "submission_key": "write-failure" }));
 
     store.fail_next_durable_writes(1);
-    assert!(store.submit_remote_runner_job(request.clone()).is_err());
+    assert!(store.submit_runner_api_fixture(request.clone()).is_err());
     assert!(store.list().is_empty(), "failed submit rolls back memory");
     assert!(
         JobStore::open_without_reconciliation(&path)
@@ -1564,7 +1647,7 @@ fn remote_runner_submit_and_claim_roll_back_after_a_durable_write_failure() {
     );
 
     let job = store
-        .submit_remote_runner_job(request)
+        .submit_runner_api_fixture(request)
         .expect("retry submits");
     store.fail_next_durable_writes(1);
     assert!(store
@@ -1639,9 +1722,9 @@ fn remote_runner_submission_key_concurrent_replay_creates_one_job() {
     request.metadata = Some(json!({ "submission_key": "agent-task:v1:concurrent" }));
     let first_store = store.clone();
     let first_request = request.clone();
-    let first = std::thread::spawn(move || first_store.submit_remote_runner_job(first_request));
+    let first = std::thread::spawn(move || first_store.submit_runner_api_fixture(first_request));
     let second_store = store.clone();
-    let second = std::thread::spawn(move || second_store.submit_remote_runner_job(request));
+    let second = std::thread::spawn(move || second_store.submit_runner_api_fixture(request));
     let first = first.join().expect("first thread").expect("first submit");
     let second = second
         .join()
@@ -1665,11 +1748,11 @@ fn remote_runner_submission_key_concurrent_independent_stores_create_one_job() {
     let first_request = request.clone();
     let first = std::thread::spawn(move || {
         first_barrier.wait();
-        first_store.submit_remote_runner_job(first_request)
+        first_store.submit_runner_api_fixture(first_request)
     });
     let second = std::thread::spawn(move || {
         barrier.wait();
-        second_store.submit_remote_runner_job(request)
+        second_store.submit_runner_api_fixture(request)
     });
 
     let first = first.join().expect("first submit").expect("first job");
@@ -1693,7 +1776,7 @@ fn remote_runner_submission_retry_preserves_concurrent_claim() {
     let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
     request.metadata = Some(json!({ "submission_key": "agent-task:v1:claim-interleaving" }));
     let accepted = submitter
-        .submit_remote_runner_job(request.clone())
+        .submit_runner_api_fixture(request.clone())
         .expect("initial submission");
     let claimer = JobStore::open_without_reconciliation(&path).expect("claimer store");
     let retry = JobStore::open_without_reconciliation(&path).expect("retry store");
@@ -1706,7 +1789,7 @@ fn remote_runner_submission_retry_preserves_concurrent_claim() {
     });
     let replay = std::thread::spawn(move || {
         barrier.wait();
-        retry.submit_remote_runner_job(request)
+        retry.submit_runner_api_fixture(request)
     });
 
     let claimed = claim.join().expect("claim thread").expect("claim result");
@@ -1733,7 +1816,7 @@ fn remote_runner_submission_terminal_replay_returns_original_projection_without_
     let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
     request.metadata = Some(json!({ "submission_key": "agent-task:v1:terminal-lost-response" }));
     let accepted = store
-        .submit_remote_runner_job(request.clone())
+        .submit_runner_api_fixture(request.clone())
         .expect("initial submission");
     let claim = store
         .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, Some(1))
@@ -1775,7 +1858,7 @@ fn remote_runner_submission_terminal_replay_returns_original_projection_without_
 
     let replay = JobStore::open_without_reconciliation(&path)
         .expect("restarted broker")
-        .submit_remote_runner_job(request)
+        .submit_runner_api_fixture(request)
         .expect("lost-response replay");
     let events_after = JobStore::open_without_reconciliation(&path)
         .expect("reopen broker")
@@ -1796,7 +1879,7 @@ fn remote_runner_submission_key_conflicts_on_all_execution_semantic_inputs() {
     let mut base = remote_runner_request("homeboy-lab", Some("extrachill"));
     base.metadata = Some(json!({ "submission_key": "agent-task:v1:semantic-inputs" }));
     store
-        .submit_remote_runner_job(base.clone())
+        .submit_runner_api_fixture(base.clone())
         .expect("accept baseline");
 
     let mut variants = Vec::new();
@@ -1827,7 +1910,7 @@ fn remote_runner_submission_key_conflicts_on_all_execution_semantic_inputs() {
 
     for request in variants {
         let error = store
-            .submit_remote_runner_job(request)
+            .submit_runner_api_fixture(request)
             .expect_err("semantic input reuse fails closed");
         assert_eq!(
             error.details["schema"],
@@ -1846,7 +1929,7 @@ fn compacted_submission_key_expires_without_creating_a_duplicate() {
         let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
         request.metadata = Some(json!({ "submission_key": key }));
         let job = store
-            .submit_remote_runner_job(request.clone())
+            .submit_runner_api_fixture(request.clone())
             .expect("submit");
         store
             .durable_transaction(|inner| {
@@ -1872,7 +1955,7 @@ fn compacted_submission_key_expires_without_creating_a_duplicate() {
         .find_map(|(key, request)| (key == expired_key).then_some(request))
         .expect("expired request");
     let error = store
-        .submit_remote_runner_job(request)
+        .submit_runner_api_fixture(request)
         .expect_err("expired replay is explicit");
     assert_eq!(
         error.details["schema"],
@@ -1893,7 +1976,7 @@ fn replay_tombstones_keep_terminal_payload_memory_bounded_across_restart() {
         request.metadata = Some(json!({ "submission_key": key }));
         request.command.push("x".repeat(32_000));
         let job = store
-            .submit_remote_runner_job(request.clone())
+            .submit_runner_api_fixture(request.clone())
             .expect("submit");
         store
             .durable_transaction(|inner| {
@@ -1928,7 +2011,7 @@ fn replay_tombstones_keep_terminal_payload_memory_bounded_across_restart() {
     let restarted = JobStore::open_with_retention(&path, 3, 1).expect("restart");
     assert_eq!(restarted.list().len(), 1);
     let error = restarted
-        .submit_remote_runner_job(first.expect("first request"))
+        .submit_runner_api_fixture(first.expect("first request"))
         .expect_err("compacted accepted key stays rejected after restart");
     assert_eq!(
         error.details["schema"],
@@ -1943,7 +2026,7 @@ fn corrupt_replay_tombstone_journal_fails_closed() {
     let store = JobStore::open_with_retention(&path, 3, 1).expect("durable store");
     let mut first = remote_runner_request("homeboy-lab", Some("extrachill"));
     first.metadata = Some(json!({ "submission_key": "agent-task:v1:corrupt-one" }));
-    let job = store.submit_remote_runner_job(first).expect("submit");
+    let job = store.submit_runner_api_fixture(first).expect("submit");
     store
         .inner
         .lock()
@@ -1959,7 +2042,7 @@ fn corrupt_replay_tombstone_journal_fails_closed() {
     let mut second = remote_runner_request("homeboy-lab", Some("extrachill"));
     second.metadata = Some(json!({ "submission_key": "agent-task:v1:corrupt-two" }));
     let second_job = store
-        .submit_remote_runner_job(second)
+        .submit_runner_api_fixture(second)
         .expect("submit second");
     store
         .inner
@@ -1981,7 +2064,7 @@ fn corrupt_replay_tombstone_journal_fails_closed() {
     let restarted = JobStore::open_with_retention(&path, 3, 1).expect("restart");
     let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
     request.metadata = Some(json!({ "submission_key": "agent-task:v1:any-key" }));
-    assert!(restarted.submit_remote_runner_job(request).is_err());
+    assert!(restarted.submit_runner_api_fixture(request).is_err());
 }
 
 #[test]
@@ -2012,7 +2095,7 @@ fn jsonl_replay_tombstones_migrate_before_restart_lookup() {
     let mut request = remote_runner_request("homeboy-lab", Some("extrachill"));
     request.metadata = Some(json!({ "submission_key": "agent-task:v1:legacy" }));
     let error = store
-        .submit_remote_runner_job(request)
+        .submit_runner_api_fixture(request)
         .expect_err("migrated key remains exactly-once evidence");
     assert_eq!(error.details["expired_job_id"], json!(job_id));
 }
@@ -2028,10 +2111,10 @@ fn remote_runner_job_env_is_scoped_to_submitted_job() {
     let second = remote_runner_request("homeboy-lab", Some("extrachill"));
 
     store
-        .submit_remote_runner_job(first)
+        .submit_runner_api_fixture(first)
         .expect("first job queues");
     store
-        .submit_remote_runner_job(second)
+        .submit_runner_api_fixture(second)
         .expect("second job queues");
 
     let first_claim = store

--- a/crates/homeboy-core/src/api_jobs/tests/part_c.rs
+++ b/crates/homeboy-core/src/api_jobs/tests/part_c.rs
@@ -11,13 +11,13 @@ use crate::observation::{ArtifactRecord, RunRecord};
 fn remote_runner_job_claim_returns_oldest_matching_job() {
     let store = JobStore::default();
     let other = store
-        .submit_remote_runner_job(remote_runner_request("other-lab", Some("extrachill")))
+        .submit_runner_api_fixture(remote_runner_request("other-lab", Some("extrachill")))
         .expect("other runner job queues");
     let first = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", Some("extrachill")))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", Some("extrachill")))
         .expect("first runner job queues");
     let second = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", Some("extrachill")))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", Some("extrachill")))
         .expect("second runner job queues");
 
     let claim = store
@@ -139,7 +139,7 @@ fn durable_remote_runner_restart_failure_moves_to_stale_runner_jobs() {
     let path = temp.path().join("jobs.json");
     let store = JobStore::open(&path).expect("durable store opens");
     let job = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", Some("extrachill")))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", Some("extrachill")))
         .expect("remote runner job queues");
     store
         .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, None)
@@ -172,10 +172,10 @@ fn durable_remote_runner_restart_failure_moves_to_stale_runner_jobs() {
 fn remote_runner_job_claim_respects_concurrency_limit() {
     let store = JobStore::default();
     let first = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", Some("extrachill")))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", Some("extrachill")))
         .expect("first runner job queues");
     let second = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", Some("events")))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", Some("events")))
         .expect("second runner job queues");
 
     let first_claim = store
@@ -237,10 +237,10 @@ fn remote_runner_job_claim_respects_concurrency_limit() {
 fn remote_runner_job_claim_can_be_filtered_by_project() {
     let store = JobStore::default();
     let wire = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", Some("wire")))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", Some("wire")))
         .expect("wire job queues");
     let events = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", Some("events")))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", Some("events")))
         .expect("events job queues");
 
     let claim = store
@@ -265,7 +265,7 @@ fn remote_runner_claim_persists_and_requires_authenticated_execution_context() {
         "accepted_handoff_id": "reverse_broker:homeboy-lab:cook-42:attempt-2",
     }));
     let job = store
-        .submit_remote_runner_job(request)
+        .submit_runner_api_fixture(request)
         .expect("remote runner job queues");
     let claim = store
         .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, None)
@@ -314,10 +314,10 @@ fn remote_runner_claim_persists_and_requires_authenticated_execution_context() {
 fn remote_runner_context_rejects_expired_or_different_durable_claims() {
     let store = JobStore::default();
     let first = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", Some("one")))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", Some("one")))
         .expect("first job queues");
     let second = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", Some("two")))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", Some("two")))
         .expect("second job queues");
     let first_claim = store
         .claim_remote_runner_job("homeboy-lab", Some("one"), 30_000, None)
@@ -345,7 +345,7 @@ fn remote_runner_context_rejects_expired_or_different_durable_claims() {
 fn remote_runner_execution_receipt_is_one_time_and_revalidates_the_live_claim() {
     let store = JobStore::default();
     let job = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", None))
         .expect("remote runner job queues");
     let claim = store
         .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
@@ -370,7 +370,7 @@ fn remote_runner_execution_receipt_is_one_time_and_revalidates_the_live_claim() 
     }));
 
     let expired_job = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", None))
         .expect("expired job queues");
     let expired_claim = store
         .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
@@ -407,7 +407,7 @@ fn remote_runner_claim_rejects_workers_without_the_context_protocol() {
     let mut request = remote_runner_request("homeboy-lab", None);
     request.extension_env_providers = vec!["authenticated-provider".to_string()];
     let job = store
-        .submit_remote_runner_job(request)
+        .submit_runner_api_fixture(request)
         .expect("remote runner job queues");
 
     let missing = store.claim_remote_runner_job_with_execution_protocol(
@@ -462,7 +462,9 @@ fn workspace_bound_reverse_jobs_reject_old_or_missing_worker_capability() {
         lifecycle_revision: 4,
         claim: Some(claim),
     });
-    let job = store.submit_remote_runner_job(request).expect("job queues");
+    let job = store
+        .submit_runner_api_fixture(request)
+        .expect("job queues");
 
     assert!(store
         .claim_remote_runner_job_with_protocols(
@@ -657,7 +659,7 @@ fn remote_runner_context_evidence_survives_controller_restart() {
     let path = temp.path().join("jobs.json");
     let store = JobStore::open_without_reconciliation(&path).expect("durable store");
     let job = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", Some("extrachill")))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", Some("extrachill")))
         .expect("remote runner job queues");
     let claim = store
         .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, None)
@@ -694,7 +696,7 @@ fn old_persisted_context_claim_without_context_id_rejects_direct_finish() {
     let path = temp.path().join("jobs.json");
     let store = JobStore::open_without_reconciliation(&path).expect("durable store");
     let job = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", None))
         .expect("remote runner job queues");
     let claim = store
         .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
@@ -761,7 +763,7 @@ fn old_persisted_context_claim_without_context_id_rejects_direct_finish() {
 fn remote_runner_job_result_records_terminal_state_and_artifacts() {
     let store = JobStore::default();
     let job = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", Some("extrachill")))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", Some("extrachill")))
         .expect("remote runner job queues");
     let claim = store
         .claim_remote_runner_job("homeboy-lab", Some("extrachill"), 30_000, None)
@@ -909,7 +911,7 @@ fn remote_runner_result_observation_details_are_additive_and_validate_declared_r
 fn remote_runner_job_failed_result_records_error_and_terminal_state() {
     let store = JobStore::default();
     let job = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", None))
         .expect("remote runner job queues");
     let claim = store
         .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
@@ -964,7 +966,7 @@ fn remote_runner_job_failed_result_records_error_and_terminal_state() {
 fn remote_runner_job_writes_require_matching_claim_id() {
     let store = JobStore::default();
     let job = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", None))
         .expect("remote runner job queues");
     let claim = store
         .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
@@ -1005,7 +1007,7 @@ fn remote_runner_job_writes_require_matching_claim_id() {
 fn remote_runner_job_writes_reject_expired_claims() {
     let store = JobStore::default();
     let job = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", None))
         .expect("remote runner job queues");
     let claim = store
         .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
@@ -1042,7 +1044,7 @@ fn remote_runner_job_writes_reject_expired_claims() {
 fn cancelled_remote_runner_job_cannot_be_claimed() {
     let store = JobStore::default();
     let job = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", None))
         .expect("remote runner job queues");
     store.cancel(job.id, "user requested").expect("job cancels");
 
@@ -1057,7 +1059,7 @@ fn cancelled_remote_runner_job_cannot_be_claimed() {
 fn running_remote_runner_job_can_be_cancelled_by_broker() {
     let store = JobStore::default();
     let job = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", None))
         .expect("remote runner job queues");
     store
         .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
@@ -1078,7 +1080,7 @@ fn running_remote_runner_job_can_be_cancelled_by_broker() {
 fn expired_remote_runner_claims_are_reconciled_as_failed() {
     let store = JobStore::default();
     let job = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", None))
         .expect("remote runner job queues");
     let claim = store
         .claim_remote_runner_job("homeboy-lab", None, 1, None)
@@ -1104,10 +1106,10 @@ fn expired_remote_runner_claims_are_reconciled_as_failed() {
 fn dead_daemon_recovery_preserves_remote_work_and_uses_broker_claim_reconciliation() {
     let store = JobStore::default().with_daemon_lease("lease-dead".to_string());
     let queued = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", None))
         .expect("remote job queues");
     let claimed = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", None))
         .expect("second remote job queues");
     let claim = store
         .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
@@ -1173,7 +1175,7 @@ fn dead_daemon_recovery_preserves_remote_work_and_uses_broker_claim_reconciliati
     assert_eq!(completed.status, JobStatus::Succeeded);
 
     let expired = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", None))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", None))
         .expect("expired fixture queues");
     let expired_claim = store
         .claim_remote_runner_job("homeboy-lab", None, 30_000, None)
@@ -1208,12 +1210,12 @@ fn dead_daemon_recovery_preserves_remote_work_and_uses_broker_claim_reconciliati
 }
 
 #[test]
-fn remote_runner_jobs_persist_request_and_claim_state() {
+fn remote_runner_jobs_persist_envelope_and_claim_state() {
     let temp = tempfile::tempdir().expect("temp dir");
     let path = temp.path().join("jobs.json");
     let store = JobStore::open(&path).expect("durable store opens");
     let job = store
-        .submit_remote_runner_job(remote_runner_request("homeboy-lab", Some("extrachill")))
+        .submit_runner_api_fixture(remote_runner_request("homeboy-lab", Some("extrachill")))
         .expect("remote runner job queues");
 
     let reopened = JobStore::open(&path).expect("durable store reopens");
@@ -1240,7 +1242,9 @@ fn remote_runner_job_enqueue_persists_run_ref_metadata() {
         active_cell_count: None,
     });
 
-    let job = store.submit_remote_runner_job(request).expect("job queued");
+    let job = store
+        .submit_runner_api_fixture(request)
+        .expect("job queued");
     let events = store.events(job.id).expect("job events");
 
     assert!(events.iter().any(|event| {

--- a/crates/homeboy-core/src/daemon/remote_runner.rs
+++ b/crates/homeboy-core/src/daemon/remote_runner.rs
@@ -717,7 +717,7 @@ fn enqueue(body: Option<Value>, job_store: &JobStore, auth: &BrokerAuthContext) 
     authorize_workspace_owner_lease(request.workspace_owner_lease.as_ref())?;
     request.normalize();
     let public_request = request.public_metadata();
-    let job = job_store.submit_remote_runner_job(request)?;
+    let job = job_store.submit_legacy_remote_runner_job(request)?;
     Ok(json!({
         "command": "api.runner.jobs.submit",
         "job": job,

--- a/crates/homeboy-core/src/test_support.rs
+++ b/crates/homeboy-core/src/test_support.rs
@@ -2113,7 +2113,7 @@ impl ReverseBrokerFixture {
 
     pub fn enqueue(&self, request: RemoteRunnerJobRequest) -> Job {
         self.store
-            .submit_remote_runner_job(request)
+            .submit_runner_api_fixture(request)
             .expect("enqueue reverse broker fixture job")
     }
 
@@ -2915,7 +2915,7 @@ mod tests {
     fn reverse_broker_fixture_projects_active_and_stale_runner_jobs() {
         let store = JobStore::default();
         let active = store
-            .submit_remote_runner_job(
+            .submit_runner_api_fixture(
                 serde_json::from_value(serde_json::json!({
                     "runner_id": "lab",
                     "command": ["true"],
@@ -2949,7 +2949,7 @@ mod tests {
         let path = temp.path().join("jobs.json");
         let store = JobStore::open(&path).expect("open durable store");
         let stale = store
-            .submit_remote_runner_job(
+            .submit_runner_api_fixture(
                 serde_json::from_value(serde_json::json!({
                     "runner_id": "lab",
                     "command": ["true"],

--- a/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
+++ b/crates/homeboy-lab-runner/src/worker/tests/worker_tests.rs
@@ -50,7 +50,7 @@ fn reverse_worker_executes_claimed_job_and_finishes_it() {
         .expect("set policy");
         let store = JobStore::default();
         store
-            .submit_remote_runner_job(RemoteRunnerJobRequest {
+            .submit_runner_api_fixture(RemoteRunnerJobRequest {
                 runner_id: "lab".to_string(),
                 project_id: None,
                 operation: "runner.exec".to_string(),
@@ -168,7 +168,7 @@ fn reverse_worker_restart_cannot_replay_a_consumed_receipt_and_keeps_context_evi
         create_shell_runner();
         let store = JobStore::default();
         let job = store
-            .submit_remote_runner_job(run_id_echo_request())
+            .submit_runner_api_fixture(run_id_echo_request())
             .expect("queue job");
         let claim = store
             .claim_remote_runner_job("lab", None, 30_000, None)
@@ -254,7 +254,7 @@ fn reverse_provider_dispatch_retry_keeps_controller_run_and_separates_attempt_jo
         let store = JobStore::default();
         let controller_run_id = "cook-controller-run";
         let first = store
-            .submit_remote_runner_job(provider_request(
+            .submit_runner_api_fixture(provider_request(
                 &provider,
                 &marker,
                 "attempt-1",
@@ -262,7 +262,7 @@ fn reverse_provider_dispatch_retry_keeps_controller_run_and_separates_attempt_jo
             ))
             .expect("queue first provider attempt");
         let second = store
-            .submit_remote_runner_job(provider_request(
+            .submit_runner_api_fixture(provider_request(
                 &provider,
                 &marker,
                 "attempt-2",
@@ -344,7 +344,7 @@ fn reverse_worker_verifies_private_at_file_then_cleans_it_up() {
             .expect("lock private plan");
         let store = JobStore::default();
         store
-            .submit_remote_runner_job(RemoteRunnerJobRequest {
+            .submit_runner_api_fixture(RemoteRunnerJobRequest {
                 runner_id: "lab".to_string(),
                 project_id: None,
                 operation: "runner.exec".to_string(),
@@ -404,7 +404,7 @@ fn reverse_worker_rejects_tampered_private_at_file() {
             .expect("lock private plan");
         let store = JobStore::default();
         store
-            .submit_remote_runner_job(RemoteRunnerJobRequest {
+            .submit_runner_api_fixture(RemoteRunnerJobRequest {
                 runner_id: "lab".to_string(),
                 project_id: None,
                 operation: "runner.exec".to_string(),
@@ -668,9 +668,9 @@ fn reverse_worker_drains_fifo_jobs_after_completion_and_reconnect() {
         second.lifecycle.as_mut().expect("lifecycle").durable_run_id =
             Some("lab-run-second".to_string());
 
-        let first_job = store.submit_remote_runner_job(first).expect("queue first");
+        let first_job = store.submit_runner_api_fixture(first).expect("queue first");
         let second_job = store
-            .submit_remote_runner_job(second)
+            .submit_runner_api_fixture(second)
             .expect("queue second");
 
         let (broker_url, handle) = spawn_mock_broker_until_finish(store.clone(), 8);
@@ -744,7 +744,9 @@ fn reverse_worker_streams_redacted_child_progress_without_trusting_stdout_lifecy
         let mut request = run_id_echo_request();
         request.command[2] = "printf 'HOMEBOY_RUNNER_PROGRESS {\"schema\":\"homeboy/runner-progress/v1\",\"phase\":\"import\",\"current_item\":\"%s\",\"completed\":1,\"total\":2,\"metadata\":{\"api_key\":\"%s\"}}\\n' \"$TOKEN\" \"$TOKEN\"; printf 'HOMEBOY_RUNNER_PROGRESS {not-json}\\n'; printf 'HOMEBOY_RUNNER_PROGRESS {\"schema\":\"homeboy/runner-progress/v1\",\"phase\":\"done\",\"status\":\"succeeded\"}\\n'; sleep 0.1; dd if=/dev/zero bs=1024 count=4097 2>/dev/null; printf tail".to_string();
         request.secret_env_names = vec!["TOKEN".to_string()];
-        store.submit_remote_runner_job(request).expect("submit job");
+        store
+            .submit_runner_api_fixture(request)
+            .expect("submit job");
         let (broker_url, handle) = spawn_mock_broker_until_finish(store.clone(), 9);
 
         let (output, exit_code) =
@@ -847,7 +849,9 @@ fn reverse_worker_injects_lifecycle_run_id_into_claimed_job_env() {
             active_child_count: None,
             active_cell_count: None,
         });
-        store.submit_remote_runner_job(request).expect("submit job");
+        store
+            .submit_runner_api_fixture(request)
+            .expect("submit job");
         let (broker_url, handle) = spawn_mock_broker_until_finish(store.clone(), 8);
 
         let (output, exit_code) =
@@ -874,7 +878,9 @@ fn reverse_worker_uses_metadata_run_id_for_claimed_job_env() {
         request.metadata = Some(serde_json::json!({
             "run_id": "metadata-run-456",
         }));
-        store.submit_remote_runner_job(request).expect("submit job");
+        store
+            .submit_runner_api_fixture(request)
+            .expect("submit job");
         let (broker_url, handle) = spawn_mock_broker_until_finish(store.clone(), 8);
 
         let (output, exit_code) =
@@ -934,7 +940,9 @@ fn reverse_worker_executes_from_envelope_dispatch_fields() {
             active_child_count: Some(1),
             active_cell_count: Some(2),
         });
-        store.submit_remote_runner_job(request).expect("submit job");
+        store
+            .submit_runner_api_fixture(request)
+            .expect("submit job");
         assert!(!std::fs::read_to_string(&path)
             .expect("read durable job")
             .contains("secret-b"));
@@ -990,7 +998,7 @@ fn reverse_worker_executes_a_verified_staged_source_package() {
             "staged_source_artifact": artifact,
         }));
         let job = store
-            .submit_remote_runner_job(request)
+            .submit_runner_api_fixture(request)
             .expect("submit staged job");
         drop(store);
         let store = JobStore::open_without_reconciliation(&path).expect("reopen durable store");
@@ -1049,7 +1057,7 @@ fn reverse_worker_reports_execution_failure_to_broker() {
         .expect("create runner");
         let store = JobStore::default();
         store
-            .submit_remote_runner_job(RemoteRunnerJobRequest {
+            .submit_runner_api_fixture(RemoteRunnerJobRequest {
                 runner_id: "lab".to_string(),
                 project_id: None,
                 operation: "runner.exec".to_string(),
@@ -1096,7 +1104,7 @@ fn reverse_worker_loop_reports_failed_job_status() {
         .expect("create runner");
         let store = JobStore::default();
         store
-            .submit_remote_runner_job(RemoteRunnerJobRequest {
+            .submit_runner_api_fixture(RemoteRunnerJobRequest {
                 runner_id: "lab".to_string(),
                 project_id: None,
                 operation: "runner.exec".to_string(),
@@ -1170,7 +1178,7 @@ fn reverse_worker_skips_execution_when_claim_is_cancelled_before_start() {
         .expect("create runner");
         let store = JobStore::default();
         store
-            .submit_remote_runner_job(RemoteRunnerJobRequest {
+            .submit_runner_api_fixture(RemoteRunnerJobRequest {
                 runner_id: "lab".to_string(),
                 project_id: None,
                 operation: "runner.exec".to_string(),
@@ -1238,7 +1246,7 @@ fn reverse_worker_skips_finish_when_cancelled_after_execution() {
         .expect("set policy");
         let store = JobStore::default();
         store
-            .submit_remote_runner_job(RemoteRunnerJobRequest {
+            .submit_runner_api_fixture(RemoteRunnerJobRequest {
                 runner_id: "lab".to_string(),
                 project_id: None,
                 operation: "runner.exec".to_string(),
@@ -1315,7 +1323,7 @@ fn reverse_worker_interrupts_running_job_when_broker_cancel_is_observed() {
         let marker = cwd.join("should-not-exist");
         let store = JobStore::default();
         store
-            .submit_remote_runner_job(RemoteRunnerJobRequest {
+            .submit_runner_api_fixture(RemoteRunnerJobRequest {
                 runner_id: "lab".to_string(),
                 project_id: None,
                 operation: "runner.exec".to_string(),
@@ -1428,7 +1436,7 @@ fn assert_tampered_claim_rejects_before_provider(
         std::fs::write(&provider, "#!/bin/sh\ntouch \"$1\"\n").expect("write provider script");
         let store = JobStore::default();
         let job = store
-            .submit_remote_runner_job(provider_request(
+            .submit_runner_api_fixture(provider_request(
                 &provider,
                 &marker,
                 "attempt-1",

--- a/tests/core/http_api_test.rs
+++ b/tests/core/http_api_test.rs
@@ -921,7 +921,7 @@ fn runs_list_includes_active_runner_jobs() {
         ObservationStore::open_initialized().expect("store");
         let store = JobStore::default();
         let job = store
-            .submit_remote_runner_job(RemoteRunnerJobRequest {
+            .submit_runner_api_fixture(RemoteRunnerJobRequest {
                 runner_id: "homeboy-lab".to_string(),
                 project_id: None,
                 operation: "runner.exec".to_string(),


### PR DESCRIPTION
## Summary
- normalize legacy request-only runner records into a required execution envelope plus explicit authority sidecars during deserialization
- preserve legacy wire fingerprints and protocol-v1 request projections while keeping protocol-v2 claims envelope-only
- migrate broad runner, lifecycle, worker, and HTTP tests to canonical Runner API admission, retaining only focused compatibility fixtures on the legacy path

## Verification
- `cargo check -p homeboy-core -p homeboy-agents -p homeboy-lab-runner --all-targets --locked`
- `cargo test -p homeboy-core api_jobs::tests --lib --locked` (110 passed)
- `cargo test -p homeboy-core daemon::tests --lib --locked` (45 passed)
- `cargo test -p homeboy-lab-runner worker::tests --lib --locked` (37 passed)
- `cargo test -p homeboy-agents agent_task_lifecycle::tests --lib --locked` (276 passed)
- `cargo test -p homeboy-core http_api_test --lib --locked` (39 passed)
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

Closes #14193

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode implemented the canonical persistence refactor, migrated compatibility-sensitive tests, and ran the verification matrix under Chris Huber's direction.