### PR TITLE
Validate promotion base before target mutation

### DIFF
--- a/crates/homeboy-agents/src/agent_task_promotion/promote.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/promote.rs
@@ -1021,17 +1021,15 @@ fn promote_with_provider_and_checkpoint_internal(
     // no patch applied and no durable post-apply state recorded, so the same
     // artifact/target can be retried with a corrected base (#9400).
     let pre_apply_verified_base = if !options.dry_run {
-        match resolve_promotion_target_path(&options.to_worktree, None, Some(&safety_baseline))? {
-            Some(target_path) => capture_declared_base(&target_path, options.base_ref.as_deref())?,
-            // No provider-owned pre-apply target path resolves; fall back to
-            // validating against the applied worktree below.
-            None => None,
-        }
+        capture_declared_base_before_apply(
+            &options.to_worktree,
+            None,
+            Some(&safety_baseline),
+            options.base_ref.as_deref(),
+        )?
     } else {
         None
     };
-    // A declared base with no resolvable pre-apply target path still needs
-    // validation after apply; an empty/absent base has nothing to verify.
     let base_verified_before_apply = pre_apply_verified_base.is_some()
         || options
             .base_ref
@@ -1794,14 +1792,12 @@ fn promote_committed_changes(
     // boundary as artifact promotion: no apply or checkpoint may precede a
     // failed declared base lookup.
     let pre_apply_verified_base = if !options.dry_run {
-        match resolve_promotion_target_path(
+        capture_declared_base_before_apply(
             &options.to_worktree,
             trusted_unpushed_candidate_destination.as_ref(),
             None,
-        )? {
-            Some(target_path) => capture_declared_base(&target_path, options.base_ref.as_deref())?,
-            None => None,
-        }
+            options.base_ref.as_deref(),
+        )?
     } else {
         None
     };
@@ -2622,9 +2618,6 @@ fn promotion_source(
     }
 }
 
-/// Resolve a provider-owned target before the patch is applied, so the declared
-/// base can be validated against it without mutating the working tree (#9400).
-/// Genuinely unmanaged destinations retain the post-apply validation fallback.
 fn candidate_patch_safety_baseline(
     patch: &str,
     artifact: &AgentTaskArtifact,
@@ -2642,13 +2635,17 @@ fn candidate_patch_safety_baseline(
     })
 }
 
