### PR TITLE
Distinguish retained candidates from promoted patches

### DIFF
--- a/crates/homeboy-cli/src/commands/agent_task/candidate.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/candidate.rs
@@ -10,7 +10,7 @@ use serde_json::{json, Value};
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) enum CandidateState {
     Finalized,
-    Promoted,
+    ApplyReady,
     PatchAvailable,
     NoChangesProduced,
     Empty,
@@ -26,7 +26,7 @@ impl CandidateState {
     pub(crate) fn as_str(self) -> &'static str {
         match self {
             Self::Finalized => "finalized",
-            Self::Promoted => "promoted",
+            Self::ApplyReady => "apply_ready",
             Self::PatchAvailable => "patch_available",
             Self::NoChangesProduced => "no_changes_produced",
             Self::Empty => "empty",
@@ -41,7 +41,7 @@ impl CandidateState {
     pub(crate) fn is_available(self) -> bool {
         matches!(
             self,
-            Self::Finalized | Self::Promoted | Self::PatchAvailable
+            Self::Finalized | Self::ApplyReady | Self::PatchAvailable
         )
     }
 }
@@ -53,7 +53,7 @@ const MAX_CHANGED_FILES_ARTIFACT_BYTES: u64 = 1024 * 1024;
 const MAX_CHANGED_FILES_PATHS: usize = 4096;
 
 /// The canonical terminal result for a Cook's candidate evidence. Evidence is
-/// monotonic: a finalized PR, promoted/adopted candidate, or durable patch
+/// monotonic: a finalized PR, retained/apply-ready candidate, or durable patch
 /// remains authoritative even when a later provider attempt is empty or fails.
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct CandidateResult {
@@ -69,7 +69,9 @@ pub(crate) struct CandidateResult {
     pub(crate) changed_files_unknown_patches: usize,
     pub(crate) provider_executions: Option<usize>,
     pub(crate) finalized: bool,
-    pub(crate) promoted: bool,
+    pub(crate) retained: bool,
+    pub(crate) target_applied: bool,
+    pub(crate) verified: bool,
     pub(crate) attempts_omitted: usize,
     pub(crate) outcomes_omitted: usize,
     pub(crate) artifacts_omitted: usize,
@@ -80,8 +82,8 @@ impl CandidateResult {
     pub(crate) fn state(self) -> CandidateState {
         if self.finalized {
             CandidateState::Finalized
-        } else if self.promoted {
-            CandidateState::Promoted
+        } else if self.retained {
+            CandidateState::ApplyReady
         } else if self.available > 0 {
             CandidateState::PatchAvailable
         } else if self.is_degraded() {
@@ -110,7 +112,7 @@ impl CandidateResult {
 
     fn record(&mut self, state: CandidateState, size: Option<u64>, changed_files: Option<usize>) {
         match state {
-            CandidateState::Finalized | CandidateState::Promoted => {
+            CandidateState::Finalized | CandidateState::ApplyReady => {
                 unreachable!("terminal facts are recorded directly")
             }
             CandidateState::PatchAvailable => {
@@ -231,11 +233,16 @@ pub(crate) fn classify_candidates(payload: &Value) -> CandidateResult {
         && counts.conflicting == 0
         && counts.retained_only == 0
         && aggregate_outcomes_are_no_op(payload);
+    let promotion =
+        latest_promotion(payload).or_else(|| payload.get("record").and_then(latest_promotion));
     counts.finalized =
         has_finalized_pr(payload) || payload.get("record").is_some_and(has_finalized_pr);
-    counts.promoted = !counts.finalized
-        && (has_promoted_candidate(payload)
-            || payload.get("record").is_some_and(has_promoted_candidate));
+    counts.retained = has_retained_candidate(payload)
+        || payload.get("record").is_some_and(has_retained_candidate)
+        || successful_adoption(payload)
+        || payload.get("record").is_some_and(successful_adoption);
+    counts.target_applied = promotion.is_some_and(promotion_target_applied);
+    counts.verified = counts.target_applied && promotion.is_some_and(promotion_verified);
     counts
 }
 
@@ -248,6 +255,12 @@ pub(crate) fn canonical_candidate_projection(result: CandidateResult) -> Value {
         "changed_files": result.changed_files,
         "changed_files_unknown_patches": result.changed_files_unknown_patches,
         "provider_executions": result.provider_executions,
+        "lifecycle": {
+            "retained": result.retained,
+            "target_applied": result.target_applied,
+            "verified": result.verified,
+            "finalized": result.finalized,
+        },
         "counts": {
             "patch_available": result.available,
             "empty": result.empty,
@@ -272,7 +285,9 @@ fn candidate_result_from_projection(value: &Value) -> Option<CandidateResult> {
     }
     let state = match value.get("state").and_then(Value::as_str)? {
         "finalized" => CandidateState::Finalized,
-        "promoted" => CandidateState::Promoted,
+        // `promoted` was emitted by the original candidate projection before
+        // target application became an independent lifecycle dimension.
+        "promoted" | "apply_ready" => CandidateState::ApplyReady,
         "patch_available" => CandidateState::PatchAvailable,
         "no_changes_produced" => CandidateState::NoChangesProduced,
         "empty" => CandidateState::Empty,
@@ -323,8 +338,22 @@ fn candidate_result_from_projection(value: &Value) -> Option<CandidateResult> {
             .get("provider_executions")
             .and_then(Value::as_u64)
             .and_then(|count| usize::try_from(count).ok()),
-        finalized: state == CandidateState::Finalized,
-        promoted: state == CandidateState::Promoted,
+        finalized: value
+            .pointer("/lifecycle/finalized")
+            .and_then(Value::as_bool)
+            .unwrap_or(state == CandidateState::Finalized),
+        retained: value
+            .pointer("/lifecycle/retained")
+            .and_then(Value::as_bool)
+            .unwrap_or(state == CandidateState::ApplyReady),
+        target_applied: value
+            .pointer("/lifecycle/target_applied")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        verified: value
+            .pointer("/lifecycle/verified")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
         attempts_omitted: omitted("attempts_omitted"),
         outcomes_omitted: omitted("outcomes_omitted"),
         artifacts_omitted: omitted("artifacts_omitted"),
@@ -616,9 +645,14 @@ fn outcome_artifact_count(outcome: &Value) -> usize {
         .map_or(0, Vec::len)
 }
 
-fn has_promoted_candidate(payload: &Value) -> bool {
-    promotion_has_candidate(payload.get("latest_promotion"))
-        || promotion_has_candidate(payload.pointer("/metadata/latest_promotion"))
+fn latest_promotion(payload: &Value) -> Option<&Value> {
+    payload
+        .get("latest_promotion")
+        .or_else(|| payload.pointer("/metadata/latest_promotion"))
+}
+
+fn has_retained_candidate(payload: &Value) -> bool {
+    promotion_has_candidate(latest_promotion(payload))
         || payload
             .get("attempts")
             .and_then(Value::as_array)
@@ -628,7 +662,6 @@ fn has_promoted_candidate(payload: &Value) -> bool {
                     .take(MAX_ATTEMPTS_SCANNED)
                     .any(|attempt| promotion_has_candidate(attempt.get("promotion")))
             })
-        || successful_adoption(payload)
 }
 
 fn successful_adoption(payload: &Value) -> bool {
@@ -682,6 +715,38 @@ fn promotion_has_candidate(promotion: Option<&Value>) -> bool {
         .or_else(|| promotion.get("patch_artifact_id").and_then(Value::as_str))
         .or_else(|| promotion.get("artifact_id").and_then(Value::as_str))
         .is_some_and(|id| !id.trim().is_empty()))
+}
+
+/// A promotion status alone is not proof that the target changed: retained
+/// candidates use the same tracker before `agent-task promote` mutates a target.
+pub(crate) fn promotion_target_applied(promotion: &Value) -> bool {
+    matches!(
+        promotion.get("status").and_then(Value::as_str),
+        Some("verification_pending" | "applied" | "gate_failed")
+    ) && promotion
+        .pointer("/provenance/post_apply")
+        .and_then(Value::as_bool)
+        == Some(true)
+        && promotion
+            .pointer("/patch_artifact/id")
+            .and_then(Value::as_str)
+            .is_some_and(|id| !id.trim().is_empty())
+        && promotion
+            .pointer("/target/worktree")
+            .or_else(|| promotion.get("to_worktree"))
+            .and_then(Value::as_str)
+            .is_some_and(|target| !target.trim().is_empty())
+        && promotion
+            .pointer("/provenance/candidate")
+            .is_some_and(|candidate| !candidate.is_null())
+}
+
+pub(crate) fn promotion_verified(promotion: &Value) -> bool {
+    promotion_target_applied(promotion)
+        && matches!(
+            promotion.get("status").and_then(Value::as_str),
+            Some("applied")
+        )
 }
 
 fn aggregate_outcomes_are_no_op(payload: &Value) -> bool {
@@ -900,19 +965,19 @@ mod tests {
                 CandidateState::Finalized,
             ),
             (
-                "adoption",
+                "retained adoption",
                 json!({ "candidate_adoption": { "candidate_sha": "abc123", "state": "completed", "result": { "status": "review_ready" } } }),
-                CandidateState::Promoted,
+                CandidateState::ApplyReady,
             ),
             (
-                "failed final attempt",
+                "retained candidate after a failed final attempt",
                 json!({
                     "attempts": [
                         { "promotion": { "status": "applied", "patch_artifact": { "id": "candidate" } } },
                         { "aggregate": { "outcomes": [{ "status": "failed", "artifacts": [] }] } }
                     ]
                 }),
-                CandidateState::Promoted,
+                CandidateState::ApplyReady,
             ),
         ];
 
@@ -930,6 +995,44 @@ mod tests {
             classify_candidates(&no_candidate).state(),
             CandidateState::Empty
         );
+    }
+
+    #[test]
+    fn candidate_lifecycle_requires_post_apply_evidence_before_target_or_gate_claims() {
+        let retained = classify_candidates(&json!({
+            "metadata": { "latest_promotion": {
+                "status": "verification_pending",
+                "patch_artifact": { "id": "patch" },
+                "target": { "worktree": "fixture@target" }
+            } }
+        }));
+        assert_eq!(retained.state(), CandidateState::ApplyReady);
+        assert!(retained.retained);
+        assert!(!retained.target_applied);
+        assert!(!retained.verified);
+
+        let target_applied = classify_candidates(&json!({
+            "metadata": { "latest_promotion": {
+                "status": "verification_pending",
+                "patch_artifact": { "id": "patch" },
+                "target": { "worktree": "fixture@target" },
+                "provenance": { "post_apply": true, "candidate": { "head": "candidate" } }
+            } }
+        }));
+        assert!(target_applied.retained);
+        assert!(target_applied.target_applied);
+        assert!(!target_applied.verified);
+
+        let verified = classify_candidates(&json!({
+            "metadata": { "latest_promotion": {
+                "status": "applied",
+                "patch_artifact": { "id": "patch" },
+                "target": { "worktree": "fixture@target" },
+                "provenance": { "post_apply": true, "candidate": { "head": "candidate" } }
+            } }
+        }));
+        assert!(verified.target_applied);
+        assert!(verified.verified);
     }
 
     #[test]
@@ -1061,12 +1164,12 @@ mod tests {
 
     #[test]
     fn review_envelope_reads_terminal_facts_from_its_record() {
-        let promoted = classify_candidates(&json!({
+        let retained = classify_candidates(&json!({
             "record": { "metadata": { "latest_promotion": {
                 "status": "applied", "patch_artifact": { "id": "patch" }
             }}}
         }));
-        assert_eq!(promoted.state(), CandidateState::Promoted);
+        assert_eq!(retained.state(), CandidateState::ApplyReady);
 
         let finalized = classify_candidates(&json!({
             "record": { "metadata": { "cook_finalization": {
@@ -1080,6 +1183,6 @@ mod tests {
                 "state": "completed", "result": { "status": "review_ready" }
             }}
         }));
-        assert_eq!(adopted.state(), CandidateState::Promoted);
+        assert_eq!(adopted.state(), CandidateState::ApplyReady);
     }
 }

--- a/crates/homeboy-cli/src/commands/agent_task/review.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/review.rs
@@ -3312,14 +3312,20 @@ fn review_next_actions(
 }
 
 fn promotion_handoff(report: &AgentTaskPromotionReport, _to_worktree: &str) -> Value {
-    let patch_promoted = report.status.patch_promoted();
+    // Typed reports are only constructed after the target mutation. The status
+    // remains a compatibility field; expose verification independently.
+    let target_applied = report.status.patch_promoted();
+    let verified = matches!(report.status, AgentTaskPromotionStatus::Applied);
     let mut next_actions = Vec::new();
     if report.status.gate_failed() {
         next_actions.push(
             "patch promoted but deterministic gates failed; use gate feedback before finalizing"
                 .to_string(),
         );
-    } else if patch_promoted {
+    } else if target_applied && verified {
+        next_actions
+            .push("patch promoted and deterministic gates verified; finalize a PR".to_string());
+    } else if target_applied {
         next_actions.push(
             "patch promoted into the target worktree; verify, then finalize a PR".to_string(),
         );
@@ -3332,7 +3338,11 @@ fn promotion_handoff(report: &AgentTaskPromotionReport, _to_worktree: &str) -> V
         "schema": "homeboy/agent-task-promotion-handoff/v1",
         "states": {
             "patch_artifact_produced": true,
-            "patch_promoted": patch_promoted,
+            "candidate_retained": true,
+            "target_applied": target_applied,
+            "patch_promoted": target_applied,
+            "verified": verified,
+            "finalized": false,
             "pr_opened": false
         },
         "boundary": report.status.handoff_boundary(),
@@ -3390,7 +3400,11 @@ fn finalization_handoff(status: &str, pr_url: Option<&str>, run_id: Option<&str>
         "schema": "homeboy/agent-task-finalization-handoff/v1",
         "states": {
             "patch_artifact_produced": true,
+            "candidate_retained": true,
+            "target_applied": true,
             "patch_promoted": true,
+            "verified": pr_opened,
+            "finalized": pr_opened,
             "pr_opened": pr_opened,
             "publication_mutated": !publication_validated && pr_opened
         },
@@ -3613,7 +3627,7 @@ mod tests {
     }
 
     #[test]
-    fn compact_review_preserves_one_promoted_candidate_fingerprint() {
+    fn compact_review_preserves_one_target_applied_candidate_fingerprint() {
         let patch = tempfile::NamedTempFile::new().expect("patch");
         std::fs::write(patch.path(), "x".repeat(7_635)).expect("write patch");
         let value = compact_review(
@@ -3632,6 +3646,7 @@ mod tests {
                                 "path": patch.path(),
                             },
                             "changed_files": ["a.rs", "b.rs", "c.rs"],
+                            "provenance": { "post_apply": true, "candidate": { "head": "candidate-head" } },
                             "deterministic_gates": [{
                                 "name": "cargo test",
                                 "status": "succeeded",

--- a/crates/homeboy-cli/src/commands/agent_task/status.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/status.rs
@@ -774,7 +774,10 @@ fn promotion_state(record: &Value) -> String {
     raw.to_string()
 }
 
-fn promotion_gate_state(record: &Value, promotion: &str) -> &'static str {
+fn promotion_gate_state(record: &Value, promotion: &str, target_applied: bool) -> &'static str {
+    if !target_applied {
+        return "not_run";
+    }
     if record
         .pointer("/metadata/latest_promotion/deterministic_gates")
         .and_then(Value::as_array)
@@ -4396,10 +4399,19 @@ pub(crate) fn execution_states_from_aggregate(
         .collect::<Vec<_>>();
     let promotion_status = promotion_state(record);
     let finalization_status = finalization_state(record);
-    let patch_promoted = matches!(
-        promotion_status.as_str(),
-        "verification_pending" | "applied" | "gate_failed"
-    );
+    let promotion = record.pointer("/metadata/latest_promotion");
+    // A retained artifact can carry a pending verification tracker before any
+    // target mutation. Only the post-apply checkpoint is evidence that this
+    // exact promotion reached its declared target.
+    let patch_promoted = canonical.target_applied;
+    let verified = canonical.verified;
+    let target = promotion_target_projection(promotion, patch_promoted);
+    let verification_phase = match promotion_status.as_str() {
+        "verification_pending" if patch_promoted => "post_apply",
+        "verification_pending" => "pre_apply",
+        "applied" | "gate_failed" if patch_promoted => "post_apply",
+        _ => "not_pending",
+    };
 
     json!({
         "schema": "homeboy/agent-task-execution-states/v1",
@@ -4415,13 +4427,37 @@ pub(crate) fn execution_states_from_aggregate(
             },
         },
         "gate": {
-            "state": promotion_gate_state(record, &promotion_status),
+            "state": promotion_gate_state(record, &promotion_status, patch_promoted),
         },
         "promotion": {
             "state": promotion_status,
             "patch_promoted": patch_promoted,
+            "verified": verified,
+            "verification_phase": verification_phase,
+            "target": target,
         },
-        "finalization": { "state": finalization_status },
+        "finalization": {
+            "state": finalization_status,
+            "finalized": canonical.finalized,
+        },
+    })
+}
+
+fn promotion_target_projection(promotion: Option<&Value>, applied: bool) -> Value {
+    let Some(promotion) = promotion else {
+        return json!({ "state": "not_declared", "candidate_fingerprint_matches": Value::Null });
+    };
+    let target = promotion
+        .pointer("/target/worktree")
+        .or_else(|| promotion.get("to_worktree"));
+    let fingerprint_matches = applied
+        && promotion
+            .pointer("/provenance/candidate")
+            .is_some_and(|fingerprint| !fingerprint.is_null());
+    json!({
+        "state": if applied { "applied" } else { "not_applied" },
+        "worktree": target,
+        "candidate_fingerprint_matches": fingerprint_matches,
     })
 }
 

--- a/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/tests/lifecycle.rs
@@ -4208,8 +4208,10 @@ fn execution_states_distinguish_patch_noop_provider_failure_and_gate_failure() {
     );
     assert_eq!(patch["provider"][0]["state"], "succeeded");
     assert_eq!(patch["candidate"]["state"], "patch_available");
-    assert_eq!(patch["gate"]["state"], "passed");
+    assert_eq!(patch["gate"]["state"], "not_run");
     assert_eq!(patch["promotion"]["state"], "applied");
+    assert_eq!(patch["promotion"]["patch_promoted"], false);
+    assert_eq!(patch["promotion"]["verified"], false);
 
     let missing = execution_states(
         fixture_execution_outcome(
@@ -4325,7 +4327,7 @@ fn execution_states_prefer_adopted_normalized_gate_outcome_over_stale_attempt_fa
 }
 
 #[test]
-fn execution_states_keep_promoted_candidate_after_a_failed_provider_attempt() {
+fn execution_states_keep_retained_candidate_after_a_failed_provider_attempt() {
     let states = super::super::status::execution_states_from_aggregate(
         &aggregate_for_execution_outcome(fixture_execution_outcome(
             AgentTaskOutcomeStatus::Failed,
@@ -4344,8 +4346,50 @@ fn execution_states_keep_promoted_candidate_after_a_failed_provider_attempt() {
     );
 
     assert_eq!(states["provider"][0]["state"], "failed");
-    assert_eq!(states["candidate"]["state"], "promoted");
+    assert_eq!(states["candidate"]["state"], "apply_ready");
     assert_eq!(states["promotion"]["state"], "applied");
+    assert_eq!(states["promotion"]["patch_promoted"], false);
+    assert_eq!(states["promotion"]["verified"], false);
+    assert_eq!(states["promotion"]["target"]["state"], "not_applied");
+}
+
+#[test]
+fn execution_states_distinguish_target_application_from_verification() {
+    let aggregate = aggregate_for_execution_outcome(fixture_execution_outcome(
+        AgentTaskOutcomeStatus::Succeeded,
+        None,
+        Vec::new(),
+        Value::Null,
+    ));
+    let target_applied = super::super::status::execution_states_from_aggregate(
+        &aggregate,
+        &json!({ "metadata": { "latest_promotion": {
+            "status": "verification_pending",
+            "to_worktree": "fixture@target",
+            "target": { "worktree": "fixture@target" },
+            "patch_artifact": { "id": "patch" },
+            "provenance": { "post_apply": true, "candidate": { "head": "candidate" } }
+        } } }),
+    );
+    assert_eq!(target_applied["promotion"]["patch_promoted"], true);
+    assert_eq!(target_applied["promotion"]["verified"], false);
+    assert_eq!(
+        target_applied["promotion"]["verification_phase"],
+        "post_apply"
+    );
+
+    let verified = super::super::status::execution_states_from_aggregate(
+        &aggregate,
+        &json!({ "metadata": { "latest_promotion": {
+            "status": "applied",
+            "to_worktree": "fixture@target",
+            "target": { "worktree": "fixture@target" },
+            "patch_artifact": { "id": "patch" },
+            "provenance": { "post_apply": true, "candidate": { "head": "candidate" } }
+        } } }),
+    );
+    assert_eq!(verified["promotion"]["patch_promoted"], true);
+    assert_eq!(verified["promotion"]["verified"], true);
 }
 
 fn execution_states(outcome: AgentTaskOutcome, promotion_status: &str) -> Value {

--- a/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
+++ b/crates/homeboy-cli/src/commands/agent_task_summary/mod.rs
@@ -511,6 +511,9 @@ fn render_status_summary(payload: &Value) -> Option<String> {
         production_lines[1] = format!("Candidate state: {candidate}");
     }
     lines.extend(production_lines);
+    if let Some(line) = target_application_line(payload) {
+        lines.push(line);
+    }
     if let Some(diagnostic) = first_actionable_diagnostic(payload) {
         lines.push(format!("Diagnostic: {diagnostic}"));
     }
@@ -776,9 +779,19 @@ fn render_review_summary(payload: &Value) -> Option<String> {
         .then(|| command_line(payload, &["promotion_candidates", "0", "command"]))
         .flatten();
 
+    let target_applied = payload
+        .pointer("/execution_states/promotion/patch_promoted")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let verified = payload
+        .pointer("/execution_states/promotion/verified")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
     let outcome = if metrics.candidate_state == CandidateState::Finalized {
         "pull request finalized"
-    } else if metrics.candidate_state == CandidateState::Promoted {
+    } else if target_applied && verified {
+        "patch promoted and verified"
+    } else if target_applied {
         "patch promoted"
     } else if promotable {
         "patch produced, not promoted"
@@ -797,6 +810,9 @@ fn render_review_summary(payload: &Value) -> Option<String> {
         format!("Outcome: {outcome}"),
     ];
     lines.extend(code_production_lines(&metrics));
+    if let Some(line) = target_application_line(payload) {
+        lines.push(line);
+    }
     if let Some(diagnostic) = first_actionable_diagnostic(payload) {
         lines.push(format!("Diagnostic: {diagnostic}"));
     }
@@ -811,6 +827,25 @@ fn render_review_summary(payload: &Value) -> Option<String> {
         lines.push(format!("Next: {next}"));
     }
     Some(finish(lines))
+}
+
+fn target_application_line(payload: &Value) -> Option<String> {
+    let promotion = value_at(payload, &["execution_states", "promotion"])?;
+    let target = string_value(promotion, &["target", "worktree"]).unwrap_or("not declared");
+    let target_state = string_value(promotion, &["target", "state"]).unwrap_or("not_applied");
+    let fingerprint = promotion
+        .pointer("/target/candidate_fingerprint_matches")
+        .and_then(Value::as_bool)
+        .map(|matches| if matches { "matches" } else { "does not match" })
+        .unwrap_or("unknown");
+    let verification = promotion
+        .get("verified")
+        .and_then(Value::as_bool)
+        .map(|verified| if verified { "verified" } else { "not verified" })
+        .unwrap_or("unknown");
+    Some(format!(
+        "Target application: {target_state} (worktree: {target}; candidate fingerprint: {fingerprint}; verification: {verification})"
+    ))
 }
 
 fn first_actionable_diagnostic(payload: &Value) -> Option<&str> {
@@ -1430,15 +1465,14 @@ mod tests {
     }
 
     #[test]
-    fn review_summary_uses_the_promoted_candidate_fingerprint() {
-        // A promoted candidate is no longer an apply candidate, but its durable
-        // promotion fingerprint remains the authoritative review summary source.
+    fn review_summary_uses_a_target_applied_candidate_fingerprint() {
+        // Target application is independent from retained candidate selection.
         let payload = json!({
             "run_id": "agent-task-11805",
             "state": "succeeded",
             "canonical_candidate": {
                 "schema": "homeboy/agent-task-candidate/v1",
-                "state": "promoted",
+                "state": "apply_ready",
                 "diff_bytes": 0,
                 "counts": { "patch_available": 1 },
                 "scan": { "degraded": false }
@@ -1449,15 +1483,55 @@ mod tests {
                 "size_bytes": 7635,
                 "changed_files": ["a.rs", "b.rs", "c.rs"]
             },
+            "execution_states": {
+                "promotion": {
+                    "patch_promoted": true,
+                    "verified": true,
+                    "target": { "state": "applied", "worktree": "fixture@target", "candidate_fingerprint_matches": true }
+                }
+            },
             "aggregate_review": { "summary": { "apply_candidates": 0, "failed": 0 } },
             "next_actions": ["finalize the pull request"]
         });
 
         let summary = render_agent_task_summary(AgentTaskSummaryKind::Review, &payload).unwrap();
 
-        assert!(summary.contains("Outcome: patch promoted\n"));
+        assert!(summary.contains("Outcome: patch promoted and verified\n"));
+        assert!(summary.contains("Target application: applied (worktree: fixture@target; candidate fingerprint: matches; verification: verified)\n"));
         assert!(summary.contains("Changed files: 3\n"));
         assert!(summary.contains("Diff bytes: 7635\n"));
+    }
+
+    #[test]
+    fn review_summary_keeps_a_pre_apply_candidate_out_of_the_promoted_outcome() {
+        let payload = json!({
+            "run_id": "retained-candidate",
+            "state": "partial_recoverable",
+            "canonical_candidate": {
+                "schema": "homeboy/agent-task-candidate/v1",
+                "state": "apply_ready",
+                "counts": { "patch_available": 1 }, "scan": { "degraded": false }
+            },
+            "selected_candidate": { "status": "verification_pending" },
+            "execution_states": {
+                "promotion": {
+                    "state": "verification_pending",
+                    "patch_promoted": false,
+                    "verification_phase": "pre_apply",
+                    "target": { "state": "not_applied", "worktree": "fixture@clean-target", "candidate_fingerprint_matches": false }
+                }
+            },
+            "aggregate_review": { "summary": { "apply_candidates": 1, "failed": 0 } }
+        });
+
+        let summary = render_agent_task_summary(AgentTaskSummaryKind::Review, &payload).unwrap();
+
+        assert!(
+            summary.contains("Outcome: patch produced, not promoted\n"),
+            "{summary}"
+        );
+        assert!(!summary.contains("Outcome: patch promoted\n"), "{summary}");
+        assert!(summary.contains("Target application: not_applied (worktree: fixture@clean-target; candidate fingerprint: does not match; verification: not verified)\n"), "{summary}");
     }
 
     #[test]
@@ -1900,11 +1974,11 @@ mod tests {
             "cook": { "state": "finalization_failed", "publication": "blocked" },
             "canonical_candidate": {
                 "schema": "homeboy/agent-task-candidate/v1",
-                "state": "promoted",
+                "state": "apply_ready",
                 "counts": {}, "scan": {}
             },
             "execution_states": {
-                "candidate": { "state": "promoted_finalization_failed" },
+                "candidate": { "state": "apply_ready_finalization_failed" },
                 "gate": { "state": "passed" },
                 "finalization": { "state": "finalization_failed" },
                 "provider": [{ "task_id": "cook", "state": "succeeded" }]
@@ -1926,12 +2000,12 @@ mod tests {
 
         assert!(
             summary.starts_with(
-                "Agent task status\nCook outcome: finalization_failed\nCandidate: yes (promoted; legacy canonical)\nGates: passed\nPR finalization: finalization_failed"
+                "Agent task status\nCook outcome: finalization_failed\nCandidate: yes (apply_ready; legacy canonical)\nGates: passed\nPR finalization: finalization_failed"
             ),
             "{summary}"
         );
         assert!(!summary.contains("Status: succeeded"), "{summary}");
-        assert!(summary.contains("Candidate state: promoted_finalization_failed\n"));
+        assert!(summary.contains("Candidate state: apply_ready_finalization_failed\n"));
         assert!(summary.contains("Publication: blocked\n"));
         assert!(summary.contains("Provider/task evidence:\n"));
         assert!(summary.contains("Tasks attempted: 1\n"));


### PR DESCRIPTION
## Summary
- separate retained/apply-ready candidate state from target application
- report promotion only when durable evidence proves the target was mutated
- align status, review, and summary projections around the canonical boundary

Closes #14198

## Verification
- `cargo test -p homeboy-cli execution_states_keep_retained_candidate_after_a_failed_provider_attempt -j1`
- `cargo check -p homeboy-cli --tests -j1`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

## AI Assistance
Implemented and reviewed with OpenAI GPT-5.6 Terra and GPT-5.6 Sol via OpenCode. AI was used to audit candidate vocabulary, unify projections, add regression coverage, and verify the branch.