### PR TITLE
Resolve ambient notifications for fanout Cook batches

### DIFF
--- a/crates/homeboy-cli/src/cli_runtime.rs
+++ b/crates/homeboy-cli/src/cli_runtime.rs
@@ -1216,15 +1216,7 @@ impl CliRuntime {
             }
         }
 
-        if matches!(
-            &cli.command,
-            Commands::AgentTask(agent_task)
-                if matches!(
-                    &agent_task.command,
-                    crate::commands::agent_task::AgentTaskCommand::Cook(_)
-                )
-        ) && notification_route.is_none()
-        {
+        if Self::admits_ambient_notification_route(&cli.command) && notification_route.is_none() {
             notification_resolution =
                 match crate::core::notification_route_resolver::resolve_installed_with_evidence() {
                     Ok(resolution) => resolution,
@@ -1441,6 +1433,23 @@ impl CliRuntime {
             schedule_runner_exec_recovery();
         }
         std::process::ExitCode::from(exit_code_to_u8(exit_code))
+    }
+
+    /// Commands that create a Cook-owned durable route may ask installed extensions
+    /// to resolve an ambient destination. Previews remain entirely side-effect-free.
+    fn admits_ambient_notification_route(command: &Commands) -> bool {
+        let Commands::AgentTask(agent_task) = command else {
+            return false;
+        };
+        match &agent_task.command {
+            crate::commands::agent_task::AgentTaskCommand::Cook(cook) => !cook.preview,
+            crate::commands::agent_task::AgentTaskCommand::Fanout(fanout) => matches!(
+                &fanout.command,
+                crate::commands::agent_task::args::AgentTaskFanoutCommand::CookBatch(cook_batch)
+                    if !cook_batch.preview
+            ),
+            _ => false,
+        }
     }
 
     fn build_augmented_command(&self) -> Command {
@@ -4906,6 +4915,55 @@ mod tests {
     #[test]
     fn normal_output_file_paths_are_allowed() {
         assert!(output_runtime::validate_output_file_path("./homeboy-output.json").is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ambient_notification_discovery_admission_is_shared_by_cook_and_cook_batch() {
+        let cook =
+            Cli::try_parse_from(["homeboy", "agent-task", "cook", "--to-worktree", "fixture"])
+                .expect("parse Cook invocation");
+        let cook_preview = Cli::try_parse_from([
+            "homeboy",
+            "agent-task",
+            "cook",
+            "--to-worktree",
+            "fixture",
+            "--preview",
+        ])
+        .expect("parse Cook preview");
+        let cook_batch = Cli::try_parse_from([
+            "homeboy",
+            "agent-task",
+            "fanout",
+            "cook-batch",
+            "--repo",
+            "fixture",
+            "https://github.com/Extra-Chill/homeboy/issues/14195",
+        ])
+        .expect("parse cook-batch invocation");
+        let cook_batch_preview = Cli::try_parse_from([
+            "homeboy",
+            "agent-task",
+            "fanout",
+            "cook-batch",
+            "--repo",
+            "fixture",
+            "--preview",
+            "https://github.com/Extra-Chill/homeboy/issues/14195",
+        ])
+        .expect("parse cook-batch preview");
+
+        assert!(CliRuntime::admits_ambient_notification_route(&cook.command));
+        assert!(CliRuntime::admits_ambient_notification_route(
+            &cook_batch.command
+        ));
+        assert!(!CliRuntime::admits_ambient_notification_route(
+            &cook_preview.command
+        ));
+        assert!(!CliRuntime::admits_ambient_notification_route(
+            &cook_batch_preview.command
+        ));
     }
 
     #[cfg(unix)]

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -12,6 +12,8 @@ mod cook_prompt_stdin;
 mod fanout_supervisor_cli;
 #[path = "cli_binary/help_fast_path.rs"]
 mod help_fast_path;
+#[path = "cli_binary/notification_route_admission.rs"]
+mod notification_route_admission;
 #[path = "cli_binary/output_dispatch.rs"]
 mod output_dispatch;
 #[path = "cli_binary/output_errors.rs"]

--- a/tests/cli_binary/notification_route_admission.rs
+++ b/tests/cli_binary/notification_route_admission.rs
@@ -1,0 +1,142 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[cfg(unix)]
+#[test]
+fn cook_batch_uses_cooks_ambient_route_admission_without_affecting_previews() {
+    let home = tempfile::tempdir().expect("temporary home");
+    let sentinel = home.path().join("resolver-invoked");
+    write_notification_resolver(home.path(), &sentinel);
+
+    let output = command(
+        &home,
+        &[
+            "agent-task",
+            "fanout",
+            "cook-batch",
+            "--repo",
+            "fixture",
+            "https://github.com/Extra-Chill/homeboy/issues/14195",
+        ],
+    )
+    .output()
+    .expect("run cook-batch");
+    assert!(
+        !output.status.success(),
+        "fixture repository must not reach execution"
+    );
+    assert!(
+        sentinel.exists(),
+        "cook-batch must admit the installed ambient route before command execution"
+    );
+
+    fs::remove_file(&sentinel).expect("clear resolver sentinel");
+    let output = command(
+        &home,
+        &[
+            "--notification-transport",
+            "explicit.completed",
+            "--notification-route",
+            "opaque-explicit-route",
+            "agent-task",
+            "fanout",
+            "cook-batch",
+            "--repo",
+            "fixture",
+            "https://github.com/Extra-Chill/homeboy/issues/14195",
+        ],
+    )
+    .output()
+    .expect("run explicit cook-batch");
+    assert!(
+        !output.status.success(),
+        "fixture repository must not execute"
+    );
+    assert!(
+        !sentinel.exists(),
+        "an explicit route must take precedence over ambient resolution"
+    );
+
+    let output = command(
+        &home,
+        &[
+            "agent-task",
+            "fanout",
+            "cook-batch",
+            "--repo",
+            "fixture",
+            "https://github.com/Extra-Chill/homeboy/issues/14195",
+        ],
+    )
+    .env("HOMEBOY_NOTIFICATION_TRANSPORT", "propagated.completed")
+    .env("HOMEBOY_NOTIFICATION_ROUTE", "opaque-propagated-route")
+    .output()
+    .expect("run propagated cook-batch");
+    assert!(
+        !output.status.success(),
+        "fixture repository must not execute"
+    );
+    assert!(
+        !sentinel.exists(),
+        "a propagated route must take precedence over ambient resolution"
+    );
+
+    for args in [
+        &["agent-task", "cook", "--preview"][..],
+        &[
+            "agent-task",
+            "fanout",
+            "cook-batch",
+            "--repo",
+            "fixture",
+            "--preview",
+            "https://github.com/Extra-Chill/homeboy/issues/14195",
+        ][..],
+    ] {
+        let _ = command(&home, args).output().expect("run preview");
+        assert!(
+            !sentinel.exists(),
+            "preview must not invoke an ambient notification resolver: {args:?}"
+        );
+    }
+}
+
+#[cfg(unix)]
+fn write_notification_resolver(home: &Path, sentinel: &Path) {
+    let extension = home.join(".config/homeboy/extensions/resolver-test");
+    fs::create_dir_all(&extension).expect("extension directory");
+    let resolver = format!(
+        "touch '{}'; printf '%s' '{{\"schema\":\"homeboy/notification-route-resolver/v1\",\"status\":\"matched\",\"route\":\"opaque-route\"}}'",
+        sentinel.display()
+    );
+    fs::write(
+        extension.join("resolver-test.json"),
+        serde_json::json!({
+            "name": "Notification resolver fixture",
+            "version": "0.0.0",
+            "notification_transports": [{
+                "id": "test.completed",
+                "command": ["true"],
+                "route_resolver": { "command": ["sh", "-c", resolver] }
+            }]
+        })
+        .to_string(),
+    )
+    .expect("extension manifest");
+}
+
+#[cfg(unix)]
+fn command(home: &tempfile::TempDir, args: &[&str]) -> Command {
+    let mut command = Command::new(homeboy_bin());
+    command
+        .args(args)
+        .env_clear()
+        .env("HOME", home.path())
+        .env("HOMEBOY_NO_UPDATE_CHECK", "1");
+    command
+}
+
+fn homeboy_bin() -> PathBuf {
+    PathBuf::from(std::env::var_os("CARGO_BIN_EXE_homeboy").expect("CARGO_BIN_EXE_homeboy"))
+}


### PR DESCRIPTION
## Summary
- apply Cook ambient notification route admission to fanout batch execution
- keep dry-run previews free of notification side effects
- cover the behavior through the process-isolated CLI binary contract

Closes #14195

## Verification
- `cargo test -p homeboy --test cli_binary cook_batch_uses_cooks_ambient_route_admission_without_affecting_previews -j1`
- `cargo check -p homeboy --test cli_binary -j1`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

## AI Assistance
Implemented and reviewed with OpenAI GPT-5.6 Terra and GPT-5.6 Sol via OpenCode. AI was used to trace notification admission, integrate fanout execution, build end-to-end CLI coverage, and verify the branch.