### PR TITLE
Admit controller-owned promotion under resource pressure

### DIFF
--- a/crates/homeboy-cli/src/commands/contract_lab_routing.rs
+++ b/crates/homeboy-cli/src/commands/contract_lab_routing.rs
@@ -385,7 +385,7 @@ fn agent_task_fanout_local_only_contract(
 /// A durable run id is resolved through the controller lifecycle store, whose
 /// aggregate and finalized artifact projections are not portable path inputs.
 /// Other promotion source forms retain their existing runner-local behavior.
-fn agent_task_promotion_source_is_controller_owned(source: &str) -> bool {
+pub(crate) fn agent_task_promotion_source_is_controller_owned(source: &str) -> bool {
     // A run artifact URI is an immutable selector over controller-owned durable
     // state, even when its bytes must be fetched from the producing runner.
     // Keep its resolution, integrity verification, and target application on

--- a/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
+++ b/crates/homeboy-cli/src/commands/utils/resource_policy/mod.rs
@@ -498,6 +498,25 @@ pub(crate) fn hot_command(command: &Commands) -> Option<HotCommand> {
         });
     }
 
+    // Promotion of a durable controller candidate cannot transfer its mutation,
+    // artifact selection, or finalization authority to Lab. Its deterministic
+    // gate workload is nevertheless portable, so a ready runner admits the
+    // controller coordinator under CPU pressure just as it does for Cook.
+    if matches!(
+        command,
+        Commands::AgentTask(agent_task::AgentTaskArgs {
+            command: agent_task::AgentTaskCommand::Promote(args),
+        }) if crate::commands::contract_lab_routing::agent_task_promotion_source_is_controller_owned(&args.source)
+    ) {
+        return Some(HotCommand {
+            label: "agent-task promote",
+            lab_offload_supported: true,
+            lab_offload_unsupported_reason: None,
+            allows_warm_runner_coordination: true,
+            offload_only_when_hot: true,
+        });
+    }
+
     let route = command.lab_route().ok()?;
     if !route.portability_contract().is_resource_intensive() {
         return None;
@@ -1837,6 +1856,68 @@ mod tests {
             Some("missing-lab"),
             Some(&ready),
         ));
+    }
+
+    #[test]
+    fn controller_owned_promotion_admits_a_ready_runner_for_portable_gates_when_hot() {
+        with_isolated_home(|_| {
+            let run_id = "promotion-admission-run";
+            crate::agents::agent_tasks::lifecycle::submit_plan(
+                &crate::agents::agent_tasks::AgentTaskPlan::new("fixture", Vec::new()),
+                Some(run_id),
+            )
+            .expect("persist controller-owned promotion source");
+            let cli = Cli::parse_from([
+                "homeboy",
+                "--runner",
+                "homeboy-lab",
+                "agent-task",
+                "promote",
+                run_id,
+                "--to-worktree",
+                "homeboy@promotion-admission",
+                "--verify",
+                "cargo test --lib",
+            ]);
+            let command = hot_command(&cli.command).expect("promotion is resource managed");
+            let preflight = parsed_command_preflight_input(
+                &cli,
+                &[
+                    "homeboy".to_string(),
+                    "--runner".to_string(),
+                    "homeboy-lab".to_string(),
+                    "agent-task".to_string(),
+                    "promote".to_string(),
+                    run_id.to_string(),
+                ],
+            );
+            let ready = ready_lab();
+            let mut resources = coordination_resources();
+            resources.recommendation = ResourceRecommendation::Hot;
+            resources.load.recommendation = ResourceRecommendation::Hot;
+
+            assert_eq!(command.label, "agent-task promote");
+            assert!(command.lab_offload_supported);
+            assert!(command.allows_warm_runner_coordination);
+            assert_eq!(
+                preflight.controller_execution,
+                crate::core::parsed_command_preflight::ControllerExecution::SplitPlacementCoordinator,
+            );
+            assert!(matches!(
+                preflight.lab_route,
+                crate::core::parsed_command_preflight::LabRouteIntent::Unsupported
+            ));
+            assert!(admits_warm_runner_coordination(
+                command,
+                &resources,
+                cli.runner.as_deref(),
+                Some(&ready),
+            ));
+            assert!(
+                !admits_warm_runner_coordination(command, &resources, None, Some(&ready)),
+                "an unpinned controller-owned promotion must not treat a ready Lab as local capacity"
+            );
+        });
     }
 
     /// #13631/#13632: an operator who explicitly pins `--runner homeboy-lab`


### PR DESCRIPTION
## Summary
- distinguish controller-owned promotion coordination from runner work admission
- allow an explicitly ready runner route on warm or hot controllers
- retain pressure safeguards for actual runner workloads

Closes #9740

## Verification
- `cargo test -p homeboy-cli runner_pinned_fanout_run_plan_admits_an_explicit_ready_runner_on_warm_or_hot_controller -j1`
- `cargo check -p homeboy-cli --tests -j1`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

## AI Assistance
Implemented and reviewed with OpenAI GPT-5.6 Terra and GPT-5.6 Sol via OpenCode. AI was used to trace resource admission, implement the ownership distinction, add tests, and verify the branch.