+/// Resolve the target before applying a patch so a declared base can be
+/// validated without mutating the working tree (#9400).
 fn resolve_promotion_target_path(
     to_worktree: &str,
     trusted_unpushed_candidate_destination: Option<&TrustedUnpushedCandidateDestination>,
     safety_baseline: Option<&Value>,
 ) -> Result<Option<PathBuf>> {
+    // Direct paths do not need provider resolution, but must participate in
+    // the same pre-apply declared-base contract as provider-owned targets.
     if Path::new(to_worktree).is_dir() {
-        return Ok(None);
+        return Ok(Some(PathBuf::from(to_worktree)));
     }
     let trusted_unpushed_destination = trusted_unpushed_candidate_destination.map(|trusted| {
         homeboy_core::worktree_provider::WorktreeTrustedUnpushedDestination {
@@ -2668,6 +2665,33 @@ fn resolve_promotion_target_path(
         Err(error) if error.details["worktree_provider_lookup"] == "not_found" => Ok(None),
         Err(error) => Err(error),
     }
+}
+
+/// A declared base is part of the pre-mutation promotion contract. Do not let
+/// an opaque provider apply before Homeboy can authenticate that contract.
+fn capture_declared_base_before_apply(
+    to_worktree: &str,
+    trusted_unpushed_candidate_destination: Option<&TrustedUnpushedCandidateDestination>,
+    safety_baseline: Option<&Value>,
+    base_ref: Option<&str>,
+) -> Result<Option<AgentTaskPromotionVerifiedBase>> {
+    if base_ref.is_none_or(|base| base.trim().is_empty()) {
+        return Ok(None);
+    }
+    let target_path = resolve_promotion_target_path(
+        to_worktree,
+        trusted_unpushed_candidate_destination,
+        safety_baseline,
+    )?
+    .ok_or_else(|| {
+        Error::validation_invalid_argument(
+            "base_ref",
+            "declared base requires a resolvable target worktree before promotion apply",
+            Some(to_worktree.to_string()),
+            None,
+        )
+    })?;
+    capture_declared_base(&target_path, base_ref)
 }
 
 pub(crate) fn capture_declared_base(

--- a/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
+++ b/crates/homeboy-agents/src/agent_task_promotion/tests/part_a.rs
@@ -618,26 +618,32 @@ fn promote_exports_committed_changes_when_executor_reports_no_patch_artifact() {
         ..Default::default()
     };
 
-    let report = promote_with_provider(
-        AgentTaskPromotionOptions {
-            source,
-            source_run_id: Some("run-no-artifact".to_string()),
-            source_path: Some(source_path),
-            source_worktree_path: Some(repo.clone()),
-            base_ref: Some("main".to_string()),
-            task_base_sha: Some(base),
-            candidate_ref: None,
-            to_worktree: "repo@promoted".to_string(),
-            task_id: None,
-            artifact_id: None,
-            dry_run: false,
-            gates: VerifyGateOptions::default(),
-            provider_command: None,
-            provider_invocation: None,
-        },
-        &mut provider,
-    )
-    .expect("committed changes are promoted without a patch artifact");
+    let options = |base_ref: &str| AgentTaskPromotionOptions {
+        source: source.clone(),
+        source_run_id: Some("run-no-artifact".to_string()),
+        source_path: Some(source_path.clone()),
+        source_worktree_path: Some(repo.clone()),
+        base_ref: Some(base_ref.to_string()),
+        task_base_sha: Some(base.clone()),
+        candidate_ref: None,
+        to_worktree: repo.display().to_string(),
+        task_id: None,
+        artifact_id: None,
+        dry_run: false,
+        gates: VerifyGateOptions::default(),
+        provider_command: None,
+        provider_invocation: None,
+    };
+
+    let error = promote_with_provider(options("trunk"), &mut provider)
+        .expect_err("invalid base rejects committed changes before apply");
+    assert!(error
+        .message
+        .contains("declared base `trunk` was not found"));
+    assert!(provider.apply_calls.is_empty());
+
+    let report = promote_with_provider(options("main"), &mut provider)
+        .expect("committed changes are promoted without a patch artifact");
 
     assert_eq!(report.status, AgentTaskPromotionStatus::Applied);
     assert_eq!(report.patch_artifact.id, "committed-changes");
@@ -1046,16 +1052,6 @@ fn promotion_validates_declared_base_before_mutating_the_target_worktree() {
         );
         git(&worktree_path, &["push", "-u", "origin", "main"]);
 
-        // Register the target as a Homeboy-managed worktree so promotion can
-        // resolve its path before applying (the pre-apply base validation gate).
-        worktree::adopt(WorktreeAdoptOptions {
-            handle: "repo@base-9400".to_string(),
-            path: worktree_path.display().to_string(),
-            kind: None,
-            provenance: None,
-        })
-        .expect("adopt target worktree");
-
         let (source_path, source) = write_patch_source(&temp);
         let options = |base: &str| AgentTaskPromotionOptions {
             source: source.clone(),
@@ -1065,7 +1061,9 @@ fn promotion_validates_declared_base_before_mutating_the_target_worktree() {
             base_ref: Some(base.to_string()),
             task_base_sha: None,
             candidate_ref: None,
-            to_worktree: "repo@base-9400".to_string(),
+            // Direct worktree paths must be preflighted too. Previously only
+            // configured provider handles resolved before apply.
+            to_worktree: worktree_path.display().to_string(),
             task_id: None,
             artifact_id: None,
             dry_run: false,


### PR DESCRIPTION
## Summary
- validate the declared promotion base before mutating the destination worktree
- preserve recoverable post-apply checkpoints against the corrected base
- add regression coverage for non-main base recovery

Closes #9400

## Verification
- `cargo test -p homeboy-agents legacy_post_apply_checkpoint_recovers_only_with_corrected_non_main_base -j1`
- `cargo check -p homeboy-agents --tests -j1`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

## AI Assistance
Implemented and reviewed with OpenAI GPT-5.6 Terra and GPT-5.6 Sol via OpenCode. AI was used to inspect the control-plane flow, implement the fix, add regression coverage, and run verification.