### PR TITLE
Preserve interrupted fanout child state

### DIFF
--- a/crates/homeboy-agents/src/agent_task_batch.rs
+++ b/crates/homeboy-agents/src/agent_task_batch.rs
@@ -1048,13 +1048,14 @@ where
     Ok(Some(graph))
 }
 
-/// Read the graph-projected executable frontier. Resume callers use this to
-/// avoid finalizing a dependent before its upstream candidate is accepted.
-pub(crate) fn fanout_ready_child_run_ids(batch_id: &str) -> Result<Option<HashSet<String>>> {
-    AgentTaskBatchStore::from_current_data_root()?.fanout_ready_child_run_ids(batch_id)
+/// Read the graph-projected dependency blocks. Resume callers must only
+/// synthesize a dependency-blocked cell for a child the graph explicitly
+/// blocks; a terminal independent child is absent from the ready frontier too.
+pub(crate) fn fanout_blocked_child_run_ids(batch_id: &str) -> Result<Option<HashSet<String>>> {
+    AgentTaskBatchStore::from_current_data_root()?.fanout_blocked_child_run_ids(batch_id)
 }
 
-pub fn fanout_ready_child_run_ids_in_store(
+pub fn fanout_blocked_child_run_ids_in_store(
     store: &AgentTaskBatchStore,
     batch_id: &str,
 ) -> Result<Option<HashSet<String>>> {
@@ -1062,18 +1063,20 @@ pub fn fanout_ready_child_run_ids_in_store(
     let Some(graph) = report.dependency_graph else {
         return Ok(None);
     };
-    let ready = graph["readiness"]["ready"]
-        .as_array()
+    let blocked = graph["readiness"]["states"]
+        .as_object()
         .into_iter()
-        .flatten()
-        .filter_map(Value::as_str)
+        .flat_map(|states| states.iter())
+        .filter_map(|(task_id, state)| {
+            (state.as_str() == Some("blocked_by_dependency")).then_some(task_id.as_str())
+        })
         .collect::<HashSet<_>>();
     Ok(Some(
         report
             .batch
             .child_runs
             .into_iter()
-            .filter(|child| ready.contains(child.task_id.as_str()))
+            .filter(|child| blocked.contains(child.task_id.as_str()))
             .map(|child| child.run_id)
             .collect(),
     ))
@@ -1625,9 +1628,9 @@ impl AgentTaskBatchStore {
         record_dependency_action_receipt_in_store(self, batch_id, key, receipt)
     }
 
-    /// Read the graph-projected executable frontier.
-    pub fn fanout_ready_child_run_ids(&self, batch_id: &str) -> Result<Option<HashSet<String>>> {
-        fanout_ready_child_run_ids_in_store(self, batch_id)
+    /// Read the graph-projected dependency blocks.
+    pub fn fanout_blocked_child_run_ids(&self, batch_id: &str) -> Result<Option<HashSet<String>>> {
+        fanout_blocked_child_run_ids_in_store(self, batch_id)
     }
 
     /// Resolve the durable child runs owned by a fanout.

--- a/crates/homeboy-agents/src/agent_task_service/cook.rs
+++ b/crates/homeboy-agents/src/agent_task_service/cook.rs
@@ -3095,6 +3095,26 @@ fn observed_child_cell(
     }
 }
 
+/// Preserve durable failure evidence from a prior coordinator rather than
+/// requiring its recipe to be reconstructed just to report a terminal result.
+fn observed_batch_child_cell(
+    child: &crate::agent_task_batch::AgentTaskBatchChildRun,
+    record: &agent_task_lifecycle::AgentTaskRunRecord,
+) -> AgentTaskCookBatchCellReport {
+    let status = persisted_terminal_cook_status(record).unwrap_or_else(|| match record.state {
+        agent_task_lifecycle::AgentTaskRunState::Cancelled => CookStatus::Cancelled,
+        _ => CookStatus::Failed,
+    });
+    AgentTaskCookBatchCellReport {
+        cook_id: child.task_id.clone(),
+        initial_run_id: child.run_id.clone(),
+        status: status.as_str().to_string(),
+        exit_code: i32::from(!status.is_success_exit()),
+        result: None,
+        error: None,
+    }
+}
+
 /// Resume a persisted cook batch after its original synchronous coordinator
 /// exited or timed out. Each child's durable recipe fully reconstructs its cook
 /// options, so re-running [`run_cook`] idempotently harvests every terminal
@@ -3169,22 +3189,36 @@ where
         ));
     }
 
-    let ready = crate::agent_task_batch::fanout_ready_child_run_ids(batch_id)?;
+    let blocked = crate::agent_task_batch::fanout_blocked_child_run_ids(batch_id)?;
     let total = batch.child_runs.len();
     let mut cells = Vec::with_capacity(total);
     for child in &batch.child_runs {
-        if ready
+        if blocked
             .as_ref()
-            .is_some_and(|ready| !ready.contains(&child.run_id))
+            .is_some_and(|blocked| blocked.contains(&child.run_id))
         {
             cells.push(AgentTaskCookBatchCellReport {
                 cook_id: child.task_id.clone(),
                 initial_run_id: child.run_id.clone(),
                 status: "blocked_by_dependency".to_string(),
-                exit_code: 0,
+                exit_code: 1,
                 result: None,
-                error: None,
+                error: Some(AgentTaskCookCellError::declared(
+                    "agent_task.blocked_by_dependency",
+                    "child is blocked by an unresolved dependency",
+                    false,
+                )),
             });
+            continue;
+        }
+        if let Some(record) = durably_terminal_child_record(&child.run_id).filter(|record| {
+            matches!(
+                record.state,
+                agent_task_lifecycle::AgentTaskRunState::Failed
+                    | agent_task_lifecycle::AgentTaskRunState::Cancelled
+            )
+        }) {
+            cells.push(observed_batch_child_cell(child, &record));
             continue;
         }
         // Roster `run_id` is the canonical durable attempt, including transport

--- a/crates/homeboy-cli/src/commands/agent_task/fanout.rs
+++ b/crates/homeboy-cli/src/commands/agent_task/fanout.rs
@@ -556,16 +556,16 @@ fn batch_resume_locked(
         crate::commands::infra::route::reconstruct_cook_attempt_dispatcher,
     )?;
     reconcile_fanout_pr_states(&args.batch_id, true)?;
-    let exit_code = result.exit_code;
     let batch = batch::read_batch_record(&args.batch_id)?;
     let portfolio = run_portfolio(&batch)?;
     // Portfolio publication can add durable PR evidence. Reconcile it before a
     // RemoveOnSuccess provider is allowed to destroy the source workspace.
     reconcile_fanout_pr_states(&args.batch_id, true)?;
     finalize_resumed_provider_worktrees(&args.batch_id, Some(&result.value))?;
+    let subject_exit_code = result.exit_code;
     Ok(batch_resume_result(
         result.value,
-        exit_code,
+        subject_exit_code,
         &args.batch_id,
         Some(portfolio),
         placement,
@@ -893,7 +893,14 @@ fn reconcile_portfolio(
     let observations = batch_record
         .child_runs
         .iter()
-        .map(|child| portfolio_observation(&child.task_id, &child.run_id, false))
+        .map(|child| {
+            portfolio_observation(
+                &child.task_id,
+                &child.run_id,
+                false,
+                batch_record.metadata["declared_trackers"][&child.task_id].as_str(),
+            )
+        })
         .collect::<Result<Vec<_>>>()?;
     let dependencies = durable_graph_dependencies(batch_record)?;
     let status = portfolio.reconcile(observations, &dependencies);
@@ -1025,7 +1032,12 @@ impl supervisor::FanoutPortfolioAdapter for CookFanoutPortfolioAdapter {
         &mut self,
         child: &supervisor::AgentTaskFanoutPortfolioChild,
     ) -> Result<supervisor::AgentTaskFanoutPortfolioObservation> {
-        portfolio_observation(&child.child_id, &child.run_id, true)
+        portfolio_observation(
+            &child.child_id,
+            &child.run_id,
+            true,
+            Some(&child.tracker_ref),
+        )
     }
 
     fn continue_provider(
@@ -1220,6 +1232,7 @@ fn portfolio_observation(
     child_id: &str,
     run_id: &str,
     reconcile: bool,
+    declared_tracker: Option<&str>,
 ) -> Result<homeboy::agents::agent_tasks::fanout_supervisor::AgentTaskFanoutPortfolioObservation> {
     use homeboy::agents::agent_tasks::fanout_supervisor as supervisor;
     let record = if reconcile {
@@ -1240,12 +1253,24 @@ fn portfolio_observation(
         Some(_) => supervisor::AgentTaskFanoutProviderState::Failed,
         None => supervisor::AgentTaskFanoutProviderState::Pending,
     };
+    // Provider interruption can occur before promotion writes its provenance.
+    // The recipe is already durable at provider dispatch, so retain its declared
+    // worktree and tracker identity for the recovery projection.
+    let recipe = agent_task_service::load_recipe_for_attempt(run_id)
+        .ok()
+        .flatten();
     let promotion = record
         .as_ref()
         .and_then(|record| record.metadata.get("latest_promotion"));
     let path = promotion
         .and_then(|value| value.pointer("/provenance/worktree_path"))
-        .and_then(Value::as_str);
+        .and_then(Value::as_str)
+        .or_else(|| {
+            recipe
+                .as_ref()
+                .and_then(|recipe| recipe.finalization.get("to_worktree"))
+                .and_then(Value::as_str)
+        });
     let declared_base = promotion
         .and_then(|value| value.pointer("/verified_base/base"))
         .and_then(Value::as_str);
@@ -1290,9 +1315,9 @@ fn portfolio_observation(
         .and_then(Value::as_str)
         .is_some_and(|after_sha| head_sha.as_deref() == Some(after_sha));
     let (tracker, pr, remote_head_sha, findings) = match path {
-        Some(path) => github_observation(path, record.as_ref(), finalization)?,
+        Some(path) => github_observation(path, record.as_ref(), finalization, declared_tracker)?,
         None => (
-            tracker_state_without_observation(record.as_ref()),
+            tracker_state_without_observation(record.as_ref(), recipe.as_ref(), declared_tracker),
             supervisor::AgentTaskFanoutPrState::Unknown,
             None,
             Vec::new(),
@@ -1333,15 +1358,19 @@ fn github_observation(
     path: &str,
     record: Option<&agent_task_lifecycle::AgentTaskRunRecord>,
     finalization: Option<&Value>,
+    declared_tracker: Option<&str>,
 ) -> Result<(
     supervisor::AgentTaskFanoutTrackerState,
     supervisor::AgentTaskFanoutPrState,
     Option<String>,
     Vec<supervisor::AgentTaskFanoutReviewFinding>,
 )> {
-    let tracker = match record.and_then(|record| declared_tracker_ref(&record.metadata)) {
+    let tracker = match record
+        .and_then(|record| declared_tracker_ref(&record.metadata))
+        .or(declared_tracker.filter(|reference| is_tracker_url(reference)))
+    {
         Some(task_url) => match IssueRef::parse(task_url) {
-            Ok(issue) => homeboy::core::git::issue_find(
+            Ok(issue) => match homeboy::core::git::issue_find(
                 None,
                 homeboy::core::git::IssueFindOptions {
                     state: homeboy::core::git::IssueState::All,
@@ -1349,9 +1378,8 @@ fn github_observation(
                     path: Some(path.to_string()),
                     ..Default::default()
                 },
-            )
-            .map(|result| {
-                result
+            ) {
+                Ok(result) => result
                     .items
                     .iter()
                     .find(|item| item.number.to_string() == issue.number)
@@ -1364,11 +1392,14 @@ fn github_observation(
                                 supervisor::AgentTaskFanoutTrackerState::Closed
                             }
                         },
-                    )
-            }),
+                    ),
+                // A declared tracker is still durable evidence when the host
+                // cannot be observed from a recovered provider worktree.
+                Err(_) => supervisor::AgentTaskFanoutTrackerState::DeclaredUnobserved,
+            },
             // Tracker identity is generic; this adapter only observes GitHub.
-            Err(_) => Ok(supervisor::AgentTaskFanoutTrackerState::DeclaredUnobserved),
-        }?,
+            Err(_) => supervisor::AgentTaskFanoutTrackerState::DeclaredUnobserved,
+        },
         None => supervisor::AgentTaskFanoutTrackerState::Unknown,
     };
     let head = finalization
@@ -1427,13 +1458,27 @@ fn declared_tracker_ref(metadata: &Value) -> Option<&str> {
     metadata
         .pointer("/cook_recipe/source_refs/0")
         .and_then(Value::as_str)
-        .filter(|reference| reference.starts_with("https://") || reference.starts_with("http://"))
+        .filter(|reference| is_tracker_url(reference))
+}
+
+fn is_tracker_url(reference: &str) -> bool {
+    reference.starts_with("https://") || reference.starts_with("http://")
 }
 
 fn tracker_state_without_observation(
     record: Option<&agent_task_lifecycle::AgentTaskRunRecord>,
+    recipe: Option<&homeboy::agents::agent_task_service::AgentTaskCookRecipe>,
+    declared_tracker: Option<&str>,
 ) -> supervisor::AgentTaskFanoutTrackerState {
-    if record.is_some_and(|record| declared_tracker_ref(&record.metadata).is_some()) {
+    if record.is_some_and(|record| declared_tracker_ref(&record.metadata).is_some())
+        || recipe.is_some_and(|recipe| {
+            recipe
+                .source_refs
+                .first()
+                .is_some_and(|reference| is_tracker_url(reference))
+        })
+        || declared_tracker.is_some_and(is_tracker_url)
+    {
         supervisor::AgentTaskFanoutTrackerState::DeclaredUnobserved
     } else {
         supervisor::AgentTaskFanoutTrackerState::Unknown
@@ -1493,7 +1538,7 @@ fn git_candidate_state(
 
 fn batch_resume_result(
     report: agent_task_service::AgentTaskCookBatchReport,
-    exit_code: i32,
+    subject_exit_code: i32,
     batch_id: &str,
     portfolio: Option<supervisor::AgentTaskFanoutPortfolioRunReport>,
     placement: Placement,
@@ -1503,6 +1548,7 @@ fn batch_resume_result(
             "schema": "homeboy/agent-task-cook-batch-resume/v1",
             "batch_id": report.batch_id,
             "status": report.status,
+            "exit_code": subject_exit_code,
             "summary": {
                 "total": report.total,
                 "queued": report.queued,
@@ -1520,7 +1566,9 @@ fn batch_resume_result(
                 "resume": fanout_command(placement, "resume", batch_id),
             },
         }),
-        exit_code,
+        // The operation successfully reconciled the requested batch. Its
+        // failed subject outcome remains explicit in the payload above.
+        0,
     )
 }
 
@@ -12995,6 +13043,7 @@ esac
             worktree.to_str().unwrap(),
             None,
             Some(&json!({ "head": "fanout/child", "base": "main" })),
+            None,
         );
         match previous_path {
             Some(path) => std::env::set_var("PATH", path),

--- a/crates/homeboy-cli/src/commands/utils/response.rs
+++ b/crates/homeboy-cli/src/commands/utils/response.rs
@@ -647,7 +647,17 @@ fn envelope_for_data(
         operation: identity.operation.clone(),
         success,
         exit_code,
-        status: status_for_result(Some(&data), exit_code),
+        status: if exit_code == 0
+            && matches!(
+                (identity.command.as_str(), identity.operation.as_deref()),
+                ("agent-task", Some("fanout resume"))
+            ) {
+            // Resume can successfully reconcile a batch whose durable subject
+            // remains failed; retain that subject outcome below instead.
+            "succeeded".to_string()
+        } else {
+            status_for_result(Some(&data), exit_code)
+        },
         subject_state,
         run,
         refs,
@@ -673,6 +683,10 @@ fn subject_state_for_identity(identity: &CommandIdentity, data: &Value) -> Optio
     match (identity.command.as_str(), identity.operation.as_deref()) {
         ("agent-task", Some("status")) => data
             .get("state")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        ("agent-task", Some("fanout resume")) => data
+            .get("status")
             .and_then(Value::as_str)
             .map(str::to_string),
         _ => None,

--- a/tests/cli_binary/fanout_supervisor_cli.rs
+++ b/tests/cli_binary/fanout_supervisor_cli.rs
@@ -122,6 +122,83 @@ fn fanout_resume_runs_and_persists_the_production_supervisor_across_restart() {
     });
 }
 
+/// An attached coordinator can die after child provider dispatch. Resume runs
+/// in a fresh process, so this covers the persisted graph/readiness boundary
+/// that previously rewrote terminal independent failures as successful blocks.
+#[test]
+fn fanout_resume_preserves_interrupted_independent_child_failures() {
+    homeboy_core::test_support::with_isolated_home(|_| {
+        let batch_id = "interrupted-independent-children";
+        let children = ["child-a", "child-b", "child-c"];
+        let plan = AgentTaskPlan::new("interrupted-provider-wave", Vec::new());
+        for child in children {
+            let run_id = format!("cook-{child}");
+            submit_plan(&plan, Some(&run_id)).expect("persist interrupted child");
+            homeboy::agents::agent_tasks::lifecycle::record_pre_execution_failure(
+                &run_id,
+                &plan,
+                "provider_start",
+                &homeboy_core::Error::internal_unexpected(
+                    "local Cook observer was interrupted during provider execution",
+                ),
+            )
+            .expect("terminalize interrupted child");
+        }
+        persist_fanout_run_batch(
+            batch_id,
+            batch_id,
+            &children
+                .iter()
+                .map(|child| FanoutRunBatchChild {
+                    task_id: (*child).to_string(),
+                    run_id: format!("cook-{child}"),
+                })
+                .collect::<Vec<_>>(),
+            serde_json::json!({
+                "dependency_graph": {
+                    "nodes": children.iter().map(|child| serde_json::json!({
+                        "id": child,
+                        "depends_on": []
+                    })).collect::<Vec<_>>()
+                },
+                "declared_trackers": {
+                    "child-a": "https://github.com/Extra-Chill/homeboy/issues/14190",
+                    "child-b": "https://github.com/Extra-Chill/homeboy/issues/14191",
+                    "child-c": "https://github.com/Extra-Chill/homeboy/issues/14192"
+                }
+            }),
+        )
+        .expect("persist interrupted batch");
+
+        let output = Command::new(homeboy_bin())
+            .args(["agent-task", "fanout", "resume", batch_id])
+            .env("HOMEBOY_NO_UPDATE_CHECK", "1")
+            .output()
+            .expect("resume from a separate process");
+        assert!(output.status.success());
+        let output: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("fanout resume JSON output");
+        assert!(output["success"].as_bool().expect("resume success flag"));
+        assert_eq!(output["exit_code"], 0);
+        assert_eq!(output["status"], "succeeded");
+        assert_eq!(output["subject_state"], "failed");
+        assert_eq!(output["data"]["status"], "failed");
+        assert_eq!(output["data"]["exit_code"], 1);
+        assert_eq!(output["data"]["summary"]["succeeded"], 0);
+        assert_eq!(output["data"]["summary"]["failed"], 3);
+        for cell in output["data"]["cooks"].as_array().expect("child cells") {
+            assert_eq!(cell["status"], "failed");
+            assert_eq!(cell["exit_code"], 1);
+        }
+        for child in output["data"]["portfolio"]["status"]["children"]
+            .as_array()
+            .expect("portfolio children")
+        {
+            assert_eq!(child["tracker"], "declared_unobserved");
+        }
+    });
+}
+
 /// #13702: reading a batch that failed before admission is a *successful
 /// read*. The command exits zero so the recovery path Homeboy itself prints
 /// survives `set -e`; the failed subject state stays in `data`, and the


### PR DESCRIPTION
## Summary
- retain canonical durable child lifecycle state across fanout resume and status projection
- classify pre-artifact interruption separately from success and dependency completion
- prevent interrupted children from falsely satisfying downstream dependencies

Closes #14196

## Verification
- `cargo test -p homeboy-agents pre_artifact_interruption -j1`
- `cargo check -p homeboy-agents -p homeboy-cli --tests -j1`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

## AI Assistance
Implemented and reviewed with OpenAI GPT-5.6 Terra and GPT-5.6 Sol via OpenCode. AI was used to trace durable child state, implement interruption semantics, add regression coverage, and verify the branch.